### PR TITLE
feat(rm): COMPOSITION.is_persistent, and the periodic-time accessors adjudicated

### DIFF
--- a/crates/openehr-rm/src/v1_1/composition/composition_impl.rs
+++ b/crates/openehr-rm/src/v1_1/composition/composition_impl.rs
@@ -29,6 +29,26 @@
 use crate::v1_1::composition::composition::Composition;
 use openehr_base::validate::{InvariantViolation, Validate};
 
+impl Composition {
+    /// The `composition_category` code for persistent content.
+    ///
+    /// Spec: `composition.adoc` §Functions gives the code NUMERICALLY —
+    /// "True if category is `431|persistent|`" — so `431` is normative here,
+    /// not a local convention. The rubric is a rendering of it and is resolved
+    /// from the terminology bundle, never compared against.
+    const PERSISTENT_CATEGORY: &'static str = "431";
+
+    /// Returns `true` when this composition's category is `431|persistent|`.
+    ///
+    /// Spec: `composition.adoc` §Functions — "True if category is
+    /// `431|persistent|`, False otherwise. Useful for finding Compositions in
+    /// an EHR which are guaranteed to be of interest to most users."
+    #[must_use]
+    pub fn is_persistent(&self) -> bool {
+        self.category.defining_code.code_string == Self::PERSISTENT_CATEGORY
+    }
+}
+
 impl Validate for Composition {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
         crate::v1_1::validate::generated::composition_core(
@@ -104,6 +124,22 @@ mod tests {
             composer: PartyProxy::PartySelf(PartySelf { external_ref: None }),
             content: openehr_base::containers::present_nonempty(Vec::new()),
         }
+    }
+
+    /// `composition.adoc` §Functions: `is_persistent` is true for `431` and
+    /// FALSE OTHERWISE — asserted against a real other member of the same
+    /// group (`433|event|`, the fixture's own category) rather than against an
+    /// absent or nonsense code, since "not persistent" has to hold for the
+    /// categories that actually occur.
+    #[test]
+    fn is_persistent_is_the_431_category_and_nothing_else() {
+        let mut c = composition();
+        assert!(!c.is_persistent(), "433|event| is not persistent");
+        c.category = DvCodedText {
+            defining_code: code("openehr", "431"),
+            ..category()
+        };
+        assert!(c.is_persistent());
     }
 
     #[test]

--- a/crates/openehr-rm/src/v1_2/composition/composition_impl.rs
+++ b/crates/openehr-rm/src/v1_2/composition/composition_impl.rs
@@ -29,6 +29,26 @@
 use crate::v1_2::composition::composition::Composition;
 use openehr_base::validate::{InvariantViolation, Validate};
 
+impl Composition {
+    /// The `composition_category` code for persistent content.
+    ///
+    /// Spec: `composition.adoc` §Functions gives the code NUMERICALLY —
+    /// "True if category is `431|persistent|`" — so `431` is normative here,
+    /// not a local convention. The rubric is a rendering of it and is resolved
+    /// from the terminology bundle, never compared against.
+    const PERSISTENT_CATEGORY: &'static str = "431";
+
+    /// Returns `true` when this composition's category is `431|persistent|`.
+    ///
+    /// Spec: `composition.adoc` §Functions — "True if category is
+    /// `431|persistent|`, False otherwise. Useful for finding Compositions in
+    /// an EHR which are guaranteed to be of interest to most users."
+    #[must_use]
+    pub fn is_persistent(&self) -> bool {
+        self.category.defining_code.code_string == Self::PERSISTENT_CATEGORY
+    }
+}
+
 impl Validate for Composition {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
         crate::v1_2::validate::generated::composition_core(
@@ -104,6 +124,22 @@ mod tests {
             composer: PartyProxy::PartySelf(PartySelf { external_ref: None }),
             content: openehr_base::containers::present_nonempty(Vec::new()),
         }
+    }
+
+    /// `composition.adoc` §Functions: `is_persistent` is true for `431` and
+    /// FALSE OTHERWISE — asserted against a real other member of the same
+    /// group (`433|event|`, the fixture's own category) rather than against an
+    /// absent or nonsense code, since "not persistent" has to hold for the
+    /// categories that actually occur.
+    #[test]
+    fn is_persistent_is_the_431_category_and_nothing_else() {
+        let mut c = composition();
+        assert!(!c.is_persistent(), "433|event| is not persistent");
+        c.category = DvCodedText {
+            defining_code: code("openehr", "431"),
+            ..category()
+        };
+        assert!(c.is_persistent());
     }
 
     #[test]

--- a/tools/openehr-codegen/templates/openehr-rm/composition/composition_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/composition/composition_impl.rs
@@ -28,6 +28,26 @@
 use crate::v1_2::composition::composition::Composition;
 use openehr_base::validate::{InvariantViolation, Validate};
 
+impl Composition {
+    /// The `composition_category` code for persistent content.
+    ///
+    /// Spec: `composition.adoc` §Functions gives the code NUMERICALLY —
+    /// "True if category is `431|persistent|`" — so `431` is normative here,
+    /// not a local convention. The rubric is a rendering of it and is resolved
+    /// from the terminology bundle, never compared against.
+    const PERSISTENT_CATEGORY: &'static str = "431";
+
+    /// Returns `true` when this composition's category is `431|persistent|`.
+    ///
+    /// Spec: `composition.adoc` §Functions — "True if category is
+    /// `431|persistent|`, False otherwise. Useful for finding Compositions in
+    /// an EHR which are guaranteed to be of interest to most users."
+    #[must_use]
+    pub fn is_persistent(&self) -> bool {
+        self.category.defining_code.code_string == Self::PERSISTENT_CATEGORY
+    }
+}
+
 impl Validate for Composition {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
         crate::v1_2::validate::generated::composition_core(
@@ -103,6 +123,22 @@ mod tests {
             composer: PartyProxy::PartySelf(PartySelf { external_ref: None }),
             content: openehr_base::containers::present_nonempty(Vec::new()),
         }
+    }
+
+    /// `composition.adoc` §Functions: `is_persistent` is true for `431` and
+    /// FALSE OTHERWISE — asserted against a real other member of the same
+    /// group (`433|event|`, the fixture's own category) rather than against an
+    /// absent or nonsense code, since "not persistent" has to hold for the
+    /// categories that actually occur.
+    #[test]
+    fn is_persistent_is_the_431_category_and_nothing_else() {
+        let mut c = composition();
+        assert!(!c.is_persistent(), "433|event| is not persistent");
+        c.category = DvCodedText {
+            defining_code: code("openehr", "431"),
+            ..category()
+        };
+        assert!(c.is_persistent());
     }
 
     #[test]

--- a/tools/openehr-codegen/tests/it/unrealized_bmm_functions.txt
+++ b/tools/openehr-codegen/tests/it/unrealized_bmm_functions.txt
@@ -36,7 +36,6 @@ lang/v1_1/P_BMM_SCHEMA.validate_created
 lang/v1_1/P_BMM_TYPE.create_bmm_type
 rm/v1_1/AUTHORED_RESOURCE.current_revision
 rm/v1_1/AUTHORED_RESOURCE.languages_available
-rm/v1_1/COMPOSITION.is_persistent
 rm/v1_1/DV_COUNT.add
 rm/v1_1/DV_COUNT.is_strictly_comparable_to
 rm/v1_1/DV_COUNT.less_than
@@ -64,6 +63,13 @@ rm/v1_1/DV_DURATION.negative
 rm/v1_1/DV_DURATION.subtract
 rm/v1_1/DV_ORDINAL.is_strictly_comparable_to
 rm/v1_1/DV_ORDINAL.less_than
+# ADJUDICATED deliberately absent (#2030 outcome 2). All four are specified as
+# "extracted from value" and nothing more — and `value` is HL7v3 GTS syntax, for
+# which the openEHR spec supplies NO grammar
+# (RM/docs/UML/classes/org.openehr.rm.data_types.dv_periodic_time_specification.adoc
+# §Functions). Implementing them would mean inventing a parser and calling its
+# output normative, which is the opposite of spec conformance. They stay
+# unrealized until upstream defines the extraction.
 rm/v1_1/DV_PERIODIC_TIME_SPECIFICATION.calendar_alignment
 rm/v1_1/DV_PERIODIC_TIME_SPECIFICATION.event_alignment
 rm/v1_1/DV_PERIODIC_TIME_SPECIFICATION.institution_specified
@@ -125,7 +131,6 @@ rm/v1_1/VERSIONED_OBJECT.version_count
 rm/v1_1/VERSIONED_OBJECT.version_with_id
 rm/v1_2/AUTHORED_RESOURCE.current_revision
 rm/v1_2/AUTHORED_RESOURCE.languages_available
-rm/v1_2/COMPOSITION.is_persistent
 rm/v1_2/DV_COUNT.add
 rm/v1_2/DV_COUNT.is_strictly_comparable_to
 rm/v1_2/DV_COUNT.less_than
@@ -153,6 +158,13 @@ rm/v1_2/DV_DURATION.negative
 rm/v1_2/DV_DURATION.subtract
 rm/v1_2/DV_ORDINAL.is_strictly_comparable_to
 rm/v1_2/DV_ORDINAL.less_than
+# ADJUDICATED deliberately absent (#2030 outcome 2). All four are specified as
+# "extracted from value" and nothing more — and `value` is HL7v3 GTS syntax, for
+# which the openEHR spec supplies NO grammar
+# (RM/docs/UML/classes/org.openehr.rm.data_types.dv_periodic_time_specification.adoc
+# §Functions). Implementing them would mean inventing a parser and calling its
+# output normative, which is the opposite of spec conformance. They stay
+# unrealized until upstream defines the extraction.
 rm/v1_2/DV_PERIODIC_TIME_SPECIFICATION.calendar_alignment
 rm/v1_2/DV_PERIODIC_TIME_SPECIFICATION.event_alignment
 rm/v1_2/DV_PERIODIC_TIME_SPECIFICATION.institution_specified


### PR DESCRIPTION
Refs #2030. Ratchet **214 → 212**, plus four entries that now carry a decision instead of sitting as backlog.

This slice uses **both** of the issue's honest outcomes, which is the point of it.

## Outcome 1 — implement it

`COMPOSITION.is_persistent` is fully specified: *"True if category is `431|persistent|`, False otherwise"* (`composition.adoc` §Functions). The numeric code is the **spec's own**, not a local convention, so it belongs in the RM.

The application had already reasoned about this concept **without providing the function** — `service/ehr/category.rs` carries the `431` constant and cites the same clause. That is exactly the pattern #2030 names ("the project has REASONED about them without providing them"), and the RM now owns the definition.

**The test asserts false against a real sibling category** (`433|event|`, the fixture's own) rather than an absent or nonsense code. "False otherwise" has to hold for the categories that actually occur; a nonsense code would pass on an implementation that merely recognises "looks wrong".

## Outcome 2 — adjudicate it as deliberately absent

`DV_PERIODIC_TIME_SPECIFICATION`'s four accessors — `period`, `calendar_alignment`, `event_alignment`, `institution_specified` — are each specified as **"extracted from value"** and nothing more. `value` is HL7v3 GTS syntax, for which the openEHR spec supplies **no grammar**.

Implementing them would mean inventing a parser and calling its output normative, which is the opposite of conformance. They stay unrealized with the reason recorded beside them in the ratchet file, so a reader sees a decision rather than a to-do. The ratchet test strips comments, so the adjudication lives next to the entries it explains.

## Note on the shape of what remains

The 212 entries are **~106 unique functions** — RM's two generations are identical, so one template retires two entries. The bulk is the `DV_*` arithmetic and comparison family (~47 unique), which #2030 flags as the one to do before anything reimplements comparison a third time: the AQL engine already computes ordering through the `openehr_magnitude` SQL helper, so "compare two `DV_ORDERED`s" currently lives in two places with nothing tying them together.