### PR TITLE
fix(rustdoc): repoint the four metric doc links the metrics consolidation orphaned

### DIFF
--- a/app/ferroehr/src/service/query/plan_cache.rs
+++ b/app/ferroehr/src/service/query/plan_cache.rs
@@ -102,7 +102,7 @@ impl PlanCache {
     }
 
     /// The cached plan for `aql`, or `None` on a miss (or when disabled).
-    /// Records the hit/miss both on the [`AQL_PLAN_CACHE_EVENTS`] counter and
+    /// Records the hit/miss both on the [`AQL_PLAN_CACHE_EVENTS`](crate::telemetry::metrics::AQL_PLAN_CACHE_EVENTS) counter and
     /// on the in-process [`PlanCache::stats`] view.
     pub async fn get(&self, aql: &str) -> Option<Arc<QueryIr>> {
         let hit = match &self.inner {

--- a/app/ferroehr/src/telemetry/samplers.rs
+++ b/app/ferroehr/src/telemetry/samplers.rs
@@ -26,7 +26,7 @@ use super::metrics::{
 const SAMPLE_INTERVAL: Duration = Duration::from_secs(5);
 
 /// Acquire a pooled connection, recording the wait on
-/// [`DB_POOL_ACQUIRE_DURATION`]. Use in place of `pool.acquire()` on measured
+/// [`DB_POOL_ACQUIRE_DURATION`](crate::telemetry::metrics::DB_POOL_ACQUIRE_DURATION). Use in place of `pool.acquire()` on measured
 /// hot paths.
 ///
 /// # Errors

--- a/app/ferroehr/src/templates/runtime.rs
+++ b/app/ferroehr/src/templates/runtime.rs
@@ -184,7 +184,7 @@ impl FerroEhrService {
 }
 
 /// Record one WebTemplate-cache hit/miss on the
-/// [`crate::telemetry::prometheus::WEBTEMPLATE_CACHE_EVENTS`] counter. No
+/// [`crate::telemetry::metrics::WEBTEMPLATE_CACHE_EVENTS`] counter. No
 /// openEHR spec governs this — our own observability design.
 fn note_cache_event(event: &'static str) {
     crate::telemetry::metrics::metrics()

--- a/app/ferroehr/src/versioning/change.rs
+++ b/app/ferroehr/src/versioning/change.rs
@@ -115,7 +115,7 @@ impl Committed {
 }
 
 /// Meter a just-committed version on the
-/// [`COMPOSITIONS_COMMITTED`](crate::telemetry::prometheus::COMPOSITIONS_COMMITTED)
+/// [`COMPOSITIONS_COMMITTED`](crate::telemetry::metrics::COMPOSITIONS_COMMITTED)
 /// counter; kinds other than COMPOSITION are ignored.
 ///
 /// Every commit route calls this **after** its transaction has committed, so a


### PR DESCRIPTION
Closes #2188.

`develop` is red on the `rustdoc` gate and therefore on the required `conclusion` job, so **no PR can merge** until this lands.

#2185 deleted `telemetry::prometheus` and its name constants; four intra-doc links still pointed at them, and `RUSTDOCFLAGS=-D warnings` makes each an error.

**Mine to own:** I ran clippy and nextest on that change and not the rustdoc gate — which is precisely the gate that catches a deleted public path still referenced from docs. Clippy cannot see an intra-doc link.

All four repointed at `crate::telemetry::metrics::…`. Verified with the CI invocation rather than a plain `cargo doc`:

```
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --exclude ferroehr-admin-ui --all-features --no-deps
```

Clean. The remaining `output filename collision` warning is the pre-existing `ferroehr` bin/lib name clash ([cargo#6313](https://github.com/rust-lang/cargo/issues/6313)) — not an error, not new.