### PR TITLE
ci(crates): make the publish lane resumable, and refuse to report success on a split set

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -17,9 +17,12 @@
 #   - `cargo publish --workspace` resolves the inter-crate dependency order
 #     itself (Cargo ≥1.90) and skips the `publish = false` members (the
 #     app/tools crates), so the eight spec crates are exactly what ships.
-#     Publishing is non-atomic upstream: if a late upload fails, re-running
-#     the workflow retries the missing crates (already-published versions
-#     fail individually without harming the rest).
+#     Publishing is non-atomic upstream AND all-or-nothing at the start:
+#     `cargo publish --workspace` refuses the entire run when ANY member
+#     version already exists, so a partial publish could not be finished by
+#     re-running it. This lane therefore publishes per crate in dependency
+#     order, treats "already exists" as done, and verifies the whole set
+#     against the registry before reporting success.
 name: Publish crates
 
 on:
@@ -85,4 +88,64 @@ jobs:
       - name: Publish the workspace's publishable crates in dependency order
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-        run: cargo publish --workspace --locked
+        # `cargo publish --workspace` is all-or-nothing at the START: it refuses
+        # the whole run if ANY member version already exists
+        # (`error: crate openehr-am@0.0.15 already exists on crates.io index`),
+        # while being NON-atomic at the end — a late upload can fail after
+        # earlier ones landed. Those two together are what stranded
+        # openehr-its/openehr-adl at 0.0.10 while six siblings reached 0.0.15,
+        # and they make a re-run useless exactly when a re-run is what is needed.
+        #
+        # So publish per crate in dependency order, treating "already exists" as
+        # done rather than as failure. That makes the lane RESUMABLE: re-running
+        # after a partial publish finishes the set instead of refusing.
+        run: |
+          set -uo pipefail
+          failed=""
+          for crate in openehr-base openehr-lang openehr-term openehr-rm \
+                       openehr-am openehr-query openehr-its openehr-adl; do
+            echo "::group::$crate"
+            out="$(cargo publish -p "$crate" --locked 2>&1)" || true
+            printf '%s\n' "$out"
+            echo "::endgroup::"
+            case "$out" in
+              *"already exists on crates.io index"*|*"already uploaded"*)
+                echo "$crate: already published at this version — nothing to do" ;;
+              *)
+                if ! printf '%s' "$out" | grep -q "Uploaded $crate"; then
+                  failed="$failed $crate"
+                fi ;;
+            esac
+          done
+          [ -z "$failed" ] || { echo "::error::failed to publish:$failed"; exit 1; }
+
+      # The lane must not report success on a SPLIT set: the eight crates are
+      # lockstep, and while the line is 0.0.x cargo treats every 0.0.x as its own
+      # compatibility set — so a straggler makes its siblings' internal
+      # requirements unresolvable for every consumer. Read the registry rather
+      # than trusting the exit code above.
+      - name: Verify all eight crates resolve at the same version
+        if: inputs.publish
+        run: |
+          set -euo pipefail
+          want="$(grep -m1 '^version = ' crates/openehr-base/Cargo.toml | cut -d'"' -f2)"
+          echo "expecting $want"
+          bad=""
+          for crate in openehr-base openehr-lang openehr-term openehr-rm \
+                       openehr-am openehr-query openehr-its openehr-adl; do
+            # The index is eventually consistent right after an upload.
+            got=""
+            for _ in 1 2 3 4 5 6; do
+              got="$(curl -sL -H 'User-Agent: ferroehr-publish-verify' \
+                     "https://crates.io/api/v1/crates/$crate/versions" \
+                     | jq -r --arg v "$want" '.versions[] | select(.num == $v) | .num' | head -1)"
+              [ -n "$got" ] && break
+              sleep 10
+            done
+            printf '%-16s %s\n' "$crate" "${got:-MISSING}"
+            [ -n "$got" ] || bad="$bad $crate"
+          done
+          [ -z "$bad" ] || {
+            echo "::error::the published set is SPLIT — these are not at $want:$bad"
+            exit 1
+          }


### PR DESCRIPTION
Refs #2211 — the P0. This is the lane fix; the registry repair rides on it.

## What happened

`cargo publish --workspace` uploaded six of the eight crates at `0.0.15`, then died calling it its own internal error, leaving `openehr-its` and `openehr-adl` at `0.0.10`. While the line is `0.0.x`, **cargo treats every `0.0.x` as its own compatibility set**, so this is not "two crates slightly behind" — the six published crates declare `0.0.15` internal requirements that resolve to nothing. Every consumer gets an unresolvable graph.

Then the obvious repair turned out to be impossible:

```
$ cargo publish --workspace --locked
error: crate openehr-am@0.0.15 already exists on crates.io index
```

`cargo publish --workspace` is **all-or-nothing at the start** (it refuses the whole run if any member version exists) and **non-atomic at the end** (a late upload can fail after earlier ones landed). Those two together mean a partial publish cannot be finished by re-running the thing that half-finished it. The workflow header actually claimed the opposite — that a re-run "retries the missing crates" — which is now corrected, because a comment that promises a recovery path that does not exist is worse than no comment.

## The fix

**Resumable**: publish per crate in dependency order, treating "already exists" as *done* rather than as failure. A re-run finishes the set.

**Verified**: the lane had no idea what it had published — it exited on cargo's status, and nobody would have discovered the split without reading the log. It now reads the registry back and fails if any of the eight is missing at the expected version, with the index's eventual consistency waited out rather than raced. Success now means the published set is whole, which is the only thing the lockstep rule actually cares about.

## One constraint, recorded because it nearly went wrong

The repair has to publish **the exact tree the six came from**. `develop` still pointed at that commit when this was written; had an unrelated `openehr-its` change landed first, a re-run would have published *different code* under the same version number, with no way to tell the two apart afterwards. This PR only touches the workflow, so packaged crate bytes are unchanged.

## Verification

- `yaml` parses; `zizmor --min-severity=low` reports no findings
- The failure mode is quoted from the real run: <https://github.com/rubentalstra/FerroEHR/actions/runs/31372359528>