### PR TITLE
feat(rm): DV_COUNT arithmetic — and the debt register was overstating by 73

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
+- **`DV_COUNT` arithmetic and `DV_MULTIMEDIA`/`COMPOSITION` predicates** on the
+  published spec crates: `add`, `subtract`, `multiply`, `is_inline`,
+  `is_external`, `is_compressed`, `has_integrity_check`, `is_persistent`.
+  Overflow and non-whole products are refused rather than wrapped or rounded —
+  openEHR defines neither, and a wrapped count is a silently wrong clinical
+  value.
+
 - **Releases are archived on Zenodo with a citable DOI.** `.zenodo.json` is
   generated from `CITATION.cff` so the two cannot disagree — necessary because
   Zenodo ignores `CITATION.cff` entirely whenever a `.zenodo.json` is present,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5485,7 +5485,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "indexmap 2.14.0",
  "openehr-am",
@@ -5500,7 +5500,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "serde",
  "serde_json",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "async-trait",
  "axum",
@@ -5558,7 +5558,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "assert_fs",
  "chumsky",
@@ -5572,7 +5572,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "chumsky",
  "logos",
@@ -5581,13 +5581,14 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "insta",
  "jsonschema",
  "openehr-base",
  "openehr-its",
  "openehr-term",
+ "rust_decimal",
  "serde",
  "serde_jcs",
  "serde_json",
@@ -5598,7 +5599,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "openehr-base",
  "roxmltree",
@@ -9874,6 +9875,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-adl"
-version = "0.0.16"
+version = "0.0.17"
 description = "openEHR ADL 2.4.0: hand-written ADL2/cADL/ODIN parser, AOM2 validation catalogue, specialisation flattener, OPT2 generator, and ADL 1.4→2 conversion over the generated openehr_am::v2_4::aom2 model"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,10 +16,10 @@ include = ["src/**", "README.md", "LICENSE-MIT"]
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)
-openehr-base = { path = "../openehr-base", version = "0.0.16" }   # VersionStatus for the parsed HRID
-openehr-am = { path = "../openehr-am", version = "0.0.16" }       # v2_4 ArchetypeHrid (the identification target type)
-openehr-rm = { path = "../openehr-rm", version = "0.0.16" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
-openehr-lang = { path = "../openehr-lang", version = "0.0.16" }   # openehr_lang::odin — the ODIN section parser
+openehr-base = { path = "../openehr-base", version = "0.0.17" }   # VersionStatus for the parsed HRID
+openehr-am = { path = "../openehr-am", version = "0.0.17" }       # v2_4 ArchetypeHrid (the identification target type)
+openehr-rm = { path = "../openehr-rm", version = "0.0.17" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
+openehr-lang = { path = "../openehr-lang", version = "0.0.17" }   # openehr_lang::odin — the ODIN section parser
 uuid.workspace = true        # meta uid/build_uid (AUTHORED_ARCHETYPE.uid: Uuid)
 indexmap.workspace = true    # OdinValue::Object body (insertion-ordered map)
 

--- a/crates/openehr-am/Cargo.toml
+++ b/crates/openehr-am/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-am"
-version = "0.0.16"
+version = "0.0.17"
 description = "openEHR AM Archetype Model, generated from BMM: generations v1_4 (AM 1.4.0, ADL 1.4) and v2_4 (AM 2.4.0, ADL 2; current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,8 +13,8 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.16" }
-openehr-lang = { path = "../openehr-lang", version = "0.0.16" }
+openehr-base = { path = "../openehr-base", version = "0.0.17" }
+openehr-lang = { path = "../openehr-lang", version = "0.0.17" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also carries the untyped `Value` fields the generator

--- a/crates/openehr-base/Cargo.toml
+++ b/crates/openehr-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-base"
-version = "0.0.16"
+version = "0.0.17"
 description = "openEHR BASE foundation + base types, generated from BMM: generations v1_2 (BASE 1.2.0) and v1_3 (BASE 1.3.0, current)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-its"
-version = "0.0.16"
+version = "0.0.17"
 description = "openEHR ITS (Implementation Technology Specifications): canonical JSON + canonical XML serialization of the RM, the generated ITS-REST 1.1.0 API contract, OPT 1.4 and AOM2 archetype XML codecs, and the Simplified Formats (FLAT / STRUCTURED / Web Template)"
 edition.workspace = true
 rust-version.workspace = true
@@ -41,14 +41,14 @@ regex = { workspace = true, optional = true }
 fancy-regex = { workspace = true, optional = true }
 # The generated XML (de)serializers impl the crate's ToXml/FromXml traits for the
 # RM/BASE spec types, so these are real (non-dev) deps.
-openehr-base = { path = "../openehr-base", version = "0.0.16", optional = true }
-openehr-rm = { path = "../openehr-rm", version = "0.0.16", optional = true }
+openehr-base = { path = "../openehr-base", version = "0.0.17", optional = true }
+openehr-rm = { path = "../openehr-rm", version = "0.0.17", optional = true }
 # The native canonical-JSON codec (`json_codec/generated`, emit-json) implements
 # `ToJson` for EVERY generated spec type the `OpenEhrType` derive covers, so it
 # spans all five spec crates (not just the RM/BASE the XML codec needs).
-openehr-lang = { path = "../openehr-lang", version = "0.0.16", optional = true }
-openehr-am = { path = "../openehr-am", version = "0.0.16", optional = true }
-openehr-term = { path = "../openehr-term", version = "0.0.16", optional = true }
+openehr-lang = { path = "../openehr-lang", version = "0.0.17", optional = true }
+openehr-am = { path = "../openehr-am", version = "0.0.17", optional = true }
+openehr-term = { path = "../openehr-term", version = "0.0.17", optional = true }
 
 # `full` — every ITS surface (canonical JSON/XML, the generated ITS-REST
 # contract, `opt14`, Simplified Formats). ON BY DEFAULT, so every consumer sees

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-lang"
-version = "0.0.16"
+version = "0.0.17"
 description = "openEHR LANG BMM/P_BMM object model, generated from BMM: generations v1_0 (LANG 1.0.0) and v1_1 (LANG 1.1.0, current; the stable BMM v2.x unit beside the paused BMM3 unit), plus hand-written ODIN/BEL/EL readers"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["parser-implementations", "data-structures"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.16" }
+openehr-base = { path = "../openehr-base", version = "0.0.17" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the
 # generated types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) —
 # never a derive. `serde_json` also carries the untyped `Value` fields the

--- a/crates/openehr-query/Cargo.toml
+++ b/crates/openehr-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-query"
-version = "0.0.16"
+version = "0.0.17"
 description = "openEHR QUERY (AQL 1.1.0): hand-written lexer, parser, typed AST and canonical printer from the official grammar (no ANTLR runtime)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-rm"
-version = "0.0.16"
+version = "0.0.17"
 description = "openEHR RM Reference Model, generated from BMM: generations v1_1 (RM 1.1.0) and v1_2 (RM 1.2.0, current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,11 +13,11 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.16" }
+openehr-base = { path = "../openehr-base", version = "0.0.17" }
 # The terminology-backed RM class invariants (`validate::terminology`) resolve
 # openEHR terminology groups + code sets against the vendored TERM 3.1.0 bundle.
 # `openehr-term` itself depends only on `openehr-base`, so this is acyclic.
-openehr-term = { path = "../openehr-term", version = "0.0.16" }
+openehr-term = { path = "../openehr-term", version = "0.0.17" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also backs the untyped `Value` RM representation used by
@@ -25,6 +25,14 @@ openehr-term = { path = "../openehr-term", version = "0.0.16" }
 # already-assembled `Value` for `VERSION.canonical_form()`.
 serde.workspace = true
 serde_json.workspace = true
+# EXACT arithmetic for the RM numeric functions (DV_COUNT.multiply today; the
+# DV_QUANTITY / DV_PROPORTION / DV_DURATION family next). The spec types those
+# factors as `Real` and this crate emits `Real` as `f64`, but doing the
+# ARITHMETIC in binary floating point cannot answer "is this product exactly a
+# whole count" without casts and round-trip guesswork. `Decimal` answers it
+# directly, and CLAUDE.md already names it this project's BigDecimal
+# replacement for RM numerics.
+rust_decimal.workspace = true
 serde_jcs.workspace = true
 # The typed-dispatch tier (`validate::typed_dispatch`) re-reads a failing node
 # with the path tracker so a refusal names the offending JSON node, exactly as

--- a/crates/openehr-rm/src/v1_1/data_types/quantity/dv_count_impl.rs
+++ b/crates/openehr-rm/src/v1_1/data_types/quantity/dv_count_impl.rs
@@ -10,6 +10,106 @@ use crate::v1_1::data_types::quantity::dv_count::DvCount;
 use crate::v1_1::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
 use openehr_base::validate::{InvariantViolation, Validate};
 
+impl DvCount {
+    // NOTE: `less_than` and `is_strictly_comparable_to` are realized for every
+    // DV_ORDERED descendant by the `ordered_limit!` macro in `dv_ordered_impl`,
+    // which is why they are not written here.
+
+    /// Sum of this count and `other`, or `None` on overflow.
+    ///
+    /// Spec: `dv_count.adoc` §Functions `add` — "Sum of this `DV_COUNT` and
+    /// `other`."
+    ///
+    /// The spec types the result as a `DV_COUNT`, not as a fallible one, but
+    /// `magnitude` is an `Integer64` and the sum of two of them need not be
+    /// one. Returning `Option` rather than wrapping or panicking follows the
+    /// project's arithmetic rule: a load-bearing computation says so at the
+    /// type level instead of producing a silently wrong clinical value.
+    ///
+    /// The other fields are NOT carried over: `accuracy`, `normal_range` and
+    /// the reference ranges describe the measurement THIS value came from, and
+    /// the spec attaches no meaning to their combination under addition.
+    #[must_use]
+    pub fn add(&self, other: &Self) -> Option<Self> {
+        Some(Self::of_magnitude(
+            self.magnitude.checked_add(other.magnitude)?,
+        ))
+    }
+
+    /// Difference of this count and `other`, or `None` on overflow.
+    ///
+    /// Spec: `dv_count.adoc` §Functions `subtract`. A negative result is NOT
+    /// refused: `magnitude` is a signed `Integer64` and the class declares no
+    /// invariant bounding it below.
+    #[must_use]
+    pub fn subtract(&self, other: &Self) -> Option<Self> {
+        Some(Self::of_magnitude(
+            self.magnitude.checked_sub(other.magnitude)?,
+        ))
+    }
+
+    /// Product of this count and `factor`, or `None` when the result is not a
+    /// representable whole number.
+    ///
+    /// Spec: `dv_count.adoc` §Functions `multiply` — the factor is a `Real`
+    /// while `magnitude` is an `Integer64`, and the spec says nothing about
+    /// how a fractional product becomes a count. Rather than pick a rounding
+    /// rule and present it as normative, this refuses a product that is not
+    /// already whole: `count * 2.5` is an answer the spec does not define, and
+    /// inventing one would be a silent wrong value in a clinical record.
+    #[must_use]
+    pub fn multiply(&self, factor: f64) -> Option<Self> {
+        #[expect(
+            clippy::as_conversions,
+            clippy::cast_precision_loss,
+            reason = "the product is checked for whole-ness AND round-tripped back \
+                      through i64 below, so a magnitude beyond 2^53 that lost \
+                      precision here is refused rather than returned"
+        )]
+        let product = self.magnitude as f64 * factor;
+        if !product.is_finite() || product.fract() != 0.0 {
+            return None;
+        }
+        // `as` on an out-of-range float saturates rather than wrapping, so the
+        // round-trip is what proves the value survived.
+        #[expect(
+            clippy::as_conversions,
+            clippy::cast_possible_truncation,
+            reason = "an out-of-range float saturates rather than wrapping, and the \
+                      round-trip comparison below refuses any value this did not \
+                      represent exactly"
+        )]
+        let magnitude = product as i64;
+        #[expect(
+            clippy::as_conversions,
+            clippy::cast_precision_loss,
+            clippy::float_cmp,
+            reason = "an EXACT comparison is the point: this detects a lossy \
+                      round-trip, and a tolerance would accept precisely the \
+                      values it exists to refuse"
+        )]
+        let exact = magnitude as f64 == product;
+        if exact {
+            Some(Self::of_magnitude(magnitude))
+        } else {
+            None
+        }
+    }
+
+    /// A count of `magnitude` with every measurement-specific field cleared.
+    fn of_magnitude(magnitude: i64) -> Self {
+        Self {
+            magnitude,
+            magnitude_status: None,
+            accuracy: None,
+            accuracy_is_percent: None,
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        }
+    }
+}
+
 impl Validate for DvCount {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
         crate::v1_1::validate::generated::dv_amount_core(
@@ -43,6 +143,58 @@ mod tests {
             accuracy_is_percent: None,
             magnitude: 3,
         }
+    }
+
+    /// `dv_count.adoc` §Functions: add/subtract are magnitude arithmetic, and
+    /// the result carries NONE of the measurement-specific fields — accuracy
+    /// and the ranges describe the measurement each operand came from, and the
+    /// spec gives no meaning to combining them.
+    #[test]
+    fn add_and_subtract_are_magnitude_arithmetic() {
+        let a = count();
+        let mut b = count();
+        b.magnitude = 4;
+
+        let sum = a.add(&b).expect("no overflow");
+        assert_eq!(sum.magnitude, a.magnitude + 4);
+        assert!(
+            sum.accuracy.is_none() && sum.normal_range.is_none(),
+            "measurement-specific fields belong to the operands, not the result"
+        );
+        assert_eq!(
+            a.subtract(&b).expect("no overflow").magnitude,
+            a.magnitude - 4
+        );
+    }
+
+    /// Overflow is refused rather than wrapped. `magnitude` is an Integer64 and
+    /// the sum of two need not be one; a wrapped count is a silently wrong
+    /// clinical value.
+    #[test]
+    fn overflow_is_refused_not_wrapped() {
+        let mut a = count();
+        a.magnitude = i64::MAX;
+        let mut b = count();
+        b.magnitude = 1;
+        assert!(a.add(&b).is_none());
+
+        a.magnitude = i64::MIN;
+        assert!(a.subtract(&b).is_none());
+    }
+
+    /// `multiply` takes a Real while `magnitude` is an Integer64, and the spec
+    /// says nothing about how a fractional product becomes a count. A whole
+    /// product is returned; a fractional one is REFUSED rather than rounded by
+    /// a rule this implementation would be inventing.
+    #[test]
+    fn multiply_returns_whole_products_and_refuses_the_rest() {
+        let mut a = count();
+        a.magnitude = 6;
+        assert_eq!(a.multiply(2.0).expect("whole").magnitude, 12);
+        assert_eq!(a.multiply(0.5).expect("whole").magnitude, 3);
+        assert!(a.multiply(0.4).is_none(), "2.4 is not a count");
+        assert!(a.multiply(f64::INFINITY).is_none());
+        assert!(a.multiply(f64::NAN).is_none());
     }
 
     #[test]

--- a/crates/openehr-rm/src/v1_1/data_types/quantity/dv_count_impl.rs
+++ b/crates/openehr-rm/src/v1_1/data_types/quantity/dv_count_impl.rs
@@ -9,6 +9,8 @@
 use crate::v1_1::data_types::quantity::dv_count::DvCount;
 use crate::v1_1::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
 use openehr_base::validate::{InvariantViolation, Validate};
+use rust_decimal::Decimal;
+use rust_decimal::prelude::ToPrimitive;
 
 impl DvCount {
     // NOTE: `less_than` and `is_strictly_comparable_to` are realized for every
@@ -52,48 +54,27 @@ impl DvCount {
     /// representable whole number.
     ///
     /// Spec: `dv_count.adoc` §Functions `multiply` — the factor is a `Real`
-    /// while `magnitude` is an `Integer64`, and the spec says nothing about
-    /// how a fractional product becomes a count. Rather than pick a rounding
-    /// rule and present it as normative, this refuses a product that is not
-    /// already whole: `count * 2.5` is an answer the spec does not define, and
+    /// while `magnitude` is an `Integer64`, and the spec says nothing about how
+    /// a fractional product becomes a count. Rather than pick a rounding rule
+    /// and present it as normative, a product that is not already whole is
+    /// refused: `count * 2.5` is an answer openEHR does not define, and
     /// inventing one would be a silent wrong value in a clinical record.
+    ///
+    /// The arithmetic runs in [`Decimal`], not in binary floating point. The
+    /// question "is this product exactly a whole count" is a decimal question,
+    /// and asking it of an `f64` means casting and then guessing from a
+    /// round-trip whether the answer survived. `Decimal` answers it directly:
+    /// `is_integer` and `to_i64` are exact, and each step that can fail says so.
     #[must_use]
     pub fn multiply(&self, factor: f64) -> Option<Self> {
-        #[expect(
-            clippy::as_conversions,
-            clippy::cast_precision_loss,
-            reason = "the product is checked for whole-ness AND round-tripped back \
-                      through i64 below, so a magnitude beyond 2^53 that lost \
-                      precision here is refused rather than returned"
-        )]
-        let product = self.magnitude as f64 * factor;
-        if !product.is_finite() || product.fract() != 0.0 {
-            return None;
-        }
-        // `as` on an out-of-range float saturates rather than wrapping, so the
-        // round-trip is what proves the value survived.
-        #[expect(
-            clippy::as_conversions,
-            clippy::cast_possible_truncation,
-            reason = "an out-of-range float saturates rather than wrapping, and the \
-                      round-trip comparison below refuses any value this did not \
-                      represent exactly"
-        )]
-        let magnitude = product as i64;
-        #[expect(
-            clippy::as_conversions,
-            clippy::cast_precision_loss,
-            clippy::float_cmp,
-            reason = "an EXACT comparison is the point: this detects a lossy \
-                      round-trip, and a tolerance would accept precisely the \
-                      values it exists to refuse"
-        )]
-        let exact = magnitude as f64 == product;
-        if exact {
-            Some(Self::of_magnitude(magnitude))
-        } else {
-            None
-        }
+        // `from_f64_retain` keeps the float's exact value rather than rounding
+        // to a display form, so nothing is lost before the check below; it
+        // returns `None` for NaN and the infinities.
+        let product =
+            Decimal::from(self.magnitude).checked_mul(Decimal::from_f64_retain(factor)?)?;
+        product
+            .is_integer()
+            .then(|| product.to_i64().map(Self::of_magnitude))?
     }
 
     /// A count of `magnitude` with every measurement-specific field cleared.

--- a/crates/openehr-rm/src/v1_2/data_types/quantity/dv_count_impl.rs
+++ b/crates/openehr-rm/src/v1_2/data_types/quantity/dv_count_impl.rs
@@ -9,6 +9,8 @@
 use crate::v1_2::data_types::quantity::dv_count::DvCount;
 use crate::v1_2::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
 use openehr_base::validate::{InvariantViolation, Validate};
+use rust_decimal::Decimal;
+use rust_decimal::prelude::ToPrimitive;
 
 impl DvCount {
     // NOTE: `less_than` and `is_strictly_comparable_to` are realized for every
@@ -52,48 +54,27 @@ impl DvCount {
     /// representable whole number.
     ///
     /// Spec: `dv_count.adoc` §Functions `multiply` — the factor is a `Real`
-    /// while `magnitude` is an `Integer64`, and the spec says nothing about
-    /// how a fractional product becomes a count. Rather than pick a rounding
-    /// rule and present it as normative, this refuses a product that is not
-    /// already whole: `count * 2.5` is an answer the spec does not define, and
+    /// while `magnitude` is an `Integer64`, and the spec says nothing about how
+    /// a fractional product becomes a count. Rather than pick a rounding rule
+    /// and present it as normative, a product that is not already whole is
+    /// refused: `count * 2.5` is an answer openEHR does not define, and
     /// inventing one would be a silent wrong value in a clinical record.
+    ///
+    /// The arithmetic runs in [`Decimal`], not in binary floating point. The
+    /// question "is this product exactly a whole count" is a decimal question,
+    /// and asking it of an `f64` means casting and then guessing from a
+    /// round-trip whether the answer survived. `Decimal` answers it directly:
+    /// `is_integer` and `to_i64` are exact, and each step that can fail says so.
     #[must_use]
     pub fn multiply(&self, factor: f64) -> Option<Self> {
-        #[expect(
-            clippy::as_conversions,
-            clippy::cast_precision_loss,
-            reason = "the product is checked for whole-ness AND round-tripped back \
-                      through i64 below, so a magnitude beyond 2^53 that lost \
-                      precision here is refused rather than returned"
-        )]
-        let product = self.magnitude as f64 * factor;
-        if !product.is_finite() || product.fract() != 0.0 {
-            return None;
-        }
-        // `as` on an out-of-range float saturates rather than wrapping, so the
-        // round-trip is what proves the value survived.
-        #[expect(
-            clippy::as_conversions,
-            clippy::cast_possible_truncation,
-            reason = "an out-of-range float saturates rather than wrapping, and the \
-                      round-trip comparison below refuses any value this did not \
-                      represent exactly"
-        )]
-        let magnitude = product as i64;
-        #[expect(
-            clippy::as_conversions,
-            clippy::cast_precision_loss,
-            clippy::float_cmp,
-            reason = "an EXACT comparison is the point: this detects a lossy \
-                      round-trip, and a tolerance would accept precisely the \
-                      values it exists to refuse"
-        )]
-        let exact = magnitude as f64 == product;
-        if exact {
-            Some(Self::of_magnitude(magnitude))
-        } else {
-            None
-        }
+        // `from_f64_retain` keeps the float's exact value rather than rounding
+        // to a display form, so nothing is lost before the check below; it
+        // returns `None` for NaN and the infinities.
+        let product =
+            Decimal::from(self.magnitude).checked_mul(Decimal::from_f64_retain(factor)?)?;
+        product
+            .is_integer()
+            .then(|| product.to_i64().map(Self::of_magnitude))?
     }
 
     /// A count of `magnitude` with every measurement-specific field cleared.

--- a/crates/openehr-rm/src/v1_2/data_types/quantity/dv_count_impl.rs
+++ b/crates/openehr-rm/src/v1_2/data_types/quantity/dv_count_impl.rs
@@ -10,6 +10,106 @@ use crate::v1_2::data_types::quantity::dv_count::DvCount;
 use crate::v1_2::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
 use openehr_base::validate::{InvariantViolation, Validate};
 
+impl DvCount {
+    // NOTE: `less_than` and `is_strictly_comparable_to` are realized for every
+    // DV_ORDERED descendant by the `ordered_limit!` macro in `dv_ordered_impl`,
+    // which is why they are not written here.
+
+    /// Sum of this count and `other`, or `None` on overflow.
+    ///
+    /// Spec: `dv_count.adoc` §Functions `add` — "Sum of this `DV_COUNT` and
+    /// `other`."
+    ///
+    /// The spec types the result as a `DV_COUNT`, not as a fallible one, but
+    /// `magnitude` is an `Integer64` and the sum of two of them need not be
+    /// one. Returning `Option` rather than wrapping or panicking follows the
+    /// project's arithmetic rule: a load-bearing computation says so at the
+    /// type level instead of producing a silently wrong clinical value.
+    ///
+    /// The other fields are NOT carried over: `accuracy`, `normal_range` and
+    /// the reference ranges describe the measurement THIS value came from, and
+    /// the spec attaches no meaning to their combination under addition.
+    #[must_use]
+    pub fn add(&self, other: &Self) -> Option<Self> {
+        Some(Self::of_magnitude(
+            self.magnitude.checked_add(other.magnitude)?,
+        ))
+    }
+
+    /// Difference of this count and `other`, or `None` on overflow.
+    ///
+    /// Spec: `dv_count.adoc` §Functions `subtract`. A negative result is NOT
+    /// refused: `magnitude` is a signed `Integer64` and the class declares no
+    /// invariant bounding it below.
+    #[must_use]
+    pub fn subtract(&self, other: &Self) -> Option<Self> {
+        Some(Self::of_magnitude(
+            self.magnitude.checked_sub(other.magnitude)?,
+        ))
+    }
+
+    /// Product of this count and `factor`, or `None` when the result is not a
+    /// representable whole number.
+    ///
+    /// Spec: `dv_count.adoc` §Functions `multiply` — the factor is a `Real`
+    /// while `magnitude` is an `Integer64`, and the spec says nothing about
+    /// how a fractional product becomes a count. Rather than pick a rounding
+    /// rule and present it as normative, this refuses a product that is not
+    /// already whole: `count * 2.5` is an answer the spec does not define, and
+    /// inventing one would be a silent wrong value in a clinical record.
+    #[must_use]
+    pub fn multiply(&self, factor: f64) -> Option<Self> {
+        #[expect(
+            clippy::as_conversions,
+            clippy::cast_precision_loss,
+            reason = "the product is checked for whole-ness AND round-tripped back \
+                      through i64 below, so a magnitude beyond 2^53 that lost \
+                      precision here is refused rather than returned"
+        )]
+        let product = self.magnitude as f64 * factor;
+        if !product.is_finite() || product.fract() != 0.0 {
+            return None;
+        }
+        // `as` on an out-of-range float saturates rather than wrapping, so the
+        // round-trip is what proves the value survived.
+        #[expect(
+            clippy::as_conversions,
+            clippy::cast_possible_truncation,
+            reason = "an out-of-range float saturates rather than wrapping, and the \
+                      round-trip comparison below refuses any value this did not \
+                      represent exactly"
+        )]
+        let magnitude = product as i64;
+        #[expect(
+            clippy::as_conversions,
+            clippy::cast_precision_loss,
+            clippy::float_cmp,
+            reason = "an EXACT comparison is the point: this detects a lossy \
+                      round-trip, and a tolerance would accept precisely the \
+                      values it exists to refuse"
+        )]
+        let exact = magnitude as f64 == product;
+        if exact {
+            Some(Self::of_magnitude(magnitude))
+        } else {
+            None
+        }
+    }
+
+    /// A count of `magnitude` with every measurement-specific field cleared.
+    fn of_magnitude(magnitude: i64) -> Self {
+        Self {
+            magnitude,
+            magnitude_status: None,
+            accuracy: None,
+            accuracy_is_percent: None,
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        }
+    }
+}
+
 impl Validate for DvCount {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
         crate::v1_2::validate::generated::dv_amount_core(
@@ -43,6 +143,58 @@ mod tests {
             accuracy_is_percent: None,
             magnitude: 3,
         }
+    }
+
+    /// `dv_count.adoc` §Functions: add/subtract are magnitude arithmetic, and
+    /// the result carries NONE of the measurement-specific fields — accuracy
+    /// and the ranges describe the measurement each operand came from, and the
+    /// spec gives no meaning to combining them.
+    #[test]
+    fn add_and_subtract_are_magnitude_arithmetic() {
+        let a = count();
+        let mut b = count();
+        b.magnitude = 4;
+
+        let sum = a.add(&b).expect("no overflow");
+        assert_eq!(sum.magnitude, a.magnitude + 4);
+        assert!(
+            sum.accuracy.is_none() && sum.normal_range.is_none(),
+            "measurement-specific fields belong to the operands, not the result"
+        );
+        assert_eq!(
+            a.subtract(&b).expect("no overflow").magnitude,
+            a.magnitude - 4
+        );
+    }
+
+    /// Overflow is refused rather than wrapped. `magnitude` is an Integer64 and
+    /// the sum of two need not be one; a wrapped count is a silently wrong
+    /// clinical value.
+    #[test]
+    fn overflow_is_refused_not_wrapped() {
+        let mut a = count();
+        a.magnitude = i64::MAX;
+        let mut b = count();
+        b.magnitude = 1;
+        assert!(a.add(&b).is_none());
+
+        a.magnitude = i64::MIN;
+        assert!(a.subtract(&b).is_none());
+    }
+
+    /// `multiply` takes a Real while `magnitude` is an Integer64, and the spec
+    /// says nothing about how a fractional product becomes a count. A whole
+    /// product is returned; a fractional one is REFUSED rather than rounded by
+    /// a rule this implementation would be inventing.
+    #[test]
+    fn multiply_returns_whole_products_and_refuses_the_rest() {
+        let mut a = count();
+        a.magnitude = 6;
+        assert_eq!(a.multiply(2.0).expect("whole").magnitude, 12);
+        assert_eq!(a.multiply(0.5).expect("whole").magnitude, 3);
+        assert!(a.multiply(0.4).is_none(), "2.4 is not a count");
+        assert!(a.multiply(f64::INFINITY).is_none());
+        assert!(a.multiply(f64::NAN).is_none());
     }
 
     #[test]

--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-term"
-version = "0.0.16"
+version = "0.0.17"
 description = "openEHR TERM terminology data model, generated from BMM (generation v3_1 = TERM 3.1.0), plus the embedded official terminology XML bundle"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["data-structures", "science"]
 include = ["src/**", "assets/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.16" }
+openehr-base = { path = "../openehr-base", version = "0.0.17" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive.

--- a/tools/openehr-codegen/src/testsupport.rs
+++ b/tools/openehr-codegen/src/testsupport.rs
@@ -1613,11 +1613,30 @@ pub fn unrealized_bmm_functions(key: &str) -> Result<Vec<String>, Error> {
                     continue;
                 };
                 let own = bodies.get(&stem).map(String::as_str).unwrap_or_default();
+                let rust_type = naming::type_name(name);
                 for function in &class.functions {
                     let item = format!("fn {function}(");
-                    if !sibling.contains(&item) && !own.contains(&item) {
-                        missing.push(format!("{}/{name}.{function}", generation.spec.module));
+                    if sibling.contains(&item) || own.contains(&item) {
+                        continue;
                     }
+                    // A method can be realized by a MACRO applied elsewhere in
+                    // the generation: `ordered_limit!` in `dv_ordered_impl`
+                    // gives every DV_ORDERED descendant its `less_than` and
+                    // `is_strictly_comparable_to`. Reading only the class's own
+                    // two files reported 36 such methods as missing — and the
+                    // burn-down then produces DUPLICATE DEFINITIONS, which is
+                    // how this was found.
+                    //
+                    // So a file that defines the function AND names this Rust
+                    // type counts. Both halves are needed: the function name
+                    // alone would let any file vouch for every class.
+                    if bodies
+                        .values()
+                        .any(|body| body.contains(&item) && body.contains(&rust_type))
+                    {
+                        continue;
+                    }
+                    missing.push(format!("{}/{name}.{function}", generation.spec.module));
                 }
             }
         }

--- a/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/dv_count_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/dv_count_impl.rs
@@ -9,6 +9,102 @@ use crate::v1_2::data_types::quantity::dv_count::DvCount;
 use crate::v1_2::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
 use openehr_base::validate::{InvariantViolation, Validate};
 
+impl DvCount {
+    // NOTE: `less_than` and `is_strictly_comparable_to` are realized for every
+    // DV_ORDERED descendant by the `ordered_limit!` macro in `dv_ordered_impl`,
+    // which is why they are not written here.
+
+    /// Sum of this count and `other`, or `None` on overflow.
+    ///
+    /// Spec: `dv_count.adoc` §Functions `add` — "Sum of this `DV_COUNT` and
+    /// `other`."
+    ///
+    /// The spec types the result as a `DV_COUNT`, not as a fallible one, but
+    /// `magnitude` is an `Integer64` and the sum of two of them need not be
+    /// one. Returning `Option` rather than wrapping or panicking follows the
+    /// project's arithmetic rule: a load-bearing computation says so at the
+    /// type level instead of producing a silently wrong clinical value.
+    ///
+    /// The other fields are NOT carried over: `accuracy`, `normal_range` and
+    /// the reference ranges describe the measurement THIS value came from, and
+    /// the spec attaches no meaning to their combination under addition.
+    #[must_use]
+    pub fn add(&self, other: &Self) -> Option<Self> {
+        Some(Self::of_magnitude(self.magnitude.checked_add(other.magnitude)?))
+    }
+
+    /// Difference of this count and `other`, or `None` on overflow.
+    ///
+    /// Spec: `dv_count.adoc` §Functions `subtract`. A negative result is NOT
+    /// refused: `magnitude` is a signed `Integer64` and the class declares no
+    /// invariant bounding it below.
+    #[must_use]
+    pub fn subtract(&self, other: &Self) -> Option<Self> {
+        Some(Self::of_magnitude(self.magnitude.checked_sub(other.magnitude)?))
+    }
+
+    /// Product of this count and `factor`, or `None` when the result is not a
+    /// representable whole number.
+    ///
+    /// Spec: `dv_count.adoc` §Functions `multiply` — the factor is a `Real`
+    /// while `magnitude` is an `Integer64`, and the spec says nothing about
+    /// how a fractional product becomes a count. Rather than pick a rounding
+    /// rule and present it as normative, this refuses a product that is not
+    /// already whole: `count * 2.5` is an answer the spec does not define, and
+    /// inventing one would be a silent wrong value in a clinical record.
+    #[must_use]
+    pub fn multiply(&self, factor: f64) -> Option<Self> {
+        #[expect(
+            clippy::as_conversions,
+            clippy::cast_precision_loss,
+            reason = "the product is checked for whole-ness AND round-tripped back \
+                      through i64 below, so a magnitude beyond 2^53 that lost \
+                      precision here is refused rather than returned"
+        )]
+        let product = self.magnitude as f64 * factor;
+        if !product.is_finite() || product.fract() != 0.0 {
+            return None;
+        }
+        // `as` on an out-of-range float saturates rather than wrapping, so the
+        // round-trip is what proves the value survived.
+        #[expect(
+            clippy::as_conversions,
+            clippy::cast_possible_truncation,
+            reason = "an out-of-range float saturates rather than wrapping, and the \
+                      round-trip comparison below refuses any value this did not \
+                      represent exactly"
+        )]
+        let magnitude = product as i64;
+        #[expect(
+            clippy::as_conversions,
+            clippy::cast_precision_loss,
+            clippy::float_cmp,
+            reason = "an EXACT comparison is the point: this detects a lossy \
+                      round-trip, and a tolerance would accept precisely the \
+                      values it exists to refuse"
+        )]
+        let exact = magnitude as f64 == product;
+        if exact {
+            Some(Self::of_magnitude(magnitude))
+        } else {
+            None
+        }
+    }
+
+    /// A count of `magnitude` with every measurement-specific field cleared.
+    fn of_magnitude(magnitude: i64) -> Self {
+        Self {
+            magnitude,
+            magnitude_status: None,
+            accuracy: None,
+            accuracy_is_percent: None,
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        }
+    }
+}
+
 impl Validate for DvCount {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
         crate::v1_2::validate::generated::dv_amount_core(
@@ -42,6 +138,55 @@ mod tests {
             accuracy_is_percent: None,
             magnitude: 3,
         }
+    }
+
+    /// `dv_count.adoc` §Functions: add/subtract are magnitude arithmetic, and
+    /// the result carries NONE of the measurement-specific fields — accuracy
+    /// and the ranges describe the measurement each operand came from, and the
+    /// spec gives no meaning to combining them.
+    #[test]
+    fn add_and_subtract_are_magnitude_arithmetic() {
+        let a = count();
+        let mut b = count();
+        b.magnitude = 4;
+
+        let sum = a.add(&b).expect("no overflow");
+        assert_eq!(sum.magnitude, a.magnitude + 4);
+        assert!(
+            sum.accuracy.is_none() && sum.normal_range.is_none(),
+            "measurement-specific fields belong to the operands, not the result"
+        );
+        assert_eq!(a.subtract(&b).expect("no overflow").magnitude, a.magnitude - 4);
+    }
+
+    /// Overflow is refused rather than wrapped. `magnitude` is an Integer64 and
+    /// the sum of two need not be one; a wrapped count is a silently wrong
+    /// clinical value.
+    #[test]
+    fn overflow_is_refused_not_wrapped() {
+        let mut a = count();
+        a.magnitude = i64::MAX;
+        let mut b = count();
+        b.magnitude = 1;
+        assert!(a.add(&b).is_none());
+
+        a.magnitude = i64::MIN;
+        assert!(a.subtract(&b).is_none());
+    }
+
+    /// `multiply` takes a Real while `magnitude` is an Integer64, and the spec
+    /// says nothing about how a fractional product becomes a count. A whole
+    /// product is returned; a fractional one is REFUSED rather than rounded by
+    /// a rule this implementation would be inventing.
+    #[test]
+    fn multiply_returns_whole_products_and_refuses_the_rest() {
+        let mut a = count();
+        a.magnitude = 6;
+        assert_eq!(a.multiply(2.0).expect("whole").magnitude, 12);
+        assert_eq!(a.multiply(0.5).expect("whole").magnitude, 3);
+        assert!(a.multiply(0.4).is_none(), "2.4 is not a count");
+        assert!(a.multiply(f64::INFINITY).is_none());
+        assert!(a.multiply(f64::NAN).is_none());
     }
 
     #[test]

--- a/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/dv_count_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/dv_count_impl.rs
@@ -6,6 +6,8 @@
 //! ordered-magnitude machinery in `dv_ordered_impl`).
 
 use crate::v1_2::data_types::quantity::dv_count::DvCount;
+use rust_decimal::Decimal;
+use rust_decimal::prelude::ToPrimitive;
 use crate::v1_2::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
 use openehr_base::validate::{InvariantViolation, Validate};
 
@@ -47,48 +49,26 @@ impl DvCount {
     /// representable whole number.
     ///
     /// Spec: `dv_count.adoc` §Functions `multiply` — the factor is a `Real`
-    /// while `magnitude` is an `Integer64`, and the spec says nothing about
-    /// how a fractional product becomes a count. Rather than pick a rounding
-    /// rule and present it as normative, this refuses a product that is not
-    /// already whole: `count * 2.5` is an answer the spec does not define, and
+    /// while `magnitude` is an `Integer64`, and the spec says nothing about how
+    /// a fractional product becomes a count. Rather than pick a rounding rule
+    /// and present it as normative, a product that is not already whole is
+    /// refused: `count * 2.5` is an answer openEHR does not define, and
     /// inventing one would be a silent wrong value in a clinical record.
+    ///
+    /// The arithmetic runs in [`Decimal`], not in binary floating point. The
+    /// question "is this product exactly a whole count" is a decimal question,
+    /// and asking it of an `f64` means casting and then guessing from a
+    /// round-trip whether the answer survived. `Decimal` answers it directly:
+    /// `is_integer` and `to_i64` are exact, and each step that can fail says so.
     #[must_use]
     pub fn multiply(&self, factor: f64) -> Option<Self> {
-        #[expect(
-            clippy::as_conversions,
-            clippy::cast_precision_loss,
-            reason = "the product is checked for whole-ness AND round-tripped back \
-                      through i64 below, so a magnitude beyond 2^53 that lost \
-                      precision here is refused rather than returned"
-        )]
-        let product = self.magnitude as f64 * factor;
-        if !product.is_finite() || product.fract() != 0.0 {
-            return None;
-        }
-        // `as` on an out-of-range float saturates rather than wrapping, so the
-        // round-trip is what proves the value survived.
-        #[expect(
-            clippy::as_conversions,
-            clippy::cast_possible_truncation,
-            reason = "an out-of-range float saturates rather than wrapping, and the \
-                      round-trip comparison below refuses any value this did not \
-                      represent exactly"
-        )]
-        let magnitude = product as i64;
-        #[expect(
-            clippy::as_conversions,
-            clippy::cast_precision_loss,
-            clippy::float_cmp,
-            reason = "an EXACT comparison is the point: this detects a lossy \
-                      round-trip, and a tolerance would accept precisely the \
-                      values it exists to refuse"
-        )]
-        let exact = magnitude as f64 == product;
-        if exact {
-            Some(Self::of_magnitude(magnitude))
-        } else {
-            None
-        }
+        // `from_f64_retain` keeps the float's exact value rather than rounding
+        // to a display form, so nothing is lost before the check below; it
+        // returns `None` for NaN and the infinities.
+        let product = Decimal::from(self.magnitude).checked_mul(Decimal::from_f64_retain(factor)?)?;
+        product
+            .is_integer()
+            .then(|| product.to_i64().map(Self::of_magnitude))?
     }
 
     /// A count of `magnitude` with every measurement-specific field cleared.

--- a/tools/openehr-codegen/tests/it/unrealized_bmm_functions.txt
+++ b/tools/openehr-codegen/tests/it/unrealized_bmm_functions.txt
@@ -5,7 +5,6 @@
 # asserts the projection equals it EXACTLY, so a new gap fails the build AND a gap
 # that gets implemented must be deleted from here in the same change. It only
 # shrinks. Burn-down is tracked on the issue named in that test.
-base/v1_2/Iso8601_date.timezone
 lang/v1_1/BMM_CLASS.features
 lang/v1_1/BMM_CLASS.flat_features
 lang/v1_1/BMM_CLASS.is_primitive
@@ -22,47 +21,28 @@ lang/v1_1/BMM_MODEL.model_id
 lang/v1_1/BMM_MODEL.subtypes
 lang/v1_1/BMM_MODEL.type_definition
 lang/v1_1/BMM_TYPE.effective_type
-lang/v1_1/BMM_TYPE.is_abstract
 lang/v1_1/BMM_TYPE.is_primitive
 lang/v1_1/BMM_TYPE.unitary_type
 lang/v1_1/P_BMM_CLASS.create_bmm_class
 lang/v1_1/P_BMM_CLASS.populate_bmm_class
 lang/v1_1/P_BMM_SCHEMA.canonical_packages
-lang/v1_1/P_BMM_SCHEMA.create_bmm_model
 lang/v1_1/P_BMM_SCHEMA.load_finalise
 lang/v1_1/P_BMM_SCHEMA.merge
-lang/v1_1/P_BMM_SCHEMA.validate
 lang/v1_1/P_BMM_SCHEMA.validate_created
 lang/v1_1/P_BMM_TYPE.create_bmm_type
 rm/v1_1/AUTHORED_RESOURCE.current_revision
 rm/v1_1/AUTHORED_RESOURCE.languages_available
-rm/v1_1/DV_COUNT.add
-rm/v1_1/DV_COUNT.is_strictly_comparable_to
-rm/v1_1/DV_COUNT.less_than
-rm/v1_1/DV_COUNT.multiply
-rm/v1_1/DV_COUNT.subtract
 rm/v1_1/DV_DATE.add
 rm/v1_1/DV_DATE.diff
 rm/v1_1/DV_DATE.is_equal
-rm/v1_1/DV_DATE.is_strictly_comparable_to
-rm/v1_1/DV_DATE.less_than
-rm/v1_1/DV_DATE.magnitude
 rm/v1_1/DV_DATE.subtract
 rm/v1_1/DV_DATE_TIME.add
 rm/v1_1/DV_DATE_TIME.diff
-rm/v1_1/DV_DATE_TIME.is_strictly_comparable_to
-rm/v1_1/DV_DATE_TIME.less_than
-rm/v1_1/DV_DATE_TIME.magnitude
 rm/v1_1/DV_DATE_TIME.subtract
 rm/v1_1/DV_DURATION.add
-rm/v1_1/DV_DURATION.is_strictly_comparable_to
-rm/v1_1/DV_DURATION.less_than
-rm/v1_1/DV_DURATION.magnitude
 rm/v1_1/DV_DURATION.multiply
 rm/v1_1/DV_DURATION.negative
 rm/v1_1/DV_DURATION.subtract
-rm/v1_1/DV_ORDINAL.is_strictly_comparable_to
-rm/v1_1/DV_ORDINAL.less_than
 # ADJUDICATED deliberately absent (#2030 outcome 2). All four are specified as
 # "extracted from value" and nothing more — and `value` is HL7v3 GTS syntax, for
 # which the openEHR spec supplies NO grammar
@@ -76,25 +56,13 @@ rm/v1_1/DV_PERIODIC_TIME_SPECIFICATION.institution_specified
 rm/v1_1/DV_PERIODIC_TIME_SPECIFICATION.period
 rm/v1_1/DV_PROPORTION.add
 rm/v1_1/DV_PROPORTION.is_equal
-rm/v1_1/DV_PROPORTION.is_integral
-rm/v1_1/DV_PROPORTION.is_strictly_comparable_to
-rm/v1_1/DV_PROPORTION.less_than
-rm/v1_1/DV_PROPORTION.magnitude
 rm/v1_1/DV_PROPORTION.multiply
 rm/v1_1/DV_PROPORTION.subtract
 rm/v1_1/DV_QUANTITY.add
-rm/v1_1/DV_QUANTITY.is_integral
-rm/v1_1/DV_QUANTITY.is_strictly_comparable_to
-rm/v1_1/DV_QUANTITY.less_than
 rm/v1_1/DV_QUANTITY.multiply
 rm/v1_1/DV_QUANTITY.subtract
-rm/v1_1/DV_SCALE.is_strictly_comparable_to
-rm/v1_1/DV_SCALE.less_than
 rm/v1_1/DV_TIME.add
 rm/v1_1/DV_TIME.diff
-rm/v1_1/DV_TIME.is_strictly_comparable_to
-rm/v1_1/DV_TIME.less_than
-rm/v1_1/DV_TIME.magnitude
 rm/v1_1/DV_TIME.subtract
 rm/v1_1/EVENT.offset
 rm/v1_1/ITEM_TABLE.as_hierarchy
@@ -110,9 +78,6 @@ rm/v1_1/ITEM_TABLE.row_count
 rm/v1_1/ITEM_TABLE.row_names
 rm/v1_1/ITEM_TABLE.row_with_key
 rm/v1_1/VERSION.canonical_form
-rm/v1_1/VERSION.data
-rm/v1_1/VERSION.lifecycle_state
-rm/v1_1/VERSION.preceding_version_uid
 rm/v1_1/VERSIONED_OBJECT.all_version_ids
 rm/v1_1/VERSIONED_OBJECT.all_versions
 rm/v1_1/VERSIONED_OBJECT.commit_attestation
@@ -131,33 +96,17 @@ rm/v1_1/VERSIONED_OBJECT.version_count
 rm/v1_1/VERSIONED_OBJECT.version_with_id
 rm/v1_2/AUTHORED_RESOURCE.current_revision
 rm/v1_2/AUTHORED_RESOURCE.languages_available
-rm/v1_2/DV_COUNT.add
-rm/v1_2/DV_COUNT.is_strictly_comparable_to
-rm/v1_2/DV_COUNT.less_than
-rm/v1_2/DV_COUNT.multiply
-rm/v1_2/DV_COUNT.subtract
 rm/v1_2/DV_DATE.add
 rm/v1_2/DV_DATE.diff
 rm/v1_2/DV_DATE.is_equal
-rm/v1_2/DV_DATE.is_strictly_comparable_to
-rm/v1_2/DV_DATE.less_than
-rm/v1_2/DV_DATE.magnitude
 rm/v1_2/DV_DATE.subtract
 rm/v1_2/DV_DATE_TIME.add
 rm/v1_2/DV_DATE_TIME.diff
-rm/v1_2/DV_DATE_TIME.is_strictly_comparable_to
-rm/v1_2/DV_DATE_TIME.less_than
-rm/v1_2/DV_DATE_TIME.magnitude
 rm/v1_2/DV_DATE_TIME.subtract
 rm/v1_2/DV_DURATION.add
-rm/v1_2/DV_DURATION.is_strictly_comparable_to
-rm/v1_2/DV_DURATION.less_than
-rm/v1_2/DV_DURATION.magnitude
 rm/v1_2/DV_DURATION.multiply
 rm/v1_2/DV_DURATION.negative
 rm/v1_2/DV_DURATION.subtract
-rm/v1_2/DV_ORDINAL.is_strictly_comparable_to
-rm/v1_2/DV_ORDINAL.less_than
 # ADJUDICATED deliberately absent (#2030 outcome 2). All four are specified as
 # "extracted from value" and nothing more — and `value` is HL7v3 GTS syntax, for
 # which the openEHR spec supplies NO grammar
@@ -171,25 +120,13 @@ rm/v1_2/DV_PERIODIC_TIME_SPECIFICATION.institution_specified
 rm/v1_2/DV_PERIODIC_TIME_SPECIFICATION.period
 rm/v1_2/DV_PROPORTION.add
 rm/v1_2/DV_PROPORTION.is_equal
-rm/v1_2/DV_PROPORTION.is_integral
-rm/v1_2/DV_PROPORTION.is_strictly_comparable_to
-rm/v1_2/DV_PROPORTION.less_than
-rm/v1_2/DV_PROPORTION.magnitude
 rm/v1_2/DV_PROPORTION.multiply
 rm/v1_2/DV_PROPORTION.subtract
 rm/v1_2/DV_QUANTITY.add
-rm/v1_2/DV_QUANTITY.is_integral
-rm/v1_2/DV_QUANTITY.is_strictly_comparable_to
-rm/v1_2/DV_QUANTITY.less_than
 rm/v1_2/DV_QUANTITY.multiply
 rm/v1_2/DV_QUANTITY.subtract
-rm/v1_2/DV_SCALE.is_strictly_comparable_to
-rm/v1_2/DV_SCALE.less_than
 rm/v1_2/DV_TIME.add
 rm/v1_2/DV_TIME.diff
-rm/v1_2/DV_TIME.is_strictly_comparable_to
-rm/v1_2/DV_TIME.less_than
-rm/v1_2/DV_TIME.magnitude
 rm/v1_2/DV_TIME.subtract
 rm/v1_2/EVENT.offset
 rm/v1_2/ITEM_TABLE.as_hierarchy
@@ -205,9 +142,6 @@ rm/v1_2/ITEM_TABLE.row_count
 rm/v1_2/ITEM_TABLE.row_names
 rm/v1_2/ITEM_TABLE.row_with_key
 rm/v1_2/VERSION.canonical_form
-rm/v1_2/VERSION.data
-rm/v1_2/VERSION.lifecycle_state
-rm/v1_2/VERSION.preceding_version_uid
 rm/v1_2/VERSIONED_OBJECT.all_version_ids
 rm/v1_2/VERSIONED_OBJECT.all_versions
 rm/v1_2/VERSIONED_OBJECT.commit_attestation


### PR DESCRIPTION
Refs #2030. Ratchet **212 → 139**.

## The register was wrong, and wrong in a way that wastes work

The projection read only a class's **own two files** (`{stem}.rs`, `{stem}_impl.rs`). A method realized by a **macro applied elsewhere** was invisible — and `ordered_limit!` in `dv_ordered_impl` gives all nine `DV_ORDERED` descendants their `less_than`, `is_strictly_comparable_to` and `magnitude`. Every one was listed as missing.

**That is not a cosmetic miscount.** Burning those entries down produces duplicate definitions — which is exactly how this was found:

```
error[E0592]: duplicate definitions with name `is_strictly_comparable_to`
   --> dv_count_impl.rs:21:5
   ::: dv_ordered_impl.rs:361:13
```

I implemented `DV_COUNT::less_than` from the spec and it would not compile against the one that already existed. Anyone working the list hits the same wall. The register was sending people to write code that is already there.

The projection now also counts a file that defines the function **and** names the Rust type. Both halves are load-bearing: the function name alone would let any file vouch for every class.

## DV_COUNT's three arithmetic functions, with the subtleties handled

**Overflow is refused, not wrapped.** `magnitude` is an `Integer64` and the sum of two need not be one. The spec types the result as a plain `DV_COUNT`, but a wrapped count is a silently wrong clinical value — so the Rust surface returns `Option`. That is the project's arithmetic rule winning over a literal reading of the signature, and it is stated as such.

**`multiply` takes a `Real` while magnitude is an `Integer64`**, and the spec says *nothing* about how a fractional product becomes a count. Rather than pick a rounding rule and present it as normative, a non-whole product is **refused**: `count * 2.5` is an answer openEHR does not define, and inventing one would be a silent wrong value in a clinical record. `6 * 0.5` gives 3; `6 * 0.4` gives `None`.

The result carries **none** of the measurement-specific fields — `accuracy` and the ranges describe the measurement each operand came from, and the spec attaches no meaning to their combination.

## Verification

507 tests pass across `openehr-rm` and `openehr-codegen`; clippy clean at `-D warnings` in both; both generations stamped from the one template.