### PR TITLE
fix(ci): cosign 3 refuses the legacy signature format, so sign in the format it has

### DIFF
--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -409,6 +409,28 @@ jobs:
       # checks the classic `sha256-<hex>.sig` tag FIRST (tag-based discovery in
       # `HasCosignSignature`, `internal/oci/oci.go`), and a plain tag needs no
       # registry capability whatever. Revisit when GHCR serves referrers.
+      # A keyless cosign SIGNATURE over the pushed digest. Distinct from the
+      # attestation below and not redundant with it: the attestation answers
+      # "built from this source, this way", the signature answers "signed by this
+      # workflow" — and the signature is what a Helm consumer's tooling and
+      # Artifact Hub's listing actually look for.
+      #
+      # NO format flag, deliberately. cosign 3 signs in the protobuf bundle
+      # format and there is no supported way to opt out here: measured against
+      # cosign v3.1.3, `--new-bundle-format=false` is refused outright —
+      # "must provide --new-bundle-format or --bundle where applicable with
+      # --signing-config or --use-signing-config" — because `--use-signing-config`
+      # defaults to true, and the flag is deprecated besides ("this will be the
+      # only supported format in future versions").
+      #
+      # That the hub can still SEE it was checked rather than assumed, and the
+      # chain is: GHCR serves no referrers API (`GET /v2/…/referrers/<digest>`
+      # answers 404 MANIFEST_UNKNOWN, measured), so the signature is written to
+      # the OCI fallback tag `sha256-<hex>`; the hub reads referrers through
+      # cosign's `remote.Referrers`, which delegates to go-containerregistry,
+      # which falls back to that same tag when the API is absent
+      # (`WithReferrersTagFallback` — "The default is true"). Same layout, both
+      # directions.
       - name: Sign the chart with keyless cosign
         id: sign
         if: steps.push.outputs.digest != ''
@@ -416,16 +438,41 @@ jobs:
           DIGEST: ${{ steps.push.outputs.digest }}
         run: |
           set -euo pipefail
-          cosign sign --yes --new-bundle-format=false "${CHART_REF}@${DIGEST}"
+          cosign sign --yes "${CHART_REF}@${DIGEST}"
 
-      # Read the signature back the way a consumer and Artifact Hub each do,
-      # because both failure modes are silent: a signature that does not verify
-      # against this workflow's identity is worse than none, and a signature the
-      # hub cannot locate presents weeks later as a listing that still says
-      # "not signed" with no error anywhere.
-      - name: Verify the signature verifies, and is where the hub looks
+      # Keyless provenance for the chart artifact, the same mechanism the images
+      # use — see the header for why neither of these is a PGP `.prov`.
+      #
+      # Ordered AFTER the signature deliberately. GHCR serves no referrers API
+      # (`GET /v2/…/referrers/<digest>` answers 404 MANIFEST_UNKNOWN, measured),
+      # so BOTH artifacts reach the registry through the same OCI fallback tag,
+      # `sha256-<hex>` — two writers to one index. Nothing in either tool
+      # promises the second writer appends rather than replaces, so this lane
+      # does not assume it: the step below reads both back and fails if either
+      # went missing.
+      - name: Attest build provenance
+        id: attest
+        if: steps.push.outputs.digest != ''
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-name: ${{ env.CHART_REF }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+      # Read both artifacts back, after both writers have run, because every
+      # failure here is otherwise silent for weeks: a signature that does not
+      # verify against this workflow's identity is worse than none; a signature
+      # Artifact Hub cannot locate presents as a listing that still says "not
+      # signed"; and an attestation the second writer dropped presents as
+      # nothing at all until someone runs `gh attestation verify` and gets a 404.
+      #
+      # `cosign verify` is the consumer's own command, so this is the check a
+      # user would run, not a proxy for it. The fallback-tag assertion is the
+      # hub's view: it lists what the shared index actually holds and requires
+      # the cosign signature and the SLSA provenance to BOTH still be there.
+      - name: Verify the signature and the attestation both survived
         id: verify
-        if: steps.sign.outcome == 'success'
+        if: steps.sign.outcome == 'success' && steps.attest.outcome == 'success'
         env:
           DIGEST: ${{ steps.push.outputs.digest }}
           REPO: ${{ github.repository }}
@@ -436,25 +483,26 @@ jobs:
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             > /dev/null
           echo "the signature verifies against ${REPO}/.github/workflows/publish-chart.yml"
-          # `cosign triangulate` prints the tag the classic layout stores the
-          # signature under — the same tag the hub's tag-based discovery reads.
-          sig_ref="$(cosign triangulate "${CHART_REF}@${DIGEST}")"
-          if ! oras manifest fetch "$sig_ref" > /dev/null; then
-            echo "::error::${sig_ref} is not fetchable — the signature verified but Artifact Hub's tag-based discovery will not find it."
+
+          # The OCI fallback tag for a subject digest: `sha256:<hex>` → `sha256-<hex>`.
+          fallback="${CHART_REF}:${DIGEST/:/-}"
+          if ! manifest=$(oras manifest fetch "$fallback" 2>&1); then
+            echo "::error::${fallback} is not fetchable, so neither the signature nor the attestation is discoverable from the registry: ${manifest}"
             exit 1
           fi
-          echo "sig=${sig_ref}" >> "$GITHUB_OUTPUT"
-          echo "::notice::signature readable at ${sig_ref}; Artifact Hub reports it on its next processing cycle."
-
-      # Keyless provenance for the chart artifact, the same mechanism the images
-      # use — see the header for why neither of these is a PGP `.prov`.
-      - name: Attest build provenance
-        if: steps.push.outputs.digest != ''
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
-        with:
-          subject-name: ${{ env.CHART_REF }}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
+          echo "--- ${fallback} ---"
+          printf '%s' "$manifest" | jq '{mediaType, manifests: [.manifests[] | {artifactType, digest, annotations}]}'
+          # The signature half is already proven by `cosign verify` above, so
+          # this only has to establish that the ATTESTATION entry is still in the
+          # shared index. It is matched on the SLSA predicate or the in-toto
+          # media type rather than on cosign's own media type, which differs
+          # between cosign's bundle formats and is not ours to predict.
+          if ! printf '%s' "$manifest" | grep -qE 'slsa\.dev/provenance|application/vnd\.in-toto'; then
+            echo "::error::${fallback} no longer carries the SLSA provenance entry — both the signature and the attestation write this one index (GHCR serves no referrers API), so one writer replaced the other's entry. The index is printed above."
+            exit 1
+          fi
+          echo "sig=${fallback}" >> "$GITHUB_OUTPUT"
+          echo "::notice::signature + provenance both readable at ${fallback}; Artifact Hub reports the signature on its next processing cycle."
 
       # Artifact Hub ownership (#2106). For an OCI repository there is no
       # `index.yaml`, so there is nowhere to commit this file as a sibling: it is


### PR DESCRIPTION
The `v5.0.0` publish attempt failed at the signing step ([run](https://github.com/rubentalstra/FerroEHR/actions/runs/31191512869/job/92909205702)):

```
Flag --new-bundle-format has been deprecated, this will be the only supported format in future versions
Error: must provide --new-bundle-format or --bundle where applicable with --signing-config or --use-signing-config
```

**My error, and worth naming precisely.** I chose `--new-bundle-format=false` from cosign's v3.0.0 release note — *"all of the new capabilities of recent releases on by default, but will still allow you to disable them if you need the older functionality"* — and never checked the flag against the binary. Verified now against cosign **v3.1.3**, the version the lane installs: `--use-signing-config` defaults to `true`, and the legacy format cannot be combined with a signing config, so the flag is refused rather than merely warned about. It is also deprecated, which on its own should have ruled it out.

## What changes

The format flag goes; the lane signs in cosign's default (protobuf bundle, attached as an OCI 1.1 referring artifact).

**That Artifact Hub can still see it is now established, not assumed** — the reason I reached for the legacy format in the first place was the worry that it could not. The chain, each link checked first-hand:

1. GHCR serves no referrers API — `GET /v2/rubentalstra/charts/ferroehr/referrers/<digest>` → `404 MANIFEST_UNKNOWN`. So the signature reaches the registry through the OCI fallback tag `sha256-<hex>`.
2. Artifact Hub reads referrers via cosign's `remote.Referrers` (`internal/oci/oci.go`: `getReferrers: csremote.Referrers`).
3. That delegates to go-containerregistry's `remote.Referrers`, which checks the API endpoint and, on 404, *"use[s] the fallback tag scheme"* — gated by `referrersTagFallback`, whose option doc says **"The default is true"** and which the hub never disables.

Same tag, both directions.

## The consequence, and the guard for it

The signature and the SLSA attestation now share one index, and **nothing in either tool promises the second writer appends rather than replaces**. The lane no longer assumes it:

- The attestation step moved **before** the verification.
- The verification reads *both* artifacts back: `cosign verify` for the signature — the consumer's own command, so a clobber by the attestation fails the run — and the fallback index for the provenance entry, so a clobber in the other direction fails too. The index is printed either way, so a failure is actionable rather than a puzzle.

**The index assertion was exercised against the really-published chart `4.1.0`**, whose fallback tag holds exactly one entry today:

```json
{
  "artifactType": "application/vnd.dev.sigstore.bundle.v0.3+json",
  "annotations": {
    "dev.sigstore.bundle.content": "dsse-envelope",
    "dev.sigstore.bundle.predicateType": "https://slsa.dev/provenance/v1"
  }
}
```

It matches — and it also confirms, from live data, why the listing reads `signed: false`: `https://slsa.dev/provenance/v1` is not the cosign *signature* predicate the hub matches on.

## Verification

`zizmor --min-severity=low` with online audits clean; `deploy/helm/validate.sh`, `docs-claims.sh --all` and `changelog-structure.sh` all green. The golden diff is the `helm.sh/chart` version label only, and the chart README is regenerated.

To publish: dispatch `publish-chart.yml` with `publish: true`, or cut the tag.

Refs #2183

## Chart 5.0.0 is already published, so this ships as 5.0.1

The failed run had **already pushed the chart** before it died at the signing step. Verified against the registry rather than assumed:

| | |
|---|---|
| `5.0.0` tag | resolves — `sha256:e7c3784…` |
| its `sha256-<hex>` fallback index | `404` — no signature, no attestation |
| its `.sig` tag | `404` |

Re-running the lane is then refused by its own overwrite guard, and that refusal is right: `helm push` over an existing tag replaces it silently, so a published chart version is immutable *only* because this lane insists on it. Deleting or re-pushing `5.0.0` would break exactly the property the guard exists to hold.

So **`5.0.0` stands as published and the signed artifact ships as `5.0.1`**, with identical chart content. Every claim that named `5.0.0` as the first signed version is corrected, and the two honest exceptions are now stated where a reader would look for them — the installation chapter, `security.md`, the README, the changelog:

- `4.1.0` — attestation, no signature.
- `5.0.0` — **neither**. Installs and runs normally; it simply cannot be verified.

## The lane now says this itself when it happens

Everything after `helm push` operates on an already-public, immutable artifact, so a failure there consumes a version instead of leaving the tree where it was. What made that confusing was the *second* failure: the immutability guard's "bump Chart.yaml version" message reads like a defect in the branch rather than the consequence of the first run. A `failure()` step now reports, at the point of the first failure, that the version is published, what may be missing from it, and that the fix ships as the next version — never as a re-run.
