### PR TITLE
refactor(its): every import names its defining module — the nine re-exports are gone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,6 +274,13 @@ workflow refuses a tag that has no matching section here.
 
 ### Changed
 
+- **Every import from `openehr-its` now names the module that defines it.** The
+  crate's nine convenience re-exports are gone, so consumers write
+  `opt14::types::CObject` and `xml::runtime::ToXml` rather than borrowing those
+  names from a parent module. Longer at the use site, and it says where a type
+  comes from. Affects anyone depending on the published `openehr-its` crate; no
+  behaviour, wire format or serialization changes with it.
+
 - **`probes.exec` is removed** (breaking, for anyone who set it). It ran
   `ferroehr healthcheck` for liveness, readiness *and* startup, passed no
   `--url`, and that flag defaults to the openEHR status document rather than a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5485,7 +5485,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "indexmap 2.14.0",
  "openehr-am",
@@ -5500,7 +5500,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "serde",
  "serde_json",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "async-trait",
  "axum",
@@ -5558,7 +5558,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "assert_fs",
  "chumsky",
@@ -5572,7 +5572,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "chumsky",
  "logos",
@@ -5581,7 +5581,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "insta",
  "jsonschema",
@@ -5598,7 +5598,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/app/ferroehr-admin-ui/src/builder/catalog.rs
+++ b/app/ferroehr-admin-ui/src/builder/catalog.rs
@@ -2,7 +2,7 @@
 //!
 //! A slim, serializable tree distilled BFF-side from the Web Template (built
 //! from the CDR's OPT with
-//! `openehr_its::flat::webtemplate::build_web_template` — the same code the
+//! `openehr_its::flat::webtemplate::builder::build_web_template` — the same code the
 //! CDR serves `application/openehr.wt+json` with) and shipped to the browser.
 //! Node shape per `docs/specs/openehr/ITS-REST/docs/simplified_formats/
 //! master04-basic_concepts.adoc` §"Web Template Metadata".
@@ -47,13 +47,13 @@ pub struct CatalogNode {
 /// Distill the Web Template tree into the catalog (BFF-side).
 #[cfg(feature = "ssr")]
 #[must_use]
-pub fn from_web_template(wt: &openehr_its::flat::webtemplate::WebTemplate) -> CatalogNode {
+pub fn from_web_template(wt: &openehr_its::flat::webtemplate::model::WebTemplate) -> CatalogNode {
     node(&wt.tree)
 }
 
 #[cfg(feature = "ssr")]
-fn node(wt: &openehr_its::flat::webtemplate::WebTemplateNode) -> CatalogNode {
-    use openehr_its::flat::webtemplate::WebTemplateInputType;
+fn node(wt: &openehr_its::flat::webtemplate::model::WebTemplateNode) -> CatalogNode {
+    use openehr_its::flat::webtemplate::model::WebTemplateInputType;
 
     let label = wt
         .localized_name
@@ -95,7 +95,7 @@ fn node(wt: &openehr_its::flat::webtemplate::WebTemplateNode) -> CatalogNode {
 
 #[cfg(all(test, feature = "ssr"))]
 mod tests {
-    use openehr_its::flat::webtemplate::{
+    use openehr_its::flat::webtemplate::model::{
         WebTemplateCodedValue, WebTemplateInput, WebTemplateInputType, WebTemplateNode,
     };
 
@@ -138,7 +138,7 @@ mod tests {
         root.id = "vitals".to_owned();
         root.children.push(obs);
 
-        let wt = openehr_its::flat::webtemplate::WebTemplate {
+        let wt = openehr_its::flat::webtemplate::model::WebTemplate {
             template_id: "vitals.v1".to_owned(),
             sem_ver: None,
             version: "2.3".to_owned(),

--- a/app/ferroehr-admin-ui/src/pages/template_detail.rs
+++ b/app/ferroehr-admin-ui/src/pages/template_detail.rs
@@ -62,7 +62,7 @@ pub async fn fetch_template_opt(
 /// The OPT XML is parsed with
 /// [`openehr_its::opt14::from_xml`](openehr_its::opt14::from_xml) — the OPT 1.4
 /// canonical-XML parse entry (root `<template>` = `OPERATIONAL_TEMPLATE`) —
-/// then [`openehr_its::flat::webtemplate::build_web_template`] produces the Web
+/// then [`openehr_its::flat::webtemplate::builder::build_web_template`] produces the Web
 /// Template, and [`crate::builder::catalog::from_web_template`] the slim
 /// serializable tree.
 ///
@@ -88,7 +88,7 @@ pub async fn fetch_template_catalog(
     let xml = crate::cdr::CdrClient::expect_success(response)?.body;
     let opt = openehr_its::opt14::from_xml(&xml)
         .map_err(|e| AdminUiError::Internal(format!("OPT 1.4 parse: {e}")))?;
-    let web_template = openehr_its::flat::webtemplate::build_web_template(&opt)
+    let web_template = openehr_its::flat::webtemplate::builder::build_web_template(&opt)
         .map_err(|e| AdminUiError::Internal(format!("WebTemplate build: {e}")))?;
     Ok(crate::builder::catalog::from_web_template(&web_template))
 }
@@ -137,7 +137,7 @@ pub async fn fetch_template_meta(
     let xml = crate::cdr::CdrClient::expect_success(response)?.body;
     let opt = openehr_its::opt14::from_xml(&xml)
         .map_err(|e| AdminUiError::Internal(format!("OPT 1.4 parse: {e}")))?;
-    let web_template = openehr_its::flat::webtemplate::build_web_template(&opt)
+    let web_template = openehr_its::flat::webtemplate::builder::build_web_template(&opt)
         .map_err(|e| AdminUiError::Internal(format!("WebTemplate build: {e}")))?;
     Ok(TemplateMeta {
         template_id: opt.template_id.value.clone(),

--- a/app/ferroehr-ext/src/fhir/mapping.rs
+++ b/app/ferroehr-ext/src/fhir/mapping.rs
@@ -400,7 +400,8 @@ mod tests {
     use std::path::PathBuf;
 
     use openehr_its::flat::convert::composition_from_flat;
-    use openehr_its::flat::webtemplate::{WebTemplate, build_web_template};
+    use openehr_its::flat::webtemplate::builder::build_web_template;
+    use openehr_its::flat::webtemplate::model::WebTemplate;
     use openehr_its::opt14;
     use serde_json::json;
 

--- a/app/ferroehr-ext/src/fhir/reverse.rs
+++ b/app/ferroehr-ext/src/fhir/reverse.rs
@@ -48,7 +48,7 @@ use super::mapping::{FhirMapError, FhirMappingDefinition, MappingEntry, Transfor
 pub fn to_fhir(
     resource_type: &str,
     composition: &Value,
-    wt: &openehr_its::flat::webtemplate::WebTemplate,
+    wt: &openehr_its::flat::webtemplate::model::WebTemplate,
     def: &FhirMappingDefinition,
     subject_id: Option<&str>,
 ) -> Result<Value, FhirMapError> {
@@ -218,7 +218,8 @@ mod tests {
     use std::path::PathBuf;
 
     use openehr_its::flat::convert::composition_from_flat;
-    use openehr_its::flat::webtemplate::{WebTemplate, build_web_template};
+    use openehr_its::flat::webtemplate::builder::build_web_template;
+    use openehr_its::flat::webtemplate::model::WebTemplate;
     use openehr_its::opt14;
     use serde_json::json;
 

--- a/app/ferroehr-rest/src/api/demographic/party.rs
+++ b/app/ferroehr-rest/src/api/demographic/party.rs
@@ -409,7 +409,7 @@ fn rm_party<Stable, Current>(
 ) -> Result<Current, ApiError>
 where
     Stable: serde::de::DeserializeOwned + serde::Serialize,
-    Current: openehr_its::xml::FromXml + serde::de::DeserializeOwned,
+    Current: openehr_its::xml::runtime::FromXml + serde::de::DeserializeOwned,
 {
     let stable_json = profile == ferroehr::config::profile::SpecProfile::Stable
         && matches!(

--- a/app/ferroehr-rest/src/formats/dispatch.rs
+++ b/app/ferroehr-rest/src/formats/dispatch.rs
@@ -197,7 +197,7 @@ pub(crate) async fn composition_flat_response(
 pub(crate) fn composition_flat_response_with(
     status: StatusCode,
     comp: &Value,
-    wt: &openehr_its::flat::webtemplate::WebTemplate,
+    wt: &openehr_its::flat::webtemplate::model::WebTemplate,
 ) -> Result<Response, RestError> {
     let flat = openehr_its::flat::convert::composition_to_flat(comp, wt)
         .map_err(|e| flat_output_err(&e))?;
@@ -226,7 +226,7 @@ pub(crate) async fn composition_structured_response(
 pub(crate) fn composition_structured_response_with(
     status: StatusCode,
     comp: &Value,
-    wt: &openehr_its::flat::webtemplate::WebTemplate,
+    wt: &openehr_its::flat::webtemplate::model::WebTemplate,
 ) -> Result<Response, RestError> {
     let structured = openehr_its::flat::convert::composition_to_structured(comp, wt)
         .map_err(|e| flat_output_err(&e))?;

--- a/app/ferroehr-rest/src/overview/negotiate.rs
+++ b/app/ferroehr-rest/src/overview/negotiate.rs
@@ -71,7 +71,7 @@ use bytes::Bytes;
 use http::{HeaderMap, HeaderValue, StatusCode, header};
 
 use openehr_its::rest::runtime::ApiError;
-use openehr_its::xml::{FromXml, Namespace, ToXml};
+use openehr_its::xml::runtime::{FromXml, Namespace, ToXml};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 

--- a/app/ferroehr-rest/tests/it/flat_http.rs
+++ b/app/ferroehr-rest/tests/it/flat_http.rs
@@ -75,9 +75,9 @@ fn canonical_composition() -> Value {
 }
 
 /// The IPS `WebTemplate` (built from the vendored OPT).
-fn web_template() -> openehr_its::flat::webtemplate::WebTemplate {
+fn web_template() -> openehr_its::flat::webtemplate::model::WebTemplate {
     let opt = openehr_its::opt14::from_xml(&opt_xml()).expect("parse OPT");
-    openehr_its::flat::webtemplate::build_web_template(&opt).expect("build web template")
+    openehr_its::flat::webtemplate::builder::build_web_template(&opt).expect("build web template")
 }
 
 fn config() -> AppConfig {

--- a/app/ferroehr/src/service/admin/dump_load.rs
+++ b/app/ferroehr/src/service/admin/dump_load.rs
@@ -106,7 +106,7 @@ use serde_json::Value;
 use sqlx::{PgConnection, Row};
 use uuid::Uuid;
 
-use openehr_its::xml::{FromXml, Namespace, ToXml};
+use openehr_its::xml::runtime::{FromXml, Namespace, ToXml};
 use openehr_rm::prelude::{Composition, EhrAccess, EhrStatus, Folder, OriginalVersion};
 use serde::de::DeserializeOwned;
 

--- a/app/ferroehr/src/service/definition/adl2.rs
+++ b/app/ferroehr/src/service/definition/adl2.rs
@@ -34,7 +34,8 @@ use openehr_am::v2_4::aom2::archetype::authored_archetype::AuthoredArchetype;
 use openehr_am::v2_4::aom2::archetype::operational_template::OperationalTemplate;
 use openehr_base::validate::InvariantViolation;
 use openehr_its::flat::example::{DetailLevel, ExampleType, apply_output_uid, example_composition};
-use openehr_its::flat::webtemplate::{WebTemplate, build_web_template_v2_4};
+use openehr_its::flat::webtemplate::builder_v2_4::build_web_template_v2_4;
+use openehr_its::flat::webtemplate::model::WebTemplate;
 use serde_json::Value;
 use sqlx::Row;
 
@@ -558,7 +559,7 @@ impl FerroEhrService {
     /// The stored source is resolved (`template_id` → HRID), parsed, compiled to
     /// its operational template (`create_opt`), turned into a `WebTemplate` by
     /// the `v2_4` front end
-    /// ([`openehr_its::flat::webtemplate::build_web_template_v2_4`]),
+    /// ([`openehr_its::flat::webtemplate::builder_v2_4::build_web_template_v2_4`]),
     /// and walked into a canonical example COMPOSITION at the requested
     /// [`DetailLevel`] — the same shared generator the ADL 1.4 example endpoint
     /// uses (`ITS-REST simplified_formats master04 §"Web Template Metadata"` is

--- a/app/ferroehr/src/service/definition/opt14_convert.rs
+++ b/app/ferroehr/src/service/definition/opt14_convert.rs
@@ -132,7 +132,7 @@ pub(crate) struct OptConversion {
 /// - [`OptConvertError::Print`] if a converted source carries a node the ADL2
 ///   serializer has no syntax for.
 pub(crate) fn convert_opt_to_adl2(
-    opt: &opt14::OperationalTemplate,
+    opt: &opt14::types::OperationalTemplate,
 ) -> Result<OptConversion, OptConvertError> {
     let (archetypes, structure) = convert_opt_to_archetypes(opt)?;
     let roots = archetypes
@@ -183,7 +183,7 @@ fn minimal_description(conversion_details: BTreeMap<String, String>) -> Resource
 }
 
 pub(crate) fn convert_opt_to_archetypes(
-    opt: &opt14::OperationalTemplate,
+    opt: &opt14::types::OperationalTemplate,
 ) -> Result<(ConvertedRoots, Vec<FillEdge>), OptConvertError> {
     let mut dx = Decomposer {
         language: opt.language.code_string.clone(),
@@ -292,8 +292,8 @@ impl RootCx {
 
 struct Decomposer<'a> {
     language: String,
-    root_ontology: Option<&'a opt14::FlatArchetypeOntology>,
-    component_ontologies: &'a [opt14::FlatArchetypeOntology],
+    root_ontology: Option<&'a opt14::types::FlatArchetypeOntology>,
+    component_ontologies: &'a [opt14::types::FlatArchetypeOntology],
     units: Vec<RawUnit>,
     edges: Vec<FillEdge>,
 }
@@ -303,7 +303,7 @@ impl Decomposer<'_> {
     /// (pushed onto `units`), recursing into any embedded child roots. `is_top`
     /// selects the OPT's top-level `ontology` vs a `component_ontologies` entry
     /// for the archetype's flattened terminology.
-    fn process_root(&mut self, root: &opt14::CArchetypeRoot, path: &str, is_top: bool) {
+    fn process_root(&mut self, root: &opt14::types::CArchetypeRoot, path: &str, is_top: bool) {
         let archetype_id = root.archetype_id.value.clone();
         // Slot at-codes are allocated strictly above every at-code node id used
         // by THIS root's own retained subtree (child roots are excluded — their
@@ -363,7 +363,7 @@ impl Decomposer<'_> {
         &self,
         archetype_id: &str,
         is_top: bool,
-    ) -> Option<&'_ opt14::FlatArchetypeOntology> {
+    ) -> Option<&'_ opt14::types::FlatArchetypeOntology> {
         if is_top {
             self.root_ontology
         } else {
@@ -375,7 +375,7 @@ impl Decomposer<'_> {
 
     fn map_attributes(
         &mut self,
-        attrs: &[opt14::CAttribute],
+        attrs: &[opt14::types::CAttribute],
         archetype_id: &str,
         path: &str,
         cx: &mut RootCx,
@@ -389,20 +389,20 @@ impl Decomposer<'_> {
 
     fn map_attribute(
         &mut self,
-        attr: &opt14::CAttribute,
+        attr: &opt14::types::CAttribute,
         archetype_id: &str,
         path: &str,
         cx: &mut RootCx,
     ) -> CAttribute {
         let (rm_attribute_name, existence, children, cardinality, is_multiple) = match attr {
-            opt14::CAttribute::CSingleAttribute(a) => (
+            opt14::types::CAttribute::CSingleAttribute(a) => (
                 a.rm_attribute_name.clone(),
                 &a.existence,
                 &a.children,
                 None,
                 false,
             ),
-            opt14::CAttribute::CMultipleAttribute(a) => (
+            opt14::types::CAttribute::CMultipleAttribute(a) => (
                 a.rm_attribute_name.clone(),
                 &a.existence,
                 &a.children,
@@ -429,7 +429,7 @@ impl Decomposer<'_> {
 
     fn map_object(
         &mut self,
-        obj: &opt14::CObject,
+        obj: &opt14::types::CObject,
         archetype_id: &str,
         path: &str,
         cx: &mut RootCx,
@@ -443,7 +443,7 @@ impl Decomposer<'_> {
             // the form EXPR_ARCHETYPE_REF matches EXPR_ARCHETYPE_ID_CONSTRAINT").
             // The fill edge is additionally recorded in the conversion
             // structure.
-            opt14::CObject::CArchetypeRoot(child) => {
+            opt14::types::CObject::CArchetypeRoot(child) => {
                 let slot_node_id = format!("at{}", cx.slot_num);
                 cx.slot_num += 1;
                 let child_id = child.archetype_id.value.clone();
@@ -470,7 +470,7 @@ impl Decomposer<'_> {
                 self.process_root(child, path, false);
                 slot
             }
-            opt14::CObject::CComplexObject(c) => {
+            opt14::types::CObject::CComplexObject(c) => {
                 let attributes = self.map_attributes(&c.attributes, archetype_id, path, cx);
                 complex(&c.rm_type_name, &c.node_id, &c.occurrences, attributes)
             }
@@ -480,7 +480,7 @@ impl Decomposer<'_> {
             // archetype and serialized by the printer as the `_default`
             // pseudo-attribute (`master06-default_values.adoc` §Syntax; the
             // intermediate is the canonical-JSON encoding).
-            opt14::CObject::TComplexObject(c) => {
+            opt14::types::CObject::TComplexObject(c) => {
                 let attributes = self.map_attributes(&c.attributes, archetype_id, path, cx);
                 let mut obj = complex(&c.rm_type_name, &c.node_id, &c.occurrences, attributes);
                 if let Some(dv) = &c.default_value
@@ -490,10 +490,10 @@ impl Decomposer<'_> {
                 }
                 obj
             }
-            opt14::CObject::CDefinedObject(c) => {
+            opt14::types::CObject::CDefinedObject(c) => {
                 complex(&c.rm_type_name, &c.node_id, &c.occurrences, Vec::new())
             }
-            opt14::CObject::ArchetypeInternalRef(r) => {
+            opt14::types::CObject::ArchetypeInternalRef(r) => {
                 CObject::CComplexObjectProxy(CComplexObjectProxy {
                     parent: None,
                     soc_parent: None,
@@ -513,7 +513,7 @@ impl Decomposer<'_> {
             // `archetype_id/value matches {/…/}` shape both models share. An
             // assertion that cannot be rendered/parsed falls back to an open
             // slot, reported in `conversion_details`.
-            opt14::CObject::ArchetypeSlot(s) => {
+            opt14::types::CObject::ArchetypeSlot(s) => {
                 let includes = map_slot_assertions(&s.includes, &s.node_id, "include", cx);
                 let excludes = map_slot_assertions(&s.excludes, &s.node_id, "exclude", cx);
                 CObject::ArchetypeSlot(ArchetypeSlot {
@@ -532,7 +532,7 @@ impl Decomposer<'_> {
             }
             // A coded-value constraint → the 1.4-shaped `C_TERMINOLOGY_CODE` the
             // converter rewrites (`terminology::code[,code…][;assumed]`).
-            opt14::CObject::CCodePhrase(c) => terminology_code(
+            opt14::types::CObject::CCodePhrase(c) => terminology_code(
                 &c.rm_type_name,
                 &c.node_id,
                 &c.occurrences,
@@ -550,7 +550,7 @@ impl Decomposer<'_> {
             // list is ALSO present the list constraint wins and the URI is
             // carried in `conversion_details` (no openEHR spec governs 1.4→2
             // conversion — our own design).
-            opt14::CObject::CCodeReference(c) => map_code_reference(c, cx),
+            opt14::types::CObject::CCodeReference(c) => map_code_reference(c, cx),
             // A `CONSTRAINT_REF` names an ac-code whose definition lives in the
             // flattened ontology's `constraint_definitions` (AOM 1.4
             // `constraint_ref.adoc`); ADL2 folds those into
@@ -558,12 +558,12 @@ impl Decomposer<'_> {
             // section), so the ac-code constraint resolves (VACDF/VTCBK). An
             // ac-code the ontology does NOT define would dangle — it stays an
             // unconstrained node, reported in `conversion_details`.
-            opt14::CObject::ConstraintRef(r) => map_constraint_ref(r, cx),
+            opt14::types::CObject::ConstraintRef(r) => map_constraint_ref(r, cx),
             // DV_ORDINAL: the 1.4 domain constrainer becomes the AOM2
             // `[value, symbol]` attribute tuple (`master04.4-cadl_second_order.adoc`
             // §Tuple Constraints — "the tuple constraint type replaces all
             // domain-specific constraint types defined in ADL/AOM 1.4").
-            opt14::CObject::CDvOrdinal(c) => ordinal_tuple(c, cx),
+            opt14::types::CObject::CDvOrdinal(c) => ordinal_tuple(c, cx),
             // DV_QUANTITY: property → a `property` terminology-code attribute;
             // the per-unit magnitude (and, where present, precision) lists →
             // the `[units, magnitude(, precision)]` attribute tuple (the
@@ -571,15 +571,15 @@ impl Decomposer<'_> {
             // vendored `C_QUANTITY_ITEM` carries no precision — including it
             // as a third tuple member uses the generic tuple mechanism, no
             // vendored spec section shows it: our own design).
-            opt14::CObject::CDvQuantity(c) => quantity_tuple(c, cx),
+            opt14::types::CObject::CDvQuantity(c) => quantity_tuple(c, cx),
             // DV_STATE: the 1.4 constrainer carries a state machine; the
             // vendored AM defines no ADL2/AOM2 constraint form for it (the
             // tuple mechanism covers co-varying attribute values, not state
             // machines) — a loose domain-typed complex object is the honest
             // valid constraint. No vendored openEHR spec governs DV_STATE
             // conversion — our own design; recorded in `conversion_details`.
-            opt14::CObject::CDvState(c) => dv_state_loose(c, cx),
-            opt14::CObject::CPrimitiveObject(c) => map_primitive_object(c, cx),
+            opt14::types::CObject::CDvState(c) => dv_state_loose(c, cx),
+            opt14::types::CObject::CPrimitiveObject(c) => map_primitive_object(c, cx),
         }
     }
 
@@ -592,7 +592,7 @@ impl Decomposer<'_> {
     fn build_terminology(
         &self,
         archetype_id: &str,
-        root: &opt14::CArchetypeRoot,
+        root: &opt14::types::CArchetypeRoot,
         is_top: bool,
         cx: &mut RootCx,
     ) -> ArchetypeTerminology {
@@ -719,12 +719,12 @@ impl Decomposer<'_> {
 
 /// The maximum at-code number among a root's own node ids (not descending into
 /// embedded child roots — their codes belong to the child's space).
-fn max_at_num(attrs: &[opt14::CAttribute]) -> i64 {
+fn max_at_num(attrs: &[opt14::types::CAttribute]) -> i64 {
     let mut max = 0;
     for attr in attrs {
         let children = match attr {
-            opt14::CAttribute::CSingleAttribute(a) => &a.children,
-            opt14::CAttribute::CMultipleAttribute(a) => &a.children,
+            opt14::types::CAttribute::CSingleAttribute(a) => &a.children,
+            opt14::types::CAttribute::CMultipleAttribute(a) => &a.children,
         };
         for child in children {
             max = max.max(max_at_num_obj(child));
@@ -733,22 +733,26 @@ fn max_at_num(attrs: &[opt14::CAttribute]) -> i64 {
     max
 }
 
-fn max_at_num_obj(obj: &opt14::CObject) -> i64 {
+fn max_at_num_obj(obj: &opt14::types::CObject) -> i64 {
     match obj {
         // Do NOT descend into an embedded root: its at-codes are its own space.
-        opt14::CObject::CArchetypeRoot(_) => 0,
-        opt14::CObject::CComplexObject(c) => at_num(&c.node_id).max(max_at_num(&c.attributes)),
-        opt14::CObject::TComplexObject(c) => at_num(&c.node_id).max(max_at_num(&c.attributes)),
-        opt14::CObject::CDefinedObject(c) => at_num(&c.node_id),
-        opt14::CObject::ArchetypeInternalRef(r) => at_num(&r.node_id),
-        opt14::CObject::ArchetypeSlot(s) => at_num(&s.node_id),
-        opt14::CObject::ConstraintRef(r) => at_num(&r.node_id),
-        opt14::CObject::CCodePhrase(c) => at_num(&c.node_id),
-        opt14::CObject::CCodeReference(c) => at_num(&c.node_id),
-        opt14::CObject::CDvOrdinal(c) => at_num(&c.node_id),
-        opt14::CObject::CDvQuantity(c) => at_num(&c.node_id),
-        opt14::CObject::CDvState(c) => at_num(&c.node_id),
-        opt14::CObject::CPrimitiveObject(c) => at_num(&c.node_id),
+        opt14::types::CObject::CArchetypeRoot(_) => 0,
+        opt14::types::CObject::CComplexObject(c) => {
+            at_num(&c.node_id).max(max_at_num(&c.attributes))
+        }
+        opt14::types::CObject::TComplexObject(c) => {
+            at_num(&c.node_id).max(max_at_num(&c.attributes))
+        }
+        opt14::types::CObject::CDefinedObject(c) => at_num(&c.node_id),
+        opt14::types::CObject::ArchetypeInternalRef(r) => at_num(&r.node_id),
+        opt14::types::CObject::ArchetypeSlot(s) => at_num(&s.node_id),
+        opt14::types::CObject::ConstraintRef(r) => at_num(&r.node_id),
+        opt14::types::CObject::CCodePhrase(c) => at_num(&c.node_id),
+        opt14::types::CObject::CCodeReference(c) => at_num(&c.node_id),
+        opt14::types::CObject::CDvOrdinal(c) => at_num(&c.node_id),
+        opt14::types::CObject::CDvQuantity(c) => at_num(&c.node_id),
+        opt14::types::CObject::CDvState(c) => at_num(&c.node_id),
+        opt14::types::CObject::CPrimitiveObject(c) => at_num(&c.node_id),
     }
 }
 
@@ -776,7 +780,7 @@ fn at_num(node_id: &str) -> i64 {
 fn complex(
     rm_type_name: &str,
     node_id: &str,
-    occurrences: &opt14::Intervalofinteger,
+    occurrences: &opt14::types::Intervalofinteger,
     attributes: Vec<CAttribute>,
 ) -> CObject {
     CObject::CComplexObject(CComplexObject::CComplexObject(CComplexObjectData {
@@ -797,7 +801,7 @@ fn complex(
 fn terminology_code(
     rm_type_name: &str,
     node_id: &str,
-    occurrences: &opt14::Intervalofinteger,
+    occurrences: &opt14::types::Intervalofinteger,
     constraint: String,
 ) -> CObject {
     CObject::CTerminologyCode(CTerminologyCode {
@@ -825,7 +829,7 @@ fn terminology_code(
     clippy::too_many_lines,
     reason = "one arm per primitive C_* struct literal — a flat mapping table"
 )]
-fn map_primitive_object(c: &opt14::CPrimitiveObject, cx: &mut RootCx) -> CObject {
+fn map_primitive_object(c: &opt14::types::CPrimitiveObject, cx: &mut RootCx) -> CObject {
     let rm = c.rm_type_name.as_str();
     let node_id = c.node_id.as_str();
     let occ = &c.occurrences;
@@ -834,7 +838,7 @@ fn map_primitive_object(c: &opt14::CPrimitiveObject, cx: &mut RootCx) -> CObject
         return c_string(rm, node_id, occ, Vec::new(), None);
     };
     match item {
-        opt14::CPrimitive::CBoolean(p) => {
+        opt14::types::CPrimitive::CBoolean(p) => {
             let mut constraint = Vec::new();
             if p.true_valid {
                 constraint.push(true);
@@ -857,7 +861,7 @@ fn map_primitive_object(c: &opt14::CPrimitiveObject, cx: &mut RootCx) -> CObject
                 constraint: openehr_base::containers::present(constraint),
             })
         }
-        opt14::CPrimitive::CString(p) => {
+        opt14::types::CPrimitive::CString(p) => {
             let constraint = if !p.list.is_empty() {
                 p.list.clone()
             } else if let Some(pat) = &p.pattern {
@@ -867,7 +871,7 @@ fn map_primitive_object(c: &opt14::CPrimitiveObject, cx: &mut RootCx) -> CObject
             };
             c_string(rm, node_id, occ, constraint, p.assumed_value.clone())
         }
-        opt14::CPrimitive::CInteger(p) => {
+        opt14::types::CPrimitive::CInteger(p) => {
             let constraint = openehr_base::containers::present(
                 p.range.as_ref().map(int_interval).into_iter().collect(),
             );
@@ -886,7 +890,7 @@ fn map_primitive_object(c: &opt14::CPrimitiveObject, cx: &mut RootCx) -> CObject
                 constraint,
             })
         }
-        opt14::CPrimitive::CReal(p) => {
+        opt14::types::CPrimitive::CReal(p) => {
             let constraint = openehr_base::containers::present(
                 p.range.as_ref().map(real_interval).into_iter().collect(),
             );
@@ -912,7 +916,7 @@ fn map_primitive_object(c: &opt14::CPrimitiveObject, cx: &mut RootCx) -> CObject
         // ADL2 surface defines pattern XOR range (`master04.5` §Mixed Pattern
         // and Interval is duration-only), so a 1.4 node carrying both keeps
         // the range and reports the dropped pattern.
-        opt14::CPrimitive::CDate(p) => CObject::CDate(CDate {
+        opt14::types::CPrimitive::CDate(p) => CObject::CDate(CDate {
             parent: None,
             soc_parent: None,
             rm_type_name: rm.to_owned(),
@@ -945,7 +949,7 @@ fn map_primitive_object(c: &opt14::CPrimitiveObject, cx: &mut RootCx) -> CObject
                 cx,
             ),
         }),
-        opt14::CPrimitive::CDateTime(p) => CObject::CDateTime(CDateTime {
+        opt14::types::CPrimitive::CDateTime(p) => CObject::CDateTime(CDateTime {
             parent: None,
             soc_parent: None,
             rm_type_name: rm.to_owned(),
@@ -981,7 +985,7 @@ fn map_primitive_object(c: &opt14::CPrimitiveObject, cx: &mut RootCx) -> CObject
                 cx,
             ),
         }),
-        opt14::CPrimitive::CDuration(p) => CObject::CDuration(CDuration {
+        opt14::types::CPrimitive::CDuration(p) => CObject::CDuration(CDuration {
             parent: None,
             soc_parent: None,
             rm_type_name: rm.to_owned(),
@@ -1011,7 +1015,7 @@ fn map_primitive_object(c: &opt14::CPrimitiveObject, cx: &mut RootCx) -> CObject
             )),
             pattern_constraint: p.pattern.clone(),
         }),
-        opt14::CPrimitive::CTime(p) => CObject::CTime(CTime {
+        opt14::types::CPrimitive::CTime(p) => CObject::CTime(CTime {
             parent: None,
             soc_parent: None,
             rm_type_name: rm.to_owned(),
@@ -1125,7 +1129,7 @@ fn temporal_interval<T>(
 fn c_string(
     rm_type_name: &str,
     node_id: &str,
-    occurrences: &opt14::Intervalofinteger,
+    occurrences: &opt14::types::Intervalofinteger,
     constraint: Vec<String>,
     assumed_value: Option<String>,
 ) -> CObject {
@@ -1156,7 +1160,7 @@ fn c_string(
 /// the (more concrete) list constraint wins and the URI is carried in
 /// `conversion_details` — a dual-constrained node has no single ADL2 form (no
 /// openEHR spec governs 1.4→2 conversion — our own design).
-fn map_code_reference(c: &opt14::CCodeReference, cx: &mut RootCx) -> CObject {
+fn map_code_reference(c: &opt14::types::CCodeReference, cx: &mut RootCx) -> CObject {
     if c.referenceSetUri.is_empty() || !c.code_list.is_empty() {
         if !c.referenceSetUri.is_empty() {
             cx.note(
@@ -1244,7 +1248,7 @@ fn regex_escape(id: &str) -> String {
 /// parser. An assertion that cannot be rendered or parsed is dropped —
 /// reported in `conversion_details` so the slot's weakening is visible.
 fn map_slot_assertions(
-    assertions: &[opt14::Assertion],
+    assertions: &[opt14::types::Assertion],
     node_id: &str,
     kind: &str,
     cx: &mut RootCx,
@@ -1278,24 +1282,24 @@ fn map_slot_assertions(
 /// Render a 1.4 `EXPR_ITEM` tree to the ADL slot-assertion surface syntax.
 /// Returns `None` for a shape outside the supported forms (binary/unary
 /// operators over attribute paths, constants and constraint leaves).
-fn render_expr(e: &opt14::ExprItem) -> Option<String> {
+fn render_expr(e: &opt14::types::ExprItem) -> Option<String> {
     match e {
-        opt14::ExprItem::ExprBinaryOperator(b) => {
+        opt14::types::ExprItem::ExprBinaryOperator(b) => {
             let l = render_expr(&b.left_operand)?;
             let r = render_expr(&b.right_operand)?;
             Some(format!("{l} {} {r}", b.operator))
         }
-        opt14::ExprItem::ExprUnaryOperator(u) => {
+        opt14::types::ExprItem::ExprUnaryOperator(u) => {
             let inner = render_expr(&u.operand)?;
             Some(format!("{} ({inner})", u.operator))
         }
-        opt14::ExprItem::ExprLeaf(leaf) => render_leaf(leaf),
+        opt14::types::ExprItem::ExprLeaf(leaf) => render_leaf(leaf),
     }
 }
 
 /// Render a 1.4 `EXPR_LEAF`: an attribute path verbatim, a constant literal,
 /// or a constraint (`C_STRING` pattern/list) as the `{/…/}`/`{"…"}` block.
-fn render_leaf(leaf: &opt14::ExprLeaf) -> Option<String> {
+fn render_leaf(leaf: &opt14::types::ExprLeaf) -> Option<String> {
     let item = &leaf.item;
     let text = item.text();
     match leaf.reference_type.to_lowercase().as_str() {
@@ -1440,7 +1444,7 @@ fn tuple_code(terminology: Option<&str>, code: &str) -> CPrimitiveObject {
 /// complex object is the honest valid constraint. No vendored openEHR spec
 /// governs `DV_STATE` conversion — our own design; recorded in
 /// `conversion_details`.
-fn dv_state_loose(c: &opt14::CDvState, cx: &mut RootCx) -> CObject {
+fn dv_state_loose(c: &opt14::types::CDvState, cx: &mut RootCx) -> CObject {
     cx.note(
         format!("dv_state.{}", c.node_id),
         format!(
@@ -1459,7 +1463,7 @@ fn dv_state_loose(c: &opt14::CDvState, cx: &mut RootCx) -> CObject {
 /// so the ac-code constraint resolves (VACDF/VTCBK). An ac-code the ontology
 /// does NOT define would dangle — it stays an unconstrained node, reported in
 /// `conversion_details`.
-fn map_constraint_ref(r: &opt14::ConstraintRef, cx: &mut RootCx) -> CObject {
+fn map_constraint_ref(r: &opt14::types::ConstraintRef, cx: &mut RootCx) -> CObject {
     if cx.defined_acs.contains(&r.reference) {
         terminology_code(
             &r.rm_type_name,
@@ -1484,7 +1488,7 @@ fn map_constraint_ref(r: &opt14::ConstraintRef, cx: &mut RootCx) -> CObject {
 /// (`master04.4-cadl_second_order.adoc` §Tuple Constraints). A 1.4
 /// `assumed_value` has no per-tuple AOM2 slot — recorded in
 /// `conversion_details`.
-fn ordinal_tuple(c: &opt14::CDvOrdinal, cx: &mut RootCx) -> CObject {
+fn ordinal_tuple(c: &opt14::types::CDvOrdinal, cx: &mut RootCx) -> CObject {
     if let Some(a) = &c.assumed_value {
         cx.note(
             format!("assumed_value.{}", c.node_id),
@@ -1541,7 +1545,7 @@ fn ordinal_tuple(c: &opt14::CDvOrdinal, cx: &mut RootCx) -> CObject {
 /// constrains it (uniform tuple arity; rows without one carry an
 /// unconstrained `C_INTEGER`). A 1.4 `assumed_value` has no per-tuple AOM2
 /// slot — recorded in `conversion_details`.
-fn quantity_tuple(c: &opt14::CDvQuantity, cx: &mut RootCx) -> CObject {
+fn quantity_tuple(c: &opt14::types::CDvQuantity, cx: &mut RootCx) -> CObject {
     if c.assumed_value.is_some() {
         cx.note(
             format!("assumed_value.{}", c.node_id),
@@ -1647,7 +1651,7 @@ fn quantity_tuple(c: &opt14::CDvQuantity, cx: &mut RootCx) -> CObject {
 /// widens to — the reference-corpus form for units-only constraints; a mixed
 /// set's dropped per-unit ranges are reported.
 fn widened_units_attribute(
-    c: &opt14::CDvQuantity,
+    c: &opt14::types::CDvQuantity,
     some_dropped: bool,
     cx: &mut RootCx,
 ) -> CAttribute {
@@ -1682,8 +1686,8 @@ fn widened_units_attribute(
 
 /// The `0..*` occurrences a synthesized single-child attribute carries (the
 /// converter core elides RM-default multiplicities).
-fn unbounded_occurrences() -> opt14::Intervalofinteger {
-    opt14::Intervalofinteger {
+fn unbounded_occurrences() -> opt14::types::Intervalofinteger {
+    opt14::types::Intervalofinteger {
         lower_included: Some(true),
         upper_included: None,
         lower_unbounded: false,
@@ -1735,7 +1739,7 @@ fn code_constraint(terminology: Option<&str>, codes: &[String], assumed: Option<
     out
 }
 
-fn map_term(t: &opt14::ArchetypeTerm) -> ArchetypeTerm {
+fn map_term(t: &opt14::types::ArchetypeTerm) -> ArchetypeTerm {
     let text = t.items.get("text").cloned().unwrap_or_default();
     let description = t.items.get("description").cloned().unwrap_or_default();
     let other_items: BTreeMap<String, String> = t
@@ -1754,7 +1758,7 @@ fn map_term(t: &opt14::ArchetypeTerm) -> ArchetypeTerm {
     }
 }
 
-fn map_mult(iv: &opt14::Intervalofinteger) -> MultiplicityInterval {
+fn map_mult(iv: &opt14::types::Intervalofinteger) -> MultiplicityInterval {
     MultiplicityInterval {
         lower: iv.lower,
         upper: iv.upper,
@@ -1765,7 +1769,7 @@ fn map_mult(iv: &opt14::Intervalofinteger) -> MultiplicityInterval {
     }
 }
 
-fn map_cardinality(c: &opt14::Cardinality) -> Cardinality {
+fn map_cardinality(c: &opt14::types::Cardinality) -> Cardinality {
     Cardinality {
         interval: map_mult(&c.interval),
         is_ordered: c.is_ordered,
@@ -1773,7 +1777,7 @@ fn map_cardinality(c: &opt14::Cardinality) -> Cardinality {
     }
 }
 
-fn int_interval(iv: &opt14::Intervalofinteger) -> Interval<i32> {
+fn int_interval(iv: &opt14::types::Intervalofinteger) -> Interval<i32> {
     if iv.lower == iv.upper && iv.lower.is_some() {
         let v = iv.lower.unwrap_or_default();
         return Interval::PointInterval(PointInterval {
@@ -1795,7 +1799,7 @@ fn int_interval(iv: &opt14::Intervalofinteger) -> Interval<i32> {
     }))
 }
 
-fn real_interval(iv: &opt14::Intervalofreal) -> Interval<f64> {
+fn real_interval(iv: &opt14::types::Intervalofreal) -> Interval<f64> {
     if iv.lower == iv.upper && iv.lower.is_some() {
         let v = iv.lower.unwrap_or_default();
         return Interval::PointInterval(PointInterval {
@@ -1845,7 +1849,7 @@ mod tests {
     const VITAL_SIGNS: &str =
         "tests/resources/service/knowledge/opt/Vital Signs Encounter (Composition).opt";
 
-    fn parse_opt(rel: &str) -> opt14::OperationalTemplate {
+    fn parse_opt(rel: &str) -> opt14::types::OperationalTemplate {
         let path = format!("{}/{rel}", env!("CARGO_MANIFEST_DIR"));
         let xml = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
         opt14::from_xml(&xml).unwrap_or_else(|e| panic!("parse OPT {rel}: {e:?}"))
@@ -2059,8 +2063,8 @@ mod tests {
     /// attribute (the reference-corpus form for units-only constraints).
     #[test]
     fn quantity_tuple_emitted_when_magnitudes_present() {
-        let item = |units: &str, magnitude: Option<(f64, f64)>| opt14::CQuantityItem {
-            magnitude: magnitude.map(|(lo, hi)| opt14::Intervalofreal {
+        let item = |units: &str, magnitude: Option<(f64, f64)>| opt14::types::CQuantityItem {
+            magnitude: magnitude.map(|(lo, hi)| opt14::types::Intervalofreal {
                 lower_included: Some(true),
                 upper_included: Some(true),
                 lower_unbounded: false,
@@ -2071,7 +2075,7 @@ mod tests {
             precision: None,
             units: units.to_owned(),
         };
-        let quantity = |list: Vec<opt14::CQuantityItem>| opt14::CDvQuantity {
+        let quantity = |list: Vec<opt14::types::CQuantityItem>| opt14::types::CDvQuantity {
             rm_type_name: "DV_QUANTITY".to_owned(),
             occurrences: unbounded_occurrences(),
             node_id: "at0004".to_owned(),
@@ -2129,7 +2133,7 @@ mod tests {
     #[test]
     fn reference_set_uri_becomes_ac_binding() {
         let mut cx = test_cx();
-        let node = opt14::CCodeReference {
+        let node = opt14::types::CCodeReference {
             rm_type_name: "CODE_PHRASE".to_owned(),
             occurrences: unbounded_occurrences(),
             node_id: "at0005".to_owned(),
@@ -2165,7 +2169,7 @@ mod tests {
     fn constraint_ref_resolves_or_reports() {
         let mut cx = test_cx();
         cx.defined_acs.insert("ac0002".to_owned());
-        let defined = opt14::ConstraintRef {
+        let defined = opt14::types::ConstraintRef {
             rm_type_name: "CODE_PHRASE".to_owned(),
             occurrences: unbounded_occurrences(),
             node_id: "at0007".to_owned(),
@@ -2177,7 +2181,7 @@ mod tests {
         assert_eq!(tc.constraint, "ac0002");
         assert!(cx.notes.is_empty(), "a resolved ref reports nothing");
 
-        let dangling = opt14::ConstraintRef {
+        let dangling = opt14::types::ConstraintRef {
             reference: "ac0099".to_owned(),
             ..defined
         };
@@ -2200,22 +2204,24 @@ mod tests {
     /// form), plus the assumed value.
     #[test]
     fn temporal_range_and_pattern_both_carried() {
-        let node = opt14::CPrimitiveObject {
+        let node = opt14::types::CPrimitiveObject {
             rm_type_name: "DV_DURATION".to_owned(),
             occurrences: unbounded_occurrences(),
             node_id: String::new(),
-            item: Some(Box::new(opt14::CPrimitive::CDuration(opt14::CDuration {
-                pattern: Some("PTH".to_owned()),
-                range: Some(opt14::Intervalofduration {
-                    lower_included: Some(true),
-                    upper_included: Some(true),
-                    lower_unbounded: false,
-                    upper_unbounded: false,
-                    lower: Some("PT0H".to_owned()),
-                    upper: Some("PT12H".to_owned()),
-                }),
-                assumed_value: Some("PT1H".to_owned()),
-            }))),
+            item: Some(Box::new(opt14::types::CPrimitive::CDuration(
+                opt14::types::CDuration {
+                    pattern: Some("PTH".to_owned()),
+                    range: Some(opt14::types::Intervalofduration {
+                        lower_included: Some(true),
+                        upper_included: Some(true),
+                        lower_unbounded: false,
+                        upper_unbounded: false,
+                        lower: Some("PT0H".to_owned()),
+                        upper: Some("PT12H".to_owned()),
+                    }),
+                    assumed_value: Some("PT1H".to_owned()),
+                },
+            ))),
         };
         let mut cx = test_cx();
         let CObject::CDuration(d) = map_primitive_object(&node, &mut cx) else {
@@ -2237,23 +2243,25 @@ mod tests {
     /// it for a date would not re-parse.
     #[test]
     fn date_pattern_plus_range_keeps_range_and_reports() {
-        let node = opt14::CPrimitiveObject {
+        let node = opt14::types::CPrimitiveObject {
             rm_type_name: "DV_DATE".to_owned(),
             occurrences: unbounded_occurrences(),
             node_id: String::new(),
-            item: Some(Box::new(opt14::CPrimitive::CDate(opt14::CDate {
-                pattern: Some("yyyy-??-??".to_owned()),
-                timezone_validity: None,
-                range: Some(opt14::Intervalofdate {
-                    lower_included: Some(true),
-                    upper_included: Some(true),
-                    lower_unbounded: false,
-                    upper_unbounded: false,
-                    lower: Some("2004-01-01".to_owned()),
-                    upper: Some("2004-12-31".to_owned()),
-                }),
-                assumed_value: None,
-            }))),
+            item: Some(Box::new(opt14::types::CPrimitive::CDate(
+                opt14::types::CDate {
+                    pattern: Some("yyyy-??-??".to_owned()),
+                    timezone_validity: None,
+                    range: Some(opt14::types::Intervalofdate {
+                        lower_included: Some(true),
+                        upper_included: Some(true),
+                        lower_unbounded: false,
+                        upper_unbounded: false,
+                        lower: Some("2004-01-01".to_owned()),
+                        upper: Some("2004-12-31".to_owned()),
+                    }),
+                    assumed_value: None,
+                },
+            ))),
         };
         let mut cx = test_cx();
         let CObject::CDate(d) = map_primitive_object(&node, &mut cx) else {
@@ -2271,13 +2279,15 @@ mod tests {
             cx.notes
         );
         // A pattern-only date keeps its pattern unreported.
-        let pattern_only = opt14::CPrimitiveObject {
-            item: Some(Box::new(opt14::CPrimitive::CDate(opt14::CDate {
-                pattern: Some("yyyy-??-??".to_owned()),
-                timezone_validity: None,
-                range: None,
-                assumed_value: None,
-            }))),
+        let pattern_only = opt14::types::CPrimitiveObject {
+            item: Some(Box::new(opt14::types::CPrimitive::CDate(
+                opt14::types::CDate {
+                    pattern: Some("yyyy-??-??".to_owned()),
+                    timezone_validity: None,
+                    range: None,
+                    assumed_value: None,
+                },
+            ))),
             ..node
         };
         let mut cx = test_cx();

--- a/app/ferroehr/src/service/mod.rs
+++ b/app/ferroehr/src/service/mod.rs
@@ -78,7 +78,7 @@ use crate::system_log::sender::AuditSender;
 use crate::versioning::SigningCtx;
 use crate::versioning::signature::signer::Signer;
 use openehr_its::flat::cache::WebTemplateCache;
-use openehr_its::flat::webtemplate::WebTemplate;
+use openehr_its::flat::webtemplate::model::WebTemplate;
 use status::SmError;
 
 /// In-process cache of resolved tenants, keyed by the claim/header value (a

--- a/app/ferroehr/src/service/terminology/binding.rs
+++ b/app/ferroehr/src/service/terminology/binding.rs
@@ -60,7 +60,7 @@
 )]
 
 use openehr_its::flat::validation::ConstraintBindingCheck;
-use openehr_its::flat::webtemplate::WebTemplate;
+use openehr_its::flat::webtemplate::model::WebTemplate;
 use openehr_its::rm_instance::{ValidationKind, ValidationMessage};
 use serde_json::Value;
 
@@ -171,7 +171,7 @@ mod tests {
     use std::collections::BTreeMap;
     use std::sync::Arc;
 
-    use openehr_its::flat::webtemplate::{
+    use openehr_its::flat::webtemplate::model::{
         WebTemplate, WebTemplateConstraintBinding, WebTemplateNode,
     };
     use serde_json::json;

--- a/app/ferroehr/src/templates/ingest.rs
+++ b/app/ferroehr/src/templates/ingest.rs
@@ -29,7 +29,7 @@
 //! Surfacing/querying the full `AUTHORED_RESOURCE` meta-data is not required by
 //! the provisioning surface.
 
-use openehr_its::opt14::OperationalTemplate;
+use openehr_its::opt14::types::OperationalTemplate;
 
 use crate::service::error::ServiceError;
 

--- a/app/ferroehr/src/templates/mod.rs
+++ b/app/ferroehr/src/templates/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This module owns the platform crate's template surface: OPT 1.4 XML
 //! ingestion, the `template_store` repository access, and the cached derived
-//! [`WebTemplate`](openehr_its::flat::webtemplate::WebTemplate) runtime form. It is decomposed
+//! [`WebTemplate`](openehr_its::flat::webtemplate::model::WebTemplate) runtime form. It is decomposed
 //! the way the spec itself layers the material — **resource identity →
 //! operational form → derived runtime artefact**:
 //!

--- a/app/ferroehr/src/templates/runtime.rs
+++ b/app/ferroehr/src/templates/runtime.rs
@@ -33,7 +33,7 @@
 use std::sync::Arc;
 
 use openehr_its::flat::example::{DetailLevel, ExampleType};
-use openehr_its::flat::webtemplate::WebTemplate;
+use openehr_its::flat::webtemplate::model::WebTemplate;
 use serde_json::Value;
 
 use super::identity;
@@ -172,7 +172,7 @@ impl FerroEhrService {
             .get_or_build(key, || {
                 let opt = openehr_its::opt14::from_xml(xml)
                     .map_err(|e| openehr_its::flat::error::FlatError::OptParse(e.to_string()))?;
-                openehr_its::flat::webtemplate::build_web_template(&opt)
+                openehr_its::flat::webtemplate::builder::build_web_template(&opt)
             })
             .await
             .map_err(|e| {

--- a/app/ferroehr/src/validation/mod.rs
+++ b/app/ferroehr/src/validation/mod.rs
@@ -8,7 +8,7 @@
 //!   constraint catalogue applied to an *uploaded* artefact, before it becomes
 //!   an operational template:
 //! - `opt` — OPT 1.4 artefact validity, the AOM2/08 catalogue on a
-//   !     flattened `openehr_its::opt14::OperationalTemplate`;
+//   !     flattened `openehr_its::opt14::types::OperationalTemplate`;
 //!   - `structure` (A3) — OPT XML well-formedness (a CNF ingestion guard,
 //!     not an AOM constraint kind).
 //!
@@ -74,7 +74,7 @@
 mod opt;
 mod structure;
 
-use openehr_its::opt14::OperationalTemplate;
+use openehr_its::opt14::types::OperationalTemplate;
 
 use crate::service::error::ServiceError;
 

--- a/app/ferroehr/src/validation/opt/interval.rs
+++ b/app/ferroehr/src/validation/opt/interval.rs
@@ -19,7 +19,7 @@
 //! numeric bounds the AOM invariants compare, not a membership decision).
 
 use openehr_base::prelude::{MultiplicityInterval, ProperIntervalData};
-use openehr_its::opt14::{Intervalofinteger, Intervalofreal};
+use openehr_its::opt14::types::{Intervalofinteger, Intervalofreal};
 
 /// The effective lower bound of an `opt14` integer interval: an unbounded or
 /// absent lower limit reads as `0` (the AOM occurrence/existence floor).

--- a/app/ferroehr/src/validation/opt/invariants.rs
+++ b/app/ferroehr/src/validation/opt/invariants.rs
@@ -21,11 +21,11 @@
 use std::collections::HashSet;
 
 use openehr_base::prelude::ArchetypeId;
-use openehr_its::opt14::{
+use openehr_its::opt14::types::{
     ArchetypeInternalRef, ArchetypeSlot, Assertion, CObject, ConstraintRef, ExprItem,
     Intervalofinteger,
 };
-use openehr_its::xml::XmlAny;
+use openehr_its::xml::runtime::XmlAny;
 
 use super::interval::{iv_lower, iv_upper};
 use super::{Ctx, NodeView, RuleViolation};

--- a/app/ferroehr/src/validation/opt/mod.rs
+++ b/app/ferroehr/src/validation/opt/mod.rs
@@ -8,7 +8,7 @@
 //! `AM/docs/AOM2/master07-terminology_package.adoc`). OPT 1.4 has no normative
 //! prose chapter, so the only formalized catalogue of standalone-artefact
 //! checks is AOM2/08; those rules are the oracle here, applied to the
-//! *flattened* OPT 1.4 tree (`openehr_its::opt14::OperationalTemplate`).
+//! *flattened* OPT 1.4 tree (`openehr_its::opt14::types::OperationalTemplate`).
 //!
 //! This module owns the tree walk (T1: the `C_COMPLEX_OBJECT`/`C_ATTRIBUTE`
 //! alternation) and the shared context; the per-*kind of check* rules live in
@@ -46,7 +46,7 @@ mod terminology;
 
 use std::collections::HashSet;
 
-use openehr_its::opt14::{CAttribute, CObject, Intervalofinteger, OperationalTemplate};
+use openehr_its::opt14::types::{CAttribute, CObject, Intervalofinteger, OperationalTemplate};
 
 use crate::service::error::ServiceError;
 

--- a/app/ferroehr/src/validation/opt/primitive.rs
+++ b/app/ferroehr/src/validation/opt/primitive.rs
@@ -12,7 +12,7 @@
 //! (UML `c_quantity`/`c_ordinal`/`c_coded_text`; ADL1.4 master09).
 
 use openehr_base::prelude::CodePhrase;
-use openehr_its::opt14::{CDvOrdinal, CDvQuantity, CPrimitive};
+use openehr_its::opt14::types::{CDvOrdinal, CDvQuantity, CPrimitive};
 
 use super::RuleViolation;
 use super::interval::{int_in_range, real_in_range};

--- a/app/ferroehr/src/validation/opt/rm_conformance.rs
+++ b/app/ferroehr/src/validation/opt/rm_conformance.rs
@@ -23,7 +23,7 @@
 use std::collections::BTreeSet;
 use std::sync::LazyLock;
 
-use openehr_its::opt14::{CAttribute, CObject, Cardinality, Intervalofinteger};
+use openehr_its::opt14::types::{CAttribute, CObject, Cardinality, Intervalofinteger};
 use openehr_rm::v1_2::model;
 
 use super::interval::{iv_lower, iv_upper};

--- a/app/ferroehr/src/validation/opt/terminology.rs
+++ b/app/ferroehr/src/validation/opt/terminology.rs
@@ -17,7 +17,7 @@
 
 use std::collections::HashSet;
 
-use openehr_its::opt14::{
+use openehr_its::opt14::types::{
     CArchetypeRoot, CAttribute, CObject, Codedefinitionset, FlatArchetypeOntology,
     OperationalTemplate,
 };

--- a/app/ferroehr/tests/it/service_definition.rs
+++ b/app/ferroehr/tests/it/service_definition.rs
@@ -1280,15 +1280,19 @@ async fn adl2_template_resolves_on_the_commit_path_and_validates() {
 #[tokio::test]
 async fn adl2_template_with_filler_projects_the_filled_web_template() {
     fn find<'a>(
-        n: &'a openehr_its::flat::webtemplate::WebTemplateNode,
+        n: &'a openehr_its::flat::webtemplate::model::WebTemplateNode,
         id: &str,
-    ) -> Option<&'a openehr_its::flat::webtemplate::WebTemplateNode> {
+    ) -> Option<&'a openehr_its::flat::webtemplate::model::WebTemplateNode> {
         if n.id == id {
             return Some(n);
         }
         n.children.iter().find_map(|c| find(c, id))
     }
-    fn dump(n: &openehr_its::flat::webtemplate::WebTemplateNode, d: usize, out: &mut String) {
+    fn dump(
+        n: &openehr_its::flat::webtemplate::model::WebTemplateNode,
+        d: usize,
+        out: &mut String,
+    ) {
         use std::fmt::Write;
         let _ = writeln!(out, "{}{} [{}]", "  ".repeat(d), n.id, n.rm_type);
         for c in &n.children {

--- a/app/ferroehr/tests/it/service_signing.rs
+++ b/app/ferroehr/tests/it/service_signing.rs
@@ -554,7 +554,7 @@ async fn canonical_xml_carries_the_signature() {
         &ov,
         "version",
         "VERSION",
-        openehr_its::xml::Namespace::V1,
+        openehr_its::xml::runtime::Namespace::V1,
     )
     .expect("to_canonical_xml_declared");
     assert!(

--- a/app/ferroehr/tests/it/service_template.rs
+++ b/app/ferroehr/tests/it/service_template.rs
@@ -173,9 +173,9 @@ const EXAMPLE_TEMPLATES: &[&str] = &[
 ];
 
 /// The (cached) `WebTemplate` built from an OPT file, as the service builds it.
-fn web_template_of(rel: &str) -> openehr_its::flat::webtemplate::WebTemplate {
+fn web_template_of(rel: &str) -> openehr_its::flat::webtemplate::model::WebTemplate {
     let opt = openehr_its::opt14::from_xml(&corpus_opt(rel)).expect("parse OPT");
-    openehr_its::flat::webtemplate::build_web_template(&opt).expect("build web template")
+    openehr_its::flat::webtemplate::builder::build_web_template(&opt).expect("build web template")
 }
 
 /// The generated `required` example is committable (passes the validator)

--- a/app/ferroehr/tests/it/validation_opt.rs
+++ b/app/ferroehr/tests/it/validation_opt.rs
@@ -19,8 +19,9 @@
 use std::path::{Path, PathBuf};
 
 use openehr_base::prelude::{CodePhrase, TerminologyId};
-use openehr_its::opt14::{
-    self, ArchetypeTerm, CAttribute, CObject, Codedefinitionset, ConstraintBindingItem,
+use openehr_its::opt14;
+use openehr_its::opt14::types::{
+    ArchetypeTerm, CAttribute, CObject, Codedefinitionset, ConstraintBindingItem,
     Constraintbindingset, FlatArchetypeOntology, Intervalofinteger, OperationalTemplate,
     TermBindingItem, Termbindingset,
 };
@@ -442,7 +443,7 @@ fn vardt_root_type_mismatch() {
 
 #[test]
 fn c_boolean_unsatisfiable() {
-    use openehr_its::opt14::{CAttribute, CBoolean, CObject, CPrimitive, CPrimitiveObject};
+    use openehr_its::opt14::types::{CAttribute, CBoolean, CObject, CPrimitive, CPrimitiveObject};
     let mut opt = parse(&minimal_xml());
     let occ = opt.definition.occurrences.clone();
     let boolean_node = CObject::CPrimitiveObject(CPrimitiveObject {
@@ -455,9 +456,8 @@ fn c_boolean_unsatisfiable() {
             assumed_value: None,
         }))),
     });
-    opt.definition
-        .attributes
-        .push(CAttribute::CSingleAttribute(opt14::CSingleAttribute {
+    opt.definition.attributes.push(CAttribute::CSingleAttribute(
+        opt14::types::CSingleAttribute {
             rm_attribute_name: "name".to_owned(),
             existence: Intervalofinteger {
                 lower_unbounded: false,
@@ -468,13 +468,14 @@ fn c_boolean_unsatisfiable() {
                 upper: Some(1),
             },
             children: vec![boolean_node],
-        }));
+        },
+    ));
     expect_code(&opt, "C_BOOLEAN_validity");
 }
 
 #[test]
 fn assumed_value_outside_closed_list() {
-    use openehr_its::opt14::{CAttribute, CObject, CPrimitive, CPrimitiveObject, CString};
+    use openehr_its::opt14::types::{CAttribute, CObject, CPrimitive, CPrimitiveObject, CString};
     let mut opt = parse(&minimal_xml());
     let occ = opt.definition.occurrences.clone();
     // A C_STRING with a closed value list and an assumed value outside it.
@@ -489,9 +490,8 @@ fn assumed_value_outside_closed_list() {
             assumed_value: Some("blue".to_owned()),
         }))),
     });
-    opt.definition
-        .attributes
-        .push(CAttribute::CSingleAttribute(opt14::CSingleAttribute {
+    opt.definition.attributes.push(CAttribute::CSingleAttribute(
+        opt14::types::CSingleAttribute {
             rm_attribute_name: "name".to_owned(),
             existence: Intervalofinteger {
                 lower_unbounded: false,
@@ -502,13 +502,14 @@ fn assumed_value_outside_closed_list() {
                 upper: Some(1),
             },
             children: vec![string_node],
-        }));
+        },
+    ));
     expect_code(&opt, "Assumed_value_valid");
 }
 
 #[test]
 fn pattern_validity_rejects_nonmonotonic_temporal_pattern() {
-    use openehr_its::opt14::{CAttribute, CDate, CObject, CPrimitive, CPrimitiveObject};
+    use openehr_its::opt14::types::{CAttribute, CDate, CObject, CPrimitive, CPrimitiveObject};
     let mut opt = parse(&minimal_xml());
     let occ = opt.definition.occurrences.clone();
     // `yyyy-XX-dd`: disallowed month followed by a mandatory day violates the
@@ -524,9 +525,8 @@ fn pattern_validity_rejects_nonmonotonic_temporal_pattern() {
             assumed_value: None,
         }))),
     });
-    opt.definition
-        .attributes
-        .push(CAttribute::CSingleAttribute(opt14::CSingleAttribute {
+    opt.definition.attributes.push(CAttribute::CSingleAttribute(
+        opt14::types::CSingleAttribute {
             rm_attribute_name: "name".to_owned(),
             existence: Intervalofinteger {
                 lower_unbounded: false,
@@ -537,7 +537,8 @@ fn pattern_validity_rejects_nonmonotonic_temporal_pattern() {
                 upper: Some(1),
             },
             children: vec![date_node],
-        }));
+        },
+    ));
     expect_code(&opt, "Pattern_validity");
 }
 

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-adl"
-version = "0.0.15"
+version = "0.0.16"
 description = "openEHR ADL 2.4.0: hand-written ADL2/cADL/ODIN parser, AOM2 validation catalogue, specialisation flattener, OPT2 generator, and ADL 1.4→2 conversion over the generated openehr_am::v2_4::aom2 model"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,10 +16,10 @@ include = ["src/**", "README.md", "LICENSE-MIT"]
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)
-openehr-base = { path = "../openehr-base", version = "0.0.15" }   # VersionStatus for the parsed HRID
-openehr-am = { path = "../openehr-am", version = "0.0.15" }       # v2_4 ArchetypeHrid (the identification target type)
-openehr-rm = { path = "../openehr-rm", version = "0.0.15" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
-openehr-lang = { path = "../openehr-lang", version = "0.0.15" }   # openehr_lang::odin — the ODIN section parser
+openehr-base = { path = "../openehr-base", version = "0.0.16" }   # VersionStatus for the parsed HRID
+openehr-am = { path = "../openehr-am", version = "0.0.16" }       # v2_4 ArchetypeHrid (the identification target type)
+openehr-rm = { path = "../openehr-rm", version = "0.0.16" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
+openehr-lang = { path = "../openehr-lang", version = "0.0.16" }   # openehr_lang::odin — the ODIN section parser
 uuid.workspace = true        # meta uid/build_uid (AUTHORED_ARCHETYPE.uid: Uuid)
 indexmap.workspace = true    # OdinValue::Object body (insertion-ordered map)
 

--- a/crates/openehr-am/Cargo.toml
+++ b/crates/openehr-am/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-am"
-version = "0.0.15"
+version = "0.0.16"
 description = "openEHR AM Archetype Model, generated from BMM: generations v1_4 (AM 1.4.0, ADL 1.4) and v2_4 (AM 2.4.0, ADL 2; current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,8 +13,8 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.15" }
-openehr-lang = { path = "../openehr-lang", version = "0.0.15" }
+openehr-base = { path = "../openehr-base", version = "0.0.16" }
+openehr-lang = { path = "../openehr-lang", version = "0.0.16" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also carries the untyped `Value` fields the generator

--- a/crates/openehr-base/Cargo.toml
+++ b/crates/openehr-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-base"
-version = "0.0.15"
+version = "0.0.16"
 description = "openEHR BASE foundation + base types, generated from BMM: generations v1_2 (BASE 1.2.0) and v1_3 (BASE 1.3.0, current)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-its"
-version = "0.0.15"
+version = "0.0.16"
 description = "openEHR ITS (Implementation Technology Specifications): canonical JSON + canonical XML serialization of the RM, the generated ITS-REST 1.1.0 API contract, OPT 1.4 and AOM2 archetype XML codecs, and the Simplified Formats (FLAT / STRUCTURED / Web Template)"
 edition.workspace = true
 rust-version.workspace = true
@@ -41,14 +41,14 @@ regex = { workspace = true, optional = true }
 fancy-regex = { workspace = true, optional = true }
 # The generated XML (de)serializers impl the crate's ToXml/FromXml traits for the
 # RM/BASE spec types, so these are real (non-dev) deps.
-openehr-base = { path = "../openehr-base", version = "0.0.15", optional = true }
-openehr-rm = { path = "../openehr-rm", version = "0.0.15", optional = true }
+openehr-base = { path = "../openehr-base", version = "0.0.16", optional = true }
+openehr-rm = { path = "../openehr-rm", version = "0.0.16", optional = true }
 # The native canonical-JSON codec (`json_codec/generated`, emit-json) implements
 # `ToJson` for EVERY generated spec type the `OpenEhrType` derive covers, so it
 # spans all five spec crates (not just the RM/BASE the XML codec needs).
-openehr-lang = { path = "../openehr-lang", version = "0.0.15", optional = true }
-openehr-am = { path = "../openehr-am", version = "0.0.15", optional = true }
-openehr-term = { path = "../openehr-term", version = "0.0.15", optional = true }
+openehr-lang = { path = "../openehr-lang", version = "0.0.16", optional = true }
+openehr-am = { path = "../openehr-am", version = "0.0.16", optional = true }
+openehr-term = { path = "../openehr-term", version = "0.0.16", optional = true }
 
 # `full` — every ITS surface (canonical JSON/XML, the generated ITS-REST
 # contract, `opt14`, Simplified Formats). ON BY DEFAULT, so every consumer sees

--- a/crates/openehr-its/examples/canonical_convert.rs
+++ b/crates/openehr-its/examples/canonical_convert.rs
@@ -35,7 +35,7 @@ use openehr_rm::v1_2::demographic::person::Person;
 use openehr_rm::v1_2::demographic::role::Role;
 use openehr_rm::v1_2::ehr::ehr_status::EhrStatus;
 
-use openehr_its::xml::{Namespace, ToXml};
+use openehr_its::xml::runtime::{Namespace, ToXml};
 
 /// The serialization the run emits, with the XML root the RM class documents
 /// itself under.

--- a/crates/openehr-its/src/aom2/impls.rs
+++ b/crates/openehr-its/src/aom2/impls.rs
@@ -14,7 +14,7 @@
 )]
 use crate::xml::runtime::{FromXml, ToXml, XmlError, XmlEvent};
 
-impl crate::xml::runtime::ToXml for crate::aom2::ArchetypeTerm {
+impl crate::xml::runtime::ToXml for crate::aom2::types::ArchetypeTerm {
     fn xml_type_name(&self) -> &'static str {
         "ARCHETYPE_TERM"
     }
@@ -31,7 +31,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::ArchetypeTerm {
             }
         }
         __attrs.push(("id", self.id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -45,7 +45,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::ArchetypeTerm {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::ArchetypeTerm {
+impl crate::xml::runtime::FromXml for crate::aom2::types::ArchetypeTerm {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -72,7 +72,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::ArchetypeTerm {
                 }
             }
         }
-        Ok(crate::aom2::ArchetypeTerm {
+        Ok(crate::aom2::types::ArchetypeTerm {
             id: start
                 .attr("id")
                 .ok_or_else(|| crate::xml::runtime::XmlError::Parse("missing attribute id".into()))?
@@ -85,7 +85,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::ArchetypeTerm {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::Assertion {
+impl crate::xml::runtime::ToXml for crate::aom2::types::Assertion {
     fn xml_type_name(&self) -> &'static str {
         "ASSERTION"
     }
@@ -107,7 +107,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::Assertion {
         if let Some(v) = &self.tag {
             __attrs.push(("tag", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -119,7 +119,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::Assertion {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::Assertion {
+impl crate::xml::runtime::FromXml for crate::aom2::types::Assertion {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -142,7 +142,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::Assertion {
                 }
             }
         }
-        Ok(crate::aom2::Assertion {
+        Ok(crate::aom2::types::Assertion {
             r#type: start.attr("type").map(|s| s.to_string()),
             tag: start.attr("tag").map(|s| s.to_string()),
             expression: __expression.ok_or_else(|| {
@@ -152,7 +152,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::Assertion {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::AssertionVariable {
+impl crate::xml::runtime::ToXml for crate::aom2::types::AssertionVariable {
     fn xml_type_name(&self) -> &'static str {
         "ASSERTION_VARIABLE"
     }
@@ -171,7 +171,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::AssertionVariable {
         if let Some(v) = &self.name {
             __attrs.push(("name", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -182,7 +182,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::AssertionVariable {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::AssertionVariable {
+impl crate::xml::runtime::FromXml for crate::aom2::types::AssertionVariable {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -205,7 +205,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::AssertionVariable {
                 }
             }
         }
-        Ok(crate::aom2::AssertionVariable {
+        Ok(crate::aom2::types::AssertionVariable {
             name: start.attr("name").map(|s| s.to_string()),
             definition: __definition.ok_or_else(|| {
                 crate::xml::runtime::XmlError::Parse("missing element definition".into())
@@ -214,7 +214,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::AssertionVariable {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::AuthoredResource {
+impl crate::xml::runtime::ToXml for crate::aom2::types::AuthoredResource {
     fn xml_type_name(&self) -> &'static str {
         "AUTHORED_RESOURCE"
     }
@@ -230,7 +230,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::AuthoredResource {
                 __attrs.push(("xsi:type", "AUTHORED_RESOURCE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -257,7 +257,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::AuthoredResource {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::AuthoredResource {
+impl crate::xml::runtime::FromXml for crate::aom2::types::AuthoredResource {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -302,7 +302,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::AuthoredResource {
                 }
             }
         }
-        Ok(crate::aom2::AuthoredResource {
+        Ok(crate::aom2::types::AuthoredResource {
             original_language: __original_language.ok_or_else(|| {
                 crate::xml::runtime::XmlError::Parse("missing element original_language".into())
             })?,
@@ -315,7 +315,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::AuthoredResource {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::Annotationlangset {
+impl crate::xml::runtime::ToXml for crate::aom2::types::Annotationlangset {
     fn xml_type_name(&self) -> &'static str {
         "AnnotationLangSet"
     }
@@ -332,7 +332,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::Annotationlangset {
             }
         }
         __attrs.push(("id", self.id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -345,7 +345,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::Annotationlangset {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::Annotationlangset {
+impl crate::xml::runtime::FromXml for crate::aom2::types::Annotationlangset {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -368,7 +368,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::Annotationlangset {
                 }
             }
         }
-        Ok(crate::aom2::Annotationlangset {
+        Ok(crate::aom2::types::Annotationlangset {
             id: start
                 .attr("id")
                 .ok_or_else(|| crate::xml::runtime::XmlError::Parse("missing attribute id".into()))?
@@ -378,7 +378,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::Annotationlangset {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::Annotationpathset {
+impl crate::xml::runtime::ToXml for crate::aom2::types::Annotationpathset {
     fn xml_type_name(&self) -> &'static str {
         "AnnotationPathSet"
     }
@@ -395,7 +395,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::Annotationpathset {
             }
         }
         __attrs.push(("id", self.id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -410,7 +410,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::Annotationpathset {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::Annotationpathset {
+impl crate::xml::runtime::FromXml for crate::aom2::types::Annotationpathset {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -435,7 +435,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::Annotationpathset {
                 }
             }
         }
-        Ok(crate::aom2::Annotationpathset {
+        Ok(crate::aom2::types::Annotationpathset {
             id: start
                 .attr("id")
                 .ok_or_else(|| crate::xml::runtime::XmlError::Parse("missing attribute id".into()))?
@@ -449,7 +449,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::Annotationpathset {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::Codedefinitionset {
+impl crate::xml::runtime::ToXml for crate::aom2::types::Codedefinitionset {
     fn xml_type_name(&self) -> &'static str {
         "CodeDefinitionSet"
     }
@@ -466,7 +466,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::Codedefinitionset {
             }
         }
         __attrs.push(("id", self.id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -479,7 +479,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::Codedefinitionset {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::Codedefinitionset {
+impl crate::xml::runtime::FromXml for crate::aom2::types::Codedefinitionset {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -502,7 +502,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::Codedefinitionset {
                 }
             }
         }
-        Ok(crate::aom2::Codedefinitionset {
+        Ok(crate::aom2::types::Codedefinitionset {
             id: start
                 .attr("id")
                 .ok_or_else(|| crate::xml::runtime::XmlError::Parse("missing attribute id".into()))?
@@ -512,7 +512,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::Codedefinitionset {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::ExprBinaryOperator {
+impl crate::xml::runtime::ToXml for crate::aom2::types::ExprBinaryOperator {
     fn xml_type_name(&self) -> &'static str {
         "EXPR_BINARY_OPERATOR"
     }
@@ -534,7 +534,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::ExprBinaryOperator {
         if let Some(v) = &self.precedence_overridden {
             __attrs.push(("precedence_overridden", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -550,7 +550,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::ExprBinaryOperator {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::ExprBinaryOperator {
+impl crate::xml::runtime::FromXml for crate::aom2::types::ExprBinaryOperator {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -583,7 +583,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::ExprBinaryOperator {
                 }
             }
         }
-        Ok(crate::aom2::ExprBinaryOperator {
+        Ok(crate::aom2::types::ExprBinaryOperator {
             r#type: start.attr("type").map(|s| s.to_string()),
             precedence_overridden: start.attr("precedence_overridden").map(|s| s.to_string()),
             operator: __operator.ok_or_else(|| {
@@ -599,12 +599,12 @@ impl crate::xml::runtime::FromXml for crate::aom2::ExprBinaryOperator {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::ExprItem {
+impl crate::xml::runtime::ToXml for crate::aom2::types::ExprItem {
     fn xml_type_name(&self) -> &'static str {
         match self {
-            crate::aom2::ExprItem::ExprBinaryOperator(x) => x.xml_type_name(),
-            crate::aom2::ExprItem::ExprLeaf(x) => x.xml_type_name(),
-            crate::aom2::ExprItem::ExprUnaryOperator(x) => x.xml_type_name(),
+            crate::aom2::types::ExprItem::ExprBinaryOperator(x) => x.xml_type_name(),
+            crate::aom2::types::ExprItem::ExprLeaf(x) => x.xml_type_name(),
+            crate::aom2::types::ExprItem::ExprUnaryOperator(x) => x.xml_type_name(),
         }
     }
     fn write_xml(
@@ -614,26 +614,26 @@ impl crate::xml::runtime::ToXml for crate::aom2::ExprItem {
         declared: Option<&str>,
     ) -> Result<(), crate::xml::runtime::XmlError> {
         match self {
-            crate::aom2::ExprItem::ExprBinaryOperator(x) => x.write_xml(w, tag, declared),
-            crate::aom2::ExprItem::ExprLeaf(x) => x.write_xml(w, tag, declared),
-            crate::aom2::ExprItem::ExprUnaryOperator(x) => x.write_xml(w, tag, declared),
+            crate::aom2::types::ExprItem::ExprBinaryOperator(x) => x.write_xml(w, tag, declared),
+            crate::aom2::types::ExprItem::ExprLeaf(x) => x.write_xml(w, tag, declared),
+            crate::aom2::types::ExprItem::ExprUnaryOperator(x) => x.write_xml(w, tag, declared),
         }
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::ExprItem {
+impl crate::xml::runtime::FromXml for crate::aom2::types::ExprItem {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
     ) -> Result<Self, crate::xml::runtime::XmlError> {
         match start.xsi_type() {
-            Some("EXPR_BINARY_OPERATOR") => Ok(crate::aom2::ExprItem::ExprBinaryOperator(
+            Some("EXPR_BINARY_OPERATOR") => Ok(crate::aom2::types::ExprItem::ExprBinaryOperator(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("EXPR_LEAF") => Ok(crate::aom2::ExprItem::ExprLeaf(
+            Some("EXPR_LEAF") => Ok(crate::aom2::types::ExprItem::ExprLeaf(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("EXPR_UNARY_OPERATOR") => Ok(crate::aom2::ExprItem::ExprUnaryOperator(
+            Some("EXPR_UNARY_OPERATOR") => Ok(crate::aom2::types::ExprItem::ExprUnaryOperator(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
             None => Err(crate::xml::runtime::XmlError::Parse(
@@ -646,7 +646,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::ExprItem {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::ExprLeaf {
+impl crate::xml::runtime::ToXml for crate::aom2::types::ExprLeaf {
     fn xml_type_name(&self) -> &'static str {
         "EXPR_LEAF"
     }
@@ -668,7 +668,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::ExprLeaf {
         if let Some(v) = &self.reference_type {
             __attrs.push(("reference_type", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -679,7 +679,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::ExprLeaf {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::ExprLeaf {
+impl crate::xml::runtime::FromXml for crate::aom2::types::ExprLeaf {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -702,7 +702,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::ExprLeaf {
                 }
             }
         }
-        Ok(crate::aom2::ExprLeaf {
+        Ok(crate::aom2::types::ExprLeaf {
             r#type: start.attr("type").map(|s| s.to_string()),
             reference_type: start.attr("reference_type").map(|s| s.to_string()),
             item: __item.ok_or_else(|| {
@@ -712,11 +712,11 @@ impl crate::xml::runtime::FromXml for crate::aom2::ExprLeaf {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::ExprOperator {
+impl crate::xml::runtime::ToXml for crate::aom2::types::ExprOperator {
     fn xml_type_name(&self) -> &'static str {
         match self {
-            crate::aom2::ExprOperator::ExprBinaryOperator(x) => x.xml_type_name(),
-            crate::aom2::ExprOperator::ExprUnaryOperator(x) => x.xml_type_name(),
+            crate::aom2::types::ExprOperator::ExprBinaryOperator(x) => x.xml_type_name(),
+            crate::aom2::types::ExprOperator::ExprUnaryOperator(x) => x.xml_type_name(),
         }
     }
     fn write_xml(
@@ -726,22 +726,26 @@ impl crate::xml::runtime::ToXml for crate::aom2::ExprOperator {
         declared: Option<&str>,
     ) -> Result<(), crate::xml::runtime::XmlError> {
         match self {
-            crate::aom2::ExprOperator::ExprBinaryOperator(x) => x.write_xml(w, tag, declared),
-            crate::aom2::ExprOperator::ExprUnaryOperator(x) => x.write_xml(w, tag, declared),
+            crate::aom2::types::ExprOperator::ExprBinaryOperator(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::aom2::types::ExprOperator::ExprUnaryOperator(x) => x.write_xml(w, tag, declared),
         }
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::ExprOperator {
+impl crate::xml::runtime::FromXml for crate::aom2::types::ExprOperator {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
     ) -> Result<Self, crate::xml::runtime::XmlError> {
         match start.xsi_type() {
-            Some("EXPR_BINARY_OPERATOR") => Ok(crate::aom2::ExprOperator::ExprBinaryOperator(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("EXPR_UNARY_OPERATOR") => Ok(crate::aom2::ExprOperator::ExprUnaryOperator(
+            Some("EXPR_BINARY_OPERATOR") => {
+                Ok(crate::aom2::types::ExprOperator::ExprBinaryOperator(
+                    crate::xml::runtime::FromXml::from_xml(reader, start)?,
+                ))
+            }
+            Some("EXPR_UNARY_OPERATOR") => Ok(crate::aom2::types::ExprOperator::ExprUnaryOperator(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
             None => Err(crate::xml::runtime::XmlError::Parse(
@@ -754,7 +758,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::ExprOperator {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::ExprUnaryOperator {
+impl crate::xml::runtime::ToXml for crate::aom2::types::ExprUnaryOperator {
     fn xml_type_name(&self) -> &'static str {
         "EXPR_UNARY_OPERATOR"
     }
@@ -776,7 +780,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::ExprUnaryOperator {
         if let Some(v) = &self.precedence_overridden {
             __attrs.push(("precedence_overridden", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -789,7 +793,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::ExprUnaryOperator {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::ExprUnaryOperator {
+impl crate::xml::runtime::FromXml for crate::aom2::types::ExprUnaryOperator {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -816,7 +820,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::ExprUnaryOperator {
                 }
             }
         }
-        Ok(crate::aom2::ExprUnaryOperator {
+        Ok(crate::aom2::types::ExprUnaryOperator {
             r#type: start.attr("type").map(|s| s.to_string()),
             precedence_overridden: start.attr("precedence_overridden").map(|s| s.to_string()),
             operator: __operator.ok_or_else(|| {
@@ -829,7 +833,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::ExprUnaryOperator {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::Intervalofdate {
+impl crate::xml::runtime::ToXml for crate::aom2::types::Intervalofdate {
     fn xml_type_name(&self) -> &'static str {
         "IntervalOfDate"
     }
@@ -857,7 +861,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::Intervalofdate {
         if let Some(v) = &self.upper_unbounded {
             __attrs.push(("upper_unbounded", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -873,7 +877,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::Intervalofdate {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::Intervalofdate {
+impl crate::xml::runtime::FromXml for crate::aom2::types::Intervalofdate {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -900,7 +904,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::Intervalofdate {
                 }
             }
         }
-        Ok(crate::aom2::Intervalofdate {
+        Ok(crate::aom2::types::Intervalofdate {
             lower_included: start.attr("lower_included").map(|s| s.to_string()),
             upper_included: start.attr("upper_included").map(|s| s.to_string()),
             lower_unbounded: start.attr("lower_unbounded").map(|s| s.to_string()),
@@ -911,7 +915,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::Intervalofdate {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::Intervalofdatetime {
+impl crate::xml::runtime::ToXml for crate::aom2::types::Intervalofdatetime {
     fn xml_type_name(&self) -> &'static str {
         "IntervalOfDateTime"
     }
@@ -939,7 +943,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::Intervalofdatetime {
         if let Some(v) = &self.upper_unbounded {
             __attrs.push(("upper_unbounded", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -955,7 +959,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::Intervalofdatetime {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::Intervalofdatetime {
+impl crate::xml::runtime::FromXml for crate::aom2::types::Intervalofdatetime {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -982,7 +986,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::Intervalofdatetime {
                 }
             }
         }
-        Ok(crate::aom2::Intervalofdatetime {
+        Ok(crate::aom2::types::Intervalofdatetime {
             lower_included: start.attr("lower_included").map(|s| s.to_string()),
             upper_included: start.attr("upper_included").map(|s| s.to_string()),
             lower_unbounded: start.attr("lower_unbounded").map(|s| s.to_string()),
@@ -993,7 +997,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::Intervalofdatetime {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::Intervalofduration {
+impl crate::xml::runtime::ToXml for crate::aom2::types::Intervalofduration {
     fn xml_type_name(&self) -> &'static str {
         "IntervalOfDuration"
     }
@@ -1021,7 +1025,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::Intervalofduration {
         if let Some(v) = &self.upper_unbounded {
             __attrs.push(("upper_unbounded", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1037,7 +1041,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::Intervalofduration {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::Intervalofduration {
+impl crate::xml::runtime::FromXml for crate::aom2::types::Intervalofduration {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -1064,7 +1068,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::Intervalofduration {
                 }
             }
         }
-        Ok(crate::aom2::Intervalofduration {
+        Ok(crate::aom2::types::Intervalofduration {
             lower_included: start.attr("lower_included").map(|s| s.to_string()),
             upper_included: start.attr("upper_included").map(|s| s.to_string()),
             lower_unbounded: start.attr("lower_unbounded").map(|s| s.to_string()),
@@ -1075,7 +1079,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::Intervalofduration {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::Intervalofinteger {
+impl crate::xml::runtime::ToXml for crate::aom2::types::Intervalofinteger {
     fn xml_type_name(&self) -> &'static str {
         "IntervalOfInteger"
     }
@@ -1103,7 +1107,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::Intervalofinteger {
         if let Some(v) = &self.upper_unbounded {
             __attrs.push(("upper_unbounded", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1119,7 +1123,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::Intervalofinteger {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::Intervalofinteger {
+impl crate::xml::runtime::FromXml for crate::aom2::types::Intervalofinteger {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -1146,7 +1150,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::Intervalofinteger {
                 }
             }
         }
-        Ok(crate::aom2::Intervalofinteger {
+        Ok(crate::aom2::types::Intervalofinteger {
             lower_included: start.attr("lower_included").map(|s| s.to_string()),
             upper_included: start.attr("upper_included").map(|s| s.to_string()),
             lower_unbounded: start.attr("lower_unbounded").map(|s| s.to_string()),
@@ -1157,7 +1161,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::Intervalofinteger {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::Intervalofreal {
+impl crate::xml::runtime::ToXml for crate::aom2::types::Intervalofreal {
     fn xml_type_name(&self) -> &'static str {
         "IntervalOfReal"
     }
@@ -1185,7 +1189,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::Intervalofreal {
         if let Some(v) = &self.upper_unbounded {
             __attrs.push(("upper_unbounded", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1201,7 +1205,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::Intervalofreal {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::Intervalofreal {
+impl crate::xml::runtime::FromXml for crate::aom2::types::Intervalofreal {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -1228,7 +1232,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::Intervalofreal {
                 }
             }
         }
-        Ok(crate::aom2::Intervalofreal {
+        Ok(crate::aom2::types::Intervalofreal {
             lower_included: start.attr("lower_included").map(|s| s.to_string()),
             upper_included: start.attr("upper_included").map(|s| s.to_string()),
             lower_unbounded: start.attr("lower_unbounded").map(|s| s.to_string()),
@@ -1239,7 +1243,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::Intervalofreal {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::Intervaloftime {
+impl crate::xml::runtime::ToXml for crate::aom2::types::Intervaloftime {
     fn xml_type_name(&self) -> &'static str {
         "IntervalOfTime"
     }
@@ -1267,7 +1271,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::Intervaloftime {
         if let Some(v) = &self.upper_unbounded {
             __attrs.push(("upper_unbounded", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1283,7 +1287,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::Intervaloftime {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::Intervaloftime {
+impl crate::xml::runtime::FromXml for crate::aom2::types::Intervaloftime {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -1310,7 +1314,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::Intervaloftime {
                 }
             }
         }
-        Ok(crate::aom2::Intervaloftime {
+        Ok(crate::aom2::types::Intervaloftime {
             lower_included: start.attr("lower_included").map(|s| s.to_string()),
             upper_included: start.attr("upper_included").map(|s| s.to_string()),
             lower_unbounded: start.attr("lower_unbounded").map(|s| s.to_string()),
@@ -1321,7 +1325,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::Intervaloftime {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::Multiplicityinterval {
+impl crate::xml::runtime::ToXml for crate::aom2::types::Multiplicityinterval {
     fn xml_type_name(&self) -> &'static str {
         "MultiplicityInterval"
     }
@@ -1349,7 +1353,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::Multiplicityinterval {
         if let Some(v) = &self.upper_unbounded {
             __attrs.push(("upper_unbounded", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1365,7 +1369,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::Multiplicityinterval {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::Multiplicityinterval {
+impl crate::xml::runtime::FromXml for crate::aom2::types::Multiplicityinterval {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -1392,7 +1396,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::Multiplicityinterval {
                 }
             }
         }
-        Ok(crate::aom2::Multiplicityinterval {
+        Ok(crate::aom2::types::Multiplicityinterval {
             lower_included: start.attr("lower_included").map(|s| s.to_string()),
             upper_included: start.attr("upper_included").map(|s| s.to_string()),
             lower_unbounded: start.attr("lower_unbounded").map(|s| s.to_string()),
@@ -1403,7 +1407,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::Multiplicityinterval {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::OperatorKind {
+impl crate::xml::runtime::ToXml for crate::aom2::types::OperatorKind {
     fn xml_type_name(&self) -> &'static str {
         "OPERATOR_KIND"
     }
@@ -1420,7 +1424,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::OperatorKind {
             }
         }
         __attrs.push(("value", self.value.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1430,7 +1434,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::OperatorKind {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::OperatorKind {
+impl crate::xml::runtime::FromXml for crate::aom2::types::OperatorKind {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -1449,7 +1453,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::OperatorKind {
                 }
             }
         }
-        Ok(crate::aom2::OperatorKind {
+        Ok(crate::aom2::types::OperatorKind {
             value: start
                 .attr("value")
                 .ok_or_else(|| {
@@ -1460,7 +1464,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::OperatorKind {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::PArchetype {
+impl crate::xml::runtime::ToXml for crate::aom2::types::PArchetype {
     fn xml_type_name(&self) -> &'static str {
         "P_ARCHETYPE"
     }
@@ -1479,7 +1483,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PArchetype {
         if let Some(v) = &self.is_generated {
             __attrs.push(("is_generated", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1502,7 +1506,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PArchetype {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::PArchetype {
+impl crate::xml::runtime::FromXml for crate::aom2::types::PArchetype {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -1548,7 +1552,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PArchetype {
                 }
             }
         }
-        Ok(crate::aom2::PArchetype {
+        Ok(crate::aom2::types::PArchetype {
             is_generated: start.attr("is_generated").map(|s| s.to_string()),
             artefact_type: __artefact_type.ok_or_else(|| {
                 crate::xml::runtime::XmlError::Parse("missing element artefact_type".into())
@@ -1568,26 +1572,26 @@ impl crate::xml::runtime::FromXml for crate::aom2::PArchetype {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::PArchetypeConstraint {
+impl crate::xml::runtime::ToXml for crate::aom2::types::PArchetypeConstraint {
     fn xml_type_name(&self) -> &'static str {
         match self {
-            crate::aom2::PArchetypeConstraint::PArchetypeSlot(x) => x.xml_type_name(),
-            crate::aom2::PArchetypeConstraint::PCArchetypeRoot(x) => x.xml_type_name(),
-            crate::aom2::PArchetypeConstraint::PCAttribute(x) => x.xml_type_name(),
-            crate::aom2::PArchetypeConstraint::PCBoolean(x) => x.xml_type_name(),
-            crate::aom2::PArchetypeConstraint::PCComplexObject(x) => x.xml_type_name(),
-            crate::aom2::PArchetypeConstraint::PCComplexObjectProxy(x) => x.xml_type_name(),
-            crate::aom2::PArchetypeConstraint::PCDate(x) => x.xml_type_name(),
-            crate::aom2::PArchetypeConstraint::PCDateTime(x) => x.xml_type_name(),
-            crate::aom2::PArchetypeConstraint::PCDefinedObject(x) => x.xml_type_name(),
-            crate::aom2::PArchetypeConstraint::PCDuration(x) => x.xml_type_name(),
-            crate::aom2::PArchetypeConstraint::PCInteger(x) => x.xml_type_name(),
-            crate::aom2::PArchetypeConstraint::PCPrimitiveObject(x) => x.xml_type_name(),
-            crate::aom2::PArchetypeConstraint::PCReal(x) => x.xml_type_name(),
-            crate::aom2::PArchetypeConstraint::PCString(x) => x.xml_type_name(),
-            crate::aom2::PArchetypeConstraint::PCTemporal(x) => x.xml_type_name(),
-            crate::aom2::PArchetypeConstraint::PCTerminologyCode(x) => x.xml_type_name(),
-            crate::aom2::PArchetypeConstraint::PCTime(x) => x.xml_type_name(),
+            crate::aom2::types::PArchetypeConstraint::PArchetypeSlot(x) => x.xml_type_name(),
+            crate::aom2::types::PArchetypeConstraint::PCArchetypeRoot(x) => x.xml_type_name(),
+            crate::aom2::types::PArchetypeConstraint::PCAttribute(x) => x.xml_type_name(),
+            crate::aom2::types::PArchetypeConstraint::PCBoolean(x) => x.xml_type_name(),
+            crate::aom2::types::PArchetypeConstraint::PCComplexObject(x) => x.xml_type_name(),
+            crate::aom2::types::PArchetypeConstraint::PCComplexObjectProxy(x) => x.xml_type_name(),
+            crate::aom2::types::PArchetypeConstraint::PCDate(x) => x.xml_type_name(),
+            crate::aom2::types::PArchetypeConstraint::PCDateTime(x) => x.xml_type_name(),
+            crate::aom2::types::PArchetypeConstraint::PCDefinedObject(x) => x.xml_type_name(),
+            crate::aom2::types::PArchetypeConstraint::PCDuration(x) => x.xml_type_name(),
+            crate::aom2::types::PArchetypeConstraint::PCInteger(x) => x.xml_type_name(),
+            crate::aom2::types::PArchetypeConstraint::PCPrimitiveObject(x) => x.xml_type_name(),
+            crate::aom2::types::PArchetypeConstraint::PCReal(x) => x.xml_type_name(),
+            crate::aom2::types::PArchetypeConstraint::PCString(x) => x.xml_type_name(),
+            crate::aom2::types::PArchetypeConstraint::PCTemporal(x) => x.xml_type_name(),
+            crate::aom2::types::PArchetypeConstraint::PCTerminologyCode(x) => x.xml_type_name(),
+            crate::aom2::types::PArchetypeConstraint::PCTime(x) => x.xml_type_name(),
         }
     }
     fn write_xml(
@@ -1597,94 +1601,118 @@ impl crate::xml::runtime::ToXml for crate::aom2::PArchetypeConstraint {
         declared: Option<&str>,
     ) -> Result<(), crate::xml::runtime::XmlError> {
         match self {
-            crate::aom2::PArchetypeConstraint::PArchetypeSlot(x) => x.write_xml(w, tag, declared),
-            crate::aom2::PArchetypeConstraint::PCArchetypeRoot(x) => x.write_xml(w, tag, declared),
-            crate::aom2::PArchetypeConstraint::PCAttribute(x) => x.write_xml(w, tag, declared),
-            crate::aom2::PArchetypeConstraint::PCBoolean(x) => x.write_xml(w, tag, declared),
-            crate::aom2::PArchetypeConstraint::PCComplexObject(x) => x.write_xml(w, tag, declared),
-            crate::aom2::PArchetypeConstraint::PCComplexObjectProxy(x) => {
+            crate::aom2::types::PArchetypeConstraint::PArchetypeSlot(x) => {
                 x.write_xml(w, tag, declared)
             }
-            crate::aom2::PArchetypeConstraint::PCDate(x) => x.write_xml(w, tag, declared),
-            crate::aom2::PArchetypeConstraint::PCDateTime(x) => x.write_xml(w, tag, declared),
-            crate::aom2::PArchetypeConstraint::PCDefinedObject(x) => x.write_xml(w, tag, declared),
-            crate::aom2::PArchetypeConstraint::PCDuration(x) => x.write_xml(w, tag, declared),
-            crate::aom2::PArchetypeConstraint::PCInteger(x) => x.write_xml(w, tag, declared),
-            crate::aom2::PArchetypeConstraint::PCPrimitiveObject(x) => {
+            crate::aom2::types::PArchetypeConstraint::PCArchetypeRoot(x) => {
                 x.write_xml(w, tag, declared)
             }
-            crate::aom2::PArchetypeConstraint::PCReal(x) => x.write_xml(w, tag, declared),
-            crate::aom2::PArchetypeConstraint::PCString(x) => x.write_xml(w, tag, declared),
-            crate::aom2::PArchetypeConstraint::PCTemporal(x) => x.write_xml(w, tag, declared),
-            crate::aom2::PArchetypeConstraint::PCTerminologyCode(x) => {
+            crate::aom2::types::PArchetypeConstraint::PCAttribute(x) => {
                 x.write_xml(w, tag, declared)
             }
-            crate::aom2::PArchetypeConstraint::PCTime(x) => x.write_xml(w, tag, declared),
+            crate::aom2::types::PArchetypeConstraint::PCBoolean(x) => x.write_xml(w, tag, declared),
+            crate::aom2::types::PArchetypeConstraint::PCComplexObject(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::aom2::types::PArchetypeConstraint::PCComplexObjectProxy(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::aom2::types::PArchetypeConstraint::PCDate(x) => x.write_xml(w, tag, declared),
+            crate::aom2::types::PArchetypeConstraint::PCDateTime(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::aom2::types::PArchetypeConstraint::PCDefinedObject(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::aom2::types::PArchetypeConstraint::PCDuration(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::aom2::types::PArchetypeConstraint::PCInteger(x) => x.write_xml(w, tag, declared),
+            crate::aom2::types::PArchetypeConstraint::PCPrimitiveObject(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::aom2::types::PArchetypeConstraint::PCReal(x) => x.write_xml(w, tag, declared),
+            crate::aom2::types::PArchetypeConstraint::PCString(x) => x.write_xml(w, tag, declared),
+            crate::aom2::types::PArchetypeConstraint::PCTemporal(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::aom2::types::PArchetypeConstraint::PCTerminologyCode(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::aom2::types::PArchetypeConstraint::PCTime(x) => x.write_xml(w, tag, declared),
         }
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::PArchetypeConstraint {
+impl crate::xml::runtime::FromXml for crate::aom2::types::PArchetypeConstraint {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
     ) -> Result<Self, crate::xml::runtime::XmlError> {
         match start.xsi_type() {
-            Some("P_ARCHETYPE_SLOT") => Ok(crate::aom2::PArchetypeConstraint::PArchetypeSlot(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("P_C_ARCHETYPE_ROOT") => Ok(crate::aom2::PArchetypeConstraint::PCArchetypeRoot(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("P_C_ATTRIBUTE") => Ok(crate::aom2::PArchetypeConstraint::PCAttribute(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("P_C_BOOLEAN") => Ok(crate::aom2::PArchetypeConstraint::PCBoolean(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("P_C_COMPLEX_OBJECT") => Ok(crate::aom2::PArchetypeConstraint::PCComplexObject(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("P_C_COMPLEX_OBJECT_PROXY") => {
-                Ok(crate::aom2::PArchetypeConstraint::PCComplexObjectProxy(
+            Some("P_ARCHETYPE_SLOT") => {
+                Ok(crate::aom2::types::PArchetypeConstraint::PArchetypeSlot(
                     crate::xml::runtime::FromXml::from_xml(reader, start)?,
                 ))
             }
-            Some("P_C_DATE") => Ok(crate::aom2::PArchetypeConstraint::PCDate(
+            Some("P_C_ARCHETYPE_ROOT") => {
+                Ok(crate::aom2::types::PArchetypeConstraint::PCArchetypeRoot(
+                    crate::xml::runtime::FromXml::from_xml(reader, start)?,
+                ))
+            }
+            Some("P_C_ATTRIBUTE") => Ok(crate::aom2::types::PArchetypeConstraint::PCAttribute(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("P_C_DATE_TIME") => Ok(crate::aom2::PArchetypeConstraint::PCDateTime(
+            Some("P_C_BOOLEAN") => Ok(crate::aom2::types::PArchetypeConstraint::PCBoolean(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("P_C_DEFINED_OBJECT") => Ok(crate::aom2::PArchetypeConstraint::PCDefinedObject(
+            Some("P_C_COMPLEX_OBJECT") => {
+                Ok(crate::aom2::types::PArchetypeConstraint::PCComplexObject(
+                    crate::xml::runtime::FromXml::from_xml(reader, start)?,
+                ))
+            }
+            Some("P_C_COMPLEX_OBJECT_PROXY") => Ok(
+                crate::aom2::types::PArchetypeConstraint::PCComplexObjectProxy(
+                    crate::xml::runtime::FromXml::from_xml(reader, start)?,
+                ),
+            ),
+            Some("P_C_DATE") => Ok(crate::aom2::types::PArchetypeConstraint::PCDate(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("P_C_DURATION") => Ok(crate::aom2::PArchetypeConstraint::PCDuration(
+            Some("P_C_DATE_TIME") => Ok(crate::aom2::types::PArchetypeConstraint::PCDateTime(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("P_C_INTEGER") => Ok(crate::aom2::PArchetypeConstraint::PCInteger(
+            Some("P_C_DEFINED_OBJECT") => {
+                Ok(crate::aom2::types::PArchetypeConstraint::PCDefinedObject(
+                    crate::xml::runtime::FromXml::from_xml(reader, start)?,
+                ))
+            }
+            Some("P_C_DURATION") => Ok(crate::aom2::types::PArchetypeConstraint::PCDuration(
+                crate::xml::runtime::FromXml::from_xml(reader, start)?,
+            )),
+            Some("P_C_INTEGER") => Ok(crate::aom2::types::PArchetypeConstraint::PCInteger(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
             Some("P_C_PRIMITIVE_OBJECT") => {
-                Ok(crate::aom2::PArchetypeConstraint::PCPrimitiveObject(
+                Ok(crate::aom2::types::PArchetypeConstraint::PCPrimitiveObject(
                     crate::xml::runtime::FromXml::from_xml(reader, start)?,
                 ))
             }
-            Some("P_C_REAL") => Ok(crate::aom2::PArchetypeConstraint::PCReal(
+            Some("P_C_REAL") => Ok(crate::aom2::types::PArchetypeConstraint::PCReal(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("P_C_STRING") => Ok(crate::aom2::PArchetypeConstraint::PCString(
+            Some("P_C_STRING") => Ok(crate::aom2::types::PArchetypeConstraint::PCString(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("P_C_TEMPORAL") => Ok(crate::aom2::PArchetypeConstraint::PCTemporal(
+            Some("P_C_TEMPORAL") => Ok(crate::aom2::types::PArchetypeConstraint::PCTemporal(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
             Some("P_C_TERMINOLOGY_CODE") => {
-                Ok(crate::aom2::PArchetypeConstraint::PCTerminologyCode(
+                Ok(crate::aom2::types::PArchetypeConstraint::PCTerminologyCode(
                     crate::xml::runtime::FromXml::from_xml(reader, start)?,
                 ))
             }
-            Some("P_C_TIME") => Ok(crate::aom2::PArchetypeConstraint::PCTime(
+            Some("P_C_TIME") => Ok(crate::aom2::types::PArchetypeConstraint::PCTime(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
             None => Err(crate::xml::runtime::XmlError::Parse(
@@ -1697,7 +1725,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PArchetypeConstraint {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::PArchetypeHrid {
+impl crate::xml::runtime::ToXml for crate::aom2::types::PArchetypeHrid {
     fn xml_type_name(&self) -> &'static str {
         "P_ARCHETYPE_HRID"
     }
@@ -1737,7 +1765,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PArchetypeHrid {
         if let Some(v) = &self.physical_id {
             __attrs.push(("physical_id", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1748,7 +1776,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PArchetypeHrid {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::PArchetypeHrid {
+impl crate::xml::runtime::FromXml for crate::aom2::types::PArchetypeHrid {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -1771,7 +1799,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PArchetypeHrid {
                 }
             }
         }
-        Ok(crate::aom2::PArchetypeHrid {
+        Ok(crate::aom2::types::PArchetypeHrid {
             namespace: start.attr("namespace").map(|s| s.to_string()),
             rm_publisher: start.attr("rm_publisher").map(|s| s.to_string()),
             rm_package: start.attr("rm_package").map(|s| s.to_string()),
@@ -1787,7 +1815,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PArchetypeHrid {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::PArchetypeSlot {
+impl crate::xml::runtime::ToXml for crate::aom2::types::PArchetypeSlot {
     fn xml_type_name(&self) -> &'static str {
         "P_ARCHETYPE_SLOT"
     }
@@ -1818,7 +1846,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PArchetypeSlot {
         if let Some(v) = &self.is_closed {
             __attrs.push(("is_closed", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1837,7 +1865,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PArchetypeSlot {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::PArchetypeSlot {
+impl crate::xml::runtime::FromXml for crate::aom2::types::PArchetypeSlot {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -1868,7 +1896,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PArchetypeSlot {
                 }
             }
         }
-        Ok(crate::aom2::PArchetypeSlot {
+        Ok(crate::aom2::types::PArchetypeSlot {
             occurrences: start.attr("occurrences").map(|s| s.to_string()),
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
@@ -1881,7 +1909,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PArchetypeSlot {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::PArchetypeTerminology {
+impl crate::xml::runtime::ToXml for crate::aom2::types::PArchetypeTerminology {
     fn xml_type_name(&self) -> &'static str {
         "P_ARCHETYPE_TERMINOLOGY"
     }
@@ -1900,7 +1928,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PArchetypeTerminology {
         if let Some(v) = &self.original_language {
             __attrs.push(("original_language", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1922,7 +1950,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PArchetypeTerminology {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::PArchetypeTerminology {
+impl crate::xml::runtime::FromXml for crate::aom2::types::PArchetypeTerminology {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -1959,7 +1987,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PArchetypeTerminology {
                 }
             }
         }
-        Ok(crate::aom2::PArchetypeTerminology {
+        Ok(crate::aom2::types::PArchetypeTerminology {
             original_language: start.attr("original_language").map(|s| s.to_string()),
             term_definitions: __term_definitions,
             terminology_extracts: __terminology_extracts,
@@ -1969,7 +1997,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PArchetypeTerminology {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::PAuthoredArchetype {
+impl crate::xml::runtime::ToXml for crate::aom2::types::PAuthoredArchetype {
     fn xml_type_name(&self) -> &'static str {
         "P_AUTHORED_ARCHETYPE"
     }
@@ -1994,7 +2022,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PAuthoredArchetype {
         if let Some(v) = &self.adl_version {
             __attrs.push(("adl_version", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2039,7 +2067,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PAuthoredArchetype {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::PAuthoredArchetype {
+impl crate::xml::runtime::FromXml for crate::aom2::types::PAuthoredArchetype {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -2117,7 +2145,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PAuthoredArchetype {
                 }
             }
         }
-        Ok(crate::aom2::PAuthoredArchetype {
+        Ok(crate::aom2::types::PAuthoredArchetype {
             is_generated: start.attr("is_generated").map(|s| s.to_string()),
             rm_release: start.attr("rm_release").map(|s| s.to_string()),
             adl_version: start.attr("adl_version").map(|s| s.to_string()),
@@ -2152,7 +2180,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PAuthoredArchetype {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::PCArchetypeRoot {
+impl crate::xml::runtime::ToXml for crate::aom2::types::PCArchetypeRoot {
     fn xml_type_name(&self) -> &'static str {
         "P_C_ARCHETYPE_ROOT"
     }
@@ -2183,7 +2211,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCArchetypeRoot {
         if let Some(v) = &self.is_frozen {
             __attrs.push(("is_frozen", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2205,7 +2233,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCArchetypeRoot {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::PCArchetypeRoot {
+impl crate::xml::runtime::FromXml for crate::aom2::types::PCArchetypeRoot {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -2242,7 +2270,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCArchetypeRoot {
                 }
             }
         }
-        Ok(crate::aom2::PCArchetypeRoot {
+        Ok(crate::aom2::types::PCArchetypeRoot {
             occurrences: start.attr("occurrences").map(|s| s.to_string()),
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
@@ -2256,7 +2284,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCArchetypeRoot {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::PCAttribute {
+impl crate::xml::runtime::ToXml for crate::aom2::types::PCAttribute {
     fn xml_type_name(&self) -> &'static str {
         "P_C_ATTRIBUTE"
     }
@@ -2284,7 +2312,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCAttribute {
         if let Some(v) = &self.is_multiple {
             __attrs.push(("is_multiple", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2300,7 +2328,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCAttribute {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::PCAttribute {
+impl crate::xml::runtime::FromXml for crate::aom2::types::PCAttribute {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -2328,7 +2356,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCAttribute {
                 }
             }
         }
-        Ok(crate::aom2::PCAttribute {
+        Ok(crate::aom2::types::PCAttribute {
             rm_attribute_name: start.attr("rm_attribute_name").map(|s| s.to_string()),
             existence: start.attr("existence").map(|s| s.to_string()),
             cardinality: start.attr("cardinality").map(|s| s.to_string()),
@@ -2339,7 +2367,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCAttribute {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::PCAttributeTuple {
+impl crate::xml::runtime::ToXml for crate::aom2::types::PCAttributeTuple {
     fn xml_type_name(&self) -> &'static str {
         "P_C_ATTRIBUTE_TUPLE"
     }
@@ -2355,7 +2383,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCAttributeTuple {
                 __attrs.push(("xsi:type", "P_C_ATTRIBUTE_TUPLE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2368,7 +2396,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCAttributeTuple {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::PCAttributeTuple {
+impl crate::xml::runtime::FromXml for crate::aom2::types::PCAttributeTuple {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -2391,11 +2419,11 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCAttributeTuple {
                 }
             }
         }
-        Ok(crate::aom2::PCAttributeTuple { members: __members })
+        Ok(crate::aom2::types::PCAttributeTuple { members: __members })
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::PCBoolean {
+impl crate::xml::runtime::ToXml for crate::aom2::types::PCBoolean {
     fn xml_type_name(&self) -> &'static str {
         "P_C_BOOLEAN"
     }
@@ -2429,7 +2457,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCBoolean {
         if let Some(v) = &self.is_enumerated_type_constraint {
             __attrs.push(("is_enumerated_type_constraint", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2451,7 +2479,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCBoolean {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::PCBoolean {
+impl crate::xml::runtime::FromXml for crate::aom2::types::PCBoolean {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -2488,7 +2516,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCBoolean {
                 }
             }
         }
-        Ok(crate::aom2::PCBoolean {
+        Ok(crate::aom2::types::PCBoolean {
             occurrences: start.attr("occurrences").map(|s| s.to_string()),
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
@@ -2505,7 +2533,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCBoolean {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::PCComplexObject {
+impl crate::xml::runtime::ToXml for crate::aom2::types::PCComplexObject {
     fn xml_type_name(&self) -> &'static str {
         "P_C_COMPLEX_OBJECT"
     }
@@ -2536,7 +2564,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCComplexObject {
         if let Some(v) = &self.is_frozen {
             __attrs.push(("is_frozen", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2555,7 +2583,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCComplexObject {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::PCComplexObject {
+impl crate::xml::runtime::FromXml for crate::aom2::types::PCComplexObject {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -2587,7 +2615,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCComplexObject {
                 }
             }
         }
-        Ok(crate::aom2::PCComplexObject {
+        Ok(crate::aom2::types::PCComplexObject {
             occurrences: start.attr("occurrences").map(|s| s.to_string()),
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
@@ -2600,7 +2628,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCComplexObject {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::PCComplexObjectProxy {
+impl crate::xml::runtime::ToXml for crate::aom2::types::PCComplexObjectProxy {
     fn xml_type_name(&self) -> &'static str {
         "P_C_COMPLEX_OBJECT_PROXY"
     }
@@ -2628,7 +2656,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCComplexObjectProxy {
         if let Some(v) = &self.rm_type_name {
             __attrs.push(("rm_type_name", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2642,7 +2670,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCComplexObjectProxy {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::PCComplexObjectProxy {
+impl crate::xml::runtime::FromXml for crate::aom2::types::PCComplexObjectProxy {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -2669,7 +2697,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCComplexObjectProxy {
                 }
             }
         }
-        Ok(crate::aom2::PCComplexObjectProxy {
+        Ok(crate::aom2::types::PCComplexObjectProxy {
             occurrences: start.attr("occurrences").map(|s| s.to_string()),
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
@@ -2682,7 +2710,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCComplexObjectProxy {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::PCDate {
+impl crate::xml::runtime::ToXml for crate::aom2::types::PCDate {
     fn xml_type_name(&self) -> &'static str {
         "P_C_DATE"
     }
@@ -2716,7 +2744,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCDate {
         if let Some(v) = &self.is_enumerated_type_constraint {
             __attrs.push(("is_enumerated_type_constraint", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2735,7 +2763,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCDate {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::PCDate {
+impl crate::xml::runtime::FromXml for crate::aom2::types::PCDate {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -2767,7 +2795,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCDate {
                 }
             }
         }
-        Ok(crate::aom2::PCDate {
+        Ok(crate::aom2::types::PCDate {
             occurrences: start.attr("occurrences").map(|s| s.to_string()),
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
@@ -2783,7 +2811,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCDate {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::PCDateTime {
+impl crate::xml::runtime::ToXml for crate::aom2::types::PCDateTime {
     fn xml_type_name(&self) -> &'static str {
         "P_C_DATE_TIME"
     }
@@ -2817,7 +2845,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCDateTime {
         if let Some(v) = &self.is_enumerated_type_constraint {
             __attrs.push(("is_enumerated_type_constraint", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2836,7 +2864,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCDateTime {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::PCDateTime {
+impl crate::xml::runtime::FromXml for crate::aom2::types::PCDateTime {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -2868,7 +2896,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCDateTime {
                 }
             }
         }
-        Ok(crate::aom2::PCDateTime {
+        Ok(crate::aom2::types::PCDateTime {
             occurrences: start.attr("occurrences").map(|s| s.to_string()),
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
@@ -2884,7 +2912,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCDateTime {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::PCDefinedObject {
+impl crate::xml::runtime::ToXml for crate::aom2::types::PCDefinedObject {
     fn xml_type_name(&self) -> &'static str {
         "P_C_DEFINED_OBJECT"
     }
@@ -2915,7 +2943,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCDefinedObject {
         if let Some(v) = &self.is_frozen {
             __attrs.push(("is_frozen", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2928,7 +2956,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCDefinedObject {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::PCDefinedObject {
+impl crate::xml::runtime::FromXml for crate::aom2::types::PCDefinedObject {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -2951,7 +2979,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCDefinedObject {
                 }
             }
         }
-        Ok(crate::aom2::PCDefinedObject {
+        Ok(crate::aom2::types::PCDefinedObject {
             occurrences: start.attr("occurrences").map(|s| s.to_string()),
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
@@ -2962,7 +2990,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCDefinedObject {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::PCDuration {
+impl crate::xml::runtime::ToXml for crate::aom2::types::PCDuration {
     fn xml_type_name(&self) -> &'static str {
         "P_C_DURATION"
     }
@@ -2996,7 +3024,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCDuration {
         if let Some(v) = &self.is_enumerated_type_constraint {
             __attrs.push(("is_enumerated_type_constraint", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3015,7 +3043,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCDuration {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::PCDuration {
+impl crate::xml::runtime::FromXml for crate::aom2::types::PCDuration {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -3047,7 +3075,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCDuration {
                 }
             }
         }
-        Ok(crate::aom2::PCDuration {
+        Ok(crate::aom2::types::PCDuration {
             occurrences: start.attr("occurrences").map(|s| s.to_string()),
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
@@ -3063,7 +3091,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCDuration {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::PCInteger {
+impl crate::xml::runtime::ToXml for crate::aom2::types::PCInteger {
     fn xml_type_name(&self) -> &'static str {
         "P_C_INTEGER"
     }
@@ -3097,7 +3125,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCInteger {
         if let Some(v) = &self.is_enumerated_type_constraint {
             __attrs.push(("is_enumerated_type_constraint", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3119,7 +3147,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCInteger {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::PCInteger {
+impl crate::xml::runtime::FromXml for crate::aom2::types::PCInteger {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -3156,7 +3184,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCInteger {
                 }
             }
         }
-        Ok(crate::aom2::PCInteger {
+        Ok(crate::aom2::types::PCInteger {
             occurrences: start.attr("occurrences").map(|s| s.to_string()),
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
@@ -3173,25 +3201,25 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCInteger {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::PCObject {
+impl crate::xml::runtime::ToXml for crate::aom2::types::PCObject {
     fn xml_type_name(&self) -> &'static str {
         match self {
-            crate::aom2::PCObject::PArchetypeSlot(x) => x.xml_type_name(),
-            crate::aom2::PCObject::PCArchetypeRoot(x) => x.xml_type_name(),
-            crate::aom2::PCObject::PCBoolean(x) => x.xml_type_name(),
-            crate::aom2::PCObject::PCComplexObject(x) => x.xml_type_name(),
-            crate::aom2::PCObject::PCComplexObjectProxy(x) => x.xml_type_name(),
-            crate::aom2::PCObject::PCDate(x) => x.xml_type_name(),
-            crate::aom2::PCObject::PCDateTime(x) => x.xml_type_name(),
-            crate::aom2::PCObject::PCDefinedObject(x) => x.xml_type_name(),
-            crate::aom2::PCObject::PCDuration(x) => x.xml_type_name(),
-            crate::aom2::PCObject::PCInteger(x) => x.xml_type_name(),
-            crate::aom2::PCObject::PCPrimitiveObject(x) => x.xml_type_name(),
-            crate::aom2::PCObject::PCReal(x) => x.xml_type_name(),
-            crate::aom2::PCObject::PCString(x) => x.xml_type_name(),
-            crate::aom2::PCObject::PCTemporal(x) => x.xml_type_name(),
-            crate::aom2::PCObject::PCTerminologyCode(x) => x.xml_type_name(),
-            crate::aom2::PCObject::PCTime(x) => x.xml_type_name(),
+            crate::aom2::types::PCObject::PArchetypeSlot(x) => x.xml_type_name(),
+            crate::aom2::types::PCObject::PCArchetypeRoot(x) => x.xml_type_name(),
+            crate::aom2::types::PCObject::PCBoolean(x) => x.xml_type_name(),
+            crate::aom2::types::PCObject::PCComplexObject(x) => x.xml_type_name(),
+            crate::aom2::types::PCObject::PCComplexObjectProxy(x) => x.xml_type_name(),
+            crate::aom2::types::PCObject::PCDate(x) => x.xml_type_name(),
+            crate::aom2::types::PCObject::PCDateTime(x) => x.xml_type_name(),
+            crate::aom2::types::PCObject::PCDefinedObject(x) => x.xml_type_name(),
+            crate::aom2::types::PCObject::PCDuration(x) => x.xml_type_name(),
+            crate::aom2::types::PCObject::PCInteger(x) => x.xml_type_name(),
+            crate::aom2::types::PCObject::PCPrimitiveObject(x) => x.xml_type_name(),
+            crate::aom2::types::PCObject::PCReal(x) => x.xml_type_name(),
+            crate::aom2::types::PCObject::PCString(x) => x.xml_type_name(),
+            crate::aom2::types::PCObject::PCTemporal(x) => x.xml_type_name(),
+            crate::aom2::types::PCObject::PCTerminologyCode(x) => x.xml_type_name(),
+            crate::aom2::types::PCObject::PCTime(x) => x.xml_type_name(),
         }
     }
     fn write_xml(
@@ -3201,78 +3229,80 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCObject {
         declared: Option<&str>,
     ) -> Result<(), crate::xml::runtime::XmlError> {
         match self {
-            crate::aom2::PCObject::PArchetypeSlot(x) => x.write_xml(w, tag, declared),
-            crate::aom2::PCObject::PCArchetypeRoot(x) => x.write_xml(w, tag, declared),
-            crate::aom2::PCObject::PCBoolean(x) => x.write_xml(w, tag, declared),
-            crate::aom2::PCObject::PCComplexObject(x) => x.write_xml(w, tag, declared),
-            crate::aom2::PCObject::PCComplexObjectProxy(x) => x.write_xml(w, tag, declared),
-            crate::aom2::PCObject::PCDate(x) => x.write_xml(w, tag, declared),
-            crate::aom2::PCObject::PCDateTime(x) => x.write_xml(w, tag, declared),
-            crate::aom2::PCObject::PCDefinedObject(x) => x.write_xml(w, tag, declared),
-            crate::aom2::PCObject::PCDuration(x) => x.write_xml(w, tag, declared),
-            crate::aom2::PCObject::PCInteger(x) => x.write_xml(w, tag, declared),
-            crate::aom2::PCObject::PCPrimitiveObject(x) => x.write_xml(w, tag, declared),
-            crate::aom2::PCObject::PCReal(x) => x.write_xml(w, tag, declared),
-            crate::aom2::PCObject::PCString(x) => x.write_xml(w, tag, declared),
-            crate::aom2::PCObject::PCTemporal(x) => x.write_xml(w, tag, declared),
-            crate::aom2::PCObject::PCTerminologyCode(x) => x.write_xml(w, tag, declared),
-            crate::aom2::PCObject::PCTime(x) => x.write_xml(w, tag, declared),
+            crate::aom2::types::PCObject::PArchetypeSlot(x) => x.write_xml(w, tag, declared),
+            crate::aom2::types::PCObject::PCArchetypeRoot(x) => x.write_xml(w, tag, declared),
+            crate::aom2::types::PCObject::PCBoolean(x) => x.write_xml(w, tag, declared),
+            crate::aom2::types::PCObject::PCComplexObject(x) => x.write_xml(w, tag, declared),
+            crate::aom2::types::PCObject::PCComplexObjectProxy(x) => x.write_xml(w, tag, declared),
+            crate::aom2::types::PCObject::PCDate(x) => x.write_xml(w, tag, declared),
+            crate::aom2::types::PCObject::PCDateTime(x) => x.write_xml(w, tag, declared),
+            crate::aom2::types::PCObject::PCDefinedObject(x) => x.write_xml(w, tag, declared),
+            crate::aom2::types::PCObject::PCDuration(x) => x.write_xml(w, tag, declared),
+            crate::aom2::types::PCObject::PCInteger(x) => x.write_xml(w, tag, declared),
+            crate::aom2::types::PCObject::PCPrimitiveObject(x) => x.write_xml(w, tag, declared),
+            crate::aom2::types::PCObject::PCReal(x) => x.write_xml(w, tag, declared),
+            crate::aom2::types::PCObject::PCString(x) => x.write_xml(w, tag, declared),
+            crate::aom2::types::PCObject::PCTemporal(x) => x.write_xml(w, tag, declared),
+            crate::aom2::types::PCObject::PCTerminologyCode(x) => x.write_xml(w, tag, declared),
+            crate::aom2::types::PCObject::PCTime(x) => x.write_xml(w, tag, declared),
         }
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::PCObject {
+impl crate::xml::runtime::FromXml for crate::aom2::types::PCObject {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
     ) -> Result<Self, crate::xml::runtime::XmlError> {
         match start.xsi_type() {
-            Some("P_ARCHETYPE_SLOT") => Ok(crate::aom2::PCObject::PArchetypeSlot(
+            Some("P_ARCHETYPE_SLOT") => Ok(crate::aom2::types::PCObject::PArchetypeSlot(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("P_C_ARCHETYPE_ROOT") => Ok(crate::aom2::PCObject::PCArchetypeRoot(
+            Some("P_C_ARCHETYPE_ROOT") => Ok(crate::aom2::types::PCObject::PCArchetypeRoot(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("P_C_BOOLEAN") => Ok(crate::aom2::PCObject::PCBoolean(
+            Some("P_C_BOOLEAN") => Ok(crate::aom2::types::PCObject::PCBoolean(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("P_C_COMPLEX_OBJECT") => Ok(crate::aom2::PCObject::PCComplexObject(
+            Some("P_C_COMPLEX_OBJECT") => Ok(crate::aom2::types::PCObject::PCComplexObject(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("P_C_COMPLEX_OBJECT_PROXY") => Ok(crate::aom2::PCObject::PCComplexObjectProxy(
+            Some("P_C_COMPLEX_OBJECT_PROXY") => {
+                Ok(crate::aom2::types::PCObject::PCComplexObjectProxy(
+                    crate::xml::runtime::FromXml::from_xml(reader, start)?,
+                ))
+            }
+            Some("P_C_DATE") => Ok(crate::aom2::types::PCObject::PCDate(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("P_C_DATE") => Ok(crate::aom2::PCObject::PCDate(
+            Some("P_C_DATE_TIME") => Ok(crate::aom2::types::PCObject::PCDateTime(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("P_C_DATE_TIME") => Ok(crate::aom2::PCObject::PCDateTime(
+            Some("P_C_DEFINED_OBJECT") => Ok(crate::aom2::types::PCObject::PCDefinedObject(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("P_C_DEFINED_OBJECT") => Ok(crate::aom2::PCObject::PCDefinedObject(
+            Some("P_C_DURATION") => Ok(crate::aom2::types::PCObject::PCDuration(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("P_C_DURATION") => Ok(crate::aom2::PCObject::PCDuration(
+            Some("P_C_INTEGER") => Ok(crate::aom2::types::PCObject::PCInteger(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("P_C_INTEGER") => Ok(crate::aom2::PCObject::PCInteger(
+            Some("P_C_PRIMITIVE_OBJECT") => Ok(crate::aom2::types::PCObject::PCPrimitiveObject(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("P_C_PRIMITIVE_OBJECT") => Ok(crate::aom2::PCObject::PCPrimitiveObject(
+            Some("P_C_REAL") => Ok(crate::aom2::types::PCObject::PCReal(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("P_C_REAL") => Ok(crate::aom2::PCObject::PCReal(
+            Some("P_C_STRING") => Ok(crate::aom2::types::PCObject::PCString(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("P_C_STRING") => Ok(crate::aom2::PCObject::PCString(
+            Some("P_C_TEMPORAL") => Ok(crate::aom2::types::PCObject::PCTemporal(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("P_C_TEMPORAL") => Ok(crate::aom2::PCObject::PCTemporal(
+            Some("P_C_TERMINOLOGY_CODE") => Ok(crate::aom2::types::PCObject::PCTerminologyCode(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("P_C_TERMINOLOGY_CODE") => Ok(crate::aom2::PCObject::PCTerminologyCode(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("P_C_TIME") => Ok(crate::aom2::PCObject::PCTime(
+            Some("P_C_TIME") => Ok(crate::aom2::types::PCObject::PCTime(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
             None => Err(crate::xml::runtime::XmlError::Parse(
@@ -3285,7 +3315,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCObject {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::PCPrimitiveObject {
+impl crate::xml::runtime::ToXml for crate::aom2::types::PCPrimitiveObject {
     fn xml_type_name(&self) -> &'static str {
         "P_C_PRIMITIVE_OBJECT"
     }
@@ -3319,7 +3349,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCPrimitiveObject {
         if let Some(v) = &self.is_enumerated_type_constraint {
             __attrs.push(("is_enumerated_type_constraint", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3332,7 +3362,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCPrimitiveObject {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::PCPrimitiveObject {
+impl crate::xml::runtime::FromXml for crate::aom2::types::PCPrimitiveObject {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -3355,7 +3385,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCPrimitiveObject {
                 }
             }
         }
-        Ok(crate::aom2::PCPrimitiveObject {
+        Ok(crate::aom2::types::PCPrimitiveObject {
             occurrences: start.attr("occurrences").map(|s| s.to_string()),
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
@@ -3369,7 +3399,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCPrimitiveObject {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::PCReal {
+impl crate::xml::runtime::ToXml for crate::aom2::types::PCReal {
     fn xml_type_name(&self) -> &'static str {
         "P_C_REAL"
     }
@@ -3403,7 +3433,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCReal {
         if let Some(v) = &self.is_enumerated_type_constraint {
             __attrs.push(("is_enumerated_type_constraint", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3425,7 +3455,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCReal {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::PCReal {
+impl crate::xml::runtime::FromXml for crate::aom2::types::PCReal {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -3462,7 +3492,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCReal {
                 }
             }
         }
-        Ok(crate::aom2::PCReal {
+        Ok(crate::aom2::types::PCReal {
             occurrences: start.attr("occurrences").map(|s| s.to_string()),
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
@@ -3479,7 +3509,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCReal {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::PCString {
+impl crate::xml::runtime::ToXml for crate::aom2::types::PCString {
     fn xml_type_name(&self) -> &'static str {
         "P_C_STRING"
     }
@@ -3513,7 +3543,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCString {
         if let Some(v) = &self.is_enumerated_type_constraint {
             __attrs.push(("is_enumerated_type_constraint", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3535,7 +3565,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCString {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::PCString {
+impl crate::xml::runtime::FromXml for crate::aom2::types::PCString {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -3572,7 +3602,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCString {
                 }
             }
         }
-        Ok(crate::aom2::PCString {
+        Ok(crate::aom2::types::PCString {
             occurrences: start.attr("occurrences").map(|s| s.to_string()),
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
@@ -3589,7 +3619,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCString {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::PCTemporal {
+impl crate::xml::runtime::ToXml for crate::aom2::types::PCTemporal {
     fn xml_type_name(&self) -> &'static str {
         "P_C_TEMPORAL"
     }
@@ -3623,7 +3653,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCTemporal {
         if let Some(v) = &self.is_enumerated_type_constraint {
             __attrs.push(("is_enumerated_type_constraint", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3636,7 +3666,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCTemporal {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::PCTemporal {
+impl crate::xml::runtime::FromXml for crate::aom2::types::PCTemporal {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -3659,7 +3689,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCTemporal {
                 }
             }
         }
-        Ok(crate::aom2::PCTemporal {
+        Ok(crate::aom2::types::PCTemporal {
             occurrences: start.attr("occurrences").map(|s| s.to_string()),
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
@@ -3673,7 +3703,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCTemporal {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::PCTerminologyCode {
+impl crate::xml::runtime::ToXml for crate::aom2::types::PCTerminologyCode {
     fn xml_type_name(&self) -> &'static str {
         "P_C_TERMINOLOGY_CODE"
     }
@@ -3707,7 +3737,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCTerminologyCode {
         if let Some(v) = &self.is_enumerated_type_constraint {
             __attrs.push(("is_enumerated_type_constraint", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3727,7 +3757,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCTerminologyCode {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::PCTerminologyCode {
+impl crate::xml::runtime::FromXml for crate::aom2::types::PCTerminologyCode {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -3764,7 +3794,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCTerminologyCode {
                 }
             }
         }
-        Ok(crate::aom2::PCTerminologyCode {
+        Ok(crate::aom2::types::PCTerminologyCode {
             occurrences: start.attr("occurrences").map(|s| s.to_string()),
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
@@ -3783,7 +3813,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCTerminologyCode {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::PCTime {
+impl crate::xml::runtime::ToXml for crate::aom2::types::PCTime {
     fn xml_type_name(&self) -> &'static str {
         "P_C_TIME"
     }
@@ -3817,7 +3847,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCTime {
         if let Some(v) = &self.is_enumerated_type_constraint {
             __attrs.push(("is_enumerated_type_constraint", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3836,7 +3866,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::PCTime {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::PCTime {
+impl crate::xml::runtime::FromXml for crate::aom2::types::PCTime {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -3868,7 +3898,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCTime {
                 }
             }
         }
-        Ok(crate::aom2::PCTime {
+        Ok(crate::aom2::types::PCTime {
             occurrences: start.attr("occurrences").map(|s| s.to_string()),
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
@@ -3884,7 +3914,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::PCTime {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::ResourceDescription {
+impl crate::xml::runtime::ToXml for crate::aom2::types::ResourceDescription {
     fn xml_type_name(&self) -> &'static str {
         "RESOURCE_DESCRIPTION"
     }
@@ -3900,7 +3930,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::ResourceDescription {
                 __attrs.push(("xsi:type", "RESOURCE_DESCRIPTION".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3957,7 +3987,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::ResourceDescription {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::ResourceDescription {
+impl crate::xml::runtime::FromXml for crate::aom2::types::ResourceDescription {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -4047,7 +4077,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::ResourceDescription {
                 }
             }
         }
-        Ok(crate::aom2::ResourceDescription {
+        Ok(crate::aom2::types::ResourceDescription {
             lifecycle_state: __lifecycle_state.ok_or_else(|| {
                 crate::xml::runtime::XmlError::Parse("missing element lifecycle_state".into())
             })?,
@@ -4080,7 +4110,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::ResourceDescription {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::ResourceDescriptionItem {
+impl crate::xml::runtime::ToXml for crate::aom2::types::ResourceDescriptionItem {
     fn xml_type_name(&self) -> &'static str {
         "RESOURCE_DESCRIPTION_ITEM"
     }
@@ -4099,7 +4129,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::ResourceDescriptionItem {
         if let Some(v) = &self.id {
             __attrs.push(("id", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4130,7 +4160,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::ResourceDescriptionItem {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::ResourceDescriptionItem {
+impl crate::xml::runtime::FromXml for crate::aom2::types::ResourceDescriptionItem {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -4181,7 +4211,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::ResourceDescriptionItem {
                 }
             }
         }
-        Ok(crate::aom2::ResourceDescriptionItem {
+        Ok(crate::aom2::types::ResourceDescriptionItem {
             id: start.attr("id").map(|s| s.to_string()),
             language: __language.ok_or_else(|| {
                 crate::xml::runtime::XmlError::Parse("missing element language".into())
@@ -4204,14 +4234,14 @@ impl crate::xml::runtime::FromXml for crate::aom2::ResourceDescriptionItem {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::RuleElement {
+impl crate::xml::runtime::ToXml for crate::aom2::types::RuleElement {
     fn xml_type_name(&self) -> &'static str {
         match self {
-            crate::aom2::RuleElement::Assertion(x) => x.xml_type_name(),
-            crate::aom2::RuleElement::ExprBinaryOperator(x) => x.xml_type_name(),
-            crate::aom2::RuleElement::ExprLeaf(x) => x.xml_type_name(),
-            crate::aom2::RuleElement::ExprUnaryOperator(x) => x.xml_type_name(),
-            crate::aom2::RuleElement::RuleStatement(x) => x.xml_type_name(),
+            crate::aom2::types::RuleElement::Assertion(x) => x.xml_type_name(),
+            crate::aom2::types::RuleElement::ExprBinaryOperator(x) => x.xml_type_name(),
+            crate::aom2::types::RuleElement::ExprLeaf(x) => x.xml_type_name(),
+            crate::aom2::types::RuleElement::ExprUnaryOperator(x) => x.xml_type_name(),
+            crate::aom2::types::RuleElement::RuleStatement(x) => x.xml_type_name(),
         }
     }
     fn write_xml(
@@ -4221,34 +4251,36 @@ impl crate::xml::runtime::ToXml for crate::aom2::RuleElement {
         declared: Option<&str>,
     ) -> Result<(), crate::xml::runtime::XmlError> {
         match self {
-            crate::aom2::RuleElement::Assertion(x) => x.write_xml(w, tag, declared),
-            crate::aom2::RuleElement::ExprBinaryOperator(x) => x.write_xml(w, tag, declared),
-            crate::aom2::RuleElement::ExprLeaf(x) => x.write_xml(w, tag, declared),
-            crate::aom2::RuleElement::ExprUnaryOperator(x) => x.write_xml(w, tag, declared),
-            crate::aom2::RuleElement::RuleStatement(x) => x.write_xml(w, tag, declared),
+            crate::aom2::types::RuleElement::Assertion(x) => x.write_xml(w, tag, declared),
+            crate::aom2::types::RuleElement::ExprBinaryOperator(x) => x.write_xml(w, tag, declared),
+            crate::aom2::types::RuleElement::ExprLeaf(x) => x.write_xml(w, tag, declared),
+            crate::aom2::types::RuleElement::ExprUnaryOperator(x) => x.write_xml(w, tag, declared),
+            crate::aom2::types::RuleElement::RuleStatement(x) => x.write_xml(w, tag, declared),
         }
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::RuleElement {
+impl crate::xml::runtime::FromXml for crate::aom2::types::RuleElement {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
     ) -> Result<Self, crate::xml::runtime::XmlError> {
         match start.xsi_type() {
-            Some("ASSERTION") => Ok(crate::aom2::RuleElement::Assertion(
+            Some("ASSERTION") => Ok(crate::aom2::types::RuleElement::Assertion(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("EXPR_BINARY_OPERATOR") => Ok(crate::aom2::RuleElement::ExprBinaryOperator(
+            Some("EXPR_BINARY_OPERATOR") => {
+                Ok(crate::aom2::types::RuleElement::ExprBinaryOperator(
+                    crate::xml::runtime::FromXml::from_xml(reader, start)?,
+                ))
+            }
+            Some("EXPR_LEAF") => Ok(crate::aom2::types::RuleElement::ExprLeaf(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("EXPR_LEAF") => Ok(crate::aom2::RuleElement::ExprLeaf(
+            Some("EXPR_UNARY_OPERATOR") => Ok(crate::aom2::types::RuleElement::ExprUnaryOperator(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("EXPR_UNARY_OPERATOR") => Ok(crate::aom2::RuleElement::ExprUnaryOperator(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("RULE_STATEMENT") => Ok(crate::aom2::RuleElement::RuleStatement(
+            Some("RULE_STATEMENT") => Ok(crate::aom2::types::RuleElement::RuleStatement(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
             None => Err(crate::xml::runtime::XmlError::Parse(
@@ -4261,7 +4293,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::RuleElement {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::RuleStatement {
+impl crate::xml::runtime::ToXml for crate::aom2::types::RuleStatement {
     fn xml_type_name(&self) -> &'static str {
         "RULE_STATEMENT"
     }
@@ -4280,7 +4312,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::RuleStatement {
         if let Some(v) = &self.r#type {
             __attrs.push(("type", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4290,7 +4322,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::RuleStatement {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::RuleStatement {
+impl crate::xml::runtime::FromXml for crate::aom2::types::RuleStatement {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -4309,13 +4341,13 @@ impl crate::xml::runtime::FromXml for crate::aom2::RuleStatement {
                 }
             }
         }
-        Ok(crate::aom2::RuleStatement {
+        Ok(crate::aom2::types::RuleStatement {
             r#type: start.attr("type").map(|s| s.to_string()),
         })
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::SiblingOrder {
+impl crate::xml::runtime::ToXml for crate::aom2::types::SiblingOrder {
     fn xml_type_name(&self) -> &'static str {
         "SIBLING_ORDER"
     }
@@ -4334,7 +4366,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::SiblingOrder {
         if let Some(v) = &self.is_before {
             __attrs.push(("is_before", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4346,7 +4378,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::SiblingOrder {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::SiblingOrder {
+impl crate::xml::runtime::FromXml for crate::aom2::types::SiblingOrder {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -4370,7 +4402,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::SiblingOrder {
                 }
             }
         }
-        Ok(crate::aom2::SiblingOrder {
+        Ok(crate::aom2::types::SiblingOrder {
             is_before: start.attr("is_before").map(|s| s.to_string()),
             sibling_node_id: __sibling_node_id.ok_or_else(|| {
                 crate::xml::runtime::XmlError::Parse("missing element sibling_node_id".into())
@@ -4379,7 +4411,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::SiblingOrder {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::TerminologyCode {
+impl crate::xml::runtime::ToXml for crate::aom2::types::TerminologyCode {
     fn xml_type_name(&self) -> &'static str {
         "TERMINOLOGY_CODE"
     }
@@ -4395,7 +4427,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::TerminologyCode {
                 __attrs.push(("xsi:type", "TERMINOLOGY_CODE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4408,7 +4440,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::TerminologyCode {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::TerminologyCode {
+impl crate::xml::runtime::FromXml for crate::aom2::types::TerminologyCode {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -4436,7 +4468,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::TerminologyCode {
                 }
             }
         }
-        Ok(crate::aom2::TerminologyCode {
+        Ok(crate::aom2::types::TerminologyCode {
             terminology_id: __terminology_id.ok_or_else(|| {
                 crate::xml::runtime::XmlError::Parse("missing element terminology_id".into())
             })?,
@@ -4447,7 +4479,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::TerminologyCode {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::TranslationDetails {
+impl crate::xml::runtime::ToXml for crate::aom2::types::TranslationDetails {
     fn xml_type_name(&self) -> &'static str {
         "TRANSLATION_DETAILS"
     }
@@ -4464,7 +4496,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::TranslationDetails {
             }
         }
         __attrs.push(("id", self.id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4489,7 +4521,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::TranslationDetails {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::TranslationDetails {
+impl crate::xml::runtime::FromXml for crate::aom2::types::TranslationDetails {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -4534,7 +4566,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::TranslationDetails {
                 }
             }
         }
-        Ok(crate::aom2::TranslationDetails {
+        Ok(crate::aom2::types::TranslationDetails {
             id: start
                 .attr("id")
                 .ok_or_else(|| crate::xml::runtime::XmlError::Parse("missing attribute id".into()))?
@@ -4554,7 +4586,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::TranslationDetails {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::Termbindingset {
+impl crate::xml::runtime::ToXml for crate::aom2::types::Termbindingset {
     fn xml_type_name(&self) -> &'static str {
         "TermBindingSet"
     }
@@ -4571,7 +4603,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::Termbindingset {
             }
         }
         __attrs.push(("id", self.id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4586,7 +4618,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::Termbindingset {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::Termbindingset {
+impl crate::xml::runtime::FromXml for crate::aom2::types::Termbindingset {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -4611,7 +4643,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::Termbindingset {
                 }
             }
         }
-        Ok(crate::aom2::Termbindingset {
+        Ok(crate::aom2::types::Termbindingset {
             id: start
                 .attr("id")
                 .ok_or_else(|| crate::xml::runtime::XmlError::Parse("missing attribute id".into()))?
@@ -4625,7 +4657,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::Termbindingset {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2::ValueSet {
+impl crate::xml::runtime::ToXml for crate::aom2::types::ValueSet {
     fn xml_type_name(&self) -> &'static str {
         "VALUE_SET"
     }
@@ -4642,7 +4674,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::ValueSet {
             }
         }
         __attrs.push(("id", self.id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4655,7 +4687,7 @@ impl crate::xml::runtime::ToXml for crate::aom2::ValueSet {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2::ValueSet {
+impl crate::xml::runtime::FromXml for crate::aom2::types::ValueSet {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -4678,7 +4710,7 @@ impl crate::xml::runtime::FromXml for crate::aom2::ValueSet {
                 }
             }
         }
-        Ok(crate::aom2::ValueSet {
+        Ok(crate::aom2::types::ValueSet {
             id: start
                 .attr("id")
                 .ok_or_else(|| crate::xml::runtime::XmlError::Parse("missing attribute id".into()))?

--- a/crates/openehr-its/src/aom2/mod.rs
+++ b/crates/openehr-its/src/aom2/mod.rs
@@ -10,22 +10,21 @@
 //! serialization — the AOM model form — is [`crate::aom2_model`].
 
 mod impls;
-mod types;
-pub use types::*;
+pub mod types;
 
-/// Parse a persistent-form AOM2 archetype XML document into a [`PAuthoredArchetype`].
+/// Parse a persistent-form AOM2 archetype XML document into a [`types::PAuthoredArchetype`].
 ///
 /// # Errors
 /// Propagates canonical-XML parse errors.
-pub fn from_xml(xml: &str) -> Result<PAuthoredArchetype, crate::xml::runtime::XmlError> {
+pub fn from_xml(xml: &str) -> Result<types::PAuthoredArchetype, crate::xml::runtime::XmlError> {
     crate::xml::runtime::from_xml(xml)
 }
 
-/// Serialize a [`PAuthoredArchetype`] back to AOM2 persistent-form archetype XML (root `<archetype>`,
+/// Serialize a [`types::PAuthoredArchetype`] back to AOM2 persistent-form archetype XML (root `<archetype>`,
 /// `http://schemas.openehr.org/v1`).
 ///
 /// # Errors
 /// Propagates canonical-XML serialization errors.
-pub fn to_xml(value: &PAuthoredArchetype) -> Result<String, crate::xml::runtime::XmlError> {
+pub fn to_xml(value: &types::PAuthoredArchetype) -> Result<String, crate::xml::runtime::XmlError> {
     crate::xml::runtime::to_xml(value, "archetype", crate::xml::runtime::Namespace::V1)
 }

--- a/crates/openehr-its/src/aom2/types.rs
+++ b/crates/openehr-its/src/aom2/types.rs
@@ -122,7 +122,7 @@ pub struct ExprLeaf {
     /// The `reference_type` attribute/element of the AOM2 persistent-form `EXPR_LEAF` XSD type.
     pub reference_type: Option<String>,
     /// The `item` attribute/element of the AOM2 persistent-form `EXPR_LEAF` XSD type.
-    pub item: crate::xml::XmlAny,
+    pub item: crate::xml::runtime::XmlAny,
 }
 
 /// openEHR AOM2 persistent-form `EXPR_OPERATOR`.

--- a/crates/openehr-its/src/aom2_model/impls.rs
+++ b/crates/openehr-its/src/aom2_model/impls.rs
@@ -14,7 +14,7 @@
 )]
 use crate::xml::runtime::{FromXml, ToXml, XmlError, XmlEvent};
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::Archetype {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::Archetype {
     fn xml_type_name(&self) -> &'static str {
         "ARCHETYPE"
     }
@@ -30,7 +30,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::Archetype {
                 __attrs.push(("xsi:type", "ARCHETYPE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -55,7 +55,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::Archetype {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::Archetype {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::Archetype {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -101,7 +101,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::Archetype {
                 }
             }
         }
-        Ok(crate::aom2_model::Archetype {
+        Ok(crate::aom2_model::types::Archetype {
             archetype_id: __archetype_id.ok_or_else(|| {
                 crate::xml::runtime::XmlError::Parse("missing element archetype_id".into())
             })?,
@@ -118,25 +118,27 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::Archetype {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::ArchetypeConstraint {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::ArchetypeConstraint {
     fn xml_type_name(&self) -> &'static str {
         match self {
-            crate::aom2_model::ArchetypeConstraint::ArchetypeSlot(x) => x.xml_type_name(),
-            crate::aom2_model::ArchetypeConstraint::CArchetypeRoot(x) => x.xml_type_name(),
-            crate::aom2_model::ArchetypeConstraint::CBoolean(x) => x.xml_type_name(),
-            crate::aom2_model::ArchetypeConstraint::CComplexObject(x) => x.xml_type_name(),
-            crate::aom2_model::ArchetypeConstraint::CComplexObjectProxy(x) => x.xml_type_name(),
-            crate::aom2_model::ArchetypeConstraint::CDate(x) => x.xml_type_name(),
-            crate::aom2_model::ArchetypeConstraint::CDateTime(x) => x.xml_type_name(),
-            crate::aom2_model::ArchetypeConstraint::CDefinedObject(x) => x.xml_type_name(),
-            crate::aom2_model::ArchetypeConstraint::CDuration(x) => x.xml_type_name(),
-            crate::aom2_model::ArchetypeConstraint::CInteger(x) => x.xml_type_name(),
-            crate::aom2_model::ArchetypeConstraint::CPrimitiveObject(x) => x.xml_type_name(),
-            crate::aom2_model::ArchetypeConstraint::CReal(x) => x.xml_type_name(),
-            crate::aom2_model::ArchetypeConstraint::CString(x) => x.xml_type_name(),
-            crate::aom2_model::ArchetypeConstraint::CTemporal(x) => x.xml_type_name(),
-            crate::aom2_model::ArchetypeConstraint::CTerminologyCode(x) => x.xml_type_name(),
-            crate::aom2_model::ArchetypeConstraint::CTime(x) => x.xml_type_name(),
+            crate::aom2_model::types::ArchetypeConstraint::ArchetypeSlot(x) => x.xml_type_name(),
+            crate::aom2_model::types::ArchetypeConstraint::CArchetypeRoot(x) => x.xml_type_name(),
+            crate::aom2_model::types::ArchetypeConstraint::CBoolean(x) => x.xml_type_name(),
+            crate::aom2_model::types::ArchetypeConstraint::CComplexObject(x) => x.xml_type_name(),
+            crate::aom2_model::types::ArchetypeConstraint::CComplexObjectProxy(x) => {
+                x.xml_type_name()
+            }
+            crate::aom2_model::types::ArchetypeConstraint::CDate(x) => x.xml_type_name(),
+            crate::aom2_model::types::ArchetypeConstraint::CDateTime(x) => x.xml_type_name(),
+            crate::aom2_model::types::ArchetypeConstraint::CDefinedObject(x) => x.xml_type_name(),
+            crate::aom2_model::types::ArchetypeConstraint::CDuration(x) => x.xml_type_name(),
+            crate::aom2_model::types::ArchetypeConstraint::CInteger(x) => x.xml_type_name(),
+            crate::aom2_model::types::ArchetypeConstraint::CPrimitiveObject(x) => x.xml_type_name(),
+            crate::aom2_model::types::ArchetypeConstraint::CReal(x) => x.xml_type_name(),
+            crate::aom2_model::types::ArchetypeConstraint::CString(x) => x.xml_type_name(),
+            crate::aom2_model::types::ArchetypeConstraint::CTemporal(x) => x.xml_type_name(),
+            crate::aom2_model::types::ArchetypeConstraint::CTerminologyCode(x) => x.xml_type_name(),
+            crate::aom2_model::types::ArchetypeConstraint::CTime(x) => x.xml_type_name(),
         }
     }
     fn write_xml(
@@ -146,98 +148,124 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::ArchetypeConstraint {
         declared: Option<&str>,
     ) -> Result<(), crate::xml::runtime::XmlError> {
         match self {
-            crate::aom2_model::ArchetypeConstraint::ArchetypeSlot(x) => {
+            crate::aom2_model::types::ArchetypeConstraint::ArchetypeSlot(x) => {
                 x.write_xml(w, tag, declared)
             }
-            crate::aom2_model::ArchetypeConstraint::CArchetypeRoot(x) => {
+            crate::aom2_model::types::ArchetypeConstraint::CArchetypeRoot(x) => {
                 x.write_xml(w, tag, declared)
             }
-            crate::aom2_model::ArchetypeConstraint::CBoolean(x) => x.write_xml(w, tag, declared),
-            crate::aom2_model::ArchetypeConstraint::CComplexObject(x) => {
+            crate::aom2_model::types::ArchetypeConstraint::CBoolean(x) => {
                 x.write_xml(w, tag, declared)
             }
-            crate::aom2_model::ArchetypeConstraint::CComplexObjectProxy(x) => {
+            crate::aom2_model::types::ArchetypeConstraint::CComplexObject(x) => {
                 x.write_xml(w, tag, declared)
             }
-            crate::aom2_model::ArchetypeConstraint::CDate(x) => x.write_xml(w, tag, declared),
-            crate::aom2_model::ArchetypeConstraint::CDateTime(x) => x.write_xml(w, tag, declared),
-            crate::aom2_model::ArchetypeConstraint::CDefinedObject(x) => {
+            crate::aom2_model::types::ArchetypeConstraint::CComplexObjectProxy(x) => {
                 x.write_xml(w, tag, declared)
             }
-            crate::aom2_model::ArchetypeConstraint::CDuration(x) => x.write_xml(w, tag, declared),
-            crate::aom2_model::ArchetypeConstraint::CInteger(x) => x.write_xml(w, tag, declared),
-            crate::aom2_model::ArchetypeConstraint::CPrimitiveObject(x) => {
+            crate::aom2_model::types::ArchetypeConstraint::CDate(x) => {
                 x.write_xml(w, tag, declared)
             }
-            crate::aom2_model::ArchetypeConstraint::CReal(x) => x.write_xml(w, tag, declared),
-            crate::aom2_model::ArchetypeConstraint::CString(x) => x.write_xml(w, tag, declared),
-            crate::aom2_model::ArchetypeConstraint::CTemporal(x) => x.write_xml(w, tag, declared),
-            crate::aom2_model::ArchetypeConstraint::CTerminologyCode(x) => {
+            crate::aom2_model::types::ArchetypeConstraint::CDateTime(x) => {
                 x.write_xml(w, tag, declared)
             }
-            crate::aom2_model::ArchetypeConstraint::CTime(x) => x.write_xml(w, tag, declared),
+            crate::aom2_model::types::ArchetypeConstraint::CDefinedObject(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::aom2_model::types::ArchetypeConstraint::CDuration(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::aom2_model::types::ArchetypeConstraint::CInteger(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::aom2_model::types::ArchetypeConstraint::CPrimitiveObject(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::aom2_model::types::ArchetypeConstraint::CReal(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::aom2_model::types::ArchetypeConstraint::CString(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::aom2_model::types::ArchetypeConstraint::CTemporal(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::aom2_model::types::ArchetypeConstraint::CTerminologyCode(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::aom2_model::types::ArchetypeConstraint::CTime(x) => {
+                x.write_xml(w, tag, declared)
+            }
         }
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::ArchetypeConstraint {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::ArchetypeConstraint {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
     ) -> Result<Self, crate::xml::runtime::XmlError> {
         match start.xsi_type() {
-            Some("ARCHETYPE_SLOT") => Ok(crate::aom2_model::ArchetypeConstraint::ArchetypeSlot(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("C_ARCHETYPE_ROOT") => Ok(crate::aom2_model::ArchetypeConstraint::CArchetypeRoot(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("C_BOOLEAN") => Ok(crate::aom2_model::ArchetypeConstraint::CBoolean(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("C_COMPLEX_OBJECT") => Ok(crate::aom2_model::ArchetypeConstraint::CComplexObject(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("C_COMPLEX_OBJECT_PROXY") => {
-                Ok(crate::aom2_model::ArchetypeConstraint::CComplexObjectProxy(
+            Some("ARCHETYPE_SLOT") => Ok(
+                crate::aom2_model::types::ArchetypeConstraint::ArchetypeSlot(
                     crate::xml::runtime::FromXml::from_xml(reader, start)?,
-                ))
-            }
-            Some("C_DATE") => Ok(crate::aom2_model::ArchetypeConstraint::CDate(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("C_DATE_TIME") => Ok(crate::aom2_model::ArchetypeConstraint::CDateTime(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("C_DEFINED_OBJECT") => Ok(crate::aom2_model::ArchetypeConstraint::CDefinedObject(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("C_DURATION") => Ok(crate::aom2_model::ArchetypeConstraint::CDuration(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("C_INTEGER") => Ok(crate::aom2_model::ArchetypeConstraint::CInteger(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("C_PRIMITIVE_OBJECT") => {
-                Ok(crate::aom2_model::ArchetypeConstraint::CPrimitiveObject(
+                ),
+            ),
+            Some("C_ARCHETYPE_ROOT") => Ok(
+                crate::aom2_model::types::ArchetypeConstraint::CArchetypeRoot(
                     crate::xml::runtime::FromXml::from_xml(reader, start)?,
-                ))
-            }
-            Some("C_REAL") => Ok(crate::aom2_model::ArchetypeConstraint::CReal(
+                ),
+            ),
+            Some("C_BOOLEAN") => Ok(crate::aom2_model::types::ArchetypeConstraint::CBoolean(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_STRING") => Ok(crate::aom2_model::ArchetypeConstraint::CString(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("C_TEMPORAL") => Ok(crate::aom2_model::ArchetypeConstraint::CTemporal(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("C_TERMINOLOGY_CODE") => {
-                Ok(crate::aom2_model::ArchetypeConstraint::CTerminologyCode(
+            Some("C_COMPLEX_OBJECT") => Ok(
+                crate::aom2_model::types::ArchetypeConstraint::CComplexObject(
                     crate::xml::runtime::FromXml::from_xml(reader, start)?,
-                ))
-            }
-            Some("C_TIME") => Ok(crate::aom2_model::ArchetypeConstraint::CTime(
+                ),
+            ),
+            Some("C_COMPLEX_OBJECT_PROXY") => Ok(
+                crate::aom2_model::types::ArchetypeConstraint::CComplexObjectProxy(
+                    crate::xml::runtime::FromXml::from_xml(reader, start)?,
+                ),
+            ),
+            Some("C_DATE") => Ok(crate::aom2_model::types::ArchetypeConstraint::CDate(
+                crate::xml::runtime::FromXml::from_xml(reader, start)?,
+            )),
+            Some("C_DATE_TIME") => Ok(crate::aom2_model::types::ArchetypeConstraint::CDateTime(
+                crate::xml::runtime::FromXml::from_xml(reader, start)?,
+            )),
+            Some("C_DEFINED_OBJECT") => Ok(
+                crate::aom2_model::types::ArchetypeConstraint::CDefinedObject(
+                    crate::xml::runtime::FromXml::from_xml(reader, start)?,
+                ),
+            ),
+            Some("C_DURATION") => Ok(crate::aom2_model::types::ArchetypeConstraint::CDuration(
+                crate::xml::runtime::FromXml::from_xml(reader, start)?,
+            )),
+            Some("C_INTEGER") => Ok(crate::aom2_model::types::ArchetypeConstraint::CInteger(
+                crate::xml::runtime::FromXml::from_xml(reader, start)?,
+            )),
+            Some("C_PRIMITIVE_OBJECT") => Ok(
+                crate::aom2_model::types::ArchetypeConstraint::CPrimitiveObject(
+                    crate::xml::runtime::FromXml::from_xml(reader, start)?,
+                ),
+            ),
+            Some("C_REAL") => Ok(crate::aom2_model::types::ArchetypeConstraint::CReal(
+                crate::xml::runtime::FromXml::from_xml(reader, start)?,
+            )),
+            Some("C_STRING") => Ok(crate::aom2_model::types::ArchetypeConstraint::CString(
+                crate::xml::runtime::FromXml::from_xml(reader, start)?,
+            )),
+            Some("C_TEMPORAL") => Ok(crate::aom2_model::types::ArchetypeConstraint::CTemporal(
+                crate::xml::runtime::FromXml::from_xml(reader, start)?,
+            )),
+            Some("C_TERMINOLOGY_CODE") => Ok(
+                crate::aom2_model::types::ArchetypeConstraint::CTerminologyCode(
+                    crate::xml::runtime::FromXml::from_xml(reader, start)?,
+                ),
+            ),
+            Some("C_TIME") => Ok(crate::aom2_model::types::ArchetypeConstraint::CTime(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
             None => Err(crate::xml::runtime::XmlError::Parse(
@@ -250,7 +278,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::ArchetypeConstraint {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::ArchetypeHrid {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::ArchetypeHrid {
     fn xml_type_name(&self) -> &'static str {
         "ARCHETYPE_HRID"
     }
@@ -287,7 +315,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::ArchetypeHrid {
         if let Some(v) = &self.build_count {
             __attrs.push(("build_count", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -300,7 +328,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::ArchetypeHrid {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::ArchetypeHrid {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::ArchetypeHrid {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -323,7 +351,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::ArchetypeHrid {
                 }
             }
         }
-        Ok(crate::aom2_model::ArchetypeHrid {
+        Ok(crate::aom2_model::types::ArchetypeHrid {
             namespace: start.attr("namespace").map(|s| s.to_string()),
             rm_publisher: start.attr("rm_publisher").map(|s| s.to_string()),
             rm_package: start.attr("rm_package").map(|s| s.to_string()),
@@ -336,7 +364,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::ArchetypeHrid {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::ArchetypeSlot {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::ArchetypeSlot {
     fn xml_type_name(&self) -> &'static str {
         "ARCHETYPE_SLOT"
     }
@@ -361,7 +389,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::ArchetypeSlot {
         if let Some(v) = &self.rm_type_name {
             __attrs.push(("rm_type_name", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -384,7 +412,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::ArchetypeSlot {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::ArchetypeSlot {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::ArchetypeSlot {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -423,7 +451,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::ArchetypeSlot {
                 }
             }
         }
-        Ok(crate::aom2_model::ArchetypeSlot {
+        Ok(crate::aom2_model::types::ArchetypeSlot {
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
             rm_type_name: start.attr("rm_type_name").map(|s| s.to_string()),
@@ -436,7 +464,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::ArchetypeSlot {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::ArchetypeTerm {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::ArchetypeTerm {
     fn xml_type_name(&self) -> &'static str {
         "ARCHETYPE_TERM"
     }
@@ -453,7 +481,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::ArchetypeTerm {
             }
         }
         __attrs.push(("id", self.id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -467,7 +495,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::ArchetypeTerm {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::ArchetypeTerm {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::ArchetypeTerm {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -494,7 +522,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::ArchetypeTerm {
                 }
             }
         }
-        Ok(crate::aom2_model::ArchetypeTerm {
+        Ok(crate::aom2_model::types::ArchetypeTerm {
             id: start
                 .attr("id")
                 .ok_or_else(|| crate::xml::runtime::XmlError::Parse("missing attribute id".into()))?
@@ -507,7 +535,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::ArchetypeTerm {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::ArchetypeTerminology {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::ArchetypeTerminology {
     fn xml_type_name(&self) -> &'static str {
         "ARCHETYPE_TERMINOLOGY"
     }
@@ -523,7 +551,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::ArchetypeTerminology {
                 __attrs.push(("xsi:type", "ARCHETYPE_TERMINOLOGY".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -542,7 +570,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::ArchetypeTerminology {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::ArchetypeTerminology {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::ArchetypeTerminology {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -574,7 +602,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::ArchetypeTerminology {
                 }
             }
         }
-        Ok(crate::aom2_model::ArchetypeTerminology {
+        Ok(crate::aom2_model::types::ArchetypeTerminology {
             term_definitions: __term_definitions,
             term_bindings: __term_bindings,
             value_sets: __value_sets,
@@ -582,7 +610,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::ArchetypeTerminology {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::Assertion {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::Assertion {
     fn xml_type_name(&self) -> &'static str {
         "ASSERTION"
     }
@@ -604,7 +632,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::Assertion {
         if let Some(v) = &self.tag {
             __attrs.push(("tag", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -616,7 +644,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::Assertion {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::Assertion {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::Assertion {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -639,7 +667,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::Assertion {
                 }
             }
         }
-        Ok(crate::aom2_model::Assertion {
+        Ok(crate::aom2_model::types::Assertion {
             r#type: start.attr("type").map(|s| s.to_string()),
             tag: start.attr("tag").map(|s| s.to_string()),
             expression: __expression.ok_or_else(|| {
@@ -649,7 +677,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::Assertion {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::AssertionVariable {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::AssertionVariable {
     fn xml_type_name(&self) -> &'static str {
         "ASSERTION_VARIABLE"
     }
@@ -668,7 +696,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::AssertionVariable {
         if let Some(v) = &self.name {
             __attrs.push(("name", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -679,7 +707,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::AssertionVariable {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::AssertionVariable {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::AssertionVariable {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -702,7 +730,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::AssertionVariable {
                 }
             }
         }
-        Ok(crate::aom2_model::AssertionVariable {
+        Ok(crate::aom2_model::types::AssertionVariable {
             name: start.attr("name").map(|s| s.to_string()),
             definition: __definition.ok_or_else(|| {
                 crate::xml::runtime::XmlError::Parse("missing element definition".into())
@@ -711,7 +739,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::AssertionVariable {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::AuthoredArchetype {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::AuthoredArchetype {
     fn xml_type_name(&self) -> &'static str {
         "AUTHORED_ARCHETYPE"
     }
@@ -727,7 +755,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::AuthoredArchetype {
                 __attrs.push(("xsi:type", "AUTHORED_ARCHETYPE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -783,7 +811,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::AuthoredArchetype {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::AuthoredArchetype {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::AuthoredArchetype {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -874,7 +902,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::AuthoredArchetype {
                 }
             }
         }
-        Ok(crate::aom2_model::AuthoredArchetype {
+        Ok(crate::aom2_model::types::AuthoredArchetype {
             original_language: __original_language.ok_or_else(|| {
                 crate::xml::runtime::XmlError::Parse("missing element original_language".into())
             })?,
@@ -907,10 +935,10 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::AuthoredArchetype {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::AuthoredResource {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::AuthoredResource {
     fn xml_type_name(&self) -> &'static str {
         match self {
-            crate::aom2_model::AuthoredResource::AuthoredArchetype(x) => x.xml_type_name(),
+            crate::aom2_model::types::AuthoredResource::AuthoredArchetype(x) => x.xml_type_name(),
         }
     }
     fn write_xml(
@@ -920,24 +948,24 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::AuthoredResource {
         declared: Option<&str>,
     ) -> Result<(), crate::xml::runtime::XmlError> {
         match self {
-            crate::aom2_model::AuthoredResource::AuthoredArchetype(x) => {
+            crate::aom2_model::types::AuthoredResource::AuthoredArchetype(x) => {
                 x.write_xml(w, tag, declared)
             }
         }
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::AuthoredResource {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::AuthoredResource {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
     ) -> Result<Self, crate::xml::runtime::XmlError> {
         match start.xsi_type() {
-            Some("AUTHORED_ARCHETYPE") => {
-                Ok(crate::aom2_model::AuthoredResource::AuthoredArchetype(
+            Some("AUTHORED_ARCHETYPE") => Ok(
+                crate::aom2_model::types::AuthoredResource::AuthoredArchetype(
                     crate::xml::runtime::FromXml::from_xml(reader, start)?,
-                ))
-            }
+                ),
+            ),
             None => Err(crate::xml::runtime::XmlError::Parse(
                 "AuthoredResource: missing xsi:type".into(),
             )),
@@ -948,7 +976,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::AuthoredResource {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::Annotationlangset {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::Annotationlangset {
     fn xml_type_name(&self) -> &'static str {
         "AnnotationLangSet"
     }
@@ -965,7 +993,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::Annotationlangset {
             }
         }
         __attrs.push(("id", self.id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -978,7 +1006,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::Annotationlangset {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::Annotationlangset {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::Annotationlangset {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -1001,7 +1029,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::Annotationlangset {
                 }
             }
         }
-        Ok(crate::aom2_model::Annotationlangset {
+        Ok(crate::aom2_model::types::Annotationlangset {
             id: start
                 .attr("id")
                 .ok_or_else(|| crate::xml::runtime::XmlError::Parse("missing attribute id".into()))?
@@ -1011,7 +1039,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::Annotationlangset {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::Annotationpathset {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::Annotationpathset {
     fn xml_type_name(&self) -> &'static str {
         "AnnotationPathSet"
     }
@@ -1028,7 +1056,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::Annotationpathset {
             }
         }
         __attrs.push(("id", self.id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1043,7 +1071,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::Annotationpathset {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::Annotationpathset {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::Annotationpathset {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -1068,7 +1096,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::Annotationpathset {
                 }
             }
         }
-        Ok(crate::aom2_model::Annotationpathset {
+        Ok(crate::aom2_model::types::Annotationpathset {
             id: start
                 .attr("id")
                 .ok_or_else(|| crate::xml::runtime::XmlError::Parse("missing attribute id".into()))?
@@ -1082,7 +1110,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::Annotationpathset {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::Cardinality {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::Cardinality {
     fn xml_type_name(&self) -> &'static str {
         "CARDINALITY"
     }
@@ -1098,7 +1126,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::Cardinality {
                 __attrs.push(("xsi:type", "CARDINALITY".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1112,7 +1140,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::Cardinality {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::Cardinality {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::Cardinality {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -1143,7 +1171,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::Cardinality {
                 }
             }
         }
-        Ok(crate::aom2_model::Cardinality {
+        Ok(crate::aom2_model::types::Cardinality {
             is_ordered: __is_ordered.unwrap_or(false),
             is_unique: __is_unique.unwrap_or(false),
             interval: __interval.ok_or_else(|| {
@@ -1153,7 +1181,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::Cardinality {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::CArchetypeRoot {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::CArchetypeRoot {
     fn xml_type_name(&self) -> &'static str {
         "C_ARCHETYPE_ROOT"
     }
@@ -1178,7 +1206,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CArchetypeRoot {
         if let Some(v) = &self.rm_type_name {
             __attrs.push(("rm_type_name", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1203,7 +1231,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CArchetypeRoot {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::CArchetypeRoot {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::CArchetypeRoot {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -1243,7 +1271,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CArchetypeRoot {
                 }
             }
         }
-        Ok(crate::aom2_model::CArchetypeRoot {
+        Ok(crate::aom2_model::types::CArchetypeRoot {
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
             rm_type_name: start.attr("rm_type_name").map(|s| s.to_string()),
@@ -1256,7 +1284,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CArchetypeRoot {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::CAttribute {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::CAttribute {
     fn xml_type_name(&self) -> &'static str {
         "C_ATTRIBUTE"
     }
@@ -1273,7 +1301,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CAttribute {
             }
         }
         __attrs.push(("rm_attribute_name", self.rm_attribute_name.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1294,7 +1322,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CAttribute {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::CAttribute {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::CAttribute {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -1334,7 +1362,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CAttribute {
                 }
             }
         }
-        Ok(crate::aom2_model::CAttribute {
+        Ok(crate::aom2_model::types::CAttribute {
             rm_attribute_name: start
                 .attr("rm_attribute_name")
                 .ok_or_else(|| {
@@ -1356,7 +1384,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CAttribute {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::CBoolean {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::CBoolean {
     fn xml_type_name(&self) -> &'static str {
         "C_BOOLEAN"
     }
@@ -1381,7 +1409,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CBoolean {
         if let Some(v) = &self.rm_type_name {
             __attrs.push(("rm_type_name", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1407,7 +1435,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CBoolean {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::CBoolean {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::CBoolean {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -1452,7 +1480,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CBoolean {
                 }
             }
         }
-        Ok(crate::aom2_model::CBoolean {
+        Ok(crate::aom2_model::types::CBoolean {
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
             rm_type_name: start.attr("rm_type_name").map(|s| s.to_string()),
@@ -1466,7 +1494,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CBoolean {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::CComplexObject {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::CComplexObject {
     fn xml_type_name(&self) -> &'static str {
         "C_COMPLEX_OBJECT"
     }
@@ -1491,7 +1519,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CComplexObject {
         if let Some(v) = &self.rm_type_name {
             __attrs.push(("rm_type_name", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1513,7 +1541,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CComplexObject {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::CComplexObject {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::CComplexObject {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -1548,7 +1576,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CComplexObject {
                 }
             }
         }
-        Ok(crate::aom2_model::CComplexObject {
+        Ok(crate::aom2_model::types::CComplexObject {
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
             rm_type_name: start.attr("rm_type_name").map(|s| s.to_string()),
@@ -1560,7 +1588,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CComplexObject {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::CComplexObjectProxy {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::CComplexObjectProxy {
     fn xml_type_name(&self) -> &'static str {
         "C_COMPLEX_OBJECT_PROXY"
     }
@@ -1585,7 +1613,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CComplexObjectProxy {
         if let Some(v) = &self.rm_type_name {
             __attrs.push(("rm_type_name", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1602,7 +1630,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CComplexObjectProxy {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::CComplexObjectProxy {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::CComplexObjectProxy {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -1633,7 +1661,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CComplexObjectProxy {
                 }
             }
         }
-        Ok(crate::aom2_model::CComplexObjectProxy {
+        Ok(crate::aom2_model::types::CComplexObjectProxy {
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
             rm_type_name: start.attr("rm_type_name").map(|s| s.to_string()),
@@ -1646,7 +1674,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CComplexObjectProxy {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::CDate {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::CDate {
     fn xml_type_name(&self) -> &'static str {
         "C_DATE"
     }
@@ -1671,7 +1699,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CDate {
         if let Some(v) = &self.rm_type_name {
             __attrs.push(("rm_type_name", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1690,7 +1718,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CDate {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::CDate {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::CDate {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -1721,7 +1749,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CDate {
                 }
             }
         }
-        Ok(crate::aom2_model::CDate {
+        Ok(crate::aom2_model::types::CDate {
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
             rm_type_name: start.attr("rm_type_name").map(|s| s.to_string()),
@@ -1732,7 +1760,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CDate {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::CDateTime {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::CDateTime {
     fn xml_type_name(&self) -> &'static str {
         "C_DATE_TIME"
     }
@@ -1757,7 +1785,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CDateTime {
         if let Some(v) = &self.rm_type_name {
             __attrs.push(("rm_type_name", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1779,7 +1807,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CDateTime {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::CDateTime {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::CDateTime {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -1815,7 +1843,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CDateTime {
                 }
             }
         }
-        Ok(crate::aom2_model::CDateTime {
+        Ok(crate::aom2_model::types::CDateTime {
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
             rm_type_name: start.attr("rm_type_name").map(|s| s.to_string()),
@@ -1827,7 +1855,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CDateTime {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::CDefinedObject {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::CDefinedObject {
     fn xml_type_name(&self) -> &'static str {
         "C_DEFINED_OBJECT"
     }
@@ -1852,7 +1880,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CDefinedObject {
         if let Some(v) = &self.rm_type_name {
             __attrs.push(("rm_type_name", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1871,7 +1899,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CDefinedObject {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::CDefinedObject {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::CDefinedObject {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -1902,7 +1930,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CDefinedObject {
                 }
             }
         }
-        Ok(crate::aom2_model::CDefinedObject {
+        Ok(crate::aom2_model::types::CDefinedObject {
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
             rm_type_name: start.attr("rm_type_name").map(|s| s.to_string()),
@@ -1913,7 +1941,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CDefinedObject {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::CDuration {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::CDuration {
     fn xml_type_name(&self) -> &'static str {
         "C_DURATION"
     }
@@ -1938,7 +1966,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CDuration {
         if let Some(v) = &self.rm_type_name {
             __attrs.push(("rm_type_name", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1960,7 +1988,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CDuration {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::CDuration {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::CDuration {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -1996,7 +2024,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CDuration {
                 }
             }
         }
-        Ok(crate::aom2_model::CDuration {
+        Ok(crate::aom2_model::types::CDuration {
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
             rm_type_name: start.attr("rm_type_name").map(|s| s.to_string()),
@@ -2008,7 +2036,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CDuration {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::CInteger {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::CInteger {
     fn xml_type_name(&self) -> &'static str {
         "C_INTEGER"
     }
@@ -2033,7 +2061,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CInteger {
         if let Some(v) = &self.rm_type_name {
             __attrs.push(("rm_type_name", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2060,7 +2088,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CInteger {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::CInteger {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::CInteger {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -2105,7 +2133,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CInteger {
                 }
             }
         }
-        Ok(crate::aom2_model::CInteger {
+        Ok(crate::aom2_model::types::CInteger {
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
             rm_type_name: start.attr("rm_type_name").map(|s| s.to_string()),
@@ -2121,25 +2149,25 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CInteger {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::CObject {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::CObject {
     fn xml_type_name(&self) -> &'static str {
         match self {
-            crate::aom2_model::CObject::ArchetypeSlot(x) => x.xml_type_name(),
-            crate::aom2_model::CObject::CArchetypeRoot(x) => x.xml_type_name(),
-            crate::aom2_model::CObject::CBoolean(x) => x.xml_type_name(),
-            crate::aom2_model::CObject::CComplexObject(x) => x.xml_type_name(),
-            crate::aom2_model::CObject::CComplexObjectProxy(x) => x.xml_type_name(),
-            crate::aom2_model::CObject::CDate(x) => x.xml_type_name(),
-            crate::aom2_model::CObject::CDateTime(x) => x.xml_type_name(),
-            crate::aom2_model::CObject::CDefinedObject(x) => x.xml_type_name(),
-            crate::aom2_model::CObject::CDuration(x) => x.xml_type_name(),
-            crate::aom2_model::CObject::CInteger(x) => x.xml_type_name(),
-            crate::aom2_model::CObject::CPrimitiveObject(x) => x.xml_type_name(),
-            crate::aom2_model::CObject::CReal(x) => x.xml_type_name(),
-            crate::aom2_model::CObject::CString(x) => x.xml_type_name(),
-            crate::aom2_model::CObject::CTemporal(x) => x.xml_type_name(),
-            crate::aom2_model::CObject::CTerminologyCode(x) => x.xml_type_name(),
-            crate::aom2_model::CObject::CTime(x) => x.xml_type_name(),
+            crate::aom2_model::types::CObject::ArchetypeSlot(x) => x.xml_type_name(),
+            crate::aom2_model::types::CObject::CArchetypeRoot(x) => x.xml_type_name(),
+            crate::aom2_model::types::CObject::CBoolean(x) => x.xml_type_name(),
+            crate::aom2_model::types::CObject::CComplexObject(x) => x.xml_type_name(),
+            crate::aom2_model::types::CObject::CComplexObjectProxy(x) => x.xml_type_name(),
+            crate::aom2_model::types::CObject::CDate(x) => x.xml_type_name(),
+            crate::aom2_model::types::CObject::CDateTime(x) => x.xml_type_name(),
+            crate::aom2_model::types::CObject::CDefinedObject(x) => x.xml_type_name(),
+            crate::aom2_model::types::CObject::CDuration(x) => x.xml_type_name(),
+            crate::aom2_model::types::CObject::CInteger(x) => x.xml_type_name(),
+            crate::aom2_model::types::CObject::CPrimitiveObject(x) => x.xml_type_name(),
+            crate::aom2_model::types::CObject::CReal(x) => x.xml_type_name(),
+            crate::aom2_model::types::CObject::CString(x) => x.xml_type_name(),
+            crate::aom2_model::types::CObject::CTemporal(x) => x.xml_type_name(),
+            crate::aom2_model::types::CObject::CTerminologyCode(x) => x.xml_type_name(),
+            crate::aom2_model::types::CObject::CTime(x) => x.xml_type_name(),
         }
     }
     fn write_xml(
@@ -2149,78 +2177,82 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CObject {
         declared: Option<&str>,
     ) -> Result<(), crate::xml::runtime::XmlError> {
         match self {
-            crate::aom2_model::CObject::ArchetypeSlot(x) => x.write_xml(w, tag, declared),
-            crate::aom2_model::CObject::CArchetypeRoot(x) => x.write_xml(w, tag, declared),
-            crate::aom2_model::CObject::CBoolean(x) => x.write_xml(w, tag, declared),
-            crate::aom2_model::CObject::CComplexObject(x) => x.write_xml(w, tag, declared),
-            crate::aom2_model::CObject::CComplexObjectProxy(x) => x.write_xml(w, tag, declared),
-            crate::aom2_model::CObject::CDate(x) => x.write_xml(w, tag, declared),
-            crate::aom2_model::CObject::CDateTime(x) => x.write_xml(w, tag, declared),
-            crate::aom2_model::CObject::CDefinedObject(x) => x.write_xml(w, tag, declared),
-            crate::aom2_model::CObject::CDuration(x) => x.write_xml(w, tag, declared),
-            crate::aom2_model::CObject::CInteger(x) => x.write_xml(w, tag, declared),
-            crate::aom2_model::CObject::CPrimitiveObject(x) => x.write_xml(w, tag, declared),
-            crate::aom2_model::CObject::CReal(x) => x.write_xml(w, tag, declared),
-            crate::aom2_model::CObject::CString(x) => x.write_xml(w, tag, declared),
-            crate::aom2_model::CObject::CTemporal(x) => x.write_xml(w, tag, declared),
-            crate::aom2_model::CObject::CTerminologyCode(x) => x.write_xml(w, tag, declared),
-            crate::aom2_model::CObject::CTime(x) => x.write_xml(w, tag, declared),
+            crate::aom2_model::types::CObject::ArchetypeSlot(x) => x.write_xml(w, tag, declared),
+            crate::aom2_model::types::CObject::CArchetypeRoot(x) => x.write_xml(w, tag, declared),
+            crate::aom2_model::types::CObject::CBoolean(x) => x.write_xml(w, tag, declared),
+            crate::aom2_model::types::CObject::CComplexObject(x) => x.write_xml(w, tag, declared),
+            crate::aom2_model::types::CObject::CComplexObjectProxy(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::aom2_model::types::CObject::CDate(x) => x.write_xml(w, tag, declared),
+            crate::aom2_model::types::CObject::CDateTime(x) => x.write_xml(w, tag, declared),
+            crate::aom2_model::types::CObject::CDefinedObject(x) => x.write_xml(w, tag, declared),
+            crate::aom2_model::types::CObject::CDuration(x) => x.write_xml(w, tag, declared),
+            crate::aom2_model::types::CObject::CInteger(x) => x.write_xml(w, tag, declared),
+            crate::aom2_model::types::CObject::CPrimitiveObject(x) => x.write_xml(w, tag, declared),
+            crate::aom2_model::types::CObject::CReal(x) => x.write_xml(w, tag, declared),
+            crate::aom2_model::types::CObject::CString(x) => x.write_xml(w, tag, declared),
+            crate::aom2_model::types::CObject::CTemporal(x) => x.write_xml(w, tag, declared),
+            crate::aom2_model::types::CObject::CTerminologyCode(x) => x.write_xml(w, tag, declared),
+            crate::aom2_model::types::CObject::CTime(x) => x.write_xml(w, tag, declared),
         }
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::CObject {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::CObject {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
     ) -> Result<Self, crate::xml::runtime::XmlError> {
         match start.xsi_type() {
-            Some("ARCHETYPE_SLOT") => Ok(crate::aom2_model::CObject::ArchetypeSlot(
+            Some("ARCHETYPE_SLOT") => Ok(crate::aom2_model::types::CObject::ArchetypeSlot(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_ARCHETYPE_ROOT") => Ok(crate::aom2_model::CObject::CArchetypeRoot(
+            Some("C_ARCHETYPE_ROOT") => Ok(crate::aom2_model::types::CObject::CArchetypeRoot(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_BOOLEAN") => Ok(crate::aom2_model::CObject::CBoolean(
+            Some("C_BOOLEAN") => Ok(crate::aom2_model::types::CObject::CBoolean(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_COMPLEX_OBJECT") => Ok(crate::aom2_model::CObject::CComplexObject(
+            Some("C_COMPLEX_OBJECT") => Ok(crate::aom2_model::types::CObject::CComplexObject(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_COMPLEX_OBJECT_PROXY") => Ok(crate::aom2_model::CObject::CComplexObjectProxy(
+            Some("C_COMPLEX_OBJECT_PROXY") => {
+                Ok(crate::aom2_model::types::CObject::CComplexObjectProxy(
+                    crate::xml::runtime::FromXml::from_xml(reader, start)?,
+                ))
+            }
+            Some("C_DATE") => Ok(crate::aom2_model::types::CObject::CDate(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_DATE") => Ok(crate::aom2_model::CObject::CDate(
+            Some("C_DATE_TIME") => Ok(crate::aom2_model::types::CObject::CDateTime(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_DATE_TIME") => Ok(crate::aom2_model::CObject::CDateTime(
+            Some("C_DEFINED_OBJECT") => Ok(crate::aom2_model::types::CObject::CDefinedObject(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_DEFINED_OBJECT") => Ok(crate::aom2_model::CObject::CDefinedObject(
+            Some("C_DURATION") => Ok(crate::aom2_model::types::CObject::CDuration(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_DURATION") => Ok(crate::aom2_model::CObject::CDuration(
+            Some("C_INTEGER") => Ok(crate::aom2_model::types::CObject::CInteger(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_INTEGER") => Ok(crate::aom2_model::CObject::CInteger(
+            Some("C_PRIMITIVE_OBJECT") => Ok(crate::aom2_model::types::CObject::CPrimitiveObject(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_PRIMITIVE_OBJECT") => Ok(crate::aom2_model::CObject::CPrimitiveObject(
+            Some("C_REAL") => Ok(crate::aom2_model::types::CObject::CReal(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_REAL") => Ok(crate::aom2_model::CObject::CReal(
+            Some("C_STRING") => Ok(crate::aom2_model::types::CObject::CString(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_STRING") => Ok(crate::aom2_model::CObject::CString(
+            Some("C_TEMPORAL") => Ok(crate::aom2_model::types::CObject::CTemporal(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_TEMPORAL") => Ok(crate::aom2_model::CObject::CTemporal(
+            Some("C_TERMINOLOGY_CODE") => Ok(crate::aom2_model::types::CObject::CTerminologyCode(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_TERMINOLOGY_CODE") => Ok(crate::aom2_model::CObject::CTerminologyCode(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("C_TIME") => Ok(crate::aom2_model::CObject::CTime(
+            Some("C_TIME") => Ok(crate::aom2_model::types::CObject::CTime(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
             None => Err(crate::xml::runtime::XmlError::Parse(
@@ -2233,7 +2265,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CObject {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::CPrimitiveObject {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::CPrimitiveObject {
     fn xml_type_name(&self) -> &'static str {
         "C_PRIMITIVE_OBJECT"
     }
@@ -2258,7 +2290,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CPrimitiveObject {
         if let Some(v) = &self.rm_type_name {
             __attrs.push(("rm_type_name", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2277,7 +2309,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CPrimitiveObject {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::CPrimitiveObject {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::CPrimitiveObject {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -2308,7 +2340,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CPrimitiveObject {
                 }
             }
         }
-        Ok(crate::aom2_model::CPrimitiveObject {
+        Ok(crate::aom2_model::types::CPrimitiveObject {
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
             rm_type_name: start.attr("rm_type_name").map(|s| s.to_string()),
@@ -2319,7 +2351,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CPrimitiveObject {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::CReal {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::CReal {
     fn xml_type_name(&self) -> &'static str {
         "C_REAL"
     }
@@ -2344,7 +2376,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CReal {
         if let Some(v) = &self.rm_type_name {
             __attrs.push(("rm_type_name", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2371,7 +2403,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CReal {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::CReal {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::CReal {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -2416,7 +2448,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CReal {
                 }
             }
         }
-        Ok(crate::aom2_model::CReal {
+        Ok(crate::aom2_model::types::CReal {
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
             rm_type_name: start.attr("rm_type_name").map(|s| s.to_string()),
@@ -2432,7 +2464,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CReal {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::CString {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::CString {
     fn xml_type_name(&self) -> &'static str {
         "C_STRING"
     }
@@ -2457,7 +2489,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CString {
         if let Some(v) = &self.rm_type_name {
             __attrs.push(("rm_type_name", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2483,7 +2515,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CString {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::CString {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::CString {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -2528,7 +2560,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CString {
                 }
             }
         }
-        Ok(crate::aom2_model::CString {
+        Ok(crate::aom2_model::types::CString {
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
             rm_type_name: start.attr("rm_type_name").map(|s| s.to_string()),
@@ -2544,7 +2576,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CString {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::CTemporal {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::CTemporal {
     fn xml_type_name(&self) -> &'static str {
         "C_TEMPORAL"
     }
@@ -2569,7 +2601,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CTemporal {
         if let Some(v) = &self.rm_type_name {
             __attrs.push(("rm_type_name", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2588,7 +2620,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CTemporal {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::CTemporal {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::CTemporal {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -2619,7 +2651,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CTemporal {
                 }
             }
         }
-        Ok(crate::aom2_model::CTemporal {
+        Ok(crate::aom2_model::types::CTemporal {
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
             rm_type_name: start.attr("rm_type_name").map(|s| s.to_string()),
@@ -2630,7 +2662,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CTemporal {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::CTerminologyCode {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::CTerminologyCode {
     fn xml_type_name(&self) -> &'static str {
         "C_TERMINOLOGY_CODE"
     }
@@ -2655,7 +2687,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CTerminologyCode {
         if let Some(v) = &self.rm_type_name {
             __attrs.push(("rm_type_name", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2681,7 +2713,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CTerminologyCode {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::CTerminologyCode {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::CTerminologyCode {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -2726,7 +2758,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CTerminologyCode {
                 }
             }
         }
-        Ok(crate::aom2_model::CTerminologyCode {
+        Ok(crate::aom2_model::types::CTerminologyCode {
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
             rm_type_name: start.attr("rm_type_name").map(|s| s.to_string()),
@@ -2742,7 +2774,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CTerminologyCode {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::CTime {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::CTime {
     fn xml_type_name(&self) -> &'static str {
         "C_TIME"
     }
@@ -2767,7 +2799,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CTime {
         if let Some(v) = &self.rm_type_name {
             __attrs.push(("rm_type_name", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2789,7 +2821,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::CTime {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::CTime {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::CTime {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -2825,7 +2857,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CTime {
                 }
             }
         }
-        Ok(crate::aom2_model::CTime {
+        Ok(crate::aom2_model::types::CTime {
             is_deprecated: start.attr("is_deprecated").map(|s| s.to_string()),
             node_id: start.attr("node_id").map(|s| s.to_string()),
             rm_type_name: start.attr("rm_type_name").map(|s| s.to_string()),
@@ -2837,7 +2869,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::CTime {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::Codedefinitionset {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::Codedefinitionset {
     fn xml_type_name(&self) -> &'static str {
         "CodeDefinitionSet"
     }
@@ -2854,7 +2886,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::Codedefinitionset {
             }
         }
         __attrs.push(("id", self.id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2867,7 +2899,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::Codedefinitionset {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::Codedefinitionset {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::Codedefinitionset {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -2890,7 +2922,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::Codedefinitionset {
                 }
             }
         }
-        Ok(crate::aom2_model::Codedefinitionset {
+        Ok(crate::aom2_model::types::Codedefinitionset {
             id: start
                 .attr("id")
                 .ok_or_else(|| crate::xml::runtime::XmlError::Parse("missing attribute id".into()))?
@@ -2900,7 +2932,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::Codedefinitionset {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::ExprBinaryOperator {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::ExprBinaryOperator {
     fn xml_type_name(&self) -> &'static str {
         "EXPR_BINARY_OPERATOR"
     }
@@ -2922,7 +2954,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::ExprBinaryOperator {
         if let Some(v) = &self.precedence_overridden {
             __attrs.push(("precedence_overridden", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2938,7 +2970,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::ExprBinaryOperator {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::ExprBinaryOperator {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::ExprBinaryOperator {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -2971,7 +3003,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::ExprBinaryOperator {
                 }
             }
         }
-        Ok(crate::aom2_model::ExprBinaryOperator {
+        Ok(crate::aom2_model::types::ExprBinaryOperator {
             r#type: start.attr("type").map(|s| s.to_string()),
             precedence_overridden: start.attr("precedence_overridden").map(|s| s.to_string()),
             operator: __operator.ok_or_else(|| {
@@ -2987,12 +3019,12 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::ExprBinaryOperator {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::ExprItem {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::ExprItem {
     fn xml_type_name(&self) -> &'static str {
         match self {
-            crate::aom2_model::ExprItem::ExprBinaryOperator(x) => x.xml_type_name(),
-            crate::aom2_model::ExprItem::ExprLeaf(x) => x.xml_type_name(),
-            crate::aom2_model::ExprItem::ExprUnaryOperator(x) => x.xml_type_name(),
+            crate::aom2_model::types::ExprItem::ExprBinaryOperator(x) => x.xml_type_name(),
+            crate::aom2_model::types::ExprItem::ExprLeaf(x) => x.xml_type_name(),
+            crate::aom2_model::types::ExprItem::ExprUnaryOperator(x) => x.xml_type_name(),
         }
     }
     fn write_xml(
@@ -3002,28 +3034,36 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::ExprItem {
         declared: Option<&str>,
     ) -> Result<(), crate::xml::runtime::XmlError> {
         match self {
-            crate::aom2_model::ExprItem::ExprBinaryOperator(x) => x.write_xml(w, tag, declared),
-            crate::aom2_model::ExprItem::ExprLeaf(x) => x.write_xml(w, tag, declared),
-            crate::aom2_model::ExprItem::ExprUnaryOperator(x) => x.write_xml(w, tag, declared),
+            crate::aom2_model::types::ExprItem::ExprBinaryOperator(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::aom2_model::types::ExprItem::ExprLeaf(x) => x.write_xml(w, tag, declared),
+            crate::aom2_model::types::ExprItem::ExprUnaryOperator(x) => {
+                x.write_xml(w, tag, declared)
+            }
         }
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::ExprItem {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::ExprItem {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
     ) -> Result<Self, crate::xml::runtime::XmlError> {
         match start.xsi_type() {
-            Some("EXPR_BINARY_OPERATOR") => Ok(crate::aom2_model::ExprItem::ExprBinaryOperator(
+            Some("EXPR_BINARY_OPERATOR") => {
+                Ok(crate::aom2_model::types::ExprItem::ExprBinaryOperator(
+                    crate::xml::runtime::FromXml::from_xml(reader, start)?,
+                ))
+            }
+            Some("EXPR_LEAF") => Ok(crate::aom2_model::types::ExprItem::ExprLeaf(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("EXPR_LEAF") => Ok(crate::aom2_model::ExprItem::ExprLeaf(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("EXPR_UNARY_OPERATOR") => Ok(crate::aom2_model::ExprItem::ExprUnaryOperator(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
+            Some("EXPR_UNARY_OPERATOR") => {
+                Ok(crate::aom2_model::types::ExprItem::ExprUnaryOperator(
+                    crate::xml::runtime::FromXml::from_xml(reader, start)?,
+                ))
+            }
             None => Err(crate::xml::runtime::XmlError::Parse(
                 "ExprItem: missing xsi:type".into(),
             )),
@@ -3034,7 +3074,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::ExprItem {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::ExprLeaf {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::ExprLeaf {
     fn xml_type_name(&self) -> &'static str {
         "EXPR_LEAF"
     }
@@ -3056,7 +3096,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::ExprLeaf {
         if let Some(v) = &self.reference_type {
             __attrs.push(("reference_type", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3067,7 +3107,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::ExprLeaf {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::ExprLeaf {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::ExprLeaf {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -3090,7 +3130,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::ExprLeaf {
                 }
             }
         }
-        Ok(crate::aom2_model::ExprLeaf {
+        Ok(crate::aom2_model::types::ExprLeaf {
             r#type: start.attr("type").map(|s| s.to_string()),
             reference_type: start.attr("reference_type").map(|s| s.to_string()),
             item: __item.ok_or_else(|| {
@@ -3100,11 +3140,11 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::ExprLeaf {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::ExprOperator {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::ExprOperator {
     fn xml_type_name(&self) -> &'static str {
         match self {
-            crate::aom2_model::ExprOperator::ExprBinaryOperator(x) => x.xml_type_name(),
-            crate::aom2_model::ExprOperator::ExprUnaryOperator(x) => x.xml_type_name(),
+            crate::aom2_model::types::ExprOperator::ExprBinaryOperator(x) => x.xml_type_name(),
+            crate::aom2_model::types::ExprOperator::ExprUnaryOperator(x) => x.xml_type_name(),
         }
     }
     fn write_xml(
@@ -3114,26 +3154,32 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::ExprOperator {
         declared: Option<&str>,
     ) -> Result<(), crate::xml::runtime::XmlError> {
         match self {
-            crate::aom2_model::ExprOperator::ExprBinaryOperator(x) => x.write_xml(w, tag, declared),
-            crate::aom2_model::ExprOperator::ExprUnaryOperator(x) => x.write_xml(w, tag, declared),
+            crate::aom2_model::types::ExprOperator::ExprBinaryOperator(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::aom2_model::types::ExprOperator::ExprUnaryOperator(x) => {
+                x.write_xml(w, tag, declared)
+            }
         }
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::ExprOperator {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::ExprOperator {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
     ) -> Result<Self, crate::xml::runtime::XmlError> {
         match start.xsi_type() {
             Some("EXPR_BINARY_OPERATOR") => {
-                Ok(crate::aom2_model::ExprOperator::ExprBinaryOperator(
+                Ok(crate::aom2_model::types::ExprOperator::ExprBinaryOperator(
                     crate::xml::runtime::FromXml::from_xml(reader, start)?,
                 ))
             }
-            Some("EXPR_UNARY_OPERATOR") => Ok(crate::aom2_model::ExprOperator::ExprUnaryOperator(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
+            Some("EXPR_UNARY_OPERATOR") => {
+                Ok(crate::aom2_model::types::ExprOperator::ExprUnaryOperator(
+                    crate::xml::runtime::FromXml::from_xml(reader, start)?,
+                ))
+            }
             None => Err(crate::xml::runtime::XmlError::Parse(
                 "ExprOperator: missing xsi:type".into(),
             )),
@@ -3144,7 +3190,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::ExprOperator {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::ExprUnaryOperator {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::ExprUnaryOperator {
     fn xml_type_name(&self) -> &'static str {
         "EXPR_UNARY_OPERATOR"
     }
@@ -3166,7 +3212,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::ExprUnaryOperator {
         if let Some(v) = &self.precedence_overridden {
             __attrs.push(("precedence_overridden", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3179,7 +3225,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::ExprUnaryOperator {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::ExprUnaryOperator {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::ExprUnaryOperator {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -3206,7 +3252,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::ExprUnaryOperator {
                 }
             }
         }
-        Ok(crate::aom2_model::ExprUnaryOperator {
+        Ok(crate::aom2_model::types::ExprUnaryOperator {
             r#type: start.attr("type").map(|s| s.to_string()),
             precedence_overridden: start.attr("precedence_overridden").map(|s| s.to_string()),
             operator: __operator.ok_or_else(|| {
@@ -3219,7 +3265,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::ExprUnaryOperator {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::Intervalofdate {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::Intervalofdate {
     fn xml_type_name(&self) -> &'static str {
         "IntervalOfDate"
     }
@@ -3247,7 +3293,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::Intervalofdate {
         if let Some(v) = &self.upper_unbounded {
             __attrs.push(("upper_unbounded", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3263,7 +3309,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::Intervalofdate {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::Intervalofdate {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::Intervalofdate {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -3290,7 +3336,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::Intervalofdate {
                 }
             }
         }
-        Ok(crate::aom2_model::Intervalofdate {
+        Ok(crate::aom2_model::types::Intervalofdate {
             lower_included: start.attr("lower_included").map(|s| s.to_string()),
             upper_included: start.attr("upper_included").map(|s| s.to_string()),
             lower_unbounded: start.attr("lower_unbounded").map(|s| s.to_string()),
@@ -3301,7 +3347,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::Intervalofdate {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::Intervalofdatetime {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::Intervalofdatetime {
     fn xml_type_name(&self) -> &'static str {
         "IntervalOfDateTime"
     }
@@ -3329,7 +3375,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::Intervalofdatetime {
         if let Some(v) = &self.upper_unbounded {
             __attrs.push(("upper_unbounded", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3345,7 +3391,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::Intervalofdatetime {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::Intervalofdatetime {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::Intervalofdatetime {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -3372,7 +3418,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::Intervalofdatetime {
                 }
             }
         }
-        Ok(crate::aom2_model::Intervalofdatetime {
+        Ok(crate::aom2_model::types::Intervalofdatetime {
             lower_included: start.attr("lower_included").map(|s| s.to_string()),
             upper_included: start.attr("upper_included").map(|s| s.to_string()),
             lower_unbounded: start.attr("lower_unbounded").map(|s| s.to_string()),
@@ -3383,7 +3429,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::Intervalofdatetime {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::Intervalofduration {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::Intervalofduration {
     fn xml_type_name(&self) -> &'static str {
         "IntervalOfDuration"
     }
@@ -3411,7 +3457,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::Intervalofduration {
         if let Some(v) = &self.upper_unbounded {
             __attrs.push(("upper_unbounded", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3427,7 +3473,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::Intervalofduration {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::Intervalofduration {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::Intervalofduration {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -3454,7 +3500,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::Intervalofduration {
                 }
             }
         }
-        Ok(crate::aom2_model::Intervalofduration {
+        Ok(crate::aom2_model::types::Intervalofduration {
             lower_included: start.attr("lower_included").map(|s| s.to_string()),
             upper_included: start.attr("upper_included").map(|s| s.to_string()),
             lower_unbounded: start.attr("lower_unbounded").map(|s| s.to_string()),
@@ -3465,7 +3511,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::Intervalofduration {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::Intervalofinteger {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::Intervalofinteger {
     fn xml_type_name(&self) -> &'static str {
         "IntervalOfInteger"
     }
@@ -3493,7 +3539,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::Intervalofinteger {
         if let Some(v) = &self.upper_unbounded {
             __attrs.push(("upper_unbounded", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3509,7 +3555,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::Intervalofinteger {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::Intervalofinteger {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::Intervalofinteger {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -3536,7 +3582,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::Intervalofinteger {
                 }
             }
         }
-        Ok(crate::aom2_model::Intervalofinteger {
+        Ok(crate::aom2_model::types::Intervalofinteger {
             lower_included: start.attr("lower_included").map(|s| s.to_string()),
             upper_included: start.attr("upper_included").map(|s| s.to_string()),
             lower_unbounded: start.attr("lower_unbounded").map(|s| s.to_string()),
@@ -3547,7 +3593,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::Intervalofinteger {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::Intervalofreal {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::Intervalofreal {
     fn xml_type_name(&self) -> &'static str {
         "IntervalOfReal"
     }
@@ -3575,7 +3621,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::Intervalofreal {
         if let Some(v) = &self.upper_unbounded {
             __attrs.push(("upper_unbounded", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3591,7 +3637,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::Intervalofreal {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::Intervalofreal {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::Intervalofreal {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -3618,7 +3664,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::Intervalofreal {
                 }
             }
         }
-        Ok(crate::aom2_model::Intervalofreal {
+        Ok(crate::aom2_model::types::Intervalofreal {
             lower_included: start.attr("lower_included").map(|s| s.to_string()),
             upper_included: start.attr("upper_included").map(|s| s.to_string()),
             lower_unbounded: start.attr("lower_unbounded").map(|s| s.to_string()),
@@ -3629,7 +3675,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::Intervalofreal {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::Intervaloftime {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::Intervaloftime {
     fn xml_type_name(&self) -> &'static str {
         "IntervalOfTime"
     }
@@ -3657,7 +3703,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::Intervaloftime {
         if let Some(v) = &self.upper_unbounded {
             __attrs.push(("upper_unbounded", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3673,7 +3719,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::Intervaloftime {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::Intervaloftime {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::Intervaloftime {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -3700,7 +3746,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::Intervaloftime {
                 }
             }
         }
-        Ok(crate::aom2_model::Intervaloftime {
+        Ok(crate::aom2_model::types::Intervaloftime {
             lower_included: start.attr("lower_included").map(|s| s.to_string()),
             upper_included: start.attr("upper_included").map(|s| s.to_string()),
             lower_unbounded: start.attr("lower_unbounded").map(|s| s.to_string()),
@@ -3711,7 +3757,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::Intervaloftime {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::Multiplicityinterval {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::Multiplicityinterval {
     fn xml_type_name(&self) -> &'static str {
         "MultiplicityInterval"
     }
@@ -3739,7 +3785,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::Multiplicityinterval {
         if let Some(v) = &self.upper_unbounded {
             __attrs.push(("upper_unbounded", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3755,7 +3801,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::Multiplicityinterval {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::Multiplicityinterval {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::Multiplicityinterval {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -3782,7 +3828,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::Multiplicityinterval {
                 }
             }
         }
-        Ok(crate::aom2_model::Multiplicityinterval {
+        Ok(crate::aom2_model::types::Multiplicityinterval {
             lower_included: start.attr("lower_included").map(|s| s.to_string()),
             upper_included: start.attr("upper_included").map(|s| s.to_string()),
             lower_unbounded: start.attr("lower_unbounded").map(|s| s.to_string()),
@@ -3793,7 +3839,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::Multiplicityinterval {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::OperatorKind {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::OperatorKind {
     fn xml_type_name(&self) -> &'static str {
         "OPERATOR_KIND"
     }
@@ -3810,7 +3856,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::OperatorKind {
             }
         }
         __attrs.push(("value", self.value.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3820,7 +3866,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::OperatorKind {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::OperatorKind {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::OperatorKind {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -3839,7 +3885,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::OperatorKind {
                 }
             }
         }
-        Ok(crate::aom2_model::OperatorKind {
+        Ok(crate::aom2_model::types::OperatorKind {
             value: start
                 .attr("value")
                 .ok_or_else(|| {
@@ -3850,7 +3896,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::OperatorKind {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::ResourceDescription {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::ResourceDescription {
     fn xml_type_name(&self) -> &'static str {
         "RESOURCE_DESCRIPTION"
     }
@@ -3866,7 +3912,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::ResourceDescription {
                 __attrs.push(("xsi:type", "RESOURCE_DESCRIPTION".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3923,7 +3969,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::ResourceDescription {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::ResourceDescription {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::ResourceDescription {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -4013,7 +4059,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::ResourceDescription {
                 }
             }
         }
-        Ok(crate::aom2_model::ResourceDescription {
+        Ok(crate::aom2_model::types::ResourceDescription {
             lifecycle_state: __lifecycle_state.ok_or_else(|| {
                 crate::xml::runtime::XmlError::Parse("missing element lifecycle_state".into())
             })?,
@@ -4046,7 +4092,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::ResourceDescription {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::ResourceDescriptionItem {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::ResourceDescriptionItem {
     fn xml_type_name(&self) -> &'static str {
         "RESOURCE_DESCRIPTION_ITEM"
     }
@@ -4065,7 +4111,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::ResourceDescriptionItem {
         if let Some(v) = &self.id {
             __attrs.push(("id", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4096,7 +4142,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::ResourceDescriptionItem {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::ResourceDescriptionItem {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::ResourceDescriptionItem {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -4147,7 +4193,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::ResourceDescriptionItem
                 }
             }
         }
-        Ok(crate::aom2_model::ResourceDescriptionItem {
+        Ok(crate::aom2_model::types::ResourceDescriptionItem {
             id: start.attr("id").map(|s| s.to_string()),
             language: __language.ok_or_else(|| {
                 crate::xml::runtime::XmlError::Parse("missing element language".into())
@@ -4170,14 +4216,14 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::ResourceDescriptionItem
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::RuleElement {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::RuleElement {
     fn xml_type_name(&self) -> &'static str {
         match self {
-            crate::aom2_model::RuleElement::Assertion(x) => x.xml_type_name(),
-            crate::aom2_model::RuleElement::ExprBinaryOperator(x) => x.xml_type_name(),
-            crate::aom2_model::RuleElement::ExprLeaf(x) => x.xml_type_name(),
-            crate::aom2_model::RuleElement::ExprUnaryOperator(x) => x.xml_type_name(),
-            crate::aom2_model::RuleElement::RuleStatement(x) => x.xml_type_name(),
+            crate::aom2_model::types::RuleElement::Assertion(x) => x.xml_type_name(),
+            crate::aom2_model::types::RuleElement::ExprBinaryOperator(x) => x.xml_type_name(),
+            crate::aom2_model::types::RuleElement::ExprLeaf(x) => x.xml_type_name(),
+            crate::aom2_model::types::RuleElement::ExprUnaryOperator(x) => x.xml_type_name(),
+            crate::aom2_model::types::RuleElement::RuleStatement(x) => x.xml_type_name(),
         }
     }
     fn write_xml(
@@ -4187,34 +4233,44 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::RuleElement {
         declared: Option<&str>,
     ) -> Result<(), crate::xml::runtime::XmlError> {
         match self {
-            crate::aom2_model::RuleElement::Assertion(x) => x.write_xml(w, tag, declared),
-            crate::aom2_model::RuleElement::ExprBinaryOperator(x) => x.write_xml(w, tag, declared),
-            crate::aom2_model::RuleElement::ExprLeaf(x) => x.write_xml(w, tag, declared),
-            crate::aom2_model::RuleElement::ExprUnaryOperator(x) => x.write_xml(w, tag, declared),
-            crate::aom2_model::RuleElement::RuleStatement(x) => x.write_xml(w, tag, declared),
+            crate::aom2_model::types::RuleElement::Assertion(x) => x.write_xml(w, tag, declared),
+            crate::aom2_model::types::RuleElement::ExprBinaryOperator(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::aom2_model::types::RuleElement::ExprLeaf(x) => x.write_xml(w, tag, declared),
+            crate::aom2_model::types::RuleElement::ExprUnaryOperator(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::aom2_model::types::RuleElement::RuleStatement(x) => {
+                x.write_xml(w, tag, declared)
+            }
         }
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::RuleElement {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::RuleElement {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
     ) -> Result<Self, crate::xml::runtime::XmlError> {
         match start.xsi_type() {
-            Some("ASSERTION") => Ok(crate::aom2_model::RuleElement::Assertion(
+            Some("ASSERTION") => Ok(crate::aom2_model::types::RuleElement::Assertion(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("EXPR_BINARY_OPERATOR") => Ok(crate::aom2_model::RuleElement::ExprBinaryOperator(
+            Some("EXPR_BINARY_OPERATOR") => {
+                Ok(crate::aom2_model::types::RuleElement::ExprBinaryOperator(
+                    crate::xml::runtime::FromXml::from_xml(reader, start)?,
+                ))
+            }
+            Some("EXPR_LEAF") => Ok(crate::aom2_model::types::RuleElement::ExprLeaf(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("EXPR_LEAF") => Ok(crate::aom2_model::RuleElement::ExprLeaf(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("EXPR_UNARY_OPERATOR") => Ok(crate::aom2_model::RuleElement::ExprUnaryOperator(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("RULE_STATEMENT") => Ok(crate::aom2_model::RuleElement::RuleStatement(
+            Some("EXPR_UNARY_OPERATOR") => {
+                Ok(crate::aom2_model::types::RuleElement::ExprUnaryOperator(
+                    crate::xml::runtime::FromXml::from_xml(reader, start)?,
+                ))
+            }
+            Some("RULE_STATEMENT") => Ok(crate::aom2_model::types::RuleElement::RuleStatement(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
             None => Err(crate::xml::runtime::XmlError::Parse(
@@ -4227,7 +4283,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::RuleElement {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::RuleStatement {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::RuleStatement {
     fn xml_type_name(&self) -> &'static str {
         "RULE_STATEMENT"
     }
@@ -4246,7 +4302,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::RuleStatement {
         if let Some(v) = &self.r#type {
             __attrs.push(("type", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4256,7 +4312,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::RuleStatement {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::RuleStatement {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::RuleStatement {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -4275,13 +4331,13 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::RuleStatement {
                 }
             }
         }
-        Ok(crate::aom2_model::RuleStatement {
+        Ok(crate::aom2_model::types::RuleStatement {
             r#type: start.attr("type").map(|s| s.to_string()),
         })
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::SiblingOrder {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::SiblingOrder {
     fn xml_type_name(&self) -> &'static str {
         "SIBLING_ORDER"
     }
@@ -4300,7 +4356,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::SiblingOrder {
         if let Some(v) = &self.is_before {
             __attrs.push(("is_before", v.to_string()));
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4312,7 +4368,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::SiblingOrder {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::SiblingOrder {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::SiblingOrder {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -4336,7 +4392,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::SiblingOrder {
                 }
             }
         }
-        Ok(crate::aom2_model::SiblingOrder {
+        Ok(crate::aom2_model::types::SiblingOrder {
             is_before: start.attr("is_before").map(|s| s.to_string()),
             sibling_node_id: __sibling_node_id.ok_or_else(|| {
                 crate::xml::runtime::XmlError::Parse("missing element sibling_node_id".into())
@@ -4345,7 +4401,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::SiblingOrder {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::TerminologyCode {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::TerminologyCode {
     fn xml_type_name(&self) -> &'static str {
         "TERMINOLOGY_CODE"
     }
@@ -4361,7 +4417,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::TerminologyCode {
                 __attrs.push(("xsi:type", "TERMINOLOGY_CODE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4374,7 +4430,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::TerminologyCode {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::TerminologyCode {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::TerminologyCode {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -4402,7 +4458,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::TerminologyCode {
                 }
             }
         }
-        Ok(crate::aom2_model::TerminologyCode {
+        Ok(crate::aom2_model::types::TerminologyCode {
             terminology_id: __terminology_id.ok_or_else(|| {
                 crate::xml::runtime::XmlError::Parse("missing element terminology_id".into())
             })?,
@@ -4413,7 +4469,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::TerminologyCode {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::TranslationDetails {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::TranslationDetails {
     fn xml_type_name(&self) -> &'static str {
         "TRANSLATION_DETAILS"
     }
@@ -4430,7 +4486,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::TranslationDetails {
             }
         }
         __attrs.push(("id", self.id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4455,7 +4511,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::TranslationDetails {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::TranslationDetails {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::TranslationDetails {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -4500,7 +4556,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::TranslationDetails {
                 }
             }
         }
-        Ok(crate::aom2_model::TranslationDetails {
+        Ok(crate::aom2_model::types::TranslationDetails {
             id: start
                 .attr("id")
                 .ok_or_else(|| crate::xml::runtime::XmlError::Parse("missing attribute id".into()))?
@@ -4520,7 +4576,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::TranslationDetails {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::Termbindingset {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::Termbindingset {
     fn xml_type_name(&self) -> &'static str {
         "TermBindingSet"
     }
@@ -4537,7 +4593,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::Termbindingset {
             }
         }
         __attrs.push(("id", self.id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4552,7 +4608,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::Termbindingset {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::Termbindingset {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::Termbindingset {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -4577,7 +4633,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::Termbindingset {
                 }
             }
         }
-        Ok(crate::aom2_model::Termbindingset {
+        Ok(crate::aom2_model::types::Termbindingset {
             id: start
                 .attr("id")
                 .ok_or_else(|| crate::xml::runtime::XmlError::Parse("missing attribute id".into()))?
@@ -4591,7 +4647,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::Termbindingset {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::aom2_model::ValueSet {
+impl crate::xml::runtime::ToXml for crate::aom2_model::types::ValueSet {
     fn xml_type_name(&self) -> &'static str {
         "VALUE_SET"
     }
@@ -4608,7 +4664,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::ValueSet {
             }
         }
         __attrs.push(("id", self.id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4621,7 +4677,7 @@ impl crate::xml::runtime::ToXml for crate::aom2_model::ValueSet {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::aom2_model::ValueSet {
+impl crate::xml::runtime::FromXml for crate::aom2_model::types::ValueSet {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -4644,7 +4700,7 @@ impl crate::xml::runtime::FromXml for crate::aom2_model::ValueSet {
                 }
             }
         }
-        Ok(crate::aom2_model::ValueSet {
+        Ok(crate::aom2_model::types::ValueSet {
             id: start
                 .attr("id")
                 .ok_or_else(|| crate::xml::runtime::XmlError::Parse("missing attribute id".into()))?

--- a/crates/openehr-its/src/aom2_model/mod.rs
+++ b/crates/openehr-its/src/aom2_model/mod.rs
@@ -27,22 +27,21 @@
 //! ceiling is stated rather than implied.
 
 mod impls;
-mod types;
-pub use types::*;
+pub mod types;
 
-/// Parse a model-form AOM2 archetype XML document into a [`AuthoredArchetype`].
+/// Parse a model-form AOM2 archetype XML document into a [`types::AuthoredArchetype`].
 ///
 /// # Errors
 /// Propagates canonical-XML parse errors.
-pub fn from_xml(xml: &str) -> Result<AuthoredArchetype, crate::xml::runtime::XmlError> {
+pub fn from_xml(xml: &str) -> Result<types::AuthoredArchetype, crate::xml::runtime::XmlError> {
     crate::xml::runtime::from_xml(xml)
 }
 
-/// Serialize a [`AuthoredArchetype`] back to AOM2 model-form archetype XML (root `<archetype>`,
+/// Serialize a [`types::AuthoredArchetype`] back to AOM2 model-form archetype XML (root `<archetype>`,
 /// `http://schemas.openehr.org/v1`).
 ///
 /// # Errors
 /// Propagates canonical-XML serialization errors.
-pub fn to_xml(value: &AuthoredArchetype) -> Result<String, crate::xml::runtime::XmlError> {
+pub fn to_xml(value: &types::AuthoredArchetype) -> Result<String, crate::xml::runtime::XmlError> {
     crate::xml::runtime::to_xml(value, "archetype", crate::xml::runtime::Namespace::V1)
 }

--- a/crates/openehr-its/src/aom2_model/types.rs
+++ b/crates/openehr-its/src/aom2_model/types.rs
@@ -620,7 +620,7 @@ pub struct ExprLeaf {
     /// The `reference_type` attribute/element of the AOM2 model-form `EXPR_LEAF` XSD type.
     pub reference_type: Option<String>,
     /// The `item` attribute/element of the AOM2 model-form `EXPR_LEAF` XSD type.
-    pub item: crate::xml::XmlAny,
+    pub item: crate::xml::runtime::XmlAny,
 }
 
 /// openEHR AOM2 model-form `EXPR_OPERATOR`.

--- a/crates/openehr-its/src/flat/build.rs
+++ b/crates/openehr-its/src/flat/build.rs
@@ -32,7 +32,7 @@ use crate::flat::error::FlatError;
 use crate::flat::map;
 use crate::flat::rmpath;
 use crate::flat::sim::{SimDocument, SimNode};
-use crate::flat::webtemplate::{CodedName, WebTemplate, WebTemplateNode};
+use crate::flat::webtemplate::model::{CodedName, WebTemplate, WebTemplateNode};
 
 /// openEHR reference-model release stamped into a rebuilt
 /// `ARCHETYPED.rm_version` (RM common `archetyped.adoc`: the "version of

--- a/crates/openehr-its/src/flat/cache.rs
+++ b/crates/openehr-its/src/flat/cache.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use moka::future::Cache;
 
-use crate::flat::webtemplate::WebTemplate;
+use crate::flat::webtemplate::model::WebTemplate;
 
 /// A shared, cloneable `WebTemplate` cache.
 #[derive(Debug, Clone)]
@@ -70,11 +70,13 @@ impl Default for WebTemplateCache {
 mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    use crate::flat::webtemplate::WebTemplate;
+    use crate::flat::webtemplate::model::WebTemplate;
 
     fn stub_template(id: &str) -> WebTemplate {
-        let mut tree =
-            crate::flat::webtemplate::WebTemplateNode::new("COMPOSITION".to_owned(), String::new());
+        let mut tree = crate::flat::webtemplate::model::WebTemplateNode::new(
+            "COMPOSITION".to_owned(),
+            String::new(),
+        );
         tree.id = "root".to_owned();
         tree.min = Some(1);
         tree.max = 1;

--- a/crates/openehr-its/src/flat/convert.rs
+++ b/crates/openehr-its/src/flat/convert.rs
@@ -27,7 +27,7 @@ use crate::flat::error::FlatError;
 use crate::flat::flatten;
 use crate::flat::sim::flat;
 use crate::flat::sim::structured;
-use crate::flat::webtemplate::WebTemplate;
+use crate::flat::webtemplate::model::WebTemplate;
 
 /// FLAT document → canonical-JSON COMPOSITION.
 ///

--- a/crates/openehr-its/src/flat/example.rs
+++ b/crates/openehr-its/src/flat/example.rs
@@ -59,7 +59,7 @@ use std::collections::HashSet;
 use serde_json::{Map, Value, json};
 
 use crate::flat::convert::composition_from_flat;
-use crate::flat::webtemplate::{
+use crate::flat::webtemplate::model::{
     WebTemplate, WebTemplateInput, WebTemplateInputType, WebTemplateNode, WebTemplateRange,
 };
 
@@ -1200,7 +1200,7 @@ fn fnv1a64(data: &[u8], basis: u64) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::flat::webtemplate::build_web_template;
+    use crate::flat::webtemplate::builder::build_web_template;
 
     fn web_template(opt_rel: &str) -> WebTemplate {
         let path = format!("{}/{opt_rel}", env!("CARGO_MANIFEST_DIR"));

--- a/crates/openehr-its/src/flat/flatten.rs
+++ b/crates/openehr-its/src/flat/flatten.rs
@@ -32,7 +32,7 @@ use crate::flat::error::FlatError;
 use crate::flat::map;
 use crate::flat::rmpath;
 use crate::flat::sim::{SimDocument, SimNode};
-use crate::flat::webtemplate::{WebTemplate, WebTemplateNode};
+use crate::flat::webtemplate::model::{WebTemplate, WebTemplateNode};
 
 /// Flatten a canonical-JSON composition into the simplified tree, driven by
 /// `wt`. The result serializes to either wire variant via [`crate::flat::sim`].

--- a/crates/openehr-its/src/flat/map/data_values.rs
+++ b/crates/openehr-its/src/flat/map/data_values.rs
@@ -22,7 +22,7 @@ use serde_json::{Map, Value, json};
 
 use super::{base_type, code_phrase_obj, family, parties, wt_coded_value, wt_terminology};
 use crate::flat::sim::SimNode;
-use crate::flat::webtemplate::WebTemplateNode;
+use crate::flat::webtemplate::model::WebTemplateNode;
 
 /// The `DV_ORDERED` concrete leaf types that carry `_normal_range` /
 /// `_other_reference_ranges` (master05 per-type tables).
@@ -932,11 +932,11 @@ mod tests {
     // template list when omitted.
     #[test]
     fn coded_text_defaults_value_from_template() {
-        use crate::flat::webtemplate::{WebTemplateInput, WebTemplateInputType};
+        use crate::flat::webtemplate::model::{WebTemplateInput, WebTemplateInputType};
         let mut input = WebTemplateInput::new(WebTemplateInputType::CodedText, Some("code"));
         input
             .list
-            .push(crate::flat::webtemplate::WebTemplateCodedValue::new(
+            .push(crate::flat::webtemplate::model::WebTemplateCodedValue::new(
                 "at0006",
                 Some("Term One".to_owned()),
             ));
@@ -956,8 +956,8 @@ mod tests {
     // master05 §DV_ORDINAL: `|ordinal`/`|value` default from the template symbol.
     #[test]
     fn ordinal_defaults_from_template() {
-        use crate::flat::webtemplate::{WebTemplateInput, WebTemplateInputType};
-        let mut cv = crate::flat::webtemplate::WebTemplateCodedValue::new(
+        use crate::flat::webtemplate::model::{WebTemplateInput, WebTemplateInputType};
+        let mut cv = crate::flat::webtemplate::model::WebTemplateCodedValue::new(
             "at0015",
             Some("value1".to_owned()),
         );

--- a/crates/openehr-its/src/flat/map/mod.rs
+++ b/crates/openehr-its/src/flat/map/mod.rs
@@ -48,7 +48,7 @@ use serde_json::{Value, json};
 
 use crate::flat::error::FlatError;
 use crate::flat::sim::{SimChild, SimNode};
-use crate::flat::webtemplate::{WebTemplateCodedValue, WebTemplateNode};
+use crate::flat::webtemplate::model::{WebTemplateCodedValue, WebTemplateNode};
 
 /// RM leaf value (canonical JSON) → datum parts on `out` (attrs only; the
 /// `|suffix` keys of master05, plus the bare `""` value where the type has one).

--- a/crates/openehr-its/src/flat/rmpath.rs
+++ b/crates/openehr-its/src/flat/rmpath.rs
@@ -5,7 +5,7 @@
 //! [`openehr_rm::v1_2::paths`] (the BASE `master11-paths` parser + `PATHABLE`
 //! navigation over canonical-JSON RM trees). It adds only the two conveniences
 //! the SDT pipeline needs and the RM primitive does not carry: taking the
-//! *relative* path between a parent and child [`WebTemplateNode`](crate::flat::webtemplate::WebTemplateNode)
+//! *relative* path between a parent and child [`WebTemplateNode`](crate::flat::webtemplate::model::WebTemplateNode)
 //! `aqlPath`, and multi-root navigation over a slice of parsed segments.
 //!
 //! A `WebTemplateNode`'s `aqlPath` is the full RM path from the versioned-object

--- a/crates/openehr-its/src/flat/tdd.rs
+++ b/crates/openehr-its/src/flat/tdd.rs
@@ -25,7 +25,7 @@
 //! # The matching rule (derived from the vendored corpus + `WebTemplate`)
 //!
 //! The [`WebTemplate`] tree
-//! ([`build_web_template`](crate::flat::webtemplate::build_web_template)) is the
+//! ([`build_web_template`](crate::flat::webtemplate::builder::build_web_template)) is the
 //! identity oracle. Each web-template node's `aqlPath` is the full RM path
 //! from the versioned-object root **with the compacted wrapper node-ids kept**
 //! (e.g. `…/data[at0001]/events[at0002]/data[at0003]/items[at0004]/value`), so it
@@ -48,7 +48,7 @@
 //!   nodes (`COMPOSITION` `name`/`language`/`territory`/`composer`/`context`/
 //!   `links`; `ENTRY` `language`/`encoding`/`subject`/`other_participations`/
 //!   `narrative`/…) is read **directly** from the TDD elements and parsed through
-//!   the canonical-XML [`FromXml`](crate::xml::FromXml) codec (fully typed:
+//!   the canonical-XML [`FromXml`](crate::xml::runtime::FromXml) codec (fully typed:
 //!   nested `_type`s, `xsi:type` dispatch, numeric coercion) — faithful to the
 //!   instance.
 //! * A **leaf** node's `DATA_VALUE` is the leaf element's `<value>` fragment,
@@ -93,7 +93,7 @@ use serde_json::{Map, Value, json};
 
 use crate::flat::error::FlatError;
 use crate::flat::rmpath;
-use crate::flat::webtemplate::{WebTemplate, WebTemplateNode};
+use crate::flat::webtemplate::model::{WebTemplate, WebTemplateNode};
 
 /// The Ocean/Marand template-data XML namespace (the default `xmlns` on a TDD
 /// root). Kept here for callers that only need the constant.
@@ -215,7 +215,7 @@ fn parse_tree(xml: &str) -> Result<El, FlatError> {
 }
 
 /// Re-serialise an [`El`] subtree to a standalone canonical-XML document so the
-/// `openehr-its` [`FromXml`](crate::xml::FromXml) codec can parse it into a
+/// `openehr-its` [`FromXml`](crate::xml::runtime::FromXml) codec can parse it into a
 /// typed RM value. The root carries the openEHR v1 namespace and, when a
 /// `type_hint` is given and the element lacks its own `xsi:type`, an injected
 /// `xsi:type` (the polymorphic slot's concrete type from the `WebTemplate`).

--- a/crates/openehr-its/src/flat/validation/leaf.rs
+++ b/crates/openehr-its/src/flat/validation/leaf.rs
@@ -21,7 +21,7 @@ use openehr_base::v1_3::base_types::definitions::definitions_impl::LOCAL_TERMINO
 use serde_json::Value;
 
 use super::{ValidationKind, Validator};
-use crate::flat::webtemplate::{
+use crate::flat::webtemplate::model::{
     WebTemplateCodedValue, WebTemplateInput, WebTemplateInputType, WebTemplateNode,
     WebTemplateRange,
 };

--- a/crates/openehr-its/src/flat/validation/mod.rs
+++ b/crates/openehr-its/src/flat/validation/mod.rs
@@ -61,7 +61,7 @@ use crate::rm_instance::{ValidationKind, ValidationMessage};
 use crate::flat::path;
 use crate::flat::rmpath;
 use crate::flat::sim::{SimDocument, SimNode, is_present};
-use crate::flat::webtemplate::{WebTemplate, WebTemplateArchetypeSlot, WebTemplateNode};
+use crate::flat::webtemplate::model::{WebTemplate, WebTemplateArchetypeSlot, WebTemplateNode};
 
 /// Validate only the archetype-conformance pass against a resolved
 /// [`WebTemplate`] (type conformance, occurrences, cardinality, and leaf
@@ -560,7 +560,7 @@ fn sibling_index_from_segments<'a>(
 }
 
 /// Populate the archetype-conformance walk plan on `node` and, recursively, every
-/// descendant — called once by [`crate::flat::webtemplate::build_web_template`] on the
+/// descendant — called once by [`crate::flat::webtemplate::builder::build_web_template`] on the
 /// finalized tree so the validation walk never re-parses a template-static
 /// constraint path.
 pub(crate) fn prepare_walk(node: &mut WebTemplateNode) {
@@ -653,7 +653,7 @@ pub struct UnenforceableConstraint {
 ///
 /// ```no_run
 /// # use openehr_its::flat::validation::unenforceable_existence_constraints;
-/// # fn demo(wt: &openehr_its::flat::webtemplate::WebTemplate) {
+/// # fn demo(wt: &openehr_its::flat::webtemplate::model::WebTemplate) {
 /// for skipped in unenforceable_existence_constraints(wt) {
 ///     eprintln!("unenforceable at {}: {}", skipped.path, skipped.attribute);
 /// }
@@ -1303,7 +1303,7 @@ mod tests {
     use serde_json::{Value, json};
 
     use super::*;
-    use crate::flat::webtemplate::{
+    use crate::flat::webtemplate::model::{
         WebTemplateCardinality, WebTemplateClosedAttribute, WebTemplateCodeList,
         WebTemplateCodedValue, WebTemplateExistence, WebTemplateInput, WebTemplateInputType,
         WebTemplateRange, WebTemplateSlot, WebTemplateValidation,

--- a/crates/openehr-its/src/flat/webtemplate/builder.rs
+++ b/crates/openehr-its/src/flat/webtemplate/builder.rs
@@ -47,7 +47,7 @@
 
 use std::collections::HashMap;
 
-use crate::opt14::{
+use crate::opt14::types::{
     ArchetypeTerm, Assertion, CArchetypeRoot, CObject, CPrimitive, Cardinality,
     Constraintbindingset, ExprItem, Intervalofinteger, OperationalTemplate, TermBindingItem,
     Termbindingset,
@@ -324,7 +324,7 @@ pub fn build_web_template(
 
 fn build_node(
     ctx: &Ctx,
-    owner: Option<&crate::opt14::CAttribute>,
+    owner: Option<&crate::opt14::types::CAttribute>,
     co: &CObject,
     parent_path: &str,
     parent_arch_id: &str,
@@ -343,7 +343,7 @@ fn build_node(
 
 fn create_node(
     ctx: &Ctx,
-    owner: Option<&crate::opt14::CAttribute>,
+    owner: Option<&crate::opt14::types::CAttribute>,
     co: &CObject,
     parent_path: &str,
     arch_id: &str,
@@ -558,7 +558,7 @@ fn is_party(rm_type: &str) -> bool {
 fn cardinalities(co: &CObject, node_path: &str) -> Vec<WebTemplateCardinality> {
     let mut out = Vec::new();
     for attr in inputs::attributes(co) {
-        if let crate::opt14::CAttribute::CMultipleAttribute(m) = attr
+        if let crate::opt14::types::CAttribute::CMultipleAttribute(m) = attr
             && requires_cardinality(&m.cardinality, m.children.len())
         {
             let (min, max) = occurrences(&m.cardinality.interval);
@@ -583,7 +583,7 @@ fn cardinalities(co: &CObject, node_path: &str) -> Vec<WebTemplateCardinality> {
 fn all_cardinalities(co: &CObject, node_path: &str) -> Vec<WebTemplateCardinality> {
     let mut out = Vec::new();
     for attr in inputs::attributes(co) {
-        if let crate::opt14::CAttribute::CMultipleAttribute(m) = attr {
+        if let crate::opt14::types::CAttribute::CMultipleAttribute(m) = attr {
             let (min, max) = occurrences(&m.cardinality.interval);
             if min.unwrap_or(0) >= 1 || max != -1 {
                 out.push(WebTemplateCardinality {
@@ -781,7 +781,7 @@ fn capture_size_range(co: &CObject, node: &mut WebTemplateNode) {
 /// real template's optional-in-intent identifier field is not over-rejected.
 fn capture_leaf_existence(co: &CObject, node: &mut WebTemplateNode) {
     for attr in inputs::attributes(co) {
-        let crate::opt14::CAttribute::CSingleAttribute(s) = attr else {
+        let crate::opt14::types::CAttribute::CSingleAttribute(s) = attr else {
             continue;
         };
         if s.rm_attribute_name == "name" {
@@ -840,7 +840,7 @@ fn existence_constraints(co: &CObject, node_path: &str) -> Vec<WebTemplateExiste
         // attribute's presence regardless of member cardinality (AOM 1.4
         // c_attribute `Existence_set`; cardinality then governs membership of
         // the present container — the two constraints are orthogonal).
-        if let crate::opt14::CAttribute::CMultipleAttribute(m) = attr {
+        if let crate::opt14::types::CAttribute::CMultipleAttribute(m) = attr {
             let (min, max) = occurrences(&m.existence);
             if min.unwrap_or(0) >= 1 {
                 out.push(WebTemplateExistence {
@@ -851,7 +851,7 @@ fn existence_constraints(co: &CObject, node_path: &str) -> Vec<WebTemplateExiste
             }
             continue;
         }
-        let crate::opt14::CAttribute::CSingleAttribute(s) = attr else {
+        let crate::opt14::types::CAttribute::CSingleAttribute(s) = attr else {
             continue;
         };
         let (min, max) = occurrences(&s.existence);
@@ -995,7 +995,7 @@ fn structural_stubs(ctx: &Ctx, co: &CObject, arch_id: &str) -> Vec<WebTemplateSt
 /// Build the validation-only slot record from an OPT `ARCHETYPE_SLOT`: its
 /// constrained RM type, occurrences bounds, and the archetype-id regexes lifted
 /// from the `includes`/`excludes` assertions (AOM 1.4 `ARCHETYPE_SLOT`).
-fn archetype_slot(s: &crate::opt14::ArchetypeSlot) -> WebTemplateArchetypeSlot {
+fn archetype_slot(s: &crate::opt14::types::ArchetypeSlot) -> WebTemplateArchetypeSlot {
     let (min, max) = occurrences(&s.occurrences);
     WebTemplateArchetypeSlot {
         rm_type: s.rm_type_name.clone(),
@@ -1087,7 +1087,7 @@ fn is_archetype_id_reference(operand: &str) -> bool {
 /// `C_PRIMITIVE_OBJECT.item` is the `C_PRIMITIVE` "actually defining the
 /// constraint" (`…aom14.c_primitive_object.adoc` §C_PRIMITIVE_OBJECT Class), so
 /// both the direct and the wrapped spelling resolve here.
-fn c_string_constraint(item: &crate::xml::XmlAny) -> Option<&crate::xml::XmlAny> {
+fn c_string_constraint(item: &crate::xml::runtime::XmlAny) -> Option<&crate::xml::runtime::XmlAny> {
     match item.xsi_type()? {
         "C_STRING" => Some(item),
         "C_PRIMITIVE_OBJECT" => item
@@ -1120,7 +1120,7 @@ fn requires_cardinality(card: &Cardinality, children_count: usize) -> bool {
 
 fn collect_languages(opt: &OperationalTemplate, default_language: &str) -> Vec<String> {
     let mut langs = vec![default_language.to_owned()];
-    let mut push = |flat: &crate::opt14::FlatArchetypeOntology| {
+    let mut push = |flat: &crate::opt14::types::FlatArchetypeOntology| {
         for set in &flat.term_definitions {
             if !langs.contains(&set.language) {
                 langs.push(set.language.clone());
@@ -1139,7 +1139,7 @@ fn collect_languages(opt: &OperationalTemplate, default_language: &str) -> Vec<S
 fn collect_ontology(opt: &OperationalTemplate, default_language: &str) -> Ontology {
     let mut ontology: Ontology = HashMap::new();
 
-    let mut register_flat = |flat: &crate::opt14::FlatArchetypeOntology| {
+    let mut register_flat = |flat: &crate::opt14::types::FlatArchetypeOntology| {
         let arch = ontology.entry(flat.archetype_id.clone()).or_default();
         for set in &flat.term_definitions {
             let lang = arch.entry(set.language.clone()).or_default();
@@ -1329,10 +1329,10 @@ fn object_occurrences(co: &CObject) -> &Intervalofinteger {
 
 /// The `C_ATTRIBUTE.existence` interval of `attr` (AOM 1.4
 /// `master04-constraint_model_package.adoc` §existence).
-fn attribute_existence(attr: &crate::opt14::CAttribute) -> &Intervalofinteger {
+fn attribute_existence(attr: &crate::opt14::types::CAttribute) -> &Intervalofinteger {
     match attr {
-        crate::opt14::CAttribute::CSingleAttribute(s) => &s.existence,
-        crate::opt14::CAttribute::CMultipleAttribute(m) => &m.existence,
+        crate::opt14::types::CAttribute::CSingleAttribute(s) => &s.existence,
+        crate::opt14::types::CAttribute::CMultipleAttribute(m) => &m.existence,
     }
 }
 
@@ -1357,9 +1357,9 @@ fn attribute_existence(attr: &crate::opt14::CAttribute) -> &Intervalofinteger {
 /// [`existence_constraints`].
 fn meet_single_existence(
     occurrences_min: Option<i32>,
-    owner: Option<&crate::opt14::CAttribute>,
+    owner: Option<&crate::opt14::types::CAttribute>,
 ) -> Option<i32> {
-    let Some(crate::opt14::CAttribute::CSingleAttribute(s)) = owner else {
+    let Some(crate::opt14::types::CAttribute::CSingleAttribute(s)) = owner else {
         return occurrences_min;
     };
     let existence_min = occurrences(&s.existence).0.unwrap_or(0);

--- a/crates/openehr-its/src/flat/webtemplate/builder.rs
+++ b/crates/openehr-its/src/flat/webtemplate/builder.rs
@@ -11,7 +11,7 @@
 //!    attribute names, collapse the always-collapsed wrapper types
 //!    (`ITEM_*`/`ITEM_STRUCTURE`/`HISTORY`) and a conditionally-collapsed single
 //!    `EVENT`, promote an `ELEMENT`/`DATA_VALUE` single child, and drop empties;
-//! 3. **assign ids** (see [`super::id`], master04 §"Node ID Generation Rules").
+//! 3. **assign ids** (see `id`, master04 §"Node ID Generation Rules").
 //!
 //! Deliberate shape boundaries of the builder (design decisions, not omissions).
 //! The `web-template` mirrors the *constraint* tree of the OPT; RM structure that

--- a/crates/openehr-its/src/flat/webtemplate/builder_v2_4.rs
+++ b/crates/openehr-its/src/flat/webtemplate/builder_v2_4.rs
@@ -8,8 +8,8 @@
 //! *is* an Operational Template. [`build_web_template_v2_4`] walks the `v2_4`
 //! constraint tree into the **same** [`WebTemplate`] model the OPT-1.4 front end
 //! ([`super::builder`]) produces, then hands it to the shared dialect-neutral
-//! passes ([`super::shape`]: level removal, in-context synthesis, post-process)
-//! and [`super::id`] (node-id generation). The whole downstream — example
+//! passes (`shape`: level removal, in-context synthesis, post-process)
+//! and `id` (node-id generation). The whole downstream — example
 //! generation, FLAT/STRUCTURED, validation — then works unchanged; there is no
 //! parallel pipeline.
 //!
@@ -26,7 +26,7 @@
 //! generator and FLAT/STRUCTURED codecs consume **and** the validation-only
 //! constraint fields (`existence`/`card_all`/`closed_attributes`/
 //! `structural_stubs`; the hoisted-wrapper `slots` are added by the shared
-//! [`super::shape`] compaction) the archetype-conformance walk
+//! `shape` compaction) the archetype-conformance walk
 //! ([`crate::flat::validation::validate_archetype_conformance`]) reads — from the
 //! AOM2 constraint model (`C_ATTRIBUTE.existence`/`.cardinality`, node-identified
 //! `C_OBJECT` alternatives, `ARCHETYPE_SLOT`; AOM2

--- a/crates/openehr-its/src/flat/webtemplate/inputs.rs
+++ b/crates/openehr-its/src/flat/webtemplate/inputs.rs
@@ -31,7 +31,7 @@
               (#1694)"
 )]
 
-use crate::opt14::{CAttribute, CObject, CPrimitive, Intervalofinteger, Intervalofreal};
+use crate::opt14::types::{CAttribute, CObject, CPrimitive, Intervalofinteger, Intervalofreal};
 use indexmap::IndexMap;
 
 use super::model::{
@@ -694,9 +694,9 @@ macro_rules! iv_bounds {
     };
 }
 
-iv_bounds!(iv_bounds_date, crate::opt14::Intervalofdate);
-iv_bounds!(iv_bounds_datetime, crate::opt14::Intervalofdatetime);
-iv_bounds!(iv_bounds_time, crate::opt14::Intervaloftime);
+iv_bounds!(iv_bounds_date, crate::opt14::types::Intervalofdate);
+iv_bounds!(iv_bounds_datetime, crate::opt14::types::Intervalofdatetime);
+iv_bounds!(iv_bounds_time, crate::opt14::types::Intervaloftime);
 
 #[cfg(test)]
 mod tests {

--- a/crates/openehr-its/src/flat/webtemplate/mod.rs
+++ b/crates/openehr-its/src/flat/webtemplate/mod.rs
@@ -4,8 +4,8 @@
 //! simplified node identifiers, AQL paths, input type definitions, localized
 //! labels, and multiplicity constraints — defined by `ITS-REST
 //! simplified_formats master04-basic_concepts.adoc` §"Web Template Metadata".
-//! [`build_web_template`] turns a parsed
-//! [`crate::opt14::types::OperationalTemplate`] into a [`WebTemplate`]. See
+//! [`builder::build_web_template`] turns a parsed
+//! [`crate::opt14::types::OperationalTemplate`] into a [`model::WebTemplate`]. See
 //! `builder` for the walk and the recorded scope boundaries, `id` for the
 //! master04 §"Node ID Generation Rules" algorithm, and `inputs` for the
 //! per-RM-type input mapping.

--- a/crates/openehr-its/src/flat/webtemplate/mod.rs
+++ b/crates/openehr-its/src/flat/webtemplate/mod.rs
@@ -5,25 +5,16 @@
 //! labels, and multiplicity constraints — defined by `ITS-REST
 //! simplified_formats master04-basic_concepts.adoc` §"Web Template Metadata".
 //! [`build_web_template`] turns a parsed
-//! [`crate::opt14::OperationalTemplate`] into a [`WebTemplate`]. See
+//! [`crate::opt14::types::OperationalTemplate`] into a [`WebTemplate`]. See
 //! `builder` for the walk and the recorded scope boundaries, `id` for the
 //! master04 §"Node ID Generation Rules" algorithm, and `inputs` for the
 //! per-RM-type input mapping.
 
-mod builder;
-mod builder_v2_4;
+pub mod builder;
+pub mod builder_v2_4;
 mod id;
 mod inputs;
-mod model;
+pub mod model;
 mod shape;
 
-pub use builder::build_web_template;
-pub use builder_v2_4::build_web_template_v2_4;
 pub(crate) use inputs::PROPORTION_KINDS;
-pub use model::{
-    CodedName, WebTemplate, WebTemplateArchetypeSlot, WebTemplateBindingCodedValue,
-    WebTemplateCardinality, WebTemplateClosedAttribute, WebTemplateCodeList, WebTemplateCodedValue,
-    WebTemplateConstraintBinding, WebTemplateExistence, WebTemplateInput, WebTemplateInputType,
-    WebTemplateNode, WebTemplateRange, WebTemplateSlot, WebTemplateStructuralStub,
-    WebTemplateValidation,
-};

--- a/crates/openehr-its/src/flat/webtemplate/model.rs
+++ b/crates/openehr-its/src/flat/webtemplate/model.rs
@@ -341,7 +341,7 @@ pub struct WebTemplateNode {
 
     /// Pre-parsed archetype-conformance walk plan: the constraint
     /// paths and sibling groups this node's validation walk needs, parsed ONCE at
-    /// build time ([`crate::flat::webtemplate::build_web_template`] calls `prepare_walk`) instead of
+    /// build time ([`crate::flat::webtemplate::builder::build_web_template`] calls `prepare_walk`) instead of
     /// re-parsing every constraint path on every instance-node visit. A hand-built
     /// node with no plan is handled by the walk building the plan on the fly.
     /// Validation-only (`#[serde(skip)]`) — no openEHR spec governs the

--- a/crates/openehr-its/src/flat/webtemplate/model.rs
+++ b/crates/openehr-its/src/flat/webtemplate/model.rs
@@ -24,7 +24,7 @@
 //! design/extension, consumed by validation and by interop consumers, and
 //! schema-legal because those schemas set no `additionalProperties: false`. The
 //! one place the schema is *stricter* than a naive render is its `Tree.required`
-//! list — satisfied by [`serialize_root`].
+//! list — satisfied by `serialize_root`.
 
 #![expect(
     clippy::disallowed_types,

--- a/crates/openehr-its/src/flat/webtemplate/shape.rs
+++ b/crates/openehr-its/src/flat/webtemplate/shape.rs
@@ -7,8 +7,8 @@
 //! passes, so the level-removal + in-context + post-process semantics are
 //! written once and never forked.
 //!
-//! The three passes, in the order [`super::build_web_template`] /
-//! [`super::build_web_template_v2_4`] run them:
+//! The three passes, in the order [`super::builder::build_web_template`] /
+//! [`super::builder_v2_4::build_web_template_v2_4`] run them:
 //!
 //! 1. [`compact`] — master04 §"Level Removal": elide container attribute names,
 //!    collapse the always-collapsed wrapper types (`ITEM_*`/`ITEM_STRUCTURE`/

--- a/crates/openehr-its/src/opt14/impls.rs
+++ b/crates/openehr-its/src/opt14/impls.rs
@@ -14,7 +14,7 @@
 )]
 use crate::xml::runtime::{FromXml, ToXml, XmlError, XmlEvent};
 
-impl crate::xml::runtime::ToXml for crate::opt14::Annotation {
+impl crate::xml::runtime::ToXml for crate::opt14::types::Annotation {
     fn xml_type_name(&self) -> &'static str {
         "ANNOTATION"
     }
@@ -31,7 +31,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::Annotation {
             }
         }
         __attrs.push(("path", self.path.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -44,7 +44,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::Annotation {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::Annotation {
+impl crate::xml::runtime::FromXml for crate::opt14::types::Annotation {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -69,7 +69,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::Annotation {
                 }
             }
         }
-        Ok(crate::opt14::Annotation {
+        Ok(crate::opt14::types::Annotation {
             path: start
                 .attr("path")
                 .ok_or_else(|| {
@@ -81,7 +81,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::Annotation {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::Archetype {
+impl crate::xml::runtime::ToXml for crate::opt14::types::Archetype {
     fn xml_type_name(&self) -> &'static str {
         "ARCHETYPE"
     }
@@ -97,7 +97,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::Archetype {
                 __attrs.push(("xsi:type", "ARCHETYPE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -140,7 +140,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::Archetype {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::Archetype {
+impl crate::xml::runtime::FromXml for crate::opt14::types::Archetype {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -216,7 +216,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::Archetype {
                 }
             }
         }
-        Ok(crate::opt14::Archetype {
+        Ok(crate::opt14::types::Archetype {
             original_language: __original_language.ok_or_else(|| {
                 crate::xml::runtime::XmlError::Parse("missing element original_language".into())
             })?,
@@ -244,24 +244,24 @@ impl crate::xml::runtime::FromXml for crate::opt14::Archetype {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::ArchetypeConstraint {
+impl crate::xml::runtime::ToXml for crate::opt14::types::ArchetypeConstraint {
     fn xml_type_name(&self) -> &'static str {
         match self {
-            crate::opt14::ArchetypeConstraint::ArchetypeInternalRef(x) => x.xml_type_name(),
-            crate::opt14::ArchetypeConstraint::ArchetypeSlot(x) => x.xml_type_name(),
-            crate::opt14::ArchetypeConstraint::ConstraintRef(x) => x.xml_type_name(),
-            crate::opt14::ArchetypeConstraint::CArchetypeRoot(x) => x.xml_type_name(),
-            crate::opt14::ArchetypeConstraint::CCodePhrase(x) => x.xml_type_name(),
-            crate::opt14::ArchetypeConstraint::CCodeReference(x) => x.xml_type_name(),
-            crate::opt14::ArchetypeConstraint::CComplexObject(x) => x.xml_type_name(),
-            crate::opt14::ArchetypeConstraint::CDefinedObject(x) => x.xml_type_name(),
-            crate::opt14::ArchetypeConstraint::CDvOrdinal(x) => x.xml_type_name(),
-            crate::opt14::ArchetypeConstraint::CDvQuantity(x) => x.xml_type_name(),
-            crate::opt14::ArchetypeConstraint::CDvState(x) => x.xml_type_name(),
-            crate::opt14::ArchetypeConstraint::CMultipleAttribute(x) => x.xml_type_name(),
-            crate::opt14::ArchetypeConstraint::CPrimitiveObject(x) => x.xml_type_name(),
-            crate::opt14::ArchetypeConstraint::CSingleAttribute(x) => x.xml_type_name(),
-            crate::opt14::ArchetypeConstraint::TComplexObject(x) => x.xml_type_name(),
+            crate::opt14::types::ArchetypeConstraint::ArchetypeInternalRef(x) => x.xml_type_name(),
+            crate::opt14::types::ArchetypeConstraint::ArchetypeSlot(x) => x.xml_type_name(),
+            crate::opt14::types::ArchetypeConstraint::ConstraintRef(x) => x.xml_type_name(),
+            crate::opt14::types::ArchetypeConstraint::CArchetypeRoot(x) => x.xml_type_name(),
+            crate::opt14::types::ArchetypeConstraint::CCodePhrase(x) => x.xml_type_name(),
+            crate::opt14::types::ArchetypeConstraint::CCodeReference(x) => x.xml_type_name(),
+            crate::opt14::types::ArchetypeConstraint::CComplexObject(x) => x.xml_type_name(),
+            crate::opt14::types::ArchetypeConstraint::CDefinedObject(x) => x.xml_type_name(),
+            crate::opt14::types::ArchetypeConstraint::CDvOrdinal(x) => x.xml_type_name(),
+            crate::opt14::types::ArchetypeConstraint::CDvQuantity(x) => x.xml_type_name(),
+            crate::opt14::types::ArchetypeConstraint::CDvState(x) => x.xml_type_name(),
+            crate::opt14::types::ArchetypeConstraint::CMultipleAttribute(x) => x.xml_type_name(),
+            crate::opt14::types::ArchetypeConstraint::CPrimitiveObject(x) => x.xml_type_name(),
+            crate::opt14::types::ArchetypeConstraint::CSingleAttribute(x) => x.xml_type_name(),
+            crate::opt14::types::ArchetypeConstraint::TComplexObject(x) => x.xml_type_name(),
         }
     }
     fn write_xml(
@@ -271,84 +271,122 @@ impl crate::xml::runtime::ToXml for crate::opt14::ArchetypeConstraint {
         declared: Option<&str>,
     ) -> Result<(), crate::xml::runtime::XmlError> {
         match self {
-            crate::opt14::ArchetypeConstraint::ArchetypeInternalRef(x) => {
+            crate::opt14::types::ArchetypeConstraint::ArchetypeInternalRef(x) => {
                 x.write_xml(w, tag, declared)
             }
-            crate::opt14::ArchetypeConstraint::ArchetypeSlot(x) => x.write_xml(w, tag, declared),
-            crate::opt14::ArchetypeConstraint::ConstraintRef(x) => x.write_xml(w, tag, declared),
-            crate::opt14::ArchetypeConstraint::CArchetypeRoot(x) => x.write_xml(w, tag, declared),
-            crate::opt14::ArchetypeConstraint::CCodePhrase(x) => x.write_xml(w, tag, declared),
-            crate::opt14::ArchetypeConstraint::CCodeReference(x) => x.write_xml(w, tag, declared),
-            crate::opt14::ArchetypeConstraint::CComplexObject(x) => x.write_xml(w, tag, declared),
-            crate::opt14::ArchetypeConstraint::CDefinedObject(x) => x.write_xml(w, tag, declared),
-            crate::opt14::ArchetypeConstraint::CDvOrdinal(x) => x.write_xml(w, tag, declared),
-            crate::opt14::ArchetypeConstraint::CDvQuantity(x) => x.write_xml(w, tag, declared),
-            crate::opt14::ArchetypeConstraint::CDvState(x) => x.write_xml(w, tag, declared),
-            crate::opt14::ArchetypeConstraint::CMultipleAttribute(x) => {
+            crate::opt14::types::ArchetypeConstraint::ArchetypeSlot(x) => {
                 x.write_xml(w, tag, declared)
             }
-            crate::opt14::ArchetypeConstraint::CPrimitiveObject(x) => x.write_xml(w, tag, declared),
-            crate::opt14::ArchetypeConstraint::CSingleAttribute(x) => x.write_xml(w, tag, declared),
-            crate::opt14::ArchetypeConstraint::TComplexObject(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::ArchetypeConstraint::ConstraintRef(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::opt14::types::ArchetypeConstraint::CArchetypeRoot(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::opt14::types::ArchetypeConstraint::CCodePhrase(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::opt14::types::ArchetypeConstraint::CCodeReference(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::opt14::types::ArchetypeConstraint::CComplexObject(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::opt14::types::ArchetypeConstraint::CDefinedObject(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::opt14::types::ArchetypeConstraint::CDvOrdinal(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::opt14::types::ArchetypeConstraint::CDvQuantity(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::opt14::types::ArchetypeConstraint::CDvState(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::ArchetypeConstraint::CMultipleAttribute(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::opt14::types::ArchetypeConstraint::CPrimitiveObject(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::opt14::types::ArchetypeConstraint::CSingleAttribute(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::opt14::types::ArchetypeConstraint::TComplexObject(x) => {
+                x.write_xml(w, tag, declared)
+            }
         }
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::ArchetypeConstraint {
+impl crate::xml::runtime::FromXml for crate::opt14::types::ArchetypeConstraint {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
     ) -> Result<Self, crate::xml::runtime::XmlError> {
         match start.xsi_type() {
-            Some("ARCHETYPE_INTERNAL_REF") => {
-                Ok(crate::opt14::ArchetypeConstraint::ArchetypeInternalRef(
+            Some("ARCHETYPE_INTERNAL_REF") => Ok(
+                crate::opt14::types::ArchetypeConstraint::ArchetypeInternalRef(
+                    crate::xml::runtime::FromXml::from_xml(reader, start)?,
+                ),
+            ),
+            Some("ARCHETYPE_SLOT") => Ok(crate::opt14::types::ArchetypeConstraint::ArchetypeSlot(
+                crate::xml::runtime::FromXml::from_xml(reader, start)?,
+            )),
+            Some("CONSTRAINT_REF") => Ok(crate::opt14::types::ArchetypeConstraint::ConstraintRef(
+                crate::xml::runtime::FromXml::from_xml(reader, start)?,
+            )),
+            Some("C_ARCHETYPE_ROOT") => {
+                Ok(crate::opt14::types::ArchetypeConstraint::CArchetypeRoot(
                     crate::xml::runtime::FromXml::from_xml(reader, start)?,
                 ))
             }
-            Some("ARCHETYPE_SLOT") => Ok(crate::opt14::ArchetypeConstraint::ArchetypeSlot(
+            Some("C_CODE_PHRASE") => Ok(crate::opt14::types::ArchetypeConstraint::CCodePhrase(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("CONSTRAINT_REF") => Ok(crate::opt14::ArchetypeConstraint::ConstraintRef(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("C_ARCHETYPE_ROOT") => Ok(crate::opt14::ArchetypeConstraint::CArchetypeRoot(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("C_CODE_PHRASE") => Ok(crate::opt14::ArchetypeConstraint::CCodePhrase(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("C_CODE_REFERENCE") => Ok(crate::opt14::ArchetypeConstraint::CCodeReference(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("C_COMPLEX_OBJECT") => Ok(crate::opt14::ArchetypeConstraint::CComplexObject(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("C_DEFINED_OBJECT") => Ok(crate::opt14::ArchetypeConstraint::CDefinedObject(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("C_DV_ORDINAL") => Ok(crate::opt14::ArchetypeConstraint::CDvOrdinal(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("C_DV_QUANTITY") => Ok(crate::opt14::ArchetypeConstraint::CDvQuantity(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("C_DV_STATE") => Ok(crate::opt14::ArchetypeConstraint::CDvState(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("C_MULTIPLE_ATTRIBUTE") => {
-                Ok(crate::opt14::ArchetypeConstraint::CMultipleAttribute(
+            Some("C_CODE_REFERENCE") => {
+                Ok(crate::opt14::types::ArchetypeConstraint::CCodeReference(
                     crate::xml::runtime::FromXml::from_xml(reader, start)?,
                 ))
             }
-            Some("C_PRIMITIVE_OBJECT") => Ok(crate::opt14::ArchetypeConstraint::CPrimitiveObject(
+            Some("C_COMPLEX_OBJECT") => {
+                Ok(crate::opt14::types::ArchetypeConstraint::CComplexObject(
+                    crate::xml::runtime::FromXml::from_xml(reader, start)?,
+                ))
+            }
+            Some("C_DEFINED_OBJECT") => {
+                Ok(crate::opt14::types::ArchetypeConstraint::CDefinedObject(
+                    crate::xml::runtime::FromXml::from_xml(reader, start)?,
+                ))
+            }
+            Some("C_DV_ORDINAL") => Ok(crate::opt14::types::ArchetypeConstraint::CDvOrdinal(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_SINGLE_ATTRIBUTE") => Ok(crate::opt14::ArchetypeConstraint::CSingleAttribute(
+            Some("C_DV_QUANTITY") => Ok(crate::opt14::types::ArchetypeConstraint::CDvQuantity(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("T_COMPLEX_OBJECT") => Ok(crate::opt14::ArchetypeConstraint::TComplexObject(
+            Some("C_DV_STATE") => Ok(crate::opt14::types::ArchetypeConstraint::CDvState(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
+            Some("C_MULTIPLE_ATTRIBUTE") => Ok(
+                crate::opt14::types::ArchetypeConstraint::CMultipleAttribute(
+                    crate::xml::runtime::FromXml::from_xml(reader, start)?,
+                ),
+            ),
+            Some("C_PRIMITIVE_OBJECT") => {
+                Ok(crate::opt14::types::ArchetypeConstraint::CPrimitiveObject(
+                    crate::xml::runtime::FromXml::from_xml(reader, start)?,
+                ))
+            }
+            Some("C_SINGLE_ATTRIBUTE") => {
+                Ok(crate::opt14::types::ArchetypeConstraint::CSingleAttribute(
+                    crate::xml::runtime::FromXml::from_xml(reader, start)?,
+                ))
+            }
+            Some("T_COMPLEX_OBJECT") => {
+                Ok(crate::opt14::types::ArchetypeConstraint::TComplexObject(
+                    crate::xml::runtime::FromXml::from_xml(reader, start)?,
+                ))
+            }
             None => Err(crate::xml::runtime::XmlError::Parse(
                 "ArchetypeConstraint: missing xsi:type".into(),
             )),
@@ -359,7 +397,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::ArchetypeConstraint {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::ArchetypeInternalRef {
+impl crate::xml::runtime::ToXml for crate::opt14::types::ArchetypeInternalRef {
     fn xml_type_name(&self) -> &'static str {
         "ARCHETYPE_INTERNAL_REF"
     }
@@ -375,7 +413,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::ArchetypeInternalRef {
                 __attrs.push(("xsi:type", "ARCHETYPE_INTERNAL_REF".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -390,7 +428,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::ArchetypeInternalRef {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::ArchetypeInternalRef {
+impl crate::xml::runtime::FromXml for crate::opt14::types::ArchetypeInternalRef {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -426,9 +464,9 @@ impl crate::xml::runtime::FromXml for crate::opt14::ArchetypeInternalRef {
                 }
             }
         }
-        Ok(crate::opt14::ArchetypeInternalRef {
+        Ok(crate::opt14::types::ArchetypeInternalRef {
             rm_type_name: __rm_type_name.unwrap_or(String::new()),
-            occurrences: __occurrences.unwrap_or(crate::opt14::Intervalofinteger {
+            occurrences: __occurrences.unwrap_or(crate::opt14::types::Intervalofinteger {
                 lower_included: Some(true),
                 upper_included: Some(true),
                 lower_unbounded: false,
@@ -444,7 +482,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::ArchetypeInternalRef {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::ArchetypeOntology {
+impl crate::xml::runtime::ToXml for crate::opt14::types::ArchetypeOntology {
     fn xml_type_name(&self) -> &'static str {
         "ARCHETYPE_ONTOLOGY"
     }
@@ -460,7 +498,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::ArchetypeOntology {
                 __attrs.push(("xsi:type", "ARCHETYPE_ONTOLOGY".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -482,7 +520,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::ArchetypeOntology {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::ArchetypeOntology {
+impl crate::xml::runtime::FromXml for crate::opt14::types::ArchetypeOntology {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -520,7 +558,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::ArchetypeOntology {
                 }
             }
         }
-        Ok(crate::opt14::ArchetypeOntology {
+        Ok(crate::opt14::types::ArchetypeOntology {
             term_definitions: __term_definitions,
             constraint_definitions: __constraint_definitions,
             term_bindings: __term_bindings,
@@ -529,7 +567,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::ArchetypeOntology {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::ArchetypeSlot {
+impl crate::xml::runtime::ToXml for crate::opt14::types::ArchetypeSlot {
     fn xml_type_name(&self) -> &'static str {
         "ARCHETYPE_SLOT"
     }
@@ -545,7 +583,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::ArchetypeSlot {
                 __attrs.push(("xsi:type", "ARCHETYPE_SLOT".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -565,7 +603,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::ArchetypeSlot {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::ArchetypeSlot {
+impl crate::xml::runtime::FromXml for crate::opt14::types::ArchetypeSlot {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -605,9 +643,9 @@ impl crate::xml::runtime::FromXml for crate::opt14::ArchetypeSlot {
                 }
             }
         }
-        Ok(crate::opt14::ArchetypeSlot {
+        Ok(crate::opt14::types::ArchetypeSlot {
             rm_type_name: __rm_type_name.unwrap_or(String::new()),
-            occurrences: __occurrences.unwrap_or(crate::opt14::Intervalofinteger {
+            occurrences: __occurrences.unwrap_or(crate::opt14::types::Intervalofinteger {
                 lower_included: Some(true),
                 upper_included: Some(true),
                 lower_unbounded: false,
@@ -622,7 +660,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::ArchetypeSlot {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::ArchetypeTerm {
+impl crate::xml::runtime::ToXml for crate::opt14::types::ArchetypeTerm {
     fn xml_type_name(&self) -> &'static str {
         "ARCHETYPE_TERM"
     }
@@ -639,7 +677,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::ArchetypeTerm {
             }
         }
         __attrs.push(("code", self.code.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -652,7 +690,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::ArchetypeTerm {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::ArchetypeTerm {
+impl crate::xml::runtime::FromXml for crate::opt14::types::ArchetypeTerm {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -677,7 +715,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::ArchetypeTerm {
                 }
             }
         }
-        Ok(crate::opt14::ArchetypeTerm {
+        Ok(crate::opt14::types::ArchetypeTerm {
             code: start
                 .attr("code")
                 .ok_or_else(|| {
@@ -689,7 +727,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::ArchetypeTerm {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::Assertion {
+impl crate::xml::runtime::ToXml for crate::opt14::types::Assertion {
     fn xml_type_name(&self) -> &'static str {
         "ASSERTION"
     }
@@ -705,7 +743,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::Assertion {
                 __attrs.push(("xsi:type", "ASSERTION".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -726,7 +764,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::Assertion {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::Assertion {
+impl crate::xml::runtime::FromXml for crate::opt14::types::Assertion {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -762,7 +800,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::Assertion {
                 }
             }
         }
-        Ok(crate::opt14::Assertion {
+        Ok(crate::opt14::types::Assertion {
             tag: __tag,
             string_expression: __string_expression,
             expression: __expression.ok_or_else(|| {
@@ -773,7 +811,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::Assertion {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::AssertionVariable {
+impl crate::xml::runtime::ToXml for crate::opt14::types::AssertionVariable {
     fn xml_type_name(&self) -> &'static str {
         "ASSERTION_VARIABLE"
     }
@@ -789,7 +827,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::AssertionVariable {
                 __attrs.push(("xsi:type", "ASSERTION_VARIABLE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -801,7 +839,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::AssertionVariable {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::AssertionVariable {
+impl crate::xml::runtime::FromXml for crate::opt14::types::AssertionVariable {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -828,7 +866,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::AssertionVariable {
                 }
             }
         }
-        Ok(crate::opt14::AssertionVariable {
+        Ok(crate::opt14::types::AssertionVariable {
             name: __name.ok_or_else(|| {
                 crate::xml::runtime::XmlError::Parse("missing element name".into())
             })?,
@@ -839,10 +877,10 @@ impl crate::xml::runtime::FromXml for crate::opt14::AssertionVariable {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::AuthoredResource {
+impl crate::xml::runtime::ToXml for crate::opt14::types::AuthoredResource {
     fn xml_type_name(&self) -> &'static str {
         match self {
-            crate::opt14::AuthoredResource::Archetype(x) => x.xml_type_name(),
+            crate::opt14::types::AuthoredResource::Archetype(x) => x.xml_type_name(),
         }
     }
     fn write_xml(
@@ -852,18 +890,18 @@ impl crate::xml::runtime::ToXml for crate::opt14::AuthoredResource {
         declared: Option<&str>,
     ) -> Result<(), crate::xml::runtime::XmlError> {
         match self {
-            crate::opt14::AuthoredResource::Archetype(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::AuthoredResource::Archetype(x) => x.write_xml(w, tag, declared),
         }
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::AuthoredResource {
+impl crate::xml::runtime::FromXml for crate::opt14::types::AuthoredResource {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
     ) -> Result<Self, crate::xml::runtime::XmlError> {
         match start.xsi_type() {
-            Some("ARCHETYPE") => Ok(crate::opt14::AuthoredResource::Archetype(
+            Some("ARCHETYPE") => Ok(crate::opt14::types::AuthoredResource::Archetype(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
             None => Err(crate::xml::runtime::XmlError::Parse(
@@ -876,7 +914,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::AuthoredResource {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::Cardinality {
+impl crate::xml::runtime::ToXml for crate::opt14::types::Cardinality {
     fn xml_type_name(&self) -> &'static str {
         "CARDINALITY"
     }
@@ -892,7 +930,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::Cardinality {
                 __attrs.push(("xsi:type", "CARDINALITY".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -906,7 +944,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::Cardinality {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::Cardinality {
+impl crate::xml::runtime::FromXml for crate::opt14::types::Cardinality {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -937,7 +975,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::Cardinality {
                 }
             }
         }
-        Ok(crate::opt14::Cardinality {
+        Ok(crate::opt14::types::Cardinality {
             is_ordered: __is_ordered.unwrap_or(false),
             is_unique: __is_unique.unwrap_or(false),
             interval: __interval.ok_or_else(|| {
@@ -947,7 +985,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::Cardinality {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::ConstraintBindingItem {
+impl crate::xml::runtime::ToXml for crate::opt14::types::ConstraintBindingItem {
     fn xml_type_name(&self) -> &'static str {
         "CONSTRAINT_BINDING_ITEM"
     }
@@ -964,7 +1002,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::ConstraintBindingItem {
             }
         }
         __attrs.push(("code", self.code.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -975,7 +1013,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::ConstraintBindingItem {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::ConstraintBindingItem {
+impl crate::xml::runtime::FromXml for crate::opt14::types::ConstraintBindingItem {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -998,7 +1036,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::ConstraintBindingItem {
                 }
             }
         }
-        Ok(crate::opt14::ConstraintBindingItem {
+        Ok(crate::opt14::types::ConstraintBindingItem {
             code: start
                 .attr("code")
                 .ok_or_else(|| {
@@ -1012,7 +1050,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::ConstraintBindingItem {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::ConstraintRef {
+impl crate::xml::runtime::ToXml for crate::opt14::types::ConstraintRef {
     fn xml_type_name(&self) -> &'static str {
         "CONSTRAINT_REF"
     }
@@ -1028,7 +1066,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::ConstraintRef {
                 __attrs.push(("xsi:type", "CONSTRAINT_REF".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1043,7 +1081,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::ConstraintRef {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::ConstraintRef {
+impl crate::xml::runtime::FromXml for crate::opt14::types::ConstraintRef {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -1079,9 +1117,9 @@ impl crate::xml::runtime::FromXml for crate::opt14::ConstraintRef {
                 }
             }
         }
-        Ok(crate::opt14::ConstraintRef {
+        Ok(crate::opt14::types::ConstraintRef {
             rm_type_name: __rm_type_name.unwrap_or(String::new()),
-            occurrences: __occurrences.unwrap_or(crate::opt14::Intervalofinteger {
+            occurrences: __occurrences.unwrap_or(crate::opt14::types::Intervalofinteger {
                 lower_included: Some(true),
                 upper_included: Some(true),
                 lower_unbounded: false,
@@ -1097,7 +1135,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::ConstraintRef {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::CArchetypeRoot {
+impl crate::xml::runtime::ToXml for crate::opt14::types::CArchetypeRoot {
     fn xml_type_name(&self) -> &'static str {
         "C_ARCHETYPE_ROOT"
     }
@@ -1113,7 +1151,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CArchetypeRoot {
                 __attrs.push(("xsi:type", "C_ARCHETYPE_ROOT".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1141,7 +1179,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CArchetypeRoot {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::CArchetypeRoot {
+impl crate::xml::runtime::FromXml for crate::opt14::types::CArchetypeRoot {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -1195,9 +1233,9 @@ impl crate::xml::runtime::FromXml for crate::opt14::CArchetypeRoot {
                 }
             }
         }
-        Ok(crate::opt14::CArchetypeRoot {
+        Ok(crate::opt14::types::CArchetypeRoot {
             rm_type_name: __rm_type_name.unwrap_or(String::new()),
-            occurrences: __occurrences.unwrap_or(crate::opt14::Intervalofinteger {
+            occurrences: __occurrences.unwrap_or(crate::opt14::types::Intervalofinteger {
                 lower_included: Some(true),
                 upper_included: Some(true),
                 lower_unbounded: false,
@@ -1217,11 +1255,11 @@ impl crate::xml::runtime::FromXml for crate::opt14::CArchetypeRoot {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::CAttribute {
+impl crate::xml::runtime::ToXml for crate::opt14::types::CAttribute {
     fn xml_type_name(&self) -> &'static str {
         match self {
-            crate::opt14::CAttribute::CMultipleAttribute(x) => x.xml_type_name(),
-            crate::opt14::CAttribute::CSingleAttribute(x) => x.xml_type_name(),
+            crate::opt14::types::CAttribute::CMultipleAttribute(x) => x.xml_type_name(),
+            crate::opt14::types::CAttribute::CSingleAttribute(x) => x.xml_type_name(),
         }
     }
     fn write_xml(
@@ -1231,22 +1269,24 @@ impl crate::xml::runtime::ToXml for crate::opt14::CAttribute {
         declared: Option<&str>,
     ) -> Result<(), crate::xml::runtime::XmlError> {
         match self {
-            crate::opt14::CAttribute::CMultipleAttribute(x) => x.write_xml(w, tag, declared),
-            crate::opt14::CAttribute::CSingleAttribute(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::CAttribute::CMultipleAttribute(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::CAttribute::CSingleAttribute(x) => x.write_xml(w, tag, declared),
         }
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::CAttribute {
+impl crate::xml::runtime::FromXml for crate::opt14::types::CAttribute {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
     ) -> Result<Self, crate::xml::runtime::XmlError> {
         match start.xsi_type() {
-            Some("C_MULTIPLE_ATTRIBUTE") => Ok(crate::opt14::CAttribute::CMultipleAttribute(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("C_SINGLE_ATTRIBUTE") => Ok(crate::opt14::CAttribute::CSingleAttribute(
+            Some("C_MULTIPLE_ATTRIBUTE") => {
+                Ok(crate::opt14::types::CAttribute::CMultipleAttribute(
+                    crate::xml::runtime::FromXml::from_xml(reader, start)?,
+                ))
+            }
+            Some("C_SINGLE_ATTRIBUTE") => Ok(crate::opt14::types::CAttribute::CSingleAttribute(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
             None => Err(crate::xml::runtime::XmlError::Parse(
@@ -1259,7 +1299,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::CAttribute {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::CBoolean {
+impl crate::xml::runtime::ToXml for crate::opt14::types::CBoolean {
     fn xml_type_name(&self) -> &'static str {
         "C_BOOLEAN"
     }
@@ -1275,7 +1315,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CBoolean {
                 __attrs.push(("xsi:type", "C_BOOLEAN".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1290,7 +1330,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CBoolean {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::CBoolean {
+impl crate::xml::runtime::FromXml for crate::opt14::types::CBoolean {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -1322,7 +1362,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::CBoolean {
                 }
             }
         }
-        Ok(crate::opt14::CBoolean {
+        Ok(crate::opt14::types::CBoolean {
             true_valid: __true_valid.unwrap_or(false),
             false_valid: __false_valid.unwrap_or(false),
             assumed_value: __assumed_value,
@@ -1330,7 +1370,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::CBoolean {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::CCodePhrase {
+impl crate::xml::runtime::ToXml for crate::opt14::types::CCodePhrase {
     fn xml_type_name(&self) -> &'static str {
         "C_CODE_PHRASE"
     }
@@ -1346,7 +1386,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CCodePhrase {
                 __attrs.push(("xsi:type", "C_CODE_PHRASE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1369,7 +1409,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CCodePhrase {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::CCodePhrase {
+impl crate::xml::runtime::FromXml for crate::opt14::types::CCodePhrase {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -1415,9 +1455,9 @@ impl crate::xml::runtime::FromXml for crate::opt14::CCodePhrase {
                 }
             }
         }
-        Ok(crate::opt14::CCodePhrase {
+        Ok(crate::opt14::types::CCodePhrase {
             rm_type_name: __rm_type_name.unwrap_or(String::new()),
-            occurrences: __occurrences.unwrap_or(crate::opt14::Intervalofinteger {
+            occurrences: __occurrences.unwrap_or(crate::opt14::types::Intervalofinteger {
                 lower_included: Some(true),
                 upper_included: Some(true),
                 lower_unbounded: false,
@@ -1433,7 +1473,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::CCodePhrase {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::CCodeReference {
+impl crate::xml::runtime::ToXml for crate::opt14::types::CCodeReference {
     fn xml_type_name(&self) -> &'static str {
         "C_CODE_REFERENCE"
     }
@@ -1449,7 +1489,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CCodeReference {
                 __attrs.push(("xsi:type", "C_CODE_REFERENCE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1474,7 +1514,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CCodeReference {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::CCodeReference {
+impl crate::xml::runtime::FromXml for crate::opt14::types::CCodeReference {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -1525,9 +1565,9 @@ impl crate::xml::runtime::FromXml for crate::opt14::CCodeReference {
                 }
             }
         }
-        Ok(crate::opt14::CCodeReference {
+        Ok(crate::opt14::types::CCodeReference {
             rm_type_name: __rm_type_name.unwrap_or(String::new()),
-            occurrences: __occurrences.unwrap_or(crate::opt14::Intervalofinteger {
+            occurrences: __occurrences.unwrap_or(crate::opt14::types::Intervalofinteger {
                 lower_included: Some(true),
                 upper_included: Some(true),
                 lower_unbounded: false,
@@ -1546,7 +1586,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::CCodeReference {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::CComplexObject {
+impl crate::xml::runtime::ToXml for crate::opt14::types::CComplexObject {
     fn xml_type_name(&self) -> &'static str {
         "C_COMPLEX_OBJECT"
     }
@@ -1562,7 +1602,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CComplexObject {
                 __attrs.push(("xsi:type", "C_COMPLEX_OBJECT".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1579,7 +1619,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CComplexObject {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::CComplexObject {
+impl crate::xml::runtime::FromXml for crate::opt14::types::CComplexObject {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -1615,9 +1655,9 @@ impl crate::xml::runtime::FromXml for crate::opt14::CComplexObject {
                 }
             }
         }
-        Ok(crate::opt14::CComplexObject {
+        Ok(crate::opt14::types::CComplexObject {
             rm_type_name: __rm_type_name.unwrap_or(String::new()),
-            occurrences: __occurrences.unwrap_or(crate::opt14::Intervalofinteger {
+            occurrences: __occurrences.unwrap_or(crate::opt14::types::Intervalofinteger {
                 lower_included: Some(true),
                 upper_included: Some(true),
                 lower_unbounded: false,
@@ -1631,7 +1671,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::CComplexObject {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::CDate {
+impl crate::xml::runtime::ToXml for crate::opt14::types::CDate {
     fn xml_type_name(&self) -> &'static str {
         "C_DATE"
     }
@@ -1647,7 +1687,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CDate {
                 __attrs.push(("xsi:type", "C_DATE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1669,7 +1709,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CDate {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::CDate {
+impl crate::xml::runtime::FromXml for crate::opt14::types::CDate {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -1706,7 +1746,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::CDate {
                 }
             }
         }
-        Ok(crate::opt14::CDate {
+        Ok(crate::opt14::types::CDate {
             pattern: __pattern,
             timezone_validity: __timezone_validity,
             range: __range,
@@ -1715,7 +1755,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::CDate {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::CDateTime {
+impl crate::xml::runtime::ToXml for crate::opt14::types::CDateTime {
     fn xml_type_name(&self) -> &'static str {
         "C_DATE_TIME"
     }
@@ -1731,7 +1771,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CDateTime {
                 __attrs.push(("xsi:type", "C_DATE_TIME".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1753,7 +1793,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CDateTime {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::CDateTime {
+impl crate::xml::runtime::FromXml for crate::opt14::types::CDateTime {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -1790,7 +1830,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::CDateTime {
                 }
             }
         }
-        Ok(crate::opt14::CDateTime {
+        Ok(crate::opt14::types::CDateTime {
             pattern: __pattern,
             timezone_validity: __timezone_validity,
             range: __range,
@@ -1799,7 +1839,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::CDateTime {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::CDefinedObject {
+impl crate::xml::runtime::ToXml for crate::opt14::types::CDefinedObject {
     fn xml_type_name(&self) -> &'static str {
         "C_DEFINED_OBJECT"
     }
@@ -1815,7 +1855,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CDefinedObject {
                 __attrs.push(("xsi:type", "C_DEFINED_OBJECT".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1829,7 +1869,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CDefinedObject {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::CDefinedObject {
+impl crate::xml::runtime::FromXml for crate::opt14::types::CDefinedObject {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -1861,9 +1901,9 @@ impl crate::xml::runtime::FromXml for crate::opt14::CDefinedObject {
                 }
             }
         }
-        Ok(crate::opt14::CDefinedObject {
+        Ok(crate::opt14::types::CDefinedObject {
             rm_type_name: __rm_type_name.unwrap_or(String::new()),
-            occurrences: __occurrences.unwrap_or(crate::opt14::Intervalofinteger {
+            occurrences: __occurrences.unwrap_or(crate::opt14::types::Intervalofinteger {
                 lower_included: Some(true),
                 upper_included: Some(true),
                 lower_unbounded: false,
@@ -1876,14 +1916,14 @@ impl crate::xml::runtime::FromXml for crate::opt14::CDefinedObject {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::CDomainType {
+impl crate::xml::runtime::ToXml for crate::opt14::types::CDomainType {
     fn xml_type_name(&self) -> &'static str {
         match self {
-            crate::opt14::CDomainType::CCodePhrase(x) => x.xml_type_name(),
-            crate::opt14::CDomainType::CCodeReference(x) => x.xml_type_name(),
-            crate::opt14::CDomainType::CDvOrdinal(x) => x.xml_type_name(),
-            crate::opt14::CDomainType::CDvQuantity(x) => x.xml_type_name(),
-            crate::opt14::CDomainType::CDvState(x) => x.xml_type_name(),
+            crate::opt14::types::CDomainType::CCodePhrase(x) => x.xml_type_name(),
+            crate::opt14::types::CDomainType::CCodeReference(x) => x.xml_type_name(),
+            crate::opt14::types::CDomainType::CDvOrdinal(x) => x.xml_type_name(),
+            crate::opt14::types::CDomainType::CDvQuantity(x) => x.xml_type_name(),
+            crate::opt14::types::CDomainType::CDvState(x) => x.xml_type_name(),
         }
     }
     fn write_xml(
@@ -1893,34 +1933,34 @@ impl crate::xml::runtime::ToXml for crate::opt14::CDomainType {
         declared: Option<&str>,
     ) -> Result<(), crate::xml::runtime::XmlError> {
         match self {
-            crate::opt14::CDomainType::CCodePhrase(x) => x.write_xml(w, tag, declared),
-            crate::opt14::CDomainType::CCodeReference(x) => x.write_xml(w, tag, declared),
-            crate::opt14::CDomainType::CDvOrdinal(x) => x.write_xml(w, tag, declared),
-            crate::opt14::CDomainType::CDvQuantity(x) => x.write_xml(w, tag, declared),
-            crate::opt14::CDomainType::CDvState(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::CDomainType::CCodePhrase(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::CDomainType::CCodeReference(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::CDomainType::CDvOrdinal(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::CDomainType::CDvQuantity(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::CDomainType::CDvState(x) => x.write_xml(w, tag, declared),
         }
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::CDomainType {
+impl crate::xml::runtime::FromXml for crate::opt14::types::CDomainType {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
     ) -> Result<Self, crate::xml::runtime::XmlError> {
         match start.xsi_type() {
-            Some("C_CODE_PHRASE") => Ok(crate::opt14::CDomainType::CCodePhrase(
+            Some("C_CODE_PHRASE") => Ok(crate::opt14::types::CDomainType::CCodePhrase(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_CODE_REFERENCE") => Ok(crate::opt14::CDomainType::CCodeReference(
+            Some("C_CODE_REFERENCE") => Ok(crate::opt14::types::CDomainType::CCodeReference(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_DV_ORDINAL") => Ok(crate::opt14::CDomainType::CDvOrdinal(
+            Some("C_DV_ORDINAL") => Ok(crate::opt14::types::CDomainType::CDvOrdinal(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_DV_QUANTITY") => Ok(crate::opt14::CDomainType::CDvQuantity(
+            Some("C_DV_QUANTITY") => Ok(crate::opt14::types::CDomainType::CDvQuantity(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_DV_STATE") => Ok(crate::opt14::CDomainType::CDvState(
+            Some("C_DV_STATE") => Ok(crate::opt14::types::CDomainType::CDvState(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
             None => Err(crate::xml::runtime::XmlError::Parse(
@@ -1933,7 +1973,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::CDomainType {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::CDuration {
+impl crate::xml::runtime::ToXml for crate::opt14::types::CDuration {
     fn xml_type_name(&self) -> &'static str {
         "C_DURATION"
     }
@@ -1949,7 +1989,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CDuration {
                 __attrs.push(("xsi:type", "C_DURATION".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1968,7 +2008,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CDuration {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::CDuration {
+impl crate::xml::runtime::FromXml for crate::opt14::types::CDuration {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -2000,7 +2040,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::CDuration {
                 }
             }
         }
-        Ok(crate::opt14::CDuration {
+        Ok(crate::opt14::types::CDuration {
             pattern: __pattern,
             range: __range,
             assumed_value: __assumed_value,
@@ -2008,7 +2048,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::CDuration {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::CDvOrdinal {
+impl crate::xml::runtime::ToXml for crate::opt14::types::CDvOrdinal {
     fn xml_type_name(&self) -> &'static str {
         "C_DV_ORDINAL"
     }
@@ -2024,7 +2064,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CDvOrdinal {
                 __attrs.push(("xsi:type", "C_DV_ORDINAL".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2044,7 +2084,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CDvOrdinal {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::CDvOrdinal {
+impl crate::xml::runtime::FromXml for crate::opt14::types::CDvOrdinal {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -2085,9 +2125,9 @@ impl crate::xml::runtime::FromXml for crate::opt14::CDvOrdinal {
                 }
             }
         }
-        Ok(crate::opt14::CDvOrdinal {
+        Ok(crate::opt14::types::CDvOrdinal {
             rm_type_name: __rm_type_name.unwrap_or(String::new()),
-            occurrences: __occurrences.unwrap_or(crate::opt14::Intervalofinteger {
+            occurrences: __occurrences.unwrap_or(crate::opt14::types::Intervalofinteger {
                 lower_included: Some(true),
                 upper_included: Some(true),
                 lower_unbounded: false,
@@ -2102,7 +2142,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::CDvOrdinal {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::CDvQuantity {
+impl crate::xml::runtime::ToXml for crate::opt14::types::CDvQuantity {
     fn xml_type_name(&self) -> &'static str {
         "C_DV_QUANTITY"
     }
@@ -2118,7 +2158,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CDvQuantity {
                 __attrs.push(("xsi:type", "C_DV_QUANTITY".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2141,7 +2181,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CDvQuantity {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::CDvQuantity {
+impl crate::xml::runtime::FromXml for crate::opt14::types::CDvQuantity {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -2186,9 +2226,9 @@ impl crate::xml::runtime::FromXml for crate::opt14::CDvQuantity {
                 }
             }
         }
-        Ok(crate::opt14::CDvQuantity {
+        Ok(crate::opt14::types::CDvQuantity {
             rm_type_name: __rm_type_name.unwrap_or(String::new()),
-            occurrences: __occurrences.unwrap_or(crate::opt14::Intervalofinteger {
+            occurrences: __occurrences.unwrap_or(crate::opt14::types::Intervalofinteger {
                 lower_included: Some(true),
                 upper_included: Some(true),
                 lower_unbounded: false,
@@ -2204,7 +2244,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::CDvQuantity {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::CDvState {
+impl crate::xml::runtime::ToXml for crate::opt14::types::CDvState {
     fn xml_type_name(&self) -> &'static str {
         "C_DV_STATE"
     }
@@ -2220,7 +2260,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CDvState {
                 __attrs.push(("xsi:type", "C_DV_STATE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2238,7 +2278,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CDvState {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::CDvState {
+impl crate::xml::runtime::FromXml for crate::opt14::types::CDvState {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -2279,9 +2319,9 @@ impl crate::xml::runtime::FromXml for crate::opt14::CDvState {
                 }
             }
         }
-        Ok(crate::opt14::CDvState {
+        Ok(crate::opt14::types::CDvState {
             rm_type_name: __rm_type_name.unwrap_or(String::new()),
-            occurrences: __occurrences.unwrap_or(crate::opt14::Intervalofinteger {
+            occurrences: __occurrences.unwrap_or(crate::opt14::types::Intervalofinteger {
                 lower_included: Some(true),
                 upper_included: Some(true),
                 lower_unbounded: false,
@@ -2298,7 +2338,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::CDvState {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::CInteger {
+impl crate::xml::runtime::ToXml for crate::opt14::types::CInteger {
     fn xml_type_name(&self) -> &'static str {
         "C_INTEGER"
     }
@@ -2314,7 +2354,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CInteger {
                 __attrs.push(("xsi:type", "C_INTEGER".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2333,7 +2373,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CInteger {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::CInteger {
+impl crate::xml::runtime::FromXml for crate::opt14::types::CInteger {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -2365,7 +2405,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::CInteger {
                 }
             }
         }
-        Ok(crate::opt14::CInteger {
+        Ok(crate::opt14::types::CInteger {
             list: __list,
             range: __range,
             assumed_value: __assumed_value,
@@ -2373,7 +2413,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::CInteger {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::CMultipleAttribute {
+impl crate::xml::runtime::ToXml for crate::opt14::types::CMultipleAttribute {
     fn xml_type_name(&self) -> &'static str {
         "C_MULTIPLE_ATTRIBUTE"
     }
@@ -2389,7 +2429,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CMultipleAttribute {
                 __attrs.push(("xsi:type", "C_MULTIPLE_ATTRIBUTE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2408,7 +2448,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CMultipleAttribute {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::CMultipleAttribute {
+impl crate::xml::runtime::FromXml for crate::opt14::types::CMultipleAttribute {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -2444,11 +2484,11 @@ impl crate::xml::runtime::FromXml for crate::opt14::CMultipleAttribute {
                 }
             }
         }
-        Ok(crate::opt14::CMultipleAttribute {
+        Ok(crate::opt14::types::CMultipleAttribute {
             rm_attribute_name: __rm_attribute_name.ok_or_else(|| {
                 crate::xml::runtime::XmlError::Parse("missing element rm_attribute_name".into())
             })?,
-            existence: __existence.unwrap_or(crate::opt14::Intervalofinteger {
+            existence: __existence.unwrap_or(crate::opt14::types::Intervalofinteger {
                 lower_included: Some(true),
                 upper_included: Some(true),
                 lower_unbounded: false,
@@ -2464,22 +2504,22 @@ impl crate::xml::runtime::FromXml for crate::opt14::CMultipleAttribute {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::CObject {
+impl crate::xml::runtime::ToXml for crate::opt14::types::CObject {
     fn xml_type_name(&self) -> &'static str {
         match self {
-            crate::opt14::CObject::ArchetypeInternalRef(x) => x.xml_type_name(),
-            crate::opt14::CObject::ArchetypeSlot(x) => x.xml_type_name(),
-            crate::opt14::CObject::ConstraintRef(x) => x.xml_type_name(),
-            crate::opt14::CObject::CArchetypeRoot(x) => x.xml_type_name(),
-            crate::opt14::CObject::CCodePhrase(x) => x.xml_type_name(),
-            crate::opt14::CObject::CCodeReference(x) => x.xml_type_name(),
-            crate::opt14::CObject::CComplexObject(x) => x.xml_type_name(),
-            crate::opt14::CObject::CDefinedObject(x) => x.xml_type_name(),
-            crate::opt14::CObject::CDvOrdinal(x) => x.xml_type_name(),
-            crate::opt14::CObject::CDvQuantity(x) => x.xml_type_name(),
-            crate::opt14::CObject::CDvState(x) => x.xml_type_name(),
-            crate::opt14::CObject::CPrimitiveObject(x) => x.xml_type_name(),
-            crate::opt14::CObject::TComplexObject(x) => x.xml_type_name(),
+            crate::opt14::types::CObject::ArchetypeInternalRef(x) => x.xml_type_name(),
+            crate::opt14::types::CObject::ArchetypeSlot(x) => x.xml_type_name(),
+            crate::opt14::types::CObject::ConstraintRef(x) => x.xml_type_name(),
+            crate::opt14::types::CObject::CArchetypeRoot(x) => x.xml_type_name(),
+            crate::opt14::types::CObject::CCodePhrase(x) => x.xml_type_name(),
+            crate::opt14::types::CObject::CCodeReference(x) => x.xml_type_name(),
+            crate::opt14::types::CObject::CComplexObject(x) => x.xml_type_name(),
+            crate::opt14::types::CObject::CDefinedObject(x) => x.xml_type_name(),
+            crate::opt14::types::CObject::CDvOrdinal(x) => x.xml_type_name(),
+            crate::opt14::types::CObject::CDvQuantity(x) => x.xml_type_name(),
+            crate::opt14::types::CObject::CDvState(x) => x.xml_type_name(),
+            crate::opt14::types::CObject::CPrimitiveObject(x) => x.xml_type_name(),
+            crate::opt14::types::CObject::TComplexObject(x) => x.xml_type_name(),
         }
     }
     fn write_xml(
@@ -2489,66 +2529,68 @@ impl crate::xml::runtime::ToXml for crate::opt14::CObject {
         declared: Option<&str>,
     ) -> Result<(), crate::xml::runtime::XmlError> {
         match self {
-            crate::opt14::CObject::ArchetypeInternalRef(x) => x.write_xml(w, tag, declared),
-            crate::opt14::CObject::ArchetypeSlot(x) => x.write_xml(w, tag, declared),
-            crate::opt14::CObject::ConstraintRef(x) => x.write_xml(w, tag, declared),
-            crate::opt14::CObject::CArchetypeRoot(x) => x.write_xml(w, tag, declared),
-            crate::opt14::CObject::CCodePhrase(x) => x.write_xml(w, tag, declared),
-            crate::opt14::CObject::CCodeReference(x) => x.write_xml(w, tag, declared),
-            crate::opt14::CObject::CComplexObject(x) => x.write_xml(w, tag, declared),
-            crate::opt14::CObject::CDefinedObject(x) => x.write_xml(w, tag, declared),
-            crate::opt14::CObject::CDvOrdinal(x) => x.write_xml(w, tag, declared),
-            crate::opt14::CObject::CDvQuantity(x) => x.write_xml(w, tag, declared),
-            crate::opt14::CObject::CDvState(x) => x.write_xml(w, tag, declared),
-            crate::opt14::CObject::CPrimitiveObject(x) => x.write_xml(w, tag, declared),
-            crate::opt14::CObject::TComplexObject(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::CObject::ArchetypeInternalRef(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::CObject::ArchetypeSlot(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::CObject::ConstraintRef(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::CObject::CArchetypeRoot(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::CObject::CCodePhrase(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::CObject::CCodeReference(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::CObject::CComplexObject(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::CObject::CDefinedObject(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::CObject::CDvOrdinal(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::CObject::CDvQuantity(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::CObject::CDvState(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::CObject::CPrimitiveObject(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::CObject::TComplexObject(x) => x.write_xml(w, tag, declared),
         }
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::CObject {
+impl crate::xml::runtime::FromXml for crate::opt14::types::CObject {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
     ) -> Result<Self, crate::xml::runtime::XmlError> {
         match start.xsi_type() {
-            Some("ARCHETYPE_INTERNAL_REF") => Ok(crate::opt14::CObject::ArchetypeInternalRef(
+            Some("ARCHETYPE_INTERNAL_REF") => {
+                Ok(crate::opt14::types::CObject::ArchetypeInternalRef(
+                    crate::xml::runtime::FromXml::from_xml(reader, start)?,
+                ))
+            }
+            Some("ARCHETYPE_SLOT") => Ok(crate::opt14::types::CObject::ArchetypeSlot(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("ARCHETYPE_SLOT") => Ok(crate::opt14::CObject::ArchetypeSlot(
+            Some("CONSTRAINT_REF") => Ok(crate::opt14::types::CObject::ConstraintRef(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("CONSTRAINT_REF") => Ok(crate::opt14::CObject::ConstraintRef(
+            Some("C_ARCHETYPE_ROOT") => Ok(crate::opt14::types::CObject::CArchetypeRoot(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_ARCHETYPE_ROOT") => Ok(crate::opt14::CObject::CArchetypeRoot(
+            Some("C_CODE_PHRASE") => Ok(crate::opt14::types::CObject::CCodePhrase(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_CODE_PHRASE") => Ok(crate::opt14::CObject::CCodePhrase(
+            Some("C_CODE_REFERENCE") => Ok(crate::opt14::types::CObject::CCodeReference(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_CODE_REFERENCE") => Ok(crate::opt14::CObject::CCodeReference(
+            Some("C_COMPLEX_OBJECT") => Ok(crate::opt14::types::CObject::CComplexObject(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_COMPLEX_OBJECT") => Ok(crate::opt14::CObject::CComplexObject(
+            Some("C_DEFINED_OBJECT") => Ok(crate::opt14::types::CObject::CDefinedObject(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_DEFINED_OBJECT") => Ok(crate::opt14::CObject::CDefinedObject(
+            Some("C_DV_ORDINAL") => Ok(crate::opt14::types::CObject::CDvOrdinal(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_DV_ORDINAL") => Ok(crate::opt14::CObject::CDvOrdinal(
+            Some("C_DV_QUANTITY") => Ok(crate::opt14::types::CObject::CDvQuantity(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_DV_QUANTITY") => Ok(crate::opt14::CObject::CDvQuantity(
+            Some("C_DV_STATE") => Ok(crate::opt14::types::CObject::CDvState(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_DV_STATE") => Ok(crate::opt14::CObject::CDvState(
+            Some("C_PRIMITIVE_OBJECT") => Ok(crate::opt14::types::CObject::CPrimitiveObject(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_PRIMITIVE_OBJECT") => Ok(crate::opt14::CObject::CPrimitiveObject(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("T_COMPLEX_OBJECT") => Ok(crate::opt14::CObject::TComplexObject(
+            Some("T_COMPLEX_OBJECT") => Ok(crate::opt14::types::CObject::TComplexObject(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
             None => Err(crate::xml::runtime::XmlError::Parse(
@@ -2561,17 +2603,17 @@ impl crate::xml::runtime::FromXml for crate::opt14::CObject {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::CPrimitive {
+impl crate::xml::runtime::ToXml for crate::opt14::types::CPrimitive {
     fn xml_type_name(&self) -> &'static str {
         match self {
-            crate::opt14::CPrimitive::CBoolean(x) => x.xml_type_name(),
-            crate::opt14::CPrimitive::CDate(x) => x.xml_type_name(),
-            crate::opt14::CPrimitive::CDateTime(x) => x.xml_type_name(),
-            crate::opt14::CPrimitive::CDuration(x) => x.xml_type_name(),
-            crate::opt14::CPrimitive::CInteger(x) => x.xml_type_name(),
-            crate::opt14::CPrimitive::CReal(x) => x.xml_type_name(),
-            crate::opt14::CPrimitive::CString(x) => x.xml_type_name(),
-            crate::opt14::CPrimitive::CTime(x) => x.xml_type_name(),
+            crate::opt14::types::CPrimitive::CBoolean(x) => x.xml_type_name(),
+            crate::opt14::types::CPrimitive::CDate(x) => x.xml_type_name(),
+            crate::opt14::types::CPrimitive::CDateTime(x) => x.xml_type_name(),
+            crate::opt14::types::CPrimitive::CDuration(x) => x.xml_type_name(),
+            crate::opt14::types::CPrimitive::CInteger(x) => x.xml_type_name(),
+            crate::opt14::types::CPrimitive::CReal(x) => x.xml_type_name(),
+            crate::opt14::types::CPrimitive::CString(x) => x.xml_type_name(),
+            crate::opt14::types::CPrimitive::CTime(x) => x.xml_type_name(),
         }
     }
     fn write_xml(
@@ -2581,46 +2623,46 @@ impl crate::xml::runtime::ToXml for crate::opt14::CPrimitive {
         declared: Option<&str>,
     ) -> Result<(), crate::xml::runtime::XmlError> {
         match self {
-            crate::opt14::CPrimitive::CBoolean(x) => x.write_xml(w, tag, declared),
-            crate::opt14::CPrimitive::CDate(x) => x.write_xml(w, tag, declared),
-            crate::opt14::CPrimitive::CDateTime(x) => x.write_xml(w, tag, declared),
-            crate::opt14::CPrimitive::CDuration(x) => x.write_xml(w, tag, declared),
-            crate::opt14::CPrimitive::CInteger(x) => x.write_xml(w, tag, declared),
-            crate::opt14::CPrimitive::CReal(x) => x.write_xml(w, tag, declared),
-            crate::opt14::CPrimitive::CString(x) => x.write_xml(w, tag, declared),
-            crate::opt14::CPrimitive::CTime(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::CPrimitive::CBoolean(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::CPrimitive::CDate(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::CPrimitive::CDateTime(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::CPrimitive::CDuration(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::CPrimitive::CInteger(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::CPrimitive::CReal(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::CPrimitive::CString(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::CPrimitive::CTime(x) => x.write_xml(w, tag, declared),
         }
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::CPrimitive {
+impl crate::xml::runtime::FromXml for crate::opt14::types::CPrimitive {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
     ) -> Result<Self, crate::xml::runtime::XmlError> {
         match start.xsi_type() {
-            Some("C_BOOLEAN") => Ok(crate::opt14::CPrimitive::CBoolean(
+            Some("C_BOOLEAN") => Ok(crate::opt14::types::CPrimitive::CBoolean(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_DATE") => Ok(crate::opt14::CPrimitive::CDate(
+            Some("C_DATE") => Ok(crate::opt14::types::CPrimitive::CDate(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_DATE_TIME") => Ok(crate::opt14::CPrimitive::CDateTime(
+            Some("C_DATE_TIME") => Ok(crate::opt14::types::CPrimitive::CDateTime(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_DURATION") => Ok(crate::opt14::CPrimitive::CDuration(
+            Some("C_DURATION") => Ok(crate::opt14::types::CPrimitive::CDuration(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_INTEGER") => Ok(crate::opt14::CPrimitive::CInteger(
+            Some("C_INTEGER") => Ok(crate::opt14::types::CPrimitive::CInteger(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_REAL") => Ok(crate::opt14::CPrimitive::CReal(
+            Some("C_REAL") => Ok(crate::opt14::types::CPrimitive::CReal(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_STRING") => Ok(crate::opt14::CPrimitive::CString(
+            Some("C_STRING") => Ok(crate::opt14::types::CPrimitive::CString(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("C_TIME") => Ok(crate::opt14::CPrimitive::CTime(
+            Some("C_TIME") => Ok(crate::opt14::types::CPrimitive::CTime(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
             None => Err(crate::xml::runtime::XmlError::Parse(
@@ -2633,7 +2675,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::CPrimitive {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::CPrimitiveObject {
+impl crate::xml::runtime::ToXml for crate::opt14::types::CPrimitiveObject {
     fn xml_type_name(&self) -> &'static str {
         "C_PRIMITIVE_OBJECT"
     }
@@ -2649,7 +2691,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CPrimitiveObject {
                 __attrs.push(("xsi:type", "C_PRIMITIVE_OBJECT".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2666,7 +2708,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CPrimitiveObject {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::CPrimitiveObject {
+impl crate::xml::runtime::FromXml for crate::opt14::types::CPrimitiveObject {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -2702,9 +2744,9 @@ impl crate::xml::runtime::FromXml for crate::opt14::CPrimitiveObject {
                 }
             }
         }
-        Ok(crate::opt14::CPrimitiveObject {
+        Ok(crate::opt14::types::CPrimitiveObject {
             rm_type_name: __rm_type_name.unwrap_or(String::new()),
-            occurrences: __occurrences.unwrap_or(crate::opt14::Intervalofinteger {
+            occurrences: __occurrences.unwrap_or(crate::opt14::types::Intervalofinteger {
                 lower_included: Some(true),
                 upper_included: Some(true),
                 lower_unbounded: false,
@@ -2718,7 +2760,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::CPrimitiveObject {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::CQuantityItem {
+impl crate::xml::runtime::ToXml for crate::opt14::types::CQuantityItem {
     fn xml_type_name(&self) -> &'static str {
         "C_QUANTITY_ITEM"
     }
@@ -2734,7 +2776,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CQuantityItem {
                 __attrs.push(("xsi:type", "C_QUANTITY_ITEM".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2751,7 +2793,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CQuantityItem {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::CQuantityItem {
+impl crate::xml::runtime::FromXml for crate::opt14::types::CQuantityItem {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -2782,7 +2824,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::CQuantityItem {
                 }
             }
         }
-        Ok(crate::opt14::CQuantityItem {
+        Ok(crate::opt14::types::CQuantityItem {
             magnitude: __magnitude,
             precision: __precision,
             units: __units.ok_or_else(|| {
@@ -2792,7 +2834,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::CQuantityItem {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::CReal {
+impl crate::xml::runtime::ToXml for crate::opt14::types::CReal {
     fn xml_type_name(&self) -> &'static str {
         "C_REAL"
     }
@@ -2808,7 +2850,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CReal {
                 __attrs.push(("xsi:type", "C_REAL".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2827,7 +2869,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CReal {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::CReal {
+impl crate::xml::runtime::FromXml for crate::opt14::types::CReal {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -2859,7 +2901,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::CReal {
                 }
             }
         }
-        Ok(crate::opt14::CReal {
+        Ok(crate::opt14::types::CReal {
             list: __list,
             range: __range,
             assumed_value: __assumed_value,
@@ -2867,7 +2909,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::CReal {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::CSingleAttribute {
+impl crate::xml::runtime::ToXml for crate::opt14::types::CSingleAttribute {
     fn xml_type_name(&self) -> &'static str {
         "C_SINGLE_ATTRIBUTE"
     }
@@ -2883,7 +2925,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CSingleAttribute {
                 __attrs.push(("xsi:type", "C_SINGLE_ATTRIBUTE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2900,7 +2942,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CSingleAttribute {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::CSingleAttribute {
+impl crate::xml::runtime::FromXml for crate::opt14::types::CSingleAttribute {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -2932,11 +2974,11 @@ impl crate::xml::runtime::FromXml for crate::opt14::CSingleAttribute {
                 }
             }
         }
-        Ok(crate::opt14::CSingleAttribute {
+        Ok(crate::opt14::types::CSingleAttribute {
             rm_attribute_name: __rm_attribute_name.ok_or_else(|| {
                 crate::xml::runtime::XmlError::Parse("missing element rm_attribute_name".into())
             })?,
-            existence: __existence.unwrap_or(crate::opt14::Intervalofinteger {
+            existence: __existence.unwrap_or(crate::opt14::types::Intervalofinteger {
                 lower_included: Some(true),
                 upper_included: Some(true),
                 lower_unbounded: false,
@@ -2949,7 +2991,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::CSingleAttribute {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::CString {
+impl crate::xml::runtime::ToXml for crate::opt14::types::CString {
     fn xml_type_name(&self) -> &'static str {
         "C_STRING"
     }
@@ -2965,7 +3007,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CString {
                 __attrs.push(("xsi:type", "C_STRING".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2987,7 +3029,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CString {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::CString {
+impl crate::xml::runtime::FromXml for crate::opt14::types::CString {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -3023,7 +3065,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::CString {
                 }
             }
         }
-        Ok(crate::opt14::CString {
+        Ok(crate::opt14::types::CString {
             pattern: __pattern,
             list: __list,
             list_open: __list_open,
@@ -3032,7 +3074,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::CString {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::CTime {
+impl crate::xml::runtime::ToXml for crate::opt14::types::CTime {
     fn xml_type_name(&self) -> &'static str {
         "C_TIME"
     }
@@ -3048,7 +3090,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CTime {
                 __attrs.push(("xsi:type", "C_TIME".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3070,7 +3112,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::CTime {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::CTime {
+impl crate::xml::runtime::FromXml for crate::opt14::types::CTime {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -3107,7 +3149,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::CTime {
                 }
             }
         }
-        Ok(crate::opt14::CTime {
+        Ok(crate::opt14::types::CTime {
             pattern: __pattern,
             timezone_validity: __timezone_validity,
             range: __range,
@@ -3116,7 +3158,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::CTime {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::Codedefinitionset {
+impl crate::xml::runtime::ToXml for crate::opt14::types::Codedefinitionset {
     fn xml_type_name(&self) -> &'static str {
         "CodeDefinitionSet"
     }
@@ -3133,7 +3175,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::Codedefinitionset {
             }
         }
         __attrs.push(("language", self.language.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3146,7 +3188,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::Codedefinitionset {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::Codedefinitionset {
+impl crate::xml::runtime::FromXml for crate::opt14::types::Codedefinitionset {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -3169,7 +3211,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::Codedefinitionset {
                 }
             }
         }
-        Ok(crate::opt14::Codedefinitionset {
+        Ok(crate::opt14::types::Codedefinitionset {
             language: start
                 .attr("language")
                 .ok_or_else(|| {
@@ -3181,7 +3223,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::Codedefinitionset {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::Constraintbindingset {
+impl crate::xml::runtime::ToXml for crate::opt14::types::Constraintbindingset {
     fn xml_type_name(&self) -> &'static str {
         "ConstraintBindingSet"
     }
@@ -3198,7 +3240,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::Constraintbindingset {
             }
         }
         __attrs.push(("terminology", self.terminology.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3211,7 +3253,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::Constraintbindingset {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::Constraintbindingset {
+impl crate::xml::runtime::FromXml for crate::opt14::types::Constraintbindingset {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -3234,7 +3276,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::Constraintbindingset {
                 }
             }
         }
-        Ok(crate::opt14::Constraintbindingset {
+        Ok(crate::opt14::types::Constraintbindingset {
             terminology: start
                 .attr("terminology")
                 .ok_or_else(|| {
@@ -3246,7 +3288,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::Constraintbindingset {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::ExprBinaryOperator {
+impl crate::xml::runtime::ToXml for crate::opt14::types::ExprBinaryOperator {
     fn xml_type_name(&self) -> &'static str {
         "EXPR_BINARY_OPERATOR"
     }
@@ -3262,7 +3304,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::ExprBinaryOperator {
                 __attrs.push(("xsi:type", "EXPR_BINARY_OPERATOR".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3280,7 +3322,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::ExprBinaryOperator {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::ExprBinaryOperator {
+impl crate::xml::runtime::FromXml for crate::opt14::types::ExprBinaryOperator {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -3322,7 +3364,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::ExprBinaryOperator {
                 }
             }
         }
-        Ok(crate::opt14::ExprBinaryOperator {
+        Ok(crate::opt14::types::ExprBinaryOperator {
             r#type: __type.ok_or_else(|| {
                 crate::xml::runtime::XmlError::Parse("missing element type".into())
             })?,
@@ -3340,12 +3382,12 @@ impl crate::xml::runtime::FromXml for crate::opt14::ExprBinaryOperator {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::ExprItem {
+impl crate::xml::runtime::ToXml for crate::opt14::types::ExprItem {
     fn xml_type_name(&self) -> &'static str {
         match self {
-            crate::opt14::ExprItem::ExprBinaryOperator(x) => x.xml_type_name(),
-            crate::opt14::ExprItem::ExprLeaf(x) => x.xml_type_name(),
-            crate::opt14::ExprItem::ExprUnaryOperator(x) => x.xml_type_name(),
+            crate::opt14::types::ExprItem::ExprBinaryOperator(x) => x.xml_type_name(),
+            crate::opt14::types::ExprItem::ExprLeaf(x) => x.xml_type_name(),
+            crate::opt14::types::ExprItem::ExprUnaryOperator(x) => x.xml_type_name(),
         }
     }
     fn write_xml(
@@ -3355,26 +3397,26 @@ impl crate::xml::runtime::ToXml for crate::opt14::ExprItem {
         declared: Option<&str>,
     ) -> Result<(), crate::xml::runtime::XmlError> {
         match self {
-            crate::opt14::ExprItem::ExprBinaryOperator(x) => x.write_xml(w, tag, declared),
-            crate::opt14::ExprItem::ExprLeaf(x) => x.write_xml(w, tag, declared),
-            crate::opt14::ExprItem::ExprUnaryOperator(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::ExprItem::ExprBinaryOperator(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::ExprItem::ExprLeaf(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::ExprItem::ExprUnaryOperator(x) => x.write_xml(w, tag, declared),
         }
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::ExprItem {
+impl crate::xml::runtime::FromXml for crate::opt14::types::ExprItem {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
     ) -> Result<Self, crate::xml::runtime::XmlError> {
         match start.xsi_type() {
-            Some("EXPR_BINARY_OPERATOR") => Ok(crate::opt14::ExprItem::ExprBinaryOperator(
+            Some("EXPR_BINARY_OPERATOR") => Ok(crate::opt14::types::ExprItem::ExprBinaryOperator(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("EXPR_LEAF") => Ok(crate::opt14::ExprItem::ExprLeaf(
+            Some("EXPR_LEAF") => Ok(crate::opt14::types::ExprItem::ExprLeaf(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("EXPR_UNARY_OPERATOR") => Ok(crate::opt14::ExprItem::ExprUnaryOperator(
+            Some("EXPR_UNARY_OPERATOR") => Ok(crate::opt14::types::ExprItem::ExprUnaryOperator(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
             None => Err(crate::xml::runtime::XmlError::Parse(
@@ -3387,7 +3429,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::ExprItem {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::ExprLeaf {
+impl crate::xml::runtime::ToXml for crate::opt14::types::ExprLeaf {
     fn xml_type_name(&self) -> &'static str {
         "EXPR_LEAF"
     }
@@ -3403,7 +3445,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::ExprLeaf {
                 __attrs.push(("xsi:type", "EXPR_LEAF".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3417,7 +3459,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::ExprLeaf {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::ExprLeaf {
+impl crate::xml::runtime::FromXml for crate::opt14::types::ExprLeaf {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -3449,7 +3491,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::ExprLeaf {
                 }
             }
         }
-        Ok(crate::opt14::ExprLeaf {
+        Ok(crate::opt14::types::ExprLeaf {
             r#type: __type.ok_or_else(|| {
                 crate::xml::runtime::XmlError::Parse("missing element type".into())
             })?,
@@ -3463,11 +3505,11 @@ impl crate::xml::runtime::FromXml for crate::opt14::ExprLeaf {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::ExprOperator {
+impl crate::xml::runtime::ToXml for crate::opt14::types::ExprOperator {
     fn xml_type_name(&self) -> &'static str {
         match self {
-            crate::opt14::ExprOperator::ExprBinaryOperator(x) => x.xml_type_name(),
-            crate::opt14::ExprOperator::ExprUnaryOperator(x) => x.xml_type_name(),
+            crate::opt14::types::ExprOperator::ExprBinaryOperator(x) => x.xml_type_name(),
+            crate::opt14::types::ExprOperator::ExprUnaryOperator(x) => x.xml_type_name(),
         }
     }
     fn write_xml(
@@ -3477,24 +3519,32 @@ impl crate::xml::runtime::ToXml for crate::opt14::ExprOperator {
         declared: Option<&str>,
     ) -> Result<(), crate::xml::runtime::XmlError> {
         match self {
-            crate::opt14::ExprOperator::ExprBinaryOperator(x) => x.write_xml(w, tag, declared),
-            crate::opt14::ExprOperator::ExprUnaryOperator(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::ExprOperator::ExprBinaryOperator(x) => {
+                x.write_xml(w, tag, declared)
+            }
+            crate::opt14::types::ExprOperator::ExprUnaryOperator(x) => {
+                x.write_xml(w, tag, declared)
+            }
         }
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::ExprOperator {
+impl crate::xml::runtime::FromXml for crate::opt14::types::ExprOperator {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
     ) -> Result<Self, crate::xml::runtime::XmlError> {
         match start.xsi_type() {
-            Some("EXPR_BINARY_OPERATOR") => Ok(crate::opt14::ExprOperator::ExprBinaryOperator(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
-            Some("EXPR_UNARY_OPERATOR") => Ok(crate::opt14::ExprOperator::ExprUnaryOperator(
-                crate::xml::runtime::FromXml::from_xml(reader, start)?,
-            )),
+            Some("EXPR_BINARY_OPERATOR") => {
+                Ok(crate::opt14::types::ExprOperator::ExprBinaryOperator(
+                    crate::xml::runtime::FromXml::from_xml(reader, start)?,
+                ))
+            }
+            Some("EXPR_UNARY_OPERATOR") => {
+                Ok(crate::opt14::types::ExprOperator::ExprUnaryOperator(
+                    crate::xml::runtime::FromXml::from_xml(reader, start)?,
+                ))
+            }
             None => Err(crate::xml::runtime::XmlError::Parse(
                 "ExprOperator: missing xsi:type".into(),
             )),
@@ -3505,7 +3555,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::ExprOperator {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::ExprUnaryOperator {
+impl crate::xml::runtime::ToXml for crate::opt14::types::ExprUnaryOperator {
     fn xml_type_name(&self) -> &'static str {
         "EXPR_UNARY_OPERATOR"
     }
@@ -3521,7 +3571,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::ExprUnaryOperator {
                 __attrs.push(("xsi:type", "EXPR_UNARY_OPERATOR".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3536,7 +3586,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::ExprUnaryOperator {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::ExprUnaryOperator {
+impl crate::xml::runtime::FromXml for crate::opt14::types::ExprUnaryOperator {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -3572,7 +3622,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::ExprUnaryOperator {
                 }
             }
         }
-        Ok(crate::opt14::ExprUnaryOperator {
+        Ok(crate::opt14::types::ExprUnaryOperator {
             r#type: __type.ok_or_else(|| {
                 crate::xml::runtime::XmlError::Parse("missing element type".into())
             })?,
@@ -3587,7 +3637,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::ExprUnaryOperator {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::FlatArchetypeOntology {
+impl crate::xml::runtime::ToXml for crate::opt14::types::FlatArchetypeOntology {
     fn xml_type_name(&self) -> &'static str {
         "FLAT_ARCHETYPE_ONTOLOGY"
     }
@@ -3604,7 +3654,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::FlatArchetypeOntology {
             }
         }
         __attrs.push(("archetype_id", self.archetype_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3626,7 +3676,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::FlatArchetypeOntology {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::FlatArchetypeOntology {
+impl crate::xml::runtime::FromXml for crate::opt14::types::FlatArchetypeOntology {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -3664,7 +3714,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::FlatArchetypeOntology {
                 }
             }
         }
-        Ok(crate::opt14::FlatArchetypeOntology {
+        Ok(crate::opt14::types::FlatArchetypeOntology {
             archetype_id: start
                 .attr("archetype_id")
                 .ok_or_else(|| {
@@ -3679,7 +3729,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::FlatArchetypeOntology {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::Intervalofdate {
+impl crate::xml::runtime::ToXml for crate::opt14::types::Intervalofdate {
     fn xml_type_name(&self) -> &'static str {
         "IntervalOfDate"
     }
@@ -3695,7 +3745,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::Intervalofdate {
                 __attrs.push(("xsi:type", "IntervalOfDate".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3721,7 +3771,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::Intervalofdate {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::Intervalofdate {
+impl crate::xml::runtime::FromXml for crate::opt14::types::Intervalofdate {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -3768,7 +3818,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::Intervalofdate {
                 }
             }
         }
-        Ok(crate::opt14::Intervalofdate {
+        Ok(crate::opt14::types::Intervalofdate {
             lower_included: __lower_included,
             upper_included: __upper_included,
             lower_unbounded: __lower_unbounded.unwrap_or(false),
@@ -3779,7 +3829,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::Intervalofdate {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::Intervalofdatetime {
+impl crate::xml::runtime::ToXml for crate::opt14::types::Intervalofdatetime {
     fn xml_type_name(&self) -> &'static str {
         "IntervalOfDateTime"
     }
@@ -3795,7 +3845,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::Intervalofdatetime {
                 __attrs.push(("xsi:type", "IntervalOfDateTime".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3821,7 +3871,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::Intervalofdatetime {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::Intervalofdatetime {
+impl crate::xml::runtime::FromXml for crate::opt14::types::Intervalofdatetime {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -3868,7 +3918,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::Intervalofdatetime {
                 }
             }
         }
-        Ok(crate::opt14::Intervalofdatetime {
+        Ok(crate::opt14::types::Intervalofdatetime {
             lower_included: __lower_included,
             upper_included: __upper_included,
             lower_unbounded: __lower_unbounded.unwrap_or(false),
@@ -3879,7 +3929,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::Intervalofdatetime {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::Intervalofduration {
+impl crate::xml::runtime::ToXml for crate::opt14::types::Intervalofduration {
     fn xml_type_name(&self) -> &'static str {
         "IntervalOfDuration"
     }
@@ -3895,7 +3945,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::Intervalofduration {
                 __attrs.push(("xsi:type", "IntervalOfDuration".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3921,7 +3971,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::Intervalofduration {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::Intervalofduration {
+impl crate::xml::runtime::FromXml for crate::opt14::types::Intervalofduration {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -3968,7 +4018,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::Intervalofduration {
                 }
             }
         }
-        Ok(crate::opt14::Intervalofduration {
+        Ok(crate::opt14::types::Intervalofduration {
             lower_included: __lower_included,
             upper_included: __upper_included,
             lower_unbounded: __lower_unbounded.unwrap_or(false),
@@ -3979,7 +4029,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::Intervalofduration {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::Intervalofinteger {
+impl crate::xml::runtime::ToXml for crate::opt14::types::Intervalofinteger {
     fn xml_type_name(&self) -> &'static str {
         "IntervalOfInteger"
     }
@@ -3995,7 +4045,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::Intervalofinteger {
                 __attrs.push(("xsi:type", "IntervalOfInteger".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4021,7 +4071,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::Intervalofinteger {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::Intervalofinteger {
+impl crate::xml::runtime::FromXml for crate::opt14::types::Intervalofinteger {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -4068,7 +4118,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::Intervalofinteger {
                 }
             }
         }
-        Ok(crate::opt14::Intervalofinteger {
+        Ok(crate::opt14::types::Intervalofinteger {
             lower_included: __lower_included,
             upper_included: __upper_included,
             lower_unbounded: __lower_unbounded.unwrap_or(false),
@@ -4079,7 +4129,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::Intervalofinteger {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::Intervalofreal {
+impl crate::xml::runtime::ToXml for crate::opt14::types::Intervalofreal {
     fn xml_type_name(&self) -> &'static str {
         "IntervalOfReal"
     }
@@ -4095,7 +4145,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::Intervalofreal {
                 __attrs.push(("xsi:type", "IntervalOfReal".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4121,7 +4171,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::Intervalofreal {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::Intervalofreal {
+impl crate::xml::runtime::FromXml for crate::opt14::types::Intervalofreal {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -4168,7 +4218,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::Intervalofreal {
                 }
             }
         }
-        Ok(crate::opt14::Intervalofreal {
+        Ok(crate::opt14::types::Intervalofreal {
             lower_included: __lower_included,
             upper_included: __upper_included,
             lower_unbounded: __lower_unbounded.unwrap_or(false),
@@ -4179,7 +4229,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::Intervalofreal {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::Intervaloftime {
+impl crate::xml::runtime::ToXml for crate::opt14::types::Intervaloftime {
     fn xml_type_name(&self) -> &'static str {
         "IntervalOfTime"
     }
@@ -4195,7 +4245,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::Intervaloftime {
                 __attrs.push(("xsi:type", "IntervalOfTime".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4221,7 +4271,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::Intervaloftime {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::Intervaloftime {
+impl crate::xml::runtime::FromXml for crate::opt14::types::Intervaloftime {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -4268,7 +4318,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::Intervaloftime {
                 }
             }
         }
-        Ok(crate::opt14::Intervaloftime {
+        Ok(crate::opt14::types::Intervaloftime {
             lower_included: __lower_included,
             upper_included: __upper_included,
             lower_unbounded: __lower_unbounded.unwrap_or(false),
@@ -4279,7 +4329,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::Intervaloftime {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::NonTerminalState {
+impl crate::xml::runtime::ToXml for crate::opt14::types::NonTerminalState {
     fn xml_type_name(&self) -> &'static str {
         "NON_TERMINAL_STATE"
     }
@@ -4295,7 +4345,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::NonTerminalState {
                 __attrs.push(("xsi:type", "NON_TERMINAL_STATE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4309,7 +4359,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::NonTerminalState {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::NonTerminalState {
+impl crate::xml::runtime::FromXml for crate::opt14::types::NonTerminalState {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -4336,7 +4386,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::NonTerminalState {
                 }
             }
         }
-        Ok(crate::opt14::NonTerminalState {
+        Ok(crate::opt14::types::NonTerminalState {
             name: __name.ok_or_else(|| {
                 crate::xml::runtime::XmlError::Parse("missing element name".into())
             })?,
@@ -4345,7 +4395,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::NonTerminalState {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::OperationalTemplate {
+impl crate::xml::runtime::ToXml for crate::opt14::types::OperationalTemplate {
     fn xml_type_name(&self) -> &'static str {
         "OPERATIONAL_TEMPLATE"
     }
@@ -4361,7 +4411,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::OperationalTemplate {
                 __attrs.push(("xsi:type", "OPERATIONAL_TEMPLATE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4405,7 +4455,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::OperationalTemplate {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::OperationalTemplate {
+impl crate::xml::runtime::FromXml for crate::opt14::types::OperationalTemplate {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -4479,7 +4529,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::OperationalTemplate {
                 }
             }
         }
-        Ok(crate::opt14::OperationalTemplate {
+        Ok(crate::opt14::types::OperationalTemplate {
             language: __language.ok_or_else(|| {
                 crate::xml::runtime::XmlError::Parse("missing element language".into())
             })?,
@@ -4505,7 +4555,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::OperationalTemplate {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::ResourceDescription {
+impl crate::xml::runtime::ToXml for crate::opt14::types::ResourceDescription {
     fn xml_type_name(&self) -> &'static str {
         "RESOURCE_DESCRIPTION"
     }
@@ -4521,7 +4571,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::ResourceDescription {
                 __attrs.push(("xsi:type", "RESOURCE_DESCRIPTION".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4553,7 +4603,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::ResourceDescription {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::ResourceDescription {
+impl crate::xml::runtime::FromXml for crate::opt14::types::ResourceDescription {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -4608,7 +4658,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::ResourceDescription {
                 }
             }
         }
-        Ok(crate::opt14::ResourceDescription {
+        Ok(crate::opt14::types::ResourceDescription {
             original_author: __original_author,
             other_contributors: __other_contributors,
             lifecycle_state: __lifecycle_state.ok_or_else(|| {
@@ -4626,7 +4676,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::ResourceDescription {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::ResourceDescriptionItem {
+impl crate::xml::runtime::ToXml for crate::opt14::types::ResourceDescriptionItem {
     fn xml_type_name(&self) -> &'static str {
         "RESOURCE_DESCRIPTION_ITEM"
     }
@@ -4642,7 +4692,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::ResourceDescriptionItem {
                 __attrs.push(("xsi:type", "RESOURCE_DESCRIPTION_ITEM".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4677,7 +4727,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::ResourceDescriptionItem {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::ResourceDescriptionItem {
+impl crate::xml::runtime::FromXml for crate::opt14::types::ResourceDescriptionItem {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -4732,7 +4782,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::ResourceDescriptionItem {
                 }
             }
         }
-        Ok(crate::opt14::ResourceDescriptionItem {
+        Ok(crate::opt14::types::ResourceDescriptionItem {
             language: __language.ok_or_else(|| {
                 crate::xml::runtime::XmlError::Parse("missing element language".into())
             })?,
@@ -4755,11 +4805,11 @@ impl crate::xml::runtime::FromXml for crate::opt14::ResourceDescriptionItem {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::State {
+impl crate::xml::runtime::ToXml for crate::opt14::types::State {
     fn xml_type_name(&self) -> &'static str {
         match self {
-            crate::opt14::State::NonTerminalState(x) => x.xml_type_name(),
-            crate::opt14::State::TerminalState(x) => x.xml_type_name(),
+            crate::opt14::types::State::NonTerminalState(x) => x.xml_type_name(),
+            crate::opt14::types::State::TerminalState(x) => x.xml_type_name(),
         }
     }
     fn write_xml(
@@ -4769,22 +4819,22 @@ impl crate::xml::runtime::ToXml for crate::opt14::State {
         declared: Option<&str>,
     ) -> Result<(), crate::xml::runtime::XmlError> {
         match self {
-            crate::opt14::State::NonTerminalState(x) => x.write_xml(w, tag, declared),
-            crate::opt14::State::TerminalState(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::State::NonTerminalState(x) => x.write_xml(w, tag, declared),
+            crate::opt14::types::State::TerminalState(x) => x.write_xml(w, tag, declared),
         }
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::State {
+impl crate::xml::runtime::FromXml for crate::opt14::types::State {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
     ) -> Result<Self, crate::xml::runtime::XmlError> {
         match start.xsi_type() {
-            Some("NON_TERMINAL_STATE") => Ok(crate::opt14::State::NonTerminalState(
+            Some("NON_TERMINAL_STATE") => Ok(crate::opt14::types::State::NonTerminalState(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
-            Some("TERMINAL_STATE") => Ok(crate::opt14::State::TerminalState(
+            Some("TERMINAL_STATE") => Ok(crate::opt14::types::State::TerminalState(
                 crate::xml::runtime::FromXml::from_xml(reader, start)?,
             )),
             None => Err(crate::xml::runtime::XmlError::Parse(
@@ -4797,7 +4847,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::State {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::StateMachine {
+impl crate::xml::runtime::ToXml for crate::opt14::types::StateMachine {
     fn xml_type_name(&self) -> &'static str {
         "STATE_MACHINE"
     }
@@ -4813,7 +4863,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::StateMachine {
                 __attrs.push(("xsi:type", "STATE_MACHINE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4826,7 +4876,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::StateMachine {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::StateMachine {
+impl crate::xml::runtime::FromXml for crate::opt14::types::StateMachine {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -4849,11 +4899,11 @@ impl crate::xml::runtime::FromXml for crate::opt14::StateMachine {
                 }
             }
         }
-        Ok(crate::opt14::StateMachine { states: __states })
+        Ok(crate::opt14::types::StateMachine { states: __states })
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::TerminalState {
+impl crate::xml::runtime::ToXml for crate::opt14::types::TerminalState {
     fn xml_type_name(&self) -> &'static str {
         "TERMINAL_STATE"
     }
@@ -4869,7 +4919,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::TerminalState {
                 __attrs.push(("xsi:type", "TERMINAL_STATE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4880,7 +4930,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::TerminalState {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::TerminalState {
+impl crate::xml::runtime::FromXml for crate::opt14::types::TerminalState {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -4903,7 +4953,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::TerminalState {
                 }
             }
         }
-        Ok(crate::opt14::TerminalState {
+        Ok(crate::opt14::types::TerminalState {
             name: __name.ok_or_else(|| {
                 crate::xml::runtime::XmlError::Parse("missing element name".into())
             })?,
@@ -4911,7 +4961,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::TerminalState {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::TermBindingItem {
+impl crate::xml::runtime::ToXml for crate::opt14::types::TermBindingItem {
     fn xml_type_name(&self) -> &'static str {
         "TERM_BINDING_ITEM"
     }
@@ -4928,7 +4978,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::TermBindingItem {
             }
         }
         __attrs.push(("code", self.code.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4939,7 +4989,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::TermBindingItem {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::TermBindingItem {
+impl crate::xml::runtime::FromXml for crate::opt14::types::TermBindingItem {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -4962,7 +5012,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::TermBindingItem {
                 }
             }
         }
-        Ok(crate::opt14::TermBindingItem {
+        Ok(crate::opt14::types::TermBindingItem {
             code: start
                 .attr("code")
                 .ok_or_else(|| {
@@ -4976,7 +5026,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::TermBindingItem {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::Transition {
+impl crate::xml::runtime::ToXml for crate::opt14::types::Transition {
     fn xml_type_name(&self) -> &'static str {
         "TRANSITION"
     }
@@ -4992,7 +5042,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::Transition {
                 __attrs.push(("xsi:type", "TRANSITION".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -5012,7 +5062,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::Transition {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::Transition {
+impl crate::xml::runtime::FromXml for crate::opt14::types::Transition {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -5047,7 +5097,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::Transition {
                 }
             }
         }
-        Ok(crate::opt14::Transition {
+        Ok(crate::opt14::types::Transition {
             event: __event.ok_or_else(|| {
                 crate::xml::runtime::XmlError::Parse("missing element event".into())
             })?,
@@ -5058,7 +5108,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::Transition {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::TranslationDetails {
+impl crate::xml::runtime::ToXml for crate::opt14::types::TranslationDetails {
     fn xml_type_name(&self) -> &'static str {
         "TRANSLATION_DETAILS"
     }
@@ -5074,7 +5124,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::TranslationDetails {
                 __attrs.push(("xsi:type", "TRANSLATION_DETAILS".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -5097,7 +5147,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::TranslationDetails {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::TranslationDetails {
+impl crate::xml::runtime::FromXml for crate::opt14::types::TranslationDetails {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -5137,7 +5187,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::TranslationDetails {
                 }
             }
         }
-        Ok(crate::opt14::TranslationDetails {
+        Ok(crate::opt14::types::TranslationDetails {
             language: __language.ok_or_else(|| {
                 crate::xml::runtime::XmlError::Parse("missing element language".into())
             })?,
@@ -5152,7 +5202,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::TranslationDetails {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::TAttribute {
+impl crate::xml::runtime::ToXml for crate::opt14::types::TAttribute {
     fn xml_type_name(&self) -> &'static str {
         "T_ATTRIBUTE"
     }
@@ -5168,7 +5218,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::TAttribute {
                 __attrs.push(("xsi:type", "T_ATTRIBUTE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -5185,7 +5235,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::TAttribute {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::TAttribute {
+impl crate::xml::runtime::FromXml for crate::opt14::types::TAttribute {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -5218,7 +5268,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::TAttribute {
                 }
             }
         }
-        Ok(crate::opt14::TAttribute {
+        Ok(crate::opt14::types::TAttribute {
             rm_attribute_name: __rm_attribute_name.ok_or_else(|| {
                 crate::xml::runtime::XmlError::Parse("missing element rm_attribute_name".into())
             })?,
@@ -5230,7 +5280,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::TAttribute {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::TComplexObject {
+impl crate::xml::runtime::ToXml for crate::opt14::types::TComplexObject {
     fn xml_type_name(&self) -> &'static str {
         "T_COMPLEX_OBJECT"
     }
@@ -5246,7 +5296,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::TComplexObject {
                 __attrs.push(("xsi:type", "T_COMPLEX_OBJECT".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -5266,7 +5316,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::TComplexObject {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::TComplexObject {
+impl crate::xml::runtime::FromXml for crate::opt14::types::TComplexObject {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -5307,9 +5357,9 @@ impl crate::xml::runtime::FromXml for crate::opt14::TComplexObject {
                 }
             }
         }
-        Ok(crate::opt14::TComplexObject {
+        Ok(crate::opt14::types::TComplexObject {
             rm_type_name: __rm_type_name.unwrap_or(String::new()),
-            occurrences: __occurrences.unwrap_or(crate::opt14::Intervalofinteger {
+            occurrences: __occurrences.unwrap_or(crate::opt14::types::Intervalofinteger {
                 lower_included: Some(true),
                 upper_included: Some(true),
                 lower_unbounded: false,
@@ -5324,7 +5374,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::TComplexObject {
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::TConstraint {
+impl crate::xml::runtime::ToXml for crate::opt14::types::TConstraint {
     fn xml_type_name(&self) -> &'static str {
         "T_CONSTRAINT"
     }
@@ -5340,7 +5390,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::TConstraint {
                 __attrs.push(("xsi:type", "T_CONSTRAINT".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -5353,7 +5403,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::TConstraint {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::TConstraint {
+impl crate::xml::runtime::FromXml for crate::opt14::types::TConstraint {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -5376,13 +5426,13 @@ impl crate::xml::runtime::FromXml for crate::opt14::TConstraint {
                 }
             }
         }
-        Ok(crate::opt14::TConstraint {
+        Ok(crate::opt14::types::TConstraint {
             attributes: __attributes,
         })
     }
 }
 
-impl crate::xml::runtime::ToXml for crate::opt14::Termbindingset {
+impl crate::xml::runtime::ToXml for crate::opt14::types::Termbindingset {
     fn xml_type_name(&self) -> &'static str {
         "TermBindingSet"
     }
@@ -5399,7 +5449,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::Termbindingset {
             }
         }
         __attrs.push(("terminology", self.terminology.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -5412,7 +5462,7 @@ impl crate::xml::runtime::ToXml for crate::opt14::Termbindingset {
     }
 }
 
-impl crate::xml::runtime::FromXml for crate::opt14::Termbindingset {
+impl crate::xml::runtime::FromXml for crate::opt14::types::Termbindingset {
     fn from_xml(
         reader: &mut crate::xml::runtime::XmlReader,
         start: &crate::xml::runtime::StartTag,
@@ -5435,7 +5485,7 @@ impl crate::xml::runtime::FromXml for crate::opt14::Termbindingset {
                 }
             }
         }
-        Ok(crate::opt14::Termbindingset {
+        Ok(crate::opt14::types::Termbindingset {
             terminology: start
                 .attr("terminology")
                 .ok_or_else(|| {

--- a/crates/openehr-its/src/opt14/mod.rs
+++ b/crates/openehr-its/src/opt14/mod.rs
@@ -4,22 +4,21 @@
 //! Parse an operational template with [`from_xml`]; the root element is `<template>` (`OPERATIONAL_TEMPLATE`).
 
 mod impls;
-mod types;
-pub use types::*;
+pub mod types;
 
-/// Parse an operational template XML document into an [`OperationalTemplate`].
+/// Parse an operational template XML document into an [`types::OperationalTemplate`].
 ///
 /// # Errors
 /// Propagates canonical-XML parse errors.
-pub fn from_xml(xml: &str) -> Result<OperationalTemplate, crate::xml::runtime::XmlError> {
+pub fn from_xml(xml: &str) -> Result<types::OperationalTemplate, crate::xml::runtime::XmlError> {
     crate::xml::runtime::from_xml(xml)
 }
 
-/// Serialize an [`OperationalTemplate`] back to OPT 1.4 XML (root `<template>`,
+/// Serialize an [`types::OperationalTemplate`] back to OPT 1.4 XML (root `<template>`,
 /// `http://schemas.openehr.org/v1`).
 ///
 /// # Errors
 /// Propagates canonical-XML serialization errors.
-pub fn to_xml(value: &OperationalTemplate) -> Result<String, crate::xml::runtime::XmlError> {
+pub fn to_xml(value: &types::OperationalTemplate) -> Result<String, crate::xml::runtime::XmlError> {
     crate::xml::runtime::to_xml(value, "template", crate::xml::runtime::Namespace::V1)
 }

--- a/crates/openehr-its/src/opt14/types.rs
+++ b/crates/openehr-its/src/opt14/types.rs
@@ -601,7 +601,7 @@ pub struct ExprLeaf {
     /// The `type` attribute/element of the OPT `EXPR_LEAF` XSD type.
     pub r#type: String,
     /// The `item` attribute/element of the OPT `EXPR_LEAF` XSD type.
-    pub item: crate::xml::XmlAny,
+    pub item: crate::xml::runtime::XmlAny,
     /// The `reference_type` attribute/element of the OPT `EXPR_LEAF` XSD type.
     pub reference_type: String,
 }
@@ -783,7 +783,7 @@ pub struct OperationalTemplate {
     /// The `constraints` attribute/element of the OPT `OPERATIONAL_TEMPLATE` XSD type.
     pub constraints: Option<TConstraint>,
     /// The `view` attribute/element of the OPT `OPERATIONAL_TEMPLATE` XSD type.
-    pub view: Option<crate::xml::XmlAny>,
+    pub view: Option<crate::xml::runtime::XmlAny>,
 }
 
 /// openEHR AOM/OPT `RESOURCE_DESCRIPTION`.

--- a/crates/openehr-its/src/rest/mod.rs
+++ b/crates/openehr-its/src/rest/mod.rs
@@ -18,6 +18,3 @@ pub mod generated;
 #[cfg(feature = "full")]
 pub mod runtime;
 pub mod smart_scopes;
-
-#[cfg(feature = "full")]
-pub use runtime::ApiError;

--- a/crates/openehr-its/src/rm_instance/mod.rs
+++ b/crates/openehr-its/src/rm_instance/mod.rs
@@ -52,7 +52,7 @@ use openehr_rm::v1_2::validate::{
     check_mandatory_containers, nonempty_list_violations,
 };
 
-use crate::flat::webtemplate::WebTemplate;
+use crate::flat::webtemplate::model::WebTemplate;
 use crate::wire_validate::validate_rm_invariants_as;
 
 /// A single validation violation, keyed by the RM path of the offending node
@@ -724,7 +724,8 @@ mod tests {
         let opt_xml = std::fs::read_to_string(format!("{dir}/international-patient-summary.opt"))
             .expect("read IPS OPT");
         let opt = crate::opt14::from_xml(&opt_xml).expect("parse IPS OPT");
-        let wt = crate::flat::webtemplate::build_web_template(&opt).expect("build IPS WebTemplate");
+        let wt = crate::flat::webtemplate::builder::build_web_template(&opt)
+            .expect("build IPS WebTemplate");
         let comp: Value = serde_json::from_str(
             &std::fs::read_to_string(format!("{dir}/international-patient-summary.example.json"))
                 .expect("read IPS example"),

--- a/crates/openehr-its/src/xml/generated/impls.rs
+++ b/crates/openehr-its/src/xml/generated/impls.rs
@@ -31,7 +31,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "ACCESS_GROUP_REF".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -111,7 +111,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "ARCHETYPE_ID".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -175,7 +175,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "AUTHORED_RESOURCE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -276,7 +276,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "CODE_PHRASE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -360,7 +360,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "Cardinality".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -442,7 +442,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "GENERIC_ID".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -514,7 +514,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "HIER_OBJECT_ID".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -577,7 +577,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "INTERNET_ID".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -639,7 +639,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "ISO_OID".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -764,7 +764,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "Iso8601_date".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -828,7 +828,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "Iso8601_date_time".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -892,7 +892,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "Iso8601_duration".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -956,7 +956,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "Iso8601_time".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1020,7 +1020,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "Iso8601_timezone".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1131,7 +1131,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "LOCATABLE_REF".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1219,7 +1219,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "Multiplicity_interval".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1371,7 +1371,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "OBJECT_REF".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1495,7 +1495,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "OBJECT_VERSION_ID".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1560,7 +1560,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "PARTY_REF".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1640,7 +1640,7 @@ impl<T: crate::xml::runtime::ToXml> crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "Point_interval".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1744,7 +1744,7 @@ impl<T: crate::xml::runtime::ToXml> crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "Proper_interval".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1886,7 +1886,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "RESOURCE_ANNOTATIONS".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -1944,7 +1944,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "RESOURCE_DESCRIPTION".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2170,7 +2170,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "RESOURCE_DESCRIPTION_ITEM".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2305,7 +2305,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "TEMPLATE_ID".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2369,7 +2369,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "TERMINOLOGY_ID".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2433,7 +2433,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "TRANSLATION_DETAILS".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2557,7 +2557,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "Terminology_code".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2649,7 +2649,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "Terminology_term".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2821,7 +2821,7 @@ impl crate::xml::runtime::ToXml for openehr_base::v1_3::base_types::identificati
                 __attrs.push(("xsi:type", "UUID".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -2937,7 +2937,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "VERSION_TREE_ID".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3001,7 +3001,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::composition::content::entr
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3237,7 +3237,7 @@ impl crate::xml::runtime::ToXml
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3437,7 +3437,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::demographic::address::Addr
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3560,7 +3560,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "ADDRESSED_MESSAGE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3665,7 +3665,7 @@ impl crate::xml::runtime::ToXml
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -3854,7 +3854,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::demographic::agent::Agent 
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4062,7 +4062,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::common::archetyped::archet
                 __attrs.push(("xsi:type", "ARCHETYPED".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4140,7 +4140,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::common::generic::attestati
                 __attrs.push(("xsi:type", "ATTESTATION".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4292,7 +4292,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "AUDIT_DETAILS".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4450,7 +4450,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "AUTHORED_RESOURCE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4543,7 +4543,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::demographic::capability::C
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4756,7 +4756,7 @@ impl crate::xml::runtime::ToXml
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4884,7 +4884,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::data_types::text::code_phr
                 __attrs.push(("xsi:type", "CODE_PHRASE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -4966,7 +4966,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "CODE_SET_ACCESS".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -5018,7 +5018,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::composition::composition::
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -5195,7 +5195,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::demographic::contact::Cont
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -5443,7 +5443,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "CONTRIBUTION".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -5825,7 +5825,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::data_types::basic::dv_bool
                 __attrs.push(("xsi:type", "DV_BOOLEAN".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -5883,7 +5883,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::data_types::text::dv_coded
                 __attrs.push(("xsi:type", "DV_CODED_TEXT".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -6007,7 +6007,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::data_types::quantity::dv_c
                 __attrs.push(("xsi:type", "DV_COUNT".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -6135,7 +6135,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "DV_DATE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -6256,7 +6256,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "DV_DATE_TIME".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -6377,7 +6377,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "DV_DURATION".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -6505,7 +6505,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::data_types::uri::dv_ehr_ur
                 __attrs.push(("xsi:type", "DV_EHR_URI".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -6590,7 +6590,7 @@ fn xml_type_name(&self) -> &'static str { "DV_GENERAL_TIME_SPECIFICATION" }
 fn write_xml(&self, w: &mut crate::xml::runtime::XmlWriter, tag: &str, declared: Option<&str>) -> Result<(), crate::xml::runtime::XmlError> {
 let mut __attrs: Vec<(&str, String)> = Vec::new();
 if let Some(d) = declared { if d != "DV_GENERAL_TIME_SPECIFICATION" { __attrs.push(("xsi:type", "DV_GENERAL_TIME_SPECIFICATION".to_string())); } }
-let mut __e = crate::xml::runtime::XmlStart::new(tag);
+let mut __e = quick_xml::events::BytesStart::new(tag);
 for (k, v) in &__attrs { __e.push_attribute((*k, v.as_str())); }
 w.write_start(__e)?;
 self.value.write_xml(w, "value", Some("DV_PARSABLE"))?;
@@ -6635,7 +6635,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "DV_IDENTIFIER".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -6723,7 +6723,7 @@ impl<T: crate::xml::runtime::ToXml> crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "DV_INTERVAL".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -6827,7 +6827,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "DV_MULTIMEDIA".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -7107,7 +7107,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::data_types::quantity::dv_o
                 __attrs.push(("xsi:type", "DV_ORDINAL".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -7217,7 +7217,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::data_types::text::dv_parag
                 __attrs.push(("xsi:type", "DV_PARAGRAPH".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -7285,7 +7285,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "DV_PARSABLE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -7360,7 +7360,7 @@ fn xml_type_name(&self) -> &'static str { "DV_PERIODIC_TIME_SPECIFICATION" }
 fn write_xml(&self, w: &mut crate::xml::runtime::XmlWriter, tag: &str, declared: Option<&str>) -> Result<(), crate::xml::runtime::XmlError> {
 let mut __attrs: Vec<(&str, String)> = Vec::new();
 if let Some(d) = declared { if d != "DV_PERIODIC_TIME_SPECIFICATION" { __attrs.push(("xsi:type", "DV_PERIODIC_TIME_SPECIFICATION".to_string())); } }
-let mut __e = crate::xml::runtime::XmlStart::new(tag);
+let mut __e = quick_xml::events::BytesStart::new(tag);
 for (k, v) in &__attrs { __e.push_attribute((*k, v.as_str())); }
 w.write_start(__e)?;
 self.value.write_xml(w, "value", Some("DV_PARSABLE"))?;
@@ -7405,7 +7405,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "DV_PROPORTION".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -7672,7 +7672,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "DV_QUANTITY".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -7834,7 +7834,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::data_types::quantity::dv_s
                 __attrs.push(("xsi:type", "DV_SCALE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -7941,7 +7941,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::data_types::basic::dv_stat
                 __attrs.push(("xsi:type", "DV_STATE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -8049,7 +8049,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::data_types::text::dv_text:
                 __attrs.push(("xsi:type", "DV_TEXT".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -8211,7 +8211,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "DV_TIME".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -8368,7 +8368,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::data_types::uri::dv_uri::D
                 __attrs.push(("xsi:type", "DV_URI".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -8472,7 +8472,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::ehr::ehr::Ehr {
                 __attrs.push(("xsi:type", "EHR".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -8632,7 +8632,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::ehr::ehr_access::EhrAccess
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -8753,7 +8753,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::ehr::ehr_status::EhrStatus
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -8905,7 +8905,7 @@ impl crate::xml::runtime::ToXml
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -9136,7 +9136,7 @@ impl crate::xml::runtime::ToXml
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -9399,7 +9399,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::composition::event_context
                 __attrs.push(("xsi:type", "EVENT_CONTEXT".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -9525,7 +9525,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::ehr_extract::common::extra
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -9714,7 +9714,7 @@ impl crate::xml::runtime::ToXml
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -9850,7 +9850,7 @@ impl crate::xml::runtime::ToXml
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -10059,7 +10059,7 @@ impl crate::xml::runtime::ToXml
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -10201,7 +10201,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "EXTRACT_ENTITY_MANIFEST".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -10311,7 +10311,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "EXTRACT_ERROR".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -10384,7 +10384,7 @@ impl crate::xml::runtime::ToXml
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -10557,7 +10557,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "EXTRACT_MANIFEST".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -10627,7 +10627,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "EXTRACT_PARTICIPATION".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -10716,7 +10716,7 @@ impl crate::xml::runtime::ToXml
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -10852,7 +10852,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "EXTRACT_SPEC".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -10988,7 +10988,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "EXTRACT_UPDATE_SPEC".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -11096,7 +11096,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "EXTRACT_VERSION_SPEC".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -11195,7 +11195,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "FEEDER_AUDIT".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -11314,7 +11314,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "FEEDER_AUDIT_DETAILS".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -11426,7 +11426,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::common::directory::folder:
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -11577,7 +11577,7 @@ impl crate::xml::runtime::ToXml
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -11800,7 +11800,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::integration::generic_entry
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -11921,7 +11921,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::demographic::group::Group 
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -12132,7 +12132,7 @@ impl<T: crate::xml::runtime::ToXml> crate::xml::runtime::ToXml
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -12296,7 +12296,7 @@ impl<T: crate::xml::runtime::ToXml> crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "IMPORTED_VERSION".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -12389,7 +12389,7 @@ impl crate::xml::runtime::ToXml
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -12635,7 +12635,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "INSTRUCTION_DETAILS".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -12713,7 +12713,7 @@ impl<T: crate::xml::runtime::ToXml> crate::xml::runtime::ToXml
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -12882,7 +12882,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "ISM_TRANSITION".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -13036,7 +13036,7 @@ impl crate::xml::runtime::ToXml
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -13169,7 +13169,7 @@ impl crate::xml::runtime::ToXml
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -13340,7 +13340,7 @@ impl crate::xml::runtime::ToXml
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -13470,7 +13470,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::common::tags::item_tag::It
                 __attrs.push(("xsi:type", "ITEM_TAG".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -13567,7 +13567,7 @@ impl crate::xml::runtime::ToXml
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -13773,7 +13773,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "Iso8601_date".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -13897,7 +13897,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "Iso8601_date_time".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -13999,7 +13999,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "Iso8601_duration".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -14101,7 +14101,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "Iso8601_time".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -14274,7 +14274,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::common::archetyped::link::
                 __attrs.push(("xsi:type", "LINK".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -14805,7 +14805,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "MEASUREMENT_SERVICE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -14856,7 +14856,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::ehr_extract::message::mess
                 __attrs.push(("xsi:type", "MESSAGE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -14980,7 +14980,7 @@ impl crate::xml::runtime::ToXml
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -15182,7 +15182,7 @@ fn xml_type_name(&self) -> &'static str { "OPENEHR_CODE_SET_IDENTIFIERS" }
 fn write_xml(&self, w: &mut crate::xml::runtime::XmlWriter, tag: &str, declared: Option<&str>) -> Result<(), crate::xml::runtime::XmlError> {
 let mut __attrs: Vec<(&str, String)> = Vec::new();
 if let Some(d) = declared { if d != "OPENEHR_CODE_SET_IDENTIFIERS" { __attrs.push(("xsi:type", "OPENEHR_CODE_SET_IDENTIFIERS".to_string())); } }
-let mut __e = crate::xml::runtime::XmlStart::new(tag);
+let mut __e = quick_xml::events::BytesStart::new(tag);
 for (k, v) in &__attrs { __e.push_attribute((*k, v.as_str())); }
 w.write_start(__e)?;
 w.write_end(tag)?;
@@ -15246,7 +15246,7 @@ impl crate::xml::runtime::ToXml
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -15361,7 +15361,7 @@ fn xml_type_name(&self) -> &'static str { "OPENEHR_TERMINOLOGY_GROUP_IDENTIFIERS
 fn write_xml(&self, w: &mut crate::xml::runtime::XmlWriter, tag: &str, declared: Option<&str>) -> Result<(), crate::xml::runtime::XmlError> {
 let mut __attrs: Vec<(&str, String)> = Vec::new();
 if let Some(d) = declared { if d != "OPENEHR_TERMINOLOGY_GROUP_IDENTIFIERS" { __attrs.push(("xsi:type", "OPENEHR_TERMINOLOGY_GROUP_IDENTIFIERS".to_string())); } }
-let mut __e = crate::xml::runtime::XmlStart::new(tag);
+let mut __e = quick_xml::events::BytesStart::new(tag);
 for (k, v) in &__attrs { __e.push_attribute((*k, v.as_str())); }
 w.write_start(__e)?;
 w.write_end(tag)?;
@@ -15423,7 +15423,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::demographic::organisation:
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -15633,7 +15633,7 @@ impl<T: crate::xml::runtime::ToXml> crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "ORIGINAL_VERSION".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -15797,7 +15797,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "PARTICIPATION".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -15945,7 +15945,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "PARTY_IDENTIFIED".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -16077,7 +16077,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::demographic::party_identit
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -16259,7 +16259,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::common::generic::party_rel
                 __attrs.push(("xsi:type", "PARTY_RELATED".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -16365,7 +16365,7 @@ impl crate::xml::runtime::ToXml
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -16514,7 +16514,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::common::generic::party_sel
                 __attrs.push(("xsi:type", "PARTY_SELF".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -17056,7 +17056,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::demographic::person::Perso
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -17267,7 +17267,7 @@ impl<T: crate::xml::runtime::ToXml> crate::xml::runtime::ToXml
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -17438,7 +17438,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "REFERENCE_RANGE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -17510,7 +17510,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "RESOURCE_DESCRIPTION".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -17628,7 +17628,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "RESOURCE_DESCRIPTION_ITEM".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -17753,7 +17753,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "REVISION_HISTORY".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -17821,7 +17821,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "REVISION_HISTORY_ITEM".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -17897,7 +17897,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::demographic::role::Role {
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -18112,7 +18112,7 @@ impl crate::xml::runtime::ToXml
             }
         }
         __attrs.push(("archetype_node_id", self.archetype_node_id.to_string()));
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -18250,7 +18250,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "SYNC_EXTRACT".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -18330,7 +18330,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "SYNC_EXTRACT_REQUEST".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -18396,7 +18396,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "SYNC_EXTRACT_SPEC".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -18495,7 +18495,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "TERMINOLOGY_ACCESS".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -18548,7 +18548,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "TERMINOLOGY_SERVICE".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -18599,7 +18599,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::data_types::text::term_map
                 __attrs.push(("xsi:type", "TERM_MAPPING".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -18679,7 +18679,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "TRANSLATION_DETAILS".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -18837,7 +18837,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "VERSIONED_COMPOSITION".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -18919,7 +18919,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "VERSIONED_EHR_ACCESS".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -19001,7 +19001,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "VERSIONED_EHR_STATUS".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -19083,7 +19083,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "VERSIONED_FOLDER".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -19165,7 +19165,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "VERSIONED_OBJECT".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -19295,7 +19295,7 @@ impl crate::xml::runtime::ToXml for openehr_rm::v1_2::demographic::versioned_par
                 __attrs.push(("xsi:type", "VERSIONED_PARTY".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -19377,7 +19377,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "X_CONTRIBUTION".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -19450,7 +19450,7 @@ fn xml_type_name(&self) -> &'static str { "X_VERSIONED_COMPOSITION" }
 fn write_xml(&self, w: &mut crate::xml::runtime::XmlWriter, tag: &str, declared: Option<&str>) -> Result<(), crate::xml::runtime::XmlError> {
 let mut __attrs: Vec<(&str, String)> = Vec::new();
 if let Some(d) = declared { if d != "X_VERSIONED_COMPOSITION" { __attrs.push(("xsi:type", "X_VERSIONED_COMPOSITION".to_string())); } }
-let mut __e = crate::xml::runtime::XmlStart::new(tag);
+let mut __e = quick_xml::events::BytesStart::new(tag);
 for (k, v) in &__attrs { __e.push_attribute((*k, v.as_str())); }
 w.write_start(__e)?;
 self.uid.write_xml(w, "uid", Some("HIER_OBJECT_ID"))?;
@@ -19519,7 +19519,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "X_VERSIONED_EHR_ACCESS".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -19628,7 +19628,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "X_VERSIONED_EHR_STATUS".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -19737,7 +19737,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "X_VERSIONED_FOLDER".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -19866,7 +19866,7 @@ impl<T: crate::xml::runtime::ToXml> crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "X_VERSIONED_OBJECT".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }
@@ -20025,7 +20025,7 @@ impl crate::xml::runtime::ToXml
                 __attrs.push(("xsi:type", "X_VERSIONED_PARTY".to_string()));
             }
         }
-        let mut __e = crate::xml::runtime::XmlStart::new(tag);
+        let mut __e = quick_xml::events::BytesStart::new(tag);
         for (k, v) in &__attrs {
             __e.push_attribute((*k, v.as_str()));
         }

--- a/crates/openehr-its/src/xml/mod.rs
+++ b/crates/openehr-its/src/xml/mod.rs
@@ -21,11 +21,6 @@ pub mod runtime;
 // Trait impls for the spec types — compiled for their effect; nothing to export.
 mod generated;
 
-pub use runtime::{
-    FromXml, Namespace, StartTag, ToXml, XmlAny, XmlAnyNode, XmlError, XmlEvent, XmlReader,
-    XmlWriter, from_xml, to_xml, to_xml_declared,
-};
-
 /// One published ITS-XML **document element** (a global `xs:element` of the
 /// vendored bundles) that this codec serves as a canonical-XML root.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -108,8 +103,11 @@ pub fn declared_abstract_root_type(element: &str) -> Option<&'static str> {
 ///
 /// # Errors
 /// Propagates serialization errors.
-pub fn to_canonical_xml<T: ToXml + ?Sized>(value: &T, root_tag: &str) -> Result<String, XmlError> {
-    to_canonical_xml_ns(value, root_tag, Namespace::V1)
+pub fn to_canonical_xml<T: runtime::ToXml + ?Sized>(
+    value: &T,
+    root_tag: &str,
+) -> Result<String, runtime::XmlError> {
+    to_canonical_xml_ns(value, root_tag, runtime::Namespace::V1)
 }
 
 /// Serialize an RM value to canonical openEHR XML in an explicitly chosen wire
@@ -130,12 +128,12 @@ pub fn to_canonical_xml<T: ToXml + ?Sized>(value: &T, root_tag: &str) -> Result<
 ///
 /// # Errors
 /// Propagates serialization errors.
-pub fn to_canonical_xml_ns<T: ToXml + ?Sized>(
+pub fn to_canonical_xml_ns<T: runtime::ToXml + ?Sized>(
     value: &T,
     root_tag: &str,
-    ns: Namespace,
-) -> Result<String, XmlError> {
-    to_xml(value, root_tag, ns)
+    ns: runtime::Namespace,
+) -> Result<String, runtime::XmlError> {
+    runtime::to_xml(value, root_tag, ns)
 }
 
 /// Serialize an RM value under a root element whose **XSD-declared type is
@@ -158,13 +156,13 @@ pub fn to_canonical_xml_ns<T: ToXml + ?Sized>(
 ///
 /// # Errors
 /// Propagates serialization errors.
-pub fn to_canonical_xml_declared<T: ToXml + ?Sized>(
+pub fn to_canonical_xml_declared<T: runtime::ToXml + ?Sized>(
     value: &T,
     root_tag: &str,
     declared_type: &str,
-    ns: Namespace,
-) -> Result<String, XmlError> {
-    to_xml_declared(value, root_tag, declared_type, ns)
+    ns: runtime::Namespace,
+) -> Result<String, runtime::XmlError> {
+    runtime::to_xml_declared(value, root_tag, declared_type, ns)
 }
 
 /// Deserialize an RM value from a canonical openEHR XML document.
@@ -179,13 +177,13 @@ pub fn to_canonical_xml_declared<T: ToXml + ?Sized>(
 /// interchangeable: the flat `Release-1.0.2v2` bundle is frozen at an older RM
 /// generation and declares neither `FOLDER.details` nor 22 other RM 1.2.0
 /// attributes, nor 50 RM 1.2.0 classes at all
-/// (`schemas/xml/PROVENANCE.md` §"Two lineages"). Namespace-agnostic READING
+/// (`schemas/xml/PROVENANCE.md` §"Two lineages"). runtime::Namespace-agnostic READING
 /// stays sound regardless, because every element name and `xsi:type` the
 /// reader dispatches on is spelled identically in both lineages; only what the
 /// two schemas ACCEPT differs.
 ///
 /// # Errors
 /// Propagates parse errors.
-pub fn from_canonical_xml<T: FromXml>(xml: &str) -> Result<T, XmlError> {
-    from_xml(xml)
+pub fn from_canonical_xml<T: runtime::FromXml>(xml: &str) -> Result<T, runtime::XmlError> {
+    runtime::from_xml(xml)
 }

--- a/crates/openehr-its/src/xml/runtime.rs
+++ b/crates/openehr-its/src/xml/runtime.rs
@@ -19,8 +19,6 @@ use quick_xml::Reader;
 use quick_xml::Writer;
 use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event};
 
-pub use quick_xml::events::BytesStart as XmlStart;
-
 /// The `xsi` namespace, declared on every serialized root element.
 pub const XSI_NS: &str = "http://www.w3.org/2001/XMLSchema-instance";
 

--- a/crates/openehr-its/tests/it/aom2_model_xml.rs
+++ b/crates/openehr-its/tests/it/aom2_model_xml.rs
@@ -34,7 +34,7 @@
     reason = "the Book ch11 test shape: `?` propagates the codec plumbing while the assertions ARE the test — an assertion panic is how these tests fail"
 )]
 
-use openehr_its::aom2_model::{
+use openehr_its::aom2_model::types::{
     ArchetypeHrid, ArchetypeTerm, ArchetypeTerminology, AuthoredArchetype, CAttribute,
     CComplexObject, CObject, CString, Cardinality, Codedefinitionset, Multiplicityinterval,
     TerminologyCode,

--- a/crates/openehr-its/tests/it/aom2_xml.rs
+++ b/crates/openehr-its/tests/it/aom2_xml.rs
@@ -25,7 +25,7 @@
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 
-use openehr_its::aom2::PAuthoredArchetype;
+use openehr_its::aom2::types::PAuthoredArchetype;
 
 /// Example documents the codec cannot read, with the reason. A refusal is a
 /// NEGATIVE test — the gate fails if the document starts reading, so the entry

--- a/crates/openehr-its/tests/it/attested_version.rs
+++ b/crates/openehr-its/tests/it/attested_version.rs
@@ -25,9 +25,8 @@
 
 use std::path::{Path, PathBuf};
 
-use openehr_its::xml::{
-    Namespace, from_canonical_xml, to_canonical_xml, to_canonical_xml_declared,
-};
+use openehr_its::xml::runtime::Namespace;
+use openehr_its::xml::{from_canonical_xml, to_canonical_xml, to_canonical_xml_declared};
 use openehr_rm::v1_2::common::change_control::original_version::OriginalVersion;
 use openehr_rm::v1_2::composition::composition::Composition;
 

--- a/crates/openehr-its/tests/it/ckm_archetype_xml.rs
+++ b/crates/openehr-its/tests/it/ckm_archetype_xml.rs
@@ -24,7 +24,7 @@
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 
-use openehr_its::opt14::Archetype;
+use openehr_its::opt14::types::Archetype;
 
 /// Archetype XML documents the codec cannot read, with the reason. A refusal
 /// here is a NEGATIVE test: the gate asserts the read still fails, so a

--- a/crates/openehr-its/tests/it/ckm_full_pack.rs
+++ b/crates/openehr-its/tests/it/ckm_full_pack.rs
@@ -7,7 +7,7 @@
 //! Breadth gate over the FULL vendored openEHR CKM template library
 //! (`tools/cnf-runner/artifacts/corpus/templates/ckm/full/`, vendored by
 //! `scripts/vendor/ckm-templates.sh`): every OPT the public CKM publishes
-//! must parse into the generated `opt14::OperationalTemplate`, build a
+//! must parse into the generated `opt14::types::OperationalTemplate`, build a
 //! WebTemplate, and generate RM-shape-valid examples at every detail level.
 //!
 //! Why the whole library and not a curated handful: real-world OPTs carry
@@ -26,7 +26,7 @@ use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 
 use openehr_its::flat::example::{DetailLevel, example_composition};
-use openehr_its::flat::webtemplate::build_web_template;
+use openehr_its::flat::webtemplate::builder::build_web_template;
 use openehr_its::opt14;
 use serde_json::Value;
 

--- a/crates/openehr-its/tests/it/cnf_vitals_template.rs
+++ b/crates/openehr-its/tests/it/cnf_vitals_template.rs
@@ -24,7 +24,8 @@
 
 use std::path::PathBuf;
 
-use openehr_its::flat::webtemplate::{WebTemplateNode, build_web_template};
+use openehr_its::flat::webtemplate::builder::build_web_template;
+use openehr_its::flat::webtemplate::model::WebTemplateNode;
 use openehr_its::opt14;
 
 fn vitals_opt() -> PathBuf {

--- a/crates/openehr-its/tests/it/coded_names.rs
+++ b/crates/openehr-its/tests/it/coded_names.rs
@@ -28,7 +28,8 @@
 use std::path::{Path, PathBuf};
 
 use openehr_its::flat::example::{DetailLevel, example_composition};
-use openehr_its::flat::webtemplate::{WebTemplate, WebTemplateNode, build_web_template};
+use openehr_its::flat::webtemplate::builder::build_web_template;
+use openehr_its::flat::webtemplate::model::{WebTemplate, WebTemplateNode};
 use openehr_its::opt14;
 use serde_json::Value;
 

--- a/crates/openehr-its/tests/it/constraint_binding_capture.rs
+++ b/crates/openehr-its/tests/it/constraint_binding_capture.rs
@@ -15,7 +15,7 @@
 //! structured) value set from that terminology". The query "is defined within a
 //! 'terminology query server'", so this crate cannot resolve it — it captures
 //! the binding
-//! ([`WebTemplateConstraintBinding`](openehr_its::flat::webtemplate::WebTemplateConstraintBinding))
+//! ([`WebTemplateConstraintBinding`](openehr_its::flat::webtemplate::model::WebTemplateConstraintBinding))
 //! and surfaces the questions
 //! ([`collect_constraint_binding_checks`](openehr_its::flat::validation::collect_constraint_binding_checks))
 //! for a caller that owns one.
@@ -30,7 +30,8 @@
 use std::path::PathBuf;
 
 use openehr_its::flat::validation::collect_constraint_binding_checks;
-use openehr_its::flat::webtemplate::{WebTemplate, WebTemplateNode, build_web_template};
+use openehr_its::flat::webtemplate::builder::build_web_template;
+use openehr_its::flat::webtemplate::model::{WebTemplate, WebTemplateNode};
 use openehr_its::opt14;
 use serde_json::json;
 

--- a/crates/openehr-its/tests/it/content_constraint_capture.rs
+++ b/crates/openehr-its/tests/it/content_constraint_capture.rs
@@ -26,7 +26,8 @@
 
 use std::path::PathBuf;
 
-use openehr_its::flat::webtemplate::{WebTemplateNode, build_web_template};
+use openehr_its::flat::webtemplate::builder::build_web_template;
+use openehr_its::flat::webtemplate::model::WebTemplateNode;
 use openehr_its::opt14;
 
 fn templates_dir() -> PathBuf {

--- a/crates/openehr-its/tests/it/content_existence_capture.rs
+++ b/crates/openehr-its/tests/it/content_existence_capture.rs
@@ -24,7 +24,8 @@
 use std::path::PathBuf;
 
 use openehr_its::flat::validation::validate_archetype_conformance;
-use openehr_its::flat::webtemplate::{WebTemplate, build_web_template};
+use openehr_its::flat::webtemplate::builder::build_web_template;
+use openehr_its::flat::webtemplate::model::WebTemplate;
 use openehr_its::opt14;
 use openehr_its::rm_instance::ValidationKind;
 use serde_json::{Value, json};

--- a/crates/openehr-its/tests/it/example_rm_validity.rs
+++ b/crates/openehr-its/tests/it/example_rm_validity.rs
@@ -7,7 +7,7 @@
 //! commit surface).
 
 use openehr_its::flat::example::{DetailLevel, example_composition};
-use openehr_its::flat::webtemplate::build_web_template;
+use openehr_its::flat::webtemplate::builder::build_web_template;
 use openehr_its::opt14;
 use serde_json::Value;
 

--- a/crates/openehr-its/tests/it/example_stub.rs
+++ b/crates/openehr-its/tests/it/example_stub.rs
@@ -28,7 +28,8 @@
 use std::path::{Path, PathBuf};
 
 use openehr_its::flat::example::{DetailLevel, example_composition};
-use openehr_its::flat::webtemplate::{WebTemplate, WebTemplateNode, build_web_template};
+use openehr_its::flat::webtemplate::builder::build_web_template;
+use openehr_its::flat::webtemplate::model::{WebTemplate, WebTemplateNode};
 use openehr_its::opt14;
 use openehr_its::rm_instance::{ValidationKind, validate_composition};
 use serde_json::Value;

--- a/crates/openehr-its/tests/it/flat.rs
+++ b/crates/openehr-its/tests/it/flat.rs
@@ -32,7 +32,8 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use openehr_its::flat::convert::{composition_from_flat, composition_to_flat};
-use openehr_its::flat::webtemplate::{WebTemplate, build_web_template};
+use openehr_its::flat::webtemplate::builder::build_web_template;
+use openehr_its::flat::webtemplate::model::WebTemplate;
 use openehr_its::opt14;
 use serde_json::Value;
 
@@ -769,9 +770,9 @@ fn action_ism_transition_from_flat_builds_supplied_state() {
 
 /// Collect every node of `rm_type` at or below `n`, in web-template pre-order.
 fn collect_by_rm_type<'a>(
-    n: &'a openehr_its::flat::webtemplate::WebTemplateNode,
+    n: &'a openehr_its::flat::webtemplate::model::WebTemplateNode,
     rm_type: &str,
-    out: &mut Vec<&'a openehr_its::flat::webtemplate::WebTemplateNode>,
+    out: &mut Vec<&'a openehr_its::flat::webtemplate::model::WebTemplateNode>,
 ) {
     if n.rm_type == rm_type {
         out.push(n);
@@ -785,8 +786,8 @@ fn collect_by_rm_type<'a>(
 /// one (master05 §ISM_TRANSITION: one `/ism_transition` node per ACTION, not one
 /// per careflow state).
 fn wt_transition(
-    action: &openehr_its::flat::webtemplate::WebTemplateNode,
-) -> Option<&openehr_its::flat::webtemplate::WebTemplateNode> {
+    action: &openehr_its::flat::webtemplate::model::WebTemplateNode,
+) -> Option<&openehr_its::flat::webtemplate::model::WebTemplateNode> {
     action
         .children
         .iter()
@@ -801,7 +802,7 @@ fn wt_transition(
 /// ACTION archetype in several slots (ips.v0 uses `medication.v1` for both
 /// medication and immunization) with per-slot careflow specialization.
 fn wt_action_careflows(
-    n: &openehr_its::flat::webtemplate::WebTemplateNode,
+    n: &openehr_its::flat::webtemplate::model::WebTemplateNode,
     out: &mut Vec<Option<(String, String)>>,
 ) {
     if n.rm_type == "ACTION" {

--- a/crates/openehr-its/tests/it/master05_tables.rs
+++ b/crates/openehr-its/tests/it/master05_tables.rs
@@ -73,7 +73,7 @@ use serde_json::{Map, Value, json};
 
 use openehr_its::flat::convert::{composition_from_flat, composition_to_flat};
 use openehr_its::flat::error::FlatError;
-use openehr_its::flat::webtemplate::{
+use openehr_its::flat::webtemplate::model::{
     WebTemplate, WebTemplateInput, WebTemplateInputType, WebTemplateNode,
 };
 

--- a/crates/openehr-its/tests/it/opt14_corpus.rs
+++ b/crates/openehr-its/tests/it/opt14_corpus.rs
@@ -6,7 +6,7 @@
     reason = "test assertions/diagnostics/fixtures"
 )]
 //! OPT 1.4 corpus gate: every vendored `.opt` operational template
-//! must parse into the generated `opt14::OperationalTemplate` model without
+//! must parse into the generated `opt14::types::OperationalTemplate` model without
 //! error. The corpus lives with the `ferroehr` app tests; this crate reads it by
 //! a workspace-relative path.
 
@@ -203,7 +203,7 @@ fn every_opt_template_round_trips() {
 /// `description`), which an alphabetically-sorted container would invert.
 #[test]
 fn string_dictionary_order_preserved() {
-    use openehr_its::opt14::{ArchetypeTerm, CAttribute, CObject};
+    use openehr_its::opt14::types::{ArchetypeTerm, CAttribute, CObject};
 
     /// Collect every inline `C_ARCHETYPE_ROOT` term definition in the tree.
     fn collect_terms<'a>(obj: &'a CObject, out: &mut Vec<&'a ArchetypeTerm>) {
@@ -228,7 +228,7 @@ fn string_dictionary_order_preserved() {
     }
 
     fn text_first_orders(
-        opt: &openehr_its::opt14::OperationalTemplate,
+        opt: &openehr_its::opt14::types::OperationalTemplate,
     ) -> Vec<(String, Vec<String>)> {
         let mut terms: Vec<&ArchetypeTerm> = opt.definition.term_definitions.iter().collect();
         for a in &opt.definition.attributes {
@@ -379,10 +379,12 @@ fn opt_revision_history_item_without_audits_is_refused_at_parse() {
 
 /// Every `ARCHETYPE_SLOT` reachable from an OPT definition tree, in document
 /// order.
-fn slots(root: &openehr_its::opt14::CArchetypeRoot) -> Vec<&openehr_its::opt14::ArchetypeSlot> {
-    use openehr_its::opt14::{CAttribute, CObject};
+fn slots(
+    root: &openehr_its::opt14::types::CArchetypeRoot,
+) -> Vec<&openehr_its::opt14::types::ArchetypeSlot> {
+    use openehr_its::opt14::types::{CAttribute, CObject};
 
-    fn walk<'a>(objs: &'a [CObject], out: &mut Vec<&'a openehr_its::opt14::ArchetypeSlot>) {
+    fn walk<'a>(objs: &'a [CObject], out: &mut Vec<&'a openehr_its::opt14::types::ArchetypeSlot>) {
         for o in objs {
             let attrs: &[CAttribute] = match o {
                 CObject::ArchetypeSlot(s) => {
@@ -414,9 +416,12 @@ fn slots(root: &openehr_its::opt14::CArchetypeRoot) -> Vec<&openehr_its::opt14::
 
 /// The two `EXPR_LEAF`s of an `archetype_id/value matches {…}` assertion.
 fn matches_operands(
-    a: &openehr_its::opt14::Assertion,
-) -> (&openehr_its::opt14::ExprLeaf, &openehr_its::opt14::ExprLeaf) {
-    use openehr_its::opt14::ExprItem;
+    a: &openehr_its::opt14::types::Assertion,
+) -> (
+    &openehr_its::opt14::types::ExprLeaf,
+    &openehr_its::opt14::types::ExprLeaf,
+) {
+    use openehr_its::opt14::types::ExprItem;
 
     let ExprItem::ExprBinaryOperator(op) = a.expression.as_ref() else {
         panic!("a slot assertion is a binary `matches` expression");
@@ -462,7 +467,7 @@ fn expr_leaf_any_type_items_carry_their_payload() {
         right
             .item
             .child("pattern")
-            .map(openehr_its::xml::XmlAny::text),
+            .map(openehr_its::xml::runtime::XmlAny::text),
         Some(r"openEHR-EHR-EVALUATION\.problem_diagnosis(-[a-zA-Z0-9_]+)*\.v1".to_owned()),
     );
 

--- a/crates/openehr-its/tests/it/opt14_v1_4_divergence.rs
+++ b/crates/openehr-its/tests/it/opt14_v1_4_divergence.rs
@@ -31,53 +31,53 @@
     reason = "the inventory fns exist for their exhaustive wildcard-free matches, which are the compile-time drift guard; nothing calls them"
 )]
 mod opt14_inventory {
-    use openehr_its::opt14 as opt;
+    use openehr_its::opt14::types;
 
-    fn c_object_variants(v: &opt::CObject) -> &'static str {
+    fn c_object_variants(v: &types::CObject) -> &'static str {
         match v {
-            opt::CObject::ArchetypeInternalRef(_) => "ARCHETYPE_INTERNAL_REF",
-            opt::CObject::ArchetypeSlot(_) => "ARCHETYPE_SLOT",
-            opt::CObject::ConstraintRef(_) => "CONSTRAINT_REF",
-            opt::CObject::CArchetypeRoot(_) => "C_ARCHETYPE_ROOT",
-            opt::CObject::CCodePhrase(_) => "C_CODE_PHRASE",
-            opt::CObject::CCodeReference(_) => "C_CODE_REFERENCE",
-            opt::CObject::CComplexObject(_) => "C_COMPLEX_OBJECT",
-            opt::CObject::CDefinedObject(_) => "C_DEFINED_OBJECT",
-            opt::CObject::CDvOrdinal(_) => "C_DV_ORDINAL",
-            opt::CObject::CDvQuantity(_) => "C_DV_QUANTITY",
-            opt::CObject::CDvState(_) => "C_DV_STATE",
-            opt::CObject::CPrimitiveObject(_) => "C_PRIMITIVE_OBJECT",
-            opt::CObject::TComplexObject(_) => "T_COMPLEX_OBJECT",
+            types::CObject::ArchetypeInternalRef(_) => "ARCHETYPE_INTERNAL_REF",
+            types::CObject::ArchetypeSlot(_) => "ARCHETYPE_SLOT",
+            types::CObject::ConstraintRef(_) => "CONSTRAINT_REF",
+            types::CObject::CArchetypeRoot(_) => "C_ARCHETYPE_ROOT",
+            types::CObject::CCodePhrase(_) => "C_CODE_PHRASE",
+            types::CObject::CCodeReference(_) => "C_CODE_REFERENCE",
+            types::CObject::CComplexObject(_) => "C_COMPLEX_OBJECT",
+            types::CObject::CDefinedObject(_) => "C_DEFINED_OBJECT",
+            types::CObject::CDvOrdinal(_) => "C_DV_ORDINAL",
+            types::CObject::CDvQuantity(_) => "C_DV_QUANTITY",
+            types::CObject::CDvState(_) => "C_DV_STATE",
+            types::CObject::CPrimitiveObject(_) => "C_PRIMITIVE_OBJECT",
+            types::CObject::TComplexObject(_) => "T_COMPLEX_OBJECT",
         }
     }
 
-    fn c_attribute_variants(v: &opt::CAttribute) -> &'static str {
+    fn c_attribute_variants(v: &types::CAttribute) -> &'static str {
         match v {
-            opt::CAttribute::CMultipleAttribute(_) => "C_MULTIPLE_ATTRIBUTE",
-            opt::CAttribute::CSingleAttribute(_) => "C_SINGLE_ATTRIBUTE",
+            types::CAttribute::CMultipleAttribute(_) => "C_MULTIPLE_ATTRIBUTE",
+            types::CAttribute::CSingleAttribute(_) => "C_SINGLE_ATTRIBUTE",
         }
     }
 
-    fn c_primitive_variants(v: &opt::CPrimitive) -> &'static str {
+    fn c_primitive_variants(v: &types::CPrimitive) -> &'static str {
         match v {
-            opt::CPrimitive::CBoolean(_) => "C_BOOLEAN",
-            opt::CPrimitive::CDate(_) => "C_DATE",
-            opt::CPrimitive::CDateTime(_) => "C_DATE_TIME",
-            opt::CPrimitive::CDuration(_) => "C_DURATION",
-            opt::CPrimitive::CInteger(_) => "C_INTEGER",
-            opt::CPrimitive::CReal(_) => "C_REAL",
-            opt::CPrimitive::CString(_) => "C_STRING",
-            opt::CPrimitive::CTime(_) => "C_TIME",
+            types::CPrimitive::CBoolean(_) => "C_BOOLEAN",
+            types::CPrimitive::CDate(_) => "C_DATE",
+            types::CPrimitive::CDateTime(_) => "C_DATE_TIME",
+            types::CPrimitive::CDuration(_) => "C_DURATION",
+            types::CPrimitive::CInteger(_) => "C_INTEGER",
+            types::CPrimitive::CReal(_) => "C_REAL",
+            types::CPrimitive::CString(_) => "C_STRING",
+            types::CPrimitive::CTime(_) => "C_TIME",
         }
     }
 
-    fn c_domain_type_variants(v: &opt::CDomainType) -> &'static str {
+    fn c_domain_type_variants(v: &types::CDomainType) -> &'static str {
         match v {
-            opt::CDomainType::CCodePhrase(_) => "C_CODE_PHRASE",
-            opt::CDomainType::CCodeReference(_) => "C_CODE_REFERENCE",
-            opt::CDomainType::CDvOrdinal(_) => "C_DV_ORDINAL",
-            opt::CDomainType::CDvQuantity(_) => "C_DV_QUANTITY",
-            opt::CDomainType::CDvState(_) => "C_DV_STATE",
+            types::CDomainType::CCodePhrase(_) => "C_CODE_PHRASE",
+            types::CDomainType::CCodeReference(_) => "C_CODE_REFERENCE",
+            types::CDomainType::CDvOrdinal(_) => "C_DV_ORDINAL",
+            types::CDomainType::CDvQuantity(_) => "C_DV_QUANTITY",
+            types::CDomainType::CDvState(_) => "C_DV_STATE",
         }
     }
 }

--- a/crates/openehr-its/tests/it/spec_vectors.rs
+++ b/crates/openehr-its/tests/it/spec_vectors.rs
@@ -59,7 +59,7 @@ use openehr_its::flat::error::FlatError;
 use openehr_its::flat::path::FlatKey;
 use openehr_its::flat::sim::flat::{emit_flat, parse_flat};
 use openehr_its::flat::validation::{validate_context, validate_flat_other};
-use openehr_its::flat::webtemplate::{
+use openehr_its::flat::webtemplate::model::{
     WebTemplate, WebTemplateCodedValue, WebTemplateInput, WebTemplateInputType, WebTemplateNode,
 };
 use openehr_its::rm_instance::ValidationKind;

--- a/crates/openehr-its/tests/it/structured.rs
+++ b/crates/openehr-its/tests/it/structured.rs
@@ -34,7 +34,8 @@ use openehr_its::flat::convert::{
     composition_from_structured, composition_to_flat, composition_to_structured,
     flat_to_structured, structured_to_flat,
 };
-use openehr_its::flat::webtemplate::{WebTemplate, build_web_template};
+use openehr_its::flat::webtemplate::builder::build_web_template;
+use openehr_its::flat::webtemplate::model::WebTemplate;
 use openehr_its::opt14;
 use serde_json::Value;
 

--- a/crates/openehr-its/tests/it/tdd.rs
+++ b/crates/openehr-its/tests/it/tdd.rs
@@ -27,7 +27,8 @@
 )]
 
 use openehr_its::flat::tdd::from_tdd;
-use openehr_its::flat::webtemplate::{WebTemplate, build_web_template};
+use openehr_its::flat::webtemplate::builder::build_web_template;
+use openehr_its::flat::webtemplate::model::WebTemplate;
 use openehr_its::opt14;
 use openehr_its::rm_instance::validate_composition;
 use openehr_rm::prelude::Composition;

--- a/crates/openehr-its/tests/it/validation.rs
+++ b/crates/openehr-its/tests/it/validation.rs
@@ -31,7 +31,8 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use indexmap::IndexMap;
-use openehr_its::flat::webtemplate::{WebTemplate, WebTemplateNode, build_web_template};
+use openehr_its::flat::webtemplate::builder::build_web_template;
+use openehr_its::flat::webtemplate::model::{WebTemplate, WebTemplateNode};
 use openehr_its::opt14;
 use openehr_its::rm_instance::{
     ValidationKind, ValidationMessage, validate_composition, validate_rm_and_terminology,

--- a/crates/openehr-its/tests/it/validation_checklist.rs
+++ b/crates/openehr-its/tests/it/validation_checklist.rs
@@ -31,9 +31,10 @@ use openehr_its::flat::convert::{composition_from_flat, composition_to_flat};
 use openehr_its::flat::error::FlatError;
 use openehr_its::flat::sim::flat::parse_flat;
 use openehr_its::flat::validation::validate_context;
-use openehr_its::flat::webtemplate::{
+use openehr_its::flat::webtemplate::builder::build_web_template;
+use openehr_its::flat::webtemplate::model::{
     WebTemplate, WebTemplateCardinality, WebTemplateClosedAttribute, WebTemplateCodedValue,
-    WebTemplateInput, WebTemplateInputType, WebTemplateNode, build_web_template,
+    WebTemplateInput, WebTemplateInputType, WebTemplateNode,
 };
 use openehr_its::opt14;
 use openehr_its::rm_instance::{ValidationKind, ValidationMessage, validate_composition};

--- a/crates/openehr-its/tests/it/validation_rules.rs
+++ b/crates/openehr-its/tests/it/validation_rules.rs
@@ -13,7 +13,7 @@ use indexmap::IndexMap;
 use serde_json::{Value, json};
 
 use openehr_its::flat::validation::*;
-use openehr_its::flat::webtemplate::{
+use openehr_its::flat::webtemplate::model::{
     WebTemplate, WebTemplateCardinality, WebTemplateCodedValue, WebTemplateExistence,
     WebTemplateInput, WebTemplateInputType, WebTemplateNode, WebTemplateRange,
     WebTemplateValidation,
@@ -806,7 +806,7 @@ fn segment_parsing_respects_brackets() {
 
 // ── CNF-hardening additions (master15/16/17 truth tables) ────────────────────
 
-use openehr_its::flat::webtemplate::{WebTemplateCodeList, WebTemplateSlot};
+use openehr_its::flat::webtemplate::model::{WebTemplateCodeList, WebTemplateSlot};
 
 /// `1..*` container cardinality with zero members → Cardinality (master15
 /// CONT-COMP-content_card_1plus; AOM 1.4 §cardinality).
@@ -1049,7 +1049,7 @@ fn media_type_code_list() {
 
 // ── closed-archetype walk ─────────────────────────────────────────
 
-use openehr_its::flat::webtemplate::{WebTemplateArchetypeSlot, WebTemplateClosedAttribute};
+use openehr_its::flat::webtemplate::model::{WebTemplateArchetypeSlot, WebTemplateClosedAttribute};
 
 /// A COMPOSITION whose `content` is closed to `openEHR-EHR-SECTION.x.v1`: the
 /// defined section is accepted, a foreign OBSERVATION is rejected as unexpected
@@ -1642,8 +1642,8 @@ fn measure_ips_validation_full_cost() {
     let opt_xml = std::fs::read_to_string(format!("{dir}/international-patient-summary.opt"))
         .expect("read IPS OPT");
     let opt = openehr_its::opt14::from_xml(&opt_xml).expect("parse IPS OPT");
-    let wt =
-        openehr_its::flat::webtemplate::build_web_template(&opt).expect("build IPS WebTemplate");
+    let wt = openehr_its::flat::webtemplate::builder::build_web_template(&opt)
+        .expect("build IPS WebTemplate");
     let comp: Value = serde_json::from_str(
         &std::fs::read_to_string(format!("{dir}/international-patient-summary.example.json"))
             .expect("read IPS example"),

--- a/crates/openehr-its/tests/it/webtemplate.rs
+++ b/crates/openehr-its/tests/it/webtemplate.rs
@@ -21,7 +21,8 @@
 
 use std::path::{Path, PathBuf};
 
-use openehr_its::flat::webtemplate::{WebTemplateInputType, WebTemplateNode, build_web_template};
+use openehr_its::flat::webtemplate::builder::build_web_template;
+use openehr_its::flat::webtemplate::model::{WebTemplateInputType, WebTemplateNode};
 use openehr_its::opt14;
 
 fn manifest_dir() -> PathBuf {
@@ -55,7 +56,9 @@ fn opt_files(dir: &Path) -> Vec<PathBuf> {
 }
 
 /// Parse an `OPT` and build a `WebTemplate`, returning any error as a string.
-fn build_from_file(path: &Path) -> Result<openehr_its::flat::webtemplate::WebTemplate, String> {
+fn build_from_file(
+    path: &Path,
+) -> Result<openehr_its::flat::webtemplate::model::WebTemplate, String> {
     let xml = std::fs::read_to_string(path).map_err(|e| format!("read: {e}"))?;
     let opt = opt14::from_xml(&xml).map_err(|e| format!("opt14 parse: {e}"))?;
     build_web_template(&opt).map_err(|e| format!("build: {e}"))
@@ -396,8 +399,9 @@ fn ontology_term_bindings_populate_node_and_coded_value_bindings() {
         .expect("build Across - Visual Acuity Report");
 
     // Node-level: a node bound to SNOMED-CT 422673001.
-    let mut node_binding: Option<openehr_its::flat::webtemplate::WebTemplateBindingCodedValue> =
-        None;
+    let mut node_binding: Option<
+        openehr_its::flat::webtemplate::model::WebTemplateBindingCodedValue,
+    > = None;
     for_each_node(&wt.tree, &mut |n| {
         if let Some(b) = n.term_bindings.get("SNOMED-CT")
             && b.value == "422673001"
@@ -414,7 +418,9 @@ fn ontology_term_bindings_populate_node_and_coded_value_bindings() {
     );
 
     // Coded-value-level: a coded option bound to SNOMED-CT 362503005.
-    let mut cv_binding: Option<openehr_its::flat::webtemplate::WebTemplateBindingCodedValue> = None;
+    let mut cv_binding: Option<
+        openehr_its::flat::webtemplate::model::WebTemplateBindingCodedValue,
+    > = None;
     for_each_node(&wt.tree, &mut |n| {
         for input in &n.inputs {
             for cv in &input.list {

--- a/crates/openehr-its/tests/it/webtemplate_v2_4.rs
+++ b/crates/openehr-its/tests/it/webtemplate_v2_4.rs
@@ -1,5 +1,5 @@
 //! The `v2_4` (ADL2 / OPT2) → Web Template front end
-//! ([`openehr_its::flat::webtemplate::build_web_template_v2_4`]).
+//! ([`openehr_its::flat::webtemplate::builder_v2_4::build_web_template_v2_4`]).
 //!
 //! Every case compiles a **real** ADL2 corpus source to its operational
 //! template (`openehr_adl::opt::create_opt`) and drives it through the same
@@ -34,9 +34,8 @@ use openehr_am::v2_4::aom2::constraint_model::c_complex_object::CComplexObject;
 use openehr_am::v2_4::aom2::constraint_model::c_object::CObject;
 use openehr_its::flat::example::{DetailLevel, ExampleType, example_composition};
 use openehr_its::flat::validation::validate_archetype_conformance;
-use openehr_its::flat::webtemplate::{
-    WebTemplate, WebTemplateCardinality, WebTemplateNode, build_web_template_v2_4,
-};
+use openehr_its::flat::webtemplate::builder_v2_4::build_web_template_v2_4;
+use openehr_its::flat::webtemplate::model::{WebTemplate, WebTemplateCardinality, WebTemplateNode};
 use openehr_its::rm_instance::{ValidationKind, validate_rm_and_terminology};
 
 const OBS_UPGRADE: &str =

--- a/crates/openehr-its/tests/it/xml_abstract_root.rs
+++ b/crates/openehr-its/tests/it/xml_abstract_root.rs
@@ -19,9 +19,8 @@
 //! `to_canonical_xml` entry point (declared type `None` at the root) cannot
 //! emit.
 
-use openehr_its::xml::{
-    Namespace, from_canonical_xml, to_canonical_xml, to_canonical_xml_declared,
-};
+use openehr_its::xml::runtime::Namespace;
+use openehr_its::xml::{from_canonical_xml, to_canonical_xml, to_canonical_xml_declared};
 use openehr_rm::prelude::{Composition, OriginalVersion};
 use serde_json::json;
 

--- a/crates/openehr-its/tests/it/xml_c14n.rs
+++ b/crates/openehr-its/tests/it/xml_c14n.rs
@@ -48,7 +48,8 @@
 //! byte. `xsi:type` *dispatch* correctness is independently covered by
 //! `xml_ehrbase`/`xml_roundtrip`.
 
-use openehr_its::xml::{from_xml, to_canonical_xml};
+use openehr_its::xml::runtime::from_xml;
+use openehr_its::xml::to_canonical_xml;
 use openehr_rm::prelude::Composition;
 use std::path::{Path, PathBuf};
 use std::process::Command;

--- a/crates/openehr-its/tests/it/xml_ehrbase.rs
+++ b/crates/openehr-its/tests/it/xml_ehrbase.rs
@@ -23,7 +23,8 @@
 //! / the live parity harness (Stage-1 acceptance). Round-trip stability of our
 //! own canonical output is the invariant this gate enforces.
 
-use openehr_its::xml::{FromXml, ToXml, from_xml, to_canonical_xml};
+use openehr_its::xml::runtime::{FromXml, ToXml, from_xml};
+use openehr_its::xml::to_canonical_xml;
 use openehr_rm::prelude::{Composition, ItemTree};
 
 const DIR: &str = concat!(

--- a/crates/openehr-its/tests/it/xml_hash.rs
+++ b/crates/openehr-its/tests/it/xml_hash.rs
@@ -7,7 +7,8 @@
 )]
 //! Verify `Hash<String,String>` (`StringDictionaryItem`) XML round-trips.
 use openehr_base::prelude::TranslationDetails;
-use openehr_its::xml::{from_xml, to_canonical_xml};
+use openehr_its::xml::runtime::from_xml;
+use openehr_its::xml::to_canonical_xml;
 
 #[test]
 fn string_hash_round_trips() {

--- a/crates/openehr-its/tests/it/xml_locatable_attr.rs
+++ b/crates/openehr-its/tests/it/xml_locatable_attr.rs
@@ -18,7 +18,8 @@
 //! these types, so they fell back to attribute-less BMM field order and emitted
 //! `<archetype_node_id>…</archetype_node_id>` — invalid canonical XML.
 
-use openehr_its::xml::{from_xml, to_canonical_xml};
+use openehr_its::xml::runtime::from_xml;
+use openehr_its::xml::to_canonical_xml;
 use openehr_rm::prelude::{EhrAccess, EhrStatus, GenericContentItem, Person};
 
 /// Assert a serialized LOCATABLE subtype carries `archetype_node_id` as an XML

--- a/crates/openehr-its/tests/it/xml_namespace.rs
+++ b/crates/openehr-its/tests/it/xml_namespace.rs
@@ -28,7 +28,8 @@
 //! `xml_xsd_validity`; the assertions below deliberately
 //! stay scoped to the serializer, which is all they ever proved.
 
-use openehr_its::xml::{Namespace, from_canonical_xml, to_canonical_xml, to_canonical_xml_ns};
+use openehr_its::xml::runtime::Namespace;
+use openehr_its::xml::{from_canonical_xml, to_canonical_xml, to_canonical_xml_ns};
 use openehr_rm::prelude::Composition;
 
 const V1_NS: &str = "xmlns=\"http://schemas.openehr.org/v1\"";

--- a/crates/openehr-its/tests/it/xml_roundtrip.rs
+++ b/crates/openehr-its/tests/it/xml_roundtrip.rs
@@ -8,7 +8,8 @@
 //! XML round-trip fidelity gate: for every composition in the openEHR
 //! corpus, RM → XML → RM → XML must be stable, proving the generated `ToXml` and
 //! `FromXml` impls are mutually consistent on real data.
-use openehr_its::xml::{from_xml, to_canonical_xml};
+use openehr_its::xml::runtime::from_xml;
+use openehr_its::xml::to_canonical_xml;
 use openehr_rm::prelude::{Composition, FeederAuditDetails};
 use std::path::Path;
 

--- a/crates/openehr-its/tests/it/xml_xsd_validity.rs
+++ b/crates/openehr-its/tests/it/xml_xsd_validity.rs
@@ -51,7 +51,8 @@
 //! tests below enumerate exactly which, and prove each at the wire.
 
 use openehr_its::json::from_canonical_value;
-use openehr_its::xml::{Namespace, to_canonical_xml_ns};
+use openehr_its::xml::runtime::Namespace;
+use openehr_its::xml::to_canonical_xml_ns;
 use openehr_rm::prelude::{Composition, Folder};
 use openehr_rm::v1_2::model;
 use serde_json::{Value, json};

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-lang"
-version = "0.0.15"
+version = "0.0.16"
 description = "openEHR LANG BMM/P_BMM object model, generated from BMM: generations v1_0 (LANG 1.0.0) and v1_1 (LANG 1.1.0, current; the stable BMM v2.x unit beside the paused BMM3 unit), plus hand-written ODIN/BEL/EL readers"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["parser-implementations", "data-structures"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.15" }
+openehr-base = { path = "../openehr-base", version = "0.0.16" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the
 # generated types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) —
 # never a derive. `serde_json` also carries the untyped `Value` fields the

--- a/crates/openehr-query/Cargo.toml
+++ b/crates/openehr-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-query"
-version = "0.0.15"
+version = "0.0.16"
 description = "openEHR QUERY (AQL 1.1.0): hand-written lexer, parser, typed AST and canonical printer from the official grammar (no ANTLR runtime)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-rm"
-version = "0.0.15"
+version = "0.0.16"
 description = "openEHR RM Reference Model, generated from BMM: generations v1_1 (RM 1.1.0) and v1_2 (RM 1.2.0, current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,11 +13,11 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.15" }
+openehr-base = { path = "../openehr-base", version = "0.0.16" }
 # The terminology-backed RM class invariants (`validate::terminology`) resolve
 # openEHR terminology groups + code sets against the vendored TERM 3.1.0 bundle.
 # `openehr-term` itself depends only on `openehr-base`, so this is acyclic.
-openehr-term = { path = "../openehr-term", version = "0.0.15" }
+openehr-term = { path = "../openehr-term", version = "0.0.16" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also backs the untyped `Value` RM representation used by

--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-term"
-version = "0.0.15"
+version = "0.0.16"
 description = "openEHR TERM terminology data model, generated from BMM (generation v3_1 = TERM 3.1.0), plus the embedded official terminology XML bundle"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["data-structures", "science"]
 include = ["src/**", "assets/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.15" }
+openehr-base = { path = "../openehr-base", version = "0.0.16" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1185,7 +1185,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "indexmap",
  "openehr-am",
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "serde",
  "serde_json",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "async-trait",
  "axum",
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "chumsky",
  "indexmap",
@@ -1258,7 +1258,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "chumsky",
  "logos",
@@ -1267,7 +1267,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "openehr-base",
  "openehr-term",
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/fuzz/fuzz_targets/opt14_template.rs
+++ b/fuzz/fuzz_targets/opt14_template.rs
@@ -17,5 +17,5 @@ fuzz_target!(|data: &[u8]| {
     let Ok(template) = openehr_its::opt14::from_xml(text) else {
         return;
     };
-    let _ = openehr_its::flat::webtemplate::build_web_template(&template);
+    let _ = openehr_its::flat::webtemplate::builder::build_web_template(&template);
 });

--- a/tools/openehr-codegen/src/render/emit_opt.rs
+++ b/tools/openehr-codegen/src/render/emit_opt.rs
@@ -76,13 +76,17 @@ use std::fmt::Write as _;
 /// `aom2_model`), and every generated impl and defaulted literal must name the
 /// module it is being emitted INTO. A hardcoded path here silently emits `aom2`
 /// impls that reference `crate::opt14` types.
-pub(crate) const OPT_PRELUDE: &str = "crate::opt14";
+///
+/// Each path ends at the defining `types` module rather than at the parent: the
+/// parent re-exported these names with a glob until the zero-re-exports rule
+/// removed it, and a generated impl must name where a type is DEFINED.
+pub(crate) const OPT_PRELUDE: &str = "crate::opt14::types";
 
 /// The Rust module path the AOM2 persistent-form model's generated types live at.
-pub(crate) const AOM2_PRELUDE: &str = "crate::aom2";
+pub(crate) const AOM2_PRELUDE: &str = "crate::aom2::types";
 
 /// The Rust module path the AOM2 model-form model's generated types live at.
-pub(crate) const AOM2_MODEL_PRELUDE: &str = "crate::aom2_model";
+pub(crate) const AOM2_MODEL_PRELUDE: &str = "crate::aom2_model::types";
 
 /// The `opt14` emission target (OPT 1.4 operational templates).
 pub(crate) static OPT_TARGET: ModelTarget = ModelTarget {
@@ -142,7 +146,7 @@ const FORCE_GENERATE: &[&str] = &[
 const STRING_DICT_ITEM: &str = "StringDictionaryItem";
 
 /// OPT-envelope sections carried as the verbatim XML subtree
-/// (`crate::xml::XmlAny`) rather than a generated struct.
+/// (`crate::xml::runtime::XmlAny`) rather than a generated struct.
 ///
 /// `T_VIEW` (the `<view>` presentation block) holds an **anonymous inline
 /// complexType** (`T_VIEW.constraints` → nested `items` with an `id` attribute
@@ -201,7 +205,7 @@ enum Resolved {
     /// A Rust primitive (`String`/`bool`/`i32`/`i64`/`f64`).
     Primitive(&'static str),
     /// `xs:anyType`/`xs:anySimpleType`/anonymous-inline → the verbatim XML
-    /// subtree carrier `crate::xml::XmlAny` (attributes, text and children in
+    /// subtree carrier `crate::xml::runtime::XmlAny` (attributes, text and children in
     /// document order, re-emitted as read).
     ///
     /// NOTE: `AM aom14 §EXPR_LEAF Class` types `item: Any`, so the payload
@@ -374,7 +378,7 @@ impl<'a> OptModel<'a> {
     fn base_decl(res: &Resolved, raw_spec: &str) -> (String, String) {
         match res {
             Resolved::Primitive(p) => ((*p).to_string(), String::new()),
-            Resolved::Any => ("crate::xml::XmlAny".to_string(), String::new()),
+            Resolved::Any => ("crate::xml::runtime::XmlAny".to_string(), String::new()),
             Resolved::Hash => (
                 "indexmap::IndexMap<String, String>".to_string(),
                 String::new(),
@@ -781,27 +785,30 @@ pub(crate) fn emit_module(spec: &ModuleSpec) -> String {
             let _ = writeln!(b, "//! {line}");
         }
     }
-    let _ = writeln!(b, "\nmod impls;\nmod types;\npub use types::*;");
+    // `pub mod types`, never a star re-export: the zero-re-exports rule means an
+    // import names its defining module, and a glob would also hide which of the
+    // three generated modules a name came from at the use site.
+    let _ = writeln!(b, "\nmod impls;\npub mod types;");
     for e in spec.entry_points {
         let _ = writeln!(
             b,
-            "\n/// Parse {} {} XML document into {} [`{}`].\n\
+            "\n/// Parse {} {} XML document into {} [`types::{}`].\n\
              ///\n\
              /// # Errors\n\
              /// Propagates canonical-XML parse errors.\n\
-             pub fn from_xml{}(xml: &str) -> Result<{}, crate::xml::runtime::XmlError> {{\n\
+             pub fn from_xml{}(xml: &str) -> Result<types::{}, crate::xml::runtime::XmlError> {{\n\
              crate::xml::runtime::from_xml(xml)\n\
              }}",
             e.article, e.what, e.article, e.root_rust, e.suffix, e.root_rust
         );
         let _ = writeln!(
             b,
-            "\n/// Serialize {} [`{}`] back to {} (root `<{}>`,\n\
+            "\n/// Serialize {} [`types::{}`] back to {} (root `<{}>`,\n\
              /// `http://schemas.openehr.org/v1`).\n\
              ///\n\
              /// # Errors\n\
              /// Propagates canonical-XML serialization errors.\n\
-             pub fn to_xml{}(value: &{}) -> Result<String, crate::xml::runtime::XmlError> {{\n\
+             pub fn to_xml{}(value: &types::{}) -> Result<String, crate::xml::runtime::XmlError> {{\n\
              crate::xml::runtime::to_xml(value, \"{}\", crate::xml::runtime::Namespace::V1)\n\
              }}",
             e.article, e.root_rust, e.wire, e.root_element, e.suffix, e.root_rust, e.root_element

--- a/tools/openehr-codegen/src/render/emit_xml.rs
+++ b/tools/openehr-codegen/src/render/emit_xml.rs
@@ -338,7 +338,7 @@ pub(crate) fn emit_to_xml(
                     unmatched.push((spec.clone(), aname.clone()));
                 }
             }
-            b.push_str("let mut __e = crate::xml::runtime::XmlStart::new(tag);\n");
+            b.push_str("let mut __e = quick_xml::events::BytesStart::new(tag);\n");
             b.push_str("for (k, v) in &__attrs { __e.push_attribute((*k, v.as_str())); }\n");
             b.push_str("w.write_start(__e)?;\n");
             for ename in &elems {


### PR DESCRIPTION
Closes #2196. Unblocks #2035.

`openehr-its` carried nine hand-written `pub use` statements against the zero-re-exports rule, and they were the only thing standing between the tree and making that rule a compile error.

## Two were simply dead

Nothing imported `rest::ApiError`, and almost nothing imported the `xml` glob — consumers were already naming `rest::runtime::ApiError` directly. Those re-exports existed, cost a rule violation, and bought nobody anything. Worth stating because it is the common case with convenience re-exports: they outlive whatever made them convenient.

## The bulk belonged in the emitter, not in 305 edits

This is the part that decided the shape of the change.

`XmlStart` — which is *also* a banned import **rename** (`quick_xml::events::BytesStart as XmlStart`) — had 305 use sites, and every single one was inside **generated** code, all emitted from one line of `emit_xml.rs`. So the fix is that line plus a regeneration.

The same holds for the three `pub use types::*` globs: `OPT_PRELUDE`, `AOM2_PRELUDE` and `AOM2_MODEL_PRELUDE` in `emit_opt.rs` now end at the defining `types` module, which repoints every generated impl at once. `emit_opt.rs` also stops emitting the glob itself (`pub mod types;`) and qualifies its own entry points, doc links included, so the rustdoc gate still resolves them.

Consumer-side, ~1100 paths gain the module that defines them. That is longer at each use site, and it is the point: `opt14::types::CObject` says where the type comes from; `opt14::CObject` was a name the parent module had borrowed.

One module **alias** went with them — `use openehr_its::opt14 as opt` in a divergence-sentinel test — which is the same rename ban in a different spelling.

## Verification

- `cargo clippy --workspace --exclude ferroehr-admin-ui --all-targets --all-features -- -D warnings` — clean
- `clippy::pub_use` at **deny** reports **nothing in `openehr-its`**. The remaining hits are the generated crates' generation preludes (`openehr-base/src/v1_3/prelude.rs` and peers), which #2035 exempts from the emitter by design — this PR does not touch them
- `cargo nextest run -p openehr-its -p ferroehr` — **1488 passed**. One run showed a single failure, `events_amqp::broker_down_then_up_delivers_without_loss`, which was a RabbitMQ testcontainer `StartupTimeout` under Docker contention; re-run in isolation it passes in 9.3s
- The generated output is regenerated from the emitter, not hand-edited: `emit`, `emit-json`, `emit-xml`, `emit-rest`, `emit-opt`, `emit-aom2`, `emit-rm-model`, `emit-validate` all re-run and the tree re-verified afterwards
- No behaviour change: the wire formats and fidelity gates are untouched