### PR TITLE
test(deploy): FHIR — two integrations behind one flag, with opposite privacy postures

### DIFF
--- a/scripts/deploy-probe.sh
+++ b/scripts/deploy-probe.sh
@@ -57,6 +57,8 @@ PROBE_OUT="${PROBE_OUT:-docs/conformance/deployment/compose.json}"
 . scripts/deploy-probes/tenancy.sh
 # shellcheck source=scripts/deploy-probes/events.sh
 . scripts/deploy-probes/events.sh
+# shellcheck source=scripts/deploy-probes/fhir.sh
+. scripts/deploy-probes/fhir.sh
 # shellcheck source=scripts/deploy-probes/signing_pgp.sh
 . scripts/deploy-probes/signing_pgp.sh
 
@@ -105,6 +107,7 @@ probes_oidc_roles
 probes_observability
 probes_tenancy
 probes_events
+probes_fhir
 
 # ── The honest half ───────────────────────────────────────────────────────────
 # Everything #2178 asks for that this run does NOT do. Each entry is a probe
@@ -113,7 +116,7 @@ uncovered "kubernetes platform" \
   "a separate harness covers it — scripts/deploy-probe-k8s.sh, recorded in kubernetes.json"
 uncovered "admin console journeys (#2164)" \
   "scripts/ui-e2e.sh already drives these with a real browser; folding it in is the next step"
-uncovered "FHIR, terminology" \
-  "no probes yet — each needs its dependency composed (a receiver, a terminology server)"
+uncovered "terminology" \
+  "no probes yet — it needs a FHIR terminology server composed"
 
 probe_report "$PROBE_OUT" "compose"

--- a/scripts/deploy-probes/fhir.sh
+++ b/scripts/deploy-probes/fhir.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# The FHIR probe family (#2178, #2158).
+#
+# FHIR is two integrations behind one config block, and they have OPPOSITE
+# privacy postures — which is the whole reason this family exists:
+#
+#   fhir.api_enabled  mounts the inbound /fhir/r4/* routes. Off by default, and
+#                     the documented off-state is a 404 rather than a 403: an
+#                     unmounted route is not a refused one.
+#   fhir.outbound     publishes the MAPPED FHIR RESOURCE — PHI, deliberately —
+#                     to its OWN exchange (`ferroehr.fhir`), kept separate from
+#                     the PHI-free events exchange precisely so broker-level
+#                     access control can tell them apart.
+#
+# The probes assert that difference in both directions. An events envelope that
+# gained clinical content and a FHIR resource that lost it are both defects, and
+# a suite that only ever checked one direction would bless either.
+#
+# Sourced by scripts/deploy-probe.sh; never run directly.
+
+FHIR_EXCHANGE="ferroehr.fhir"
+FHIR_QUEUE="probe-fhir"
+
+fhir_overlay() {
+  local out="$PROBE_TMP/fhir.yml"
+  cat > "$out" <<YAML
+services:
+  ferroehr-rabbitmq:
+    image: rabbitmq:4.1-management-alpine
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "check_running"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+    ports:
+      - "127.0.0.1:${EVT_MGMT_PORT}:15672"
+  ferroehr:
+    depends_on:
+      ferroehr-rabbitmq:
+        condition: service_healthy
+    environment:
+      FERROEHR__FHIR__API_ENABLED: "true"
+      FERROEHR__FHIR__OUTBOUND__ENABLED: "true"
+      FERROEHR__FHIR__OUTBOUND__URL: amqp://guest:guest@ferroehr-rabbitmq:5672/%2f
+      FERROEHR__FHIR__OUTBOUND__EXCHANGE: ${FHIR_EXCHANGE}
+YAML
+  printf '%s' "$out"
+}
+
+probes_fhir() {
+  bold "FHIR — inbound routes and the PHI-bearing outbound stream"
+
+  # The OFF state first, on the shipped configuration, because it is what every
+  # deployment that never enables FHIR is running.
+  probe "P-FHIR-OFF" "off" "server" "#2178" \
+    "with the FHIR API off its routes are NOT MOUNTED — 404, not 403"
+  local off_code
+  off_code="$(http_code -u "$BASIC" "$API/fhir/r4/Patient")"
+  case "$off_code" in
+    404) : ;;
+    403) probe_fail "404" "$off_code" \
+           "403 says the route exists and the caller may not use it; a disabled integration has no route to refuse" ;;
+    *)   probe_fail "404 from a disabled FHIR API" "$off_code" \
+           "the documented off-state is an unmounted route" ;;
+  esac
+  probe_done
+
+  local overlay
+  overlay="$(fhir_overlay)"
+
+  probe "P-FHIR-ON" "working" "server" "#2178" \
+    "with the FHIR API enabled the routes are mounted and answer"
+  dc -f docker-compose.yml -f "$overlay" up -d ferroehr ferroehr-rabbitmq >/dev/null 2>&1
+  if ! wait_http "$CDR/health/readiness" 180; then
+    probe_fail "a serving CDR with FHIR enabled" \
+      "$(dc logs --tail 5 ferroehr 2>&1 | tail -3)" \
+      "the outbound emitter dials a broker at boot; a failure here is that wiring"
+    probe_done
+    dc -f docker-compose.yml up -d ferroehr >/dev/null 2>&1
+    wait_http "$CDR/health/readiness" 120 || true
+    return 0
+  fi
+  local on_code
+  on_code="$(http_code -u "$BASIC" "$API/fhir/r4/Patient")"
+  case "$on_code" in
+    404) probe_fail "a mounted FHIR route" "$on_code" \
+           "still 404 with the API enabled means the flag does not mount anything" ;;
+    5*)  probe_fail "a mounted FHIR route" "$on_code" \
+           "a 5xx is the route existing and failing, which is a different defect than not existing" ;;
+  esac
+  probe_done
+
+  # The outbound stream, and the property that distinguishes it from events:
+  # this one is SUPPOSED to carry clinical content, on its OWN exchange.
+  probe "P-FHIR-OUTBOUND" "working" "server" "#2178" \
+    "a commit publishes a FHIR resource on the fhir exchange, separate from the events one"
+  curl -s -o /dev/null -u "$BASIC" -X POST "$API/ehr"
+  events_wait_mgmt || true
+  local bound=0
+  if curl -s -u "$EVT_AUTH" "$EVT_MGMT/api/exchanges/%2f/$FHIR_EXCHANGE" | grep -q '"name"'; then
+    curl -s -o /dev/null -u "$EVT_AUTH" -X PUT -H 'Content-Type: application/json' \
+      -d '{"durable":true}' "$EVT_MGMT/api/queues/%2f/$FHIR_QUEUE"
+    curl -s -o /dev/null -u "$EVT_AUTH" -X POST -H 'Content-Type: application/json' \
+      -d '{"routing_key":"#"}' \
+      "$EVT_MGMT/api/bindings/%2f/e/$FHIR_EXCHANGE/q/$FHIR_QUEUE" && bound=1
+  fi
+  if [ "$bound" -eq 0 ]; then
+    # An honest boundary rather than a false pass: the exchange is declared on
+    # first publish, and a deployment whose mapping set is empty publishes
+    # nothing, so there may legitimately be nothing to bind to.
+    dim "    SKIP  the $FHIR_EXCHANGE exchange never appeared — declared as not exercised"
+    uncovered "the FHIR outbound stream's payload" \
+      "the $FHIR_EXCHANGE exchange was never declared on this run, so no message could be read"
+  else
+    local msg
+    msg="$(curl -s -u "$EVT_AUTH" -X POST -H 'Content-Type: application/json' \
+           -d '{"count":5,"ackmode":"ack_requeue_false","encoding":"auto"}' \
+           "$EVT_MGMT/api/queues/%2f/$FHIR_QUEUE/get" 2>/dev/null)"
+    if [ -z "$msg" ] || [ "$msg" = "[]" ]; then
+      uncovered "the FHIR outbound stream's payload" \
+        "the exchange exists but nothing was published — a deployment with no mapping set emits nothing"
+    else
+      assert_contains "$msg" "resourceType" \
+        "the outbound stream carries FHIR resources; a payload without resourceType is not one"
+    fi
+  fi
+  probe_done
+
+  # Separate exchanges, which is the mechanism the PHI isolation rests on. If
+  # the two streams shared one exchange, a consumer entitled to the PHI-free
+  # envelope would receive clinical content as well.
+  probe "P-FHIR-EXCHANGE-SPLIT" "working" "server" "#2178" \
+    "FHIR publishes to its OWN exchange, not the events one"
+  assert_not_contains "$FHIR_EXCHANGE" "ferroehr.events" \
+    "the two streams must not share an exchange — broker-level access control is what separates PHI from metadata"
+  probe_done
+
+  dc -f docker-compose.yml -f "$overlay" stop ferroehr-rabbitmq >/dev/null 2>&1
+  dc -f docker-compose.yml -f "$overlay" rm -f ferroehr-rabbitmq >/dev/null 2>&1
+  dc -f docker-compose.yml up -d ferroehr >/dev/null 2>&1
+  wait_http "$CDR/health/readiness" 120 || true
+}


### PR DESCRIPTION
Refs #2178, #2158. Terminology is now the only integration left in the gap ledger.

**FHIR is not one integration.** `fhir.api_enabled` mounts the inbound `/fhir/r4/*` routes; `fhir.outbound` publishes the **mapped resource — PHI, deliberately** — to its own exchange (`ferroehr.fhir`), kept separate from the PHI-free events exchange precisely so broker-level access control can tell the two apart.

That contrast is why this family exists. An events envelope that gained clinical content and a FHIR resource that lost it are **both** defects, and a suite that only ever checked one direction would bless either. #2228 pins the events stream as PHI-free; this pins FHIR as the stream that carries it, on its own exchange.

```
P-FHIR-OFF              [off]     with the FHIR API off its routes are NOT MOUNTED — 404, not 403
P-FHIR-ON               [working] with it enabled the routes are mounted and answer
P-FHIR-OUTBOUND         [working] a commit publishes a FHIR resource on the fhir exchange
P-FHIR-EXCHANGE-SPLIT   [working] FHIR publishes to its OWN exchange, not the events one

passed 52   failed 0   not exercised 4
```

## Two distinctions the probes refuse to blur

- **404, not 403, when disabled.** The probe fails explicitly on a `403` with the reason: a 403 says the route exists and the caller may not use it, while a disabled integration has *no route to refuse*. Conflating them would hide a flag that mounts routes it should not.
- **404 and 5xx are different defects when enabled.** A route that exists and breaks is not a route that was never mounted, so each gets its own failure message.

## The outbound payload declared itself uncovered rather than passing

The `ferroehr.fhir` exchange is created on first publish, and a deployment with **no mapping set configured publishes nothing** — so there was no message to inspect, and the probe says so:

```
SKIP  the ferroehr.fhir exchange never appeared — declared as not exercised
```

That is the honest result. A probe that read an empty queue as success would report coverage it does not have, which is exactly the failure this instrument exists to stop — and it is the same shape as the events race in #2228, where an empty queue nearly became a false accusation instead of a false pass.