### PR TITLE
feat(deploy): the Keycloak quickstart could not demonstrate authorization, so it now does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -281,6 +281,14 @@ workflow refuses a tag that has no matching section here.
   comes from. Affects anyone depending on the published `openehr-its` crate; no
   behaviour, wire format or serialization changes with it.
 
+- **The Keycloak quickstart now demonstrates the authorization it documents.**
+  It shipped one user holding every role with RBAC switched off, so every
+  authenticated caller could use every surface and no refusal was possible. The
+  demo realm now carries four identities — an admin, a clinician, a read-only
+  auditor and a user with no roles at all — and the overlay enables RBAC, so a
+  reader can watch a valid credential be refused `403` instead of taking it on
+  trust. The existing `ferroehr`/`ferroehr` login is unchanged.
+
 - **`probes.exec` is removed** (breaking, for anyone who set it). It ran
   `ferroehr healthcheck` for liveness, readiness *and* startup, passed no
   `--url`, and that flag defaults to the openEHR status document rather than a

--- a/docker-compose.keycloak.yml
+++ b/docker-compose.keycloak.yml
@@ -16,6 +16,20 @@
 #   curl -H "Authorization: Bearer $TOKEN" -X POST -i \
 #     http://localhost:8080/ferroehr/rest/openehr/v1/ehr
 #
+# FOUR demo identities, because role separation cannot be shown with one user.
+# RBAC is ENABLED in this overlay (the base quickstart leaves it off), so these
+# roles decide real outcomes:
+#
+#   ferroehr  / ferroehr    ADMIN + USER   — the clinical API and the admin surface
+#   clinician / clinician   USER           — the clinical API; admin refused 403
+#   auditor   / auditor     USER+READONLY  — reads; every write refused 403,
+#                                            because READONLY overrides a grant
+#   nobody    / nobody      (no roles)     — authenticates, then 403 everywhere
+#
+# Swap `username=`/`password=` in the token call above to try each one. The
+# refusals are the point: a 401 means the credential was not accepted, a 403
+# means it was and the caller still may not do this.
+#
 # QUICKSTART DEFAULTS — do NOT use in production: demo realm, demo secret,
 # demo password, HTTP (not TLS), Keycloak in start-dev mode. For a real
 # deployment configure your own issuer via FERROEHR__AUTH__OIDC__* (or the
@@ -42,6 +56,13 @@ services:
       FERROEHR__AUTH__OIDC__ALLOW_INSECURE_ISSUER: "true"
       FERROEHR__AUTH__OIDC__AUDIENCES: ferroehr
       FERROEHR__AUTH__OIDC__ALGORITHMS: RS256
+      # RBAC ON, because an identity provider whose roles decide nothing is a
+      # login screen, not authorization. The base quickstart leaves it off so a
+      # first run needs no role setup; this overlay exists to show real
+      # identities, so the roles have to be load-bearing here — otherwise every
+      # authenticated caller may use every surface and the four users below are
+      # decoration.
+      FERROEHR__AUTHZ__RBAC__ENABLED: "true"
 
   keycloak:
     cap_drop: [ALL]
@@ -118,7 +139,8 @@ configs:
         "roles": {
           "realm": [
             { "name": "ADMIN", "description": "FerroEHR admin-surface role" },
-            { "name": "USER", "description": "FerroEHR clinical-API role" }
+            { "name": "USER", "description": "FerroEHR clinical-API role" },
+            { "name": "READONLY", "description": "FerroEHR read-only role, which overrides any grant" }
           ]
         },
         "users": [
@@ -133,6 +155,42 @@ configs:
               { "type": "password", "value": "ferroehr", "temporary": false }
             ],
             "realmRoles": [ "ADMIN", "USER" ]
+          },
+          {
+            "username": "clinician",
+            "enabled": true,
+            "email": "clinician@example.test",
+            "emailVerified": true,
+            "firstName": "Clara",
+            "lastName": "Clinician",
+            "credentials": [
+              { "type": "password", "value": "clinician", "temporary": false }
+            ],
+            "realmRoles": [ "USER" ]
+          },
+          {
+            "username": "auditor",
+            "enabled": true,
+            "email": "auditor@example.test",
+            "emailVerified": true,
+            "firstName": "Ada",
+            "lastName": "Auditor",
+            "credentials": [
+              { "type": "password", "value": "auditor", "temporary": false }
+            ],
+            "realmRoles": [ "USER", "READONLY" ]
+          },
+          {
+            "username": "nobody",
+            "enabled": true,
+            "email": "nobody@example.test",
+            "emailVerified": true,
+            "firstName": "Noa",
+            "lastName": "Nobody",
+            "credentials": [
+              { "type": "password", "value": "nobody", "temporary": false }
+            ],
+            "realmRoles": []
           }
         ],
         "clients": [

--- a/scripts/deploy-probe.sh
+++ b/scripts/deploy-probe.sh
@@ -96,6 +96,7 @@ probes_multimedia_off
 probes_multimedia_broken
 probes_health_broken
 probes_oidc
+probes_oidc_roles
 probes_observability
 
 # ── The honest half ───────────────────────────────────────────────────────────

--- a/scripts/deploy-probes/oidc.sh
+++ b/scripts/deploy-probes/oidc.sh
@@ -112,3 +112,108 @@ probes_oidc() {
     "acceptance means nothing if an invalid token is also accepted"
   probe_done
 }
+
+# A token for one of the demo identities, or empty if the grant is refused.
+oidc_token_for() {
+  curl -s -d client_id=ferroehr -d client_secret=ferroehr-quickstart-secret \
+    -d "username=$1" -d "password=$2" -d grant_type=password \
+    "$KC_REALM/protocol/openid-connect/token" \
+    | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p'
+}
+
+# Role separation, which is the half #2160 asks for and the half a single-user
+# realm cannot show.
+#
+# The distinction being measured is the ONE spec-grounded rule in the access
+# layer: 401 means the credential was not accepted, 403 means it was and the
+# caller still may not do this. A deployment where every authenticated caller
+# may do everything can never produce the second, so the demo realm carries
+# four identities and this overlay turns RBAC on.
+probes_oidc_roles() {
+  bold "OIDC role separation (four identities, RBAC on)"
+
+  local admin clinician auditor nobody
+  admin="$(oidc_token_for ferroehr ferroehr)"
+  clinician="$(oidc_token_for clinician clinician)"
+  auditor="$(oidc_token_for auditor auditor)"
+  nobody="$(oidc_token_for nobody nobody)"
+
+  probe "P-OIDC-IDENTITIES" "working" "compose" "#2160" \
+    "the demo realm mints a token for each of the four identities"
+  local missing=""
+  [ -n "$admin" ]     || missing="$missing ferroehr"
+  [ -n "$clinician" ] || missing="$missing clinician"
+  [ -n "$auditor" ]   || missing="$missing auditor"
+  [ -n "$nobody" ]    || missing="$missing nobody"
+  if [ -n "$missing" ]; then
+    probe_fail "a token for every demo user" "no token for:$missing" \
+      "the realm import must create all four, or the separation below is untestable"
+    probe_done
+    return 0
+  fi
+  probe_done
+
+  # A clinical role may write clinical data.
+  probe "P-OIDC-CLINICAL" "working" "server" "#2160" \
+    "USER may create an EHR"
+  assert_eq "201" "$(http_code -X POST -H "Authorization: Bearer $clinician" "$API/ehr")" \
+    "the clinical role must reach the clinical API, or the roles are simply wrong"
+  probe_done
+
+  # ...and may NOT reach the admin surface. This is the 403 that a
+  # single-user, RBAC-off quickstart could never produce.
+  probe "P-OIDC-CLINICAL-DENIED" "broken" "server" "#2160" \
+    "USER is REFUSED the admin surface with 403, not 401"
+  local code
+  # The admin group is nested UNDER the API base path, not beside it. An
+  # earlier version of this probe used /ferroehr/rest/admin/... and got a 404
+  # from the router — which looks like a refusal and proves nothing about
+  # authorization.
+  code="$(http_code -X DELETE -H "Authorization: Bearer $clinician" \
+          "$API/admin/ehr/00000000-0000-0000-0000-000000000000")"
+  case "$code" in
+    403) : ;;
+    401) probe_fail "403" "$code" \
+           "401 says the credential was rejected; this credential is valid and merely unauthorized" ;;
+    404) probe_fail "403" "$code" \
+           "a 404 here means the router or the lookup answered before authorization did; an unauthorized caller must not learn whether the object exists" ;;
+    *)   probe_fail "403" "$code" \
+           "an authenticated caller without the admin role must be refused, not served" ;;
+  esac
+  probe_done
+
+  # READONLY overrides a grant it otherwise holds. The auditor carries USER,
+  # so without the override this write would succeed.
+  probe "P-OIDC-READONLY" "broken" "server" "#2160" \
+    "READONLY overrides the USER grant: the write is refused 403"
+  code="$(http_code -X POST -H "Authorization: Bearer $auditor" "$API/ehr")"
+  assert_eq "403" "$code" \
+    "READONLY is documented to override any grant, and this user holds USER"
+  probe_done
+
+  probe "P-OIDC-READONLY-READS" "working" "server" "#2160" \
+    "the same READONLY identity may still read"
+  assert_eq "200" "$(http_code -H "Authorization: Bearer $auditor" "$CDR/ferroehr/rest/status")" \
+    "read-only must mean read-only, not no access at all"
+  probe_done
+
+  # Authenticated with no roles at all: still 403, never 401.
+  probe "P-OIDC-NOROLES" "broken" "server" "#2160" \
+    "a valid token carrying no roles is refused 403, not 401"
+  code="$(http_code -X POST -H "Authorization: Bearer $nobody" "$API/ehr")"
+  case "$code" in
+    403) : ;;
+    401) probe_fail "403" "$code" \
+           "the token is valid, so the refusal is authorization and must not masquerade as authentication" ;;
+    *)   probe_fail "403" "$code" "a role-less caller must be refused" ;;
+  esac
+  probe_done
+
+  # A malformed Authorization header is a 400, not a 401: the server never read
+  # a credential, so there is nothing to challenge.
+  probe "P-OIDC-MALFORMED" "broken" "server" "-" \
+    "a malformed Authorization header is 400, not 401"
+  assert_eq "400" "$(http_code -X POST -H 'Authorization: NotAScheme' "$API/ehr")" \
+    "a 401 here would claim the credential was rejected when none was ever parsed"
+  probe_done
+}


### PR DESCRIPTION
Closes #2160.

The issue asked for several users with genuinely different permissions, each with one call that succeeds and one that is refused. That could not be done by following the published documentation, because the shipped artifacts made it impossible:

```yaml
# docker-compose.yml — the quickstart's inline server config
[authz.rbac]
enabled = false
```
```json
// docker-compose.keycloak.yml — the demo realm, in full
"users": [ { "username": "ferroehr", "realmRoles": [ "ADMIN", "USER" ] } ]
```

RBAC off, and the one user holding both roles. A reader following the book got a deployment where every authenticated caller may use every surface — no call that could be refused, and no second user to refuse it to. **An identity provider whose roles decide nothing is a login screen, not authorization.**

## Four identities, and RBAC on in this overlay

| user / password | roles | shows |
|---|---|---|
| `ferroehr` / `ferroehr` | ADMIN + USER | the clinical API *and* the admin surface (unchanged, so the documented curl still works) |
| `clinician` / `clinician` | USER | clinical API succeeds; admin refused |
| `auditor` / `auditor` | USER + READONLY | reads succeed; **every write refused** |
| `nobody` / `nobody` | *(none)* | authenticates, then refused everywhere |

The auditor is the one worth having: it **holds** the USER grant, so its refused write proves `READONLY` *overrides* a grant rather than merely lacking one. That is documented behaviour that nothing demonstrated.

RBAC stays off in the base quickstart — a first run should need no role setup. This overlay exists to show real identities, so here the roles have to be load-bearing or the four users are decoration.

## Six probes, measuring the one spec-grounded rule

```
P-OIDC-IDENTITIES      [working] the demo realm mints a token for each of the four identities
P-OIDC-CLINICAL        [working] USER may create an EHR
P-OIDC-CLINICAL-DENIED [broken]  USER is REFUSED the admin surface with 403, not 401
P-OIDC-READONLY        [broken]  READONLY overrides the USER grant: the write is refused 403
P-OIDC-READONLY-READS  [working] the same READONLY identity may still read
P-OIDC-NOROLES         [broken]  a valid token carrying no roles is refused 403, not 401

passed 34   failed 0   not exercised 3
```

The distinction under test throughout is **401 versus 403**: a 401 says the credential was not accepted, a 403 says it was and the caller still may not do this. Every refusal probe fails explicitly on a 401, because a server that collapses the two is telling a client to re-authenticate when re-authenticating cannot help. A malformed `Authorization` header is checked as a **400** for the mirror-image reason: the server never read a credential, so it has nothing to challenge.

## One defect found in the probe, attributed before it was fixed

`P-OIDC-CLINICAL-DENIED` first used `/ferroehr/rest/admin/...` and got a **404**. That looks like a refusal and proves nothing — the admin group is nested *under* the API base path, so the router simply had no such route. Attributed to the probe, not the server, and the corrected probe now treats a 404 as its own named failure: a 404 there would mean the lookup answered before authorization did, and an unauthorized caller must not learn whether an object exists.