### PR TITLE
fix(brand): the logo rendered tiny because every icon declared a 64-pixel intrinsic size

### DIFF
--- a/assets/brand/README.md
+++ b/assets/brand/README.md
@@ -19,6 +19,20 @@ tick in the atomic-number corner — with the **"Oxide & Iron"** palette.
 | `favicon-32.png` / `favicon-16.png` / `favicon.ico` | The raster favicon set, rendered from `favicon.svg` (48/32/16 in the `.ico`). |
 | `tokens.css` | The palette as CSS custom properties — the single source for brand colours. |
 
+## Intrinsic size
+
+Every icon declares `width`/`height` of **512** beside its `viewBox="0 0 64 64"`.
+The viewBox is what the artwork is drawn in; the attributes are what a consumer
+that RASTERIZES the file uses as its natural size.
+
+That distinction is not academic: with `width="64" height="64"` a package
+registry stores a 64-pixel bitmap and a listing header wanting several hundred
+renders it blurry or small. The artwork is vector and loses nothing at any size,
+so the cap was purely those two attributes.
+
+`favicon.svg` is deliberately excluded — a favicon genuinely wants a small
+intrinsic size.
+
 ## Palette — "Oxide & Iron"
 
 | Token | Hex | Role |

--- a/assets/brand/ferroehr-icon-iron.svg
+++ b/assets/brand/ferroehr-icon-iron.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-label="FerroEHR icon">
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 64 64" role="img" aria-label="FerroEHR icon">
   <!-- FerroEHR icon, iron-tile variant: for contexts where the rust tile is too loud.
      Text is outlined Inter SemiBold (SIL OFL 1.1). -->
   <rect x="2" y="2" width="60" height="60" rx="12" fill="#21262B"/>

--- a/assets/brand/ferroehr-icon-mono.svg
+++ b/assets/brand/ferroehr-icon-mono.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-label="FerroEHR icon, monochrome">
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 64 64" role="img" aria-label="FerroEHR icon, monochrome">
   <!-- FerroEHR monochrome icon: single-colour via currentColor.
      Text is outlined Inter SemiBold (SIL OFL 1.1). -->
   <rect x="3.5" y="3.5" width="57" height="57" rx="11" fill="none" stroke="currentColor" stroke-width="3"/>

--- a/assets/brand/ferroehr-icon.svg
+++ b/assets/brand/ferroehr-icon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-label="FerroEHR icon">
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 64 64" role="img" aria-label="FerroEHR icon">
   <!-- FerroEHR primary icon: iron element tile (Fe) with heartbeat tick.
      Rust tile carries its own background, so it works on light and dark grounds.
      Text is outlined Inter SemiBold (SIL OFL 1.1) - no font dependency. -->

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # A published OCI version is immutable by refusal rather than by the registry —
 # `helm push` over an existing tag replaces it silently — so a correction always
 # ships as a NEW version and the published one stands as it was.
-version: 6.0.1
+version: 6.0.2
 # The default container image tag (overridable via image.tag), and the released
 # application version — kept equal to the workspace version by the
 # `chart-appversion` CI guard, so a release cannot ship a chart pointing at the

--- a/deploy/helm/ferroehr/README.md
+++ b/deploy/helm/ferroehr/README.md
@@ -2,7 +2,7 @@
 
 Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.1.0 + AQL 1.1). A single static binary deployed with a hardened-by-default security posture: runs as a non-root, read-only-rootfs, default-deny-ingress workload that connects to an EXTERNAL PostgreSQL 18 as an unprivileged app role (migrations are run out of band by a separate migrator role).
 
-![Version: 6.0.0](https://img.shields.io/badge/Version-6.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.17.3](https://img.shields.io/badge/AppVersion-3.17.3-informational?style=flat-square)
+![Version: 6.0.2](https://img.shields.io/badge/Version-6.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.17.3](https://img.shields.io/badge/AppVersion-3.17.3-informational?style=flat-square)
 
 FerroEHR is a pure-Rust openEHR Clinical Data Repository: ITS-REST 1.1.0 at the
 API, AQL 1.1 as the query language, PostgreSQL 18-native storage, shipped as a
@@ -33,7 +33,7 @@ add — `helm repo add` does not apply to this chart and never will:
 
 ```console
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 6.0.0 \
+  --version 6.0.2 \
   --namespace ferroehr --create-namespace \
   --set database.existingSecret=ferroehr-db \
   --set image.tag=3.17.3
@@ -47,7 +47,7 @@ They are independent SemVer lines and they move independently:
 
 | What | Set with | This release |
 |---|---|---|
-| the **chart** (templates, defaults, this document) | `--version` | `6.0.0` |
+| the **chart** (templates, defaults, this document) | `--version` | `6.0.2` |
 | the **server image** | `image.tag` | `3.17.3` |
 
 `appVersion` is the image the chart defaults to; pinning `image.tag` explicitly
@@ -59,7 +59,7 @@ The chart carries two keyless Sigstore artifacts, and they answer different
 questions. A **cosign signature** — who signed this:
 
 ```console
-cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.0 \
+cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.2 \
   --certificate-identity-regexp '^https://github\.com/rubentalstra/FerroEHR/\.github/workflows/publish-chart\.yml@' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
@@ -67,7 +67,7 @@ cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.0 \
 A **SLSA build provenance attestation** — what source it was built from, and how:
 
 ```console
-gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:6.0.0 \
+gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:6.0.2 \
   -R rubentalstra/FerroEHR
 gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:3.17.3 \
   -R rubentalstra/FerroEHR

--- a/deploy/helm/golden/admin-ui.yaml
+++ b/deploy/helm/golden/admin-ui.yaml
@@ -5,7 +5,7 @@ kind: NetworkPolicy
 metadata:
   name: ferroehr-admin-ui
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -69,7 +69,7 @@ metadata:
     kubernetes.io/description: >-
       Default-deny ingress for the CDR: only the API port (and the management port when enabled) is admitted. An empty ingressFrom admits every source — narrow it for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -97,7 +97,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -118,7 +118,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr-admin-ui
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -133,7 +133,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -163,7 +163,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -180,7 +180,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -311,7 +311,7 @@ metadata:
     kubernetes.io/description: >-
       In-cluster address for the FerroEHR admin console. The console is a REST client of the CDR and holds no data of its own; it is the human-facing surface, so this is the Service an Ingress normally publishes.
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -334,7 +334,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -364,7 +364,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR admin console: a Leptos SSR web UI that consumes the CDR strictly over ITS-REST. It never reaches the database, which the console NetworkPolicy enforces rather than assumes.
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -471,7 +471,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -15,7 +15,7 @@ metadata:
     kubernetes.io/description: >-
       Default-deny ingress for the CDR: only the API port (and the management port when enabled) is admitted. An empty ingressFrom admits every source — narrow it for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -89,7 +89,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -110,7 +110,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -142,7 +142,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -168,7 +168,7 @@ kind: Secret
 metadata:
   name: ferroehr-config
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -189,7 +189,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -380,7 +380,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -414,7 +414,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -645,7 +645,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -679,7 +679,7 @@ kind: Ingress
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -717,7 +717,7 @@ kind: ServiceMonitor
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"

--- a/deploy/helm/golden/basic-auth.yaml
+++ b/deploy/helm/golden/basic-auth.yaml
@@ -15,7 +15,7 @@ metadata:
     kubernetes.io/description: >-
       Default-deny ingress for the CDR: only the API port (and the management port when enabled) is admitted. An empty ingressFrom admits every source — narrow it for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -43,7 +43,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -64,7 +64,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -94,7 +94,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -111,7 +111,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -239,7 +239,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -269,7 +269,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -15,7 +15,7 @@ metadata:
     kubernetes.io/description: >-
       Default-deny ingress for the CDR: only the API port (and the management port when enabled) is admitted. An empty ingressFrom admits every source — narrow it for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -43,7 +43,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -64,7 +64,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -79,7 +79,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -204,7 +204,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"
@@ -234,7 +234,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.1
+    helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.3"

--- a/website/landing/assets/logo-mark-dark.svg
+++ b/website/landing/assets/logo-mark-dark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-label="FerroEHR icon">
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 64 64" role="img" aria-label="FerroEHR icon">
   <!-- FerroEHR icon, iron-tile variant: for contexts where the rust tile is too loud.
      Text is outlined Inter SemiBold (SIL OFL 1.1). -->
   <rect x="2" y="2" width="60" height="60" rx="12" fill="#21262B"/>

--- a/website/landing/assets/logo-mark.svg
+++ b/website/landing/assets/logo-mark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-label="FerroEHR icon">
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 64 64" role="img" aria-label="FerroEHR icon">
   <!-- FerroEHR primary icon: iron element tile (Fe) with heartbeat tick.
      Rust tile carries its own background, so it works on light and dark grounds.
      Text is outlined Inter SemiBold (SIL OFL 1.1) - no font dependency. -->


### PR DESCRIPTION
Refs #2232. Bumps the chart to **6.0.2** so the corrected image can be published — a bump on its own would have republished the same tiny logo.

## The cause is in the files, not the listing

Every brand icon carried fixed pixel dimensions beside its `viewBox`:

```svg
<svg width="64" height="64" viewBox="0 0 64 64" …>
```

An SVG with only a `viewBox` scales to whatever box it is given. One that **also** declares `width`/`height` has an *intrinsic size* — and any consumer that rasterizes it, which is what a package registry does when it stores and re-serves an image, gets a 64×64 bitmap. Upscaled into a listing header wanting several hundred pixels, that is either blurry or laid out small.

The artwork is vector and loses nothing at any size. Those two attributes were the entire cap.

## Raised to 512, not removed

Dropping `width`/`height` leaves a rasterizer to pick its own default (often 300px, sometimes the viewBox) — which is exactly the guess this change exists to stop making. Setting a large intrinsic size is explicit. The `viewBox` is untouched, so nothing about the drawing changes and browsers scale it as before.

`favicon.svg` is **deliberately excluded**: a favicon genuinely wants a small intrinsic size.

## Recorded so the next asset does not repeat it

`assets/brand/README.md` now states the convention and the reason, because the distinction between "the box the artwork is drawn in" and "the size a consumer thinks the file is" is not obvious from looking at the file.

## Note for verifying it

#2232 asks for the rendered listing to be checked *after* the next publish, since a cached image at Artifact Hub would otherwise look exactly like the fix not working.

The chart README is generated from `README.md.gotmpl`, so it is regenerated with the version bump rather than hand-edited, and the goldens carry the new version stamp.