### PR TITLE
fix(release): immutability would have frozen the release before its binaries existed

### DIFF
--- a/.claude/rules/changelog.md
+++ b/.claude/rules/changelog.md
@@ -54,6 +54,19 @@ optional:
   re-publish a chart version — bump it:** an OCI tag is MUTABLE, so `helm push`
   would silently replace it with a different digest, and the immutability the
   guards assume exists only because the lane enforces it.
+- **A published release is IMMUTABLE.** GitHub release immutability is enabled:
+  once a release is published, its assets and its tag cannot be modified. The
+  release lane therefore creates the release as a **draft**, attaches the
+  binaries, SBOMs and Sigstore bundles from the per-arch matrix, checks the
+  expected asset set is complete, and only then publishes it — the freeze
+  happens last, on purpose. The recovery path for a bad cut is **a new patch
+  version**, never a retag.
+
+  Do not confuse this with the chart lane one section above: a **GHCR OCI tag
+  is still mutable**, which is exactly why `publish-chart.yml` refuses to
+  overwrite a published chart version. GitHub releases are immutable by the
+  platform; container tags are immutable only because our lane enforces it.
+
 - **The tag also produces an archived artifact.** Zenodo is connected to this
   repository, so publishing a release makes Zenodo take the zipball and mint a
   DOI from `.zenodo.json`. That deposit is immutable — whatever the metadata

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -185,6 +185,11 @@ jobs:
       - name: Upload to release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
+          # The release is still a DRAFT at this point and must stay one: it is
+          # finalized by the caller's finalize-release job once every arch has
+          # attached its assets. Release immutability freezes a PUBLISHED
+          # release, so flipping it here would lock the other architecture out.
+          draft: true
           tag_name: ${{ inputs.tag }}
           files: |
             ${{ env.ASSET }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,9 +105,19 @@ jobs:
           fi
         env:
           TAG: ${{ steps.tag.outputs.tag }}
-      - name: Publish (or update) the GitHub release
+      # Created as a DRAFT, and finalized only after every asset is attached.
+      #
+      # Release immutability is enabled on this repository: once a release is
+      # PUBLISHED, its assets and tag can no longer be modified. The binaries,
+      # SBOMs and Sigstore bundles are produced by the build-binaries matrix
+      # that runs after this job, so publishing here would freeze the release
+      # before its most important assets exist — a release carrying the compose
+      # files and nothing to verify. A draft is still mutable, which is exactly
+      # the window those uploads need.
+      - name: Create the GitHub release as a draft
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
+          draft: true
           tag_name: ${{ steps.tag.outputs.tag }}
           name: ${{ steps.tag.outputs.tag }}
           body_path: release-notes.md
@@ -163,3 +173,47 @@ jobs:
       sha: ${{ needs.publish-release.outputs.sha }}
       target: ${{ matrix.target }}
       runner: ${{ matrix.runner }}
+
+  # The moment the release becomes immutable, so it happens LAST and only when
+  # every asset is in place. `needs` both jobs rather than just the matrix: a
+  # draft with no binaries must never be flipped to published, and a failed
+  # matrix leaves the draft visible for inspection instead of shipping a
+  # release nobody can add to afterwards.
+  finalize-release:
+    needs: [publish-release, build-binaries]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      # Refuse to publish a release whose assets are missing. After this step
+      # the set is frozen for good, so this is the last moment the check is
+      # worth anything.
+      - name: Every expected asset is attached before the release is frozen
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.publish-release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          assets="$(gh release view "$TAG" --json assets --jq '.assets[].name')"
+          echo "$assets"
+          missing=""
+          for arch in x86_64 aarch64; do
+            for suffix in ".tar.gz" ".tar.gz.sigstore.json" ".tar.gz.intoto.jsonl"; do
+              printf '%s\n' "$assets" \
+                | grep -q "ferroehr-${TAG}-${arch}-unknown-linux-gnu${suffix}" \
+                || missing="$missing ferroehr-${TAG}-${arch}-unknown-linux-gnu${suffix}"
+            done
+          done
+          [ -z "$missing" ] || {
+            echo "::error::the draft is missing assets, so it will not be published:$missing"
+            exit 1
+          }
+      - name: Publish the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.publish-release.outputs.tag }}
+        run: gh release edit "$TAG" --draft=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -538,6 +538,13 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **The release lane would have shipped a release with no binaries.** GitHub
+  release immutability is now enabled, which freezes a release's assets the
+  moment it is published — and the binaries, SBOMs and Sigstore bundles are
+  attached by a job that runs *after* the release is created. The release is now
+  created as a draft, its assets are attached, the expected set is verified, and
+  only then is it published, so nothing can be locked out.
+
 - **Three list-typed configuration settings could not be set from the
   environment at all.** `signing.retired_key_paths`,
   `smart.endpoints.capabilities` and every `authz.abac.policy.<kind>.parameters`


### PR DESCRIPTION
Closes #2209. Found while writing the procedure text the issue asked for — the documentation gap turned out to be hiding a release blocker.

## The interaction

Release immutability is now enabled: **once a release is published, its assets and its tag cannot be modified.**

The release lane creates the release in `publish-release`, then a per-arch matrix (`build-binaries` → `release-build.yml`) attaches the tarballs, SBOMs and Sigstore bundles **afterwards**:

```yaml
# release.yml — job 1
- name: Publish (or update) the GitHub release      # ← published here
    files: |
      docker-compose.yml …

# release-build.yml — job 2, per architecture
- uses: softprops/action-gh-release@…               # ← appends here
    files: |
      ${{ env.ASSET }}  ${{ env.SBOM }}  ${{ env.PROVENANCE_BUNDLE_ASSET }} …
```

Published-then-append is precisely the sequence immutability forbids. The next cut would have produced a release carrying **the compose files and nothing to verify** — or failed part-way with one architecture attached and the other locked out permanently.

Worth noting what this does to two issues already open: #2212 asks that the Scorecard signing assets be verified at this cut *because they have never run*, and #2208's Zenodo deposit archives whatever the release holds. All three converge on the same cut, and this one had to be fixed first or the other two would measure an empty release.

## The fix

Create as a **draft** — still mutable — attach everything, then publish last.

`finalize-release` needs both the create and the matrix, and before flipping the draft it **checks the expected asset set is complete**: three files per architecture (`.tar.gz`, `.tar.gz.sigstore.json`, `.tar.gz.intoto.jsonl`). That check runs there and nowhere else on purpose — after that step the release is frozen for good, so it is the last moment the check is worth anything.

A failed matrix now leaves the draft visible for inspection rather than shipping a release nobody can add to.

## The procedure

`.claude/rules/changelog.md` states the consequence that costs the most to learn at the wrong moment: **the recovery path for a bad cut is a new patch version, never a retag.**

It also separates the two immutability stories that live one section apart and read as contradictory:

- a **GitHub release** is immutable **by the platform**;
- a **GHCR OCI tag** is still **mutable**, which is exactly why `publish-chart.yml` refuses to overwrite a published chart version.

One is a guarantee we receive, the other is a guarantee we enforce. Inferring either from the other gets a release wrong.