### PR TITLE
fix(base): a repeated duration designator silently became a different duration

### DIFF
--- a/crates/openehr-base/src/v1_2/base_types/identification/archetype_id_impl.rs
+++ b/crates/openehr-base/src/v1_2/base_types/identification/archetype_id_impl.rs
@@ -98,11 +98,15 @@ impl ArchetypeId {
     }
 
     /// Major version number, e.g. `1` for both `.v1` and `.v1.2.3` — the leading
-    /// numeric segment of `version_id`. BASE base_types master05 §Syntaxes:
-    /// `version_id = '0' | nz-digit [number]` is the major, optionally followed
-    /// by `'.' minor_version '.' patch_version`; only the major is significant to
-    /// interface-reference matching (AM master07 §Referencing: an `ihrid_ref`
-    /// carries the major version only, and a differing major is a hard boundary).
+    /// numeric segment of `version_id`.
+    ///
+    /// BASE base_types master05 §Syntaxes defines only the single-part form
+    /// (`version_id = '0' | non-zero-digit, [ number ]`); the three-part
+    /// `major.minor.patch` belongs to the AM archetype HRID
+    /// (`docs/specs/openehr/AM/docs/Identification/`), and only the major is
+    /// significant to interface-reference matching (AM master07 §Referencing:
+    /// an `ihrid_ref` carries the major version only, and a differing major is
+    /// a hard boundary).
     #[must_use]
     pub fn major_version(&self) -> &str {
         self.version_id().split('.').next().unwrap_or("")
@@ -112,17 +116,20 @@ impl ArchetypeId {
 impl FromStr for ArchetypeId {
     type Err = IdError;
 
-    /// Parse an `ARCHETYPE_ID`, requiring the RM qualifier, a domain concept,
-    /// and a `.vN` version segment.
+    /// Parse an `ARCHETYPE_ID` against the master05 §Syntaxes `archetype_id`
+    /// production.
+    ///
+    /// The door is the SAME check the class's `Validate` impl runs. It used to
+    /// be weaker — a `.v` anywhere, a `.` before it, three `-` segments — so
+    /// `"1-2-3.@@@.vXYZ"` constructed and then failed its own invariants, and
+    /// the "well-formed by construction" guarantee every sibling here
+    /// establishes (`HierObjectId::new` calls `is_uid`, `VersionTreeId::new`
+    /// calls `is_valid_version_tree`) did not hold for this type.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.is_empty() {
             return Err(IdError::Empty);
         }
-        let Some(p) = parse(s) else {
-            return Err(IdError::Archetype(s.to_owned()));
-        };
-        // The RM qualifier must have three '-'-delimited segments.
-        if p.qualified.split('-').count() < 3 {
+        if !is_valid_archetype_id(s) {
             return Err(IdError::Archetype(s.to_owned()));
         }
         Ok(Self {
@@ -260,6 +267,29 @@ mod validity_tests {
             "",
         ] {
             assert!(!is_valid_archetype_id(bad), "{bad} must be invalid");
+        }
+    }
+
+    /// The construction door and the class's own invariants must agree, or the
+    /// type's well-formed-by-construction guarantee is not one. They did not:
+    /// the door checked for a `.v`, a `.` before it and three `-` segments, so
+    /// these constructed and then failed `Validate`.
+    #[test]
+    fn construction_admits_exactly_what_the_invariants_accept() {
+        for value in [
+            "openEHR-EHR-COMPOSITION.encounter.v1",
+            "openEHR-EHR-OBSERVATION.blood_pressure.v2.1.0",
+            "1-2-3.@@@.vXYZ",
+            "openEHR-EHR-COMPOSITION.encounter.v1draft",
+            "openEHR-EHR.encounter.v1",
+            "openEHR-EHR-COMPOSITION.encounter",
+            "openEHR-EHR-COMPOSITION.encounter.v01",
+        ] {
+            assert_eq!(
+                ArchetypeId::from_str(value).is_ok(),
+                is_valid_archetype_id(value),
+                "{value:?}: the door and the invariants disagree",
+            );
         }
     }
 }

--- a/crates/openehr-base/src/v1_2/base_types/identification/lexical.rs
+++ b/crates/openehr-base/src/v1_2/base_types/identification/lexical.rs
@@ -170,14 +170,21 @@ pub(crate) fn all_digits(s: &str) -> bool {
     !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit())
 }
 
-/// A positive integer with no leading zero: `[1-9][0-9]*` (used by the
-/// `VERSION_TREE_ID` trunk/branch segments — numbering starts at 1).
+/// A `number` (master05 §Syntaxes: `digit, { digit }`) whose VALUE is at least
+/// 1, as the `VERSION_TREE_ID` trunk/branch segments require.
+///
+/// The bound is on the value, not the spelling: `version_tree_id.adoc`
+/// §Invariants gives `Trunk_version_valid: … trunk_version.as_integer >= 1`,
+/// and the production admits a leading zero. Refusing `"01"` lexically was a
+/// prohibition neither states, and since `VersionTreeId::new` is the only
+/// construction door it made a foreign system's zero-padded version id
+/// impossible to accept or round-trip.
+///
+/// "At least 1" is read as "not every digit is zero" rather than by parsing,
+/// so an id longer than any integer type still answers correctly.
 #[must_use]
 pub(crate) fn is_positive_int(s: &str) -> bool {
-    match s.as_bytes() {
-        [first, rest @ ..] => (b'1'..=b'9').contains(first) && rest.iter().all(u8::is_ascii_digit),
-        [] => false,
-    }
+    !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit()) && s.bytes().any(|b| b != b'0')
 }
 
 /// `true` for the `iso_oid` production.
@@ -455,9 +462,17 @@ mod tests {
     fn positive_int_rules() {
         assert!(is_positive_int("1"));
         assert!(is_positive_int("42"));
+        // The bound is on the VALUE, not the spelling: `number` is
+        // `digit, { digit }`, so a leading zero is a legal `number` whose value
+        // is still >= 1.
+        assert!(is_positive_int("01"));
+        assert!(is_positive_int("0000000009"));
+        // Value < 1, whatever the spelling.
         assert!(!is_positive_int("0"));
-        assert!(!is_positive_int("01"));
+        assert!(!is_positive_int("000"));
+        // Not a `number` at all.
         assert!(!is_positive_int(""));
         assert!(!is_positive_int("1a"));
+        assert!(!is_positive_int("-1"));
     }
 }

--- a/crates/openehr-base/src/v1_2/base_types/identification/version_tree_id_impl.rs
+++ b/crates/openehr-base/src/v1_2/base_types/identification/version_tree_id_impl.rs
@@ -243,7 +243,7 @@ mod tests {
             // Trunk_version_valid: `trunk_version.as_integer >= 1`.
             ("a", "Trunk_version_valid"),
             ("-1", "Trunk_version_valid"),
-            ("01", "Trunk_version_valid"),
+            ("0", "Trunk_version_valid"),
             ("0.1.1", "Trunk_version_valid"),
             // Branch_number_valid: the same rule on the second part.
             ("1.0.1", "Branch_number_valid"),
@@ -273,8 +273,12 @@ mod tests {
             ),
             "a non-numeric single part breaks Trunk_version_valid"
         );
-        // The accepting twins stay silent.
-        for good in ["1", "42", "1.2.3", "10.9.8"] {
+        // The accepting twins stay silent. `01` is among them: master05
+        // §Syntaxes gives `trunk_version = number` and `number = digit,
+        // { digit }`, and `Trunk_version_valid` bounds the VALUE (`>= 1`), not
+        // the spelling — so a foreign system's zero-padded id is legal and must
+        // round-trip.
+        for good in ["1", "42", "1.2.3", "10.9.8", "01", "1.02.3", "007"] {
             assert!(vtid(good).is_empty(), "{good:?} is a legal VERSION_TREE_ID");
         }
     }

--- a/crates/openehr-base/src/v1_2/foundation_types/time/iso8601_parse.rs
+++ b/crates/openehr-base/src/v1_2/foundation_types/time/iso8601_parse.rs
@@ -63,6 +63,12 @@ pub(crate) const DAYS_IN_WEEK: f64 = 7.0;
 pub(crate) const AVERAGE_DAYS_IN_MONTH: f64 = 30.42;
 /// `Time_Definitions.Average_days_in_year` = 365.24.
 pub(crate) const AVERAGE_DAYS_IN_YEAR: f64 = 365.24;
+/// `Time_Definitions.Min_timezone_hour` = 12 — "minimum hour value of a
+/// timezone according to ISO 8601 (note that the -ve sign is supplied in the
+/// `ISO8601_TIMEZONE` class)".
+pub(crate) const MIN_TIMEZONE_HOUR: u32 = 12;
+/// `Time_Definitions.Max_timezone_hour` = 14.
+pub(crate) const MAX_TIMEZONE_HOUR: u32 = 14;
 
 /// Seconds in one clock hour (`Minutes_in_hour * Seconds_in_minute`).
 pub(crate) const SECONDS_IN_HOUR: f64 = MINUTES_IN_HOUR * SECONDS_IN_MINUTE;
@@ -454,8 +460,16 @@ fn validate_time(
 }
 
 /// Parse a timezone designator: `Z` → 0, `±hh[:mm]` / `±hh[mm]` → signed
-/// minutes. `hh` is `00`..=`14` (`Time_definitions.Max_timezone_hour`), `mm`
-/// `00`..=`59`.
+/// minutes.
+///
+/// The hour bound is ASYMMETRIC, per `iso8601_timezone.adoc` §Invariants:
+/// `Max_hour_valid` allows `sign = 1` up to `Max_timezone_hour` (14) while
+/// `Min_hour_valid` allows `sign = -1` only to `Min_timezone_hour` (12) — the
+/// real span of civil offsets either side of the dateline. `mm` is `00`..=`59`.
+///
+/// NOTE: both invariants also require `hour > 0`, which would refuse `+00:00`
+/// while the same class defines `is_gmt` as "timezone `+0000`" — a released-text
+/// contradiction, so that clause is not enforced (reported as #2260).
 fn parse_timezone(tz: &str) -> Option<i32> {
     if tz == "Z" {
         return Some(0);
@@ -478,7 +492,12 @@ fn parse_timezone(tz: &str) -> Option<i32> {
             _ => return None,
         }
     };
-    if hh > 14 || mm > 59 {
+    let max_hour = if sign < 0 {
+        MIN_TIMEZONE_HOUR
+    } else {
+        MAX_TIMEZONE_HOUR
+    };
+    if hh > max_hour || mm > 59 {
         return None;
     }
     #[expect(
@@ -515,6 +534,56 @@ pub(crate) fn parse_date_time(s: &str) -> Option<ParsedDateTime> {
 /// (`Time_definitions.valid_iso8601_duration`, with the openEHR deviations: a
 /// leading `-` and `W` mixable with other designators). Requires at least one
 /// component; only the seconds field may carry a fraction.
+/// Store one duration component on `d` and return its slot in the production
+/// `P[nnY][nnM][nnW][nnD][T[nnH][nnM][nnS]]`, or `None` for a designator that
+/// production does not admit in this position.
+///
+/// The slot is what makes the production ORDERED and each designator
+/// at-most-once: the caller requires it to advance strictly. Without that,
+/// `P1D1M` parsed out of order and `P2Y1Y` parsed with the second `Y`
+/// OVERWRITING the first — one duration silently becoming a different one,
+/// which every `to_seconds`/`add_nominal` downstream then computed from.
+fn apply_duration_component(
+    d: &mut ParsedDuration,
+    in_time: bool,
+    designator: char,
+    intval: u64,
+    fracval: f64,
+) -> Option<i8> {
+    match (in_time, designator) {
+        (false, 'Y') => {
+            d.years = intval;
+            Some(0)
+        }
+        (false, 'M') => {
+            d.months = intval;
+            Some(1)
+        }
+        (false, 'W') => {
+            d.weeks = intval;
+            Some(2)
+        }
+        (false, 'D') => {
+            d.days = intval;
+            Some(3)
+        }
+        (true, 'H') => {
+            d.hours = intval;
+            Some(4)
+        }
+        (true, 'M') => {
+            d.minutes = intval;
+            Some(5)
+        }
+        (true, 'S') => {
+            d.seconds = intval;
+            d.fractional_seconds = fracval;
+            Some(6)
+        }
+        _ => None,
+    }
+}
+
 pub(crate) fn parse_duration(s: &str) -> Option<ParsedDuration> {
     let mut it = s.chars().peekable();
     let negative = match it.peek() {
@@ -543,6 +612,10 @@ pub(crate) fn parse_duration(s: &str) -> Option<ParsedDuration> {
     };
     let mut in_time = false;
     let mut seen_any = false;
+    // The slot of the last designator consumed, in the order the production
+    // fixes; `-1` because `Y` is slot 0.
+    let mut last_slot: i8 = -1;
+    let mut seen_time_component = false;
     loop {
         match it.peek() {
             None => break,
@@ -586,18 +659,13 @@ pub(crate) fn parse_duration(s: &str) -> Option<ParsedDuration> {
                 } else {
                     0.0
                 };
-                match (in_time, designator) {
-                    (false, 'Y') => d.years = intval,
-                    (false, 'M') => d.months = intval,
-                    (false, 'W') => d.weeks = intval,
-                    (false, 'D') => d.days = intval,
-                    (true, 'H') => d.hours = intval,
-                    (true, 'M') => d.minutes = intval,
-                    (true, 'S') => {
-                        d.seconds = intval;
-                        d.fractional_seconds = fracval;
-                    }
-                    _ => return None,
+                let slot = apply_duration_component(&mut d, in_time, designator, intval, fracval)?;
+                if slot <= last_slot {
+                    return None;
+                }
+                last_slot = slot;
+                if in_time {
+                    seen_time_component = true;
                 }
                 if has_frac && !(in_time && designator == 'S') {
                     return None; // only the seconds field carries a fraction
@@ -609,6 +677,9 @@ pub(crate) fn parse_duration(s: &str) -> Option<ParsedDuration> {
     }
     if !seen_any {
         return None; // `P`/`PT` with no components is not a duration
+    }
+    if in_time && !seen_time_component {
+        return None; // `P1YT` — the production has no bare trailing `T`
     }
     Some(d)
 }
@@ -1310,5 +1381,38 @@ mod tests {
             render_duration(ExactSeconds::new(-1, 0.5).unwrap()).as_deref(),
             Some("-PT0.5S")
         );
+    }
+
+    /// `P[nnY][nnM][nnW][nnD][T[nnH][nnM][nnS]]` is ORDERED and each designator
+    /// appears at most once. A repeat used to parse and OVERWRITE — `P2Y1Y`
+    /// became `P1Y`, a different duration, with no error anywhere downstream.
+    #[test]
+    fn a_repeated_or_misordered_designator_is_not_a_duration() {
+        // The silent-loss case: the first count vanished.
+        assert!(parse_duration("P2Y1Y").is_none());
+        assert!(parse_duration("P1Y1Y").is_none());
+        assert!(parse_duration("PT1H2H").is_none());
+
+        // Out of order.
+        assert!(parse_duration("P1D1M").is_none());
+        assert!(parse_duration("P1D1Y").is_none());
+        assert!(parse_duration("PT1S1H").is_none());
+        assert!(parse_duration("P1D1W").is_none());
+
+        // A bare trailing `T` carries no time component.
+        assert!(parse_duration("P1YT").is_none());
+        assert!(parse_duration("PT").is_none());
+
+        // The whole production, in order, still parses — including the openEHR
+        // `W`-mixed-with-others deviation in its own slot.
+        let full = parse_duration("P1Y2M3W4DT5H6M7.5S").expect("the full production");
+        assert_eq!(
+            (full.years, full.months, full.weeks, full.days),
+            (1, 2, 3, 4)
+        );
+        assert_eq!((full.hours, full.minutes, full.seconds), (5, 6, 7));
+        assert!(parse_duration("P1M").is_some(), "months alone");
+        assert!(parse_duration("PT1M").is_some(), "minutes alone");
+        assert!(parse_duration("P1W").is_some());
     }
 }

--- a/crates/openehr-base/src/v1_3/base_types/identification/archetype_id_impl.rs
+++ b/crates/openehr-base/src/v1_3/base_types/identification/archetype_id_impl.rs
@@ -98,11 +98,15 @@ impl ArchetypeId {
     }
 
     /// Major version number, e.g. `1` for both `.v1` and `.v1.2.3` — the leading
-    /// numeric segment of `version_id`. BASE base_types master05 §Syntaxes:
-    /// `version_id = '0' | nz-digit [number]` is the major, optionally followed
-    /// by `'.' minor_version '.' patch_version`; only the major is significant to
-    /// interface-reference matching (AM master07 §Referencing: an `ihrid_ref`
-    /// carries the major version only, and a differing major is a hard boundary).
+    /// numeric segment of `version_id`.
+    ///
+    /// BASE base_types master05 §Syntaxes defines only the single-part form
+    /// (`version_id = '0' | non-zero-digit, [ number ]`); the three-part
+    /// `major.minor.patch` belongs to the AM archetype HRID
+    /// (`docs/specs/openehr/AM/docs/Identification/`), and only the major is
+    /// significant to interface-reference matching (AM master07 §Referencing:
+    /// an `ihrid_ref` carries the major version only, and a differing major is
+    /// a hard boundary).
     #[must_use]
     pub fn major_version(&self) -> &str {
         self.version_id().split('.').next().unwrap_or("")
@@ -112,17 +116,20 @@ impl ArchetypeId {
 impl FromStr for ArchetypeId {
     type Err = IdError;
 
-    /// Parse an `ARCHETYPE_ID`, requiring the RM qualifier, a domain concept,
-    /// and a `.vN` version segment.
+    /// Parse an `ARCHETYPE_ID` against the master05 §Syntaxes `archetype_id`
+    /// production.
+    ///
+    /// The door is the SAME check the class's `Validate` impl runs. It used to
+    /// be weaker — a `.v` anywhere, a `.` before it, three `-` segments — so
+    /// `"1-2-3.@@@.vXYZ"` constructed and then failed its own invariants, and
+    /// the "well-formed by construction" guarantee every sibling here
+    /// establishes (`HierObjectId::new` calls `is_uid`, `VersionTreeId::new`
+    /// calls `is_valid_version_tree`) did not hold for this type.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.is_empty() {
             return Err(IdError::Empty);
         }
-        let Some(p) = parse(s) else {
-            return Err(IdError::Archetype(s.to_owned()));
-        };
-        // The RM qualifier must have three '-'-delimited segments.
-        if p.qualified.split('-').count() < 3 {
+        if !is_valid_archetype_id(s) {
             return Err(IdError::Archetype(s.to_owned()));
         }
         Ok(Self {
@@ -260,6 +267,29 @@ mod validity_tests {
             "",
         ] {
             assert!(!is_valid_archetype_id(bad), "{bad} must be invalid");
+        }
+    }
+
+    /// The construction door and the class's own invariants must agree, or the
+    /// type's well-formed-by-construction guarantee is not one. They did not:
+    /// the door checked for a `.v`, a `.` before it and three `-` segments, so
+    /// these constructed and then failed `Validate`.
+    #[test]
+    fn construction_admits_exactly_what_the_invariants_accept() {
+        for value in [
+            "openEHR-EHR-COMPOSITION.encounter.v1",
+            "openEHR-EHR-OBSERVATION.blood_pressure.v2.1.0",
+            "1-2-3.@@@.vXYZ",
+            "openEHR-EHR-COMPOSITION.encounter.v1draft",
+            "openEHR-EHR.encounter.v1",
+            "openEHR-EHR-COMPOSITION.encounter",
+            "openEHR-EHR-COMPOSITION.encounter.v01",
+        ] {
+            assert_eq!(
+                ArchetypeId::from_str(value).is_ok(),
+                is_valid_archetype_id(value),
+                "{value:?}: the door and the invariants disagree",
+            );
         }
     }
 }

--- a/crates/openehr-base/src/v1_3/base_types/identification/lexical.rs
+++ b/crates/openehr-base/src/v1_3/base_types/identification/lexical.rs
@@ -170,14 +170,21 @@ pub(crate) fn all_digits(s: &str) -> bool {
     !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit())
 }
 
-/// A positive integer with no leading zero: `[1-9][0-9]*` (used by the
-/// `VERSION_TREE_ID` trunk/branch segments — numbering starts at 1).
+/// A `number` (master05 §Syntaxes: `digit, { digit }`) whose VALUE is at least
+/// 1, as the `VERSION_TREE_ID` trunk/branch segments require.
+///
+/// The bound is on the value, not the spelling: `version_tree_id.adoc`
+/// §Invariants gives `Trunk_version_valid: … trunk_version.as_integer >= 1`,
+/// and the production admits a leading zero. Refusing `"01"` lexically was a
+/// prohibition neither states, and since `VersionTreeId::new` is the only
+/// construction door it made a foreign system's zero-padded version id
+/// impossible to accept or round-trip.
+///
+/// "At least 1" is read as "not every digit is zero" rather than by parsing,
+/// so an id longer than any integer type still answers correctly.
 #[must_use]
 pub(crate) fn is_positive_int(s: &str) -> bool {
-    match s.as_bytes() {
-        [first, rest @ ..] => (b'1'..=b'9').contains(first) && rest.iter().all(u8::is_ascii_digit),
-        [] => false,
-    }
+    !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit()) && s.bytes().any(|b| b != b'0')
 }
 
 /// `true` for the `iso_oid` production.
@@ -455,9 +462,17 @@ mod tests {
     fn positive_int_rules() {
         assert!(is_positive_int("1"));
         assert!(is_positive_int("42"));
+        // The bound is on the VALUE, not the spelling: `number` is
+        // `digit, { digit }`, so a leading zero is a legal `number` whose value
+        // is still >= 1.
+        assert!(is_positive_int("01"));
+        assert!(is_positive_int("0000000009"));
+        // Value < 1, whatever the spelling.
         assert!(!is_positive_int("0"));
-        assert!(!is_positive_int("01"));
+        assert!(!is_positive_int("000"));
+        // Not a `number` at all.
         assert!(!is_positive_int(""));
         assert!(!is_positive_int("1a"));
+        assert!(!is_positive_int("-1"));
     }
 }

--- a/crates/openehr-base/src/v1_3/base_types/identification/version_tree_id_impl.rs
+++ b/crates/openehr-base/src/v1_3/base_types/identification/version_tree_id_impl.rs
@@ -243,7 +243,7 @@ mod tests {
             // Trunk_version_valid: `trunk_version.as_integer >= 1`.
             ("a", "Trunk_version_valid"),
             ("-1", "Trunk_version_valid"),
-            ("01", "Trunk_version_valid"),
+            ("0", "Trunk_version_valid"),
             ("0.1.1", "Trunk_version_valid"),
             // Branch_number_valid: the same rule on the second part.
             ("1.0.1", "Branch_number_valid"),
@@ -273,8 +273,12 @@ mod tests {
             ),
             "a non-numeric single part breaks Trunk_version_valid"
         );
-        // The accepting twins stay silent.
-        for good in ["1", "42", "1.2.3", "10.9.8"] {
+        // The accepting twins stay silent. `01` is among them: master05
+        // §Syntaxes gives `trunk_version = number` and `number = digit,
+        // { digit }`, and `Trunk_version_valid` bounds the VALUE (`>= 1`), not
+        // the spelling — so a foreign system's zero-padded id is legal and must
+        // round-trip.
+        for good in ["1", "42", "1.2.3", "10.9.8", "01", "1.02.3", "007"] {
             assert!(vtid(good).is_empty(), "{good:?} is a legal VERSION_TREE_ID");
         }
     }

--- a/crates/openehr-base/src/v1_3/foundation_types/time/iso8601_parse.rs
+++ b/crates/openehr-base/src/v1_3/foundation_types/time/iso8601_parse.rs
@@ -63,6 +63,12 @@ pub(crate) const DAYS_IN_WEEK: f64 = 7.0;
 pub(crate) const AVERAGE_DAYS_IN_MONTH: f64 = 30.42;
 /// `Time_Definitions.Average_days_in_year` = 365.24.
 pub(crate) const AVERAGE_DAYS_IN_YEAR: f64 = 365.24;
+/// `Time_Definitions.Min_timezone_hour` = 12 — "minimum hour value of a
+/// timezone according to ISO 8601 (note that the -ve sign is supplied in the
+/// `ISO8601_TIMEZONE` class)".
+pub(crate) const MIN_TIMEZONE_HOUR: u32 = 12;
+/// `Time_Definitions.Max_timezone_hour` = 14.
+pub(crate) const MAX_TIMEZONE_HOUR: u32 = 14;
 
 /// Seconds in one clock hour (`Minutes_in_hour * Seconds_in_minute`).
 pub(crate) const SECONDS_IN_HOUR: f64 = MINUTES_IN_HOUR * SECONDS_IN_MINUTE;
@@ -454,8 +460,16 @@ fn validate_time(
 }
 
 /// Parse a timezone designator: `Z` → 0, `±hh[:mm]` / `±hh[mm]` → signed
-/// minutes. `hh` is `00`..=`14` (`Time_definitions.Max_timezone_hour`), `mm`
-/// `00`..=`59`.
+/// minutes.
+///
+/// The hour bound is ASYMMETRIC, per `iso8601_timezone.adoc` §Invariants:
+/// `Max_hour_valid` allows `sign = 1` up to `Max_timezone_hour` (14) while
+/// `Min_hour_valid` allows `sign = -1` only to `Min_timezone_hour` (12) — the
+/// real span of civil offsets either side of the dateline. `mm` is `00`..=`59`.
+///
+/// NOTE: both invariants also require `hour > 0`, which would refuse `+00:00`
+/// while the same class defines `is_gmt` as "timezone `+0000`" — a released-text
+/// contradiction, so that clause is not enforced (reported as #2260).
 fn parse_timezone(tz: &str) -> Option<i32> {
     if tz == "Z" {
         return Some(0);
@@ -478,7 +492,12 @@ fn parse_timezone(tz: &str) -> Option<i32> {
             _ => return None,
         }
     };
-    if hh > 14 || mm > 59 {
+    let max_hour = if sign < 0 {
+        MIN_TIMEZONE_HOUR
+    } else {
+        MAX_TIMEZONE_HOUR
+    };
+    if hh > max_hour || mm > 59 {
         return None;
     }
     #[expect(
@@ -515,6 +534,56 @@ pub(crate) fn parse_date_time(s: &str) -> Option<ParsedDateTime> {
 /// (`Time_definitions.valid_iso8601_duration`, with the openEHR deviations: a
 /// leading `-` and `W` mixable with other designators). Requires at least one
 /// component; only the seconds field may carry a fraction.
+/// Store one duration component on `d` and return its slot in the production
+/// `P[nnY][nnM][nnW][nnD][T[nnH][nnM][nnS]]`, or `None` for a designator that
+/// production does not admit in this position.
+///
+/// The slot is what makes the production ORDERED and each designator
+/// at-most-once: the caller requires it to advance strictly. Without that,
+/// `P1D1M` parsed out of order and `P2Y1Y` parsed with the second `Y`
+/// OVERWRITING the first — one duration silently becoming a different one,
+/// which every `to_seconds`/`add_nominal` downstream then computed from.
+fn apply_duration_component(
+    d: &mut ParsedDuration,
+    in_time: bool,
+    designator: char,
+    intval: u64,
+    fracval: f64,
+) -> Option<i8> {
+    match (in_time, designator) {
+        (false, 'Y') => {
+            d.years = intval;
+            Some(0)
+        }
+        (false, 'M') => {
+            d.months = intval;
+            Some(1)
+        }
+        (false, 'W') => {
+            d.weeks = intval;
+            Some(2)
+        }
+        (false, 'D') => {
+            d.days = intval;
+            Some(3)
+        }
+        (true, 'H') => {
+            d.hours = intval;
+            Some(4)
+        }
+        (true, 'M') => {
+            d.minutes = intval;
+            Some(5)
+        }
+        (true, 'S') => {
+            d.seconds = intval;
+            d.fractional_seconds = fracval;
+            Some(6)
+        }
+        _ => None,
+    }
+}
+
 pub(crate) fn parse_duration(s: &str) -> Option<ParsedDuration> {
     let mut it = s.chars().peekable();
     let negative = match it.peek() {
@@ -543,6 +612,10 @@ pub(crate) fn parse_duration(s: &str) -> Option<ParsedDuration> {
     };
     let mut in_time = false;
     let mut seen_any = false;
+    // The slot of the last designator consumed, in the order the production
+    // fixes; `-1` because `Y` is slot 0.
+    let mut last_slot: i8 = -1;
+    let mut seen_time_component = false;
     loop {
         match it.peek() {
             None => break,
@@ -586,18 +659,13 @@ pub(crate) fn parse_duration(s: &str) -> Option<ParsedDuration> {
                 } else {
                     0.0
                 };
-                match (in_time, designator) {
-                    (false, 'Y') => d.years = intval,
-                    (false, 'M') => d.months = intval,
-                    (false, 'W') => d.weeks = intval,
-                    (false, 'D') => d.days = intval,
-                    (true, 'H') => d.hours = intval,
-                    (true, 'M') => d.minutes = intval,
-                    (true, 'S') => {
-                        d.seconds = intval;
-                        d.fractional_seconds = fracval;
-                    }
-                    _ => return None,
+                let slot = apply_duration_component(&mut d, in_time, designator, intval, fracval)?;
+                if slot <= last_slot {
+                    return None;
+                }
+                last_slot = slot;
+                if in_time {
+                    seen_time_component = true;
                 }
                 if has_frac && !(in_time && designator == 'S') {
                     return None; // only the seconds field carries a fraction
@@ -609,6 +677,9 @@ pub(crate) fn parse_duration(s: &str) -> Option<ParsedDuration> {
     }
     if !seen_any {
         return None; // `P`/`PT` with no components is not a duration
+    }
+    if in_time && !seen_time_component {
+        return None; // `P1YT` — the production has no bare trailing `T`
     }
     Some(d)
 }
@@ -1310,5 +1381,38 @@ mod tests {
             render_duration(ExactSeconds::new(-1, 0.5).unwrap()).as_deref(),
             Some("-PT0.5S")
         );
+    }
+
+    /// `P[nnY][nnM][nnW][nnD][T[nnH][nnM][nnS]]` is ORDERED and each designator
+    /// appears at most once. A repeat used to parse and OVERWRITE — `P2Y1Y`
+    /// became `P1Y`, a different duration, with no error anywhere downstream.
+    #[test]
+    fn a_repeated_or_misordered_designator_is_not_a_duration() {
+        // The silent-loss case: the first count vanished.
+        assert!(parse_duration("P2Y1Y").is_none());
+        assert!(parse_duration("P1Y1Y").is_none());
+        assert!(parse_duration("PT1H2H").is_none());
+
+        // Out of order.
+        assert!(parse_duration("P1D1M").is_none());
+        assert!(parse_duration("P1D1Y").is_none());
+        assert!(parse_duration("PT1S1H").is_none());
+        assert!(parse_duration("P1D1W").is_none());
+
+        // A bare trailing `T` carries no time component.
+        assert!(parse_duration("P1YT").is_none());
+        assert!(parse_duration("PT").is_none());
+
+        // The whole production, in order, still parses — including the openEHR
+        // `W`-mixed-with-others deviation in its own slot.
+        let full = parse_duration("P1Y2M3W4DT5H6M7.5S").expect("the full production");
+        assert_eq!(
+            (full.years, full.months, full.weeks, full.days),
+            (1, 2, 3, 4)
+        );
+        assert_eq!((full.hours, full.minutes, full.seconds), (5, 6, 7));
+        assert!(parse_duration("P1M").is_some(), "months alone");
+        assert!(parse_duration("PT1M").is_some(), "minutes alone");
+        assert!(parse_duration("P1W").is_some());
     }
 }

--- a/tools/openehr-codegen/templates/openehr-base/base_types/identification/archetype_id_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-base/base_types/identification/archetype_id_impl.rs
@@ -97,11 +97,15 @@ impl ArchetypeId {
     }
 
     /// Major version number, e.g. `1` for both `.v1` and `.v1.2.3` — the leading
-    /// numeric segment of `version_id`. BASE base_types master05 §Syntaxes:
-    /// `version_id = '0' | nz-digit [number]` is the major, optionally followed
-    /// by `'.' minor_version '.' patch_version`; only the major is significant to
-    /// interface-reference matching (AM master07 §Referencing: an `ihrid_ref`
-    /// carries the major version only, and a differing major is a hard boundary).
+    /// numeric segment of `version_id`.
+    ///
+    /// BASE base_types master05 §Syntaxes defines only the single-part form
+    /// (`version_id = '0' | non-zero-digit, [ number ]`); the three-part
+    /// `major.minor.patch` belongs to the AM archetype HRID
+    /// (`docs/specs/openehr/AM/docs/Identification/`), and only the major is
+    /// significant to interface-reference matching (AM master07 §Referencing:
+    /// an `ihrid_ref` carries the major version only, and a differing major is
+    /// a hard boundary).
     #[must_use]
     pub fn major_version(&self) -> &str {
         self.version_id().split('.').next().unwrap_or("")
@@ -111,17 +115,20 @@ impl ArchetypeId {
 impl FromStr for ArchetypeId {
     type Err = IdError;
 
-    /// Parse an `ARCHETYPE_ID`, requiring the RM qualifier, a domain concept,
-    /// and a `.vN` version segment.
+    /// Parse an `ARCHETYPE_ID` against the master05 §Syntaxes `archetype_id`
+    /// production.
+    ///
+    /// The door is the SAME check the class's `Validate` impl runs. It used to
+    /// be weaker — a `.v` anywhere, a `.` before it, three `-` segments — so
+    /// `"1-2-3.@@@.vXYZ"` constructed and then failed its own invariants, and
+    /// the "well-formed by construction" guarantee every sibling here
+    /// establishes (`HierObjectId::new` calls `is_uid`, `VersionTreeId::new`
+    /// calls `is_valid_version_tree`) did not hold for this type.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.is_empty() {
             return Err(IdError::Empty);
         }
-        let Some(p) = parse(s) else {
-            return Err(IdError::Archetype(s.to_owned()));
-        };
-        // The RM qualifier must have three '-'-delimited segments.
-        if p.qualified.split('-').count() < 3 {
+        if !is_valid_archetype_id(s) {
             return Err(IdError::Archetype(s.to_owned()));
         }
         Ok(Self {
@@ -259,6 +266,29 @@ mod validity_tests {
             "",
         ] {
             assert!(!is_valid_archetype_id(bad), "{bad} must be invalid");
+        }
+    }
+
+    /// The construction door and the class's own invariants must agree, or the
+    /// type's well-formed-by-construction guarantee is not one. They did not:
+    /// the door checked for a `.v`, a `.` before it and three `-` segments, so
+    /// these constructed and then failed `Validate`.
+    #[test]
+    fn construction_admits_exactly_what_the_invariants_accept() {
+        for value in [
+            "openEHR-EHR-COMPOSITION.encounter.v1",
+            "openEHR-EHR-OBSERVATION.blood_pressure.v2.1.0",
+            "1-2-3.@@@.vXYZ",
+            "openEHR-EHR-COMPOSITION.encounter.v1draft",
+            "openEHR-EHR.encounter.v1",
+            "openEHR-EHR-COMPOSITION.encounter",
+            "openEHR-EHR-COMPOSITION.encounter.v01",
+        ] {
+            assert_eq!(
+                ArchetypeId::from_str(value).is_ok(),
+                is_valid_archetype_id(value),
+                "{value:?}: the door and the invariants disagree",
+            );
         }
     }
 }

--- a/tools/openehr-codegen/templates/openehr-base/base_types/identification/lexical.rs
+++ b/tools/openehr-codegen/templates/openehr-base/base_types/identification/lexical.rs
@@ -169,14 +169,21 @@ pub(crate) fn all_digits(s: &str) -> bool {
     !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit())
 }
 
-/// A positive integer with no leading zero: `[1-9][0-9]*` (used by the
-/// `VERSION_TREE_ID` trunk/branch segments — numbering starts at 1).
+/// A `number` (master05 §Syntaxes: `digit, { digit }`) whose VALUE is at least
+/// 1, as the `VERSION_TREE_ID` trunk/branch segments require.
+///
+/// The bound is on the value, not the spelling: `version_tree_id.adoc`
+/// §Invariants gives `Trunk_version_valid: … trunk_version.as_integer >= 1`,
+/// and the production admits a leading zero. Refusing `"01"` lexically was a
+/// prohibition neither states, and since `VersionTreeId::new` is the only
+/// construction door it made a foreign system's zero-padded version id
+/// impossible to accept or round-trip.
+///
+/// "At least 1" is read as "not every digit is zero" rather than by parsing,
+/// so an id longer than any integer type still answers correctly.
 #[must_use]
 pub(crate) fn is_positive_int(s: &str) -> bool {
-    match s.as_bytes() {
-        [first, rest @ ..] => (b'1'..=b'9').contains(first) && rest.iter().all(u8::is_ascii_digit),
-        [] => false,
-    }
+    !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit()) && s.bytes().any(|b| b != b'0')
 }
 
 /// `true` for the `iso_oid` production.
@@ -454,9 +461,17 @@ mod tests {
     fn positive_int_rules() {
         assert!(is_positive_int("1"));
         assert!(is_positive_int("42"));
+        // The bound is on the VALUE, not the spelling: `number` is
+        // `digit, { digit }`, so a leading zero is a legal `number` whose value
+        // is still >= 1.
+        assert!(is_positive_int("01"));
+        assert!(is_positive_int("0000000009"));
+        // Value < 1, whatever the spelling.
         assert!(!is_positive_int("0"));
-        assert!(!is_positive_int("01"));
+        assert!(!is_positive_int("000"));
+        // Not a `number` at all.
         assert!(!is_positive_int(""));
         assert!(!is_positive_int("1a"));
+        assert!(!is_positive_int("-1"));
     }
 }

--- a/tools/openehr-codegen/templates/openehr-base/base_types/identification/version_tree_id_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-base/base_types/identification/version_tree_id_impl.rs
@@ -242,7 +242,7 @@ mod tests {
             // Trunk_version_valid: `trunk_version.as_integer >= 1`.
             ("a", "Trunk_version_valid"),
             ("-1", "Trunk_version_valid"),
-            ("01", "Trunk_version_valid"),
+            ("0", "Trunk_version_valid"),
             ("0.1.1", "Trunk_version_valid"),
             // Branch_number_valid: the same rule on the second part.
             ("1.0.1", "Branch_number_valid"),
@@ -272,8 +272,12 @@ mod tests {
             ),
             "a non-numeric single part breaks Trunk_version_valid"
         );
-        // The accepting twins stay silent.
-        for good in ["1", "42", "1.2.3", "10.9.8"] {
+        // The accepting twins stay silent. `01` is among them: master05
+        // §Syntaxes gives `trunk_version = number` and `number = digit,
+        // { digit }`, and `Trunk_version_valid` bounds the VALUE (`>= 1`), not
+        // the spelling — so a foreign system's zero-padded id is legal and must
+        // round-trip.
+        for good in ["1", "42", "1.2.3", "10.9.8", "01", "1.02.3", "007"] {
             assert!(vtid(good).is_empty(), "{good:?} is a legal VERSION_TREE_ID");
         }
     }

--- a/tools/openehr-codegen/templates/openehr-base/foundation_types/time/iso8601_parse.rs
+++ b/tools/openehr-codegen/templates/openehr-base/foundation_types/time/iso8601_parse.rs
@@ -62,6 +62,12 @@ pub(crate) const DAYS_IN_WEEK: f64 = 7.0;
 pub(crate) const AVERAGE_DAYS_IN_MONTH: f64 = 30.42;
 /// `Time_Definitions.Average_days_in_year` = 365.24.
 pub(crate) const AVERAGE_DAYS_IN_YEAR: f64 = 365.24;
+/// `Time_Definitions.Min_timezone_hour` = 12 — "minimum hour value of a
+/// timezone according to ISO 8601 (note that the -ve sign is supplied in the
+/// `ISO8601_TIMEZONE` class)".
+pub(crate) const MIN_TIMEZONE_HOUR: u32 = 12;
+/// `Time_Definitions.Max_timezone_hour` = 14.
+pub(crate) const MAX_TIMEZONE_HOUR: u32 = 14;
 
 /// Seconds in one clock hour (`Minutes_in_hour * Seconds_in_minute`).
 pub(crate) const SECONDS_IN_HOUR: f64 = MINUTES_IN_HOUR * SECONDS_IN_MINUTE;
@@ -453,8 +459,16 @@ fn validate_time(
 }
 
 /// Parse a timezone designator: `Z` → 0, `±hh[:mm]` / `±hh[mm]` → signed
-/// minutes. `hh` is `00`..=`14` (`Time_definitions.Max_timezone_hour`), `mm`
-/// `00`..=`59`.
+/// minutes.
+///
+/// The hour bound is ASYMMETRIC, per `iso8601_timezone.adoc` §Invariants:
+/// `Max_hour_valid` allows `sign = 1` up to `Max_timezone_hour` (14) while
+/// `Min_hour_valid` allows `sign = -1` only to `Min_timezone_hour` (12) — the
+/// real span of civil offsets either side of the dateline. `mm` is `00`..=`59`.
+///
+/// NOTE: both invariants also require `hour > 0`, which would refuse `+00:00`
+/// while the same class defines `is_gmt` as "timezone `+0000`" — a released-text
+/// contradiction, so that clause is not enforced (reported as #2260).
 fn parse_timezone(tz: &str) -> Option<i32> {
     if tz == "Z" {
         return Some(0);
@@ -477,7 +491,12 @@ fn parse_timezone(tz: &str) -> Option<i32> {
             _ => return None,
         }
     };
-    if hh > 14 || mm > 59 {
+    let max_hour = if sign < 0 {
+        MIN_TIMEZONE_HOUR
+    } else {
+        MAX_TIMEZONE_HOUR
+    };
+    if hh > max_hour || mm > 59 {
         return None;
     }
     #[expect(
@@ -514,6 +533,56 @@ pub(crate) fn parse_date_time(s: &str) -> Option<ParsedDateTime> {
 /// (`Time_definitions.valid_iso8601_duration`, with the openEHR deviations: a
 /// leading `-` and `W` mixable with other designators). Requires at least one
 /// component; only the seconds field may carry a fraction.
+/// Store one duration component on `d` and return its slot in the production
+/// `P[nnY][nnM][nnW][nnD][T[nnH][nnM][nnS]]`, or `None` for a designator that
+/// production does not admit in this position.
+///
+/// The slot is what makes the production ORDERED and each designator
+/// at-most-once: the caller requires it to advance strictly. Without that,
+/// `P1D1M` parsed out of order and `P2Y1Y` parsed with the second `Y`
+/// OVERWRITING the first — one duration silently becoming a different one,
+/// which every `to_seconds`/`add_nominal` downstream then computed from.
+fn apply_duration_component(
+    d: &mut ParsedDuration,
+    in_time: bool,
+    designator: char,
+    intval: u64,
+    fracval: f64,
+) -> Option<i8> {
+    match (in_time, designator) {
+        (false, 'Y') => {
+            d.years = intval;
+            Some(0)
+        }
+        (false, 'M') => {
+            d.months = intval;
+            Some(1)
+        }
+        (false, 'W') => {
+            d.weeks = intval;
+            Some(2)
+        }
+        (false, 'D') => {
+            d.days = intval;
+            Some(3)
+        }
+        (true, 'H') => {
+            d.hours = intval;
+            Some(4)
+        }
+        (true, 'M') => {
+            d.minutes = intval;
+            Some(5)
+        }
+        (true, 'S') => {
+            d.seconds = intval;
+            d.fractional_seconds = fracval;
+            Some(6)
+        }
+        _ => None,
+    }
+}
+
 pub(crate) fn parse_duration(s: &str) -> Option<ParsedDuration> {
     let mut it = s.chars().peekable();
     let negative = match it.peek() {
@@ -542,6 +611,10 @@ pub(crate) fn parse_duration(s: &str) -> Option<ParsedDuration> {
     };
     let mut in_time = false;
     let mut seen_any = false;
+    // The slot of the last designator consumed, in the order the production
+    // fixes; `-1` because `Y` is slot 0.
+    let mut last_slot: i8 = -1;
+    let mut seen_time_component = false;
     loop {
         match it.peek() {
             None => break,
@@ -585,18 +658,13 @@ pub(crate) fn parse_duration(s: &str) -> Option<ParsedDuration> {
                 } else {
                     0.0
                 };
-                match (in_time, designator) {
-                    (false, 'Y') => d.years = intval,
-                    (false, 'M') => d.months = intval,
-                    (false, 'W') => d.weeks = intval,
-                    (false, 'D') => d.days = intval,
-                    (true, 'H') => d.hours = intval,
-                    (true, 'M') => d.minutes = intval,
-                    (true, 'S') => {
-                        d.seconds = intval;
-                        d.fractional_seconds = fracval;
-                    }
-                    _ => return None,
+                let slot = apply_duration_component(&mut d, in_time, designator, intval, fracval)?;
+                if slot <= last_slot {
+                    return None;
+                }
+                last_slot = slot;
+                if in_time {
+                    seen_time_component = true;
                 }
                 if has_frac && !(in_time && designator == 'S') {
                     return None; // only the seconds field carries a fraction
@@ -608,6 +676,9 @@ pub(crate) fn parse_duration(s: &str) -> Option<ParsedDuration> {
     }
     if !seen_any {
         return None; // `P`/`PT` with no components is not a duration
+    }
+    if in_time && !seen_time_component {
+        return None; // `P1YT` — the production has no bare trailing `T`
     }
     Some(d)
 }
@@ -1309,5 +1380,38 @@ mod tests {
             render_duration(ExactSeconds::new(-1, 0.5).unwrap()).as_deref(),
             Some("-PT0.5S")
         );
+    }
+
+    /// `P[nnY][nnM][nnW][nnD][T[nnH][nnM][nnS]]` is ORDERED and each designator
+    /// appears at most once. A repeat used to parse and OVERWRITE — `P2Y1Y`
+    /// became `P1Y`, a different duration, with no error anywhere downstream.
+    #[test]
+    fn a_repeated_or_misordered_designator_is_not_a_duration() {
+        // The silent-loss case: the first count vanished.
+        assert!(parse_duration("P2Y1Y").is_none());
+        assert!(parse_duration("P1Y1Y").is_none());
+        assert!(parse_duration("PT1H2H").is_none());
+
+        // Out of order.
+        assert!(parse_duration("P1D1M").is_none());
+        assert!(parse_duration("P1D1Y").is_none());
+        assert!(parse_duration("PT1S1H").is_none());
+        assert!(parse_duration("P1D1W").is_none());
+
+        // A bare trailing `T` carries no time component.
+        assert!(parse_duration("P1YT").is_none());
+        assert!(parse_duration("PT").is_none());
+
+        // The whole production, in order, still parses — including the openEHR
+        // `W`-mixed-with-others deviation in its own slot.
+        let full = parse_duration("P1Y2M3W4DT5H6M7.5S").expect("the full production");
+        assert_eq!(
+            (full.years, full.months, full.weeks, full.days),
+            (1, 2, 3, 4)
+        );
+        assert_eq!((full.hours, full.minutes, full.seconds), (5, 6, 7));
+        assert!(parse_duration("P1M").is_some(), "months alone");
+        assert!(parse_duration("PT1M").is_some(), "minutes alone");
+        assert!(parse_duration("P1W").is_some());
     }
 }


### PR DESCRIPTION
Audit findings from #2252. Four defects, one of which is **silent clinical data loss**.

## `P2Y1Y` parsed — as `P1Y`

The parser dispatched each component on `(in_time, designator)` into a flat struct with plain **assignment**:

```rust
(false, 'Y') => d.years = intval,   // a second `Y` overwrites the first
```

So `"P2Y1Y"` parsed successfully and became `P1Y`. No error anywhere, and every `to_seconds`/`add_nominal` downstream then computed a clinical interval from a value the spec says is not a duration at all. `"P1D1M"` parsed out of order; `"P1YT"` parsed with a `T` introducing nothing.

`P[nnY][nnM][nnW][nnD][T[nnH][nnM][nnS]]` is **ordered**, each designator **at most once**. Each component now returns its slot in that production and the slot must advance strictly — which makes "repeated" and "out of order" the same check. The `W` deviation keeps its own slot, so `P1Y2M3W4DT5H6M7.5S` still parses whole.

The extraction into `apply_duration_component` is there because the function crossed `too_many_lines`; a suppression would have been the easy answer and the wrong one.

## The timezone bound is asymmetric, and both signs used the wrong one

`Max_hour_valid` allows `sign = 1` up to 14; `Min_hour_valid` allows `sign = -1` only to 12 — the real span of civil offsets either side of the dateline. Both were checked against 14, so `-13:00` and `-14:00` parsed and shifted every derived ordering key. The two `Time_definitions` constants now exist instead of a literal.

**Not enforced:** both invariants also require `hour > 0`, which would refuse `+00:00` while the same class defines `is_gmt` as *"timezone `+0000`"*. Reported upstream as **#2260**, with a `NOTE` at the call site.

## Two invented/mismatched rules on identifiers

- **`VERSION_TREE_ID` refused `"01"`.** master05 gives `trunk_version = number`, `number = digit, { digit }`, and `Trunk_version_valid` bounds the **value** (`>= 1`), not the spelling. Since `VersionTreeId::new` is the only construction door, that made a foreign system's zero-padded id impossible to accept *or* round-trip. "At least 1" is now "not every digit is zero", so an id longer than any integer type still answers correctly.
- **`ArchetypeId::from_str` accepted what its own `Validate` rejects** — `"1-2-3.@@@.vXYZ"` constructed, then failed its invariants, so the well-formed-by-construction guarantee its siblings establish did not hold. The door now runs `is_valid_archetype_id`, and a test asserts the door and the invariants agree on every case rather than trusting that they do.

Also corrected: `major_version` cited BASE master05 for a `major.minor.patch` form **master05 does not define** — that shape belongs to AM's archetype HRID.

## Verification

947 `openehr-base`/`openehr-rm` tests and 2739 workspace tests pass; workspace clippy clean at `-D warnings`; comment-style clean. Crates bumped to `0.0.23`.

Filed en route, not skipped: **#2260** (upstream: `hour > 0` vs `is_gmt`), **#2261** (`AUTHORED_RESOURCE` and the four ISO-8601 types have no `Validate` impl).