### PR TITLE
ci(chart): validate values against a schema, and sign the published chart with keyless cosign

### DIFF
--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -24,12 +24,17 @@
 # WHY there is no `helm package --sign` / `.prov` provenance: PGP signing needs a
 # long-lived private key in CI, which is the exact thing the crates.io lane was
 # built to avoid (Trusted Publishing via OIDC, no long-lived token anywhere), and
-# a key in a repository secret is a worse posture than no key at all. The chart is
-# instead attested KEYLESS through Sigstore, the same mechanism and the same
-# verification command as the images:
-#   gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:X.Y.Z -R rubentalstra/FerroEHR
+# a key in a repository secret is a worse posture than no key at all. The chart
+# instead carries two KEYLESS Sigstore artifacts, which answer different
+# questions and are both produced below:
+#   * a cosign SIGNATURE — "this artifact was signed by this workflow"
+#       cosign verify ghcr.io/rubentalstra/charts/ferroehr@sha256:… \
+#         --certificate-identity-regexp '^https://github\.com/rubentalstra/FerroEHR/\.github/workflows/publish-chart\.yml@' \
+#         --certificate-oidc-issuer https://token.actions.githubusercontent.com
+#   * a SLSA build PROVENANCE attestation — "it was built from this source, this way"
+#       gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:X.Y.Z -R rubentalstra/FerroEHR
 # The consequence for consumers is honest: `helm install --verify` (which only
-# understands a `.prov`) does not apply; `gh attestation verify` does.
+# understands a `.prov`) does not apply; the two commands above do.
 name: Publish chart
 
 on:
@@ -101,6 +106,9 @@ jobs:
       - uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
         with:
           version: 1.3.3
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.1.3
 
       # No build cache is restored anywhere in this lane (#2011): everything it
       # publishes is built from this checkout and nothing else.
@@ -384,8 +392,62 @@ jobs:
           [ -n "$digest" ] || { echo "::error::could not read the pushed digest from helm push output"; exit 1; }
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
+      # A keyless cosign SIGNATURE over the pushed digest. Distinct from the
+      # attestation below and not redundant with it: the attestation answers
+      # "built from this source, this way", the signature answers "signed by this
+      # workflow" — and the signature is the artifact a Helm consumer's tooling
+      # and Artifact Hub's listing actually look for.
+      #
+      # `--new-bundle-format=false` is a DECISION, not inertia. cosign 3 defaults
+      # to the protobuf bundle attached as an OCI 1.1 referring artifact, and
+      # GHCR implements no referrers API at all — measured against the published
+      # chart, `GET /v2/rubentalstra/charts/ferroehr/referrers/<digest>` answers
+      # `404 MANIFEST_UNKNOWN`, so a referring artifact reaches the registry only
+      # through the OCI fallback TAG (`sha256-<hex>`), which on this repository is
+      # the very index the attestation step below already writes. Two writers to
+      # one index is a way to lose the attestation, for no gain: Artifact Hub
+      # checks the classic `sha256-<hex>.sig` tag FIRST (tag-based discovery in
+      # `HasCosignSignature`, `internal/oci/oci.go`), and a plain tag needs no
+      # registry capability whatever. Revisit when GHCR serves referrers.
+      - name: Sign the chart with keyless cosign
+        id: sign
+        if: steps.push.outputs.digest != ''
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          set -euo pipefail
+          cosign sign --yes --new-bundle-format=false "${CHART_REF}@${DIGEST}"
+
+      # Read the signature back the way a consumer and Artifact Hub each do,
+      # because both failure modes are silent: a signature that does not verify
+      # against this workflow's identity is worse than none, and a signature the
+      # hub cannot locate presents weeks later as a listing that still says
+      # "not signed" with no error anywhere.
+      - name: Verify the signature verifies, and is where the hub looks
+        id: verify
+        if: steps.sign.outcome == 'success'
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          cosign verify "${CHART_REF}@${DIGEST}" \
+            --certificate-identity-regexp "^https://github\.com/${REPO}/\.github/workflows/publish-chart\.yml@" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            > /dev/null
+          echo "the signature verifies against ${REPO}/.github/workflows/publish-chart.yml"
+          # `cosign triangulate` prints the tag the classic layout stores the
+          # signature under — the same tag the hub's tag-based discovery reads.
+          sig_ref="$(cosign triangulate "${CHART_REF}@${DIGEST}")"
+          if ! oras manifest fetch "$sig_ref" > /dev/null; then
+            echo "::error::${sig_ref} is not fetchable — the signature verified but Artifact Hub's tag-based discovery will not find it."
+            exit 1
+          fi
+          echo "sig=${sig_ref}" >> "$GITHUB_OUTPUT"
+          echo "::notice::signature readable at ${sig_ref}; Artifact Hub reports it on its next processing cycle."
+
       # Keyless provenance for the chart artifact, the same mechanism the images
-      # use — see the header for why this replaces a PGP `.prov`.
+      # use — see the header for why neither of these is a PGP `.prov`.
       - name: Attest build provenance
         if: steps.push.outputs.digest != ''
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
@@ -453,6 +515,7 @@ jobs:
           VERSION: ${{ steps.chart.outputs.version }}
           APP: ${{ steps.chart.outputs.app }}
           DIGEST: ${{ steps.push.outputs.digest }}
+          SIGNATURE: ${{ steps.verify.outputs.sig }}
           JUDGED: ${{ steps.judge.outputs.image }}
           WHY: ${{ steps.judge.outputs.why }}
         run: |
@@ -464,6 +527,7 @@ jobs:
             printf '| judged against | `%s` (%s) |\n' "${JUDGED:-not selected}" "${WHY:-—}"
             printf '| repository | `%s` |\n' "$CHART_REF"
             printf '| digest | `%s` |\n' "${DIGEST:-not pushed}"
+            printf '| signature | `%s` |\n' "${SIGNATURE:-not signed}"
             printf '\nInstall:\n\n```shell\nhelm install ferroehr oci://%s/ferroehr --version %s\n```\n' \
               "${CHART_REF%/ferroehr}" "$VERSION"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -102,7 +102,7 @@ jobs:
       # Generated from the release commit's own `Cargo.lock` with `--locked`, so
       # it describes the graph that was actually built, not one resolved later.
       - name: Install cargo-cyclonedx
-        uses: taiki-e/install-action@91ddec75689c4c78665b598d188dc821c5a43e5c # v2
+        uses: taiki-e/install-action@91ddec75689c4c78665b598d188dc821c5a43e5c # v2.85.9
         with:
           tool: cargo-cyclonedx
       - name: Generate the dependency SBOM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,23 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
+- **The Helm chart validates your values file** (`values.schema.json`, chart
+  `5.0.0`). `helm install`, `upgrade`, `lint` and `template` now refuse a values
+  file that misspells one of the chart's own keys, gets a type wrong, or names a
+  value outside the permitted set, instead of rendering and ignoring it — a
+  breaking chart change, which is why the chart's major version moves. The
+  `config:` tree stays deliberately open: that vocabulary belongs to the server
+  and is validated by the binary at boot, so copying it into the chart would fork
+  it. Artifact Hub renders the schema on the chart's listing. (#2184)
+- **The published Helm chart is signed** with a keyless
+  [cosign](https://docs.sigstore.dev/cosign/) signature, from chart `5.0.0`
+  onward, alongside the SLSA build provenance attestation it already carried —
+  the attestation says what the chart was built from, the signature says who
+  signed the artifact you pulled. No key material exists anywhere; verification
+  requires an identity and an issuer, and both are in the installation guide.
+  `helm install --verify` still does not apply: the chart ships no PGP `.prov`.
+  (#2184)
+
 - **The PGP signing key can be rotated without losing history.** Signing now
   uses a signing-capable *subkey* selected by its OpenPGP key flags, which is
   the rotation mechanism the standard provides: issue a new subkey, the

--- a/README.md
+++ b/README.md
@@ -506,15 +506,17 @@ deploys, and listed on
 
 ```shell
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 4.0.0 --set database.existingSecret=my-db-secret
+  --version 5.0.0 --set database.existingSecret=my-db-secret
 ```
 
 There is no HTTP chart repository, so `helm repo add` does not apply — OCI is the
 only publication path. The chart version and the image tag are separate SemVer
-lines: `--version` pins the chart, `--set image.tag=` pins the server. The chart
-and the images are published with signed keyless provenance
-(`gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:<chart-version> -R rubentalstra/FerroEHR`);
-signing landed in the 3.17.4 cycle, so tags built before it carry none.
+lines: `--version` pins the chart, `--set image.tag=` pins the server. Your values
+file is checked against the chart's `values.schema.json` before anything is
+applied. The chart and the images are published with signed keyless provenance
+(`gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:<chart-version> -R rubentalstra/FerroEHR`),
+and the chart additionally carries a keyless `cosign` signature from chart `5.0.0`
+onward; signing landed in the 3.17.4 cycle, so tags built before it carry none.
 
 See the [Kubernetes chapter](https://ferroehr.eu/docs/latest/installation/kubernetes.html)
 and the [documentation website](https://ferroehr.eu/)

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -10,10 +10,15 @@ type: application
 
 # Chart versioning is independent of the application version, and is SemVer 2
 # over the CHART's own contract — its values schema and rendered output
-# (https://helm.sh/docs/topics/charts/#charts-and-versioning). 4.0.0 is a major
+# (https://helm.sh/docs/topics/charts/#charts-and-versioning). 4.0.0 was a major
 # bump because a values file that set a secret-bearing key under `config:` used
-# to render (into a ConfigMap) and is now refused.
-version: 4.1.0
+# to render (into a ConfigMap) and is now refused. 5.0.0 is one for the same
+# reason in a wider form: the chart now ships `values.schema.json`, which helm
+# enforces on install/upgrade/lint/template, so a values file carrying a
+# misspelled or wrong-typed key of the CHART's own vocabulary is refused where it
+# previously rendered with the key silently ignored. The server's `config:` tree
+# stays open — that vocabulary belongs to the binary, not to this schema.
+version: 5.0.0
 # The default container image tag (overridable via image.tag), and the released
 # application version — kept equal to the workspace version by the
 # `chart-appversion` CI guard, so a release cannot ship a chart pointing at the
@@ -67,11 +72,14 @@ maintainers:
 # Deliberately absent, so a later reader does not wonder:
 #   operator, operatorCapabilities — this is not an operator.
 #   crds, crdsExamples             — the chart defines no CustomResourceDefinition.
-#   signKey                        — the chart carries no PGP provenance (`.prov`);
-#                                    it is attested keyless through Sigstore
-#                                    instead, and this annotation has no field for
-#                                    that (its `url` is mandatory and would have to
-#                                    point at a key that does not exist).
+#   signKey                        — the chart carries no PGP provenance (`.prov`).
+#                                    It is signed keyless with cosign and attested
+#                                    through Sigstore, and this annotation cannot
+#                                    describe either: its `url` is mandatory and
+#                                    would have to point at a public key that does
+#                                    not exist. Artifact Hub reports the cosign
+#                                    signature from the registry itself, so the
+#                                    "Signed" state needs no annotation.
 #   alternativeName, recommendations — nothing to name or recommend.
 # ─────────────────────────────────────────────────────────────────────────────
 annotations:

--- a/deploy/helm/ferroehr/README.md
+++ b/deploy/helm/ferroehr/README.md
@@ -2,7 +2,7 @@
 
 Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.1.0 + AQL 1.1). A single static binary deployed with a hardened-by-default security posture: runs as a non-root, read-only-rootfs, default-deny-ingress workload that connects to an EXTERNAL PostgreSQL 18 as an unprivileged app role (migrations are run out of band by a separate migrator role).
 
-![Version: 4.1.0](https://img.shields.io/badge/Version-4.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.17.3](https://img.shields.io/badge/AppVersion-3.17.3-informational?style=flat-square)
+![Version: 5.0.0](https://img.shields.io/badge/Version-5.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.17.3](https://img.shields.io/badge/AppVersion-3.17.3-informational?style=flat-square)
 
 FerroEHR is a pure-Rust openEHR Clinical Data Repository: ITS-REST 1.1.0 at the
 API, AQL 1.1 as the query language, PostgreSQL 18-native storage, shipped as a
@@ -33,7 +33,7 @@ add — `helm repo add` does not apply to this chart and never will:
 
 ```console
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 4.1.0 \
+  --version 5.0.0 \
   --namespace ferroehr --create-namespace \
   --set database.existingSecret=ferroehr-db \
   --set image.tag=3.17.3
@@ -47,7 +47,7 @@ They are independent SemVer lines and they move independently:
 
 | What | Set with | This release |
 |---|---|---|
-| the **chart** (templates, defaults, this document) | `--version` | `4.1.0` |
+| the **chart** (templates, defaults, this document) | `--version` | `5.0.0` |
 | the **server image** | `image.tag` | `3.17.3` |
 
 `appVersion` is the image the chart defaults to; pinning `image.tag` explicitly
@@ -55,19 +55,40 @@ is what keeps an upgrade of one from silently moving the other.
 
 ### Verify what you pulled
 
-Both the chart and the images carry Sigstore-signed build provenance:
+The chart carries two keyless Sigstore artifacts, and they answer different
+questions. A **cosign signature** — who signed this:
 
 ```console
-gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:4.1.0 \
+cosign verify ghcr.io/rubentalstra/charts/ferroehr:5.0.0 \
+  --certificate-identity-regexp '^https://github\.com/rubentalstra/FerroEHR/\.github/workflows/publish-chart\.yml@' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+A **SLSA build provenance attestation** — what source it was built from, and how:
+
+```console
+gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:5.0.0 \
   -R rubentalstra/FerroEHR
 gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:3.17.3 \
   -R rubentalstra/FerroEHR
 ```
 
-`helm install --verify` does **not** apply: it reads a `.prov` provenance file,
-and this chart is attested through Sigstore rather than signed with a long-lived
-PGP key — deliberately, because keeping such a key in CI is a worse posture than
-not having one.
+`helm install --verify` does **not** apply: it reads a PGP `.prov` provenance
+file, and this chart ships none — deliberately, because keeping a long-lived
+private key in CI is a worse posture than not having one. The two commands above
+are what replace it.
+
+### Your values file is validated
+
+The chart ships a `values.schema.json`, so `helm install`, `upgrade`, `lint` and
+`template` refuse a values file that misspells a key of the chart's own
+vocabulary, gets a type wrong, or names a value outside the permitted set —
+instead of rendering and ignoring it.
+
+Everything under `config:` stays deliberately open: that vocabulary is the
+**server's** (`ferroehr config default` prints it in full), it is validated by
+the binary at boot, and duplicating it here would fork it. So a typo under
+`config:` is caught when the pod starts, not when the chart renders.
 
 ## Secrets
 

--- a/deploy/helm/ferroehr/README.md.gotmpl
+++ b/deploy/helm/ferroehr/README.md.gotmpl
@@ -55,7 +55,16 @@ is what keeps an upgrade of one from silently moving the other.
 
 ### Verify what you pulled
 
-Both the chart and the images carry Sigstore-signed build provenance:
+The chart carries two keyless Sigstore artifacts, and they answer different
+questions. A **cosign signature** — who signed this:
+
+```console
+cosign verify ghcr.io/rubentalstra/charts/ferroehr:{{ template "chart.version" . }} \
+  --certificate-identity-regexp '^https://github\.com/rubentalstra/FerroEHR/\.github/workflows/publish-chart\.yml@' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+A **SLSA build provenance attestation** — what source it was built from, and how:
 
 ```console
 gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:{{ template "chart.version" . }} \
@@ -64,10 +73,22 @@ gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:{{ template "chart.app
   -R rubentalstra/FerroEHR
 ```
 
-`helm install --verify` does **not** apply: it reads a `.prov` provenance file,
-and this chart is attested through Sigstore rather than signed with a long-lived
-PGP key — deliberately, because keeping such a key in CI is a worse posture than
-not having one.
+`helm install --verify` does **not** apply: it reads a PGP `.prov` provenance
+file, and this chart ships none — deliberately, because keeping a long-lived
+private key in CI is a worse posture than not having one. The two commands above
+are what replace it.
+
+### Your values file is validated
+
+The chart ships a `values.schema.json`, so `helm install`, `upgrade`, `lint` and
+`template` refuse a values file that misspells a key of the chart's own
+vocabulary, gets a type wrong, or names a value outside the permitted set —
+instead of rendering and ignoring it.
+
+Everything under `config:` stays deliberately open: that vocabulary is the
+**server's** (`ferroehr config default` prints it in full), it is validated by
+the binary at boot, and duplicating it here would fork it. So a typo under
+`config:` is caught when the pod starts, not when the chart renders.
 
 ## Secrets
 

--- a/deploy/helm/ferroehr/values.schema.json
+++ b/deploy/helm/ferroehr/values.schema.json
@@ -1,0 +1,749 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "ferroehr chart values",
+  "description": "Draft-07 because that is what consumes it: helm 4 validates through santhosh-tekuri/jsonschema/v6 (multi-draft), but Artifact Hub's Values-schema renderer is typed against json-schema draft 4/6/7. Descriptions here state CONSTRAINTS the type cannot; the prose reference is the generated README table, and defaults are read from values.yaml, so neither is repeated.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "global": {
+      "description": "Injected by a parent chart when this one is used as a dependency. Nothing in this chart reads it, but refusing it would make the chart unusable as a subchart.",
+      "type": "object"
+    },
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "strategy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["RollingUpdate", "Recreate"]
+        },
+        "rollingUpdate": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "maxSurge": {
+              "description": "A count or a percentage string (\"25%\").",
+              "type": ["integer", "string"]
+            },
+            "maxUnavailable": {
+              "description": "A count or a percentage string (\"25%\").",
+              "type": ["integer", "string"]
+            }
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "repository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        },
+        "tag": {
+          "description": "Empty falls back to .Chart.appVersion.",
+          "type": "string"
+        },
+        "digest": {
+          "description": "Wins over `tag` entirely when set.",
+          "type": "string",
+          "pattern": "^(sha256:[0-9a-f]{64})?$"
+        }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "type": "string"
+        },
+        "automountServiceAccountToken": {
+          "type": "boolean"
+        }
+      }
+    },
+    "database": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "existingSecret": {
+          "type": "string"
+        },
+        "existingSecretKey": {
+          "description": "A key name INSIDE existingSecret, not an environment variable name: the chart mounts that key as a file and passes only its path.",
+          "type": "string"
+        },
+        "url": {
+          "description": "Inline DSN (dev/test only). Ignored when existingSecret is set.",
+          "type": "string"
+        }
+      }
+    },
+    "migrations": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "runByMigratorRole": {
+          "type": "boolean"
+        },
+        "job": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "existingSecret": {
+              "description": "Required when enabled: the MIGRATOR DSN, a different credential from database.*.",
+              "type": "string"
+            },
+            "existingSecretKey": {
+              "type": "string"
+            },
+            "backoffLimit": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "ttlSecondsAfterFinished": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "activeDeadlineSeconds": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "resources": {
+              "$ref": "#/definitions/resourceRequirements"
+            },
+            "podAnnotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "nodeSelector": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "tolerations": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "secrets": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "authOidcHmacSecret": {
+          "type": "string"
+        },
+        "signingKeyPassphrase": {
+          "type": "string"
+        },
+        "eventsUrl": {
+          "type": "string"
+        },
+        "fhirOutboundUrl": {
+          "type": "string"
+        },
+        "basicUserPasswordHashes": {
+          "description": "Keyed by username; each username also needs an entry under config.auth.basic.users, or rendering fails.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "auditFhirFeedUrl": {
+          "type": "string"
+        },
+        "terminologyOauth2ClientSecrets": {
+          "description": "Keyed by client name; each name also needs an entry under config.terminology.external.oauth2_clients, or rendering fails.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "multimediaAccessKeyId": {
+          "type": "string"
+        },
+        "multimediaSecretAccessKey": {
+          "type": "string"
+        }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "serviceMonitor": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "namespace": {
+              "type": "string"
+            },
+            "labels": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "interval": {
+              "$ref": "#/definitions/duration"
+            },
+            "scrapeTimeout": {
+              "$ref": "#/definitions/duration"
+            }
+          }
+        }
+      }
+    },
+    "config": {
+      "description": "Rendered into ferroehr.toml, so its vocabulary is the SERVER's config tree and this schema deliberately does not fork it: unknown keys are accepted here and adjudicated by the server at boot. Only the keys the chart's own templates branch on are typed, and each accepts null — setting a key to null is how an overlay deletes it when a pinned older image does not know it yet.",
+      "type": "object",
+      "properties": {
+        "server": {
+          "type": ["object", "null"],
+          "properties": {
+            "base_path": {
+              "type": ["string", "null"]
+            }
+          }
+        },
+        "db": {
+          "type": ["object", "null"],
+          "properties": {
+            "migrate": {
+              "type": ["string", "null"]
+            }
+          }
+        },
+        "auth": {
+          "type": ["object", "null"],
+          "properties": {
+            "enabled": {
+              "type": ["boolean", "null"]
+            }
+          }
+        },
+        "admin": {
+          "type": ["object", "null"],
+          "properties": {
+            "enabled": {
+              "type": ["boolean", "null"]
+            }
+          }
+        },
+        "tenancy": {
+          "type": ["object", "null"],
+          "properties": {
+            "enabled": {
+              "type": ["boolean", "null"]
+            }
+          }
+        },
+        "management": {
+          "type": ["object", "null"],
+          "properties": {
+            "enabled": {
+              "type": ["boolean", "null"]
+            },
+            "base_path": {
+              "type": ["string", "null"]
+            },
+            "port": {
+              "description": "Unset serves the management surface on the API port; set, it becomes a second container port.",
+              "type": ["integer", "null"],
+              "minimum": 1,
+              "maximum": 65535
+            }
+          }
+        },
+        "audit": {
+          "type": ["object", "null"],
+          "properties": {
+            "enabled": {
+              "type": ["boolean", "null"]
+            }
+          }
+        },
+        "events": {
+          "type": ["object", "null"],
+          "properties": {
+            "enabled": {
+              "type": ["boolean", "null"]
+            }
+          }
+        },
+        "fhir": {
+          "type": ["object", "null"],
+          "properties": {
+            "api_enabled": {
+              "type": ["boolean", "null"]
+            },
+            "outbound": {
+              "type": ["object", "null"],
+              "properties": {
+                "enabled": {
+                  "type": ["boolean", "null"]
+                },
+                "exchange": {
+                  "type": ["string", "null"]
+                }
+              }
+            }
+          }
+        },
+        "terminology": {
+          "type": ["object", "null"],
+          "properties": {
+            "external": {
+              "type": ["object", "null"],
+              "properties": {
+                "enabled": {
+                  "type": ["boolean", "null"]
+                }
+              }
+            }
+          }
+        },
+        "multimedia": {
+          "type": ["object", "null"],
+          "properties": {
+            "enabled": {
+              "type": ["boolean", "null"]
+            },
+            "allow_http": {
+              "type": ["boolean", "null"]
+            }
+          }
+        },
+        "files": {
+          "description": "NOT part of the TOML: each key becomes /etc/ferroehr/<key> from a chart Secret. Values are file contents, so they are strings.",
+          "type": ["object", "null"],
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "extraEnv": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "extraEnvFrom": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"]
+        },
+        "port": {
+          "$ref": "#/definitions/port"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "className": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "host": {
+                "type": "string",
+                "minLength": 1
+              },
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "path": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "pathType": {
+                      "type": "string",
+                      "enum": ["Exact", "Prefix", "ImplementationSpecific"]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "secretName": {
+                "type": "string"
+              },
+              "hosts": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "ingressFrom": {
+          "description": "Raw NetworkPolicyPeer entries. EMPTY means the rule carries no `from` at all, which admits every source.",
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "egress": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "database": {
+              "description": "Not optional when egress is enabled: rendering refuses an egress policy with no database destination.",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "to": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  }
+                },
+                "port": {
+                  "$ref": "#/definitions/port"
+                }
+              }
+            },
+            "rules": {
+              "description": "Raw NetworkPolicyEgressRule entries, one per enabled integration.",
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "podSecurityContext": {
+      "description": "Rendered verbatim as the pod's securityContext, so the whole Kubernetes PodSecurityContext surface is permitted.",
+      "type": "object"
+    },
+    "securityContext": {
+      "description": "Rendered verbatim as the container's securityContext, so the whole Kubernetes SecurityContext surface is permitted.",
+      "type": "object"
+    },
+    "resources": {
+      "$ref": "#/definitions/resourceRequirements"
+    },
+    "probes": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "exec": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          }
+        },
+        "liveness": {
+          "$ref": "#/definitions/probeTiming"
+        },
+        "readiness": {
+          "$ref": "#/definitions/probeTiming"
+        },
+        "startup": {
+          "description": "Unlike liveness/readiness, these four fields are read individually rather than rendered whole, so the set is closed.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "initialDelaySeconds": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "periodSeconds": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "timeoutSeconds": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "failureThreshold": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        }
+      }
+    },
+    "autoscaling": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "minReplicas": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "maxReplicas": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "targetCPUUtilizationPercentage": {
+          "description": "0 disables the metric.",
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "targetMemoryUtilizationPercentage": {
+          "description": "0 disables the metric.",
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
+    },
+    "podDisruptionBudget": {
+      "description": "Set one of minAvailable / maxUnavailable, never both.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "minAvailable": {
+          "type": ["integer", "string"]
+        },
+        "maxUnavailable": {
+          "type": ["integer", "string"]
+        }
+      }
+    },
+    "podLabels": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "podAnnotations": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "nodeSelector": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "tolerations": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "affinity": {
+      "type": "object"
+    },
+    "topologySpreadConstraints": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "terminationGracePeriodSeconds": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "extraVolumes": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "extraVolumeMounts": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    }
+  },
+  "definitions": {
+    "port": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 65535
+    },
+    "duration": {
+      "description": "A Prometheus duration: a digit run followed by ms, s, m, h, d, w or y.",
+      "type": "string",
+      "pattern": "^([0-9]+(ms|[smhdwy]))+$"
+    },
+    "quantity": {
+      "description": "A Kubernetes quantity — \"250m\", \"1Gi\", or a bare number.",
+      "type": ["string", "number"]
+    },
+    "resourceRequirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "limits": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/quantity"
+          }
+        },
+        "requests": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/quantity"
+          }
+        },
+        "claims": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "probeTiming": {
+      "description": "Rendered whole beside the chart's own httpGet/exec handler, so any Kubernetes probe field is permitted; these four are typed because they are the ones the chart ships.",
+      "type": ["object", "null"],
+      "properties": {
+        "initialDelaySeconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    }
+  }
+}

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -12,7 +12,7 @@ kind: NetworkPolicy
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.1.0
+    helm.sh/chart: ferroehr-5.0.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -82,7 +82,7 @@ kind: PodDisruptionBudget
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.1.0
+    helm.sh/chart: ferroehr-5.0.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -101,7 +101,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.1.0
+    helm.sh/chart: ferroehr-5.0.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -132,7 +132,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-4.1.0
+    helm.sh/chart: ferroehr-5.0.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -158,7 +158,7 @@ kind: Secret
 metadata:
   name: ferroehr-config
   labels:
-    helm.sh/chart: ferroehr-4.1.0
+    helm.sh/chart: ferroehr-5.0.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -177,7 +177,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.1.0
+    helm.sh/chart: ferroehr-5.0.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -368,7 +368,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.1.0
+    helm.sh/chart: ferroehr-5.0.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -395,7 +395,7 @@ kind: Deployment
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.1.0
+    helm.sh/chart: ferroehr-5.0.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -598,7 +598,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.1.0
+    helm.sh/chart: ferroehr-5.0.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -631,7 +631,7 @@ kind: Ingress
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.1.0
+    helm.sh/chart: ferroehr-5.0.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -668,7 +668,7 @@ kind: ServiceMonitor
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.1.0
+    helm.sh/chart: ferroehr-5.0.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"

--- a/deploy/helm/golden/basic-auth.yaml
+++ b/deploy/helm/golden/basic-auth.yaml
@@ -12,7 +12,7 @@ kind: NetworkPolicy
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.1.0
+    helm.sh/chart: ferroehr-5.0.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -36,7 +36,7 @@ kind: PodDisruptionBudget
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.1.0
+    helm.sh/chart: ferroehr-5.0.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -55,7 +55,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.1.0
+    helm.sh/chart: ferroehr-5.0.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -84,7 +84,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-4.1.0
+    helm.sh/chart: ferroehr-5.0.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -100,7 +100,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.1.0
+    helm.sh/chart: ferroehr-5.0.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -228,7 +228,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.1.0
+    helm.sh/chart: ferroehr-5.0.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -251,7 +251,7 @@ kind: Deployment
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.1.0
+    helm.sh/chart: ferroehr-5.0.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -12,7 +12,7 @@ kind: NetworkPolicy
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.1.0
+    helm.sh/chart: ferroehr-5.0.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -36,7 +36,7 @@ kind: PodDisruptionBudget
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.1.0
+    helm.sh/chart: ferroehr-5.0.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -55,7 +55,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.1.0
+    helm.sh/chart: ferroehr-5.0.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -69,7 +69,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.1.0
+    helm.sh/chart: ferroehr-5.0.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -194,7 +194,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.1.0
+    helm.sh/chart: ferroehr-5.0.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -217,7 +217,7 @@ kind: Deployment
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-4.1.0
+    helm.sh/chart: ferroehr-5.0.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"

--- a/deploy/helm/validate.sh
+++ b/deploy/helm/validate.sh
@@ -16,6 +16,10 @@
 #                        releases, so the goldens are only reproducible on the pin)
 #   5. kubeconform     — schema-validate the manifests IF kubeconform is on PATH
 #                        (optional; skipped with a note when absent/offline)
+#   6. values schema   — assert values.schema.json REFUSES what it claims to
+#                        (typos, wrong types, bad enums, out-of-range ports) and
+#                        still ACCEPTS what must stay open (the server's own
+#                        config vocabulary, a parent chart's `global`)
 #
 # What it does NOT check is printed at the end of every run, and is not a
 # footnote: every one of those properties has failed while this script was green
@@ -253,6 +257,87 @@ secret_leak_gate() {
   fi
 }
 secret_leak_gate
+
+# ── The values schema must refuse and permit exactly what it claims to ────────
+# A schema that is present but vacuous is worse than none: `helm template` stays
+# green, Artifact Hub renders a Values-schema tab, and an operator reads both as
+# evidence their values file was checked. So the file is exercised from both
+# sides — every refusal it promises, and every place it must stay OPEN.
+#
+# It has to stay open in two directions. `config:` is a 1:1 passthrough of the
+# SERVER's TOML tree, adjudicated at boot by the binary that owns that
+# vocabulary; typing it here would fork the config tree into the chart and refuse
+# keys the server accepts. And `global:` is what a parent chart injects when this
+# chart is used as a dependency — refusing it would make the chart unusable as a
+# subchart, with an error that names nothing the operator wrote.
+schema_gate() {
+  bold "── values schema ────────────────────────────────────────"
+  local schema="${CHART_DIR}/values.schema.json"
+  if [[ ! -f "$schema" ]]; then
+    red "  missing: ${schema} — nothing validates an operator's values file, and"
+    red "  Artifact Hub reports the chart as having no values schema."
+    FAIL=1
+    return
+  fi
+  # Not a preference: helm validates through a multi-draft library, but Artifact
+  # Hub's renderer is typed against json-schema draft 4/6/7, so a newer dialect
+  # renders wrong on the page that consumes the file.
+  if ! grep -q 'json-schema.org/draft-07/schema' "$schema"; then
+    red "  ${schema} does not declare the draft-07 dialect"
+    FAIL=1
+  fi
+
+  # <helm --set argument>|<the refusal must name this>
+  local -a refusals=(
+    "autoscalng.enabled=true|additional properties 'autoscalng' not allowed"
+    "probes.startup.periodSecond=5|/probes/startup"
+    "replicaCount=two|/replicaCount"
+    "image.pullPolicy=Sometimes|/image/pullPolicy"
+    "image.digest=sha256:nothex|/image/digest"
+    "service.port=70000|/service/port"
+    "metrics.serviceMonitor.interval=30|/metrics/serviceMonitor/interval"
+  )
+  local refused=0 probe want out
+  for case in "${refusals[@]}"; do
+    probe="${case%%|*}"
+    want="${case##*|}"
+    if out="$(helm template "$RELEASE_NAME" "$CHART_DIR" -n "$NAMESPACE" \
+              -f "${CI_DIR}/default-values.yaml" --set "$probe" 2>&1)"; then
+      red "  NOT REFUSED: --set ${probe} rendered instead of failing schema validation"
+      refused=1
+    elif ! grep -qF -- "$want" <<<"$out"; then
+      red "  --set ${probe} was refused, but the message does not mention '${want}':"
+      printf '%s\n' "$out" | head -4
+      refused=1
+    fi
+  done
+  if [[ "$refused" -eq 0 ]]; then
+    echo "  all ${#refusals[@]} malformed-values probes refused, each naming the offending path"
+  else
+    FAIL=1
+  fi
+
+  local -a acceptances=(
+    "config.server.future_api_key=probe"
+    "config.telemetry.otlp_endpoint=http://otel-collector:4317"
+    "global.imageRegistry=registry.example.com"
+  )
+  local accepted=0
+  for probe in "${acceptances[@]}"; do
+    if ! out="$(helm template "$RELEASE_NAME" "$CHART_DIR" -n "$NAMESPACE" \
+                -f "${CI_DIR}/default-values.yaml" --set "$probe" 2>&1)"; then
+      red "  WRONGLY REFUSED: --set ${probe} must be accepted (see the note above this gate):"
+      printf '%s\n' "$out" | head -4
+      accepted=1
+    fi
+  done
+  if [[ "$accepted" -eq 0 ]]; then
+    echo "  all ${#acceptances[@]} must-stay-open probes accepted (server config vocabulary, parent-chart global)"
+  else
+    FAIL=1
+  fi
+}
+schema_gate
 
 # ── The live-test fixture must still track the chart ──────────────────────────
 # WHY a `.claude/` path appears in a deploy gate: `.claude/skills/k8s-test/` holds

--- a/scripts/checks/docs-claims.sh
+++ b/scripts/checks/docs-claims.sh
@@ -180,15 +180,23 @@ done
 # catch, and that page may not be in a narrow diff.
 #
 # The reference may sit in an mdBook `{{#include}}` source rather than in a page
-# — `comparison.md` pulls three of its figures in from `website/book/generated/`
-# — so both trees are searched. Searching only the pages reported a chart as
-# orphaned when it was in fact published, which is the failure mode that gets a
-# guard ignored.
+# — `comparison.md` pulls its figures in from `website/book/generated/` — so that
+# tree is searched too. Searching only the pages reported a chart as orphaned when
+# it was in fact published, which is the failure mode that gets a guard ignored.
+#
+# And `website/book/generated/` is a BUILD ARTIFACT: it is not committed and does
+# not exist in a fresh checkout, so on its own it never matches and a figure
+# published only through an include is reported as orphaned regardless — measured
+# on `perf-stress-compare.svg`, which `scripts/render/comparison.sh` both renders
+# AND embeds, while this guard called it unpublished. The durable reference for
+# generated markdown is therefore the GENERATOR, so the render scripts are the
+# third haystack.
 while read -r svg; do
   [ -n "$svg" ] || continue
   base=${svg##*/}
   grep -rqF "$base" --include='*.md' "$BOOK" website/book/generated \
-    || report "$svg" "is committed but nothing embeds it"
+    || grep -rqF "$base" scripts/render \
+    || report "$svg" "is committed but neither a page, a generated include, nor a render script embeds it"
 done < <(git ls-files "$BOOK/*-assets/*.svg")
 
 if [ "$failures" -gt 0 ]; then

--- a/website/book/src/installation/kubernetes.md
+++ b/website/book/src/installation/kubernetes.md
@@ -24,7 +24,7 @@ kubectl -n ferroehr create secret generic ferroehr-db \
   --from-literal=FERROEHR__DB__URL='postgres://ferroehr_app:***@pg-host:5432/ferroehr?sslmode=verify-full'
 
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 4.0.0 -n ferroehr \
+  --version 5.0.0 -n ferroehr \
   --set database.existingSecret=ferroehr-db \
   --set image.tag=3.17.3
 ```
@@ -41,7 +41,7 @@ helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
 `oci://` reference. To read the chart's metadata without installing it:
 
 ```shell
-helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 4.0.0
+helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 5.0.0
 ```
 
 ### Pin two versions, not one
@@ -54,7 +54,7 @@ against.
 
 | | Selects | Pin with | Line |
 |---|---|---|---|
-| Chart version | templates, values schema, defaults | `--version 4.0.0` | SemVer over the chart's own contract |
+| Chart version | templates, values schema, defaults | `--version 5.0.0` | SemVer over the chart's own contract |
 | Image tag | the server binary | `--set image.tag=3.17.3` (or `image.digest`) | the application's SemVer line |
 
 Always pin the image to an immutable version or, better, a `@sha256` digest —
@@ -67,9 +67,26 @@ artifact.
 
 ### Verifying what you installed
 
-The chart and the images are published with **signed, keyless
-[Sigstore](https://docs.sigstore.dev/) provenance**, bound to this repository's
-build identity, so every claim here is checkable rather than asserted:
+Everything published here is signed **keyless** through
+[Sigstore](https://docs.sigstore.dev/), bound to this repository's build
+identity, so every claim is checkable rather than asserted. Two different
+artifacts answer two different questions, and you can ask both.
+
+**Who signed this chart** — a [cosign](https://docs.sigstore.dev/cosign/)
+signature over the chart's digest:
+
+```shell
+cosign verify ghcr.io/rubentalstra/charts/ferroehr:<chart-version> \
+  --certificate-identity-regexp '^https://github\.com/rubentalstra/FerroEHR/\.github/workflows/publish-chart\.yml@' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+Both flags matter. Without them `cosign verify` would accept a signature from
+*any* identity in the transparency log; with them you are requiring that this
+repository's chart-publishing workflow, authenticated by GitHub's OIDC issuer,
+is what signed the bytes you pulled.
+
+**What it was built from** — a SLSA build provenance attestation:
 
 ```shell
 # the chart
@@ -79,23 +96,43 @@ gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:<tag> -R rubentalstra/
 ```
 
 > [!IMPORTANT]
-> Signing was added to the publishing lanes **after** `3.17.3` was built, so that
-> tag and everything before it carry no attestation and the command above answers
-> `HTTP 404: Not Found` for them. Attestations exist from the first release
-> published by the signing lane onward. If you are pinning an older tag and need
-> provenance, pin a newer one — the development images
-> (`ghcr.io/rubentalstra/ferroehr:develop`) already verify. **No chart version has
-> been published yet**, so the chart command has nothing to answer for until the
-> first release cut by the signing lanes; the images it deploys are already
-> verifiable.
+> Signing was added to the publishing lanes over time, so the answer depends on
+> what you pinned. Image attestations exist from the first release published by
+> the signing lane onward — `3.17.3` and everything before it answer `HTTP 404:
+> Not Found`, which is the honest state rather than a verification failure (the
+> development images, `ghcr.io/rubentalstra/ferroehr:develop`, already verify).
+> For the chart, attestations exist from the first published version and the
+> **cosign signature from chart `5.0.0` onward**; chart `4.1.0` carries the
+> attestation but no signature.
 
 > [!NOTE]
 > `helm install --verify` and `helm verify` do **not** apply: they check a PGP
 > `.prov` file, and this chart ships none. That is deliberate — a `.prov` needs a
 > long-lived private key in CI, which is the exact thing this project's publishing
 > lanes are built to avoid (the crates.io lane uses OIDC Trusted Publishing and
-> holds no token at all). Keyless attestation gives a stronger guarantee with no
-> key to leak, and it is the same command and the same trust root as the images.
+> holds no token at all). The two keyless commands above are what replace it:
+> nothing to leak, and the same trust root as the images.
+
+### Your values file is checked before anything is applied
+
+The chart ships a `values.schema.json`, so `helm install`, `helm upgrade`, `helm
+lint` and `helm template` **refuse** a values file that misspells one of the
+chart's own keys, gets a type wrong, or names a value outside the permitted set —
+rather than rendering and silently ignoring it:
+
+```text
+Error: values don't meet the specifications of the schema(s) in the following chart(s):
+ferroehr:
+- at '/image/pullPolicy': value must be one of 'Always', 'IfNotPresent', 'Never'
+```
+
+**The `config:` tree is deliberately exempt.** Those keys are the *server's*
+(see the [configuration reference](configuration.md)), the binary validates them
+at boot, and copying that vocabulary into the chart's schema would fork it — a
+new configuration key would then be rejected by the chart until someone
+remembered to widen the schema. So a mistake under `config:` is reported when the
+pod starts, not when the chart renders; `--skip-schema-validation` disables the
+check entirely if you ever need to bypass it.
 
 The chart is also listed on **[Artifact
 Hub](https://artifacthub.io/packages/helm/ferroehr/ferroehr)**, which renders this
@@ -107,7 +144,7 @@ chapter's metadata plus a security report over the published images.
 > the image itself as the authority:
 >
 > ```shell
-> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 4.0.0 \
+> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 5.0.0 \
 >   -s templates/configmap.yaml --set database.existingSecret=ferroehr-db \
 >   | sed -n '/ferroehr.toml/,$p' | sed '1d;s/^    //' > /tmp/ferroehr.toml
 > docker run --rm -v /tmp/ferroehr.toml:/etc/ferroehr/ferroehr.toml:ro \
@@ -462,7 +499,7 @@ Preview an upgrade against what you have installed with
 `helm diff`, or render the new chart version and read it:
 
 ```shell
-helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 4.0.0 \
+helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 5.0.0 \
   -n ferroehr -f my-values.yaml | less
 ```
 

--- a/website/book/src/security.md
+++ b/website/book/src/security.md
@@ -444,6 +444,21 @@ Add `--signer-workflow rubentalstra/FerroEHR/.github/workflows/containers.yml` t
 require the image lane specifically, not merely some workflow in this repository.
 On a release, substitute the `vX.Y.Z` tag for `develop`.
 
+**The Helm chart** carries a keyless cosign **signature** in addition to its
+attestation, from chart `5.0.0` onward — the attestation says what the chart was
+built from, the signature says who signed the artifact you pulled:
+
+```bash
+cosign verify ghcr.io/rubentalstra/charts/ferroehr:<chart-version> \
+  --certificate-identity-regexp '^https://github\.com/rubentalstra/FerroEHR/\.github/workflows/publish-chart\.yml@' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+Both flags are the point: without an identity and an issuer, `cosign verify`
+accepts a signature from anyone in the transparency log. The chart ships **no**
+PGP `.prov`, so `helm install --verify` does not apply — deliberately, since a
+`.prov` needs a long-lived private key in CI.
+
 **A release binary:**
 
 ```bash


### PR DESCRIPTION
The chart's Artifact Hub listing reported three unclaimed properties. The live API before this change:

```
{ "signed": false, "has_values_schema": false, "official": null, "verified_publisher": true }
```

This PR does the two halves that are in-repo work. The third — **official status** — cannot be self-set; it is granted upstream on request, so #2184 stays open for it (details at the bottom).

## A values schema that actually refuses things

`deploy/helm/ferroehr/values.schema.json`, draft-07. The dialect is not a preference: helm 4.1.3 validates through `santhosh-tekuri/jsonschema/v6` (multi-draft), but Artifact Hub's renderer is typed against json-schema draft 4/6/7 (`web/src/jsonschema.ts`), so a 2020-12 document risks rendering wrong on the page that consumes it.

It **closes the vocabulary the chart owns** — every top-level and nested chart key, with enums for `image.pullPolicy`, `service.type`, `ingress.pathType`, a `sha256:` pattern on `image.digest`, port ranges, and Prometheus-duration patterns on the ServiceMonitor timings. A misspelled or wrong-typed key is now refused where it previously rendered with the key silently ignored:

```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
ferroehr:
- at '/probes/startup': additional properties 'periodSecond' not allowed
```

It **stays open in two directions**, both deliberate:

- `config:` is a 1:1 passthrough of the *server's* TOML tree, adjudicated at boot by the binary that owns that vocabulary. Typing it here would fork the config tree into the chart, so a new server key would be refused by the chart until someone remembered to widen the schema. Only the keys the chart's own templates branch on are typed — and each accepts `null`, because setting a key to `null` is how an overlay deletes one a pinned older image does not know (the k8s-test fixture and `boot-check.sh`'s `FERROEHR_SKEW_UNSET` both rely on it).
- `global:` is what a parent chart injects when this chart is used as a dependency. Refusing it would make the chart unusable as a subchart, with an error naming nothing the operator wrote.

**A gate, because a schema that is present but vacuous is worse than none** — `helm template` stays green, the hub renders a Values-schema tab, and an operator reads both as evidence their file was checked. The new `schema_gate` in `deploy/helm/validate.sh` exercises the file from both sides: seven refusal probes (each of which must also *name* the offending path in its message) and three must-stay-open probes. Proven non-vacuous rather than assumed: replacing the schema with `{}` makes the gate fail on all eight counts.

## A signature Artifact Hub can actually see

The publish lane now signs the pushed digest with **keyless cosign**, alongside the SLSA attestation it already produced. The two are not redundant — the attestation says what the chart was built from, the signature says who signed the artifact you pulled — and the second is what the hub's "Signed" state reads.

The keyless Sigstore attestation we already had never qualified: `actions/attest-build-provenance` writes a SLSA provenance predicate, not a cosign signature predicate, which is why the listing read `signed: false` beside a genuinely attested artifact.

**`--new-bundle-format=false` is a measured decision, not inertia.** cosign 3 defaults to the protobuf bundle attached as an OCI 1.1 referring artifact, and GHCR implements no referrers API at all — measured against the published chart, `GET /v2/rubentalstra/charts/ferroehr/referrers/<digest>` answers `404 MANIFEST_UNKNOWN`. A referring artifact would therefore reach the registry only through the OCI fallback tag (`sha256-<hex>`), which on this repository is the very index the attestation step already writes: two writers to one index, risking the attestation, for no gain — Artifact Hub checks the classic `sha256-<hex>.sig` tag *first* (tag-based discovery in `HasCosignSignature`), and a plain tag needs no registry capability whatever. Worth revisiting when GHCR serves referrers.

**Verified back before the job ends**, the same discipline as the ownership-claim step, because both failure modes are silent for weeks: `cosign verify` against this workflow's identity and GitHub's OIDC issuer, then `cosign triangulate` + `oras manifest fetch` to prove the signature is fetchable at the tag the hub reads.

## Chart 5.0.0, and the docs

Major, for the reason the file already records for 4.0.0: a values file that used to render is now refused. `appVersion` is untouched.

Consumer-facing docs updated in the same PR — the chart README (generated), the Kubernetes installation chapter and `security.md` all carry the `cosign verify` form with its identity and issuer flags spelled out (without them `cosign verify` accepts a signature from anyone in the transparency log), and the installation chapter gains a section on values validation and why `config:` is exempt. Two stale claims fixed while there: the book still said *"No chart version has been published yet"*, and its examples still pinned chart `4.0.0`.

## Verification

- `deploy/helm/validate.sh` green: secret-leak gate, the new schema gate, the live-test fixture, three overlays linted + rendered + security-gated + golden-matched. The golden diff is exactly the `helm.sh/chart` version label.
- Every committed overlay and the k8s-test fixture render against the schema unchanged, including the secret-leak gate's deny-by-default probe (`--set-string config.server.future_api_key=…`).
- `shellcheck -S warning` clean on `validate.sh`; `changelog-structure.sh` OK.
- `GH_TOKEN=… zizmor --min-severity=low .github/workflows/` and `docs-claims.sh --all` both clean — after the two pre-existing failures described below.

## What remains on #2184

The issue stays open, deliberately:

- **Official status** is granted upstream via the `official-status-request` template on `artifacthub/hub`. All three prerequisites are already met (Verified Publisher is live, the requester is the publisher, the chart carries a `README.md`), so what remains is the request itself and recording its outcome.
- **`signed: true` / `has_values_schema: true`** become true on the hub only after the next chart publish and the following processing cycle. Nothing to assert until then.

Refs #2184

## Two red gates on `develop`, fixed here because they block every PR (#2187)

Neither is caused by this branch; both were failing the required `conclusion` job before it existed.

- **`docs-claims` called a published chart orphaned.** `perf-stress-compare.svg` is rendered *and* embedded by `scripts/render/comparison.sh`, into `website/book/generated/comparison-bench.md` — which `comparison.md` pulls in with `{{#include}}`. The guard already searched that generated tree, but it is a build artifact: uncommitted, absent from a fresh checkout, so that half of the search never matched and any figure published only through a generated include was reported regardless. Its own comment warns about exactly this failure mode; the recurrence is that the previous fix reached for a directory CI does not have. The generator is the durable reference, so `scripts/render` becomes a third haystack — and the check stays non-vacuous, verified by committing a probe SVG and watching it fail.
- **`zizmor` failed `ref-version-mismatch`** on `release-build.yml`: the SHA pin is correct, its comment said `# v2` while the SHA is tag `v2.85.9`. It is an **online** audit, so an offline local run does not reproduce it — the CI lane is `GH_TOKEN=$(gh auth token) zizmor --min-severity=low .github/workflows/`. Since `zizmor` is ungated on the changes filter, this was failing every pull request.

Closes #2187
