### PR TITLE
feat(deploy): the chart listing had no logo, and its annotation set could drift unnoticed

### DIFF
--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -67,6 +67,21 @@ maintainers:
   - name: FerroEHR maintainers
     url: https://github.com/rubentalstra/FerroEHR
 
+# The listing logo. Artifact Hub reads `icon` from Chart.yaml, not from an
+# annotation, and a chart without one is rendered with a generic placeholder
+# beside charts that have theirs.
+#
+# Served from our own site rather than raw.githubusercontent.com: a raw URL
+# carries a branch name in the path, is rate-limited, and is not meant to be a
+# CDN. It reuses the existing published mark instead of copying a second brand
+# file into the tree — the mark is already square (64x64), which is the shape a
+# listing avatar wants.
+#
+# The IRON variant, which is the dark tile (#21262B) rather than the rust one —
+# the brand's own note is that iron is for surfaces where the rust tile is too
+# loud, and a package listing sitting in a grid of other charts is one of them.
+icon: https://ferroehr.eu/assets/logo-mark-dark.svg
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Artifact Hub display metadata (https://artifacthub.io/docs/topics/annotations/helm/).
 #

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # A published OCI version is immutable by refusal rather than by the registry —
 # `helm push` over an existing tag replaces it silently — so a correction always
 # ships as a NEW version and the published one stands as it was.
-version: 6.0.0
+version: 6.0.1
 # The default container image tag (overridable via image.tag), and the released
 # application version — kept equal to the workspace version by the
 # `chart-appversion` CI guard, so a release cannot ship a chart pointing at the

--- a/deploy/helm/golden/admin-ui.yaml
+++ b/deploy/helm/golden/admin-ui.yaml
@@ -5,7 +5,7 @@ kind: NetworkPolicy
 metadata:
   name: ferroehr-admin-ui
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -69,7 +69,7 @@ metadata:
     kubernetes.io/description: >-
       Default-deny ingress for the CDR: only the API port (and the management port when enabled) is admitted. An empty ingressFrom admits every source — narrow it for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -97,7 +97,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -118,7 +118,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr-admin-ui
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -133,7 +133,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -163,7 +163,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -180,7 +180,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -311,7 +311,7 @@ metadata:
     kubernetes.io/description: >-
       In-cluster address for the FerroEHR admin console. The console is a REST client of the CDR and holds no data of its own; it is the human-facing surface, so this is the Service an Ingress normally publishes.
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -334,7 +334,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -364,7 +364,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR admin console: a Leptos SSR web UI that consumes the CDR strictly over ITS-REST. It never reaches the database, which the console NetworkPolicy enforces rather than assumes.
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -471,7 +471,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -15,7 +15,7 @@ metadata:
     kubernetes.io/description: >-
       Default-deny ingress for the CDR: only the API port (and the management port when enabled) is admitted. An empty ingressFrom admits every source — narrow it for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -89,7 +89,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -110,7 +110,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -142,7 +142,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -168,7 +168,7 @@ kind: Secret
 metadata:
   name: ferroehr-config
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -189,7 +189,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -380,7 +380,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -414,7 +414,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -645,7 +645,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -679,7 +679,7 @@ kind: Ingress
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -717,7 +717,7 @@ kind: ServiceMonitor
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"

--- a/deploy/helm/golden/basic-auth.yaml
+++ b/deploy/helm/golden/basic-auth.yaml
@@ -15,7 +15,7 @@ metadata:
     kubernetes.io/description: >-
       Default-deny ingress for the CDR: only the API port (and the management port when enabled) is admitted. An empty ingressFrom admits every source — narrow it for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -43,7 +43,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -64,7 +64,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -94,7 +94,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -111,7 +111,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -239,7 +239,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -269,7 +269,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -15,7 +15,7 @@ metadata:
     kubernetes.io/description: >-
       Default-deny ingress for the CDR: only the API port (and the management port when enabled) is admitted. An empty ingressFrom admits every source — narrow it for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -43,7 +43,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -64,7 +64,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -79,7 +79,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -204,7 +204,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -234,7 +234,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.0
+    helm.sh/chart: ferroehr-6.0.1
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"

--- a/deploy/helm/validate.sh
+++ b/deploy/helm/validate.sh
@@ -467,6 +467,33 @@ for case in "${CASES[@]}"; do
   rm -f "$rendered"
 done
 
+# ── The Artifact Hub metadata set is DECIDED, so a change must be deliberate ──
+# Every supported annotation was adjudicated (#2206): six are set here, three are
+# injected per release by the publish lane, and the rest are declined in a
+# comment block above `annotations:` with the reason. That record is only worth
+# keeping if it cannot drift, so the set is pinned: adding an annotation without
+# recording the decision, or losing one silently, fails here.
+bold "Artifact Hub metadata is the decided set"
+expected_annotations="artifacthub.io/category
+artifacthub.io/images
+artifacthub.io/license
+artifacthub.io/links
+artifacthub.io/maintainers
+artifacthub.io/screenshots"
+actual_annotations="$(yq -r '.annotations | keys | .[]' "$CHART_DIR/Chart.yaml" | sort)"
+if [ "$actual_annotations" != "$expected_annotations" ]; then
+  red "  Artifact Hub annotation set changed — decide it on the record (#2206), then update this list"
+  diff <(printf '%s\n' "$expected_annotations") <(printf '%s\n' "$actual_annotations") || true
+  exit 1
+fi
+# The listing logo is a Chart.yaml field, not an annotation, and its absence is
+# invisible except on the published page.
+[ -n "$(yq -r '.icon // ""' "$CHART_DIR/Chart.yaml")" ] || {
+  red "  Chart.yaml has no icon — Artifact Hub renders a placeholder without one"
+  exit 1
+}
+echo "  annotations are the decided set, and the listing icon is present"
+
 # ── the chart README is GENERATED, so it is drift-checked, not reviewed ───────
 # helm-docs renders README.md from README.md.gotmpl + the `# --` comments in
 # values.yaml. A hand-edited README, or a new value documented nowhere, is drift:

--- a/website/landing/assets/logo-mark-dark.svg
+++ b/website/landing/assets/logo-mark-dark.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-label="FerroEHR icon">
+  <!-- FerroEHR icon, iron-tile variant: for contexts where the rust tile is too loud.
+     Text is outlined Inter SemiBold (SIL OFL 1.1). -->
+  <rect x="2" y="2" width="60" height="60" rx="12" fill="#21262B"/>
+  <path transform="translate(14.80 44.00)" d="M2.20 0.00V-21.83H16.17V-18.53H6.11V-11.98H15.19V-8.73H6.11V0.00Z M25.93 0.34Q23.45 0.34 21.67 -0.70Q19.89 -1.74 18.93 -3.63Q17.97 -5.52 17.97 -8.09Q17.97 -10.61 18.92 -12.52Q19.86 -14.43 21.60 -15.51Q23.33 -16.58 25.68 -16.58Q27.67 -16.58 29.38 -15.71Q31.08 -14.84 32.12 -13.02Q33.16 -11.19 33.16 -8.32V-7.12H21.77Q21.84 -4.94 22.99 -3.79Q24.14 -2.65 25.97 -2.65Q27.23 -2.65 28.13 -3.19Q29.03 -3.74 29.41 -4.78L32.92 -4.06Q32.33 -2.08 30.49 -0.87Q28.65 0.34 25.93 0.34ZM21.78 -9.71H29.46Q29.28 -11.47 28.34 -12.53Q27.39 -13.59 25.69 -13.59Q23.95 -13.59 22.93 -12.47Q21.91 -11.35 21.78 -9.71Z" fill="#F2F1EF"/>
+  <polyline points="12,15 17,15 20,9 23,19 26,13 29,15 36,15" fill="none" stroke="#D97742" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
Closes #2206.

The audit the issue asked for was largely already on the record: six annotations set in `Chart.yaml`, three injected per release by the publish lane from `CHANGELOG.md` and the tag, and the rest **declined in a comment block with the reason** — not an operator, no CRDs, no PGP `.prov` for `signKey` (the chart is signed keyless with cosign, and that annotation's mandatory `url` would have to point at a public key that does not exist).

What that record lacked was any way to stay true. An annotation added without a decision, or lost in an edit, changed nothing a check could see — which is how a carefully adjudicated list quietly becomes a stale one.

## The set is pinned

Adding or losing an annotation now fails the chart gate with a diff and a pointer back to the decision record. Mutation-proven: adding `artifacthub.io/operator: "true"` fails it.

## The listing had no logo at all

`icon` is a `Chart.yaml` field, not an annotation, so it slipped past an annotation-shaped audit entirely. Its absence is invisible everywhere except on the published page, where the chart renders with a generic placeholder beside charts that have one. Checked separately, and mutation-proven by deleting it.

**Served from our own site**, not `raw.githubusercontent.com`: a raw URL carries a branch name in its path, is rate-limited, and is not intended as a CDN.

**The iron variant** — the dark `#21262B` tile, not the rust one. The names cross wires (iron *is* the dark one; `ferroehr-icon.svg` and the published `logo-mark.svg` are the rust `#B7431B` one), so worth stating: this is the dark tile. It follows the brand's own note that iron is for surfaces where the rust tile is too loud, and a package listing sitting in a grid of other charts is exactly that.

## Verification

- `bash deploy/helm/validate.sh` — green across all four golden cases
- both new assertions mutation-proven, in the failing direction
- the icon URL confirmed live (`200`) before pinning it