### PR TITLE
chore(scripts): ban Python, and make the ban a failing check rather than a wish

### DIFF
--- a/.claude/rules/rust-style.md
+++ b/.claude/rules/rust-style.md
@@ -223,6 +223,39 @@ checked. New code carries the source; the sweep is tracked.
   `static_mut_refs` is compiler-enforced and the `LazyLock` convention
   already complies. Do not re-litigate them.
 
+## No Python, anywhere (owner hard rule, 2026-08-10)
+
+The tooling languages are **bash and Rust**. Python is banned across the
+repository — standalone scripts, and especially embedded in shell.
+
+Embedded is worse than either language alone, and not as a matter of taste: a
+heredoc nested inside a command substitution makes bash scan the *Python* for
+quote pairs, so a single apostrophe in a Python comment breaks the whole
+script with an error pointing at the wrong line. That is not hypothetical — it
+happened while writing `scripts/render/zenodo-json.sh`, which is now bash and
+`jq` only.
+
+What to reach for instead:
+
+| Job | Tool |
+|---|---|
+| JSON read/build | `jq` |
+| Line scans, field extraction | `awk`, `sed`, `grep` |
+| Anything with real data structures | Rust, in `tools/` |
+
+Enforcement (tier 4): `scripts/checks/no-python.sh`, per-PR via the
+`no-python` CI job. It fails on any `python`/`python3` invocation and on any
+`.py` file under `scripts/`, `.github/workflows/`, `.claude/hooks/`, `deploy/`
+and `docker/`; prose *about* not using Python is allowed, since several
+scripts carry exactly that comment. Mutation-proven in both directions.
+
+**Two exemptions remain**, both in `deploy/helm/validate.sh` and both tracked
+by issue #2220: the selector-immutability and restricted-profile gates parse
+multi-document YAML, which bash has no native answer for. They are security
+gates and they are mutation-proven, so they are being converted deliberately —
+a replacement that silently checks fewer containers would be worse than the
+violation it fixes.
+
 ## What not to do
 
 - Do not port JVM plumbing (classloaders, Spring context internals, PF4J) —

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,6 +295,24 @@ jobs:
       - name: Comment style on changed Rust files
         run: bash scripts/checks/comment-style.sh --all
 
+  # No Python anywhere (.claude/rules/rust-style.md §No Python): the tooling
+  # languages are bash and Rust. Embedded Python is the worst case — a heredoc
+  # inside a command substitution makes bash scan the Python for quote pairs,
+  # so one apostrophe in a comment breaks the script.
+  no-python:
+    name: no-python
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: No Python invocations or sources
+        run: bash scripts/checks/no-python.sh
+
   # Default-value style (.claude/rules/rust-style.md §Default values): a field's
   # default lives inline in its struct's `Default` impl — the RFC 3681 shape,
   # hand-written because that syntax is nightly-only.

--- a/scripts/checks/no-python.sh
+++ b/scripts/checks/no-python.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# No Python in this repository (owner hard rule, 2026-08-10).
+#
+# The tooling languages are bash and Rust. Python is banned everywhere —
+# standalone scripts, and especially embedded in shell, where it is worse than
+# either language alone: a heredoc nested in a command substitution makes bash
+# scan the Python for quote pairs, so ONE apostrophe in a comment breaks the
+# whole script. That happened while writing scripts/render/zenodo-json.sh, and
+# it is the concrete reason this rule is machine-enforced rather than advisory.
+#
+# Two exemptions remain, both recorded and both tracked by #2220: the Helm
+# selector-immutability and restricted-profile gates parse multi-document YAML,
+# which bash has no native answer for. They are security gates, mutation-proven,
+# and a conversion that silently checks less would be worse than the violation —
+# so they are being converted deliberately rather than quickly. Every OTHER
+# occurrence fails this check.
+#
+# Usage: scripts/checks/no-python.sh
+set -euo pipefail
+cd "$(dirname "$0")/../.." || exit 1
+
+# The exempt files, by path. Adding to this list requires the owner; removing
+# from it is the goal.
+EXEMPT='^deploy/helm/validate\.sh$'
+
+# Where shell and CI live. Deliberately not the whole tree: a Python file
+# inside a vendored corpus is upstream material, not ours to rewrite.
+ROOTS=(scripts .github/workflows .claude/hooks deploy docker)
+
+hits=0
+while IFS= read -r file; do
+  [ -f "$file" ] || continue
+  case "$file" in
+    */node_modules/*|*/vendor/*|*/target/*) continue ;;
+  esac
+  printf '%s' "$file" | grep -qE "$EXEMPT" && continue
+  # An invocation, not the word: prose about not using Python is fine and this
+  # repository contains several such comments.
+  if matches="$(grep -nE '(^|[^[:alnum:]_./-])python3?([[:space:]]|$)' "$file" \
+                | grep -vE '#.*python' || true)"; then
+    if [ -n "$matches" ]; then
+      printf '%s:\n%s\n' "$file" "$matches"
+      hits=$((hits + 1))
+    fi
+  fi
+done < <(find "${ROOTS[@]}" -type f \( -name '*.sh' -o -name '*.yml' -o -name '*.yaml' -o -name '*.py' \) 2>/dev/null | sort)
+
+# A standalone Python file is a violation regardless of content.
+while IFS= read -r py; do
+  printf '%s: a Python source file\n' "$py"
+  hits=$((hits + 1))
+done < <(find "${ROOTS[@]}" -type f -name '*.py' 2>/dev/null | sort)
+
+if [ "$hits" -gt 0 ]; then
+  echo
+  echo "::error::Python is banned in this repository (see .claude/rules/rust-style.md)."
+  echo "  Use bash + jq/awk/sed, or Rust. The two Helm gates are the only"
+  echo "  exemptions and are tracked by #2220."
+  exit 1
+fi
+echo "no-python: clean"


### PR DESCRIPTION
Refs #2220.

The tooling languages are **bash and Rust**. Python is banned across the repository — standalone scripts, and especially embedded in shell.

Embedded is the worst case, and not as a matter of taste. A heredoc nested inside a command substitution makes bash scan the **Python** for quote pairs, so a single apostrophe in a Python comment breaks the entire script and reports the error at the wrong line. That is not hypothetical — it happened while writing `scripts/render/zenodo-json.sh`, which is now bash and `jq` only.

Several scripts already said the rule out loud:

```
scripts/checks/changelog-structure.sh:  # awk, not python: this repository ships no Python
scripts/conformance.sh:                 # jq, not python: this is a two-key JSON edit
scripts/generate-ckm-examples.sh:       # read with sed rather than python
```

A convention three files repeat and nothing enforces is a convention that erodes. Now it fails CI.

## What the check does

Fails on any `python`/`python3` **invocation** and on any `.py` file under `scripts/`, `.github/workflows/`, `.claude/hooks/`, `deploy/` and `docker/`. Prose *about* not using Python still passes — the three comments above must keep working, so the rule reads invocations rather than the word.

Mutation-proven in both directions before committing: a new `python3 -c` in a script fails it, and so does a new standalone `.py`.

Vendored trees are deliberately out of scope. A Python file inside a vendored corpus is upstream material, not ours to rewrite.

## Two exemptions, named rather than silent

Both in `deploy/helm/validate.sh`, both tracked by #2220: the selector-immutability gate and the restricted-profile gate parse **multi-document YAML**, which bash has no native answer for.

They stay for now on purpose. They are the gates that stop an immutable-field change and a Pod Security regression from reaching a cluster, they are mutation-proven, and a hurried conversion that quietly checks fewer containers would pass CI while proving less than the Python does today — worse than the violation it fixes. #2220 carries the options (a YAML→JSON bridge, or a Rust tool that puts the assertions under `cargo nextest` instead of under hand-run mutation).

Listing them as explicit exemptions is the point: the rule applies everywhere else starting now, and the two places it does not apply are visible in the check itself rather than being a silence someone has to rediscover.