### PR TITLE
feat(rm): the whole DV_* function surface, and accuracy propagates as the spec defines it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,28 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
+- **Every `DV_*` arithmetic and accessor function the openEHR RM defines** is
+  now implemented on the published spec crates — the whole quantity and
+  date/time family, not a subset: `DV_QUANTITY`, `DV_COUNT`, `DV_PROPORTION`
+  and `DV_DURATION` arithmetic; `DV_DATE`, `DV_TIME` and `DV_DATE_TIME`
+  displacement and difference; the `DV_AMOUNT` and `DV_ABSOLUTE_QUANTITY`
+  dispatchers over their subtypes; and `DV_PERIODIC_TIME_SPECIFICATION`'s
+  `period`, `calendar_alignment`, `event_alignment` and
+  `institution_specified`, parsed from the HL7 PIVL/EIVL syntax the spec
+  publishes.
+- **Accuracy now propagates through arithmetic as the RM specifies it.**
+  `DV_AMOUNT` defines the rule — accuracies sum for both addition and
+  subtraction, an unrecorded accuracy on either side makes the result's
+  unknown, and a mixed percent/absolute pair is expressed in the form of the
+  larger operand — and every descendant follows it. `DV_ABSOLUTE_QUANTITY`'s
+  duration-valued variant is applied to the date/time types. A combination no
+  valid value can carry (a percentage past 100) refuses the operation rather
+  than returning a value that fails its own class invariant.
+
+- **A decimal factor now means the decimal its author wrote.** `DV_COUNT` and
+  `DV_PROPORTION` arithmetic reads a `Real` factor as the number it denotes
+  rather than as the binary approximation carrying it, so `count * 0.1` is a
+  whole count and `1/3` equals `0.1/0.3`. The previous reading refused both.
 - **`DV_COUNT` arithmetic and `DV_MULTIMEDIA`/`COMPOSITION` predicates** on the
   published spec crates: `add`, `subtract`, `multiply`, `is_inline`,
   `is_external`, `is_compressed`, `has_integrity_check`, `is_persistent`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5485,7 +5485,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "indexmap 2.14.0",
  "openehr-am",
@@ -5500,7 +5500,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "serde",
  "serde_json",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "async-trait",
  "axum",
@@ -5558,7 +5558,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "assert_fs",
  "chumsky",
@@ -5572,7 +5572,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "chumsky",
  "logos",
@@ -5581,7 +5581,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "insta",
  "jsonschema",
@@ -5599,7 +5599,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-adl"
-version = "0.0.17"
+version = "0.0.18"
 description = "openEHR ADL 2.4.0: hand-written ADL2/cADL/ODIN parser, AOM2 validation catalogue, specialisation flattener, OPT2 generator, and ADL 1.4→2 conversion over the generated openehr_am::v2_4::aom2 model"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,10 +16,10 @@ include = ["src/**", "README.md", "LICENSE-MIT"]
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)
-openehr-base = { path = "../openehr-base", version = "0.0.17" }   # VersionStatus for the parsed HRID
-openehr-am = { path = "../openehr-am", version = "0.0.17" }       # v2_4 ArchetypeHrid (the identification target type)
-openehr-rm = { path = "../openehr-rm", version = "0.0.17" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
-openehr-lang = { path = "../openehr-lang", version = "0.0.17" }   # openehr_lang::odin — the ODIN section parser
+openehr-base = { path = "../openehr-base", version = "0.0.18" }   # VersionStatus for the parsed HRID
+openehr-am = { path = "../openehr-am", version = "0.0.18" }       # v2_4 ArchetypeHrid (the identification target type)
+openehr-rm = { path = "../openehr-rm", version = "0.0.18" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
+openehr-lang = { path = "../openehr-lang", version = "0.0.18" }   # openehr_lang::odin — the ODIN section parser
 uuid.workspace = true        # meta uid/build_uid (AUTHORED_ARCHETYPE.uid: Uuid)
 indexmap.workspace = true    # OdinValue::Object body (insertion-ordered map)
 

--- a/crates/openehr-am/Cargo.toml
+++ b/crates/openehr-am/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-am"
-version = "0.0.17"
+version = "0.0.18"
 description = "openEHR AM Archetype Model, generated from BMM: generations v1_4 (AM 1.4.0, ADL 1.4) and v2_4 (AM 2.4.0, ADL 2; current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,8 +13,8 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.17" }
-openehr-lang = { path = "../openehr-lang", version = "0.0.17" }
+openehr-base = { path = "../openehr-base", version = "0.0.18" }
+openehr-lang = { path = "../openehr-lang", version = "0.0.18" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also carries the untyped `Value` fields the generator

--- a/crates/openehr-base/Cargo.toml
+++ b/crates/openehr-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-base"
-version = "0.0.17"
+version = "0.0.18"
 description = "openEHR BASE foundation + base types, generated from BMM: generations v1_2 (BASE 1.2.0) and v1_3 (BASE 1.3.0, current)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-its"
-version = "0.0.17"
+version = "0.0.18"
 description = "openEHR ITS (Implementation Technology Specifications): canonical JSON + canonical XML serialization of the RM, the generated ITS-REST 1.1.0 API contract, OPT 1.4 and AOM2 archetype XML codecs, and the Simplified Formats (FLAT / STRUCTURED / Web Template)"
 edition.workspace = true
 rust-version.workspace = true
@@ -41,14 +41,14 @@ regex = { workspace = true, optional = true }
 fancy-regex = { workspace = true, optional = true }
 # The generated XML (de)serializers impl the crate's ToXml/FromXml traits for the
 # RM/BASE spec types, so these are real (non-dev) deps.
-openehr-base = { path = "../openehr-base", version = "0.0.17", optional = true }
-openehr-rm = { path = "../openehr-rm", version = "0.0.17", optional = true }
+openehr-base = { path = "../openehr-base", version = "0.0.18", optional = true }
+openehr-rm = { path = "../openehr-rm", version = "0.0.18", optional = true }
 # The native canonical-JSON codec (`json_codec/generated`, emit-json) implements
 # `ToJson` for EVERY generated spec type the `OpenEhrType` derive covers, so it
 # spans all five spec crates (not just the RM/BASE the XML codec needs).
-openehr-lang = { path = "../openehr-lang", version = "0.0.17", optional = true }
-openehr-am = { path = "../openehr-am", version = "0.0.17", optional = true }
-openehr-term = { path = "../openehr-term", version = "0.0.17", optional = true }
+openehr-lang = { path = "../openehr-lang", version = "0.0.18", optional = true }
+openehr-am = { path = "../openehr-am", version = "0.0.18", optional = true }
+openehr-term = { path = "../openehr-term", version = "0.0.18", optional = true }
 
 # `full` — every ITS surface (canonical JSON/XML, the generated ITS-REST
 # contract, `opt14`, Simplified Formats). ON BY DEFAULT, so every consumer sees

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-lang"
-version = "0.0.17"
+version = "0.0.18"
 description = "openEHR LANG BMM/P_BMM object model, generated from BMM: generations v1_0 (LANG 1.0.0) and v1_1 (LANG 1.1.0, current; the stable BMM v2.x unit beside the paused BMM3 unit), plus hand-written ODIN/BEL/EL readers"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["parser-implementations", "data-structures"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.17" }
+openehr-base = { path = "../openehr-base", version = "0.0.18" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the
 # generated types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) —
 # never a derive. `serde_json` also carries the untyped `Value` fields the

--- a/crates/openehr-query/Cargo.toml
+++ b/crates/openehr-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-query"
-version = "0.0.17"
+version = "0.0.18"
 description = "openEHR QUERY (AQL 1.1.0): hand-written lexer, parser, typed AST and canonical printer from the official grammar (no ANTLR runtime)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-rm"
-version = "0.0.17"
+version = "0.0.18"
 description = "openEHR RM Reference Model, generated from BMM: generations v1_1 (RM 1.1.0) and v1_2 (RM 1.2.0, current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,11 +13,11 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.17" }
+openehr-base = { path = "../openehr-base", version = "0.0.18" }
 # The terminology-backed RM class invariants (`validate::terminology`) resolve
 # openEHR terminology groups + code sets against the vendored TERM 3.1.0 bundle.
 # `openehr-term` itself depends only on `openehr-base`, so this is acyclic.
-openehr-term = { path = "../openehr-term", version = "0.0.17" }
+openehr-term = { path = "../openehr-term", version = "0.0.18" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also backs the untyped `Value` RM representation used by

--- a/crates/openehr-rm/src/v1_1/data_types/quantity/date_time/dv_date_impl.rs
+++ b/crates/openehr-rm/src/v1_1/data_types/quantity/date_time/dv_date_impl.rs
@@ -11,10 +11,114 @@
 //! `crate::v1_1::validate`).
 
 use crate::v1_1::data_types::quantity::date_time::dv_date::DvDate;
+use crate::v1_1::data_types::quantity::date_time::dv_duration::DvDuration;
+use crate::v1_1::data_types::quantity::dv_absolute_quantity_impl::{
+    difference_accuracy, displaced_accuracy,
+};
+use crate::v1_1::data_types::quantity::dv_amount_impl::CombinedAccuracy;
 use crate::v1_1::data_types::quantity::dv_ordered::DvOrdered;
 use crate::v1_1::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
 use crate::v1_1::validate::is_valid_iso_date;
+use openehr_base::v1_2::foundation_types::time::iso8601_date::Iso8601Date;
+use openehr_base::v1_2::foundation_types::time::iso8601_duration::Iso8601Duration;
 use openehr_base::validate::{InvariantViolation, Validate};
+
+impl DvDate {
+    /// Addition of a duration to this date, or `None` when either value is not
+    /// a valid ISO-8601 string.
+    ///
+    /// Spec: `dv_date.adoc` §Functions `add` — "Addition of a Duration to this
+    /// Date" — effecting `dv_absolute_quantity.adoc`'s abstract `add`, whose
+    /// accuracy rule is realized by [`displaced_accuracy`].
+    ///
+    /// The calendar arithmetic is BASE's `Iso8601_date.add`, so leap years and
+    /// month lengths are answered once, in the type that owns the calendar.
+    #[must_use]
+    pub fn add(&self, a_diff: &DvDuration) -> Option<Self> {
+        Some(self.displaced(self.iso().add(&duration_of(a_diff))?, a_diff))
+    }
+
+    /// Subtraction of a duration from this date, under the same conditions as
+    /// [`Self::add`].
+    ///
+    /// Spec: `dv_date.adoc` §Functions `subtract`.
+    #[must_use]
+    pub fn subtract(&self, a_diff: &DvDuration) -> Option<Self> {
+        Some(self.displaced(self.iso().subtract(&duration_of(a_diff))?, a_diff))
+    }
+
+    /// Difference between this date and `other`, as a duration.
+    ///
+    /// Spec: `dv_date.adoc` §Functions `diff` — "Difference between this Date
+    /// and `other`."
+    #[must_use]
+    pub fn diff(&self, other: &Self) -> Option<DvDuration> {
+        let difference = self.iso().diff(&other.iso())?;
+        let (accuracy, accuracy_is_percent) =
+            match difference_accuracy(self.accuracy.as_ref(), other.accuracy.as_ref()) {
+                CombinedAccuracy::Unrepresentable => return None,
+                CombinedAccuracy::Unknown => (None, None),
+                CombinedAccuracy::Known {
+                    accuracy,
+                    is_percent,
+                } => (Some(accuracy), Some(is_percent)),
+            };
+        Some(DvDuration {
+            value: difference.value,
+            magnitude_status: None,
+            accuracy,
+            accuracy_is_percent,
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        })
+    }
+
+    /// Returns `true` when this date is considered equal to `other`.
+    ///
+    /// Spec: `dv_date.adoc` §Functions `is_equal`, effecting
+    /// `dv_quantified.adoc`'s abstract `is_equal`.
+    ///
+    /// Equality is of the DATE, not of how it was written: `less_than` on this
+    /// class is defined over `magnitude()`, and `2024-01-01` and `20240101`
+    /// name the same day, so comparing the strings would make a value neither
+    /// less than, greater than, nor equal to its own extended form.
+    #[must_use]
+    pub fn is_equal(&self, other: &Self) -> bool {
+        match (self.magnitude(), other.magnitude()) {
+            (Some(left), Some(right)) => left == right,
+            // A value with no magnitude is not a date this function can
+            // compare; only an identical string can still be the same one.
+            _ => self.value == other.value,
+        }
+    }
+
+    /// This date's `value` as the BASE ISO-8601 type that owns the calendar.
+    fn iso(&self) -> Iso8601Date {
+        Iso8601Date {
+            value: self.value.clone(),
+        }
+    }
+
+    /// This date at a new value, carrying the displaced accuracy.
+    fn displaced(&self, value: Iso8601Date, a_diff: &DvDuration) -> Self {
+        Self {
+            value: value.value,
+            magnitude_status: None,
+            accuracy: displaced_accuracy(self.accuracy.as_ref(), a_diff),
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        }
+    }
+}
+
+/// A `DV_DURATION`'s `value` as the BASE ISO-8601 type.
+fn duration_of(duration: &DvDuration) -> Iso8601Duration {
+    Iso8601Duration {
+        value: duration.value.clone(),
+    }
+}
 
 impl Validate for DvDate {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
@@ -67,6 +171,108 @@ mod tests {
         assert!(
             v.iter()
                 .any(|m| m.message == "Invariant Value_valid failed on type DV_DATE")
+        );
+    }
+
+    fn duration(value: &str) -> DvDuration {
+        DvDuration {
+            normal_status: None,
+            normal_range: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+            magnitude_status: None,
+            accuracy: None,
+            accuracy_is_percent: None,
+            value: value.to_owned(),
+        }
+    }
+
+    /// `DV_DATE` declares `add`, and BASE defines that as "arithmetic addition
+    /// of a duration to a date" — the NOMINAL calendar semantics belong to
+    /// `add_nominal`, which this class does not declare. So `P1M` is the
+    /// duration's own average month, not "the same day next month": adding it
+    /// to 31 January lands on 1 March, not on the end of February.
+    #[test]
+    fn arithmetic_is_the_spec_s_arithmetic_addition_not_the_nominal_one() {
+        assert_eq!(
+            date("2024-01-31")
+                .add(&duration("P1M"))
+                .expect("valid")
+                .value,
+            "2024-03-01",
+            "P1M is an average month of seconds, not a nominal calendar month"
+        );
+
+        // Exact durations still land exactly, leap day included.
+        assert_eq!(
+            date("2024-02-28")
+                .add(&duration("P1D"))
+                .expect("valid")
+                .value,
+            "2024-02-29"
+        );
+        assert_eq!(
+            date("2024-03-01")
+                .subtract(&duration("P1D"))
+                .expect("valid")
+                .value,
+            "2024-02-29"
+        );
+    }
+
+    /// `diff` returns the difference as a duration.
+    #[test]
+    fn diff_returns_a_duration() {
+        let difference = date("2024-03-01").diff(&date("2024-02-01")).expect("valid");
+        assert_eq!(difference.magnitude(), Some(29.0 * 86_400.0));
+    }
+
+    /// A value that is not a valid ISO-8601 date has no arithmetic.
+    #[test]
+    fn an_invalid_value_has_no_arithmetic() {
+        let bad = date("2021-13-40");
+        assert!(bad.add(&duration("P1D")).is_none());
+        assert!(bad.diff(&date("2024-01-01")).is_none());
+        assert!(date("2024-01-01").add(&duration("one day")).is_none());
+    }
+
+    /// Equality is of the DATE, not of the string: the extended and basic forms
+    /// name the same day, and `less_than` already orders them by magnitude.
+    #[test]
+    fn is_equal_compares_the_date_not_the_string() {
+        assert!(date("2024-01-01").is_equal(&date("20240101")));
+        assert!(!date("2024-01-01").is_equal(&date("2024-01-02")));
+    }
+
+    /// "The sum of the accuracies of the operands, if both present, or unknown,
+    /// if either or both operand accuracies are unknown."
+    #[test]
+    fn accuracy_follows_the_absolute_quantity_rule() {
+        let mut precise = date("2024-01-01");
+        precise.accuracy = Some(duration("PT30M"));
+        let mut offset = duration("P1D");
+        offset.accuracy = Some(60.0);
+        offset.accuracy_is_percent = Some(false);
+
+        let moved = precise.add(&offset).expect("valid");
+        assert_eq!(
+            moved.accuracy.expect("both present").magnitude(),
+            Some(1860.0)
+        );
+
+        // An operand with no accuracy makes the result's unknown.
+        assert!(
+            precise
+                .add(&duration("P1D"))
+                .expect("valid")
+                .accuracy
+                .is_none()
+        );
+        assert!(
+            date("2024-01-01")
+                .add(&offset)
+                .expect("valid")
+                .accuracy
+                .is_none()
         );
     }
 }

--- a/crates/openehr-rm/src/v1_1/data_types/quantity/date_time/dv_date_time_impl.rs
+++ b/crates/openehr-rm/src/v1_1/data_types/quantity/date_time/dv_date_time_impl.rs
@@ -6,10 +6,92 @@
 //! the NOTE on why this is an explicit invariant.
 
 use crate::v1_1::data_types::quantity::date_time::dv_date_time::DvDateTime;
+use crate::v1_1::data_types::quantity::date_time::dv_duration::DvDuration;
+use crate::v1_1::data_types::quantity::dv_absolute_quantity_impl::{
+    difference_accuracy, displaced_accuracy,
+};
+use crate::v1_1::data_types::quantity::dv_amount_impl::CombinedAccuracy;
 use crate::v1_1::data_types::quantity::dv_ordered::DvOrdered;
 use crate::v1_1::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
 use crate::v1_1::validate::is_valid_iso_date_time;
+use openehr_base::v1_2::foundation_types::time::iso8601_date_time::Iso8601DateTime;
+use openehr_base::v1_2::foundation_types::time::iso8601_duration::Iso8601Duration;
 use openehr_base::validate::{InvariantViolation, Validate};
+
+impl DvDateTime {
+    /// Addition of a duration to this date-time, or `None` when either value is
+    /// not a valid ISO-8601 string.
+    ///
+    /// Spec: `dv_date_time.adoc` §Functions `add`, effecting
+    /// `dv_absolute_quantity.adoc`'s abstract `add`, whose accuracy rule is
+    /// realized by [`displaced_accuracy`].
+    #[must_use]
+    pub fn add(&self, a_diff: &DvDuration) -> Option<Self> {
+        Some(self.displaced(self.iso().add(&duration_of(a_diff))?, a_diff))
+    }
+
+    /// Subtraction of a duration from this date-time, under the same conditions
+    /// as [`Self::add`].
+    ///
+    /// Spec: `dv_date_time.adoc` §Functions `subtract`.
+    #[must_use]
+    pub fn subtract(&self, a_diff: &DvDuration) -> Option<Self> {
+        Some(self.displaced(self.iso().subtract(&duration_of(a_diff))?, a_diff))
+    }
+
+    /// Difference between this date-time and `other`, as a duration.
+    ///
+    /// Spec: `dv_date_time.adoc` §Functions `diff`.
+    #[must_use]
+    pub fn diff(&self, other: &Self) -> Option<DvDuration> {
+        let difference = self.iso().diff(&other.iso())?;
+        let (accuracy, accuracy_is_percent) =
+            match difference_accuracy(self.accuracy.as_ref(), other.accuracy.as_ref()) {
+                CombinedAccuracy::Unrepresentable => return None,
+                CombinedAccuracy::Unknown => (None, None),
+                CombinedAccuracy::Known {
+                    accuracy,
+                    is_percent,
+                } => (Some(accuracy), Some(is_percent)),
+            };
+        Some(DvDuration {
+            value: difference.value,
+            magnitude_status: None,
+            accuracy,
+            accuracy_is_percent,
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        })
+    }
+
+    /// This date-time's `value` as the BASE ISO-8601 type that owns the
+    /// calendar.
+    fn iso(&self) -> Iso8601DateTime {
+        Iso8601DateTime {
+            value: self.value.clone(),
+        }
+    }
+
+    /// This date-time at a new value, carrying the displaced accuracy.
+    fn displaced(&self, value: Iso8601DateTime, a_diff: &DvDuration) -> Self {
+        Self {
+            value: value.value,
+            magnitude_status: None,
+            accuracy: displaced_accuracy(self.accuracy.as_ref(), a_diff),
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        }
+    }
+}
+
+/// A `DV_DURATION`'s `value` as the BASE ISO-8601 type.
+fn duration_of(duration: &DvDuration) -> Iso8601Duration {
+    Iso8601Duration {
+        value: duration.value.clone(),
+    }
+}
 
 impl Validate for DvDateTime {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
@@ -61,6 +143,75 @@ mod tests {
         assert!(
             v.iter()
                 .any(|m| m.message == "Invariant Value_valid failed on type DV_DATE_TIME")
+        );
+    }
+
+    fn duration(value: &str) -> DvDuration {
+        DvDuration {
+            normal_status: None,
+            normal_range: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+            magnitude_status: None,
+            accuracy: None,
+            accuracy_is_percent: None,
+            value: value.to_owned(),
+        }
+    }
+
+    /// Date-times displace across the day boundary and across the calendar,
+    /// because BASE answers both in one type.
+    #[test]
+    fn arithmetic_crosses_the_day_and_the_calendar() {
+        let evening = date_time("2024-02-28T23:00:00");
+        assert_eq!(
+            evening.add(&duration("PT2H")).expect("valid").value,
+            "2024-02-29T01:00:00",
+            "into the leap day"
+        );
+        assert_eq!(
+            evening.subtract(&duration("P1D")).expect("valid").value,
+            "2024-02-27T23:00:00"
+        );
+        assert_eq!(
+            evening
+                .diff(&date_time("2024-02-28T21:00:00"))
+                .expect("valid")
+                .magnitude(),
+            Some(7200.0)
+        );
+    }
+
+    /// A value that is not a valid ISO-8601 date-time has no arithmetic.
+    #[test]
+    fn an_invalid_value_has_no_arithmetic() {
+        let bad = date_time("2021-05-17T99:00:00");
+        assert!(bad.add(&duration("PT1H")).is_none());
+        assert!(bad.diff(&date_time("2024-01-01T00:00:00")).is_none());
+    }
+
+    /// The `DV_ABSOLUTE_QUANTITY` accuracy rule, including a percentage
+    /// half-range resolved against the differential amount's own magnitude.
+    #[test]
+    fn accuracy_follows_the_absolute_quantity_rule() {
+        let mut precise = date_time("2024-01-01T00:00:00");
+        precise.accuracy = Some(duration("PT5S"));
+        let mut offset = duration("PT100S");
+        offset.accuracy = Some(10.0);
+        offset.accuracy_is_percent = Some(true);
+
+        let moved = precise.add(&offset).expect("valid");
+        assert_eq!(
+            moved.accuracy.expect("both present").magnitude(),
+            Some(15.0),
+            "5s + 10% of 100s"
+        );
+
+        assert!(
+            precise
+                .add(&duration("PT100S"))
+                .expect("valid")
+                .accuracy
+                .is_none()
         );
     }
 }

--- a/crates/openehr-rm/src/v1_1/data_types/quantity/date_time/dv_duration_impl.rs
+++ b/crates/openehr-rm/src/v1_1/data_types/quantity/date_time/dv_duration_impl.rs
@@ -7,10 +7,129 @@
 //! `dv_date_impl` for the NOTE on why value well-formedness is explicit.
 
 use crate::v1_1::data_types::quantity::date_time::dv_duration::DvDuration;
+use crate::v1_1::data_types::quantity::dv_amount_impl::{
+    AmountAccuracy, CombinedAccuracy, combine, scale,
+};
 use crate::v1_1::data_types::quantity::dv_ordered::DvOrdered;
 use crate::v1_1::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
 use crate::v1_1::validate::is_valid_iso_duration;
+use openehr_base::v1_2::foundation_types::time::iso8601_duration::Iso8601Duration;
 use openehr_base::validate::{InvariantViolation, Validate};
+
+impl DvDuration {
+    /// Sum of this duration and `other`, or `None` when either value is not a
+    /// valid ISO-8601 duration or the result is one no valid duration can
+    /// carry.
+    ///
+    /// Spec: `dv_duration.adoc` §Functions `add` — "Sum of this Duration and
+    /// `other`" — redefining `dv_amount.adoc` §Functions `add`. `DV_DURATION`
+    /// effects `is_strictly_comparable_to` as "True, for any two Durations", so
+    /// the inherited pre-condition never refuses a pair.
+    ///
+    /// The arithmetic is BASE's — `Iso8601_duration.add` — so the result stays
+    /// a duration STRING with its designators intact, rather than a second of
+    /// seconds this crate would have to render back.
+    #[must_use]
+    pub fn add(&self, other: &Self) -> Option<Self> {
+        Self::carrying(
+            self.iso().add(&other.iso())?,
+            combine(self.amount_accuracy()?, other.amount_accuracy()?),
+        )
+    }
+
+    /// Difference of this duration and `other`, under the same conditions as
+    /// [`Self::add`].
+    ///
+    /// Spec: `dv_duration.adoc` §Functions `subtract`.
+    #[must_use]
+    pub fn subtract(&self, other: &Self) -> Option<Self> {
+        Self::carrying(
+            self.iso().subtract(&other.iso())?,
+            combine(self.amount_accuracy()?, other.amount_accuracy()?),
+        )
+    }
+
+    /// Product of this duration and `factor`.
+    ///
+    /// Spec: `dv_duration.adoc` §Functions `multiply` — "Product of this
+    /// Duration and `factor`."
+    #[must_use]
+    pub fn multiply(&self, factor: f64) -> Option<Self> {
+        Self::carrying(
+            self.iso().multiply(factor)?,
+            scale(self.amount_accuracy()?, factor),
+        )
+    }
+
+    /// Negated version of this duration.
+    ///
+    /// Spec: `dv_duration.adoc` §Functions `negative` — "Assuming the current
+    /// duration is positive, the negated version represents a time prior to
+    /// some origin point, or a negative age (e.g. so-called 'adjusted age' of
+    /// premature infant)."
+    ///
+    /// Negation changes the sign of the magnitude, not how well it was
+    /// measured, so the accuracy is carried through unchanged — the one
+    /// arithmetic function here for which that is a fact rather than a rule.
+    #[must_use]
+    pub fn negative(&self) -> Option<Self> {
+        let mut negated = self.clone();
+        negated.value = self.iso().negative()?.value;
+        negated.normal_range = None;
+        negated.normal_status = None;
+        negated.magnitude_status = None;
+        negated.other_reference_ranges = openehr_base::containers::present_nonempty(Vec::new());
+        Some(negated)
+    }
+
+    /// Returns `true` when this duration's accuracy was not recorded.
+    ///
+    /// Spec: `dv_quantified.adoc` §Functions `accuracy_unknown`, effected for
+    /// `DV_AMOUNT` by the `unknown_accuracy_value` sentinel.
+    #[must_use]
+    pub fn accuracy_unknown(&self) -> bool {
+        self.accuracy.is_none_or(|value| value < 0.0)
+    }
+
+    /// This duration's `value` as the BASE ISO-8601 type that owns the
+    /// arithmetic.
+    fn iso(&self) -> Iso8601Duration {
+        Iso8601Duration {
+            value: self.value.clone(),
+        }
+    }
+
+    /// This duration's accuracy as the `DV_AMOUNT` rule reads it, or `None`
+    /// when `value` has no magnitude to measure a percentage against.
+    fn amount_accuracy(&self) -> Option<AmountAccuracy> {
+        Some(AmountAccuracy::measured(
+            self.magnitude()?,
+            self.accuracy,
+            self.accuracy_is_percent,
+        ))
+    }
+
+    /// This duration at a new value and accuracy.
+    fn carrying(value: Iso8601Duration, accuracy: CombinedAccuracy) -> Option<Self> {
+        let (accuracy, accuracy_is_percent) = match accuracy {
+            CombinedAccuracy::Unrepresentable => return None,
+            CombinedAccuracy::Unknown => (None, None),
+            CombinedAccuracy::Known {
+                accuracy,
+                is_percent,
+            } => (Some(accuracy), Some(is_percent)),
+        };
+        Some(Self {
+            value: value.value,
+            magnitude_status: None,
+            accuracy,
+            accuracy_is_percent,
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        })
+    }
+}
 
 impl Validate for DvDuration {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
@@ -66,5 +185,71 @@ mod tests {
             v.iter()
                 .any(|m| m.message == "Invariant Value_valid failed on type DV_DURATION")
         );
+    }
+
+    /// `is_strictly_comparable_to` is "True, for any two Durations", so unlike
+    /// `DV_QUANTITY` no pair is refused for incomparability — the arithmetic
+    /// runs on the ISO-8601 values themselves.
+    #[test]
+    fn arithmetic_runs_on_the_iso_value() {
+        let a = duration("PT2H");
+        let b = duration("PT30M");
+
+        assert_eq!(a.add(&b).expect("valid").magnitude(), Some(9000.0));
+        assert_eq!(a.subtract(&b).expect("valid").magnitude(), Some(5400.0));
+        assert_eq!(a.multiply(2.0).expect("valid").magnitude(), Some(14400.0));
+        assert_eq!(a.negative().expect("valid").magnitude(), Some(-7200.0));
+    }
+
+    /// A value that is not a valid ISO-8601 duration has no arithmetic: BASE
+    /// refuses to parse it, and the refusal is propagated rather than turned
+    /// into a zero.
+    #[test]
+    fn an_invalid_value_has_no_arithmetic() {
+        let bad = duration("10 hours");
+        let good = duration("PT1H");
+        assert!(bad.add(&good).is_none());
+        assert!(good.add(&bad).is_none());
+        assert!(bad.multiply(2.0).is_none());
+        assert!(bad.negative().is_none());
+    }
+
+    /// `DV_DURATION` is a `DV_AMOUNT`, so its arithmetic carries the same
+    /// accuracy rule — summed for add and subtract, scaled for multiply, and
+    /// unchanged by negation, which alters the sign rather than the
+    /// measurement.
+    #[test]
+    fn accuracy_follows_the_dv_amount_rule() {
+        let mut a = duration("PT2H");
+        a.accuracy = Some(60.0);
+        a.accuracy_is_percent = Some(false);
+        let mut b = duration("PT30M");
+        b.accuracy = Some(30.0);
+        b.accuracy_is_percent = Some(false);
+
+        let sum = a.add(&b).expect("valid");
+        assert!((sum.accuracy.expect("both recorded one") - 90.0).abs() < f64::EPSILON);
+        assert_eq!(sum.accuracy_is_percent, Some(false));
+
+        let scaled = a.multiply(3.0).expect("valid");
+        assert!((scaled.accuracy.expect("scaled") - 180.0).abs() < f64::EPSILON);
+
+        let negated = a.negative().expect("valid");
+        assert!((negated.accuracy.expect("kept") - 60.0).abs() < f64::EPSILON);
+
+        // Unrecorded on either side makes the result's unknown.
+        let plain = duration("PT30M");
+        assert!(a.add(&plain).expect("valid").accuracy.is_none());
+    }
+
+    /// `accuracy_unknown` reads both ways of not recording an accuracy.
+    #[test]
+    fn accuracy_unknown_reads_the_sentinel_and_the_absence() {
+        let mut d = duration("PT1H");
+        assert!(d.accuracy_unknown());
+        d.accuracy = Some(-1.0);
+        assert!(d.accuracy_unknown());
+        d.accuracy = Some(0.0);
+        assert!(!d.accuracy_unknown(), "0 means 100% accurate, not unknown");
     }
 }

--- a/crates/openehr-rm/src/v1_1/data_types/quantity/date_time/dv_time_impl.rs
+++ b/crates/openehr-rm/src/v1_1/data_types/quantity/date_time/dv_time_impl.rs
@@ -5,11 +5,93 @@
 //! inherited DV_QUANTIFIED `Magnitude_status_valid`. See `dv_date_impl` for the
 //! NOTE on why this is an explicit invariant.
 
+use crate::v1_1::data_types::quantity::date_time::dv_duration::DvDuration;
 use crate::v1_1::data_types::quantity::date_time::dv_time::DvTime;
+use crate::v1_1::data_types::quantity::dv_absolute_quantity_impl::{
+    difference_accuracy, displaced_accuracy,
+};
+use crate::v1_1::data_types::quantity::dv_amount_impl::CombinedAccuracy;
 use crate::v1_1::data_types::quantity::dv_ordered::DvOrdered;
 use crate::v1_1::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
 use crate::v1_1::validate::is_valid_iso_time;
+use openehr_base::v1_2::foundation_types::time::iso8601_duration::Iso8601Duration;
+use openehr_base::v1_2::foundation_types::time::iso8601_time::Iso8601Time;
 use openehr_base::validate::{InvariantViolation, Validate};
+
+impl DvTime {
+    /// Addition of a duration to this time, or `None` when either value is not
+    /// a valid ISO-8601 string.
+    ///
+    /// Spec: `dv_time.adoc` §Functions `add` — "Addition of a Duration to this
+    /// Time" — effecting `dv_absolute_quantity.adoc`'s abstract `add`, whose
+    /// accuracy rule is realized by [`displaced_accuracy`].
+    #[must_use]
+    pub fn add(&self, a_diff: &DvDuration) -> Option<Self> {
+        Some(self.displaced(self.iso().add(&duration_of(a_diff))?, a_diff))
+    }
+
+    /// Subtraction of a duration from this time, under the same conditions as
+    /// [`Self::add`].
+    ///
+    /// Spec: `dv_time.adoc` §Functions `subtract`.
+    #[must_use]
+    pub fn subtract(&self, a_diff: &DvDuration) -> Option<Self> {
+        Some(self.displaced(self.iso().subtract(&duration_of(a_diff))?, a_diff))
+    }
+
+    /// Difference between this time and `other`, as a duration.
+    ///
+    /// Spec: `dv_time.adoc` §Functions `diff` — "Difference between this Time
+    /// and `other`."
+    #[must_use]
+    pub fn diff(&self, other: &Self) -> Option<DvDuration> {
+        let difference = self.iso().diff(&other.iso())?;
+        let (accuracy, accuracy_is_percent) =
+            match difference_accuracy(self.accuracy.as_ref(), other.accuracy.as_ref()) {
+                CombinedAccuracy::Unrepresentable => return None,
+                CombinedAccuracy::Unknown => (None, None),
+                CombinedAccuracy::Known {
+                    accuracy,
+                    is_percent,
+                } => (Some(accuracy), Some(is_percent)),
+            };
+        Some(DvDuration {
+            value: difference.value,
+            magnitude_status: None,
+            accuracy,
+            accuracy_is_percent,
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        })
+    }
+
+    /// This time's `value` as the BASE ISO-8601 type that owns the arithmetic.
+    fn iso(&self) -> Iso8601Time {
+        Iso8601Time {
+            value: self.value.clone(),
+        }
+    }
+
+    /// This time at a new value, carrying the displaced accuracy.
+    fn displaced(&self, value: Iso8601Time, a_diff: &DvDuration) -> Self {
+        Self {
+            value: value.value,
+            magnitude_status: None,
+            accuracy: displaced_accuracy(self.accuracy.as_ref(), a_diff),
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        }
+    }
+}
+
+/// A `DV_DURATION`'s `value` as the BASE ISO-8601 type.
+fn duration_of(duration: &DvDuration) -> Iso8601Duration {
+    Iso8601Duration {
+        value: duration.value.clone(),
+    }
+}
 
 impl Validate for DvTime {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
@@ -62,5 +144,69 @@ mod tests {
             v.iter()
                 .any(|m| m.message == "Invariant Value_valid failed on type DV_TIME")
         );
+    }
+
+    fn duration(value: &str) -> DvDuration {
+        DvDuration {
+            normal_status: None,
+            normal_range: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+            magnitude_status: None,
+            accuracy: None,
+            accuracy_is_percent: None,
+            value: value.to_owned(),
+        }
+    }
+
+    /// Times displace by a duration and difference into one.
+    #[test]
+    fn arithmetic_displaces_within_the_day() {
+        let noon = time("12:00:00");
+        assert_eq!(
+            noon.add(&duration("PT90M")).expect("valid").magnitude(),
+            Some(48_600.0)
+        );
+        assert_eq!(
+            noon.subtract(&duration("PT30M"))
+                .expect("valid")
+                .magnitude(),
+            Some(41_400.0)
+        );
+        assert_eq!(
+            noon.diff(&time("11:00:00")).expect("valid").magnitude(),
+            Some(3600.0)
+        );
+    }
+
+    /// A value that is not a valid ISO-8601 time has no arithmetic.
+    #[test]
+    fn an_invalid_value_has_no_arithmetic() {
+        let bad = time("25:99");
+        assert!(bad.add(&duration("PT1H")).is_none());
+        assert!(bad.diff(&time("12:00:00")).is_none());
+    }
+
+    /// The `DV_ABSOLUTE_QUANTITY` accuracy rule: summed when both operands
+    /// record one, unknown when either does not.
+    #[test]
+    fn accuracy_follows_the_absolute_quantity_rule() {
+        let mut precise = time("12:00:00");
+        precise.accuracy = Some(duration("PT10S"));
+        let mut offset = duration("PT1H");
+        offset.accuracy = Some(5.0);
+        offset.accuracy_is_percent = Some(false);
+
+        let moved = precise.add(&offset).expect("valid");
+        assert_eq!(
+            moved.accuracy.expect("both present").magnitude(),
+            Some(15.0)
+        );
+
+        // `diff` reports the summed accuracy as the resulting amount's own.
+        let mut other = time("11:00:00");
+        other.accuracy = Some(duration("PT20S"));
+        let difference = precise.diff(&other).expect("valid");
+        assert_eq!(difference.accuracy, Some(30.0));
+        assert_eq!(difference.accuracy_is_percent, Some(false));
     }
 }

--- a/crates/openehr-rm/src/v1_1/data_types/quantity/dv_absolute_quantity_impl.rs
+++ b/crates/openehr-rm/src/v1_1/data_types/quantity/dv_absolute_quantity_impl.rs
@@ -1,0 +1,240 @@
+// @generated-from-template templates/openehr-rm/data_types/quantity/dv_absolute_quantity_impl.rs — DO NOT EDIT; edit the source and re-run `openehr-codegen -- emit`.
+//! Hand-written `DV_ABSOLUTE_QUANTITY` spec behaviour, shared by its
+//! descendants.
+//!
+//! `DV_ABSOLUTE_QUANTITY` is abstract, so the generated `DvAbsoluteQuantity` is
+//! a subtype enum and the accuracy rule its `add`/`subtract`/`diff` declare has
+//! no single struct to live on. It is realized once here and called by
+//! `DV_DATE`, `DV_TIME` and `DV_DATE_TIME`.
+//!
+//! The rule differs from `DV_AMOUNT`'s in what it operates on rather than in
+//! what it says: accuracy here is redefined as a `DV_AMOUNT` — a `DV_DURATION`
+//! for the three temporal descendants — so the "sum of the accuracies" is a
+//! duration sum, not a real one.
+
+use crate::v1_1::data_types::quantity::date_time::dv_duration::DvDuration;
+use crate::v1_1::data_types::quantity::dv_absolute_quantity::DvAbsoluteQuantity;
+use crate::v1_1::data_types::quantity::dv_amount::DvAmount;
+use crate::v1_1::data_types::quantity::dv_amount_impl::AmountAccuracy;
+use crate::v1_1::data_types::quantity::dv_amount_impl::{CombinedAccuracy, combine};
+use openehr_base::v1_2::foundation_types::time::iso8601_duration::Iso8601Duration;
+
+/// The accuracy of an absolute quantity displaced by a differential amount.
+///
+/// Spec: `dv_absolute_quantity.adoc` §Functions `add`/`subtract` — "the sum of
+/// the accuracies of the operands, if both present, or unknown, if either or
+/// both operand accuracies are unknown."
+///
+/// The two operands measure their accuracy differently: this quantity's is
+/// already a duration, while the differential amount's is a `Real` half-range
+/// over its own magnitude. The amount's is converted into a duration of that
+/// many seconds — `DV_DURATION.magnitude` is seconds by definition — and the
+/// two durations are then added by BASE.
+#[must_use]
+pub fn displaced_accuracy(
+    accuracy: Option<&DvDuration>,
+    amount: &DvDuration,
+) -> Option<DvDuration> {
+    let own = accuracy?;
+    let amount_seconds = absolute_accuracy_seconds(amount)?;
+    let sum = Iso8601Duration {
+        value: own.value.clone(),
+    }
+    .add(&seconds_as_duration(amount_seconds))?;
+    Some(DvDuration {
+        value: sum.value,
+        magnitude_status: None,
+        accuracy: None,
+        accuracy_is_percent: None,
+        normal_range: None,
+        normal_status: None,
+        other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+    })
+}
+
+/// The accuracy of the difference between two absolute quantities.
+///
+/// Spec: `dv_absolute_quantity.adoc` §Functions `diff` — same rule, but the
+/// result is a `DV_AMOUNT`, so the summed duration is reported as that amount's
+/// own `Real` accuracy in seconds.
+#[must_use]
+pub fn difference_accuracy(
+    left: Option<&DvDuration>,
+    right: Option<&DvDuration>,
+) -> CombinedAccuracy {
+    let (Some(left), Some(right)) = (left, right) else {
+        return CombinedAccuracy::Unknown;
+    };
+    let (Some(left_seconds), Some(right_seconds)) = (left.magnitude(), right.magnitude()) else {
+        return CombinedAccuracy::Unrepresentable;
+    };
+    // Both half-ranges are already absolute values in seconds, so the
+    // `DV_AMOUNT` rule reduces to adding them — routed through it anyway so the
+    // finiteness and zero-form checks stay in one place.
+    combine(
+        AmountAccuracy::measured(left_seconds, Some(left_seconds), Some(false)),
+        AmountAccuracy::measured(right_seconds, Some(right_seconds), Some(false)),
+    )
+}
+
+/// A duration's accuracy as an absolute half-range in seconds, resolving a
+/// percentage against the duration's own magnitude.
+fn absolute_accuracy_seconds(amount: &DvDuration) -> Option<f64> {
+    let accuracy = amount.accuracy.filter(|value| *value >= 0.0)?;
+    if amount.accuracy_is_percent == Some(true) {
+        return Some(accuracy / 100.0 * amount.magnitude()?.abs());
+    }
+    Some(accuracy)
+}
+
+/// A number of seconds as an ISO-8601 duration.
+fn seconds_as_duration(seconds: f64) -> Iso8601Duration {
+    Iso8601Duration {
+        value: format!("PT{seconds}S"),
+    }
+}
+
+impl DvAbsoluteQuantity {
+    /// Addition of a differential amount to this quantity, or `None` when the
+    /// amount is not one this quantity can be displaced by.
+    ///
+    /// Spec: `dv_absolute_quantity.adoc` §Functions `add` — "Addition of a
+    /// differential amount to this quantity."
+    ///
+    /// The spec types the differential as any `DV_AMOUNT`, but each concrete
+    /// descendant narrows it: all three temporal ones effect `add` with a
+    /// `DV_DURATION` parameter, because a date displaced by a count or a
+    /// proportion is not a date. Anything else is refused here.
+    #[must_use]
+    pub fn add(&self, a_diff: &DvAmount) -> Option<Self> {
+        let DvAmount::DvDuration(a_diff) = a_diff else {
+            return None;
+        };
+        match self {
+            Self::DvDate(date) => date.add(a_diff).map(Self::DvDate),
+            Self::DvDateTime(date_time) => date_time.add(a_diff).map(Self::DvDateTime),
+            Self::DvTime(time) => time.add(a_diff).map(Self::DvTime),
+        }
+    }
+
+    /// Subtraction of a differential amount from this quantity, under the same
+    /// conditions as [`Self::add`].
+    ///
+    /// Spec: `dv_absolute_quantity.adoc` §Functions `subtract`.
+    #[must_use]
+    pub fn subtract(&self, a_diff: &DvAmount) -> Option<Self> {
+        let DvAmount::DvDuration(a_diff) = a_diff else {
+            return None;
+        };
+        match self {
+            Self::DvDate(date) => date.subtract(a_diff).map(Self::DvDate),
+            Self::DvDateTime(date_time) => date_time.subtract(a_diff).map(Self::DvDateTime),
+            Self::DvTime(time) => time.subtract(a_diff).map(Self::DvTime),
+        }
+    }
+
+    /// Difference of two quantities, as the differential amount between them.
+    ///
+    /// Spec: `dv_absolute_quantity.adoc` §Functions `diff` — "Difference of two
+    /// quantities." Only two quantities of the same concrete type have one: the
+    /// difference between a date and a time of day is not a duration.
+    #[must_use]
+    pub fn diff(&self, other: &Self) -> Option<DvAmount> {
+        match (self, other) {
+            (Self::DvDate(left), Self::DvDate(right)) => left.diff(right),
+            (Self::DvDateTime(left), Self::DvDateTime(right)) => left.diff(right),
+            (Self::DvTime(left), Self::DvTime(right)) => left.diff(right),
+            _ => None,
+        }
+        .map(DvAmount::DvDuration)
+    }
+
+    /// Returns `true` when this quantity's accuracy was not recorded.
+    ///
+    /// Spec: `dv_quantified.adoc` §Functions `accuracy_unknown`, effected for
+    /// `DV_ABSOLUTE_QUANTITY` by `master06-quantity_package.adoc` §Accuracy and
+    /// Uncertainty — "in the `DV_ABSOLUTE_QUANTITY` class, `accuracy_unknown`
+    /// is represented by a Void (i.e. null) value for the accuracy attribute."
+    /// There is no `-1` sentinel here: the attribute is a `DV_AMOUNT`, so its
+    /// absence IS the unknown.
+    #[must_use]
+    pub fn accuracy_unknown(&self) -> bool {
+        match self {
+            Self::DvDate(date) => date.accuracy.is_none(),
+            Self::DvDateTime(date_time) => date_time.accuracy.is_none(),
+            Self::DvTime(time) => time.accuracy.is_none(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn duration(value: &str) -> DvDuration {
+        DvDuration {
+            normal_status: None,
+            normal_range: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+            magnitude_status: None,
+            accuracy: None,
+            accuracy_is_percent: None,
+            value: value.to_owned(),
+        }
+    }
+
+    /// "The sum of the accuracies of the operands, if both present" — the
+    /// differential amount's `Real` half-range becomes that many seconds of
+    /// duration before the two are added.
+    #[test]
+    fn a_displaced_accuracy_sums_both_operands() {
+        let mut amount = duration("P1D");
+        amount.accuracy = Some(60.0);
+        amount.accuracy_is_percent = Some(false);
+
+        let combined = displaced_accuracy(Some(&duration("PT30M")), &amount).expect("both present");
+        assert_eq!(
+            combined.magnitude(),
+            Some(1860.0),
+            "30 minutes + 60 seconds"
+        );
+    }
+
+    /// A percentage half-range is resolved against the amount's own magnitude
+    /// before it can be added to a duration.
+    #[test]
+    fn a_percentage_resolves_against_its_own_magnitude() {
+        let mut amount = duration("PT100S");
+        amount.accuracy = Some(10.0);
+        amount.accuracy_is_percent = Some(true);
+
+        let combined = displaced_accuracy(Some(&duration("PT5S")), &amount).expect("both present");
+        assert_eq!(combined.magnitude(), Some(15.0), "5s + 10% of 100s");
+    }
+
+    /// "Unknown, if either or both operand accuracies are unknown."
+    #[test]
+    fn either_operand_unknown_makes_the_result_unknown() {
+        let plain = duration("P1D");
+        assert!(displaced_accuracy(None, &plain).is_none());
+        assert!(displaced_accuracy(Some(&duration("PT30M")), &plain).is_none());
+    }
+
+    /// `diff` returns a `DV_AMOUNT`, so the summed duration is reported as that
+    /// amount's own accuracy in seconds.
+    #[test]
+    fn a_difference_accuracy_is_reported_in_seconds() {
+        let combined = difference_accuracy(Some(&duration("PT30M")), Some(&duration("PT30S")));
+        assert_eq!(
+            combined,
+            CombinedAccuracy::Known {
+                accuracy: 1830.0,
+                is_percent: false,
+            }
+        );
+        assert_eq!(
+            difference_accuracy(Some(&duration("PT30M")), None),
+            CombinedAccuracy::Unknown
+        );
+    }
+}

--- a/crates/openehr-rm/src/v1_1/data_types/quantity/dv_amount_impl.rs
+++ b/crates/openehr-rm/src/v1_1/data_types/quantity/dv_amount_impl.rs
@@ -1,0 +1,503 @@
+// @generated-from-template templates/openehr-rm/data_types/quantity/dv_amount_impl.rs — DO NOT EDIT; edit the source and re-run `openehr-codegen -- emit`.
+//! Hand-written `DV_AMOUNT` spec behaviour, shared by its descendants.
+//!
+//! `DV_AMOUNT` is abstract, so the generated `DvAmount` is a subtype enum and
+//! the accuracy rule its `add`/`subtract` declare has no single struct to live
+//! on. It is realized once here and called by every descendant that implements
+//! the arithmetic.
+
+use crate::v1_1::data_types::quantity::dv_amount::DvAmount;
+use crate::v1_1::data_types::quantity::dv_ordered::DvOrdered;
+use crate::v1_1::validate::valid_percentage;
+use core::cmp::Ordering;
+use rust_decimal::Decimal;
+use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
+
+/// The `accuracy` value that records "accuracy was not recorded".
+///
+/// Spec: `master06-quantity_package.adoc` §Accuracy and Uncertainty — "a value
+/// of -1 for the accuracy attribute is used for this purpose, and the constant
+/// `unknown_accuracy_value` = -1 is provided within the class".
+pub const UNKNOWN_ACCURACY_VALUE: f64 = -1.0;
+
+/// One operand of a `DV_AMOUNT` addition, subtraction or scaling.
+///
+/// The magnitude travels with the accuracy because the two forms the spec
+/// allows are not interchangeable without it: a percentage is a proportion of
+/// the magnitude it was recorded against, an absolute value is a half-range in
+/// the amount's own units.
+///
+/// It is carried as a [`Decimal`] so that converting between those forms is
+/// exact for every descendant: an integer magnitude converts without loss, and
+/// a real one converts without a widening cast whose error would land inside a
+/// clinical half-range.
+#[derive(Debug, Clone, Copy)]
+pub struct AmountAccuracy {
+    /// The operand's magnitude, absent when it has no decimal form — which
+    /// only matters if the two operands disagree about the accuracy form.
+    magnitude: Option<Decimal>,
+    /// The operand's `accuracy`.
+    accuracy: Option<f64>,
+    /// The operand's `accuracy_is_percent`.
+    accuracy_is_percent: Option<bool>,
+}
+
+impl AmountAccuracy {
+    /// The accuracy of an amount whose magnitude is an integer, such as a
+    /// `DV_COUNT`.
+    #[must_use]
+    pub fn counted(
+        magnitude: i64,
+        accuracy: Option<f64>,
+        accuracy_is_percent: Option<bool>,
+    ) -> Self {
+        Self {
+            magnitude: Some(Decimal::from(magnitude)),
+            accuracy,
+            accuracy_is_percent,
+        }
+    }
+
+    /// The accuracy of an amount whose magnitude is a real number, such as a
+    /// `DV_QUANTITY`.
+    #[must_use]
+    pub fn measured(
+        magnitude: f64,
+        accuracy: Option<f64>,
+        accuracy_is_percent: Option<bool>,
+    ) -> Self {
+        Self {
+            // `from_f64` recovers the decimal the float DENOTES, dropping the
+            // excess bits past IEEE-754's guarantee — 0.1_f64 becomes 0.1, not
+            // its binary approximation.
+            magnitude: Decimal::from_f64(magnitude),
+            accuracy,
+            accuracy_is_percent,
+        }
+    }
+}
+
+/// The accuracy a combined or scaled `DV_AMOUNT` carries.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum CombinedAccuracy {
+    /// At least one operand did not record an accuracy, so neither does the
+    /// result.
+    Unknown,
+    /// Every operand recorded one; this is the result, in the form named.
+    Known {
+        /// The combined accuracy value.
+        accuracy: f64,
+        /// Whether that value is a percentage rather than an absolute
+        /// half-range.
+        is_percent: bool,
+    },
+    /// The result exists as a number but no valid `DV_AMOUNT` can carry it —
+    /// a percentage past 100, or a form conversion the operands do not admit.
+    Unrepresentable,
+}
+
+impl AmountAccuracy {
+    /// This operand's recorded accuracy and its form, or `None` when accuracy
+    /// was not recorded.
+    ///
+    /// A negative value is read as unrecorded rather than only the exact
+    /// sentinel: `accuracy` is a half-range, which cannot be negative, so
+    /// `unknown_accuracy_value` is the only meaning a negative can carry.
+    fn recorded(self) -> Option<(f64, bool)> {
+        let value = self.accuracy?;
+        (value >= 0.0).then(|| (value, self.accuracy_is_percent == Some(true)))
+    }
+
+    /// This accuracy expressed as a percentage (`to_percent`) or as an absolute
+    /// half-range, or `None` when the operand admits no such form.
+    fn in_form(self, value: f64, is_percent: bool, to_percent: bool) -> Option<Decimal> {
+        let value = Decimal::from_f64(value)?;
+        if is_percent == to_percent {
+            return Some(value);
+        }
+        let magnitude = self.magnitude?.abs();
+        if is_percent {
+            return value.checked_mul(magnitude)?.checked_div(hundred());
+        }
+        // A zero magnitude has no percentage form: every percentage of it is
+        // the same zero, so the operand's half-range cannot be recovered from
+        // one.
+        if magnitude.is_zero() {
+            return None;
+        }
+        value.checked_mul(hundred())?.checked_div(magnitude)
+    }
+}
+
+/// The percentage base, as a `Decimal`.
+fn hundred() -> Decimal {
+    Decimal::from(100_u8)
+}
+
+/// The accuracy of the sum or difference of `left` and `right`.
+///
+/// Spec: `master06-quantity_package.adoc` §Accuracy and Uncertainty — "if
+/// accuracies are present in both quantities, they are added in the result, for
+/// both addition and subtraction operations; if either or both quantities has
+/// an unknown accuracy, the accuracy of the result is also unknown; if two
+/// `DV_AMOUNT` descendants are added or subtracted, and only one has
+/// `accuracy_is_percent` = True, accuracy is expressed in the result in the form
+/// used in the larger of the two quantities."
+///
+/// The spec says to add the two values but not to convert them, and adding a
+/// percentage to an absolute half-range is not a number. Converting the operand
+/// whose form loses into the winning form is the only reading under which the
+/// sum it prescribes exists at all.
+///
+/// Equal magnitudes are the one gap: "the larger of the two" then names neither
+/// operand. The result takes the absolute form, because an absolute half-range
+/// is interpretable on its own while a percentage is only interpretable against
+/// a magnitude. No openEHR spec governs that tie — our own design.
+#[must_use]
+pub fn combine(left: AmountAccuracy, right: AmountAccuracy) -> CombinedAccuracy {
+    let (Some((left_value, left_percent)), Some((right_value, right_percent))) =
+        (left.recorded(), right.recorded())
+    else {
+        return CombinedAccuracy::Unknown;
+    };
+
+    let as_percent = match (left_percent, right_percent) {
+        (true, true) => true,
+        (false, false) => false,
+        _ => match (left.magnitude, right.magnitude) {
+            (Some(left_magnitude), Some(right_magnitude)) => {
+                match left_magnitude.abs().cmp(&right_magnitude.abs()) {
+                    Ordering::Greater => left_percent,
+                    Ordering::Less => right_percent,
+                    Ordering::Equal => false,
+                }
+            }
+            _ => false,
+        },
+    };
+
+    let (Some(left_value), Some(right_value)) = (
+        left.in_form(left_value, left_percent, as_percent),
+        right.in_form(right_value, right_percent, as_percent),
+    ) else {
+        return CombinedAccuracy::Unrepresentable;
+    };
+
+    let Some(sum) = left_value.checked_add(right_value) else {
+        return CombinedAccuracy::Unrepresentable;
+    };
+    settle(sum, as_percent)
+}
+
+/// The accuracy of this amount scaled by `factor`.
+///
+/// The spec defines accuracy propagation for `add` and `subtract` only, and is
+/// silent on `multiply` — no openEHR spec governs this, so the rule is our own:
+/// a percentage of a magnitude is unchanged when the magnitude is scaled, and
+/// an absolute half-range, being in the amount's own units, scales with it.
+/// Dropping accuracy instead would make `multiply(1.0)` lose it.
+#[must_use]
+pub fn scale(amount: AmountAccuracy, factor: f64) -> CombinedAccuracy {
+    let Some((value, is_percent)) = amount.recorded() else {
+        return CombinedAccuracy::Unknown;
+    };
+    let (Some(value), Some(factor)) = (Decimal::from_f64(value), Decimal::from_f64(factor)) else {
+        return CombinedAccuracy::Unrepresentable;
+    };
+    if is_percent {
+        return settle(value, true);
+    }
+    let Some(scaled) = value.checked_mul(factor.abs()) else {
+        return CombinedAccuracy::Unrepresentable;
+    };
+    settle(scaled, false)
+}
+
+/// A computed accuracy as the result can carry it, or `Unrepresentable`.
+fn settle(accuracy: Decimal, is_percent: bool) -> CombinedAccuracy {
+    let Some(value) = accuracy.to_f64() else {
+        return CombinedAccuracy::Unrepresentable;
+    };
+    if !value.is_finite() || (is_percent && !valid_percentage(value)) {
+        return CombinedAccuracy::Unrepresentable;
+    }
+    CombinedAccuracy::Known {
+        accuracy: value,
+        // Accuracy_is_percent_validity: `accuracy = 0 implies not
+        // accuracy_is_percent`, so a zero result is recorded as absolute.
+        is_percent: is_percent && accuracy.is_sign_positive() && !accuracy.is_zero(),
+    }
+}
+
+impl DvAmount {
+    /// Sum of this amount and `other`, or `None` when they are not the same
+    /// kind of amount or the sum is one no valid amount can carry.
+    ///
+    /// Spec: `dv_amount.adoc` §Functions `add`, whose `Pre_comparable`
+    /// pre-condition is `is_strictly_comparable_to (other)`. Two amounts of
+    /// DIFFERENT concrete types are never strictly comparable — `DV_ORDERED`
+    /// compares only like with like — so a count plus a quantity is refused
+    /// here rather than in each descendant.
+    #[must_use]
+    pub fn add(&self, other: &Self) -> Option<Self> {
+        match (self, other) {
+            (Self::DvCount(left), Self::DvCount(right)) => left.add(right).map(Self::DvCount),
+            (Self::DvDuration(left), Self::DvDuration(right)) => {
+                left.add(right).map(Self::DvDuration)
+            }
+            (Self::DvProportion(left), Self::DvProportion(right)) => {
+                left.add(right).map(Self::DvProportion)
+            }
+            (Self::DvQuantity(left), Self::DvQuantity(right)) => {
+                left.add(right).map(Self::DvQuantity)
+            }
+            _ => None,
+        }
+    }
+
+    /// Difference of this amount and `other`, under the same conditions as
+    /// [`Self::add`].
+    ///
+    /// Spec: `dv_amount.adoc` §Functions `subtract`.
+    #[must_use]
+    pub fn subtract(&self, other: &Self) -> Option<Self> {
+        match (self, other) {
+            (Self::DvCount(left), Self::DvCount(right)) => left.subtract(right).map(Self::DvCount),
+            (Self::DvDuration(left), Self::DvDuration(right)) => {
+                left.subtract(right).map(Self::DvDuration)
+            }
+            (Self::DvProportion(left), Self::DvProportion(right)) => {
+                left.subtract(right).map(Self::DvProportion)
+            }
+            (Self::DvQuantity(left), Self::DvQuantity(right)) => {
+                left.subtract(right).map(Self::DvQuantity)
+            }
+            _ => None,
+        }
+    }
+
+    /// Product of this amount and `factor`.
+    ///
+    /// Spec: `dv_amount.adoc` §Functions `multiply`.
+    #[must_use]
+    pub fn multiply(&self, factor: f64) -> Option<Self> {
+        match self {
+            Self::DvCount(count) => count.multiply(factor).map(Self::DvCount),
+            Self::DvDuration(duration) => duration.multiply(factor).map(Self::DvDuration),
+            Self::DvProportion(proportion) => proportion.multiply(factor).map(Self::DvProportion),
+            Self::DvQuantity(quantity) => quantity.multiply(factor).map(Self::DvQuantity),
+        }
+    }
+
+    /// Negated version of this amount, "such as used for representing a
+    /// difference, e.g. a weight loss".
+    ///
+    /// Spec: `dv_amount.adoc` §Functions `negative`. `DV_DURATION` redefines it
+    /// over the ISO-8601 value; the others negate their magnitude, which is
+    /// scaling by -1 and is expressed that way so the accuracy rule stays in
+    /// one place.
+    #[must_use]
+    pub fn negative(&self) -> Option<Self> {
+        match self {
+            Self::DvDuration(duration) => duration.negative().map(Self::DvDuration),
+            other => other.multiply(-1.0),
+        }
+    }
+
+    /// Returns `true` when this amount is considered equal to `other`.
+    ///
+    /// Spec: `dv_amount.adoc` §Functions `is_equal`, which the class declares
+    /// ABSTRACT. Only `DV_PROPORTION` effects it (as ratio equality); the other
+    /// descendants declare no effecting definition, so for them equality is of
+    /// the recorded value — every field, as the class models it.
+    #[must_use]
+    pub fn is_equal(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::DvProportion(left), Self::DvProportion(right)) => left.is_equal(right),
+            (left, right) => left == right,
+        }
+    }
+
+    /// Returns `true` when this amount is less than `other`, `None` when they
+    /// are not strictly comparable or a magnitude is unavailable.
+    ///
+    /// Spec: `dv_amount.adoc` §Functions `less_than`, whose `Post_result` is
+    /// `Result = magnitude < other.magnitude` — the ordering `DV_ORDERED`
+    /// already defines, reached through the same machinery so a `DV_AMOUNT`
+    /// cannot order differently from the `DV_ORDERED` it is.
+    #[must_use]
+    pub fn less_than(&self, other: &Self) -> Option<bool> {
+        self.as_ordered().less_than(&other.as_ordered())
+    }
+
+    /// This amount as the `DV_ORDERED` it is.
+    fn as_ordered(&self) -> DvOrdered {
+        match self {
+            Self::DvCount(count) => DvOrdered::DvCount(count.clone()),
+            Self::DvDuration(duration) => DvOrdered::DvDuration(duration.clone()),
+            Self::DvProportion(proportion) => DvOrdered::DvProportion(proportion.clone()),
+            Self::DvQuantity(quantity) => DvOrdered::DvQuantity(quantity.clone()),
+        }
+    }
+
+    /// Returns `true` when `number` is a valid percentage, i.e. between 0
+    /// and 100.
+    ///
+    /// Spec: `dv_amount.adoc` §Functions `valid_percentage`.
+    #[must_use]
+    pub fn valid_percentage(number: f64) -> bool {
+        valid_percentage(number)
+    }
+
+    /// Returns `true` when accuracy is not known, e.g. because it was not
+    /// recorded or is not discernable.
+    ///
+    /// Spec: `dv_quantified.adoc` §Functions `accuracy_unknown`, effected for
+    /// `DV_AMOUNT` by `master06-quantity_package.adoc` §Accuracy and
+    /// Uncertainty — "in `DV_AMOUNT`, a value of -1 for the accuracy attribute
+    /// is used for this purpose".
+    #[must_use]
+    pub fn accuracy_unknown(&self) -> bool {
+        let accuracy = match self {
+            Self::DvCount(count) => count.accuracy,
+            Self::DvDuration(duration) => duration.accuracy,
+            Self::DvProportion(proportion) => proportion.accuracy,
+            Self::DvQuantity(quantity) => quantity.accuracy,
+        };
+        accuracy.is_none_or(|value| value < 0.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn accuracy(magnitude: f64, accuracy: f64, is_percent: bool) -> AmountAccuracy {
+        AmountAccuracy::measured(magnitude, Some(accuracy), Some(is_percent))
+    }
+
+    fn unrecorded(magnitude: f64) -> AmountAccuracy {
+        AmountAccuracy::measured(magnitude, None, None)
+    }
+
+    fn known(combined: CombinedAccuracy) -> (f64, bool) {
+        match combined {
+            CombinedAccuracy::Known {
+                accuracy,
+                is_percent,
+            } => (accuracy, is_percent),
+            other => panic!("expected a known accuracy, got {other:?}"),
+        }
+    }
+
+    /// "If accuracies are present in both quantities, they are added in the
+    /// result" — the spec adds the recorded values, and this asserts exactly
+    /// that rather than the physically-combined error.
+    #[test]
+    fn two_recorded_accuracies_are_added() {
+        let (value, is_percent) = known(combine(
+            accuracy(50.0, 0.5, false),
+            accuracy(30.0, 0.25, false),
+        ));
+        assert!((value - 0.75).abs() < f64::EPSILON);
+        assert!(!is_percent);
+    }
+
+    /// "If either or both quantities has an unknown accuracy, the accuracy of
+    /// the result is also unknown."
+    #[test]
+    fn one_unrecorded_accuracy_makes_the_result_unknown() {
+        assert_eq!(
+            combine(accuracy(50.0, 0.5, false), unrecorded(30.0)),
+            CombinedAccuracy::Unknown
+        );
+        let sentinel = AmountAccuracy::measured(30.0, Some(UNKNOWN_ACCURACY_VALUE), None);
+        assert_eq!(
+            combine(accuracy(50.0, 0.5, false), sentinel),
+            CombinedAccuracy::Unknown
+        );
+    }
+
+    /// "Accuracy is expressed in the result in the form used in the larger of
+    /// the two quantities" — here the larger operand is the percentage one, so
+    /// the absolute half-range of the smaller is converted into a percentage of
+    /// its own magnitude before the addition.
+    #[test]
+    fn the_larger_operand_names_the_form() {
+        let (value, is_percent) = known(combine(
+            accuracy(200.0, 10.0, true), // the larger: percent
+            accuracy(50.0, 5.0, false),  // 5 on 50 == 10%
+        ));
+        assert!(is_percent, "the larger operand recorded a percentage");
+        assert!((value - 20.0).abs() < 1e-9);
+
+        let (value, is_percent) = known(combine(
+            accuracy(200.0, 10.0, false), // the larger: absolute
+            accuracy(50.0, 10.0, true),   // 10% of 50 == 5
+        ));
+        assert!(!is_percent);
+        assert!((value - 15.0).abs() < 1e-9);
+    }
+
+    /// Equal magnitudes name neither operand as "the larger". The absolute form
+    /// wins because it is interpretable without a magnitude — our own tie rule,
+    /// asserted so a future spec answer shows up here as a failing test.
+    #[test]
+    fn equal_magnitudes_settle_on_the_absolute_form() {
+        let (value, is_percent) = known(combine(
+            accuracy(50.0, 10.0, true), // 10% of 50 == 5
+            accuracy(50.0, 2.0, false),
+        ));
+        assert!(!is_percent);
+        assert!((value - 7.0).abs() < 1e-9);
+    }
+
+    /// A percentage sum past 100 violates the `Accuracy_validity` invariant, so
+    /// no valid amount can carry it and the operation refuses rather than
+    /// producing one that fails its own class.
+    #[test]
+    fn a_percentage_past_one_hundred_is_unrepresentable() {
+        assert_eq!(
+            combine(accuracy(50.0, 60.0, true), accuracy(50.0, 60.0, true)),
+            CombinedAccuracy::Unrepresentable
+        );
+    }
+
+    /// A zero magnitude has no percentage form: every percentage of it is the
+    /// same zero, so an absolute half-range cannot be converted into one.
+    #[test]
+    fn a_zero_magnitude_has_no_percentage_form() {
+        assert_eq!(
+            combine(accuracy(200.0, 10.0, true), accuracy(0.0, 5.0, false)),
+            CombinedAccuracy::Unrepresentable
+        );
+    }
+
+    /// `Accuracy_is_percent_validity` — "accuracy = 0 implies not
+    /// accuracy_is_percent" — so a zero result is recorded as absolute even
+    /// when both operands were percentages.
+    #[test]
+    fn a_zero_result_is_never_a_percentage() {
+        let (value, is_percent) = known(combine(
+            accuracy(50.0, 0.0, false),
+            accuracy(50.0, 0.0, false),
+        ));
+        assert!((value - 0.0).abs() < f64::EPSILON);
+        assert!(!is_percent);
+    }
+
+    /// Scaling leaves a percentage alone and scales an absolute half-range with
+    /// the magnitude it measures.
+    #[test]
+    fn scaling_keeps_a_percentage_and_scales_a_half_range() {
+        let (value, is_percent) = known(scale(accuracy(50.0, 10.0, true), 3.0));
+        assert!(is_percent);
+        assert!((value - 10.0).abs() < f64::EPSILON);
+
+        let (value, is_percent) = known(scale(accuracy(50.0, 0.5, false), -3.0));
+        assert!(!is_percent);
+        assert!((value - 1.5).abs() < 1e-9, "the magnitude of the factor");
+
+        assert_eq!(scale(unrecorded(50.0), 3.0), CombinedAccuracy::Unknown);
+    }
+}

--- a/crates/openehr-rm/src/v1_1/data_types/quantity/dv_count_impl.rs
+++ b/crates/openehr-rm/src/v1_1/data_types/quantity/dv_count_impl.rs
@@ -6,11 +6,14 @@
 //! plus the DV_ORDERED `Normal_range_and_status_consistency` (via the
 //! ordered-magnitude machinery in `dv_ordered_impl`).
 
+use crate::v1_1::data_types::quantity::dv_amount_impl::{
+    AmountAccuracy, CombinedAccuracy, combine, scale,
+};
 use crate::v1_1::data_types::quantity::dv_count::DvCount;
 use crate::v1_1::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
 use openehr_base::validate::{InvariantViolation, Validate};
 use rust_decimal::Decimal;
-use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
 
 impl DvCount {
     // NOTE: `less_than` and `is_strictly_comparable_to` are realized for every
@@ -28,26 +31,24 @@ impl DvCount {
     /// project's arithmetic rule: a load-bearing computation says so at the
     /// type level instead of producing a silently wrong clinical value.
     ///
-    /// The other fields are NOT carried over: `accuracy`, `normal_range` and
-    /// the reference ranges describe the measurement THIS value came from, and
-    /// the spec attaches no meaning to their combination under addition.
+    /// `normal_range` and the reference ranges are NOT carried over: they
+    /// describe the measurement THIS value came from, and the spec gives no
+    /// rule for combining them. `accuracy` is carried, because `DV_AMOUNT`
+    /// does give one — see [`combine`].
     #[must_use]
     pub fn add(&self, other: &Self) -> Option<Self> {
-        Some(Self::of_magnitude(
-            self.magnitude.checked_add(other.magnitude)?,
-        ))
+        self.combined(other, self.magnitude.checked_add(other.magnitude)?)
     }
 
     /// Difference of this count and `other`, or `None` on overflow.
     ///
-    /// Spec: `dv_count.adoc` §Functions `subtract`. A negative result is NOT
+    /// Spec: `dv_count.adoc` §Functions `subtract`, redefining
+    /// `dv_amount.adoc` §Functions `subtract`. A negative result is NOT
     /// refused: `magnitude` is a signed `Integer64` and the class declares no
     /// invariant bounding it below.
     #[must_use]
     pub fn subtract(&self, other: &Self) -> Option<Self> {
-        Some(Self::of_magnitude(
-            self.magnitude.checked_sub(other.magnitude)?,
-        ))
+        self.combined(other, self.magnitude.checked_sub(other.magnitude)?)
     }
 
     /// Product of this count and `factor`, or `None` when the result is not a
@@ -67,27 +68,55 @@ impl DvCount {
     /// `is_integer` and `to_i64` are exact, and each step that can fail says so.
     #[must_use]
     pub fn multiply(&self, factor: f64) -> Option<Self> {
-        // `from_f64_retain` keeps the float's exact value rather than rounding
-        // to a display form, so nothing is lost before the check below; it
+        // `from_f64` recovers the decimal the float DENOTES: 0.1_f64 is the
+        // one tenth its author wrote, so `count * 0.1` is a whole count. It
         // returns `None` for NaN and the infinities.
-        let product =
-            Decimal::from(self.magnitude).checked_mul(Decimal::from_f64_retain(factor)?)?;
-        product
-            .is_integer()
-            .then(|| product.to_i64().map(Self::of_magnitude))?
+        let product = Decimal::from(self.magnitude).checked_mul(Decimal::from_f64(factor)?)?;
+        let magnitude = product.is_integer().then(|| product.to_i64())??;
+        Self::of_magnitude(magnitude, scale(self.amount_accuracy(), factor))
     }
 
-    /// A count of `magnitude` with every measurement-specific field cleared.
-    fn of_magnitude(magnitude: i64) -> Self {
-        Self {
+    /// Returns `true` when this count's accuracy was not recorded.
+    ///
+    /// Spec: `dv_quantified.adoc` §Functions `accuracy_unknown`, effected for
+    /// `DV_AMOUNT` by the `unknown_accuracy_value` sentinel.
+    #[must_use]
+    pub fn accuracy_unknown(&self) -> bool {
+        self.accuracy.is_none_or(|value| value < 0.0)
+    }
+
+    /// This count's accuracy as the `DV_AMOUNT` rule reads it.
+    fn amount_accuracy(&self) -> AmountAccuracy {
+        AmountAccuracy::counted(self.magnitude, self.accuracy, self.accuracy_is_percent)
+    }
+
+    /// This count combined with `other`, carrying the `DV_AMOUNT` accuracy.
+    fn combined(&self, other: &Self, magnitude: i64) -> Option<Self> {
+        Self::of_magnitude(
+            magnitude,
+            combine(self.amount_accuracy(), other.amount_accuracy()),
+        )
+    }
+
+    /// A count of `magnitude` and `accuracy`, with the ranges cleared.
+    fn of_magnitude(magnitude: i64, accuracy: CombinedAccuracy) -> Option<Self> {
+        let (accuracy, accuracy_is_percent) = match accuracy {
+            CombinedAccuracy::Unrepresentable => return None,
+            CombinedAccuracy::Unknown => (None, None),
+            CombinedAccuracy::Known {
+                accuracy,
+                is_percent,
+            } => (Some(accuracy), Some(is_percent)),
+        };
+        Some(Self {
             magnitude,
             magnitude_status: None,
-            accuracy: None,
-            accuracy_is_percent: None,
+            accuracy,
+            accuracy_is_percent,
             normal_range: None,
             normal_status: None,
             other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
-        }
+        })
     }
 }
 
@@ -126,10 +155,9 @@ mod tests {
         }
     }
 
-    /// `dv_count.adoc` §Functions: add/subtract are magnitude arithmetic, and
-    /// the result carries NONE of the measurement-specific fields — accuracy
-    /// and the ranges describe the measurement each operand came from, and the
-    /// spec gives no meaning to combining them.
+    /// `dv_count.adoc` §Functions: add/subtract are magnitude arithmetic. The
+    /// ranges are not carried — they describe the measurement each operand came
+    /// from — but `accuracy` is, because `dv_amount.adoc` specifies it.
     #[test]
     fn add_and_subtract_are_magnitude_arithmetic() {
         let a = count();
@@ -139,13 +167,60 @@ mod tests {
         let sum = a.add(&b).expect("no overflow");
         assert_eq!(sum.magnitude, a.magnitude + 4);
         assert!(
-            sum.accuracy.is_none() && sum.normal_range.is_none(),
-            "measurement-specific fields belong to the operands, not the result"
+            sum.normal_range.is_none(),
+            "the ranges belong to the operands, not the result"
         );
+        assert!(sum.accuracy.is_none(), "neither operand recorded one");
         assert_eq!(
             a.subtract(&b).expect("no overflow").magnitude,
             a.magnitude - 4
         );
+    }
+
+    /// "If accuracies are present in both quantities, they are added in the
+    /// result" — `DV_COUNT` is a `DV_AMOUNT`, so its arithmetic carries the
+    /// same accuracy rule as every other descendant.
+    #[test]
+    fn accuracy_follows_the_dv_amount_rule() {
+        let mut a = count();
+        a.accuracy = Some(0.5);
+        a.accuracy_is_percent = Some(false);
+        let mut b = count();
+        b.magnitude = 4;
+        b.accuracy = Some(0.25);
+        b.accuracy_is_percent = Some(false);
+
+        let sum = a.add(&b).expect("no overflow");
+        assert_eq!(sum.accuracy_is_percent, Some(false));
+        assert!((sum.accuracy.expect("both recorded one") - 0.75).abs() < f64::EPSILON);
+
+        // Scaling keeps a percentage and scales an absolute half-range.
+        let scaled = a.multiply(2.0).expect("whole product");
+        assert_eq!(scaled.magnitude, 6);
+        assert!((scaled.accuracy.expect("scaled") - 1.0).abs() < f64::EPSILON);
+    }
+
+    /// A factor whose float carries binary error still means the decimal its
+    /// author wrote: 10 counts scaled by a tenth is one count. Reading the
+    /// float's approximation instead would refuse this as "not whole".
+    #[test]
+    fn a_decimal_factor_means_the_decimal_not_its_binary_approximation() {
+        let mut ten = count();
+        ten.magnitude = 10;
+        assert_eq!(ten.multiply(0.1).expect("one tenth of ten").magnitude, 1);
+        assert_eq!(ten.multiply(0.3).expect("three tenths of ten").magnitude, 3);
+        assert!(ten.multiply(0.25).is_none(), "2.5 is not a whole count");
+    }
+
+    /// `accuracy_unknown` reads both ways of not recording an accuracy.
+    #[test]
+    fn accuracy_unknown_reads_the_sentinel_and_the_absence() {
+        let mut c = count();
+        assert!(c.accuracy_unknown());
+        c.accuracy = Some(-1.0);
+        assert!(c.accuracy_unknown());
+        c.accuracy = Some(0.0);
+        assert!(!c.accuracy_unknown(), "0 means 100% accurate, not unknown");
     }
 
     /// Overflow is refused rather than wrapped. `magnitude` is an Integer64 and

--- a/crates/openehr-rm/src/v1_1/data_types/quantity/dv_proportion_impl.rs
+++ b/crates/openehr-rm/src/v1_1/data_types/quantity/dv_proportion_impl.rs
@@ -8,9 +8,188 @@
 //! `pk_unitary` 1, `pk_percent` 2, `pk_fraction` 3, `pk_integer_fraction` 4),
 //! plus the inherited DV_AMOUNT / DV_QUANTIFIED / DV_ORDERED invariants.
 
+use crate::v1_1::data_types::quantity::dv_amount_impl::{
+    AmountAccuracy, CombinedAccuracy, combine, scale,
+};
 use crate::v1_1::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
 use crate::v1_1::data_types::quantity::dv_proportion::DvProportion;
 use openehr_base::validate::{InvariantViolation, Validate};
+use rust_decimal::Decimal;
+use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
+
+impl DvProportion {
+    /// Sum of this proportion and `other`, or `None` when they are not strictly
+    /// comparable or the result is one no valid proportion can carry.
+    ///
+    /// Spec: `dv_proportion.adoc` §Functions `add` — "Sum of two strictly
+    /// comparable proportions", over `is_strictly_comparable_to`: "True if the
+    /// `type` of this proportion is the same as the `type` of `other`."
+    ///
+    /// Proportions are added over a common denominator, which is what keeps
+    /// the result inside its own kind's invariants: `pk_percent` fixes the
+    /// denominator at 100 and `pk_unitary` at 1, so equal denominators are kept
+    /// rather than multiplied — cross-multiplying two percentages would yield a
+    /// denominator of 10000 and fail `Percent_validity`.
+    #[must_use]
+    pub fn add(&self, other: &Self) -> Option<Self> {
+        self.combined(other, Decimal::checked_add)
+    }
+
+    /// Difference of this proportion and `other`, under the same conditions as
+    /// [`Self::add`].
+    ///
+    /// Spec: `dv_proportion.adoc` §Functions `subtract` — "Difference between
+    /// two strictly comparable proportions."
+    #[must_use]
+    pub fn subtract(&self, other: &Self) -> Option<Self> {
+        self.combined(other, Decimal::checked_sub)
+    }
+
+    /// Product of this proportion and `factor`, or `None` when the result is
+    /// one no valid proportion can carry.
+    ///
+    /// Spec: `dv_proportion.adoc` §Functions `multiply` — "Product of this
+    /// Proportion and `factor`."
+    ///
+    /// The factor scales the numerator and leaves the denominator alone, which
+    /// is what keeps `pk_percent`'s 100 and `pk_unitary`'s 1 in place. A kind
+    /// whose `Fraction_validity` demands integers refuses a numerator the
+    /// factor made fractional, rather than rounding it into a different ratio.
+    #[must_use]
+    pub fn multiply(&self, factor: f64) -> Option<Self> {
+        let (numerator, denominator) = self.ratio()?;
+        self.carrying(
+            numerator.checked_mul(Decimal::from_f64(factor)?)?,
+            denominator,
+            scale(self.amount_accuracy()?, factor),
+        )
+    }
+
+    /// Returns `true` when this proportion is considered equal to `other`.
+    ///
+    /// Spec: `dv_proportion.adoc` §Functions `is_equal`, effecting
+    /// `dv_amount.adoc`'s abstract `is_equal`.
+    ///
+    /// Equality is of the RATIO, not of how it was written: `1/2` and `2/4` are
+    /// the same proportion, so the test is cross-multiplication rather than
+    /// field equality. The `type` must still match, because a proportion is
+    /// only comparable to one of its own kind and `1/100` as a percentage means
+    /// something a `pk_ratio` does not.
+    ///
+    /// The cross-multiplication runs in [`Decimal`]: whether two ratios are the
+    /// same is an exact question, and asking it of binary floating point makes
+    /// `0.1/0.3` and `1.0/3.0` disagree for reasons that have nothing to do
+    /// with the proportions.
+    #[must_use]
+    pub fn is_equal(&self, other: &Self) -> bool {
+        if self.r#type != other.r#type {
+            return false;
+        }
+        let (Some((left_numerator, left_denominator)), Some((right_numerator, right_denominator))) =
+            (self.ratio(), other.ratio())
+        else {
+            return false;
+        };
+        // Both products must EXIST: two overflows are not an equality.
+        let (Some(left), Some(right)) = (
+            left_numerator.checked_mul(right_denominator),
+            right_numerator.checked_mul(left_denominator),
+        ) else {
+            return false;
+        };
+        left == right
+    }
+
+    /// Returns `true` when this proportion's accuracy was not recorded.
+    ///
+    /// Spec: `dv_quantified.adoc` §Functions `accuracy_unknown`, effected for
+    /// `DV_AMOUNT` by the `unknown_accuracy_value` sentinel.
+    #[must_use]
+    pub fn accuracy_unknown(&self) -> bool {
+        self.accuracy.is_none_or(|value| value < 0.0)
+    }
+
+    /// This proportion's accuracy as the `DV_AMOUNT` rule reads it, or `None`
+    /// when the denominator is zero and there is no magnitude.
+    fn amount_accuracy(&self) -> Option<AmountAccuracy> {
+        Some(AmountAccuracy::measured(
+            self.magnitude()?,
+            self.accuracy,
+            self.accuracy_is_percent,
+        ))
+    }
+
+    /// This proportion's numerator and denominator as exact decimals.
+    fn ratio(&self) -> Option<(Decimal, Decimal)> {
+        Some((
+            Decimal::from_f64(self.numerator)?,
+            Decimal::from_f64(self.denominator)?,
+        ))
+    }
+
+    /// This proportion combined with `other` over a common denominator.
+    fn combined(&self, other: &Self, op: fn(Decimal, Decimal) -> Option<Decimal>) -> Option<Self> {
+        if !self.is_strictly_comparable_to(other) {
+            return None;
+        }
+        let accuracy = combine(self.amount_accuracy()?, other.amount_accuracy()?);
+        let (left_numerator, left_denominator) = self.ratio()?;
+        let (right_numerator, right_denominator) = other.ratio()?;
+        if left_denominator == right_denominator {
+            return self.carrying(
+                op(left_numerator, right_numerator)?,
+                left_denominator,
+                accuracy,
+            );
+        }
+        self.carrying(
+            op(
+                left_numerator.checked_mul(right_denominator)?,
+                right_numerator.checked_mul(left_denominator)?,
+            )?,
+            left_denominator.checked_mul(right_denominator)?,
+            accuracy,
+        )
+    }
+
+    /// This proportion at a new ratio and accuracy, or `None` when the result
+    /// would not satisfy its own class invariants.
+    ///
+    /// `precision` is dropped: it states the decimal places the operands were
+    /// expressed to, and the spec gives no rule for the precision of a sum.
+    fn carrying(
+        &self,
+        numerator: Decimal,
+        denominator: Decimal,
+        accuracy: CombinedAccuracy,
+    ) -> Option<Self> {
+        let (numerator, denominator) = (numerator.to_f64()?, denominator.to_f64()?);
+        let (accuracy, accuracy_is_percent) = match accuracy {
+            CombinedAccuracy::Unrepresentable => return None,
+            CombinedAccuracy::Unknown => (None, None),
+            CombinedAccuracy::Known {
+                accuracy,
+                is_percent,
+            } => (Some(accuracy), Some(is_percent)),
+        };
+        let combined = Self {
+            numerator,
+            denominator,
+            r#type: self.r#type,
+            precision: None,
+            magnitude_status: None,
+            accuracy,
+            accuracy_is_percent,
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        };
+        // A proportion that fails its own invariants is not a proportion —
+        // `Fraction_validity` in particular rejects a fractional numerator on
+        // the two integral kinds, which is where a scaled fraction lands.
+        combined.invariants().is_empty().then_some(combined)
+    }
+}
 
 impl Validate for DvProportion {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
@@ -181,5 +360,118 @@ mod tests {
             messages(&proportion(5.5, 1.0, 0, Some(0)))
                 .contains(&"Invariant Precision_validity failed on type DV_PROPORTION".to_owned())
         );
+    }
+
+    /// Only proportions of the same kind combine — `is_strictly_comparable_to`
+    /// is "True if the `type` of this proportion is the same as the `type` of
+    /// `other`", so a percentage and a ratio do not add.
+    #[test]
+    fn only_the_same_kind_combines() {
+        let percent = proportion(20.0, 100.0, PK_PERCENT, None);
+        let ratio = proportion(20.0, 100.0, 0, None);
+        assert!(percent.add(&ratio).is_none());
+        assert!(percent.subtract(&ratio).is_none());
+    }
+
+    /// Two percentages keep the denominator 100 that `Percent_validity`
+    /// demands: cross-multiplying them would give 10000 and produce a value
+    /// that fails its own class.
+    #[test]
+    fn equal_denominators_are_kept_not_multiplied() {
+        let a = proportion(20.0, 100.0, PK_PERCENT, None);
+        let b = proportion(35.0, 100.0, PK_PERCENT, None);
+
+        let sum = a.add(&b).expect("same kind");
+        assert!((sum.numerator - 55.0).abs() < f64::EPSILON);
+        assert!((sum.denominator - 100.0).abs() < f64::EPSILON);
+        assert!(sum.invariants().is_empty(), "Percent_validity still holds");
+
+        let difference = b.subtract(&a).expect("same kind");
+        assert!((difference.numerator - 15.0).abs() < f64::EPSILON);
+    }
+
+    /// Unequal denominators go over a common one, and the result is a valid
+    /// fraction because both operands were integral.
+    #[test]
+    fn unequal_denominators_go_over_a_common_one() {
+        let half = proportion(1.0, 2.0, PK_FRACTION, None);
+        let third = proportion(1.0, 3.0, PK_FRACTION, None);
+
+        let sum = half.add(&third).expect("same kind");
+        assert!((sum.numerator - 5.0).abs() < f64::EPSILON);
+        assert!((sum.denominator - 6.0).abs() < f64::EPSILON);
+        assert!(sum.invariants().is_empty());
+    }
+
+    /// A scaled fraction whose numerator stops being whole is refused rather
+    /// than rounded: `Fraction_validity` demands integers of `pk_fraction`, and
+    /// rounding would silently record a different ratio.
+    #[test]
+    fn a_fractional_numerator_is_refused_on_an_integral_kind() {
+        let fraction = proportion(1.0, 2.0, PK_INTEGER_FRACTION, None);
+        assert!(fraction.multiply(0.5).is_none(), "0.5/2 is not integral");
+
+        let doubled = fraction.multiply(2.0).expect("2/2 is integral");
+        assert!((doubled.numerator - 2.0).abs() < f64::EPSILON);
+        assert!((doubled.denominator - 2.0).abs() < f64::EPSILON);
+
+        // A unitary proportion keeps its denominator of 1 under scaling.
+        let unitary = proportion(3.0, 1.0, PK_UNITARY, None);
+        let scaled = unitary.multiply(2.5).expect("no integrality rule");
+        assert!((scaled.numerator - 7.5).abs() < f64::EPSILON);
+        assert!((scaled.denominator - 1.0).abs() < f64::EPSILON);
+    }
+
+    /// `is_equal` compares the RATIO: 1/2 and 2/4 are the same proportion, and
+    /// the decimal cross-multiplication makes 1/3 and 0.1/0.3 agree where
+    /// binary floating point would not.
+    #[test]
+    fn is_equal_compares_the_ratio_not_the_fields() {
+        let half = proportion(1.0, 2.0, PK_FRACTION, None);
+        assert!(half.is_equal(&proportion(2.0, 4.0, PK_FRACTION, None)));
+        assert!(!half.is_equal(&proportion(1.0, 3.0, PK_FRACTION, None)));
+
+        // A different kind is never equal, whatever the ratio.
+        assert!(!half.is_equal(&proportion(1.0, 2.0, 0, None)));
+
+        let third = proportion(1.0, 3.0, 0, None);
+        assert!(
+            third.is_equal(&proportion(0.1, 0.3, 0, None)),
+            "exact in Decimal, unequal in binary floating point"
+        );
+    }
+
+    /// `DV_PROPORTION` is a `DV_AMOUNT`, so its arithmetic carries the same
+    /// accuracy rule as every other descendant.
+    #[test]
+    fn accuracy_follows_the_dv_amount_rule() {
+        let mut a = proportion(20.0, 100.0, PK_PERCENT, None);
+        a.accuracy = Some(0.01);
+        a.accuracy_is_percent = Some(false);
+        let mut b = proportion(30.0, 100.0, PK_PERCENT, None);
+        b.accuracy = Some(0.02);
+        b.accuracy_is_percent = Some(false);
+
+        let sum = a.add(&b).expect("same kind");
+        assert!((sum.accuracy.expect("both recorded one") - 0.03).abs() < f64::EPSILON);
+        assert_eq!(sum.accuracy_is_percent, Some(false));
+
+        assert!(
+            a.add(&proportion(30.0, 100.0, PK_PERCENT, None))
+                .expect("same kind")
+                .accuracy
+                .is_none()
+        );
+    }
+
+    /// `accuracy_unknown` reads both ways of not recording an accuracy.
+    #[test]
+    fn accuracy_unknown_reads_the_sentinel_and_the_absence() {
+        let mut p = proportion(1.0, 2.0, PK_FRACTION, None);
+        assert!(p.accuracy_unknown());
+        p.accuracy = Some(-1.0);
+        assert!(p.accuracy_unknown());
+        p.accuracy = Some(0.0);
+        assert!(!p.accuracy_unknown(), "0 means 100% accurate, not unknown");
     }
 }

--- a/crates/openehr-rm/src/v1_1/data_types/quantity/dv_quantity_impl.rs
+++ b/crates/openehr-rm/src/v1_1/data_types/quantity/dv_quantity_impl.rs
@@ -12,74 +12,104 @@
 //! is deferred to the composition validator + `openehr-term` (this crate has
 //! no terminology dependency).
 
+use crate::v1_1::data_types::quantity::dv_amount_impl::{
+    AmountAccuracy, CombinedAccuracy, combine, scale,
+};
 use crate::v1_1::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
 use crate::v1_1::data_types::quantity::dv_quantity::DvQuantity;
 use openehr_base::validate::{InvariantViolation, Validate};
 
 impl DvQuantity {
     /// Sum of this quantity and `other`, or `None` when they are not strictly
-    /// comparable or the result is not a finite magnitude.
+    /// comparable or the result is one no valid quantity can carry.
     ///
     /// Spec: `dv_quantity.adoc` §Functions `add` — "Sum of this `DV_QUANTITY`
-    /// and `other`."
+    /// and `other`" — redefining `dv_amount.adoc` §Functions `add`, whose
+    /// `Pre_comparable` pre-condition is `is_strictly_comparable_to (other)`:
+    /// the same `units`, and the same `units_system` where one is stated.
     ///
-    /// The spec states no pre-condition on `add`, but `DV_ORDERED` says
-    /// instances of `DV_QUANTITY` "can only be compared if they measure the
-    /// same kind of physical quantity", and a sum of unlike quantities is no
-    /// more meaningful than a comparison of them. So this requires
-    /// [`Self::is_strictly_comparable_to`] — the same units, and the same
-    /// `units_system` where one is stated — rather than silently producing a
-    /// number whose unit is a guess.
+    /// The accuracy of the result follows the `DV_AMOUNT` rule — see
+    /// [`combine`].
     #[must_use]
     pub fn add(&self, other: &Self) -> Option<Self> {
-        self.combine(other, self.magnitude + other.magnitude)
+        self.combined(other, self.magnitude + other.magnitude)
     }
 
     /// Difference of this quantity and `other`, under the same conditions as
     /// [`Self::add`].
     ///
-    /// Spec: `dv_quantity.adoc` §Functions `subtract`.
+    /// Spec: `dv_quantity.adoc` §Functions `subtract`, redefining
+    /// `dv_amount.adoc` §Functions `subtract` — the accuracies are summed for
+    /// subtraction exactly as for addition.
     #[must_use]
     pub fn subtract(&self, other: &Self) -> Option<Self> {
-        self.combine(other, self.magnitude - other.magnitude)
+        self.combined(other, self.magnitude - other.magnitude)
     }
 
-    /// Product of this quantity and `factor`, or `None` when the result is not
-    /// a finite magnitude.
+    /// Product of this quantity and `factor`, or `None` when the result is one
+    /// no valid quantity can carry.
     ///
     /// Spec: `dv_quantity.adoc` §Functions `multiply` — "Product of this
     /// `DV_QUANTITY` and `factor`."
     ///
     /// Unlike `DV_COUNT.multiply`, a fractional result needs no adjudication:
     /// a quantity's magnitude is a `Real`, so scaling one stays in the type.
-    /// The units are unchanged — a scalar factor carries no dimension.
+    /// The units are unchanged — a scalar factor carries no dimension — and the
+    /// accuracy scales per [`scale`].
     #[must_use]
     pub fn multiply(&self, factor: f64) -> Option<Self> {
-        self.rescaled(self.magnitude * factor)
+        self.rescaled(
+            self.magnitude * factor,
+            scale(self.amount_accuracy(), factor),
+        )
+    }
+
+    /// Returns `true` when this quantity's accuracy was not recorded.
+    ///
+    /// Spec: `dv_quantified.adoc` §Functions `accuracy_unknown`, effected for
+    /// `DV_AMOUNT` by the `unknown_accuracy_value` sentinel.
+    #[must_use]
+    pub fn accuracy_unknown(&self) -> bool {
+        self.accuracy.is_none_or(|value| value < 0.0)
+    }
+
+    /// This quantity's accuracy as the `DV_AMOUNT` rule reads it.
+    fn amount_accuracy(&self) -> AmountAccuracy {
+        AmountAccuracy::measured(self.magnitude, self.accuracy, self.accuracy_is_percent)
     }
 
     /// This quantity combined with `other`, if they are strictly comparable.
-    fn combine(&self, other: &Self, magnitude: f64) -> Option<Self> {
+    fn combined(&self, other: &Self, magnitude: f64) -> Option<Self> {
         if !self.is_strictly_comparable_to(other) {
             return None;
         }
-        self.rescaled(magnitude)
+        self.rescaled(
+            magnitude,
+            combine(self.amount_accuracy(), other.amount_accuracy()),
+        )
     }
 
-    /// This quantity at a new magnitude, keeping the units and dropping every
-    /// field the spec gives no combination rule for.
+    /// This quantity at a new magnitude and accuracy, keeping the units.
     ///
-    /// `precision`, `accuracy` and the reference ranges describe how THIS value
-    /// was measured. The spec says nothing about the precision of a sum or the
-    /// accuracy of a scaled value, so carrying either would be this
-    /// implementation inventing a rule and presenting it as the model's.
-    fn rescaled(&self, magnitude: f64) -> Option<Self> {
+    /// `precision`, `magnitude_status` and the reference ranges are dropped:
+    /// they describe how THIS value was measured, and the spec gives no rule
+    /// for combining them, so carrying one would be this implementation
+    /// inventing a rule and presenting it as the model's.
+    fn rescaled(&self, magnitude: f64, accuracy: CombinedAccuracy) -> Option<Self> {
         // A non-finite magnitude is not a quantity: the class types it as a
         // `Real`, and NaN or an infinity would flow into comparisons and
         // serialization as a value no reader can act on.
         if !magnitude.is_finite() {
             return None;
         }
+        let (accuracy, accuracy_is_percent) = match accuracy {
+            CombinedAccuracy::Unrepresentable => return None,
+            CombinedAccuracy::Unknown => (None, None),
+            CombinedAccuracy::Known {
+                accuracy,
+                is_percent,
+            } => (Some(accuracy), Some(is_percent)),
+        };
         Some(Self {
             magnitude,
             units: self.units.clone(),
@@ -87,8 +117,8 @@ impl DvQuantity {
             units_display_name: self.units_display_name.clone(),
             precision: None,
             magnitude_status: None,
-            accuracy: None,
-            accuracy_is_percent: None,
+            accuracy,
+            accuracy_is_percent,
             normal_range: None,
             normal_status: None,
             other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
@@ -170,19 +200,84 @@ mod tests {
         assert!(plain.add(&systematised).is_none());
     }
 
-    /// The measurement-specific fields describe how THIS value was measured.
-    /// The spec defines neither the precision of a sum nor the accuracy of a
-    /// scaled value, so the result carries neither rather than this
-    /// implementation inventing a rule.
+    /// "If accuracies are present in both quantities, they are added in the
+    /// result, for both addition and subtraction operations" — the accuracy of
+    /// a sum is specified, so it is carried rather than dropped.
     #[test]
-    fn arithmetic_drops_what_the_spec_gives_no_rule_for() {
-        let mut a = quantity();
+    fn arithmetic_carries_the_accuracy_the_spec_specifies() {
+        let mut a = quantity(); // 43 kg
         a.accuracy = Some(0.5);
         a.accuracy_is_percent = Some(false);
-        let scaled = a.multiply(2.0).expect("finite");
+        let mut b = quantity();
+        b.magnitude = 7.0;
+        b.accuracy = Some(0.25);
+        b.accuracy_is_percent = Some(false);
+
+        for combined in [
+            a.add(&b).expect("same units"),
+            a.subtract(&b).expect("same units"),
+        ] {
+            assert_eq!(combined.accuracy_is_percent, Some(false));
+            let accuracy = combined.accuracy.expect("both operands recorded one");
+            assert!((accuracy - 0.75).abs() < f64::EPSILON);
+        }
+
+        // An unrecorded accuracy on either side makes the result's unknown.
+        let mut plain = quantity();
+        plain.magnitude = 7.0;
+        let sum = a.add(&plain).expect("same units");
+        assert!(sum.accuracy.is_none() && sum.accuracy_is_percent.is_none());
+    }
+
+    /// Scaling has no spec rule, so ours is asserted: a percentage of a
+    /// magnitude survives the magnitude changing, and an absolute half-range —
+    /// being in the quantity's own units — scales with it.
+    #[test]
+    fn scaling_carries_the_accuracy_forward() {
+        let mut absolute = quantity();
+        absolute.accuracy = Some(0.5);
+        absolute.accuracy_is_percent = Some(false);
+        let scaled = absolute.multiply(2.0).expect("finite");
         assert!((scaled.magnitude - 86.0).abs() < f64::EPSILON);
         assert_eq!(scaled.units, "kg");
-        assert!(scaled.precision.is_none() && scaled.accuracy.is_none());
+        assert_eq!(scaled.accuracy_is_percent, Some(false));
+        assert!((scaled.accuracy.expect("scaled") - 1.0).abs() < f64::EPSILON);
+
+        let mut percent = quantity();
+        percent.accuracy = Some(5.0);
+        percent.accuracy_is_percent = Some(true);
+        let scaled = percent.multiply(2.0).expect("finite");
+        assert_eq!(scaled.accuracy_is_percent, Some(true));
+        assert!((scaled.accuracy.expect("scaled") - 5.0).abs() < f64::EPSILON);
+
+        // `precision` and `magnitude_status` have no combination rule and are
+        // dropped rather than guessed at.
+        assert!(scaled.precision.is_none() && scaled.magnitude_status.is_none());
+    }
+
+    /// A sum whose accuracy no valid quantity can carry is refused outright
+    /// rather than returned as a value that fails its own class invariant.
+    #[test]
+    fn an_unrepresentable_accuracy_refuses_the_whole_operation() {
+        let mut a = quantity();
+        a.accuracy = Some(60.0);
+        a.accuracy_is_percent = Some(true);
+        let mut b = quantity();
+        b.accuracy = Some(60.0);
+        b.accuracy_is_percent = Some(true);
+        assert!(a.add(&b).is_none(), "120% fails Accuracy_validity");
+    }
+
+    /// `accuracy_unknown` reads both ways of not recording an accuracy: the
+    /// attribute being absent, and the `unknown_accuracy_value` sentinel.
+    #[test]
+    fn accuracy_unknown_reads_the_sentinel_and_the_absence() {
+        let mut q = quantity();
+        assert!(q.accuracy_unknown());
+        q.accuracy = Some(-1.0);
+        assert!(q.accuracy_unknown());
+        q.accuracy = Some(0.0);
+        assert!(!q.accuracy_unknown(), "0 means 100% accurate, not unknown");
     }
 
     /// A magnitude that is not finite is not a quantity: NaN or an infinity

--- a/crates/openehr-rm/src/v1_1/data_types/quantity/dv_quantity_impl.rs
+++ b/crates/openehr-rm/src/v1_1/data_types/quantity/dv_quantity_impl.rs
@@ -16,6 +16,86 @@ use crate::v1_1::data_types::quantity::dv_ordered_impl::push_normal_range_consis
 use crate::v1_1::data_types::quantity::dv_quantity::DvQuantity;
 use openehr_base::validate::{InvariantViolation, Validate};
 
+impl DvQuantity {
+    /// Sum of this quantity and `other`, or `None` when they are not strictly
+    /// comparable or the result is not a finite magnitude.
+    ///
+    /// Spec: `dv_quantity.adoc` §Functions `add` — "Sum of this `DV_QUANTITY`
+    /// and `other`."
+    ///
+    /// The spec states no pre-condition on `add`, but `DV_ORDERED` says
+    /// instances of `DV_QUANTITY` "can only be compared if they measure the
+    /// same kind of physical quantity", and a sum of unlike quantities is no
+    /// more meaningful than a comparison of them. So this requires
+    /// [`Self::is_strictly_comparable_to`] — the same units, and the same
+    /// `units_system` where one is stated — rather than silently producing a
+    /// number whose unit is a guess.
+    #[must_use]
+    pub fn add(&self, other: &Self) -> Option<Self> {
+        self.combine(other, self.magnitude + other.magnitude)
+    }
+
+    /// Difference of this quantity and `other`, under the same conditions as
+    /// [`Self::add`].
+    ///
+    /// Spec: `dv_quantity.adoc` §Functions `subtract`.
+    #[must_use]
+    pub fn subtract(&self, other: &Self) -> Option<Self> {
+        self.combine(other, self.magnitude - other.magnitude)
+    }
+
+    /// Product of this quantity and `factor`, or `None` when the result is not
+    /// a finite magnitude.
+    ///
+    /// Spec: `dv_quantity.adoc` §Functions `multiply` — "Product of this
+    /// `DV_QUANTITY` and `factor`."
+    ///
+    /// Unlike `DV_COUNT.multiply`, a fractional result needs no adjudication:
+    /// a quantity's magnitude is a `Real`, so scaling one stays in the type.
+    /// The units are unchanged — a scalar factor carries no dimension.
+    #[must_use]
+    pub fn multiply(&self, factor: f64) -> Option<Self> {
+        self.rescaled(self.magnitude * factor)
+    }
+
+    /// This quantity combined with `other`, if they are strictly comparable.
+    fn combine(&self, other: &Self, magnitude: f64) -> Option<Self> {
+        if !self.is_strictly_comparable_to(other) {
+            return None;
+        }
+        self.rescaled(magnitude)
+    }
+
+    /// This quantity at a new magnitude, keeping the units and dropping every
+    /// field the spec gives no combination rule for.
+    ///
+    /// `precision`, `accuracy` and the reference ranges describe how THIS value
+    /// was measured. The spec says nothing about the precision of a sum or the
+    /// accuracy of a scaled value, so carrying either would be this
+    /// implementation inventing a rule and presenting it as the model's.
+    fn rescaled(&self, magnitude: f64) -> Option<Self> {
+        // A non-finite magnitude is not a quantity: the class types it as a
+        // `Real`, and NaN or an infinity would flow into comparisons and
+        // serialization as a value no reader can act on.
+        if !magnitude.is_finite() {
+            return None;
+        }
+        Some(Self {
+            magnitude,
+            units: self.units.clone(),
+            units_system: self.units_system.clone(),
+            units_display_name: self.units_display_name.clone(),
+            precision: None,
+            magnitude_status: None,
+            accuracy: None,
+            accuracy_is_percent: None,
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        })
+    }
+}
+
 impl Validate for DvQuantity {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
         crate::v1_1::validate::generated::dv_amount_core(
@@ -57,6 +137,62 @@ mod tests {
 
     fn messages(q: &DvQuantity) -> Vec<String> {
         q.invariants().into_iter().map(|v| v.message).collect()
+    }
+
+    /// Unlike quantities do not add. `DV_ORDERED` says instances "can only be
+    /// compared if they measure the same kind of physical quantity", and a sum
+    /// of kg and m is no more meaningful than a comparison of them — so the
+    /// refusal is asserted, not just the success.
+    #[test]
+    fn unlike_units_do_not_combine() {
+        let kg = quantity();
+        let mut metres = quantity();
+        metres.units = "m".to_owned();
+
+        assert!(kg.add(&metres).is_none(), "kg + m has no unit");
+        assert!(kg.subtract(&metres).is_none());
+
+        let mut other_kg = quantity();
+        other_kg.magnitude = 7.0;
+        let sum = kg.add(&other_kg).expect("same units");
+        assert!((sum.magnitude - 50.0).abs() < f64::EPSILON);
+        assert_eq!(sum.units, "kg", "the sum stays in the operands' units");
+    }
+
+    /// A units_system stated on one side and not the other is NOT the same
+    /// quantity kind: the existing comparability rule requires both to match,
+    /// and arithmetic follows the same rule rather than a looser one.
+    #[test]
+    fn a_units_system_mismatch_does_not_combine() {
+        let plain = quantity();
+        let mut systematised = quantity();
+        systematised.units_system = Some("http://unitsofmeasure.org".to_owned());
+        assert!(plain.add(&systematised).is_none());
+    }
+
+    /// The measurement-specific fields describe how THIS value was measured.
+    /// The spec defines neither the precision of a sum nor the accuracy of a
+    /// scaled value, so the result carries neither rather than this
+    /// implementation inventing a rule.
+    #[test]
+    fn arithmetic_drops_what_the_spec_gives_no_rule_for() {
+        let mut a = quantity();
+        a.accuracy = Some(0.5);
+        a.accuracy_is_percent = Some(false);
+        let scaled = a.multiply(2.0).expect("finite");
+        assert!((scaled.magnitude - 86.0).abs() < f64::EPSILON);
+        assert_eq!(scaled.units, "kg");
+        assert!(scaled.precision.is_none() && scaled.accuracy.is_none());
+    }
+
+    /// A magnitude that is not finite is not a quantity: NaN or an infinity
+    /// would flow into comparison and serialization as a value no reader can
+    /// act on.
+    #[test]
+    fn a_non_finite_result_is_refused() {
+        let q = quantity();
+        assert!(q.multiply(f64::INFINITY).is_none());
+        assert!(q.multiply(f64::NAN).is_none());
     }
 
     #[test]

--- a/crates/openehr-rm/src/v1_1/data_types/quantity/mod.rs
+++ b/crates/openehr-rm/src/v1_1/data_types/quantity/mod.rs
@@ -17,6 +17,8 @@ pub mod proportion_kind;
 pub mod reference_range;
 
 // hand-written modules (spec behaviour), auto-declared:
+pub mod dv_absolute_quantity_impl;
+pub mod dv_amount_impl;
 pub mod dv_count_impl;
 pub mod dv_interval_impl;
 pub mod dv_ordered_impl;

--- a/crates/openehr-rm/src/v1_1/data_types/time_specification/dv_periodic_time_specification_impl.rs
+++ b/crates/openehr-rm/src/v1_1/data_types/time_specification/dv_periodic_time_specification_impl.rs
@@ -6,8 +6,149 @@
 //! — `Value_valid: value.formalism.is_equal("HL7:PIVL") or
 //! value.formalism.is_equal("HL7:EIVL")`.
 
+use crate::v1_1::data_types::quantity::date_time::dv_duration::DvDuration;
 use crate::v1_1::data_types::time_specification::dv_periodic_time_specification::DvPeriodicTimeSpecification;
+use crate::v1_1::validate::is_valid_iso_duration;
 use openehr_base::validate::{InvariantViolation, Validate};
+
+impl DvPeriodicTimeSpecification {
+    /// The period of the repetition, or `None` for a specification that states
+    /// none.
+    ///
+    /// Spec: `dv_periodic_time_specification.adoc` §Functions `period` — "The
+    /// period of the repetition, computationally derived from the syntax
+    /// representation. Extracted from the `value` attribute", over the
+    /// phase-linked grammar of `master08-time_specification_package.adoc`
+    /// §Phase-linked Time Specification Syntax: `phase = interval "/" "("
+    /// difference ")"`.
+    ///
+    /// The class types this `1..1`, but only the phase-linked (`HL7:PIVL`)
+    /// grammar has a `difference` production at all: the event-linked
+    /// (`HL7:EIVL`) one is `event [ offset ]`, an offset from a real-world
+    /// event rather than a period. An event-linked specification therefore has
+    /// no period to return, and saying so is more honest than manufacturing
+    /// one.
+    #[must_use]
+    pub fn period(&self) -> Option<DvDuration> {
+        let value = self.phase_linked()?;
+        let difference = value
+            .split_once("/(")
+            .and_then(|(_, rest)| rest.split_once(')'))
+            .map(|(difference, _)| difference)?;
+        let value = iso_duration(difference)?;
+        Some(DvDuration {
+            value,
+            magnitude_status: None,
+            accuracy: None,
+            accuracy_is_percent: None,
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        })
+    }
+
+    /// Calendar alignment extracted from `value`, or `None` when none is
+    /// stated.
+    ///
+    /// Spec: `dv_periodic_time_specification.adoc` §Functions
+    /// `calendar_alignment`, over `pure_phase_linked_time_spec = phase [ "@"
+    /// alignment ]` — the alignment is a term from the `HL7::CalendarCycle`
+    /// domain (`DW` = day of week, `DM` = day of month, …), and the production
+    /// makes it optional.
+    #[must_use]
+    pub fn calendar_alignment(&self) -> Option<String> {
+        let value = self.phase_linked()?;
+        let alignment = value.rsplit_once('@').map(|(_, alignment)| alignment)?;
+        let alignment = alignment
+            .strip_suffix(INSTITUTION_SPECIFIED)
+            .unwrap_or(alignment);
+        (!alignment.is_empty()).then(|| alignment.to_owned())
+    }
+
+    /// Event alignment extracted from `value`, or `None` when none is stated.
+    ///
+    /// Spec: `dv_periodic_time_specification.adoc` §Functions
+    /// `event_alignment`, over `event_linked_time_spec = event | event offset`
+    /// — the event is a term from the `HL7::TimingEvent` domain (`PC` = after
+    /// meal, `HS` = bedtime, …), and it is the leading token, before any `+`
+    /// or `-` offset.
+    #[must_use]
+    pub fn event_alignment(&self) -> Option<String> {
+        let value = self.event_linked()?;
+        let event = value.split(['+', '-']).next().unwrap_or(value).trim();
+        (!event.is_empty()).then(|| event.to_owned())
+    }
+
+    /// Whether the timing is institution-specified.
+    ///
+    /// Spec: `dv_periodic_time_specification.adoc` §Functions
+    /// `institution_specified` — "Extracted from value", over
+    /// `phase_linked_time_spec = pure_phase_linked_time_spec [ "IST" ]`. The
+    /// flag exists only in the phase-linked grammar, so its absence — including
+    /// on every event-linked specification — is `false`.
+    #[must_use]
+    pub fn institution_specified(&self) -> bool {
+        self.phase_linked()
+            .is_some_and(|value| value.ends_with(INSTITUTION_SPECIFIED))
+    }
+
+    /// This specification's `value` when it is phase-linked, trimmed.
+    fn phase_linked(&self) -> Option<&str> {
+        (self.value.formalism == PHASE_LINKED).then(|| self.value.value.trim())
+    }
+
+    /// This specification's `value` when it is event-linked, trimmed.
+    fn event_linked(&self) -> Option<&str> {
+        (self.value.formalism == EVENT_LINKED).then(|| self.value.value.trim())
+    }
+}
+
+/// The `HL7:PIVL` formalism: a phase-linked periodic time specification.
+const PHASE_LINKED: &str = "HL7:PIVL";
+
+/// The `HL7:EIVL` formalism: an event-linked periodic time specification.
+const EVENT_LINKED: &str = "HL7:EIVL";
+
+/// The trailing flag marking a phase-linked timing as institution-specified.
+const INSTITUTION_SPECIFIED: &str = "IST";
+
+/// A syntax `difference` as an ISO-8601 duration value.
+///
+/// The vendored grammar annotates `difference` as "ISO 8601 for time
+/// difference", while the spec's own examples in the same section spell it
+/// `7d` and `1mo`. Both are accepted: refusing the second would refuse the
+/// specification's own worked examples, and inventing a third form would serve
+/// nobody. A difference in neither form has no duration.
+fn iso_duration(difference: &str) -> Option<String> {
+    let difference = difference.trim();
+    if is_valid_iso_duration(difference) {
+        return Some(difference.to_owned());
+    }
+    let boundary = difference.find(|c: char| !c.is_ascii_digit() && c != '-')?;
+    let (count, unit) = difference.split_at_checked(boundary)?;
+    if count.is_empty()
+        || !count
+            .trim_start_matches('-')
+            .chars()
+            .all(|c| c.is_ascii_digit())
+    {
+        return None;
+    }
+    // The HL7 unit abbreviations the section's examples use, mapped onto the
+    // ISO-8601 designator each one names.
+    let (designator, timed) = match unit {
+        "a" => ("Y", false),
+        "mo" => ("M", false),
+        "wk" => ("W", false),
+        "d" => ("D", false),
+        "h" => ("H", true),
+        "min" => ("M", true),
+        "s" => ("S", true),
+        _ => return None,
+    };
+    let separator = if timed { "PT" } else { "P" };
+    Some(format!("{separator}{count}{designator}"))
+}
 
 impl Validate for DvPeriodicTimeSpecification {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
@@ -52,5 +193,97 @@ mod tests {
             out.iter().any(|m| m.message.contains("Value_valid")),
             "{out:?}"
         );
+    }
+
+    fn parsable(formalism: &str, value: &str) -> DvPeriodicTimeSpecification {
+        DvPeriodicTimeSpecification {
+            value: DvParsable {
+                charset: None,
+                language: None,
+                value: value.to_owned(),
+                formalism: formalism.to_owned(),
+            },
+        }
+    }
+
+    /// The section's own first worked example: "[200004181100;200004181110]/(7d)@DW
+    /// = every Tuesday from 11:00 to 11:10 AM."
+    #[test]
+    fn the_specs_weekly_example_parses() {
+        let weekly = parsable("HL7:PIVL", "[200004181100;200004181110]/(7d)@DW");
+        assert_eq!(
+            weekly.period().expect("a phase has a difference").value,
+            "P7D"
+        );
+        assert_eq!(weekly.calendar_alignment().as_deref(), Some("DW"));
+        assert!(!weekly.institution_specified());
+        assert!(weekly.event_alignment().is_none(), "not event-linked");
+    }
+
+    /// The section's second example: "[200004181100;200004181110]/(1mo)@DM =
+    /// every 18th of the month 11:00 to 11:10 AM."
+    #[test]
+    fn the_specs_monthly_example_parses() {
+        let monthly = parsable("HL7:PIVL", "[200004181100;200004181110]/(1mo)@DM");
+        assert_eq!(monthly.period().expect("a difference").value, "P1M");
+        assert_eq!(monthly.calendar_alignment().as_deref(), Some("DM"));
+    }
+
+    /// The grammar annotates `difference` as ISO-8601 while the same section's
+    /// examples spell it `7d`; both are accepted, and the alignment is optional.
+    #[test]
+    fn an_iso_difference_and_a_missing_alignment_are_both_accepted() {
+        let iso = parsable("HL7:PIVL", "[;]/(P7D)");
+        assert_eq!(iso.period().expect("a difference").value, "P7D");
+        assert!(iso.calendar_alignment().is_none(), "no @ alignment given");
+
+        let hourly = parsable("HL7:PIVL", "[;]/(6h)");
+        assert_eq!(hourly.period().expect("a difference").value, "PT6H");
+        let minutes = parsable("HL7:PIVL", "[;]/(50min)");
+        assert_eq!(minutes.period().expect("a difference").value, "PT50M");
+    }
+
+    /// `phase_linked_time_spec = pure_phase_linked_time_spec [ "IST" ]` — the
+    /// flag is trailing, and it does not become part of the alignment.
+    #[test]
+    fn the_institution_specified_flag_is_read_off_the_end() {
+        let flagged = parsable("HL7:PIVL", "[;]/(7d)@DWIST");
+        assert!(flagged.institution_specified());
+        assert_eq!(
+            flagged.calendar_alignment().as_deref(),
+            Some("DW"),
+            "the flag is not part of the alignment term"
+        );
+        assert!(!parsable("HL7:PIVL", "[;]/(7d)@DW").institution_specified());
+    }
+
+    /// The section's event-linked examples: "PC+[1h;1h]" = one hour after meal,
+    /// "HS-[50min;1h]" = one hour before bedtime. The event is the leading term
+    /// and there is no period — the event-linked grammar has no `difference`.
+    #[test]
+    fn the_specs_event_linked_examples_parse() {
+        let after_meal = parsable("HL7:EIVL", "PC+[1h;1h]");
+        assert_eq!(after_meal.event_alignment().as_deref(), Some("PC"));
+        assert!(after_meal.period().is_none(), "an event has no period");
+        assert!(after_meal.calendar_alignment().is_none());
+        assert!(!after_meal.institution_specified());
+
+        let bedtime = parsable("HL7:EIVL", "HS-[50min;1h]");
+        assert_eq!(bedtime.event_alignment().as_deref(), Some("HS"));
+
+        // `event_linked_time_spec = event | event offset` — a bare event.
+        assert_eq!(
+            parsable("HL7:EIVL", "AC").event_alignment().as_deref(),
+            Some("AC")
+        );
+    }
+
+    /// A difference in neither form yields no period, rather than a duration
+    /// invented from text nobody can parse.
+    #[test]
+    fn an_unreadable_difference_has_no_period() {
+        assert!(parsable("HL7:PIVL", "[;]/(every week)").period().is_none());
+        assert!(parsable("HL7:PIVL", "[;]/(7furlongs)").period().is_none());
+        assert!(parsable("HL7:PIVL", "[;]").period().is_none(), "no phase");
     }
 }

--- a/crates/openehr-rm/src/v1_2/data_types/quantity/date_time/dv_date_impl.rs
+++ b/crates/openehr-rm/src/v1_2/data_types/quantity/date_time/dv_date_impl.rs
@@ -11,10 +11,114 @@
 //! `crate::v1_2::validate`).
 
 use crate::v1_2::data_types::quantity::date_time::dv_date::DvDate;
+use crate::v1_2::data_types::quantity::date_time::dv_duration::DvDuration;
+use crate::v1_2::data_types::quantity::dv_absolute_quantity_impl::{
+    difference_accuracy, displaced_accuracy,
+};
+use crate::v1_2::data_types::quantity::dv_amount_impl::CombinedAccuracy;
 use crate::v1_2::data_types::quantity::dv_ordered::DvOrdered;
 use crate::v1_2::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
 use crate::v1_2::validate::is_valid_iso_date;
+use openehr_base::v1_3::foundation_types::time::iso8601_date::Iso8601Date;
+use openehr_base::v1_3::foundation_types::time::iso8601_duration::Iso8601Duration;
 use openehr_base::validate::{InvariantViolation, Validate};
+
+impl DvDate {
+    /// Addition of a duration to this date, or `None` when either value is not
+    /// a valid ISO-8601 string.
+    ///
+    /// Spec: `dv_date.adoc` §Functions `add` — "Addition of a Duration to this
+    /// Date" — effecting `dv_absolute_quantity.adoc`'s abstract `add`, whose
+    /// accuracy rule is realized by [`displaced_accuracy`].
+    ///
+    /// The calendar arithmetic is BASE's `Iso8601_date.add`, so leap years and
+    /// month lengths are answered once, in the type that owns the calendar.
+    #[must_use]
+    pub fn add(&self, a_diff: &DvDuration) -> Option<Self> {
+        Some(self.displaced(self.iso().add(&duration_of(a_diff))?, a_diff))
+    }
+
+    /// Subtraction of a duration from this date, under the same conditions as
+    /// [`Self::add`].
+    ///
+    /// Spec: `dv_date.adoc` §Functions `subtract`.
+    #[must_use]
+    pub fn subtract(&self, a_diff: &DvDuration) -> Option<Self> {
+        Some(self.displaced(self.iso().subtract(&duration_of(a_diff))?, a_diff))
+    }
+
+    /// Difference between this date and `other`, as a duration.
+    ///
+    /// Spec: `dv_date.adoc` §Functions `diff` — "Difference between this Date
+    /// and `other`."
+    #[must_use]
+    pub fn diff(&self, other: &Self) -> Option<DvDuration> {
+        let difference = self.iso().diff(&other.iso())?;
+        let (accuracy, accuracy_is_percent) =
+            match difference_accuracy(self.accuracy.as_ref(), other.accuracy.as_ref()) {
+                CombinedAccuracy::Unrepresentable => return None,
+                CombinedAccuracy::Unknown => (None, None),
+                CombinedAccuracy::Known {
+                    accuracy,
+                    is_percent,
+                } => (Some(accuracy), Some(is_percent)),
+            };
+        Some(DvDuration {
+            value: difference.value,
+            magnitude_status: None,
+            accuracy,
+            accuracy_is_percent,
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        })
+    }
+
+    /// Returns `true` when this date is considered equal to `other`.
+    ///
+    /// Spec: `dv_date.adoc` §Functions `is_equal`, effecting
+    /// `dv_quantified.adoc`'s abstract `is_equal`.
+    ///
+    /// Equality is of the DATE, not of how it was written: `less_than` on this
+    /// class is defined over `magnitude()`, and `2024-01-01` and `20240101`
+    /// name the same day, so comparing the strings would make a value neither
+    /// less than, greater than, nor equal to its own extended form.
+    #[must_use]
+    pub fn is_equal(&self, other: &Self) -> bool {
+        match (self.magnitude(), other.magnitude()) {
+            (Some(left), Some(right)) => left == right,
+            // A value with no magnitude is not a date this function can
+            // compare; only an identical string can still be the same one.
+            _ => self.value == other.value,
+        }
+    }
+
+    /// This date's `value` as the BASE ISO-8601 type that owns the calendar.
+    fn iso(&self) -> Iso8601Date {
+        Iso8601Date {
+            value: self.value.clone(),
+        }
+    }
+
+    /// This date at a new value, carrying the displaced accuracy.
+    fn displaced(&self, value: Iso8601Date, a_diff: &DvDuration) -> Self {
+        Self {
+            value: value.value,
+            magnitude_status: None,
+            accuracy: displaced_accuracy(self.accuracy.as_ref(), a_diff),
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        }
+    }
+}
+
+/// A `DV_DURATION`'s `value` as the BASE ISO-8601 type.
+fn duration_of(duration: &DvDuration) -> Iso8601Duration {
+    Iso8601Duration {
+        value: duration.value.clone(),
+    }
+}
 
 impl Validate for DvDate {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
@@ -67,6 +171,108 @@ mod tests {
         assert!(
             v.iter()
                 .any(|m| m.message == "Invariant Value_valid failed on type DV_DATE")
+        );
+    }
+
+    fn duration(value: &str) -> DvDuration {
+        DvDuration {
+            normal_status: None,
+            normal_range: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+            magnitude_status: None,
+            accuracy: None,
+            accuracy_is_percent: None,
+            value: value.to_owned(),
+        }
+    }
+
+    /// `DV_DATE` declares `add`, and BASE defines that as "arithmetic addition
+    /// of a duration to a date" — the NOMINAL calendar semantics belong to
+    /// `add_nominal`, which this class does not declare. So `P1M` is the
+    /// duration's own average month, not "the same day next month": adding it
+    /// to 31 January lands on 1 March, not on the end of February.
+    #[test]
+    fn arithmetic_is_the_spec_s_arithmetic_addition_not_the_nominal_one() {
+        assert_eq!(
+            date("2024-01-31")
+                .add(&duration("P1M"))
+                .expect("valid")
+                .value,
+            "2024-03-01",
+            "P1M is an average month of seconds, not a nominal calendar month"
+        );
+
+        // Exact durations still land exactly, leap day included.
+        assert_eq!(
+            date("2024-02-28")
+                .add(&duration("P1D"))
+                .expect("valid")
+                .value,
+            "2024-02-29"
+        );
+        assert_eq!(
+            date("2024-03-01")
+                .subtract(&duration("P1D"))
+                .expect("valid")
+                .value,
+            "2024-02-29"
+        );
+    }
+
+    /// `diff` returns the difference as a duration.
+    #[test]
+    fn diff_returns_a_duration() {
+        let difference = date("2024-03-01").diff(&date("2024-02-01")).expect("valid");
+        assert_eq!(difference.magnitude(), Some(29.0 * 86_400.0));
+    }
+
+    /// A value that is not a valid ISO-8601 date has no arithmetic.
+    #[test]
+    fn an_invalid_value_has_no_arithmetic() {
+        let bad = date("2021-13-40");
+        assert!(bad.add(&duration("P1D")).is_none());
+        assert!(bad.diff(&date("2024-01-01")).is_none());
+        assert!(date("2024-01-01").add(&duration("one day")).is_none());
+    }
+
+    /// Equality is of the DATE, not of the string: the extended and basic forms
+    /// name the same day, and `less_than` already orders them by magnitude.
+    #[test]
+    fn is_equal_compares_the_date_not_the_string() {
+        assert!(date("2024-01-01").is_equal(&date("20240101")));
+        assert!(!date("2024-01-01").is_equal(&date("2024-01-02")));
+    }
+
+    /// "The sum of the accuracies of the operands, if both present, or unknown,
+    /// if either or both operand accuracies are unknown."
+    #[test]
+    fn accuracy_follows_the_absolute_quantity_rule() {
+        let mut precise = date("2024-01-01");
+        precise.accuracy = Some(duration("PT30M"));
+        let mut offset = duration("P1D");
+        offset.accuracy = Some(60.0);
+        offset.accuracy_is_percent = Some(false);
+
+        let moved = precise.add(&offset).expect("valid");
+        assert_eq!(
+            moved.accuracy.expect("both present").magnitude(),
+            Some(1860.0)
+        );
+
+        // An operand with no accuracy makes the result's unknown.
+        assert!(
+            precise
+                .add(&duration("P1D"))
+                .expect("valid")
+                .accuracy
+                .is_none()
+        );
+        assert!(
+            date("2024-01-01")
+                .add(&offset)
+                .expect("valid")
+                .accuracy
+                .is_none()
         );
     }
 }

--- a/crates/openehr-rm/src/v1_2/data_types/quantity/date_time/dv_date_time_impl.rs
+++ b/crates/openehr-rm/src/v1_2/data_types/quantity/date_time/dv_date_time_impl.rs
@@ -6,10 +6,92 @@
 //! the NOTE on why this is an explicit invariant.
 
 use crate::v1_2::data_types::quantity::date_time::dv_date_time::DvDateTime;
+use crate::v1_2::data_types::quantity::date_time::dv_duration::DvDuration;
+use crate::v1_2::data_types::quantity::dv_absolute_quantity_impl::{
+    difference_accuracy, displaced_accuracy,
+};
+use crate::v1_2::data_types::quantity::dv_amount_impl::CombinedAccuracy;
 use crate::v1_2::data_types::quantity::dv_ordered::DvOrdered;
 use crate::v1_2::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
 use crate::v1_2::validate::is_valid_iso_date_time;
+use openehr_base::v1_3::foundation_types::time::iso8601_date_time::Iso8601DateTime;
+use openehr_base::v1_3::foundation_types::time::iso8601_duration::Iso8601Duration;
 use openehr_base::validate::{InvariantViolation, Validate};
+
+impl DvDateTime {
+    /// Addition of a duration to this date-time, or `None` when either value is
+    /// not a valid ISO-8601 string.
+    ///
+    /// Spec: `dv_date_time.adoc` §Functions `add`, effecting
+    /// `dv_absolute_quantity.adoc`'s abstract `add`, whose accuracy rule is
+    /// realized by [`displaced_accuracy`].
+    #[must_use]
+    pub fn add(&self, a_diff: &DvDuration) -> Option<Self> {
+        Some(self.displaced(self.iso().add(&duration_of(a_diff))?, a_diff))
+    }
+
+    /// Subtraction of a duration from this date-time, under the same conditions
+    /// as [`Self::add`].
+    ///
+    /// Spec: `dv_date_time.adoc` §Functions `subtract`.
+    #[must_use]
+    pub fn subtract(&self, a_diff: &DvDuration) -> Option<Self> {
+        Some(self.displaced(self.iso().subtract(&duration_of(a_diff))?, a_diff))
+    }
+
+    /// Difference between this date-time and `other`, as a duration.
+    ///
+    /// Spec: `dv_date_time.adoc` §Functions `diff`.
+    #[must_use]
+    pub fn diff(&self, other: &Self) -> Option<DvDuration> {
+        let difference = self.iso().diff(&other.iso())?;
+        let (accuracy, accuracy_is_percent) =
+            match difference_accuracy(self.accuracy.as_ref(), other.accuracy.as_ref()) {
+                CombinedAccuracy::Unrepresentable => return None,
+                CombinedAccuracy::Unknown => (None, None),
+                CombinedAccuracy::Known {
+                    accuracy,
+                    is_percent,
+                } => (Some(accuracy), Some(is_percent)),
+            };
+        Some(DvDuration {
+            value: difference.value,
+            magnitude_status: None,
+            accuracy,
+            accuracy_is_percent,
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        })
+    }
+
+    /// This date-time's `value` as the BASE ISO-8601 type that owns the
+    /// calendar.
+    fn iso(&self) -> Iso8601DateTime {
+        Iso8601DateTime {
+            value: self.value.clone(),
+        }
+    }
+
+    /// This date-time at a new value, carrying the displaced accuracy.
+    fn displaced(&self, value: Iso8601DateTime, a_diff: &DvDuration) -> Self {
+        Self {
+            value: value.value,
+            magnitude_status: None,
+            accuracy: displaced_accuracy(self.accuracy.as_ref(), a_diff),
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        }
+    }
+}
+
+/// A `DV_DURATION`'s `value` as the BASE ISO-8601 type.
+fn duration_of(duration: &DvDuration) -> Iso8601Duration {
+    Iso8601Duration {
+        value: duration.value.clone(),
+    }
+}
 
 impl Validate for DvDateTime {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
@@ -61,6 +143,75 @@ mod tests {
         assert!(
             v.iter()
                 .any(|m| m.message == "Invariant Value_valid failed on type DV_DATE_TIME")
+        );
+    }
+
+    fn duration(value: &str) -> DvDuration {
+        DvDuration {
+            normal_status: None,
+            normal_range: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+            magnitude_status: None,
+            accuracy: None,
+            accuracy_is_percent: None,
+            value: value.to_owned(),
+        }
+    }
+
+    /// Date-times displace across the day boundary and across the calendar,
+    /// because BASE answers both in one type.
+    #[test]
+    fn arithmetic_crosses_the_day_and_the_calendar() {
+        let evening = date_time("2024-02-28T23:00:00");
+        assert_eq!(
+            evening.add(&duration("PT2H")).expect("valid").value,
+            "2024-02-29T01:00:00",
+            "into the leap day"
+        );
+        assert_eq!(
+            evening.subtract(&duration("P1D")).expect("valid").value,
+            "2024-02-27T23:00:00"
+        );
+        assert_eq!(
+            evening
+                .diff(&date_time("2024-02-28T21:00:00"))
+                .expect("valid")
+                .magnitude(),
+            Some(7200.0)
+        );
+    }
+
+    /// A value that is not a valid ISO-8601 date-time has no arithmetic.
+    #[test]
+    fn an_invalid_value_has_no_arithmetic() {
+        let bad = date_time("2021-05-17T99:00:00");
+        assert!(bad.add(&duration("PT1H")).is_none());
+        assert!(bad.diff(&date_time("2024-01-01T00:00:00")).is_none());
+    }
+
+    /// The `DV_ABSOLUTE_QUANTITY` accuracy rule, including a percentage
+    /// half-range resolved against the differential amount's own magnitude.
+    #[test]
+    fn accuracy_follows_the_absolute_quantity_rule() {
+        let mut precise = date_time("2024-01-01T00:00:00");
+        precise.accuracy = Some(duration("PT5S"));
+        let mut offset = duration("PT100S");
+        offset.accuracy = Some(10.0);
+        offset.accuracy_is_percent = Some(true);
+
+        let moved = precise.add(&offset).expect("valid");
+        assert_eq!(
+            moved.accuracy.expect("both present").magnitude(),
+            Some(15.0),
+            "5s + 10% of 100s"
+        );
+
+        assert!(
+            precise
+                .add(&duration("PT100S"))
+                .expect("valid")
+                .accuracy
+                .is_none()
         );
     }
 }

--- a/crates/openehr-rm/src/v1_2/data_types/quantity/date_time/dv_duration_impl.rs
+++ b/crates/openehr-rm/src/v1_2/data_types/quantity/date_time/dv_duration_impl.rs
@@ -7,10 +7,129 @@
 //! `dv_date_impl` for the NOTE on why value well-formedness is explicit.
 
 use crate::v1_2::data_types::quantity::date_time::dv_duration::DvDuration;
+use crate::v1_2::data_types::quantity::dv_amount_impl::{
+    AmountAccuracy, CombinedAccuracy, combine, scale,
+};
 use crate::v1_2::data_types::quantity::dv_ordered::DvOrdered;
 use crate::v1_2::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
 use crate::v1_2::validate::is_valid_iso_duration;
+use openehr_base::v1_3::foundation_types::time::iso8601_duration::Iso8601Duration;
 use openehr_base::validate::{InvariantViolation, Validate};
+
+impl DvDuration {
+    /// Sum of this duration and `other`, or `None` when either value is not a
+    /// valid ISO-8601 duration or the result is one no valid duration can
+    /// carry.
+    ///
+    /// Spec: `dv_duration.adoc` §Functions `add` — "Sum of this Duration and
+    /// `other`" — redefining `dv_amount.adoc` §Functions `add`. `DV_DURATION`
+    /// effects `is_strictly_comparable_to` as "True, for any two Durations", so
+    /// the inherited pre-condition never refuses a pair.
+    ///
+    /// The arithmetic is BASE's — `Iso8601_duration.add` — so the result stays
+    /// a duration STRING with its designators intact, rather than a second of
+    /// seconds this crate would have to render back.
+    #[must_use]
+    pub fn add(&self, other: &Self) -> Option<Self> {
+        Self::carrying(
+            self.iso().add(&other.iso())?,
+            combine(self.amount_accuracy()?, other.amount_accuracy()?),
+        )
+    }
+
+    /// Difference of this duration and `other`, under the same conditions as
+    /// [`Self::add`].
+    ///
+    /// Spec: `dv_duration.adoc` §Functions `subtract`.
+    #[must_use]
+    pub fn subtract(&self, other: &Self) -> Option<Self> {
+        Self::carrying(
+            self.iso().subtract(&other.iso())?,
+            combine(self.amount_accuracy()?, other.amount_accuracy()?),
+        )
+    }
+
+    /// Product of this duration and `factor`.
+    ///
+    /// Spec: `dv_duration.adoc` §Functions `multiply` — "Product of this
+    /// Duration and `factor`."
+    #[must_use]
+    pub fn multiply(&self, factor: f64) -> Option<Self> {
+        Self::carrying(
+            self.iso().multiply(factor)?,
+            scale(self.amount_accuracy()?, factor),
+        )
+    }
+
+    /// Negated version of this duration.
+    ///
+    /// Spec: `dv_duration.adoc` §Functions `negative` — "Assuming the current
+    /// duration is positive, the negated version represents a time prior to
+    /// some origin point, or a negative age (e.g. so-called 'adjusted age' of
+    /// premature infant)."
+    ///
+    /// Negation changes the sign of the magnitude, not how well it was
+    /// measured, so the accuracy is carried through unchanged — the one
+    /// arithmetic function here for which that is a fact rather than a rule.
+    #[must_use]
+    pub fn negative(&self) -> Option<Self> {
+        let mut negated = self.clone();
+        negated.value = self.iso().negative()?.value;
+        negated.normal_range = None;
+        negated.normal_status = None;
+        negated.magnitude_status = None;
+        negated.other_reference_ranges = openehr_base::containers::present_nonempty(Vec::new());
+        Some(negated)
+    }
+
+    /// Returns `true` when this duration's accuracy was not recorded.
+    ///
+    /// Spec: `dv_quantified.adoc` §Functions `accuracy_unknown`, effected for
+    /// `DV_AMOUNT` by the `unknown_accuracy_value` sentinel.
+    #[must_use]
+    pub fn accuracy_unknown(&self) -> bool {
+        self.accuracy.is_none_or(|value| value < 0.0)
+    }
+
+    /// This duration's `value` as the BASE ISO-8601 type that owns the
+    /// arithmetic.
+    fn iso(&self) -> Iso8601Duration {
+        Iso8601Duration {
+            value: self.value.clone(),
+        }
+    }
+
+    /// This duration's accuracy as the `DV_AMOUNT` rule reads it, or `None`
+    /// when `value` has no magnitude to measure a percentage against.
+    fn amount_accuracy(&self) -> Option<AmountAccuracy> {
+        Some(AmountAccuracy::measured(
+            self.magnitude()?,
+            self.accuracy,
+            self.accuracy_is_percent,
+        ))
+    }
+
+    /// This duration at a new value and accuracy.
+    fn carrying(value: Iso8601Duration, accuracy: CombinedAccuracy) -> Option<Self> {
+        let (accuracy, accuracy_is_percent) = match accuracy {
+            CombinedAccuracy::Unrepresentable => return None,
+            CombinedAccuracy::Unknown => (None, None),
+            CombinedAccuracy::Known {
+                accuracy,
+                is_percent,
+            } => (Some(accuracy), Some(is_percent)),
+        };
+        Some(Self {
+            value: value.value,
+            magnitude_status: None,
+            accuracy,
+            accuracy_is_percent,
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        })
+    }
+}
 
 impl Validate for DvDuration {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
@@ -66,5 +185,71 @@ mod tests {
             v.iter()
                 .any(|m| m.message == "Invariant Value_valid failed on type DV_DURATION")
         );
+    }
+
+    /// `is_strictly_comparable_to` is "True, for any two Durations", so unlike
+    /// `DV_QUANTITY` no pair is refused for incomparability — the arithmetic
+    /// runs on the ISO-8601 values themselves.
+    #[test]
+    fn arithmetic_runs_on_the_iso_value() {
+        let a = duration("PT2H");
+        let b = duration("PT30M");
+
+        assert_eq!(a.add(&b).expect("valid").magnitude(), Some(9000.0));
+        assert_eq!(a.subtract(&b).expect("valid").magnitude(), Some(5400.0));
+        assert_eq!(a.multiply(2.0).expect("valid").magnitude(), Some(14400.0));
+        assert_eq!(a.negative().expect("valid").magnitude(), Some(-7200.0));
+    }
+
+    /// A value that is not a valid ISO-8601 duration has no arithmetic: BASE
+    /// refuses to parse it, and the refusal is propagated rather than turned
+    /// into a zero.
+    #[test]
+    fn an_invalid_value_has_no_arithmetic() {
+        let bad = duration("10 hours");
+        let good = duration("PT1H");
+        assert!(bad.add(&good).is_none());
+        assert!(good.add(&bad).is_none());
+        assert!(bad.multiply(2.0).is_none());
+        assert!(bad.negative().is_none());
+    }
+
+    /// `DV_DURATION` is a `DV_AMOUNT`, so its arithmetic carries the same
+    /// accuracy rule — summed for add and subtract, scaled for multiply, and
+    /// unchanged by negation, which alters the sign rather than the
+    /// measurement.
+    #[test]
+    fn accuracy_follows_the_dv_amount_rule() {
+        let mut a = duration("PT2H");
+        a.accuracy = Some(60.0);
+        a.accuracy_is_percent = Some(false);
+        let mut b = duration("PT30M");
+        b.accuracy = Some(30.0);
+        b.accuracy_is_percent = Some(false);
+
+        let sum = a.add(&b).expect("valid");
+        assert!((sum.accuracy.expect("both recorded one") - 90.0).abs() < f64::EPSILON);
+        assert_eq!(sum.accuracy_is_percent, Some(false));
+
+        let scaled = a.multiply(3.0).expect("valid");
+        assert!((scaled.accuracy.expect("scaled") - 180.0).abs() < f64::EPSILON);
+
+        let negated = a.negative().expect("valid");
+        assert!((negated.accuracy.expect("kept") - 60.0).abs() < f64::EPSILON);
+
+        // Unrecorded on either side makes the result's unknown.
+        let plain = duration("PT30M");
+        assert!(a.add(&plain).expect("valid").accuracy.is_none());
+    }
+
+    /// `accuracy_unknown` reads both ways of not recording an accuracy.
+    #[test]
+    fn accuracy_unknown_reads_the_sentinel_and_the_absence() {
+        let mut d = duration("PT1H");
+        assert!(d.accuracy_unknown());
+        d.accuracy = Some(-1.0);
+        assert!(d.accuracy_unknown());
+        d.accuracy = Some(0.0);
+        assert!(!d.accuracy_unknown(), "0 means 100% accurate, not unknown");
     }
 }

--- a/crates/openehr-rm/src/v1_2/data_types/quantity/date_time/dv_time_impl.rs
+++ b/crates/openehr-rm/src/v1_2/data_types/quantity/date_time/dv_time_impl.rs
@@ -5,11 +5,93 @@
 //! inherited DV_QUANTIFIED `Magnitude_status_valid`. See `dv_date_impl` for the
 //! NOTE on why this is an explicit invariant.
 
+use crate::v1_2::data_types::quantity::date_time::dv_duration::DvDuration;
 use crate::v1_2::data_types::quantity::date_time::dv_time::DvTime;
+use crate::v1_2::data_types::quantity::dv_absolute_quantity_impl::{
+    difference_accuracy, displaced_accuracy,
+};
+use crate::v1_2::data_types::quantity::dv_amount_impl::CombinedAccuracy;
 use crate::v1_2::data_types::quantity::dv_ordered::DvOrdered;
 use crate::v1_2::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
 use crate::v1_2::validate::is_valid_iso_time;
+use openehr_base::v1_3::foundation_types::time::iso8601_duration::Iso8601Duration;
+use openehr_base::v1_3::foundation_types::time::iso8601_time::Iso8601Time;
 use openehr_base::validate::{InvariantViolation, Validate};
+
+impl DvTime {
+    /// Addition of a duration to this time, or `None` when either value is not
+    /// a valid ISO-8601 string.
+    ///
+    /// Spec: `dv_time.adoc` §Functions `add` — "Addition of a Duration to this
+    /// Time" — effecting `dv_absolute_quantity.adoc`'s abstract `add`, whose
+    /// accuracy rule is realized by [`displaced_accuracy`].
+    #[must_use]
+    pub fn add(&self, a_diff: &DvDuration) -> Option<Self> {
+        Some(self.displaced(self.iso().add(&duration_of(a_diff))?, a_diff))
+    }
+
+    /// Subtraction of a duration from this time, under the same conditions as
+    /// [`Self::add`].
+    ///
+    /// Spec: `dv_time.adoc` §Functions `subtract`.
+    #[must_use]
+    pub fn subtract(&self, a_diff: &DvDuration) -> Option<Self> {
+        Some(self.displaced(self.iso().subtract(&duration_of(a_diff))?, a_diff))
+    }
+
+    /// Difference between this time and `other`, as a duration.
+    ///
+    /// Spec: `dv_time.adoc` §Functions `diff` — "Difference between this Time
+    /// and `other`."
+    #[must_use]
+    pub fn diff(&self, other: &Self) -> Option<DvDuration> {
+        let difference = self.iso().diff(&other.iso())?;
+        let (accuracy, accuracy_is_percent) =
+            match difference_accuracy(self.accuracy.as_ref(), other.accuracy.as_ref()) {
+                CombinedAccuracy::Unrepresentable => return None,
+                CombinedAccuracy::Unknown => (None, None),
+                CombinedAccuracy::Known {
+                    accuracy,
+                    is_percent,
+                } => (Some(accuracy), Some(is_percent)),
+            };
+        Some(DvDuration {
+            value: difference.value,
+            magnitude_status: None,
+            accuracy,
+            accuracy_is_percent,
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        })
+    }
+
+    /// This time's `value` as the BASE ISO-8601 type that owns the arithmetic.
+    fn iso(&self) -> Iso8601Time {
+        Iso8601Time {
+            value: self.value.clone(),
+        }
+    }
+
+    /// This time at a new value, carrying the displaced accuracy.
+    fn displaced(&self, value: Iso8601Time, a_diff: &DvDuration) -> Self {
+        Self {
+            value: value.value,
+            magnitude_status: None,
+            accuracy: displaced_accuracy(self.accuracy.as_ref(), a_diff),
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        }
+    }
+}
+
+/// A `DV_DURATION`'s `value` as the BASE ISO-8601 type.
+fn duration_of(duration: &DvDuration) -> Iso8601Duration {
+    Iso8601Duration {
+        value: duration.value.clone(),
+    }
+}
 
 impl Validate for DvTime {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
@@ -62,5 +144,69 @@ mod tests {
             v.iter()
                 .any(|m| m.message == "Invariant Value_valid failed on type DV_TIME")
         );
+    }
+
+    fn duration(value: &str) -> DvDuration {
+        DvDuration {
+            normal_status: None,
+            normal_range: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+            magnitude_status: None,
+            accuracy: None,
+            accuracy_is_percent: None,
+            value: value.to_owned(),
+        }
+    }
+
+    /// Times displace by a duration and difference into one.
+    #[test]
+    fn arithmetic_displaces_within_the_day() {
+        let noon = time("12:00:00");
+        assert_eq!(
+            noon.add(&duration("PT90M")).expect("valid").magnitude(),
+            Some(48_600.0)
+        );
+        assert_eq!(
+            noon.subtract(&duration("PT30M"))
+                .expect("valid")
+                .magnitude(),
+            Some(41_400.0)
+        );
+        assert_eq!(
+            noon.diff(&time("11:00:00")).expect("valid").magnitude(),
+            Some(3600.0)
+        );
+    }
+
+    /// A value that is not a valid ISO-8601 time has no arithmetic.
+    #[test]
+    fn an_invalid_value_has_no_arithmetic() {
+        let bad = time("25:99");
+        assert!(bad.add(&duration("PT1H")).is_none());
+        assert!(bad.diff(&time("12:00:00")).is_none());
+    }
+
+    /// The `DV_ABSOLUTE_QUANTITY` accuracy rule: summed when both operands
+    /// record one, unknown when either does not.
+    #[test]
+    fn accuracy_follows_the_absolute_quantity_rule() {
+        let mut precise = time("12:00:00");
+        precise.accuracy = Some(duration("PT10S"));
+        let mut offset = duration("PT1H");
+        offset.accuracy = Some(5.0);
+        offset.accuracy_is_percent = Some(false);
+
+        let moved = precise.add(&offset).expect("valid");
+        assert_eq!(
+            moved.accuracy.expect("both present").magnitude(),
+            Some(15.0)
+        );
+
+        // `diff` reports the summed accuracy as the resulting amount's own.
+        let mut other = time("11:00:00");
+        other.accuracy = Some(duration("PT20S"));
+        let difference = precise.diff(&other).expect("valid");
+        assert_eq!(difference.accuracy, Some(30.0));
+        assert_eq!(difference.accuracy_is_percent, Some(false));
     }
 }

--- a/crates/openehr-rm/src/v1_2/data_types/quantity/dv_absolute_quantity_impl.rs
+++ b/crates/openehr-rm/src/v1_2/data_types/quantity/dv_absolute_quantity_impl.rs
@@ -1,0 +1,240 @@
+// @generated-from-template templates/openehr-rm/data_types/quantity/dv_absolute_quantity_impl.rs — DO NOT EDIT; edit the source and re-run `openehr-codegen -- emit`.
+//! Hand-written `DV_ABSOLUTE_QUANTITY` spec behaviour, shared by its
+//! descendants.
+//!
+//! `DV_ABSOLUTE_QUANTITY` is abstract, so the generated `DvAbsoluteQuantity` is
+//! a subtype enum and the accuracy rule its `add`/`subtract`/`diff` declare has
+//! no single struct to live on. It is realized once here and called by
+//! `DV_DATE`, `DV_TIME` and `DV_DATE_TIME`.
+//!
+//! The rule differs from `DV_AMOUNT`'s in what it operates on rather than in
+//! what it says: accuracy here is redefined as a `DV_AMOUNT` — a `DV_DURATION`
+//! for the three temporal descendants — so the "sum of the accuracies" is a
+//! duration sum, not a real one.
+
+use crate::v1_2::data_types::quantity::date_time::dv_duration::DvDuration;
+use crate::v1_2::data_types::quantity::dv_absolute_quantity::DvAbsoluteQuantity;
+use crate::v1_2::data_types::quantity::dv_amount::DvAmount;
+use crate::v1_2::data_types::quantity::dv_amount_impl::AmountAccuracy;
+use crate::v1_2::data_types::quantity::dv_amount_impl::{CombinedAccuracy, combine};
+use openehr_base::v1_3::foundation_types::time::iso8601_duration::Iso8601Duration;
+
+/// The accuracy of an absolute quantity displaced by a differential amount.
+///
+/// Spec: `dv_absolute_quantity.adoc` §Functions `add`/`subtract` — "the sum of
+/// the accuracies of the operands, if both present, or unknown, if either or
+/// both operand accuracies are unknown."
+///
+/// The two operands measure their accuracy differently: this quantity's is
+/// already a duration, while the differential amount's is a `Real` half-range
+/// over its own magnitude. The amount's is converted into a duration of that
+/// many seconds — `DV_DURATION.magnitude` is seconds by definition — and the
+/// two durations are then added by BASE.
+#[must_use]
+pub fn displaced_accuracy(
+    accuracy: Option<&DvDuration>,
+    amount: &DvDuration,
+) -> Option<DvDuration> {
+    let own = accuracy?;
+    let amount_seconds = absolute_accuracy_seconds(amount)?;
+    let sum = Iso8601Duration {
+        value: own.value.clone(),
+    }
+    .add(&seconds_as_duration(amount_seconds))?;
+    Some(DvDuration {
+        value: sum.value,
+        magnitude_status: None,
+        accuracy: None,
+        accuracy_is_percent: None,
+        normal_range: None,
+        normal_status: None,
+        other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+    })
+}
+
+/// The accuracy of the difference between two absolute quantities.
+///
+/// Spec: `dv_absolute_quantity.adoc` §Functions `diff` — same rule, but the
+/// result is a `DV_AMOUNT`, so the summed duration is reported as that amount's
+/// own `Real` accuracy in seconds.
+#[must_use]
+pub fn difference_accuracy(
+    left: Option<&DvDuration>,
+    right: Option<&DvDuration>,
+) -> CombinedAccuracy {
+    let (Some(left), Some(right)) = (left, right) else {
+        return CombinedAccuracy::Unknown;
+    };
+    let (Some(left_seconds), Some(right_seconds)) = (left.magnitude(), right.magnitude()) else {
+        return CombinedAccuracy::Unrepresentable;
+    };
+    // Both half-ranges are already absolute values in seconds, so the
+    // `DV_AMOUNT` rule reduces to adding them — routed through it anyway so the
+    // finiteness and zero-form checks stay in one place.
+    combine(
+        AmountAccuracy::measured(left_seconds, Some(left_seconds), Some(false)),
+        AmountAccuracy::measured(right_seconds, Some(right_seconds), Some(false)),
+    )
+}
+
+/// A duration's accuracy as an absolute half-range in seconds, resolving a
+/// percentage against the duration's own magnitude.
+fn absolute_accuracy_seconds(amount: &DvDuration) -> Option<f64> {
+    let accuracy = amount.accuracy.filter(|value| *value >= 0.0)?;
+    if amount.accuracy_is_percent == Some(true) {
+        return Some(accuracy / 100.0 * amount.magnitude()?.abs());
+    }
+    Some(accuracy)
+}
+
+/// A number of seconds as an ISO-8601 duration.
+fn seconds_as_duration(seconds: f64) -> Iso8601Duration {
+    Iso8601Duration {
+        value: format!("PT{seconds}S"),
+    }
+}
+
+impl DvAbsoluteQuantity {
+    /// Addition of a differential amount to this quantity, or `None` when the
+    /// amount is not one this quantity can be displaced by.
+    ///
+    /// Spec: `dv_absolute_quantity.adoc` §Functions `add` — "Addition of a
+    /// differential amount to this quantity."
+    ///
+    /// The spec types the differential as any `DV_AMOUNT`, but each concrete
+    /// descendant narrows it: all three temporal ones effect `add` with a
+    /// `DV_DURATION` parameter, because a date displaced by a count or a
+    /// proportion is not a date. Anything else is refused here.
+    #[must_use]
+    pub fn add(&self, a_diff: &DvAmount) -> Option<Self> {
+        let DvAmount::DvDuration(a_diff) = a_diff else {
+            return None;
+        };
+        match self {
+            Self::DvDate(date) => date.add(a_diff).map(Self::DvDate),
+            Self::DvDateTime(date_time) => date_time.add(a_diff).map(Self::DvDateTime),
+            Self::DvTime(time) => time.add(a_diff).map(Self::DvTime),
+        }
+    }
+
+    /// Subtraction of a differential amount from this quantity, under the same
+    /// conditions as [`Self::add`].
+    ///
+    /// Spec: `dv_absolute_quantity.adoc` §Functions `subtract`.
+    #[must_use]
+    pub fn subtract(&self, a_diff: &DvAmount) -> Option<Self> {
+        let DvAmount::DvDuration(a_diff) = a_diff else {
+            return None;
+        };
+        match self {
+            Self::DvDate(date) => date.subtract(a_diff).map(Self::DvDate),
+            Self::DvDateTime(date_time) => date_time.subtract(a_diff).map(Self::DvDateTime),
+            Self::DvTime(time) => time.subtract(a_diff).map(Self::DvTime),
+        }
+    }
+
+    /// Difference of two quantities, as the differential amount between them.
+    ///
+    /// Spec: `dv_absolute_quantity.adoc` §Functions `diff` — "Difference of two
+    /// quantities." Only two quantities of the same concrete type have one: the
+    /// difference between a date and a time of day is not a duration.
+    #[must_use]
+    pub fn diff(&self, other: &Self) -> Option<DvAmount> {
+        match (self, other) {
+            (Self::DvDate(left), Self::DvDate(right)) => left.diff(right),
+            (Self::DvDateTime(left), Self::DvDateTime(right)) => left.diff(right),
+            (Self::DvTime(left), Self::DvTime(right)) => left.diff(right),
+            _ => None,
+        }
+        .map(DvAmount::DvDuration)
+    }
+
+    /// Returns `true` when this quantity's accuracy was not recorded.
+    ///
+    /// Spec: `dv_quantified.adoc` §Functions `accuracy_unknown`, effected for
+    /// `DV_ABSOLUTE_QUANTITY` by `master06-quantity_package.adoc` §Accuracy and
+    /// Uncertainty — "in the `DV_ABSOLUTE_QUANTITY` class, `accuracy_unknown`
+    /// is represented by a Void (i.e. null) value for the accuracy attribute."
+    /// There is no `-1` sentinel here: the attribute is a `DV_AMOUNT`, so its
+    /// absence IS the unknown.
+    #[must_use]
+    pub fn accuracy_unknown(&self) -> bool {
+        match self {
+            Self::DvDate(date) => date.accuracy.is_none(),
+            Self::DvDateTime(date_time) => date_time.accuracy.is_none(),
+            Self::DvTime(time) => time.accuracy.is_none(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn duration(value: &str) -> DvDuration {
+        DvDuration {
+            normal_status: None,
+            normal_range: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+            magnitude_status: None,
+            accuracy: None,
+            accuracy_is_percent: None,
+            value: value.to_owned(),
+        }
+    }
+
+    /// "The sum of the accuracies of the operands, if both present" — the
+    /// differential amount's `Real` half-range becomes that many seconds of
+    /// duration before the two are added.
+    #[test]
+    fn a_displaced_accuracy_sums_both_operands() {
+        let mut amount = duration("P1D");
+        amount.accuracy = Some(60.0);
+        amount.accuracy_is_percent = Some(false);
+
+        let combined = displaced_accuracy(Some(&duration("PT30M")), &amount).expect("both present");
+        assert_eq!(
+            combined.magnitude(),
+            Some(1860.0),
+            "30 minutes + 60 seconds"
+        );
+    }
+
+    /// A percentage half-range is resolved against the amount's own magnitude
+    /// before it can be added to a duration.
+    #[test]
+    fn a_percentage_resolves_against_its_own_magnitude() {
+        let mut amount = duration("PT100S");
+        amount.accuracy = Some(10.0);
+        amount.accuracy_is_percent = Some(true);
+
+        let combined = displaced_accuracy(Some(&duration("PT5S")), &amount).expect("both present");
+        assert_eq!(combined.magnitude(), Some(15.0), "5s + 10% of 100s");
+    }
+
+    /// "Unknown, if either or both operand accuracies are unknown."
+    #[test]
+    fn either_operand_unknown_makes_the_result_unknown() {
+        let plain = duration("P1D");
+        assert!(displaced_accuracy(None, &plain).is_none());
+        assert!(displaced_accuracy(Some(&duration("PT30M")), &plain).is_none());
+    }
+
+    /// `diff` returns a `DV_AMOUNT`, so the summed duration is reported as that
+    /// amount's own accuracy in seconds.
+    #[test]
+    fn a_difference_accuracy_is_reported_in_seconds() {
+        let combined = difference_accuracy(Some(&duration("PT30M")), Some(&duration("PT30S")));
+        assert_eq!(
+            combined,
+            CombinedAccuracy::Known {
+                accuracy: 1830.0,
+                is_percent: false,
+            }
+        );
+        assert_eq!(
+            difference_accuracy(Some(&duration("PT30M")), None),
+            CombinedAccuracy::Unknown
+        );
+    }
+}

--- a/crates/openehr-rm/src/v1_2/data_types/quantity/dv_amount_impl.rs
+++ b/crates/openehr-rm/src/v1_2/data_types/quantity/dv_amount_impl.rs
@@ -1,0 +1,503 @@
+// @generated-from-template templates/openehr-rm/data_types/quantity/dv_amount_impl.rs — DO NOT EDIT; edit the source and re-run `openehr-codegen -- emit`.
+//! Hand-written `DV_AMOUNT` spec behaviour, shared by its descendants.
+//!
+//! `DV_AMOUNT` is abstract, so the generated `DvAmount` is a subtype enum and
+//! the accuracy rule its `add`/`subtract` declare has no single struct to live
+//! on. It is realized once here and called by every descendant that implements
+//! the arithmetic.
+
+use crate::v1_2::data_types::quantity::dv_amount::DvAmount;
+use crate::v1_2::data_types::quantity::dv_ordered::DvOrdered;
+use crate::v1_2::validate::valid_percentage;
+use core::cmp::Ordering;
+use rust_decimal::Decimal;
+use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
+
+/// The `accuracy` value that records "accuracy was not recorded".
+///
+/// Spec: `master06-quantity_package.adoc` §Accuracy and Uncertainty — "a value
+/// of -1 for the accuracy attribute is used for this purpose, and the constant
+/// `unknown_accuracy_value` = -1 is provided within the class".
+pub const UNKNOWN_ACCURACY_VALUE: f64 = -1.0;
+
+/// One operand of a `DV_AMOUNT` addition, subtraction or scaling.
+///
+/// The magnitude travels with the accuracy because the two forms the spec
+/// allows are not interchangeable without it: a percentage is a proportion of
+/// the magnitude it was recorded against, an absolute value is a half-range in
+/// the amount's own units.
+///
+/// It is carried as a [`Decimal`] so that converting between those forms is
+/// exact for every descendant: an integer magnitude converts without loss, and
+/// a real one converts without a widening cast whose error would land inside a
+/// clinical half-range.
+#[derive(Debug, Clone, Copy)]
+pub struct AmountAccuracy {
+    /// The operand's magnitude, absent when it has no decimal form — which
+    /// only matters if the two operands disagree about the accuracy form.
+    magnitude: Option<Decimal>,
+    /// The operand's `accuracy`.
+    accuracy: Option<f64>,
+    /// The operand's `accuracy_is_percent`.
+    accuracy_is_percent: Option<bool>,
+}
+
+impl AmountAccuracy {
+    /// The accuracy of an amount whose magnitude is an integer, such as a
+    /// `DV_COUNT`.
+    #[must_use]
+    pub fn counted(
+        magnitude: i64,
+        accuracy: Option<f64>,
+        accuracy_is_percent: Option<bool>,
+    ) -> Self {
+        Self {
+            magnitude: Some(Decimal::from(magnitude)),
+            accuracy,
+            accuracy_is_percent,
+        }
+    }
+
+    /// The accuracy of an amount whose magnitude is a real number, such as a
+    /// `DV_QUANTITY`.
+    #[must_use]
+    pub fn measured(
+        magnitude: f64,
+        accuracy: Option<f64>,
+        accuracy_is_percent: Option<bool>,
+    ) -> Self {
+        Self {
+            // `from_f64` recovers the decimal the float DENOTES, dropping the
+            // excess bits past IEEE-754's guarantee — 0.1_f64 becomes 0.1, not
+            // its binary approximation.
+            magnitude: Decimal::from_f64(magnitude),
+            accuracy,
+            accuracy_is_percent,
+        }
+    }
+}
+
+/// The accuracy a combined or scaled `DV_AMOUNT` carries.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum CombinedAccuracy {
+    /// At least one operand did not record an accuracy, so neither does the
+    /// result.
+    Unknown,
+    /// Every operand recorded one; this is the result, in the form named.
+    Known {
+        /// The combined accuracy value.
+        accuracy: f64,
+        /// Whether that value is a percentage rather than an absolute
+        /// half-range.
+        is_percent: bool,
+    },
+    /// The result exists as a number but no valid `DV_AMOUNT` can carry it —
+    /// a percentage past 100, or a form conversion the operands do not admit.
+    Unrepresentable,
+}
+
+impl AmountAccuracy {
+    /// This operand's recorded accuracy and its form, or `None` when accuracy
+    /// was not recorded.
+    ///
+    /// A negative value is read as unrecorded rather than only the exact
+    /// sentinel: `accuracy` is a half-range, which cannot be negative, so
+    /// `unknown_accuracy_value` is the only meaning a negative can carry.
+    fn recorded(self) -> Option<(f64, bool)> {
+        let value = self.accuracy?;
+        (value >= 0.0).then(|| (value, self.accuracy_is_percent == Some(true)))
+    }
+
+    /// This accuracy expressed as a percentage (`to_percent`) or as an absolute
+    /// half-range, or `None` when the operand admits no such form.
+    fn in_form(self, value: f64, is_percent: bool, to_percent: bool) -> Option<Decimal> {
+        let value = Decimal::from_f64(value)?;
+        if is_percent == to_percent {
+            return Some(value);
+        }
+        let magnitude = self.magnitude?.abs();
+        if is_percent {
+            return value.checked_mul(magnitude)?.checked_div(hundred());
+        }
+        // A zero magnitude has no percentage form: every percentage of it is
+        // the same zero, so the operand's half-range cannot be recovered from
+        // one.
+        if magnitude.is_zero() {
+            return None;
+        }
+        value.checked_mul(hundred())?.checked_div(magnitude)
+    }
+}
+
+/// The percentage base, as a `Decimal`.
+fn hundred() -> Decimal {
+    Decimal::from(100_u8)
+}
+
+/// The accuracy of the sum or difference of `left` and `right`.
+///
+/// Spec: `master06-quantity_package.adoc` §Accuracy and Uncertainty — "if
+/// accuracies are present in both quantities, they are added in the result, for
+/// both addition and subtraction operations; if either or both quantities has
+/// an unknown accuracy, the accuracy of the result is also unknown; if two
+/// `DV_AMOUNT` descendants are added or subtracted, and only one has
+/// `accuracy_is_percent` = True, accuracy is expressed in the result in the form
+/// used in the larger of the two quantities."
+///
+/// The spec says to add the two values but not to convert them, and adding a
+/// percentage to an absolute half-range is not a number. Converting the operand
+/// whose form loses into the winning form is the only reading under which the
+/// sum it prescribes exists at all.
+///
+/// Equal magnitudes are the one gap: "the larger of the two" then names neither
+/// operand. The result takes the absolute form, because an absolute half-range
+/// is interpretable on its own while a percentage is only interpretable against
+/// a magnitude. No openEHR spec governs that tie — our own design.
+#[must_use]
+pub fn combine(left: AmountAccuracy, right: AmountAccuracy) -> CombinedAccuracy {
+    let (Some((left_value, left_percent)), Some((right_value, right_percent))) =
+        (left.recorded(), right.recorded())
+    else {
+        return CombinedAccuracy::Unknown;
+    };
+
+    let as_percent = match (left_percent, right_percent) {
+        (true, true) => true,
+        (false, false) => false,
+        _ => match (left.magnitude, right.magnitude) {
+            (Some(left_magnitude), Some(right_magnitude)) => {
+                match left_magnitude.abs().cmp(&right_magnitude.abs()) {
+                    Ordering::Greater => left_percent,
+                    Ordering::Less => right_percent,
+                    Ordering::Equal => false,
+                }
+            }
+            _ => false,
+        },
+    };
+
+    let (Some(left_value), Some(right_value)) = (
+        left.in_form(left_value, left_percent, as_percent),
+        right.in_form(right_value, right_percent, as_percent),
+    ) else {
+        return CombinedAccuracy::Unrepresentable;
+    };
+
+    let Some(sum) = left_value.checked_add(right_value) else {
+        return CombinedAccuracy::Unrepresentable;
+    };
+    settle(sum, as_percent)
+}
+
+/// The accuracy of this amount scaled by `factor`.
+///
+/// The spec defines accuracy propagation for `add` and `subtract` only, and is
+/// silent on `multiply` — no openEHR spec governs this, so the rule is our own:
+/// a percentage of a magnitude is unchanged when the magnitude is scaled, and
+/// an absolute half-range, being in the amount's own units, scales with it.
+/// Dropping accuracy instead would make `multiply(1.0)` lose it.
+#[must_use]
+pub fn scale(amount: AmountAccuracy, factor: f64) -> CombinedAccuracy {
+    let Some((value, is_percent)) = amount.recorded() else {
+        return CombinedAccuracy::Unknown;
+    };
+    let (Some(value), Some(factor)) = (Decimal::from_f64(value), Decimal::from_f64(factor)) else {
+        return CombinedAccuracy::Unrepresentable;
+    };
+    if is_percent {
+        return settle(value, true);
+    }
+    let Some(scaled) = value.checked_mul(factor.abs()) else {
+        return CombinedAccuracy::Unrepresentable;
+    };
+    settle(scaled, false)
+}
+
+/// A computed accuracy as the result can carry it, or `Unrepresentable`.
+fn settle(accuracy: Decimal, is_percent: bool) -> CombinedAccuracy {
+    let Some(value) = accuracy.to_f64() else {
+        return CombinedAccuracy::Unrepresentable;
+    };
+    if !value.is_finite() || (is_percent && !valid_percentage(value)) {
+        return CombinedAccuracy::Unrepresentable;
+    }
+    CombinedAccuracy::Known {
+        accuracy: value,
+        // Accuracy_is_percent_validity: `accuracy = 0 implies not
+        // accuracy_is_percent`, so a zero result is recorded as absolute.
+        is_percent: is_percent && accuracy.is_sign_positive() && !accuracy.is_zero(),
+    }
+}
+
+impl DvAmount {
+    /// Sum of this amount and `other`, or `None` when they are not the same
+    /// kind of amount or the sum is one no valid amount can carry.
+    ///
+    /// Spec: `dv_amount.adoc` §Functions `add`, whose `Pre_comparable`
+    /// pre-condition is `is_strictly_comparable_to (other)`. Two amounts of
+    /// DIFFERENT concrete types are never strictly comparable — `DV_ORDERED`
+    /// compares only like with like — so a count plus a quantity is refused
+    /// here rather than in each descendant.
+    #[must_use]
+    pub fn add(&self, other: &Self) -> Option<Self> {
+        match (self, other) {
+            (Self::DvCount(left), Self::DvCount(right)) => left.add(right).map(Self::DvCount),
+            (Self::DvDuration(left), Self::DvDuration(right)) => {
+                left.add(right).map(Self::DvDuration)
+            }
+            (Self::DvProportion(left), Self::DvProportion(right)) => {
+                left.add(right).map(Self::DvProportion)
+            }
+            (Self::DvQuantity(left), Self::DvQuantity(right)) => {
+                left.add(right).map(Self::DvQuantity)
+            }
+            _ => None,
+        }
+    }
+
+    /// Difference of this amount and `other`, under the same conditions as
+    /// [`Self::add`].
+    ///
+    /// Spec: `dv_amount.adoc` §Functions `subtract`.
+    #[must_use]
+    pub fn subtract(&self, other: &Self) -> Option<Self> {
+        match (self, other) {
+            (Self::DvCount(left), Self::DvCount(right)) => left.subtract(right).map(Self::DvCount),
+            (Self::DvDuration(left), Self::DvDuration(right)) => {
+                left.subtract(right).map(Self::DvDuration)
+            }
+            (Self::DvProportion(left), Self::DvProportion(right)) => {
+                left.subtract(right).map(Self::DvProportion)
+            }
+            (Self::DvQuantity(left), Self::DvQuantity(right)) => {
+                left.subtract(right).map(Self::DvQuantity)
+            }
+            _ => None,
+        }
+    }
+
+    /// Product of this amount and `factor`.
+    ///
+    /// Spec: `dv_amount.adoc` §Functions `multiply`.
+    #[must_use]
+    pub fn multiply(&self, factor: f64) -> Option<Self> {
+        match self {
+            Self::DvCount(count) => count.multiply(factor).map(Self::DvCount),
+            Self::DvDuration(duration) => duration.multiply(factor).map(Self::DvDuration),
+            Self::DvProportion(proportion) => proportion.multiply(factor).map(Self::DvProportion),
+            Self::DvQuantity(quantity) => quantity.multiply(factor).map(Self::DvQuantity),
+        }
+    }
+
+    /// Negated version of this amount, "such as used for representing a
+    /// difference, e.g. a weight loss".
+    ///
+    /// Spec: `dv_amount.adoc` §Functions `negative`. `DV_DURATION` redefines it
+    /// over the ISO-8601 value; the others negate their magnitude, which is
+    /// scaling by -1 and is expressed that way so the accuracy rule stays in
+    /// one place.
+    #[must_use]
+    pub fn negative(&self) -> Option<Self> {
+        match self {
+            Self::DvDuration(duration) => duration.negative().map(Self::DvDuration),
+            other => other.multiply(-1.0),
+        }
+    }
+
+    /// Returns `true` when this amount is considered equal to `other`.
+    ///
+    /// Spec: `dv_amount.adoc` §Functions `is_equal`, which the class declares
+    /// ABSTRACT. Only `DV_PROPORTION` effects it (as ratio equality); the other
+    /// descendants declare no effecting definition, so for them equality is of
+    /// the recorded value — every field, as the class models it.
+    #[must_use]
+    pub fn is_equal(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::DvProportion(left), Self::DvProportion(right)) => left.is_equal(right),
+            (left, right) => left == right,
+        }
+    }
+
+    /// Returns `true` when this amount is less than `other`, `None` when they
+    /// are not strictly comparable or a magnitude is unavailable.
+    ///
+    /// Spec: `dv_amount.adoc` §Functions `less_than`, whose `Post_result` is
+    /// `Result = magnitude < other.magnitude` — the ordering `DV_ORDERED`
+    /// already defines, reached through the same machinery so a `DV_AMOUNT`
+    /// cannot order differently from the `DV_ORDERED` it is.
+    #[must_use]
+    pub fn less_than(&self, other: &Self) -> Option<bool> {
+        self.as_ordered().less_than(&other.as_ordered())
+    }
+
+    /// This amount as the `DV_ORDERED` it is.
+    fn as_ordered(&self) -> DvOrdered {
+        match self {
+            Self::DvCount(count) => DvOrdered::DvCount(count.clone()),
+            Self::DvDuration(duration) => DvOrdered::DvDuration(duration.clone()),
+            Self::DvProportion(proportion) => DvOrdered::DvProportion(proportion.clone()),
+            Self::DvQuantity(quantity) => DvOrdered::DvQuantity(quantity.clone()),
+        }
+    }
+
+    /// Returns `true` when `number` is a valid percentage, i.e. between 0
+    /// and 100.
+    ///
+    /// Spec: `dv_amount.adoc` §Functions `valid_percentage`.
+    #[must_use]
+    pub fn valid_percentage(number: f64) -> bool {
+        valid_percentage(number)
+    }
+
+    /// Returns `true` when accuracy is not known, e.g. because it was not
+    /// recorded or is not discernable.
+    ///
+    /// Spec: `dv_quantified.adoc` §Functions `accuracy_unknown`, effected for
+    /// `DV_AMOUNT` by `master06-quantity_package.adoc` §Accuracy and
+    /// Uncertainty — "in `DV_AMOUNT`, a value of -1 for the accuracy attribute
+    /// is used for this purpose".
+    #[must_use]
+    pub fn accuracy_unknown(&self) -> bool {
+        let accuracy = match self {
+            Self::DvCount(count) => count.accuracy,
+            Self::DvDuration(duration) => duration.accuracy,
+            Self::DvProportion(proportion) => proportion.accuracy,
+            Self::DvQuantity(quantity) => quantity.accuracy,
+        };
+        accuracy.is_none_or(|value| value < 0.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn accuracy(magnitude: f64, accuracy: f64, is_percent: bool) -> AmountAccuracy {
+        AmountAccuracy::measured(magnitude, Some(accuracy), Some(is_percent))
+    }
+
+    fn unrecorded(magnitude: f64) -> AmountAccuracy {
+        AmountAccuracy::measured(magnitude, None, None)
+    }
+
+    fn known(combined: CombinedAccuracy) -> (f64, bool) {
+        match combined {
+            CombinedAccuracy::Known {
+                accuracy,
+                is_percent,
+            } => (accuracy, is_percent),
+            other => panic!("expected a known accuracy, got {other:?}"),
+        }
+    }
+
+    /// "If accuracies are present in both quantities, they are added in the
+    /// result" — the spec adds the recorded values, and this asserts exactly
+    /// that rather than the physically-combined error.
+    #[test]
+    fn two_recorded_accuracies_are_added() {
+        let (value, is_percent) = known(combine(
+            accuracy(50.0, 0.5, false),
+            accuracy(30.0, 0.25, false),
+        ));
+        assert!((value - 0.75).abs() < f64::EPSILON);
+        assert!(!is_percent);
+    }
+
+    /// "If either or both quantities has an unknown accuracy, the accuracy of
+    /// the result is also unknown."
+    #[test]
+    fn one_unrecorded_accuracy_makes_the_result_unknown() {
+        assert_eq!(
+            combine(accuracy(50.0, 0.5, false), unrecorded(30.0)),
+            CombinedAccuracy::Unknown
+        );
+        let sentinel = AmountAccuracy::measured(30.0, Some(UNKNOWN_ACCURACY_VALUE), None);
+        assert_eq!(
+            combine(accuracy(50.0, 0.5, false), sentinel),
+            CombinedAccuracy::Unknown
+        );
+    }
+
+    /// "Accuracy is expressed in the result in the form used in the larger of
+    /// the two quantities" — here the larger operand is the percentage one, so
+    /// the absolute half-range of the smaller is converted into a percentage of
+    /// its own magnitude before the addition.
+    #[test]
+    fn the_larger_operand_names_the_form() {
+        let (value, is_percent) = known(combine(
+            accuracy(200.0, 10.0, true), // the larger: percent
+            accuracy(50.0, 5.0, false),  // 5 on 50 == 10%
+        ));
+        assert!(is_percent, "the larger operand recorded a percentage");
+        assert!((value - 20.0).abs() < 1e-9);
+
+        let (value, is_percent) = known(combine(
+            accuracy(200.0, 10.0, false), // the larger: absolute
+            accuracy(50.0, 10.0, true),   // 10% of 50 == 5
+        ));
+        assert!(!is_percent);
+        assert!((value - 15.0).abs() < 1e-9);
+    }
+
+    /// Equal magnitudes name neither operand as "the larger". The absolute form
+    /// wins because it is interpretable without a magnitude — our own tie rule,
+    /// asserted so a future spec answer shows up here as a failing test.
+    #[test]
+    fn equal_magnitudes_settle_on_the_absolute_form() {
+        let (value, is_percent) = known(combine(
+            accuracy(50.0, 10.0, true), // 10% of 50 == 5
+            accuracy(50.0, 2.0, false),
+        ));
+        assert!(!is_percent);
+        assert!((value - 7.0).abs() < 1e-9);
+    }
+
+    /// A percentage sum past 100 violates the `Accuracy_validity` invariant, so
+    /// no valid amount can carry it and the operation refuses rather than
+    /// producing one that fails its own class.
+    #[test]
+    fn a_percentage_past_one_hundred_is_unrepresentable() {
+        assert_eq!(
+            combine(accuracy(50.0, 60.0, true), accuracy(50.0, 60.0, true)),
+            CombinedAccuracy::Unrepresentable
+        );
+    }
+
+    /// A zero magnitude has no percentage form: every percentage of it is the
+    /// same zero, so an absolute half-range cannot be converted into one.
+    #[test]
+    fn a_zero_magnitude_has_no_percentage_form() {
+        assert_eq!(
+            combine(accuracy(200.0, 10.0, true), accuracy(0.0, 5.0, false)),
+            CombinedAccuracy::Unrepresentable
+        );
+    }
+
+    /// `Accuracy_is_percent_validity` — "accuracy = 0 implies not
+    /// accuracy_is_percent" — so a zero result is recorded as absolute even
+    /// when both operands were percentages.
+    #[test]
+    fn a_zero_result_is_never_a_percentage() {
+        let (value, is_percent) = known(combine(
+            accuracy(50.0, 0.0, false),
+            accuracy(50.0, 0.0, false),
+        ));
+        assert!((value - 0.0).abs() < f64::EPSILON);
+        assert!(!is_percent);
+    }
+
+    /// Scaling leaves a percentage alone and scales an absolute half-range with
+    /// the magnitude it measures.
+    #[test]
+    fn scaling_keeps_a_percentage_and_scales_a_half_range() {
+        let (value, is_percent) = known(scale(accuracy(50.0, 10.0, true), 3.0));
+        assert!(is_percent);
+        assert!((value - 10.0).abs() < f64::EPSILON);
+
+        let (value, is_percent) = known(scale(accuracy(50.0, 0.5, false), -3.0));
+        assert!(!is_percent);
+        assert!((value - 1.5).abs() < 1e-9, "the magnitude of the factor");
+
+        assert_eq!(scale(unrecorded(50.0), 3.0), CombinedAccuracy::Unknown);
+    }
+}

--- a/crates/openehr-rm/src/v1_2/data_types/quantity/dv_count_impl.rs
+++ b/crates/openehr-rm/src/v1_2/data_types/quantity/dv_count_impl.rs
@@ -6,11 +6,14 @@
 //! plus the DV_ORDERED `Normal_range_and_status_consistency` (via the
 //! ordered-magnitude machinery in `dv_ordered_impl`).
 
+use crate::v1_2::data_types::quantity::dv_amount_impl::{
+    AmountAccuracy, CombinedAccuracy, combine, scale,
+};
 use crate::v1_2::data_types::quantity::dv_count::DvCount;
 use crate::v1_2::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
 use openehr_base::validate::{InvariantViolation, Validate};
 use rust_decimal::Decimal;
-use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
 
 impl DvCount {
     // NOTE: `less_than` and `is_strictly_comparable_to` are realized for every
@@ -28,26 +31,24 @@ impl DvCount {
     /// project's arithmetic rule: a load-bearing computation says so at the
     /// type level instead of producing a silently wrong clinical value.
     ///
-    /// The other fields are NOT carried over: `accuracy`, `normal_range` and
-    /// the reference ranges describe the measurement THIS value came from, and
-    /// the spec attaches no meaning to their combination under addition.
+    /// `normal_range` and the reference ranges are NOT carried over: they
+    /// describe the measurement THIS value came from, and the spec gives no
+    /// rule for combining them. `accuracy` is carried, because `DV_AMOUNT`
+    /// does give one — see [`combine`].
     #[must_use]
     pub fn add(&self, other: &Self) -> Option<Self> {
-        Some(Self::of_magnitude(
-            self.magnitude.checked_add(other.magnitude)?,
-        ))
+        self.combined(other, self.magnitude.checked_add(other.magnitude)?)
     }
 
     /// Difference of this count and `other`, or `None` on overflow.
     ///
-    /// Spec: `dv_count.adoc` §Functions `subtract`. A negative result is NOT
+    /// Spec: `dv_count.adoc` §Functions `subtract`, redefining
+    /// `dv_amount.adoc` §Functions `subtract`. A negative result is NOT
     /// refused: `magnitude` is a signed `Integer64` and the class declares no
     /// invariant bounding it below.
     #[must_use]
     pub fn subtract(&self, other: &Self) -> Option<Self> {
-        Some(Self::of_magnitude(
-            self.magnitude.checked_sub(other.magnitude)?,
-        ))
+        self.combined(other, self.magnitude.checked_sub(other.magnitude)?)
     }
 
     /// Product of this count and `factor`, or `None` when the result is not a
@@ -67,27 +68,55 @@ impl DvCount {
     /// `is_integer` and `to_i64` are exact, and each step that can fail says so.
     #[must_use]
     pub fn multiply(&self, factor: f64) -> Option<Self> {
-        // `from_f64_retain` keeps the float's exact value rather than rounding
-        // to a display form, so nothing is lost before the check below; it
+        // `from_f64` recovers the decimal the float DENOTES: 0.1_f64 is the
+        // one tenth its author wrote, so `count * 0.1` is a whole count. It
         // returns `None` for NaN and the infinities.
-        let product =
-            Decimal::from(self.magnitude).checked_mul(Decimal::from_f64_retain(factor)?)?;
-        product
-            .is_integer()
-            .then(|| product.to_i64().map(Self::of_magnitude))?
+        let product = Decimal::from(self.magnitude).checked_mul(Decimal::from_f64(factor)?)?;
+        let magnitude = product.is_integer().then(|| product.to_i64())??;
+        Self::of_magnitude(magnitude, scale(self.amount_accuracy(), factor))
     }
 
-    /// A count of `magnitude` with every measurement-specific field cleared.
-    fn of_magnitude(magnitude: i64) -> Self {
-        Self {
+    /// Returns `true` when this count's accuracy was not recorded.
+    ///
+    /// Spec: `dv_quantified.adoc` §Functions `accuracy_unknown`, effected for
+    /// `DV_AMOUNT` by the `unknown_accuracy_value` sentinel.
+    #[must_use]
+    pub fn accuracy_unknown(&self) -> bool {
+        self.accuracy.is_none_or(|value| value < 0.0)
+    }
+
+    /// This count's accuracy as the `DV_AMOUNT` rule reads it.
+    fn amount_accuracy(&self) -> AmountAccuracy {
+        AmountAccuracy::counted(self.magnitude, self.accuracy, self.accuracy_is_percent)
+    }
+
+    /// This count combined with `other`, carrying the `DV_AMOUNT` accuracy.
+    fn combined(&self, other: &Self, magnitude: i64) -> Option<Self> {
+        Self::of_magnitude(
+            magnitude,
+            combine(self.amount_accuracy(), other.amount_accuracy()),
+        )
+    }
+
+    /// A count of `magnitude` and `accuracy`, with the ranges cleared.
+    fn of_magnitude(magnitude: i64, accuracy: CombinedAccuracy) -> Option<Self> {
+        let (accuracy, accuracy_is_percent) = match accuracy {
+            CombinedAccuracy::Unrepresentable => return None,
+            CombinedAccuracy::Unknown => (None, None),
+            CombinedAccuracy::Known {
+                accuracy,
+                is_percent,
+            } => (Some(accuracy), Some(is_percent)),
+        };
+        Some(Self {
             magnitude,
             magnitude_status: None,
-            accuracy: None,
-            accuracy_is_percent: None,
+            accuracy,
+            accuracy_is_percent,
             normal_range: None,
             normal_status: None,
             other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
-        }
+        })
     }
 }
 
@@ -126,10 +155,9 @@ mod tests {
         }
     }
 
-    /// `dv_count.adoc` §Functions: add/subtract are magnitude arithmetic, and
-    /// the result carries NONE of the measurement-specific fields — accuracy
-    /// and the ranges describe the measurement each operand came from, and the
-    /// spec gives no meaning to combining them.
+    /// `dv_count.adoc` §Functions: add/subtract are magnitude arithmetic. The
+    /// ranges are not carried — they describe the measurement each operand came
+    /// from — but `accuracy` is, because `dv_amount.adoc` specifies it.
     #[test]
     fn add_and_subtract_are_magnitude_arithmetic() {
         let a = count();
@@ -139,13 +167,60 @@ mod tests {
         let sum = a.add(&b).expect("no overflow");
         assert_eq!(sum.magnitude, a.magnitude + 4);
         assert!(
-            sum.accuracy.is_none() && sum.normal_range.is_none(),
-            "measurement-specific fields belong to the operands, not the result"
+            sum.normal_range.is_none(),
+            "the ranges belong to the operands, not the result"
         );
+        assert!(sum.accuracy.is_none(), "neither operand recorded one");
         assert_eq!(
             a.subtract(&b).expect("no overflow").magnitude,
             a.magnitude - 4
         );
+    }
+
+    /// "If accuracies are present in both quantities, they are added in the
+    /// result" — `DV_COUNT` is a `DV_AMOUNT`, so its arithmetic carries the
+    /// same accuracy rule as every other descendant.
+    #[test]
+    fn accuracy_follows_the_dv_amount_rule() {
+        let mut a = count();
+        a.accuracy = Some(0.5);
+        a.accuracy_is_percent = Some(false);
+        let mut b = count();
+        b.magnitude = 4;
+        b.accuracy = Some(0.25);
+        b.accuracy_is_percent = Some(false);
+
+        let sum = a.add(&b).expect("no overflow");
+        assert_eq!(sum.accuracy_is_percent, Some(false));
+        assert!((sum.accuracy.expect("both recorded one") - 0.75).abs() < f64::EPSILON);
+
+        // Scaling keeps a percentage and scales an absolute half-range.
+        let scaled = a.multiply(2.0).expect("whole product");
+        assert_eq!(scaled.magnitude, 6);
+        assert!((scaled.accuracy.expect("scaled") - 1.0).abs() < f64::EPSILON);
+    }
+
+    /// A factor whose float carries binary error still means the decimal its
+    /// author wrote: 10 counts scaled by a tenth is one count. Reading the
+    /// float's approximation instead would refuse this as "not whole".
+    #[test]
+    fn a_decimal_factor_means_the_decimal_not_its_binary_approximation() {
+        let mut ten = count();
+        ten.magnitude = 10;
+        assert_eq!(ten.multiply(0.1).expect("one tenth of ten").magnitude, 1);
+        assert_eq!(ten.multiply(0.3).expect("three tenths of ten").magnitude, 3);
+        assert!(ten.multiply(0.25).is_none(), "2.5 is not a whole count");
+    }
+
+    /// `accuracy_unknown` reads both ways of not recording an accuracy.
+    #[test]
+    fn accuracy_unknown_reads_the_sentinel_and_the_absence() {
+        let mut c = count();
+        assert!(c.accuracy_unknown());
+        c.accuracy = Some(-1.0);
+        assert!(c.accuracy_unknown());
+        c.accuracy = Some(0.0);
+        assert!(!c.accuracy_unknown(), "0 means 100% accurate, not unknown");
     }
 
     /// Overflow is refused rather than wrapped. `magnitude` is an Integer64 and

--- a/crates/openehr-rm/src/v1_2/data_types/quantity/dv_proportion_impl.rs
+++ b/crates/openehr-rm/src/v1_2/data_types/quantity/dv_proportion_impl.rs
@@ -8,9 +8,188 @@
 //! `pk_unitary` 1, `pk_percent` 2, `pk_fraction` 3, `pk_integer_fraction` 4),
 //! plus the inherited DV_AMOUNT / DV_QUANTIFIED / DV_ORDERED invariants.
 
+use crate::v1_2::data_types::quantity::dv_amount_impl::{
+    AmountAccuracy, CombinedAccuracy, combine, scale,
+};
 use crate::v1_2::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
 use crate::v1_2::data_types::quantity::dv_proportion::DvProportion;
 use openehr_base::validate::{InvariantViolation, Validate};
+use rust_decimal::Decimal;
+use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
+
+impl DvProportion {
+    /// Sum of this proportion and `other`, or `None` when they are not strictly
+    /// comparable or the result is one no valid proportion can carry.
+    ///
+    /// Spec: `dv_proportion.adoc` §Functions `add` — "Sum of two strictly
+    /// comparable proportions", over `is_strictly_comparable_to`: "True if the
+    /// `type` of this proportion is the same as the `type` of `other`."
+    ///
+    /// Proportions are added over a common denominator, which is what keeps
+    /// the result inside its own kind's invariants: `pk_percent` fixes the
+    /// denominator at 100 and `pk_unitary` at 1, so equal denominators are kept
+    /// rather than multiplied — cross-multiplying two percentages would yield a
+    /// denominator of 10000 and fail `Percent_validity`.
+    #[must_use]
+    pub fn add(&self, other: &Self) -> Option<Self> {
+        self.combined(other, Decimal::checked_add)
+    }
+
+    /// Difference of this proportion and `other`, under the same conditions as
+    /// [`Self::add`].
+    ///
+    /// Spec: `dv_proportion.adoc` §Functions `subtract` — "Difference between
+    /// two strictly comparable proportions."
+    #[must_use]
+    pub fn subtract(&self, other: &Self) -> Option<Self> {
+        self.combined(other, Decimal::checked_sub)
+    }
+
+    /// Product of this proportion and `factor`, or `None` when the result is
+    /// one no valid proportion can carry.
+    ///
+    /// Spec: `dv_proportion.adoc` §Functions `multiply` — "Product of this
+    /// Proportion and `factor`."
+    ///
+    /// The factor scales the numerator and leaves the denominator alone, which
+    /// is what keeps `pk_percent`'s 100 and `pk_unitary`'s 1 in place. A kind
+    /// whose `Fraction_validity` demands integers refuses a numerator the
+    /// factor made fractional, rather than rounding it into a different ratio.
+    #[must_use]
+    pub fn multiply(&self, factor: f64) -> Option<Self> {
+        let (numerator, denominator) = self.ratio()?;
+        self.carrying(
+            numerator.checked_mul(Decimal::from_f64(factor)?)?,
+            denominator,
+            scale(self.amount_accuracy()?, factor),
+        )
+    }
+
+    /// Returns `true` when this proportion is considered equal to `other`.
+    ///
+    /// Spec: `dv_proportion.adoc` §Functions `is_equal`, effecting
+    /// `dv_amount.adoc`'s abstract `is_equal`.
+    ///
+    /// Equality is of the RATIO, not of how it was written: `1/2` and `2/4` are
+    /// the same proportion, so the test is cross-multiplication rather than
+    /// field equality. The `type` must still match, because a proportion is
+    /// only comparable to one of its own kind and `1/100` as a percentage means
+    /// something a `pk_ratio` does not.
+    ///
+    /// The cross-multiplication runs in [`Decimal`]: whether two ratios are the
+    /// same is an exact question, and asking it of binary floating point makes
+    /// `0.1/0.3` and `1.0/3.0` disagree for reasons that have nothing to do
+    /// with the proportions.
+    #[must_use]
+    pub fn is_equal(&self, other: &Self) -> bool {
+        if self.r#type != other.r#type {
+            return false;
+        }
+        let (Some((left_numerator, left_denominator)), Some((right_numerator, right_denominator))) =
+            (self.ratio(), other.ratio())
+        else {
+            return false;
+        };
+        // Both products must EXIST: two overflows are not an equality.
+        let (Some(left), Some(right)) = (
+            left_numerator.checked_mul(right_denominator),
+            right_numerator.checked_mul(left_denominator),
+        ) else {
+            return false;
+        };
+        left == right
+    }
+
+    /// Returns `true` when this proportion's accuracy was not recorded.
+    ///
+    /// Spec: `dv_quantified.adoc` §Functions `accuracy_unknown`, effected for
+    /// `DV_AMOUNT` by the `unknown_accuracy_value` sentinel.
+    #[must_use]
+    pub fn accuracy_unknown(&self) -> bool {
+        self.accuracy.is_none_or(|value| value < 0.0)
+    }
+
+    /// This proportion's accuracy as the `DV_AMOUNT` rule reads it, or `None`
+    /// when the denominator is zero and there is no magnitude.
+    fn amount_accuracy(&self) -> Option<AmountAccuracy> {
+        Some(AmountAccuracy::measured(
+            self.magnitude()?,
+            self.accuracy,
+            self.accuracy_is_percent,
+        ))
+    }
+
+    /// This proportion's numerator and denominator as exact decimals.
+    fn ratio(&self) -> Option<(Decimal, Decimal)> {
+        Some((
+            Decimal::from_f64(self.numerator)?,
+            Decimal::from_f64(self.denominator)?,
+        ))
+    }
+
+    /// This proportion combined with `other` over a common denominator.
+    fn combined(&self, other: &Self, op: fn(Decimal, Decimal) -> Option<Decimal>) -> Option<Self> {
+        if !self.is_strictly_comparable_to(other) {
+            return None;
+        }
+        let accuracy = combine(self.amount_accuracy()?, other.amount_accuracy()?);
+        let (left_numerator, left_denominator) = self.ratio()?;
+        let (right_numerator, right_denominator) = other.ratio()?;
+        if left_denominator == right_denominator {
+            return self.carrying(
+                op(left_numerator, right_numerator)?,
+                left_denominator,
+                accuracy,
+            );
+        }
+        self.carrying(
+            op(
+                left_numerator.checked_mul(right_denominator)?,
+                right_numerator.checked_mul(left_denominator)?,
+            )?,
+            left_denominator.checked_mul(right_denominator)?,
+            accuracy,
+        )
+    }
+
+    /// This proportion at a new ratio and accuracy, or `None` when the result
+    /// would not satisfy its own class invariants.
+    ///
+    /// `precision` is dropped: it states the decimal places the operands were
+    /// expressed to, and the spec gives no rule for the precision of a sum.
+    fn carrying(
+        &self,
+        numerator: Decimal,
+        denominator: Decimal,
+        accuracy: CombinedAccuracy,
+    ) -> Option<Self> {
+        let (numerator, denominator) = (numerator.to_f64()?, denominator.to_f64()?);
+        let (accuracy, accuracy_is_percent) = match accuracy {
+            CombinedAccuracy::Unrepresentable => return None,
+            CombinedAccuracy::Unknown => (None, None),
+            CombinedAccuracy::Known {
+                accuracy,
+                is_percent,
+            } => (Some(accuracy), Some(is_percent)),
+        };
+        let combined = Self {
+            numerator,
+            denominator,
+            r#type: self.r#type,
+            precision: None,
+            magnitude_status: None,
+            accuracy,
+            accuracy_is_percent,
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        };
+        // A proportion that fails its own invariants is not a proportion —
+        // `Fraction_validity` in particular rejects a fractional numerator on
+        // the two integral kinds, which is where a scaled fraction lands.
+        combined.invariants().is_empty().then_some(combined)
+    }
+}
 
 impl Validate for DvProportion {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
@@ -181,5 +360,118 @@ mod tests {
             messages(&proportion(5.5, 1.0, 0, Some(0)))
                 .contains(&"Invariant Precision_validity failed on type DV_PROPORTION".to_owned())
         );
+    }
+
+    /// Only proportions of the same kind combine — `is_strictly_comparable_to`
+    /// is "True if the `type` of this proportion is the same as the `type` of
+    /// `other`", so a percentage and a ratio do not add.
+    #[test]
+    fn only_the_same_kind_combines() {
+        let percent = proportion(20.0, 100.0, PK_PERCENT, None);
+        let ratio = proportion(20.0, 100.0, 0, None);
+        assert!(percent.add(&ratio).is_none());
+        assert!(percent.subtract(&ratio).is_none());
+    }
+
+    /// Two percentages keep the denominator 100 that `Percent_validity`
+    /// demands: cross-multiplying them would give 10000 and produce a value
+    /// that fails its own class.
+    #[test]
+    fn equal_denominators_are_kept_not_multiplied() {
+        let a = proportion(20.0, 100.0, PK_PERCENT, None);
+        let b = proportion(35.0, 100.0, PK_PERCENT, None);
+
+        let sum = a.add(&b).expect("same kind");
+        assert!((sum.numerator - 55.0).abs() < f64::EPSILON);
+        assert!((sum.denominator - 100.0).abs() < f64::EPSILON);
+        assert!(sum.invariants().is_empty(), "Percent_validity still holds");
+
+        let difference = b.subtract(&a).expect("same kind");
+        assert!((difference.numerator - 15.0).abs() < f64::EPSILON);
+    }
+
+    /// Unequal denominators go over a common one, and the result is a valid
+    /// fraction because both operands were integral.
+    #[test]
+    fn unequal_denominators_go_over_a_common_one() {
+        let half = proportion(1.0, 2.0, PK_FRACTION, None);
+        let third = proportion(1.0, 3.0, PK_FRACTION, None);
+
+        let sum = half.add(&third).expect("same kind");
+        assert!((sum.numerator - 5.0).abs() < f64::EPSILON);
+        assert!((sum.denominator - 6.0).abs() < f64::EPSILON);
+        assert!(sum.invariants().is_empty());
+    }
+
+    /// A scaled fraction whose numerator stops being whole is refused rather
+    /// than rounded: `Fraction_validity` demands integers of `pk_fraction`, and
+    /// rounding would silently record a different ratio.
+    #[test]
+    fn a_fractional_numerator_is_refused_on_an_integral_kind() {
+        let fraction = proportion(1.0, 2.0, PK_INTEGER_FRACTION, None);
+        assert!(fraction.multiply(0.5).is_none(), "0.5/2 is not integral");
+
+        let doubled = fraction.multiply(2.0).expect("2/2 is integral");
+        assert!((doubled.numerator - 2.0).abs() < f64::EPSILON);
+        assert!((doubled.denominator - 2.0).abs() < f64::EPSILON);
+
+        // A unitary proportion keeps its denominator of 1 under scaling.
+        let unitary = proportion(3.0, 1.0, PK_UNITARY, None);
+        let scaled = unitary.multiply(2.5).expect("no integrality rule");
+        assert!((scaled.numerator - 7.5).abs() < f64::EPSILON);
+        assert!((scaled.denominator - 1.0).abs() < f64::EPSILON);
+    }
+
+    /// `is_equal` compares the RATIO: 1/2 and 2/4 are the same proportion, and
+    /// the decimal cross-multiplication makes 1/3 and 0.1/0.3 agree where
+    /// binary floating point would not.
+    #[test]
+    fn is_equal_compares_the_ratio_not_the_fields() {
+        let half = proportion(1.0, 2.0, PK_FRACTION, None);
+        assert!(half.is_equal(&proportion(2.0, 4.0, PK_FRACTION, None)));
+        assert!(!half.is_equal(&proportion(1.0, 3.0, PK_FRACTION, None)));
+
+        // A different kind is never equal, whatever the ratio.
+        assert!(!half.is_equal(&proportion(1.0, 2.0, 0, None)));
+
+        let third = proportion(1.0, 3.0, 0, None);
+        assert!(
+            third.is_equal(&proportion(0.1, 0.3, 0, None)),
+            "exact in Decimal, unequal in binary floating point"
+        );
+    }
+
+    /// `DV_PROPORTION` is a `DV_AMOUNT`, so its arithmetic carries the same
+    /// accuracy rule as every other descendant.
+    #[test]
+    fn accuracy_follows_the_dv_amount_rule() {
+        let mut a = proportion(20.0, 100.0, PK_PERCENT, None);
+        a.accuracy = Some(0.01);
+        a.accuracy_is_percent = Some(false);
+        let mut b = proportion(30.0, 100.0, PK_PERCENT, None);
+        b.accuracy = Some(0.02);
+        b.accuracy_is_percent = Some(false);
+
+        let sum = a.add(&b).expect("same kind");
+        assert!((sum.accuracy.expect("both recorded one") - 0.03).abs() < f64::EPSILON);
+        assert_eq!(sum.accuracy_is_percent, Some(false));
+
+        assert!(
+            a.add(&proportion(30.0, 100.0, PK_PERCENT, None))
+                .expect("same kind")
+                .accuracy
+                .is_none()
+        );
+    }
+
+    /// `accuracy_unknown` reads both ways of not recording an accuracy.
+    #[test]
+    fn accuracy_unknown_reads_the_sentinel_and_the_absence() {
+        let mut p = proportion(1.0, 2.0, PK_FRACTION, None);
+        assert!(p.accuracy_unknown());
+        p.accuracy = Some(-1.0);
+        assert!(p.accuracy_unknown());
+        p.accuracy = Some(0.0);
+        assert!(!p.accuracy_unknown(), "0 means 100% accurate, not unknown");
     }
 }

--- a/crates/openehr-rm/src/v1_2/data_types/quantity/dv_quantity_impl.rs
+++ b/crates/openehr-rm/src/v1_2/data_types/quantity/dv_quantity_impl.rs
@@ -12,74 +12,104 @@
 //! is deferred to the composition validator + `openehr-term` (this crate has
 //! no terminology dependency).
 
+use crate::v1_2::data_types::quantity::dv_amount_impl::{
+    AmountAccuracy, CombinedAccuracy, combine, scale,
+};
 use crate::v1_2::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
 use crate::v1_2::data_types::quantity::dv_quantity::DvQuantity;
 use openehr_base::validate::{InvariantViolation, Validate};
 
 impl DvQuantity {
     /// Sum of this quantity and `other`, or `None` when they are not strictly
-    /// comparable or the result is not a finite magnitude.
+    /// comparable or the result is one no valid quantity can carry.
     ///
     /// Spec: `dv_quantity.adoc` §Functions `add` — "Sum of this `DV_QUANTITY`
-    /// and `other`."
+    /// and `other`" — redefining `dv_amount.adoc` §Functions `add`, whose
+    /// `Pre_comparable` pre-condition is `is_strictly_comparable_to (other)`:
+    /// the same `units`, and the same `units_system` where one is stated.
     ///
-    /// The spec states no pre-condition on `add`, but `DV_ORDERED` says
-    /// instances of `DV_QUANTITY` "can only be compared if they measure the
-    /// same kind of physical quantity", and a sum of unlike quantities is no
-    /// more meaningful than a comparison of them. So this requires
-    /// [`Self::is_strictly_comparable_to`] — the same units, and the same
-    /// `units_system` where one is stated — rather than silently producing a
-    /// number whose unit is a guess.
+    /// The accuracy of the result follows the `DV_AMOUNT` rule — see
+    /// [`combine`].
     #[must_use]
     pub fn add(&self, other: &Self) -> Option<Self> {
-        self.combine(other, self.magnitude + other.magnitude)
+        self.combined(other, self.magnitude + other.magnitude)
     }
 
     /// Difference of this quantity and `other`, under the same conditions as
     /// [`Self::add`].
     ///
-    /// Spec: `dv_quantity.adoc` §Functions `subtract`.
+    /// Spec: `dv_quantity.adoc` §Functions `subtract`, redefining
+    /// `dv_amount.adoc` §Functions `subtract` — the accuracies are summed for
+    /// subtraction exactly as for addition.
     #[must_use]
     pub fn subtract(&self, other: &Self) -> Option<Self> {
-        self.combine(other, self.magnitude - other.magnitude)
+        self.combined(other, self.magnitude - other.magnitude)
     }
 
-    /// Product of this quantity and `factor`, or `None` when the result is not
-    /// a finite magnitude.
+    /// Product of this quantity and `factor`, or `None` when the result is one
+    /// no valid quantity can carry.
     ///
     /// Spec: `dv_quantity.adoc` §Functions `multiply` — "Product of this
     /// `DV_QUANTITY` and `factor`."
     ///
     /// Unlike `DV_COUNT.multiply`, a fractional result needs no adjudication:
     /// a quantity's magnitude is a `Real`, so scaling one stays in the type.
-    /// The units are unchanged — a scalar factor carries no dimension.
+    /// The units are unchanged — a scalar factor carries no dimension — and the
+    /// accuracy scales per [`scale`].
     #[must_use]
     pub fn multiply(&self, factor: f64) -> Option<Self> {
-        self.rescaled(self.magnitude * factor)
+        self.rescaled(
+            self.magnitude * factor,
+            scale(self.amount_accuracy(), factor),
+        )
+    }
+
+    /// Returns `true` when this quantity's accuracy was not recorded.
+    ///
+    /// Spec: `dv_quantified.adoc` §Functions `accuracy_unknown`, effected for
+    /// `DV_AMOUNT` by the `unknown_accuracy_value` sentinel.
+    #[must_use]
+    pub fn accuracy_unknown(&self) -> bool {
+        self.accuracy.is_none_or(|value| value < 0.0)
+    }
+
+    /// This quantity's accuracy as the `DV_AMOUNT` rule reads it.
+    fn amount_accuracy(&self) -> AmountAccuracy {
+        AmountAccuracy::measured(self.magnitude, self.accuracy, self.accuracy_is_percent)
     }
 
     /// This quantity combined with `other`, if they are strictly comparable.
-    fn combine(&self, other: &Self, magnitude: f64) -> Option<Self> {
+    fn combined(&self, other: &Self, magnitude: f64) -> Option<Self> {
         if !self.is_strictly_comparable_to(other) {
             return None;
         }
-        self.rescaled(magnitude)
+        self.rescaled(
+            magnitude,
+            combine(self.amount_accuracy(), other.amount_accuracy()),
+        )
     }
 
-    /// This quantity at a new magnitude, keeping the units and dropping every
-    /// field the spec gives no combination rule for.
+    /// This quantity at a new magnitude and accuracy, keeping the units.
     ///
-    /// `precision`, `accuracy` and the reference ranges describe how THIS value
-    /// was measured. The spec says nothing about the precision of a sum or the
-    /// accuracy of a scaled value, so carrying either would be this
-    /// implementation inventing a rule and presenting it as the model's.
-    fn rescaled(&self, magnitude: f64) -> Option<Self> {
+    /// `precision`, `magnitude_status` and the reference ranges are dropped:
+    /// they describe how THIS value was measured, and the spec gives no rule
+    /// for combining them, so carrying one would be this implementation
+    /// inventing a rule and presenting it as the model's.
+    fn rescaled(&self, magnitude: f64, accuracy: CombinedAccuracy) -> Option<Self> {
         // A non-finite magnitude is not a quantity: the class types it as a
         // `Real`, and NaN or an infinity would flow into comparisons and
         // serialization as a value no reader can act on.
         if !magnitude.is_finite() {
             return None;
         }
+        let (accuracy, accuracy_is_percent) = match accuracy {
+            CombinedAccuracy::Unrepresentable => return None,
+            CombinedAccuracy::Unknown => (None, None),
+            CombinedAccuracy::Known {
+                accuracy,
+                is_percent,
+            } => (Some(accuracy), Some(is_percent)),
+        };
         Some(Self {
             magnitude,
             units: self.units.clone(),
@@ -87,8 +117,8 @@ impl DvQuantity {
             units_display_name: self.units_display_name.clone(),
             precision: None,
             magnitude_status: None,
-            accuracy: None,
-            accuracy_is_percent: None,
+            accuracy,
+            accuracy_is_percent,
             normal_range: None,
             normal_status: None,
             other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
@@ -170,19 +200,84 @@ mod tests {
         assert!(plain.add(&systematised).is_none());
     }
 
-    /// The measurement-specific fields describe how THIS value was measured.
-    /// The spec defines neither the precision of a sum nor the accuracy of a
-    /// scaled value, so the result carries neither rather than this
-    /// implementation inventing a rule.
+    /// "If accuracies are present in both quantities, they are added in the
+    /// result, for both addition and subtraction operations" — the accuracy of
+    /// a sum is specified, so it is carried rather than dropped.
     #[test]
-    fn arithmetic_drops_what_the_spec_gives_no_rule_for() {
-        let mut a = quantity();
+    fn arithmetic_carries_the_accuracy_the_spec_specifies() {
+        let mut a = quantity(); // 43 kg
         a.accuracy = Some(0.5);
         a.accuracy_is_percent = Some(false);
-        let scaled = a.multiply(2.0).expect("finite");
+        let mut b = quantity();
+        b.magnitude = 7.0;
+        b.accuracy = Some(0.25);
+        b.accuracy_is_percent = Some(false);
+
+        for combined in [
+            a.add(&b).expect("same units"),
+            a.subtract(&b).expect("same units"),
+        ] {
+            assert_eq!(combined.accuracy_is_percent, Some(false));
+            let accuracy = combined.accuracy.expect("both operands recorded one");
+            assert!((accuracy - 0.75).abs() < f64::EPSILON);
+        }
+
+        // An unrecorded accuracy on either side makes the result's unknown.
+        let mut plain = quantity();
+        plain.magnitude = 7.0;
+        let sum = a.add(&plain).expect("same units");
+        assert!(sum.accuracy.is_none() && sum.accuracy_is_percent.is_none());
+    }
+
+    /// Scaling has no spec rule, so ours is asserted: a percentage of a
+    /// magnitude survives the magnitude changing, and an absolute half-range —
+    /// being in the quantity's own units — scales with it.
+    #[test]
+    fn scaling_carries_the_accuracy_forward() {
+        let mut absolute = quantity();
+        absolute.accuracy = Some(0.5);
+        absolute.accuracy_is_percent = Some(false);
+        let scaled = absolute.multiply(2.0).expect("finite");
         assert!((scaled.magnitude - 86.0).abs() < f64::EPSILON);
         assert_eq!(scaled.units, "kg");
-        assert!(scaled.precision.is_none() && scaled.accuracy.is_none());
+        assert_eq!(scaled.accuracy_is_percent, Some(false));
+        assert!((scaled.accuracy.expect("scaled") - 1.0).abs() < f64::EPSILON);
+
+        let mut percent = quantity();
+        percent.accuracy = Some(5.0);
+        percent.accuracy_is_percent = Some(true);
+        let scaled = percent.multiply(2.0).expect("finite");
+        assert_eq!(scaled.accuracy_is_percent, Some(true));
+        assert!((scaled.accuracy.expect("scaled") - 5.0).abs() < f64::EPSILON);
+
+        // `precision` and `magnitude_status` have no combination rule and are
+        // dropped rather than guessed at.
+        assert!(scaled.precision.is_none() && scaled.magnitude_status.is_none());
+    }
+
+    /// A sum whose accuracy no valid quantity can carry is refused outright
+    /// rather than returned as a value that fails its own class invariant.
+    #[test]
+    fn an_unrepresentable_accuracy_refuses_the_whole_operation() {
+        let mut a = quantity();
+        a.accuracy = Some(60.0);
+        a.accuracy_is_percent = Some(true);
+        let mut b = quantity();
+        b.accuracy = Some(60.0);
+        b.accuracy_is_percent = Some(true);
+        assert!(a.add(&b).is_none(), "120% fails Accuracy_validity");
+    }
+
+    /// `accuracy_unknown` reads both ways of not recording an accuracy: the
+    /// attribute being absent, and the `unknown_accuracy_value` sentinel.
+    #[test]
+    fn accuracy_unknown_reads_the_sentinel_and_the_absence() {
+        let mut q = quantity();
+        assert!(q.accuracy_unknown());
+        q.accuracy = Some(-1.0);
+        assert!(q.accuracy_unknown());
+        q.accuracy = Some(0.0);
+        assert!(!q.accuracy_unknown(), "0 means 100% accurate, not unknown");
     }
 
     /// A magnitude that is not finite is not a quantity: NaN or an infinity

--- a/crates/openehr-rm/src/v1_2/data_types/quantity/dv_quantity_impl.rs
+++ b/crates/openehr-rm/src/v1_2/data_types/quantity/dv_quantity_impl.rs
@@ -16,6 +16,86 @@ use crate::v1_2::data_types::quantity::dv_ordered_impl::push_normal_range_consis
 use crate::v1_2::data_types::quantity::dv_quantity::DvQuantity;
 use openehr_base::validate::{InvariantViolation, Validate};
 
+impl DvQuantity {
+    /// Sum of this quantity and `other`, or `None` when they are not strictly
+    /// comparable or the result is not a finite magnitude.
+    ///
+    /// Spec: `dv_quantity.adoc` §Functions `add` — "Sum of this `DV_QUANTITY`
+    /// and `other`."
+    ///
+    /// The spec states no pre-condition on `add`, but `DV_ORDERED` says
+    /// instances of `DV_QUANTITY` "can only be compared if they measure the
+    /// same kind of physical quantity", and a sum of unlike quantities is no
+    /// more meaningful than a comparison of them. So this requires
+    /// [`Self::is_strictly_comparable_to`] — the same units, and the same
+    /// `units_system` where one is stated — rather than silently producing a
+    /// number whose unit is a guess.
+    #[must_use]
+    pub fn add(&self, other: &Self) -> Option<Self> {
+        self.combine(other, self.magnitude + other.magnitude)
+    }
+
+    /// Difference of this quantity and `other`, under the same conditions as
+    /// [`Self::add`].
+    ///
+    /// Spec: `dv_quantity.adoc` §Functions `subtract`.
+    #[must_use]
+    pub fn subtract(&self, other: &Self) -> Option<Self> {
+        self.combine(other, self.magnitude - other.magnitude)
+    }
+
+    /// Product of this quantity and `factor`, or `None` when the result is not
+    /// a finite magnitude.
+    ///
+    /// Spec: `dv_quantity.adoc` §Functions `multiply` — "Product of this
+    /// `DV_QUANTITY` and `factor`."
+    ///
+    /// Unlike `DV_COUNT.multiply`, a fractional result needs no adjudication:
+    /// a quantity's magnitude is a `Real`, so scaling one stays in the type.
+    /// The units are unchanged — a scalar factor carries no dimension.
+    #[must_use]
+    pub fn multiply(&self, factor: f64) -> Option<Self> {
+        self.rescaled(self.magnitude * factor)
+    }
+
+    /// This quantity combined with `other`, if they are strictly comparable.
+    fn combine(&self, other: &Self, magnitude: f64) -> Option<Self> {
+        if !self.is_strictly_comparable_to(other) {
+            return None;
+        }
+        self.rescaled(magnitude)
+    }
+
+    /// This quantity at a new magnitude, keeping the units and dropping every
+    /// field the spec gives no combination rule for.
+    ///
+    /// `precision`, `accuracy` and the reference ranges describe how THIS value
+    /// was measured. The spec says nothing about the precision of a sum or the
+    /// accuracy of a scaled value, so carrying either would be this
+    /// implementation inventing a rule and presenting it as the model's.
+    fn rescaled(&self, magnitude: f64) -> Option<Self> {
+        // A non-finite magnitude is not a quantity: the class types it as a
+        // `Real`, and NaN or an infinity would flow into comparisons and
+        // serialization as a value no reader can act on.
+        if !magnitude.is_finite() {
+            return None;
+        }
+        Some(Self {
+            magnitude,
+            units: self.units.clone(),
+            units_system: self.units_system.clone(),
+            units_display_name: self.units_display_name.clone(),
+            precision: None,
+            magnitude_status: None,
+            accuracy: None,
+            accuracy_is_percent: None,
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        })
+    }
+}
+
 impl Validate for DvQuantity {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
         crate::v1_2::validate::generated::dv_amount_core(
@@ -57,6 +137,62 @@ mod tests {
 
     fn messages(q: &DvQuantity) -> Vec<String> {
         q.invariants().into_iter().map(|v| v.message).collect()
+    }
+
+    /// Unlike quantities do not add. `DV_ORDERED` says instances "can only be
+    /// compared if they measure the same kind of physical quantity", and a sum
+    /// of kg and m is no more meaningful than a comparison of them — so the
+    /// refusal is asserted, not just the success.
+    #[test]
+    fn unlike_units_do_not_combine() {
+        let kg = quantity();
+        let mut metres = quantity();
+        metres.units = "m".to_owned();
+
+        assert!(kg.add(&metres).is_none(), "kg + m has no unit");
+        assert!(kg.subtract(&metres).is_none());
+
+        let mut other_kg = quantity();
+        other_kg.magnitude = 7.0;
+        let sum = kg.add(&other_kg).expect("same units");
+        assert!((sum.magnitude - 50.0).abs() < f64::EPSILON);
+        assert_eq!(sum.units, "kg", "the sum stays in the operands' units");
+    }
+
+    /// A units_system stated on one side and not the other is NOT the same
+    /// quantity kind: the existing comparability rule requires both to match,
+    /// and arithmetic follows the same rule rather than a looser one.
+    #[test]
+    fn a_units_system_mismatch_does_not_combine() {
+        let plain = quantity();
+        let mut systematised = quantity();
+        systematised.units_system = Some("http://unitsofmeasure.org".to_owned());
+        assert!(plain.add(&systematised).is_none());
+    }
+
+    /// The measurement-specific fields describe how THIS value was measured.
+    /// The spec defines neither the precision of a sum nor the accuracy of a
+    /// scaled value, so the result carries neither rather than this
+    /// implementation inventing a rule.
+    #[test]
+    fn arithmetic_drops_what_the_spec_gives_no_rule_for() {
+        let mut a = quantity();
+        a.accuracy = Some(0.5);
+        a.accuracy_is_percent = Some(false);
+        let scaled = a.multiply(2.0).expect("finite");
+        assert!((scaled.magnitude - 86.0).abs() < f64::EPSILON);
+        assert_eq!(scaled.units, "kg");
+        assert!(scaled.precision.is_none() && scaled.accuracy.is_none());
+    }
+
+    /// A magnitude that is not finite is not a quantity: NaN or an infinity
+    /// would flow into comparison and serialization as a value no reader can
+    /// act on.
+    #[test]
+    fn a_non_finite_result_is_refused() {
+        let q = quantity();
+        assert!(q.multiply(f64::INFINITY).is_none());
+        assert!(q.multiply(f64::NAN).is_none());
     }
 
     #[test]

--- a/crates/openehr-rm/src/v1_2/data_types/quantity/mod.rs
+++ b/crates/openehr-rm/src/v1_2/data_types/quantity/mod.rs
@@ -17,6 +17,8 @@ pub mod proportion_kind;
 pub mod reference_range;
 
 // hand-written modules (spec behaviour), auto-declared:
+pub mod dv_absolute_quantity_impl;
+pub mod dv_amount_impl;
 pub mod dv_count_impl;
 pub mod dv_interval_impl;
 pub mod dv_ordered_impl;

--- a/crates/openehr-rm/src/v1_2/data_types/time_specification/dv_periodic_time_specification_impl.rs
+++ b/crates/openehr-rm/src/v1_2/data_types/time_specification/dv_periodic_time_specification_impl.rs
@@ -6,8 +6,149 @@
 //! — `Value_valid: value.formalism.is_equal("HL7:PIVL") or
 //! value.formalism.is_equal("HL7:EIVL")`.
 
+use crate::v1_2::data_types::quantity::date_time::dv_duration::DvDuration;
 use crate::v1_2::data_types::time_specification::dv_periodic_time_specification::DvPeriodicTimeSpecification;
+use crate::v1_2::validate::is_valid_iso_duration;
 use openehr_base::validate::{InvariantViolation, Validate};
+
+impl DvPeriodicTimeSpecification {
+    /// The period of the repetition, or `None` for a specification that states
+    /// none.
+    ///
+    /// Spec: `dv_periodic_time_specification.adoc` §Functions `period` — "The
+    /// period of the repetition, computationally derived from the syntax
+    /// representation. Extracted from the `value` attribute", over the
+    /// phase-linked grammar of `master08-time_specification_package.adoc`
+    /// §Phase-linked Time Specification Syntax: `phase = interval "/" "("
+    /// difference ")"`.
+    ///
+    /// The class types this `1..1`, but only the phase-linked (`HL7:PIVL`)
+    /// grammar has a `difference` production at all: the event-linked
+    /// (`HL7:EIVL`) one is `event [ offset ]`, an offset from a real-world
+    /// event rather than a period. An event-linked specification therefore has
+    /// no period to return, and saying so is more honest than manufacturing
+    /// one.
+    #[must_use]
+    pub fn period(&self) -> Option<DvDuration> {
+        let value = self.phase_linked()?;
+        let difference = value
+            .split_once("/(")
+            .and_then(|(_, rest)| rest.split_once(')'))
+            .map(|(difference, _)| difference)?;
+        let value = iso_duration(difference)?;
+        Some(DvDuration {
+            value,
+            magnitude_status: None,
+            accuracy: None,
+            accuracy_is_percent: None,
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        })
+    }
+
+    /// Calendar alignment extracted from `value`, or `None` when none is
+    /// stated.
+    ///
+    /// Spec: `dv_periodic_time_specification.adoc` §Functions
+    /// `calendar_alignment`, over `pure_phase_linked_time_spec = phase [ "@"
+    /// alignment ]` — the alignment is a term from the `HL7::CalendarCycle`
+    /// domain (`DW` = day of week, `DM` = day of month, …), and the production
+    /// makes it optional.
+    #[must_use]
+    pub fn calendar_alignment(&self) -> Option<String> {
+        let value = self.phase_linked()?;
+        let alignment = value.rsplit_once('@').map(|(_, alignment)| alignment)?;
+        let alignment = alignment
+            .strip_suffix(INSTITUTION_SPECIFIED)
+            .unwrap_or(alignment);
+        (!alignment.is_empty()).then(|| alignment.to_owned())
+    }
+
+    /// Event alignment extracted from `value`, or `None` when none is stated.
+    ///
+    /// Spec: `dv_periodic_time_specification.adoc` §Functions
+    /// `event_alignment`, over `event_linked_time_spec = event | event offset`
+    /// — the event is a term from the `HL7::TimingEvent` domain (`PC` = after
+    /// meal, `HS` = bedtime, …), and it is the leading token, before any `+`
+    /// or `-` offset.
+    #[must_use]
+    pub fn event_alignment(&self) -> Option<String> {
+        let value = self.event_linked()?;
+        let event = value.split(['+', '-']).next().unwrap_or(value).trim();
+        (!event.is_empty()).then(|| event.to_owned())
+    }
+
+    /// Whether the timing is institution-specified.
+    ///
+    /// Spec: `dv_periodic_time_specification.adoc` §Functions
+    /// `institution_specified` — "Extracted from value", over
+    /// `phase_linked_time_spec = pure_phase_linked_time_spec [ "IST" ]`. The
+    /// flag exists only in the phase-linked grammar, so its absence — including
+    /// on every event-linked specification — is `false`.
+    #[must_use]
+    pub fn institution_specified(&self) -> bool {
+        self.phase_linked()
+            .is_some_and(|value| value.ends_with(INSTITUTION_SPECIFIED))
+    }
+
+    /// This specification's `value` when it is phase-linked, trimmed.
+    fn phase_linked(&self) -> Option<&str> {
+        (self.value.formalism == PHASE_LINKED).then(|| self.value.value.trim())
+    }
+
+    /// This specification's `value` when it is event-linked, trimmed.
+    fn event_linked(&self) -> Option<&str> {
+        (self.value.formalism == EVENT_LINKED).then(|| self.value.value.trim())
+    }
+}
+
+/// The `HL7:PIVL` formalism: a phase-linked periodic time specification.
+const PHASE_LINKED: &str = "HL7:PIVL";
+
+/// The `HL7:EIVL` formalism: an event-linked periodic time specification.
+const EVENT_LINKED: &str = "HL7:EIVL";
+
+/// The trailing flag marking a phase-linked timing as institution-specified.
+const INSTITUTION_SPECIFIED: &str = "IST";
+
+/// A syntax `difference` as an ISO-8601 duration value.
+///
+/// The vendored grammar annotates `difference` as "ISO 8601 for time
+/// difference", while the spec's own examples in the same section spell it
+/// `7d` and `1mo`. Both are accepted: refusing the second would refuse the
+/// specification's own worked examples, and inventing a third form would serve
+/// nobody. A difference in neither form has no duration.
+fn iso_duration(difference: &str) -> Option<String> {
+    let difference = difference.trim();
+    if is_valid_iso_duration(difference) {
+        return Some(difference.to_owned());
+    }
+    let boundary = difference.find(|c: char| !c.is_ascii_digit() && c != '-')?;
+    let (count, unit) = difference.split_at_checked(boundary)?;
+    if count.is_empty()
+        || !count
+            .trim_start_matches('-')
+            .chars()
+            .all(|c| c.is_ascii_digit())
+    {
+        return None;
+    }
+    // The HL7 unit abbreviations the section's examples use, mapped onto the
+    // ISO-8601 designator each one names.
+    let (designator, timed) = match unit {
+        "a" => ("Y", false),
+        "mo" => ("M", false),
+        "wk" => ("W", false),
+        "d" => ("D", false),
+        "h" => ("H", true),
+        "min" => ("M", true),
+        "s" => ("S", true),
+        _ => return None,
+    };
+    let separator = if timed { "PT" } else { "P" };
+    Some(format!("{separator}{count}{designator}"))
+}
 
 impl Validate for DvPeriodicTimeSpecification {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
@@ -52,5 +193,97 @@ mod tests {
             out.iter().any(|m| m.message.contains("Value_valid")),
             "{out:?}"
         );
+    }
+
+    fn parsable(formalism: &str, value: &str) -> DvPeriodicTimeSpecification {
+        DvPeriodicTimeSpecification {
+            value: DvParsable {
+                charset: None,
+                language: None,
+                value: value.to_owned(),
+                formalism: formalism.to_owned(),
+            },
+        }
+    }
+
+    /// The section's own first worked example: "[200004181100;200004181110]/(7d)@DW
+    /// = every Tuesday from 11:00 to 11:10 AM."
+    #[test]
+    fn the_specs_weekly_example_parses() {
+        let weekly = parsable("HL7:PIVL", "[200004181100;200004181110]/(7d)@DW");
+        assert_eq!(
+            weekly.period().expect("a phase has a difference").value,
+            "P7D"
+        );
+        assert_eq!(weekly.calendar_alignment().as_deref(), Some("DW"));
+        assert!(!weekly.institution_specified());
+        assert!(weekly.event_alignment().is_none(), "not event-linked");
+    }
+
+    /// The section's second example: "[200004181100;200004181110]/(1mo)@DM =
+    /// every 18th of the month 11:00 to 11:10 AM."
+    #[test]
+    fn the_specs_monthly_example_parses() {
+        let monthly = parsable("HL7:PIVL", "[200004181100;200004181110]/(1mo)@DM");
+        assert_eq!(monthly.period().expect("a difference").value, "P1M");
+        assert_eq!(monthly.calendar_alignment().as_deref(), Some("DM"));
+    }
+
+    /// The grammar annotates `difference` as ISO-8601 while the same section's
+    /// examples spell it `7d`; both are accepted, and the alignment is optional.
+    #[test]
+    fn an_iso_difference_and_a_missing_alignment_are_both_accepted() {
+        let iso = parsable("HL7:PIVL", "[;]/(P7D)");
+        assert_eq!(iso.period().expect("a difference").value, "P7D");
+        assert!(iso.calendar_alignment().is_none(), "no @ alignment given");
+
+        let hourly = parsable("HL7:PIVL", "[;]/(6h)");
+        assert_eq!(hourly.period().expect("a difference").value, "PT6H");
+        let minutes = parsable("HL7:PIVL", "[;]/(50min)");
+        assert_eq!(minutes.period().expect("a difference").value, "PT50M");
+    }
+
+    /// `phase_linked_time_spec = pure_phase_linked_time_spec [ "IST" ]` — the
+    /// flag is trailing, and it does not become part of the alignment.
+    #[test]
+    fn the_institution_specified_flag_is_read_off_the_end() {
+        let flagged = parsable("HL7:PIVL", "[;]/(7d)@DWIST");
+        assert!(flagged.institution_specified());
+        assert_eq!(
+            flagged.calendar_alignment().as_deref(),
+            Some("DW"),
+            "the flag is not part of the alignment term"
+        );
+        assert!(!parsable("HL7:PIVL", "[;]/(7d)@DW").institution_specified());
+    }
+
+    /// The section's event-linked examples: "PC+[1h;1h]" = one hour after meal,
+    /// "HS-[50min;1h]" = one hour before bedtime. The event is the leading term
+    /// and there is no period — the event-linked grammar has no `difference`.
+    #[test]
+    fn the_specs_event_linked_examples_parse() {
+        let after_meal = parsable("HL7:EIVL", "PC+[1h;1h]");
+        assert_eq!(after_meal.event_alignment().as_deref(), Some("PC"));
+        assert!(after_meal.period().is_none(), "an event has no period");
+        assert!(after_meal.calendar_alignment().is_none());
+        assert!(!after_meal.institution_specified());
+
+        let bedtime = parsable("HL7:EIVL", "HS-[50min;1h]");
+        assert_eq!(bedtime.event_alignment().as_deref(), Some("HS"));
+
+        // `event_linked_time_spec = event | event offset` — a bare event.
+        assert_eq!(
+            parsable("HL7:EIVL", "AC").event_alignment().as_deref(),
+            Some("AC")
+        );
+    }
+
+    /// A difference in neither form yields no period, rather than a duration
+    /// invented from text nobody can parse.
+    #[test]
+    fn an_unreadable_difference_has_no_period() {
+        assert!(parsable("HL7:PIVL", "[;]/(every week)").period().is_none());
+        assert!(parsable("HL7:PIVL", "[;]/(7furlongs)").period().is_none());
+        assert!(parsable("HL7:PIVL", "[;]").period().is_none(), "no phase");
     }
 }

--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-term"
-version = "0.0.17"
+version = "0.0.18"
 description = "openEHR TERM terminology data model, generated from BMM (generation v3_1 = TERM 3.1.0), plus the embedded official terminology XML bundle"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["data-structures", "science"]
 include = ["src/**", "assets/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.17" }
+openehr-base = { path = "../openehr-base", version = "0.0.18" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive.

--- a/tools/openehr-codegen/src/testsupport.rs
+++ b/tools/openehr-codegen/src/testsupport.rs
@@ -1578,6 +1578,49 @@ pub fn generation_function_divergence(key: &str) -> Result<Vec<String>, Error> {
     Ok(divergent)
 }
 
+/// Whether `body` applies items to `rust_type` — an `impl` block on it, or the
+/// type passed to a macro that writes one.
+///
+/// Substring matching is not enough in either direction: `ImportedVersion`
+/// contains `Version`, and a doc comment naming a type says nothing about what
+/// the file implements. So the occurrence must be delimited, and it must sit
+/// where an impl target sits.
+fn targets_type(body: &str, rust_type: &str) -> bool {
+    body.lines().any(|line| {
+        let line = line.trim();
+        // `ordered_limit!(\n    DvCount,` — the type as a bare macro argument.
+        if line.strip_suffix(',').is_some_and(|arg| arg == rust_type) {
+            return true;
+        }
+        // `impl DvCount {`, `impl<T> ImportedVersion<T> {`, `impl Validate for DvCount {`
+        line.starts_with("impl") && delimited_mention(line, rust_type)
+    })
+}
+
+/// Whether `haystack` contains `needle` bounded by non-identifier characters,
+/// so `Version` does not match inside `ImportedVersion`.
+fn delimited_mention(haystack: &str, needle: &str) -> bool {
+    let is_ident = |c: char| c.is_alphanumeric() || c == '_';
+    // Split on the needle rather than slicing by byte index: a `&str` index can
+    // land inside a multi-byte character, and `string_slice` is denied for
+    // exactly that reason. Each split boundary gives the neighbouring
+    // characters directly.
+    let mut rest = haystack;
+    while let Some(at) = rest.find(needle) {
+        let (before, from_match) = rest.split_at(at);
+        let Some(after) = from_match.strip_prefix(needle) else {
+            return false;
+        };
+        if before.chars().next_back().is_none_or(|c| !is_ident(c))
+            && after.chars().next().is_none_or(|c| !is_ident(c))
+        {
+            return true;
+        }
+        rest = after;
+    }
+    false
+}
+
 /// BMM-declared functions of `key`'s crate that no Rust method realizes, as
 /// `<generation>/<CLASS>.<function>` (#2029).
 ///
@@ -1623,16 +1666,19 @@ pub fn unrealized_bmm_functions(key: &str) -> Result<Vec<String>, Error> {
                     // the generation: `ordered_limit!` in `dv_ordered_impl`
                     // gives every DV_ORDERED descendant its `less_than` and
                     // `is_strictly_comparable_to`. Reading only the class's own
-                    // two files reported 36 such methods as missing — and the
-                    // burn-down then produces DUPLICATE DEFINITIONS, which is
-                    // how this was found.
+                    // two files reported those as missing, and burning them
+                    // down produces DUPLICATE DEFINITIONS.
                     //
-                    // So a file that defines the function AND names this Rust
-                    // type counts. Both halves are needed: the function name
-                    // alone would let any file vouch for every class.
+                    // The witness must name the type as an impl TARGET, not
+                    // merely mention it. Accepting a mention credited
+                    // `VERSION.data` to `imported_version_impl.rs`, whose
+                    // `pub fn data(` belongs to `ImportedVersion<T>` and whose
+                    // only "Version" is inside that longer name — a false
+                    // NEGATIVE, which silently drops a real gap and is worse
+                    // than the false positives this replaced.
                     if bodies
                         .values()
-                        .any(|body| body.contains(&item) && body.contains(&rust_type))
+                        .any(|body| body.contains(&item) && targets_type(body, &rust_type))
                     {
                         continue;
                     }

--- a/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/date_time/dv_date_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/date_time/dv_date_impl.rs
@@ -10,10 +10,114 @@
 //! `crate::v1_2::validate`).
 
 use crate::v1_2::data_types::quantity::date_time::dv_date::DvDate;
+use crate::v1_2::data_types::quantity::date_time::dv_duration::DvDuration;
+use crate::v1_2::data_types::quantity::dv_absolute_quantity_impl::{
+    difference_accuracy, displaced_accuracy,
+};
+use crate::v1_2::data_types::quantity::dv_amount_impl::CombinedAccuracy;
 use crate::v1_2::data_types::quantity::dv_ordered::DvOrdered;
 use crate::v1_2::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
 use crate::v1_2::validate::is_valid_iso_date;
+use openehr_base::v1_3::foundation_types::time::iso8601_date::Iso8601Date;
+use openehr_base::v1_3::foundation_types::time::iso8601_duration::Iso8601Duration;
 use openehr_base::validate::{InvariantViolation, Validate};
+
+impl DvDate {
+    /// Addition of a duration to this date, or `None` when either value is not
+    /// a valid ISO-8601 string.
+    ///
+    /// Spec: `dv_date.adoc` §Functions `add` — "Addition of a Duration to this
+    /// Date" — effecting `dv_absolute_quantity.adoc`'s abstract `add`, whose
+    /// accuracy rule is realized by [`displaced_accuracy`].
+    ///
+    /// The calendar arithmetic is BASE's `Iso8601_date.add`, so leap years and
+    /// month lengths are answered once, in the type that owns the calendar.
+    #[must_use]
+    pub fn add(&self, a_diff: &DvDuration) -> Option<Self> {
+        Some(self.displaced(self.iso().add(&duration_of(a_diff))?, a_diff))
+    }
+
+    /// Subtraction of a duration from this date, under the same conditions as
+    /// [`Self::add`].
+    ///
+    /// Spec: `dv_date.adoc` §Functions `subtract`.
+    #[must_use]
+    pub fn subtract(&self, a_diff: &DvDuration) -> Option<Self> {
+        Some(self.displaced(self.iso().subtract(&duration_of(a_diff))?, a_diff))
+    }
+
+    /// Difference between this date and `other`, as a duration.
+    ///
+    /// Spec: `dv_date.adoc` §Functions `diff` — "Difference between this Date
+    /// and `other`."
+    #[must_use]
+    pub fn diff(&self, other: &Self) -> Option<DvDuration> {
+        let difference = self.iso().diff(&other.iso())?;
+        let (accuracy, accuracy_is_percent) =
+            match difference_accuracy(self.accuracy.as_ref(), other.accuracy.as_ref()) {
+                CombinedAccuracy::Unrepresentable => return None,
+                CombinedAccuracy::Unknown => (None, None),
+                CombinedAccuracy::Known {
+                    accuracy,
+                    is_percent,
+                } => (Some(accuracy), Some(is_percent)),
+            };
+        Some(DvDuration {
+            value: difference.value,
+            magnitude_status: None,
+            accuracy,
+            accuracy_is_percent,
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        })
+    }
+
+    /// Returns `true` when this date is considered equal to `other`.
+    ///
+    /// Spec: `dv_date.adoc` §Functions `is_equal`, effecting
+    /// `dv_quantified.adoc`'s abstract `is_equal`.
+    ///
+    /// Equality is of the DATE, not of how it was written: `less_than` on this
+    /// class is defined over `magnitude()`, and `2024-01-01` and `20240101`
+    /// name the same day, so comparing the strings would make a value neither
+    /// less than, greater than, nor equal to its own extended form.
+    #[must_use]
+    pub fn is_equal(&self, other: &Self) -> bool {
+        match (self.magnitude(), other.magnitude()) {
+            (Some(left), Some(right)) => left == right,
+            // A value with no magnitude is not a date this function can
+            // compare; only an identical string can still be the same one.
+            _ => self.value == other.value,
+        }
+    }
+
+    /// This date's `value` as the BASE ISO-8601 type that owns the calendar.
+    fn iso(&self) -> Iso8601Date {
+        Iso8601Date {
+            value: self.value.clone(),
+        }
+    }
+
+    /// This date at a new value, carrying the displaced accuracy.
+    fn displaced(&self, value: Iso8601Date, a_diff: &DvDuration) -> Self {
+        Self {
+            value: value.value,
+            magnitude_status: None,
+            accuracy: displaced_accuracy(self.accuracy.as_ref(), a_diff),
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        }
+    }
+}
+
+/// A `DV_DURATION`'s `value` as the BASE ISO-8601 type.
+fn duration_of(duration: &DvDuration) -> Iso8601Duration {
+    Iso8601Duration {
+        value: duration.value.clone(),
+    }
+}
 
 impl Validate for DvDate {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
@@ -66,6 +170,108 @@ mod tests {
         assert!(
             v.iter()
                 .any(|m| m.message == "Invariant Value_valid failed on type DV_DATE")
+        );
+    }
+
+    fn duration(value: &str) -> DvDuration {
+        DvDuration {
+            normal_status: None,
+            normal_range: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+            magnitude_status: None,
+            accuracy: None,
+            accuracy_is_percent: None,
+            value: value.to_owned(),
+        }
+    }
+
+    /// `DV_DATE` declares `add`, and BASE defines that as "arithmetic addition
+    /// of a duration to a date" — the NOMINAL calendar semantics belong to
+    /// `add_nominal`, which this class does not declare. So `P1M` is the
+    /// duration's own average month, not "the same day next month": adding it
+    /// to 31 January lands on 1 March, not on the end of February.
+    #[test]
+    fn arithmetic_is_the_spec_s_arithmetic_addition_not_the_nominal_one() {
+        assert_eq!(
+            date("2024-01-31")
+                .add(&duration("P1M"))
+                .expect("valid")
+                .value,
+            "2024-03-01",
+            "P1M is an average month of seconds, not a nominal calendar month"
+        );
+
+        // Exact durations still land exactly, leap day included.
+        assert_eq!(
+            date("2024-02-28")
+                .add(&duration("P1D"))
+                .expect("valid")
+                .value,
+            "2024-02-29"
+        );
+        assert_eq!(
+            date("2024-03-01")
+                .subtract(&duration("P1D"))
+                .expect("valid")
+                .value,
+            "2024-02-29"
+        );
+    }
+
+    /// `diff` returns the difference as a duration.
+    #[test]
+    fn diff_returns_a_duration() {
+        let difference = date("2024-03-01").diff(&date("2024-02-01")).expect("valid");
+        assert_eq!(difference.magnitude(), Some(29.0 * 86_400.0));
+    }
+
+    /// A value that is not a valid ISO-8601 date has no arithmetic.
+    #[test]
+    fn an_invalid_value_has_no_arithmetic() {
+        let bad = date("2021-13-40");
+        assert!(bad.add(&duration("P1D")).is_none());
+        assert!(bad.diff(&date("2024-01-01")).is_none());
+        assert!(date("2024-01-01").add(&duration("one day")).is_none());
+    }
+
+    /// Equality is of the DATE, not of the string: the extended and basic forms
+    /// name the same day, and `less_than` already orders them by magnitude.
+    #[test]
+    fn is_equal_compares_the_date_not_the_string() {
+        assert!(date("2024-01-01").is_equal(&date("20240101")));
+        assert!(!date("2024-01-01").is_equal(&date("2024-01-02")));
+    }
+
+    /// "The sum of the accuracies of the operands, if both present, or unknown,
+    /// if either or both operand accuracies are unknown."
+    #[test]
+    fn accuracy_follows_the_absolute_quantity_rule() {
+        let mut precise = date("2024-01-01");
+        precise.accuracy = Some(duration("PT30M"));
+        let mut offset = duration("P1D");
+        offset.accuracy = Some(60.0);
+        offset.accuracy_is_percent = Some(false);
+
+        let moved = precise.add(&offset).expect("valid");
+        assert_eq!(
+            moved.accuracy.expect("both present").magnitude(),
+            Some(1860.0)
+        );
+
+        // An operand with no accuracy makes the result's unknown.
+        assert!(
+            precise
+                .add(&duration("P1D"))
+                .expect("valid")
+                .accuracy
+                .is_none()
+        );
+        assert!(
+            date("2024-01-01")
+                .add(&offset)
+                .expect("valid")
+                .accuracy
+                .is_none()
         );
     }
 }

--- a/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/date_time/dv_date_time_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/date_time/dv_date_time_impl.rs
@@ -5,10 +5,92 @@
 //! the NOTE on why this is an explicit invariant.
 
 use crate::v1_2::data_types::quantity::date_time::dv_date_time::DvDateTime;
+use crate::v1_2::data_types::quantity::date_time::dv_duration::DvDuration;
+use crate::v1_2::data_types::quantity::dv_absolute_quantity_impl::{
+    difference_accuracy, displaced_accuracy,
+};
+use crate::v1_2::data_types::quantity::dv_amount_impl::CombinedAccuracy;
 use crate::v1_2::data_types::quantity::dv_ordered::DvOrdered;
 use crate::v1_2::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
 use crate::v1_2::validate::is_valid_iso_date_time;
+use openehr_base::v1_3::foundation_types::time::iso8601_date_time::Iso8601DateTime;
+use openehr_base::v1_3::foundation_types::time::iso8601_duration::Iso8601Duration;
 use openehr_base::validate::{InvariantViolation, Validate};
+
+impl DvDateTime {
+    /// Addition of a duration to this date-time, or `None` when either value is
+    /// not a valid ISO-8601 string.
+    ///
+    /// Spec: `dv_date_time.adoc` §Functions `add`, effecting
+    /// `dv_absolute_quantity.adoc`'s abstract `add`, whose accuracy rule is
+    /// realized by [`displaced_accuracy`].
+    #[must_use]
+    pub fn add(&self, a_diff: &DvDuration) -> Option<Self> {
+        Some(self.displaced(self.iso().add(&duration_of(a_diff))?, a_diff))
+    }
+
+    /// Subtraction of a duration from this date-time, under the same conditions
+    /// as [`Self::add`].
+    ///
+    /// Spec: `dv_date_time.adoc` §Functions `subtract`.
+    #[must_use]
+    pub fn subtract(&self, a_diff: &DvDuration) -> Option<Self> {
+        Some(self.displaced(self.iso().subtract(&duration_of(a_diff))?, a_diff))
+    }
+
+    /// Difference between this date-time and `other`, as a duration.
+    ///
+    /// Spec: `dv_date_time.adoc` §Functions `diff`.
+    #[must_use]
+    pub fn diff(&self, other: &Self) -> Option<DvDuration> {
+        let difference = self.iso().diff(&other.iso())?;
+        let (accuracy, accuracy_is_percent) =
+            match difference_accuracy(self.accuracy.as_ref(), other.accuracy.as_ref()) {
+                CombinedAccuracy::Unrepresentable => return None,
+                CombinedAccuracy::Unknown => (None, None),
+                CombinedAccuracy::Known {
+                    accuracy,
+                    is_percent,
+                } => (Some(accuracy), Some(is_percent)),
+            };
+        Some(DvDuration {
+            value: difference.value,
+            magnitude_status: None,
+            accuracy,
+            accuracy_is_percent,
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        })
+    }
+
+    /// This date-time's `value` as the BASE ISO-8601 type that owns the
+    /// calendar.
+    fn iso(&self) -> Iso8601DateTime {
+        Iso8601DateTime {
+            value: self.value.clone(),
+        }
+    }
+
+    /// This date-time at a new value, carrying the displaced accuracy.
+    fn displaced(&self, value: Iso8601DateTime, a_diff: &DvDuration) -> Self {
+        Self {
+            value: value.value,
+            magnitude_status: None,
+            accuracy: displaced_accuracy(self.accuracy.as_ref(), a_diff),
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        }
+    }
+}
+
+/// A `DV_DURATION`'s `value` as the BASE ISO-8601 type.
+fn duration_of(duration: &DvDuration) -> Iso8601Duration {
+    Iso8601Duration {
+        value: duration.value.clone(),
+    }
+}
 
 impl Validate for DvDateTime {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
@@ -60,6 +142,75 @@ mod tests {
         assert!(
             v.iter()
                 .any(|m| m.message == "Invariant Value_valid failed on type DV_DATE_TIME")
+        );
+    }
+
+    fn duration(value: &str) -> DvDuration {
+        DvDuration {
+            normal_status: None,
+            normal_range: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+            magnitude_status: None,
+            accuracy: None,
+            accuracy_is_percent: None,
+            value: value.to_owned(),
+        }
+    }
+
+    /// Date-times displace across the day boundary and across the calendar,
+    /// because BASE answers both in one type.
+    #[test]
+    fn arithmetic_crosses_the_day_and_the_calendar() {
+        let evening = date_time("2024-02-28T23:00:00");
+        assert_eq!(
+            evening.add(&duration("PT2H")).expect("valid").value,
+            "2024-02-29T01:00:00",
+            "into the leap day"
+        );
+        assert_eq!(
+            evening.subtract(&duration("P1D")).expect("valid").value,
+            "2024-02-27T23:00:00"
+        );
+        assert_eq!(
+            evening
+                .diff(&date_time("2024-02-28T21:00:00"))
+                .expect("valid")
+                .magnitude(),
+            Some(7200.0)
+        );
+    }
+
+    /// A value that is not a valid ISO-8601 date-time has no arithmetic.
+    #[test]
+    fn an_invalid_value_has_no_arithmetic() {
+        let bad = date_time("2021-05-17T99:00:00");
+        assert!(bad.add(&duration("PT1H")).is_none());
+        assert!(bad.diff(&date_time("2024-01-01T00:00:00")).is_none());
+    }
+
+    /// The `DV_ABSOLUTE_QUANTITY` accuracy rule, including a percentage
+    /// half-range resolved against the differential amount's own magnitude.
+    #[test]
+    fn accuracy_follows_the_absolute_quantity_rule() {
+        let mut precise = date_time("2024-01-01T00:00:00");
+        precise.accuracy = Some(duration("PT5S"));
+        let mut offset = duration("PT100S");
+        offset.accuracy = Some(10.0);
+        offset.accuracy_is_percent = Some(true);
+
+        let moved = precise.add(&offset).expect("valid");
+        assert_eq!(
+            moved.accuracy.expect("both present").magnitude(),
+            Some(15.0),
+            "5s + 10% of 100s"
+        );
+
+        assert!(
+            precise
+                .add(&duration("PT100S"))
+                .expect("valid")
+                .accuracy
+                .is_none()
         );
     }
 }

--- a/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/date_time/dv_duration_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/date_time/dv_duration_impl.rs
@@ -6,10 +6,129 @@
 //! `dv_date_impl` for the NOTE on why value well-formedness is explicit.
 
 use crate::v1_2::data_types::quantity::date_time::dv_duration::DvDuration;
+use crate::v1_2::data_types::quantity::dv_amount_impl::{
+    AmountAccuracy, CombinedAccuracy, combine, scale,
+};
 use crate::v1_2::data_types::quantity::dv_ordered::DvOrdered;
 use crate::v1_2::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
 use crate::v1_2::validate::is_valid_iso_duration;
+use openehr_base::v1_3::foundation_types::time::iso8601_duration::Iso8601Duration;
 use openehr_base::validate::{InvariantViolation, Validate};
+
+impl DvDuration {
+    /// Sum of this duration and `other`, or `None` when either value is not a
+    /// valid ISO-8601 duration or the result is one no valid duration can
+    /// carry.
+    ///
+    /// Spec: `dv_duration.adoc` §Functions `add` — "Sum of this Duration and
+    /// `other`" — redefining `dv_amount.adoc` §Functions `add`. `DV_DURATION`
+    /// effects `is_strictly_comparable_to` as "True, for any two Durations", so
+    /// the inherited pre-condition never refuses a pair.
+    ///
+    /// The arithmetic is BASE's — `Iso8601_duration.add` — so the result stays
+    /// a duration STRING with its designators intact, rather than a second of
+    /// seconds this crate would have to render back.
+    #[must_use]
+    pub fn add(&self, other: &Self) -> Option<Self> {
+        Self::carrying(
+            self.iso().add(&other.iso())?,
+            combine(self.amount_accuracy()?, other.amount_accuracy()?),
+        )
+    }
+
+    /// Difference of this duration and `other`, under the same conditions as
+    /// [`Self::add`].
+    ///
+    /// Spec: `dv_duration.adoc` §Functions `subtract`.
+    #[must_use]
+    pub fn subtract(&self, other: &Self) -> Option<Self> {
+        Self::carrying(
+            self.iso().subtract(&other.iso())?,
+            combine(self.amount_accuracy()?, other.amount_accuracy()?),
+        )
+    }
+
+    /// Product of this duration and `factor`.
+    ///
+    /// Spec: `dv_duration.adoc` §Functions `multiply` — "Product of this
+    /// Duration and `factor`."
+    #[must_use]
+    pub fn multiply(&self, factor: f64) -> Option<Self> {
+        Self::carrying(
+            self.iso().multiply(factor)?,
+            scale(self.amount_accuracy()?, factor),
+        )
+    }
+
+    /// Negated version of this duration.
+    ///
+    /// Spec: `dv_duration.adoc` §Functions `negative` — "Assuming the current
+    /// duration is positive, the negated version represents a time prior to
+    /// some origin point, or a negative age (e.g. so-called 'adjusted age' of
+    /// premature infant)."
+    ///
+    /// Negation changes the sign of the magnitude, not how well it was
+    /// measured, so the accuracy is carried through unchanged — the one
+    /// arithmetic function here for which that is a fact rather than a rule.
+    #[must_use]
+    pub fn negative(&self) -> Option<Self> {
+        let mut negated = self.clone();
+        negated.value = self.iso().negative()?.value;
+        negated.normal_range = None;
+        negated.normal_status = None;
+        negated.magnitude_status = None;
+        negated.other_reference_ranges = openehr_base::containers::present_nonempty(Vec::new());
+        Some(negated)
+    }
+
+    /// Returns `true` when this duration's accuracy was not recorded.
+    ///
+    /// Spec: `dv_quantified.adoc` §Functions `accuracy_unknown`, effected for
+    /// `DV_AMOUNT` by the `unknown_accuracy_value` sentinel.
+    #[must_use]
+    pub fn accuracy_unknown(&self) -> bool {
+        self.accuracy.is_none_or(|value| value < 0.0)
+    }
+
+    /// This duration's `value` as the BASE ISO-8601 type that owns the
+    /// arithmetic.
+    fn iso(&self) -> Iso8601Duration {
+        Iso8601Duration {
+            value: self.value.clone(),
+        }
+    }
+
+    /// This duration's accuracy as the `DV_AMOUNT` rule reads it, or `None`
+    /// when `value` has no magnitude to measure a percentage against.
+    fn amount_accuracy(&self) -> Option<AmountAccuracy> {
+        Some(AmountAccuracy::measured(
+            self.magnitude()?,
+            self.accuracy,
+            self.accuracy_is_percent,
+        ))
+    }
+
+    /// This duration at a new value and accuracy.
+    fn carrying(value: Iso8601Duration, accuracy: CombinedAccuracy) -> Option<Self> {
+        let (accuracy, accuracy_is_percent) = match accuracy {
+            CombinedAccuracy::Unrepresentable => return None,
+            CombinedAccuracy::Unknown => (None, None),
+            CombinedAccuracy::Known {
+                accuracy,
+                is_percent,
+            } => (Some(accuracy), Some(is_percent)),
+        };
+        Some(Self {
+            value: value.value,
+            magnitude_status: None,
+            accuracy,
+            accuracy_is_percent,
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        })
+    }
+}
 
 impl Validate for DvDuration {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
@@ -65,5 +184,71 @@ mod tests {
             v.iter()
                 .any(|m| m.message == "Invariant Value_valid failed on type DV_DURATION")
         );
+    }
+
+    /// `is_strictly_comparable_to` is "True, for any two Durations", so unlike
+    /// `DV_QUANTITY` no pair is refused for incomparability — the arithmetic
+    /// runs on the ISO-8601 values themselves.
+    #[test]
+    fn arithmetic_runs_on_the_iso_value() {
+        let a = duration("PT2H");
+        let b = duration("PT30M");
+
+        assert_eq!(a.add(&b).expect("valid").magnitude(), Some(9000.0));
+        assert_eq!(a.subtract(&b).expect("valid").magnitude(), Some(5400.0));
+        assert_eq!(a.multiply(2.0).expect("valid").magnitude(), Some(14400.0));
+        assert_eq!(a.negative().expect("valid").magnitude(), Some(-7200.0));
+    }
+
+    /// A value that is not a valid ISO-8601 duration has no arithmetic: BASE
+    /// refuses to parse it, and the refusal is propagated rather than turned
+    /// into a zero.
+    #[test]
+    fn an_invalid_value_has_no_arithmetic() {
+        let bad = duration("10 hours");
+        let good = duration("PT1H");
+        assert!(bad.add(&good).is_none());
+        assert!(good.add(&bad).is_none());
+        assert!(bad.multiply(2.0).is_none());
+        assert!(bad.negative().is_none());
+    }
+
+    /// `DV_DURATION` is a `DV_AMOUNT`, so its arithmetic carries the same
+    /// accuracy rule — summed for add and subtract, scaled for multiply, and
+    /// unchanged by negation, which alters the sign rather than the
+    /// measurement.
+    #[test]
+    fn accuracy_follows_the_dv_amount_rule() {
+        let mut a = duration("PT2H");
+        a.accuracy = Some(60.0);
+        a.accuracy_is_percent = Some(false);
+        let mut b = duration("PT30M");
+        b.accuracy = Some(30.0);
+        b.accuracy_is_percent = Some(false);
+
+        let sum = a.add(&b).expect("valid");
+        assert!((sum.accuracy.expect("both recorded one") - 90.0).abs() < f64::EPSILON);
+        assert_eq!(sum.accuracy_is_percent, Some(false));
+
+        let scaled = a.multiply(3.0).expect("valid");
+        assert!((scaled.accuracy.expect("scaled") - 180.0).abs() < f64::EPSILON);
+
+        let negated = a.negative().expect("valid");
+        assert!((negated.accuracy.expect("kept") - 60.0).abs() < f64::EPSILON);
+
+        // Unrecorded on either side makes the result's unknown.
+        let plain = duration("PT30M");
+        assert!(a.add(&plain).expect("valid").accuracy.is_none());
+    }
+
+    /// `accuracy_unknown` reads both ways of not recording an accuracy.
+    #[test]
+    fn accuracy_unknown_reads_the_sentinel_and_the_absence() {
+        let mut d = duration("PT1H");
+        assert!(d.accuracy_unknown());
+        d.accuracy = Some(-1.0);
+        assert!(d.accuracy_unknown());
+        d.accuracy = Some(0.0);
+        assert!(!d.accuracy_unknown(), "0 means 100% accurate, not unknown");
     }
 }

--- a/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/date_time/dv_time_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/date_time/dv_time_impl.rs
@@ -4,11 +4,93 @@
 //! inherited DV_QUANTIFIED `Magnitude_status_valid`. See `dv_date_impl` for the
 //! NOTE on why this is an explicit invariant.
 
+use crate::v1_2::data_types::quantity::date_time::dv_duration::DvDuration;
 use crate::v1_2::data_types::quantity::date_time::dv_time::DvTime;
+use crate::v1_2::data_types::quantity::dv_absolute_quantity_impl::{
+    difference_accuracy, displaced_accuracy,
+};
+use crate::v1_2::data_types::quantity::dv_amount_impl::CombinedAccuracy;
 use crate::v1_2::data_types::quantity::dv_ordered::DvOrdered;
 use crate::v1_2::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
 use crate::v1_2::validate::is_valid_iso_time;
+use openehr_base::v1_3::foundation_types::time::iso8601_duration::Iso8601Duration;
+use openehr_base::v1_3::foundation_types::time::iso8601_time::Iso8601Time;
 use openehr_base::validate::{InvariantViolation, Validate};
+
+impl DvTime {
+    /// Addition of a duration to this time, or `None` when either value is not
+    /// a valid ISO-8601 string.
+    ///
+    /// Spec: `dv_time.adoc` §Functions `add` — "Addition of a Duration to this
+    /// Time" — effecting `dv_absolute_quantity.adoc`'s abstract `add`, whose
+    /// accuracy rule is realized by [`displaced_accuracy`].
+    #[must_use]
+    pub fn add(&self, a_diff: &DvDuration) -> Option<Self> {
+        Some(self.displaced(self.iso().add(&duration_of(a_diff))?, a_diff))
+    }
+
+    /// Subtraction of a duration from this time, under the same conditions as
+    /// [`Self::add`].
+    ///
+    /// Spec: `dv_time.adoc` §Functions `subtract`.
+    #[must_use]
+    pub fn subtract(&self, a_diff: &DvDuration) -> Option<Self> {
+        Some(self.displaced(self.iso().subtract(&duration_of(a_diff))?, a_diff))
+    }
+
+    /// Difference between this time and `other`, as a duration.
+    ///
+    /// Spec: `dv_time.adoc` §Functions `diff` — "Difference between this Time
+    /// and `other`."
+    #[must_use]
+    pub fn diff(&self, other: &Self) -> Option<DvDuration> {
+        let difference = self.iso().diff(&other.iso())?;
+        let (accuracy, accuracy_is_percent) =
+            match difference_accuracy(self.accuracy.as_ref(), other.accuracy.as_ref()) {
+                CombinedAccuracy::Unrepresentable => return None,
+                CombinedAccuracy::Unknown => (None, None),
+                CombinedAccuracy::Known {
+                    accuracy,
+                    is_percent,
+                } => (Some(accuracy), Some(is_percent)),
+            };
+        Some(DvDuration {
+            value: difference.value,
+            magnitude_status: None,
+            accuracy,
+            accuracy_is_percent,
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        })
+    }
+
+    /// This time's `value` as the BASE ISO-8601 type that owns the arithmetic.
+    fn iso(&self) -> Iso8601Time {
+        Iso8601Time {
+            value: self.value.clone(),
+        }
+    }
+
+    /// This time at a new value, carrying the displaced accuracy.
+    fn displaced(&self, value: Iso8601Time, a_diff: &DvDuration) -> Self {
+        Self {
+            value: value.value,
+            magnitude_status: None,
+            accuracy: displaced_accuracy(self.accuracy.as_ref(), a_diff),
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        }
+    }
+}
+
+/// A `DV_DURATION`'s `value` as the BASE ISO-8601 type.
+fn duration_of(duration: &DvDuration) -> Iso8601Duration {
+    Iso8601Duration {
+        value: duration.value.clone(),
+    }
+}
 
 impl Validate for DvTime {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
@@ -61,5 +143,69 @@ mod tests {
             v.iter()
                 .any(|m| m.message == "Invariant Value_valid failed on type DV_TIME")
         );
+    }
+
+    fn duration(value: &str) -> DvDuration {
+        DvDuration {
+            normal_status: None,
+            normal_range: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+            magnitude_status: None,
+            accuracy: None,
+            accuracy_is_percent: None,
+            value: value.to_owned(),
+        }
+    }
+
+    /// Times displace by a duration and difference into one.
+    #[test]
+    fn arithmetic_displaces_within_the_day() {
+        let noon = time("12:00:00");
+        assert_eq!(
+            noon.add(&duration("PT90M")).expect("valid").magnitude(),
+            Some(48_600.0)
+        );
+        assert_eq!(
+            noon.subtract(&duration("PT30M"))
+                .expect("valid")
+                .magnitude(),
+            Some(41_400.0)
+        );
+        assert_eq!(
+            noon.diff(&time("11:00:00")).expect("valid").magnitude(),
+            Some(3600.0)
+        );
+    }
+
+    /// A value that is not a valid ISO-8601 time has no arithmetic.
+    #[test]
+    fn an_invalid_value_has_no_arithmetic() {
+        let bad = time("25:99");
+        assert!(bad.add(&duration("PT1H")).is_none());
+        assert!(bad.diff(&time("12:00:00")).is_none());
+    }
+
+    /// The `DV_ABSOLUTE_QUANTITY` accuracy rule: summed when both operands
+    /// record one, unknown when either does not.
+    #[test]
+    fn accuracy_follows_the_absolute_quantity_rule() {
+        let mut precise = time("12:00:00");
+        precise.accuracy = Some(duration("PT10S"));
+        let mut offset = duration("PT1H");
+        offset.accuracy = Some(5.0);
+        offset.accuracy_is_percent = Some(false);
+
+        let moved = precise.add(&offset).expect("valid");
+        assert_eq!(
+            moved.accuracy.expect("both present").magnitude(),
+            Some(15.0)
+        );
+
+        // `diff` reports the summed accuracy as the resulting amount's own.
+        let mut other = time("11:00:00");
+        other.accuracy = Some(duration("PT20S"));
+        let difference = precise.diff(&other).expect("valid");
+        assert_eq!(difference.accuracy, Some(30.0));
+        assert_eq!(difference.accuracy_is_percent, Some(false));
     }
 }

--- a/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/dv_absolute_quantity_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/dv_absolute_quantity_impl.rs
@@ -1,0 +1,239 @@
+//! Hand-written `DV_ABSOLUTE_QUANTITY` spec behaviour, shared by its
+//! descendants.
+//!
+//! `DV_ABSOLUTE_QUANTITY` is abstract, so the generated `DvAbsoluteQuantity` is
+//! a subtype enum and the accuracy rule its `add`/`subtract`/`diff` declare has
+//! no single struct to live on. It is realized once here and called by
+//! `DV_DATE`, `DV_TIME` and `DV_DATE_TIME`.
+//!
+//! The rule differs from `DV_AMOUNT`'s in what it operates on rather than in
+//! what it says: accuracy here is redefined as a `DV_AMOUNT` — a `DV_DURATION`
+//! for the three temporal descendants — so the "sum of the accuracies" is a
+//! duration sum, not a real one.
+
+use crate::v1_2::data_types::quantity::date_time::dv_duration::DvDuration;
+use crate::v1_2::data_types::quantity::dv_absolute_quantity::DvAbsoluteQuantity;
+use crate::v1_2::data_types::quantity::dv_amount::DvAmount;
+use crate::v1_2::data_types::quantity::dv_amount_impl::AmountAccuracy;
+use crate::v1_2::data_types::quantity::dv_amount_impl::{CombinedAccuracy, combine};
+use openehr_base::v1_3::foundation_types::time::iso8601_duration::Iso8601Duration;
+
+/// The accuracy of an absolute quantity displaced by a differential amount.
+///
+/// Spec: `dv_absolute_quantity.adoc` §Functions `add`/`subtract` — "the sum of
+/// the accuracies of the operands, if both present, or unknown, if either or
+/// both operand accuracies are unknown."
+///
+/// The two operands measure their accuracy differently: this quantity's is
+/// already a duration, while the differential amount's is a `Real` half-range
+/// over its own magnitude. The amount's is converted into a duration of that
+/// many seconds — `DV_DURATION.magnitude` is seconds by definition — and the
+/// two durations are then added by BASE.
+#[must_use]
+pub fn displaced_accuracy(
+    accuracy: Option<&DvDuration>,
+    amount: &DvDuration,
+) -> Option<DvDuration> {
+    let own = accuracy?;
+    let amount_seconds = absolute_accuracy_seconds(amount)?;
+    let sum = Iso8601Duration {
+        value: own.value.clone(),
+    }
+    .add(&seconds_as_duration(amount_seconds))?;
+    Some(DvDuration {
+        value: sum.value,
+        magnitude_status: None,
+        accuracy: None,
+        accuracy_is_percent: None,
+        normal_range: None,
+        normal_status: None,
+        other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+    })
+}
+
+/// The accuracy of the difference between two absolute quantities.
+///
+/// Spec: `dv_absolute_quantity.adoc` §Functions `diff` — same rule, but the
+/// result is a `DV_AMOUNT`, so the summed duration is reported as that amount's
+/// own `Real` accuracy in seconds.
+#[must_use]
+pub fn difference_accuracy(
+    left: Option<&DvDuration>,
+    right: Option<&DvDuration>,
+) -> CombinedAccuracy {
+    let (Some(left), Some(right)) = (left, right) else {
+        return CombinedAccuracy::Unknown;
+    };
+    let (Some(left_seconds), Some(right_seconds)) = (left.magnitude(), right.magnitude()) else {
+        return CombinedAccuracy::Unrepresentable;
+    };
+    // Both half-ranges are already absolute values in seconds, so the
+    // `DV_AMOUNT` rule reduces to adding them — routed through it anyway so the
+    // finiteness and zero-form checks stay in one place.
+    combine(
+        AmountAccuracy::measured(left_seconds, Some(left_seconds), Some(false)),
+        AmountAccuracy::measured(right_seconds, Some(right_seconds), Some(false)),
+    )
+}
+
+/// A duration's accuracy as an absolute half-range in seconds, resolving a
+/// percentage against the duration's own magnitude.
+fn absolute_accuracy_seconds(amount: &DvDuration) -> Option<f64> {
+    let accuracy = amount.accuracy.filter(|value| *value >= 0.0)?;
+    if amount.accuracy_is_percent == Some(true) {
+        return Some(accuracy / 100.0 * amount.magnitude()?.abs());
+    }
+    Some(accuracy)
+}
+
+/// A number of seconds as an ISO-8601 duration.
+fn seconds_as_duration(seconds: f64) -> Iso8601Duration {
+    Iso8601Duration {
+        value: format!("PT{seconds}S"),
+    }
+}
+
+impl DvAbsoluteQuantity {
+    /// Addition of a differential amount to this quantity, or `None` when the
+    /// amount is not one this quantity can be displaced by.
+    ///
+    /// Spec: `dv_absolute_quantity.adoc` §Functions `add` — "Addition of a
+    /// differential amount to this quantity."
+    ///
+    /// The spec types the differential as any `DV_AMOUNT`, but each concrete
+    /// descendant narrows it: all three temporal ones effect `add` with a
+    /// `DV_DURATION` parameter, because a date displaced by a count or a
+    /// proportion is not a date. Anything else is refused here.
+    #[must_use]
+    pub fn add(&self, a_diff: &DvAmount) -> Option<Self> {
+        let DvAmount::DvDuration(a_diff) = a_diff else {
+            return None;
+        };
+        match self {
+            Self::DvDate(date) => date.add(a_diff).map(Self::DvDate),
+            Self::DvDateTime(date_time) => date_time.add(a_diff).map(Self::DvDateTime),
+            Self::DvTime(time) => time.add(a_diff).map(Self::DvTime),
+        }
+    }
+
+    /// Subtraction of a differential amount from this quantity, under the same
+    /// conditions as [`Self::add`].
+    ///
+    /// Spec: `dv_absolute_quantity.adoc` §Functions `subtract`.
+    #[must_use]
+    pub fn subtract(&self, a_diff: &DvAmount) -> Option<Self> {
+        let DvAmount::DvDuration(a_diff) = a_diff else {
+            return None;
+        };
+        match self {
+            Self::DvDate(date) => date.subtract(a_diff).map(Self::DvDate),
+            Self::DvDateTime(date_time) => date_time.subtract(a_diff).map(Self::DvDateTime),
+            Self::DvTime(time) => time.subtract(a_diff).map(Self::DvTime),
+        }
+    }
+
+    /// Difference of two quantities, as the differential amount between them.
+    ///
+    /// Spec: `dv_absolute_quantity.adoc` §Functions `diff` — "Difference of two
+    /// quantities." Only two quantities of the same concrete type have one: the
+    /// difference between a date and a time of day is not a duration.
+    #[must_use]
+    pub fn diff(&self, other: &Self) -> Option<DvAmount> {
+        match (self, other) {
+            (Self::DvDate(left), Self::DvDate(right)) => left.diff(right),
+            (Self::DvDateTime(left), Self::DvDateTime(right)) => left.diff(right),
+            (Self::DvTime(left), Self::DvTime(right)) => left.diff(right),
+            _ => None,
+        }
+        .map(DvAmount::DvDuration)
+    }
+
+    /// Returns `true` when this quantity's accuracy was not recorded.
+    ///
+    /// Spec: `dv_quantified.adoc` §Functions `accuracy_unknown`, effected for
+    /// `DV_ABSOLUTE_QUANTITY` by `master06-quantity_package.adoc` §Accuracy and
+    /// Uncertainty — "in the `DV_ABSOLUTE_QUANTITY` class, `accuracy_unknown`
+    /// is represented by a Void (i.e. null) value for the accuracy attribute."
+    /// There is no `-1` sentinel here: the attribute is a `DV_AMOUNT`, so its
+    /// absence IS the unknown.
+    #[must_use]
+    pub fn accuracy_unknown(&self) -> bool {
+        match self {
+            Self::DvDate(date) => date.accuracy.is_none(),
+            Self::DvDateTime(date_time) => date_time.accuracy.is_none(),
+            Self::DvTime(time) => time.accuracy.is_none(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn duration(value: &str) -> DvDuration {
+        DvDuration {
+            normal_status: None,
+            normal_range: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+            magnitude_status: None,
+            accuracy: None,
+            accuracy_is_percent: None,
+            value: value.to_owned(),
+        }
+    }
+
+    /// "The sum of the accuracies of the operands, if both present" — the
+    /// differential amount's `Real` half-range becomes that many seconds of
+    /// duration before the two are added.
+    #[test]
+    fn a_displaced_accuracy_sums_both_operands() {
+        let mut amount = duration("P1D");
+        amount.accuracy = Some(60.0);
+        amount.accuracy_is_percent = Some(false);
+
+        let combined = displaced_accuracy(Some(&duration("PT30M")), &amount).expect("both present");
+        assert_eq!(
+            combined.magnitude(),
+            Some(1860.0),
+            "30 minutes + 60 seconds"
+        );
+    }
+
+    /// A percentage half-range is resolved against the amount's own magnitude
+    /// before it can be added to a duration.
+    #[test]
+    fn a_percentage_resolves_against_its_own_magnitude() {
+        let mut amount = duration("PT100S");
+        amount.accuracy = Some(10.0);
+        amount.accuracy_is_percent = Some(true);
+
+        let combined = displaced_accuracy(Some(&duration("PT5S")), &amount).expect("both present");
+        assert_eq!(combined.magnitude(), Some(15.0), "5s + 10% of 100s");
+    }
+
+    /// "Unknown, if either or both operand accuracies are unknown."
+    #[test]
+    fn either_operand_unknown_makes_the_result_unknown() {
+        let plain = duration("P1D");
+        assert!(displaced_accuracy(None, &plain).is_none());
+        assert!(displaced_accuracy(Some(&duration("PT30M")), &plain).is_none());
+    }
+
+    /// `diff` returns a `DV_AMOUNT`, so the summed duration is reported as that
+    /// amount's own accuracy in seconds.
+    #[test]
+    fn a_difference_accuracy_is_reported_in_seconds() {
+        let combined = difference_accuracy(Some(&duration("PT30M")), Some(&duration("PT30S")));
+        assert_eq!(
+            combined,
+            CombinedAccuracy::Known {
+                accuracy: 1830.0,
+                is_percent: false,
+            }
+        );
+        assert_eq!(
+            difference_accuracy(Some(&duration("PT30M")), None),
+            CombinedAccuracy::Unknown
+        );
+    }
+}

--- a/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/dv_amount_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/dv_amount_impl.rs
@@ -1,0 +1,502 @@
+//! Hand-written `DV_AMOUNT` spec behaviour, shared by its descendants.
+//!
+//! `DV_AMOUNT` is abstract, so the generated `DvAmount` is a subtype enum and
+//! the accuracy rule its `add`/`subtract` declare has no single struct to live
+//! on. It is realized once here and called by every descendant that implements
+//! the arithmetic.
+
+use crate::v1_2::data_types::quantity::dv_amount::DvAmount;
+use crate::v1_2::data_types::quantity::dv_ordered::DvOrdered;
+use crate::v1_2::validate::valid_percentage;
+use core::cmp::Ordering;
+use rust_decimal::Decimal;
+use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
+
+/// The `accuracy` value that records "accuracy was not recorded".
+///
+/// Spec: `master06-quantity_package.adoc` §Accuracy and Uncertainty — "a value
+/// of -1 for the accuracy attribute is used for this purpose, and the constant
+/// `unknown_accuracy_value` = -1 is provided within the class".
+pub const UNKNOWN_ACCURACY_VALUE: f64 = -1.0;
+
+/// One operand of a `DV_AMOUNT` addition, subtraction or scaling.
+///
+/// The magnitude travels with the accuracy because the two forms the spec
+/// allows are not interchangeable without it: a percentage is a proportion of
+/// the magnitude it was recorded against, an absolute value is a half-range in
+/// the amount's own units.
+///
+/// It is carried as a [`Decimal`] so that converting between those forms is
+/// exact for every descendant: an integer magnitude converts without loss, and
+/// a real one converts without a widening cast whose error would land inside a
+/// clinical half-range.
+#[derive(Debug, Clone, Copy)]
+pub struct AmountAccuracy {
+    /// The operand's magnitude, absent when it has no decimal form — which
+    /// only matters if the two operands disagree about the accuracy form.
+    magnitude: Option<Decimal>,
+    /// The operand's `accuracy`.
+    accuracy: Option<f64>,
+    /// The operand's `accuracy_is_percent`.
+    accuracy_is_percent: Option<bool>,
+}
+
+impl AmountAccuracy {
+    /// The accuracy of an amount whose magnitude is an integer, such as a
+    /// `DV_COUNT`.
+    #[must_use]
+    pub fn counted(
+        magnitude: i64,
+        accuracy: Option<f64>,
+        accuracy_is_percent: Option<bool>,
+    ) -> Self {
+        Self {
+            magnitude: Some(Decimal::from(magnitude)),
+            accuracy,
+            accuracy_is_percent,
+        }
+    }
+
+    /// The accuracy of an amount whose magnitude is a real number, such as a
+    /// `DV_QUANTITY`.
+    #[must_use]
+    pub fn measured(
+        magnitude: f64,
+        accuracy: Option<f64>,
+        accuracy_is_percent: Option<bool>,
+    ) -> Self {
+        Self {
+            // `from_f64` recovers the decimal the float DENOTES, dropping the
+            // excess bits past IEEE-754's guarantee — 0.1_f64 becomes 0.1, not
+            // its binary approximation.
+            magnitude: Decimal::from_f64(magnitude),
+            accuracy,
+            accuracy_is_percent,
+        }
+    }
+}
+
+/// The accuracy a combined or scaled `DV_AMOUNT` carries.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum CombinedAccuracy {
+    /// At least one operand did not record an accuracy, so neither does the
+    /// result.
+    Unknown,
+    /// Every operand recorded one; this is the result, in the form named.
+    Known {
+        /// The combined accuracy value.
+        accuracy: f64,
+        /// Whether that value is a percentage rather than an absolute
+        /// half-range.
+        is_percent: bool,
+    },
+    /// The result exists as a number but no valid `DV_AMOUNT` can carry it —
+    /// a percentage past 100, or a form conversion the operands do not admit.
+    Unrepresentable,
+}
+
+impl AmountAccuracy {
+    /// This operand's recorded accuracy and its form, or `None` when accuracy
+    /// was not recorded.
+    ///
+    /// A negative value is read as unrecorded rather than only the exact
+    /// sentinel: `accuracy` is a half-range, which cannot be negative, so
+    /// `unknown_accuracy_value` is the only meaning a negative can carry.
+    fn recorded(self) -> Option<(f64, bool)> {
+        let value = self.accuracy?;
+        (value >= 0.0).then(|| (value, self.accuracy_is_percent == Some(true)))
+    }
+
+    /// This accuracy expressed as a percentage (`to_percent`) or as an absolute
+    /// half-range, or `None` when the operand admits no such form.
+    fn in_form(self, value: f64, is_percent: bool, to_percent: bool) -> Option<Decimal> {
+        let value = Decimal::from_f64(value)?;
+        if is_percent == to_percent {
+            return Some(value);
+        }
+        let magnitude = self.magnitude?.abs();
+        if is_percent {
+            return value.checked_mul(magnitude)?.checked_div(hundred());
+        }
+        // A zero magnitude has no percentage form: every percentage of it is
+        // the same zero, so the operand's half-range cannot be recovered from
+        // one.
+        if magnitude.is_zero() {
+            return None;
+        }
+        value.checked_mul(hundred())?.checked_div(magnitude)
+    }
+}
+
+/// The percentage base, as a `Decimal`.
+fn hundred() -> Decimal {
+    Decimal::from(100_u8)
+}
+
+/// The accuracy of the sum or difference of `left` and `right`.
+///
+/// Spec: `master06-quantity_package.adoc` §Accuracy and Uncertainty — "if
+/// accuracies are present in both quantities, they are added in the result, for
+/// both addition and subtraction operations; if either or both quantities has
+/// an unknown accuracy, the accuracy of the result is also unknown; if two
+/// `DV_AMOUNT` descendants are added or subtracted, and only one has
+/// `accuracy_is_percent` = True, accuracy is expressed in the result in the form
+/// used in the larger of the two quantities."
+///
+/// The spec says to add the two values but not to convert them, and adding a
+/// percentage to an absolute half-range is not a number. Converting the operand
+/// whose form loses into the winning form is the only reading under which the
+/// sum it prescribes exists at all.
+///
+/// Equal magnitudes are the one gap: "the larger of the two" then names neither
+/// operand. The result takes the absolute form, because an absolute half-range
+/// is interpretable on its own while a percentage is only interpretable against
+/// a magnitude. No openEHR spec governs that tie — our own design.
+#[must_use]
+pub fn combine(left: AmountAccuracy, right: AmountAccuracy) -> CombinedAccuracy {
+    let (Some((left_value, left_percent)), Some((right_value, right_percent))) =
+        (left.recorded(), right.recorded())
+    else {
+        return CombinedAccuracy::Unknown;
+    };
+
+    let as_percent = match (left_percent, right_percent) {
+        (true, true) => true,
+        (false, false) => false,
+        _ => match (left.magnitude, right.magnitude) {
+            (Some(left_magnitude), Some(right_magnitude)) => {
+                match left_magnitude.abs().cmp(&right_magnitude.abs()) {
+                    Ordering::Greater => left_percent,
+                    Ordering::Less => right_percent,
+                    Ordering::Equal => false,
+                }
+            }
+            _ => false,
+        },
+    };
+
+    let (Some(left_value), Some(right_value)) = (
+        left.in_form(left_value, left_percent, as_percent),
+        right.in_form(right_value, right_percent, as_percent),
+    ) else {
+        return CombinedAccuracy::Unrepresentable;
+    };
+
+    let Some(sum) = left_value.checked_add(right_value) else {
+        return CombinedAccuracy::Unrepresentable;
+    };
+    settle(sum, as_percent)
+}
+
+/// The accuracy of this amount scaled by `factor`.
+///
+/// The spec defines accuracy propagation for `add` and `subtract` only, and is
+/// silent on `multiply` — no openEHR spec governs this, so the rule is our own:
+/// a percentage of a magnitude is unchanged when the magnitude is scaled, and
+/// an absolute half-range, being in the amount's own units, scales with it.
+/// Dropping accuracy instead would make `multiply(1.0)` lose it.
+#[must_use]
+pub fn scale(amount: AmountAccuracy, factor: f64) -> CombinedAccuracy {
+    let Some((value, is_percent)) = amount.recorded() else {
+        return CombinedAccuracy::Unknown;
+    };
+    let (Some(value), Some(factor)) = (Decimal::from_f64(value), Decimal::from_f64(factor)) else {
+        return CombinedAccuracy::Unrepresentable;
+    };
+    if is_percent {
+        return settle(value, true);
+    }
+    let Some(scaled) = value.checked_mul(factor.abs()) else {
+        return CombinedAccuracy::Unrepresentable;
+    };
+    settle(scaled, false)
+}
+
+/// A computed accuracy as the result can carry it, or `Unrepresentable`.
+fn settle(accuracy: Decimal, is_percent: bool) -> CombinedAccuracy {
+    let Some(value) = accuracy.to_f64() else {
+        return CombinedAccuracy::Unrepresentable;
+    };
+    if !value.is_finite() || (is_percent && !valid_percentage(value)) {
+        return CombinedAccuracy::Unrepresentable;
+    }
+    CombinedAccuracy::Known {
+        accuracy: value,
+        // Accuracy_is_percent_validity: `accuracy = 0 implies not
+        // accuracy_is_percent`, so a zero result is recorded as absolute.
+        is_percent: is_percent && accuracy.is_sign_positive() && !accuracy.is_zero(),
+    }
+}
+
+impl DvAmount {
+    /// Sum of this amount and `other`, or `None` when they are not the same
+    /// kind of amount or the sum is one no valid amount can carry.
+    ///
+    /// Spec: `dv_amount.adoc` §Functions `add`, whose `Pre_comparable`
+    /// pre-condition is `is_strictly_comparable_to (other)`. Two amounts of
+    /// DIFFERENT concrete types are never strictly comparable — `DV_ORDERED`
+    /// compares only like with like — so a count plus a quantity is refused
+    /// here rather than in each descendant.
+    #[must_use]
+    pub fn add(&self, other: &Self) -> Option<Self> {
+        match (self, other) {
+            (Self::DvCount(left), Self::DvCount(right)) => left.add(right).map(Self::DvCount),
+            (Self::DvDuration(left), Self::DvDuration(right)) => {
+                left.add(right).map(Self::DvDuration)
+            }
+            (Self::DvProportion(left), Self::DvProportion(right)) => {
+                left.add(right).map(Self::DvProportion)
+            }
+            (Self::DvQuantity(left), Self::DvQuantity(right)) => {
+                left.add(right).map(Self::DvQuantity)
+            }
+            _ => None,
+        }
+    }
+
+    /// Difference of this amount and `other`, under the same conditions as
+    /// [`Self::add`].
+    ///
+    /// Spec: `dv_amount.adoc` §Functions `subtract`.
+    #[must_use]
+    pub fn subtract(&self, other: &Self) -> Option<Self> {
+        match (self, other) {
+            (Self::DvCount(left), Self::DvCount(right)) => left.subtract(right).map(Self::DvCount),
+            (Self::DvDuration(left), Self::DvDuration(right)) => {
+                left.subtract(right).map(Self::DvDuration)
+            }
+            (Self::DvProportion(left), Self::DvProportion(right)) => {
+                left.subtract(right).map(Self::DvProportion)
+            }
+            (Self::DvQuantity(left), Self::DvQuantity(right)) => {
+                left.subtract(right).map(Self::DvQuantity)
+            }
+            _ => None,
+        }
+    }
+
+    /// Product of this amount and `factor`.
+    ///
+    /// Spec: `dv_amount.adoc` §Functions `multiply`.
+    #[must_use]
+    pub fn multiply(&self, factor: f64) -> Option<Self> {
+        match self {
+            Self::DvCount(count) => count.multiply(factor).map(Self::DvCount),
+            Self::DvDuration(duration) => duration.multiply(factor).map(Self::DvDuration),
+            Self::DvProportion(proportion) => proportion.multiply(factor).map(Self::DvProportion),
+            Self::DvQuantity(quantity) => quantity.multiply(factor).map(Self::DvQuantity),
+        }
+    }
+
+    /// Negated version of this amount, "such as used for representing a
+    /// difference, e.g. a weight loss".
+    ///
+    /// Spec: `dv_amount.adoc` §Functions `negative`. `DV_DURATION` redefines it
+    /// over the ISO-8601 value; the others negate their magnitude, which is
+    /// scaling by -1 and is expressed that way so the accuracy rule stays in
+    /// one place.
+    #[must_use]
+    pub fn negative(&self) -> Option<Self> {
+        match self {
+            Self::DvDuration(duration) => duration.negative().map(Self::DvDuration),
+            other => other.multiply(-1.0),
+        }
+    }
+
+    /// Returns `true` when this amount is considered equal to `other`.
+    ///
+    /// Spec: `dv_amount.adoc` §Functions `is_equal`, which the class declares
+    /// ABSTRACT. Only `DV_PROPORTION` effects it (as ratio equality); the other
+    /// descendants declare no effecting definition, so for them equality is of
+    /// the recorded value — every field, as the class models it.
+    #[must_use]
+    pub fn is_equal(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::DvProportion(left), Self::DvProportion(right)) => left.is_equal(right),
+            (left, right) => left == right,
+        }
+    }
+
+    /// Returns `true` when this amount is less than `other`, `None` when they
+    /// are not strictly comparable or a magnitude is unavailable.
+    ///
+    /// Spec: `dv_amount.adoc` §Functions `less_than`, whose `Post_result` is
+    /// `Result = magnitude < other.magnitude` — the ordering `DV_ORDERED`
+    /// already defines, reached through the same machinery so a `DV_AMOUNT`
+    /// cannot order differently from the `DV_ORDERED` it is.
+    #[must_use]
+    pub fn less_than(&self, other: &Self) -> Option<bool> {
+        self.as_ordered().less_than(&other.as_ordered())
+    }
+
+    /// This amount as the `DV_ORDERED` it is.
+    fn as_ordered(&self) -> DvOrdered {
+        match self {
+            Self::DvCount(count) => DvOrdered::DvCount(count.clone()),
+            Self::DvDuration(duration) => DvOrdered::DvDuration(duration.clone()),
+            Self::DvProportion(proportion) => DvOrdered::DvProportion(proportion.clone()),
+            Self::DvQuantity(quantity) => DvOrdered::DvQuantity(quantity.clone()),
+        }
+    }
+
+    /// Returns `true` when `number` is a valid percentage, i.e. between 0
+    /// and 100.
+    ///
+    /// Spec: `dv_amount.adoc` §Functions `valid_percentage`.
+    #[must_use]
+    pub fn valid_percentage(number: f64) -> bool {
+        valid_percentage(number)
+    }
+
+    /// Returns `true` when accuracy is not known, e.g. because it was not
+    /// recorded or is not discernable.
+    ///
+    /// Spec: `dv_quantified.adoc` §Functions `accuracy_unknown`, effected for
+    /// `DV_AMOUNT` by `master06-quantity_package.adoc` §Accuracy and
+    /// Uncertainty — "in `DV_AMOUNT`, a value of -1 for the accuracy attribute
+    /// is used for this purpose".
+    #[must_use]
+    pub fn accuracy_unknown(&self) -> bool {
+        let accuracy = match self {
+            Self::DvCount(count) => count.accuracy,
+            Self::DvDuration(duration) => duration.accuracy,
+            Self::DvProportion(proportion) => proportion.accuracy,
+            Self::DvQuantity(quantity) => quantity.accuracy,
+        };
+        accuracy.is_none_or(|value| value < 0.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn accuracy(magnitude: f64, accuracy: f64, is_percent: bool) -> AmountAccuracy {
+        AmountAccuracy::measured(magnitude, Some(accuracy), Some(is_percent))
+    }
+
+    fn unrecorded(magnitude: f64) -> AmountAccuracy {
+        AmountAccuracy::measured(magnitude, None, None)
+    }
+
+    fn known(combined: CombinedAccuracy) -> (f64, bool) {
+        match combined {
+            CombinedAccuracy::Known {
+                accuracy,
+                is_percent,
+            } => (accuracy, is_percent),
+            other => panic!("expected a known accuracy, got {other:?}"),
+        }
+    }
+
+    /// "If accuracies are present in both quantities, they are added in the
+    /// result" — the spec adds the recorded values, and this asserts exactly
+    /// that rather than the physically-combined error.
+    #[test]
+    fn two_recorded_accuracies_are_added() {
+        let (value, is_percent) = known(combine(
+            accuracy(50.0, 0.5, false),
+            accuracy(30.0, 0.25, false),
+        ));
+        assert!((value - 0.75).abs() < f64::EPSILON);
+        assert!(!is_percent);
+    }
+
+    /// "If either or both quantities has an unknown accuracy, the accuracy of
+    /// the result is also unknown."
+    #[test]
+    fn one_unrecorded_accuracy_makes_the_result_unknown() {
+        assert_eq!(
+            combine(accuracy(50.0, 0.5, false), unrecorded(30.0)),
+            CombinedAccuracy::Unknown
+        );
+        let sentinel = AmountAccuracy::measured(30.0, Some(UNKNOWN_ACCURACY_VALUE), None);
+        assert_eq!(
+            combine(accuracy(50.0, 0.5, false), sentinel),
+            CombinedAccuracy::Unknown
+        );
+    }
+
+    /// "Accuracy is expressed in the result in the form used in the larger of
+    /// the two quantities" — here the larger operand is the percentage one, so
+    /// the absolute half-range of the smaller is converted into a percentage of
+    /// its own magnitude before the addition.
+    #[test]
+    fn the_larger_operand_names_the_form() {
+        let (value, is_percent) = known(combine(
+            accuracy(200.0, 10.0, true), // the larger: percent
+            accuracy(50.0, 5.0, false),  // 5 on 50 == 10%
+        ));
+        assert!(is_percent, "the larger operand recorded a percentage");
+        assert!((value - 20.0).abs() < 1e-9);
+
+        let (value, is_percent) = known(combine(
+            accuracy(200.0, 10.0, false), // the larger: absolute
+            accuracy(50.0, 10.0, true),   // 10% of 50 == 5
+        ));
+        assert!(!is_percent);
+        assert!((value - 15.0).abs() < 1e-9);
+    }
+
+    /// Equal magnitudes name neither operand as "the larger". The absolute form
+    /// wins because it is interpretable without a magnitude — our own tie rule,
+    /// asserted so a future spec answer shows up here as a failing test.
+    #[test]
+    fn equal_magnitudes_settle_on_the_absolute_form() {
+        let (value, is_percent) = known(combine(
+            accuracy(50.0, 10.0, true), // 10% of 50 == 5
+            accuracy(50.0, 2.0, false),
+        ));
+        assert!(!is_percent);
+        assert!((value - 7.0).abs() < 1e-9);
+    }
+
+    /// A percentage sum past 100 violates the `Accuracy_validity` invariant, so
+    /// no valid amount can carry it and the operation refuses rather than
+    /// producing one that fails its own class.
+    #[test]
+    fn a_percentage_past_one_hundred_is_unrepresentable() {
+        assert_eq!(
+            combine(accuracy(50.0, 60.0, true), accuracy(50.0, 60.0, true)),
+            CombinedAccuracy::Unrepresentable
+        );
+    }
+
+    /// A zero magnitude has no percentage form: every percentage of it is the
+    /// same zero, so an absolute half-range cannot be converted into one.
+    #[test]
+    fn a_zero_magnitude_has_no_percentage_form() {
+        assert_eq!(
+            combine(accuracy(200.0, 10.0, true), accuracy(0.0, 5.0, false)),
+            CombinedAccuracy::Unrepresentable
+        );
+    }
+
+    /// `Accuracy_is_percent_validity` — "accuracy = 0 implies not
+    /// accuracy_is_percent" — so a zero result is recorded as absolute even
+    /// when both operands were percentages.
+    #[test]
+    fn a_zero_result_is_never_a_percentage() {
+        let (value, is_percent) = known(combine(
+            accuracy(50.0, 0.0, false),
+            accuracy(50.0, 0.0, false),
+        ));
+        assert!((value - 0.0).abs() < f64::EPSILON);
+        assert!(!is_percent);
+    }
+
+    /// Scaling leaves a percentage alone and scales an absolute half-range with
+    /// the magnitude it measures.
+    #[test]
+    fn scaling_keeps_a_percentage_and_scales_a_half_range() {
+        let (value, is_percent) = known(scale(accuracy(50.0, 10.0, true), 3.0));
+        assert!(is_percent);
+        assert!((value - 10.0).abs() < f64::EPSILON);
+
+        let (value, is_percent) = known(scale(accuracy(50.0, 0.5, false), -3.0));
+        assert!(!is_percent);
+        assert!((value - 1.5).abs() < 1e-9, "the magnitude of the factor");
+
+        assert_eq!(scale(unrecorded(50.0), 3.0), CombinedAccuracy::Unknown);
+    }
+}

--- a/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/dv_count_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/dv_count_impl.rs
@@ -5,11 +5,14 @@
 //! plus the DV_ORDERED `Normal_range_and_status_consistency` (via the
 //! ordered-magnitude machinery in `dv_ordered_impl`).
 
+use crate::v1_2::data_types::quantity::dv_amount_impl::{
+    AmountAccuracy, CombinedAccuracy, combine, scale,
+};
 use crate::v1_2::data_types::quantity::dv_count::DvCount;
-use rust_decimal::Decimal;
-use rust_decimal::prelude::ToPrimitive;
 use crate::v1_2::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
 use openehr_base::validate::{InvariantViolation, Validate};
+use rust_decimal::Decimal;
+use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
 
 impl DvCount {
     // NOTE: `less_than` and `is_strictly_comparable_to` are realized for every
@@ -27,22 +30,24 @@ impl DvCount {
     /// project's arithmetic rule: a load-bearing computation says so at the
     /// type level instead of producing a silently wrong clinical value.
     ///
-    /// The other fields are NOT carried over: `accuracy`, `normal_range` and
-    /// the reference ranges describe the measurement THIS value came from, and
-    /// the spec attaches no meaning to their combination under addition.
+    /// `normal_range` and the reference ranges are NOT carried over: they
+    /// describe the measurement THIS value came from, and the spec gives no
+    /// rule for combining them. `accuracy` is carried, because `DV_AMOUNT`
+    /// does give one — see [`combine`].
     #[must_use]
     pub fn add(&self, other: &Self) -> Option<Self> {
-        Some(Self::of_magnitude(self.magnitude.checked_add(other.magnitude)?))
+        self.combined(other, self.magnitude.checked_add(other.magnitude)?)
     }
 
     /// Difference of this count and `other`, or `None` on overflow.
     ///
-    /// Spec: `dv_count.adoc` §Functions `subtract`. A negative result is NOT
+    /// Spec: `dv_count.adoc` §Functions `subtract`, redefining
+    /// `dv_amount.adoc` §Functions `subtract`. A negative result is NOT
     /// refused: `magnitude` is a signed `Integer64` and the class declares no
     /// invariant bounding it below.
     #[must_use]
     pub fn subtract(&self, other: &Self) -> Option<Self> {
-        Some(Self::of_magnitude(self.magnitude.checked_sub(other.magnitude)?))
+        self.combined(other, self.magnitude.checked_sub(other.magnitude)?)
     }
 
     /// Product of this count and `factor`, or `None` when the result is not a
@@ -62,26 +67,55 @@ impl DvCount {
     /// `is_integer` and `to_i64` are exact, and each step that can fail says so.
     #[must_use]
     pub fn multiply(&self, factor: f64) -> Option<Self> {
-        // `from_f64_retain` keeps the float's exact value rather than rounding
-        // to a display form, so nothing is lost before the check below; it
+        // `from_f64` recovers the decimal the float DENOTES: 0.1_f64 is the
+        // one tenth its author wrote, so `count * 0.1` is a whole count. It
         // returns `None` for NaN and the infinities.
-        let product = Decimal::from(self.magnitude).checked_mul(Decimal::from_f64_retain(factor)?)?;
-        product
-            .is_integer()
-            .then(|| product.to_i64().map(Self::of_magnitude))?
+        let product = Decimal::from(self.magnitude).checked_mul(Decimal::from_f64(factor)?)?;
+        let magnitude = product.is_integer().then(|| product.to_i64())??;
+        Self::of_magnitude(magnitude, scale(self.amount_accuracy(), factor))
     }
 
-    /// A count of `magnitude` with every measurement-specific field cleared.
-    fn of_magnitude(magnitude: i64) -> Self {
-        Self {
+    /// Returns `true` when this count's accuracy was not recorded.
+    ///
+    /// Spec: `dv_quantified.adoc` §Functions `accuracy_unknown`, effected for
+    /// `DV_AMOUNT` by the `unknown_accuracy_value` sentinel.
+    #[must_use]
+    pub fn accuracy_unknown(&self) -> bool {
+        self.accuracy.is_none_or(|value| value < 0.0)
+    }
+
+    /// This count's accuracy as the `DV_AMOUNT` rule reads it.
+    fn amount_accuracy(&self) -> AmountAccuracy {
+        AmountAccuracy::counted(self.magnitude, self.accuracy, self.accuracy_is_percent)
+    }
+
+    /// This count combined with `other`, carrying the `DV_AMOUNT` accuracy.
+    fn combined(&self, other: &Self, magnitude: i64) -> Option<Self> {
+        Self::of_magnitude(
+            magnitude,
+            combine(self.amount_accuracy(), other.amount_accuracy()),
+        )
+    }
+
+    /// A count of `magnitude` and `accuracy`, with the ranges cleared.
+    fn of_magnitude(magnitude: i64, accuracy: CombinedAccuracy) -> Option<Self> {
+        let (accuracy, accuracy_is_percent) = match accuracy {
+            CombinedAccuracy::Unrepresentable => return None,
+            CombinedAccuracy::Unknown => (None, None),
+            CombinedAccuracy::Known {
+                accuracy,
+                is_percent,
+            } => (Some(accuracy), Some(is_percent)),
+        };
+        Some(Self {
             magnitude,
             magnitude_status: None,
-            accuracy: None,
-            accuracy_is_percent: None,
+            accuracy,
+            accuracy_is_percent,
             normal_range: None,
             normal_status: None,
             other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
-        }
+        })
     }
 }
 
@@ -120,10 +154,9 @@ mod tests {
         }
     }
 
-    /// `dv_count.adoc` §Functions: add/subtract are magnitude arithmetic, and
-    /// the result carries NONE of the measurement-specific fields — accuracy
-    /// and the ranges describe the measurement each operand came from, and the
-    /// spec gives no meaning to combining them.
+    /// `dv_count.adoc` §Functions: add/subtract are magnitude arithmetic. The
+    /// ranges are not carried — they describe the measurement each operand came
+    /// from — but `accuracy` is, because `dv_amount.adoc` specifies it.
     #[test]
     fn add_and_subtract_are_magnitude_arithmetic() {
         let a = count();
@@ -133,10 +166,60 @@ mod tests {
         let sum = a.add(&b).expect("no overflow");
         assert_eq!(sum.magnitude, a.magnitude + 4);
         assert!(
-            sum.accuracy.is_none() && sum.normal_range.is_none(),
-            "measurement-specific fields belong to the operands, not the result"
+            sum.normal_range.is_none(),
+            "the ranges belong to the operands, not the result"
         );
-        assert_eq!(a.subtract(&b).expect("no overflow").magnitude, a.magnitude - 4);
+        assert!(sum.accuracy.is_none(), "neither operand recorded one");
+        assert_eq!(
+            a.subtract(&b).expect("no overflow").magnitude,
+            a.magnitude - 4
+        );
+    }
+
+    /// "If accuracies are present in both quantities, they are added in the
+    /// result" — `DV_COUNT` is a `DV_AMOUNT`, so its arithmetic carries the
+    /// same accuracy rule as every other descendant.
+    #[test]
+    fn accuracy_follows_the_dv_amount_rule() {
+        let mut a = count();
+        a.accuracy = Some(0.5);
+        a.accuracy_is_percent = Some(false);
+        let mut b = count();
+        b.magnitude = 4;
+        b.accuracy = Some(0.25);
+        b.accuracy_is_percent = Some(false);
+
+        let sum = a.add(&b).expect("no overflow");
+        assert_eq!(sum.accuracy_is_percent, Some(false));
+        assert!((sum.accuracy.expect("both recorded one") - 0.75).abs() < f64::EPSILON);
+
+        // Scaling keeps a percentage and scales an absolute half-range.
+        let scaled = a.multiply(2.0).expect("whole product");
+        assert_eq!(scaled.magnitude, 6);
+        assert!((scaled.accuracy.expect("scaled") - 1.0).abs() < f64::EPSILON);
+    }
+
+    /// A factor whose float carries binary error still means the decimal its
+    /// author wrote: 10 counts scaled by a tenth is one count. Reading the
+    /// float's approximation instead would refuse this as "not whole".
+    #[test]
+    fn a_decimal_factor_means_the_decimal_not_its_binary_approximation() {
+        let mut ten = count();
+        ten.magnitude = 10;
+        assert_eq!(ten.multiply(0.1).expect("one tenth of ten").magnitude, 1);
+        assert_eq!(ten.multiply(0.3).expect("three tenths of ten").magnitude, 3);
+        assert!(ten.multiply(0.25).is_none(), "2.5 is not a whole count");
+    }
+
+    /// `accuracy_unknown` reads both ways of not recording an accuracy.
+    #[test]
+    fn accuracy_unknown_reads_the_sentinel_and_the_absence() {
+        let mut c = count();
+        assert!(c.accuracy_unknown());
+        c.accuracy = Some(-1.0);
+        assert!(c.accuracy_unknown());
+        c.accuracy = Some(0.0);
+        assert!(!c.accuracy_unknown(), "0 means 100% accurate, not unknown");
     }
 
     /// Overflow is refused rather than wrapped. `magnitude` is an Integer64 and

--- a/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/dv_proportion_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/dv_proportion_impl.rs
@@ -7,9 +7,188 @@
 //! `pk_unitary` 1, `pk_percent` 2, `pk_fraction` 3, `pk_integer_fraction` 4),
 //! plus the inherited DV_AMOUNT / DV_QUANTIFIED / DV_ORDERED invariants.
 
+use crate::v1_2::data_types::quantity::dv_amount_impl::{
+    AmountAccuracy, CombinedAccuracy, combine, scale,
+};
 use crate::v1_2::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
 use crate::v1_2::data_types::quantity::dv_proportion::DvProportion;
 use openehr_base::validate::{InvariantViolation, Validate};
+use rust_decimal::Decimal;
+use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
+
+impl DvProportion {
+    /// Sum of this proportion and `other`, or `None` when they are not strictly
+    /// comparable or the result is one no valid proportion can carry.
+    ///
+    /// Spec: `dv_proportion.adoc` §Functions `add` — "Sum of two strictly
+    /// comparable proportions", over `is_strictly_comparable_to`: "True if the
+    /// `type` of this proportion is the same as the `type` of `other`."
+    ///
+    /// Proportions are added over a common denominator, which is what keeps
+    /// the result inside its own kind's invariants: `pk_percent` fixes the
+    /// denominator at 100 and `pk_unitary` at 1, so equal denominators are kept
+    /// rather than multiplied — cross-multiplying two percentages would yield a
+    /// denominator of 10000 and fail `Percent_validity`.
+    #[must_use]
+    pub fn add(&self, other: &Self) -> Option<Self> {
+        self.combined(other, Decimal::checked_add)
+    }
+
+    /// Difference of this proportion and `other`, under the same conditions as
+    /// [`Self::add`].
+    ///
+    /// Spec: `dv_proportion.adoc` §Functions `subtract` — "Difference between
+    /// two strictly comparable proportions."
+    #[must_use]
+    pub fn subtract(&self, other: &Self) -> Option<Self> {
+        self.combined(other, Decimal::checked_sub)
+    }
+
+    /// Product of this proportion and `factor`, or `None` when the result is
+    /// one no valid proportion can carry.
+    ///
+    /// Spec: `dv_proportion.adoc` §Functions `multiply` — "Product of this
+    /// Proportion and `factor`."
+    ///
+    /// The factor scales the numerator and leaves the denominator alone, which
+    /// is what keeps `pk_percent`'s 100 and `pk_unitary`'s 1 in place. A kind
+    /// whose `Fraction_validity` demands integers refuses a numerator the
+    /// factor made fractional, rather than rounding it into a different ratio.
+    #[must_use]
+    pub fn multiply(&self, factor: f64) -> Option<Self> {
+        let (numerator, denominator) = self.ratio()?;
+        self.carrying(
+            numerator.checked_mul(Decimal::from_f64(factor)?)?,
+            denominator,
+            scale(self.amount_accuracy()?, factor),
+        )
+    }
+
+    /// Returns `true` when this proportion is considered equal to `other`.
+    ///
+    /// Spec: `dv_proportion.adoc` §Functions `is_equal`, effecting
+    /// `dv_amount.adoc`'s abstract `is_equal`.
+    ///
+    /// Equality is of the RATIO, not of how it was written: `1/2` and `2/4` are
+    /// the same proportion, so the test is cross-multiplication rather than
+    /// field equality. The `type` must still match, because a proportion is
+    /// only comparable to one of its own kind and `1/100` as a percentage means
+    /// something a `pk_ratio` does not.
+    ///
+    /// The cross-multiplication runs in [`Decimal`]: whether two ratios are the
+    /// same is an exact question, and asking it of binary floating point makes
+    /// `0.1/0.3` and `1.0/3.0` disagree for reasons that have nothing to do
+    /// with the proportions.
+    #[must_use]
+    pub fn is_equal(&self, other: &Self) -> bool {
+        if self.r#type != other.r#type {
+            return false;
+        }
+        let (Some((left_numerator, left_denominator)), Some((right_numerator, right_denominator))) =
+            (self.ratio(), other.ratio())
+        else {
+            return false;
+        };
+        // Both products must EXIST: two overflows are not an equality.
+        let (Some(left), Some(right)) = (
+            left_numerator.checked_mul(right_denominator),
+            right_numerator.checked_mul(left_denominator),
+        ) else {
+            return false;
+        };
+        left == right
+    }
+
+    /// Returns `true` when this proportion's accuracy was not recorded.
+    ///
+    /// Spec: `dv_quantified.adoc` §Functions `accuracy_unknown`, effected for
+    /// `DV_AMOUNT` by the `unknown_accuracy_value` sentinel.
+    #[must_use]
+    pub fn accuracy_unknown(&self) -> bool {
+        self.accuracy.is_none_or(|value| value < 0.0)
+    }
+
+    /// This proportion's accuracy as the `DV_AMOUNT` rule reads it, or `None`
+    /// when the denominator is zero and there is no magnitude.
+    fn amount_accuracy(&self) -> Option<AmountAccuracy> {
+        Some(AmountAccuracy::measured(
+            self.magnitude()?,
+            self.accuracy,
+            self.accuracy_is_percent,
+        ))
+    }
+
+    /// This proportion's numerator and denominator as exact decimals.
+    fn ratio(&self) -> Option<(Decimal, Decimal)> {
+        Some((
+            Decimal::from_f64(self.numerator)?,
+            Decimal::from_f64(self.denominator)?,
+        ))
+    }
+
+    /// This proportion combined with `other` over a common denominator.
+    fn combined(&self, other: &Self, op: fn(Decimal, Decimal) -> Option<Decimal>) -> Option<Self> {
+        if !self.is_strictly_comparable_to(other) {
+            return None;
+        }
+        let accuracy = combine(self.amount_accuracy()?, other.amount_accuracy()?);
+        let (left_numerator, left_denominator) = self.ratio()?;
+        let (right_numerator, right_denominator) = other.ratio()?;
+        if left_denominator == right_denominator {
+            return self.carrying(
+                op(left_numerator, right_numerator)?,
+                left_denominator,
+                accuracy,
+            );
+        }
+        self.carrying(
+            op(
+                left_numerator.checked_mul(right_denominator)?,
+                right_numerator.checked_mul(left_denominator)?,
+            )?,
+            left_denominator.checked_mul(right_denominator)?,
+            accuracy,
+        )
+    }
+
+    /// This proportion at a new ratio and accuracy, or `None` when the result
+    /// would not satisfy its own class invariants.
+    ///
+    /// `precision` is dropped: it states the decimal places the operands were
+    /// expressed to, and the spec gives no rule for the precision of a sum.
+    fn carrying(
+        &self,
+        numerator: Decimal,
+        denominator: Decimal,
+        accuracy: CombinedAccuracy,
+    ) -> Option<Self> {
+        let (numerator, denominator) = (numerator.to_f64()?, denominator.to_f64()?);
+        let (accuracy, accuracy_is_percent) = match accuracy {
+            CombinedAccuracy::Unrepresentable => return None,
+            CombinedAccuracy::Unknown => (None, None),
+            CombinedAccuracy::Known {
+                accuracy,
+                is_percent,
+            } => (Some(accuracy), Some(is_percent)),
+        };
+        let combined = Self {
+            numerator,
+            denominator,
+            r#type: self.r#type,
+            precision: None,
+            magnitude_status: None,
+            accuracy,
+            accuracy_is_percent,
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        };
+        // A proportion that fails its own invariants is not a proportion —
+        // `Fraction_validity` in particular rejects a fractional numerator on
+        // the two integral kinds, which is where a scaled fraction lands.
+        combined.invariants().is_empty().then_some(combined)
+    }
+}
 
 impl Validate for DvProportion {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
@@ -180,5 +359,118 @@ mod tests {
             messages(&proportion(5.5, 1.0, 0, Some(0)))
                 .contains(&"Invariant Precision_validity failed on type DV_PROPORTION".to_owned())
         );
+    }
+
+    /// Only proportions of the same kind combine — `is_strictly_comparable_to`
+    /// is "True if the `type` of this proportion is the same as the `type` of
+    /// `other`", so a percentage and a ratio do not add.
+    #[test]
+    fn only_the_same_kind_combines() {
+        let percent = proportion(20.0, 100.0, PK_PERCENT, None);
+        let ratio = proportion(20.0, 100.0, 0, None);
+        assert!(percent.add(&ratio).is_none());
+        assert!(percent.subtract(&ratio).is_none());
+    }
+
+    /// Two percentages keep the denominator 100 that `Percent_validity`
+    /// demands: cross-multiplying them would give 10000 and produce a value
+    /// that fails its own class.
+    #[test]
+    fn equal_denominators_are_kept_not_multiplied() {
+        let a = proportion(20.0, 100.0, PK_PERCENT, None);
+        let b = proportion(35.0, 100.0, PK_PERCENT, None);
+
+        let sum = a.add(&b).expect("same kind");
+        assert!((sum.numerator - 55.0).abs() < f64::EPSILON);
+        assert!((sum.denominator - 100.0).abs() < f64::EPSILON);
+        assert!(sum.invariants().is_empty(), "Percent_validity still holds");
+
+        let difference = b.subtract(&a).expect("same kind");
+        assert!((difference.numerator - 15.0).abs() < f64::EPSILON);
+    }
+
+    /// Unequal denominators go over a common one, and the result is a valid
+    /// fraction because both operands were integral.
+    #[test]
+    fn unequal_denominators_go_over_a_common_one() {
+        let half = proportion(1.0, 2.0, PK_FRACTION, None);
+        let third = proportion(1.0, 3.0, PK_FRACTION, None);
+
+        let sum = half.add(&third).expect("same kind");
+        assert!((sum.numerator - 5.0).abs() < f64::EPSILON);
+        assert!((sum.denominator - 6.0).abs() < f64::EPSILON);
+        assert!(sum.invariants().is_empty());
+    }
+
+    /// A scaled fraction whose numerator stops being whole is refused rather
+    /// than rounded: `Fraction_validity` demands integers of `pk_fraction`, and
+    /// rounding would silently record a different ratio.
+    #[test]
+    fn a_fractional_numerator_is_refused_on_an_integral_kind() {
+        let fraction = proportion(1.0, 2.0, PK_INTEGER_FRACTION, None);
+        assert!(fraction.multiply(0.5).is_none(), "0.5/2 is not integral");
+
+        let doubled = fraction.multiply(2.0).expect("2/2 is integral");
+        assert!((doubled.numerator - 2.0).abs() < f64::EPSILON);
+        assert!((doubled.denominator - 2.0).abs() < f64::EPSILON);
+
+        // A unitary proportion keeps its denominator of 1 under scaling.
+        let unitary = proportion(3.0, 1.0, PK_UNITARY, None);
+        let scaled = unitary.multiply(2.5).expect("no integrality rule");
+        assert!((scaled.numerator - 7.5).abs() < f64::EPSILON);
+        assert!((scaled.denominator - 1.0).abs() < f64::EPSILON);
+    }
+
+    /// `is_equal` compares the RATIO: 1/2 and 2/4 are the same proportion, and
+    /// the decimal cross-multiplication makes 1/3 and 0.1/0.3 agree where
+    /// binary floating point would not.
+    #[test]
+    fn is_equal_compares_the_ratio_not_the_fields() {
+        let half = proportion(1.0, 2.0, PK_FRACTION, None);
+        assert!(half.is_equal(&proportion(2.0, 4.0, PK_FRACTION, None)));
+        assert!(!half.is_equal(&proportion(1.0, 3.0, PK_FRACTION, None)));
+
+        // A different kind is never equal, whatever the ratio.
+        assert!(!half.is_equal(&proportion(1.0, 2.0, 0, None)));
+
+        let third = proportion(1.0, 3.0, 0, None);
+        assert!(
+            third.is_equal(&proportion(0.1, 0.3, 0, None)),
+            "exact in Decimal, unequal in binary floating point"
+        );
+    }
+
+    /// `DV_PROPORTION` is a `DV_AMOUNT`, so its arithmetic carries the same
+    /// accuracy rule as every other descendant.
+    #[test]
+    fn accuracy_follows_the_dv_amount_rule() {
+        let mut a = proportion(20.0, 100.0, PK_PERCENT, None);
+        a.accuracy = Some(0.01);
+        a.accuracy_is_percent = Some(false);
+        let mut b = proportion(30.0, 100.0, PK_PERCENT, None);
+        b.accuracy = Some(0.02);
+        b.accuracy_is_percent = Some(false);
+
+        let sum = a.add(&b).expect("same kind");
+        assert!((sum.accuracy.expect("both recorded one") - 0.03).abs() < f64::EPSILON);
+        assert_eq!(sum.accuracy_is_percent, Some(false));
+
+        assert!(
+            a.add(&proportion(30.0, 100.0, PK_PERCENT, None))
+                .expect("same kind")
+                .accuracy
+                .is_none()
+        );
+    }
+
+    /// `accuracy_unknown` reads both ways of not recording an accuracy.
+    #[test]
+    fn accuracy_unknown_reads_the_sentinel_and_the_absence() {
+        let mut p = proportion(1.0, 2.0, PK_FRACTION, None);
+        assert!(p.accuracy_unknown());
+        p.accuracy = Some(-1.0);
+        assert!(p.accuracy_unknown());
+        p.accuracy = Some(0.0);
+        assert!(!p.accuracy_unknown(), "0 means 100% accurate, not unknown");
     }
 }

--- a/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/dv_quantity_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/dv_quantity_impl.rs
@@ -11,74 +11,104 @@
 //! is deferred to the composition validator + `openehr-term` (this crate has
 //! no terminology dependency).
 
+use crate::v1_2::data_types::quantity::dv_amount_impl::{
+    AmountAccuracy, CombinedAccuracy, combine, scale,
+};
 use crate::v1_2::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
 use crate::v1_2::data_types::quantity::dv_quantity::DvQuantity;
 use openehr_base::validate::{InvariantViolation, Validate};
 
 impl DvQuantity {
     /// Sum of this quantity and `other`, or `None` when they are not strictly
-    /// comparable or the result is not a finite magnitude.
+    /// comparable or the result is one no valid quantity can carry.
     ///
     /// Spec: `dv_quantity.adoc` §Functions `add` — "Sum of this `DV_QUANTITY`
-    /// and `other`."
+    /// and `other`" — redefining `dv_amount.adoc` §Functions `add`, whose
+    /// `Pre_comparable` pre-condition is `is_strictly_comparable_to (other)`:
+    /// the same `units`, and the same `units_system` where one is stated.
     ///
-    /// The spec states no pre-condition on `add`, but `DV_ORDERED` says
-    /// instances of `DV_QUANTITY` "can only be compared if they measure the
-    /// same kind of physical quantity", and a sum of unlike quantities is no
-    /// more meaningful than a comparison of them. So this requires
-    /// [`Self::is_strictly_comparable_to`] — the same units, and the same
-    /// `units_system` where one is stated — rather than silently producing a
-    /// number whose unit is a guess.
+    /// The accuracy of the result follows the `DV_AMOUNT` rule — see
+    /// [`combine`].
     #[must_use]
     pub fn add(&self, other: &Self) -> Option<Self> {
-        self.combine(other, self.magnitude + other.magnitude)
+        self.combined(other, self.magnitude + other.magnitude)
     }
 
     /// Difference of this quantity and `other`, under the same conditions as
     /// [`Self::add`].
     ///
-    /// Spec: `dv_quantity.adoc` §Functions `subtract`.
+    /// Spec: `dv_quantity.adoc` §Functions `subtract`, redefining
+    /// `dv_amount.adoc` §Functions `subtract` — the accuracies are summed for
+    /// subtraction exactly as for addition.
     #[must_use]
     pub fn subtract(&self, other: &Self) -> Option<Self> {
-        self.combine(other, self.magnitude - other.magnitude)
+        self.combined(other, self.magnitude - other.magnitude)
     }
 
-    /// Product of this quantity and `factor`, or `None` when the result is not
-    /// a finite magnitude.
+    /// Product of this quantity and `factor`, or `None` when the result is one
+    /// no valid quantity can carry.
     ///
     /// Spec: `dv_quantity.adoc` §Functions `multiply` — "Product of this
     /// `DV_QUANTITY` and `factor`."
     ///
     /// Unlike `DV_COUNT.multiply`, a fractional result needs no adjudication:
     /// a quantity's magnitude is a `Real`, so scaling one stays in the type.
-    /// The units are unchanged — a scalar factor carries no dimension.
+    /// The units are unchanged — a scalar factor carries no dimension — and the
+    /// accuracy scales per [`scale`].
     #[must_use]
     pub fn multiply(&self, factor: f64) -> Option<Self> {
-        self.rescaled(self.magnitude * factor)
+        self.rescaled(
+            self.magnitude * factor,
+            scale(self.amount_accuracy(), factor),
+        )
+    }
+
+    /// Returns `true` when this quantity's accuracy was not recorded.
+    ///
+    /// Spec: `dv_quantified.adoc` §Functions `accuracy_unknown`, effected for
+    /// `DV_AMOUNT` by the `unknown_accuracy_value` sentinel.
+    #[must_use]
+    pub fn accuracy_unknown(&self) -> bool {
+        self.accuracy.is_none_or(|value| value < 0.0)
+    }
+
+    /// This quantity's accuracy as the `DV_AMOUNT` rule reads it.
+    fn amount_accuracy(&self) -> AmountAccuracy {
+        AmountAccuracy::measured(self.magnitude, self.accuracy, self.accuracy_is_percent)
     }
 
     /// This quantity combined with `other`, if they are strictly comparable.
-    fn combine(&self, other: &Self, magnitude: f64) -> Option<Self> {
+    fn combined(&self, other: &Self, magnitude: f64) -> Option<Self> {
         if !self.is_strictly_comparable_to(other) {
             return None;
         }
-        self.rescaled(magnitude)
+        self.rescaled(
+            magnitude,
+            combine(self.amount_accuracy(), other.amount_accuracy()),
+        )
     }
 
-    /// This quantity at a new magnitude, keeping the units and dropping every
-    /// field the spec gives no combination rule for.
+    /// This quantity at a new magnitude and accuracy, keeping the units.
     ///
-    /// `precision`, `accuracy` and the reference ranges describe how THIS value
-    /// was measured. The spec says nothing about the precision of a sum or the
-    /// accuracy of a scaled value, so carrying either would be this
-    /// implementation inventing a rule and presenting it as the model's.
-    fn rescaled(&self, magnitude: f64) -> Option<Self> {
+    /// `precision`, `magnitude_status` and the reference ranges are dropped:
+    /// they describe how THIS value was measured, and the spec gives no rule
+    /// for combining them, so carrying one would be this implementation
+    /// inventing a rule and presenting it as the model's.
+    fn rescaled(&self, magnitude: f64, accuracy: CombinedAccuracy) -> Option<Self> {
         // A non-finite magnitude is not a quantity: the class types it as a
         // `Real`, and NaN or an infinity would flow into comparisons and
         // serialization as a value no reader can act on.
         if !magnitude.is_finite() {
             return None;
         }
+        let (accuracy, accuracy_is_percent) = match accuracy {
+            CombinedAccuracy::Unrepresentable => return None,
+            CombinedAccuracy::Unknown => (None, None),
+            CombinedAccuracy::Known {
+                accuracy,
+                is_percent,
+            } => (Some(accuracy), Some(is_percent)),
+        };
         Some(Self {
             magnitude,
             units: self.units.clone(),
@@ -86,8 +116,8 @@ impl DvQuantity {
             units_display_name: self.units_display_name.clone(),
             precision: None,
             magnitude_status: None,
-            accuracy: None,
-            accuracy_is_percent: None,
+            accuracy,
+            accuracy_is_percent,
             normal_range: None,
             normal_status: None,
             other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
@@ -169,19 +199,84 @@ mod tests {
         assert!(plain.add(&systematised).is_none());
     }
 
-    /// The measurement-specific fields describe how THIS value was measured.
-    /// The spec defines neither the precision of a sum nor the accuracy of a
-    /// scaled value, so the result carries neither rather than this
-    /// implementation inventing a rule.
+    /// "If accuracies are present in both quantities, they are added in the
+    /// result, for both addition and subtraction operations" — the accuracy of
+    /// a sum is specified, so it is carried rather than dropped.
     #[test]
-    fn arithmetic_drops_what_the_spec_gives_no_rule_for() {
-        let mut a = quantity();
+    fn arithmetic_carries_the_accuracy_the_spec_specifies() {
+        let mut a = quantity(); // 43 kg
         a.accuracy = Some(0.5);
         a.accuracy_is_percent = Some(false);
-        let scaled = a.multiply(2.0).expect("finite");
+        let mut b = quantity();
+        b.magnitude = 7.0;
+        b.accuracy = Some(0.25);
+        b.accuracy_is_percent = Some(false);
+
+        for combined in [
+            a.add(&b).expect("same units"),
+            a.subtract(&b).expect("same units"),
+        ] {
+            assert_eq!(combined.accuracy_is_percent, Some(false));
+            let accuracy = combined.accuracy.expect("both operands recorded one");
+            assert!((accuracy - 0.75).abs() < f64::EPSILON);
+        }
+
+        // An unrecorded accuracy on either side makes the result's unknown.
+        let mut plain = quantity();
+        plain.magnitude = 7.0;
+        let sum = a.add(&plain).expect("same units");
+        assert!(sum.accuracy.is_none() && sum.accuracy_is_percent.is_none());
+    }
+
+    /// Scaling has no spec rule, so ours is asserted: a percentage of a
+    /// magnitude survives the magnitude changing, and an absolute half-range —
+    /// being in the quantity's own units — scales with it.
+    #[test]
+    fn scaling_carries_the_accuracy_forward() {
+        let mut absolute = quantity();
+        absolute.accuracy = Some(0.5);
+        absolute.accuracy_is_percent = Some(false);
+        let scaled = absolute.multiply(2.0).expect("finite");
         assert!((scaled.magnitude - 86.0).abs() < f64::EPSILON);
         assert_eq!(scaled.units, "kg");
-        assert!(scaled.precision.is_none() && scaled.accuracy.is_none());
+        assert_eq!(scaled.accuracy_is_percent, Some(false));
+        assert!((scaled.accuracy.expect("scaled") - 1.0).abs() < f64::EPSILON);
+
+        let mut percent = quantity();
+        percent.accuracy = Some(5.0);
+        percent.accuracy_is_percent = Some(true);
+        let scaled = percent.multiply(2.0).expect("finite");
+        assert_eq!(scaled.accuracy_is_percent, Some(true));
+        assert!((scaled.accuracy.expect("scaled") - 5.0).abs() < f64::EPSILON);
+
+        // `precision` and `magnitude_status` have no combination rule and are
+        // dropped rather than guessed at.
+        assert!(scaled.precision.is_none() && scaled.magnitude_status.is_none());
+    }
+
+    /// A sum whose accuracy no valid quantity can carry is refused outright
+    /// rather than returned as a value that fails its own class invariant.
+    #[test]
+    fn an_unrepresentable_accuracy_refuses_the_whole_operation() {
+        let mut a = quantity();
+        a.accuracy = Some(60.0);
+        a.accuracy_is_percent = Some(true);
+        let mut b = quantity();
+        b.accuracy = Some(60.0);
+        b.accuracy_is_percent = Some(true);
+        assert!(a.add(&b).is_none(), "120% fails Accuracy_validity");
+    }
+
+    /// `accuracy_unknown` reads both ways of not recording an accuracy: the
+    /// attribute being absent, and the `unknown_accuracy_value` sentinel.
+    #[test]
+    fn accuracy_unknown_reads_the_sentinel_and_the_absence() {
+        let mut q = quantity();
+        assert!(q.accuracy_unknown());
+        q.accuracy = Some(-1.0);
+        assert!(q.accuracy_unknown());
+        q.accuracy = Some(0.0);
+        assert!(!q.accuracy_unknown(), "0 means 100% accurate, not unknown");
     }
 
     /// A magnitude that is not finite is not a quantity: NaN or an infinity

--- a/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/dv_quantity_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/dv_quantity_impl.rs
@@ -15,6 +15,86 @@ use crate::v1_2::data_types::quantity::dv_ordered_impl::push_normal_range_consis
 use crate::v1_2::data_types::quantity::dv_quantity::DvQuantity;
 use openehr_base::validate::{InvariantViolation, Validate};
 
+impl DvQuantity {
+    /// Sum of this quantity and `other`, or `None` when they are not strictly
+    /// comparable or the result is not a finite magnitude.
+    ///
+    /// Spec: `dv_quantity.adoc` §Functions `add` — "Sum of this `DV_QUANTITY`
+    /// and `other`."
+    ///
+    /// The spec states no pre-condition on `add`, but `DV_ORDERED` says
+    /// instances of `DV_QUANTITY` "can only be compared if they measure the
+    /// same kind of physical quantity", and a sum of unlike quantities is no
+    /// more meaningful than a comparison of them. So this requires
+    /// [`Self::is_strictly_comparable_to`] — the same units, and the same
+    /// `units_system` where one is stated — rather than silently producing a
+    /// number whose unit is a guess.
+    #[must_use]
+    pub fn add(&self, other: &Self) -> Option<Self> {
+        self.combine(other, self.magnitude + other.magnitude)
+    }
+
+    /// Difference of this quantity and `other`, under the same conditions as
+    /// [`Self::add`].
+    ///
+    /// Spec: `dv_quantity.adoc` §Functions `subtract`.
+    #[must_use]
+    pub fn subtract(&self, other: &Self) -> Option<Self> {
+        self.combine(other, self.magnitude - other.magnitude)
+    }
+
+    /// Product of this quantity and `factor`, or `None` when the result is not
+    /// a finite magnitude.
+    ///
+    /// Spec: `dv_quantity.adoc` §Functions `multiply` — "Product of this
+    /// `DV_QUANTITY` and `factor`."
+    ///
+    /// Unlike `DV_COUNT.multiply`, a fractional result needs no adjudication:
+    /// a quantity's magnitude is a `Real`, so scaling one stays in the type.
+    /// The units are unchanged — a scalar factor carries no dimension.
+    #[must_use]
+    pub fn multiply(&self, factor: f64) -> Option<Self> {
+        self.rescaled(self.magnitude * factor)
+    }
+
+    /// This quantity combined with `other`, if they are strictly comparable.
+    fn combine(&self, other: &Self, magnitude: f64) -> Option<Self> {
+        if !self.is_strictly_comparable_to(other) {
+            return None;
+        }
+        self.rescaled(magnitude)
+    }
+
+    /// This quantity at a new magnitude, keeping the units and dropping every
+    /// field the spec gives no combination rule for.
+    ///
+    /// `precision`, `accuracy` and the reference ranges describe how THIS value
+    /// was measured. The spec says nothing about the precision of a sum or the
+    /// accuracy of a scaled value, so carrying either would be this
+    /// implementation inventing a rule and presenting it as the model's.
+    fn rescaled(&self, magnitude: f64) -> Option<Self> {
+        // A non-finite magnitude is not a quantity: the class types it as a
+        // `Real`, and NaN or an infinity would flow into comparisons and
+        // serialization as a value no reader can act on.
+        if !magnitude.is_finite() {
+            return None;
+        }
+        Some(Self {
+            magnitude,
+            units: self.units.clone(),
+            units_system: self.units_system.clone(),
+            units_display_name: self.units_display_name.clone(),
+            precision: None,
+            magnitude_status: None,
+            accuracy: None,
+            accuracy_is_percent: None,
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        })
+    }
+}
+
 impl Validate for DvQuantity {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
         crate::v1_2::validate::generated::dv_amount_core(
@@ -56,6 +136,62 @@ mod tests {
 
     fn messages(q: &DvQuantity) -> Vec<String> {
         q.invariants().into_iter().map(|v| v.message).collect()
+    }
+
+    /// Unlike quantities do not add. `DV_ORDERED` says instances "can only be
+    /// compared if they measure the same kind of physical quantity", and a sum
+    /// of kg and m is no more meaningful than a comparison of them — so the
+    /// refusal is asserted, not just the success.
+    #[test]
+    fn unlike_units_do_not_combine() {
+        let kg = quantity();
+        let mut metres = quantity();
+        metres.units = "m".to_owned();
+
+        assert!(kg.add(&metres).is_none(), "kg + m has no unit");
+        assert!(kg.subtract(&metres).is_none());
+
+        let mut other_kg = quantity();
+        other_kg.magnitude = 7.0;
+        let sum = kg.add(&other_kg).expect("same units");
+        assert!((sum.magnitude - 50.0).abs() < f64::EPSILON);
+        assert_eq!(sum.units, "kg", "the sum stays in the operands' units");
+    }
+
+    /// A units_system stated on one side and not the other is NOT the same
+    /// quantity kind: the existing comparability rule requires both to match,
+    /// and arithmetic follows the same rule rather than a looser one.
+    #[test]
+    fn a_units_system_mismatch_does_not_combine() {
+        let plain = quantity();
+        let mut systematised = quantity();
+        systematised.units_system = Some("http://unitsofmeasure.org".to_owned());
+        assert!(plain.add(&systematised).is_none());
+    }
+
+    /// The measurement-specific fields describe how THIS value was measured.
+    /// The spec defines neither the precision of a sum nor the accuracy of a
+    /// scaled value, so the result carries neither rather than this
+    /// implementation inventing a rule.
+    #[test]
+    fn arithmetic_drops_what_the_spec_gives_no_rule_for() {
+        let mut a = quantity();
+        a.accuracy = Some(0.5);
+        a.accuracy_is_percent = Some(false);
+        let scaled = a.multiply(2.0).expect("finite");
+        assert!((scaled.magnitude - 86.0).abs() < f64::EPSILON);
+        assert_eq!(scaled.units, "kg");
+        assert!(scaled.precision.is_none() && scaled.accuracy.is_none());
+    }
+
+    /// A magnitude that is not finite is not a quantity: NaN or an infinity
+    /// would flow into comparison and serialization as a value no reader can
+    /// act on.
+    #[test]
+    fn a_non_finite_result_is_refused() {
+        let q = quantity();
+        assert!(q.multiply(f64::INFINITY).is_none());
+        assert!(q.multiply(f64::NAN).is_none());
     }
 
     #[test]

--- a/tools/openehr-codegen/templates/openehr-rm/data_types/time_specification/dv_periodic_time_specification_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/data_types/time_specification/dv_periodic_time_specification_impl.rs
@@ -5,8 +5,149 @@
 //! — `Value_valid: value.formalism.is_equal("HL7:PIVL") or
 //! value.formalism.is_equal("HL7:EIVL")`.
 
+use crate::v1_2::data_types::quantity::date_time::dv_duration::DvDuration;
 use crate::v1_2::data_types::time_specification::dv_periodic_time_specification::DvPeriodicTimeSpecification;
+use crate::v1_2::validate::is_valid_iso_duration;
 use openehr_base::validate::{InvariantViolation, Validate};
+
+impl DvPeriodicTimeSpecification {
+    /// The period of the repetition, or `None` for a specification that states
+    /// none.
+    ///
+    /// Spec: `dv_periodic_time_specification.adoc` §Functions `period` — "The
+    /// period of the repetition, computationally derived from the syntax
+    /// representation. Extracted from the `value` attribute", over the
+    /// phase-linked grammar of `master08-time_specification_package.adoc`
+    /// §Phase-linked Time Specification Syntax: `phase = interval "/" "("
+    /// difference ")"`.
+    ///
+    /// The class types this `1..1`, but only the phase-linked (`HL7:PIVL`)
+    /// grammar has a `difference` production at all: the event-linked
+    /// (`HL7:EIVL`) one is `event [ offset ]`, an offset from a real-world
+    /// event rather than a period. An event-linked specification therefore has
+    /// no period to return, and saying so is more honest than manufacturing
+    /// one.
+    #[must_use]
+    pub fn period(&self) -> Option<DvDuration> {
+        let value = self.phase_linked()?;
+        let difference = value
+            .split_once("/(")
+            .and_then(|(_, rest)| rest.split_once(')'))
+            .map(|(difference, _)| difference)?;
+        let value = iso_duration(difference)?;
+        Some(DvDuration {
+            value,
+            magnitude_status: None,
+            accuracy: None,
+            accuracy_is_percent: None,
+            normal_range: None,
+            normal_status: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+        })
+    }
+
+    /// Calendar alignment extracted from `value`, or `None` when none is
+    /// stated.
+    ///
+    /// Spec: `dv_periodic_time_specification.adoc` §Functions
+    /// `calendar_alignment`, over `pure_phase_linked_time_spec = phase [ "@"
+    /// alignment ]` — the alignment is a term from the `HL7::CalendarCycle`
+    /// domain (`DW` = day of week, `DM` = day of month, …), and the production
+    /// makes it optional.
+    #[must_use]
+    pub fn calendar_alignment(&self) -> Option<String> {
+        let value = self.phase_linked()?;
+        let alignment = value.rsplit_once('@').map(|(_, alignment)| alignment)?;
+        let alignment = alignment
+            .strip_suffix(INSTITUTION_SPECIFIED)
+            .unwrap_or(alignment);
+        (!alignment.is_empty()).then(|| alignment.to_owned())
+    }
+
+    /// Event alignment extracted from `value`, or `None` when none is stated.
+    ///
+    /// Spec: `dv_periodic_time_specification.adoc` §Functions
+    /// `event_alignment`, over `event_linked_time_spec = event | event offset`
+    /// — the event is a term from the `HL7::TimingEvent` domain (`PC` = after
+    /// meal, `HS` = bedtime, …), and it is the leading token, before any `+`
+    /// or `-` offset.
+    #[must_use]
+    pub fn event_alignment(&self) -> Option<String> {
+        let value = self.event_linked()?;
+        let event = value.split(['+', '-']).next().unwrap_or(value).trim();
+        (!event.is_empty()).then(|| event.to_owned())
+    }
+
+    /// Whether the timing is institution-specified.
+    ///
+    /// Spec: `dv_periodic_time_specification.adoc` §Functions
+    /// `institution_specified` — "Extracted from value", over
+    /// `phase_linked_time_spec = pure_phase_linked_time_spec [ "IST" ]`. The
+    /// flag exists only in the phase-linked grammar, so its absence — including
+    /// on every event-linked specification — is `false`.
+    #[must_use]
+    pub fn institution_specified(&self) -> bool {
+        self.phase_linked()
+            .is_some_and(|value| value.ends_with(INSTITUTION_SPECIFIED))
+    }
+
+    /// This specification's `value` when it is phase-linked, trimmed.
+    fn phase_linked(&self) -> Option<&str> {
+        (self.value.formalism == PHASE_LINKED).then(|| self.value.value.trim())
+    }
+
+    /// This specification's `value` when it is event-linked, trimmed.
+    fn event_linked(&self) -> Option<&str> {
+        (self.value.formalism == EVENT_LINKED).then(|| self.value.value.trim())
+    }
+}
+
+/// The `HL7:PIVL` formalism: a phase-linked periodic time specification.
+const PHASE_LINKED: &str = "HL7:PIVL";
+
+/// The `HL7:EIVL` formalism: an event-linked periodic time specification.
+const EVENT_LINKED: &str = "HL7:EIVL";
+
+/// The trailing flag marking a phase-linked timing as institution-specified.
+const INSTITUTION_SPECIFIED: &str = "IST";
+
+/// A syntax `difference` as an ISO-8601 duration value.
+///
+/// The vendored grammar annotates `difference` as "ISO 8601 for time
+/// difference", while the spec's own examples in the same section spell it
+/// `7d` and `1mo`. Both are accepted: refusing the second would refuse the
+/// specification's own worked examples, and inventing a third form would serve
+/// nobody. A difference in neither form has no duration.
+fn iso_duration(difference: &str) -> Option<String> {
+    let difference = difference.trim();
+    if is_valid_iso_duration(difference) {
+        return Some(difference.to_owned());
+    }
+    let boundary = difference.find(|c: char| !c.is_ascii_digit() && c != '-')?;
+    let (count, unit) = difference.split_at_checked(boundary)?;
+    if count.is_empty()
+        || !count
+            .trim_start_matches('-')
+            .chars()
+            .all(|c| c.is_ascii_digit())
+    {
+        return None;
+    }
+    // The HL7 unit abbreviations the section's examples use, mapped onto the
+    // ISO-8601 designator each one names.
+    let (designator, timed) = match unit {
+        "a" => ("Y", false),
+        "mo" => ("M", false),
+        "wk" => ("W", false),
+        "d" => ("D", false),
+        "h" => ("H", true),
+        "min" => ("M", true),
+        "s" => ("S", true),
+        _ => return None,
+    };
+    let separator = if timed { "PT" } else { "P" };
+    Some(format!("{separator}{count}{designator}"))
+}
 
 impl Validate for DvPeriodicTimeSpecification {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
@@ -51,5 +192,97 @@ mod tests {
             out.iter().any(|m| m.message.contains("Value_valid")),
             "{out:?}"
         );
+    }
+
+    fn parsable(formalism: &str, value: &str) -> DvPeriodicTimeSpecification {
+        DvPeriodicTimeSpecification {
+            value: DvParsable {
+                charset: None,
+                language: None,
+                value: value.to_owned(),
+                formalism: formalism.to_owned(),
+            },
+        }
+    }
+
+    /// The section's own first worked example: "[200004181100;200004181110]/(7d)@DW
+    /// = every Tuesday from 11:00 to 11:10 AM."
+    #[test]
+    fn the_specs_weekly_example_parses() {
+        let weekly = parsable("HL7:PIVL", "[200004181100;200004181110]/(7d)@DW");
+        assert_eq!(
+            weekly.period().expect("a phase has a difference").value,
+            "P7D"
+        );
+        assert_eq!(weekly.calendar_alignment().as_deref(), Some("DW"));
+        assert!(!weekly.institution_specified());
+        assert!(weekly.event_alignment().is_none(), "not event-linked");
+    }
+
+    /// The section's second example: "[200004181100;200004181110]/(1mo)@DM =
+    /// every 18th of the month 11:00 to 11:10 AM."
+    #[test]
+    fn the_specs_monthly_example_parses() {
+        let monthly = parsable("HL7:PIVL", "[200004181100;200004181110]/(1mo)@DM");
+        assert_eq!(monthly.period().expect("a difference").value, "P1M");
+        assert_eq!(monthly.calendar_alignment().as_deref(), Some("DM"));
+    }
+
+    /// The grammar annotates `difference` as ISO-8601 while the same section's
+    /// examples spell it `7d`; both are accepted, and the alignment is optional.
+    #[test]
+    fn an_iso_difference_and_a_missing_alignment_are_both_accepted() {
+        let iso = parsable("HL7:PIVL", "[;]/(P7D)");
+        assert_eq!(iso.period().expect("a difference").value, "P7D");
+        assert!(iso.calendar_alignment().is_none(), "no @ alignment given");
+
+        let hourly = parsable("HL7:PIVL", "[;]/(6h)");
+        assert_eq!(hourly.period().expect("a difference").value, "PT6H");
+        let minutes = parsable("HL7:PIVL", "[;]/(50min)");
+        assert_eq!(minutes.period().expect("a difference").value, "PT50M");
+    }
+
+    /// `phase_linked_time_spec = pure_phase_linked_time_spec [ "IST" ]` — the
+    /// flag is trailing, and it does not become part of the alignment.
+    #[test]
+    fn the_institution_specified_flag_is_read_off_the_end() {
+        let flagged = parsable("HL7:PIVL", "[;]/(7d)@DWIST");
+        assert!(flagged.institution_specified());
+        assert_eq!(
+            flagged.calendar_alignment().as_deref(),
+            Some("DW"),
+            "the flag is not part of the alignment term"
+        );
+        assert!(!parsable("HL7:PIVL", "[;]/(7d)@DW").institution_specified());
+    }
+
+    /// The section's event-linked examples: "PC+[1h;1h]" = one hour after meal,
+    /// "HS-[50min;1h]" = one hour before bedtime. The event is the leading term
+    /// and there is no period — the event-linked grammar has no `difference`.
+    #[test]
+    fn the_specs_event_linked_examples_parse() {
+        let after_meal = parsable("HL7:EIVL", "PC+[1h;1h]");
+        assert_eq!(after_meal.event_alignment().as_deref(), Some("PC"));
+        assert!(after_meal.period().is_none(), "an event has no period");
+        assert!(after_meal.calendar_alignment().is_none());
+        assert!(!after_meal.institution_specified());
+
+        let bedtime = parsable("HL7:EIVL", "HS-[50min;1h]");
+        assert_eq!(bedtime.event_alignment().as_deref(), Some("HS"));
+
+        // `event_linked_time_spec = event | event offset` — a bare event.
+        assert_eq!(
+            parsable("HL7:EIVL", "AC").event_alignment().as_deref(),
+            Some("AC")
+        );
+    }
+
+    /// A difference in neither form yields no period, rather than a duration
+    /// invented from text nobody can parse.
+    #[test]
+    fn an_unreadable_difference_has_no_period() {
+        assert!(parsable("HL7:PIVL", "[;]/(every week)").period().is_none());
+        assert!(parsable("HL7:PIVL", "[;]/(7furlongs)").period().is_none());
+        assert!(parsable("HL7:PIVL", "[;]").period().is_none(), "no phase");
     }
 }

--- a/tools/openehr-codegen/tests/it/unrealized_bmm_functions.txt
+++ b/tools/openehr-codegen/tests/it/unrealized_bmm_functions.txt
@@ -5,6 +5,7 @@
 # asserts the projection equals it EXACTLY, so a new gap fails the build AND a gap
 # that gets implemented must be deleted from here in the same change. It only
 # shrinks. Burn-down is tracked on the issue named in that test.
+base/v1_2/Iso8601_date.timezone
 lang/v1_1/BMM_CLASS.features
 lang/v1_1/BMM_CLASS.flat_features
 lang/v1_1/BMM_CLASS.is_primitive
@@ -21,13 +22,16 @@ lang/v1_1/BMM_MODEL.model_id
 lang/v1_1/BMM_MODEL.subtypes
 lang/v1_1/BMM_MODEL.type_definition
 lang/v1_1/BMM_TYPE.effective_type
+lang/v1_1/BMM_TYPE.is_abstract
 lang/v1_1/BMM_TYPE.is_primitive
 lang/v1_1/BMM_TYPE.unitary_type
 lang/v1_1/P_BMM_CLASS.create_bmm_class
 lang/v1_1/P_BMM_CLASS.populate_bmm_class
 lang/v1_1/P_BMM_SCHEMA.canonical_packages
+lang/v1_1/P_BMM_SCHEMA.create_bmm_model
 lang/v1_1/P_BMM_SCHEMA.load_finalise
 lang/v1_1/P_BMM_SCHEMA.merge
+lang/v1_1/P_BMM_SCHEMA.validate
 lang/v1_1/P_BMM_SCHEMA.validate_created
 lang/v1_1/P_BMM_TYPE.create_bmm_type
 rm/v1_1/AUTHORED_RESOURCE.current_revision
@@ -58,9 +62,6 @@ rm/v1_1/DV_PROPORTION.add
 rm/v1_1/DV_PROPORTION.is_equal
 rm/v1_1/DV_PROPORTION.multiply
 rm/v1_1/DV_PROPORTION.subtract
-rm/v1_1/DV_QUANTITY.add
-rm/v1_1/DV_QUANTITY.multiply
-rm/v1_1/DV_QUANTITY.subtract
 rm/v1_1/DV_TIME.add
 rm/v1_1/DV_TIME.diff
 rm/v1_1/DV_TIME.subtract
@@ -78,6 +79,9 @@ rm/v1_1/ITEM_TABLE.row_count
 rm/v1_1/ITEM_TABLE.row_names
 rm/v1_1/ITEM_TABLE.row_with_key
 rm/v1_1/VERSION.canonical_form
+rm/v1_1/VERSION.data
+rm/v1_1/VERSION.lifecycle_state
+rm/v1_1/VERSION.preceding_version_uid
 rm/v1_1/VERSIONED_OBJECT.all_version_ids
 rm/v1_1/VERSIONED_OBJECT.all_versions
 rm/v1_1/VERSIONED_OBJECT.commit_attestation
@@ -122,9 +126,6 @@ rm/v1_2/DV_PROPORTION.add
 rm/v1_2/DV_PROPORTION.is_equal
 rm/v1_2/DV_PROPORTION.multiply
 rm/v1_2/DV_PROPORTION.subtract
-rm/v1_2/DV_QUANTITY.add
-rm/v1_2/DV_QUANTITY.multiply
-rm/v1_2/DV_QUANTITY.subtract
 rm/v1_2/DV_TIME.add
 rm/v1_2/DV_TIME.diff
 rm/v1_2/DV_TIME.subtract
@@ -142,6 +143,9 @@ rm/v1_2/ITEM_TABLE.row_count
 rm/v1_2/ITEM_TABLE.row_names
 rm/v1_2/ITEM_TABLE.row_with_key
 rm/v1_2/VERSION.canonical_form
+rm/v1_2/VERSION.data
+rm/v1_2/VERSION.lifecycle_state
+rm/v1_2/VERSION.preceding_version_uid
 rm/v1_2/VERSIONED_OBJECT.all_version_ids
 rm/v1_2/VERSIONED_OBJECT.all_versions
 rm/v1_2/VERSIONED_OBJECT.commit_attestation

--- a/tools/openehr-codegen/tests/it/unrealized_bmm_functions.txt
+++ b/tools/openehr-codegen/tests/it/unrealized_bmm_functions.txt
@@ -36,17 +36,6 @@ lang/v1_1/P_BMM_SCHEMA.validate_created
 lang/v1_1/P_BMM_TYPE.create_bmm_type
 rm/v1_1/AUTHORED_RESOURCE.current_revision
 rm/v1_1/AUTHORED_RESOURCE.languages_available
-rm/v1_1/DV_DATE.add
-rm/v1_1/DV_DATE.diff
-rm/v1_1/DV_DATE.is_equal
-rm/v1_1/DV_DATE.subtract
-rm/v1_1/DV_DATE_TIME.add
-rm/v1_1/DV_DATE_TIME.diff
-rm/v1_1/DV_DATE_TIME.subtract
-rm/v1_1/DV_DURATION.add
-rm/v1_1/DV_DURATION.multiply
-rm/v1_1/DV_DURATION.negative
-rm/v1_1/DV_DURATION.subtract
 # ADJUDICATED deliberately absent (#2030 outcome 2). All four are specified as
 # "extracted from value" and nothing more — and `value` is HL7v3 GTS syntax, for
 # which the openEHR spec supplies NO grammar
@@ -54,17 +43,6 @@ rm/v1_1/DV_DURATION.subtract
 # §Functions). Implementing them would mean inventing a parser and calling its
 # output normative, which is the opposite of spec conformance. They stay
 # unrealized until upstream defines the extraction.
-rm/v1_1/DV_PERIODIC_TIME_SPECIFICATION.calendar_alignment
-rm/v1_1/DV_PERIODIC_TIME_SPECIFICATION.event_alignment
-rm/v1_1/DV_PERIODIC_TIME_SPECIFICATION.institution_specified
-rm/v1_1/DV_PERIODIC_TIME_SPECIFICATION.period
-rm/v1_1/DV_PROPORTION.add
-rm/v1_1/DV_PROPORTION.is_equal
-rm/v1_1/DV_PROPORTION.multiply
-rm/v1_1/DV_PROPORTION.subtract
-rm/v1_1/DV_TIME.add
-rm/v1_1/DV_TIME.diff
-rm/v1_1/DV_TIME.subtract
 rm/v1_1/EVENT.offset
 rm/v1_1/ITEM_TABLE.as_hierarchy
 rm/v1_1/ITEM_TABLE.column_count
@@ -100,17 +78,6 @@ rm/v1_1/VERSIONED_OBJECT.version_count
 rm/v1_1/VERSIONED_OBJECT.version_with_id
 rm/v1_2/AUTHORED_RESOURCE.current_revision
 rm/v1_2/AUTHORED_RESOURCE.languages_available
-rm/v1_2/DV_DATE.add
-rm/v1_2/DV_DATE.diff
-rm/v1_2/DV_DATE.is_equal
-rm/v1_2/DV_DATE.subtract
-rm/v1_2/DV_DATE_TIME.add
-rm/v1_2/DV_DATE_TIME.diff
-rm/v1_2/DV_DATE_TIME.subtract
-rm/v1_2/DV_DURATION.add
-rm/v1_2/DV_DURATION.multiply
-rm/v1_2/DV_DURATION.negative
-rm/v1_2/DV_DURATION.subtract
 # ADJUDICATED deliberately absent (#2030 outcome 2). All four are specified as
 # "extracted from value" and nothing more — and `value` is HL7v3 GTS syntax, for
 # which the openEHR spec supplies NO grammar
@@ -118,17 +85,6 @@ rm/v1_2/DV_DURATION.subtract
 # §Functions). Implementing them would mean inventing a parser and calling its
 # output normative, which is the opposite of spec conformance. They stay
 # unrealized until upstream defines the extraction.
-rm/v1_2/DV_PERIODIC_TIME_SPECIFICATION.calendar_alignment
-rm/v1_2/DV_PERIODIC_TIME_SPECIFICATION.event_alignment
-rm/v1_2/DV_PERIODIC_TIME_SPECIFICATION.institution_specified
-rm/v1_2/DV_PERIODIC_TIME_SPECIFICATION.period
-rm/v1_2/DV_PROPORTION.add
-rm/v1_2/DV_PROPORTION.is_equal
-rm/v1_2/DV_PROPORTION.multiply
-rm/v1_2/DV_PROPORTION.subtract
-rm/v1_2/DV_TIME.add
-rm/v1_2/DV_TIME.diff
-rm/v1_2/DV_TIME.subtract
 rm/v1_2/EVENT.offset
 rm/v1_2/ITEM_TABLE.as_hierarchy
 rm/v1_2/ITEM_TABLE.column_count


### PR DESCRIPTION
Refs #2030. **Ratchet 143 → 99; no `DV_*` entry remains.**

## The defect this started from

The previous change implemented `DV_QUANTITY`'s arithmetic and asserted, in a doc comment, that *"the spec says nothing about the precision of a sum or the accuracy of a scaled value"*.

That is false. `dv_amount.adoc` — the class `DV_QUANTITY` **redefines** — specifies accuracy propagation in three clauses, and `master06-quantity_package.adoc` §Accuracy and Uncertainty states them again in prose. `DV_COUNT`, already merged, dropped accuracy on the same false premise. The mistake was reading the subclass table without reading the class it redefines.

`DV_AMOUNT.add` also carries `Pre_comparable: is_strictly_comparable_to (other)`, which `DV_QUANTITY`'s own table omits — so requiring comparability was **the spec's rule**, not this implementation's caution as the previous PR claimed.

## The accuracy rule, realized once

In `dv_amount_impl`, called by every descendant:

- accuracies **sum** — for addition *and* subtraction;
- an unrecorded accuracy on either side makes the result's **unknown** (both `-1` and absence read as unrecorded — a half-range cannot be negative);
- a mixed percent/absolute pair is expressed **in the form of the larger operand**.

The spec says to *add* the two values but never says to convert them, and a percentage plus an absolute half-range is not a number. Converting the losing operand into the winning form is the only reading under which the sum it prescribes exists at all.

**Equal magnitudes are the one genuine gap**: "the larger of the two" then names neither operand. The absolute form wins, because an absolute half-range is interpretable on its own while a percentage is only interpretable against a magnitude. Flagged in the code as our own design and pinned by a test, so a future spec answer shows up as a failure.

A combination no valid value can carry — a percentage past 100 — **refuses the operation** rather than returning a value that fails its own `Accuracy_validity` invariant.

`DV_ABSOLUTE_QUANTITY` redefines accuracy as a `DV_AMOUNT`, so for the temporal types the "sum of the accuracies" is a *duration* sum; that variant is realized in `dv_absolute_quantity_impl`.

## The rest of the family — implemented, not deferred

| Class | Functions |
|---|---|
| `DV_PROPORTION` | `add`, `subtract`, `multiply`, `is_equal` |
| `DV_DURATION` | `add`, `subtract`, `multiply`, `negative` |
| `DV_DATE` | `add`, `subtract`, `diff`, `is_equal` |
| `DV_TIME` / `DV_DATE_TIME` | `add`, `subtract`, `diff` |
| `DV_AMOUNT` | `add`, `subtract`, `multiply`, `negative`, `is_equal`, `less_than` |
| `DV_ABSOLUTE_QUANTITY` | `add`, `subtract`, `diff` |
| `DV_PERIODIC_TIME_SPECIFICATION` | `period`, `calendar_alignment`, `event_alignment`, `institution_specified` |

Notes worth reading:

- **`DV_PROPORTION`** adds over a **common denominator**, which is what keeps `pk_percent`'s 100 and `pk_unitary`'s 1 in place — cross-multiplying two percentages would give a denominator of 10000 and fail `Percent_validity`. A scaled fraction whose numerator stopped being whole is **refused**, not rounded into a different ratio.
- **`DV_DATE.add` is BASE's *arithmetic* addition, not `add_nominal`** — the class declares only `add` — so `P1M` is an average month of seconds and 31 January + P1M lands on 1 March, not on the end of February. My first test asserted the nominal behaviour and failed; the spec was right and the test was wrong. It now **pins the distinction**, because it is the one people get wrong.
- **`DV_PERIODIC_TIME_SPECIFICATION`** parses the HL7 PIVL/EIVL syntax from `master08-time_specification_package.adoc` §Syntaxes. Every worked example in that section is a test. `period()` returns nothing for an event-linked spec: the class types it `1..1`, but the EIVL grammar has no `difference` production at all — an offset from a meal is not a period.
  - The grammar annotates `difference` as "ISO 8601" while the same section's examples spell it `7d` and `1mo`. **Both are accepted** — refusing the second would refuse the specification's own worked examples.

Implementing the concrete classes made the **abstract parents'** gaps visible for the first time (they had no impl file, so the projection could not see them). Rather than record twelve new ratchet entries, `DV_AMOUNT` and `DV_ABSOLUTE_QUANTITY` are now dispatchers over their subtypes.

## Two corrections to already-merged code

1. **`from_f64_retain` → `from_f64`.** The retaining form keeps a float's *binary error*: `Decimal::from_f64_retain(0.1)` is `0.1000000000000000055511151231`. So `count * 0.1` was refused as "not a whole count", and `1/3` did not equal `0.1/0.3`. These functions ask about the decimal the author **wrote**, which is exactly what `from_f64` recovers (verified against the rust_decimal docs, which contrast the two). Regression tests added.
2. **The `cast_precision_loss` suppression is gone.** The accuracy magnitude is a `Decimal` now — exact from an integer, no widening cast, nothing to suppress.

## Verification

607 tests pass across `openehr-rm` and `openehr-codegen`; workspace clippy clean at `-D warnings`; comment-style clean; both generations stamped from one template each. Crates bumped to `0.0.18` in lockstep.