### PR TITLE
feat(rm): ITEM_TABLE's twelve accessors, over the encoding rules that define them

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -27,3 +27,4 @@
 - [Multi-gen refactor: no legacy carried](multi-generation-refactor-no-legacy.md) — residue found under #1936 is removed or filed as a sub-issue of #1936, never kept
 - [No worktrees — one checkout](no-worktrees-single-checkout.md) — every change in the main tree on the current branch; one worker at a time with explicit fences, never `isolation: worktree`
 - [K8s testing uses a compose postgres](k8s-testing-uses-compose-postgres.md) — database runs in docker compose on the host and the chart points at it; never deploy postgres into the test cluster
+- [This is a rewrite, not inherited code](rewrite-not-inherited-code.md) — existing code is never assumed correct; read the ancestor spec + existing code before implementing; breaking changes preferred over preserving bad code; distrust instruments too

--- a/.claude/memory/rewrite-not-inherited-code.md
+++ b/.claude/memory/rewrite-not-inherited-code.md
@@ -1,0 +1,43 @@
+---
+name: rewrite-not-inherited-code
+description: "This is a REWRITE — existing hand-written code is never assumed correct; read the ancestor spec and the existing code before implementing, and prefer a breaking change over preserving bad code"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 7a390181-e5e7-4508-9316-33a300a4aedb
+  modified: 2026-08-11T08:53:10.210Z
+---
+
+Existing code in this repo is prior work, not a baseline. Owner directive
+(2026-08-11, after repeated defects): "old code is bad code and need breaking
+changes so we implement everything proper". Never treat a file as settled
+because it is already merged and green.
+
+**Why:** two defects shipped and were only caught later by accident —
+`DV_COUNT.add` dropped the accuracy `DV_AMOUNT` normatively specifies under a
+doc comment claiming the spec was silent (the redefined ANCESTOR class had
+never been read), and `DV_COUNT.multiply` read a `Real` factor's binary
+approximation rather than the decimal its author wrote. No gate found either.
+The owner's standing complaint is that these were spec-reading and
+code-reading failures, not bad luck.
+
+**How to apply:**
+- Before implementing a spec function, read the class's own table AND every
+  ancestor whose function it redefines/effects. A subclass table routinely
+  omits pre-conditions and rules the parent states.
+- Before writing a method, grep for it — it may already exist, or be produced
+  by a macro applied elsewhere (`ordered_limit!` gives every DV_ORDERED
+  descendant `less_than`/`is_strictly_comparable_to`).
+- Read the region of a file before editing it, and verify the edit landed.
+  Blind string substitution passed its anchor check and still orphaned a
+  `#[test]` attribute.
+- Never add `#[expect]`/`#[allow]` as the first move — the lints are strict
+  deliberately. Find the shape that does not need one (a `Decimal` field
+  instead of an `as f64` cast removed one outright).
+- A wrong spec citation in a doc comment is a DEFECT, not a wording issue.
+- Distrust measurement instruments too: the `unrealized_bmm_functions` ratchet
+  silently skipped any class with no `*_impl.rs` sibling, hiding 239 declared
+  functions (#2247) while reporting 75.
+
+Related: [[spec-chapter-audit-programs]], [[comments-less-is-more]],
+[[owner-work-style]], [[en-route-findings-always-filed]].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
+- **`ITEM_TABLE`'s twelve accessors** on the published spec crates — `row_count`,
+  `column_count`, `row_names`, `column_names`, `ith_row`, `named_row`,
+  `has_row_with_name`, `has_column_with_name`, `has_row_with_key`,
+  `row_with_key`, `element_at_cell_ij` and `as_hierarchy`, which transposes the
+  stored row-per-CLUSTER form into the column CLUSTERs the spec asks for.
+
 - **Every `DV_*` arithmetic and accessor function the openEHR RM defines** is
   now implemented on the published spec crates — the whole quantity and
   date/time family, not a subset: `DV_QUANTITY`, `DV_COUNT`, `DV_PROPORTION`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5485,7 +5485,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "indexmap 2.14.0",
  "openehr-am",
@@ -5500,7 +5500,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "serde",
  "serde_json",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "async-trait",
  "axum",
@@ -5558,7 +5558,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "assert_fs",
  "chumsky",
@@ -5572,7 +5572,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "chumsky",
  "logos",
@@ -5581,7 +5581,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "insta",
  "jsonschema",
@@ -5599,7 +5599,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-adl"
-version = "0.0.18"
+version = "0.0.19"
 description = "openEHR ADL 2.4.0: hand-written ADL2/cADL/ODIN parser, AOM2 validation catalogue, specialisation flattener, OPT2 generator, and ADL 1.4→2 conversion over the generated openehr_am::v2_4::aom2 model"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,10 +16,10 @@ include = ["src/**", "README.md", "LICENSE-MIT"]
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)
-openehr-base = { path = "../openehr-base", version = "0.0.18" }   # VersionStatus for the parsed HRID
-openehr-am = { path = "../openehr-am", version = "0.0.18" }       # v2_4 ArchetypeHrid (the identification target type)
-openehr-rm = { path = "../openehr-rm", version = "0.0.18" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
-openehr-lang = { path = "../openehr-lang", version = "0.0.18" }   # openehr_lang::odin — the ODIN section parser
+openehr-base = { path = "../openehr-base", version = "0.0.19" }   # VersionStatus for the parsed HRID
+openehr-am = { path = "../openehr-am", version = "0.0.19" }       # v2_4 ArchetypeHrid (the identification target type)
+openehr-rm = { path = "../openehr-rm", version = "0.0.19" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
+openehr-lang = { path = "../openehr-lang", version = "0.0.19" }   # openehr_lang::odin — the ODIN section parser
 uuid.workspace = true        # meta uid/build_uid (AUTHORED_ARCHETYPE.uid: Uuid)
 indexmap.workspace = true    # OdinValue::Object body (insertion-ordered map)
 

--- a/crates/openehr-am/Cargo.toml
+++ b/crates/openehr-am/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-am"
-version = "0.0.18"
+version = "0.0.19"
 description = "openEHR AM Archetype Model, generated from BMM: generations v1_4 (AM 1.4.0, ADL 1.4) and v2_4 (AM 2.4.0, ADL 2; current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,8 +13,8 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.18" }
-openehr-lang = { path = "../openehr-lang", version = "0.0.18" }
+openehr-base = { path = "../openehr-base", version = "0.0.19" }
+openehr-lang = { path = "../openehr-lang", version = "0.0.19" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also carries the untyped `Value` fields the generator

--- a/crates/openehr-base/Cargo.toml
+++ b/crates/openehr-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-base"
-version = "0.0.18"
+version = "0.0.19"
 description = "openEHR BASE foundation + base types, generated from BMM: generations v1_2 (BASE 1.2.0) and v1_3 (BASE 1.3.0, current)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-its"
-version = "0.0.18"
+version = "0.0.19"
 description = "openEHR ITS (Implementation Technology Specifications): canonical JSON + canonical XML serialization of the RM, the generated ITS-REST 1.1.0 API contract, OPT 1.4 and AOM2 archetype XML codecs, and the Simplified Formats (FLAT / STRUCTURED / Web Template)"
 edition.workspace = true
 rust-version.workspace = true
@@ -41,14 +41,14 @@ regex = { workspace = true, optional = true }
 fancy-regex = { workspace = true, optional = true }
 # The generated XML (de)serializers impl the crate's ToXml/FromXml traits for the
 # RM/BASE spec types, so these are real (non-dev) deps.
-openehr-base = { path = "../openehr-base", version = "0.0.18", optional = true }
-openehr-rm = { path = "../openehr-rm", version = "0.0.18", optional = true }
+openehr-base = { path = "../openehr-base", version = "0.0.19", optional = true }
+openehr-rm = { path = "../openehr-rm", version = "0.0.19", optional = true }
 # The native canonical-JSON codec (`json_codec/generated`, emit-json) implements
 # `ToJson` for EVERY generated spec type the `OpenEhrType` derive covers, so it
 # spans all five spec crates (not just the RM/BASE the XML codec needs).
-openehr-lang = { path = "../openehr-lang", version = "0.0.18", optional = true }
-openehr-am = { path = "../openehr-am", version = "0.0.18", optional = true }
-openehr-term = { path = "../openehr-term", version = "0.0.18", optional = true }
+openehr-lang = { path = "../openehr-lang", version = "0.0.19", optional = true }
+openehr-am = { path = "../openehr-am", version = "0.0.19", optional = true }
+openehr-term = { path = "../openehr-term", version = "0.0.19", optional = true }
 
 # `full` — every ITS surface (canonical JSON/XML, the generated ITS-REST
 # contract, `opt14`, Simplified Formats). ON BY DEFAULT, so every consumer sees

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-lang"
-version = "0.0.18"
+version = "0.0.19"
 description = "openEHR LANG BMM/P_BMM object model, generated from BMM: generations v1_0 (LANG 1.0.0) and v1_1 (LANG 1.1.0, current; the stable BMM v2.x unit beside the paused BMM3 unit), plus hand-written ODIN/BEL/EL readers"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["parser-implementations", "data-structures"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.18" }
+openehr-base = { path = "../openehr-base", version = "0.0.19" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the
 # generated types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) —
 # never a derive. `serde_json` also carries the untyped `Value` fields the

--- a/crates/openehr-query/Cargo.toml
+++ b/crates/openehr-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-query"
-version = "0.0.18"
+version = "0.0.19"
 description = "openEHR QUERY (AQL 1.1.0): hand-written lexer, parser, typed AST and canonical printer from the official grammar (no ANTLR runtime)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-rm"
-version = "0.0.18"
+version = "0.0.19"
 description = "openEHR RM Reference Model, generated from BMM: generations v1_1 (RM 1.1.0) and v1_2 (RM 1.2.0, current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,11 +13,11 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.18" }
+openehr-base = { path = "../openehr-base", version = "0.0.19" }
 # The terminology-backed RM class invariants (`validate::terminology`) resolve
 # openEHR terminology groups + code sets against the vendored TERM 3.1.0 bundle.
 # `openehr-term` itself depends only on `openehr-base`, so this is acyclic.
-openehr-term = { path = "../openehr-term", version = "0.0.18" }
+openehr-term = { path = "../openehr-term", version = "0.0.19" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also backs the untyped `Value` RM representation used by

--- a/crates/openehr-rm/src/v1_1/data_structures/item_structure/item_table_impl.rs
+++ b/crates/openehr-rm/src/v1_1/data_structures/item_structure/item_table_impl.rs
@@ -20,8 +20,244 @@
 //! column) are our own labels for §Description rules.
 
 use crate::v1_1::data_structures::item_structure::item_table::ItemTable;
+use crate::v1_1::data_structures::representation::cluster::Cluster;
+use crate::v1_1::data_structures::representation::element::Element;
 use crate::v1_1::data_structures::representation::item::Item;
+use crate::v1_1::data_types::basic::data_value::DataValue;
+use crate::v1_1::data_types::text::dv_text::DvText;
 use openehr_base::validate::{InvariantViolation, Validate};
+
+impl ItemTable {
+    /// Number of rows in the table.
+    ///
+    /// Spec: `item_table.adoc` §Functions `row_count`.
+    #[must_use]
+    pub fn row_count(&self) -> usize {
+        self.rows.as_deref().unwrap_or_default().len()
+    }
+
+    /// Number of columns in the table.
+    ///
+    /// Spec: `item_table.adoc` §Functions `column_count`.
+    ///
+    /// Every row carries one `ELEMENT` per column and the `Valid_number_of_rows`
+    /// check above holds them to the same count, so the first row answers for
+    /// the table. An empty table has no columns.
+    #[must_use]
+    pub fn column_count(&self) -> usize {
+        self.rows
+            .as_deref()
+            .unwrap_or_default()
+            .first()
+            .map_or(0, |row| row.items.len())
+    }
+
+    /// The row names.
+    ///
+    /// Spec: `item_table.adoc` §Functions `row_names`, over
+    /// `master04-item_structure_package.adoc` §ITEM_TABLE — "the names of the
+    /// containing `CLUSTER` of each row is the stringified number of the row in
+    /// the overall table."
+    #[must_use]
+    pub fn row_names(&self) -> Vec<DvText> {
+        self.rows
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .map(|row| row.name.clone())
+            .collect()
+    }
+
+    /// The column names.
+    ///
+    /// Spec: `item_table.adoc` §Functions `column_names`, over
+    /// `master04-item_structure_package.adoc` §ITEM_TABLE — "the names of the
+    /// `ELEMENT` in a row are the column names."
+    #[must_use]
+    pub fn column_names(&self) -> Vec<DvText> {
+        self.rows
+            .as_deref()
+            .unwrap_or_default()
+            .first()
+            .into_iter()
+            .flat_map(|row| row.items.iter())
+            .map(|item| match item {
+                Item::Element(element) => element.name.clone(),
+                Item::Cluster(cluster) => cluster.name.clone(),
+            })
+            .collect()
+    }
+
+    /// The i-th row, or `None` when the table has no such row.
+    ///
+    /// Spec: `item_table.adoc` §Functions `ith_row` — "Return i-th row."
+    ///
+    /// `i` is ONE-based. No openEHR spec states the base — BASE's `List` class
+    /// declares no indexed accessor at all — but the encoding rules name each
+    /// row `CLUSTER` after "the stringified number of the row in the overall
+    /// table", so a base that disagreed with those names would make
+    /// `ith_row(i)` and `named_row(i)` return different rows. The two agree by
+    /// construction here, and a test pins it.
+    #[must_use]
+    pub fn ith_row(&self, i: usize) -> Option<&Cluster> {
+        self.rows.as_deref()?.get(i.checked_sub(1)?)
+    }
+
+    /// Returns `true` when a row has name `a_key`.
+    ///
+    /// Spec: `item_table.adoc` §Functions `has_row_with_name`. The published
+    /// description reads "Return `True` if there is a COLUMN with name =
+    /// `a_key`" — word for word what `has_column_with_name` says one row below
+    /// it in the same table. The function name, its position and its
+    /// `named_row` counterpart all say row; the description is a copy of the
+    /// neighbouring cell.
+    #[must_use]
+    pub fn has_row_with_name(&self, a_key: &str) -> bool {
+        self.named_row(a_key).is_some()
+    }
+
+    /// Returns `true` when a column has name `a_key`.
+    ///
+    /// Spec: `item_table.adoc` §Functions `has_column_with_name`.
+    #[must_use]
+    pub fn has_column_with_name(&self, a_key: &str) -> bool {
+        self.column_names()
+            .iter()
+            .any(|name| text_of(name) == a_key)
+    }
+
+    /// The row named `a_key`, or `None` when no row carries that name.
+    ///
+    /// Spec: `item_table.adoc` §Functions `named_row` — "Return row with name =
+    /// `a_key`."
+    #[must_use]
+    pub fn named_row(&self, a_key: &str) -> Option<&Cluster> {
+        self.rows
+            .as_deref()?
+            .iter()
+            .find(|row| text_of(&row.name) == a_key)
+    }
+
+    /// Returns `true` when a row has key `keys`.
+    ///
+    /// Spec: `item_table.adoc` §Functions `has_row_with_key`.
+    #[must_use]
+    pub fn has_row_with_key(&self, keys: &[String]) -> bool {
+        self.row_with_key(keys).is_some()
+    }
+
+    /// The row with key `keys`, or `None` when no row carries it.
+    ///
+    /// Spec: `item_table.adoc` §Functions `row_with_key`, over §Description —
+    /// "some columns may be designated 'key' columns, containing key data for
+    /// each row, in the manner of relational tables."
+    ///
+    /// Two things the spec does not supply, so both are our own design and
+    /// stated as such. It defines no way to DESIGNATE a column as a key column,
+    /// so the key is read from the leading columns — the only ordering the
+    /// class does define is that columns are "named and ordered with respect to
+    /// each other", and relational key columns lead. And `DATA_VALUE` declares
+    /// no function at all, so there is no spec-defined way to render a cell as
+    /// a `String`; a key therefore matches a cell only where that cell IS text,
+    /// which is what "key data" for row-naming means. A quantity-valued cell
+    /// matches no key rather than being stringified by a rule this
+    /// implementation would have had to invent.
+    #[must_use]
+    pub fn row_with_key(&self, keys: &[String]) -> Option<&Cluster> {
+        if keys.is_empty() {
+            return None;
+        }
+        self.rows.as_deref()?.iter().find(|row| {
+            keys.len() <= row.items.len()
+                && keys
+                    .iter()
+                    .zip(row.items.iter())
+                    .all(|(key, item)| cell_text(item).is_some_and(|value| value == key.as_str()))
+        })
+    }
+
+    /// The cell at row `i`, column `j`, or `None` when the table has no such
+    /// cell.
+    ///
+    /// Spec: `item_table.adoc` §Functions `element_at_cell_ij` — "Return cell at
+    /// a particular location." Both indices are one-based, per [`Self::ith_row`].
+    #[must_use]
+    pub fn element_at_cell_ij(&self, i: usize, j: usize) -> Option<&Element> {
+        match self.ith_row(i)?.items.get(j.checked_sub(1)?)? {
+            Item::Element(element) => Some(element),
+            Item::Cluster(_) => None,
+        }
+    }
+
+    /// This table as a CEN EN13606-compatible hierarchy, or `None` for a table
+    /// with no cells.
+    ///
+    /// Spec: `item_table.adoc` §Functions `as_hierarchy` — "Generate a CEN
+    /// EN13606-compatible hierarchy consisting of a single `CLUSTER` containing
+    /// the `CLUSTERs` representing the COLUMNS of this table."
+    ///
+    /// The hierarchy is therefore a TRANSPOSE of the stored form, which is
+    /// row-per-`CLUSTER`: one `CLUSTER` per column, named with the column name,
+    /// holding that column's cell from each row in row order. An empty table
+    /// has no columns to build from, and `CLUSTER.items` is `1..*`, so there is
+    /// no hierarchy to return rather than an ill-formed one.
+    #[must_use]
+    pub fn as_hierarchy(&self) -> Option<Cluster> {
+        let rows = self.rows.as_deref()?;
+        let names = self.column_names();
+        let columns: Vec<Item> = names
+            .into_iter()
+            .enumerate()
+            .filter_map(|(index, name)| {
+                let cells: Vec<Item> = rows
+                    .iter()
+                    .filter_map(|row| row.items.get(index).cloned())
+                    .collect();
+                Some(Item::Cluster(column_cluster(
+                    name,
+                    &self.archetype_node_id,
+                    cells,
+                )?))
+            })
+            .collect();
+        column_cluster(self.name.clone(), &self.archetype_node_id, columns)
+    }
+}
+
+/// A `CLUSTER` over `items`, or `None` when there are none — `CLUSTER.items` is
+/// `1..*`, so an empty one is not a `CLUSTER`.
+fn column_cluster(name: DvText, archetype_node_id: &str, items: Vec<Item>) -> Option<Cluster> {
+    Some(Cluster {
+        name,
+        archetype_node_id: archetype_node_id.to_owned(),
+        uid: None,
+        links: openehr_base::containers::present_nonempty(Vec::new()),
+        archetype_details: None,
+        feeder_audit: None,
+        // NOTE: the only failure is an empty `items`, which is this function's
+        // absent case rather than a defect — see the doc comment.
+        items: openehr_base::containers::NonEmptyVec::new(items).ok()?,
+    })
+}
+
+/// The text of a name, whichever `DV_TEXT` form carries it.
+fn text_of(name: &DvText) -> &str {
+    match name {
+        DvText::DvText(text) => &text.value,
+        DvText::DvCodedText(text) => &text.value,
+    }
+}
+
+/// A cell's value as text, when the cell is text-valued.
+fn cell_text(item: &Item) -> Option<&str> {
+    let Item::Element(element) = item else {
+        return None;
+    };
+    match element.value.as_ref()? {
+        DataValue::DvText(text) => Some(text_of(text)),
+        _ => None,
+    }
+}
 
 impl Validate for ItemTable {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
@@ -58,19 +294,18 @@ impl Validate for ItemTable {
                 DvText::DvText(t) => t.value.clone(),
                 DvText::DvCodedText(t) => t.value.clone(),
             };
-            let signature =
-                |row: &crate::v1_1::data_structures::representation::cluster::Cluster| {
-                    row.items
-                        .iter()
-                        .map(|item| match item {
-                            Item::Element(e) => (
-                                name_of(&e.name),
-                                e.value.as_ref().map(std::mem::discriminant),
-                            ),
-                            Item::Cluster(c) => (name_of(&c.name), None),
-                        })
-                        .collect::<Vec<_>>()
-                };
+            let signature = |row: &Cluster| {
+                row.items
+                    .iter()
+                    .map(|item| match item {
+                        Item::Element(e) => (
+                            name_of(&e.name),
+                            e.value.as_ref().map(std::mem::discriminant),
+                        ),
+                        Item::Cluster(c) => (name_of(&c.name), None),
+                    })
+                    .collect::<Vec<_>>()
+            };
             let first_sig = signature(first);
             if self
                 .rows
@@ -280,6 +515,178 @@ mod tests {
         assert!(
             out.iter().any(|m| m.message.contains("Row_regularity")),
             "name-irregular rows must fail, got {out:?}"
+        );
+    }
+
+    /// A table of two rows and two named columns, with the row `CLUSTER`s named
+    /// per `master04-item_structure_package.adoc` §ITEM_TABLE — "the stringified
+    /// number of the row in the overall table".
+    fn cell(column: &str, value: &str) -> Element {
+        use crate::v1_1::data_types::text::dv_text::DvTextData;
+        Element {
+            name: text(column),
+            archetype_node_id: "at0010".to_owned(),
+            uid: None,
+            links: openehr_base::containers::present_nonempty(Vec::new()),
+            archetype_details: None,
+            feeder_audit: None,
+            null_flavour: None,
+            value: Some(DataValue::DvText(DvText::DvText(DvTextData {
+                value: value.to_owned(),
+                hyperlink: None,
+                formatting: None,
+                mappings: openehr_base::containers::present_nonempty(Vec::new()),
+                language: None,
+                encoding: None,
+            }))),
+            null_reason: None,
+        }
+    }
+
+    fn numbered_row(number: &str, cells: Vec<Element>) -> Cluster {
+        Cluster {
+            name: text(number),
+            archetype_node_id: "at0002".to_owned(),
+            uid: None,
+            links: openehr_base::containers::present_nonempty(Vec::new()),
+            archetype_details: None,
+            feeder_audit: None,
+            items: openehr_base::containers::NonEmptyVec::new(
+                cells.into_iter().map(Item::Element).collect(),
+            )
+            .expect("the fixture row carries cells"),
+        }
+    }
+
+    fn acuity() -> ItemTable {
+        table(vec![
+            numbered_row("1", vec![cell("site", "left eye"), cell("result", "6/6")]),
+            numbered_row("2", vec![cell("site", "right eye"), cell("result", "6/9")]),
+        ])
+    }
+
+    /// The counts and the two name lists, over the encoding rules: the row
+    /// `CLUSTER` names are the row names, the `ELEMENT` names are the column
+    /// names.
+    #[test]
+    fn counts_and_names_come_from_the_encoding_rules() {
+        let acuity = acuity();
+        assert_eq!(acuity.row_count(), 2);
+        assert_eq!(acuity.column_count(), 2);
+        assert_eq!(
+            acuity.row_names().iter().map(text_of).collect::<Vec<_>>(),
+            ["1", "2"]
+        );
+        assert_eq!(
+            acuity
+                .column_names()
+                .iter()
+                .map(text_of)
+                .collect::<Vec<_>>(),
+            ["site", "result"]
+        );
+
+        let empty = table(vec![]);
+        assert_eq!(empty.row_count(), 0);
+        assert_eq!(empty.column_count(), 0);
+        assert!(empty.row_names().is_empty() && empty.column_names().is_empty());
+    }
+
+    /// The index base is not stated by any openEHR spec, so it is pinned to the
+    /// one thing that is: rows are NAMED after their number in the table. If
+    /// `ith_row` disagreed with `named_row`, one of them would be wrong.
+    #[test]
+    fn ith_row_agrees_with_the_row_numbering_that_names_the_rows() {
+        let acuity = acuity();
+        for number in 1..=acuity.row_count() {
+            assert_eq!(
+                acuity.ith_row(number),
+                acuity.named_row(&number.to_string()),
+                "row {number} must be the row named {number}"
+            );
+        }
+        assert!(acuity.ith_row(0).is_none(), "there is no row zero");
+        assert!(acuity.ith_row(3).is_none());
+    }
+
+    /// Lookup by name, on both axes. `has_row_with_name`'s published
+    /// description says "column"; it is the neighbouring cell's text, and this
+    /// asserts the two functions actually differ.
+    #[test]
+    fn name_lookup_distinguishes_rows_from_columns() {
+        let acuity = acuity();
+        assert!(acuity.has_row_with_name("1") && acuity.has_row_with_name("2"));
+        assert!(!acuity.has_row_with_name("site"), "that is a column");
+
+        assert!(acuity.has_column_with_name("site") && acuity.has_column_with_name("result"));
+        assert!(!acuity.has_column_with_name("1"), "that is a row");
+
+        assert!(acuity.named_row("nope").is_none());
+    }
+
+    /// Key lookup reads the leading columns and matches text-valued cells.
+    #[test]
+    fn key_lookup_matches_the_leading_columns() {
+        let acuity = acuity();
+        let key = |values: &[&str]| values.iter().map(|v| (*v).to_owned()).collect::<Vec<_>>();
+
+        assert!(acuity.has_row_with_key(&key(&["left eye"])));
+        assert_eq!(
+            acuity.row_with_key(&key(&["right eye", "6/9"])),
+            acuity.ith_row(2)
+        );
+        assert!(
+            !acuity.has_row_with_key(&key(&["6/6"])),
+            "that is the second column, not the leading key"
+        );
+        assert!(!acuity.has_row_with_key(&key(&["left eye", "6/9"])));
+        assert!(
+            !acuity.has_row_with_key(&[]),
+            "no key selects no row, rather than the first one"
+        );
+        assert!(
+            !acuity.has_row_with_key(&key(&["left eye", "6/6", "extra"])),
+            "a key longer than the row cannot match"
+        );
+    }
+
+    /// Cell access, one-based on both axes.
+    #[test]
+    fn cells_are_addressed_one_based_on_both_axes() {
+        let acuity = acuity();
+        assert_eq!(
+            acuity.element_at_cell_ij(2, 1).map(|e| text_of(&e.name)),
+            Some("site")
+        );
+        assert!(acuity.element_at_cell_ij(0, 1).is_none());
+        assert!(acuity.element_at_cell_ij(1, 0).is_none());
+        assert!(acuity.element_at_cell_ij(1, 3).is_none());
+        assert!(acuity.element_at_cell_ij(3, 1).is_none());
+    }
+
+    /// `as_hierarchy` is a TRANSPOSE: "a single CLUSTER containing the CLUSTERs
+    /// representing the COLUMNS of this table", while the stored form is one
+    /// CLUSTER per row.
+    #[test]
+    fn as_hierarchy_transposes_rows_into_columns() {
+        let hierarchy = acuity().as_hierarchy().expect("a table with cells");
+        assert_eq!(text_of(&hierarchy.name), "table");
+        assert_eq!(hierarchy.items.len(), 2, "one CLUSTER per column");
+
+        let Item::Cluster(site) = &hierarchy.items[0] else {
+            panic!("a column is a CLUSTER");
+        };
+        assert_eq!(text_of(&site.name), "site");
+        assert_eq!(site.items.len(), 2, "one cell per row");
+        assert_eq!(
+            site.items.iter().filter_map(cell_text).collect::<Vec<_>>(),
+            ["left eye", "right eye"],
+            "in row order"
+        );
+
+        assert!(
+            table(vec![]).as_hierarchy().is_none(),
+            "CLUSTER.items is 1..*, so an empty table has no hierarchy"
         );
     }
 }

--- a/crates/openehr-rm/src/v1_2/data_structures/item_structure/item_table_impl.rs
+++ b/crates/openehr-rm/src/v1_2/data_structures/item_structure/item_table_impl.rs
@@ -20,8 +20,244 @@
 //! column) are our own labels for §Description rules.
 
 use crate::v1_2::data_structures::item_structure::item_table::ItemTable;
+use crate::v1_2::data_structures::representation::cluster::Cluster;
+use crate::v1_2::data_structures::representation::element::Element;
 use crate::v1_2::data_structures::representation::item::Item;
+use crate::v1_2::data_types::basic::data_value::DataValue;
+use crate::v1_2::data_types::text::dv_text::DvText;
 use openehr_base::validate::{InvariantViolation, Validate};
+
+impl ItemTable {
+    /// Number of rows in the table.
+    ///
+    /// Spec: `item_table.adoc` §Functions `row_count`.
+    #[must_use]
+    pub fn row_count(&self) -> usize {
+        self.rows.as_deref().unwrap_or_default().len()
+    }
+
+    /// Number of columns in the table.
+    ///
+    /// Spec: `item_table.adoc` §Functions `column_count`.
+    ///
+    /// Every row carries one `ELEMENT` per column and the `Valid_number_of_rows`
+    /// check above holds them to the same count, so the first row answers for
+    /// the table. An empty table has no columns.
+    #[must_use]
+    pub fn column_count(&self) -> usize {
+        self.rows
+            .as_deref()
+            .unwrap_or_default()
+            .first()
+            .map_or(0, |row| row.items.len())
+    }
+
+    /// The row names.
+    ///
+    /// Spec: `item_table.adoc` §Functions `row_names`, over
+    /// `master04-item_structure_package.adoc` §ITEM_TABLE — "the names of the
+    /// containing `CLUSTER` of each row is the stringified number of the row in
+    /// the overall table."
+    #[must_use]
+    pub fn row_names(&self) -> Vec<DvText> {
+        self.rows
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .map(|row| row.name.clone())
+            .collect()
+    }
+
+    /// The column names.
+    ///
+    /// Spec: `item_table.adoc` §Functions `column_names`, over
+    /// `master04-item_structure_package.adoc` §ITEM_TABLE — "the names of the
+    /// `ELEMENT` in a row are the column names."
+    #[must_use]
+    pub fn column_names(&self) -> Vec<DvText> {
+        self.rows
+            .as_deref()
+            .unwrap_or_default()
+            .first()
+            .into_iter()
+            .flat_map(|row| row.items.iter())
+            .map(|item| match item {
+                Item::Element(element) => element.name.clone(),
+                Item::Cluster(cluster) => cluster.name.clone(),
+            })
+            .collect()
+    }
+
+    /// The i-th row, or `None` when the table has no such row.
+    ///
+    /// Spec: `item_table.adoc` §Functions `ith_row` — "Return i-th row."
+    ///
+    /// `i` is ONE-based. No openEHR spec states the base — BASE's `List` class
+    /// declares no indexed accessor at all — but the encoding rules name each
+    /// row `CLUSTER` after "the stringified number of the row in the overall
+    /// table", so a base that disagreed with those names would make
+    /// `ith_row(i)` and `named_row(i)` return different rows. The two agree by
+    /// construction here, and a test pins it.
+    #[must_use]
+    pub fn ith_row(&self, i: usize) -> Option<&Cluster> {
+        self.rows.as_deref()?.get(i.checked_sub(1)?)
+    }
+
+    /// Returns `true` when a row has name `a_key`.
+    ///
+    /// Spec: `item_table.adoc` §Functions `has_row_with_name`. The published
+    /// description reads "Return `True` if there is a COLUMN with name =
+    /// `a_key`" — word for word what `has_column_with_name` says one row below
+    /// it in the same table. The function name, its position and its
+    /// `named_row` counterpart all say row; the description is a copy of the
+    /// neighbouring cell.
+    #[must_use]
+    pub fn has_row_with_name(&self, a_key: &str) -> bool {
+        self.named_row(a_key).is_some()
+    }
+
+    /// Returns `true` when a column has name `a_key`.
+    ///
+    /// Spec: `item_table.adoc` §Functions `has_column_with_name`.
+    #[must_use]
+    pub fn has_column_with_name(&self, a_key: &str) -> bool {
+        self.column_names()
+            .iter()
+            .any(|name| text_of(name) == a_key)
+    }
+
+    /// The row named `a_key`, or `None` when no row carries that name.
+    ///
+    /// Spec: `item_table.adoc` §Functions `named_row` — "Return row with name =
+    /// `a_key`."
+    #[must_use]
+    pub fn named_row(&self, a_key: &str) -> Option<&Cluster> {
+        self.rows
+            .as_deref()?
+            .iter()
+            .find(|row| text_of(&row.name) == a_key)
+    }
+
+    /// Returns `true` when a row has key `keys`.
+    ///
+    /// Spec: `item_table.adoc` §Functions `has_row_with_key`.
+    #[must_use]
+    pub fn has_row_with_key(&self, keys: &[String]) -> bool {
+        self.row_with_key(keys).is_some()
+    }
+
+    /// The row with key `keys`, or `None` when no row carries it.
+    ///
+    /// Spec: `item_table.adoc` §Functions `row_with_key`, over §Description —
+    /// "some columns may be designated 'key' columns, containing key data for
+    /// each row, in the manner of relational tables."
+    ///
+    /// Two things the spec does not supply, so both are our own design and
+    /// stated as such. It defines no way to DESIGNATE a column as a key column,
+    /// so the key is read from the leading columns — the only ordering the
+    /// class does define is that columns are "named and ordered with respect to
+    /// each other", and relational key columns lead. And `DATA_VALUE` declares
+    /// no function at all, so there is no spec-defined way to render a cell as
+    /// a `String`; a key therefore matches a cell only where that cell IS text,
+    /// which is what "key data" for row-naming means. A quantity-valued cell
+    /// matches no key rather than being stringified by a rule this
+    /// implementation would have had to invent.
+    #[must_use]
+    pub fn row_with_key(&self, keys: &[String]) -> Option<&Cluster> {
+        if keys.is_empty() {
+            return None;
+        }
+        self.rows.as_deref()?.iter().find(|row| {
+            keys.len() <= row.items.len()
+                && keys
+                    .iter()
+                    .zip(row.items.iter())
+                    .all(|(key, item)| cell_text(item).is_some_and(|value| value == key.as_str()))
+        })
+    }
+
+    /// The cell at row `i`, column `j`, or `None` when the table has no such
+    /// cell.
+    ///
+    /// Spec: `item_table.adoc` §Functions `element_at_cell_ij` — "Return cell at
+    /// a particular location." Both indices are one-based, per [`Self::ith_row`].
+    #[must_use]
+    pub fn element_at_cell_ij(&self, i: usize, j: usize) -> Option<&Element> {
+        match self.ith_row(i)?.items.get(j.checked_sub(1)?)? {
+            Item::Element(element) => Some(element),
+            Item::Cluster(_) => None,
+        }
+    }
+
+    /// This table as a CEN EN13606-compatible hierarchy, or `None` for a table
+    /// with no cells.
+    ///
+    /// Spec: `item_table.adoc` §Functions `as_hierarchy` — "Generate a CEN
+    /// EN13606-compatible hierarchy consisting of a single `CLUSTER` containing
+    /// the `CLUSTERs` representing the COLUMNS of this table."
+    ///
+    /// The hierarchy is therefore a TRANSPOSE of the stored form, which is
+    /// row-per-`CLUSTER`: one `CLUSTER` per column, named with the column name,
+    /// holding that column's cell from each row in row order. An empty table
+    /// has no columns to build from, and `CLUSTER.items` is `1..*`, so there is
+    /// no hierarchy to return rather than an ill-formed one.
+    #[must_use]
+    pub fn as_hierarchy(&self) -> Option<Cluster> {
+        let rows = self.rows.as_deref()?;
+        let names = self.column_names();
+        let columns: Vec<Item> = names
+            .into_iter()
+            .enumerate()
+            .filter_map(|(index, name)| {
+                let cells: Vec<Item> = rows
+                    .iter()
+                    .filter_map(|row| row.items.get(index).cloned())
+                    .collect();
+                Some(Item::Cluster(column_cluster(
+                    name,
+                    &self.archetype_node_id,
+                    cells,
+                )?))
+            })
+            .collect();
+        column_cluster(self.name.clone(), &self.archetype_node_id, columns)
+    }
+}
+
+/// A `CLUSTER` over `items`, or `None` when there are none — `CLUSTER.items` is
+/// `1..*`, so an empty one is not a `CLUSTER`.
+fn column_cluster(name: DvText, archetype_node_id: &str, items: Vec<Item>) -> Option<Cluster> {
+    Some(Cluster {
+        name,
+        archetype_node_id: archetype_node_id.to_owned(),
+        uid: None,
+        links: openehr_base::containers::present_nonempty(Vec::new()),
+        archetype_details: None,
+        feeder_audit: None,
+        // NOTE: the only failure is an empty `items`, which is this function's
+        // absent case rather than a defect — see the doc comment.
+        items: openehr_base::containers::NonEmptyVec::new(items).ok()?,
+    })
+}
+
+/// The text of a name, whichever `DV_TEXT` form carries it.
+fn text_of(name: &DvText) -> &str {
+    match name {
+        DvText::DvText(text) => &text.value,
+        DvText::DvCodedText(text) => &text.value,
+    }
+}
+
+/// A cell's value as text, when the cell is text-valued.
+fn cell_text(item: &Item) -> Option<&str> {
+    let Item::Element(element) = item else {
+        return None;
+    };
+    match element.value.as_ref()? {
+        DataValue::DvText(text) => Some(text_of(text)),
+        _ => None,
+    }
+}
 
 impl Validate for ItemTable {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
@@ -58,19 +294,18 @@ impl Validate for ItemTable {
                 DvText::DvText(t) => t.value.clone(),
                 DvText::DvCodedText(t) => t.value.clone(),
             };
-            let signature =
-                |row: &crate::v1_2::data_structures::representation::cluster::Cluster| {
-                    row.items
-                        .iter()
-                        .map(|item| match item {
-                            Item::Element(e) => (
-                                name_of(&e.name),
-                                e.value.as_ref().map(std::mem::discriminant),
-                            ),
-                            Item::Cluster(c) => (name_of(&c.name), None),
-                        })
-                        .collect::<Vec<_>>()
-                };
+            let signature = |row: &Cluster| {
+                row.items
+                    .iter()
+                    .map(|item| match item {
+                        Item::Element(e) => (
+                            name_of(&e.name),
+                            e.value.as_ref().map(std::mem::discriminant),
+                        ),
+                        Item::Cluster(c) => (name_of(&c.name), None),
+                    })
+                    .collect::<Vec<_>>()
+            };
             let first_sig = signature(first);
             if self
                 .rows
@@ -280,6 +515,178 @@ mod tests {
         assert!(
             out.iter().any(|m| m.message.contains("Row_regularity")),
             "name-irregular rows must fail, got {out:?}"
+        );
+    }
+
+    /// A table of two rows and two named columns, with the row `CLUSTER`s named
+    /// per `master04-item_structure_package.adoc` §ITEM_TABLE — "the stringified
+    /// number of the row in the overall table".
+    fn cell(column: &str, value: &str) -> Element {
+        use crate::v1_2::data_types::text::dv_text::DvTextData;
+        Element {
+            name: text(column),
+            archetype_node_id: "at0010".to_owned(),
+            uid: None,
+            links: openehr_base::containers::present_nonempty(Vec::new()),
+            archetype_details: None,
+            feeder_audit: None,
+            null_flavour: None,
+            value: Some(DataValue::DvText(DvText::DvText(DvTextData {
+                value: value.to_owned(),
+                hyperlink: None,
+                formatting: None,
+                mappings: openehr_base::containers::present_nonempty(Vec::new()),
+                language: None,
+                encoding: None,
+            }))),
+            null_reason: None,
+        }
+    }
+
+    fn numbered_row(number: &str, cells: Vec<Element>) -> Cluster {
+        Cluster {
+            name: text(number),
+            archetype_node_id: "at0002".to_owned(),
+            uid: None,
+            links: openehr_base::containers::present_nonempty(Vec::new()),
+            archetype_details: None,
+            feeder_audit: None,
+            items: openehr_base::containers::NonEmptyVec::new(
+                cells.into_iter().map(Item::Element).collect(),
+            )
+            .expect("the fixture row carries cells"),
+        }
+    }
+
+    fn acuity() -> ItemTable {
+        table(vec![
+            numbered_row("1", vec![cell("site", "left eye"), cell("result", "6/6")]),
+            numbered_row("2", vec![cell("site", "right eye"), cell("result", "6/9")]),
+        ])
+    }
+
+    /// The counts and the two name lists, over the encoding rules: the row
+    /// `CLUSTER` names are the row names, the `ELEMENT` names are the column
+    /// names.
+    #[test]
+    fn counts_and_names_come_from_the_encoding_rules() {
+        let acuity = acuity();
+        assert_eq!(acuity.row_count(), 2);
+        assert_eq!(acuity.column_count(), 2);
+        assert_eq!(
+            acuity.row_names().iter().map(text_of).collect::<Vec<_>>(),
+            ["1", "2"]
+        );
+        assert_eq!(
+            acuity
+                .column_names()
+                .iter()
+                .map(text_of)
+                .collect::<Vec<_>>(),
+            ["site", "result"]
+        );
+
+        let empty = table(vec![]);
+        assert_eq!(empty.row_count(), 0);
+        assert_eq!(empty.column_count(), 0);
+        assert!(empty.row_names().is_empty() && empty.column_names().is_empty());
+    }
+
+    /// The index base is not stated by any openEHR spec, so it is pinned to the
+    /// one thing that is: rows are NAMED after their number in the table. If
+    /// `ith_row` disagreed with `named_row`, one of them would be wrong.
+    #[test]
+    fn ith_row_agrees_with_the_row_numbering_that_names_the_rows() {
+        let acuity = acuity();
+        for number in 1..=acuity.row_count() {
+            assert_eq!(
+                acuity.ith_row(number),
+                acuity.named_row(&number.to_string()),
+                "row {number} must be the row named {number}"
+            );
+        }
+        assert!(acuity.ith_row(0).is_none(), "there is no row zero");
+        assert!(acuity.ith_row(3).is_none());
+    }
+
+    /// Lookup by name, on both axes. `has_row_with_name`'s published
+    /// description says "column"; it is the neighbouring cell's text, and this
+    /// asserts the two functions actually differ.
+    #[test]
+    fn name_lookup_distinguishes_rows_from_columns() {
+        let acuity = acuity();
+        assert!(acuity.has_row_with_name("1") && acuity.has_row_with_name("2"));
+        assert!(!acuity.has_row_with_name("site"), "that is a column");
+
+        assert!(acuity.has_column_with_name("site") && acuity.has_column_with_name("result"));
+        assert!(!acuity.has_column_with_name("1"), "that is a row");
+
+        assert!(acuity.named_row("nope").is_none());
+    }
+
+    /// Key lookup reads the leading columns and matches text-valued cells.
+    #[test]
+    fn key_lookup_matches_the_leading_columns() {
+        let acuity = acuity();
+        let key = |values: &[&str]| values.iter().map(|v| (*v).to_owned()).collect::<Vec<_>>();
+
+        assert!(acuity.has_row_with_key(&key(&["left eye"])));
+        assert_eq!(
+            acuity.row_with_key(&key(&["right eye", "6/9"])),
+            acuity.ith_row(2)
+        );
+        assert!(
+            !acuity.has_row_with_key(&key(&["6/6"])),
+            "that is the second column, not the leading key"
+        );
+        assert!(!acuity.has_row_with_key(&key(&["left eye", "6/9"])));
+        assert!(
+            !acuity.has_row_with_key(&[]),
+            "no key selects no row, rather than the first one"
+        );
+        assert!(
+            !acuity.has_row_with_key(&key(&["left eye", "6/6", "extra"])),
+            "a key longer than the row cannot match"
+        );
+    }
+
+    /// Cell access, one-based on both axes.
+    #[test]
+    fn cells_are_addressed_one_based_on_both_axes() {
+        let acuity = acuity();
+        assert_eq!(
+            acuity.element_at_cell_ij(2, 1).map(|e| text_of(&e.name)),
+            Some("site")
+        );
+        assert!(acuity.element_at_cell_ij(0, 1).is_none());
+        assert!(acuity.element_at_cell_ij(1, 0).is_none());
+        assert!(acuity.element_at_cell_ij(1, 3).is_none());
+        assert!(acuity.element_at_cell_ij(3, 1).is_none());
+    }
+
+    /// `as_hierarchy` is a TRANSPOSE: "a single CLUSTER containing the CLUSTERs
+    /// representing the COLUMNS of this table", while the stored form is one
+    /// CLUSTER per row.
+    #[test]
+    fn as_hierarchy_transposes_rows_into_columns() {
+        let hierarchy = acuity().as_hierarchy().expect("a table with cells");
+        assert_eq!(text_of(&hierarchy.name), "table");
+        assert_eq!(hierarchy.items.len(), 2, "one CLUSTER per column");
+
+        let Item::Cluster(site) = &hierarchy.items[0] else {
+            panic!("a column is a CLUSTER");
+        };
+        assert_eq!(text_of(&site.name), "site");
+        assert_eq!(site.items.len(), 2, "one cell per row");
+        assert_eq!(
+            site.items.iter().filter_map(cell_text).collect::<Vec<_>>(),
+            ["left eye", "right eye"],
+            "in row order"
+        );
+
+        assert!(
+            table(vec![]).as_hierarchy().is_none(),
+            "CLUSTER.items is 1..*, so an empty table has no hierarchy"
         );
     }
 }

--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-term"
-version = "0.0.18"
+version = "0.0.19"
 description = "openEHR TERM terminology data model, generated from BMM (generation v3_1 = TERM 3.1.0), plus the embedded official terminology XML bundle"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["data-structures", "science"]
 include = ["src/**", "assets/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.18" }
+openehr-base = { path = "../openehr-base", version = "0.0.19" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive.

--- a/tools/openehr-codegen/templates/openehr-rm/data_structures/item_structure/item_table_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/data_structures/item_structure/item_table_impl.rs
@@ -19,8 +19,244 @@
 //! column) are our own labels for §Description rules.
 
 use crate::v1_2::data_structures::item_structure::item_table::ItemTable;
+use crate::v1_2::data_structures::representation::cluster::Cluster;
+use crate::v1_2::data_structures::representation::element::Element;
 use crate::v1_2::data_structures::representation::item::Item;
+use crate::v1_2::data_types::basic::data_value::DataValue;
+use crate::v1_2::data_types::text::dv_text::DvText;
 use openehr_base::validate::{InvariantViolation, Validate};
+
+impl ItemTable {
+    /// Number of rows in the table.
+    ///
+    /// Spec: `item_table.adoc` §Functions `row_count`.
+    #[must_use]
+    pub fn row_count(&self) -> usize {
+        self.rows.as_deref().unwrap_or_default().len()
+    }
+
+    /// Number of columns in the table.
+    ///
+    /// Spec: `item_table.adoc` §Functions `column_count`.
+    ///
+    /// Every row carries one `ELEMENT` per column and the `Valid_number_of_rows`
+    /// check above holds them to the same count, so the first row answers for
+    /// the table. An empty table has no columns.
+    #[must_use]
+    pub fn column_count(&self) -> usize {
+        self.rows
+            .as_deref()
+            .unwrap_or_default()
+            .first()
+            .map_or(0, |row| row.items.len())
+    }
+
+    /// The row names.
+    ///
+    /// Spec: `item_table.adoc` §Functions `row_names`, over
+    /// `master04-item_structure_package.adoc` §ITEM_TABLE — "the names of the
+    /// containing `CLUSTER` of each row is the stringified number of the row in
+    /// the overall table."
+    #[must_use]
+    pub fn row_names(&self) -> Vec<DvText> {
+        self.rows
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .map(|row| row.name.clone())
+            .collect()
+    }
+
+    /// The column names.
+    ///
+    /// Spec: `item_table.adoc` §Functions `column_names`, over
+    /// `master04-item_structure_package.adoc` §ITEM_TABLE — "the names of the
+    /// `ELEMENT` in a row are the column names."
+    #[must_use]
+    pub fn column_names(&self) -> Vec<DvText> {
+        self.rows
+            .as_deref()
+            .unwrap_or_default()
+            .first()
+            .into_iter()
+            .flat_map(|row| row.items.iter())
+            .map(|item| match item {
+                Item::Element(element) => element.name.clone(),
+                Item::Cluster(cluster) => cluster.name.clone(),
+            })
+            .collect()
+    }
+
+    /// The i-th row, or `None` when the table has no such row.
+    ///
+    /// Spec: `item_table.adoc` §Functions `ith_row` — "Return i-th row."
+    ///
+    /// `i` is ONE-based. No openEHR spec states the base — BASE's `List` class
+    /// declares no indexed accessor at all — but the encoding rules name each
+    /// row `CLUSTER` after "the stringified number of the row in the overall
+    /// table", so a base that disagreed with those names would make
+    /// `ith_row(i)` and `named_row(i)` return different rows. The two agree by
+    /// construction here, and a test pins it.
+    #[must_use]
+    pub fn ith_row(&self, i: usize) -> Option<&Cluster> {
+        self.rows.as_deref()?.get(i.checked_sub(1)?)
+    }
+
+    /// Returns `true` when a row has name `a_key`.
+    ///
+    /// Spec: `item_table.adoc` §Functions `has_row_with_name`. The published
+    /// description reads "Return `True` if there is a COLUMN with name =
+    /// `a_key`" — word for word what `has_column_with_name` says one row below
+    /// it in the same table. The function name, its position and its
+    /// `named_row` counterpart all say row; the description is a copy of the
+    /// neighbouring cell.
+    #[must_use]
+    pub fn has_row_with_name(&self, a_key: &str) -> bool {
+        self.named_row(a_key).is_some()
+    }
+
+    /// Returns `true` when a column has name `a_key`.
+    ///
+    /// Spec: `item_table.adoc` §Functions `has_column_with_name`.
+    #[must_use]
+    pub fn has_column_with_name(&self, a_key: &str) -> bool {
+        self.column_names()
+            .iter()
+            .any(|name| text_of(name) == a_key)
+    }
+
+    /// The row named `a_key`, or `None` when no row carries that name.
+    ///
+    /// Spec: `item_table.adoc` §Functions `named_row` — "Return row with name =
+    /// `a_key`."
+    #[must_use]
+    pub fn named_row(&self, a_key: &str) -> Option<&Cluster> {
+        self.rows
+            .as_deref()?
+            .iter()
+            .find(|row| text_of(&row.name) == a_key)
+    }
+
+    /// Returns `true` when a row has key `keys`.
+    ///
+    /// Spec: `item_table.adoc` §Functions `has_row_with_key`.
+    #[must_use]
+    pub fn has_row_with_key(&self, keys: &[String]) -> bool {
+        self.row_with_key(keys).is_some()
+    }
+
+    /// The row with key `keys`, or `None` when no row carries it.
+    ///
+    /// Spec: `item_table.adoc` §Functions `row_with_key`, over §Description —
+    /// "some columns may be designated 'key' columns, containing key data for
+    /// each row, in the manner of relational tables."
+    ///
+    /// Two things the spec does not supply, so both are our own design and
+    /// stated as such. It defines no way to DESIGNATE a column as a key column,
+    /// so the key is read from the leading columns — the only ordering the
+    /// class does define is that columns are "named and ordered with respect to
+    /// each other", and relational key columns lead. And `DATA_VALUE` declares
+    /// no function at all, so there is no spec-defined way to render a cell as
+    /// a `String`; a key therefore matches a cell only where that cell IS text,
+    /// which is what "key data" for row-naming means. A quantity-valued cell
+    /// matches no key rather than being stringified by a rule this
+    /// implementation would have had to invent.
+    #[must_use]
+    pub fn row_with_key(&self, keys: &[String]) -> Option<&Cluster> {
+        if keys.is_empty() {
+            return None;
+        }
+        self.rows.as_deref()?.iter().find(|row| {
+            keys.len() <= row.items.len()
+                && keys
+                    .iter()
+                    .zip(row.items.iter())
+                    .all(|(key, item)| cell_text(item).is_some_and(|value| value == key.as_str()))
+        })
+    }
+
+    /// The cell at row `i`, column `j`, or `None` when the table has no such
+    /// cell.
+    ///
+    /// Spec: `item_table.adoc` §Functions `element_at_cell_ij` — "Return cell at
+    /// a particular location." Both indices are one-based, per [`Self::ith_row`].
+    #[must_use]
+    pub fn element_at_cell_ij(&self, i: usize, j: usize) -> Option<&Element> {
+        match self.ith_row(i)?.items.get(j.checked_sub(1)?)? {
+            Item::Element(element) => Some(element),
+            Item::Cluster(_) => None,
+        }
+    }
+
+    /// This table as a CEN EN13606-compatible hierarchy, or `None` for a table
+    /// with no cells.
+    ///
+    /// Spec: `item_table.adoc` §Functions `as_hierarchy` — "Generate a CEN
+    /// EN13606-compatible hierarchy consisting of a single `CLUSTER` containing
+    /// the `CLUSTERs` representing the COLUMNS of this table."
+    ///
+    /// The hierarchy is therefore a TRANSPOSE of the stored form, which is
+    /// row-per-`CLUSTER`: one `CLUSTER` per column, named with the column name,
+    /// holding that column's cell from each row in row order. An empty table
+    /// has no columns to build from, and `CLUSTER.items` is `1..*`, so there is
+    /// no hierarchy to return rather than an ill-formed one.
+    #[must_use]
+    pub fn as_hierarchy(&self) -> Option<Cluster> {
+        let rows = self.rows.as_deref()?;
+        let names = self.column_names();
+        let columns: Vec<Item> = names
+            .into_iter()
+            .enumerate()
+            .filter_map(|(index, name)| {
+                let cells: Vec<Item> = rows
+                    .iter()
+                    .filter_map(|row| row.items.get(index).cloned())
+                    .collect();
+                Some(Item::Cluster(column_cluster(
+                    name,
+                    &self.archetype_node_id,
+                    cells,
+                )?))
+            })
+            .collect();
+        column_cluster(self.name.clone(), &self.archetype_node_id, columns)
+    }
+}
+
+/// A `CLUSTER` over `items`, or `None` when there are none — `CLUSTER.items` is
+/// `1..*`, so an empty one is not a `CLUSTER`.
+fn column_cluster(name: DvText, archetype_node_id: &str, items: Vec<Item>) -> Option<Cluster> {
+    Some(Cluster {
+        name,
+        archetype_node_id: archetype_node_id.to_owned(),
+        uid: None,
+        links: openehr_base::containers::present_nonempty(Vec::new()),
+        archetype_details: None,
+        feeder_audit: None,
+        // NOTE: the only failure is an empty `items`, which is this function's
+        // absent case rather than a defect — see the doc comment.
+        items: openehr_base::containers::NonEmptyVec::new(items).ok()?,
+    })
+}
+
+/// The text of a name, whichever `DV_TEXT` form carries it.
+fn text_of(name: &DvText) -> &str {
+    match name {
+        DvText::DvText(text) => &text.value,
+        DvText::DvCodedText(text) => &text.value,
+    }
+}
+
+/// A cell's value as text, when the cell is text-valued.
+fn cell_text(item: &Item) -> Option<&str> {
+    let Item::Element(element) = item else {
+        return None;
+    };
+    match element.value.as_ref()? {
+        DataValue::DvText(text) => Some(text_of(text)),
+        _ => None,
+    }
+}
 
 impl Validate for ItemTable {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
@@ -57,19 +293,18 @@ impl Validate for ItemTable {
                 DvText::DvText(t) => t.value.clone(),
                 DvText::DvCodedText(t) => t.value.clone(),
             };
-            let signature =
-                |row: &crate::v1_2::data_structures::representation::cluster::Cluster| {
-                    row.items
-                        .iter()
-                        .map(|item| match item {
-                            Item::Element(e) => (
-                                name_of(&e.name),
-                                e.value.as_ref().map(std::mem::discriminant),
-                            ),
-                            Item::Cluster(c) => (name_of(&c.name), None),
-                        })
-                        .collect::<Vec<_>>()
-                };
+            let signature = |row: &Cluster| {
+                row.items
+                    .iter()
+                    .map(|item| match item {
+                        Item::Element(e) => (
+                            name_of(&e.name),
+                            e.value.as_ref().map(std::mem::discriminant),
+                        ),
+                        Item::Cluster(c) => (name_of(&c.name), None),
+                    })
+                    .collect::<Vec<_>>()
+            };
             let first_sig = signature(first);
             if self
                 .rows
@@ -279,6 +514,178 @@ mod tests {
         assert!(
             out.iter().any(|m| m.message.contains("Row_regularity")),
             "name-irregular rows must fail, got {out:?}"
+        );
+    }
+
+    /// A table of two rows and two named columns, with the row `CLUSTER`s named
+    /// per `master04-item_structure_package.adoc` §ITEM_TABLE — "the stringified
+    /// number of the row in the overall table".
+    fn cell(column: &str, value: &str) -> Element {
+        use crate::v1_2::data_types::text::dv_text::DvTextData;
+        Element {
+            name: text(column),
+            archetype_node_id: "at0010".to_owned(),
+            uid: None,
+            links: openehr_base::containers::present_nonempty(Vec::new()),
+            archetype_details: None,
+            feeder_audit: None,
+            null_flavour: None,
+            value: Some(DataValue::DvText(DvText::DvText(DvTextData {
+                value: value.to_owned(),
+                hyperlink: None,
+                formatting: None,
+                mappings: openehr_base::containers::present_nonempty(Vec::new()),
+                language: None,
+                encoding: None,
+            }))),
+            null_reason: None,
+        }
+    }
+
+    fn numbered_row(number: &str, cells: Vec<Element>) -> Cluster {
+        Cluster {
+            name: text(number),
+            archetype_node_id: "at0002".to_owned(),
+            uid: None,
+            links: openehr_base::containers::present_nonempty(Vec::new()),
+            archetype_details: None,
+            feeder_audit: None,
+            items: openehr_base::containers::NonEmptyVec::new(
+                cells.into_iter().map(Item::Element).collect(),
+            )
+            .expect("the fixture row carries cells"),
+        }
+    }
+
+    fn acuity() -> ItemTable {
+        table(vec![
+            numbered_row("1", vec![cell("site", "left eye"), cell("result", "6/6")]),
+            numbered_row("2", vec![cell("site", "right eye"), cell("result", "6/9")]),
+        ])
+    }
+
+    /// The counts and the two name lists, over the encoding rules: the row
+    /// `CLUSTER` names are the row names, the `ELEMENT` names are the column
+    /// names.
+    #[test]
+    fn counts_and_names_come_from_the_encoding_rules() {
+        let acuity = acuity();
+        assert_eq!(acuity.row_count(), 2);
+        assert_eq!(acuity.column_count(), 2);
+        assert_eq!(
+            acuity.row_names().iter().map(text_of).collect::<Vec<_>>(),
+            ["1", "2"]
+        );
+        assert_eq!(
+            acuity
+                .column_names()
+                .iter()
+                .map(text_of)
+                .collect::<Vec<_>>(),
+            ["site", "result"]
+        );
+
+        let empty = table(vec![]);
+        assert_eq!(empty.row_count(), 0);
+        assert_eq!(empty.column_count(), 0);
+        assert!(empty.row_names().is_empty() && empty.column_names().is_empty());
+    }
+
+    /// The index base is not stated by any openEHR spec, so it is pinned to the
+    /// one thing that is: rows are NAMED after their number in the table. If
+    /// `ith_row` disagreed with `named_row`, one of them would be wrong.
+    #[test]
+    fn ith_row_agrees_with_the_row_numbering_that_names_the_rows() {
+        let acuity = acuity();
+        for number in 1..=acuity.row_count() {
+            assert_eq!(
+                acuity.ith_row(number),
+                acuity.named_row(&number.to_string()),
+                "row {number} must be the row named {number}"
+            );
+        }
+        assert!(acuity.ith_row(0).is_none(), "there is no row zero");
+        assert!(acuity.ith_row(3).is_none());
+    }
+
+    /// Lookup by name, on both axes. `has_row_with_name`'s published
+    /// description says "column"; it is the neighbouring cell's text, and this
+    /// asserts the two functions actually differ.
+    #[test]
+    fn name_lookup_distinguishes_rows_from_columns() {
+        let acuity = acuity();
+        assert!(acuity.has_row_with_name("1") && acuity.has_row_with_name("2"));
+        assert!(!acuity.has_row_with_name("site"), "that is a column");
+
+        assert!(acuity.has_column_with_name("site") && acuity.has_column_with_name("result"));
+        assert!(!acuity.has_column_with_name("1"), "that is a row");
+
+        assert!(acuity.named_row("nope").is_none());
+    }
+
+    /// Key lookup reads the leading columns and matches text-valued cells.
+    #[test]
+    fn key_lookup_matches_the_leading_columns() {
+        let acuity = acuity();
+        let key = |values: &[&str]| values.iter().map(|v| (*v).to_owned()).collect::<Vec<_>>();
+
+        assert!(acuity.has_row_with_key(&key(&["left eye"])));
+        assert_eq!(
+            acuity.row_with_key(&key(&["right eye", "6/9"])),
+            acuity.ith_row(2)
+        );
+        assert!(
+            !acuity.has_row_with_key(&key(&["6/6"])),
+            "that is the second column, not the leading key"
+        );
+        assert!(!acuity.has_row_with_key(&key(&["left eye", "6/9"])));
+        assert!(
+            !acuity.has_row_with_key(&[]),
+            "no key selects no row, rather than the first one"
+        );
+        assert!(
+            !acuity.has_row_with_key(&key(&["left eye", "6/6", "extra"])),
+            "a key longer than the row cannot match"
+        );
+    }
+
+    /// Cell access, one-based on both axes.
+    #[test]
+    fn cells_are_addressed_one_based_on_both_axes() {
+        let acuity = acuity();
+        assert_eq!(
+            acuity.element_at_cell_ij(2, 1).map(|e| text_of(&e.name)),
+            Some("site")
+        );
+        assert!(acuity.element_at_cell_ij(0, 1).is_none());
+        assert!(acuity.element_at_cell_ij(1, 0).is_none());
+        assert!(acuity.element_at_cell_ij(1, 3).is_none());
+        assert!(acuity.element_at_cell_ij(3, 1).is_none());
+    }
+
+    /// `as_hierarchy` is a TRANSPOSE: "a single CLUSTER containing the CLUSTERs
+    /// representing the COLUMNS of this table", while the stored form is one
+    /// CLUSTER per row.
+    #[test]
+    fn as_hierarchy_transposes_rows_into_columns() {
+        let hierarchy = acuity().as_hierarchy().expect("a table with cells");
+        assert_eq!(text_of(&hierarchy.name), "table");
+        assert_eq!(hierarchy.items.len(), 2, "one CLUSTER per column");
+
+        let Item::Cluster(site) = &hierarchy.items[0] else {
+            panic!("a column is a CLUSTER");
+        };
+        assert_eq!(text_of(&site.name), "site");
+        assert_eq!(site.items.len(), 2, "one cell per row");
+        assert_eq!(
+            site.items.iter().filter_map(cell_text).collect::<Vec<_>>(),
+            ["left eye", "right eye"],
+            "in row order"
+        );
+
+        assert!(
+            table(vec![]).as_hierarchy().is_none(),
+            "CLUSTER.items is 1..*, so an empty table has no hierarchy"
         );
     }
 }

--- a/tools/openehr-codegen/tests/it/unrealized_bmm_functions.txt
+++ b/tools/openehr-codegen/tests/it/unrealized_bmm_functions.txt
@@ -44,18 +44,6 @@ rm/v1_1/AUTHORED_RESOURCE.languages_available
 # output normative, which is the opposite of spec conformance. They stay
 # unrealized until upstream defines the extraction.
 rm/v1_1/EVENT.offset
-rm/v1_1/ITEM_TABLE.as_hierarchy
-rm/v1_1/ITEM_TABLE.column_count
-rm/v1_1/ITEM_TABLE.column_names
-rm/v1_1/ITEM_TABLE.element_at_cell_ij
-rm/v1_1/ITEM_TABLE.has_column_with_name
-rm/v1_1/ITEM_TABLE.has_row_with_key
-rm/v1_1/ITEM_TABLE.has_row_with_name
-rm/v1_1/ITEM_TABLE.ith_row
-rm/v1_1/ITEM_TABLE.named_row
-rm/v1_1/ITEM_TABLE.row_count
-rm/v1_1/ITEM_TABLE.row_names
-rm/v1_1/ITEM_TABLE.row_with_key
 rm/v1_1/VERSION.canonical_form
 rm/v1_1/VERSION.data
 rm/v1_1/VERSION.lifecycle_state
@@ -86,18 +74,6 @@ rm/v1_2/AUTHORED_RESOURCE.languages_available
 # output normative, which is the opposite of spec conformance. They stay
 # unrealized until upstream defines the extraction.
 rm/v1_2/EVENT.offset
-rm/v1_2/ITEM_TABLE.as_hierarchy
-rm/v1_2/ITEM_TABLE.column_count
-rm/v1_2/ITEM_TABLE.column_names
-rm/v1_2/ITEM_TABLE.element_at_cell_ij
-rm/v1_2/ITEM_TABLE.has_column_with_name
-rm/v1_2/ITEM_TABLE.has_row_with_key
-rm/v1_2/ITEM_TABLE.has_row_with_name
-rm/v1_2/ITEM_TABLE.ith_row
-rm/v1_2/ITEM_TABLE.named_row
-rm/v1_2/ITEM_TABLE.row_count
-rm/v1_2/ITEM_TABLE.row_names
-rm/v1_2/ITEM_TABLE.row_with_key
 rm/v1_2/VERSION.canonical_form
 rm/v1_2/VERSION.data
 rm/v1_2/VERSION.lifecycle_state


### PR DESCRIPTION
Refs #2030. **Ratchet 99 → 75.** Upstream defects reported as #2246.

## The class table is not enough on its own

`item_table.adoc` §Functions gives no index base, no way to designate a key column, and its `has_row_with_name` description is a **verbatim copy** of the `has_column_with_name` cell directly below it. `master04-item_structure_package.adoc` §ITEM_TABLE supplies the encoding rules that fill most of the gap; where it does not, the code says so.

## Index base — pinned by the spec's own row naming

BASE's `List` class declares **no indexed accessor at all** (only `first`/`last`), so there is no inherited convention. But the encoding rules name each row `CLUSTER` after *"the stringified number of the row in the overall table"* — so a base disagreeing with those names would make `ith_row(i)` and `named_row(i)` return different rows.

One-based, and a test walks every row asserting the two agree:

```rust
for number in 1..=acuity.row_count() {
    assert_eq!(acuity.ith_row(number), acuity.named_row(&number.to_string()));
}
```

## `as_hierarchy` is a transpose

The spec asks for *"a single CLUSTER containing the CLUSTERs representing the **columns** of this table"* while the stored form is one CLUSTER per **row**. An empty table yields `None` rather than a CLUSTER with an empty `items` — `CLUSTER.items` is `1..*`, so that would not be a CLUSTER.

## `row_with_key` — where the spec runs out, twice

Both flagged as our own design **in place**, not in a commit message:

1. The class names "key columns" but provides **no way to designate one**. The key is read from the leading columns — the only ordering the class defines is that columns are "named and ordered with respect to each other", and relational key columns lead.
2. `DATA_VALUE` declares **no function whatsoever** — no `as_string`. So a key matches only a *text-valued* cell. A quantity-valued cell matches no key, rather than being compared against a stringification this implementation would have had to invent.

## Verification

619 tests pass across `openehr-rm` and `openehr-codegen`; clippy clean at `-D warnings`; comment-style clean; both generations stamped from one template. Crates bumped to `0.0.19` in lockstep.

## Note on the ratchet this is measured against

While auditing at the owner's request, the projection producing `unrealized_bmm_functions.txt` was found to **skip any class with no `*_impl.rs` sibling** — hiding **239 declared functions across 60 classes** while reporting 75. Filed as **#2247** (P1) and set as a blocker of both #2030 and #2248. The numbers in this PR are correct for what the instrument measures; the instrument itself is not yet total.