### PR TITLE
refactor(errors): the request path is swept, and the rest is adjudicated rather than owed

### DIFF
--- a/app/ferroehr/src/versioning/change.rs
+++ b/app/ferroehr/src/versioning/change.rs
@@ -549,7 +549,7 @@ async fn apply_change(
                 engine
                     .offload(&mut canonical)
                     .await
-                    .map_err(|e| ServiceError::exception(e.to_string()))?;
+                    .map_err(|e| ServiceError::internal("externalize multimedia", e))?;
             }
             let lifecycle = resolve_lifecycle(lifecycle_state)?;
             // This arm commits CONTENT, so the deleted state is refused here
@@ -600,7 +600,7 @@ async fn apply_change(
                 engine
                     .offload(&mut canonical)
                     .await
-                    .map_err(|e| ServiceError::exception(e.to_string()))?;
+                    .map_err(|e| ServiceError::internal("externalize multimedia", e))?;
             }
             let lifecycle = resolve_lifecycle(lifecycle_state)?;
             // Same coupling as the create arm: a modification carries content,

--- a/scripts/checks/error-source-chain.sh
+++ b/scripts/checks/error-source-chain.sh
@@ -30,12 +30,25 @@ cd "$(dirname "$0")/../.." || exit 1
 # Trees still being swept. Each is a COUNT, and a count may only go DOWN:
 # the sweep is judgement-per-site (#2034), so this pins progress rather than
 # demanding a big-bang change.
+#
+# `tools/*` is NOT swept, and that is an adjudication rather than an omission —
+# both trees fall under the shapes #2034 itself names as legitimate:
+#
+#   tools/cnf-runner        its `Result<_, String>` IS the recorded observation.
+#                           A driver error is surfaced as an inconclusive row in
+#                           results.json naming what went wrong; the runner never
+#                           branches on the error TYPE, it reports the message.
+#                           Typing them would redesign the result model to say
+#                           the same thing.
+#   tools/openehr-codegen   every site is in testsupport.rs — test code, which
+#                           #2034 exempts outright.
+#
+# Both stay out of the budget list so the gate measures the request path, where
+# a status code is chosen BY TYPE and a flattened cause actually costs something.
 declare -a BUDGETS=(
-  "app/ferroehr:11"
+  "app/ferroehr:9"
   "app/ferroehr-ext:1"
   "app/ferroehr-admin-ui:6"
-  "tools/cnf-runner:40"
-  "tools/openehr-codegen:11"
 )
 
 fail=0


### PR DESCRIPTION
Refs #2034.

Two more causes carried — the multimedia offload on both the create and modify arms, now using `ServiceError::internal(context, source)`, a constructor that already existed and was documented for exactly this.

## The more useful outcome is the triage

I walked all 62 remaining sites first-hand. **The request path is essentially done, and the count was overstating it:**

| n | shape | disposition |
|---:|---|---|
| 2 | genuinely fixable | **fixed here** (`versioning/change.rs`) |
| 2 | **already carry their source** | `SmError::precondition(..).with_source(e)` — counted by a grep that cannot see it |
| 5 | the message **is** the answer | `dump_load` and terminology `decode` return a human-readable message the caller turns into a report entry — *their own doc comments say so*; telemetry reload returns operator-facing text |
| 1 | forced by a third party | `prometheus::Error` has only `Msg(String)` |
| 1 | needs a published-API change | `FlatError::OptParse` lives in `openehr-its`, so typing it means an **eight-crate lockstep bump for one call site** — worth doing next time those crates bump anyway, not on its own |

## The tools trees leave the budget list — as an adjudication, not an omission

- **`tools/cnf-runner` (40)** — its `Result<_, String>` **is the recorded observation**. A driver error becomes an inconclusive row in `results.json` naming what went wrong, and the runner never branches on the error *type*. Typing them would redesign the result model to say the same thing.
- **`tools/openehr-codegen` (11)** — every site is in `testsupport.rs`. #2034 exempts test code outright.

Both are #2034's own named-legitimate shapes, so carrying them as debt was misleading — the number looked like work owed when it was work already decided.

The gate now measures the **request path**, where a status code is chosen by type and a flattened cause actually costs something:

```
app/ferroehr                 9 flattened (budget 9)
app/ferroehr-ext             1 flattened (budget 1)
app/ferroehr-admin-ui        6 flattened (budget 6)
```

Clippy clean under `-D warnings`.