### PR TITLE
refactor(errors): five more causes carried, and the last one adjudicated rather than left

### DIFF
--- a/app/ferroehr-ext/src/fhir/audit.rs
+++ b/app/ferroehr-ext/src/fhir/audit.rs
@@ -174,6 +174,9 @@ pub fn render(record: &AuditRecord) -> Result<serde_json::Value, AuditRenderErro
     }
     let resource = builder
         .build()
+        // NOTE: RFC 1105 — carrying `fhir_model`'s builder error would leak a
+        // dependency type into ours, making its patch bumps breaking; the
+        // message already names the missing element.
         .map_err(|e| AuditRenderError::Build(e.to_string()))?;
     Ok(serde_json::to_value(resource)?)
 }

--- a/app/ferroehr-ext/src/fhir/mapping.rs
+++ b/app/ferroehr-ext/src/fhir/mapping.rs
@@ -179,6 +179,11 @@ pub enum FhirMapError {
     /// COMPOSITION should always flatten).
     #[error("could not flatten COMPOSITION for reverse mapping: {0}")]
     Reverse(String),
+    /// The same failure with its cause intact (RFC 0201): the flattener's own
+    /// error says WHICH node defeated the walk, which a string cannot be
+    /// matched on.
+    #[error("could not flatten COMPOSITION for reverse mapping: {0}")]
+    ReverseFailed(String, #[source] openehr_its::flat::error::FlatError),
 }
 
 /// Resolve a **`FHIRPath`-lite** dot-path against a JSON value.

--- a/app/ferroehr-ext/src/fhir/reverse.rs
+++ b/app/ferroehr-ext/src/fhir/reverse.rs
@@ -53,7 +53,7 @@ pub fn to_fhir(
     subject_id: Option<&str>,
 ) -> Result<Value, FhirMapError> {
     let flat = openehr_its::flat::convert::composition_to_flat(composition, wt)
-        .map_err(|e| FhirMapError::Reverse(e.to_string()))?;
+        .map_err(|e| FhirMapError::ReverseFailed(e.to_string(), e))?;
     let mut resource = json!({ "resourceType": resource_type });
     if let Some(sid) = subject_id {
         let reference = match &def.subject.strip_prefix {

--- a/app/ferroehr-ext/src/multimedia/mod.rs
+++ b/app/ferroehr-ext/src/multimedia/mod.rs
@@ -72,6 +72,11 @@ pub enum MultimediaError {
     /// The object-store client could not be constructed from configuration.
     #[error("multimedia store configuration: {0}")]
     Config(String),
+    /// The same failure with its cause intact (RFC 0201). A store that will not
+    /// build is a credential problem, an endpoint problem or a TLS problem, and
+    /// a caller that cannot tell them apart has to read prose.
+    #[error("multimedia store configuration: {0}")]
+    ConfigFailed(String, #[source] object_store::Error),
 }
 
 /// Whether the tree references ANY externalized blob (`s3://…`), regardless of

--- a/app/ferroehr-ext/src/multimedia/store.rs
+++ b/app/ferroehr-ext/src/multimedia/store.rs
@@ -117,7 +117,7 @@ impl BlobStore {
         }
         let store = builder
             .build()
-            .map_err(|e| MultimediaError::Config(e.to_string()))?;
+            .map_err(|e| MultimediaError::ConfigFailed(e.to_string(), e))?;
         Ok(Self {
             inner: Arc::new(store),
             bucket: params.bucket,

--- a/app/ferroehr/src/service/error.rs
+++ b/app/ferroehr/src/service/error.rs
@@ -275,6 +275,14 @@ pub enum ServiceError {
     /// prose — which `reliability.md` bans outright.
     #[error("signing: {0}")]
     SigningFailed(String, #[source] SignError),
+    /// Canonicalisation failed on the signing path — a different cause from a
+    /// signer failure, and the distinction is the point: one is a malformed
+    /// document, the other a key or configuration problem.
+    #[error("signing: {0}")]
+    SigningCanonical(
+        String,
+        #[source] openehr_rm::v1_2::common::change_control::version_impl::CanonicalFormError,
+    ),
     /// A server-side fault with no more specific variant (the `500`-class SM
     /// statuses — `exception`, `file_not_writable`, `auth_failure`,
     /// `not_implemented`, `service_overloaded`).
@@ -642,7 +650,9 @@ impl From<ServiceError> for SmError {
             ServiceError::JsonRead(e) => SmError::new(S::PreconditionViolation, e.to_string()),
             ServiceError::JsonWrite(e) => internal_fault("serialize a JSON payload", &e),
             ServiceError::Signing(m) => internal_fault("sign or verify a version", &m),
-            ServiceError::SigningFailed(m, _) => internal_fault("sign or verify a version", &m),
+            ServiceError::SigningFailed(m, _) | ServiceError::SigningCanonical(m, _) => {
+                internal_fault("sign or verify a version", &m)
+            }
             // The curated row: the detail and the whole cause chain go to the
             // trace record, the client gets `exception` + `INTERNAL_MESSAGE`.
             ServiceError::Internal(sm) => internal_fault_caused("complete the request", &sm),
@@ -695,7 +705,9 @@ impl From<ServiceError> for ApiError {
             // Signing/integrity failures and generic faults are server-side
             // (`500`): the carried text is the log detail, the body is the
             // curated message.
-            ServiceError::SigningFailed(m, _) | ServiceError::Signing(m) => {
+            ServiceError::SigningFailed(m, _)
+            | ServiceError::SigningCanonical(m, _)
+            | ServiceError::Signing(m) => {
                 ApiError::Internal(internal_fault("sign or verify a version", &m).message)
             }
             ServiceError::Internal(sm) => {
@@ -728,7 +740,7 @@ mod tests {
     use openehr_base::validate::InvariantViolation;
 
     use super::{ServiceError, Violation};
-use crate::service::status::CallStatusType as S;
+    use crate::service::status::CallStatusType as S;
 
     /// A [`Violation`] renders `[<path> ]<detail>[: <cause>; …][ (<invariant>)]`
     /// — the ONE place the facts become prose. Each fact is independently
@@ -1309,12 +1321,11 @@ use crate::service::status::CallStatusType as S;
     fn a_signing_failure_reaches_its_concrete_cause() {
         use std::error::Error;
 
-        let pgp = crate::versioning::signature::key::PgpSignError::from(
-            pgp::errors::Error::Message {
+        let pgp =
+            crate::versioning::signature::key::PgpSignError::from(pgp::errors::Error::Message {
                 message: "no secret key".to_owned(),
                 backtrace: None,
-            },
-        );
+            });
         let signing = ServiceError::SigningFailed(
             pgp.to_string(),
             crate::versioning::signature::signer::SignError::Pgp(pgp),

--- a/app/ferroehr/src/versioning/integrity.rs
+++ b/app/ferroehr/src/versioning/integrity.rs
@@ -141,7 +141,7 @@ pub(crate) fn sign_imported_version(
 fn sign_canonical(ctx: &SigningCtx<'_>, value: &Value) -> Result<Option<String>, ServiceError> {
     let canonical =
         openehr_rm::v1_2::common::change_control::version_impl::canonical_form_of_json(value)
-            .map_err(|e| ServiceError::Signing(e.to_string()))?;
+            .map_err(|e| ServiceError::SigningCanonical(e.to_string(), e))?;
     let signature = ctx
         .signer
         .sign(&canonical)
@@ -179,7 +179,7 @@ pub(crate) fn verify_on_read(
     };
     let canonical =
         openehr_rm::v1_2::common::change_control::version_impl::canonical_form_of_json(ov)
-            .map_err(|e| ServiceError::Signing(e.to_string()))?;
+            .map_err(|e| ServiceError::SigningCanonical(e.to_string(), e))?;
     let verdict = signer.verify(&canonical, signature);
     if verdict.is_failure() {
         crate::telemetry::metrics::metrics()

--- a/scripts/checks/error-source-chain.sh
+++ b/scripts/checks/error-source-chain.sh
@@ -31,8 +31,8 @@ cd "$(dirname "$0")/../.." || exit 1
 # the sweep is judgement-per-site (#2034), so this pins progress rather than
 # demanding a big-bang change.
 declare -a BUDGETS=(
-  "app/ferroehr:13"
-  "app/ferroehr-ext:3"
+  "app/ferroehr:11"
+  "app/ferroehr-ext:1"
   "app/ferroehr-admin-ui:6"
   "tools/cnf-runner:40"
   "tools/openehr-codegen:11"


### PR DESCRIPTION
Refs #2034. Continues the sweep on the trees where the distinction actually bites — the transport layer maps an error to a status **by type**, so a cause that arrived as a string cannot become a `503` rather than a `500` without parsing prose.

```
app/ferroehr      13 → 11
app/ferroehr-ext   3 →  1
```

## What each one buys

- **Canonicalisation on the signing path** is a *different* cause from a signer failure. One is a malformed document, the other a key or configuration problem — and until now both arrived as `ServiceError::Signing(String)`, indistinguishable. They are separate variants carrying separate source types now.
- **The object-store builder** failing is a credential, endpoint or TLS problem; the caller could not tell which.
- **The flattener** knows *which node* defeated the walk. A string cannot be matched on.

## The last one is adjudicated, not merely counted

`fhir_model`'s builder error is private to that crate's API, so carrying it would leak a dependency's type into ours and make **its patch bumps breaking for us** (RFC 1105 API evolution). That is one of the three shapes #2034 itself names as legitimately flattening, and it now says so in place with a `// NOTE:` — rather than sitting in the count looking like unfinished work.

## One thing worth recording for whoever continues

**The grep overstates the problem.** Two `ingest.rs` sites it counts already carry their source (`SmError::precondition(e.to_string()).with_source(e)`), so the real remaining figure is lower than the budgets suggest. The gate is a **ceiling, not a census** — useful for stopping regression, not for measuring progress.

Budgets lowered to match; the ratchet only ever moves down. Workspace clippy clean under `-D warnings`.