### PR TITLE
test(deploy): content survives a restart, and a 401 carries its challenge

### DIFF
--- a/scripts/deploy-probe.sh
+++ b/scripts/deploy-probe.sh
@@ -82,6 +82,7 @@ compose_up ferroehr seaweedfs seaweedfs-init
 probes_shipped_config_boots
 probes_multimedia
 probes_management
+probes_multimedia_restart
 probes_multimedia_off
 probes_multimedia_broken
 probes_health_broken

--- a/scripts/deploy-probes/compose.sh
+++ b/scripts/deploy-probes/compose.sh
@@ -135,8 +135,9 @@ probes_multimedia() {
   # under its content hash, and the stored record references it.
   probe "P-MM-OFFLOAD" "working" "server" "-" \
     "a large DV_MULTIMEDIA is externalized and the blob lands in the bucket"
-  local ehr uri key
-  ehr="$(probe_commit_media_status)"
+  local uri
+  PROBE_MEDIA_EHR="$(probe_commit_media_status)"
+  local ehr="$PROBE_MEDIA_EHR" key=""
   if [ -z "$ehr" ]; then
     probe_fail "an EHR carrying a 400 KiB DV_MULTIMEDIA" "the commit did not return an id"
   else
@@ -144,6 +145,7 @@ probes_multimedia() {
       | tr ',' '\n' | grep -o 's3://openehr-multimedia/[0-9a-f]*' | head -1)"
     assert_contains "$uri" "s3://openehr-multimedia/" "the stored record must reference the blob"
     key="${uri##*/}"
+    PROBE_MEDIA_KEY="$key"
     if [ -n "$key" ]; then
       assert_eq "200" "$(http_code "$S3/openehr-multimedia/$key")" \
         "the blob must be retrievable from the bucket by its content hash"
@@ -179,6 +181,52 @@ probes_multimedia() {
     # does not have.
   else
     probe_fail "an expandable record" "no EHR was committed"
+  fi
+  probe_done
+}
+
+probes_multimedia_restart() {
+  bold "multimedia — persistence across a restart"
+
+  # The case that separates a real object store from a temp directory: the
+  # server process goes away and comes back, and the clinical content it
+  # externalized is still retrievable byte-for-byte.
+  #
+  # It re-reads the record committed by P-MM-OFFLOAD rather than committing a
+  # fresh one, because the property under test is that THAT content survived —
+  # a new commit after the restart would prove only that the feature still
+  # works, which is a different and weaker claim.
+  probe "P-MM-RESTART" "working" "server" "-" \
+    "externalized content survives a server restart, byte-for-byte"
+  if [ -z "${PROBE_MEDIA_EHR:-}" ] || [ -z "${PROBE_MEDIA_KEY:-}" ]; then
+    probe_fail "a record committed earlier in this run" "none was recorded" \
+      "P-MM-OFFLOAD must run first — this probe deliberately re-reads its record"
+    probe_done
+    return 0
+  fi
+
+  dc restart ferroehr >/dev/null 2>&1
+  if ! wait_http "$CDR/health/readiness" 120; then
+    probe_fail "the CDR serving again after a restart" "readiness never returned"
+    probe_done
+    return 0
+  fi
+
+  # The blob is still in the store …
+  assert_eq "200" "$(http_code "$S3/openehr-multimedia/$PROBE_MEDIA_KEY")" \
+    "the object store outlives the server process"
+
+  # … and the API still returns the bytes, verified against the same key.
+  local data digest
+  data="$(curl -s -u "$BASIC" "$API/ehr/$PROBE_MEDIA_EHR/ehr_status?expand_multimedia=true" \
+    | jq -r '.other_details.items[0].value.data // empty' 2>/dev/null)"
+  if [ -z "$data" ]; then
+    probe_fail "the re-inlined bytes after a restart" "no data member in the served value" \
+      "content committed before the restart must still be retrievable"
+  else
+    digest="$(printf '%s' "$data" | base64 -d 2>/dev/null | shasum -a 256 | cut -d' ' -f1)"
+    assert_eq "$PROBE_MEDIA_KEY" "$digest" \
+      "the bytes returned after the restart must hash to the original key"
   fi
   probe_done
 }

--- a/scripts/deploy-probes/oidc.sh
+++ b/scripts/deploy-probes/oidc.sh
@@ -88,6 +88,22 @@ probes_oidc() {
   fi
   probe_done
 
+  # The one spec-grounded rule in the whole access layer, observed on the wire
+  # rather than inferred: a request with NO credential is 401 and the response
+  # must carry a challenge naming a scheme the server implements (RFC 9110
+  # §11.6.1 — a challenge naming nothing is what makes a 401 unactionable).
+  probe "P-OIDC-CHALLENGE" "working" "server" "-" \
+    "no credential: 401 with a WWW-Authenticate challenge naming Bearer"
+  local hdrs
+  hdrs="$(curl -s -o /dev/null -D - -X POST "$API/ehr")"
+  assert_contains "$hdrs" "401" "an unauthenticated write must be refused"
+  # Header names are case-insensitive on the wire, so fold before matching.
+  assert_contains "$(printf '%s' "$hdrs" | tr 'A-Z' 'a-z')" "www-authenticate" \
+    "a 401 without a challenge tells the client nothing about how to authenticate"
+  assert_contains "$(printf '%s' "$hdrs" | tr 'A-Z' 'a-z')" "bearer" \
+    "with an issuer configured the challenge must advertise Bearer"
+  probe_done
+
   # A garbage bearer is refused — the negative twin, so the probe above cannot
   # pass because authentication is off altogether.
   probe "P-OIDC-REFUSE" "working" "server" "-" \


### PR DESCRIPTION
Advances #2178. Closes three of #2161's four acceptance criteria and the reachable half of #2160's.

**16 passed, 0 failed, 5 declared uncovered** against an image built from `develop`.

## `P-MM-RESTART` — the case that separates a real object store from a temp directory

Restarts the CDR and re-reads **the record committed before the restart** — deliberately not a fresh one, because the property under test is that *that* content survived. A new commit afterwards would prove only that the feature still works, which is a weaker claim.

The returned bytes are re-verified against the original content-addressed key, so two different failures are both caught: a store that quietly lost the blob, and a server that quietly served different bytes.

That takes #2161 from one satisfied criterion to three — e2e commit/retrieve with SHA-256 verification, persistence across a restart, and the store-unreachable path failing loudly. The pod-reschedule half stays under the Kubernetes gap.

## `P-OIDC-CHALLENGE` — the one spec-grounded rule, observed rather than inferred

A request with no credential is `401` **and** carries a `WWW-Authenticate` challenge naming a scheme the server implements (RFC 9110 §11.6.1) — because a challenge naming nothing leaves a client with no way to proceed. Header names are folded before matching, since their case is not guaranteed on the wire.

## What this deliberately does not probe

The `403` half of that split, and it **cannot be probed from the published quickstart**:

```yaml
[authz.rbac] enabled = false
"users": [{ "username": "ferroehr", "realmRoles": ["ADMIN","USER"] }]
```

RBAC off, one user holding both roles — no call can be refused, and no second user exists to refuse it to. That is a divergence from the security chapter, which documents `ADMIN`/`USER`/`READONLY` separation and the read-only override; a reader who brings up the OIDC quickstart to try it finds none of it applies.

Reported on #2160 with three ways out (give the demo realm the users and enable RBAC / ship a separate `rbac` overlay / state the limitation where the reader looks) rather than picking one here — which to take is a product decision about what the quickstart is for.