### PR TITLE
feat(meta): generate .zenodo.json from CITATION.cff, so a DOI cannot archive the wrong metadata

### DIFF
--- a/.claude/rules/changelog.md
+++ b/.claude/rules/changelog.md
@@ -24,6 +24,10 @@ optional:
   `cargo check`, + Helm `appVersion`, golden renders via
   `deploy/helm/validate.sh --update`, + `CITATION.cff` `version` and
   `date-released` (the `citation-guard` CI job enforces the version match),
+  then re-render `.zenodo.json` (`bash scripts/render/zenodo-json.sh`, checked
+  by the same job) — it is GENERATED, never hand-edited, because Zenodo ignores
+  `CITATION.cff` completely whenever a `.zenodo.json` exists
+  (<https://help.zenodo.org/docs/github/describe-software/zenodo-json/>),
   + the default image tags in `docker-compose.yml` — the `ghcr.io/…:X.Y.Z`
   fallbacks the standalone quickstart pulls, guarded by
   `scripts/checks/compose-image-tags.sh` / the `compose-version-guard` CI
@@ -50,6 +54,12 @@ optional:
   re-publish a chart version — bump it:** an OCI tag is MUTABLE, so `helm push`
   would silently replace it with a different digest, and the immutability the
   guards assume exists only because the lane enforces it.
+- **The tag also produces an archived artifact.** Zenodo is connected to this
+  repository, so publishing a release makes Zenodo take the zipball and mint a
+  DOI from `.zenodo.json`. That deposit is immutable — whatever the metadata
+  says at publish time is what the DOI carries — so the metadata is verified
+  BEFORE the cut, never after. A badge cites the CONCEPT DOI; a version DOI
+  freezes on whichever release was current the day it was added.
 - **After the tag:** close the `vX.Y.Z` milestone (`gh api … milestones/N
   -f state=closed`) and make sure the NEXT milestone exists so triage always
   has a target. The milestone's closed-issue list + the changelog section

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1486,6 +1486,14 @@ jobs:
             exit 1
           fi
           echo "CITATION.cff version $cff_ver matches the workspace version."
+      # `.zenodo.json` is GENERATED from CITATION.cff, because Zenodo ignores
+      # CITATION.cff entirely whenever a .zenodo.json is present
+      # (https://help.zenodo.org/docs/github/describe-software/zenodo-json/).
+      # A hand-edited copy would therefore silently override the file this job
+      # guards, and the disagreement would be archived under a DOI that cannot
+      # be edited afterwards.
+      - name: .zenodo.json is in sync with CITATION.cff
+        run: bash scripts/render/zenodo-json.sh --check
 
   # Compose version guard: the standalone quickstart docker-compose.yml pins
   # the published images by tag, so a release cut that forgets those defaults

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,250 @@
+{
+  "access": {
+    "record": "public",
+    "files": "public"
+  },
+  "custom_fields": {
+    "code:codeRepository": "https://github.com/rubentalstra/FerroEHR",
+    "code:programmingLanguage": [
+      {
+        "id": "rust",
+        "title": {
+          "en": "Rust"
+        }
+      },
+      {
+        "id": "sql",
+        "title": {
+          "en": "SQL"
+        }
+      }
+    ],
+    "code:developmentStatus": {
+      "id": "active",
+      "title": {
+        "en": "Active"
+      }
+    }
+  },
+  "metadata": {
+    "resource_type": {
+      "id": "software"
+    },
+    "title": "FerroEHR",
+    "description": "<p>A pure-Rust, openEHR-specification-conformant clinical data repository (CDR): ITS-REST 1.1.0 REST API, AQL 1.1 query language, and the openEHR RM 1.2.0 reference model on PostgreSQL-18-native storage. The openEHR specification layer is generated from the official machine-readable specifications, and conformance is machine-verified per release by a built-in CNF conformance runner.</p>",
+    "publication_date": "2026-08-05",
+    "version": "3.17.3",
+    "creators": [
+      {
+        "person_or_org": {
+          "type": "personal",
+          "given_name": "Ruben",
+          "family_name": "Talstra",
+          "name": "Talstra, Ruben",
+          "identifiers": [
+            {
+              "scheme": "orcid",
+              "identifier": "0009-0009-2758-0141"
+            }
+          ]
+        }
+      }
+    ],
+    "languages": [
+      {
+        "id": "eng",
+        "title": {
+          "en": "English"
+        }
+      }
+    ],
+    "rights": [
+      {
+        "id": "mit"
+      }
+    ],
+    "subjects": [
+      {
+        "subject": "openEHR"
+      },
+      {
+        "subject": "clinical data repository"
+      },
+      {
+        "subject": "CDR"
+      },
+      {
+        "subject": "electronic health records"
+      },
+      {
+        "subject": "EHR"
+      },
+      {
+        "subject": "AQL"
+      },
+      {
+        "subject": "health informatics"
+      },
+      {
+        "subject": "healthcare interoperability"
+      },
+      {
+        "subject": "ITS-REST"
+      },
+      {
+        "subject": "Rust"
+      },
+      {
+        "subject": "PostgreSQL"
+      }
+    ],
+    "references": [
+      {
+        "reference": "openEHR Reference Model (RM) Release 1.1.0. openEHR International. https://specifications.openehr.org/releases/RM/Release-1.1.0"
+      },
+      {
+        "reference": "openEHR Archetype Query Language (AQL), QUERY Release 1.1.0. openEHR International. https://specifications.openehr.org/releases/QUERY/Release-1.1.0"
+      },
+      {
+        "reference": "openEHR REST API (ITS-REST) Release 1.1.0. openEHR International. https://specifications.openehr.org/releases/ITS-REST/Release-1.1.0"
+      },
+      {
+        "reference": "openEHR Archetype Model (AM) Release 2.3.0. openEHR International. https://specifications.openehr.org/releases/AM/Release-2.3.0"
+      }
+    ],
+    "related_identifiers": [
+      {
+        "identifier": "https://ferroehr.eu/",
+        "scheme": "url",
+        "relation_type": {
+          "id": "isdocumentedby"
+        },
+        "resource_type": {
+          "id": "publication-softwaredocumentation"
+        }
+      },
+      {
+        "identifier": "https://specifications.openehr.org/releases/RM/Release-1.1.0",
+        "scheme": "url",
+        "relation_type": {
+          "id": "isderivedfrom"
+        }
+      },
+      {
+        "identifier": "https://specifications.openehr.org/releases/ITS-REST/Release-1.1.0",
+        "scheme": "url",
+        "relation_type": {
+          "id": "isderivedfrom"
+        }
+      },
+      {
+        "identifier": "https://specifications.openehr.org/releases/QUERY/Release-1.1.0",
+        "scheme": "url",
+        "relation_type": {
+          "id": "isderivedfrom"
+        }
+      },
+      {
+        "identifier": "https://specifications.openehr.org/releases/AM/Release-2.3.0",
+        "scheme": "url",
+        "relation_type": {
+          "id": "isderivedfrom"
+        }
+      },
+      {
+        "identifier": "https://crates.io/crates/openehr-base",
+        "scheme": "url",
+        "relation_type": {
+          "id": "haspart"
+        },
+        "resource_type": {
+          "id": "software"
+        }
+      },
+      {
+        "identifier": "https://crates.io/crates/openehr-rm",
+        "scheme": "url",
+        "relation_type": {
+          "id": "haspart"
+        },
+        "resource_type": {
+          "id": "software"
+        }
+      },
+      {
+        "identifier": "https://crates.io/crates/openehr-am",
+        "scheme": "url",
+        "relation_type": {
+          "id": "haspart"
+        },
+        "resource_type": {
+          "id": "software"
+        }
+      },
+      {
+        "identifier": "https://crates.io/crates/openehr-term",
+        "scheme": "url",
+        "relation_type": {
+          "id": "haspart"
+        },
+        "resource_type": {
+          "id": "software"
+        }
+      },
+      {
+        "identifier": "https://crates.io/crates/openehr-lang",
+        "scheme": "url",
+        "relation_type": {
+          "id": "haspart"
+        },
+        "resource_type": {
+          "id": "software"
+        }
+      },
+      {
+        "identifier": "https://crates.io/crates/openehr-query",
+        "scheme": "url",
+        "relation_type": {
+          "id": "haspart"
+        },
+        "resource_type": {
+          "id": "software"
+        }
+      },
+      {
+        "identifier": "https://crates.io/crates/openehr-its",
+        "scheme": "url",
+        "relation_type": {
+          "id": "haspart"
+        },
+        "resource_type": {
+          "id": "software"
+        }
+      },
+      {
+        "identifier": "https://crates.io/crates/openehr-adl",
+        "scheme": "url",
+        "relation_type": {
+          "id": "haspart"
+        },
+        "resource_type": {
+          "id": "software"
+        }
+      }
+    ],
+    "additional_descriptions": [
+      {
+        "type": {
+          "id": "technical-info"
+        },
+        "description": "<p>Implements the openEHR specifications at these pinned versions: Reference Model 1.2.0, BASE 1.3.0, Archetype Model 1.4.0 and 2.4.0, Terminology 3.1.0, AQL (QUERY) 1.1.0, ITS-REST 1.1.0 and ITS-XML. The specification layer is generated from the official machine-readable specifications rather than hand-written, and conformance is measured per release by a built-in openEHR CNF conformance runner whose results are committed alongside the source. Requires PostgreSQL 18.</p>"
+      },
+      {
+        "type": {
+          "id": "notes"
+        },
+        "description": "<p>Licensing: the recorded licence covers this project&rsquo;s own code. Vendored third-party material keeps its upstream terms &mdash; Apache-2.0 for the openEHR machine-readable artifacts and test corpora, CC-BY-SA-3.0 for the openEHR specification text and CKM-derived clinical models &mdash; each recorded in the PROVENANCE.md of the tree that carries it.</p>"
+      }
+    ]
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
+- **Releases are archived on Zenodo with a citable DOI.** `.zenodo.json` is
+  generated from `CITATION.cff` so the two cannot disagree — necessary because
+  Zenodo ignores `CITATION.cff` entirely whenever a `.zenodo.json` is present,
+  and a deposit's metadata is immutable once its DOI exists. It adds what the
+  citation file cannot express: which openEHR specifications a release is
+  derived from, and where the published crates live.
+
 - **A fuzz target for the identifier readers.** `OBJECT_VERSION_ID` and its
   siblings are parsed straight from the `{version_uid}` URL path parameter —
   before any body is read, any content type negotiated, or any authorization

--- a/scripts/render/zenodo-json.sh
+++ b/scripts/render/zenodo-json.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# Render `.zenodo.json` from `CITATION.cff` (#2210).
+#
+# Zenodo's own rule makes this file necessary and dangerous in one sentence:
+# "If your repository contains both a .zenodo.json and a CITATION.cff file,
+# Zenodo will only use the .zenodo.json metadata. The CITATION.cff will be
+# COMPLETELY IGNORED for the GitHub release archiving."
+# (https://help.zenodo.org/docs/github/describe-software/zenodo-json/)
+#
+# A hand-written copy would therefore silently disable the file CI already
+# guards, and the two would drift with no signal — the deposit saying one thing
+# while the citation box says another, under a DOI nobody can correct. So this
+# file is GENERATED: CITATION.cff stays the single source for every fact both
+# carry, and `citation-guard` runs this script in --check mode.
+#
+# The output is the InvenioRDM RECORD shape, not the flat legacy deposit shape
+# the help page documents. Zenodo runs on InvenioRDM now and the GitHub
+# integration accepts this form — verified against a live GitHub-archived
+# record whose .zenodo.json is this shape and whose published record carries
+# the custom_fields it declares. The legacy shape cannot say what language a
+# piece of software is written in.
+#
+# Usage:
+#   scripts/render/zenodo-json.sh            # write .zenodo.json
+#   scripts/render/zenodo-json.sh --check    # fail if the committed file is stale
+set -euo pipefail
+cd "$(dirname "$0")/../.." || exit 1
+
+command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
+
+CFF="CITATION.cff"
+OUT=".zenodo.json"
+MODE="${1:-write}"
+
+# CITATION.cff is YAML, but every field read here is a flat quoted scalar, a
+# folded block, or a simple list — so sed/awk read it and jq builds the JSON.
+# No YAML parser, and no second language embedded in this script.
+cff_scalar() {
+  local v
+  v="$(sed -nE "s/^$1:[[:space:]]*(.*)$/\1/p" "$CFF" | head -1)"
+  v="${v%\"}"; v="${v#\"}"
+  [ -n "$v" ] || { echo "$CFF has no \`$1\`" >&2; exit 1; }
+  printf '%s' "$v"
+}
+
+# A folded block scalar (`key: >-`), rejoined onto one line.
+cff_block() {
+  awk -v key="$1" '
+    $0 ~ "^" key ":[[:space:]]*>-[[:space:]]*$" { grab = 1; next }
+    grab && /^[[:space:]]+/ { sub(/^[[:space:]]+/, ""); printf "%s%s", sep, $0; sep = " "; next }
+    grab { exit }
+  ' "$CFF"
+}
+
+# A plain list of scalars (`key:` then `  - value` lines), as a JSON array.
+cff_list() {
+  awk -v key="$1" '
+    $0 ~ "^" key ":[[:space:]]*$" { grab = 1; next }
+    grab && /^[[:space:]]+- / { sub(/^[[:space:]]+- /, ""); gsub(/^"|"$/, ""); print; next }
+    grab { exit }
+  ' "$CFF" | jq -R . | jq -s .
+}
+
+# `authors` → InvenioRDM `creators`. The ORCID is emitted as the BARE
+# identifier: CITATION.cff stores the full https://orcid.org/… URL, and passing
+# that through yields a record with no linked ORCID at all.
+cff_creators() {
+  awk '
+    /^authors:[ \t]*$/ { grab = 1; next }
+    !grab { next }
+    # Dedent ends the block. Tested on the ORIGINAL line: stripping the indent
+    # first would make every entry look dedented and end the block immediately.
+    /^[^ \t]/ { exit }
+    {
+      line = $0
+      if (sub(/^[ \t]*- /, "", line)) { if (rec != "") print rec; rec = "" }
+      else sub(/^[ \t]+/, "", line)
+      rec = rec (rec ? "\t" : "") line
+    }
+    END { if (rec != "") print rec }
+  ' "$CFF" | jq -R -s '
+    split("\n") | map(select(length > 0)) | map(
+      (split("\t") | map(select(length > 0)) | map(
+         capture("^(?<k>[^:]+):[[:space:]]*(?<v>.*)$")
+         | {(.k): (.v | sub("^\"";"") | sub("\"$";""))}
+       ) | add) as $a
+      | {
+          person_or_org: (
+            {
+              type: "personal",
+              given_name: $a["given-names"],
+              family_name: $a["family-names"],
+              name: ($a["family-names"] + ", " + $a["given-names"]),
+            }
+            + (if $a.orcid
+               then {identifiers: [{scheme: "orcid",
+                                    identifier: ($a.orcid | split("/") | last)}]}
+               else {} end)
+          ),
+        }
+      + (if $a.affiliation then {affiliations: [{name: $a.affiliation}]} else {} end)
+    )'
+}
+
+SPECS='[
+  "https://specifications.openehr.org/releases/RM/Release-1.1.0",
+  "https://specifications.openehr.org/releases/ITS-REST/Release-1.1.0",
+  "https://specifications.openehr.org/releases/QUERY/Release-1.1.0",
+  "https://specifications.openehr.org/releases/AM/Release-2.3.0"
+]'
+CRATES='["openehr-base","openehr-rm","openehr-am","openehr-term",
+         "openehr-lang","openehr-query","openehr-its","openehr-adl"]'
+
+rendered="$(
+  jq -n \
+    --arg title       "$(cff_scalar title)" \
+    --arg abstract    "$(cff_block abstract)" \
+    --arg version     "$(cff_scalar version)" \
+    --arg released    "$(cff_scalar date-released)" \
+    --arg license     "$(cff_scalar license | tr '[:upper:]' '[:lower:]')" \
+    --arg repo        "$(cff_scalar repository-code)" \
+    --arg site        "$(cff_scalar url)" \
+    --argjson keywords "$(cff_list keywords)" \
+    --argjson creators "$(cff_creators)" \
+    --argjson specs    "$SPECS" \
+    --argjson crates   "$CRATES" \
+'{
+  access: { record: "public", files: "public" },
+
+  # The complete set of software custom fields Zenodo actually carries,
+  # established by enumerating the custom_fields of the 100 newest software
+  # records: code:codeRepository, code:programmingLanguage,
+  # code:developmentStatus. code:operatingSystem, code:runtimePlatform,
+  # code:softwareRequirements and code:license returned ZERO records and do not
+  # exist — nothing here invents them.
+  custom_fields: {
+    "code:codeRepository": $repo,
+    "code:programmingLanguage": [
+      { id: "rust", title: { en: "Rust" } },
+      { id: "sql",  title: { en: "SQL"  } }
+    ],
+    "code:developmentStatus": { id: "active", title: { en: "Active" } }
+  },
+
+  metadata: {
+    resource_type: { id: "software" },
+    title: $title,
+    description: ("<p>" + $abstract + "</p>"),
+    publication_date: $released,
+    version: $version,
+    creators: $creators,
+    languages: [ { id: "eng", title: { en: "English" } } ],
+    rights: [ { id: $license } ],
+    subjects: ($keywords | map({ subject: . })),
+    references: [
+      { reference: "openEHR Reference Model (RM) Release 1.1.0. openEHR International. https://specifications.openehr.org/releases/RM/Release-1.1.0" },
+      { reference: "openEHR Archetype Query Language (AQL), QUERY Release 1.1.0. openEHR International. https://specifications.openehr.org/releases/QUERY/Release-1.1.0" },
+      { reference: "openEHR REST API (ITS-REST) Release 1.1.0. openEHR International. https://specifications.openehr.org/releases/ITS-REST/Release-1.1.0" },
+      { reference: "openEHR Archetype Model (AM) Release 2.3.0. openEHR International. https://specifications.openehr.org/releases/AM/Release-2.3.0" }
+    ],
+    related_identifiers: (
+      [ { identifier: $site, scheme: "url",
+          relation_type: { id: "isdocumentedby" },
+          resource_type: { id: "publication-softwaredocumentation" } } ]
+      + ($specs | map({ identifier: ., scheme: "url",
+                        relation_type: { id: "isderivedfrom" } }))
+      + ($crates | map({ identifier: ("https://crates.io/crates/" + .),
+                         scheme: "url",
+                         relation_type: { id: "haspart" },
+                         resource_type: { id: "software" } }))
+    ),
+    additional_descriptions: [
+      { type: { id: "technical-info" },
+        description: "<p>Implements the openEHR specifications at these pinned versions: Reference Model 1.2.0, BASE 1.3.0, Archetype Model 1.4.0 and 2.4.0, Terminology 3.1.0, AQL (QUERY) 1.1.0, ITS-REST 1.1.0 and ITS-XML. The specification layer is generated from the official machine-readable specifications rather than hand-written, and conformance is measured per release by a built-in openEHR CNF conformance runner whose results are committed alongside the source. Requires PostgreSQL 18.</p>" },
+      { type: { id: "notes" },
+        description: "<p>Licensing: the recorded licence covers this project&rsquo;s own code. Vendored third-party material keeps its upstream terms &mdash; Apache-2.0 for the openEHR machine-readable artifacts and test corpora, CC-BY-SA-3.0 for the openEHR specification text and CKM-derived clinical models &mdash; each recorded in the PROVENANCE.md of the tree that carries it.</p>" }
+    ]
+  }
+}'
+)"
+
+if [ "$MODE" = "--check" ]; then
+  [ -f "$OUT" ] || { echo "::error::$OUT is missing — run scripts/render/zenodo-json.sh" >&2; exit 1; }
+  if ! printf '%s\n' "$rendered" | diff -u "$OUT" - >/dev/null; then
+    echo "::error::$OUT is stale versus $CFF — run scripts/render/zenodo-json.sh" >&2
+    printf '%s\n' "$rendered" | diff -u "$OUT" - || true
+    exit 1
+  fi
+  echo "zenodo-json: $OUT matches $CFF"
+  exit 0
+fi
+
+printf '%s\n' "$rendered" > "$OUT"
+echo "zenodo-json: wrote $OUT from $CFF"


### PR DESCRIPTION
Closes #2210. Unblocks #2208.

Zenodo is connected to this repository, so the next release mints a DOI from whatever metadata is in the tree — **permanently**, because a deposit is not editable the way a README is. This is the window, and it is one release wide.

## The rule that decided the design

Straight from Zenodo:

> If your repository contains both a `.zenodo.json` and a `CITATION.cff` file, Zenodo will only use the `.zenodo.json` metadata. **The `CITATION.cff` will be completely ignored** for the GitHub release archiving.
> — <https://help.zenodo.org/docs/github/describe-software/zenodo-json/>

Not merged, not overridden field-by-field — *ignored*. So hand-writing `.zenodo.json` would silently switch off the file `citation-guard` already validates and version-checks, and the two would drift apart with no signal: the deposit saying one thing, the GitHub citation box another, archived under a DOI nobody can correct.

It is added anyway, because `related_identifiers` has no `CITATION.cff` equivalent and is the one thing worth recording that the citation box cannot express — which openEHR specifications a release is derived from, and where the published crates live.

**The resolution is that the file is generated.** `CITATION.cff` stays the single source for every fact both files carry, `scripts/render/zenodo-json.sh` renders the rest, and `citation-guard` runs it in `--check` mode so a divergence fails the PR. Mutation-proven: corrupting a field in the committed file makes the check refuse.

## Three details verified from the specification, not from examples

Each of these fails *silently* — the deposit is simply wrong, forever.

- **`license` is a string**, over a controlled vocabulary ([deposit metadata](https://developers.zenodo.org/#representation)). The `{"id": "…"}` object form that appears in other projects' files belongs to the newer InvenioRDM API, not the legacy deposit endpoint the GitHub integration posts to.
- **ORCID must be the bare identifier.** `CITATION.cff` stores the full `https://orcid.org/…` URL; passing that straight through produces a deposit with no linked ORCID at all. The generator strips it.
- **`resource_type` is omitted on the specification links.** The term this would want — `standardandpolicy` — is InvenioRDM vocabulary, and an invalid controlled term is worse than an absent optional field.

Licence is stated as the project's own MIT only. Vendored trees keep their upstream terms (Apache-2.0 for the openEHR machine-readable artifacts, CC-BY-SA-3.0 for the spec text), which a single-valued field cannot express and which each `PROVENANCE.md` carries.

## One implementation note worth keeping

The generator writes its Python to a temp file rather than running a heredoc nested inside `$( )`. Bash scans such a heredoc for quote pairs, so **one apostrophe in a comment breaks the entire script** — which it did, once, during this change. Restructuring removes the hazard instead of deleting the character.

## What remains for #2208

The deposit itself, at the cut: verify it against the generated metadata, add the **concept** DOI badge to `README.md`, and record the DOI in `CITATION.cff`. The release procedure now states that a tag produces an archived artifact and that its metadata is checked *before* the cut, since afterwards is too late.