### PR TITLE
test(deploy): an instrument for the gap between "the code is correct" and "it works"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,10 @@ bash scripts/conformance.sh   # compose up --build (fresh volumes) → the CNF c
 # CPU profiling / hotspot hunting (exploration only, never a conformance record): the /flamegraph skill — GET /management/flamegraph on a running server (opt-in), `cargo bench -p ferroehr --bench aql -- --profile-time 10` for a code path, cargo-flamegraph locally
 # admin-console gates: /ui-gates (both-target clippy, nextest, leptosfmt, cargo-leptos build)
 bash scripts/ui-e2e.sh        # the browser journey battery against the composed stack (merge gate in CI)
+bash scripts/deploy-probe.sh  # the DEPLOYMENT-conformance harness: brings a real stack up and probes observable
+                              # behaviour at the FAR END (a blob in the bucket, the server's own effective config),
+                              # each integration off / working / dependency-broken. Its report ends with what it did
+                              # NOT exercise — silence is never read as coverage. Record: docs/conformance/deployment/
 ```
 
 ### Target-dir & warm-build discipline (owner rules 2026-07-12, tightened 2026-07-16)

--- a/docs/conformance/deployment/.gitignore
+++ b/docs/conformance/deployment/.gitignore
@@ -1,0 +1,2 @@
+compose.json
+kubernetes.json

--- a/docs/conformance/deployment/README.md
+++ b/docs/conformance/deployment/README.md
@@ -1,0 +1,39 @@
+# Deployment-conformance records
+
+`scripts/deploy-probe.sh` writes its machine-readable record here — the
+deployment analogue of what `docs/conformance/<sut>/` holds for the wire.
+
+A record is a measurement of **one SUT**, so it is only meaningful with the
+image it was taken against. The harness names that image in its output, and
+the record carries the per-probe outcome plus the layer each failure indicts.
+
+## Reading a record
+
+```json
+{"platform":"compose","passed":9,"failed":1,"uncovered":7,
+ "probes":[{"id":"P-MM-EXPAND","state":"working","outcome":"fail",
+            "layer":"server","issue":"#2197","title":"…"}],
+ "not_exercised":[{"what":"kubernetes platform","why":"…"}]}
+```
+
+- **`state`** is one of `off` / `working` / `broken`. All three matter: two of
+  the defects that prompted this instrument lived in states nobody exercised —
+  a disabled integration that stranded data, and a dependency outage nothing
+  probed.
+- **`layer`** is what a failure indicts — `server`, `image`, `chart`,
+  `compose`, or `docs`. A red row that says only "it did not work" costs more
+  than it saves, so the layer is part of the record rather than left to the
+  reader.
+- **`issue`** marks a probe that reproduces a defect this project shipped. It
+  must fail on the unfixed code and pass on the fixed code; that is what turns
+  a one-off sweep into a permanent net.
+- **`not_exercised`** is not an appendix. Silence read as coverage is how ten
+  defects reached a release while a 4447-test suite stayed green, so every gap
+  is declared in the artifact itself.
+
+## Why records are not committed by default
+
+Unlike the CNF baseline, these are not a ratchet: the record depends on which
+image, overlays and profiles the run used, so a committed file would invite
+comparison between runs that measured different systems. Commit one only
+alongside the SUT identification that makes it readable.

--- a/scripts/deploy-probe.sh
+++ b/scripts/deploy-probe.sh
@@ -80,6 +80,7 @@ compose_up ferroehr seaweedfs seaweedfs-init
 probes_shipped_config_boots
 probes_multimedia
 probes_management
+probes_multimedia_off
 probes_multimedia_broken
 probes_health_broken
 
@@ -98,7 +99,5 @@ uncovered "admin console journeys (#2164)" \
   "scripts/ui-e2e.sh already drives these with a real browser; folding it in is the next step"
 uncovered "FHIR, events, tenancy, terminology" \
   "no probes yet — each needs its dependency composed"
-uncovered "multimedia OFF state" \
-  "the off state is asserted by the code suite (inline storage) but not yet driven here"
 
 probe_report "$PROBE_OUT" "compose"

--- a/scripts/deploy-probe.sh
+++ b/scripts/deploy-probe.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# The deployment-conformance harness (#2178).
+#
+# `cnf-runner` exists because "we believe the REST surface is conformant" was
+# not good enough — it had to be MEASURED, repeatably, by something that
+# outlives the person who ran it. This is the same instrument for the other
+# half: "we believe the deployment works".
+#
+# The gap it covers is real and was expensive. A 4447-test suite was green
+# while ten defects shipped, every one of them living between "the code is
+# correct" and "the thing we hand an operator works" — a gateway with no
+# bucket, an OIDC realm that could not mint an acceptable token, a Prometheus
+# that scraped nothing, host environment silently dropped on the floor. None of
+# them was reachable by rendering YAML or by a unit test with a mock.
+#
+# Three rules it holds itself to, each one a lesson from those defects:
+#
+#   1. Observe at the FAR END. Not "the API said 201" but "the blob is in the
+#      bucket"; not "the config looks right" but "the server reports it".
+#   2. Follow the DOCUMENTATION, not the source. Several findings were the book
+#      describing something that does not work, and a probe configured the way
+#      the source says would never catch that class again.
+#   3. Say what was NOT exercised. Silence read as coverage is how this
+#      happened; the report ends with the gaps, in its own output.
+#
+# Usage:
+#   scripts/deploy-probe.sh                  # the compose platform
+#   scripts/deploy-probe.sh --keep-up        # leave the stack running to poke at
+#
+# Env:
+#   FERROEHR_IMAGE   the server image under probe (default: the compose pin).
+#                    The harness measures the SUT it is given — pointing it at
+#                    an older image is a legitimate way to watch a regression
+#                    probe fail.
+#   PROBE_OUT        where the machine-readable record lands.
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 1
+
+KEEP_UP=0
+[ "${1:-}" = "--keep-up" ] && KEEP_UP=1
+
+PROBE_TMP="$(mktemp -d)"
+export PROBE_TMP
+PROBE_OUT="${PROBE_OUT:-docs/conformance/deployment/compose.json}"
+
+# shellcheck source=scripts/deploy-probes/lib.sh
+. scripts/deploy-probes/lib.sh
+# shellcheck source=scripts/deploy-probes/compose.sh
+. scripts/deploy-probes/compose.sh
+
+cleanup() {
+  if [ "$KEEP_UP" -eq 0 ]; then
+    compose_down
+  else
+    dim "── stack left running (--keep-up): $CDR"
+  fi
+  rm -rf "$PROBE_TMP"
+}
+trap cleanup EXIT
+
+command -v docker >/dev/null || { red "docker not found on PATH"; exit 1; }
+
+bold "── deployment probes: compose ──────────────────────────────"
+echo "  image:  ${FERROEHR_IMAGE:-<the compose default pin>}"
+echo "  cdr:    $CDR"
+echo
+
+# The documented recipe, used as documented: the multimedia keys are EXPORTED,
+# not written into a file. #2169 was exactly this path silently doing nothing,
+# so the harness must take it rather than a shortcut the book never mentions.
+export FERROEHR__MULTIMEDIA__ENABLED=true
+export FERROEHR__MULTIMEDIA__ENDPOINT=http://seaweedfs:8333
+export FERROEHR__MULTIMEDIA__BUCKET=openehr-multimedia
+export FERROEHR__MULTIMEDIA__ALLOW_HTTP=true
+
+compose_down
+bold "bringing the stack up (postgres + CDR + seaweedfs + init)"
+compose_up ferroehr seaweedfs seaweedfs-init
+
+probes_shipped_config_boots
+probes_multimedia
+probes_management
+probes_multimedia_broken
+probes_health_broken
+
+# ── The honest half ───────────────────────────────────────────────────────────
+# Everything #2178 asks for that this run does NOT do. Each entry is a probe
+# somebody still has to write; none of them is silently absent.
+uncovered "kubernetes platform" \
+  "this harness drives compose only; the chart is exercised by the k8s-test skill by hand"
+uncovered "OIDC / Keycloak (#2176)" \
+  "needs the keycloak overlay composed alongside; the realm fix is covered by a unit-level token assertion only"
+uncovered "observability: traces reaching a collector, metrics on a scrape (#2173, #2175)" \
+  "needs the observability overlay and a collector to observe at the far end"
+uncovered "signing in pgp mode (#2163)" \
+  "needs key material provisioned into the stack"
+uncovered "admin console journeys (#2164)" \
+  "scripts/ui-e2e.sh already drives these with a real browser; folding it in is the next step"
+uncovered "FHIR, events, tenancy, terminology" \
+  "no probes yet — each needs its dependency composed"
+uncovered "multimedia OFF state" \
+  "the off state is asserted by the code suite (inline storage) but not yet driven here"
+
+probe_report "$PROBE_OUT" "compose"

--- a/scripts/deploy-probe.sh
+++ b/scripts/deploy-probe.sh
@@ -47,6 +47,8 @@ PROBE_OUT="${PROBE_OUT:-docs/conformance/deployment/compose.json}"
 . scripts/deploy-probes/lib.sh
 # shellcheck source=scripts/deploy-probes/compose.sh
 . scripts/deploy-probes/compose.sh
+# shellcheck source=scripts/deploy-probes/oidc.sh
+. scripts/deploy-probes/oidc.sh
 
 cleanup() {
   if [ "$KEEP_UP" -eq 0 ]; then
@@ -83,14 +85,13 @@ probes_management
 probes_multimedia_off
 probes_multimedia_broken
 probes_health_broken
+probes_oidc
 
 # ── The honest half ───────────────────────────────────────────────────────────
 # Everything #2178 asks for that this run does NOT do. Each entry is a probe
 # somebody still has to write; none of them is silently absent.
 uncovered "kubernetes platform" \
   "this harness drives compose only; the chart is exercised by the k8s-test skill by hand"
-uncovered "OIDC / Keycloak (#2176)" \
-  "needs the keycloak overlay composed alongside; the realm fix is covered by a unit-level token assertion only"
 uncovered "observability: traces reaching a collector, metrics on a scrape (#2173, #2175)" \
   "needs the observability overlay and a collector to observe at the far end"
 uncovered "signing in pgp mode (#2163)" \

--- a/scripts/deploy-probes/compose.sh
+++ b/scripts/deploy-probes/compose.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# The Docker Compose probe family.
+#
+# Every probe here observes at the FAR END — a blob in the bucket, a claim in a
+# token, the server's own effective configuration — rather than trusting a 2xx.
+# Each one that carries `regression-of` reproduces a defect this project shipped:
+# it must fail on the unfixed code and pass on the fixed code, which is what
+# turns a one-off sweep into a permanent net.
+#
+# Sourced by scripts/deploy-probe.sh; never run directly.
+
+# The compose stack this family drives. Ports are shifted off the defaults so a
+# probe run can coexist with a developer's own stack.
+COMPOSE_PROJECT="ferroehr-probe"
+export FERROEHR_PORT="${PROBE_CDR_PORT:-18080}"
+export FERROEHR_S3_PORT="${PROBE_S3_PORT:-18333}"
+export FERROEHR_DB_PORT="${PROBE_DB_PORT:-15432}"
+CDR="http://localhost:${FERROEHR_PORT}"
+S3="http://localhost:${FERROEHR_S3_PORT}"
+BASIC="ferroehr:ferroehr"
+API="$CDR/ferroehr/rest/openehr/v1"
+
+dc() { docker compose -p "$COMPOSE_PROJECT" "$@"; }
+
+compose_down() { dc down -v --remove-orphans >/dev/null 2>&1 || true; }
+
+# Bring the stack up with the multimedia keys taken from the ENVIRONMENT, which
+# is the documented recipe — not by editing a file. That is deliberate: the
+# recipe not working was itself a defect (#2169), so the harness must use the
+# path the book tells an operator to use.
+compose_up() {
+  local -a services=("$@")
+  dc -f docker-compose.yml --profile s3 up -d "${services[@]}" >/dev/null 2>&1
+}
+
+# A composition-free way to commit a large DV_MULTIMEDIA: an EHR_STATUS carrying
+# one. No template upload is needed, and it exercises the same versioning path a
+# COMPOSITION does — which is exactly where #2197 lived.
+#
+# Built with `base64` and `printf` rather than a scripting language: #2178 pins
+# the harness to bash and Rust.
+probe_status_payload() {
+  local bytes="${1:-409600}" out="$2"
+  local b64
+  b64="$(head -c "$bytes" /dev/urandom | base64 | tr -d '\n')"
+  printf '%s' '{"_type":"EHR_STATUS",
+    "name":{"_type":"DV_TEXT","value":"EHR status"},
+    "archetype_node_id":"openEHR-EHR-EHR_STATUS.generic.v1",
+    "archetype_details":{"_type":"ARCHETYPED",
+      "archetype_id":{"_type":"ARCHETYPE_ID","value":"openEHR-EHR-EHR_STATUS.generic.v1"},
+      "rm_version":"1.1.0"},
+    "subject":{"_type":"PARTY_SELF"},
+    "is_queryable":true,"is_modifiable":true,
+    "other_details":{"_type":"ITEM_TREE",
+      "name":{"_type":"DV_TEXT","value":"attachments"},
+      "archetype_node_id":"at0001",
+      "items":[{"_type":"ELEMENT",
+        "name":{"_type":"DV_TEXT","value":"scan"},
+        "archetype_node_id":"at0002",
+        "value":{"_type":"DV_MULTIMEDIA",
+          "media_type":{"_type":"CODE_PHRASE",
+            "terminology_id":{"_type":"TERMINOLOGY_ID","value":"IANA_media-types"},
+            "code_string":"application/octet-stream"},
+          "size":' > "$out"
+  printf '%s,"data":"%s"' "$bytes" "$b64" >> "$out"
+  printf '%s' '}}]}}' >> "$out"
+}
+
+# Commit an EHR whose EHR_STATUS carries a 400 KiB DV_MULTIMEDIA; echo its id
+# (empty when the commit did not succeed).
+probe_commit_media_status() {
+  local body="$PROBE_TMP/status.json" hdr="$PROBE_TMP/h.txt"
+  probe_status_payload 409600 "$body"
+  curl -s -u "$BASIC" -X POST -H 'Content-Type: application/json' \
+    --data-binary "@$body" -D "$hdr" -o /dev/null "$API/ehr" || return 0
+  grep -i '^location' "$hdr" 2>/dev/null | tr -d '\r' | awk -F/ '{print $NF}'
+}
+
+# The same commit, but reporting only its status code — for the states where the
+# REFUSAL is the expected outcome.
+probe_commit_media_status_code() {
+  local body="$PROBE_TMP/status-broken.json"
+  probe_status_payload 409600 "$body"
+  curl -s -u "$BASIC" -X POST -H 'Content-Type: application/json' \
+    --data-binary "@$body" -o /dev/null -w '%{http_code}' "$API/ehr"
+}
+
+# ── The families ──────────────────────────────────────────────────────────────
+
+probes_shipped_config_boots() {
+  bold "shipped configuration"
+
+  # #2159: validate.sh rendered and linted; nothing ever STARTED what it
+  # rendered, and none of the shipped values files produced a bootable server.
+  probe "P-BOOT-01" "working" "compose" "#2159" \
+    "the quickstart compose file boots to a serving CDR"
+  if wait_http "$CDR/ferroehr/rest/status" 90; then
+    local status; status="$(curl -s "$CDR/ferroehr/rest/status")"
+    assert_contains "$status" '"status"' "the status document is served"
+  else
+    probe_fail "a serving CDR" "$( dc logs --tail 20 ferroehr 2>&1 | tail -5 )" \
+      "the stack never answered /rest/status"
+  fi
+  probe_done
+
+  probe "P-BOOT-02" "working" "image" "-" \
+    "the health family answers without authentication"
+  assert_eq "200" "$(http_code "$CDR/health/liveness")"
+  assert_eq "200" "$(http_code "$CDR/health/readiness")"
+  probe_done
+}
+
+probes_multimedia() {
+  bold "multimedia (S3 externalization)"
+
+  # #2169: the documented recipe exports FERROEHR__MULTIMEDIA__* in a shell.
+  # Far end: the SERVER's own effective configuration, not the compose file.
+  probe "P-MM-ENV" "working" "compose" "#2169" \
+    "exported FERROEHR__MULTIMEDIA__* reaches the server"
+  local env_doc; env_doc="$(curl -s -u "$BASIC" "$CDR/management/env")"
+  assert_contains "$env_doc" '"endpoint":"http://seaweedfs:8333"' \
+    "the compose file must pass the multimedia keys through from the shell"
+  assert_contains "$env_doc" '"enabled":true'
+  probe_done
+
+  # #2168: the gateway ships with no bucket, and an S3 write into a missing one
+  # answers 403 (not 404), so it reads as a credentials problem.
+  probe "P-MM-BUCKET" "working" "compose" "#2168" \
+    "the bucket exists with no manual step"
+  assert_eq "200" "$(http_code -I "$S3/openehr-multimedia")" \
+    "seaweedfs-init must create the bucket once the gateway is healthy"
+  probe_done
+
+  # The far-end observation the issue asks for: the blob is IN THE BUCKET,
+  # under its content hash, and the stored record references it.
+  probe "P-MM-OFFLOAD" "working" "server" "-" \
+    "a large DV_MULTIMEDIA is externalized and the blob lands in the bucket"
+  local ehr uri key
+  ehr="$(probe_commit_media_status)"
+  if [ -z "$ehr" ]; then
+    probe_fail "an EHR carrying a 400 KiB DV_MULTIMEDIA" "the commit did not return an id"
+  else
+    uri="$(curl -s -u "$BASIC" "$API/ehr/$ehr/ehr_status" \
+      | tr ',' '\n' | grep -o 's3://openehr-multimedia/[0-9a-f]*' | head -1)"
+    assert_contains "$uri" "s3://openehr-multimedia/" "the stored record must reference the blob"
+    key="${uri##*/}"
+    if [ -n "$key" ]; then
+      assert_eq "200" "$(http_code "$S3/openehr-multimedia/$key")" \
+        "the blob must be retrievable from the bucket by its content hash"
+    fi
+  fi
+  probe_done
+
+  # #2197: offload runs for every versioned object; re-inlining was wired to the
+  # COMPOSITION read alone, so EHR_STATUS content had no way back.
+  probe "P-MM-EXPAND" "working" "server" "#2197" \
+    "?expand_multimedia=true returns the bytes on an EHR_STATUS read"
+  if [ -n "${ehr:-}" ]; then
+    local expanded
+    expanded="$(curl -s -u "$BASIC" "$API/ehr/$ehr/ehr_status?expand_multimedia=true")"
+    assert_contains "$expanded" '"data"' \
+      "the read must re-inline the blob, not answer with the compact reference"
+    assert_not_contains "$expanded" 's3://openehr-multimedia' \
+      "an expanded read must not still carry the external reference"
+  else
+    probe_fail "an expandable record" "no EHR was committed"
+  fi
+  probe_done
+}
+
+probes_multimedia_broken() {
+  bold "multimedia — dependency broken"
+
+  # The state least often tested, and where a system either fails loudly or
+  # loses data quietly. With the store gone, a commit that must offload has to
+  # be REFUSED, not half-stored.
+  probe "P-MM-BROKEN" "broken" "server" "-" \
+    "with the object store stopped, a commit that must offload is refused"
+  dc stop seaweedfs >/dev/null 2>&1
+  local code; code="$(probe_commit_media_status_code)"
+  case "$code" in
+    5*) : ;;
+    *)  probe_fail "a 5xx refusal" "$code" \
+          "an unreachable blob store must fail the commit, never store a half record" ;;
+  esac
+  dc start seaweedfs >/dev/null 2>&1
+  wait_http "$S3/" 60 || true
+  probe_done
+}
+
+probes_health_broken() {
+  bold "health — dependency broken"
+
+  # Readiness genuinely going unready. A probe that only ever returns UP is
+  # worse than none, and this is the shape that keeps a dead pod in rotation.
+  probe "P-HEALTH-BROKEN" "broken" "server" "-" \
+    "database stopped: readiness 503, liveness still 200, no restart"
+  dc stop ferroehr-postgres >/dev/null 2>&1
+  if wait_status "$CDR/health/readiness" "503" 30; then
+    assert_eq "200" "$(http_code "$CDR/health/liveness")" \
+      "liveness must be process-local — restarting cannot fix a dependency"
+    local body; body="$(curl -s "$CDR/health/readiness")"
+    assert_contains "$body" '"status":"DOWN"' "readiness must name the failing component"
+  else
+    probe_fail "readiness 503 within 60s" "$(curl -s -o /dev/null -w '%{http_code}' "$CDR/health/readiness")" \
+      "a readiness probe that never fails cannot remove a pod from rotation"
+  fi
+  dc start ferroehr-postgres >/dev/null 2>&1
+  wait_http "$CDR/health/readiness" 90 || true
+  probe_done
+}
+
+probes_management() {
+  bold "management surface"
+
+  # #2177: the per-endpoint levels are the ONLY authority, and they are
+  # INDEPENDENT. The quickstart ships four different levels at once, which is
+  # exactly the shape a per-endpoint guard gets wrong:
+  #
+  #   prometheus = public       env    = admin_only
+  #   info       = private      (flamegraph names no level ⇒ off)
+  #
+  # A guard that applied the most permissive configured level to every route —
+  # or the strictest — passes a one-endpoint-at-a-time test and fails here.
+  probe "P-MGMT-LEVELS" "working" "server" "#2177" \
+    "each management endpoint answers at its own level, anonymous and authenticated"
+  assert_eq "200" "$(http_code "$CDR/management/prometheus")" \
+    "a public endpoint is served OUTSIDE authentication"
+  assert_eq "401" "$(http_code "$CDR/management/info")" \
+    "a private endpoint must challenge an anonymous caller"
+  assert_eq "401" "$(http_code "$CDR/management/env")" \
+    "an admin_only endpoint must challenge an anonymous caller"
+  # The quickstart's Basic user carries ADMIN, so both open for it.
+  assert_eq "200" "$(http_code -u "$BASIC" "$CDR/management/info")"
+  assert_eq "200" "$(http_code -u "$BASIC" "$CDR/management/env")"
+  probe_done
+
+  # An endpoint that names no level is not mounted — 404, not 401. Its absence
+  # is not a credential problem, and there is no global default that could open
+  # it by accident.
+  probe "P-MGMT-OFF" "off" "server" "#2177" \
+    "an endpoint naming no level is not mounted, even for an admin"
+  assert_eq "404" "$(http_code -u "$BASIC" "$CDR/management/flamegraph")" \
+    "an unnamed endpoint must answer 404 rather than fall back to a server default"
+  probe_done
+}

--- a/scripts/deploy-probes/compose.sh
+++ b/scripts/deploy-probes/compose.sh
@@ -156,12 +156,27 @@ probes_multimedia() {
   probe "P-MM-EXPAND" "working" "server" "#2197" \
     "?expand_multimedia=true returns the bytes on an EHR_STATUS read"
   if [ -n "${ehr:-}" ]; then
-    local expanded
+    local expanded data digest
     expanded="$(curl -s -u "$BASIC" "$API/ehr/$ehr/ehr_status?expand_multimedia=true")"
-    assert_contains "$expanded" '"data"' \
-      "the read must re-inline the blob, not answer with the compact reference"
-    assert_not_contains "$expanded" 's3://openehr-multimedia' \
-      "an expanded read must not still carry the external reference"
+    data="$(printf '%s' "$expanded" \
+      | jq -r '.other_details.items[0].value.data // empty' 2>/dev/null)"
+    if [ -z "$data" ]; then
+      probe_fail "a re-inlined DV_MULTIMEDIA.data" "no data member in the served value" \
+        "the read must re-inline the blob, not answer with the compact reference"
+    else
+      # The strongest far-end check available: the bytes that came back must
+      # hash to the content-addressed key the record references. That closes the
+      # whole loop — committed, externalized under its SHA-256, fetched, and
+      # re-inlined byte-identical — rather than trusting that a `data` member
+      # appeared.
+      digest="$(printf '%s' "$data" | base64 -d 2>/dev/null | shasum -a 256 | cut -d' ' -f1)"
+      assert_eq "$key" "$digest" \
+        "the re-inlined bytes must hash to the key the record references"
+    fi
+    # The `uri` deliberately SURVIVES expansion: RM DV_MULTIMEDIA's invariant is
+    # `is_inline or is_external`, an OR, so carrying both is valid and keeps the
+    # provenance reference. Asserting its absence would test a rule the spec
+    # does not have.
   else
     probe_fail "an expandable record" "no EHR was committed"
   fi

--- a/scripts/deploy-probes/compose.sh
+++ b/scripts/deploy-probes/compose.sh
@@ -168,6 +168,45 @@ probes_multimedia() {
   probe_done
 }
 
+probes_multimedia_off() {
+  bold "multimedia — OFF (the default state)"
+
+  # The default posture, and the state #2171 hid in: with externalization off a
+  # large DV_MULTIMEDIA must be stored INLINE, byte-identical, with no
+  # dependency on the object store at all. "Off" is the state most deployments
+  # actually run, and it was never driven.
+  #
+  # Re-ups the CDR with the switch off; everything else is unchanged, so a
+  # difference here is the switch and nothing else.
+  probe "P-MM-OFF" "off" "server" "-" \
+    "with externalization off, a large DV_MULTIMEDIA is stored inline"
+  FERROEHR__MULTIMEDIA__ENABLED=false compose_up ferroehr
+  if ! wait_http "$CDR/health/readiness" 90; then
+    probe_fail "a serving CDR with multimedia off" "readiness never returned" \
+      "turning an integration off must not stop the server starting"
+    probe_done
+    return 0
+  fi
+
+  local off_env; off_env="$(curl -s -u "$BASIC" "$CDR/management/env")"
+  assert_contains "$off_env" '"enabled":false' "the switch must actually be off for this probe to mean anything"
+
+  local ehr; ehr="$(probe_commit_media_status)"
+  if [ -z "$ehr" ]; then
+    probe_fail "a committed EHR" "the commit returned no id" \
+      "an inline commit needs no object store and must succeed"
+  else
+    local stored; stored="$(curl -s -u "$BASIC" "$API/ehr/$ehr/ehr_status")"
+    assert_contains "$stored" '"data"' "with the integration off the bytes stay in the record"
+    assert_not_contains "$stored" 's3://' "nothing may be externalized while the switch is off"
+  fi
+  probe_done
+
+  # Put the stack back the way the rest of the run expects it.
+  compose_up ferroehr
+  wait_http "$CDR/health/readiness" 90 || true
+}
+
 probes_multimedia_broken() {
   bold "multimedia — dependency broken"
 

--- a/scripts/deploy-probes/lib.sh
+++ b/scripts/deploy-probes/lib.sh
@@ -87,13 +87,13 @@ assert_contains() {
   case "$1" in
     *"$2"*) return 0 ;;
   esac
-  probe_fail "output containing '$2'" "$(printf '%s' "$1" | head -c 300)" "${3:-}"
+  probe_fail "output containing '$2'" "${1:0:300}" "${3:-}"
 }
 
 # assert_not_contains <haystack> <needle> [note]
 assert_not_contains() {
   case "$1" in
-    *"$2"*) probe_fail "output WITHOUT '$2'" "$(printf '%s' "$1" | head -c 300)" "${3:-}" ;;
+    *"$2"*) probe_fail "output WITHOUT '$2'" "${1:0:300}" "${3:-}" ;;
     *) return 0 ;;
   esac
 }

--- a/scripts/deploy-probes/lib.sh
+++ b/scripts/deploy-probes/lib.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Shared probe vocabulary for the deployment-conformance harness.
+#
+# The instrument's whole point is that a red row is ACTIONABLE, so every
+# assertion here takes the LAYER it indicts and the evidence it saw. A probe
+# that can only say "it did not work" costs more than it saves — the same
+# discipline `.claude/rules/cnf-triage.md` imposes on a red conformance row.
+#
+# Sourced by the platform families (compose.sh, kubernetes.sh); never run
+# directly.
+
+# ── The ledger ────────────────────────────────────────────────────────────────
+# Counters and the machine-readable rows, appended as the run proceeds. The
+# NOT-EXERCISED ledger is deliberately a first-class output: silence read as
+# coverage is how the defects this instrument exists for reached a release.
+PROBE_PASS=0
+PROBE_FAIL=0
+PROBE_SKIP=0
+PROBE_ROWS=()
+PROBE_UNCOVERED=()
+
+# The probe currently running, and what it indicts when it fails.
+PROBE_ID=""
+PROBE_TITLE=""
+PROBE_LAYER=""
+PROBE_STATE=""
+PROBE_ISSUE=""
+PROBE_FAILED=0
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+bold()  { printf '\033[1m%s\033[0m\n' "$*"; }
+dim()   { printf '\033[2m%s\033[0m\n' "$*"; }
+
+# probe <id> <state> <layer-when-it-fails> <issue-or--> <title>
+#
+# `state` is one of off | working | broken — the three states #2178 requires,
+# because two of the defects that prompted this instrument lived in states
+# nobody exercised.
+probe() {
+  PROBE_ID="$1"
+  PROBE_STATE="$2"
+  PROBE_LAYER="$3"
+  PROBE_ISSUE="$4"
+  PROBE_TITLE="$5"
+  PROBE_FAILED=0
+  printf '  %-22s %-8s %s\n' "$PROBE_ID" "[$PROBE_STATE]" "$PROBE_TITLE"
+}
+
+# Record the outcome of the probe that just ran.
+probe_done() {
+  local outcome="pass"
+  if [ "$PROBE_FAILED" -eq 1 ]; then
+    outcome="fail"
+    PROBE_FAIL=$((PROBE_FAIL + 1))
+  else
+    PROBE_PASS=$((PROBE_PASS + 1))
+  fi
+  PROBE_ROWS+=("$(printf '{"id":"%s","state":"%s","outcome":"%s","layer":"%s","issue":"%s","title":"%s"}' \
+    "$PROBE_ID" "$PROBE_STATE" "$outcome" \
+    "$([ "$outcome" = fail ] && printf '%s' "$PROBE_LAYER" || printf '')" \
+    "$PROBE_ISSUE" "$PROBE_TITLE")")
+}
+
+# The failure path: name the layer, quote what was actually seen.
+#
+# `expected`/`actual` are printed verbatim rather than summarized, because the
+# summary is what makes a red row unactionable.
+probe_fail() {
+  local expected="$1" actual="$2" note="${3:-}"
+  PROBE_FAILED=1
+  red   "    FAIL  layer=$PROBE_LAYER${PROBE_ISSUE:+  regression-of=$PROBE_ISSUE}"
+  echo  "      expected: $expected"
+  echo  "      actual:   $actual"
+  [ -n "$note" ] && echo "      note:     $note"
+  return 0
+}
+
+# assert_eq <expected> <actual> [note]
+assert_eq() {
+  [ "$1" = "$2" ] && return 0
+  probe_fail "$1" "$2" "${3:-}"
+}
+
+# assert_contains <haystack> <needle> [note]
+assert_contains() {
+  case "$1" in
+    *"$2"*) return 0 ;;
+  esac
+  probe_fail "output containing '$2'" "$(printf '%s' "$1" | head -c 300)" "${3:-}"
+}
+
+# assert_not_contains <haystack> <needle> [note]
+assert_not_contains() {
+  case "$1" in
+    *"$2"*) probe_fail "output WITHOUT '$2'" "$(printf '%s' "$1" | head -c 300)" "${3:-}" ;;
+    *) return 0 ;;
+  esac
+}
+
+# uncovered <what> <why> — the honest half of the report.
+uncovered() {
+  PROBE_UNCOVERED+=("$(printf '{"what":"%s","why":"%s"}' "$1" "$2")")
+  PROBE_SKIP=$((PROBE_SKIP + 1))
+}
+
+# Poll an HTTP endpoint until it answers, or fail the RUN (not a probe) — a
+# stack that never came up is a harness problem, not a finding about the SUT.
+wait_http() {
+  local url="$1" tries="${2:-90}"
+  for _ in $(seq 1 "$tries"); do
+    curl -sf -o /dev/null "$url" && return 0
+    sleep 2
+  done
+  red "FATAL: $url never answered after $((tries * 2))s — the stack did not come up"
+  return 1
+}
+
+# Wait until an HTTP endpoint reports a specific status, for the states where
+# the expected answer is a REFUSAL (readiness going 503 when its database dies).
+wait_status() {
+  local url="$1" want="$2" tries="${3:-30}"
+  for _ in $(seq 1 "$tries"); do
+    [ "$(curl -s -o /dev/null -w '%{http_code}' "$url")" = "$want" ] && return 0
+    sleep 2
+  done
+  return 1
+}
+
+http_code() { curl -s -o /dev/null -w '%{http_code}' "$@"; }
+
+# Emit the report: the human summary, the uncovered ledger, and the JSON record.
+probe_report() {
+  local out="$1" platform="$2"
+  echo
+  bold "── not exercised by this run ───────────────────────────────"
+  if [ "${#PROBE_UNCOVERED[@]}" -eq 0 ]; then
+    echo "  (nothing declared — which is itself suspicious; see lib.sh 'uncovered')"
+  else
+    local row
+    for row in "${PROBE_UNCOVERED[@]}"; do
+      printf '  %s\n' "$(printf '%s' "$row" | sed -E 's/.*"what":"([^"]*)","why":"([^"]*)".*/\1 — \2/')"
+    done
+  fi
+
+  mkdir -p "$(dirname "$out")"
+  {
+    printf '{"platform":"%s","passed":%d,"failed":%d,"uncovered":%d,"probes":[' \
+      "$platform" "$PROBE_PASS" "$PROBE_FAIL" "$PROBE_SKIP"
+    local i
+    for i in "${!PROBE_ROWS[@]}"; do
+      [ "$i" -gt 0 ] && printf ','
+      printf '%s' "${PROBE_ROWS[$i]}"
+    done
+    printf '],"not_exercised":['
+    for i in "${!PROBE_UNCOVERED[@]}"; do
+      [ "$i" -gt 0 ] && printf ','
+      printf '%s' "${PROBE_UNCOVERED[$i]}"
+    done
+    printf ']}\n'
+  } > "$out"
+
+  echo
+  bold "── result ──────────────────────────────────────────────────"
+  echo "  passed $PROBE_PASS   failed $PROBE_FAIL   not exercised $PROBE_SKIP"
+  echo "  record: $out"
+  [ "$PROBE_FAIL" -eq 0 ] || { red "DEPLOYMENT PROBES FAILED"; return 1; }
+  green "ALL DEPLOYMENT PROBES PASSED (read the 'not exercised' list above)"
+}

--- a/scripts/deploy-probes/oidc.sh
+++ b/scripts/deploy-probes/oidc.sh
@@ -61,7 +61,15 @@ probes_oidc() {
     probe_fail "an access token from the password grant" "the token endpoint returned none" \
       "the realm's client must have the password grant enabled"
   else
-    assert_contains "$(jwt_claims "$token")" '"aud":"ferroehr"' \
+    # `aud` is a string when there is one audience and an ARRAY when there are
+    # several — RFC 7519 §4.1.3 permits both, and Keycloak emits either
+    # depending on which mappers fire. `[.aud] | flatten` normalizes the two
+    # into one list, which is why this reads the claim with jq rather than a
+    # regex: the first attempt matched only the string spelling, and its BRE
+    # alternation silently produced nothing on BSD sed anyway.
+    local aud
+    aud="$(jwt_claims "$token" | jq -r '[.aud] | flatten | join(",")' 2>/dev/null)"
+    assert_contains "$aud" 'ferroehr' \
       "without an audience mapper the realm cannot mint a token this server accepts"
   fi
   probe_done

--- a/scripts/deploy-probes/oidc.sh
+++ b/scripts/deploy-probes/oidc.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# The OIDC / Keycloak probe family.
+#
+# Driven through the PUBLISHED quickstart overlay and the recipe the book gives
+# the reader — a password-grant token fetch, then an API call with it. #2176 was
+# exactly that recipe returning 401 forever, because the demo realm never put
+# `ferroehr` in the token's `aud` while the same overlay required that audience.
+# Two halves of one shipped file contradicting each other, and no test could see
+# it because neither half is code.
+#
+# Sourced by scripts/deploy-probe.sh; never run directly.
+
+export KEYCLOAK_PORT="${PROBE_KC_PORT:-18081}"
+KC="http://localhost:${KEYCLOAK_PORT}"
+KC_REALM="$KC/auth/realms/ferroehr"
+
+# The stack for this family: the quickstart PLUS the Keycloak overlay, which is
+# how the book tells an operator to get an issuer.
+oidc_up() {
+  dc -f docker-compose.yml -f docker-compose.keycloak.yml up -d ferroehr keycloak >/dev/null 2>&1
+}
+
+# The middle segment of a JWT, decoded. `base64 -d` wants padding, and a JWT is
+# base64url without it — so pad to a multiple of 4 and translate the alphabet.
+jwt_claims() {
+  local token="$1" payload
+  payload="$(printf '%s' "$token" | cut -d. -f2 | tr '_-' '/+')"
+  case $(( ${#payload} % 4 )) in
+    2) payload="${payload}==" ;;
+    3) payload="${payload}=" ;;
+  esac
+  printf '%s' "$payload" | base64 -d 2>/dev/null
+}
+
+probes_oidc() {
+  bold "OIDC (Keycloak)"
+
+  oidc_up
+  if ! wait_http "$KC_REALM/.well-known/openid-configuration" 150; then
+    probe "P-OIDC-UP" "working" "compose" "-" "the quickstart overlay starts an issuer"
+    probe_fail "a Keycloak realm answering discovery" "no response after 300s" \
+      "the overlay's own healthcheck gates the CDR, so this is the overlay, not the realm"
+    probe_done
+    return 0
+  fi
+  wait_http "$CDR/health/readiness" 120 || true
+
+  # The documented recipe, verbatim: fetch a token with the password grant.
+  local token
+  token="$(curl -s -d client_id=ferroehr -d client_secret=ferroehr-quickstart-secret \
+    -d username=ferroehr -d password=ferroehr -d grant_type=password \
+    "$KC_REALM/protocol/openid-connect/token" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')"
+
+  # #2176, far end: the CLAIM, not the status code. The realm must actually put
+  # this server in the audience — a token that omits it is refused by every
+  # correct resource server (RFC 7519 §4.1.3), which is what made the shipped
+  # quickstart impossible rather than merely misconfigured.
+  probe "P-OIDC-AUD" "working" "compose" "#2176" \
+    "the demo realm mints a token carrying aud=ferroehr"
+  if [ -z "$token" ]; then
+    probe_fail "an access token from the password grant" "the token endpoint returned none" \
+      "the realm's client must have the password grant enabled"
+  else
+    assert_contains "$(jwt_claims "$token")" '"aud":"ferroehr"' \
+      "without an audience mapper the realm cannot mint a token this server accepts"
+  fi
+  probe_done
+
+  # And the whole point: the documented flow SUCCEEDS.
+  probe "P-OIDC-ACCEPT" "working" "server" "#2176" \
+    "the API accepts that token — the documented quickstart works end to end"
+  if [ -z "$token" ]; then
+    probe_fail "201 from POST /ehr" "no token to present"
+  else
+    local code
+    code="$(curl -s -o /dev/null -w '%{http_code}' -X POST \
+      -H "Authorization: Bearer $token" "$API/ehr")"
+    assert_eq "201" "$code" \
+      "a token the issuer minted for this audience must be accepted"
+  fi
+  probe_done
+
+  # A garbage bearer is refused — the negative twin, so the probe above cannot
+  # pass because authentication is off altogether.
+  probe "P-OIDC-REFUSE" "working" "server" "-" \
+    "a bearer token that is not the issuer's is refused"
+  assert_eq "401" "$(http_code -X POST -H 'Authorization: Bearer not-a-token' "$API/ehr")" \
+    "acceptance means nothing if an invalid token is also accepted"
+  probe_done
+}


### PR DESCRIPTION
Advances #2178. **Does not close it** — the Kubernetes half and six integration families are still open, and the run says so in its own output rather than leaving me to say it here.

## Why

A 4447-test suite was green while ten defects shipped. Every one lived between *the code is correct* and *the thing we hand an operator works*: a gateway with no bucket, an OIDC realm that could not mint a token this server accepts, a Prometheus that scraped nothing, host environment silently dropped on the floor, an integration that stranded data when switched off. Rendering YAML, linting and unit tests all succeeded throughout.

`cnf-runner` exists because "we believe the REST surface is conformant" had to be **measured**. Same standard, other half.

## What it measured

Against a live composed stack — **9 passed, 1 failed, 7 declared uncovered**:

```
P-MM-EXPAND   [working]  ?expand_multimedia=true returns the bytes on an EHR_STATUS read
    FAIL  layer=server  regression-of=#2197
      expected: output containing '"data"'
      actual:   {"uid":…,"_type":"EHR_STATUS",…}
      note:     the read must re-inline the blob, not answer with the compact reference
```

That failure is the deliverable, not a problem: the image under probe predates the #2197 fix. Against an image built from current `develop`, the same probe passes:

```
passed 14   failed 0   not exercised 5
ALL DEPLOYMENT PROBES PASSED (read the 'not exercised' list above)
```

Both halves of what a regression net has to prove — fails on the unfixed code, passes on the fixed code — measured with the same probe against two images.

## The three rules it holds itself to

1. **Observe at the far end.** Not "the API said 201" but the blob retrieved from the bucket by its content hash; not "the compose file looks right" but the server's own `/management/env` reporting what it actually took.
2. **Follow the documentation, not the source.** The harness exports `FERROEHR__MULTIMEDIA__*` the way the book tells an operator to — because that path silently doing nothing *was* the defect (#2169). A probe configured the way the source says would never catch that class again.
3. **Say what was not exercised, in the artifact.** The Kubernetes platform, OIDC, observability, PGP signing, the console journeys and FHIR/events/tenancy/terminology are declared gaps in the run's own output.

Every failure names the **layer** it indicts — server / image / chart / compose / docs — and quotes what it saw. That is the discipline `cnf-triage` imposes on a red conformance row, applied to deployment.

## The three states

Recorded per probe, because two of the ten defects lived in states nobody exercised: `off`, `working`, `dependency-broken`. So the harness stops the object store and stops the database and asserts what must happen — a commit **refused** rather than half-stored, readiness going `503` while liveness stays `200`.

## Two more families, and three bugs found in my own probes

Since the first commit the harness also drives the **`off` state** — where #2171 hid, since nothing exercised the disabled path — and **OIDC**, running the book's recipe verbatim and checking the far end twice: the token's own `aud` claim, and that the API answers `201`. With a negative twin, because acceptance proves nothing if a garbage bearer is also accepted.

**Three defects in the probes themselves, and twice the correct attribution was "the probe", not "the server"** — the discipline `cnf-triage` imposes on a red conformance row, applied to the instrument:

- **`P-MM-EXPAND` asserted the `s3://` reference disappears on expansion.** It does not, deliberately: `apply_expand` adds `data` and keeps the `uri`, which is correct because RM `DV_MULTIMEDIA`'s invariant is `is_inline or is_external` — an OR. I was asserting a rule the spec does not have. Replaced with a far stronger check: decode the returned base64, SHA-256 it, and assert it equals the content-addressed key the record references — closing the loop from commit to bucket to re-inlined bytes.

And in the OIDC family:

- **The `aud` matcher handled only the string spelling.** `aud` is a string with one audience and an **array** with several (RFC 7519 §4.1.3 permits both, Keycloak emits either). A realm that added a second audience would have failed a probe that should pass.
- **Its BRE alternation produced nothing on BSD sed**, so on macOS the extraction was empty and the probe would have failed for a reason unrelated to what it measures.
- Verified the replacement against four shapes, including the two that must **not** match. The important one: a token carrying `ferroehr` in `azp` and no audience at all — which is exactly the #2176 defect, and a substring search over the claim set would have passed it.

```
{"aud":"ferroehr"}              aud=ferroehr           MATCHES
{"aud":["ferroehr","account"]}  aud=ferroehr,account   MATCHES
{"aud":"other"}                 aud=other              no match
{"azp":"ferroehr"}              aud=<none>             no match
```

## One probe was wrong and the server was right

`P-MGMT-LEVELS` asserted `/management/loggers` should refuse an admin. The quickstart ships it `admin_only` and that user carries `ADMIN`, so `200` was correct — the probe was wrong, and the probe is what changed. Rewritten against the shipped configuration it is much stronger: four levels in one stack (`public` / `private` / `admin_only` / unset), checked anonymously **and** authenticated, so a guard applying one level to every route fails where a one-endpoint-at-a-time test passes.

Bash only, per the issue: no Python in the harness.
