### PR TITLE
test(deploy): the compose harness still declared Kubernetes unprobed after the Kubernetes harness landed

### DIFF
--- a/scripts/deploy-probe.sh
+++ b/scripts/deploy-probe.sh
@@ -102,7 +102,7 @@ probes_observability
 # Everything #2178 asks for that this run does NOT do. Each entry is a probe
 # somebody still has to write; none of them is silently absent.
 uncovered "kubernetes platform" \
-  "this harness drives compose only; the chart is exercised by the k8s-test skill by hand"
+  "a separate harness covers it — scripts/deploy-probe-k8s.sh, recorded in kubernetes.json"
 uncovered "admin console journeys (#2164)" \
   "scripts/ui-e2e.sh already drives these with a real browser; folding it in is the next step"
 uncovered "FHIR, events, tenancy, terminology" \


### PR DESCRIPTION
Refs #2178.

The compose harness ends every run with what it did **not** exercise, and that list is the instrument's honesty claim — the reason a green result can be trusted at all. Since #2207 it has been wrong: it still said the Kubernetes platform is unprobed and points at a manual skill, when `scripts/deploy-probe-k8s.sh` covers it and writes `kubernetes.json`.

A ledger naming a gap that is closed is the same defect as one omitting a gap that is open. Both make the output untrue, and this one degrades in the direction that looks humble, which is exactly why nobody would have caught it by reading.

Verified on a fresh `develop` image built from source: **27 passed, 0 failed**, three declared gaps — now Kubernetes-free and reading FHIR/events/tenancy/terminology, the console journeys (#2164), and the pointer to the Kubernetes harness.