### PR TITLE
test(deploy): probe the cluster, not the manifest — the Kubernetes half of the harness

### DIFF
--- a/.claude/rules/kubernetes-helm.md
+++ b/.claude/rules/kubernetes-helm.md
@@ -21,6 +21,15 @@ rendered perfectly and were wrong on a cluster. **Rendering is never
 acceptance.** Acceptance is `helm upgrade --install` on a live cluster, the
 behaviour observed, and the observation quoted in the PR.
 
+That acceptance is now an INSTRUMENT rather than a habit:
+**`scripts/deploy-probe-k8s.sh`** installs the chart on a real cluster and
+reads each answer from the layer that actually decides it — the container
+runtime's own spec for the security posture, the API server for admission, the
+EndpointSlice for readiness. Run it for any chart change with behavioural
+reach and quote the record (`docs/conformance/deployment/kubernetes.json`).
+The `/k8s-test` skill stays the manual procedure for what the harness does not
+cover, and the harness declares those gaps in its own output.
+
 ## 1. Version-gate every field against the declared `kubeVersion` floor
 
 An API server **silently prunes** a field its schema does not know, and a
@@ -186,4 +195,5 @@ evidence if it ran in an enforcing namespace — say which.
 | Golden render drift | CI compare against `deploy/helm/golden/` |
 | Chart/app version bumps | `chart-version-guard`, `chart-appversion-guard` |
 | Field-vs-`kubeVersion` availability | **review-enforced** — no tool knows which fields a manifest uses; §1 is the procedure |
-| Live behaviour | **review-enforced** — the `/k8s-test` skill is the procedure; the PR quotes observations |
+| Applied posture, admission, readiness gating, secret reads | `scripts/deploy-probe-k8s.sh` — observed on a live cluster, machine-readable record |
+| Live behaviour beyond those probes | **review-enforced** — the `/k8s-test` skill is the procedure; the PR quotes observations |

--- a/docs/conformance/deployment/README.md
+++ b/docs/conformance/deployment/README.md
@@ -1,7 +1,19 @@
 # Deployment-conformance records
 
-`scripts/deploy-probe.sh` writes its machine-readable record here — the
+The two deployment harnesses write their machine-readable records here — the
 deployment analogue of what `docs/conformance/<sut>/` holds for the wire.
+
+| Harness | Record | Asks |
+|---|---|---|
+| `scripts/deploy-probe.sh` | `compose.json` | does the software work when it is deployed? |
+| `scripts/deploy-probe-k8s.sh` | `kubernetes.json` | does the cluster apply what the chart asked for? |
+
+Those are different questions, and only the second is what an operator running
+the chart actually gets. `helm template` proves the YAML; the API server, the
+kubelet and the container runtime each get a say afterwards, and every one of
+them can decline. So the Kubernetes probes read their answers from the runtime
+spec, from admission, and from the EndpointSlice — never from the manifest we
+wrote.
 
 A record is a measurement of **one SUT**, so it is only meaningful with the
 image it was taken against. The harness names that image in its output, and

--- a/scripts/deploy-probe-k8s.sh
+++ b/scripts/deploy-probe-k8s.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# The deployment-conformance harness, Kubernetes platform (#2178).
+#
+# The compose harness (scripts/deploy-probe.sh) measures whether the software
+# works when deployed. This one measures something compose cannot see: whether
+# the CLUSTER applies what the chart asked for. `securityContext` is a request,
+# admission is a separate judge, and a mounted secret that is never read looks
+# exactly like one that is — so each of those is observed at its own far end,
+# from the container runtime, the API server and the EndpointSlice rather than
+# from the manifest we wrote.
+#
+# The database is a docker compose PostgreSQL on the host that the chart is
+# pointed at (owner ruling): the chart provisions no database and takes an
+# external DSN, so a host database is the faithful shape, and an in-cluster pod
+# with no volume turns any restart into an empty database.
+#
+# Usage:
+#   scripts/deploy-probe-k8s.sh                # install, probe, tear down
+#   scripts/deploy-probe-k8s.sh --keep-up      # leave the release for poking at
+#
+# Env:
+#   PROBE_K8S_IMAGE   repo:tag of the server image under probe. Defaults to a
+#                     `dev-local` build if the node already has one, else the
+#                     chart's appVersion. The chart's `config:` defaults track
+#                     develop while appVersion names the last release, so a key
+#                     added since that release makes the appVersion image refuse
+#                     to boot — that is a real finding, and P-K8S-BOOT reports it
+#                     against the chart rather than hiding it.
+#   PROBE_K8S_NS      namespace (default ferroehr-probe; created and deleted).
+#   PROBE_OUT         where the machine-readable record lands.
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 1
+
+KEEP_UP=0
+[ "${1:-}" = "--keep-up" ] && KEEP_UP=1
+
+PROBE_TMP="$(mktemp -d)"
+export PROBE_TMP
+PROBE_OUT="${PROBE_OUT:-docs/conformance/deployment/kubernetes.json}"
+# shellcheck disable=SC2034  # read by the sourced kubernetes.sh helpers
+COMPOSE_PROJECT="ferroehr-probe-k8s"
+
+# shellcheck source=scripts/deploy-probes/lib.sh
+. scripts/deploy-probes/lib.sh
+# shellcheck source=scripts/deploy-probes/kubernetes.sh
+. scripts/deploy-probes/kubernetes.sh
+
+cleanup() {
+  if [ "$KEEP_UP" -eq 0 ]; then
+    k8s_teardown
+  else
+    k8s_pf_stop
+    dim "── release left installed (--keep-up): kubectl -n $K8S_NS get pods"
+  fi
+  rm -rf "$PROBE_TMP"
+}
+trap cleanup EXIT
+
+for tool in kubectl helm docker jq; do
+  command -v "$tool" >/dev/null || { red "$tool not found on PATH"; exit 1; }
+done
+kubectl cluster-info >/dev/null 2>&1 || {
+  red "no reachable cluster — this harness needs one (Docker Desktop Kubernetes is enough)"
+  exit 1
+}
+
+# Which image to probe. A locally built one is a legitimate SUT for behaviour
+# and hardening; it is NOT legitimate for a provenance claim, since it carries
+# no attestation — nothing here makes one.
+if [ -n "${PROBE_K8S_IMAGE:-}" ]; then
+  PROBE_K8S_IMAGE_REPO="${PROBE_K8S_IMAGE%:*}"
+  PROBE_K8S_IMAGE_TAG="${PROBE_K8S_IMAGE##*:}"
+else
+  PROBE_K8S_IMAGE_REPO="ghcr.io/rubentalstra/ferroehr"
+  # Detection goes through the cluster's node name, not `docker ps` — Docker
+  # Desktop hides its node from the container list while `docker exec` into it
+  # works, so a ps-based check reports "no node" on the commonest dev cluster.
+  node="$(k8s_node_container || true)"
+  if [ -n "$node" ] && [ "$(docker exec "$node" crictl images 2>/dev/null \
+       | grep -cE 'rubentalstra/ferroehr +dev-local')" != "0" ]; then
+    PROBE_K8S_IMAGE_TAG="dev-local"
+  else
+    PROBE_K8S_IMAGE_TAG="$(grep '^appVersion:' deploy/helm/ferroehr/Chart.yaml | awk '{print $2}' | tr -d '"')"
+  fi
+fi
+
+bold "── deployment probes: kubernetes ───────────────────────────"
+echo "  context:   $(kubectl config current-context)"
+echo "  node:      $(kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.kubeletVersion}' 2>/dev/null)"
+echo "  image:     $PROBE_K8S_IMAGE_REPO:$PROBE_K8S_IMAGE_TAG"
+echo "  namespace: $K8S_NS"
+echo
+
+bold "bringing up the host database the chart will be pointed at"
+k8s_db_up || { red "FATAL: the compose PostgreSQL never became ready"; exit 1; }
+K8S_DB_HOST="$(k8s_resolve_db_host)"
+if [ -z "$K8S_DB_HOST" ]; then
+  red "FATAL: no address reached the host database from inside a pod"
+  echo "  tried host.docker.internal, gateway.docker.internal and the node's default gateway"
+  exit 1
+fi
+echo "  pods reach the database at $K8S_DB_HOST:$K8S_DB_PORT"
+k8s_namespace
+
+if probes_k8s_boot; then
+  probes_k8s_runtime_posture
+  probes_k8s_psa
+  probes_k8s_service_links
+  probes_k8s_secrets
+  probes_k8s_readiness
+else
+  red "the release never served — the probes that need a running CDR were not run"
+  uncovered "every probe after P-K8S-SERVE" \
+    "the release did not come up, so nothing downstream could be observed"
+fi
+
+# ── The honest half ───────────────────────────────────────────────────────────
+uncovered "NetworkPolicy enforcement" \
+  "whether a policy is enforced is a property of the CNI, so a green result here would say nothing about the operator's cluster"
+uncovered "load balancing across replicas" \
+  "kube-proxy distributes connections, which needs conntrack on the node — readable only on a local-container node"
+uncovered "horizontal autoscaling" \
+  "the HPA needs a metrics API that a stock local cluster does not ship"
+uncovered "Ingress and TLS termination" \
+  "no controller is installed by this harness; the chart's Ingress is rendered but never reached"
+uncovered "the admin console on this platform (#2164)" \
+  "scripts/ui-e2e.sh drives the console against compose; the chart's console Deployment is not probed"
+
+probe_report "$PROBE_OUT" "kubernetes"

--- a/scripts/deploy-probes/kubernetes.sh
+++ b/scripts/deploy-probes/kubernetes.sh
@@ -1,0 +1,489 @@
+#!/usr/bin/env bash
+# The Kubernetes probe family (#2178's second platform).
+#
+# The compose family answers "does the software work when it is deployed". This
+# one answers a question compose cannot reach at all: **does the cluster apply
+# what the chart asked for?** Those are different claims, and only the second is
+# what an operator running the chart actually gets. `helm template` proves the
+# YAML we generate; the API server, the kubelet and the container runtime each
+# get a say afterwards, and every one of them can decline.
+#
+# So every probe here observes at the far end of THAT chain:
+#
+#   - the security posture is read out of the container runtime's own spec, not
+#     out of the pod manifest — an empty capability bounding set is a fact about
+#     the kernel, whereas `drop: [ALL]` is a request;
+#   - Pod Security admission is judged by the API server refusing or admitting,
+#     not by us re-reading the profile;
+#   - a mounted secret is proven READ by breaking its path and watching the boot
+#     refuse, because a secret that is mounted and never read looks identical in
+#     `kubectl describe`;
+#   - readiness is proven to GATE by removing the database and watching the
+#     EndpointSlice drop the pod, not by a probe that has only ever returned UP.
+#
+# The database runs in docker compose on the host and the chart is pointed at it
+# (owner ruling): the chart provisions no database and takes an external DSN, so
+# a host database is the faithful shape rather than a convenience — and an
+# in-cluster `kubectl create deployment pg` has no volume, which turns any
+# restart into an empty database and a diagnosis cycle.
+#
+# Sourced by scripts/deploy-probe-k8s.sh; never run directly.
+
+K8S_NS="${PROBE_K8S_NS:-ferroehr-probe}"
+K8S_RELEASE="ferroehr"
+K8S_PORT="${PROBE_K8S_PORT:-18081}"
+K8S_CDR="http://127.0.0.1:${K8S_PORT}"
+K8S_API="$K8S_CDR/ferroehr/rest/openehr/v1"
+# The identity the documented Basic-auth overlay ships. The chart REFUSES to
+# render with authentication on and no mechanism configured, so every install
+# below carries deploy/helm/ci/basic-auth-values.yaml — which is the file the
+# chart's own error message points an operator at.
+K8S_BASIC="clinician:ferroehr"
+K8S_AUTH_VALUES="deploy/helm/ci/basic-auth-values.yaml"
+K8S_PF_PID=""
+
+# The compose database this cluster is pointed at. It binds 0.0.0.0 because a
+# pod reaches the host through the Docker Desktop gateway, which a loopback bind
+# would refuse; the stack is thrown away at the end of the run.
+K8S_DB_PORT="${PROBE_DB_PORT:-15432}"
+K8S_DB_HOST=""
+
+kc() { kubectl -n "$K8S_NS" "$@"; }
+
+# The node as a local CONTAINER, when it is one — which is what makes the
+# runtime posture readable at all.
+#
+# Derived from the cluster's own node names and confirmed with `docker exec`,
+# never from `docker ps`: Docker Desktop keeps its Kubernetes node out of the
+# user's container list while `docker exec` into it works perfectly. Detecting
+# by `docker ps` therefore reports "no local node" on the single most common
+# development cluster, and the strongest probe in this file would quietly
+# downgrade itself to "not exercised" — a false gap, which is worse than a red
+# row because it reads as honesty.
+k8s_node_container() {
+  local n
+  for n in $(kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null); do
+    if docker exec "$n" true >/dev/null 2>&1; then printf '%s' "$n"; return 0; fi
+  done
+  return 1
+}
+
+# ── Bring-up ──────────────────────────────────────────────────────────────────
+
+# The host address a POD can reach, measured rather than assumed: Docker
+# Desktop publishes `host.docker.internal` and a kind-style node also routes its
+# default gateway, but which one answers is a property of the cluster, not
+# something a script may declare. Echoes the winner; empty means neither works,
+# which is a harness problem and not a finding about the chart.
+k8s_resolve_db_host() {
+  # Retried, because the far end is EVENTUALLY reachable: `pg_isready` answers
+  # from inside the container before Docker has necessarily finished publishing
+  # the port to the host, and a single attempt then reports "no address works"
+  # about a database that is simply not published yet. Asking once cost a run.
+  local _try host
+  for _try in 1 2 3 4 5; do
+    host="$(k8s_try_db_hosts)"
+    [ -n "$host" ] && { printf '%s' "$host"; return 0; }
+    sleep 4
+  done
+  return 1
+}
+
+k8s_try_db_hosts() {
+  local out
+  out="$(kubectl run "probe-hostcheck-$$-$RANDOM" --image=busybox:1.37 --restart=Never --rm \
+    --attach --quiet --command -- sh -c '
+      for h in host.docker.internal gateway.docker.internal $(ip route | awk "/default/ {print \$3}"); do
+        nc -w3 -z "$h" '"$K8S_DB_PORT"' && { echo "HOST=$h"; break; }
+      done' 2>/dev/null)"
+  printf '%s' "$out" | sed -n 's/.*HOST=\([^ ]*\).*/\1/p' | tr -d '\r' | head -1
+}
+
+k8s_db_up() {
+  FERROEHR_BIND_HOST=0.0.0.0 FERROEHR_DB_PORT="$K8S_DB_PORT" \
+    docker compose -p "$COMPOSE_PROJECT" up -d ferroehr-postgres >/dev/null 2>&1
+  local _i
+  for _i in $(seq 1 40); do
+    docker compose -p "$COMPOSE_PROJECT" exec -T ferroehr-postgres \
+      pg_isready -U "${PG_INIT_USER:-ferroehr}" >/dev/null 2>&1 && return 0
+    sleep 2
+  done
+  return 1
+}
+
+k8s_db_stop()  { docker compose -p "$COMPOSE_PROJECT" stop ferroehr-postgres >/dev/null 2>&1; }
+k8s_db_start() { docker compose -p "$COMPOSE_PROJECT" start ferroehr-postgres >/dev/null 2>&1; }
+
+k8s_namespace() {
+  kubectl create namespace "$K8S_NS" >/dev/null 2>&1 || true
+  kc delete secret ferroehr-db >/dev/null 2>&1 || true
+  kc create secret generic ferroehr-db \
+    --from-literal=FERROEHR__DB__URL="postgres://${PG_INIT_USER:-ferroehr}:${PG_INIT_PASSWORD:-ferroehr}@${K8S_DB_HOST}:${K8S_DB_PORT}/${PG_INIT_DB:-ferroehr}" \
+    >/dev/null 2>&1
+}
+
+# Install with the chart's OWN defaults plus the two things no default can carry
+# — where the database is and which image is under probe. Deliberately nothing
+# else: an overlay tuned until it works is exactly what this instrument exists
+# to stop being the only evidence.
+k8s_install() {
+  helm upgrade --install "$K8S_RELEASE" deploy/helm/ferroehr -n "$K8S_NS" \
+    -f "$K8S_AUTH_VALUES" \
+    --set database.existingSecret=ferroehr-db \
+    --set image.repository="$PROBE_K8S_IMAGE_REPO" \
+    --set image.tag="$PROBE_K8S_IMAGE_TAG" \
+    --set image.pullPolicy=IfNotPresent \
+    "$@" >/dev/null 2>&1
+}
+
+k8s_rollout() { kc rollout status "deploy/$K8S_RELEASE" --timeout="${1:-180s}" >/dev/null 2>&1; }
+
+# A READY pod, preferred over merely the first one.
+#
+# `.items[0]` is whichever pod the API server lists first, which after a probe
+# that deliberately breaks the boot is the crash-looping one still terminating.
+# Port-forwarding to that pod waits for a container that will never serve, and
+# reports it as a finding about readiness. Falls back to any pod so a genuine
+# "nothing is ready" still surfaces rather than returning empty.
+k8s_pod() {
+  local ready
+  ready="$(kc get pod -l app.kubernetes.io/name=ferroehr \
+    -o jsonpath='{range .items[?(@.status.containerStatuses[0].ready==true)]}{.metadata.name}{"\n"}{end}' \
+    2>/dev/null | head -1)"
+  [ -n "$ready" ] && { printf '%s' "$ready"; return 0; }
+  kc get pod -l app.kubernetes.io/name=ferroehr -o jsonpath='{.items[0].metadata.name}' 2>/dev/null
+}
+
+k8s_pf_start() {
+  kc port-forward "svc/$K8S_RELEASE" "${K8S_PORT}:8080" >/dev/null 2>&1 &
+  K8S_PF_PID=$!
+  wait_http "$K8S_CDR/health/liveness" 45
+}
+
+# A forward bound to ONE POD rather than the Service.
+#
+# Needed for exactly one probe, for a reason worth stating: `port-forward
+# svc/…` resolves the Service to a READY endpoint, so the moment the pods go
+# unready it has nothing to forward to and every request fails to connect. That
+# is the precise state the readiness probe exists to observe, so measuring it
+# through a Service forward reports a connection failure and calls it a finding
+# about the server.
+k8s_pf_pod_start() {
+  k8s_pf_stop
+  kc port-forward "pod/$1" "${K8S_PORT}:8080" >/dev/null 2>&1 &
+  K8S_PF_PID=$!
+  wait_http "$K8S_CDR/health/liveness" 30
+}
+
+k8s_pf_stop() {
+  # `disown` first: killing a backgrounded job otherwise makes the shell print
+  # a "Terminated" notice into the report, which reads like a failure in an
+  # instrument whose whole value is that its output means something.
+  if [ -n "$K8S_PF_PID" ]; then
+    disown "$K8S_PF_PID" 2>/dev/null || true
+    kill "$K8S_PF_PID" >/dev/null 2>&1 || true
+    wait "$K8S_PF_PID" 2>/dev/null || true
+  fi
+  K8S_PF_PID=""
+}
+
+k8s_teardown() {
+  k8s_pf_stop
+  helm uninstall "$K8S_RELEASE" -n "$K8S_NS" >/dev/null 2>&1 || true
+  kubectl delete namespace "$K8S_NS" --wait=false >/dev/null 2>&1 || true
+  docker compose -p "$COMPOSE_PROJECT" down -v --remove-orphans >/dev/null 2>&1 || true
+}
+
+# ── The probes ────────────────────────────────────────────────────────────────
+
+probes_k8s_boot() {
+  bold "the chart on a real cluster"
+
+  # A stock install must fail where an operator can read it. Authentication is
+  # on by default and no mechanism is configured by default, and the failure
+  # mode that costs an afternoon is a pod that starts, crash-loops, and explains
+  # itself only in a log nobody has tailed yet. So the chart refuses at RENDER —
+  # and the refusal has to name the ways out, or it is just a different wall.
+  probe "P-K8S-AUTH-GUARD" "broken" "chart" "-" \
+    "a stock install is refused at render, naming every configured way forward"
+  local guard
+  guard="$(helm template "$K8S_RELEASE" deploy/helm/ferroehr -n "$K8S_NS" \
+             --set database.existingSecret=ferroehr-db 2>&1)"
+  assert_contains "$guard" "no authentication mechanism is configured" \
+    "without this the stock install boots into a crash loop and explains itself in a log"
+  assert_contains "$guard" "config.auth.basic.users" \
+    "a refusal that does not name the Basic route leaves an operator guessing"
+  assert_contains "$guard" "config.auth.oidc.issuer" \
+    "the OIDC route is the other real answer and must be named too"
+  assert_contains "$guard" "config.auth.enabled=false" \
+    "the development escape must be stated as such, not discovered"
+  probe_done
+
+  # #2159's class on this platform: our own values files rendered and linted for
+  # a whole release cycle while none of them produced a bootable configuration.
+  # Rendering is not installing, and only one of the two is what an operator does.
+  probe "P-K8S-BOOT" "working" "chart" "#2159" \
+    "the chart's default values install and the Deployment rolls out"
+  if ! k8s_install; then
+    probe_fail "a successful helm upgrade --install" "helm refused the release" \
+      "the render itself failed; re-run the helm command without -q to see it"
+    probe_done
+    return 1
+  fi
+  if ! k8s_rollout; then
+    probe_fail "a rolled-out Deployment" \
+      "$(kc logs -l app.kubernetes.io/name=ferroehr --tail=6 --all-containers 2>&1 | tail -6)" \
+      "a config key the chart renders that this image does not accept lands here"
+    probe_done
+    return 1
+  fi
+  probe_done
+
+  # The proof an operator cares about: not that pods are Running, but that the
+  # deployment answers openEHR. Everything below this needs the port-forward.
+  probe "P-K8S-SERVE" "working" "server" "-" \
+    "the deployed CDR serves a real openEHR write and read"
+  if ! k8s_pf_start; then
+    probe_fail "a reachable Service" "port-forward never answered /health/liveness"
+    probe_done
+    return 1
+  fi
+  local headers ehr
+  headers="$(curl -s -u "$K8S_BASIC" -X POST -D - -o /dev/null "$K8S_API/ehr")"
+  ehr="$(printf '%s' "$headers" | grep -i '^location' | tr -d '\r' | awk -F/ '{print $NF}')"
+  if [ -z "$ehr" ]; then
+    probe_fail "a Location header naming the new EHR" "$(printf '%s' "$headers" | head -3)"
+  else
+    assert_contains "$(curl -s -u "$K8S_BASIC" "$K8S_API/ehr/$ehr")" "\"$ehr\"" \
+      "the EHR just created must read back from the deployed server"
+  fi
+  probe_done
+  return 0
+}
+
+# What the kernel actually got, read from the container runtime rather than from
+# the manifest. This is the whole reason to run on a cluster: `securityContext`
+# is a REQUEST, and a request that a runtime quietly declines looks identical in
+# `kubectl get pod -o yaml`.
+probes_k8s_runtime_posture() {
+  bold "the security posture, read out of the container runtime"
+
+  local node
+  node="$(k8s_node_container)"
+  if [ -z "$node" ]; then
+    uncovered "the applied runtime posture (uid, capabilities, seccomp, read-only root)" \
+      "this cluster's node is not a local container, so its runtime spec is not readable from here"
+    return 0
+  fi
+
+  probe "P-K8S-RUNTIME" "working" "chart" "-" \
+    "the runtime applied non-root, no-new-privileges, no capabilities, read-only root, seccomp"
+  local cid spec
+  cid="$(docker exec "$node" crictl ps --name ferroehr -q 2>/dev/null | head -1)"
+  if [ -z "$cid" ]; then
+    probe_fail "a running ferroehr container on the node" "crictl listed none"
+    probe_done
+    return 0
+  fi
+  spec="$(docker exec "$node" crictl inspect "$cid" 2>/dev/null | jq -c '.info.runtimeSpec')"
+
+  assert_eq "65532" "$(printf '%s' "$spec" | jq -r '.process.user.uid')" \
+    "the image's nonroot uid must be what the process actually runs as"
+  assert_eq "true" "$(printf '%s' "$spec" | jq -r '.process.noNewPrivileges')" \
+    "without this a setuid binary inside the image could still escalate"
+  # An EMPTY bounding set, not "the default fourteen minus the ones we dropped":
+  # drop: [ALL] is only honoured if the runtime clears the bounding set, and
+  # nothing short of reading it proves that.
+  assert_eq "0" "$(printf '%s' "$spec" | jq -r '.process.capabilities.bounding | length')" \
+    "a non-empty bounding set means drop: [ALL] did not take effect"
+  assert_eq "true" "$(printf '%s' "$spec" | jq -r '.root.readonly')" \
+    "a writable root filesystem makes the container's own binaries replaceable"
+  assert_eq "SCMP_ACT_ERRNO" "$(printf '%s' "$spec" | jq -r '.linux.seccomp.defaultAction')" \
+    "RuntimeDefault must resolve to a deny-by-default filter, not to no filter at all"
+  probe_done
+
+  # The mounts, from the same source. `/etc/ferroehr` holding the configuration
+  # and `/etc/ferroehr-secrets` holding key material must both be read-only:
+  # a writable configuration mount is a way to change the server's behaviour
+  # from inside a compromised container.
+  probe "P-K8S-MOUNTS" "working" "chart" "-" \
+    "configuration and secret mounts are read-only in the runtime spec"
+  local writable
+  writable="$(printf '%s' "$spec" | jq -r '
+    .mounts[] | select(.destination | test("^/etc/ferroehr"))
+    | select((.options // []) | index("ro") | not) | .destination' | tr '\n' ' ')"
+  if [ -n "${writable// /}" ]; then
+    probe_fail "every /etc/ferroehr* mount carrying 'ro'" "writable: $writable" \
+      "configuration and key material must not be rewritable from inside the container"
+  fi
+  probe_done
+}
+
+# The API server as the judge. Labelling the namespace and rolling the workload
+# is the only way to learn whether the chart's pods are admissible under the
+# Restricted profile — reading the profile ourselves and grading our own
+# manifest is the check that cannot fail honestly.
+probes_k8s_psa() {
+  bold "Pod Security admission (the API server judges, not us)"
+
+  probe "P-K8S-PSA" "working" "chart" "-" \
+    "the chart's pods are admitted under the Restricted profile"
+  kubectl label namespace "$K8S_NS" \
+    pod-security.kubernetes.io/enforce=restricted --overwrite >/dev/null 2>&1
+  kc rollout restart "deploy/$K8S_RELEASE" >/dev/null 2>&1
+  if ! k8s_rollout 180s; then
+    probe_fail "an admitted rollout under enforce=restricted" \
+      "$(kc get events --sort-by=.lastTimestamp 2>/dev/null | grep -i 'violate\|forbidden' | tail -3)" \
+      "the chart claims Restricted compliance; admission is what settles it"
+  fi
+  probe_done
+
+  # Acceptance must not be able to pass vacuously: if the label were silently
+  # ignored, the probe above would pass on a cluster enforcing nothing. So a pod
+  # that MUST be refused is offered, and its refusal is what proves the judge
+  # was awake.
+  probe "P-K8S-PSA-ARMED" "broken" "compose" "-" \
+    "a privileged pod is REFUSED, proving enforcement is really on"
+  local out
+  out="$(kc run probe-privileged --image=busybox:1.37 --restart=Never \
+      --overrides='{"spec":{"containers":[{"name":"bad","image":"busybox:1.37","command":["sleep","5"],"securityContext":{"privileged":true}}]}}' \
+      2>&1)"
+  assert_contains "$out" "violates PodSecurity" \
+    "without a refusal here the admission probe above proves nothing about this cluster"
+  kc delete pod probe-privileged --ignore-not-found >/dev/null 2>&1
+  probe_done
+
+  kubectl label namespace "$K8S_NS" pod-security.kubernetes.io/enforce- >/dev/null 2>&1
+}
+
+# Service links are a real trap on this platform: the kubelet injects
+# <SVC>_SERVICE_HOST and friends for every Service in the namespace, and for a
+# Service named `ferroehr*` those land inside the server's reserved FERROEHR_
+# namespace, where its strict environment sweep refuses to boot. The chart pins
+# enableServiceLinks: false; this proves the pin still holds where it matters.
+probes_k8s_service_links() {
+  bold "service-link injection (the trap that stops this server booting)"
+
+  probe "P-K8S-SVCLINKS" "working" "chart" "-" \
+    "a new ferroehr-named Service does not poison the pod's environment"
+  kc create service clusterip ferroehr-probe-link --tcp=8080:8080 >/dev/null 2>&1 || true
+  kc rollout restart "deploy/$K8S_RELEASE" >/dev/null 2>&1
+  if ! k8s_rollout 180s; then
+    probe_fail "a pod that boots with another ferroehr-named Service present" \
+      "$(kc logs -l app.kubernetes.io/name=ferroehr --tail=5 --all-containers 2>&1 | tail -5)" \
+      "this is what enableServiceLinks: false prevents; a boot refusal here means the pin is gone"
+  fi
+  kc delete service ferroehr-probe-link --ignore-not-found >/dev/null 2>&1
+  probe_done
+}
+
+probes_k8s_secrets() {
+  bold "secrets: where they are, and whether they are actually read"
+
+  # A DSN is a credential. It must reach the process as a PATH, never as a value
+  # in the pod spec — `kubectl describe pod` and every controller that logs a
+  # spec would otherwise carry it.
+  probe "P-K8S-SECRET-ENV" "working" "chart" "-" \
+    "no credential value appears in the pod environment or the ConfigMap"
+  local env_dump cm_dump
+  env_dump="$(kc get pod "$(k8s_pod)" \
+    -o jsonpath='{range .spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}' 2>/dev/null)"
+  assert_contains "$env_dump" "FERROEHR__DB__URL_FILE=" \
+    "the DSN must arrive as a file path the server reads, not as an environment value"
+  assert_not_contains "$env_dump" "postgres://" \
+    "a DSN in the pod spec is readable by anyone who can describe the pod"
+  cm_dump="$(kc get configmap -o yaml 2>/dev/null)"
+  assert_not_contains "$cm_dump" "argon2id" \
+    "a password hash in a ConfigMap is a secret stored where secrets are not"
+  assert_not_contains "$cm_dump" "postgres://" \
+    "the ConfigMap is not a place for a DSN"
+  probe_done
+
+  # Mounted and READ are different claims, and only one of them is worth
+  # anything. Breaking the path is the only way to tell them apart: a secret
+  # that is projected and never opened looks identical from outside.
+  probe "P-K8S-SECRET-READ" "broken" "chart" "-" \
+    "a *_file key pointing at a missing path makes the boot REFUSE, naming the file"
+  k8s_install --set config.signing.enabled=true \
+              --set config.signing.mode=pgp \
+              --set config.signing.key_passphrase_file=/etc/ferroehr-secrets/absent
+  # The rollout is EXPECTED to fail here; what matters is the reason it gives.
+  k8s_rollout 90s
+  local bad_logs
+  bad_logs="$(kc logs -l app.kubernetes.io/name=ferroehr --tail=25 --all-containers 2>&1 \
+              | grep -i 'absent\|secret file' | tail -3)"
+  assert_contains "$bad_logs" "/etc/ferroehr-secrets/absent" \
+    "the refusal must name the unreadable path, or an operator cannot act on it"
+  probe_done
+
+  # Back to the shipped posture for everything that follows.
+  k8s_install
+  k8s_rollout 180s
+}
+
+# Readiness that has only ever returned UP is not a health check, it is a
+# decoration. The far end here is the EndpointSlice: a pod that reports itself
+# unready must actually leave the Service, and liveness must NOT restart it —
+# restarting a healthy process because its database is down turns an outage
+# into a crash loop.
+probes_k8s_readiness() {
+  bold "readiness under a broken dependency (the state least often tested)"
+
+  probe "P-K8S-READY-GATES" "broken" "server" "-" \
+    "with the database gone, readiness fails, the pod leaves the Service, and liveness does not restart it"
+  local pod restarts_before
+  pod="$(k8s_pod)"
+  restarts_before="$(kc get pod "$pod" -o jsonpath='{.status.containerStatuses[0].restartCount}' 2>/dev/null)"
+  if ! k8s_pf_pod_start "$pod"; then
+    probe_fail "a forward to the pod under test" "it never answered /health/liveness"
+    probe_done
+    return 0
+  fi
+
+  k8s_db_stop
+  if ! wait_status "$K8S_CDR/health/readiness" "503" 40; then
+    probe_fail "readiness answering 503 once the database is unreachable" \
+      "$(curl -s -o /dev/null -w '%{http_code}' "$K8S_CDR/health/readiness")" \
+      "a readiness probe that stays UP through a dead database gates nothing"
+    k8s_db_start
+    probe_done
+    return 0
+  fi
+  assert_contains "$(curl -s "$K8S_CDR/health/readiness")" '"db"' \
+    "the readiness body must name the component that failed, not just report DOWN"
+  assert_eq "200" "$(http_code "$K8S_CDR/health/liveness")" \
+    "liveness must stay green: the process is healthy, its dependency is not"
+
+  # The two far ends, in order of authority. The KUBELET's verdict comes from
+  # its own probe rather than ours, and the EndpointSlice is what actually
+  # stops kube-proxy sending traffic here — a pod that reports itself unready
+  # and stays in the Service is still serving production requests. Both are
+  # eventually consistent, so each is waited for rather than sampled once.
+  local _i ready="unknown" kubelet="unknown"
+  for _i in $(seq 1 20); do
+    kubelet="$(kc get pod "$pod" -o jsonpath='{.status.containerStatuses[0].ready}' 2>/dev/null)"
+    [ "$kubelet" = "false" ] && break
+    sleep 3
+  done
+  assert_eq "false" "$kubelet" \
+    "the kubelet's own readiness probe must agree; ours answering 503 is only half the claim"
+  for _i in $(seq 1 20); do
+    ready="$(kc get endpointslice -l "kubernetes.io/service-name=$K8S_RELEASE" \
+             -o jsonpath='{.items[0].endpoints[0].conditions.ready}' 2>/dev/null)"
+    [ "$ready" = "false" ] && break
+    sleep 3
+  done
+  assert_eq "false" "$ready" \
+    "an unready pod that stays in the EndpointSlice still receives production traffic"
+
+  k8s_db_start
+  if ! wait_status "$K8S_CDR/health/readiness" "200" 60; then
+    probe_fail "readiness recovering once the database returns" "still not 200 after 120s" \
+      "recovery without a restart is the point; a probe that latches DOWN needs a rollout to clear"
+  fi
+  local restarts_after
+  restarts_after="$(kc get pod "$pod" -o jsonpath='{.status.containerStatuses[0].restartCount}' 2>/dev/null)"
+  assert_eq "${restarts_before:-0}" "${restarts_after:-x}" \
+    "liveness restarted a process whose only problem was its dependency"
+  probe_done
+}


### PR DESCRIPTION
Refs #2178 — closes its second platform, the one its acceptance criteria named and the compose harness declared as its largest gap.

`helm template` proves the chart produces YAML. It proves nothing about whether Kubernetes honours it: `securityContext` is a **request**, admission is a separate judge, and a mounted secret that is never opened looks exactly like one that is. So every probe here reads its answer from the layer that actually decides it.

## The run, on Docker Desktop Kubernetes v1.36.1

```
P-K8S-AUTH-GUARD   [broken]  a stock install is refused at render, naming every configured way forward
P-K8S-BOOT         [working] the chart's default values install and the Deployment rolls out
P-K8S-SERVE        [working] the deployed CDR serves a real openEHR write and read
P-K8S-RUNTIME      [working] the runtime applied non-root, no-new-privileges, no capabilities, read-only root, seccomp
P-K8S-MOUNTS       [working] configuration and secret mounts are read-only in the runtime spec
P-K8S-PSA          [working] the chart's pods are admitted under the Restricted profile
P-K8S-PSA-ARMED    [broken]  a privileged pod is REFUSED, proving enforcement is really on
P-K8S-SVCLINKS     [working] a new ferroehr-named Service does not poison the pod's environment
P-K8S-SECRET-ENV   [working] no credential value appears in the pod environment or the ConfigMap
P-K8S-SECRET-READ  [broken]  a *_file key pointing at a missing path makes the boot REFUSE, naming the file
P-K8S-READY-GATES  [broken]  with the database gone, readiness fails, the pod leaves the Service, and liveness does not restart it

passed 11   failed 0   not exercised 5
```

## Why each one is read where it is

- **The security posture comes from `crictl inspect`, not the pod spec.** An **empty** capability bounding set is a fact about the kernel; `drop: [ALL]` is a request, and a request a runtime quietly declines looks identical in `kubectl get pod -o yaml`. Same for the read-only root, the uid and seccomp resolving to `SCMP_ACT_ERRNO` rather than to no filter at all.
- **Admission is judged by the API server.** Re-reading the Restricted profile and grading our own manifest is the check that cannot fail honestly. And because a green result would say nothing on a cluster enforcing nothing, a privileged pod is offered alongside and its refusal is what proves the judge was awake.
- **A secret is proven READ by breaking its path.** Mounted and read are different claims and only one is worth anything; the boot must refuse *naming the unreadable file*, or an operator cannot act on it.
- **Readiness is proven to gate by the EndpointSlice.** A pod that reports itself unready and stays in the Service still receives production traffic. The kubelet's own verdict is asserted too — our curl answering 503 is only half the claim — along with liveness **not** restarting a process whose only problem is its dependency, and recovery without a rollout.
- **The render-time refusal is itself a probe.** Authentication is on by default with no mechanism configured by default, and the failure mode that costs an afternoon is a pod that starts, crash-loops, and explains itself in a log nobody has tailed. The refusal must name the Basic route, the OIDC route *and* the development escape — a refusal that names none of them is just a different wall.

## The database

A compose PostgreSQL the chart is pointed at, which is the faithful shape rather than a convenience: the chart provisions no database and takes an external DSN. The address a pod can reach is **measured** — which of `host.docker.internal`, the gateway alias, or the node's default route answers is a property of the cluster, not something a script may declare.

## Four defects found in the harness itself, attributed before they were fixed

That discipline applies to the instrument, not only to the SUT:

1. **A Service port-forward has no ready endpoint in exactly the state the readiness probe observes.** It reported `000` — a connection failure — against a server that was behaving correctly. The observation channel vanished precisely when it was needed; readiness is now watched through a pod-scoped forward.
2. **The pod selector took `.items[0]`**, which right after the deliberately-broken-boot probe is the crash-looping pod still terminating. It waited for a container that would never serve and called that a readiness finding.
3. **Node detection went through `docker ps`.** Docker Desktop keeps its Kubernetes node out of the container list while `docker exec` into it works perfectly — so the strongest probe in the file silently downgraded itself to "not exercised". A false gap is worse than a red row, because it reads as honesty.
4. **The database's address was asked for once.** `pg_isready` answers from inside the container before Docker has finished publishing the port, so a single attempt reported "no address works" about a database that simply was not published yet — the same lesson the observability family learned about fixed sleeps.

## Declared gaps, in the run's own output

NetworkPolicy enforcement (a property of the CNI, so a green result would say nothing about an operator's cluster), load balancing across replicas, horizontal autoscaling, Ingress/TLS, and the console on this platform (#2164). None of them is silently absent.

`.claude/rules/kubernetes-helm.md` now points its prime rule at this harness and lists it in the enforcement register, so live behaviour moves from review-enforced habit to a measured record for the four properties it covers.