### PR TITLE
ci(crates): a transient registry error read as a split set, and the rule still mandated the broken command

### DIFF
--- a/.claude/rules/changelog.md
+++ b/.claude/rules/changelog.md
@@ -76,15 +76,25 @@ optional:
   (dry-run by default; a real publish needs the `publish` input set to
   `true`) that authenticates via **crates.io Trusted Publishing** (OIDC,
   `rust-lang/crates-io-auth-action`, `id-token: write`, the `crates-io`
-  environment) and runs `cargo publish --workspace` over the eight
-  `crates/*` members in dependency order — no long-lived crates.io token
-  exists anywhere. Version bumps happen in the CONTENT PR, not at publish
+  environment) and publishes the eight `crates/*` members **one at a time in
+  dependency order**, treating "already exists on crates.io index" as done —
+  no long-lived crates.io token exists anywhere. It is deliberately NOT
+  `cargo publish --workspace`: that command is all-or-nothing at the START
+  (it refuses the entire run if any member version already exists) while
+  being non-atomic at the END, so a partial publish cannot be finished by
+  re-running it. That combination stranded `openehr-its` and `openehr-adl` at
+  `0.0.10` while six siblings reached `0.0.15` (issue #2211), and a split set
+  is a broken graph for every consumer, not a cosmetic lag. The lane also
+  reads the registry back before reporting success, so a publish that
+  finished half the set fails instead of going green. Version bumps happen in the CONTENT PR, not at publish
   time: any PR changing packaged crate content bumps every crate's `version`
   and the internal `version =` requirements together (lockstep `0.0.x` —
   the `crate-version-guard` CI job and the local push hook enforce it; full
   rule in `.claude/rules/crates-publishing.md`), so a publish just ships the
   version already in the tree — verify locally with
-  `cargo publish --workspace --dry-run`. The very first release
+  `cargo publish --workspace --dry-run` (the whole-workspace form is still
+  the right DRY RUN: nothing is uploaded, so its all-or-nothing behaviour
+  costs nothing and it checks every member together). The very first release
   of a crate cannot use OIDC (crates.io requires an existing crate to
   configure a Trusted Publisher) — it is pushed manually with a scoped API
   token, after which each crate's Trusted Publisher is configured on

--- a/.claude/rules/crates-publishing.md
+++ b/.claude/rules/crates-publishing.md
@@ -54,6 +54,27 @@ by the `crate-version-guard` CI job.
   (`.claude/rules/reliability.md`) — the version chosen then is still ours,
   never a spec number.
 
+## The publish lane is per crate, resumable, and verified
+
+`publish-crates.yml` publishes the eight members **one at a time in
+dependency order**, treats "already exists on crates.io index" as done, and
+reads the registry back before reporting success.
+
+It is deliberately not `cargo publish --workspace` for the real upload.
+That command is all-or-nothing at the START — it refuses the whole run if any
+member version already exists — while being non-atomic at the END, so a
+partial publish cannot be finished by re-running it. Issue #2211 is the live
+proof: six crates reached `0.0.15`, `openehr-its` and `openehr-adl` stayed at
+`0.0.10`, and the retry was refused. Under lockstep `0.0.x`, where cargo
+treats every `0.0.x` as its own compatibility set, that is a broken
+dependency graph for every consumer rather than a cosmetic lag — which is why
+the lane now fails when the published set is incomplete instead of exiting on
+cargo's status.
+
+`cargo publish --workspace --dry-run` remains the right whole-workspace
+check: nothing is uploaded, so the all-or-nothing behaviour costs nothing and
+every member is verified together.
+
 ## Packaging hygiene
 
 - A new runtime-embedded asset (`include_str!`/`include_bytes!`) MUST be

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -133,12 +133,21 @@ jobs:
           bad=""
           for crate in openehr-base openehr-lang openehr-term openehr-rm \
                        openehr-am openehr-query openehr-its openehr-adl; do
-            # The index is eventually consistent right after an upload.
+            # The index is eventually consistent right after an upload, so a
+            # miss is retried rather than believed. A FAILED REQUEST is not a
+            # miss either: without --fail, curl hands an error BODY to jq, jq
+            # dies on the absent .versions, and `pipefail` ends the whole step —
+            # so one transient 429 would report a split set that does not exist.
+            # Guarding the pipeline in an `if` keeps a bad response as "not seen
+            # yet" and lets the remaining polls run.
             got=""
             for _ in 1 2 3 4 5 6; do
-              got="$(curl -sL -H 'User-Agent: ferroehr-publish-verify' \
-                     "https://crates.io/api/v1/crates/$crate/versions" \
-                     | jq -r --arg v "$want" '.versions[] | select(.num == $v) | .num' | head -1)"
+              if body="$(curl -sSL --fail -H 'User-Agent: ferroehr-publish-verify' \
+                         "https://crates.io/api/v1/crates/$crate/versions" 2>/dev/null)"; then
+                got="$(printf '%s' "$body" \
+                       | jq -r --arg v "$want" '.versions[]? | select(.num == $v) | .num' \
+                       | head -1)" || got=""
+              fi
               [ -n "$got" ] && break
               sleep 10
             done


### PR DESCRIPTION
Refs #2211. Two corrections from CodeRabbit's review of #2213 — both findings were right, and one of them is a real bug in the merged change.

## 1. The verification step could report a split set that does not exist

The poll ran `curl -sL … | jq …` under `set -euo pipefail`. Without `--fail`, curl hands an HTTP **error body** to `jq`, `jq` dies on the absent `.versions`, and `pipefail` ends the whole step. So one transient `429` or `5xx` from crates.io would have failed the run and announced a split publish — in the one place whose entire purpose is telling the truth about whether the set is whole. A verification gate that cries wolf on a rate limit is worse than none, because the next real split gets read as noise.

The request is now guarded in an `if`: a failed response means "not seen yet", and the remaining polls run.

## 2. The governing rule still mandated the command that cannot work

This is a genuine policy conflict, not a style note, and CodeRabbit was correct to stop on it: `.claude/rules/changelog.md` required `cargo publish --workspace` in dependency order, and the lane no longer does that.

The resolution is to fix the **rule**, because its factual premise is disproved. `cargo publish --workspace` is all-or-nothing at the START — it refuses the entire run if any member version already exists — while being **non-atomic at the END**. Those two together mean a partial publish cannot be finished by re-running the thing that half-finished it, which is exactly what #2211 hit:

```
error: crate openehr-am@0.0.15 already exists on crates.io index
```

Six crates at `0.0.15`, `openehr-its` and `openehr-adl` stranded at `0.0.10`, and no way back through the mandated command. Under lockstep `0.0.x` — where cargo treats every `0.0.x` as its own compatibility set — that is a broken dependency graph for every consumer, not a crate or two lagging.

A rule whose premise is false is worse than no rule: it would have blocked the only design that can recover the exact failure it was written to prevent. Both `changelog.md` and `crates-publishing.md` now describe the per-crate resumable lane and record *why*, with the reproduction, so the next person does not re-litigate it from the command's name.

**`cargo publish --workspace --dry-run` is deliberately kept**, and the rule now says so explicitly: nothing is uploaded, so the all-or-nothing behaviour costs nothing and every member is checked together. The change is to the upload, not to the check.

## What did not change

Manual `workflow_dispatch` only, dry run by default, crates.io Trusted Publishing via OIDC with no long-lived token, dependency order, lockstep versions. The only difference is that the lane can now finish what it started — and refuses to call a half-published set a success.