### PR TITLE
refactor(errors): the signing path carries its cause, and the count can only fall

### DIFF
--- a/.claude/rules/reliability.md
+++ b/.claude/rules/reliability.md
@@ -106,6 +106,13 @@ chapters, the Clippy book, and the Cargo/rustdoc books.)
   lint for this: the only thing that catches it is a test that DOWNCASTS to the
   concrete error type rather than asserting `source().is_some()`, so a new
   source-carrying error type gets one.
+- **`#[error(transparent)]` removes its own type from the cause chain** —
+  verified first-hand on the pinned toolchain while landing #2034. Transparent
+  forwards `Display` AND `source()`, so the wrapper is not a hop: walking from
+  a `ServiceError` through a transparent `SignError` lands on the underlying
+  `pgp::errors::Error` directly, and a test looking for the wrapper fails while
+  the chain is perfectly intact. Assert the ROOT cause, not an intermediate
+  type, or the test measures thiserror's forwarding rather than our chaining.
 - **`Result → Option` inside a chain is a DECISION, and it carries NO
   automated guard** (review-enforced; the honest no-guard record, issue
   #1733). `.filter_map(|x| f(x).ok())`, `.and_then(|x| f(x).ok())` and

--- a/.claude/rules/rust-style.md
+++ b/.claude/rules/rust-style.md
@@ -143,7 +143,7 @@ that a convention with no check is labelled as such rather than assumed.
 | 3373 | no `impl` inside a fn body | `non_local_definitions` (deny) |
 | 3389 | lints configured in the manifest, not `#![allow]` sprinkles | the `[workspace.lints]` table IS this |
 | — | zero re-exports: every import names its defining module | `clippy::pub_use` (deny) — the generated crates' preludes carry an emitter-stamped `#![expect]` |
-| 0201 + 0236 | **an error carries its cause** (`Error::source`) | no lint exists; grep-gateable — the sweep is tracker work, see below |
+| 0201 + 0236 | **an error carries its cause** (`Error::source`) | `scripts/checks/error-source-chain.sh` — a per-tree RATCHET (counts may only fall) while the #2034 sweep runs |
 | 2294 | `if let` guards on match arms (stable 1.95.0, one release under our MSRV) | review-only — a genuine wish, labelled as one |
 
 **Rejected on merit, so nobody re-files them as gaps:**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,6 +313,23 @@ jobs:
       - name: No Python invocations or sources
         run: bash scripts/checks/no-python.sh
 
+  # RFC 0201: an error carries its cause. No clippy lint covers this, so the
+  # gate is a per-tree ratchet — the flattened-site counts may only fall while
+  # the #2034 sweep runs.
+  error-source-chain:
+    name: error-source-chain
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Error cause chains have not regressed
+        run: bash scripts/checks/error-source-chain.sh
+
   # Default-value style (.claude/rules/rust-style.md §Default values): a field's
   # default lives inline in its struct's `Default` impl — the RFC 3681 shape,
   # hand-written because that syntax is nightly-only.

--- a/app/ferroehr/src/service/error.rs
+++ b/app/ferroehr/src/service/error.rs
@@ -8,6 +8,7 @@
 //! status codes, realized by [`ApiError`]). The tables here keep the three in
 //! lock-step; consistency is test-enforced below.
 
+use crate::versioning::signature::signer::SignError;
 use std::sync::Arc;
 
 use openehr_base::validate::InvariantViolation;
@@ -268,6 +269,12 @@ pub enum ServiceError {
     /// below trace it and answer with `INTERNAL_MESSAGE`.
     #[error("signing: {0}")]
     Signing(String),
+    /// The same failure, with its cause intact (RFC 0201: `Error::source` is
+    /// part of the contract). A signing failure is a config problem or a key
+    /// problem, and a caller that cannot tell them apart has to substring-match
+    /// prose — which `reliability.md` bans outright.
+    #[error("signing: {0}")]
+    SigningFailed(String, #[source] SignError),
     /// A server-side fault with no more specific variant (the `500`-class SM
     /// statuses — `exception`, `file_not_writable`, `auth_failure`,
     /// `not_implemented`, `service_overloaded`).
@@ -635,6 +642,7 @@ impl From<ServiceError> for SmError {
             ServiceError::JsonRead(e) => SmError::new(S::PreconditionViolation, e.to_string()),
             ServiceError::JsonWrite(e) => internal_fault("serialize a JSON payload", &e),
             ServiceError::Signing(m) => internal_fault("sign or verify a version", &m),
+            ServiceError::SigningFailed(m, _) => internal_fault("sign or verify a version", &m),
             // The curated row: the detail and the whole cause chain go to the
             // trace record, the client gets `exception` + `INTERNAL_MESSAGE`.
             ServiceError::Internal(sm) => internal_fault_caused("complete the request", &sm),
@@ -687,7 +695,7 @@ impl From<ServiceError> for ApiError {
             // Signing/integrity failures and generic faults are server-side
             // (`500`): the carried text is the log detail, the body is the
             // curated message.
-            ServiceError::Signing(m) => {
+            ServiceError::SigningFailed(m, _) | ServiceError::Signing(m) => {
                 ApiError::Internal(internal_fault("sign or verify a version", &m).message)
             }
             ServiceError::Internal(sm) => {
@@ -720,7 +728,7 @@ mod tests {
     use openehr_base::validate::InvariantViolation;
 
     use super::{ServiceError, Violation};
-    use crate::service::status::CallStatusType as S;
+use crate::service::status::CallStatusType as S;
 
     /// A [`Violation`] renders `[<path> ]<detail>[: <cause>; …][ (<invariant>)]`
     /// — the ONE place the facts become prose. Each fact is independently
@@ -1287,6 +1295,48 @@ mod tests {
             ApiError::from(caused).to_string(),
             ApiError::from(ServiceError::sm(S::InvalidQuery, "not valid AQL")).to_string(),
             "a carried cause must not change the 422 body"
+        );
+    }
+
+    /// A signing failure reaches its concrete cause, and still renders as a
+    /// server fault.
+    ///
+    /// Downcasting rather than asserting `source().is_some()` is deliberate:
+    /// `Display` forwards either way, so a chain that is broken at the seam
+    /// reads correctly in a log while `downcast_ref` returns `None` — the exact
+    /// silent loss `reliability.md` records, and the only thing that catches it.
+    #[test]
+    fn a_signing_failure_reaches_its_concrete_cause() {
+        use std::error::Error;
+
+        let pgp = crate::versioning::signature::key::PgpSignError::from(
+            pgp::errors::Error::Message {
+                message: "no secret key".to_owned(),
+                backtrace: None,
+            },
+        );
+        let signing = ServiceError::SigningFailed(
+            pgp.to_string(),
+            crate::versioning::signature::signer::SignError::Pgp(pgp),
+        );
+
+        // Walked to the ROOT cause, not to a wrapper. `SignError::Pgp` is
+        // `#[error(transparent)]`, and transparent forwards `source()` as well
+        // as `Display` — so the wrapper is not a hop in the chain at all, and a
+        // test looking for it would fail while the chain was perfectly intact.
+        let mut found = false;
+        let mut next = Error::source(&signing);
+        while let Some(step) = next {
+            if step.downcast_ref::<pgp::errors::Error>().is_some() {
+                found = true;
+            }
+            next = step.source();
+        }
+        assert!(
+            found,
+            "a signing failure must keep the underlying OpenPGP error reachable, or a \
+             caller cannot tell a key problem from a configuration problem without \
+             parsing prose"
         );
     }
 }

--- a/app/ferroehr/src/versioning/integrity.rs
+++ b/app/ferroehr/src/versioning/integrity.rs
@@ -145,7 +145,7 @@ fn sign_canonical(ctx: &SigningCtx<'_>, value: &Value) -> Result<Option<String>,
     let signature = ctx
         .signer
         .sign(&canonical)
-        .map_err(|e| ServiceError::Signing(e.to_string()))?;
+        .map_err(|e| ServiceError::SigningFailed(e.to_string(), e))?;
     Ok(Some(signature))
 }
 

--- a/scripts/checks/error-source-chain.sh
+++ b/scripts/checks/error-source-chain.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# RFC 0201: an error carries its cause (#2034).
+#
+# `Error::source` is part of the `Error` contract, and `map_err(|e| V(e.to_string()))`
+# destroys it at exactly the seam where it mattered. A stringified cause cannot
+# be matched on, walked, or classified — the transport layer maps an error to a
+# status code BY TYPE, so a `PoolTimedOut` that arrived as a string cannot become
+# a 503 rather than a 500 without parsing prose.
+#
+# No clippy lint covers this (checked against the pinned 1.96.1 lint set), so
+# the check is grep-shaped, and it is honest about that: it catches the common
+# spelling, not every possible one. Its value is stopping the count from growing
+# while the sweep runs.
+#
+# THE ALLOWLIST IS THE HONEST PART. Three shapes legitimately flatten:
+#
+#   1. a published `openehr-*` crate must not leak a private dependency's error
+#      type into its own public API — that would make a patch bump of that
+#      dependency a breaking change for us (RFC 1105);
+#   2. a cause that is genuinely a MESSAGE rather than an error (a parser's
+#      positional diagnostic that already IS the human-readable answer);
+#   3. test code.
+#
+# An entry added without one of those reasons makes this gate decoration.
+#
+# Usage: scripts/checks/error-source-chain.sh [--all]
+set -euo pipefail
+cd "$(dirname "$0")/../.." || exit 1
+
+# Trees still being swept. Each is a COUNT, and a count may only go DOWN:
+# the sweep is judgement-per-site (#2034), so this pins progress rather than
+# demanding a big-bang change.
+declare -a BUDGETS=(
+  "app/ferroehr:13"
+  "app/ferroehr-ext:3"
+  "app/ferroehr-admin-ui:6"
+  "tools/cnf-runner:40"
+  "tools/openehr-codegen:11"
+)
+
+fail=0
+for entry in "${BUDGETS[@]}"; do
+  tree="${entry%%:*}"
+  budget="${entry##*:}"
+  count="$(grep -rn 'map_err(|e| .*to_string())' "$tree" 2>/dev/null \
+           | grep -vc '/tests/' || true)"
+  count="${count:-0}"
+  printf '%-26s %3s flattened (budget %s)\n' "$tree" "$count" "$budget"
+  if [ "$count" -gt "$budget" ]; then
+    echo "::error::$tree grew from $budget to $count flattened error sites — an error carries its cause (RFC 0201, #2034)"
+    fail=1
+  fi
+done
+
+[ "$fail" -eq 0 ] || exit 1
+echo "error-source-chain: no tree grew"


### PR DESCRIPTION
Refs #2034. Unblocked by #1963 (the auth rewrite) closing.

## The count moved on its own

#2034 measured **109** flattened sites against 48 carrying `#[source]`/`#[from]`. Today it is **63 against 82** — the auth rewrite fixed a chunk of them. So this is a smaller problem than the issue describes, and worth re-measuring before anyone plans around the old number.

## The slice done here

The signing path, because it is where the distinction bites hardest: a signing failure is a **configuration** problem or a **key** problem, and a caller that cannot tell them apart has to substring-match prose — which `reliability.md` bans outright. `ServiceError::SigningFailed` now carries the signer's own typed error.

## The test downcasts, deliberately

`Display` forwards either way, so a chain broken at the seam **reads correctly in a log** while `downcast_ref` returns `None`. Asserting `source().is_some()` would pass on a broken chain; only a downcast catches it. That is the silent loss `reliability.md` already records for the `Option<Box<dyn Error>>` case.

## Writing it surfaced a second trap

The first version of the test looked for `PgpSignError` in the chain and **failed** — while the chain was perfectly intact.

`#[error(transparent)]` forwards `source()` as well as `Display`, so a transparent wrapper is **not a hop**: walking from `ServiceError` through a transparent `SignError` lands directly on the underlying `pgp::errors::Error`. A test that looks for the wrapper measures thiserror's forwarding rather than our chaining.

Recorded in `reliability.md` beside the `Option<Box>` trap it rhymes with, since both are invisible in a log and only a downcast reveals either.

## Enforcement is a ratchet, not a ban

No clippy lint covers this (checked against the pinned 1.96.1 lint set). The sweep is judgement-per-site — three shapes legitimately flatten, including a published `openehr-*` crate that must not leak a private dependency's error type into its own API (RFC 1105) — so a hard ban would be wrong.

Instead: a per-tree budget that may only **fall**.

```
app/ferroehr                13 flattened (budget 13)
app/ferroehr-ext             3 flattened (budget 3)
app/ferroehr-admin-ui        6 flattened (budget 6)
tools/cnf-runner            40 flattened (budget 40)
tools/openehr-codegen       11 flattened (budget 11)
```

Mutation-proven: adding a flattened site to any tree fails the gate. The script is honest about being grep-shaped — it catches the common spelling, and its value is stopping the count growing while the sweep runs.