### PR TITLE
feat(rm): DV_MULTIMEDIA's four computed predicates, from the normative text

### DIFF
--- a/crates/openehr-rm/src/v1_1/data_types/encapsulated/dv_multimedia_impl.rs
+++ b/crates/openehr-rm/src/v1_1/data_types/encapsulated/dv_multimedia_impl.rs
@@ -21,9 +21,49 @@
 use crate::v1_1::data_types::encapsulated::dv_multimedia::DvMultimedia;
 use openehr_base::validate::{InvariantViolation, Validate};
 
+impl DvMultimedia {
+    /// Returns `true` when the data is stored in expanded form, within the EHR
+    /// itself.
+    ///
+    /// Spec: `dv_multimedia.adoc` §Functions — "Computed from the value of the
+    /// data attribute."
+    #[must_use]
+    pub const fn is_inline(&self) -> bool {
+        self.data.is_some()
+    }
+
+    /// Returns `true` when the data is stored externally to the record.
+    ///
+    /// Spec: `dv_multimedia.adoc` §Functions — "Computed from the value of the
+    /// `uri` attribute". Inline and external are not exclusive: the invariant
+    /// is `is_inline or is_external`, and a copy may be held both ways.
+    #[must_use]
+    pub const fn is_external(&self) -> bool {
+        self.uri.is_some()
+    }
+
+    /// Returns `true` when the data is stored in compressed form.
+    ///
+    /// Spec: `dv_multimedia.adoc` §Functions — "Computed from the value of the
+    /// `compression_algorithm` attribute."
+    #[must_use]
+    pub const fn is_compressed(&self) -> bool {
+        self.compression_algorithm.is_some()
+    }
+
+    /// Returns `true` when an integrity check has been computed.
+    ///
+    /// Spec: `dv_multimedia.adoc` §Functions — "Computed from the value of the
+    /// `integrity_check_algorithm` attribute."
+    #[must_use]
+    pub const fn has_integrity_check(&self) -> bool {
+        self.integrity_check_algorithm.is_some()
+    }
+}
+
 impl Validate for DvMultimedia {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
-        if self.data.is_none() && self.uri.is_none() {
+        if !self.is_inline() && !self.is_external() {
             out.push(InvariantViolation::here(
                 "Invariant Not_empty failed on type DV_MULTIMEDIA",
             ));
@@ -116,6 +156,34 @@ mod tests {
     fn zero_size_valid_per_spec() {
         let mut m = valid();
         m.size = 0;
+        assert!(m.invariants().is_empty());
+    }
+
+    /// The four §Functions predicates, each "computed from the value of" one
+    /// attribute.
+    ///
+    /// `is_inline` and `is_external` are asserted TOGETHER on one value that
+    /// carries both: the invariant is `is_inline or is_external`, an OR, so a
+    /// value held inline AND externally is valid and both must answer true.
+    /// Testing them apart would pass on an implementation that treated them as
+    /// exclusive.
+    #[test]
+    fn the_computed_predicates_follow_their_attributes() {
+        let mut m = valid();
+        assert!(m.is_inline(), "data is present");
+        assert!(!m.is_external(), "no uri is present");
+        assert!(!m.is_compressed());
+        assert!(!m.has_integrity_check());
+
+        m.uri = Some(crate::v1_1::data_types::uri::dv_uri::DvUri::DvUri(
+            crate::v1_1::data_types::uri::dv_uri::DvUriData {
+                value: "s3://bucket/key".to_owned(),
+            },
+        ));
+        assert!(
+            m.is_inline() && m.is_external(),
+            "Not_empty is an OR: a value stored both ways answers true to both"
+        );
         assert!(m.invariants().is_empty());
     }
 }

--- a/crates/openehr-rm/src/v1_2/data_types/encapsulated/dv_multimedia_impl.rs
+++ b/crates/openehr-rm/src/v1_2/data_types/encapsulated/dv_multimedia_impl.rs
@@ -21,9 +21,49 @@
 use crate::v1_2::data_types::encapsulated::dv_multimedia::DvMultimedia;
 use openehr_base::validate::{InvariantViolation, Validate};
 
+impl DvMultimedia {
+    /// Returns `true` when the data is stored in expanded form, within the EHR
+    /// itself.
+    ///
+    /// Spec: `dv_multimedia.adoc` §Functions — "Computed from the value of the
+    /// data attribute."
+    #[must_use]
+    pub const fn is_inline(&self) -> bool {
+        self.data.is_some()
+    }
+
+    /// Returns `true` when the data is stored externally to the record.
+    ///
+    /// Spec: `dv_multimedia.adoc` §Functions — "Computed from the value of the
+    /// `uri` attribute". Inline and external are not exclusive: the invariant
+    /// is `is_inline or is_external`, and a copy may be held both ways.
+    #[must_use]
+    pub const fn is_external(&self) -> bool {
+        self.uri.is_some()
+    }
+
+    /// Returns `true` when the data is stored in compressed form.
+    ///
+    /// Spec: `dv_multimedia.adoc` §Functions — "Computed from the value of the
+    /// `compression_algorithm` attribute."
+    #[must_use]
+    pub const fn is_compressed(&self) -> bool {
+        self.compression_algorithm.is_some()
+    }
+
+    /// Returns `true` when an integrity check has been computed.
+    ///
+    /// Spec: `dv_multimedia.adoc` §Functions — "Computed from the value of the
+    /// `integrity_check_algorithm` attribute."
+    #[must_use]
+    pub const fn has_integrity_check(&self) -> bool {
+        self.integrity_check_algorithm.is_some()
+    }
+}
+
 impl Validate for DvMultimedia {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
-        if self.data.is_none() && self.uri.is_none() {
+        if !self.is_inline() && !self.is_external() {
             out.push(InvariantViolation::here(
                 "Invariant Not_empty failed on type DV_MULTIMEDIA",
             ));
@@ -116,6 +156,34 @@ mod tests {
     fn zero_size_valid_per_spec() {
         let mut m = valid();
         m.size = 0;
+        assert!(m.invariants().is_empty());
+    }
+
+    /// The four §Functions predicates, each "computed from the value of" one
+    /// attribute.
+    ///
+    /// `is_inline` and `is_external` are asserted TOGETHER on one value that
+    /// carries both: the invariant is `is_inline or is_external`, an OR, so a
+    /// value held inline AND externally is valid and both must answer true.
+    /// Testing them apart would pass on an implementation that treated them as
+    /// exclusive.
+    #[test]
+    fn the_computed_predicates_follow_their_attributes() {
+        let mut m = valid();
+        assert!(m.is_inline(), "data is present");
+        assert!(!m.is_external(), "no uri is present");
+        assert!(!m.is_compressed());
+        assert!(!m.has_integrity_check());
+
+        m.uri = Some(crate::v1_2::data_types::uri::dv_uri::DvUri::DvUri(
+            crate::v1_2::data_types::uri::dv_uri::DvUriData {
+                value: "s3://bucket/key".to_owned(),
+            },
+        ));
+        assert!(
+            m.is_inline() && m.is_external(),
+            "Not_empty is an OR: a value stored both ways answers true to both"
+        );
         assert!(m.invariants().is_empty());
     }
 }

--- a/tools/openehr-codegen/templates/openehr-rm/data_types/encapsulated/dv_multimedia_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/data_types/encapsulated/dv_multimedia_impl.rs
@@ -20,9 +20,49 @@
 use crate::v1_2::data_types::encapsulated::dv_multimedia::DvMultimedia;
 use openehr_base::validate::{InvariantViolation, Validate};
 
+impl DvMultimedia {
+    /// Returns `true` when the data is stored in expanded form, within the EHR
+    /// itself.
+    ///
+    /// Spec: `dv_multimedia.adoc` §Functions — "Computed from the value of the
+    /// data attribute."
+    #[must_use]
+    pub const fn is_inline(&self) -> bool {
+        self.data.is_some()
+    }
+
+    /// Returns `true` when the data is stored externally to the record.
+    ///
+    /// Spec: `dv_multimedia.adoc` §Functions — "Computed from the value of the
+    /// `uri` attribute". Inline and external are not exclusive: the invariant
+    /// is `is_inline or is_external`, and a copy may be held both ways.
+    #[must_use]
+    pub const fn is_external(&self) -> bool {
+        self.uri.is_some()
+    }
+
+    /// Returns `true` when the data is stored in compressed form.
+    ///
+    /// Spec: `dv_multimedia.adoc` §Functions — "Computed from the value of the
+    /// `compression_algorithm` attribute."
+    #[must_use]
+    pub const fn is_compressed(&self) -> bool {
+        self.compression_algorithm.is_some()
+    }
+
+    /// Returns `true` when an integrity check has been computed.
+    ///
+    /// Spec: `dv_multimedia.adoc` §Functions — "Computed from the value of the
+    /// `integrity_check_algorithm` attribute."
+    #[must_use]
+    pub const fn has_integrity_check(&self) -> bool {
+        self.integrity_check_algorithm.is_some()
+    }
+}
+
 impl Validate for DvMultimedia {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
-        if self.data.is_none() && self.uri.is_none() {
+        if !self.is_inline() && !self.is_external() {
             out.push(InvariantViolation::here(
                 "Invariant Not_empty failed on type DV_MULTIMEDIA",
             ));
@@ -115,6 +155,34 @@ mod tests {
     fn zero_size_valid_per_spec() {
         let mut m = valid();
         m.size = 0;
+        assert!(m.invariants().is_empty());
+    }
+
+    /// The four §Functions predicates, each "computed from the value of" one
+    /// attribute.
+    ///
+    /// `is_inline` and `is_external` are asserted TOGETHER on one value that
+    /// carries both: the invariant is `is_inline or is_external`, an OR, so a
+    /// value held inline AND externally is valid and both must answer true.
+    /// Testing them apart would pass on an implementation that treated them as
+    /// exclusive.
+    #[test]
+    fn the_computed_predicates_follow_their_attributes() {
+        let mut m = valid();
+        assert!(m.is_inline(), "data is present");
+        assert!(!m.is_external(), "no uri is present");
+        assert!(!m.is_compressed());
+        assert!(!m.has_integrity_check());
+
+        m.uri = Some(crate::v1_2::data_types::uri::dv_uri::DvUri::DvUri(
+            crate::v1_2::data_types::uri::dv_uri::DvUriData {
+                value: "s3://bucket/key".to_owned(),
+            },
+        ));
+        assert!(
+            m.is_inline() && m.is_external(),
+            "Not_empty is an OR: a value stored both ways answers true to both"
+        );
         assert!(m.invariants().is_empty());
     }
 }

--- a/tools/openehr-codegen/tests/it/unrealized_bmm_functions.txt
+++ b/tools/openehr-codegen/tests/it/unrealized_bmm_functions.txt
@@ -62,10 +62,6 @@ rm/v1_1/DV_DURATION.magnitude
 rm/v1_1/DV_DURATION.multiply
 rm/v1_1/DV_DURATION.negative
 rm/v1_1/DV_DURATION.subtract
-rm/v1_1/DV_MULTIMEDIA.has_integrity_check
-rm/v1_1/DV_MULTIMEDIA.is_compressed
-rm/v1_1/DV_MULTIMEDIA.is_external
-rm/v1_1/DV_MULTIMEDIA.is_inline
 rm/v1_1/DV_ORDINAL.is_strictly_comparable_to
 rm/v1_1/DV_ORDINAL.less_than
 rm/v1_1/DV_PERIODIC_TIME_SPECIFICATION.calendar_alignment
@@ -155,10 +151,6 @@ rm/v1_2/DV_DURATION.magnitude
 rm/v1_2/DV_DURATION.multiply
 rm/v1_2/DV_DURATION.negative
 rm/v1_2/DV_DURATION.subtract
-rm/v1_2/DV_MULTIMEDIA.has_integrity_check
-rm/v1_2/DV_MULTIMEDIA.is_compressed
-rm/v1_2/DV_MULTIMEDIA.is_external
-rm/v1_2/DV_MULTIMEDIA.is_inline
 rm/v1_2/DV_ORDINAL.is_strictly_comparable_to
 rm/v1_2/DV_ORDINAL.less_than
 rm/v1_2/DV_PERIODIC_TIME_SPECIFICATION.calendar_alignment


### PR DESCRIPTION
Refs #2030. Ratchet **222 → 214**.

The realization gate records 215 BMM-declared spec functions this implementation does not provide. These four are the cheapest honest slice, because the spec leaves nothing to design — each is defined as *"computed from the value of"* one attribute (`dv_multimedia.adoc` §Functions):

| function | spec definition |
|---|---|
| `is_inline` | "Computed from the value of the data attribute. True if the data is stored in expanded form, ie within the EHR itself." |
| `is_external` | "Computed from the value of the `uri` attribute: True if the data is stored externally to the record." |
| `is_compressed` | "Computed from the value of the `compression_algorithm` attribute." |
| `has_integrity_check` | "Computed from the value of the `integrity_check_algorithm` attribute." |

## The invariant now says what the spec says

`Not_empty` is literally `is_inline or is_external`. It was hand-inlined as a field check; it now calls the predicates, so the two cannot drift apart.

## The test asserts the pair together, on purpose

`Not_empty` is an **OR** — the spec's own note says a copy may be held externally *and* internally, so a value stored both ways is valid and both predicates must answer true.

Tested apart, they would pass on an implementation that treated them as **exclusive**. That is not hypothetical: earlier in this cycle a deployment probe asserted that expanding an externalized value *removes* its `uri`, and was wrong for exactly this reason. So the test builds one value carrying both and asserts both.

## Stamped, not duplicated

Edited in the generation-twin **template**, so `v1_1` and `v1_2` are stamped from one source and cannot diverge. Both generations' tests pass, the realization ratchet accepts the shorter list, and clippy is clean under `-D warnings`.