### PR TITLE
ci(crates): a successful publish reported failure, and the check that would have said so was skipped

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -108,11 +108,17 @@ jobs:
             out="$(cargo publish -p "$crate" --locked 2>&1)" || true
             printf '%s\n' "$out"
             echo "::endgroup::"
-            case "$out" in
+            # Match against ANSI-STRIPPED text. This job sets
+            # CARGO_TERM_COLOR: always, and cargo colours the status word
+            # alone — the bytes are `Uploaded<RESET> openehr-adl`, so a
+            # literal "Uploaded openehr-adl" never matches and a perfectly
+            # successful publish is reported as a failure.
+            plain="$(printf '%s' "$out" | sed -E 's/\x1b\[[0-9;]*m//g')"
+            case "$plain" in
               *"already exists on crates.io index"*|*"already uploaded"*)
                 echo "$crate: already published at this version — nothing to do" ;;
               *)
-                if ! printf '%s' "$out" | grep -q "Uploaded $crate"; then
+                if ! printf '%s' "$plain" | grep -q "Uploaded $crate"; then
                   failed="$failed $crate"
                 fi ;;
             esac
@@ -125,7 +131,13 @@ jobs:
       # requirements unresolvable for every consumer. Read the registry rather
       # than trusting the exit code above.
       - name: Verify all eight crates resolve at the same version
-        if: inputs.publish
+        # `always()`, because this step is the GROUND TRUTH and a failed publish
+        # step is exactly when it is most needed. Without it GitHub skips the
+        # verification on failure, so a run that actually published everything
+        # but misread its own output ends red with nothing to contradict it —
+        # and a run that genuinely stranded a crate ends red with no record of
+        # WHICH one.
+        if: always() && inputs.publish
         run: |
           set -euo pipefail
           want="$(grep -m1 '^version = ' crates/openehr-base/Cargo.toml | cut -d'"' -f2)"


### PR DESCRIPTION
Refs #2211. **The split is repaired** — all eight crates now resolve at `0.0.15` on crates.io. This PR fixes two defects the repair run exposed in the lane itself.

## The registry, verified just now

```
openehr-base 0.0.15   openehr-am    0.0.15
openehr-lang 0.0.15   openehr-query 0.0.15
openehr-term 0.0.15   openehr-its   0.0.15
openehr-rm   0.0.15   openehr-adl   0.0.15
```

`crates/` was byte-identical to `58320aa0` — the commit the first six were published from — so `0.0.15` names one tree, which was the constraint that made this repair honest rather than a version number quietly meaning two things.

## 1. Every successful publish would have been reported as a failure

The run that fixed the split **exited 1**, claiming it had failed to publish `openehr-its openehr-adl` — the two crates its own log shows as `Uploaded` and `Published`.

The job sets `CARGO_TERM_COLOR: always`, and cargo colours the status word by itself. The actual bytes are:

```
\e[1m\e[92m    Uploaded\e[0m openehr-adl v0.0.15 to registry `crates-io`
```

So the literal `"Uploaded openehr-adl"` the success check grepped for is never present — the reset sequence sits between the word and the crate name. This was not specific to those two crates; **no** publish could ever have been detected as successful. Matching now runs against ANSI-stripped text, verified against that exact byte sequence rather than against a guess about how cargo formats.

## 2. The check that would have caught it was skipped, by design, at the worst moment

The registry verification carried `if: inputs.publish`. GitHub skips remaining steps once one fails, so the moment the publish step went red the ground-truth check was bypassed — the one place that could have said "actually, all eight are present".

That cuts both ways, and both are bad:

- a run that published everything but misread its own output ends red with nothing able to contradict it (what happened here), and
- a run that genuinely stranded a crate ends red **without recording which one** — the exact information #2211 needed and had to be reconstructed by hand from the registry API.

It now runs on `always()`. The verification is the authority on what was published; a failed publish step is when that authority matters most.

## Why this pair matters beyond the annoyance

A publishing lane that cries wolf gets ignored, and an ignored publish lane is how a split set reaches the registry unnoticed in the first place. The point of #2211's fix was that success should mean the published set is whole — which requires failure to mean something too.