### PR TITLE
test(signing): prove the detection, not just that a signature field exists

### DIFF
--- a/scripts/deploy-probe.sh
+++ b/scripts/deploy-probe.sh
@@ -49,6 +49,8 @@ PROBE_OUT="${PROBE_OUT:-docs/conformance/deployment/compose.json}"
 . scripts/deploy-probes/compose.sh
 # shellcheck source=scripts/deploy-probes/oidc.sh
 . scripts/deploy-probes/oidc.sh
+# shellcheck source=scripts/deploy-probes/signing.sh
+. scripts/deploy-probes/signing.sh
 
 cleanup() {
   if [ "$KEEP_UP" -eq 0 ]; then
@@ -82,6 +84,7 @@ compose_up ferroehr seaweedfs seaweedfs-init
 probes_shipped_config_boots
 probes_multimedia
 probes_management
+probes_signing
 probes_multimedia_restart
 probes_multimedia_off
 probes_multimedia_broken
@@ -95,8 +98,8 @@ uncovered "kubernetes platform" \
   "this harness drives compose only; the chart is exercised by the k8s-test skill by hand"
 uncovered "observability: traces reaching a collector, metrics on a scrape (#2173, #2175)" \
   "needs the observability overlay and a collector to observe at the far end"
-uncovered "signing in pgp mode (#2163)" \
-  "needs key material provisioned into the stack"
+uncovered "signing in PGP mode (#2163)" \
+  "digest mode and tamper detection are probed; the PGP path needs key material mounted as the docs instruct"
 uncovered "admin console journeys (#2164)" \
   "scripts/ui-e2e.sh already drives these with a real browser; folding it in is the next step"
 uncovered "FHIR, events, tenancy, terminology" \

--- a/scripts/deploy-probes/signing.sh
+++ b/scripts/deploy-probes/signing.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# The VERSION-signing probe family (#2163).
+#
+# `[signing]` is on by default in `digest` mode with read-time verification
+# `strict`, which means the server recomputes the signature of a version it
+# signed on every read and refuses to serve a provably corrupt record. That is a
+# strong claim, and it had never been watched work.
+#
+# The probe that matters is the TAMPER one: a signing feature with no
+# demonstrated detection is decoration. So this reaches past the API into the
+# stored rows, changes a byte of clinical content, and asserts the next read
+# FAILS — the only way to show the verification is real rather than a field
+# nobody checks.
+#
+# Sourced by scripts/deploy-probe.sh; never run directly.
+
+# Run SQL against the composed database as the quickstart's role.
+probe_psql() {
+  dc exec -T ferroehr-postgres psql -U "${PG_INIT_USER:-ferroehr}" \
+    -d "${PG_INIT_DB:-ferroehr}" -tAc "$1" 2>/dev/null
+}
+
+probes_signing() {
+  bold "VERSION signing (digest mode)"
+
+  # A committed version must carry a signature the server generated, and the
+  # read path must serve it. Digest mode is the shipped default, so this is the
+  # posture nearly every deployment runs.
+  probe "P-SIGN-DIGEST" "working" "server" "-" \
+    "a committed VERSION carries a server signature and reads back cleanly"
+  local ehr version
+  ehr="$(curl -s -u "$BASIC" -X POST -D - -o /dev/null "$API/ehr" \
+    | grep -i '^location' | tr -d '\r' | awk -F/ '{print $NF}')"
+  if [ -z "$ehr" ]; then
+    probe_fail "a committed EHR" "no id returned"
+    probe_done
+    return 0
+  fi
+  version="$(curl -s -u "$BASIC" "$API/ehr/$ehr/versioned_ehr_status/version")"
+  assert_contains "$version" '"signature"' \
+    "with signing enabled a served ORIGINAL_VERSION must carry its signature"
+  assert_eq "200" "$(http_code -u "$BASIC" "$API/ehr/$ehr/versioned_ehr_status/version")" \
+    "an untampered version verifies on read"
+  probe_done
+
+  # The one that makes the feature more than decoration. Reaching past the API
+  # into the stored rows is the point: an attacker or a corrupt disk does not
+  # go through the write path, so neither does this.
+  probe "P-SIGN-TAMPER" "broken" "server" "-" \
+    "a tampered stored version is REFUSED on read, not served"
+  local before after rows
+  before="$(http_code -u "$BASIC" "$API/ehr/$ehr/versioned_ehr_status/version")"
+  rows="$(probe_psql "UPDATE ehr.node
+                         SET data = jsonb_set(data, '{name,value}', '\"tampered\"')
+                       WHERE ehr_id = '$ehr'::uuid AND rm_type = 'EHR_STATUS';" \
+          && probe_psql "SELECT count(*) FROM ehr.node
+                          WHERE ehr_id = '$ehr'::uuid
+                            AND data #>> '{name,value}' = 'tampered';")"
+  if [ "${rows:-0}" = "0" ]; then
+    probe_fail "a tampered stored row" "the UPDATE matched nothing" \
+      "the probe could not reach the stored content, so detection was never tested"
+  else
+    after="$(http_code -u "$BASIC" "$API/ehr/$ehr/versioned_ehr_status/version")"
+    case "$after" in
+      5*) : ;;
+      *)  probe_fail "a 5xx integrity refusal" "$after" \
+            "verify_on_read is strict by default, so a corrupt record must not be served (was $before before tampering)" ;;
+    esac
+  fi
+  probe_done
+}


### PR DESCRIPTION
Advances #2163 and #2178. **18 passed, 0 failed, 5 declared uncovered** against an image built from `develop`.

## The probe that matters

The issue puts it best: *"A signing feature with no demonstrated detection is decoration."*

`P-SIGN-TAMPER` reaches **past the API into the stored rows**, rewrites a byte of clinical content with SQL, and asserts the next read is **refused 5xx**. Going around the write path is the point — an attacker or a corrupt disk does not use it either.

It also asserts the `UPDATE` actually matched a row before drawing any conclusion. Without that, "no failure" would mean "the probe never reached the content", which reads identically to "detection works" — the vacuous-pass shape this harness has already produced twice, and the last place it should recur is the probe that exists to catch tampering.

`P-SIGN-DIGEST` covers the ordinary path: a committed VERSION carries a server-generated signature and reads back `200`.

## Scope

Digest mode — the shipped default, and what nearly every deployment runs — is demonstrated end to end, along with detection. The **PGP path stays a declared gap**: it needs key material mounted exactly as the documentation instructs (a file plus its passphrase `*_file` sibling), which is its own setup rather than another assertion, and #2163 is explicit that the documented production shape is the one that must be exercised.