### PR TITLE
chore(deploy): the last two Python gates are gone — the chart checks are yq and jq now

### DIFF
--- a/.claude/rules/kubernetes-helm.md
+++ b/.claude/rules/kubernetes-helm.md
@@ -188,8 +188,8 @@ evidence if it ran in an enforcing namespace — say which.
 
 | Property | Check |
 |---|---|
-| Restricted profile, per container | `validate.sh` `assert_security` (YAML-parsing, mutation-proven) |
-| Selector immutability | `validate.sh` `assert_selector_stable` |
+| Restricted profile, per container | `validate.sh` `assert_security` → `deploy/helm/gates/restricted.jq` (structural, mutation-proven) |
+| Selector immutability + selector disjointness | `validate.sh` `assert_selector_stable` → `deploy/helm/gates/selector.jq` |
 | Secrets never env-borne as values | `validate.sh` `secret_leak_gate` |
 | `values.schema.json` accepts/rejects | `validate.sh` `schema_gate`, `fixture_gate` |
 | Golden render drift | CI compare against `deploy/helm/golden/` |

--- a/.claude/rules/rust-style.md
+++ b/.claude/rules/rust-style.md
@@ -249,12 +249,10 @@ Enforcement (tier 4): `scripts/checks/no-python.sh`, per-PR via the
 and `docker/`; prose *about* not using Python is allowed, since several
 scripts carry exactly that comment. Mutation-proven in both directions.
 
-**Two exemptions remain**, both in `deploy/helm/validate.sh` and both tracked
-by issue #2220: the selector-immutability and restricted-profile gates parse
-multi-document YAML, which bash has no native answer for. They are security
-gates and they are mutation-proven, so they are being converted deliberately —
-a replacement that silently checks fewer containers would be worse than the
-violation it fixes.
+**There are no exemptions.** The last two were the Helm selector-immutability
+and restricted-profile gates, which parsed multi-document YAML; they are now
+`yq -o=json | jq` gate programs under `deploy/helm/gates/`, with every
+assertion re-proven against the same mutations the Python caught.
 
 ## What not to do
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -783,6 +783,21 @@ jobs:
         run: |
           helm lint deploy/helm/ferroehr -f deploy/helm/ci/default-values.yaml
           helm lint deploy/helm/ferroehr -f deploy/helm/ci/all-features-values.yaml
+      # The chart gates read the rendered YAML structurally (yq -o=json | jq),
+      # because a grep over a manifest passes as soon as ONE container carries a
+      # field. Pinned by version and verified by checksum: this step runs before
+      # the security gates, so a substituted binary would decide whether they
+      # pass.
+      - name: Install yq
+        env:
+          YQ_VERSION: v4.53.3
+          YQ_SHA256: fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/yq             "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+          echo "${YQ_SHA256}  /tmp/yq" | sha256sum -c -
+          sudo install -m 0755 /tmp/yq /usr/local/bin/yq
+          yq --version
       # No --update: the goldens in the tree must already match this render.
       - name: Chart validation + golden renders
         run: bash deploy/helm/validate.sh

--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -139,6 +139,21 @@ jobs:
             exit 1
           fi
 
+      # The chart gates read the rendered YAML structurally (yq -o=json | jq),
+      # because a grep over a manifest passes as soon as ONE container carries a
+      # field. Pinned by version and verified by checksum: this step runs before
+      # the security gates, so a substituted binary would decide whether they
+      # pass.
+      - name: Install yq
+        env:
+          YQ_VERSION: v4.53.3
+          YQ_SHA256: fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/yq             "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+          echo "${YQ_SHA256}  /tmp/yq" | sha256sum -c -
+          sudo install -m 0755 /tmp/yq /usr/local/bin/yq
+          yq --version
       - name: Chart validation + golden renders
         run: bash deploy/helm/validate.sh
 

--- a/deploy/helm/gates/restricted.jq
+++ b/deploy/helm/gates/restricted.jq
@@ -1,0 +1,83 @@
+# Pod Security `restricted` compliance, plus the availability and isolation
+# properties that live in the same walk, over the array of rendered documents.
+#
+# Emits one line per violation and nothing when clean. Ported from the Python
+# this replaced; every assertion is unchanged.
+
+[ "configMap", "csi", "downwardAPI", "emptyDir", "ephemeral",
+  "persistentVolumeClaim", "projected", "secret" ] as $allowed_volumes
+| . as $docs
+| [ $docs[]
+    | select(.kind == "Deployment" or .kind == "StatefulSet"
+             or .kind == "DaemonSet" or .kind == "Job")
+    | select(.spec.template != null)
+    | { kind: .kind, name: .metadata.name,
+        replicas: .spec.replicas,
+        pod: (.spec.template.spec // {}) } ] as $workloads
+| ( [ $workloads[]
+      | . as $w
+      | ($w.pod.securityContext // {}) as $sc
+      | (
+          ( if ($sc.runAsNonRoot != true)
+            then ["\($w.kind)/\($w.name): pod runAsNonRoot must be true"] else [] end )
+        + ( if ((($sc.seccompProfile // {}).type) as $t
+                | $t != "RuntimeDefault" and $t != "Localhost")
+            then ["\($w.kind)/\($w.name): pod seccompProfile.type must be RuntimeDefault or Localhost"] else [] end )
+        # The kubelet's per-Service link variables land in the reserved
+        # FERROEHR_ namespace and the strict env sweep then refuses to boot, so
+        # losing this makes every install crash-loop.
+        + ( if ($w.pod.enableServiceLinks != false)
+            then ["\($w.kind)/\($w.name): enableServiceLinks must be false"] else [] end )
+        + ( [ ($w.pod.volumes // [])[]
+              | . as $v
+              | ($v | keys | map(select(. != "name")))[]
+              | select(. as $t | ($allowed_volumes | index($t)) == null)
+              | "\($w.kind)/\($w.name): volume \($v.name) type \(.) is outside the restricted set" ] )
+        + ( [ (($w.pod.containers // []) + ($w.pod.initContainers // []))[]
+              | . as $c
+              | ($c.securityContext // {}) as $csc
+              | (
+                  ( if ($csc.allowPrivilegeEscalation != false)
+                    then ["\($w.kind)/\($w.name)/\($c.name): allowPrivilegeEscalation must be false"] else [] end )
+                + ( if ($csc.runAsNonRoot != true and $sc.runAsNonRoot != true)
+                    then ["\($w.kind)/\($w.name)/\($c.name): runAsNonRoot must be true"] else [] end )
+                + ( if ($csc.readOnlyRootFilesystem != true)
+                    then ["\($w.kind)/\($w.name)/\($c.name): readOnlyRootFilesystem must be true"] else [] end )
+                + ( if ((($csc.capabilities // {}).drop // []) | index("ALL")) == null
+                    then ["\($w.kind)/\($w.name)/\($c.name): capabilities.drop must include ALL"] else [] end )
+                + ( if ((($csc.capabilities // {}).add // []) | length) > 0
+                    then ["\($w.kind)/\($w.name)/\($c.name): capabilities.add must be empty, got \((($csc.capabilities // {}).add))"] else [] end )
+                )[] ] )
+        )[] ] )
+  +
+  # Availability, not security: a Deployment asking for more than one replica
+  # with nothing telling the scheduler to spread them can put every replica on
+  # one node. An ABSENT `replicas` counts as multi-replica — the chart omits the
+  # field when autoscaling is on, so reading it as the API default of 1 would
+  # exempt precisely the elastic workload that most needs spreading.
+  ( [ $workloads[]
+      | select(.kind == "Deployment")
+      | select(.replicas == null or .replicas > 1)
+      | select((.pod.topologySpreadConstraints // []) == [] and (.pod.affinity // {}) == {})
+      | "Deployment/\(.name): multi-replica with neither topologySpreadConstraints nor affinity — every replica may land on one node" ] )
+  +
+  ( if ($workloads | length) == 0
+    then ["no pod-bearing workload found — the gate would pass vacuously"] else [] end )
+  +
+  ( if ([ $docs[] | select(.kind == "NetworkPolicy") ] | length) == 0
+    then ["no NetworkPolicy in the render"] else [] end )
+  +
+  # Pod-level ISOLATION, recorded per workload rather than asserted per workload.
+  # These are not restricted-profile controls, so the property that matters is
+  # not "every pod sets X" but that every pod of one release AGREES. A release
+  # whose console shares the host user namespace while its server does not has a
+  # posture nobody can state.
+  ( [ $workloads[]
+      | { k: "\(.kind)/\(.name)",
+          v: [ (if .pod.hostUsers == null then true else .pod.hostUsers end),
+               ((.pod.securityContext // {}).supplementalGroupsPolicy) ] } ] as $iso
+    | if (($iso | map(.v) | unique | length) > 1)
+      then ["pod isolation differs across workloads of one release: "
+            + (($iso | sort_by(.k) | map("\(.k) hostUsers=\(.v[0]) supplementalGroupsPolicy=\(.v[1])")) | join(", "))]
+      else [] end )
+| .[]

--- a/deploy/helm/gates/selector.jq
+++ b/deploy/helm/gates/selector.jq
@@ -1,0 +1,38 @@
+# Selector immutability + disjointness, over the array of rendered documents.
+#
+# Emits one line per violation and nothing when clean, so the caller decides the
+# exit status from the output. Ported from the Python this replaced; the
+# assertions are unchanged.
+
+["app.kubernetes.io/instance", "app.kubernetes.io/name"] as $expect
+| . as $docs
+| [ $docs[]
+    | select(.kind == "Deployment")
+    | { name:   .metadata.name,
+        labels: (.spec.template.metadata.labels // {}),
+        keys:   ((.spec.selector.matchLabels // {}) | keys) } ] as $deps
+| (
+    [ $deps[]
+      | select(.keys != $expect)
+      | "\(.name): selector.matchLabels is \(.keys), expected \($expect) — this field is IMMUTABLE; changing it breaks helm upgrade on every existing release" ]
+  )
+  +
+  (
+    # A Service/PDB selector is a SUBSET match, so a selector naming only the
+    # labels two workloads share silently selects both. Key sets alone cannot
+    # catch this: after the CDR/console fix both Deployments have the SAME
+    # selector keys and differ only in the name's value.
+    [ $docs[]
+      | select(.kind == "Service" or .kind == "PodDisruptionBudget")
+      | . as $d
+      | ( ($d.spec.selector // {})
+          | if (type == "object" and has("matchLabels")) then .matchLabels else . end ) as $sel
+      | select(($sel | type) == "object" and ($sel | length) > 0)
+      | ( [ $deps[]
+            | . as $dep
+            | select([ $sel | to_entries[] | ($dep.labels[.key] == .value) ] | all)
+            | $dep.name ] ) as $hit
+      | select(($hit | length) > 1)
+      | "\($d.kind)/\($d.metadata.name): selector \($sel | tostring) matches \($hit) — a subset match selects BOTH workloads; give each its own app.kubernetes.io/name rather than a shared name plus a component" ]
+  )
+| .[]

--- a/deploy/helm/validate.sh
+++ b/deploy/helm/validate.sh
@@ -134,52 +134,25 @@ yaml_ok() {
 # Pinned as an explicit expectation rather than left to the golden diff: a
 # golden churns for a dozen innocent reasons and this field must never move
 # quietly among them.
+# Run one gate program over a rendered manifest.
+#
+# `yq -o=json` turns the multi-document YAML into one JSON document per line
+# and `jq -s` slurps them into an array, which is the shape every gate program
+# expects. A gate prints one line per violation and nothing when clean, so the
+# exit status is decided here rather than repeated in each program.
+#
+# yq and jq rather than a YAML parser in another language: this repository ships
+# no Python (.claude/rules/rust-style.md §No Python).
+gate_jq() {
+  local file="$1" program="$2" out
+  out="$(yq -o=json -I0 '.' "$file" | jq -s -r -f "$(dirname "$0")/gates/$program")" || return 1
+  [ -z "$out" ] || { printf '%s\n' "$out" | sed 's/^/  /'; return 1; }
+  return 0
+}
+
 assert_selector_stable() {
   local file="$1"
-  python3 - "$file" <<'PYSEL' || { red "  selector immutability gate FAILED for ${file}"; exit 1; }
-import sys, yaml
-EXPECTED = {"ferroehr": {"app.kubernetes.io/name", "app.kubernetes.io/instance"},
-            "admin-ui": {"app.kubernetes.io/name", "app.kubernetes.io/instance"}}
-bad = []
-docs = [d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
-
-pod_labels = {}
-for d in docs:
-    if d.get("kind") != "Deployment":
-        continue
-    name = d["metadata"]["name"]
-    pod_labels[name] = d["spec"]["template"]["metadata"]["labels"] or {}
-    keys = set((d["spec"]["selector"]["matchLabels"] or {}).keys())
-    which = "admin-ui" if name.endswith("-admin-ui") else "ferroehr"
-    if keys != EXPECTED[which]:
-        bad.append(f"  {name}: selector.matchLabels is {sorted(keys)}, expected {sorted(EXPECTED[which])}"
-                   f" — this field is IMMUTABLE; changing it breaks helm upgrade on every existing release")
-
-# Disjointness. A Service/PDB selector is a SUBSET match, so a selector naming
-# only the labels two workloads share silently selects both. That is not a
-# cosmetic overlap: the CDR Service and the admin console both expose a port
-# named `http`, so `targetPort: http` resolved to the console's 3000 and a share
-# of openEHR API requests were answered by the console; the PDB counted the
-# console toward the server's budget and would have let a drain evict every
-# server replica at once. Key sets alone cannot catch this — after the fix both
-# Deployments have the SAME selector keys and differ only in the name's value.
-for d in docs:
-    if d.get("kind") not in ("Service", "PodDisruptionBudget"):
-        continue
-    sel = d["spec"].get("selector") or {}
-    sel = sel.get("matchLabels", sel)
-    if not sel:
-        continue
-    hit = [n for n, lbl in pod_labels.items()
-           if all(lbl.get(k) == v for k, v in sel.items())]
-    if len(hit) > 1:
-        bad.append(f"  {d['kind']}/{d['metadata']['name']}: selector {sel} matches {sorted(hit)}"
-                   f" — a subset match selects BOTH workloads; give each its own"
-                   f" app.kubernetes.io/name rather than a shared name plus a component")
-for b in bad:
-    print(b)
-sys.exit(1 if bad else 0)
-PYSEL
+  gate_jq "$file" selector.jq || { red "  selector immutability gate FAILED for ${file}"; exit 1; }
   echo "  selector.matchLabels unchanged, and no selector matches two workloads"
 }
 
@@ -193,101 +166,7 @@ PYSEL
 # place it can be caught before a cluster refuses the pod.
 assert_security() {
   local file="$1"
-  python3 - "$file" <<'PYGATE' || { red "  restricted-profile gate FAILED for ${file}"; exit 1; }
-import sys, yaml
-
-ALLOWED_VOLUMES = {
-    "configMap", "csi", "downwardAPI", "emptyDir", "ephemeral",
-    "persistentVolumeClaim", "projected", "secret",
-}
-bad = []
-# Pod-level ISOLATION, recorded per workload rather than asserted per workload.
-# These are not restricted-profile controls — the profile says nothing about
-# user namespaces — so the property that matters is not "every pod sets X", it
-# is that every pod of one release agrees. A release whose console shares the
-# host user namespace while its server does not has a posture nobody can state,
-# and that is the exact shape of the defect this chart already shipped once,
-# where a second workload quietly lost a hardening the first one had.
-isolation = {}
-
-def check_pod(kind, name, spec):
-    pod = spec.get("securityContext") or {}
-    isolation[f"{kind}/{name}"] = (
-        spec.get("hostUsers", True),
-        pod.get("supplementalGroupsPolicy"),
-    )
-    if pod.get("runAsNonRoot") is not True:
-        bad.append(f"{kind}/{name}: pod runAsNonRoot must be true")
-    if (pod.get("seccompProfile") or {}).get("type") not in ("RuntimeDefault", "Localhost"):
-        bad.append(f"{kind}/{name}: pod seccompProfile.type must be RuntimeDefault or Localhost")
-    # The kubelet's per-Service link variables land in the reserved FERROEHR_
-    # namespace and the strict env sweep then refuses to boot, so losing this
-    # makes every install crash-loop. Not a profile control; checked here
-    # because this is where pod specs are inspected.
-    if spec.get("enableServiceLinks") is not False:
-        bad.append(f"{kind}/{name}: enableServiceLinks must be false")
-    for v in spec.get("volumes") or []:
-        used = [k for k in v if k != "name"]
-        for t in used:
-            if t not in ALLOWED_VOLUMES:
-                bad.append(f"{kind}/{name}: volume {v.get('name')} type {t} is outside the restricted set")
-    for c in (spec.get("containers") or []) + (spec.get("initContainers") or []):
-        sc = c.get("securityContext") or {}
-        cn = c.get("name")
-        if sc.get("allowPrivilegeEscalation") is not False:
-            bad.append(f"{kind}/{name}/{cn}: allowPrivilegeEscalation must be false")
-        if sc.get("runAsNonRoot") is not True and pod.get("runAsNonRoot") is not True:
-            bad.append(f"{kind}/{name}/{cn}: runAsNonRoot must be true")
-        if sc.get("readOnlyRootFilesystem") is not True:
-            bad.append(f"{kind}/{name}/{cn}: readOnlyRootFilesystem must be true")
-        caps = sc.get("capabilities") or {}
-        if "ALL" not in (caps.get("drop") or []):
-            bad.append(f"{kind}/{name}/{cn}: capabilities.drop must include ALL")
-        if caps.get("add"):
-            bad.append(f"{kind}/{name}/{cn}: capabilities.add must be empty, got {caps['add']}")
-
-pods = 0
-netpol = False
-spread = []
-for doc in yaml.safe_load_all(open(sys.argv[1])):
-    if not doc:
-        continue
-    kind = doc.get("kind")
-    if kind == "NetworkPolicy":
-        netpol = True
-    tmpl = (doc.get("spec") or {}).get("template")
-    if kind in ("Deployment", "StatefulSet", "DaemonSet", "Job") and tmpl:
-        pods += 1
-        check_pod(kind, (doc.get("metadata") or {}).get("name"), tmpl.get("spec") or {})
-    # Availability, not security: a Deployment asking for more than one replica
-    # with nothing telling the scheduler to spread them can put every replica on
-    # one node, so one node failure is a total outage. A Job is exempt (it runs
-    # once) and so is a single-replica Deployment (there is nothing to spread).
-    #
-    # An ABSENT `replicas` counts as multi-replica, and that is the whole
-    # subtlety: the chart omits the field when autoscaling is on, so reading it
-    # as the API default of 1 exempted precisely the elastic workload that most
-    # needs spreading. Written the naive way first, and caught by mutation.
-    replicas = (doc.get("spec") or {}).get("replicas")
-    if kind == "Deployment" and tmpl and (replicas is None or replicas > 1):
-        if not ((tmpl.get("spec") or {}).get("topologySpreadConstraints") or
-                (tmpl.get("spec") or {}).get("affinity")):
-            spread.append((doc.get("metadata") or {}).get("name"))
-
-if pods == 0:
-    bad.append("no pod-bearing workload found — the gate would pass vacuously")
-if not netpol:
-    bad.append("no NetworkPolicy in the render")
-for name in spread:
-    bad.append(f"Deployment/{name}: multi-replica with neither topologySpreadConstraints nor affinity — every replica may land on one node")
-if len(set(isolation.values())) > 1:
-    bad.append("pod isolation differs across workloads of one release: "
-               + ", ".join(f"{k} hostUsers={v[0]} supplementalGroupsPolicy={v[1]}"
-                           for k, v in sorted(isolation.items())))
-for b in bad:
-    print(f"  {b}")
-sys.exit(1 if bad else 0)
-PYGATE
+  gate_jq "$file" restricted.jq || { red "  restricted-profile gate FAILED for ${file}"; exit 1; }
   echo "  restricted profile satisfied by every pod in the render (per container)"
   echo "  pod isolation agrees across workloads, and every multi-replica workload spreads"
 }

--- a/scripts/checks/no-python.sh
+++ b/scripts/checks/no-python.sh
@@ -8,20 +8,18 @@
 # whole script. That happened while writing scripts/render/zenodo-json.sh, and
 # it is the concrete reason this rule is machine-enforced rather than advisory.
 #
-# Two exemptions remain, both recorded and both tracked by #2220: the Helm
-# selector-immutability and restricted-profile gates parse multi-document YAML,
-# which bash has no native answer for. They are security gates, mutation-proven,
-# and a conversion that silently checks less would be worse than the violation —
-# so they are being converted deliberately rather than quickly. Every OTHER
-# occurrence fails this check.
+# There are no exemptions. The last two — the Helm selector-immutability and
+# restricted-profile gates — parsed multi-document YAML and were converted to
+# yq + jq under #2220, every assertion re-proven against the same mutations it
+# caught before.
 #
 # Usage: scripts/checks/no-python.sh
 set -euo pipefail
 cd "$(dirname "$0")/../.." || exit 1
 
-# The exempt files, by path. Adding to this list requires the owner; removing
-# from it is the goal.
-EXEMPT='^deploy/helm/validate\.sh$'
+# No file is exempt. If one ever has to be, it goes here WITH its tracking
+# issue — never as a quiet omission from ROOTS below.
+EXEMPT='^$'
 
 # Where shell and CI live. Deliberately not the whole tree: a Python file
 # inside a vendored corpus is upstream material, not ours to rewrite.


### PR DESCRIPTION
Closes #2220. These were the **only** exemptions the Python ban carried; it now has none.

Both gates parsed multi-document YAML, which bash has no native answer for — a real constraint, not laziness. Both are also security gates:

- **selector** — stops an **immutable** `selector.matchLabels` changing under an existing release, and catches a subset-match selecting two workloads at once. That second one is not hypothetical: the CDR Service and the admin console both expose a port named `http`, so `targetPort: http` once resolved to the console's 3000 and answered a share of openEHR API requests, while the PDB counted the console toward the server's budget.
- **restricted** — checks the Pod Security `restricted` profile **per container**, because a substring search passes as soon as one container carries a field, so a compliant server would vouch for a non-compliant console.

They are now jq programs under `deploy/helm/gates/`, fed by `yq -o=json | jq -s`.

## The assertions are unchanged, and that was proven rather than asserted

Every assertion was re-run against the same mutation it catches today. **Twelve mutations, twelve caught, none survived:**

```
pod runAsNonRoot                 CAUGHT      capabilities.drop ALL       CAUGHT
seccompProfile                   CAUGHT      capabilities.add            CAUGHT
enableServiceLinks               CAUGHT      volume type                 CAUGHT
allowPrivilegeEscalation         CAUGHT      NetworkPolicy present       CAUGHT
readOnlyRootFilesystem           CAUGHT      no workloads (vacuous pass) CAUGHT
selector key drift               CAUGHT      selector disjointness       CAUGHT
```

Including the two the old comments singled out as easy to get wrong, and which a careless port would have quietly dropped:

- **an ABSENT `replicas` counts as multi-replica** — the chart omits the field when autoscaling is on, so reading it as the API default of `1` exempts precisely the elastic workload that most needs spreading. Caught by mutation the first time it was written naively; caught again here.
- **pod isolation must AGREE across workloads of one release** — not "every pod sets X", because `hostUsers`/`supplementalGroupsPolicy` are not restricted-profile controls. A release whose console shares the host user namespace while its server does not has a posture nobody can state.

## The dependency, and why it is pinned the way it is

`yq` is installed in the two lanes that run the gates (`helm-golden`, `publish-chart`), pinned by version and **verified by SHA-256**. That check matters more here than usual: the install runs *before* the security gates, so a substituted binary would be deciding whether they pass.

The checksum came from the release's published `checksums` file **and was then confirmed by downloading the binary and hashing it** — a published checksum copied on trust proves only that the file matches itself.

## Verification

- `bash deploy/helm/validate.sh` — all render checks pass across all four golden cases
- `scripts/checks/no-python.sh` — clean, with the exemption list now empty, and still catching a newly introduced violation
- `zizmor --min-severity=low` on both touched workflows — no findings