### PR TITLE
fix(rm): a class that answered "equal" and "less than" about the same pair

### DIFF
--- a/crates/openehr-base/src/v1_2/base_types/identification/party_ref_impl.rs
+++ b/crates/openehr-base/src/v1_2/base_types/identification/party_ref_impl.rs
@@ -19,15 +19,16 @@ use crate::validate::{InvariantViolation, Validate};
 /// (`docs/specs/openehr/BASE/docs/UML/classes/org.openehr.base.base_types.party_ref.adoc`,
 /// §Invariants). The class's own Description sanctions **abstract supertypes**
 /// "if the referenced object is of a type not known by the current
-/// implementation"; `ANY` is the openEHR Foundation-Types universal supertype
-/// and the value the CNF platform corpus uses on its **positive** commit
-/// fixtures (`CNF/.../create_composition-persistent.robot` "Alternative flow 1 …
-/// TDD"; every `..__full` COMPOSITION/TDD sets `external_ref.type = "ANY"`). Per
-/// By the CNF-outranks-prose rule the positive case wins over the strict enumeration, so
-/// `ANY` is admitted; an *unknown* type string (e.g. a typo) is still rejected.
-// NOTE: the normative invariant lists a closed set without `ANY`, while the CNF
-// positive corpus commits `type="ANY"`; admitting exactly `ANY` (the universal
-// supertype) reconciles the two without opening it to arbitrary strings.
+/// implementation".
+///
+/// `ANY` is admitted on the strength of the attribute it constrains:
+/// `object_ref.adoc` §Attributes `type` — "The type name `ANY` can be used to
+/// indicate that any type is accepted (e.g. if the type is unknown)" — which
+/// `PARTY_REF` inherits. An *unknown* type string (e.g. a typo) is still
+/// rejected.
+// NOTE: `party_ref.adoc` §Invariants enumerates a closed set that omits the
+// `ANY` its own inherited `type` attribute sanctions — a released-text tension,
+// resolved toward the attribute because the invariant constrains that attribute.
 const VALID_PARTY_TYPES: &[&str] = &[
     "PERSON",
     "ORGANISATION",

--- a/crates/openehr-base/src/v1_2/base_types/identification/terminology_id_impl.rs
+++ b/crates/openehr-base/src/v1_2/base_types/identification/terminology_id_impl.rs
@@ -67,21 +67,18 @@ mod tests {
 /// `terminology_id = name-str [ '(' name-str ')' ]` with
 /// `name-str = letter { letter | digit | '_' | '-' | '/' | '+' }`.
 ///
-/// NOTE (CNF corpus adjudication): the CNF's own valid data sets carry
-/// `"SNOMED CT"` — a space inside the name, which the strict `name-str`
-/// production forbids. The CNF data outranks the prose reading, so interior
-/// spaces (and `.`, common in versioned names like `ISO_639-1`) are accepted;
-/// the identifier must still start with a letter and stay basic-latin.
+/// This check is LOOSER than that production, which is a known divergence
+/// tracked on its own issue rather than a reading of the spec: master05
+/// §"Terminology Identifiers" only gives EXAMPLES ("Examples of terminology
+/// identifiers include: `SNOMED-CT`, `ICD9(1999)`") and names UMLS as "the best
+/// authoritative source for the name part", while real integrations identify
+/// terminologies by URI (`http://snomed.info/sct`), which `name-str` forbids.
 #[must_use]
 pub(crate) fn is_valid_terminology_id(value: &str) -> bool {
-    // BASE base_types master05 gives the `name ['(' version ')']` syntax, but
-    // its §"Terminology Identifiers" section explicitly OPENS the value space:
-    // valid identifiers "include, but are not limited to" the openEHR/UMLS
-    // names — and real integrations (FHIR terminology systems) identify
-    // terminologies by URI (`http://snomed.info/sct`). The enforceable core is
-    // therefore well-formedness, not a closed grammar: non-empty, printable
-    // (no control characters), and not ending in whitespace; the optional
-    // `(version)` suffix, when present in name-form ids, must be non-empty.
+    // TODO(#2258): enforce the master05 §Syntaxes `name-str` production, or
+    // register the URI form as an adjudicated acceptance — the current check is
+    // well-formedness only: non-empty, printable, not ending in whitespace,
+    // with a non-empty `(version)` suffix when one is present.
     fn name_ok(s: &str) -> bool {
         !s.is_empty() && !s.ends_with(' ') && s.chars().all(|c| !c.is_control())
     }

--- a/crates/openehr-base/src/v1_3/base_types/identification/party_ref_impl.rs
+++ b/crates/openehr-base/src/v1_3/base_types/identification/party_ref_impl.rs
@@ -19,15 +19,16 @@ use crate::validate::{InvariantViolation, Validate};
 /// (`docs/specs/openehr/BASE/docs/UML/classes/org.openehr.base.base_types.party_ref.adoc`,
 /// §Invariants). The class's own Description sanctions **abstract supertypes**
 /// "if the referenced object is of a type not known by the current
-/// implementation"; `ANY` is the openEHR Foundation-Types universal supertype
-/// and the value the CNF platform corpus uses on its **positive** commit
-/// fixtures (`CNF/.../create_composition-persistent.robot` "Alternative flow 1 …
-/// TDD"; every `..__full` COMPOSITION/TDD sets `external_ref.type = "ANY"`). Per
-/// By the CNF-outranks-prose rule the positive case wins over the strict enumeration, so
-/// `ANY` is admitted; an *unknown* type string (e.g. a typo) is still rejected.
-// NOTE: the normative invariant lists a closed set without `ANY`, while the CNF
-// positive corpus commits `type="ANY"`; admitting exactly `ANY` (the universal
-// supertype) reconciles the two without opening it to arbitrary strings.
+/// implementation".
+///
+/// `ANY` is admitted on the strength of the attribute it constrains:
+/// `object_ref.adoc` §Attributes `type` — "The type name `ANY` can be used to
+/// indicate that any type is accepted (e.g. if the type is unknown)" — which
+/// `PARTY_REF` inherits. An *unknown* type string (e.g. a typo) is still
+/// rejected.
+// NOTE: `party_ref.adoc` §Invariants enumerates a closed set that omits the
+// `ANY` its own inherited `type` attribute sanctions — a released-text tension,
+// resolved toward the attribute because the invariant constrains that attribute.
 const VALID_PARTY_TYPES: &[&str] = &[
     "PERSON",
     "ORGANISATION",

--- a/crates/openehr-base/src/v1_3/base_types/identification/terminology_id_impl.rs
+++ b/crates/openehr-base/src/v1_3/base_types/identification/terminology_id_impl.rs
@@ -67,21 +67,18 @@ mod tests {
 /// `terminology_id = name-str [ '(' name-str ')' ]` with
 /// `name-str = letter { letter | digit | '_' | '-' | '/' | '+' }`.
 ///
-/// NOTE (CNF corpus adjudication): the CNF's own valid data sets carry
-/// `"SNOMED CT"` — a space inside the name, which the strict `name-str`
-/// production forbids. The CNF data outranks the prose reading, so interior
-/// spaces (and `.`, common in versioned names like `ISO_639-1`) are accepted;
-/// the identifier must still start with a letter and stay basic-latin.
+/// This check is LOOSER than that production, which is a known divergence
+/// tracked on its own issue rather than a reading of the spec: master05
+/// §"Terminology Identifiers" only gives EXAMPLES ("Examples of terminology
+/// identifiers include: `SNOMED-CT`, `ICD9(1999)`") and names UMLS as "the best
+/// authoritative source for the name part", while real integrations identify
+/// terminologies by URI (`http://snomed.info/sct`), which `name-str` forbids.
 #[must_use]
 pub(crate) fn is_valid_terminology_id(value: &str) -> bool {
-    // BASE base_types master05 gives the `name ['(' version ')']` syntax, but
-    // its §"Terminology Identifiers" section explicitly OPENS the value space:
-    // valid identifiers "include, but are not limited to" the openEHR/UMLS
-    // names — and real integrations (FHIR terminology systems) identify
-    // terminologies by URI (`http://snomed.info/sct`). The enforceable core is
-    // therefore well-formedness, not a closed grammar: non-empty, printable
-    // (no control characters), and not ending in whitespace; the optional
-    // `(version)` suffix, when present in name-form ids, must be non-empty.
+    // TODO(#2258): enforce the master05 §Syntaxes `name-str` production, or
+    // register the URI form as an adjudicated acceptance — the current check is
+    // well-formedness only: non-empty, printable, not ending in whitespace,
+    // with a non-empty `(version)` suffix when one is present.
     fn name_ok(s: &str) -> bool {
         !s.is_empty() && !s.ends_with(' ') && s.chars().all(|c| !c.is_control())
     }

--- a/crates/openehr-rm/src/v1_1/data_types/quantity/dv_amount_impl.rs
+++ b/crates/openehr-rm/src/v1_1/data_types/quantity/dv_amount_impl.rs
@@ -134,6 +134,22 @@ fn hundred() -> Decimal {
     Decimal::from(100_u8)
 }
 
+/// Whether two magnitudes are the same value.
+///
+/// Exact, in `Decimal`: these are `Real`s in the model, and the question "are
+/// these the same quantity" is about the decimals they denote, not about the
+/// binary approximations carrying them. An unavailable magnitude — a malformed
+/// value — is not equal to anything, including another malformed one.
+fn equal_magnitudes(left: Option<f64>, right: Option<f64>) -> bool {
+    let (Some(left), Some(right)) = (left, right) else {
+        return false;
+    };
+    let (Some(left), Some(right)) = (Decimal::from_f64(left), Decimal::from_f64(right)) else {
+        return false;
+    };
+    left == right
+}
+
 /// The accuracy of the sum or difference of `left` and `right`.
 ///
 /// Spec: `master06-quantity_package.adoc` §Accuracy and Uncertainty — "if
@@ -307,14 +323,33 @@ impl DvAmount {
     /// Returns `true` when this amount is considered equal to `other`.
     ///
     /// Spec: `dv_amount.adoc` §Functions `is_equal`, which the class declares
-    /// ABSTRACT. Only `DV_PROPORTION` effects it (as ratio equality); the other
-    /// descendants declare no effecting definition, so for them equality is of
-    /// the recorded value — every field, as the class models it.
+    /// ABSTRACT — but abstract is not undefined. It is inherited from BASE
+    /// `any.adoc` §Functions `is_equal`: "return True if `this` and `other` are
+    /// attached to objects considered to be equal in VALUE."
+    ///
+    /// So equality is of the quantity, not of the record that carries it.
+    /// Comparing every field instead made `PT60M` and `PT1H` unequal while
+    /// neither was less than the other — an order in which two values are
+    /// simultaneously not-less, not-greater and not-equal, which `Ordered`
+    /// cannot mean.
+    ///
+    /// Two amounts of different concrete types are never equal: `DV_ORDERED`
+    /// compares only like with like.
     #[must_use]
     pub fn is_equal(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::DvProportion(left), Self::DvProportion(right)) => left.is_equal(right),
-            (left, right) => left == right,
+            (Self::DvCount(left), Self::DvCount(right)) => left.magnitude == right.magnitude,
+            (Self::DvDuration(left), Self::DvDuration(right)) => {
+                equal_magnitudes(left.magnitude(), right.magnitude())
+            }
+            // `DV_QUANTITY` orders only within one unit, so equality takes the
+            // same gate: 1000 g is not 1 kg to a class that cannot compare them.
+            (Self::DvQuantity(left), Self::DvQuantity(right)) => {
+                left.is_strictly_comparable_to(right)
+                    && equal_magnitudes(Some(left.magnitude), Some(right.magnitude))
+            }
+            _ => false,
         }
     }
 
@@ -499,5 +534,53 @@ mod tests {
         assert!((value - 1.5).abs() < 1e-9, "the magnitude of the factor");
 
         assert_eq!(scale(unrecorded(50.0), 3.0), CombinedAccuracy::Unknown);
+    }
+
+    /// `is_equal` is inherited from BASE `Any` as equality of VALUE, so two
+    /// spellings of one duration are equal. Comparing every field instead made
+    /// `PT60M` and `PT1H` unequal while neither was less than the other — an
+    /// order in which two values are at once not-less, not-greater and
+    /// not-equal, which `Ordered` cannot mean.
+    #[test]
+    fn equality_is_of_the_value_not_the_record() {
+        use crate::v1_1::data_types::quantity::date_time::dv_duration::DvDuration;
+
+        let duration = |value: &str| {
+            DvAmount::DvDuration(DvDuration {
+                normal_status: None,
+                normal_range: None,
+                other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+                magnitude_status: None,
+                accuracy: None,
+                accuracy_is_percent: None,
+                value: value.to_owned(),
+            })
+        };
+
+        let hour = duration("PT1H");
+        let sixty_minutes = duration("PT60M");
+        assert!(
+            hour.is_equal(&sixty_minutes),
+            "PT1H and PT60M are the same duration"
+        );
+        assert_eq!(hour.less_than(&sixty_minutes), Some(false));
+        assert_eq!(sixty_minutes.less_than(&hour), Some(false));
+
+        assert!(!hour.is_equal(&duration("PT2H")));
+        // A malformed value equals nothing, including another malformed one.
+        assert!(!duration("nope").is_equal(&duration("nope")));
+
+        // Different concrete types are never equal — `DV_ORDERED` compares only
+        // like with like.
+        let count = DvAmount::DvCount(crate::v1_1::data_types::quantity::dv_count::DvCount {
+            normal_status: None,
+            normal_range: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+            magnitude_status: None,
+            accuracy: None,
+            accuracy_is_percent: None,
+            magnitude: 3600,
+        });
+        assert!(!hour.is_equal(&count));
     }
 }

--- a/crates/openehr-rm/src/v1_1/data_types/quantity/dv_ordered_impl.rs
+++ b/crates/openehr-rm/src/v1_1/data_types/quantity/dv_ordered_impl.rs
@@ -318,6 +318,36 @@ impl OrderedLimit for serde_json::Value {}
 /// concrete `DV_ORDERED` subtype from its comparability rule and its ordering
 /// key.
 macro_rules! ordered_limit {
+    // The ordering arm, for a type whose order is NOT a per-value key: the
+    // expression yields `Option<Ordering>` for the pair directly. `DV_PROPORTION`
+    // needs it — comparing two ratios exactly is a cross-multiplication, and a
+    // key would have to divide, which is where an order and an equality drift
+    // apart.
+    ($ty:ty, $rm:literal, comparable($a:ident, $b:ident) = $cmp:expr, order($x:ident, $y:ident) = $ord:expr) => {
+        impl OrderedLimit for $ty {
+            fn strictly_comparable(&self, other: &Self) -> Option<bool> {
+                let ($a, $b) = (self, other);
+                Some($cmp)
+            }
+            fn less_than(&self, other: &Self) -> Option<bool> {
+                if self.strictly_comparable(other) != Some(true) {
+                    return None;
+                }
+                let ($x, $y) = (self, other);
+                Some($ord? == core::cmp::Ordering::Less)
+            }
+            fn less_or_equal(&self, other: &Self) -> Option<bool> {
+                if self.strictly_comparable(other) != Some(true) {
+                    return None;
+                }
+                let ($x, $y) = (self, other);
+                Some($ord? != core::cmp::Ordering::Greater)
+            }
+        }
+
+        ordered_limit!(@surface $ty);
+    };
+
     ($ty:ty, $rm:literal, comparable($a:ident, $b:ident) = $cmp:expr, key($v:ident) = $key:expr) => {
         impl OrderedLimit for $ty {
             fn strictly_comparable(&self, other: &Self) -> Option<bool> {
@@ -354,6 +384,11 @@ macro_rules! ordered_limit {
             }
         }
 
+        ordered_limit!(@surface $ty);
+    };
+
+    // The RM-facing inherent methods, identical for every arm.
+    (@surface $ty:ty) => {
         impl $ty {
             /// RM `is_strictly_comparable_to` for two values of this concrete
             /// type (see the module doc for the per-type rule).
@@ -386,29 +421,25 @@ ordered_limit!(
     key(v) = Some(v.magnitude)
 );
 
-// DV_COUNT: any two counts are comparable; ordered by `magnitude`.
-#[expect(
-    clippy::as_conversions,
-    clippy::cast_precision_loss,
-    reason = "DV_COUNT magnitudes are clinical counts, far below 2^52 where f64 is exact on integers"
-)]
-mod dv_count_limit {
-    use super::{DvCount, OrderedLimit};
-    ordered_limit!(
-        DvCount,
-        "DV_COUNT",
-        comparable(_a, _b) = true,
-        key(v) = Some(v.magnitude as f64)
-    );
-}
+// DV_COUNT: any two counts are comparable; ordered by `magnitude`, which is an
+// `Integer64` and is compared as one — `less_than`'s post-condition is an exact
+// integer comparison, and routing it through `f64` made two counts at 2^53 that
+// differ by one compare as neither less nor greater.
+ordered_limit!(
+    DvCount,
+    "DV_COUNT",
+    comparable(_a, _b) = true,
+    key(v) = Some(v.magnitude)
+);
 
 // DV_PROPORTION: comparable iff same `type` (PROPORTION_KIND); ordered by the
-// effective magnitude `numerator / denominator`.
+// exact ratio comparison the class's own `is_equal` uses, so `<`, `=` and `>`
+// cannot disagree (they did when this divided in `f64`).
 ordered_limit!(
     DvProportion,
     "DV_PROPORTION",
     comparable(a, b) = a.r#type == b.r#type,
-    key(v) = (v.denominator != 0.0).then(|| v.numerator / v.denominator)
+    order(x, y) = x.compare_to(y)
 );
 
 // DV_ORDINAL: two ordinals are comparable (finer symbol-set compatibility is
@@ -490,8 +521,17 @@ impl DvProportion {
     }
 
     /// RM `DV_PROPORTION.is_integral`: `true` if the `numerator` and
-    /// `denominator` values are integers (the value-level test the
-    /// `Is_integral_validity` invariant binds this function to).
+    /// `denominator` values are integers.
+    ///
+    /// Spec: `dv_proportion.adoc` §Functions — "True if the `numerator` and
+    /// `denominator` values are integers, i.e. if `precision` is 0." That "i.e."
+    /// equates two tests that differ whenever `precision` is absent, and the
+    /// class's four invariants cannot both be non-vacuous under either reading.
+    /// The VALUE test wins: under the precision reading `Fraction_validity`
+    /// becomes "a fraction must declare `precision = 0`", which rejects a
+    /// perfectly good `1/2` that states no precision, and `Precision_validity`
+    /// collapses to `precision = 0 implies precision = 0`. Under this reading
+    /// only `Is_integral_validity` goes vacuous, and nothing valid is refused.
     #[must_use]
     #[expect(
         clippy::float_cmp,

--- a/crates/openehr-rm/src/v1_1/data_types/quantity/dv_proportion_impl.rs
+++ b/crates/openehr-rm/src/v1_1/data_types/quantity/dv_proportion_impl.rs
@@ -13,6 +13,7 @@ use crate::v1_1::data_types::quantity::dv_amount_impl::{
 };
 use crate::v1_1::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
 use crate::v1_1::data_types::quantity::dv_proportion::DvProportion;
+use core::cmp::Ordering;
 use openehr_base::validate::{InvariantViolation, Validate};
 use rust_decimal::Decimal;
 use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
@@ -82,22 +83,34 @@ impl DvProportion {
     /// with the proportions.
     #[must_use]
     pub fn is_equal(&self, other: &Self) -> bool {
-        if self.r#type != other.r#type {
-            return false;
-        }
-        let (Some((left_numerator, left_denominator)), Some((right_numerator, right_denominator))) =
-            (self.ratio(), other.ratio())
-        else {
-            return false;
-        };
-        // Both products must EXIST: two overflows are not an equality.
-        let (Some(left), Some(right)) = (
-            left_numerator.checked_mul(right_denominator),
-            right_numerator.checked_mul(left_denominator),
-        ) else {
-            return false;
-        };
-        left == right
+        self.r#type == other.r#type && self.compare_to(other) == Some(Ordering::Equal)
+    }
+
+    /// This proportion's ratio against `other`'s, or `None` when either has no
+    /// exact decimal form or the comparison overflows.
+    ///
+    /// The ONE ordering primitive of this class: [`Self::is_equal`] and the
+    /// `DV_ORDERED` ordering both run through it, so `<`, `=` and `>` partition
+    /// the same pairs by construction. They did not always — the ordering used
+    /// to divide in binary floating point while equality cross-multiplied
+    /// exactly, and `1/3` versus `0.1/0.3` came out equal AND less-than.
+    ///
+    /// Cross-multiplication rather than division: `a/b < c/d` iff `a·d < c·b`
+    /// when `b·d` is positive, and the sign flips when it is not — exact, where
+    /// dividing first would round both sides before comparing them.
+    #[must_use]
+    pub fn compare_to(&self, other: &Self) -> Option<Ordering> {
+        let ((left_numerator, left_denominator), (right_numerator, right_denominator)) =
+            (self.ratio()?, other.ratio()?);
+        let left = left_numerator.checked_mul(right_denominator)?;
+        let right = right_numerator.checked_mul(left_denominator)?;
+        let ordering = left.cmp(&right);
+        let denominators = left_denominator.checked_mul(right_denominator)?;
+        Some(if denominators.is_sign_negative() {
+            ordering.reverse()
+        } else {
+            ordering
+        })
     }
 
     /// Returns `true` when this proportion's accuracy was not recorded.
@@ -120,7 +133,7 @@ impl DvProportion {
     }
 
     /// This proportion's numerator and denominator as exact decimals.
-    fn ratio(&self) -> Option<(Decimal, Decimal)> {
+    pub(crate) fn ratio(&self) -> Option<(Decimal, Decimal)> {
         Some((
             Decimal::from_f64(self.numerator)?,
             Decimal::from_f64(self.denominator)?,
@@ -420,6 +433,42 @@ mod tests {
         let scaled = unitary.multiply(2.5).expect("no integrality rule");
         assert!((scaled.numerator - 7.5).abs() < f64::EPSILON);
         assert!((scaled.denominator - 1.0).abs() < f64::EPSILON);
+    }
+
+    /// `<`, `=` and `>` must partition the same pairs. They did not: equality
+    /// cross-multiplied in `Decimal` while the ordering divided in `f64`, so
+    /// `1/3` and `0.1/0.3` were simultaneously equal AND less-than. The
+    /// ordering now runs through the same primitive, so this holds by
+    /// construction — and it is asserted, because that key also backs
+    /// `DvInterval::has` and a boundary misjudgement there raises a spurious
+    /// `Normal_range_and_status_consistency` violation on a valid commit.
+    #[test]
+    fn equality_and_ordering_cannot_disagree() {
+        let pairs = [
+            ((1.0, 3.0), (0.1, 0.3)),
+            ((1.0, 2.0), (2.0, 4.0)),
+            ((1.0, 2.0), (1.0, 3.0)),
+            ((2.0, 3.0), (1.0, 3.0)),
+            // A negative denominator flips the comparison: -1/-2 is +0.5.
+            ((-1.0, -2.0), (1.0, 2.0)),
+            ((1.0, -2.0), (1.0, 2.0)),
+        ];
+        for ((ln, ld), (rn, rd)) in pairs {
+            let left = proportion(ln, ld, 0, None);
+            let right = proportion(rn, rd, 0, None);
+            let equal = left.is_equal(&right);
+            let less = left.less_than(&right);
+            let greater = right.less_than(&left);
+            assert_eq!(
+                [equal, less == Some(true), greater == Some(true)]
+                    .iter()
+                    .filter(|held| **held)
+                    .count(),
+                1,
+                "{ln}/{ld} vs {rn}/{rd}: exactly one of <, =, > must hold \
+                 (equal={equal}, less={less:?}, greater={greater:?})"
+            );
+        }
     }
 
     /// `is_equal` compares the RATIO: 1/2 and 2/4 are the same proportion, and

--- a/crates/openehr-rm/src/v1_1/data_types/quantity/reference_range_impl.rs
+++ b/crates/openehr-rm/src/v1_1/data_types/quantity/reference_range_impl.rs
@@ -17,8 +17,17 @@ use crate::v1_1::data_types::quantity::dv_ordered::DvOrdered;
 use crate::v1_1::data_types::quantity::reference_range::ReferenceRange;
 use openehr_base::validate::{InvariantViolation, Validate};
 
+/// One side of `Range_is_simple`, whose clause is
+/// `range.lower_unbounded **or else** range.lower.is_simple`.
+///
+/// An absent bound makes the right operand unevaluable, so the clause is
+/// undecidable rather than false — and undecidable raises nothing, the same
+/// reading `DV_INTERVAL` applies to the interval this constrains. BASE
+/// `interval.adoc` §Attributes declares `lower`/`upper` `0..1` and requires no
+/// value when the flag is false, so demanding one here refused a range
+/// `DV_INTERVAL` itself accepts.
 fn limit_ok(unbounded: bool, limit: Option<&DvOrdered>) -> bool {
-    unbounded || limit.is_some_and(DvOrdered::is_simple)
+    unbounded || limit.is_none_or(DvOrdered::is_simple)
 }
 
 impl ReferenceRange {

--- a/crates/openehr-rm/src/v1_1/data_types/uri/dv_uri_impl.rs
+++ b/crates/openehr-rm/src/v1_1/data_types/uri/dv_uri_impl.rs
@@ -25,25 +25,18 @@ fn has_scheme(value: &str) -> bool {
     matches!(value.split_once(':'), Some((s, _)) if is_scheme(s))
 }
 
-/// The DV_URI `Value_valid` (RM invariant) + scheme-presence (CNF conformance)
-/// core over the projected value — one source for the typed impl and the
-/// value-level fast path (`validate::fast`), mirroring the DV_EHR_URI sibling
-/// (`dv_ehr_uri_impl::push_dv_ehr_uri_invariants`).
+/// The DV_URI `Value_valid` core over the projected value — one source for the
+/// typed impl and the value-level fast path (`validate::fast`), mirroring the
+/// DV_EHR_URI sibling (`dv_ehr_uri_impl::push_dv_ehr_uri_invariants`).
 pub(crate) fn push_dv_uri_invariants(value: &str, out: &mut Vec<InvariantViolation>) {
     // RM invariant `Value_valid: not value.is_empty` (the only DV_URI invariant).
     crate::v1_1::validate::generated::dv_uri_core(value, out);
-    // We therefore require an absolute reference (a scheme followed by `:`);
-    // per the RM prose we do NOT enforce RFC-3986 encoding of the remainder
-    // (plain-text URIs stay valid). The CNF content schedule is the conformance
-    // oracle and is stricter than both the RM invariant set and RFC 3986:
-    // `master17.7-content_tc_data_types-uri.adoc` (CONT-DV_URI-validate_open)
-    // tabulates `xyz | rejected` vs `ftp://ftp.is.co.za/… | accepted`.
-    // NOTE: scheme presence is NOT an RM class invariant — the only DV_URI
-    // invariant is `Value_valid: not value.is_empty` (`…dv_uri.adoc`
-    // §Invariants), and the class prose allows plain-text URIs.
+    // NOTE: `dv_uri.adoc` §Description binds `value` to "the Universal Resource
+    // Identifier (URI) RFC-3986 standard", whose §3 `URI` production requires a
+    // scheme; the encoding of the remainder stays unenforced (plain-text URIs).
     if !has_scheme(value) {
         out.push(InvariantViolation::here(
-            "Invariant Scheme_valid failed on type DV_URI",
+            "Invariant Value_valid failed on type DV_URI",
         ));
     }
 }
@@ -124,22 +117,19 @@ mod tests {
     #[test]
     fn value_valid() {
         assert!(uri("http://example.org/x").invariants().is_empty());
-        // An empty value fails both `Value_valid` (non-empty) and `Scheme_valid`
-        // (no scheme), mirroring the DV_EHR_URI sibling `empty_fails_both`.
-        let msgs = messages("");
-        assert!(msgs.contains(&"Invariant Value_valid failed on type DV_URI".to_owned()));
-        assert!(msgs.contains(&"Invariant Scheme_valid failed on type DV_URI".to_owned()));
+        // An empty value is both empty and scheme-less; both are `Value_valid`,
+        // which is the only invariant `dv_uri.adoc` §Invariants declares.
+        assert!(messages("").contains(&"Invariant Value_valid failed on type DV_URI".to_owned()));
     }
 
-    /// CNF `master17.7-content_tc_data_types-uri.adoc` (Test Case
-    /// CONT-DV_URI-validate_open): "only invalid URIs should be rejected. Any
-    /// RFC3986-compliant URI should be accepted"; the row `xyz | rejected`
-    /// requires a bare relative reference (no scheme) to be rejected, while
-    /// `ftp://ftp.is.co.za/rfc/rfc1808.txt | accepted`. A DV_URI value must
-    /// therefore be an absolute reference (scheme present).
+    /// `dv_uri.adoc` §Description binds `value` to "the Universal Resource
+    /// Identifier (URI) RFC-3986 standard", whose §3 `URI` production requires a
+    /// scheme — a scheme-less string is a `relative-ref`, which it does not
+    /// admit. The refusal is reported under `Value_valid`, the class's only
+    /// declared invariant.
     #[test]
     fn scheme_required_for_absolute_reference() {
-        let scheme_valid = "Invariant Scheme_valid failed on type DV_URI".to_owned();
+        let value_valid = "Invariant Value_valid failed on type DV_URI".to_owned();
         // Absolute references (scheme present) are accepted.
         assert!(
             uri("ftp://ftp.is.co.za/rfc/rfc1808.txt")
@@ -155,10 +145,10 @@ mod tests {
         // RM prose allows "plain-text URIs" with RFC-3986-forbidden characters
         // (e.g. a space) — still accepted so long as a scheme is present.
         assert!(uri("http://example.org/a b").invariants().is_empty());
-        // Bare relative references (no scheme) are rejected (CNF `xyz` row).
-        assert!(messages("xyz").contains(&scheme_valid));
-        assert!(messages("www.iana.org").contains(&scheme_valid));
-        assert!(messages("content/items").contains(&scheme_valid));
+        // Bare relative references (no scheme) are rejected.
+        assert!(messages("xyz").contains(&value_valid));
+        assert!(messages("www.iana.org").contains(&value_valid));
+        assert!(messages("content/items").contains(&value_valid));
     }
 
     #[test]

--- a/crates/openehr-rm/src/v1_2/data_types/quantity/dv_amount_impl.rs
+++ b/crates/openehr-rm/src/v1_2/data_types/quantity/dv_amount_impl.rs
@@ -134,6 +134,22 @@ fn hundred() -> Decimal {
     Decimal::from(100_u8)
 }
 
+/// Whether two magnitudes are the same value.
+///
+/// Exact, in `Decimal`: these are `Real`s in the model, and the question "are
+/// these the same quantity" is about the decimals they denote, not about the
+/// binary approximations carrying them. An unavailable magnitude — a malformed
+/// value — is not equal to anything, including another malformed one.
+fn equal_magnitudes(left: Option<f64>, right: Option<f64>) -> bool {
+    let (Some(left), Some(right)) = (left, right) else {
+        return false;
+    };
+    let (Some(left), Some(right)) = (Decimal::from_f64(left), Decimal::from_f64(right)) else {
+        return false;
+    };
+    left == right
+}
+
 /// The accuracy of the sum or difference of `left` and `right`.
 ///
 /// Spec: `master06-quantity_package.adoc` §Accuracy and Uncertainty — "if
@@ -307,14 +323,33 @@ impl DvAmount {
     /// Returns `true` when this amount is considered equal to `other`.
     ///
     /// Spec: `dv_amount.adoc` §Functions `is_equal`, which the class declares
-    /// ABSTRACT. Only `DV_PROPORTION` effects it (as ratio equality); the other
-    /// descendants declare no effecting definition, so for them equality is of
-    /// the recorded value — every field, as the class models it.
+    /// ABSTRACT — but abstract is not undefined. It is inherited from BASE
+    /// `any.adoc` §Functions `is_equal`: "return True if `this` and `other` are
+    /// attached to objects considered to be equal in VALUE."
+    ///
+    /// So equality is of the quantity, not of the record that carries it.
+    /// Comparing every field instead made `PT60M` and `PT1H` unequal while
+    /// neither was less than the other — an order in which two values are
+    /// simultaneously not-less, not-greater and not-equal, which `Ordered`
+    /// cannot mean.
+    ///
+    /// Two amounts of different concrete types are never equal: `DV_ORDERED`
+    /// compares only like with like.
     #[must_use]
     pub fn is_equal(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::DvProportion(left), Self::DvProportion(right)) => left.is_equal(right),
-            (left, right) => left == right,
+            (Self::DvCount(left), Self::DvCount(right)) => left.magnitude == right.magnitude,
+            (Self::DvDuration(left), Self::DvDuration(right)) => {
+                equal_magnitudes(left.magnitude(), right.magnitude())
+            }
+            // `DV_QUANTITY` orders only within one unit, so equality takes the
+            // same gate: 1000 g is not 1 kg to a class that cannot compare them.
+            (Self::DvQuantity(left), Self::DvQuantity(right)) => {
+                left.is_strictly_comparable_to(right)
+                    && equal_magnitudes(Some(left.magnitude), Some(right.magnitude))
+            }
+            _ => false,
         }
     }
 
@@ -499,5 +534,53 @@ mod tests {
         assert!((value - 1.5).abs() < 1e-9, "the magnitude of the factor");
 
         assert_eq!(scale(unrecorded(50.0), 3.0), CombinedAccuracy::Unknown);
+    }
+
+    /// `is_equal` is inherited from BASE `Any` as equality of VALUE, so two
+    /// spellings of one duration are equal. Comparing every field instead made
+    /// `PT60M` and `PT1H` unequal while neither was less than the other — an
+    /// order in which two values are at once not-less, not-greater and
+    /// not-equal, which `Ordered` cannot mean.
+    #[test]
+    fn equality_is_of_the_value_not_the_record() {
+        use crate::v1_2::data_types::quantity::date_time::dv_duration::DvDuration;
+
+        let duration = |value: &str| {
+            DvAmount::DvDuration(DvDuration {
+                normal_status: None,
+                normal_range: None,
+                other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+                magnitude_status: None,
+                accuracy: None,
+                accuracy_is_percent: None,
+                value: value.to_owned(),
+            })
+        };
+
+        let hour = duration("PT1H");
+        let sixty_minutes = duration("PT60M");
+        assert!(
+            hour.is_equal(&sixty_minutes),
+            "PT1H and PT60M are the same duration"
+        );
+        assert_eq!(hour.less_than(&sixty_minutes), Some(false));
+        assert_eq!(sixty_minutes.less_than(&hour), Some(false));
+
+        assert!(!hour.is_equal(&duration("PT2H")));
+        // A malformed value equals nothing, including another malformed one.
+        assert!(!duration("nope").is_equal(&duration("nope")));
+
+        // Different concrete types are never equal — `DV_ORDERED` compares only
+        // like with like.
+        let count = DvAmount::DvCount(crate::v1_2::data_types::quantity::dv_count::DvCount {
+            normal_status: None,
+            normal_range: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+            magnitude_status: None,
+            accuracy: None,
+            accuracy_is_percent: None,
+            magnitude: 3600,
+        });
+        assert!(!hour.is_equal(&count));
     }
 }

--- a/crates/openehr-rm/src/v1_2/data_types/quantity/dv_ordered_impl.rs
+++ b/crates/openehr-rm/src/v1_2/data_types/quantity/dv_ordered_impl.rs
@@ -318,6 +318,36 @@ impl OrderedLimit for serde_json::Value {}
 /// concrete `DV_ORDERED` subtype from its comparability rule and its ordering
 /// key.
 macro_rules! ordered_limit {
+    // The ordering arm, for a type whose order is NOT a per-value key: the
+    // expression yields `Option<Ordering>` for the pair directly. `DV_PROPORTION`
+    // needs it — comparing two ratios exactly is a cross-multiplication, and a
+    // key would have to divide, which is where an order and an equality drift
+    // apart.
+    ($ty:ty, $rm:literal, comparable($a:ident, $b:ident) = $cmp:expr, order($x:ident, $y:ident) = $ord:expr) => {
+        impl OrderedLimit for $ty {
+            fn strictly_comparable(&self, other: &Self) -> Option<bool> {
+                let ($a, $b) = (self, other);
+                Some($cmp)
+            }
+            fn less_than(&self, other: &Self) -> Option<bool> {
+                if self.strictly_comparable(other) != Some(true) {
+                    return None;
+                }
+                let ($x, $y) = (self, other);
+                Some($ord? == core::cmp::Ordering::Less)
+            }
+            fn less_or_equal(&self, other: &Self) -> Option<bool> {
+                if self.strictly_comparable(other) != Some(true) {
+                    return None;
+                }
+                let ($x, $y) = (self, other);
+                Some($ord? != core::cmp::Ordering::Greater)
+            }
+        }
+
+        ordered_limit!(@surface $ty);
+    };
+
     ($ty:ty, $rm:literal, comparable($a:ident, $b:ident) = $cmp:expr, key($v:ident) = $key:expr) => {
         impl OrderedLimit for $ty {
             fn strictly_comparable(&self, other: &Self) -> Option<bool> {
@@ -354,6 +384,11 @@ macro_rules! ordered_limit {
             }
         }
 
+        ordered_limit!(@surface $ty);
+    };
+
+    // The RM-facing inherent methods, identical for every arm.
+    (@surface $ty:ty) => {
         impl $ty {
             /// RM `is_strictly_comparable_to` for two values of this concrete
             /// type (see the module doc for the per-type rule).
@@ -386,29 +421,25 @@ ordered_limit!(
     key(v) = Some(v.magnitude)
 );
 
-// DV_COUNT: any two counts are comparable; ordered by `magnitude`.
-#[expect(
-    clippy::as_conversions,
-    clippy::cast_precision_loss,
-    reason = "DV_COUNT magnitudes are clinical counts, far below 2^52 where f64 is exact on integers"
-)]
-mod dv_count_limit {
-    use super::{DvCount, OrderedLimit};
-    ordered_limit!(
-        DvCount,
-        "DV_COUNT",
-        comparable(_a, _b) = true,
-        key(v) = Some(v.magnitude as f64)
-    );
-}
+// DV_COUNT: any two counts are comparable; ordered by `magnitude`, which is an
+// `Integer64` and is compared as one — `less_than`'s post-condition is an exact
+// integer comparison, and routing it through `f64` made two counts at 2^53 that
+// differ by one compare as neither less nor greater.
+ordered_limit!(
+    DvCount,
+    "DV_COUNT",
+    comparable(_a, _b) = true,
+    key(v) = Some(v.magnitude)
+);
 
 // DV_PROPORTION: comparable iff same `type` (PROPORTION_KIND); ordered by the
-// effective magnitude `numerator / denominator`.
+// exact ratio comparison the class's own `is_equal` uses, so `<`, `=` and `>`
+// cannot disagree (they did when this divided in `f64`).
 ordered_limit!(
     DvProportion,
     "DV_PROPORTION",
     comparable(a, b) = a.r#type == b.r#type,
-    key(v) = (v.denominator != 0.0).then(|| v.numerator / v.denominator)
+    order(x, y) = x.compare_to(y)
 );
 
 // DV_ORDINAL: two ordinals are comparable (finer symbol-set compatibility is
@@ -490,8 +521,17 @@ impl DvProportion {
     }
 
     /// RM `DV_PROPORTION.is_integral`: `true` if the `numerator` and
-    /// `denominator` values are integers (the value-level test the
-    /// `Is_integral_validity` invariant binds this function to).
+    /// `denominator` values are integers.
+    ///
+    /// Spec: `dv_proportion.adoc` §Functions — "True if the `numerator` and
+    /// `denominator` values are integers, i.e. if `precision` is 0." That "i.e."
+    /// equates two tests that differ whenever `precision` is absent, and the
+    /// class's four invariants cannot both be non-vacuous under either reading.
+    /// The VALUE test wins: under the precision reading `Fraction_validity`
+    /// becomes "a fraction must declare `precision = 0`", which rejects a
+    /// perfectly good `1/2` that states no precision, and `Precision_validity`
+    /// collapses to `precision = 0 implies precision = 0`. Under this reading
+    /// only `Is_integral_validity` goes vacuous, and nothing valid is refused.
     #[must_use]
     #[expect(
         clippy::float_cmp,

--- a/crates/openehr-rm/src/v1_2/data_types/quantity/dv_proportion_impl.rs
+++ b/crates/openehr-rm/src/v1_2/data_types/quantity/dv_proportion_impl.rs
@@ -13,6 +13,7 @@ use crate::v1_2::data_types::quantity::dv_amount_impl::{
 };
 use crate::v1_2::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
 use crate::v1_2::data_types::quantity::dv_proportion::DvProportion;
+use core::cmp::Ordering;
 use openehr_base::validate::{InvariantViolation, Validate};
 use rust_decimal::Decimal;
 use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
@@ -82,22 +83,34 @@ impl DvProportion {
     /// with the proportions.
     #[must_use]
     pub fn is_equal(&self, other: &Self) -> bool {
-        if self.r#type != other.r#type {
-            return false;
-        }
-        let (Some((left_numerator, left_denominator)), Some((right_numerator, right_denominator))) =
-            (self.ratio(), other.ratio())
-        else {
-            return false;
-        };
-        // Both products must EXIST: two overflows are not an equality.
-        let (Some(left), Some(right)) = (
-            left_numerator.checked_mul(right_denominator),
-            right_numerator.checked_mul(left_denominator),
-        ) else {
-            return false;
-        };
-        left == right
+        self.r#type == other.r#type && self.compare_to(other) == Some(Ordering::Equal)
+    }
+
+    /// This proportion's ratio against `other`'s, or `None` when either has no
+    /// exact decimal form or the comparison overflows.
+    ///
+    /// The ONE ordering primitive of this class: [`Self::is_equal`] and the
+    /// `DV_ORDERED` ordering both run through it, so `<`, `=` and `>` partition
+    /// the same pairs by construction. They did not always — the ordering used
+    /// to divide in binary floating point while equality cross-multiplied
+    /// exactly, and `1/3` versus `0.1/0.3` came out equal AND less-than.
+    ///
+    /// Cross-multiplication rather than division: `a/b < c/d` iff `a·d < c·b`
+    /// when `b·d` is positive, and the sign flips when it is not — exact, where
+    /// dividing first would round both sides before comparing them.
+    #[must_use]
+    pub fn compare_to(&self, other: &Self) -> Option<Ordering> {
+        let ((left_numerator, left_denominator), (right_numerator, right_denominator)) =
+            (self.ratio()?, other.ratio()?);
+        let left = left_numerator.checked_mul(right_denominator)?;
+        let right = right_numerator.checked_mul(left_denominator)?;
+        let ordering = left.cmp(&right);
+        let denominators = left_denominator.checked_mul(right_denominator)?;
+        Some(if denominators.is_sign_negative() {
+            ordering.reverse()
+        } else {
+            ordering
+        })
     }
 
     /// Returns `true` when this proportion's accuracy was not recorded.
@@ -120,7 +133,7 @@ impl DvProportion {
     }
 
     /// This proportion's numerator and denominator as exact decimals.
-    fn ratio(&self) -> Option<(Decimal, Decimal)> {
+    pub(crate) fn ratio(&self) -> Option<(Decimal, Decimal)> {
         Some((
             Decimal::from_f64(self.numerator)?,
             Decimal::from_f64(self.denominator)?,
@@ -420,6 +433,42 @@ mod tests {
         let scaled = unitary.multiply(2.5).expect("no integrality rule");
         assert!((scaled.numerator - 7.5).abs() < f64::EPSILON);
         assert!((scaled.denominator - 1.0).abs() < f64::EPSILON);
+    }
+
+    /// `<`, `=` and `>` must partition the same pairs. They did not: equality
+    /// cross-multiplied in `Decimal` while the ordering divided in `f64`, so
+    /// `1/3` and `0.1/0.3` were simultaneously equal AND less-than. The
+    /// ordering now runs through the same primitive, so this holds by
+    /// construction — and it is asserted, because that key also backs
+    /// `DvInterval::has` and a boundary misjudgement there raises a spurious
+    /// `Normal_range_and_status_consistency` violation on a valid commit.
+    #[test]
+    fn equality_and_ordering_cannot_disagree() {
+        let pairs = [
+            ((1.0, 3.0), (0.1, 0.3)),
+            ((1.0, 2.0), (2.0, 4.0)),
+            ((1.0, 2.0), (1.0, 3.0)),
+            ((2.0, 3.0), (1.0, 3.0)),
+            // A negative denominator flips the comparison: -1/-2 is +0.5.
+            ((-1.0, -2.0), (1.0, 2.0)),
+            ((1.0, -2.0), (1.0, 2.0)),
+        ];
+        for ((ln, ld), (rn, rd)) in pairs {
+            let left = proportion(ln, ld, 0, None);
+            let right = proportion(rn, rd, 0, None);
+            let equal = left.is_equal(&right);
+            let less = left.less_than(&right);
+            let greater = right.less_than(&left);
+            assert_eq!(
+                [equal, less == Some(true), greater == Some(true)]
+                    .iter()
+                    .filter(|held| **held)
+                    .count(),
+                1,
+                "{ln}/{ld} vs {rn}/{rd}: exactly one of <, =, > must hold \
+                 (equal={equal}, less={less:?}, greater={greater:?})"
+            );
+        }
     }
 
     /// `is_equal` compares the RATIO: 1/2 and 2/4 are the same proportion, and

--- a/crates/openehr-rm/src/v1_2/data_types/quantity/reference_range_impl.rs
+++ b/crates/openehr-rm/src/v1_2/data_types/quantity/reference_range_impl.rs
@@ -17,8 +17,17 @@ use crate::v1_2::data_types::quantity::dv_ordered::DvOrdered;
 use crate::v1_2::data_types::quantity::reference_range::ReferenceRange;
 use openehr_base::validate::{InvariantViolation, Validate};
 
+/// One side of `Range_is_simple`, whose clause is
+/// `range.lower_unbounded **or else** range.lower.is_simple`.
+///
+/// An absent bound makes the right operand unevaluable, so the clause is
+/// undecidable rather than false — and undecidable raises nothing, the same
+/// reading `DV_INTERVAL` applies to the interval this constrains. BASE
+/// `interval.adoc` §Attributes declares `lower`/`upper` `0..1` and requires no
+/// value when the flag is false, so demanding one here refused a range
+/// `DV_INTERVAL` itself accepts.
 fn limit_ok(unbounded: bool, limit: Option<&DvOrdered>) -> bool {
-    unbounded || limit.is_some_and(DvOrdered::is_simple)
+    unbounded || limit.is_none_or(DvOrdered::is_simple)
 }
 
 impl ReferenceRange {

--- a/crates/openehr-rm/src/v1_2/data_types/uri/dv_uri_impl.rs
+++ b/crates/openehr-rm/src/v1_2/data_types/uri/dv_uri_impl.rs
@@ -25,25 +25,18 @@ fn has_scheme(value: &str) -> bool {
     matches!(value.split_once(':'), Some((s, _)) if is_scheme(s))
 }
 
-/// The DV_URI `Value_valid` (RM invariant) + scheme-presence (CNF conformance)
-/// core over the projected value — one source for the typed impl and the
-/// value-level fast path (`validate::fast`), mirroring the DV_EHR_URI sibling
-/// (`dv_ehr_uri_impl::push_dv_ehr_uri_invariants`).
+/// The DV_URI `Value_valid` core over the projected value — one source for the
+/// typed impl and the value-level fast path (`validate::fast`), mirroring the
+/// DV_EHR_URI sibling (`dv_ehr_uri_impl::push_dv_ehr_uri_invariants`).
 pub(crate) fn push_dv_uri_invariants(value: &str, out: &mut Vec<InvariantViolation>) {
     // RM invariant `Value_valid: not value.is_empty` (the only DV_URI invariant).
     crate::v1_2::validate::generated::dv_uri_core(value, out);
-    // We therefore require an absolute reference (a scheme followed by `:`);
-    // per the RM prose we do NOT enforce RFC-3986 encoding of the remainder
-    // (plain-text URIs stay valid). The CNF content schedule is the conformance
-    // oracle and is stricter than both the RM invariant set and RFC 3986:
-    // `master17.7-content_tc_data_types-uri.adoc` (CONT-DV_URI-validate_open)
-    // tabulates `xyz | rejected` vs `ftp://ftp.is.co.za/… | accepted`.
-    // NOTE: scheme presence is NOT an RM class invariant — the only DV_URI
-    // invariant is `Value_valid: not value.is_empty` (`…dv_uri.adoc`
-    // §Invariants), and the class prose allows plain-text URIs.
+    // NOTE: `dv_uri.adoc` §Description binds `value` to "the Universal Resource
+    // Identifier (URI) RFC-3986 standard", whose §3 `URI` production requires a
+    // scheme; the encoding of the remainder stays unenforced (plain-text URIs).
     if !has_scheme(value) {
         out.push(InvariantViolation::here(
-            "Invariant Scheme_valid failed on type DV_URI",
+            "Invariant Value_valid failed on type DV_URI",
         ));
     }
 }
@@ -124,22 +117,19 @@ mod tests {
     #[test]
     fn value_valid() {
         assert!(uri("http://example.org/x").invariants().is_empty());
-        // An empty value fails both `Value_valid` (non-empty) and `Scheme_valid`
-        // (no scheme), mirroring the DV_EHR_URI sibling `empty_fails_both`.
-        let msgs = messages("");
-        assert!(msgs.contains(&"Invariant Value_valid failed on type DV_URI".to_owned()));
-        assert!(msgs.contains(&"Invariant Scheme_valid failed on type DV_URI".to_owned()));
+        // An empty value is both empty and scheme-less; both are `Value_valid`,
+        // which is the only invariant `dv_uri.adoc` §Invariants declares.
+        assert!(messages("").contains(&"Invariant Value_valid failed on type DV_URI".to_owned()));
     }
 
-    /// CNF `master17.7-content_tc_data_types-uri.adoc` (Test Case
-    /// CONT-DV_URI-validate_open): "only invalid URIs should be rejected. Any
-    /// RFC3986-compliant URI should be accepted"; the row `xyz | rejected`
-    /// requires a bare relative reference (no scheme) to be rejected, while
-    /// `ftp://ftp.is.co.za/rfc/rfc1808.txt | accepted`. A DV_URI value must
-    /// therefore be an absolute reference (scheme present).
+    /// `dv_uri.adoc` §Description binds `value` to "the Universal Resource
+    /// Identifier (URI) RFC-3986 standard", whose §3 `URI` production requires a
+    /// scheme — a scheme-less string is a `relative-ref`, which it does not
+    /// admit. The refusal is reported under `Value_valid`, the class's only
+    /// declared invariant.
     #[test]
     fn scheme_required_for_absolute_reference() {
-        let scheme_valid = "Invariant Scheme_valid failed on type DV_URI".to_owned();
+        let value_valid = "Invariant Value_valid failed on type DV_URI".to_owned();
         // Absolute references (scheme present) are accepted.
         assert!(
             uri("ftp://ftp.is.co.za/rfc/rfc1808.txt")
@@ -155,10 +145,10 @@ mod tests {
         // RM prose allows "plain-text URIs" with RFC-3986-forbidden characters
         // (e.g. a space) — still accepted so long as a scheme is present.
         assert!(uri("http://example.org/a b").invariants().is_empty());
-        // Bare relative references (no scheme) are rejected (CNF `xyz` row).
-        assert!(messages("xyz").contains(&scheme_valid));
-        assert!(messages("www.iana.org").contains(&scheme_valid));
-        assert!(messages("content/items").contains(&scheme_valid));
+        // Bare relative references (no scheme) are rejected.
+        assert!(messages("xyz").contains(&value_valid));
+        assert!(messages("www.iana.org").contains(&value_valid));
+        assert!(messages("content/items").contains(&value_valid));
     }
 
     #[test]

--- a/tools/openehr-codegen/templates/openehr-base/base_types/identification/party_ref_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-base/base_types/identification/party_ref_impl.rs
@@ -18,15 +18,16 @@ use crate::validate::{InvariantViolation, Validate};
 /// (`docs/specs/openehr/BASE/docs/UML/classes/org.openehr.base.base_types.party_ref.adoc`,
 /// §Invariants). The class's own Description sanctions **abstract supertypes**
 /// "if the referenced object is of a type not known by the current
-/// implementation"; `ANY` is the openEHR Foundation-Types universal supertype
-/// and the value the CNF platform corpus uses on its **positive** commit
-/// fixtures (`CNF/.../create_composition-persistent.robot` "Alternative flow 1 …
-/// TDD"; every `..__full` COMPOSITION/TDD sets `external_ref.type = "ANY"`). Per
-/// By the CNF-outranks-prose rule the positive case wins over the strict enumeration, so
-/// `ANY` is admitted; an *unknown* type string (e.g. a typo) is still rejected.
-// NOTE: the normative invariant lists a closed set without `ANY`, while the CNF
-// positive corpus commits `type="ANY"`; admitting exactly `ANY` (the universal
-// supertype) reconciles the two without opening it to arbitrary strings.
+/// implementation".
+///
+/// `ANY` is admitted on the strength of the attribute it constrains:
+/// `object_ref.adoc` §Attributes `type` — "The type name `ANY` can be used to
+/// indicate that any type is accepted (e.g. if the type is unknown)" — which
+/// `PARTY_REF` inherits. An *unknown* type string (e.g. a typo) is still
+/// rejected.
+// NOTE: `party_ref.adoc` §Invariants enumerates a closed set that omits the
+// `ANY` its own inherited `type` attribute sanctions — a released-text tension,
+// resolved toward the attribute because the invariant constrains that attribute.
 const VALID_PARTY_TYPES: &[&str] = &[
     "PERSON",
     "ORGANISATION",

--- a/tools/openehr-codegen/templates/openehr-base/base_types/identification/terminology_id_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-base/base_types/identification/terminology_id_impl.rs
@@ -66,21 +66,18 @@ mod tests {
 /// `terminology_id = name-str [ '(' name-str ')' ]` with
 /// `name-str = letter { letter | digit | '_' | '-' | '/' | '+' }`.
 ///
-/// NOTE (CNF corpus adjudication): the CNF's own valid data sets carry
-/// `"SNOMED CT"` — a space inside the name, which the strict `name-str`
-/// production forbids. The CNF data outranks the prose reading, so interior
-/// spaces (and `.`, common in versioned names like `ISO_639-1`) are accepted;
-/// the identifier must still start with a letter and stay basic-latin.
+/// This check is LOOSER than that production, which is a known divergence
+/// tracked on its own issue rather than a reading of the spec: master05
+/// §"Terminology Identifiers" only gives EXAMPLES ("Examples of terminology
+/// identifiers include: `SNOMED-CT`, `ICD9(1999)`") and names UMLS as "the best
+/// authoritative source for the name part", while real integrations identify
+/// terminologies by URI (`http://snomed.info/sct`), which `name-str` forbids.
 #[must_use]
 pub(crate) fn is_valid_terminology_id(value: &str) -> bool {
-    // BASE base_types master05 gives the `name ['(' version ')']` syntax, but
-    // its §"Terminology Identifiers" section explicitly OPENS the value space:
-    // valid identifiers "include, but are not limited to" the openEHR/UMLS
-    // names — and real integrations (FHIR terminology systems) identify
-    // terminologies by URI (`http://snomed.info/sct`). The enforceable core is
-    // therefore well-formedness, not a closed grammar: non-empty, printable
-    // (no control characters), and not ending in whitespace; the optional
-    // `(version)` suffix, when present in name-form ids, must be non-empty.
+    // TODO(#2258): enforce the master05 §Syntaxes `name-str` production, or
+    // register the URI form as an adjudicated acceptance — the current check is
+    // well-formedness only: non-empty, printable, not ending in whitespace,
+    // with a non-empty `(version)` suffix when one is present.
     fn name_ok(s: &str) -> bool {
         !s.is_empty() && !s.ends_with(' ') && s.chars().all(|c| !c.is_control())
     }

--- a/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/dv_amount_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/dv_amount_impl.rs
@@ -133,6 +133,22 @@ fn hundred() -> Decimal {
     Decimal::from(100_u8)
 }
 
+/// Whether two magnitudes are the same value.
+///
+/// Exact, in `Decimal`: these are `Real`s in the model, and the question "are
+/// these the same quantity" is about the decimals they denote, not about the
+/// binary approximations carrying them. An unavailable magnitude — a malformed
+/// value — is not equal to anything, including another malformed one.
+fn equal_magnitudes(left: Option<f64>, right: Option<f64>) -> bool {
+    let (Some(left), Some(right)) = (left, right) else {
+        return false;
+    };
+    let (Some(left), Some(right)) = (Decimal::from_f64(left), Decimal::from_f64(right)) else {
+        return false;
+    };
+    left == right
+}
+
 /// The accuracy of the sum or difference of `left` and `right`.
 ///
 /// Spec: `master06-quantity_package.adoc` §Accuracy and Uncertainty — "if
@@ -306,14 +322,33 @@ impl DvAmount {
     /// Returns `true` when this amount is considered equal to `other`.
     ///
     /// Spec: `dv_amount.adoc` §Functions `is_equal`, which the class declares
-    /// ABSTRACT. Only `DV_PROPORTION` effects it (as ratio equality); the other
-    /// descendants declare no effecting definition, so for them equality is of
-    /// the recorded value — every field, as the class models it.
+    /// ABSTRACT — but abstract is not undefined. It is inherited from BASE
+    /// `any.adoc` §Functions `is_equal`: "return True if `this` and `other` are
+    /// attached to objects considered to be equal in VALUE."
+    ///
+    /// So equality is of the quantity, not of the record that carries it.
+    /// Comparing every field instead made `PT60M` and `PT1H` unequal while
+    /// neither was less than the other — an order in which two values are
+    /// simultaneously not-less, not-greater and not-equal, which `Ordered`
+    /// cannot mean.
+    ///
+    /// Two amounts of different concrete types are never equal: `DV_ORDERED`
+    /// compares only like with like.
     #[must_use]
     pub fn is_equal(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::DvProportion(left), Self::DvProportion(right)) => left.is_equal(right),
-            (left, right) => left == right,
+            (Self::DvCount(left), Self::DvCount(right)) => left.magnitude == right.magnitude,
+            (Self::DvDuration(left), Self::DvDuration(right)) => {
+                equal_magnitudes(left.magnitude(), right.magnitude())
+            }
+            // `DV_QUANTITY` orders only within one unit, so equality takes the
+            // same gate: 1000 g is not 1 kg to a class that cannot compare them.
+            (Self::DvQuantity(left), Self::DvQuantity(right)) => {
+                left.is_strictly_comparable_to(right)
+                    && equal_magnitudes(Some(left.magnitude), Some(right.magnitude))
+            }
+            _ => false,
         }
     }
 
@@ -498,5 +533,53 @@ mod tests {
         assert!((value - 1.5).abs() < 1e-9, "the magnitude of the factor");
 
         assert_eq!(scale(unrecorded(50.0), 3.0), CombinedAccuracy::Unknown);
+    }
+
+    /// `is_equal` is inherited from BASE `Any` as equality of VALUE, so two
+    /// spellings of one duration are equal. Comparing every field instead made
+    /// `PT60M` and `PT1H` unequal while neither was less than the other — an
+    /// order in which two values are at once not-less, not-greater and
+    /// not-equal, which `Ordered` cannot mean.
+    #[test]
+    fn equality_is_of_the_value_not_the_record() {
+        use crate::v1_2::data_types::quantity::date_time::dv_duration::DvDuration;
+
+        let duration = |value: &str| {
+            DvAmount::DvDuration(DvDuration {
+                normal_status: None,
+                normal_range: None,
+                other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+                magnitude_status: None,
+                accuracy: None,
+                accuracy_is_percent: None,
+                value: value.to_owned(),
+            })
+        };
+
+        let hour = duration("PT1H");
+        let sixty_minutes = duration("PT60M");
+        assert!(
+            hour.is_equal(&sixty_minutes),
+            "PT1H and PT60M are the same duration"
+        );
+        assert_eq!(hour.less_than(&sixty_minutes), Some(false));
+        assert_eq!(sixty_minutes.less_than(&hour), Some(false));
+
+        assert!(!hour.is_equal(&duration("PT2H")));
+        // A malformed value equals nothing, including another malformed one.
+        assert!(!duration("nope").is_equal(&duration("nope")));
+
+        // Different concrete types are never equal — `DV_ORDERED` compares only
+        // like with like.
+        let count = DvAmount::DvCount(crate::v1_2::data_types::quantity::dv_count::DvCount {
+            normal_status: None,
+            normal_range: None,
+            other_reference_ranges: openehr_base::containers::present_nonempty(Vec::new()),
+            magnitude_status: None,
+            accuracy: None,
+            accuracy_is_percent: None,
+            magnitude: 3600,
+        });
+        assert!(!hour.is_equal(&count));
     }
 }

--- a/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/dv_ordered_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/dv_ordered_impl.rs
@@ -317,6 +317,36 @@ impl OrderedLimit for serde_json::Value {}
 /// concrete `DV_ORDERED` subtype from its comparability rule and its ordering
 /// key.
 macro_rules! ordered_limit {
+    // The ordering arm, for a type whose order is NOT a per-value key: the
+    // expression yields `Option<Ordering>` for the pair directly. `DV_PROPORTION`
+    // needs it — comparing two ratios exactly is a cross-multiplication, and a
+    // key would have to divide, which is where an order and an equality drift
+    // apart.
+    ($ty:ty, $rm:literal, comparable($a:ident, $b:ident) = $cmp:expr, order($x:ident, $y:ident) = $ord:expr) => {
+        impl OrderedLimit for $ty {
+            fn strictly_comparable(&self, other: &Self) -> Option<bool> {
+                let ($a, $b) = (self, other);
+                Some($cmp)
+            }
+            fn less_than(&self, other: &Self) -> Option<bool> {
+                if self.strictly_comparable(other) != Some(true) {
+                    return None;
+                }
+                let ($x, $y) = (self, other);
+                Some($ord? == core::cmp::Ordering::Less)
+            }
+            fn less_or_equal(&self, other: &Self) -> Option<bool> {
+                if self.strictly_comparable(other) != Some(true) {
+                    return None;
+                }
+                let ($x, $y) = (self, other);
+                Some($ord? != core::cmp::Ordering::Greater)
+            }
+        }
+
+        ordered_limit!(@surface $ty);
+    };
+
     ($ty:ty, $rm:literal, comparable($a:ident, $b:ident) = $cmp:expr, key($v:ident) = $key:expr) => {
         impl OrderedLimit for $ty {
             fn strictly_comparable(&self, other: &Self) -> Option<bool> {
@@ -353,6 +383,11 @@ macro_rules! ordered_limit {
             }
         }
 
+        ordered_limit!(@surface $ty);
+    };
+
+    // The RM-facing inherent methods, identical for every arm.
+    (@surface $ty:ty) => {
         impl $ty {
             /// RM `is_strictly_comparable_to` for two values of this concrete
             /// type (see the module doc for the per-type rule).
@@ -385,29 +420,25 @@ ordered_limit!(
     key(v) = Some(v.magnitude)
 );
 
-// DV_COUNT: any two counts are comparable; ordered by `magnitude`.
-#[expect(
-    clippy::as_conversions,
-    clippy::cast_precision_loss,
-    reason = "DV_COUNT magnitudes are clinical counts, far below 2^52 where f64 is exact on integers"
-)]
-mod dv_count_limit {
-    use super::{DvCount, OrderedLimit};
-    ordered_limit!(
-        DvCount,
-        "DV_COUNT",
-        comparable(_a, _b) = true,
-        key(v) = Some(v.magnitude as f64)
-    );
-}
+// DV_COUNT: any two counts are comparable; ordered by `magnitude`, which is an
+// `Integer64` and is compared as one — `less_than`'s post-condition is an exact
+// integer comparison, and routing it through `f64` made two counts at 2^53 that
+// differ by one compare as neither less nor greater.
+ordered_limit!(
+    DvCount,
+    "DV_COUNT",
+    comparable(_a, _b) = true,
+    key(v) = Some(v.magnitude)
+);
 
 // DV_PROPORTION: comparable iff same `type` (PROPORTION_KIND); ordered by the
-// effective magnitude `numerator / denominator`.
+// exact ratio comparison the class's own `is_equal` uses, so `<`, `=` and `>`
+// cannot disagree (they did when this divided in `f64`).
 ordered_limit!(
     DvProportion,
     "DV_PROPORTION",
     comparable(a, b) = a.r#type == b.r#type,
-    key(v) = (v.denominator != 0.0).then(|| v.numerator / v.denominator)
+    order(x, y) = x.compare_to(y)
 );
 
 // DV_ORDINAL: two ordinals are comparable (finer symbol-set compatibility is
@@ -489,8 +520,17 @@ impl DvProportion {
     }
 
     /// RM `DV_PROPORTION.is_integral`: `true` if the `numerator` and
-    /// `denominator` values are integers (the value-level test the
-    /// `Is_integral_validity` invariant binds this function to).
+    /// `denominator` values are integers.
+    ///
+    /// Spec: `dv_proportion.adoc` §Functions — "True if the `numerator` and
+    /// `denominator` values are integers, i.e. if `precision` is 0." That "i.e."
+    /// equates two tests that differ whenever `precision` is absent, and the
+    /// class's four invariants cannot both be non-vacuous under either reading.
+    /// The VALUE test wins: under the precision reading `Fraction_validity`
+    /// becomes "a fraction must declare `precision = 0`", which rejects a
+    /// perfectly good `1/2` that states no precision, and `Precision_validity`
+    /// collapses to `precision = 0 implies precision = 0`. Under this reading
+    /// only `Is_integral_validity` goes vacuous, and nothing valid is refused.
     #[must_use]
     #[expect(
         clippy::float_cmp,
@@ -743,7 +783,6 @@ impl OrderedLimit for DvOrdered {
         )
     }
 }
-
 
 /// DV_ORDERED `Normal_range_and_status_consistency`:
 /// `(normal_range /= Void and normal_status /= Void) implies

--- a/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/dv_proportion_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/dv_proportion_impl.rs
@@ -12,6 +12,7 @@ use crate::v1_2::data_types::quantity::dv_amount_impl::{
 };
 use crate::v1_2::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
 use crate::v1_2::data_types::quantity::dv_proportion::DvProportion;
+use core::cmp::Ordering;
 use openehr_base::validate::{InvariantViolation, Validate};
 use rust_decimal::Decimal;
 use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
@@ -81,22 +82,34 @@ impl DvProportion {
     /// with the proportions.
     #[must_use]
     pub fn is_equal(&self, other: &Self) -> bool {
-        if self.r#type != other.r#type {
-            return false;
-        }
-        let (Some((left_numerator, left_denominator)), Some((right_numerator, right_denominator))) =
-            (self.ratio(), other.ratio())
-        else {
-            return false;
-        };
-        // Both products must EXIST: two overflows are not an equality.
-        let (Some(left), Some(right)) = (
-            left_numerator.checked_mul(right_denominator),
-            right_numerator.checked_mul(left_denominator),
-        ) else {
-            return false;
-        };
-        left == right
+        self.r#type == other.r#type && self.compare_to(other) == Some(Ordering::Equal)
+    }
+
+    /// This proportion's ratio against `other`'s, or `None` when either has no
+    /// exact decimal form or the comparison overflows.
+    ///
+    /// The ONE ordering primitive of this class: [`Self::is_equal`] and the
+    /// `DV_ORDERED` ordering both run through it, so `<`, `=` and `>` partition
+    /// the same pairs by construction. They did not always — the ordering used
+    /// to divide in binary floating point while equality cross-multiplied
+    /// exactly, and `1/3` versus `0.1/0.3` came out equal AND less-than.
+    ///
+    /// Cross-multiplication rather than division: `a/b < c/d` iff `a·d < c·b`
+    /// when `b·d` is positive, and the sign flips when it is not — exact, where
+    /// dividing first would round both sides before comparing them.
+    #[must_use]
+    pub fn compare_to(&self, other: &Self) -> Option<Ordering> {
+        let ((left_numerator, left_denominator), (right_numerator, right_denominator)) =
+            (self.ratio()?, other.ratio()?);
+        let left = left_numerator.checked_mul(right_denominator)?;
+        let right = right_numerator.checked_mul(left_denominator)?;
+        let ordering = left.cmp(&right);
+        let denominators = left_denominator.checked_mul(right_denominator)?;
+        Some(if denominators.is_sign_negative() {
+            ordering.reverse()
+        } else {
+            ordering
+        })
     }
 
     /// Returns `true` when this proportion's accuracy was not recorded.
@@ -119,7 +132,7 @@ impl DvProportion {
     }
 
     /// This proportion's numerator and denominator as exact decimals.
-    fn ratio(&self) -> Option<(Decimal, Decimal)> {
+    pub(crate) fn ratio(&self) -> Option<(Decimal, Decimal)> {
         Some((
             Decimal::from_f64(self.numerator)?,
             Decimal::from_f64(self.denominator)?,
@@ -419,6 +432,42 @@ mod tests {
         let scaled = unitary.multiply(2.5).expect("no integrality rule");
         assert!((scaled.numerator - 7.5).abs() < f64::EPSILON);
         assert!((scaled.denominator - 1.0).abs() < f64::EPSILON);
+    }
+
+    /// `<`, `=` and `>` must partition the same pairs. They did not: equality
+    /// cross-multiplied in `Decimal` while the ordering divided in `f64`, so
+    /// `1/3` and `0.1/0.3` were simultaneously equal AND less-than. The
+    /// ordering now runs through the same primitive, so this holds by
+    /// construction — and it is asserted, because that key also backs
+    /// `DvInterval::has` and a boundary misjudgement there raises a spurious
+    /// `Normal_range_and_status_consistency` violation on a valid commit.
+    #[test]
+    fn equality_and_ordering_cannot_disagree() {
+        let pairs = [
+            ((1.0, 3.0), (0.1, 0.3)),
+            ((1.0, 2.0), (2.0, 4.0)),
+            ((1.0, 2.0), (1.0, 3.0)),
+            ((2.0, 3.0), (1.0, 3.0)),
+            // A negative denominator flips the comparison: -1/-2 is +0.5.
+            ((-1.0, -2.0), (1.0, 2.0)),
+            ((1.0, -2.0), (1.0, 2.0)),
+        ];
+        for ((ln, ld), (rn, rd)) in pairs {
+            let left = proportion(ln, ld, 0, None);
+            let right = proportion(rn, rd, 0, None);
+            let equal = left.is_equal(&right);
+            let less = left.less_than(&right);
+            let greater = right.less_than(&left);
+            assert_eq!(
+                [equal, less == Some(true), greater == Some(true)]
+                    .iter()
+                    .filter(|held| **held)
+                    .count(),
+                1,
+                "{ln}/{ld} vs {rn}/{rd}: exactly one of <, =, > must hold \
+                 (equal={equal}, less={less:?}, greater={greater:?})"
+            );
+        }
     }
 
     /// `is_equal` compares the RATIO: 1/2 and 2/4 are the same proportion, and

--- a/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/reference_range_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/reference_range_impl.rs
@@ -16,8 +16,17 @@ use crate::v1_2::data_types::quantity::dv_ordered::DvOrdered;
 use crate::v1_2::data_types::quantity::reference_range::ReferenceRange;
 use openehr_base::validate::{InvariantViolation, Validate};
 
+/// One side of `Range_is_simple`, whose clause is
+/// `range.lower_unbounded **or else** range.lower.is_simple`.
+///
+/// An absent bound makes the right operand unevaluable, so the clause is
+/// undecidable rather than false — and undecidable raises nothing, the same
+/// reading `DV_INTERVAL` applies to the interval this constrains. BASE
+/// `interval.adoc` §Attributes declares `lower`/`upper` `0..1` and requires no
+/// value when the flag is false, so demanding one here refused a range
+/// `DV_INTERVAL` itself accepts.
 fn limit_ok(unbounded: bool, limit: Option<&DvOrdered>) -> bool {
-    unbounded || limit.is_some_and(DvOrdered::is_simple)
+    unbounded || limit.is_none_or(DvOrdered::is_simple)
 }
 
 impl ReferenceRange {

--- a/tools/openehr-codegen/templates/openehr-rm/data_types/uri/dv_uri_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/data_types/uri/dv_uri_impl.rs
@@ -24,25 +24,18 @@ fn has_scheme(value: &str) -> bool {
     matches!(value.split_once(':'), Some((s, _)) if is_scheme(s))
 }
 
-/// The DV_URI `Value_valid` (RM invariant) + scheme-presence (CNF conformance)
-/// core over the projected value — one source for the typed impl and the
-/// value-level fast path (`validate::fast`), mirroring the DV_EHR_URI sibling
-/// (`dv_ehr_uri_impl::push_dv_ehr_uri_invariants`).
+/// The DV_URI `Value_valid` core over the projected value — one source for the
+/// typed impl and the value-level fast path (`validate::fast`), mirroring the
+/// DV_EHR_URI sibling (`dv_ehr_uri_impl::push_dv_ehr_uri_invariants`).
 pub(crate) fn push_dv_uri_invariants(value: &str, out: &mut Vec<InvariantViolation>) {
     // RM invariant `Value_valid: not value.is_empty` (the only DV_URI invariant).
     crate::v1_2::validate::generated::dv_uri_core(value, out);
-    // We therefore require an absolute reference (a scheme followed by `:`);
-    // per the RM prose we do NOT enforce RFC-3986 encoding of the remainder
-    // (plain-text URIs stay valid). The CNF content schedule is the conformance
-    // oracle and is stricter than both the RM invariant set and RFC 3986:
-    // `master17.7-content_tc_data_types-uri.adoc` (CONT-DV_URI-validate_open)
-    // tabulates `xyz | rejected` vs `ftp://ftp.is.co.za/… | accepted`.
-    // NOTE: scheme presence is NOT an RM class invariant — the only DV_URI
-    // invariant is `Value_valid: not value.is_empty` (`…dv_uri.adoc`
-    // §Invariants), and the class prose allows plain-text URIs.
+    // NOTE: `dv_uri.adoc` §Description binds `value` to "the Universal Resource
+    // Identifier (URI) RFC-3986 standard", whose §3 `URI` production requires a
+    // scheme; the encoding of the remainder stays unenforced (plain-text URIs).
     if !has_scheme(value) {
         out.push(InvariantViolation::here(
-            "Invariant Scheme_valid failed on type DV_URI",
+            "Invariant Value_valid failed on type DV_URI",
         ));
     }
 }
@@ -123,22 +116,19 @@ mod tests {
     #[test]
     fn value_valid() {
         assert!(uri("http://example.org/x").invariants().is_empty());
-        // An empty value fails both `Value_valid` (non-empty) and `Scheme_valid`
-        // (no scheme), mirroring the DV_EHR_URI sibling `empty_fails_both`.
-        let msgs = messages("");
-        assert!(msgs.contains(&"Invariant Value_valid failed on type DV_URI".to_owned()));
-        assert!(msgs.contains(&"Invariant Scheme_valid failed on type DV_URI".to_owned()));
+        // An empty value is both empty and scheme-less; both are `Value_valid`,
+        // which is the only invariant `dv_uri.adoc` §Invariants declares.
+        assert!(messages("").contains(&"Invariant Value_valid failed on type DV_URI".to_owned()));
     }
 
-    /// CNF `master17.7-content_tc_data_types-uri.adoc` (Test Case
-    /// CONT-DV_URI-validate_open): "only invalid URIs should be rejected. Any
-    /// RFC3986-compliant URI should be accepted"; the row `xyz | rejected`
-    /// requires a bare relative reference (no scheme) to be rejected, while
-    /// `ftp://ftp.is.co.za/rfc/rfc1808.txt | accepted`. A DV_URI value must
-    /// therefore be an absolute reference (scheme present).
+    /// `dv_uri.adoc` §Description binds `value` to "the Universal Resource
+    /// Identifier (URI) RFC-3986 standard", whose §3 `URI` production requires a
+    /// scheme — a scheme-less string is a `relative-ref`, which it does not
+    /// admit. The refusal is reported under `Value_valid`, the class's only
+    /// declared invariant.
     #[test]
     fn scheme_required_for_absolute_reference() {
-        let scheme_valid = "Invariant Scheme_valid failed on type DV_URI".to_owned();
+        let value_valid = "Invariant Value_valid failed on type DV_URI".to_owned();
         // Absolute references (scheme present) are accepted.
         assert!(
             uri("ftp://ftp.is.co.za/rfc/rfc1808.txt")
@@ -154,10 +144,10 @@ mod tests {
         // RM prose allows "plain-text URIs" with RFC-3986-forbidden characters
         // (e.g. a space) — still accepted so long as a scheme is present.
         assert!(uri("http://example.org/a b").invariants().is_empty());
-        // Bare relative references (no scheme) are rejected (CNF `xyz` row).
-        assert!(messages("xyz").contains(&scheme_valid));
-        assert!(messages("www.iana.org").contains(&scheme_valid));
-        assert!(messages("content/items").contains(&scheme_valid));
+        // Bare relative references (no scheme) are rejected.
+        assert!(messages("xyz").contains(&value_valid));
+        assert!(messages("www.iana.org").contains(&value_valid));
+        assert!(messages("content/items").contains(&value_valid));
     }
 
     #[test]


### PR DESCRIPTION
Audit findings from #2252 and #2253. **Four of these are contradictions inside one class, not gaps** — which is why no ratchet or completeness gate saw them. Every function existed and returned an answer; the answers disagreed with each other.

## `DV_PROPORTION` — equal *and* less-than, on a pair the crate's own test asserts

#2245 made `is_equal` exact (cross-multiplication in `Decimal`) and left the `DV_ORDERED` key dividing in `f64`. For `1/3` vs `0.1/0.3`:

| | result |
|---|---|
| `is_equal` (Decimal) | `true` |
| `less_than` (f64) | `Some(true)` |

That key also backs `DvInterval::has` → `REFERENCE_RANGE::is_in_range` → `Normal_range_and_status_consistency`, so a proportion sitting on a reference-range boundary could raise a **validation error on a valid commit**.

The class now has **one** ordering primitive that `is_equal` and `less_than` both call, so `<`, `=` and `>` partition the same pairs by construction. `ordered_limit!` grew an `order(a, b)` arm for types whose order is a pair comparison rather than a per-value key. A test asserts exactly-one-of-three holds across six pairs including negative denominators.

## The other three contradictions

- **`DV_AMOUNT::is_equal` compared every field** — on my own note that the abstract declaration left it undefined. It doesn't: `is_equal` is inherited from BASE `any.adoc` as equality of **value**. `PT60M` and `PT1H` were unequal while neither was less than the other.
- **`DV_COUNT` ordering routed an `Integer64` through `f64`**, under a suppression whose reason was an assumption about clinical data rather than a proof. It compares as an integer now; the suppression is gone.
- **`REFERENCE_RANGE.Range_is_simple` refused a range with an absent bound** while the flag is false. BASE `Interval` declares those `0..1`, `DV_INTERVAL` accepts it, and the clause is `or else` — undecidable, not violated.

## `DV_URI` reported another class's invariant to clients

`"Invariant Scheme_valid failed on type DV_URI"` — but `Scheme_valid` is **`DV_EHR_URI`'s** invariant, and `DV_URI` declares only `Value_valid`. That message reaches clients in 422 bodies. Its justification also named the CNF schedule "the conformance oracle", which `spec-adherence.md` explicitly forbids.

The refusal is unchanged and correct — `§Description` binds the value to RFC 3986, whose `URI` production requires a scheme. It is now reported under the invariant it belongs to.

## Two fabricated citations in PUBLISHED crates

- `party_ref_impl` justified admitting `ANY` by *"the CNF-outranks-prose rule"* — the inverse of ours — citing a Robot fixture path. **The real ground was one class up all along**: `object_ref.adoc`'s own `type` Meaning says "The type name `ANY` can be used to indicate that any type is accepted". Behaviour unchanged, justification now real.
- `terminology_id_impl` quoted master05 as saying identifiers *"include, but are not limited to"*. **That phrase appears nowhere in `docs/specs/openehr/`** — only inside a CNF robot filename. The actual text is "Examples of terminology identifiers include:", and its example is `SNOMED-CT` with a hyphen, not the space the comment claimed justified leniency. The acceptance behaviour is **unchanged here** (narrowing it could reject stored data and CNF fixtures) and the divergence is stated honestly under **#2258**.

## One finding I did NOT take

The audit proposed reading `DV_PROPORTION.is_integral` as `precision = 0`, per the spec's own "i.e.". I checked the four interlocking invariants: that branch makes `Fraction_validity` demand every fraction *declare* a precision, so a valid `1/2` stating none becomes invalid. Both readings make one invariant vacuous; only that one refuses valid data. The value test stays — and the adjudication now sits where the wrong citation was.

## Verification

943 `openehr-rm`/`openehr-base` tests and 2735 workspace tests pass; clippy clean at `-D warnings`; comment-style clean (it caught one of my own NOTEs at 11 lines and I shortened it). Crates bumped to `0.0.22`.