### PR TITLE
fix(chart): 5.0.0 is published unsigned, so the signed chart ships as 5.0.1

### DIFF
--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -557,6 +557,32 @@ jobs:
           echo "ownership claim readable at ${CHART_REF}:artifacthub.io, repositoryID $got"
           echo "::notice::Verified Publisher applies on Artifact Hub's next processing cycle. The GHCR package must be PUBLIC for the hub to read it at all."
 
+      # Everything after `helm push` operates on an artifact that is already
+      # PUBLIC and, by this lane's own refusal, immutable — so a failure there
+      # consumes the chart version rather than leaving the tree where it was. It
+      # happened on 5.0.0: the signing step failed, the chart stayed published
+      # unsigned and un-attested, and the obvious next move — re-run the lane —
+      # then failed on the immutability guard with a message about bumping
+      # Chart.yaml that read like a mistake in the branch rather than the
+      # consequence of the first failure. This says it at the point of the first
+      # failure instead.
+      - name: What the failure left behind
+        if: failure() && steps.push.outputs.digest != ''
+        env:
+          VERSION: ${{ steps.chart.outputs.version }}
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          {
+            printf '## Chart %s is published, and this run failed after that\n\n' "$VERSION"
+            printf 'The chart was pushed (`%s`) before the failing step, so it is public and\n' "$DIGEST"
+            printf 'immutable: re-running this lane will be refused by the overwrite guard, and\n'
+            printf 're-pushing the tag would silently replace a version consumers may already have.\n\n'
+            printf 'It may be missing its signature, its attestation, or the Artifact Hub ownership\n'
+            printf 'tag, depending on where this run stopped — check the steps above.\n\n'
+            printf 'Fix the cause and ship it as the NEXT chart version. Leave %s as it is.\n' "$VERSION"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::error::chart ${VERSION} is already published; fix the cause and ship the next version — do not re-run this lane for ${VERSION}."
+
       - name: Summary
         if: always()
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ workflow refuses a tag that has no matching section here.
 ### Added
 
 - **The Helm chart validates your values file** (`values.schema.json`, chart
-  `5.0.0`). `helm install`, `upgrade`, `lint` and `template` now refuse a values
+  `5.0.0`, unchanged in `5.0.1`). `helm install`, `upgrade`, `lint` and
+  `template` now refuse a values
   file that misspells one of the chart's own keys, gets a type wrong, or names a
   value outside the permitted set, instead of rendering and ignoring it — a
   breaking chart change, which is why the chart's major version moves. The
@@ -27,13 +28,16 @@ workflow refuses a tag that has no matching section here.
   and is validated by the binary at boot, so copying it into the chart would fork
   it. Artifact Hub renders the schema on the chart's listing. (#2184)
 - **The published Helm chart is signed** with a keyless
-  [cosign](https://docs.sigstore.dev/cosign/) signature, from chart `5.0.0`
+  [cosign](https://docs.sigstore.dev/cosign/) signature, from chart `5.0.1`
   onward, alongside the SLSA build provenance attestation it already carried —
   the attestation says what the chart was built from, the signature says who
   signed the artifact you pulled. No key material exists anywhere; verification
   requires an identity and an issuer, and both are in the installation guide.
   `helm install --verify` still does not apply: the chart ships no PGP `.prov`.
-  (#2184)
+  Chart `5.0.0` is published but carries **neither** signature nor attestation —
+  its publishing run pushed the chart and then failed at the signing step, and a
+  published chart version is never replaced. It installs and runs normally; pin
+  `5.0.1` or newer if you verify what you deploy. (#2183, #2184)
 
 - **The PGP signing key can be rotated without losing history.** Signing now
   uses a signing-capable *subkey* selected by its OpenPGP key flags, which is

--- a/README.md
+++ b/README.md
@@ -506,7 +506,7 @@ deploys, and listed on
 
 ```shell
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 5.0.0 --set database.existingSecret=my-db-secret
+  --version 5.0.1 --set database.existingSecret=my-db-secret
 ```
 
 There is no HTTP chart repository, so `helm repo add` does not apply — OCI is the
@@ -515,7 +515,7 @@ lines: `--version` pins the chart, `--set image.tag=` pins the server. Your valu
 file is checked against the chart's `values.schema.json` before anything is
 applied. The chart and the images are published with signed keyless provenance
 (`gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:<chart-version> -R rubentalstra/FerroEHR`),
-and the chart additionally carries a keyless `cosign` signature from chart `5.0.0`
+and the chart additionally carries a keyless `cosign` signature from chart `5.0.1`
 onward; signing landed in the 3.17.4 cycle, so tags built before it carry none.
 
 See the [Kubernetes chapter](https://ferroehr.eu/docs/latest/installation/kubernetes.html)

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -18,7 +18,14 @@ type: application
 # misspelled or wrong-typed key of the CHART's own vocabulary is refused where it
 # previously rendered with the key silently ignored. The server's `config:` tree
 # stays open — that vocabulary belongs to the binary, not to this schema.
-version: 5.0.0
+#
+# 5.0.1 carries the SAME chart content as 5.0.0 and exists because 5.0.0 is
+# already published: its run pushed the chart and then failed at the signing
+# step, so 5.0.0 is installable but carries neither a cosign signature nor an
+# attestation. A published OCI version is immutable here by refusal rather than
+# by the registry — `helm push` over an existing tag replaces it silently — so
+# the signed artifact ships as a new version and 5.0.0 stays as it is.
+version: 5.0.1
 # The default container image tag (overridable via image.tag), and the released
 # application version — kept equal to the workspace version by the
 # `chart-appversion` CI guard, so a release cannot ship a chart pointing at the

--- a/deploy/helm/ferroehr/README.md
+++ b/deploy/helm/ferroehr/README.md
@@ -2,7 +2,7 @@
 
 Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.1.0 + AQL 1.1). A single static binary deployed with a hardened-by-default security posture: runs as a non-root, read-only-rootfs, default-deny-ingress workload that connects to an EXTERNAL PostgreSQL 18 as an unprivileged app role (migrations are run out of band by a separate migrator role).
 
-![Version: 5.0.0](https://img.shields.io/badge/Version-5.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.17.3](https://img.shields.io/badge/AppVersion-3.17.3-informational?style=flat-square)
+![Version: 5.0.1](https://img.shields.io/badge/Version-5.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.17.3](https://img.shields.io/badge/AppVersion-3.17.3-informational?style=flat-square)
 
 FerroEHR is a pure-Rust openEHR Clinical Data Repository: ITS-REST 1.1.0 at the
 API, AQL 1.1 as the query language, PostgreSQL 18-native storage, shipped as a
@@ -33,7 +33,7 @@ add — `helm repo add` does not apply to this chart and never will:
 
 ```console
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 5.0.0 \
+  --version 5.0.1 \
   --namespace ferroehr --create-namespace \
   --set database.existingSecret=ferroehr-db \
   --set image.tag=3.17.3
@@ -47,7 +47,7 @@ They are independent SemVer lines and they move independently:
 
 | What | Set with | This release |
 |---|---|---|
-| the **chart** (templates, defaults, this document) | `--version` | `5.0.0` |
+| the **chart** (templates, defaults, this document) | `--version` | `5.0.1` |
 | the **server image** | `image.tag` | `3.17.3` |
 
 `appVersion` is the image the chart defaults to; pinning `image.tag` explicitly
@@ -59,7 +59,7 @@ The chart carries two keyless Sigstore artifacts, and they answer different
 questions. A **cosign signature** — who signed this:
 
 ```console
-cosign verify ghcr.io/rubentalstra/charts/ferroehr:5.0.0 \
+cosign verify ghcr.io/rubentalstra/charts/ferroehr:5.0.1 \
   --certificate-identity-regexp '^https://github\.com/rubentalstra/FerroEHR/\.github/workflows/publish-chart\.yml@' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
@@ -67,7 +67,7 @@ cosign verify ghcr.io/rubentalstra/charts/ferroehr:5.0.0 \
 A **SLSA build provenance attestation** — what source it was built from, and how:
 
 ```console
-gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:5.0.0 \
+gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:5.0.1 \
   -R rubentalstra/FerroEHR
 gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:3.17.3 \
   -R rubentalstra/FerroEHR

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -12,7 +12,7 @@ kind: NetworkPolicy
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-5.0.0
+    helm.sh/chart: ferroehr-5.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -82,7 +82,7 @@ kind: PodDisruptionBudget
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-5.0.0
+    helm.sh/chart: ferroehr-5.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -101,7 +101,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-5.0.0
+    helm.sh/chart: ferroehr-5.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -132,7 +132,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-5.0.0
+    helm.sh/chart: ferroehr-5.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -158,7 +158,7 @@ kind: Secret
 metadata:
   name: ferroehr-config
   labels:
-    helm.sh/chart: ferroehr-5.0.0
+    helm.sh/chart: ferroehr-5.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -177,7 +177,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-5.0.0
+    helm.sh/chart: ferroehr-5.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -368,7 +368,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-5.0.0
+    helm.sh/chart: ferroehr-5.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -395,7 +395,7 @@ kind: Deployment
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-5.0.0
+    helm.sh/chart: ferroehr-5.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -598,7 +598,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-5.0.0
+    helm.sh/chart: ferroehr-5.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -631,7 +631,7 @@ kind: Ingress
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-5.0.0
+    helm.sh/chart: ferroehr-5.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -668,7 +668,7 @@ kind: ServiceMonitor
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-5.0.0
+    helm.sh/chart: ferroehr-5.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"

--- a/deploy/helm/golden/basic-auth.yaml
+++ b/deploy/helm/golden/basic-auth.yaml
@@ -12,7 +12,7 @@ kind: NetworkPolicy
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-5.0.0
+    helm.sh/chart: ferroehr-5.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -36,7 +36,7 @@ kind: PodDisruptionBudget
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-5.0.0
+    helm.sh/chart: ferroehr-5.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -55,7 +55,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-5.0.0
+    helm.sh/chart: ferroehr-5.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -84,7 +84,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-5.0.0
+    helm.sh/chart: ferroehr-5.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -100,7 +100,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-5.0.0
+    helm.sh/chart: ferroehr-5.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -228,7 +228,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-5.0.0
+    helm.sh/chart: ferroehr-5.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -251,7 +251,7 @@ kind: Deployment
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-5.0.0
+    helm.sh/chart: ferroehr-5.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -12,7 +12,7 @@ kind: NetworkPolicy
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-5.0.0
+    helm.sh/chart: ferroehr-5.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -36,7 +36,7 @@ kind: PodDisruptionBudget
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-5.0.0
+    helm.sh/chart: ferroehr-5.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -55,7 +55,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-5.0.0
+    helm.sh/chart: ferroehr-5.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -69,7 +69,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-5.0.0
+    helm.sh/chart: ferroehr-5.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -194,7 +194,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-5.0.0
+    helm.sh/chart: ferroehr-5.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -217,7 +217,7 @@ kind: Deployment
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-5.0.0
+    helm.sh/chart: ferroehr-5.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"

--- a/website/book/src/installation/kubernetes.md
+++ b/website/book/src/installation/kubernetes.md
@@ -24,7 +24,7 @@ kubectl -n ferroehr create secret generic ferroehr-db \
   --from-literal=FERROEHR__DB__URL='postgres://ferroehr_app:***@pg-host:5432/ferroehr?sslmode=verify-full'
 
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 5.0.0 -n ferroehr \
+  --version 5.0.1 -n ferroehr \
   --set database.existingSecret=ferroehr-db \
   --set image.tag=3.17.3
 ```
@@ -41,7 +41,7 @@ helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
 `oci://` reference. To read the chart's metadata without installing it:
 
 ```shell
-helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 5.0.0
+helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 5.0.1
 ```
 
 ### Pin two versions, not one
@@ -54,7 +54,7 @@ against.
 
 | | Selects | Pin with | Line |
 |---|---|---|---|
-| Chart version | templates, values schema, defaults | `--version 5.0.0` | SemVer over the chart's own contract |
+| Chart version | templates, values schema, defaults | `--version 5.0.1` | SemVer over the chart's own contract |
 | Image tag | the server binary | `--set image.tag=3.17.3` (or `image.digest`) | the application's SemVer line |
 
 Always pin the image to an immutable version or, better, a `@sha256` digest —
@@ -101,9 +101,12 @@ gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:<tag> -R rubentalstra/
 > the signing lane onward — `3.17.3` and everything before it answer `HTTP 404:
 > Not Found`, which is the honest state rather than a verification failure (the
 > development images, `ghcr.io/rubentalstra/ferroehr:develop`, already verify).
-> For the chart, attestations exist from the first published version and the
-> **cosign signature from chart `5.0.0` onward**; chart `4.1.0` carries the
-> attestation but no signature.
+> For the chart, the **cosign signature exists from chart `5.0.1` onward**. Two
+> earlier versions are honest exceptions: `4.1.0` carries the attestation but no
+> signature, and `5.0.0` carries **neither** — its publishing run pushed the chart
+> and then failed at the signing step, and a published chart version is never
+> replaced, so it stands as it was published. Both install and run normally; they
+> simply cannot be verified. Pin `5.0.1` or newer if verification matters to you.
 
 > [!NOTE]
 > `helm install --verify` and `helm verify` do **not** apply: they check a PGP
@@ -144,7 +147,7 @@ chapter's metadata plus a security report over the published images.
 > the image itself as the authority:
 >
 > ```shell
-> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 5.0.0 \
+> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 5.0.1 \
 >   -s templates/configmap.yaml --set database.existingSecret=ferroehr-db \
 >   | sed -n '/ferroehr.toml/,$p' | sed '1d;s/^    //' > /tmp/ferroehr.toml
 > docker run --rm -v /tmp/ferroehr.toml:/etc/ferroehr/ferroehr.toml:ro \
@@ -499,7 +502,7 @@ Preview an upgrade against what you have installed with
 `helm diff`, or render the new chart version and read it:
 
 ```shell
-helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 5.0.0 \
+helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 5.0.1 \
   -n ferroehr -f my-values.yaml | less
 ```
 

--- a/website/book/src/security.md
+++ b/website/book/src/security.md
@@ -445,8 +445,11 @@ require the image lane specifically, not merely some workflow in this repository
 On a release, substitute the `vX.Y.Z` tag for `develop`.
 
 **The Helm chart** carries a keyless cosign **signature** in addition to its
-attestation, from chart `5.0.0` onward — the attestation says what the chart was
-built from, the signature says who signed the artifact you pulled:
+attestation, from chart `5.0.1` onward — the attestation says what the chart was
+built from, the signature says who signed the artifact you pulled. (`4.1.0` has
+the attestation only; `5.0.0` has neither — its publishing run failed at the
+signing step after the chart was already pushed, and a published chart version is
+never replaced.)
 
 ```bash
 cosign verify ghcr.io/rubentalstra/charts/ferroehr:<chart-version> \


### PR DESCRIPTION
#2190 landed the cosign format fix but was merged before this half of it reached the branch, so `develop` still carries chart `5.0.0` — which is why re-running the publish lane refuses:

```
Error: chart version 5.0.0 is already published at ghcr.io/rubentalstra/charts/ferroehr — a published version is immutable; bump Chart.yaml version.
```

The guard is right. The failed `5.0.0` run had **already pushed the chart** before it died at the signing step, verified against the registry rather than assumed:

| | |
|---|---|
| `5.0.0` tag | resolves — `sha256:e7c3784…` |
| its `sha256-<hex>` fallback index | `404` — no signature, no attestation |
| its `.sig` tag | `404` |

`helm push` over an existing tag replaces it silently, so a published chart version is immutable *only* because this lane insists on it. Deleting or re-pushing `5.0.0` would break exactly the property the guard exists to hold.

## What this does

**Chart `5.0.1`, identical content to `5.0.0`.** Goldens and the generated chart README regenerated with it.

**Every claim that named `5.0.0` as the first signed version is corrected**, and the two honest exceptions are now stated where a reader would check them — the installation chapter, `security.md`, the README, the changelog:

- `4.1.0` — attestation, no signature.
- `5.0.0` — **neither**. It installs and runs normally; it simply cannot be verified. Pin `5.0.1` or newer if verification matters.

**The lane now says this itself when it happens.** Everything after `helm push` operates on an already-public, immutable artifact, so a failure there consumes a version instead of leaving the tree where it was — and the *second* failure then reads like a defect in the branch ("bump Chart.yaml version") rather than fallout from the first. A `failure()` step now reports, at the point of the first failure, that the version is published, what may be missing from it, and that the fix ships as the next version, never as a re-run.

## Verification

`deploy/helm/validate.sh`, `docs-claims.sh --all`, `changelog-structure.sh` all green; `zizmor --min-severity=low` with online audits clean. The golden diff is the `helm.sh/chart` version label only.

After merge, `publish-chart.yml` with `publish: true` publishes `5.0.1` signed — the format fix it needs is already on `develop`.

Refs #2183
