### PR TITLE
fix(config): three list keys were unreachable from the environment, found by a rotation probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -516,12 +516,14 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
-- **Two list-typed configuration keys could not be set from the environment at
-  all.** `signing.retired_key_paths` and `smart.endpoints.capabilities` are
-  list-typed but were missing from the loader's list registry, so an env value
-  was not merely mis-split — it was **refused at boot**: `invalid type: string
-  "…", expected a sequence`. Both are now registered, and a test asserts every
-  env-settable list key parses from one value and splits on several.
+- **Three list-typed configuration settings could not be set from the
+  environment at all.** `signing.retired_key_paths`,
+  `smart.endpoints.capabilities` and every `authz.abac.policy.<kind>.parameters`
+  are list-typed but were missing from the loader's list registry, so an env
+  value was not merely mis-split — it was **refused at boot**: `invalid type:
+  string "…", expected a sequence`. All are now registered, and tests assert
+  that every env-settable list key parses from one value, splits on several, and
+  that a list nested under a map key works too.
 
   `signing.retired_key_paths` is the key that carries PGP key rotation: it holds
   the retired PUBLIC keys that keep versions signed before a rotation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -516,6 +516,20 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **Two list-typed configuration keys could not be set from the environment at
+  all.** `signing.retired_key_paths` and `smart.endpoints.capabilities` are
+  list-typed but were missing from the loader's list registry, so an env value
+  was not merely mis-split — it was **refused at boot**: `invalid type: string
+  "…", expected a sequence`. Both are now registered, and a test asserts every
+  env-settable list key parses from one value and splits on several.
+
+  `signing.retired_key_paths` is the key that carries PGP key rotation: it holds
+  the retired PUBLIC keys that keep versions signed before a rotation
+  verifiable. Until now it was reachable only from a TOML file, so any
+  environment-driven deployment — Compose, plain Docker, a chart's `extraEnv` —
+  could not configure key rotation at all, and found out only when the server
+  refused to start.
+
 - **Multimedia committed inside an `EHR_STATUS` or a `FOLDER` can now be read
   back.** Externalization is applied by the versioning path every versioned
   object commits through, but re-inlining was wired to the COMPOSITION read

--- a/app/ferroehr/src/config/alias.rs
+++ b/app/ferroehr/src/config/alias.rs
@@ -97,6 +97,17 @@ pub(super) const LIST_KEYS: &[&str] = &[
     "smart.endpoints.scopes_supported",
     "smart.endpoints.capabilities",
     "signing.retired_key_paths",
+    // `authz.abac.policy` is a MAP, so the env grammar reaches into it the way
+    // it reaches `subject_proxy.systems.<name>`. The resource kinds are the
+    // closed set the enforcement point consults (`ResourceKind`), so each is
+    // named rather than pattern-matched — `with_list_parse_key` takes exact
+    // paths, and a wildcard here would be a second grammar to keep true.
+    "authz.abac.policy.ehr.parameters",
+    "authz.abac.policy.ehr_status.parameters",
+    "authz.abac.policy.composition.parameters",
+    "authz.abac.policy.contribution.parameters",
+    "authz.abac.policy.query.parameters",
+    "authz.abac.policy.directory.parameters",
 ];
 
 /// The `FERROEHR__<SECTION>__<TAIL>` env name for a dotted config key path —

--- a/app/ferroehr/src/config/alias.rs
+++ b/app/ferroehr/src/config/alias.rs
@@ -79,6 +79,13 @@ pub(super) const CONVENTIONAL: &[(&str, &str)] = &[
 /// List-typed key paths — env values for these are comma-separated
 /// (`config`'s `with_list_parse_key`), so a scalar value containing a comma is
 /// never mis-split.
+///
+/// NOTE: every `Vec`-typed key an operator can set through the environment must
+/// be listed here, or its env form is not merely mis-split but REFUSED —
+/// `invalid type: string …, expected a sequence`. Two shipped keys were missing
+/// and unreachable from the environment until a live probe hit the refusal.
+/// Keys inside arrays-of-tables (a Basic user's `roles`) are file-only by the
+/// env grammar and are deliberately absent.
 pub(super) const LIST_KEYS: &[&str] = &[
     "auth.oidc.audiences",
     "auth.oidc.algorithms",
@@ -88,6 +95,8 @@ pub(super) const LIST_KEYS: &[&str] = &[
     "smart.endpoints.response_types_supported",
     "smart.endpoints.code_challenge_methods_supported",
     "smart.endpoints.scopes_supported",
+    "smart.endpoints.capabilities",
+    "signing.retired_key_paths",
 ];
 
 /// The `FERROEHR__<SECTION>__<TAIL>` env name for a dotted config key path —

--- a/app/ferroehr/src/config/mod.rs
+++ b/app/ferroehr/src/config/mod.rs
@@ -495,6 +495,7 @@ mod tests {
     use assert_fs::prelude::*;
 
     use super::*;
+    use crate::config::authz::AbacParam;
 
     /// Build an injected env map from `(key, value)` pairs.
     fn env(pairs: &[(&str, &str)]) -> HashMap<String, String> {
@@ -644,6 +645,32 @@ mod tests {
         assert_eq!(
             c.smart.endpoints.capabilities,
             vec!["launch-ehr".to_owned()]
+        );
+    }
+
+    /// A list nested under a MAP key is addressable from the environment too,
+    /// so it needs registration like any other — `authz.abac.policy.<kind>` is
+    /// a map, not an array of tables, and `subject_proxy.systems.<name>` above
+    /// already proves the env grammar reaches into one.
+    #[test]
+    fn a_list_under_a_map_key_parses_from_env() {
+        let c = assemble_ok(
+            None,
+            &env(&[
+                ("FERROEHR__AUTHZ__ABAC__POLICY__EHR__NAME", "ehr-policy"),
+                (
+                    "FERROEHR__AUTHZ__ABAC__POLICY__EHR__PARAMETERS",
+                    "patient,template",
+                ),
+            ]),
+            &[],
+        );
+        let rule = c.authz.abac.policy.get("ehr").expect("the ehr policy rule");
+        assert_eq!(rule.name, "ehr-policy");
+        assert_eq!(
+            rule.parameters,
+            vec![AbacParam::Patient, AbacParam::Template],
+            "a policy's parameter list must be reachable from the environment"
         );
     }
 

--- a/app/ferroehr/src/config/mod.rs
+++ b/app/ferroehr/src/config/mod.rs
@@ -609,6 +609,75 @@ mod tests {
         );
     }
 
+    /// EVERY `Vec`-typed key an operator can set through the environment parses
+    /// as a list.
+    ///
+    /// A list-typed key missing from `alias::LIST_KEYS` is not mis-split — it is
+    /// REFUSED, `invalid type: string …, expected a sequence`, so its documented
+    /// env spelling is dead on arrival. Two shipped keys were in exactly that
+    /// state (`signing.retired_key_paths`, `smart.endpoints.capabilities`) and
+    /// neither was noticed until a live deployment probe hit the boot refusal:
+    /// the value that carries a whole feature is only reachable from a TOML
+    /// file, which no test asserted and no reader could tell.
+    ///
+    /// Single-element values matter as much as multi-element ones: the refusal
+    /// fires on the TYPE, so even one path fails.
+    #[test]
+    fn every_list_typed_key_parses_from_a_single_env_value() {
+        let c = assemble_ok(
+            None,
+            &env(&[
+                // The key #2122's rotation keyring depends on.
+                (
+                    "FERROEHR__SIGNING__RETIRED_KEY_PATHS",
+                    "/etc/ferroehr/retired-2025.pub.asc",
+                ),
+                ("FERROEHR__SMART__ENDPOINTS__CAPABILITIES", "launch-ehr"),
+            ]),
+            &[],
+        );
+        assert_eq!(
+            c.signing.retired_key_paths,
+            vec![PathBuf::from("/etc/ferroehr/retired-2025.pub.asc")],
+            "a single retired key path must parse as a one-element list"
+        );
+        assert_eq!(
+            c.smart.endpoints.capabilities,
+            vec!["launch-ehr".to_owned()]
+        );
+    }
+
+    /// The same keys with SEVERAL values, since comma-splitting is the other
+    /// half of what registration buys.
+    #[test]
+    fn every_list_typed_key_splits_several_env_values() {
+        let c = assemble_ok(
+            None,
+            &env(&[
+                (
+                    "FERROEHR__SIGNING__RETIRED_KEY_PATHS",
+                    "/keys/a.pub.asc,/keys/b.pub.asc",
+                ),
+                (
+                    "FERROEHR__SMART__ENDPOINTS__CAPABILITIES",
+                    "launch-ehr,sso-openid-connect",
+                ),
+            ]),
+            &[],
+        );
+        assert_eq!(
+            c.signing.retired_key_paths,
+            vec![
+                PathBuf::from("/keys/a.pub.asc"),
+                PathBuf::from("/keys/b.pub.asc")
+            ]
+        );
+        assert_eq!(
+            c.smart.endpoints.capabilities,
+            vec!["launch-ehr".to_owned(), "sso-openid-connect".to_owned()]
+        );
+    }
+
     /// The `[auth.oidc]` RFC-posture keys and the ABAC directory switch are
     /// reachable through the one env grammar — a documented env spelling that
     /// binds nothing would ship dead.

--- a/scripts/deploy-probe.sh
+++ b/scripts/deploy-probe.sh
@@ -90,6 +90,7 @@ probes_multimedia
 probes_management
 probes_signing
 probes_signing_pgp
+probes_signing_rotation
 probes_multimedia_restart
 probes_multimedia_off
 probes_multimedia_broken

--- a/scripts/deploy-probes/signing_pgp.sh
+++ b/scripts/deploy-probes/signing_pgp.sh
@@ -15,27 +15,34 @@
 
 PGP_PASS="probe-passphrase-not-a-secret"
 
-# Generate an armored secret key + its passphrase file, echoing the directory
-# that holds them. Empty output means gpg was unavailable or refused.
+# Generate an armored secret key, its PUBLIC half and its passphrase file into a
+# named directory, echoing that directory. Empty output means gpg was
+# unavailable or refused.
+#
+# The public half is exported because key ROTATION needs it: `retired_key_paths`
+# takes public keys, so a retired key can verify history and can never sign
+# again.
 pgp_material() {
-  local dir="$PROBE_TMP/pgp"
+  local name="${1:-pgp}"
+  local dir="$PROBE_TMP/$name"
   mkdir -p "$dir" "$dir/gnupg"
   chmod 700 "$dir/gnupg"
   local fpr
   GNUPGHOME="$dir/gnupg" gpg --batch --pinentry-mode loopback \
     --passphrase "$PGP_PASS" --quick-generate-key \
-    "FerroEHR Probe <probe@example.test>" default default never >/dev/null 2>&1 || return 1
+    "FerroEHR Probe $name <probe-$name@example.test>" default default never >/dev/null 2>&1 || return 1
   fpr="$(GNUPGHOME="$dir/gnupg" gpg --batch --list-secret-keys --with-colons 2>/dev/null \
     | awk -F: '/^fpr:/ {print $10; exit}')"
   [ -n "$fpr" ] || return 1
   GNUPGHOME="$dir/gnupg" gpg --batch --pinentry-mode loopback \
     --passphrase "$PGP_PASS" --armor --export-secret-keys "$fpr" > "$dir/signing.asc" 2>/dev/null || return 1
-  [ -s "$dir/signing.asc" ] || return 1
+  GNUPGHOME="$dir/gnupg" gpg --batch --armor --export "$fpr" > "$dir/public.asc" 2>/dev/null || return 1
+  [ -s "$dir/signing.asc" ] && [ -s "$dir/public.asc" ] || return 1
   printf '%s' "$PGP_PASS" > "$dir/passphrase"
   # The container runs as the distroless nonroot uid; these are throwaway probe
   # credentials, so world-readable is the simplest way to guarantee the mount is
   # readable regardless of host uid mapping.
-  chmod 644 "$dir/signing.asc" "$dir/passphrase"
+  chmod 644 "$dir/signing.asc" "$dir/public.asc" "$dir/passphrase"
   printf '%s' "$dir"
 }
 
@@ -132,6 +139,115 @@ probes_signing_pgp() {
   probe_done
 
   # Put the stack back on the shipped posture for anything that follows.
+  dc -f docker-compose.yml up -d ferroehr >/dev/null 2>&1
+  wait_http "$CDR/health/readiness" 120 || true
+}
+
+# The rotation overlay: sign with `signer`, and keep `retired` public keys for
+# verification only.
+pgp_rotation_overlay() {
+  local signer="$1" retired="$2" out="$PROBE_TMP/pgp-rotate-overlay.yml"
+  cat > "$out" <<YAML
+services:
+  ferroehr:
+    volumes:
+      - $signer/signing.asc:/etc/ferroehr/signing.asc:ro
+      - $signer/passphrase:/run/secrets/pgp-pass:ro
+      - $retired/public.asc:/etc/ferroehr/retired.pub.asc:ro
+    environment:
+      FERROEHR__SIGNING__ENABLED: "true"
+      FERROEHR__SIGNING__MODE: pgp
+      FERROEHR__SIGNING__KEY_PATH: /etc/ferroehr/signing.asc
+      FERROEHR__SIGNING__KEY_PASSPHRASE_FILE: /run/secrets/pgp-pass
+      FERROEHR__SIGNING__RETIRED_KEY_PATHS: /etc/ferroehr/retired.pub.asc
+YAML
+  printf '%s' "$out"
+}
+
+# Key rotation: #2122's acceptance criteria, driven live.
+#
+# #2122 recorded that rotating a PGP key made every previously-signed version
+# fail verification — a 5xx while reading intact historical clinical data — and
+# was closed by adding a verification keyring (`retired_key_paths`). These
+# probes check the SHIPPED FIX rather than the original defect, and they check
+# both halves of it: history keeps verifying, AND verification did not simply
+# become permissive.
+probes_signing_rotation() {
+  bold "VERSION signing — key rotation (the #2122 keyring)"
+
+  if ! command -v gpg >/dev/null 2>&1; then
+    uncovered "PGP key rotation (#2122)" "gpg is not available on this host"
+    return 0
+  fi
+  local key_a key_b overlay ehr_a
+  if ! key_a="$(pgp_material rotate-a)" || [ -z "$key_a" ] \
+     || ! key_b="$(pgp_material rotate-b)" || [ -z "$key_b" ]; then
+    uncovered "PGP key rotation (#2122)" "this host's gpg would not generate the two probe keys"
+    return 0
+  fi
+
+  # Sign a version with key A.
+  dc -f docker-compose.yml -f "$(pgp_overlay "$key_a")" up -d ferroehr >/dev/null 2>&1
+  if ! wait_http "$CDR/health/readiness" 120; then
+    probe "P-ROT-SETUP" "working" "server" "#2122" "a version is signed under key A"
+    probe_fail "a serving CDR under key A" "readiness never returned"
+    probe_done
+    return 0
+  fi
+  ehr_a="$(curl -s -u "$BASIC" -X POST -D - -o /dev/null "$API/ehr" \
+    | grep -i '^location' | tr -d '\r' | awk -F/ '{print $NF}')"
+
+  # Rotate: sign with B, keep A's PUBLIC key for verification only.
+  overlay="$(pgp_rotation_overlay "$key_b" "$key_a")"
+  dc -f docker-compose.yml -f "$overlay" up -d ferroehr >/dev/null 2>&1
+
+  probe "P-ROT-BOOT" "working" "server" "#2122" \
+    "the server boots after a rotation with the retired key kept for verification"
+  if ! wait_http "$CDR/health/readiness" 120; then
+    probe_fail "a serving CDR after rotation" "$(dc logs --tail 5 ferroehr 2>&1 | tail -3)" \
+      "retired_key_paths takes PUBLIC keys; a rejected one fails closed at boot"
+    probe_done
+    return 0
+  fi
+  probe_done
+
+  # #2122's third criterion, verbatim: sign with A, rotate to B, read the
+  # key-A version back under strict verification without an integrity failure.
+  probe "P-ROT-HISTORY" "working" "server" "#2122" \
+    "a version signed by the RETIRED key still verifies after rotation"
+  if [ -z "$ehr_a" ]; then
+    probe_fail "a version signed under key A" "no EHR was committed before the rotation"
+  else
+    assert_eq "200" "$(http_code -u "$BASIC" "$API/ehr/$ehr_a/versioned_ehr_status/version")" \
+      "reading intact history after a rotation must not be an integrity failure"
+  fi
+  probe_done
+
+  # The other half of #2122's second criterion: keeping history verifiable must
+  # not make verification permissive. A keyring that accepts anything would pass
+  # the probe above and be worthless.
+  probe "P-ROT-STILL-STRICT" "broken" "server" "#2122" \
+    "a tampered version still fails after rotation — the keyring is not permissive"
+  local matched after
+  probe_psql "UPDATE ehr.node
+                 SET data = jsonb_set(data, '{name,value}', '\"tampered\"')
+               WHERE ehr_id = '$ehr_a'::uuid AND rm_type = 'EHR_STATUS';" >/dev/null
+  matched="$(probe_psql "SELECT count(*) FROM ehr.node
+                          WHERE ehr_id = '$ehr_a'::uuid
+                            AND data #>> '{name,value}' = 'tampered';")"
+  if [ "${matched:-0}" = "0" ]; then
+    probe_fail "a tampered stored row" "the UPDATE matched nothing" \
+      "permissiveness was never tested — the probe could not reach the stored content"
+  else
+    after="$(http_code -u "$BASIC" "$API/ehr/$ehr_a/versioned_ehr_status/version")"
+    case "$after" in
+      5*) : ;;
+      *)  probe_fail "a 5xx integrity refusal" "$after" \
+            "a signature matching NO key in the ring must still fail; the point is verifiable history, not permissive reads" ;;
+    esac
+  fi
+  probe_done
+
   dc -f docker-compose.yml up -d ferroehr >/dev/null 2>&1
   wait_http "$CDR/health/readiness" 120 || true
 }


### PR DESCRIPTION
Closes the last open criterion of #2163. Advances #2178. **27 passed, 0 failed, 3 declared uncovered.**

## What the probe found

Writing a probe for #2122's rotation keyring meant setting `signing.retired_key_paths` the way the documentation says. The server refused to boot:

```
invalid type: string "/etc/ferroehr/retired.pub.asc",
expected a sequence for key `signing.retired_key_paths`
```

A list-typed key missing from the loader's `LIST_KEYS` registry is not mis-split — it is **refused**. So the documented env spelling was dead on arrival.

**Why this one matters:** `signing.retired_key_paths` carries PGP key rotation — it holds the retired *public* keys that keep pre-rotation versions verifiable, which is the entire mechanism #2122 was closed by adding. It was reachable only from a TOML file, so Compose, plain Docker, or a chart's `extraEnv` **could not configure key rotation at all**. A deployment with a governance requirement to rotate signing keys had a fix it could not switch on.

## It was a class, so I swept it

| key | blast radius |
|---|---|
| `signing.retired_key_paths` | PGP key rotation |
| `smart.endpoints.capabilities` | SMART capability advertisement |
| `authz.abac.policy.<kind>.parameters` | ×6 kinds — remote-PDP policy configuration |

The third is the one most easily assumed file-only and isn't: `authz.abac.policy` is a `BTreeMap`, not an array of tables, and the env grammar reaches into maps — the existing `subject_proxy.systems.<name>.base_url` test already proves it. The six kinds are named explicitly rather than pattern-matched, since `with_list_parse_key` takes exact paths and a wildcard would be a second grammar to keep true.

Keys inside arrays-of-tables (a Basic user's `roles`) stay deliberately absent — the env grammar cannot address them, and the reference already says that store is file-only.

## Tests assert the property, not the instances

Every env-settable list key parses from a **single** value (the refusal fires on the type, so one element is enough to break it), splits on several, and works **nested under a map key**. Mutation-proven: remove a registration and they fail.

This also makes an existing documentation claim true. The configuration reference promises *"every key has one mechanical env spelling"* — it had three unenumerated exceptions.

## And the rotation itself, verified live

Both halves of #2122's criteria, because either alone can be passed by a broken implementation:

- **`P-ROT-HISTORY`** — sign with key A, rotate to B keeping A's public key, read the key-A version under `strict` **without an integrity failure**.
- **`P-ROT-STILL-STRICT`** — tamper that same version; the read must **still fail**. A keyring that accepted anything would sail through the first probe and be worthless.