### PR TITLE
chore(lints): zero re-exports becomes a compile error, not a review note

### DIFF
--- a/.claude/rules/rust-style.md
+++ b/.claude/rules/rust-style.md
@@ -142,6 +142,7 @@ that a convention with no check is labelled as such rather than assumed.
 | 3013 | no typo'd `cfg` predicates | `unexpected_cfgs` (deny) |
 | 3373 | no `impl` inside a fn body | `non_local_definitions` (deny) |
 | 3389 | lints configured in the manifest, not `#![allow]` sprinkles | the `[workspace.lints]` table IS this |
+| — | zero re-exports: every import names its defining module | `clippy::pub_use` (deny) — the generated crates' preludes carry an emitter-stamped `#![expect]` |
 | 0201 + 0236 | **an error carries its cause** (`Error::source`) | no lint exists; grep-gateable — the sweep is tracker work, see below |
 | 2294 | `if let` guards on match arms (stable 1.95.0, one release under our MSRV) | review-only — a genuine wish, labelled as one |
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,12 @@ edition = "2024"
 rust-version = "1.96"
 license = "MIT"
 repository = "https://github.com/rubentalstra/FerroEHR"
+# No `authors`, deliberately. The cargo manifest reference opens that section
+# with "Warning: This field is deprecated"
+# (https://doc.rust-lang.org/cargo/reference/manifest.html#the-authors-field),
+# and it cannot be corrected after publication. Attribution for the published
+# `openehr-*` crates is the repository link above plus CITATION.cff, which IS
+# editable and is what GitHub's citation box and the Zenodo deposit both read.
 # C-METADATA (https://rust-lang.github.io/api-guidelines/documentation.html#c-metadata):
 # members inherit via `<key>.workspace = true`; `readme` resolves from this root.
 documentation = "https://ferroehr.eu/"
@@ -25,6 +31,13 @@ keywords = ["openehr", "cdr", "healthcare", "ehr", "aql"]
 categories = ["database-implementations", "science", "web-programming::http-server"]
 
 [workspace.lints.clippy]
+# Zero re-exports (owner hard rule 2026-07-16: every import names its defining
+# module) becomes a compile error rather than a review note. It costs nothing
+# where it matters — `app/*` and `tools/*` carry no re-exports at all. The only
+# exception is the generated spec crates, where the generation preludes ARE the
+# public surface; that exception is stamped by the emitter into their `lib.rs`
+# as an `#![expect(...)]`, so it self-reports if a crate ever stops re-exporting.
+pub_use = "deny"
 # The reliability hard-rule set (.claude/rules/reliability.md, owner
 # 2026-07-17; hardened per issue #1311, owner 2026-07-30): deny-tier = fails
 # every local clippy; warn-tier still fails CI (-D warnings). Tests keep the

--- a/crates/openehr-am/src/lib.rs
+++ b/crates/openehr-am/src/lib.rs
@@ -17,6 +17,11 @@
     clippy::enum_variant_names,
     reason = "inherent to faithful openEHR spec generation: verbatim spec prose in doc comments, and spec-owned class/variant/field names (a field name IS the normative BMM attribute name)"
 )]
+// The generation preludes ARE this crate's public surface: the crate prelude re-exports the current generation, and each generation module re-exports its own types. That is the design (codegen.md), and it is the one place `clippy::pub_use` is satisfied by an exception rather than by removal. `expect` rather than `allow`: if a crate ever stops re-exporting, the exception self-reports instead of outliving its reason.
+#![expect(
+    clippy::pub_use,
+    reason = "the generation preludes are this crate's public surface"
+)]
 // A vendored BMM model is a deep, mutually-recursive type graph (the LANG // BMM-3 expression/statement families reach several hundred levels), so // auto-trait inference — `Send`/`Sync`/`RefUnwindSafe`, which rustdoc // evaluates for every item — overflows the default limit of 128. Raising // the limit is exactly what rustc prescribes for that overflow // (<https://doc.rust-lang.org/reference/attributes/limits.html>); it // changes no emitted type.
 #![recursion_limit = "512"]
 

--- a/crates/openehr-base/src/lib.rs
+++ b/crates/openehr-base/src/lib.rs
@@ -17,6 +17,11 @@
     clippy::enum_variant_names,
     reason = "inherent to faithful openEHR spec generation: verbatim spec prose in doc comments, and spec-owned class/variant/field names (a field name IS the normative BMM attribute name)"
 )]
+// The generation preludes ARE this crate's public surface: the crate prelude re-exports the current generation, and each generation module re-exports its own types. That is the design (codegen.md), and it is the one place `clippy::pub_use` is satisfied by an exception rather than by removal. `expect` rather than `allow`: if a crate ever stops re-exporting, the exception self-reports instead of outliving its reason.
+#![expect(
+    clippy::pub_use,
+    reason = "the generation preludes are this crate's public surface"
+)]
 // A vendored BMM model is a deep, mutually-recursive type graph (the LANG // BMM-3 expression/statement families reach several hundred levels), so // auto-trait inference — `Send`/`Sync`/`RefUnwindSafe`, which rustdoc // evaluates for every item — overflows the default limit of 128. Raising // the limit is exactly what rustc prescribes for that overflow // (<https://doc.rust-lang.org/reference/attributes/limits.html>); it // changes no emitted type.
 #![recursion_limit = "512"]
 

--- a/crates/openehr-lang/src/lib.rs
+++ b/crates/openehr-lang/src/lib.rs
@@ -17,6 +17,11 @@
     clippy::enum_variant_names,
     reason = "inherent to faithful openEHR spec generation: verbatim spec prose in doc comments, and spec-owned class/variant/field names (a field name IS the normative BMM attribute name)"
 )]
+// The generation preludes ARE this crate's public surface: the crate prelude re-exports the current generation, and each generation module re-exports its own types. That is the design (codegen.md), and it is the one place `clippy::pub_use` is satisfied by an exception rather than by removal. `expect` rather than `allow`: if a crate ever stops re-exporting, the exception self-reports instead of outliving its reason.
+#![expect(
+    clippy::pub_use,
+    reason = "the generation preludes are this crate's public surface"
+)]
 // A vendored BMM model is a deep, mutually-recursive type graph (the LANG // BMM-3 expression/statement families reach several hundred levels), so // auto-trait inference — `Send`/`Sync`/`RefUnwindSafe`, which rustdoc // evaluates for every item — overflows the default limit of 128. Raising // the limit is exactly what rustc prescribes for that overflow // (<https://doc.rust-lang.org/reference/attributes/limits.html>); it // changes no emitted type.
 #![recursion_limit = "512"]
 

--- a/crates/openehr-rm/src/lib.rs
+++ b/crates/openehr-rm/src/lib.rs
@@ -17,6 +17,11 @@
     clippy::enum_variant_names,
     reason = "inherent to faithful openEHR spec generation: verbatim spec prose in doc comments, and spec-owned class/variant/field names (a field name IS the normative BMM attribute name)"
 )]
+// The generation preludes ARE this crate's public surface: the crate prelude re-exports the current generation, and each generation module re-exports its own types. That is the design (codegen.md), and it is the one place `clippy::pub_use` is satisfied by an exception rather than by removal. `expect` rather than `allow`: if a crate ever stops re-exporting, the exception self-reports instead of outliving its reason.
+#![expect(
+    clippy::pub_use,
+    reason = "the generation preludes are this crate's public surface"
+)]
 // A vendored BMM model is a deep, mutually-recursive type graph (the LANG // BMM-3 expression/statement families reach several hundred levels), so // auto-trait inference — `Send`/`Sync`/`RefUnwindSafe`, which rustdoc // evaluates for every item — overflows the default limit of 128. Raising // the limit is exactly what rustc prescribes for that overflow // (<https://doc.rust-lang.org/reference/attributes/limits.html>); it // changes no emitted type.
 #![recursion_limit = "512"]
 

--- a/crates/openehr-term/src/lib.rs
+++ b/crates/openehr-term/src/lib.rs
@@ -17,6 +17,11 @@
     clippy::enum_variant_names,
     reason = "inherent to faithful openEHR spec generation: verbatim spec prose in doc comments, and spec-owned class/variant/field names (a field name IS the normative BMM attribute name)"
 )]
+// The generation preludes ARE this crate's public surface: the crate prelude re-exports the current generation, and each generation module re-exports its own types. That is the design (codegen.md), and it is the one place `clippy::pub_use` is satisfied by an exception rather than by removal. `expect` rather than `allow`: if a crate ever stops re-exporting, the exception self-reports instead of outliving its reason.
+#![expect(
+    clippy::pub_use,
+    reason = "the generation preludes are this crate's public surface"
+)]
 // A vendored BMM model is a deep, mutually-recursive type graph (the LANG // BMM-3 expression/statement families reach several hundred levels), so // auto-trait inference — `Send`/`Sync`/`RefUnwindSafe`, which rustdoc // evaluates for every item — overflows the default limit of 128. Raising // the limit is exactly what rustc prescribes for that overflow // (<https://doc.rust-lang.org/reference/attributes/limits.html>); it // changes no emitted type.
 #![recursion_limit = "512"]
 

--- a/docs/conformance/deployment/README.md
+++ b/docs/conformance/deployment/README.md
@@ -64,6 +64,12 @@ no CI lane — a workflow that downloaded it onto a shared runner would be movin
 licensed content somewhere this project does not control. Without a package the
 family declares itself not exercised rather than substituting a fixture.
 
+**It never runs by default.** Snowstorm plus a real SNOMED import takes longer
+than every other family combined, so a plain `bash scripts/deploy-probe.sh`
+skips it and says so — even with the archive sitting in the repository root.
+It runs only when asked for, with `PROBE_ONLY=terminology` or an explicit
+`FERROEHR_SNOMED_RF2`.
+
 **The setup is: drop the archive in the repository root.** `SnomedCT_*.zip` is
 gitignored precisely so it can live there, and the probe finds it — no
 configuration:

--- a/scripts/deploy-probes/terminology.sh
+++ b/scripts/deploy-probes/terminology.sh
@@ -170,6 +170,21 @@ terminology_verify() {
 probes_terminology() {
   bold "terminology — a real FHIR terminology server with real content"
 
+  # NEVER in a default run. Snowstorm plus a real SNOMED import takes longer
+  # than every other family combined, and the archive now sits in the repository
+  # root where the discovery below would find it — so a plain
+  # `bash scripts/deploy-probe.sh` would silently turn a fifteen-minute harness
+  # into an hour. This family runs only when it is ASKED for:
+  #
+  #   PROBE_ONLY=terminology bash scripts/deploy-probe.sh
+  #
+  # or when FERROEHR_SNOMED_RF2 is set explicitly, which is itself an ask.
+  if [ "${PROBE_ONLY:-}" != "terminology" ] && [ -z "${FERROEHR_SNOMED_RF2:-}" ]; then
+    uncovered "terminology against a real server (#2178)" \
+      "opt-in: run PROBE_ONLY=terminology, because a real SNOMED import takes longer than every other family combined"
+    return 0
+  fi
+
   local zip
   if ! zip="$(terminology_release)"; then
     uncovered "terminology against a real server (#2178)" \

--- a/tools/openehr-codegen/src/render/emit.rs
+++ b/tools/openehr-codegen/src/render/emit.rs
@@ -482,6 +482,15 @@ fn emit_lib(top: &BTreeSet<String>, comp: &CrateComposition) -> GenFile {
          prose in doc comments, and spec-owned class/variant/field names (a field \
          name IS the normative BMM attribute name)\"\n\
          )]\n\
+         // The generation preludes ARE this crate's public surface: the crate \
+         prelude re-exports the current generation, and each generation module \
+         re-exports its own types. That is the design (codegen.md), and it is \
+         the one place `clippy::pub_use` is satisfied by an exception rather \
+         than by removal. `expect` rather than `allow`: if a crate ever stops \
+         re-exporting, the exception self-reports instead of outliving its \
+         reason.\n\
+         #![expect(clippy::pub_use, reason = \"the generation preludes are this \
+         crate's public surface\")]\n\
          // A vendored BMM model is a deep, mutually-recursive type graph (the LANG \
          // BMM-3 expression/statement families reach several hundred levels), so \
          // auto-trait inference — `Send`/`Sync`/`RefUnwindSafe`, which rustdoc \


### PR DESCRIPTION
Closes #2035. Unblocked by #2196, which removed the last hand-written re-exports.

## The lint costs nothing, which was checked rather than assumed

| tree | real `pub use` sites |
|---|---:|
| `app/*` (all five crates) | **0** |
| `tools/*` | **0** |
| `crates/openehr-*` | the generation preludes |

Every remaining re-export is in the generated spec crates, where the prelude **is** the public surface by design (`codegen.md`: the crate prelude re-exports the current generation).

## The exception is stamped, because it cannot be written

It belongs in a `// @generated` `lib.rs`, which must never be hand-edited — so the emitter emits it, and emits it as `#![expect(clippy::pub_use, …)]` rather than `#![allow(…)]`. If a crate ever stops re-exporting, the expectation goes unfulfilled and **self-reports**, instead of an exception quietly outliving its reason.

That meant a full regeneration across all eight emit targets, landing with the emitter change as `codegen-drift` requires.

## Proven in the failing direction

A `pub use` added to an app crate is rejected by the lint; removing it leaves the workspace clean under `-D warnings` with **zero suppressions** outside the stamped preludes.

## The `authors` field

Already absent — with nothing recording that this was a decision rather than an oversight. The manifest now says so: the cargo reference opens that section with *"Warning: This field is deprecated"*, and unlike a published crate's authors list, `CITATION.cff` and the repository link can still be corrected. That is where attribution lives, and it is what GitHub's citation box and the Zenodo deposit both read.

## Also in here

The terminology probe family is made **opt-in**, which is a defect I introduced in #2231: auto-discovering the SNOMED archive from the repository root meant a default `bash scripts/deploy-probe.sh` would find it and spend an hour importing. It now runs only when asked for (`PROBE_ONLY=terminology`, or an explicit `FERROEHR_SNOMED_RF2`), and a default run declares it not exercised with the reason — verified with the archive present.