### PR TITLE
fix: validators that disagreed with the readers they gate, and a guard that could not see the emitter

### DIFF
--- a/crates/openehr-base/src/v1_2/foundation_types/time/iso8601_date_impl.rs
+++ b/crates/openehr-base/src/v1_2/foundation_types/time/iso8601_date_impl.rs
@@ -17,6 +17,20 @@
 //!   Functions: the definite/nominal split and the average-length constants the
 //!   definite forms use).
 //!
+//! Invariants — the FOUR entries the class table declares under §Invariants,
+//! plus one rule of our own naming:
+//! - `Month_valid` (`not month_unknown implies valid_month (month)`) and
+//!   `Day_valid` (`not day_unknown implies valid_day (year, month, day)`) —
+//!   checked, each under its own name.
+//! - `Year_valid` (`valid_year (year)`, i.e. `year >= 0`) — structurally
+//!   satisfied: the accepted forms admit only four zero-filled digits.
+//! - `Partial_validity` (`month_unknown implies day_unknown`) — structurally
+//!   satisfied: no accepted form writes a day without a month.
+//! - `Value_lexical_form_valid` — OUR OWN name, because the class table
+//!   declares none: a value that is not the `valid_iso8601_date` production at
+//!   all has no components, so every declared invariant holds vacuously
+//!   (the same rule `version_tree_id_impl.rs` names for identifiers).
+//!
 //! NOTE: arithmetic needs every component of the value, and the openEHR spec
 //! says nothing about computing on a PARTIAL date (`2020`, `2020-06`) — the
 //! `add`/`diff` signatures simply take complete values. A partial (or
@@ -46,8 +60,10 @@ use super::iso8601_date::Iso8601Date;
 use super::iso8601_duration::Iso8601Duration;
 use super::iso8601_parse::{
     EXACT_SECONDS_IN_DAY, ExactSeconds, ParsedDate, as_extended_date, civil_from_days,
-    days_from_civil, parse_date, render_date_extended, render_duration, shift_months,
+    days_from_civil, days_in_month, parse_date, render_date_extended, render_duration, scan_date,
+    shift_months,
 };
+use crate::validate::{InvariantViolation, Validate};
 
 impl Iso8601Date {
     /// Parsed components, or `None` when `value` is not a valid ISO 8601 date.
@@ -250,6 +266,48 @@ impl PartialOrd for Iso8601Date {
             return Some(Ordering::Equal); // consistent with the derived PartialEq
         }
         cmp_date(&self.parsed()?, &other.parsed()?)
+    }
+}
+
+/// The uniform violation for one named invariant, on the class reporting it —
+/// `Iso8601_date`, or `Iso8601_date_time` where it re-declares the same rule.
+fn failed(invariant: &str, type_name: &str) -> InvariantViolation {
+    InvariantViolation::here(format!("Invariant {invariant} failed on type {type_name}"))
+}
+
+/// Appends the date-component invariant violations of a scanned value.
+///
+/// The rules are `Month_valid` and `Day_valid`, reported on `type_name` —
+/// `Iso8601_date_time` re-declares both.
+///
+/// `Day_valid` is checked only under an in-range month: its rule is
+/// `valid_day (y, m, d) = d >= 1 and d <= days_in_month (m, y)`
+/// (`time_definitions.adoc` §Functions), which is undefined where `valid_month`
+/// already fails.
+pub(crate) fn push_date_component_violations(
+    d: &ParsedDate,
+    type_name: &str,
+    out: &mut Vec<InvariantViolation>,
+) {
+    let month_valid = d.month.is_none_or(|m| (1..=12).contains(&m));
+    if !month_valid {
+        out.push(failed("Month_valid", type_name));
+    }
+    if month_valid
+        && let (Some(month), Some(day)) = (d.month, d.day)
+        && !days_in_month(d.year, month).is_some_and(|last| (1..=last).contains(&day))
+    {
+        out.push(failed("Day_valid", type_name));
+    }
+}
+
+impl Validate for Iso8601Date {
+    fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
+        let Some(d) = scan_date(&self.value) else {
+            out.push(failed("Value_lexical_form_valid", "Iso8601_date"));
+            return;
+        };
+        push_date_component_violations(&d, "Iso8601_date", out);
     }
 }
 
@@ -608,6 +666,71 @@ mod tests {
         assert!(date("not-a-date").add(&dur("P1D")).is_none());
         // A malformed duration is equally uncomputable.
         assert!(date("2020-06-15").add(&dur("1D")).is_none());
+    }
+
+    // ── invariants ───────────────────────────────────────────────────────────
+
+    /// Every invalid value names the `iso8601_date.adoc` §Invariants entry it
+    /// breaks — the point of the per-invariant realization: a report says WHICH
+    /// rule failed, not merely that the string was rejected.
+    #[test]
+    fn invalid_dates_name_the_invariant_they_break() {
+        for (bad, invariant) in [
+            // Month_valid: valid_month (m) = m >= 1 and m <= Months_in_year.
+            ("2020-13-01", "Month_valid"),
+            ("2020-00-15", "Month_valid"),
+            ("202013", "Month_valid"),
+            // Day_valid: d >= 1 and d <= days_in_month (m, y).
+            ("2021-02-29", "Day_valid"), // 2021 is not a leap year
+            ("2020-02-30", "Day_valid"),
+            ("2020-04-31", "Day_valid"),
+            ("2020-06-00", "Day_valid"),
+            ("20210229", "Day_valid"),
+            // Our own lexical rule: not the valid_iso8601_date production.
+            ("2020-W01", "Value_lexical_form_valid"),
+            ("not-a-date", "Value_lexical_form_valid"),
+            ("2020-6-15", "Value_lexical_form_valid"),
+            ("+2020-06-15", "Value_lexical_form_valid"),
+            ("", "Value_lexical_form_valid"),
+        ] {
+            let v = date(bad).invariants();
+            let expected = format!("Invariant {invariant} failed on type Iso8601_date");
+            assert!(
+                v.iter().any(|m| m.message == expected),
+                "{bad:?} should report {invariant}, got {v:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn valid_dates_including_every_partial_form_report_nothing() {
+        for good in [
+            "2020",
+            "2020-06",
+            "2020-06-15",
+            "202006",
+            "20200615",
+            "2020-02-29",
+            "0000-01-01",
+            "9999-12-31",
+        ] {
+            assert!(
+                date(good).invariants().is_empty(),
+                "{good:?} is a valid Iso8601_date"
+            );
+        }
+    }
+
+    /// `valid_day` is defined in terms of `days_in_month (m, y)`, so a month
+    /// `valid_month` already rejects leaves `Day_valid` undecided.
+    #[test]
+    fn an_out_of_range_month_reports_month_valid_alone() {
+        let v = date("2020-13-01").invariants();
+        assert_eq!(v.len(), 1);
+        assert_eq!(
+            v[0].message,
+            "Invariant Month_valid failed on type Iso8601_date"
+        );
     }
 
     #[test]

--- a/crates/openehr-base/src/v1_2/foundation_types/time/iso8601_date_time_impl.rs
+++ b/crates/openehr-base/src/v1_2/foundation_types/time/iso8601_date_time_impl.rs
@@ -17,6 +17,33 @@
 //!   `24:00:00` disallowed; §Computational Functions: the definite/nominal
 //!   split).
 //!
+//! Invariants — the TWELVE rows the class table declares under §Invariants:
+//! - `Month_valid`, `Day_valid` (shared with `iso8601_date_impl.rs`) and
+//!   `Hour_valid`, `Minute_valid`, `Second_valid`, `Fractional_second_valid`
+//!   (shared with `iso8601_time_impl.rs`) — checked, each under its own name.
+//!   The first two are read in the GUARDED form the sibling `Iso8601_date`
+//!   class spells them (`not month_unknown implies valid_month (month)`); the
+//!   unguarded literal form would reject every partial this class's own
+//!   Description permits.
+//! - `Year_valid` — structurally satisfied (four zero-filled digits).
+//! - `Partial_validity_minute` (`minute_unknown implies second_unknown`) —
+//!   structurally satisfied: no accepted form writes a second without a minute.
+//! - `Partial_validity_year`, `Partial_validity_month`, `Partial_validity_day`,
+//!   `Partial_validity_hour` — refused, see the NOTEs below.
+//! - `Value_lexical_form_valid` — OUR OWN name, because the class table
+//!   declares no rule for a value that is not the production at all (the same
+//!   rule `iso8601_date_impl.rs` names).
+//!
+//! NOTE: `Partial_validity_day` (`not day_unknown`) and `Partial_validity_hour`
+//! (`not hour_unknown` — a function this class never declares) are NOT
+//! enforced: `master06` §Primitive Time Types states that partial variants of
+//! this type "can include missing hours, days and months".
+//!
+//! NOTE: `Partial_validity_year` carries `Partial_validity_month`'s identical
+//! expression (`not month_unknown`) rather than any year rule, and
+//! `Time_definitions.valid_iso8601_date_time` enumerates no date-only partial;
+//! both are refused on the same `master06` ground.
+//!
 //! NOTE: arithmetic needs every component, and the openEHR spec says nothing
 //! about computing on a PARTIAL date/time — a partial (or unparseable) operand
 //! yields `None`, the same undecidable answer this module's comparison gives.
@@ -46,14 +73,17 @@
 
 use std::cmp::Ordering;
 
+use super::iso8601_date_impl::push_date_component_violations;
 use super::iso8601_date_time::Iso8601DateTime;
 use super::iso8601_duration::Iso8601Duration;
 use super::iso8601_parse::{
     EXACT_SECONDS_IN_DAY, EXACT_SECONDS_IN_HOUR, EXACT_SECONDS_IN_MINUTE, ExactSeconds,
     ParsedDateTime, ParsedTime, as_extended_date_time, civil_from_days, date_time_completion_range,
     days_from_civil, hms_from_seconds_of_day, parse_date_time, range_before, render_date_extended,
-    render_duration, render_time_extended, shift_months,
+    render_duration, render_time_extended, scan_date_time, shift_months,
 };
+use super::iso8601_time_impl::push_time_component_violations;
+use crate::validate::{InvariantViolation, Validate};
 
 impl Iso8601DateTime {
     /// Parsed components, or `None` when `value` is not a valid ISO 8601
@@ -348,6 +378,21 @@ impl PartialOrd for Iso8601DateTime {
             return Some(Ordering::Equal); // consistent with the derived PartialEq
         }
         cmp_date_time(&self.parsed()?, &other.parsed()?)
+    }
+}
+
+impl Validate for Iso8601DateTime {
+    fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
+        let Some(dt) = scan_date_time(&self.value) else {
+            out.push(InvariantViolation::here(
+                "Invariant Value_lexical_form_valid failed on type Iso8601_date_time",
+            ));
+            return;
+        };
+        push_date_component_violations(&dt.date, "Iso8601_date_time", out);
+        if let Some(time) = dt.time {
+            push_time_component_violations(&time, "Iso8601_date_time", out);
+        }
     }
 }
 
@@ -733,6 +778,56 @@ mod tests {
         );
         assert!(dt("garbage").add(&dur("PT1H")).is_none());
         assert!(dt("2020-06-15T12:00:00").add(&dur("1H")).is_none());
+    }
+
+    // ── invariants ───────────────────────────────────────────────────────────
+
+    /// Every invalid value names the `iso8601_date_time.adoc` §Invariants entry
+    /// it breaks, on this class rather than on the date/time class the rule is
+    /// shared with.
+    #[test]
+    fn invalid_date_times_name_the_invariant_they_break() {
+        for (bad, invariant) in [
+            ("2020-13-01T10:00", "Month_valid"),
+            ("2021-02-29T10:00:00", "Day_valid"),
+            ("2020-06-15T24:00:00", "Hour_valid"),
+            ("2020-06-15T12:60", "Minute_valid"),
+            ("2020-06-15T12:00:60", "Second_valid"),
+            ("2020-06-15T12:00.5", "Fractional_second_valid"),
+            ("2020-06-15T", "Value_lexical_form_valid"),
+            ("garbage", "Value_lexical_form_valid"),
+            ("2020-06-15T12:00:00+15:00", "Value_lexical_form_valid"),
+        ] {
+            let v = dt(bad).invariants();
+            let expected = format!("Invariant {invariant} failed on type Iso8601_date_time");
+            assert!(
+                v.iter().any(|m| m.message == expected),
+                "{bad:?} should report {invariant}, got {v:?}"
+            );
+        }
+    }
+
+    /// The partials `master06` §Primitive Time Types permits — "missing hours,
+    /// days and months" — validate clean, which is exactly what the refused
+    /// `Partial_validity_day`/`_hour` clauses would have rejected.
+    #[test]
+    fn valid_date_times_including_every_partial_form_report_nothing() {
+        for good in [
+            "2020",
+            "2020-06",
+            "2020-06-15",
+            "2020-06-15T10",
+            "2020-06-15T10:30",
+            "2020-06-15T10:30:00",
+            "2020-06-15T10:30:00.25Z",
+            "20200615T103000+0200",
+            "2020-02-29T00:00:00",
+        ] {
+            assert!(
+                dt(good).invariants().is_empty(),
+                "{good:?} is a valid Iso8601_date_time"
+            );
+        }
     }
 
     #[test]

--- a/crates/openehr-base/src/v1_2/foundation_types/time/iso8601_duration_impl.rs
+++ b/crates/openehr-base/src/v1_2/foundation_types/time/iso8601_duration_impl.rs
@@ -19,6 +19,20 @@
 //!   Types: the negative-duration and mixed-`W` deviations; §Computational
 //!   Functions).
 //!
+//! Invariants — the EIGHT entries the class table declares under §Invariants
+//! (`Years_valid` … `Seconds_valid`, each `>= 0`, and `Fractional_second_valid`
+//! `>= 0.0 and < 1.0`) are ALL structurally satisfied by the reader: a
+//! component is a digit run scanned into an unsigned count, and a fraction is
+//! scanned as `0.<digits>`, so no parsed value can break one. What a value CAN
+//! be is not a duration at all, which the class table names no rule for, so it
+//! is reported under our own `Value_lexical_form_valid` (the same rule
+//! `iso8601_date_impl.rs` names).
+//!
+//! NOTE: the openEHR negative-duration deviation (`master06` §Primitive Time
+//! Types) is a leading sign on the VALUE, not on any component, so `-P1Y` still
+//! satisfies `Years_valid` — the class declares no sign accessor to read it
+//! from.
+//!
 //! NOTE: the class doc gives an algorithm for `add`/`subtract` (reduce both
 //! operands via `to_seconds`) but none for `multiply`/`divide`. Component-wise
 //! scaling is not even expressible — `P1Y * 1.5` would need a fractional year,
@@ -40,6 +54,7 @@ use std::cmp::Ordering;
 
 use super::iso8601_duration::Iso8601Duration;
 use super::iso8601_parse::{ExactSeconds, ParsedDuration, parse_duration, render_duration};
+use crate::validate::{InvariantViolation, Validate};
 
 impl Iso8601Duration {
     /// Parsed components, or `None` when `value` is not a valid ISO 8601
@@ -241,6 +256,16 @@ impl PartialOrd for Iso8601Duration {
             // spellings ⇒ incomparable per decision 4, not equal.
             Ordering::Equal => None,
             ord => Some(ord),
+        }
+    }
+}
+
+impl Validate for Iso8601Duration {
+    fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
+        if self.parsed().is_none() {
+            out.push(InvariantViolation::here(
+                "Invariant Value_lexical_form_valid failed on type Iso8601_duration",
+            ));
         }
     }
 }
@@ -463,5 +488,44 @@ mod tests {
         assert_eq!(flipped.value, "-P1Y2M3W4DT5H6M7,50S");
         assert_eq!(flipped.negative().unwrap().value, original.value);
         assert!(dur("nonsense").negative().is_none());
+    }
+
+    // ── invariants ───────────────────────────────────────────────────────────
+
+    /// A value that is not the `P[nnY][nnM][nnW][nnD][T[nnH][nnM][nnS]]`
+    /// production is refused under the one rule this class can break.
+    #[test]
+    fn a_value_that_is_not_a_duration_reports_the_lexical_rule() {
+        for bad in [
+            "1D", "P", "PT", "", "nonsense", "P1Y1Y", "P1D1M", "P1YT", "-P", "PT1.S",
+        ] {
+            let v = dur(bad).invariants();
+            assert_eq!(v.len(), 1, "{bad:?} should be refused, got {v:?}");
+            assert_eq!(
+                v[0].message,
+                "Invariant Value_lexical_form_valid failed on type Iso8601_duration"
+            );
+        }
+    }
+
+    /// Every declared component invariant is structurally satisfied, including
+    /// on a negative duration (the sign is on the value, not on a component).
+    #[test]
+    fn valid_durations_report_nothing() {
+        for good in [
+            "P1Y",
+            "-P3M",
+            "P1W",
+            "P30D",
+            "PT1M",
+            "PT0S",
+            "PT0,5S",
+            "P1Y2M3W4DT5H6M7.5S",
+        ] {
+            assert!(
+                dur(good).invariants().is_empty(),
+                "{good:?} is a valid Iso8601_duration"
+            );
+        }
     }
 }

--- a/crates/openehr-base/src/v1_2/foundation_types/time/iso8601_parse.rs
+++ b/crates/openehr-base/src/v1_2/foundation_types/time/iso8601_parse.rs
@@ -225,6 +225,20 @@ pub(crate) fn days_from_civil(year: u32, month: u32, day: u32) -> i64 {
 /// Types); component combinations must be calendar-valid
 /// (`Time_definitions.valid_iso8601_date`).
 pub(crate) fn parse_date(s: &str) -> Option<ParsedDate> {
+    let d = scan_date(s)?;
+    validate_date(d.year, d.month, d.day)?;
+    Some(d)
+}
+
+/// Decompose a date LEXICALLY, without the calendar-validity checks: the same
+/// accepted spellings as [`parse_date`], but `2021-02-29` still yields its
+/// three components.
+///
+/// The invariant reporting in `iso8601_date_impl.rs` needs the components of an
+/// INVALID value to name the rule that value breaks (`Month_valid` versus
+/// `Day_valid`); a form that is not the production at all (a week date, an
+/// expanded year) has no components to report and is refused here.
+pub(crate) fn scan_date(s: &str) -> Option<ParsedDate> {
     if s.is_empty() || s.bytes().any(|b| b == b'W' || b == b'w') {
         return None;
     }
@@ -259,7 +273,6 @@ pub(crate) fn parse_date(s: &str) -> Option<ParsedDate> {
             _ => return None,
         }
     };
-    validate_date(year, month, day)?;
     // `Iso8601_date.is_extended`: "True if this date uses '-' separators".
     // NOTE: the spec does not say what a form with NO separator position
     // (`YYYY`) reports; we report it extended, keeping `as_string() == value`
@@ -300,17 +313,32 @@ fn validate_date(year: u32, month: Option<u32>, day: Option<u32>) -> Option<()> 
 /// (`master06`; `Time_definitions.valid_second` Post `s < Seconds_in_minute`),
 /// see the leap-second NOTE in `iso8601_time_impl.rs`.
 pub(crate) fn parse_time(s: &str) -> Option<ParsedTime> {
+    let t = scan_time(s)?;
+    validate_time(t.hour, t.minute, t.second, t.fractional_second)?;
+    Some(t)
+}
+
+/// Decompose a time LEXICALLY, without the component-validity checks: the same
+/// accepted spellings as [`parse_time`], but `24:00:00` and `12:00:60` still
+/// yield their components, and a fractional part is kept even where no second
+/// carries it (`12:00.5`).
+///
+/// The invariant reporting in `iso8601_time_impl.rs` needs those components to
+/// name the rule the value breaks. The timezone lexeme is still range-checked
+/// by [`parse_timezone`]: its bounds are `Iso8601_timezone`'s own invariants,
+/// which this class does not declare.
+pub(crate) fn scan_time(s: &str) -> Option<ParsedTime> {
     let (main, tz) = split_timezone_lexeme(s)?;
     let timezone = if tz.is_empty() {
         None
     } else {
         Some(parse_timezone(tz)?)
     };
-    let (hour, minute, second, fractional_second) = parse_time_main(main)?;
+    let (hour, minute, second, fractional_second) = scan_time_main(main)?;
     // `Iso8601_time.is_extended`: "True if this time uses '-', ':' separators".
     // A value counts as extended when every separator position it actually has
     // is written with a separator (so `hh`, `Z` and `±hh`, which have none, do
-    // not disqualify it) — see the `parse_date` is_extended NOTE.
+    // not disqualify it) — see the `scan_date` is_extended NOTE.
     let extended = body_is_extended(split_fraction_lexeme(main).0) && timezone_is_extended(tz);
     Some(ParsedTime {
         hour,
@@ -347,8 +375,9 @@ fn timezone_is_extended(tz: &str) -> bool {
     tz.contains(':') || tz.len() <= 3
 }
 
-/// Parse the time-of-day part (no timezone) in extended or compact form.
-fn parse_time_main(main: &str) -> Option<TimeParts> {
+/// Decompose the time-of-day part (no timezone) in extended or compact form,
+/// lexically only — see [`scan_time`].
+fn scan_time_main(main: &str) -> Option<TimeParts> {
     // Separate an optional fractional-seconds tail introduced by '.' or ','.
     let (body, frac) = split_fraction(main);
     let (hour, minute, second) = if body.contains(':') {
@@ -382,13 +411,7 @@ fn parse_time_main(main: &str) -> Option<TimeParts> {
             _ => return None,
         }
     };
-    // A fractional part is only meaningful on a present second.
-    let fractional_second = match frac {
-        Some(f) if second.is_some() => Some(f),
-        Some(_) => return None,
-        None => None,
-    };
-    validate_time(hour, minute, second, fractional_second)
+    Some((hour, minute, second, frac))
 }
 
 /// Split a trailing `(.|,)digits` fractional part off the time body, returning
@@ -451,8 +474,10 @@ fn validate_time(
     {
         return None; // leap second `:60` rejected per valid_second
     }
+    // `Fractional_second_valid`: a fraction is significant only on a present
+    // second, and lies in `[0.0, 1.0)` (`valid_fractional_second`).
     if let Some(f) = fractional_second
-        && !(f.is_finite() && (0.0..1.0).contains(&f))
+        && (second.is_none() || !(f.is_finite() && (0.0..1.0).contains(&f)))
     {
         return None; // includes the NaN split_fraction uses to flag malformed input
     }
@@ -523,6 +548,23 @@ pub(crate) fn parse_date_time(s: &str) -> Option<ParsedDateTime> {
     } else {
         Some(ParsedDateTime {
             date: parse_date(s)?,
+            time: None,
+        })
+    }
+}
+
+/// Decompose a date/time LEXICALLY, without the component-validity checks — see
+/// [`scan_date`] and [`scan_time`], which it composes on the same `T` split as
+/// [`parse_date_time`].
+pub(crate) fn scan_date_time(s: &str) -> Option<ParsedDateTime> {
+    if let Some((d, t)) = s.split_once('T') {
+        Some(ParsedDateTime {
+            date: scan_date(d)?,
+            time: Some(scan_time(t)?),
+        })
+    } else {
+        Some(ParsedDateTime {
+            date: scan_date(s)?,
             time: None,
         })
     }
@@ -1337,6 +1379,41 @@ mod tests {
         assert!((month - 2_628_288.0).abs() < 1e-6);
         assert_eq!(EXACT_SECONDS_IN_AVERAGE_YEAR, 31_556_736);
         assert_eq!(EXACT_SECONDS_IN_AVERAGE_MONTH, 2_628_288);
+    }
+
+    /// The lenient scanners accept EXACTLY what the strict parsers accept, plus
+    /// the values whose only defect is a class invariant — which is what lets
+    /// the `*_impl.rs` validators name the rule a bad value breaks.
+    #[test]
+    fn the_scanners_extend_the_parsers_only_where_an_invariant_decides() {
+        for good in ["2020", "2020-06", "2020-06-15", "20200615", "202006"] {
+            assert_eq!(scan_date(good), parse_date(good), "{good:?}");
+        }
+        for good in [
+            "12",
+            "12:00",
+            "12:00:00",
+            "120000",
+            "12:00:00.5",
+            "120000,25Z",
+        ] {
+            assert_eq!(scan_time(good), parse_time(good), "{good:?}");
+        }
+        for bad in ["2020-W01", "not-a-date", "2020-6-15", ""] {
+            assert!(scan_date(bad).is_none(), "{bad:?} is not the production");
+        }
+        // Calendar- and component-invalid values still decompose.
+        assert!(parse_date("2021-02-29").is_none() && scan_date("2021-02-29").is_some());
+        assert!(parse_date("2020-13-01").is_none() && scan_date("2020-13-01").is_some());
+        assert!(parse_time("24:00:00").is_none() && scan_time("24:00:00").is_some());
+        assert!(parse_time("12:00:60").is_none() && scan_time("12:00:60").is_some());
+        // A fraction with no second to carry it: refused by the parser (the
+        // `Fractional_second_valid` clause), kept by the scanner.
+        assert!(parse_time("12:00.5").is_none());
+        assert_eq!(
+            scan_time("12:00.5").and_then(|t| t.fractional_second),
+            Some(0.5)
+        );
     }
 
     #[test]

--- a/crates/openehr-base/src/v1_2/foundation_types/time/iso8601_time_impl.rs
+++ b/crates/openehr-base/src/v1_2/foundation_types/time/iso8601_time_impl.rs
@@ -19,6 +19,27 @@
 //!   definite forms exist for a time — 'year' and 'month' cannot land on a clock
 //!   face, so `Iso8601_time` declares no `add_nominal`).
 //!
+//! Invariants — the FIVE entries the class table declares under §Invariants,
+//! plus one rule of our own naming:
+//! - `Hour_valid`, `Minute_valid`, `Second_valid` and
+//!   `Fractional_second_valid` — checked, each under its own name (shared with
+//!   `Iso8601_date_time`, which re-declares all four verbatim).
+//! - `Partial_validity` (`minute_unknown implies second_unknown`) —
+//!   structurally satisfied: no accepted form writes a second without a minute.
+//! - `Value_lexical_form_valid` — OUR OWN name, because the class table
+//!   declares none: a value that is not the `valid_iso8601_time` production at
+//!   all has no components, so every declared invariant holds vacuously.
+//!
+//! NOTE: `Hour_valid` is `valid_hour (hour, minute, second)`, whose
+//! postcondition also admits `h = Hours_in_day and m = 0 and s = 0`; this class
+//! and `master06` §Primitive Time Types both forbid `24:00:00` "anywhere", so
+//! the invariant is enforced as `hour < 24`.
+//!
+//! NOTE: the timezone's own bounds are `Iso8601_timezone`'s invariants
+//! (`org.openehr.base.foundation_types.iso8601_timezone.adoc` §Invariants), a
+//! class an `Iso8601_time` carries only as a lexeme, so an out-of-range offset
+//! is reported as a lexical-form failure rather than under one of them.
+//!
 //! NOTE: arithmetic needs every component, and the openEHR spec says nothing
 //! about computing on a PARTIAL time (`hh`, `hh:mm`) — a partial (or
 //! unparseable) operand yields `None`, the same undecidable answer this
@@ -51,9 +72,10 @@ use super::iso8601_duration::Iso8601Duration;
 use super::iso8601_parse::{
     EXACT_SECONDS_IN_DAY, EXACT_SECONDS_IN_HOUR, EXACT_SECONDS_IN_MINUTE, ExactSeconds, ParsedTime,
     as_extended_time, hms_from_seconds_of_day, parse_time, range_before, render_duration,
-    render_time_extended, time_completion_range,
+    render_time_extended, scan_time, time_completion_range,
 };
 use super::iso8601_time::Iso8601Time;
+use crate::validate::{InvariantViolation, Validate};
 
 impl Iso8601Time {
     /// Parsed components, or `None` when `value` is not a valid ISO 8601 time.
@@ -254,6 +276,55 @@ impl PartialOrd for Iso8601Time {
             return Some(Ordering::Equal); // consistent with the derived PartialEq
         }
         cmp_time(&self.parsed()?, &other.parsed()?)
+    }
+}
+
+/// The uniform violation for one named invariant, on the class reporting it —
+/// `Iso8601_time`, or `Iso8601_date_time` where it re-declares the same rule.
+fn failed(invariant: &str, type_name: &str) -> InvariantViolation {
+    InvariantViolation::here(format!("Invariant {invariant} failed on type {type_name}"))
+}
+
+/// Appends the time-component invariant violations of a scanned value.
+///
+/// The rules are `Hour_valid`, `Minute_valid`, `Second_valid` and
+/// `Fractional_second_valid`, reported on `type_name`. `Iso8601_date_time`
+/// declares the same four under the same names with the same expressions, so
+/// both classes report through this one body.
+pub(crate) fn push_time_component_violations(
+    t: &ParsedTime,
+    type_name: &str,
+    out: &mut Vec<InvariantViolation>,
+) {
+    // Hour_valid — `24:00:00` is forbidden anywhere (module NOTE).
+    if t.hour >= 24 {
+        out.push(failed("Hour_valid", type_name));
+    }
+    // Minute_valid / Second_valid: `valid_minute (m)` is `m < Minutes_in_hour`
+    // and `valid_second (s)` is `s < Seconds_in_minute`, each on a present
+    // component (the implication is vacuous on an absent one).
+    if t.minute.is_some_and(|m| m >= 60) {
+        out.push(failed("Minute_valid", type_name));
+    }
+    if t.second.is_some_and(|s| s >= 60) {
+        out.push(failed("Second_valid", type_name));
+    }
+    // Fractional_second_valid: significant only alongside a present second, and
+    // `valid_fractional_second (fs)` is `fs >= 0.0 and fs < 1.0`.
+    if let Some(f) = t.fractional_second
+        && (t.second.is_none() || !(0.0..1.0).contains(&f))
+    {
+        out.push(failed("Fractional_second_valid", type_name));
+    }
+}
+
+impl Validate for Iso8601Time {
+    fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
+        let Some(t) = scan_time(&self.value) else {
+            out.push(failed("Value_lexical_form_valid", "Iso8601_time"));
+            return;
+        };
+        push_time_component_violations(&t, "Iso8601_time", out);
     }
 }
 
@@ -563,6 +634,59 @@ mod tests {
     }
 
     // ── partial / malformed operands ─────────────────────────────────────────
+
+    // ── invariants ───────────────────────────────────────────────────────────
+
+    /// Every invalid value names the `iso8601_time.adoc` §Invariants entry it
+    /// breaks, rather than merely failing to parse.
+    #[test]
+    fn invalid_times_name_the_invariant_they_break() {
+        for (bad, invariant) in [
+            // Hour_valid — including the `24:00:00` openEHR deviation.
+            ("24:00:00", "Hour_valid"),
+            ("25:30", "Hour_valid"),
+            ("990000", "Hour_valid"),
+            // Minute_valid / Second_valid.
+            ("12:60:00", "Minute_valid"),
+            ("12:00:60", "Second_valid"),
+            // Fractional_second_valid: a fraction with no second to carry it.
+            ("12:00.5", "Fractional_second_valid"),
+            // Our own lexical rule: not the valid_iso8601_time production.
+            ("nonsense", "Value_lexical_form_valid"),
+            ("12:00:00+15:00", "Value_lexical_form_valid"),
+            ("12:0:00", "Value_lexical_form_valid"),
+            ("", "Value_lexical_form_valid"),
+        ] {
+            let v = time(bad).invariants();
+            let expected = format!("Invariant {invariant} failed on type Iso8601_time");
+            assert!(
+                v.iter().any(|m| m.message == expected),
+                "{bad:?} should report {invariant}, got {v:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn valid_times_including_every_partial_form_report_nothing() {
+        for good in [
+            "12",
+            "12:00",
+            "12:00:00",
+            "1200",
+            "120000",
+            "12:00:00.5",
+            "12:00:00,25",
+            "23:59:59",
+            "00:00:00Z",
+            "12:00:00+02:00",
+            "120000-0500",
+        ] {
+            assert!(
+                time(good).invariants().is_empty(),
+                "{good:?} is a valid Iso8601_time"
+            );
+        }
+    }
 
     #[test]
     fn partial_and_malformed_values_have_no_arithmetic() {

--- a/crates/openehr-base/src/v1_2/resource/authored_resource_impl.rs
+++ b/crates/openehr-base/src/v1_2/resource/authored_resource_impl.rs
@@ -1,12 +1,40 @@
 // @generated-from-template templates/openehr-base/resource/authored_resource_impl.rs — DO NOT EDIT; edit the source and re-run `openehr-codegen -- emit`.
-//! Hand-written spec functions of `AUTHORED_RESOURCE`.
+//! Hand-written spec functions + invariants of `AUTHORED_RESOURCE`.
 //!
 //! Spec: `BASE/docs/UML/classes/org.openehr.base.resource.authored_resource.adoc`
-//! §Functions, and `BASE/docs/resource/master02-resource_package.adoc`
-//! §Natural Languages and Translation ("The languages_available function
-//! provides a complete list of languages in the resource").
+//! §Functions and §Invariants, and
+//! `BASE/docs/resource/master02-resource_package.adoc` §Natural Languages and
+//! Translation ("The languages_available function provides a complete list of
+//! languages in the resource").
+//!
+//! Invariants — the FOUR entries the class table declares:
+//! - `Translations_valid` and `Description_valid` — checked, each under its
+//!   own name.
+//! - `Languages_available_valid` (`languages_available.has
+//!   (original_language)`) — structurally satisfied: `languages_available`
+//!   opens with the original language.
+//! - `Original_language_valid` — a terminology boundary, see the NOTE below.
+//!
+//! NOTE: `Original_language_valid`
+//! (`code_set (Code_set_id_languages).has_code (original_language.as_string)`)
+//! is not enforced here: the languages code set lives in the terminology
+//! service, which `openehr-base` has no dependency on.
+//!
+//! NOTE: `Description_valid`'s literal form would reject the resource's own
+//! ORIGINAL-language detail, which `master02-resource_package.adoc` §Meta-data
+//! requires each translated resource to keep, so it is read as "every detail
+//! language is the original language or a declared translation".
+//!
+//! NOTE: `Translations_valid` spells its second clause `translations.has
+//! (original_language.code_string)` over a list "keyed by language code" whose
+//! §Attributes text says the original language "does not appear in this list",
+//! so it is read as the KEY test its sibling clause spells `has_key`.
 
 use crate::v1_2::resource::authored_resource::AuthoredResource;
+use crate::v1_2::resource::resource_description_item::ResourceDescriptionItem;
+use crate::v1_2::resource::translation_details::TranslationDetails;
+use crate::validate::{InvariantViolation, Validate};
+use std::collections::BTreeMap;
 
 impl AuthoredResource {
     /// `AUTHORED_RESOURCE.languages_available`: the total list of languages
@@ -25,50 +53,114 @@ impl AuthoredResource {
     }
 }
 
+/// The uniform violation for one named invariant of this class.
+fn failed(invariant: &str) -> InvariantViolation {
+    InvariantViolation::here(format!(
+        "Invariant {invariant} failed on type AUTHORED_RESOURCE"
+    ))
+}
+
+/// Appends `Description_valid` when any description detail is written in a
+/// language the resource declares neither as its original nor as a translation.
+fn push_description_violation(
+    details: &BTreeMap<String, ResourceDescriptionItem>,
+    original_language: &str,
+    translations: &BTreeMap<String, TranslationDetails>,
+    out: &mut Vec<InvariantViolation>,
+) {
+    let undeclared = details.values().any(|item| {
+        let language = item.language.code_string.as_str();
+        language != original_language && !translations.contains_key(language)
+    });
+    if undeclared {
+        out.push(failed("Description_valid"));
+    }
+}
+
+impl Validate for AuthoredResource {
+    fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
+        // Both declared rules are `translations /= Void implies …`, so a
+        // resource with no translation list satisfies each vacuously.
+        let Some(translations) = &self.translations else {
+            return;
+        };
+        let original_language = self.original_language.code_string.as_str();
+        if translations.is_empty() || translations.contains_key(original_language) {
+            out.push(failed("Translations_valid"));
+        }
+        if let Some(details) = self.description.as_ref().and_then(|d| d.details.as_ref()) {
+            push_description_violation(details, original_language, translations, out);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::v1_2::foundation_types::terminology::terminology_code::TerminologyCode;
-    use crate::v1_2::resource::authored_resource::AuthoredResource;
-    use crate::v1_2::resource::translation_details::TranslationDetails;
+
+    /// An ISO 639-1 language code as a `TERMINOLOGY_CODE`.
+    fn language_code(code: &str) -> TerminologyCode {
+        TerminologyCode {
+            terminology_id: "ISO_639-1".to_owned(),
+            terminology_version: None,
+            code_string: code.to_owned(),
+            uri: None,
+        }
+    }
+
+    /// A `translations` list keyed by the given language codes.
+    fn translation_map(languages: &[&str]) -> BTreeMap<String, TranslationDetails> {
+        languages
+            .iter()
+            .map(|lang| {
+                (
+                    (*lang).to_owned(),
+                    TranslationDetails {
+                        language: language_code(lang),
+                        author: BTreeMap::new(),
+                        accreditation: None,
+                        other_details: None,
+                        version_last_translated: None,
+                        other_contributors: None,
+                    },
+                )
+            })
+            .collect()
+    }
+
+    /// A `description.details` list keyed by the given language codes.
+    fn details_map(languages: &[&str]) -> BTreeMap<String, ResourceDescriptionItem> {
+        languages
+            .iter()
+            .map(|lang| {
+                (
+                    (*lang).to_owned(),
+                    ResourceDescriptionItem {
+                        language: language_code(lang),
+                        purpose: "purpose".to_owned(),
+                        keywords: None,
+                        use_: None,
+                        misuse: None,
+                        original_resource_uri: None,
+                        other_details: None,
+                    },
+                )
+            })
+            .collect()
+    }
 
     fn resource(translations: &[&str]) -> AuthoredResource {
         AuthoredResource {
             uid: None,
-            original_language: TerminologyCode {
-                terminology_id: "ISO_639-1".to_owned(),
-                terminology_version: None,
-                code_string: "en".to_owned(),
-                uri: None,
-            },
+            original_language: language_code("en"),
             description: None,
             is_controlled: None,
             annotations: None,
             translations: if translations.is_empty() {
                 None
             } else {
-                Some(
-                    translations
-                        .iter()
-                        .map(|lang| {
-                            (
-                                (*lang).to_owned(),
-                                TranslationDetails {
-                                    language: TerminologyCode {
-                                        terminology_id: "ISO_639-1".to_owned(),
-                                        terminology_version: None,
-                                        code_string: (*lang).to_owned(),
-                                        uri: None,
-                                    },
-                                    author: std::collections::BTreeMap::new(),
-                                    accreditation: None,
-                                    other_details: None,
-                                    version_last_translated: None,
-                                    other_contributors: None,
-                                },
-                            )
-                        })
-                        .collect(),
-                )
+                Some(translation_map(translations))
             },
         }
     }
@@ -85,5 +177,90 @@ mod tests {
             resource(&["de", "pt"]).languages_available(),
             ["en", "de", "pt"]
         );
+    }
+
+    // ── invariants ───────────────────────────────────────────────────────────
+
+    /// `Translations_valid`: a present list is neither empty nor a re-statement
+    /// of the original language.
+    #[test]
+    fn translations_valid_refuses_an_empty_or_self_naming_list() {
+        for (languages, case) in [
+            (Vec::new(), "an empty list"),
+            (vec!["en"], "the original language alone"),
+            (vec!["de", "en"], "the original language among others"),
+        ] {
+            let mut authored = resource(&[]);
+            authored.translations = Some(translation_map(&languages));
+            let violations = authored.invariants();
+            assert_eq!(violations.len(), 1, "{case}");
+            assert_eq!(
+                violations[0].message,
+                "Invariant Translations_valid failed on type AUTHORED_RESOURCE",
+                "{case}"
+            );
+        }
+    }
+
+    /// The state `Translations_valid` exists to prevent: `languages_available`
+    /// reports the original language twice.
+    #[test]
+    fn a_self_naming_translation_list_duplicates_a_language() {
+        let mut authored = resource(&[]);
+        authored.translations = Some(translation_map(&["en"]));
+        assert_eq!(authored.languages_available(), ["en", "en"]);
+        assert!(!authored.invariants().is_empty());
+    }
+
+    #[test]
+    fn a_valid_translation_list_reports_nothing() {
+        // No list at all: both rules are vacuous.
+        assert!(resource(&[]).invariants().is_empty());
+        assert!(resource(&["de", "pt"]).invariants().is_empty());
+    }
+
+    /// `Description_valid`: a detail written in a language the resource
+    /// declares nowhere.
+    #[test]
+    fn description_valid_refuses_a_detail_in_an_undeclared_language() {
+        // NOTE: BASE 1.2.0's RESOURCE_DESCRIPTION declares a different field set
+        // from 1.3.0's, so a whole-value fixture is not writable in a generation
+        // twin — the rule is asserted on the core every generation shares.
+        let mut violations = Vec::new();
+        push_description_violation(
+            &details_map(&["en", "fr"]),
+            "en",
+            &translation_map(&["de"]),
+            &mut violations,
+        );
+        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            violations[0].message,
+            "Invariant Description_valid failed on type AUTHORED_RESOURCE"
+        );
+    }
+
+    /// The accepting twin, including the ORIGINAL-language detail the literal
+    /// invariant text would have rejected (module NOTE).
+    #[test]
+    fn description_valid_accepts_the_original_language_and_every_translation() {
+        for details in [
+            details_map(&["en"]),
+            details_map(&["en", "de"]),
+            details_map(&["en", "de", "pt"]),
+            details_map(&[]),
+        ] {
+            let mut violations = Vec::new();
+            push_description_violation(
+                &details,
+                "en",
+                &translation_map(&["de", "pt"]),
+                &mut violations,
+            );
+            assert!(
+                violations.is_empty(),
+                "{details:?} declares only known languages"
+            );
+        }
     }
 }

--- a/crates/openehr-base/src/v1_3/foundation_types/time/iso8601_date_impl.rs
+++ b/crates/openehr-base/src/v1_3/foundation_types/time/iso8601_date_impl.rs
@@ -17,6 +17,20 @@
 //!   Functions: the definite/nominal split and the average-length constants the
 //!   definite forms use).
 //!
+//! Invariants — the FOUR entries the class table declares under §Invariants,
+//! plus one rule of our own naming:
+//! - `Month_valid` (`not month_unknown implies valid_month (month)`) and
+//!   `Day_valid` (`not day_unknown implies valid_day (year, month, day)`) —
+//!   checked, each under its own name.
+//! - `Year_valid` (`valid_year (year)`, i.e. `year >= 0`) — structurally
+//!   satisfied: the accepted forms admit only four zero-filled digits.
+//! - `Partial_validity` (`month_unknown implies day_unknown`) — structurally
+//!   satisfied: no accepted form writes a day without a month.
+//! - `Value_lexical_form_valid` — OUR OWN name, because the class table
+//!   declares none: a value that is not the `valid_iso8601_date` production at
+//!   all has no components, so every declared invariant holds vacuously
+//!   (the same rule `version_tree_id_impl.rs` names for identifiers).
+//!
 //! NOTE: arithmetic needs every component of the value, and the openEHR spec
 //! says nothing about computing on a PARTIAL date (`2020`, `2020-06`) — the
 //! `add`/`diff` signatures simply take complete values. A partial (or
@@ -46,8 +60,10 @@ use super::iso8601_date::Iso8601Date;
 use super::iso8601_duration::Iso8601Duration;
 use super::iso8601_parse::{
     EXACT_SECONDS_IN_DAY, ExactSeconds, ParsedDate, as_extended_date, civil_from_days,
-    days_from_civil, parse_date, render_date_extended, render_duration, shift_months,
+    days_from_civil, days_in_month, parse_date, render_date_extended, render_duration, scan_date,
+    shift_months,
 };
+use crate::validate::{InvariantViolation, Validate};
 
 impl Iso8601Date {
     /// Parsed components, or `None` when `value` is not a valid ISO 8601 date.
@@ -250,6 +266,48 @@ impl PartialOrd for Iso8601Date {
             return Some(Ordering::Equal); // consistent with the derived PartialEq
         }
         cmp_date(&self.parsed()?, &other.parsed()?)
+    }
+}
+
+/// The uniform violation for one named invariant, on the class reporting it —
+/// `Iso8601_date`, or `Iso8601_date_time` where it re-declares the same rule.
+fn failed(invariant: &str, type_name: &str) -> InvariantViolation {
+    InvariantViolation::here(format!("Invariant {invariant} failed on type {type_name}"))
+}
+
+/// Appends the date-component invariant violations of a scanned value.
+///
+/// The rules are `Month_valid` and `Day_valid`, reported on `type_name` —
+/// `Iso8601_date_time` re-declares both.
+///
+/// `Day_valid` is checked only under an in-range month: its rule is
+/// `valid_day (y, m, d) = d >= 1 and d <= days_in_month (m, y)`
+/// (`time_definitions.adoc` §Functions), which is undefined where `valid_month`
+/// already fails.
+pub(crate) fn push_date_component_violations(
+    d: &ParsedDate,
+    type_name: &str,
+    out: &mut Vec<InvariantViolation>,
+) {
+    let month_valid = d.month.is_none_or(|m| (1..=12).contains(&m));
+    if !month_valid {
+        out.push(failed("Month_valid", type_name));
+    }
+    if month_valid
+        && let (Some(month), Some(day)) = (d.month, d.day)
+        && !days_in_month(d.year, month).is_some_and(|last| (1..=last).contains(&day))
+    {
+        out.push(failed("Day_valid", type_name));
+    }
+}
+
+impl Validate for Iso8601Date {
+    fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
+        let Some(d) = scan_date(&self.value) else {
+            out.push(failed("Value_lexical_form_valid", "Iso8601_date"));
+            return;
+        };
+        push_date_component_violations(&d, "Iso8601_date", out);
     }
 }
 
@@ -608,6 +666,71 @@ mod tests {
         assert!(date("not-a-date").add(&dur("P1D")).is_none());
         // A malformed duration is equally uncomputable.
         assert!(date("2020-06-15").add(&dur("1D")).is_none());
+    }
+
+    // ── invariants ───────────────────────────────────────────────────────────
+
+    /// Every invalid value names the `iso8601_date.adoc` §Invariants entry it
+    /// breaks — the point of the per-invariant realization: a report says WHICH
+    /// rule failed, not merely that the string was rejected.
+    #[test]
+    fn invalid_dates_name_the_invariant_they_break() {
+        for (bad, invariant) in [
+            // Month_valid: valid_month (m) = m >= 1 and m <= Months_in_year.
+            ("2020-13-01", "Month_valid"),
+            ("2020-00-15", "Month_valid"),
+            ("202013", "Month_valid"),
+            // Day_valid: d >= 1 and d <= days_in_month (m, y).
+            ("2021-02-29", "Day_valid"), // 2021 is not a leap year
+            ("2020-02-30", "Day_valid"),
+            ("2020-04-31", "Day_valid"),
+            ("2020-06-00", "Day_valid"),
+            ("20210229", "Day_valid"),
+            // Our own lexical rule: not the valid_iso8601_date production.
+            ("2020-W01", "Value_lexical_form_valid"),
+            ("not-a-date", "Value_lexical_form_valid"),
+            ("2020-6-15", "Value_lexical_form_valid"),
+            ("+2020-06-15", "Value_lexical_form_valid"),
+            ("", "Value_lexical_form_valid"),
+        ] {
+            let v = date(bad).invariants();
+            let expected = format!("Invariant {invariant} failed on type Iso8601_date");
+            assert!(
+                v.iter().any(|m| m.message == expected),
+                "{bad:?} should report {invariant}, got {v:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn valid_dates_including_every_partial_form_report_nothing() {
+        for good in [
+            "2020",
+            "2020-06",
+            "2020-06-15",
+            "202006",
+            "20200615",
+            "2020-02-29",
+            "0000-01-01",
+            "9999-12-31",
+        ] {
+            assert!(
+                date(good).invariants().is_empty(),
+                "{good:?} is a valid Iso8601_date"
+            );
+        }
+    }
+
+    /// `valid_day` is defined in terms of `days_in_month (m, y)`, so a month
+    /// `valid_month` already rejects leaves `Day_valid` undecided.
+    #[test]
+    fn an_out_of_range_month_reports_month_valid_alone() {
+        let v = date("2020-13-01").invariants();
+        assert_eq!(v.len(), 1);
+        assert_eq!(
+            v[0].message,
+            "Invariant Month_valid failed on type Iso8601_date"
+        );
     }
 
     #[test]

--- a/crates/openehr-base/src/v1_3/foundation_types/time/iso8601_date_time_impl.rs
+++ b/crates/openehr-base/src/v1_3/foundation_types/time/iso8601_date_time_impl.rs
@@ -17,6 +17,33 @@
 //!   `24:00:00` disallowed; §Computational Functions: the definite/nominal
 //!   split).
 //!
+//! Invariants — the TWELVE rows the class table declares under §Invariants:
+//! - `Month_valid`, `Day_valid` (shared with `iso8601_date_impl.rs`) and
+//!   `Hour_valid`, `Minute_valid`, `Second_valid`, `Fractional_second_valid`
+//!   (shared with `iso8601_time_impl.rs`) — checked, each under its own name.
+//!   The first two are read in the GUARDED form the sibling `Iso8601_date`
+//!   class spells them (`not month_unknown implies valid_month (month)`); the
+//!   unguarded literal form would reject every partial this class's own
+//!   Description permits.
+//! - `Year_valid` — structurally satisfied (four zero-filled digits).
+//! - `Partial_validity_minute` (`minute_unknown implies second_unknown`) —
+//!   structurally satisfied: no accepted form writes a second without a minute.
+//! - `Partial_validity_year`, `Partial_validity_month`, `Partial_validity_day`,
+//!   `Partial_validity_hour` — refused, see the NOTEs below.
+//! - `Value_lexical_form_valid` — OUR OWN name, because the class table
+//!   declares no rule for a value that is not the production at all (the same
+//!   rule `iso8601_date_impl.rs` names).
+//!
+//! NOTE: `Partial_validity_day` (`not day_unknown`) and `Partial_validity_hour`
+//! (`not hour_unknown` — a function this class never declares) are NOT
+//! enforced: `master06` §Primitive Time Types states that partial variants of
+//! this type "can include missing hours, days and months".
+//!
+//! NOTE: `Partial_validity_year` carries `Partial_validity_month`'s identical
+//! expression (`not month_unknown`) rather than any year rule, and
+//! `Time_definitions.valid_iso8601_date_time` enumerates no date-only partial;
+//! both are refused on the same `master06` ground.
+//!
 //! NOTE: arithmetic needs every component, and the openEHR spec says nothing
 //! about computing on a PARTIAL date/time — a partial (or unparseable) operand
 //! yields `None`, the same undecidable answer this module's comparison gives.
@@ -46,14 +73,17 @@
 
 use std::cmp::Ordering;
 
+use super::iso8601_date_impl::push_date_component_violations;
 use super::iso8601_date_time::Iso8601DateTime;
 use super::iso8601_duration::Iso8601Duration;
 use super::iso8601_parse::{
     EXACT_SECONDS_IN_DAY, EXACT_SECONDS_IN_HOUR, EXACT_SECONDS_IN_MINUTE, ExactSeconds,
     ParsedDateTime, ParsedTime, as_extended_date_time, civil_from_days, date_time_completion_range,
     days_from_civil, hms_from_seconds_of_day, parse_date_time, range_before, render_date_extended,
-    render_duration, render_time_extended, shift_months,
+    render_duration, render_time_extended, scan_date_time, shift_months,
 };
+use super::iso8601_time_impl::push_time_component_violations;
+use crate::validate::{InvariantViolation, Validate};
 
 impl Iso8601DateTime {
     /// Parsed components, or `None` when `value` is not a valid ISO 8601
@@ -348,6 +378,21 @@ impl PartialOrd for Iso8601DateTime {
             return Some(Ordering::Equal); // consistent with the derived PartialEq
         }
         cmp_date_time(&self.parsed()?, &other.parsed()?)
+    }
+}
+
+impl Validate for Iso8601DateTime {
+    fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
+        let Some(dt) = scan_date_time(&self.value) else {
+            out.push(InvariantViolation::here(
+                "Invariant Value_lexical_form_valid failed on type Iso8601_date_time",
+            ));
+            return;
+        };
+        push_date_component_violations(&dt.date, "Iso8601_date_time", out);
+        if let Some(time) = dt.time {
+            push_time_component_violations(&time, "Iso8601_date_time", out);
+        }
     }
 }
 
@@ -733,6 +778,56 @@ mod tests {
         );
         assert!(dt("garbage").add(&dur("PT1H")).is_none());
         assert!(dt("2020-06-15T12:00:00").add(&dur("1H")).is_none());
+    }
+
+    // ── invariants ───────────────────────────────────────────────────────────
+
+    /// Every invalid value names the `iso8601_date_time.adoc` §Invariants entry
+    /// it breaks, on this class rather than on the date/time class the rule is
+    /// shared with.
+    #[test]
+    fn invalid_date_times_name_the_invariant_they_break() {
+        for (bad, invariant) in [
+            ("2020-13-01T10:00", "Month_valid"),
+            ("2021-02-29T10:00:00", "Day_valid"),
+            ("2020-06-15T24:00:00", "Hour_valid"),
+            ("2020-06-15T12:60", "Minute_valid"),
+            ("2020-06-15T12:00:60", "Second_valid"),
+            ("2020-06-15T12:00.5", "Fractional_second_valid"),
+            ("2020-06-15T", "Value_lexical_form_valid"),
+            ("garbage", "Value_lexical_form_valid"),
+            ("2020-06-15T12:00:00+15:00", "Value_lexical_form_valid"),
+        ] {
+            let v = dt(bad).invariants();
+            let expected = format!("Invariant {invariant} failed on type Iso8601_date_time");
+            assert!(
+                v.iter().any(|m| m.message == expected),
+                "{bad:?} should report {invariant}, got {v:?}"
+            );
+        }
+    }
+
+    /// The partials `master06` §Primitive Time Types permits — "missing hours,
+    /// days and months" — validate clean, which is exactly what the refused
+    /// `Partial_validity_day`/`_hour` clauses would have rejected.
+    #[test]
+    fn valid_date_times_including_every_partial_form_report_nothing() {
+        for good in [
+            "2020",
+            "2020-06",
+            "2020-06-15",
+            "2020-06-15T10",
+            "2020-06-15T10:30",
+            "2020-06-15T10:30:00",
+            "2020-06-15T10:30:00.25Z",
+            "20200615T103000+0200",
+            "2020-02-29T00:00:00",
+        ] {
+            assert!(
+                dt(good).invariants().is_empty(),
+                "{good:?} is a valid Iso8601_date_time"
+            );
+        }
     }
 
     #[test]

--- a/crates/openehr-base/src/v1_3/foundation_types/time/iso8601_duration_impl.rs
+++ b/crates/openehr-base/src/v1_3/foundation_types/time/iso8601_duration_impl.rs
@@ -19,6 +19,20 @@
 //!   Types: the negative-duration and mixed-`W` deviations; §Computational
 //!   Functions).
 //!
+//! Invariants — the EIGHT entries the class table declares under §Invariants
+//! (`Years_valid` … `Seconds_valid`, each `>= 0`, and `Fractional_second_valid`
+//! `>= 0.0 and < 1.0`) are ALL structurally satisfied by the reader: a
+//! component is a digit run scanned into an unsigned count, and a fraction is
+//! scanned as `0.<digits>`, so no parsed value can break one. What a value CAN
+//! be is not a duration at all, which the class table names no rule for, so it
+//! is reported under our own `Value_lexical_form_valid` (the same rule
+//! `iso8601_date_impl.rs` names).
+//!
+//! NOTE: the openEHR negative-duration deviation (`master06` §Primitive Time
+//! Types) is a leading sign on the VALUE, not on any component, so `-P1Y` still
+//! satisfies `Years_valid` — the class declares no sign accessor to read it
+//! from.
+//!
 //! NOTE: the class doc gives an algorithm for `add`/`subtract` (reduce both
 //! operands via `to_seconds`) but none for `multiply`/`divide`. Component-wise
 //! scaling is not even expressible — `P1Y * 1.5` would need a fractional year,
@@ -40,6 +54,7 @@ use std::cmp::Ordering;
 
 use super::iso8601_duration::Iso8601Duration;
 use super::iso8601_parse::{ExactSeconds, ParsedDuration, parse_duration, render_duration};
+use crate::validate::{InvariantViolation, Validate};
 
 impl Iso8601Duration {
     /// Parsed components, or `None` when `value` is not a valid ISO 8601
@@ -241,6 +256,16 @@ impl PartialOrd for Iso8601Duration {
             // spellings ⇒ incomparable per decision 4, not equal.
             Ordering::Equal => None,
             ord => Some(ord),
+        }
+    }
+}
+
+impl Validate for Iso8601Duration {
+    fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
+        if self.parsed().is_none() {
+            out.push(InvariantViolation::here(
+                "Invariant Value_lexical_form_valid failed on type Iso8601_duration",
+            ));
         }
     }
 }
@@ -463,5 +488,44 @@ mod tests {
         assert_eq!(flipped.value, "-P1Y2M3W4DT5H6M7,50S");
         assert_eq!(flipped.negative().unwrap().value, original.value);
         assert!(dur("nonsense").negative().is_none());
+    }
+
+    // ── invariants ───────────────────────────────────────────────────────────
+
+    /// A value that is not the `P[nnY][nnM][nnW][nnD][T[nnH][nnM][nnS]]`
+    /// production is refused under the one rule this class can break.
+    #[test]
+    fn a_value_that_is_not_a_duration_reports_the_lexical_rule() {
+        for bad in [
+            "1D", "P", "PT", "", "nonsense", "P1Y1Y", "P1D1M", "P1YT", "-P", "PT1.S",
+        ] {
+            let v = dur(bad).invariants();
+            assert_eq!(v.len(), 1, "{bad:?} should be refused, got {v:?}");
+            assert_eq!(
+                v[0].message,
+                "Invariant Value_lexical_form_valid failed on type Iso8601_duration"
+            );
+        }
+    }
+
+    /// Every declared component invariant is structurally satisfied, including
+    /// on a negative duration (the sign is on the value, not on a component).
+    #[test]
+    fn valid_durations_report_nothing() {
+        for good in [
+            "P1Y",
+            "-P3M",
+            "P1W",
+            "P30D",
+            "PT1M",
+            "PT0S",
+            "PT0,5S",
+            "P1Y2M3W4DT5H6M7.5S",
+        ] {
+            assert!(
+                dur(good).invariants().is_empty(),
+                "{good:?} is a valid Iso8601_duration"
+            );
+        }
     }
 }

--- a/crates/openehr-base/src/v1_3/foundation_types/time/iso8601_parse.rs
+++ b/crates/openehr-base/src/v1_3/foundation_types/time/iso8601_parse.rs
@@ -225,6 +225,20 @@ pub(crate) fn days_from_civil(year: u32, month: u32, day: u32) -> i64 {
 /// Types); component combinations must be calendar-valid
 /// (`Time_definitions.valid_iso8601_date`).
 pub(crate) fn parse_date(s: &str) -> Option<ParsedDate> {
+    let d = scan_date(s)?;
+    validate_date(d.year, d.month, d.day)?;
+    Some(d)
+}
+
+/// Decompose a date LEXICALLY, without the calendar-validity checks: the same
+/// accepted spellings as [`parse_date`], but `2021-02-29` still yields its
+/// three components.
+///
+/// The invariant reporting in `iso8601_date_impl.rs` needs the components of an
+/// INVALID value to name the rule that value breaks (`Month_valid` versus
+/// `Day_valid`); a form that is not the production at all (a week date, an
+/// expanded year) has no components to report and is refused here.
+pub(crate) fn scan_date(s: &str) -> Option<ParsedDate> {
     if s.is_empty() || s.bytes().any(|b| b == b'W' || b == b'w') {
         return None;
     }
@@ -259,7 +273,6 @@ pub(crate) fn parse_date(s: &str) -> Option<ParsedDate> {
             _ => return None,
         }
     };
-    validate_date(year, month, day)?;
     // `Iso8601_date.is_extended`: "True if this date uses '-' separators".
     // NOTE: the spec does not say what a form with NO separator position
     // (`YYYY`) reports; we report it extended, keeping `as_string() == value`
@@ -300,17 +313,32 @@ fn validate_date(year: u32, month: Option<u32>, day: Option<u32>) -> Option<()> 
 /// (`master06`; `Time_definitions.valid_second` Post `s < Seconds_in_minute`),
 /// see the leap-second NOTE in `iso8601_time_impl.rs`.
 pub(crate) fn parse_time(s: &str) -> Option<ParsedTime> {
+    let t = scan_time(s)?;
+    validate_time(t.hour, t.minute, t.second, t.fractional_second)?;
+    Some(t)
+}
+
+/// Decompose a time LEXICALLY, without the component-validity checks: the same
+/// accepted spellings as [`parse_time`], but `24:00:00` and `12:00:60` still
+/// yield their components, and a fractional part is kept even where no second
+/// carries it (`12:00.5`).
+///
+/// The invariant reporting in `iso8601_time_impl.rs` needs those components to
+/// name the rule the value breaks. The timezone lexeme is still range-checked
+/// by [`parse_timezone`]: its bounds are `Iso8601_timezone`'s own invariants,
+/// which this class does not declare.
+pub(crate) fn scan_time(s: &str) -> Option<ParsedTime> {
     let (main, tz) = split_timezone_lexeme(s)?;
     let timezone = if tz.is_empty() {
         None
     } else {
         Some(parse_timezone(tz)?)
     };
-    let (hour, minute, second, fractional_second) = parse_time_main(main)?;
+    let (hour, minute, second, fractional_second) = scan_time_main(main)?;
     // `Iso8601_time.is_extended`: "True if this time uses '-', ':' separators".
     // A value counts as extended when every separator position it actually has
     // is written with a separator (so `hh`, `Z` and `±hh`, which have none, do
-    // not disqualify it) — see the `parse_date` is_extended NOTE.
+    // not disqualify it) — see the `scan_date` is_extended NOTE.
     let extended = body_is_extended(split_fraction_lexeme(main).0) && timezone_is_extended(tz);
     Some(ParsedTime {
         hour,
@@ -347,8 +375,9 @@ fn timezone_is_extended(tz: &str) -> bool {
     tz.contains(':') || tz.len() <= 3
 }
 
-/// Parse the time-of-day part (no timezone) in extended or compact form.
-fn parse_time_main(main: &str) -> Option<TimeParts> {
+/// Decompose the time-of-day part (no timezone) in extended or compact form,
+/// lexically only — see [`scan_time`].
+fn scan_time_main(main: &str) -> Option<TimeParts> {
     // Separate an optional fractional-seconds tail introduced by '.' or ','.
     let (body, frac) = split_fraction(main);
     let (hour, minute, second) = if body.contains(':') {
@@ -382,13 +411,7 @@ fn parse_time_main(main: &str) -> Option<TimeParts> {
             _ => return None,
         }
     };
-    // A fractional part is only meaningful on a present second.
-    let fractional_second = match frac {
-        Some(f) if second.is_some() => Some(f),
-        Some(_) => return None,
-        None => None,
-    };
-    validate_time(hour, minute, second, fractional_second)
+    Some((hour, minute, second, frac))
 }
 
 /// Split a trailing `(.|,)digits` fractional part off the time body, returning
@@ -451,8 +474,10 @@ fn validate_time(
     {
         return None; // leap second `:60` rejected per valid_second
     }
+    // `Fractional_second_valid`: a fraction is significant only on a present
+    // second, and lies in `[0.0, 1.0)` (`valid_fractional_second`).
     if let Some(f) = fractional_second
-        && !(f.is_finite() && (0.0..1.0).contains(&f))
+        && (second.is_none() || !(f.is_finite() && (0.0..1.0).contains(&f)))
     {
         return None; // includes the NaN split_fraction uses to flag malformed input
     }
@@ -523,6 +548,23 @@ pub(crate) fn parse_date_time(s: &str) -> Option<ParsedDateTime> {
     } else {
         Some(ParsedDateTime {
             date: parse_date(s)?,
+            time: None,
+        })
+    }
+}
+
+/// Decompose a date/time LEXICALLY, without the component-validity checks — see
+/// [`scan_date`] and [`scan_time`], which it composes on the same `T` split as
+/// [`parse_date_time`].
+pub(crate) fn scan_date_time(s: &str) -> Option<ParsedDateTime> {
+    if let Some((d, t)) = s.split_once('T') {
+        Some(ParsedDateTime {
+            date: scan_date(d)?,
+            time: Some(scan_time(t)?),
+        })
+    } else {
+        Some(ParsedDateTime {
+            date: scan_date(s)?,
             time: None,
         })
     }
@@ -1337,6 +1379,41 @@ mod tests {
         assert!((month - 2_628_288.0).abs() < 1e-6);
         assert_eq!(EXACT_SECONDS_IN_AVERAGE_YEAR, 31_556_736);
         assert_eq!(EXACT_SECONDS_IN_AVERAGE_MONTH, 2_628_288);
+    }
+
+    /// The lenient scanners accept EXACTLY what the strict parsers accept, plus
+    /// the values whose only defect is a class invariant — which is what lets
+    /// the `*_impl.rs` validators name the rule a bad value breaks.
+    #[test]
+    fn the_scanners_extend_the_parsers_only_where_an_invariant_decides() {
+        for good in ["2020", "2020-06", "2020-06-15", "20200615", "202006"] {
+            assert_eq!(scan_date(good), parse_date(good), "{good:?}");
+        }
+        for good in [
+            "12",
+            "12:00",
+            "12:00:00",
+            "120000",
+            "12:00:00.5",
+            "120000,25Z",
+        ] {
+            assert_eq!(scan_time(good), parse_time(good), "{good:?}");
+        }
+        for bad in ["2020-W01", "not-a-date", "2020-6-15", ""] {
+            assert!(scan_date(bad).is_none(), "{bad:?} is not the production");
+        }
+        // Calendar- and component-invalid values still decompose.
+        assert!(parse_date("2021-02-29").is_none() && scan_date("2021-02-29").is_some());
+        assert!(parse_date("2020-13-01").is_none() && scan_date("2020-13-01").is_some());
+        assert!(parse_time("24:00:00").is_none() && scan_time("24:00:00").is_some());
+        assert!(parse_time("12:00:60").is_none() && scan_time("12:00:60").is_some());
+        // A fraction with no second to carry it: refused by the parser (the
+        // `Fractional_second_valid` clause), kept by the scanner.
+        assert!(parse_time("12:00.5").is_none());
+        assert_eq!(
+            scan_time("12:00.5").and_then(|t| t.fractional_second),
+            Some(0.5)
+        );
     }
 
     #[test]

--- a/crates/openehr-base/src/v1_3/foundation_types/time/iso8601_time_impl.rs
+++ b/crates/openehr-base/src/v1_3/foundation_types/time/iso8601_time_impl.rs
@@ -19,6 +19,27 @@
 //!   definite forms exist for a time — 'year' and 'month' cannot land on a clock
 //!   face, so `Iso8601_time` declares no `add_nominal`).
 //!
+//! Invariants — the FIVE entries the class table declares under §Invariants,
+//! plus one rule of our own naming:
+//! - `Hour_valid`, `Minute_valid`, `Second_valid` and
+//!   `Fractional_second_valid` — checked, each under its own name (shared with
+//!   `Iso8601_date_time`, which re-declares all four verbatim).
+//! - `Partial_validity` (`minute_unknown implies second_unknown`) —
+//!   structurally satisfied: no accepted form writes a second without a minute.
+//! - `Value_lexical_form_valid` — OUR OWN name, because the class table
+//!   declares none: a value that is not the `valid_iso8601_time` production at
+//!   all has no components, so every declared invariant holds vacuously.
+//!
+//! NOTE: `Hour_valid` is `valid_hour (hour, minute, second)`, whose
+//! postcondition also admits `h = Hours_in_day and m = 0 and s = 0`; this class
+//! and `master06` §Primitive Time Types both forbid `24:00:00` "anywhere", so
+//! the invariant is enforced as `hour < 24`.
+//!
+//! NOTE: the timezone's own bounds are `Iso8601_timezone`'s invariants
+//! (`org.openehr.base.foundation_types.iso8601_timezone.adoc` §Invariants), a
+//! class an `Iso8601_time` carries only as a lexeme, so an out-of-range offset
+//! is reported as a lexical-form failure rather than under one of them.
+//!
 //! NOTE: arithmetic needs every component, and the openEHR spec says nothing
 //! about computing on a PARTIAL time (`hh`, `hh:mm`) — a partial (or
 //! unparseable) operand yields `None`, the same undecidable answer this
@@ -51,9 +72,10 @@ use super::iso8601_duration::Iso8601Duration;
 use super::iso8601_parse::{
     EXACT_SECONDS_IN_DAY, EXACT_SECONDS_IN_HOUR, EXACT_SECONDS_IN_MINUTE, ExactSeconds, ParsedTime,
     as_extended_time, hms_from_seconds_of_day, parse_time, range_before, render_duration,
-    render_time_extended, time_completion_range,
+    render_time_extended, scan_time, time_completion_range,
 };
 use super::iso8601_time::Iso8601Time;
+use crate::validate::{InvariantViolation, Validate};
 
 impl Iso8601Time {
     /// Parsed components, or `None` when `value` is not a valid ISO 8601 time.
@@ -254,6 +276,55 @@ impl PartialOrd for Iso8601Time {
             return Some(Ordering::Equal); // consistent with the derived PartialEq
         }
         cmp_time(&self.parsed()?, &other.parsed()?)
+    }
+}
+
+/// The uniform violation for one named invariant, on the class reporting it —
+/// `Iso8601_time`, or `Iso8601_date_time` where it re-declares the same rule.
+fn failed(invariant: &str, type_name: &str) -> InvariantViolation {
+    InvariantViolation::here(format!("Invariant {invariant} failed on type {type_name}"))
+}
+
+/// Appends the time-component invariant violations of a scanned value.
+///
+/// The rules are `Hour_valid`, `Minute_valid`, `Second_valid` and
+/// `Fractional_second_valid`, reported on `type_name`. `Iso8601_date_time`
+/// declares the same four under the same names with the same expressions, so
+/// both classes report through this one body.
+pub(crate) fn push_time_component_violations(
+    t: &ParsedTime,
+    type_name: &str,
+    out: &mut Vec<InvariantViolation>,
+) {
+    // Hour_valid — `24:00:00` is forbidden anywhere (module NOTE).
+    if t.hour >= 24 {
+        out.push(failed("Hour_valid", type_name));
+    }
+    // Minute_valid / Second_valid: `valid_minute (m)` is `m < Minutes_in_hour`
+    // and `valid_second (s)` is `s < Seconds_in_minute`, each on a present
+    // component (the implication is vacuous on an absent one).
+    if t.minute.is_some_and(|m| m >= 60) {
+        out.push(failed("Minute_valid", type_name));
+    }
+    if t.second.is_some_and(|s| s >= 60) {
+        out.push(failed("Second_valid", type_name));
+    }
+    // Fractional_second_valid: significant only alongside a present second, and
+    // `valid_fractional_second (fs)` is `fs >= 0.0 and fs < 1.0`.
+    if let Some(f) = t.fractional_second
+        && (t.second.is_none() || !(0.0..1.0).contains(&f))
+    {
+        out.push(failed("Fractional_second_valid", type_name));
+    }
+}
+
+impl Validate for Iso8601Time {
+    fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
+        let Some(t) = scan_time(&self.value) else {
+            out.push(failed("Value_lexical_form_valid", "Iso8601_time"));
+            return;
+        };
+        push_time_component_violations(&t, "Iso8601_time", out);
     }
 }
 
@@ -563,6 +634,59 @@ mod tests {
     }
 
     // ── partial / malformed operands ─────────────────────────────────────────
+
+    // ── invariants ───────────────────────────────────────────────────────────
+
+    /// Every invalid value names the `iso8601_time.adoc` §Invariants entry it
+    /// breaks, rather than merely failing to parse.
+    #[test]
+    fn invalid_times_name_the_invariant_they_break() {
+        for (bad, invariant) in [
+            // Hour_valid — including the `24:00:00` openEHR deviation.
+            ("24:00:00", "Hour_valid"),
+            ("25:30", "Hour_valid"),
+            ("990000", "Hour_valid"),
+            // Minute_valid / Second_valid.
+            ("12:60:00", "Minute_valid"),
+            ("12:00:60", "Second_valid"),
+            // Fractional_second_valid: a fraction with no second to carry it.
+            ("12:00.5", "Fractional_second_valid"),
+            // Our own lexical rule: not the valid_iso8601_time production.
+            ("nonsense", "Value_lexical_form_valid"),
+            ("12:00:00+15:00", "Value_lexical_form_valid"),
+            ("12:0:00", "Value_lexical_form_valid"),
+            ("", "Value_lexical_form_valid"),
+        ] {
+            let v = time(bad).invariants();
+            let expected = format!("Invariant {invariant} failed on type Iso8601_time");
+            assert!(
+                v.iter().any(|m| m.message == expected),
+                "{bad:?} should report {invariant}, got {v:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn valid_times_including_every_partial_form_report_nothing() {
+        for good in [
+            "12",
+            "12:00",
+            "12:00:00",
+            "1200",
+            "120000",
+            "12:00:00.5",
+            "12:00:00,25",
+            "23:59:59",
+            "00:00:00Z",
+            "12:00:00+02:00",
+            "120000-0500",
+        ] {
+            assert!(
+                time(good).invariants().is_empty(),
+                "{good:?} is a valid Iso8601_time"
+            );
+        }
+    }
 
     #[test]
     fn partial_and_malformed_values_have_no_arithmetic() {

--- a/crates/openehr-base/src/v1_3/resource/authored_resource_impl.rs
+++ b/crates/openehr-base/src/v1_3/resource/authored_resource_impl.rs
@@ -1,12 +1,40 @@
 // @generated-from-template templates/openehr-base/resource/authored_resource_impl.rs — DO NOT EDIT; edit the source and re-run `openehr-codegen -- emit`.
-//! Hand-written spec functions of `AUTHORED_RESOURCE`.
+//! Hand-written spec functions + invariants of `AUTHORED_RESOURCE`.
 //!
 //! Spec: `BASE/docs/UML/classes/org.openehr.base.resource.authored_resource.adoc`
-//! §Functions, and `BASE/docs/resource/master02-resource_package.adoc`
-//! §Natural Languages and Translation ("The languages_available function
-//! provides a complete list of languages in the resource").
+//! §Functions and §Invariants, and
+//! `BASE/docs/resource/master02-resource_package.adoc` §Natural Languages and
+//! Translation ("The languages_available function provides a complete list of
+//! languages in the resource").
+//!
+//! Invariants — the FOUR entries the class table declares:
+//! - `Translations_valid` and `Description_valid` — checked, each under its
+//!   own name.
+//! - `Languages_available_valid` (`languages_available.has
+//!   (original_language)`) — structurally satisfied: `languages_available`
+//!   opens with the original language.
+//! - `Original_language_valid` — a terminology boundary, see the NOTE below.
+//!
+//! NOTE: `Original_language_valid`
+//! (`code_set (Code_set_id_languages).has_code (original_language.as_string)`)
+//! is not enforced here: the languages code set lives in the terminology
+//! service, which `openehr-base` has no dependency on.
+//!
+//! NOTE: `Description_valid`'s literal form would reject the resource's own
+//! ORIGINAL-language detail, which `master02-resource_package.adoc` §Meta-data
+//! requires each translated resource to keep, so it is read as "every detail
+//! language is the original language or a declared translation".
+//!
+//! NOTE: `Translations_valid` spells its second clause `translations.has
+//! (original_language.code_string)` over a list "keyed by language code" whose
+//! §Attributes text says the original language "does not appear in this list",
+//! so it is read as the KEY test its sibling clause spells `has_key`.
 
 use crate::v1_3::resource::authored_resource::AuthoredResource;
+use crate::v1_3::resource::resource_description_item::ResourceDescriptionItem;
+use crate::v1_3::resource::translation_details::TranslationDetails;
+use crate::validate::{InvariantViolation, Validate};
+use std::collections::BTreeMap;
 
 impl AuthoredResource {
     /// `AUTHORED_RESOURCE.languages_available`: the total list of languages
@@ -25,50 +53,114 @@ impl AuthoredResource {
     }
 }
 
+/// The uniform violation for one named invariant of this class.
+fn failed(invariant: &str) -> InvariantViolation {
+    InvariantViolation::here(format!(
+        "Invariant {invariant} failed on type AUTHORED_RESOURCE"
+    ))
+}
+
+/// Appends `Description_valid` when any description detail is written in a
+/// language the resource declares neither as its original nor as a translation.
+fn push_description_violation(
+    details: &BTreeMap<String, ResourceDescriptionItem>,
+    original_language: &str,
+    translations: &BTreeMap<String, TranslationDetails>,
+    out: &mut Vec<InvariantViolation>,
+) {
+    let undeclared = details.values().any(|item| {
+        let language = item.language.code_string.as_str();
+        language != original_language && !translations.contains_key(language)
+    });
+    if undeclared {
+        out.push(failed("Description_valid"));
+    }
+}
+
+impl Validate for AuthoredResource {
+    fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
+        // Both declared rules are `translations /= Void implies …`, so a
+        // resource with no translation list satisfies each vacuously.
+        let Some(translations) = &self.translations else {
+            return;
+        };
+        let original_language = self.original_language.code_string.as_str();
+        if translations.is_empty() || translations.contains_key(original_language) {
+            out.push(failed("Translations_valid"));
+        }
+        if let Some(details) = self.description.as_ref().and_then(|d| d.details.as_ref()) {
+            push_description_violation(details, original_language, translations, out);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::v1_3::foundation_types::terminology::terminology_code::TerminologyCode;
-    use crate::v1_3::resource::authored_resource::AuthoredResource;
-    use crate::v1_3::resource::translation_details::TranslationDetails;
+
+    /// An ISO 639-1 language code as a `TERMINOLOGY_CODE`.
+    fn language_code(code: &str) -> TerminologyCode {
+        TerminologyCode {
+            terminology_id: "ISO_639-1".to_owned(),
+            terminology_version: None,
+            code_string: code.to_owned(),
+            uri: None,
+        }
+    }
+
+    /// A `translations` list keyed by the given language codes.
+    fn translation_map(languages: &[&str]) -> BTreeMap<String, TranslationDetails> {
+        languages
+            .iter()
+            .map(|lang| {
+                (
+                    (*lang).to_owned(),
+                    TranslationDetails {
+                        language: language_code(lang),
+                        author: BTreeMap::new(),
+                        accreditation: None,
+                        other_details: None,
+                        version_last_translated: None,
+                        other_contributors: None,
+                    },
+                )
+            })
+            .collect()
+    }
+
+    /// A `description.details` list keyed by the given language codes.
+    fn details_map(languages: &[&str]) -> BTreeMap<String, ResourceDescriptionItem> {
+        languages
+            .iter()
+            .map(|lang| {
+                (
+                    (*lang).to_owned(),
+                    ResourceDescriptionItem {
+                        language: language_code(lang),
+                        purpose: "purpose".to_owned(),
+                        keywords: None,
+                        use_: None,
+                        misuse: None,
+                        original_resource_uri: None,
+                        other_details: None,
+                    },
+                )
+            })
+            .collect()
+    }
 
     fn resource(translations: &[&str]) -> AuthoredResource {
         AuthoredResource {
             uid: None,
-            original_language: TerminologyCode {
-                terminology_id: "ISO_639-1".to_owned(),
-                terminology_version: None,
-                code_string: "en".to_owned(),
-                uri: None,
-            },
+            original_language: language_code("en"),
             description: None,
             is_controlled: None,
             annotations: None,
             translations: if translations.is_empty() {
                 None
             } else {
-                Some(
-                    translations
-                        .iter()
-                        .map(|lang| {
-                            (
-                                (*lang).to_owned(),
-                                TranslationDetails {
-                                    language: TerminologyCode {
-                                        terminology_id: "ISO_639-1".to_owned(),
-                                        terminology_version: None,
-                                        code_string: (*lang).to_owned(),
-                                        uri: None,
-                                    },
-                                    author: std::collections::BTreeMap::new(),
-                                    accreditation: None,
-                                    other_details: None,
-                                    version_last_translated: None,
-                                    other_contributors: None,
-                                },
-                            )
-                        })
-                        .collect(),
-                )
+                Some(translation_map(translations))
             },
         }
     }
@@ -85,5 +177,90 @@ mod tests {
             resource(&["de", "pt"]).languages_available(),
             ["en", "de", "pt"]
         );
+    }
+
+    // ── invariants ───────────────────────────────────────────────────────────
+
+    /// `Translations_valid`: a present list is neither empty nor a re-statement
+    /// of the original language.
+    #[test]
+    fn translations_valid_refuses_an_empty_or_self_naming_list() {
+        for (languages, case) in [
+            (Vec::new(), "an empty list"),
+            (vec!["en"], "the original language alone"),
+            (vec!["de", "en"], "the original language among others"),
+        ] {
+            let mut authored = resource(&[]);
+            authored.translations = Some(translation_map(&languages));
+            let violations = authored.invariants();
+            assert_eq!(violations.len(), 1, "{case}");
+            assert_eq!(
+                violations[0].message,
+                "Invariant Translations_valid failed on type AUTHORED_RESOURCE",
+                "{case}"
+            );
+        }
+    }
+
+    /// The state `Translations_valid` exists to prevent: `languages_available`
+    /// reports the original language twice.
+    #[test]
+    fn a_self_naming_translation_list_duplicates_a_language() {
+        let mut authored = resource(&[]);
+        authored.translations = Some(translation_map(&["en"]));
+        assert_eq!(authored.languages_available(), ["en", "en"]);
+        assert!(!authored.invariants().is_empty());
+    }
+
+    #[test]
+    fn a_valid_translation_list_reports_nothing() {
+        // No list at all: both rules are vacuous.
+        assert!(resource(&[]).invariants().is_empty());
+        assert!(resource(&["de", "pt"]).invariants().is_empty());
+    }
+
+    /// `Description_valid`: a detail written in a language the resource
+    /// declares nowhere.
+    #[test]
+    fn description_valid_refuses_a_detail_in_an_undeclared_language() {
+        // NOTE: BASE 1.2.0's RESOURCE_DESCRIPTION declares a different field set
+        // from 1.3.0's, so a whole-value fixture is not writable in a generation
+        // twin — the rule is asserted on the core every generation shares.
+        let mut violations = Vec::new();
+        push_description_violation(
+            &details_map(&["en", "fr"]),
+            "en",
+            &translation_map(&["de"]),
+            &mut violations,
+        );
+        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            violations[0].message,
+            "Invariant Description_valid failed on type AUTHORED_RESOURCE"
+        );
+    }
+
+    /// The accepting twin, including the ORIGINAL-language detail the literal
+    /// invariant text would have rejected (module NOTE).
+    #[test]
+    fn description_valid_accepts_the_original_language_and_every_translation() {
+        for details in [
+            details_map(&["en"]),
+            details_map(&["en", "de"]),
+            details_map(&["en", "de", "pt"]),
+            details_map(&[]),
+        ] {
+            let mut violations = Vec::new();
+            push_description_violation(
+                &details,
+                "en",
+                &translation_map(&["de", "pt"]),
+                &mut violations,
+            );
+            assert!(
+                violations.is_empty(),
+                "{details:?} declares only known languages"
+            );
+        }
     }
 }

--- a/crates/openehr-lang/src/v1_0/odin/parser.rs
+++ b/crates/openehr-lang/src/v1_0/odin/parser.rs
@@ -819,15 +819,16 @@ fn decode_string(raw: &str) -> String {
 /// Decode a single-quoted `CHARACTER` literal to its `char`.
 ///
 /// The lexer (`validate_char`) admits only the six quoted forms in a character
-/// literal, so the decode cannot fail here.
+/// literal, so the decode cannot fail here, and its token regex admits exactly
+/// one body character, so the decoded literal is never empty.
 #[expect(
     clippy::expect_used,
-    reason = "`Token::Character` only exists when the lexer's validate_char admitted the body, which restricts an escape to the six quoted forms none of which can fail to decode"
+    reason = "`Token::Character` only exists when the lexer's validate_char admitted the body, which restricts an escape to the six quoted forms none of which can fail to decode; the same token regex admits one body character or one two-character escape, each decoding to exactly one char, so the literal is never empty"
 )]
 fn decode_char(raw: &str) -> char {
     crate::v1_0::escape::decode_character_literal(raw)
         .expect("a lexer-validated character literal should decode")
         .chars()
         .next()
-        .unwrap_or('\u{fffd}')
+        .expect("a lexer-validated character literal should decode to one character")
 }

--- a/crates/openehr-lang/src/v1_1/bel/parser.rs
+++ b/crates/openehr-lang/src/v1_1/bel/parser.rs
@@ -222,27 +222,28 @@ impl<'a, 'b, B: BelBuilder> Parser<'a, 'b, B> {
     /// An interval `primitive_object` value (`| … |`), captured VERBATIM from
     /// the source between (and including) its two `|` delimiters — see the
     /// [`BelLiteral::Interval`] adjudication.
+    #[expect(
+        clippy::expect_used,
+        reason = "`self.src` IS the string the token spans were produced from (parse_statements_with lexes `src` and hands the same `src` to Parser::new), and the range runs from the opening delimiter's span start to the closing delimiter's span end, so it is always an in-bounds, char-boundary slice"
+    )]
     fn parse_interval_literal(&mut self) -> Result<B::Expr, BelError> {
         let open = self.pos;
         let Some(open_span) = self.toks.get(open).map(|s| s.span.clone()) else {
             return self.err("expected '|' opening an interval value");
         };
         self.pos += 1; // the opening '|'
-        while let Some(token) = self.peek() {
-            if *token == Token::SymIvlDelim {
-                let close_span = self
-                    .toks
-                    .get(self.pos)
-                    .map_or_else(|| open_span.clone(), |s| s.span.clone());
-                self.pos += 1;
+        while let Some(entry) = self.toks.get(self.pos) {
+            let close_end = entry.span.end;
+            let closes = entry.token == Token::SymIvlDelim;
+            self.pos += 1;
+            if closes {
                 let text = self
                     .src
-                    .get(open_span.start..close_span.end)
-                    .unwrap_or_default()
+                    .get(open_span.start..close_end)
+                    .expect("a token span range should slice the source it was lexed from")
                     .to_owned();
                 return Ok(self.builder.literal(BelLiteral::Interval(text)));
             }
-            self.pos += 1;
         }
         self.err("expected '|' closing an interval value")
     }
@@ -552,6 +553,10 @@ impl<'a, 'b, B: BelBuilder> Parser<'a, 'b, B> {
     /// Capture the verbatim source of a `matches` right-hand side: either a
     /// single `CONTAINED_REGEXP` token, or a `{ … }` block captured by
     /// brace-depth over the token stream. Returns `(raw_text, byte_offset)`.
+    #[expect(
+        clippy::expect_used,
+        reason = "`self.src` IS the string the token spans were produced from (parse_statements_with lexes `src` and hands the same `src` to Parser::new), and the range runs from an opening token's span start to a later token's span end, so it is always an in-bounds, char-boundary slice"
+    )]
     fn constraint_rhs(&mut self) -> Result<(String, usize), BelError> {
         if let Some(Token::ContainedRegexp(raw)) = self.peek().cloned() {
             let at = self.at();
@@ -575,7 +580,11 @@ impl<'a, 'b, B: BelBuilder> Parser<'a, 'b, B> {
             }
             self.pos += 1;
             if depth == 0 {
-                let raw = self.src.get(start..end).unwrap_or_default().to_owned();
+                let raw = self
+                    .src
+                    .get(start..end)
+                    .expect("a token span range should slice the source it was lexed from")
+                    .to_owned();
                 return Ok((raw, start));
             }
         }
@@ -633,15 +642,16 @@ fn decode_string(raw: &str) -> String {
 /// Decode a single-quoted character literal to a `char`.
 ///
 /// The lexer (`validate_char`) admits only the six quoted forms in a character
-/// literal, so the decode cannot fail here.
+/// literal, so the decode cannot fail here, and its token regex admits exactly
+/// one body character, so the decoded literal is never empty.
 #[expect(
     clippy::expect_used,
-    reason = "`Token::Character` only exists when the lexer's validate_char admitted the body, which restricts an escape to the six quoted forms none of which can fail to decode"
+    reason = "`Token::Character` only exists when the lexer's validate_char admitted the body, which restricts an escape to the six quoted forms none of which can fail to decode; the same token regex admits one body character or one two-character escape, each decoding to exactly one char, so the literal is never empty"
 )]
 fn decode_char(raw: &str) -> char {
     crate::v1_1::escape::decode_character_literal(raw)
         .expect("a lexer-validated character literal should decode")
         .chars()
         .next()
-        .unwrap_or('\u{fffd}')
+        .expect("a lexer-validated character literal should decode to one character")
 }

--- a/crates/openehr-lang/src/v1_1/bmm/core/bmm_type_impl.rs
+++ b/crates/openehr-lang/src/v1_1/bmm/core/bmm_type_impl.rs
@@ -105,8 +105,8 @@ impl BmmSimpleType {
         self.base_class.type_signature()
     }
 
-    /// `BMM_CLASSIFIER.conformance_type_name` for a simple type: "a simple
-    /// class name" (`master05-core.adoc` §Basics).
+    /// `conformance_type_name` for a simple type: "a simple class name"
+    /// (`master05-core.adoc` §Semantics §Basics).
     #[must_use]
     pub fn conformance_type_name(&self) -> String {
         self.base_class.name().to_owned()
@@ -139,9 +139,9 @@ impl BmmGenericType {
         self.rendered(BmmType::type_signature)
     }
 
-    /// `BMM_CLASSIFIER.conformance_type_name` for a generic type: "the _root_
-    /// type from a generic type (e.g. `Interval` from `Interval<T>`)"
-    /// (`master05-core.adoc` §Basics).
+    /// `conformance_type_name` for a generic type: "the _root_ type from a
+    /// generic type (e.g. `Interval` from `Interval<T>`)"
+    /// (`master05-core.adoc` §Semantics §Basics).
     #[must_use]
     pub fn conformance_type_name(&self) -> String {
         self.base_class.name.clone()
@@ -195,9 +195,9 @@ impl BmmContainerType {
         self.rendered(BmmType::type_signature)
     }
 
-    /// `BMM_CLASSIFIER.conformance_type_name` for a container type: "the
-    /// _contained_ type for a container type (e.g. `ELEMENT` from the type
-    /// `List<ELEMENT>`)" (`master05-core.adoc` §Basics).
+    /// `conformance_type_name` for a container type: "the _contained_ type for
+    /// a container type (e.g. `ELEMENT` from the type `List<ELEMENT>`)"
+    /// (`master05-core.adoc` §Semantics §Basics).
     #[must_use]
     pub fn conformance_type_name(&self) -> String {
         self.base_type().conformance_type_name()
@@ -268,9 +268,9 @@ impl BmmIndexedContainerType {
         self.rendered(BmmType::type_signature)
     }
 
-    /// `BMM_CLASSIFIER.conformance_type_name` for an indexed container: "the
-    /// _contained_ type" (`master05-core.adoc` §Semantics §Basics), i.e. the
-    /// VALUE type `base_type` — not the key type.
+    /// `conformance_type_name` for an indexed container: "the _contained_
+    /// type" (`master05-core.adoc` §Semantics §Basics), i.e. the VALUE type
+    /// `base_type` — not the key type.
     #[must_use]
     pub fn conformance_type_name(&self) -> String {
         self.base_type.conformance_type_name()
@@ -335,11 +335,14 @@ impl BmmType {
         }
     }
 
-    /// `BMM_CLASSIFIER.conformance_type_name`: "a reduced form of the type …
-    /// either a simple class name, the _contained_ type for a container type
-    /// (e.g. `ELEMENT` from the type `List<ELEMENT>`), and the _root_ type from
-    /// a generic type (e.g. `Interval` from `Interval<T>`)"
-    /// (`master05-core.adoc` §Semantics §Basics).
+    /// `conformance_type_name`: "a reduced form of the type … either a simple
+    /// class name, the _contained_ type for a container type (e.g. `ELEMENT`
+    /// from the type `List<ELEMENT>`), and the _root_ type from a generic type
+    /// (e.g. `Interval` from `Interval<T>`)"
+    /// (`LANG/docs/bmm/master05-core.adoc` §Semantics §Basics — the function is
+    /// defined there in prose; of the class docs only
+    /// `org.openehr.lang.bmm.bmm_open_type.adoc` carries it in a §Functions
+    /// table).
     #[must_use]
     pub fn conformance_type_name(&self) -> String {
         match self {

--- a/crates/openehr-lang/src/v1_1/bmm3/core/model/bmm_model_impl.rs
+++ b/crates/openehr-lang/src/v1_1/bmm3/core/model/bmm_model_impl.rs
@@ -226,6 +226,12 @@ impl BmmModel {
     ///   "Conforms - case where anc type is not provided in generic form, but
     ///   desc is, e.g. `Interval<Integer>` conforms to `Interval`".
     ///
+    /// Each generic branch is gated on BOTH halves the section states —
+    /// "`valid_generic_type_name (a_type)` and `bmm_def_class instanceOf
+    /// (BMM_GENERIC_CLASS)`" — so a generic-SHAPED name whose root class the
+    /// model does not define as a `BMM_GENERIC_CLASS` takes the non-generic
+    /// path.
+    ///
     /// A non-generic descendant against a GENERIC ancestor is therefore not
     /// conformant: the section's final `else` returns "not
     /// valid_generic_type_name (anc_type)".
@@ -243,10 +249,16 @@ impl BmmModel {
         if !self.base_class_conforms_to(descendant_root, ancestor_root) {
             return false;
         }
-        if ancestor_parameters.is_empty() {
+        if !self.is_generic_type(descendant_root, &descendant_parameters) {
+            return ancestor_parameters.is_empty();
+        }
+        if !self.is_generic_type(ancestor_root, &ancestor_parameters) {
             return true;
         }
         if descendant_parameters.len() != ancestor_parameters.len() {
+            // NOTE: no openEHR spec governs this — our own design/extension;
+            // §Type Conformance's pseudocode returns nothing when two generic
+            // types differ in parameter count, and a count mismatch is refused.
             return false;
         }
         descendant_parameters
@@ -265,6 +277,23 @@ impl BmmModel {
                 };
                 self.type_conforms_to(&source, &target)
             })
+    }
+
+    /// The generic-branch guard of §Type Conformance:
+    /// "`valid_generic_type_name (a_type)` and `bmm_def_class instanceOf
+    /// (BMM_GENERIC_CLASS)`".
+    ///
+    /// The name must both CARRY generic parameters and root in a class this
+    /// model defines as a `BMM_GENERIC_CLASS`
+    /// (`org.openehr.lang.bmm3.bmm_generic_class.adoc` §Description); a class
+    /// the model does not define satisfies no `instanceOf` test, so it takes
+    /// the non-generic path.
+    fn is_generic_type(&self, root: &str, parameters: &[&str]) -> bool {
+        !parameters.is_empty()
+            && matches!(
+                self.class_definition(root),
+                Some(BmmClass::BmmGenericClass(_))
+            )
     }
 
     /// The base-class half of §Type Conformance: "`base_class`
@@ -292,5 +321,83 @@ impl BmmModel {
                 .unwrap_or_else(|| ANY_TYPE_NAME.to_owned()),
             _ => ANY_TYPE_NAME.to_owned(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::v1_1::bmm_persistence::create_bmm3_model::create_bmm3_model;
+    use crate::v1_1::bmm_persistence::reader::read_schema;
+    use crate::v1_1::bmm3::core::model::bmm_model::BmmModel;
+
+    /// A schema listing `ORDERED`, `INTEGER` and an `INTERVAL` whose definition
+    /// the caller supplies, in the `master04-syntax.adoc` §Header Items shape.
+    fn model(interval: &str) -> BmmModel {
+        let src = format!(
+            r#"
+            bmm_version = <"2.4">
+            rm_publisher = <"openehr">
+            schema_name = <"bmm3_conformance">
+            rm_release = <"1.0.2">
+            packages = <
+                ["test"] = <
+                    name = <"test">
+                    classes = <"ORDERED", "INTEGER", "INTERVAL">
+                >
+            >
+            class_definitions = <
+                ["ORDERED"] = < name = <"ORDERED"> >
+                ["INTEGER"] = < name = <"INTEGER"> ancestors = <"ORDERED"> >
+                {interval}
+            >
+            "#
+        );
+        create_bmm3_model(&read_schema(&src).expect("the fixture reads"))
+            .expect("the fixture materialises")
+    }
+
+    /// A generic class taking one parameter constrained to `ORDERED`.
+    const GENERIC_INTERVAL: &str = r#"["INTERVAL"] = <
+            name = <"INTERVAL">
+            generic_parameter_defs = <
+                ["T"] = < name = <"T"> conforms_to_type = <"ORDERED"> >
+            >
+        >"#;
+
+    /// The same name declared WITHOUT generic parameters.
+    const PLAIN_INTERVAL: &str = r#"["INTERVAL"] = < name = <"INTERVAL"> >"#;
+
+    /// `master06-core-types.adoc` §Type Conformance gates the generic branch on
+    /// "`valid_generic_type_name (a_type)` and `bmm_def_class instanceOf
+    /// (BMM_GENERIC_CLASS)`", so a generic-SHAPED name over a class the model
+    /// defines as non-generic takes the section's final `else` — "return not
+    /// valid_generic_type_name (anc_type)".
+    #[test]
+    fn a_generic_shaped_name_over_a_non_generic_class_is_not_generic() {
+        let model = model(PLAIN_INTERVAL);
+        assert!(!model.type_conforms_to("INTERVAL<INTEGER>", "INTERVAL<ORDERED>"));
+        // The same `else` admits a non-generic ancestor name.
+        assert!(model.type_conforms_to("INTERVAL<INTEGER>", "INTERVAL"));
+    }
+
+    /// The generic branches themselves, over a root the model DOES define as a
+    /// `BMM_GENERIC_CLASS`: parameters recurse pairwise, and an ancestor stated
+    /// without its generic form conforms ("e.g. `Interval<Integer>` conforms to
+    /// `Interval`").
+    #[test]
+    fn a_generic_class_compares_its_parameters() {
+        let model = model(GENERIC_INTERVAL);
+        assert!(model.type_conforms_to("INTERVAL<INTEGER>", "INTERVAL<ORDERED>"));
+        assert!(!model.type_conforms_to("INTERVAL<ORDERED>", "INTERVAL<INTEGER>"));
+        assert!(model.type_conforms_to("INTERVAL<INTEGER>", "INTERVAL"));
+        assert!(!model.type_conforms_to("INTERVAL", "INTERVAL<ORDERED>"));
+    }
+
+    /// Two generic types differing in parameter count: the section's pseudocode
+    /// returns nothing, and this implementation refuses.
+    #[test]
+    fn generic_types_of_differing_parameter_counts_do_not_conform() {
+        let model = model(GENERIC_INTERVAL);
+        assert!(!model.type_conforms_to("INTERVAL<INTEGER,INTEGER>", "INTERVAL<ORDERED>"));
     }
 }

--- a/crates/openehr-lang/src/v1_1/bmm_persistence/create_bmm3_model.rs
+++ b/crates/openehr-lang/src/v1_1/bmm_persistence/create_bmm3_model.rs
@@ -41,6 +41,15 @@
 //!   not resolve, is COLLECTED as a
 //!   [`crate::v1_1::bmm_persistence::validate::PBmmValidityFinding::AssertionNotMaterialised`]
 //!   and omitted, never a refusal of the schema.
+//! * **A constant stating no value.** `P_BMM_CONSTANT.value` is `0..1`
+//!   (`…bmm_persistence.p_bmm_constant.adoc` §Attributes) while the v3
+//!   `BMM_CONSTANT.generator` is `1..1` over a `1..1` `value_literal`
+//!   (`…bmm3.bmm_constant.adoc`, `…bmm3.bmm_literal_value.adoc` §Attributes),
+//!   and openEHR's own published LANG schemas omit the value on
+//!   `BMM_DEFINITIONS.Bmm_internal_version`. The constant is therefore
+//!   COLLECTED as a
+//!   [`crate::v1_1::bmm_persistence::validate::PBmmValidityFinding::ConstantNotMaterialised`]
+//!   and omitted; no empty serial form is invented.
 //!
 //! NOTE (embedding depth, the same adjudication as the v2.x transform): a v3
 //! `BMM_CLASS.ancestors` entry is a type whose `base_class` is a `BMM_CLASS`, so
@@ -96,6 +105,7 @@ use crate::v1_1::bmm3::core::entity::bmm_module::BmmModule;
 use crate::v1_1::bmm3::core::entity::bmm_parameter_type::BmmParameterType;
 use crate::v1_1::bmm3::core::entity::bmm_simple_class::BmmSimpleClass;
 use crate::v1_1::bmm3::core::entity::bmm_simple_class::BmmSimpleClassData;
+use crate::v1_1::bmm3::core::entity::bmm_simple_type::BmmSimpleType;
 use crate::v1_1::bmm3::core::entity::bmm_type::BmmType;
 use crate::v1_1::bmm3::core::entity::bmm_unitary_type::BmmUnitaryType;
 use crate::v1_1::bmm3::core::entity::range_constrained::bmm_enumeration::BmmEnumeration;
@@ -115,6 +125,7 @@ use crate::v1_1::bmm3::core::feature::bmm_procedure::BmmProcedure;
 use crate::v1_1::bmm3::core::feature::bmm_property::BmmProperty;
 use crate::v1_1::bmm3::core::feature::bmm_result::BmmResult;
 use crate::v1_1::bmm3::core::feature::bmm_static::BmmStatic;
+use crate::v1_1::bmm3::core::literal_value::bmm_integer_value::BmmIntegerValue;
 use crate::v1_1::bmm3::core::literal_value::bmm_literal_value::BmmLiteralValue;
 use crate::v1_1::bmm3::core::literal_value::bmm_primitive_value::BmmPrimitiveValue;
 use crate::v1_1::bmm3::core::literal_value::bmm_primitive_value::BmmPrimitiveValueData;
@@ -152,18 +163,22 @@ const VALUE_SET_SEPARATOR: &str = "::";
 /// [`PBmmReadError::NotAGenericClass`],
 /// [`PBmmReadError::EnumerationAncestorCount`] and
 /// [`PBmmReadError::EnumerationItemListsNotOneToOne`] — the two transforms share
-/// one enumeration-validity check, so they refuse the same schemas.
+/// one enumeration-validity check, so they refuse the same schemas there — plus
+/// [`PBmmReadError::EnumerationItemValueNotAnInteger`], which only this
+/// generation can raise because only v3 types the item values.
 pub fn create_bmm3_model(schema: &PBmmSchema) -> Result<BmmModel, PBmmReadError> {
     create_bmm3_model_reporting(schema).map(|(model, _)| model)
 }
 
-/// Materialises the v3 `BMM_MODEL` and returns the assertion findings alongside
-/// it.
+/// Materialises the v3 `BMM_MODEL` and returns the materialisation findings
+/// alongside it.
 ///
 /// Same transform as [`create_bmm3_model`]; the second element is every
 /// persisted invariant / pre-condition / post-condition string that could not
 /// become a `BMM_ASSERTION`
-/// ([`crate::v1_1::bmm_persistence::validate::PBmmValidityFinding::AssertionNotMaterialised`]).
+/// ([`crate::v1_1::bmm_persistence::validate::PBmmValidityFinding::AssertionNotMaterialised`])
+/// and every constant that states no value
+/// ([`crate::v1_1::bmm_persistence::validate::PBmmValidityFinding::ConstantNotMaterialised`]).
 /// The findings are COLLECTED rather than fatal, for the same reason
 /// [`crate::v1_1::bmm_persistence::validate::validate_schema`]'s are: a validity
 /// report is only useful whole.
@@ -1733,6 +1748,12 @@ fn parameter_context(class: &str, routine: &str, parameter: &str) -> String {
 /// constants — "Static properties defined in this class"
 /// (`org.openehr.lang.bmm3.bmm_class.adoc` §Attributes), of which `BMM_CONSTANT`
 /// is the literal-valued form (`…bmm3.bmm_static.adoc`).
+///
+/// A constant stating no value carries no `value_literal`, so it is COLLECTED
+/// as a
+/// [`crate::v1_1::bmm_persistence::validate::PBmmValidityFinding::ConstantNotMaterialised`]
+/// and omitted — the same boundary the assertions take, and for the same
+/// reason: the persisted form is legal, so the schema is not refused.
 fn build_constants(
     builder: &Builder<'_>,
     persisted: &PBmmClass,
@@ -1743,9 +1764,25 @@ fn build_constants(
     };
     let mut out = BTreeMap::new();
     for (key, constant) in constants {
+        let Some(value_literal) = constant.value.clone() else {
+            builder
+                .findings
+                .borrow_mut()
+                .push(PBmmValidityFinding::ConstantNotMaterialised {
+                    class: persisted.name().to_owned(),
+                    constant: constant.name.clone(),
+                });
+            continue;
+        };
         out.insert(
             key.clone(),
-            BmmStatic::BmmConstant(build_constant(builder, persisted, constant, visiting)?),
+            BmmStatic::BmmConstant(build_constant(
+                builder,
+                persisted,
+                constant,
+                value_literal,
+                visiting,
+            )?),
         );
     }
     Ok((!out.is_empty()).then_some(out))
@@ -1761,10 +1798,14 @@ fn build_constants(
 /// native `value` is left unset, per the literal-evaluation boundary recorded in
 /// [`crate::v1_1::bmm3::core::literal_value::bmm_literal_value_impl`]. `Inv_not_nullable`
 /// makes a constant non-nullable (`…bmm3.bmm_constant.adoc` §Invariants).
+///
+/// `value_literal` is `1..1`, so the persisted value arrives as a parameter its
+/// caller has already resolved: a constant that states none never reaches here.
 fn build_constant(
     builder: &Builder<'_>,
     owner: &PBmmClass,
     constant: &PBmmConstant,
+    value_literal: String,
     visiting: &mut BTreeSet<String>,
 ) -> Result<BmmConstant, PBmmReadError> {
     let context = format!("class `{}` constant `{}`", owner.name(), constant.name);
@@ -1790,7 +1831,7 @@ fn build_constant(
         group: group_back_reference(),
         generator: BmmLiteralValue::BmmPrimitiveValue(BmmPrimitiveValue::BmmPrimitiveValue(
             BmmPrimitiveValueData {
-                value_literal: constant.value.clone().unwrap_or_default(),
+                value_literal,
                 value: None,
                 // `_syntax_` unset means the `json` default applies
                 // (`…bmm3.bmm_literal_value.adoc` §Attributes); P_BMM states no
@@ -1838,47 +1879,34 @@ fn build_enumeration(
     };
     let item_names = persisted.item_names().to_vec();
     match persisted {
-        PBmmEnumeration::PBmmEnumerationInteger(_) => Ok(BmmEnumeration::BmmEnumerationInteger(
-            BmmEnumerationInteger {
-                name: core.name,
-                documentation: core.documentation,
-                extensions: None,
-                feature_groups: present(core.feature_groups),
-                features: present(core.features),
-                ancestors: core.ancestors,
-                package: core.package,
-                properties: core.properties,
-                source_schema_id: core.source_schema_id,
-                immediate_descendants: present(Vec::new()),
-                is_override: core.is_override,
-                static_properties: core.static_properties,
-                functions: core.functions,
-                procedures: core.procedures,
-                is_primitive: core.is_primitive,
-                is_abstract: core.is_abstract,
-                invariants: present(core.invariants.clone()),
-                creators: None,
-                converters: None,
-                item_names: present(item_names),
-                item_values: present(
-                    persisted
-                        .item_values()
-                        .iter()
-                        .map(|value| {
-                            crate::v1_1::bmm3::core::literal_value::bmm_integer_value::BmmIntegerValue {
-                                value_literal: literal_form(value),
-                                value: value
-                                    .as_i64()
-                                    .and_then(|v| i32::try_from(v).ok())
-                                    .unwrap_or_default(),
-                                syntax: None,
-                                r#type: underlying.clone(),
-                            }
-                        })
-                        .collect(),
-                ),
-            },
-        )),
+        PBmmEnumeration::PBmmEnumerationInteger(_) => {
+            let item_values = integer_item_values(&core.name, persisted, &underlying)?;
+            Ok(BmmEnumeration::BmmEnumerationInteger(
+                BmmEnumerationInteger {
+                    name: core.name,
+                    documentation: core.documentation,
+                    extensions: None,
+                    feature_groups: present(core.feature_groups),
+                    features: present(core.features),
+                    ancestors: core.ancestors,
+                    package: core.package,
+                    properties: core.properties,
+                    source_schema_id: core.source_schema_id,
+                    immediate_descendants: present(Vec::new()),
+                    is_override: core.is_override,
+                    static_properties: core.static_properties,
+                    functions: core.functions,
+                    procedures: core.procedures,
+                    is_primitive: core.is_primitive,
+                    is_abstract: core.is_abstract,
+                    invariants: present(core.invariants.clone()),
+                    creators: None,
+                    converters: None,
+                    item_names: present(item_names),
+                    item_values: present(item_values),
+                },
+            ))
+        }
         PBmmEnumeration::PBmmEnumerationString(_) => {
             Ok(BmmEnumeration::BmmEnumerationString(BmmEnumerationString {
                 name: core.name,
@@ -1960,6 +1988,55 @@ fn build_enumeration(
     }
 }
 
+/// Builds the `BMM_ENUMERATION_INTEGER` item values, one `BMM_INTEGER_VALUE`
+/// per persisted scalar.
+///
+/// `BMM_ENUMERATION_INTEGER` redefines `item_values` to
+/// `List<BMM_INTEGER_VALUE>`
+/// (`org.openehr.lang.bmm3.bmm_enumeration_integer.adoc` §Attributes) whose
+/// `value` is a "Native Integer value"
+/// (`org.openehr.lang.bmm3.bmm_integer_value.adoc` §Attributes) — an `Integer`
+/// being a 32-bit integer
+/// (`BASE/docs/foundation_types/master03-primitive_types.adoc` §Overview) — so
+/// a persisted scalar of another kind, or outside that range, states no native
+/// value and is refused rather than substituted.
+///
+/// The item is named from `item_names` at the same position, which
+/// [`check_enumeration_validity`] has already proven 1:1 with the values
+/// whenever any value is stated.
+///
+/// # Errors
+/// [`PBmmReadError::EnumerationItemValueNotAnInteger`].
+fn integer_item_values(
+    class: &str,
+    persisted: &PBmmEnumeration,
+    underlying: &BmmSimpleType,
+) -> Result<Vec<BmmIntegerValue>, PBmmReadError> {
+    let names = persisted.item_names();
+    persisted
+        .item_values()
+        .iter()
+        .enumerate()
+        .map(|(index, value)| {
+            let native = value
+                .as_i64()
+                .and_then(|wide| i32::try_from(wide).ok())
+                .ok_or_else(|| PBmmReadError::EnumerationItemValueNotAnInteger {
+                    class: class.to_owned(),
+                    index,
+                    item: names.get(index).cloned(),
+                    value: literal_form(value),
+                })?;
+            Ok(BmmIntegerValue {
+                value_literal: literal_form(value),
+                value: native,
+                syntax: None,
+                r#type: underlying.clone(),
+            })
+        })
+        .collect()
+}
+
 /// The serial form of a persisted enumeration value — `BMM_LITERAL_VALUE.value_literal`,
 /// "A serial representation of the value"
 /// (`org.openehr.lang.bmm3.bmm_literal_value.adoc` §Attributes). A JSON string
@@ -2013,4 +2090,214 @@ fn build_packages(
         );
     }
     Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    #![expect(
+        clippy::panic_in_result_fn,
+        reason = "the Book ch11 test shape: `?` propagates the read/model plumbing while a let-else over the materialised class shape IS the assertion"
+    )]
+
+    use crate::v1_1::bmm_persistence::create_bmm3_model::create_bmm3_model;
+    use crate::v1_1::bmm_persistence::create_bmm3_model::create_bmm3_model_reporting;
+    use crate::v1_1::bmm_persistence::error::PBmmReadError;
+    use crate::v1_1::bmm_persistence::reader::read_schema;
+    use crate::v1_1::bmm_persistence::validate::PBmmValidityFinding;
+    use crate::v1_1::bmm3::core::entity::bmm_class::BmmClass;
+    use crate::v1_1::bmm3::core::entity::bmm_simple_class::BmmSimpleClass;
+    use crate::v1_1::bmm3::core::entity::range_constrained::bmm_enumeration::BmmEnumeration;
+    use crate::v1_1::bmm3::core::feature::bmm_static::BmmStatic;
+    use crate::v1_1::bmm3::core::literal_value::bmm_literal_value::BmmLiteralValue;
+    use crate::v1_1::bmm3::core::literal_value::bmm_primitive_value::BmmPrimitiveValue;
+    use crate::v1_1::bmm3::core::model::bmm_model::BmmModel;
+
+    /// A schema whose single package lists the primitive base classes plus the
+    /// class under test, in the `master04-syntax.adoc` §Header Items shape.
+    fn schema_src(definitions: &str) -> String {
+        format!(
+            r#"
+            bmm_version = <"2.4">
+            rm_publisher = <"openehr">
+            schema_name = <"bmm3_literal_values">
+            rm_release = <"1.0.2">
+            packages = <
+                ["test"] = <
+                    name = <"test">
+                    classes = <"Integer", "String", "SUBJECT">
+                >
+            >
+            class_definitions = <
+                ["Integer"] = < name = <"Integer"> >
+                ["String"] = < name = <"String"> >
+                {definitions}
+            >
+            "#
+        )
+    }
+
+    /// The v3 model of a schema built by [`schema_src`].
+    fn model_of(definitions: &str) -> Result<BmmModel, PBmmReadError> {
+        create_bmm3_model(&read_schema(&schema_src(definitions))?)
+    }
+
+    /// The `BMM_ENUMERATION_INTEGER` item values of the class `SUBJECT` in a
+    /// model built from `definitions`.
+    fn integer_items(definitions: &str) -> Result<Vec<i32>, PBmmReadError> {
+        let model = model_of(definitions)?;
+        let classes = model
+            .class_definitions
+            .as_ref()
+            .expect("the model defines classes");
+        let subject = classes.get("SUBJECT").expect("SUBJECT materialised");
+        let BmmClass::BmmSimpleClass(BmmSimpleClass::BmmEnumeration(
+            BmmEnumeration::BmmEnumerationInteger(enumeration),
+        )) = subject
+        else {
+            panic!("SUBJECT is not an integer enumeration");
+        };
+        Ok(enumeration
+            .item_values
+            .iter()
+            .flatten()
+            .map(|item| item.value)
+            .collect())
+    }
+
+    /// `org.openehr.lang.bmm3.bmm_enumeration_integer.adoc` §Attributes: the
+    /// item values are `BMM_INTEGER_VALUE`s, so distinct persisted scalars stay
+    /// distinct native values.
+    #[test]
+    fn integer_enumeration_values_reach_the_model_unchanged() {
+        let items = integer_items(
+            r#"["SUBJECT"] = (P_BMM_ENUMERATION_INTEGER) <
+                    name = <"SUBJECT">
+                    ancestors = <"Integer">
+                    item_names = <"first", "second">
+                    item_values = <1001, 1002>
+                >"#,
+        )
+        .expect("the enumeration materialises");
+        assert_eq!(items, vec![1001, 1002]);
+    }
+
+    /// An item value outside `Integer`'s 32-bit range
+    /// (`BASE/docs/foundation_types/master03-primitive_types.adoc` §Overview)
+    /// has no `BMM_INTEGER_VALUE.value`, so it is refused with the item named
+    /// rather than collapsed onto another item's value.
+    #[test]
+    fn an_out_of_range_integer_enumeration_value_is_refused() {
+        let refusal = integer_items(
+            r#"["SUBJECT"] = (P_BMM_ENUMERATION_INTEGER) <
+                    name = <"SUBJECT">
+                    ancestors = <"Integer">
+                    item_names = <"first", "second">
+                    item_values = <3000000000, 4000000000>
+                >"#,
+        )
+        .expect_err("an out-of-range item value is refused");
+        assert_eq!(
+            refusal,
+            PBmmReadError::EnumerationItemValueNotAnInteger {
+                class: "SUBJECT".to_owned(),
+                index: 0,
+                item: Some("first".to_owned()),
+                value: "3000000000".to_owned(),
+            },
+        );
+    }
+
+    /// A persisted item value of another JSON kind names no `Integer` either.
+    #[test]
+    fn a_non_numeric_integer_enumeration_value_is_refused() {
+        let refusal = integer_items(
+            r#"["SUBJECT"] = (P_BMM_ENUMERATION_INTEGER) <
+                    name = <"SUBJECT">
+                    ancestors = <"Integer">
+                    item_names = <"first", "second">
+                    item_values = <"one", "two">
+                >"#,
+        )
+        .expect_err("a non-integer item value is refused");
+        assert_eq!(
+            refusal,
+            PBmmReadError::EnumerationItemValueNotAnInteger {
+                class: "SUBJECT".to_owned(),
+                index: 0,
+                item: Some("first".to_owned()),
+                value: "one".to_owned(),
+            },
+        );
+    }
+
+    /// `org.openehr.lang.bmm3.bmm_constant.adoc` §Attributes: `generator` is
+    /// `1..1`, and its `value_literal` carries the persisted serial form.
+    #[test]
+    fn a_persisted_constant_value_becomes_the_generator_literal() {
+        let model = model_of(
+            r#"["SUBJECT"] = <
+                    name = <"SUBJECT">
+                    constants = <
+                        ["Max_retries"] = < name = <"Max_retries"> type = <"Integer"> value = <"3"> >
+                    >
+                >"#,
+        )
+        .expect("the class materialises");
+        let classes = model
+            .class_definitions
+            .as_ref()
+            .expect("the model defines classes");
+        let subject = classes.get("SUBJECT").expect("SUBJECT materialised");
+        let statics = subject.static_properties().expect("SUBJECT has constants");
+        let BmmStatic::BmmConstant(constant) =
+            statics.get("Max_retries").expect("the constant is keyed")
+        else {
+            panic!("Max_retries is not a constant");
+        };
+        let BmmLiteralValue::BmmPrimitiveValue(BmmPrimitiveValue::BmmPrimitiveValue(literal)) =
+            &constant.generator
+        else {
+            panic!("the generator is not a primitive value");
+        };
+        assert_eq!(literal.value_literal, "3");
+    }
+
+    /// `P_BMM_CONSTANT.value` is `0..1` while `BMM_LITERAL_VALUE.value_literal`
+    /// is `1..1`, so a constant stating no value is omitted with a finding —
+    /// never materialised with an empty serial form, and never a refusal of a
+    /// persisted form the P_BMM spec admits.
+    #[test]
+    fn a_constant_without_a_persisted_value_is_omitted_with_a_finding() {
+        let (model, findings) = create_bmm3_model_reporting(
+            &read_schema(&schema_src(
+                r#"["SUBJECT"] = <
+                    name = <"SUBJECT">
+                    constants = <
+                        ["Max_retries"] = < name = <"Max_retries"> type = <"Integer"> >
+                        ["Min_retries"] = < name = <"Min_retries"> type = <"Integer"> value = <"1"> >
+                    >
+                >"#,
+            ))
+            .expect("the fixture reads"),
+        )
+        .expect("the class materialises");
+        assert_eq!(
+            findings,
+            vec![PBmmValidityFinding::ConstantNotMaterialised {
+                class: "SUBJECT".to_owned(),
+                constant: "Max_retries".to_owned(),
+            }],
+        );
+        let classes = model
+            .class_definitions
+            .as_ref()
+            .expect("the model defines classes");
+        let subject = classes.get("SUBJECT").expect("SUBJECT materialised");
+        let statics = subject.static_properties().expect("SUBJECT has constants");
+        assert!(!statics.contains_key("Max_retries"));
+        assert!(statics.contains_key("Min_retries"));
+        // The omission reaches the feature list too, which is derived from the
+        // same map (`master07-core-classes.adoc` §Overview).
+        assert!(!subject.features().iter().any(|f| f.name() == "Max_retries"));
+    }
 }

--- a/crates/openehr-lang/src/v1_1/bmm_persistence/error.rs
+++ b/crates/openehr-lang/src/v1_1/bmm_persistence/error.rs
@@ -290,6 +290,38 @@ pub enum PBmmReadError {
         values: usize,
     },
 
+    /// An integer enumeration states an item value that is not an `Integer`.
+    ///
+    /// `BMM_ENUMERATION_INTEGER` redefines `item_values` to
+    /// `List<BMM_INTEGER_VALUE>`
+    /// (`org.openehr.lang.bmm3.bmm_enumeration_integer.adoc` §Attributes), and
+    /// `BMM_INTEGER_VALUE.value` is a "Native Integer value"
+    /// (`org.openehr.lang.bmm3.bmm_integer_value.adoc` §Attributes) — an
+    /// `Integer` being a 32-bit integer
+    /// (`BASE/docs/foundation_types/master03-primitive_types.adoc` §Overview).
+    /// `P_BMM_ENUMERATION.item_values` persists `List<Any>`
+    /// (`org.openehr.lang.bmm_persistence.p_bmm_enumeration.adoc` §Attributes),
+    /// so a persisted scalar of another kind, or outside that range, names no
+    /// `BMM_INTEGER_VALUE` that can be constructed.
+    #[error(
+        "enumeration class `{class}` item {} states value `{value}`, which is not an Integer",
+        item.as_ref().map_or_else(
+            || format!("at position {index}"),
+            |name| format!("`{name}`"),
+        )
+    )]
+    EnumerationItemValueNotAnInteger {
+        /// The enumeration class's name.
+        class: String,
+        /// The value's 0-based position in `item_values`.
+        index: usize,
+        /// The `item_names` entry at the same position, where the two lists
+        /// are 1:1.
+        item: Option<String>,
+        /// The persisted value's serial form.
+        value: String,
+    },
+
     /// A generic type's root class is not generic — `BMM_GENERIC_TYPE.base_class`
     /// is a `BMM_GENERIC_CLASS` (`org.openehr.lang.bmm.bmm_generic_type.adoc`
     /// §Attributes).

--- a/crates/openehr-lang/src/v1_1/bmm_persistence/validate.rs
+++ b/crates/openehr-lang/src/v1_1/bmm_persistence/validate.rs
@@ -85,6 +85,26 @@ pub enum PBmmValidityFinding {
         reason: String,
     },
 
+    /// A persisted constant states no value, so the class carries it nowhere.
+    ///
+    /// `P_BMM_CONSTANT.value` is `0..1` — "The literal value of this constant,
+    /// in its persisted (serialised) form"
+    /// (`org.openehr.lang.bmm_persistence.p_bmm_constant.adoc` §Attributes) —
+    /// while the v3 destination is a `1..1` `BMM_CONSTANT.generator`
+    /// (`org.openehr.lang.bmm3.bmm_constant.adoc` §Attributes) over a
+    /// `BMM_LITERAL_VALUE` whose `value_literal` is a `1..1` "serial
+    /// representation of the value"
+    /// (`org.openehr.lang.bmm3.bmm_literal_value.adoc` §Attributes). Stating no
+    /// value is legal P_BMM — openEHR's own published LANG schemas do it for
+    /// `BMM_DEFINITIONS.Bmm_internal_version` — so it is reported here rather
+    /// than refusing the schema, and no empty serial form is invented.
+    ConstantNotMaterialised {
+        /// The class the constant belongs to.
+        class: String,
+        /// The constant's name, as persisted.
+        constant: String,
+    },
+
     /// A class redefines an inherited property with a type that does not
     /// conform to the overridden property's type.
     ///
@@ -162,6 +182,11 @@ impl fmt::Display for PBmmValidityFinding {
                     "{owner} {kind} `{tag}` ({expression:?}) is not materialisable                      as a BMM_ASSERTION: {reason}"
                 )
             }
+            Self::ConstantNotMaterialised { class, constant } => write!(
+                formatter,
+                "class `{class}` constant `{constant}` states no value, so it is not \
+                 materialisable as a BMM_CONSTANT"
+            ),
             Self::OverriddenPropertyNonConformance {
                 class,
                 property,

--- a/crates/openehr-lang/src/v1_1/el/parser.rs
+++ b/crates/openehr-lang/src/v1_1/el/parser.rs
@@ -452,6 +452,10 @@ impl<'a, 'b, B: ElBuilder> Parser<'a, 'b, B> {
 
     /// Captures the verbatim `{ … }` source of a `matches` right-hand side by
     /// brace depth, or the single `CONTAINED_REGEXP` token.
+    #[expect(
+        clippy::expect_used,
+        reason = "`self.src` IS the string the token spans were produced from (parse_boolean_expression_with lexes `src` and hands the same `src` to Parser::new), and the range runs from an opening token's span start to a later token's span end, so it is always an in-bounds, char-boundary slice"
+    )]
     fn constraint_rhs(&mut self) -> Result<(String, usize), ElError> {
         if let Some(Token::ContainedRegexp(raw)) = self.peek().cloned() {
             let at = self.at();
@@ -475,7 +479,11 @@ impl<'a, 'b, B: ElBuilder> Parser<'a, 'b, B> {
             }
             self.pos += 1;
             if depth == 0 {
-                let raw = self.src.get(start..end).unwrap_or_default().to_owned();
+                let raw = self
+                    .src
+                    .get(start..end)
+                    .expect("a token span range should slice the source it was lexed from")
+                    .to_owned();
                 return Ok((raw, start));
             }
         }
@@ -520,15 +528,16 @@ fn decode_string(raw: &str) -> String {
 /// Decodes a single-quoted character literal to a `char`.
 ///
 /// The lexer admits only the six quoted forms in a character literal, so the
-/// decode cannot fail here.
+/// decode cannot fail here, and its token regex admits exactly one body
+/// character, so the decoded literal is never empty.
 #[expect(
     clippy::expect_used,
-    reason = "`Token::Character` only exists when the lexer's validate_char admitted the body, which restricts an escape to the six quoted forms none of which can fail to decode"
+    reason = "`Token::Character` only exists when the lexer's validate_char admitted the body, which restricts an escape to the six quoted forms none of which can fail to decode; the same token regex admits one body character or one two-character escape, each decoding to exactly one char, so the literal is never empty"
 )]
 fn decode_char(raw: &str) -> char {
     crate::v1_1::escape::decode_character_literal(raw)
         .expect("a lexer-validated character literal should decode")
         .chars()
         .next()
-        .unwrap_or('\u{fffd}')
+        .expect("a lexer-validated character literal should decode to one character")
 }

--- a/crates/openehr-lang/src/v1_1/odin/parser.rs
+++ b/crates/openehr-lang/src/v1_1/odin/parser.rs
@@ -757,15 +757,16 @@ fn decode_string(raw: &str) -> String {
 /// Decode a single-quoted `CHARACTER` literal to its `char`.
 ///
 /// The lexer (`validate_char`) admits only the six quoted forms in a character
-/// literal, so the decode cannot fail here.
+/// literal, so the decode cannot fail here, and its token regex admits exactly
+/// one body character, so the decoded literal is never empty.
 #[expect(
     clippy::expect_used,
-    reason = "`Token::Character` only exists when the lexer's validate_char admitted the body, which restricts an escape to the six quoted forms none of which can fail to decode"
+    reason = "`Token::Character` only exists when the lexer's validate_char admitted the body, which restricts an escape to the six quoted forms none of which can fail to decode; the same token regex admits one body character or one two-character escape, each decoding to exactly one char, so the literal is never empty"
 )]
 fn decode_char(raw: &str) -> char {
     crate::v1_1::escape::decode_character_literal(raw)
         .expect("a lexer-validated character literal should decode")
         .chars()
         .next()
-        .unwrap_or('\u{fffd}')
+        .expect("a lexer-validated character literal should decode to one character")
 }

--- a/crates/openehr-rm/src/v1_1/common/change_control/versioned_object_impl.rs
+++ b/crates/openehr-rm/src/v1_1/common/change_control/versioned_object_impl.rs
@@ -5,7 +5,7 @@
 //!
 //! Spec: RM
 //! `docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.common.versioned_object.adoc`
-//! §Functions declares fourteen operations on a version container:
+//! §Functions declares sixteen operations on a version container:
 //! `version_count`, `all_version_ids`, `all_versions`, `has_version_at_time`,
 //! `has_version_id`, `version_with_id`, `is_original_version`,
 //! `version_at_time`, `revision_history`, `latest_version`,

--- a/crates/openehr-rm/src/v1_1/common/directory/folder_impl.rs
+++ b/crates/openehr-rm/src/v1_1/common/directory/folder_impl.rs
@@ -5,9 +5,10 @@
 //! (`RM/docs/UML/classes/org.openehr.rm.common.folder.adoc`) carries
 //! Description / Inherit / Attributes rows and no Invariants section, and the
 //! vendored BMM class definition likewise has no `invariants` member. So the
-//! only invariant that applies to a `FOLDER` is the one it inherits from
-//! `LOCATABLE` — `Archetype_node_id_valid`
-//! (`…common.locatable.adoc` §Invariants) — and that is all this impl runs.
+//! `FOLDER` inherits three from `LOCATABLE` (`…common.locatable.adoc`
+//! §Invariants): `Archetype_node_id_valid`, which this impl runs; `Links_valid`,
+//! structural (`links` is `Option<NonEmptyVec<Link>>`); and `Archetyped_valid`,
+//! whose enforceable arm runs per node in the `openehr-its` instance pass.
 
 use crate::v1_1::common::directory::folder::Folder;
 use openehr_base::validate::{InvariantViolation, Validate};

--- a/crates/openehr-rm/src/v1_1/common/generic/attestation_impl.rs
+++ b/crates/openehr-rm/src/v1_1/common/generic/attestation_impl.rs
@@ -14,11 +14,9 @@
 //! - `Reason_valid` (a `DV_CODED_TEXT` `reason` must code to the openEHR
 //!   `attestation reason` group) — terminology-bound likewise, and realized in
 //!   the same binding table.
-//! - `Items_valid` (`items /= Void implies not items.is_empty`) — the BMM
-//!   `List` emits as a `Vec`, so absent and present-but-empty are one value
-//!   here and the rule has nothing to distinguish; it is realized where the
-//!   raw wire body still separates them, on the application's
-//!   attestation-completion path (a `422`).
+//! - `Items_valid` (`items /= Void implies not items.is_empty`) — structural:
+//!   `items` is `Option<NonEmptyVec<DvEhrUri>>`, whose `Deserialize` refuses an
+//!   empty list at the door, so a violating value cannot be built or read.
 
 use crate::v1_1::common::generic::attestation::Attestation;
 use openehr_base::validate::{InvariantViolation, Validate};

--- a/crates/openehr-rm/src/v1_1/common/generic/party_identified_impl.rs
+++ b/crates/openehr-rm/src/v1_1/common/generic/party_identified_impl.rs
@@ -8,10 +8,9 @@
 //!   /= Void` — realized here, through the generated `party_identified_core`.
 //! - `Name_valid`: `name /= Void implies not name.is_empty` — same core.
 //! - `Identifiers_valid`: `identifiers /= Void implies not
-//!   identifiers.is_empty` — realized here, through the generated
-//!   `nonempty_list_core`: the optional-container emission shape
-//!   (`Option<Vec<T>>`) makes present-but-empty a distinct value, so the rule
-//!   has something to judge.
+//!   identifiers.is_empty` — structural: `identifiers` is
+//!   `Option<NonEmptyVec<DvIdentifier>>`, whose `Deserialize` refuses an empty
+//!   list, so a violating value cannot be built or read.
 
 use crate::v1_1::common::generic::party_identified::PartyIdentifiedData;
 use openehr_base::validate::{InvariantViolation, Validate};

--- a/crates/openehr-rm/src/v1_1/common/generic/party_related_impl.rs
+++ b/crates/openehr-rm/src/v1_1/common/generic/party_related_impl.rs
@@ -6,9 +6,8 @@
 //! `…org.openehr.rm.common.party_identified.adoc` §Invariants:
 //!
 //! - inherited `Basic_validity` and `Name_valid` — realized here, through the
-//!   generated `party_identified_core` (the inherited `Identifiers_valid` is
-//!   unrealizable on the typed node for the reason given in
-//!   `party_identified_impl`).
+//!   generated `party_identified_core`; the inherited `Identifiers_valid` is
+//!   structural, for the reason given in `party_identified_impl`.
 //! - `Relationship_valid`: `terminology (Terminology_id_openehr)
 //!   .has_code_for_group_id (Group_id_subject_relationship,
 //!   relationship.defining_code)` — terminology-bound, so it needs a bundle

--- a/crates/openehr-rm/src/v1_1/common/generic/revision_history_impl.rs
+++ b/crates/openehr-rm/src/v1_1/common/generic/revision_history_impl.rs
@@ -17,13 +17,9 @@
 //! … there may also be further attestations"
 //! (`…org.openehr.rm.common.revision_history_item.adoc` §Attributes).
 //!
-//! NOTE: the spec types both functions `1..1`, but the BMM `List` attributes
-//! they walk emit as `Vec`, so a value with no items — or an item with no
-//! audits, which `REVISION_HISTORY_ITEM.Audit_valid` (`not audits.is_empty`)
-//! forbids — is representable in the Rust type and not in the spec model. Each
-//! function therefore returns an `Option`, `None` exactly on that
-//! spec-unrepresentable input, so a caller can never read a fabricated id or
-//! instant out of an empty history.
+//! NOTE: both functions are `1..1` and stay total — `items` and
+//! `REVISION_HISTORY_ITEM.audits` are `NonEmptyVec`, so the empty cases the
+//! spec model forbids are unrepresentable rather than merely rejected.
 
 use crate::v1_1::common::generic::audit_details::AuditDetails;
 use crate::v1_1::common::generic::revision_history::RevisionHistory;
@@ -44,12 +40,11 @@ impl RevisionHistory {
     /// date/time of the most recent item — the `time_committed` of that item's
     /// FIRST audit, which is its commit audit — as its `String` value.
     ///
-    /// Returns `None` when the history holds no items, or the most recent item
-    /// carries no audit (`REVISION_HISTORY_ITEM.Audit_valid` forbids the
-    /// latter; see the module docs).
+    /// Returns `None` only when `items` has no last element — `NonEmptyVec`
+    /// offers no total `last`, unlike the `head` the audits are read through.
     #[must_use]
     pub fn most_recent_version_time_committed(&self) -> Option<&str> {
-        self.items.last()?.audits.first().map(|a| match a {
+        Some(match self.items.last()?.audits.head() {
             AuditDetails::AuditDetails(d) => d.time_committed.value.as_str(),
             AuditDetails::Attestation(a) => a.time_committed.value.as_str(),
         })

--- a/crates/openehr-rm/src/v1_1/common/resource/authored_resource_impl.rs
+++ b/crates/openehr-rm/src/v1_1/common/resource/authored_resource_impl.rs
@@ -14,6 +14,10 @@
 //! `Original_language_valid` stays with the terminology binding table;
 //! `Translations_valid`/`Description_valid` are cross-member map rules over
 //! `translations`, realized where a whole authored resource is ingested.
+//! `Languages_available_valid` (`languages_available.has (original_language)`)
+//! constrains the derived `languages_available()` function, which builds its
+//! result from `original_language` — so it holds by that function's own
+//! definition, the same venue as `Current_revision_valid`.
 
 use crate::v1_1::common::resource::authored_resource::AuthoredResource;
 use openehr_base::validate::{InvariantViolation, Validate};

--- a/crates/openehr-rm/src/v1_1/integration/generic_entry_impl.rs
+++ b/crates/openehr-rm/src/v1_1/integration/generic_entry_impl.rs
@@ -5,7 +5,8 @@
 //! `org.openehr.rm.integration.generic_entry.adoc` — GENERIC_ENTRY carries
 //! only the generic `data: ITEM` (1..1, enforced structurally by the typed
 //! deserialize) plus the inherited LOCATABLE duties
-//! (`Archetype_node_id_valid`).
+//! (`Archetype_node_id_valid`; the sibling `Links_valid` is structural and
+//! `Archetyped_valid` runs in the `openehr-its` instance pass).
 
 use crate::v1_1::integration::generic_entry::GenericEntry;
 use openehr_base::validate::{InvariantViolation, Validate};

--- a/crates/openehr-rm/src/v1_1/paths.rs
+++ b/crates/openehr-rm/src/v1_1/paths.rs
@@ -186,8 +186,14 @@ impl CmpOp {
 }
 
 /// The right-hand literal of a general comparison conjunct: a single-quoted
-/// string (compared lexically — ISO 8601 date/time strings order temporally)
-/// or an unquoted number (compared numerically).
+/// string (compared byte-lexically) or an unquoted number (compared
+/// numerically).
+///
+/// BASE `master11-paths.adoc` §Predicate Expressions defines the predicate
+/// SYNTAX only, so the evaluation rule is our own design. A lexical compare
+/// coincides with temporal order only for identically-formatted, same-offset,
+/// fully-specified ISO-8601 values — master11's own example literal is
+/// day-first, where it does not.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CmpLiteral {
     /// A `'…'` string literal.
@@ -1083,9 +1089,11 @@ impl fmt::Display for VersionLocator {
 /// A parsed `top_level_structure_locator`: an optional `EHR` attribute name and
 /// an optional versioned-object reference.
 ///
-/// Master11 writes locators as `compositions/<uid-or-OVID>` or `directory`; the
-/// CNF `DV_EHR_URI` fixtures also use the attribute-less short form where the
-/// versioned-object id follows the `ehr_id` directly (both are accepted here).
+/// Master11 writes locators as `compositions/<uid-or-OVID>` or `directory`.
+///
+/// The attribute-less short form — the versioned-object id following the
+/// `ehr_id` directly — is ALSO accepted, and no released form defines it: no
+/// openEHR spec governs that acceptance, it is our own extension (#2270).
 #[derive(Debug, Clone, PartialEq)]
 pub struct TopLevelLocator {
     /// The `EHR` attribute name (`compositions`, `directory`, …), if present.

--- a/crates/openehr-rm/src/v1_1/validate.rs
+++ b/crates/openehr-rm/src/v1_1/validate.rs
@@ -644,10 +644,9 @@ fn is_valid_tz(tz: &str) -> bool {
     // Max_timezone_hour = 14, Min_timezone_hour = 12): `+` offsets go to
     // +14:00, `-` offsets only to -12:00 (reject `-13:00`).
     //
-    // NOTE (corpus adjudication): the invariants literally require
-    // `hour > 0` when signed, but the canonical corpus + CNF data sets carry
-    // `+00:00`/`-00:00` UTC forms in 42 files — the corpus outranks the prose
-    // reading, so hour 0 is accepted with either sign (≡ `Z`).
+    // NOTE: hour 0 is accepted with either sign — `iso8601_timezone.adoc`
+    // §Description gives `hh` as "`00` - `23`" and §Functions defines `is_gmt`
+    // as "timezone `+0000`", which the `hour > 0` invariants would forbid.
     let max_hour = if tz.starts_with('+') { 14 } else { 12 };
     if rest.contains(':') {
         matches!(rest.split(':').collect::<Vec<_>>().as_slice(),
@@ -662,15 +661,12 @@ fn is_valid_tz(tz: &str) -> bool {
 }
 
 fn is_valid_time_core(s: &str) -> bool {
-    // A trailing decimal fraction (after '.' or ',') is legal ONLY on the
-    // seconds component: "partial date/times with fractional minutes or hours
-    // … in openEHR, only fractional seconds are supported" (BASE
-    // `foundation_types/master06-time_types.adoc` §"ISO 8601 semantics not
-    // included in these types"). A fractional hour ("10.5") or fractional
-    // minute ("10:05.5") is therefore rejected — a fraction is accepted only
-    // when the base carries full `HH:MM:SS` (seconds present). This mirrors the
-    // seconds-only fraction rule the duration path enforces
-    // (`parse_duration_components`).
+    // NOTE: a decimal fraction is legal only on seconds — BASE
+    // `master06-time_types.adoc`: "only fractional seconds are supported".
+    //
+    // NOTE: seconds are `0..=59` per `time_definitions.adoc` §Functions
+    // `valid_second` (`Post: … s < Seconds_in_minute`) — the machine-checkable
+    // clause, which BASE's own reader also took over the `00`-`60` prose.
     let (base, frac) = match s.split_once(['.', ',']) {
         Some((b, f)) => (b, Some(f)),
         None => (s, None),
@@ -685,7 +681,7 @@ fn is_valid_time_core(s: &str) -> bool {
         match base.split(':').collect::<Vec<_>>().as_slice() {
             [h] => !has_frac && in_range(h, 0, 23),
             [h, m] => !has_frac && in_range(h, 0, 23) && in_range(m, 0, 59),
-            [h, m, sec] => in_range(h, 0, 23) && in_range(m, 0, 59) && in_range(sec, 0, 60),
+            [h, m, sec] => in_range(h, 0, 23) && in_range(m, 0, 59) && in_range(sec, 0, 59),
             _ => false,
         }
     } else {
@@ -697,7 +693,7 @@ fn is_valid_time_core(s: &str) -> bool {
             6 => {
                 in_range(part(base, 0..2), 0, 23)
                     && in_range(part(base, 2..4), 0, 59)
-                    && in_range(part(base, 4..6), 0, 60)
+                    && in_range(part(base, 4..6), 0, 59)
             }
             _ => false,
         }
@@ -909,6 +905,27 @@ mod tests {
         assert!(!is_valid_iso_duration("PT"));
     }
 
+    /// This validator and BASE's `Iso8601Time` reader must accept the same
+    /// strings: `valid_second` bounds seconds below 60, and a value that passes
+    /// here but not there is stored with no magnitude and no arithmetic.
+    #[test]
+    fn time_validity_agrees_with_the_base_reader() {
+        for value in [
+            "10:30:00", "10:30:59", "23:59:59", "10:30:60", "103060", "25:00:00",
+        ] {
+            let base = openehr_base::v1_2::foundation_types::time::iso8601_time::Iso8601Time {
+                value: value.to_owned(),
+            }
+            .hour()
+            .is_some();
+            assert_eq!(
+                is_valid_iso_time(value),
+                base,
+                "{value:?}: the RM validator and the BASE reader disagree",
+            );
+        }
+    }
+
     /// This validator and BASE's `Iso8601Duration` reader must accept the same
     /// strings, or a value passes `Value_valid`, gets stored, and then has no
     /// arithmetic. `P1Y1Y` validated here while BASE refused it and
@@ -964,17 +981,12 @@ mod tests {
         assert!(!is_valid_iso_duration("PT2H14,5M"));
     }
 
-    // NOTE: the `_type`-dispatch tests (fast/typed equivalence, corpus, mutation
-    // battery) live in `openehr-its/tests/it/rm_validation.rs`, where the tiers
-    // are reachable through the COMPOSED wire entry points — the fast path
-    // (`try_fast_validate`) and the typed table
-    // (`typed_dispatch::dispatch_typed`) both live in this crate, but the
-    // generated five-crate structural fallthrough they are composed with can
-    // only exist downstream. The ISO-8601 helper tests below stay with the
-    // helpers they exercise.
+    // NOTE: the `_type`-dispatch tests live in
+    // `openehr-its/tests/it/rm_validation.rs`, where the tiers are reachable
+    // through the composed wire entry points.
 
     /// BASE `Iso8601_timezone`: `+` offsets reach +14:00, `-` offsets stop at
-    /// -12:00; ±00:00 accepted per the corpus (see `is_valid_tz`).
+    /// -12:00; ±00:00 is accepted (see `is_valid_tz`).
     #[test]
     fn timezone_bounds_are_asymmetric() {
         assert!(is_valid_iso_time("10:00:00+14:00"));

--- a/crates/openehr-rm/src/v1_1/validate/terminology.rs
+++ b/crates/openehr-rm/src/v1_1/validate/terminology.rs
@@ -377,12 +377,22 @@ pub fn slots_for(rm_type: &str) -> &'static [Slot] {
             invariant: "Change_type_valid",
             binding: Binding::Group(Group::AuditChangeType),
         }],
-        // attestation.adoc: Reason_valid (attestation_reason group).
-        "ATTESTATION" => &[Slot {
-            field: "reason",
-            invariant: "Reason_valid",
-            binding: Binding::Group(Group::AttestationReason),
-        }],
+        // attestation.adoc: Reason_valid (attestation_reason group), PLUS the
+        // Change_type_valid it inherits from AUDIT_DETAILS — this table is keyed
+        // on the exact wire `_type`, so an ancestor's slot reaches a descendant
+        // only by being repeated here.
+        "ATTESTATION" => &[
+            Slot {
+                field: "reason",
+                invariant: "Reason_valid",
+                binding: Binding::Group(Group::AttestationReason),
+            },
+            Slot {
+                field: "change_type",
+                invariant: "Change_type_valid",
+                binding: Binding::Group(Group::AuditChangeType),
+            },
+        ],
         // party_related.adoc: Relationship_valid (subject_relationship group).
         "PARTY_RELATED" => &[Slot {
             field: "relationship",
@@ -485,6 +495,58 @@ pub fn validate_rm_terminology(ty: &str, value: &Value, out: &mut Vec<InvariantV
                 slot.field,
                 format!("Invariant {} failed on type {ty}", slot.invariant),
             ));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// This table is keyed on the exact wire `_type`, so an invariant declared
+    /// on an ancestor reaches a descendant only by being repeated. `ATTESTATION`
+    /// inherits `AUDIT_DETAILS`, so an out-of-group `change_type` must be
+    /// refused on both — it was accepted on `ATTESTATION` while the identical
+    /// `AUDIT_DETAILS` node was refused.
+    #[test]
+    fn an_inherited_coded_invariant_reaches_the_descendant() {
+        let node = serde_json::json!({
+            "change_type": {
+                "value": "creation",
+                "defining_code": {
+                    "terminology_id": { "value": "openehr" },
+                    "code_string": "9999"
+                }
+            }
+        });
+        for ty in ["AUDIT_DETAILS", "ATTESTATION"] {
+            let mut out = Vec::new();
+            validate_rm_terminology(ty, &node, &mut out);
+            assert!(
+                out.iter().any(
+                    |v| v.message == format!("Invariant Change_type_valid failed on type {ty}")
+                ),
+                "{ty}: an out-of-group change_type must be refused, got {out:?}",
+            );
+        }
+
+        // The accepting twin: a code the group does carry raises nothing.
+        let valid = serde_json::json!({
+            "change_type": {
+                "value": "creation",
+                "defining_code": {
+                    "terminology_id": { "value": "openehr" },
+                    "code_string": "249"
+                }
+            }
+        });
+        for ty in ["AUDIT_DETAILS", "ATTESTATION"] {
+            let mut out = Vec::new();
+            validate_rm_terminology(ty, &valid, &mut out);
+            assert!(
+                out.is_empty(),
+                "{ty}: a valid change_type raises nothing, got {out:?}"
+            );
         }
     }
 }

--- a/crates/openehr-rm/src/v1_2/common/change_control/versioned_object_impl.rs
+++ b/crates/openehr-rm/src/v1_2/common/change_control/versioned_object_impl.rs
@@ -5,7 +5,7 @@
 //!
 //! Spec: RM
 //! `docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.common.versioned_object.adoc`
-//! §Functions declares fourteen operations on a version container:
+//! §Functions declares sixteen operations on a version container:
 //! `version_count`, `all_version_ids`, `all_versions`, `has_version_at_time`,
 //! `has_version_id`, `version_with_id`, `is_original_version`,
 //! `version_at_time`, `revision_history`, `latest_version`,

--- a/crates/openehr-rm/src/v1_2/common/directory/folder_impl.rs
+++ b/crates/openehr-rm/src/v1_2/common/directory/folder_impl.rs
@@ -5,9 +5,10 @@
 //! (`RM/docs/UML/classes/org.openehr.rm.common.folder.adoc`) carries
 //! Description / Inherit / Attributes rows and no Invariants section, and the
 //! vendored BMM class definition likewise has no `invariants` member. So the
-//! only invariant that applies to a `FOLDER` is the one it inherits from
-//! `LOCATABLE` — `Archetype_node_id_valid`
-//! (`…common.locatable.adoc` §Invariants) — and that is all this impl runs.
+//! `FOLDER` inherits three from `LOCATABLE` (`…common.locatable.adoc`
+//! §Invariants): `Archetype_node_id_valid`, which this impl runs; `Links_valid`,
+//! structural (`links` is `Option<NonEmptyVec<Link>>`); and `Archetyped_valid`,
+//! whose enforceable arm runs per node in the `openehr-its` instance pass.
 
 use crate::v1_2::common::directory::folder::Folder;
 use openehr_base::validate::{InvariantViolation, Validate};

--- a/crates/openehr-rm/src/v1_2/common/generic/attestation_impl.rs
+++ b/crates/openehr-rm/src/v1_2/common/generic/attestation_impl.rs
@@ -14,11 +14,9 @@
 //! - `Reason_valid` (a `DV_CODED_TEXT` `reason` must code to the openEHR
 //!   `attestation reason` group) — terminology-bound likewise, and realized in
 //!   the same binding table.
-//! - `Items_valid` (`items /= Void implies not items.is_empty`) — the BMM
-//!   `List` emits as a `Vec`, so absent and present-but-empty are one value
-//!   here and the rule has nothing to distinguish; it is realized where the
-//!   raw wire body still separates them, on the application's
-//!   attestation-completion path (a `422`).
+//! - `Items_valid` (`items /= Void implies not items.is_empty`) — structural:
+//!   `items` is `Option<NonEmptyVec<DvEhrUri>>`, whose `Deserialize` refuses an
+//!   empty list at the door, so a violating value cannot be built or read.
 
 use crate::v1_2::common::generic::attestation::Attestation;
 use openehr_base::validate::{InvariantViolation, Validate};

--- a/crates/openehr-rm/src/v1_2/common/generic/party_identified_impl.rs
+++ b/crates/openehr-rm/src/v1_2/common/generic/party_identified_impl.rs
@@ -8,10 +8,9 @@
 //!   /= Void` — realized here, through the generated `party_identified_core`.
 //! - `Name_valid`: `name /= Void implies not name.is_empty` — same core.
 //! - `Identifiers_valid`: `identifiers /= Void implies not
-//!   identifiers.is_empty` — realized here, through the generated
-//!   `nonempty_list_core`: the optional-container emission shape
-//!   (`Option<Vec<T>>`) makes present-but-empty a distinct value, so the rule
-//!   has something to judge.
+//!   identifiers.is_empty` — structural: `identifiers` is
+//!   `Option<NonEmptyVec<DvIdentifier>>`, whose `Deserialize` refuses an empty
+//!   list, so a violating value cannot be built or read.
 
 use crate::v1_2::common::generic::party_identified::PartyIdentifiedData;
 use openehr_base::validate::{InvariantViolation, Validate};

--- a/crates/openehr-rm/src/v1_2/common/generic/party_related_impl.rs
+++ b/crates/openehr-rm/src/v1_2/common/generic/party_related_impl.rs
@@ -6,9 +6,8 @@
 //! `…org.openehr.rm.common.party_identified.adoc` §Invariants:
 //!
 //! - inherited `Basic_validity` and `Name_valid` — realized here, through the
-//!   generated `party_identified_core` (the inherited `Identifiers_valid` is
-//!   unrealizable on the typed node for the reason given in
-//!   `party_identified_impl`).
+//!   generated `party_identified_core`; the inherited `Identifiers_valid` is
+//!   structural, for the reason given in `party_identified_impl`.
 //! - `Relationship_valid`: `terminology (Terminology_id_openehr)
 //!   .has_code_for_group_id (Group_id_subject_relationship,
 //!   relationship.defining_code)` — terminology-bound, so it needs a bundle

--- a/crates/openehr-rm/src/v1_2/common/generic/revision_history_impl.rs
+++ b/crates/openehr-rm/src/v1_2/common/generic/revision_history_impl.rs
@@ -17,13 +17,9 @@
 //! … there may also be further attestations"
 //! (`…org.openehr.rm.common.revision_history_item.adoc` §Attributes).
 //!
-//! NOTE: the spec types both functions `1..1`, but the BMM `List` attributes
-//! they walk emit as `Vec`, so a value with no items — or an item with no
-//! audits, which `REVISION_HISTORY_ITEM.Audit_valid` (`not audits.is_empty`)
-//! forbids — is representable in the Rust type and not in the spec model. Each
-//! function therefore returns an `Option`, `None` exactly on that
-//! spec-unrepresentable input, so a caller can never read a fabricated id or
-//! instant out of an empty history.
+//! NOTE: both functions are `1..1` and stay total — `items` and
+//! `REVISION_HISTORY_ITEM.audits` are `NonEmptyVec`, so the empty cases the
+//! spec model forbids are unrepresentable rather than merely rejected.
 
 use crate::v1_2::common::generic::audit_details::AuditDetails;
 use crate::v1_2::common::generic::revision_history::RevisionHistory;
@@ -44,12 +40,11 @@ impl RevisionHistory {
     /// date/time of the most recent item — the `time_committed` of that item's
     /// FIRST audit, which is its commit audit — as its `String` value.
     ///
-    /// Returns `None` when the history holds no items, or the most recent item
-    /// carries no audit (`REVISION_HISTORY_ITEM.Audit_valid` forbids the
-    /// latter; see the module docs).
+    /// Returns `None` only when `items` has no last element — `NonEmptyVec`
+    /// offers no total `last`, unlike the `head` the audits are read through.
     #[must_use]
     pub fn most_recent_version_time_committed(&self) -> Option<&str> {
-        self.items.last()?.audits.first().map(|a| match a {
+        Some(match self.items.last()?.audits.head() {
             AuditDetails::AuditDetails(d) => d.time_committed.value.as_str(),
             AuditDetails::Attestation(a) => a.time_committed.value.as_str(),
         })

--- a/crates/openehr-rm/src/v1_2/common/resource/authored_resource_impl.rs
+++ b/crates/openehr-rm/src/v1_2/common/resource/authored_resource_impl.rs
@@ -14,6 +14,10 @@
 //! `Original_language_valid` stays with the terminology binding table;
 //! `Translations_valid`/`Description_valid` are cross-member map rules over
 //! `translations`, realized where a whole authored resource is ingested.
+//! `Languages_available_valid` (`languages_available.has (original_language)`)
+//! constrains the derived `languages_available()` function, which builds its
+//! result from `original_language` — so it holds by that function's own
+//! definition, the same venue as `Current_revision_valid`.
 
 use crate::v1_2::common::resource::authored_resource::AuthoredResource;
 use openehr_base::validate::{InvariantViolation, Validate};

--- a/crates/openehr-rm/src/v1_2/integration/generic_entry_impl.rs
+++ b/crates/openehr-rm/src/v1_2/integration/generic_entry_impl.rs
@@ -5,7 +5,8 @@
 //! `org.openehr.rm.integration.generic_entry.adoc` — GENERIC_ENTRY carries
 //! only the generic `data: ITEM` (1..1, enforced structurally by the typed
 //! deserialize) plus the inherited LOCATABLE duties
-//! (`Archetype_node_id_valid`).
+//! (`Archetype_node_id_valid`; the sibling `Links_valid` is structural and
+//! `Archetyped_valid` runs in the `openehr-its` instance pass).
 
 use crate::v1_2::integration::generic_entry::GenericEntry;
 use openehr_base::validate::{InvariantViolation, Validate};

--- a/crates/openehr-rm/src/v1_2/paths.rs
+++ b/crates/openehr-rm/src/v1_2/paths.rs
@@ -186,8 +186,14 @@ impl CmpOp {
 }
 
 /// The right-hand literal of a general comparison conjunct: a single-quoted
-/// string (compared lexically — ISO 8601 date/time strings order temporally)
-/// or an unquoted number (compared numerically).
+/// string (compared byte-lexically) or an unquoted number (compared
+/// numerically).
+///
+/// BASE `master11-paths.adoc` §Predicate Expressions defines the predicate
+/// SYNTAX only, so the evaluation rule is our own design. A lexical compare
+/// coincides with temporal order only for identically-formatted, same-offset,
+/// fully-specified ISO-8601 values — master11's own example literal is
+/// day-first, where it does not.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CmpLiteral {
     /// A `'…'` string literal.
@@ -1083,9 +1089,11 @@ impl fmt::Display for VersionLocator {
 /// A parsed `top_level_structure_locator`: an optional `EHR` attribute name and
 /// an optional versioned-object reference.
 ///
-/// Master11 writes locators as `compositions/<uid-or-OVID>` or `directory`; the
-/// CNF `DV_EHR_URI` fixtures also use the attribute-less short form where the
-/// versioned-object id follows the `ehr_id` directly (both are accepted here).
+/// Master11 writes locators as `compositions/<uid-or-OVID>` or `directory`.
+///
+/// The attribute-less short form — the versioned-object id following the
+/// `ehr_id` directly — is ALSO accepted, and no released form defines it: no
+/// openEHR spec governs that acceptance, it is our own extension (#2270).
 #[derive(Debug, Clone, PartialEq)]
 pub struct TopLevelLocator {
     /// The `EHR` attribute name (`compositions`, `directory`, …), if present.

--- a/crates/openehr-rm/src/v1_2/validate.rs
+++ b/crates/openehr-rm/src/v1_2/validate.rs
@@ -644,10 +644,9 @@ fn is_valid_tz(tz: &str) -> bool {
     // Max_timezone_hour = 14, Min_timezone_hour = 12): `+` offsets go to
     // +14:00, `-` offsets only to -12:00 (reject `-13:00`).
     //
-    // NOTE (corpus adjudication): the invariants literally require
-    // `hour > 0` when signed, but the canonical corpus + CNF data sets carry
-    // `+00:00`/`-00:00` UTC forms in 42 files — the corpus outranks the prose
-    // reading, so hour 0 is accepted with either sign (≡ `Z`).
+    // NOTE: hour 0 is accepted with either sign — `iso8601_timezone.adoc`
+    // §Description gives `hh` as "`00` - `23`" and §Functions defines `is_gmt`
+    // as "timezone `+0000`", which the `hour > 0` invariants would forbid.
     let max_hour = if tz.starts_with('+') { 14 } else { 12 };
     if rest.contains(':') {
         matches!(rest.split(':').collect::<Vec<_>>().as_slice(),
@@ -662,15 +661,12 @@ fn is_valid_tz(tz: &str) -> bool {
 }
 
 fn is_valid_time_core(s: &str) -> bool {
-    // A trailing decimal fraction (after '.' or ',') is legal ONLY on the
-    // seconds component: "partial date/times with fractional minutes or hours
-    // … in openEHR, only fractional seconds are supported" (BASE
-    // `foundation_types/master06-time_types.adoc` §"ISO 8601 semantics not
-    // included in these types"). A fractional hour ("10.5") or fractional
-    // minute ("10:05.5") is therefore rejected — a fraction is accepted only
-    // when the base carries full `HH:MM:SS` (seconds present). This mirrors the
-    // seconds-only fraction rule the duration path enforces
-    // (`parse_duration_components`).
+    // NOTE: a decimal fraction is legal only on seconds — BASE
+    // `master06-time_types.adoc`: "only fractional seconds are supported".
+    //
+    // NOTE: seconds are `0..=59` per `time_definitions.adoc` §Functions
+    // `valid_second` (`Post: … s < Seconds_in_minute`) — the machine-checkable
+    // clause, which BASE's own reader also took over the `00`-`60` prose.
     let (base, frac) = match s.split_once(['.', ',']) {
         Some((b, f)) => (b, Some(f)),
         None => (s, None),
@@ -685,7 +681,7 @@ fn is_valid_time_core(s: &str) -> bool {
         match base.split(':').collect::<Vec<_>>().as_slice() {
             [h] => !has_frac && in_range(h, 0, 23),
             [h, m] => !has_frac && in_range(h, 0, 23) && in_range(m, 0, 59),
-            [h, m, sec] => in_range(h, 0, 23) && in_range(m, 0, 59) && in_range(sec, 0, 60),
+            [h, m, sec] => in_range(h, 0, 23) && in_range(m, 0, 59) && in_range(sec, 0, 59),
             _ => false,
         }
     } else {
@@ -697,7 +693,7 @@ fn is_valid_time_core(s: &str) -> bool {
             6 => {
                 in_range(part(base, 0..2), 0, 23)
                     && in_range(part(base, 2..4), 0, 59)
-                    && in_range(part(base, 4..6), 0, 60)
+                    && in_range(part(base, 4..6), 0, 59)
             }
             _ => false,
         }
@@ -909,6 +905,27 @@ mod tests {
         assert!(!is_valid_iso_duration("PT"));
     }
 
+    /// This validator and BASE's `Iso8601Time` reader must accept the same
+    /// strings: `valid_second` bounds seconds below 60, and a value that passes
+    /// here but not there is stored with no magnitude and no arithmetic.
+    #[test]
+    fn time_validity_agrees_with_the_base_reader() {
+        for value in [
+            "10:30:00", "10:30:59", "23:59:59", "10:30:60", "103060", "25:00:00",
+        ] {
+            let base = openehr_base::v1_3::foundation_types::time::iso8601_time::Iso8601Time {
+                value: value.to_owned(),
+            }
+            .hour()
+            .is_some();
+            assert_eq!(
+                is_valid_iso_time(value),
+                base,
+                "{value:?}: the RM validator and the BASE reader disagree",
+            );
+        }
+    }
+
     /// This validator and BASE's `Iso8601Duration` reader must accept the same
     /// strings, or a value passes `Value_valid`, gets stored, and then has no
     /// arithmetic. `P1Y1Y` validated here while BASE refused it and
@@ -964,17 +981,12 @@ mod tests {
         assert!(!is_valid_iso_duration("PT2H14,5M"));
     }
 
-    // NOTE: the `_type`-dispatch tests (fast/typed equivalence, corpus, mutation
-    // battery) live in `openehr-its/tests/it/rm_validation.rs`, where the tiers
-    // are reachable through the COMPOSED wire entry points — the fast path
-    // (`try_fast_validate`) and the typed table
-    // (`typed_dispatch::dispatch_typed`) both live in this crate, but the
-    // generated five-crate structural fallthrough they are composed with can
-    // only exist downstream. The ISO-8601 helper tests below stay with the
-    // helpers they exercise.
+    // NOTE: the `_type`-dispatch tests live in
+    // `openehr-its/tests/it/rm_validation.rs`, where the tiers are reachable
+    // through the composed wire entry points.
 
     /// BASE `Iso8601_timezone`: `+` offsets reach +14:00, `-` offsets stop at
-    /// -12:00; ±00:00 accepted per the corpus (see `is_valid_tz`).
+    /// -12:00; ±00:00 is accepted (see `is_valid_tz`).
     #[test]
     fn timezone_bounds_are_asymmetric() {
         assert!(is_valid_iso_time("10:00:00+14:00"));

--- a/crates/openehr-rm/src/v1_2/validate/terminology.rs
+++ b/crates/openehr-rm/src/v1_2/validate/terminology.rs
@@ -377,12 +377,22 @@ pub fn slots_for(rm_type: &str) -> &'static [Slot] {
             invariant: "Change_type_valid",
             binding: Binding::Group(Group::AuditChangeType),
         }],
-        // attestation.adoc: Reason_valid (attestation_reason group).
-        "ATTESTATION" => &[Slot {
-            field: "reason",
-            invariant: "Reason_valid",
-            binding: Binding::Group(Group::AttestationReason),
-        }],
+        // attestation.adoc: Reason_valid (attestation_reason group), PLUS the
+        // Change_type_valid it inherits from AUDIT_DETAILS — this table is keyed
+        // on the exact wire `_type`, so an ancestor's slot reaches a descendant
+        // only by being repeated here.
+        "ATTESTATION" => &[
+            Slot {
+                field: "reason",
+                invariant: "Reason_valid",
+                binding: Binding::Group(Group::AttestationReason),
+            },
+            Slot {
+                field: "change_type",
+                invariant: "Change_type_valid",
+                binding: Binding::Group(Group::AuditChangeType),
+            },
+        ],
         // party_related.adoc: Relationship_valid (subject_relationship group).
         "PARTY_RELATED" => &[Slot {
             field: "relationship",
@@ -485,6 +495,58 @@ pub fn validate_rm_terminology(ty: &str, value: &Value, out: &mut Vec<InvariantV
                 slot.field,
                 format!("Invariant {} failed on type {ty}", slot.invariant),
             ));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// This table is keyed on the exact wire `_type`, so an invariant declared
+    /// on an ancestor reaches a descendant only by being repeated. `ATTESTATION`
+    /// inherits `AUDIT_DETAILS`, so an out-of-group `change_type` must be
+    /// refused on both — it was accepted on `ATTESTATION` while the identical
+    /// `AUDIT_DETAILS` node was refused.
+    #[test]
+    fn an_inherited_coded_invariant_reaches_the_descendant() {
+        let node = serde_json::json!({
+            "change_type": {
+                "value": "creation",
+                "defining_code": {
+                    "terminology_id": { "value": "openehr" },
+                    "code_string": "9999"
+                }
+            }
+        });
+        for ty in ["AUDIT_DETAILS", "ATTESTATION"] {
+            let mut out = Vec::new();
+            validate_rm_terminology(ty, &node, &mut out);
+            assert!(
+                out.iter().any(
+                    |v| v.message == format!("Invariant Change_type_valid failed on type {ty}")
+                ),
+                "{ty}: an out-of-group change_type must be refused, got {out:?}",
+            );
+        }
+
+        // The accepting twin: a code the group does carry raises nothing.
+        let valid = serde_json::json!({
+            "change_type": {
+                "value": "creation",
+                "defining_code": {
+                    "terminology_id": { "value": "openehr" },
+                    "code_string": "249"
+                }
+            }
+        });
+        for ty in ["AUDIT_DETAILS", "ATTESTATION"] {
+            let mut out = Vec::new();
+            validate_rm_terminology(ty, &valid, &mut out);
+            assert!(
+                out.is_empty(),
+                "{ty}: a valid change_type raises nothing, got {out:?}"
+            );
         }
     }
 }

--- a/crates/openehr-rm/tests/it/enforcement_reach.rs
+++ b/crates/openehr-rm/tests/it/enforcement_reach.rs
@@ -96,11 +96,13 @@ fn every_terminology_slot_detects_a_violation_and_passes_its_valid_twin() {
     // The pinned table size: an arm can only leave this table together with a
     // deliberate register/test change, never silently. (Types outside the
     // static model would silently drop out of `all_slots` — the pin catches
-    // that shrinkage too; 55 = the whole binding table, verified in-audit:
-    // every match arm of `slots_for` names a static-model class.)
+    // that shrinkage too; every match arm of `slots_for` names a static-model
+    // class.) 56 since ATTESTATION gained the `change_type` slot it inherits
+    // from AUDIT_DETAILS: the table is keyed on the exact wire `_type`, so an
+    // ancestor's slot reaches a descendant only by being repeated.
     assert_eq!(
         slots.len(),
-        55,
+        56,
         "the slot table changed size — re-pin deliberately"
     );
 

--- a/scripts/checks/comment-style.sh
+++ b/scripts/checks/comment-style.sh
@@ -66,7 +66,11 @@ esac
 
 fail=0
 for f in "${files[@]}"; do
-  grep -q '@generated' "$f" 2>/dev/null && continue
+  # A generated file carries its banner in the HEADER. Matching the marker
+  # anywhere let a hand-written file exempt itself by merely mentioning it in
+  # prose — `templates/openehr-rm/validate.rs` did exactly that and carried an
+  # over-budget NOTE the guard never saw (#2266).
+  head -n 3 "$f" 2>/dev/null | grep -q '@generated' && continue
   out="$(awk -v NOTE_MAX="$NOTE_MAX" -v RUN_MAX="$RUN_MAX" '
     function flush_note() {
       if (note_len > NOTE_MAX)

--- a/tools/openehr-codegen/CLAUDE.md
+++ b/tools/openehr-codegen/CLAUDE.md
@@ -86,3 +86,37 @@ output, never the raw files:
   `*_impl.rs` siblings or hand-written runtimes.
 - Gates: `cargo clippy -p openehr-codegen --all-targets` +
   `cargo nextest run -p openehr-codegen` + a clean drift check.
+
+## Container shapes (the emission adjudication)
+
+A container property's Rust shape follows its BMM **existence** and
+**cardinality**, decided at one point in `render/emit.rs`:
+
+| BMM | Rust | why |
+|---|---|---|
+| mandatory (`1..1`), cardinality `0..*` | `Vec<T>` | genuinely admits zero members |
+| mandatory, cardinality `1..*` | `NonEmptyVec<T>` | the bound is a structural statement about the model, so the type carries it |
+| optional (`0..1`), no non-empty rule | `Option<Vec<T>>` | "absent" and "present-but-empty" are two legitimate model states |
+| optional, with a non-empty invariant | `Option<NonEmptyVec<T>>` | no valid instance can carry present-but-empty, so it stops being representable |
+
+The RM **does** distinguish Void from empty on a `0..1 List<T>`. Where a class
+invariant of the `x /= Void implies not x.is_empty` family forbids the
+present-but-empty state (`LOCATABLE.Links_valid`,
+`docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.common.locatable.adoc`
+§Invariants), the invariant then holds by construction and the strict readers
+refuse `[]` at parse — parse-don't-validate, the same door the `1..*` mandatory
+containers take. Where no such rule exists (`FOLDER.items`/`folders`,
+`…org.openehr.rm.common.folder.adoc` §Attributes types both `0..1` with no
+non-empty rule), both states are real and the type must carry both.
+
+The `1..*` cardinality source is the BMM, minus the overrides in
+`plan/overrides.rs` `cardinality_contradicted` — a class whose own invariants
+contradict its declared lower bound.
+
+**The wire is unaffected in the write direction**: the canonical-JSON writer
+omits an empty list whether it is `None` or `Some(vec![])`, per
+`docs/specs/openehr/ITS-REST/specifications/docs/overview/Resources.md` §JSON
+Format ("The RM attributes (even required ones) that are `Null` or an empty
+list (array) SHOULD be absent when serialized as JSON"). The reader is the
+direction that gains: absent → `None`, `[]` → `Some(vec![])` (or a refusal
+where the type is `NonEmptyVec`).

--- a/tools/openehr-codegen/src/cli.rs
+++ b/tools/openehr-codegen/src/cli.rs
@@ -279,20 +279,12 @@ fn cmd_emit_xml() -> Result<(), Box<dyn std::error::Error>> {
     let rm_unit = rm.current().unit()?;
     let rm_aug = augmented_schema(rm.current(), rm_unit);
 
-    // The RM-instance wire shape (element names, order, xsi:type, attributes) is
-    // identical across the two ITS-XML lineages; they differ only by the root
-    // `xmlns` string, which the `Namespace` serialize-time param selects. So a
-    // single `ToXml` impl set — generated from the v1 (parity) XSD — serves both
-    // (one impl per type; a second set would be a duplicate-impl conflict).
-    //
-    // The v1 `ALL/` bundle is not a complete RM closure: it has no `Ehr.xsd` and
-    // no demographic schema, and its `Extract.xsd` is the stale RM-1.0.2 model.
-    // So the emit-xml input is the v1 *served* core (which wins for shared types
-    // via first-wins `.or_insert`) followed by the v2 RM-1.1.0 EHR/demographic/
-    // extract schemas, which supply the LOCATABLE subtypes the v1 bundle lacks —
-    // resolving `archetype_node_id` as the required XML **attribute** for
-    // EHR_STATUS/EHR_ACCESS, the demographic PARTY hierarchy, and the extract
-    // LOCATABLE subtypes. Same wire shape bar the root `xmlns`.
+    // The two ITS-XML lineages differ only by the root `xmlns`, so ONE `ToXml`
+    // impl set serves both. The v1 `ALL/` bundle is not a complete RM closure
+    // (no `Ehr.xsd`, no demographic schema, a stale `Extract.xsd`), so the input
+    // is the v1 served core — first-wins for shared types — followed by the v2
+    // RM-1.1.0 EHR/demographic/extract schemas that supply the LOCATABLE
+    // subtypes it lacks.
     let v1 = xsd::XsdModel::parse_files(&xsd::xml_emit_files(
         Path::new(XSD_V1_DIR),
         Path::new(XSD_V2_DIR),
@@ -417,17 +409,12 @@ fn cmd_emit_json() -> Result<(), Box<dyn std::error::Error>> {
         written.push(path);
     }
 
-    // The structural dispatch is keyed by the bare canonical-JSON `_type`
-    // string, so a class name several components' BMMs declare (110 of them —
-    // `RESOURCE_DESCRIPTION`, `AUTHORED_RESOURCE`, the `BMM_*` family) resolves
-    // by SCHEMA PRIORITY, and this is the priority order: RM first, then BASE,
-    // then the archetype/meta components (each crate's generations in table
-    // order). Rationale: the dispatch's caller is the RM wire-boundary
-    // validator (`openehr_its::wire_validate`), and the same-named twins
-    // differ materially (RM's `RESOURCE_DESCRIPTION_ITEM.language` is a
-    // `CODE_PHRASE`, BASE's a `Terminology_code`), so decoding an RM wire
-    // node with another component's shape would be wrong. No openEHR spec
-    // governs a cross-component `_type` namespace — our own design.
+    // The structural dispatch is keyed by the bare `_type`, so a name several
+    // components declare resolves by SCHEMA PRIORITY: RM, then BASE, then the
+    // archetype/meta components. The caller is the RM wire-boundary validator
+    // and same-named twins differ materially, so decoding an RM node with
+    // another component's shape would be wrong. No openEHR spec governs a
+    // cross-component `_type` namespace — our own design.
     let mut structural_schemas: Vec<emit_json::JsonSchema<'_>> = Vec::new();
     for key in ["rm", "base", "lang", "am", "term"] {
         let i = keys
@@ -847,26 +834,13 @@ fn templates_root() -> PathBuf {
 }
 
 fn cmd_emit(_outdir: Option<PathBuf>) -> Result<(), Box<dyn std::error::Error>> {
-    // ONE uniform path for every crate: the declarative
-    // `plan::composition::COMPOSITIONS` table lists each crate's BMM
-    // generations (vendored file, version module, per-generation spec pin,
-    // current marker, paired dependency generations); `compose` resolves an
-    // entry and `emit_composed` renders every generation under its version
-    // module. See the table for the `includes` citations behind each entry.
-    //
-    // `cross_schema_reemit` computes the COMPLETE set of upstream classes
-    // whose Rust form widens in a generation and grafts them into its schema
-    // at the source package paths — a full, non-minimal re-emission (owner
-    // ruling 2026-07-19), applied uniformly by `augmented_schema` (#1699):
-    // AM 1.4 re-emits BASE's AUTHORED_RESOURCE + RESOURCE_DESCRIPTION
-    // (ARCHETYPE extends the former), AM 2.4 the reachable LANG beom closure,
-    // RM the BASE Interval/Iso8601 family.
-    //
-    // openehr-rm additionally carries the static RM attribute/type model and
-    // the invariant cores, emitted here too (under the CURRENT generation
-    // module) so a plain `emit` keeps the crate self-consistent — the
-    // standalone `emit-rm-model`/`emit-validate` targets regenerate the same
-    // subtrees byte-identically.
+    // ONE uniform path for every crate, driven by the declarative
+    // `plan::composition::COMPOSITIONS` table (see it for the `includes`
+    // citations). `cross_schema_reemit` grafts the COMPLETE set of upstream
+    // classes whose Rust form widens in a generation — a full, non-minimal
+    // re-emission (owner ruling 2026-07-19, #1699). `openehr-rm` additionally
+    // carries the static RM model and the invariant cores, emitted here so a
+    // plain `emit` keeps the crate self-consistent.
     for comp in composition::COMPOSITIONS {
         let c = compose(comp.key)?;
         let impls = sibling_impls(comp.crate_name);

--- a/tools/openehr-codegen/src/render/emit.rs
+++ b/tools/openehr-codegen/src/render/emit.rs
@@ -449,23 +449,11 @@ fn emit_lib(top: &BTreeSet<String>, comp: &CrateComposition) -> GenFile {
     }
     b.push_str("//!\n//! The type files are generated; hand-written spec behaviour\n");
     b.push_str("//! lives in sibling `*_impl.rs` files.\n\n");
-    // Lint exceptions inherent to faithful spec generation:
-    //  - doc comments are verbatim openEHR spec text (bare URLs, un-backticked
-    //    terms, tabs, quote-style links, loose/overindented list continuation);
-    //  - some spec classes carry >3 boolean flags (e.g. `Interval` bounds);
-    //  - the package tree can nest a module of the same name (module_inception);
-    //  - closed-slot enums can have size-disparate variants;
-    //  - the spec owns the subtype names, so a closed set can share a prefix or
-    //    postfix (`OBJECT_ID` ⊇ `TEMPLATE_ID`, `TERMINOLOGY_ID`, …) — renaming
-    //    a variant would fork the spec model;
-    //  - the spec likewise owns the ATTRIBUTE names, so a class's fields can
-    //    share the class's own stem (`EHR.ehr_id`/`ehr_status`/`ehr_access`,
-    //    `ARCHETYPE.archetype_id`, `C_TEMPORAL.valid_*`) — the BMM attribute
-    //    name is the wire name, so `struct_field_names` cannot be satisfied
-    //    without forking the model.
-    // `reason` is mandatory (`clippy::allow_attributes_without_reason` is deny
-    // workspace-wide); `expect` is wrong here because a given crate need not
-    // trigger every listed lint.
+    // Lint exceptions inherent to faithful spec generation: the spec owns the
+    // doc text, the subtype names and the attribute names, so satisfying the
+    // doc, name-prefix and struct-field lints would fork the model.
+    // `reason` is mandatory (`allow_attributes_without_reason` is deny); `expect`
+    // is wrong because a given crate need not trigger every listed lint.
     b.push_str(
         "#![allow(\n    \
          clippy::doc_markdown,\n    \
@@ -1085,51 +1073,9 @@ pub(crate) fn field_type(
                     "Option<String>".to_string()
                 };
             }
-            // NOTE: a container property's Rust shape follows its BMM
-            // EXISTENCE, exactly like a single-valued one — `Vec<T>` when the
-            // attribute is mandatory (existence `1..1`), `Option<Vec<T>>` when
-            // it is optional (`0..1`). This is the ONE decision point of the
-            // optionality-aware container convention, so the adjudication lives
-            // here.
-            //
-            // The RM DOES distinguish Void from empty on a `0..1 List<T>`
-            // attribute — and where a class invariant of the
-            // `x /= Void implies not x.is_empty` family FORBIDS the
-            // present-but-empty state (`LOCATABLE.Links_valid`,
-            // `docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.common.locatable.adoc`
-            // §Invariants), no valid instance can carry it, so the attribute
-            // emits `Option<NonEmptyVec<T>>` and the state stops being
-            // representable at all (#1730 — parse-don't-validate, the same
-            // door the `1..*` mandatory containers took at leg 6b-i; the
-            // invariant then holds by construction and the strict readers
-            // refuse `[]` at parse). An optional container WITHOUT such an
-            // invariant (FOLDER.items/folders — RM common
-            // `UML/classes/org.openehr.rm.common.folder.adoc` §Attributes
-            // types both 0..1 with no non-empty rule) keeps `Option<Vec<T>>`:
-            // there, "absent" and "present-but-empty" are two legitimate
-            // model states and the type must carry both.
-            //
-            // The WIRE is unaffected in the write direction — the canonical
-            // JSON writer omits an empty list either way (Resources.md §JSON
-            // Format: attributes that are Null or an empty list SHOULD be
-            // absent).
-            //
-            // The WIRE is unaffected: the canonical-JSON writer omits an empty
-            // list whether it is `None` or `Some(vec![])`, per the released
-            // sentence `docs/specs/openehr/ITS-REST/specifications/docs/overview/Resources.md`
-            // §JSON Format ("The RM attributes (even required ones) that are
-            // `Null` or an empty list (array) SHOULD be absent when serialized
-            // as JSON"). The reader is the direction that gains: absent → `None`,
-            // `[]` → `Some(vec![])`.
-            //
-            // A MANDATORY container whose BMM cardinality has a lower bound of
-            // 1 (`CLUSTER.items: List<ITEM> {1..*}`,
-            // `docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.data_structures.cluster.adoc`
-            // §Attributes) emits `NonEmptyVec<T>` instead of `Vec<T>`: the bound
-            // is a structural statement about the model, so the type carries it
-            // and the empty state stops being representable. A mandatory
-            // container with a `0..*` cardinality keeps the plain `Vec<T>` — it
-            // genuinely admits zero members.
+            // NOTE: a container property's Rust shape follows its BMM existence
+            // and cardinality — the emission table in this crate's `CLAUDE.md`
+            // §Container shapes carries the adjudication and its citations.
             let item_ty = model.render_type(item, generics, subst, local, external);
             let lower_bound_one = cardinality.as_ref().is_some_and(|c| c.lower >= 1)
                 && !crate::plan::overrides::cardinality_contradicted(&class.name, &p.name);

--- a/tools/openehr-codegen/src/render/emit_json.rs
+++ b/tools/openehr-codegen/src/render/emit_json.rs
@@ -610,15 +610,11 @@ fn emit_write_field(b: &mut String, f: &JsonField) {
                 "if !self.{rust}.is_empty() {{ ::serde::ser::SerializeStruct::serialize_field(&mut __st, \"{wire}\", &self.{rust})?; }}"
             );
         }
-        // An optional container omits BOTH states an empty array could carry —
-        // `None` and `Some(vec![])` — because the released serialization rule is
-        // about emptiness, not about optionality:
-        // `docs/specs/openehr/ITS-REST/specifications/docs/overview/Resources.md`
-        // §JSON Format, "The RM attributes (even required ones) that are `Null`
-        // or an empty list (array) SHOULD be absent when serialized as JSON."
-        // The present-but-empty state therefore lives in the typed model (where
-        // the `x /= Void implies not x.is_empty` invariants judge it) and never
-        // reaches the wire.
+        // An optional container omits BOTH states an empty array could carry, the
+        // released rule being about emptiness rather than optionality:
+        // `…/overview/Resources.md` §JSON Format — attributes "that are `Null` or
+        // an empty list (array) SHOULD be absent when serialized as JSON".
+        // Present-but-empty therefore lives in the typed model, never on the wire.
         JsonFieldKind::OptionalContainer => {
             let _ = writeln!(
                 b,

--- a/tools/openehr-codegen/src/render/emit_opt.rs
+++ b/tools/openehr-codegen/src/render/emit_opt.rs
@@ -347,14 +347,9 @@ impl<'a> OptModel<'a> {
         // A named `xs:simpleType` (restriction over string/integer): text on the
         // wire — `OPERATOR_KIND`, `Iso8601Date`, `VALIDITY_KIND`, patterns, … .
         //
-        // NOTE: the AOM integer-enum `*_KIND` restrictions
-        // (`VALIDITY_KIND` = 1001/1002/1003, `OPERATOR_KIND` = 2001..2024) are
-        // carried verbatim as their wire text (`"1001"`, `"2001"`), not decoded
-        // to a typed enum. This round-trips losslessly (text in, text out) and
-        // defers the validity/operator *semantics* to the consumer; the
-        // WebTemplate builder does not read these fields, so no fidelity is lost
-        // in practice. Emitting typed enums from the XSD `enumeration` facets is
-        // a possible future enhancement.
+        // NOTE: the AOM integer-enum `*_KIND` restrictions are carried verbatim as
+        // their wire text, round-tripping losslessly and deferring the validity
+        // and operator semantics to the consumer (#2271).
         Resolved::Primitive("String")
     }
 
@@ -557,12 +552,8 @@ impl<'a> OptModel<'a> {
             // never dropped, which would leave a dangling field type.
             //
             // NOTE: such a type is NOT added to the variant set of the enums it
-            // descends from. `XsdModel::descendants` reports concrete subtypes
-            // only, which is the XSD rule for `xsi:type` (a type declared abstract
-            // is not a legal `xsi:type` value); the closures we emit contain no
-            // slot declared as an ancestor of one of these types, so the two
-            // readings are indistinguishable on the wire today. Revisit if a
-            // future closure declares such a slot.
+            // descends from — `XsdModel::descendants` reports concrete subtypes
+            // only, which is the XSD rule for `xsi:type` (#2271).
             if ty.is_abstract && !self.enum_specs.contains(spec) {
                 let _ = writeln!(
                     b,

--- a/tools/openehr-codegen/src/render/emit_rest.rs
+++ b/tools/openehr-codegen/src/render/emit_rest.rs
@@ -490,22 +490,13 @@ impl Ctx<'_> {
             return self.rust_type(self.oas.resolve(schema));
         }
         // `allOf` COMPOSITION. A schema whose only structural content is a
-        // single-`$ref` `allOf` — no `properties` of its own — is a pure alias
-        // for its referent: OAS 3.0 defines `allOf` as "inline or referenced
-        // schema MUST be of a Schema Object and not a standard JSON Schema …
-        // allOf takes an array of object definitions that are validated
-        // *independently* but together compose a single object"
+        // single-`$ref` `allOf` is a pure alias for its referent — OAS 3.0
+        // composes independently-validated definitions
         // (<https://spec.openapis.org/oas/v3.0.3#composition-and-inheritance-polymorphism>),
-        // so an empty own-contribution leaves exactly the referent's shape.
-        // The released ITS-REST OAS uses precisely this form to give one
-        // `ITEM_TAG` schema a per-resource NAME (`ItemTagOfComposition`,
-        // `ItemTagOfEhrStatus`, `ItemTagOfPerson`, …). Dropping the
-        // composition degraded all seven to an untyped map.
-        //
-        // A schema that ALSO declares its own `properties` is a genuine
-        // extension of its referent and keeps its own struct (the RM/BASE
-        // subtype chain); it never reaches here, because the caller emits it
-        // through the object branch.
+        // so an empty own-contribution leaves exactly the referent's shape. The
+        // released OAS uses it to give one `ITEM_TAG` schema a per-resource name.
+        // A schema that ALSO declares `properties` is a genuine extension and
+        // reaches the object branch instead.
         if schema.get("properties").is_none()
             && let Some(members) = schema.get("allOf").and_then(Value::as_array)
         {
@@ -663,18 +654,11 @@ fn emit_dto(b: &mut String, name: &str, schema: &Value, ctx: &Ctx) {
         .and_then(|d| d.get("mapping"))
         .and_then(Value::as_object)
     {
-        // A base that carries `x-discriminator-value` is INSTANTIABLE IN ITS
-        // OWN RIGHT — the OAS extension names the `_type` an instance of the
-        // base itself sends (`UpdateAudit` → `UPDATE_AUDIT`, whose own
-        // `example` block is a bare `UPDATE_AUDIT` object), exactly as
-        // `x-discriminator-value` marks every concrete RM class in the same
-        // bundles. Its own members therefore have to survive: the base emits
-        // as a `…Data` struct and joins the enum as one more variant (the
-        // shape the BMM emitter already uses for a concrete class with
-        // concrete descendants, e.g. `PartyIdentified::PartyIdentified(
-        // PartyIdentifiedData)`). A base with NO `x-discriminator-value` is
-        // abstract (`DataValue`, `Versionable`, `AbstractEntry`) and stays a
-        // pure union over its mapping.
+        // A base carrying `x-discriminator-value` is INSTANTIABLE in its own
+        // right — the extension names the `_type` an instance of the base itself
+        // sends — so its members survive: it emits as a `…Data` struct and joins
+        // the enum as one more variant. A base WITHOUT it is abstract and stays
+        // a pure union over its mapping.
         let base_tag = schema
             .get("x-discriminator-value")
             .and_then(Value::as_str)
@@ -758,15 +742,11 @@ fn emit_struct(
         .map(String::as_str)
         .filter(|f| crate::plan::overrides::rest_optional_override(ty_name, f).is_none())
         .collect();
-    // A schema that declares `additionalProperties: false` is CLOSED by the
-    // released OAS, and a closed object must refuse an undeclared member —
-    // otherwise the generated DTO silently accepts payloads the
-    // specification's own computable artifact rejects. serde's
-    // `deny_unknown_fields` is the exact realization
-    // (<https://serde.rs/container-attrs.html#deny_unknown_fields>), and it
-    // is mutually exclusive with the `#[serde(flatten)]` extension map by
-    // construction: that map is emitted only when `additionalProperties` is
-    // present and NOT `false`.
+    // A schema declaring `additionalProperties: false` is CLOSED by the released
+    // OAS, so the DTO must refuse an undeclared member rather than accept what
+    // the specification's own computable artifact rejects. serde's
+    // `deny_unknown_fields` is the exact realization, and it is mutually
+    // exclusive with the flatten extension map by construction.
     let closed = schema.get("additionalProperties") == Some(&Value::Bool(false));
     let (deny_doc, deny_attr) = if closed {
         (

--- a/tools/openehr-codegen/src/testsupport.rs
+++ b/tools/openehr-codegen/src/testsupport.rs
@@ -1676,20 +1676,12 @@ pub fn unrealized_bmm_functions(key: &str) -> Result<Vec<String>, Error> {
                     if sibling.contains(&item) || own.contains(&item) {
                         continue;
                     }
-                    // A method can be realized by a MACRO applied elsewhere in
-                    // the generation: `ordered_limit!` in `dv_ordered_impl`
-                    // gives every DV_ORDERED descendant its `less_than` and
-                    // `is_strictly_comparable_to`. Reading only the class's own
-                    // two files reported those as missing, and burning them
-                    // down produces DUPLICATE DEFINITIONS.
-                    //
-                    // The witness must name the type as an impl TARGET, not
-                    // merely mention it. Accepting a mention credited
-                    // `VERSION.data` to `imported_version_impl.rs`, whose
-                    // `pub fn data(` belongs to `ImportedVersion<T>` and whose
-                    // only "Version" is inside that longer name — a false
-                    // NEGATIVE, which silently drops a real gap and is worse
-                    // than the false positives this replaced.
+                    // A method can be realized by a MACRO applied elsewhere in the
+                    // generation, so the witness searches the whole generation —
+                    // but it must name the type as an impl TARGET, not merely
+                    // mention it: a mention credited `VERSION.data` to
+                    // `imported_version_impl.rs`, a false NEGATIVE that silently
+                    // drops a real gap (#2247).
                     if bodies
                         .values()
                         .any(|body| body.contains(&item) && targets_type(body, &rust_type))

--- a/tools/openehr-codegen/templates/openehr-base/foundation_types/time/iso8601_date_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-base/foundation_types/time/iso8601_date_impl.rs
@@ -16,6 +16,20 @@
 //!   Functions: the definite/nominal split and the average-length constants the
 //!   definite forms use).
 //!
+//! Invariants — the FOUR entries the class table declares under §Invariants,
+//! plus one rule of our own naming:
+//! - `Month_valid` (`not month_unknown implies valid_month (month)`) and
+//!   `Day_valid` (`not day_unknown implies valid_day (year, month, day)`) —
+//!   checked, each under its own name.
+//! - `Year_valid` (`valid_year (year)`, i.e. `year >= 0`) — structurally
+//!   satisfied: the accepted forms admit only four zero-filled digits.
+//! - `Partial_validity` (`month_unknown implies day_unknown`) — structurally
+//!   satisfied: no accepted form writes a day without a month.
+//! - `Value_lexical_form_valid` — OUR OWN name, because the class table
+//!   declares none: a value that is not the `valid_iso8601_date` production at
+//!   all has no components, so every declared invariant holds vacuously
+//!   (the same rule `version_tree_id_impl.rs` names for identifiers).
+//!
 //! NOTE: arithmetic needs every component of the value, and the openEHR spec
 //! says nothing about computing on a PARTIAL date (`2020`, `2020-06`) — the
 //! `add`/`diff` signatures simply take complete values. A partial (or
@@ -45,8 +59,10 @@ use super::iso8601_date::Iso8601Date;
 use super::iso8601_duration::Iso8601Duration;
 use super::iso8601_parse::{
     EXACT_SECONDS_IN_DAY, ExactSeconds, ParsedDate, as_extended_date, civil_from_days,
-    days_from_civil, parse_date, render_date_extended, render_duration, shift_months,
+    days_from_civil, days_in_month, parse_date, render_date_extended, render_duration, scan_date,
+    shift_months,
 };
+use crate::validate::{InvariantViolation, Validate};
 
 impl Iso8601Date {
     /// Parsed components, or `None` when `value` is not a valid ISO 8601 date.
@@ -249,6 +265,48 @@ impl PartialOrd for Iso8601Date {
             return Some(Ordering::Equal); // consistent with the derived PartialEq
         }
         cmp_date(&self.parsed()?, &other.parsed()?)
+    }
+}
+
+/// The uniform violation for one named invariant, on the class reporting it —
+/// `Iso8601_date`, or `Iso8601_date_time` where it re-declares the same rule.
+fn failed(invariant: &str, type_name: &str) -> InvariantViolation {
+    InvariantViolation::here(format!("Invariant {invariant} failed on type {type_name}"))
+}
+
+/// Appends the date-component invariant violations of a scanned value.
+///
+/// The rules are `Month_valid` and `Day_valid`, reported on `type_name` —
+/// `Iso8601_date_time` re-declares both.
+///
+/// `Day_valid` is checked only under an in-range month: its rule is
+/// `valid_day (y, m, d) = d >= 1 and d <= days_in_month (m, y)`
+/// (`time_definitions.adoc` §Functions), which is undefined where `valid_month`
+/// already fails.
+pub(crate) fn push_date_component_violations(
+    d: &ParsedDate,
+    type_name: &str,
+    out: &mut Vec<InvariantViolation>,
+) {
+    let month_valid = d.month.is_none_or(|m| (1..=12).contains(&m));
+    if !month_valid {
+        out.push(failed("Month_valid", type_name));
+    }
+    if month_valid
+        && let (Some(month), Some(day)) = (d.month, d.day)
+        && !days_in_month(d.year, month).is_some_and(|last| (1..=last).contains(&day))
+    {
+        out.push(failed("Day_valid", type_name));
+    }
+}
+
+impl Validate for Iso8601Date {
+    fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
+        let Some(d) = scan_date(&self.value) else {
+            out.push(failed("Value_lexical_form_valid", "Iso8601_date"));
+            return;
+        };
+        push_date_component_violations(&d, "Iso8601_date", out);
     }
 }
 
@@ -607,6 +665,71 @@ mod tests {
         assert!(date("not-a-date").add(&dur("P1D")).is_none());
         // A malformed duration is equally uncomputable.
         assert!(date("2020-06-15").add(&dur("1D")).is_none());
+    }
+
+    // ── invariants ───────────────────────────────────────────────────────────
+
+    /// Every invalid value names the `iso8601_date.adoc` §Invariants entry it
+    /// breaks — the point of the per-invariant realization: a report says WHICH
+    /// rule failed, not merely that the string was rejected.
+    #[test]
+    fn invalid_dates_name_the_invariant_they_break() {
+        for (bad, invariant) in [
+            // Month_valid: valid_month (m) = m >= 1 and m <= Months_in_year.
+            ("2020-13-01", "Month_valid"),
+            ("2020-00-15", "Month_valid"),
+            ("202013", "Month_valid"),
+            // Day_valid: d >= 1 and d <= days_in_month (m, y).
+            ("2021-02-29", "Day_valid"), // 2021 is not a leap year
+            ("2020-02-30", "Day_valid"),
+            ("2020-04-31", "Day_valid"),
+            ("2020-06-00", "Day_valid"),
+            ("20210229", "Day_valid"),
+            // Our own lexical rule: not the valid_iso8601_date production.
+            ("2020-W01", "Value_lexical_form_valid"),
+            ("not-a-date", "Value_lexical_form_valid"),
+            ("2020-6-15", "Value_lexical_form_valid"),
+            ("+2020-06-15", "Value_lexical_form_valid"),
+            ("", "Value_lexical_form_valid"),
+        ] {
+            let v = date(bad).invariants();
+            let expected = format!("Invariant {invariant} failed on type Iso8601_date");
+            assert!(
+                v.iter().any(|m| m.message == expected),
+                "{bad:?} should report {invariant}, got {v:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn valid_dates_including_every_partial_form_report_nothing() {
+        for good in [
+            "2020",
+            "2020-06",
+            "2020-06-15",
+            "202006",
+            "20200615",
+            "2020-02-29",
+            "0000-01-01",
+            "9999-12-31",
+        ] {
+            assert!(
+                date(good).invariants().is_empty(),
+                "{good:?} is a valid Iso8601_date"
+            );
+        }
+    }
+
+    /// `valid_day` is defined in terms of `days_in_month (m, y)`, so a month
+    /// `valid_month` already rejects leaves `Day_valid` undecided.
+    #[test]
+    fn an_out_of_range_month_reports_month_valid_alone() {
+        let v = date("2020-13-01").invariants();
+        assert_eq!(v.len(), 1);
+        assert_eq!(
+            v[0].message,
+            "Invariant Month_valid failed on type Iso8601_date"
+        );
     }
 
     #[test]

--- a/tools/openehr-codegen/templates/openehr-base/foundation_types/time/iso8601_date_time_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-base/foundation_types/time/iso8601_date_time_impl.rs
@@ -16,6 +16,33 @@
 //!   `24:00:00` disallowed; §Computational Functions: the definite/nominal
 //!   split).
 //!
+//! Invariants — the TWELVE rows the class table declares under §Invariants:
+//! - `Month_valid`, `Day_valid` (shared with `iso8601_date_impl.rs`) and
+//!   `Hour_valid`, `Minute_valid`, `Second_valid`, `Fractional_second_valid`
+//!   (shared with `iso8601_time_impl.rs`) — checked, each under its own name.
+//!   The first two are read in the GUARDED form the sibling `Iso8601_date`
+//!   class spells them (`not month_unknown implies valid_month (month)`); the
+//!   unguarded literal form would reject every partial this class's own
+//!   Description permits.
+//! - `Year_valid` — structurally satisfied (four zero-filled digits).
+//! - `Partial_validity_minute` (`minute_unknown implies second_unknown`) —
+//!   structurally satisfied: no accepted form writes a second without a minute.
+//! - `Partial_validity_year`, `Partial_validity_month`, `Partial_validity_day`,
+//!   `Partial_validity_hour` — refused, see the NOTEs below.
+//! - `Value_lexical_form_valid` — OUR OWN name, because the class table
+//!   declares no rule for a value that is not the production at all (the same
+//!   rule `iso8601_date_impl.rs` names).
+//!
+//! NOTE: `Partial_validity_day` (`not day_unknown`) and `Partial_validity_hour`
+//! (`not hour_unknown` — a function this class never declares) are NOT
+//! enforced: `master06` §Primitive Time Types states that partial variants of
+//! this type "can include missing hours, days and months".
+//!
+//! NOTE: `Partial_validity_year` carries `Partial_validity_month`'s identical
+//! expression (`not month_unknown`) rather than any year rule, and
+//! `Time_definitions.valid_iso8601_date_time` enumerates no date-only partial;
+//! both are refused on the same `master06` ground.
+//!
 //! NOTE: arithmetic needs every component, and the openEHR spec says nothing
 //! about computing on a PARTIAL date/time — a partial (or unparseable) operand
 //! yields `None`, the same undecidable answer this module's comparison gives.
@@ -45,14 +72,17 @@
 
 use std::cmp::Ordering;
 
+use super::iso8601_date_impl::push_date_component_violations;
 use super::iso8601_date_time::Iso8601DateTime;
 use super::iso8601_duration::Iso8601Duration;
 use super::iso8601_parse::{
     EXACT_SECONDS_IN_DAY, EXACT_SECONDS_IN_HOUR, EXACT_SECONDS_IN_MINUTE, ExactSeconds,
     ParsedDateTime, ParsedTime, as_extended_date_time, civil_from_days, date_time_completion_range,
     days_from_civil, hms_from_seconds_of_day, parse_date_time, range_before, render_date_extended,
-    render_duration, render_time_extended, shift_months,
+    render_duration, render_time_extended, scan_date_time, shift_months,
 };
+use super::iso8601_time_impl::push_time_component_violations;
+use crate::validate::{InvariantViolation, Validate};
 
 impl Iso8601DateTime {
     /// Parsed components, or `None` when `value` is not a valid ISO 8601
@@ -347,6 +377,21 @@ impl PartialOrd for Iso8601DateTime {
             return Some(Ordering::Equal); // consistent with the derived PartialEq
         }
         cmp_date_time(&self.parsed()?, &other.parsed()?)
+    }
+}
+
+impl Validate for Iso8601DateTime {
+    fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
+        let Some(dt) = scan_date_time(&self.value) else {
+            out.push(InvariantViolation::here(
+                "Invariant Value_lexical_form_valid failed on type Iso8601_date_time",
+            ));
+            return;
+        };
+        push_date_component_violations(&dt.date, "Iso8601_date_time", out);
+        if let Some(time) = dt.time {
+            push_time_component_violations(&time, "Iso8601_date_time", out);
+        }
     }
 }
 
@@ -732,6 +777,56 @@ mod tests {
         );
         assert!(dt("garbage").add(&dur("PT1H")).is_none());
         assert!(dt("2020-06-15T12:00:00").add(&dur("1H")).is_none());
+    }
+
+    // ── invariants ───────────────────────────────────────────────────────────
+
+    /// Every invalid value names the `iso8601_date_time.adoc` §Invariants entry
+    /// it breaks, on this class rather than on the date/time class the rule is
+    /// shared with.
+    #[test]
+    fn invalid_date_times_name_the_invariant_they_break() {
+        for (bad, invariant) in [
+            ("2020-13-01T10:00", "Month_valid"),
+            ("2021-02-29T10:00:00", "Day_valid"),
+            ("2020-06-15T24:00:00", "Hour_valid"),
+            ("2020-06-15T12:60", "Minute_valid"),
+            ("2020-06-15T12:00:60", "Second_valid"),
+            ("2020-06-15T12:00.5", "Fractional_second_valid"),
+            ("2020-06-15T", "Value_lexical_form_valid"),
+            ("garbage", "Value_lexical_form_valid"),
+            ("2020-06-15T12:00:00+15:00", "Value_lexical_form_valid"),
+        ] {
+            let v = dt(bad).invariants();
+            let expected = format!("Invariant {invariant} failed on type Iso8601_date_time");
+            assert!(
+                v.iter().any(|m| m.message == expected),
+                "{bad:?} should report {invariant}, got {v:?}"
+            );
+        }
+    }
+
+    /// The partials `master06` §Primitive Time Types permits — "missing hours,
+    /// days and months" — validate clean, which is exactly what the refused
+    /// `Partial_validity_day`/`_hour` clauses would have rejected.
+    #[test]
+    fn valid_date_times_including_every_partial_form_report_nothing() {
+        for good in [
+            "2020",
+            "2020-06",
+            "2020-06-15",
+            "2020-06-15T10",
+            "2020-06-15T10:30",
+            "2020-06-15T10:30:00",
+            "2020-06-15T10:30:00.25Z",
+            "20200615T103000+0200",
+            "2020-02-29T00:00:00",
+        ] {
+            assert!(
+                dt(good).invariants().is_empty(),
+                "{good:?} is a valid Iso8601_date_time"
+            );
+        }
     }
 
     #[test]

--- a/tools/openehr-codegen/templates/openehr-base/foundation_types/time/iso8601_duration_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-base/foundation_types/time/iso8601_duration_impl.rs
@@ -18,6 +18,20 @@
 //!   Types: the negative-duration and mixed-`W` deviations; §Computational
 //!   Functions).
 //!
+//! Invariants — the EIGHT entries the class table declares under §Invariants
+//! (`Years_valid` … `Seconds_valid`, each `>= 0`, and `Fractional_second_valid`
+//! `>= 0.0 and < 1.0`) are ALL structurally satisfied by the reader: a
+//! component is a digit run scanned into an unsigned count, and a fraction is
+//! scanned as `0.<digits>`, so no parsed value can break one. What a value CAN
+//! be is not a duration at all, which the class table names no rule for, so it
+//! is reported under our own `Value_lexical_form_valid` (the same rule
+//! `iso8601_date_impl.rs` names).
+//!
+//! NOTE: the openEHR negative-duration deviation (`master06` §Primitive Time
+//! Types) is a leading sign on the VALUE, not on any component, so `-P1Y` still
+//! satisfies `Years_valid` — the class declares no sign accessor to read it
+//! from.
+//!
 //! NOTE: the class doc gives an algorithm for `add`/`subtract` (reduce both
 //! operands via `to_seconds`) but none for `multiply`/`divide`. Component-wise
 //! scaling is not even expressible — `P1Y * 1.5` would need a fractional year,
@@ -39,6 +53,7 @@ use std::cmp::Ordering;
 
 use super::iso8601_duration::Iso8601Duration;
 use super::iso8601_parse::{ExactSeconds, ParsedDuration, parse_duration, render_duration};
+use crate::validate::{InvariantViolation, Validate};
 
 impl Iso8601Duration {
     /// Parsed components, or `None` when `value` is not a valid ISO 8601
@@ -240,6 +255,16 @@ impl PartialOrd for Iso8601Duration {
             // spellings ⇒ incomparable per decision 4, not equal.
             Ordering::Equal => None,
             ord => Some(ord),
+        }
+    }
+}
+
+impl Validate for Iso8601Duration {
+    fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
+        if self.parsed().is_none() {
+            out.push(InvariantViolation::here(
+                "Invariant Value_lexical_form_valid failed on type Iso8601_duration",
+            ));
         }
     }
 }
@@ -462,5 +487,44 @@ mod tests {
         assert_eq!(flipped.value, "-P1Y2M3W4DT5H6M7,50S");
         assert_eq!(flipped.negative().unwrap().value, original.value);
         assert!(dur("nonsense").negative().is_none());
+    }
+
+    // ── invariants ───────────────────────────────────────────────────────────
+
+    /// A value that is not the `P[nnY][nnM][nnW][nnD][T[nnH][nnM][nnS]]`
+    /// production is refused under the one rule this class can break.
+    #[test]
+    fn a_value_that_is_not_a_duration_reports_the_lexical_rule() {
+        for bad in [
+            "1D", "P", "PT", "", "nonsense", "P1Y1Y", "P1D1M", "P1YT", "-P", "PT1.S",
+        ] {
+            let v = dur(bad).invariants();
+            assert_eq!(v.len(), 1, "{bad:?} should be refused, got {v:?}");
+            assert_eq!(
+                v[0].message,
+                "Invariant Value_lexical_form_valid failed on type Iso8601_duration"
+            );
+        }
+    }
+
+    /// Every declared component invariant is structurally satisfied, including
+    /// on a negative duration (the sign is on the value, not on a component).
+    #[test]
+    fn valid_durations_report_nothing() {
+        for good in [
+            "P1Y",
+            "-P3M",
+            "P1W",
+            "P30D",
+            "PT1M",
+            "PT0S",
+            "PT0,5S",
+            "P1Y2M3W4DT5H6M7.5S",
+        ] {
+            assert!(
+                dur(good).invariants().is_empty(),
+                "{good:?} is a valid Iso8601_duration"
+            );
+        }
     }
 }

--- a/tools/openehr-codegen/templates/openehr-base/foundation_types/time/iso8601_parse.rs
+++ b/tools/openehr-codegen/templates/openehr-base/foundation_types/time/iso8601_parse.rs
@@ -224,6 +224,20 @@ pub(crate) fn days_from_civil(year: u32, month: u32, day: u32) -> i64 {
 /// Types); component combinations must be calendar-valid
 /// (`Time_definitions.valid_iso8601_date`).
 pub(crate) fn parse_date(s: &str) -> Option<ParsedDate> {
+    let d = scan_date(s)?;
+    validate_date(d.year, d.month, d.day)?;
+    Some(d)
+}
+
+/// Decompose a date LEXICALLY, without the calendar-validity checks: the same
+/// accepted spellings as [`parse_date`], but `2021-02-29` still yields its
+/// three components.
+///
+/// The invariant reporting in `iso8601_date_impl.rs` needs the components of an
+/// INVALID value to name the rule that value breaks (`Month_valid` versus
+/// `Day_valid`); a form that is not the production at all (a week date, an
+/// expanded year) has no components to report and is refused here.
+pub(crate) fn scan_date(s: &str) -> Option<ParsedDate> {
     if s.is_empty() || s.bytes().any(|b| b == b'W' || b == b'w') {
         return None;
     }
@@ -258,7 +272,6 @@ pub(crate) fn parse_date(s: &str) -> Option<ParsedDate> {
             _ => return None,
         }
     };
-    validate_date(year, month, day)?;
     // `Iso8601_date.is_extended`: "True if this date uses '-' separators".
     // NOTE: the spec does not say what a form with NO separator position
     // (`YYYY`) reports; we report it extended, keeping `as_string() == value`
@@ -299,17 +312,32 @@ fn validate_date(year: u32, month: Option<u32>, day: Option<u32>) -> Option<()> 
 /// (`master06`; `Time_definitions.valid_second` Post `s < Seconds_in_minute`),
 /// see the leap-second NOTE in `iso8601_time_impl.rs`.
 pub(crate) fn parse_time(s: &str) -> Option<ParsedTime> {
+    let t = scan_time(s)?;
+    validate_time(t.hour, t.minute, t.second, t.fractional_second)?;
+    Some(t)
+}
+
+/// Decompose a time LEXICALLY, without the component-validity checks: the same
+/// accepted spellings as [`parse_time`], but `24:00:00` and `12:00:60` still
+/// yield their components, and a fractional part is kept even where no second
+/// carries it (`12:00.5`).
+///
+/// The invariant reporting in `iso8601_time_impl.rs` needs those components to
+/// name the rule the value breaks. The timezone lexeme is still range-checked
+/// by [`parse_timezone`]: its bounds are `Iso8601_timezone`'s own invariants,
+/// which this class does not declare.
+pub(crate) fn scan_time(s: &str) -> Option<ParsedTime> {
     let (main, tz) = split_timezone_lexeme(s)?;
     let timezone = if tz.is_empty() {
         None
     } else {
         Some(parse_timezone(tz)?)
     };
-    let (hour, minute, second, fractional_second) = parse_time_main(main)?;
+    let (hour, minute, second, fractional_second) = scan_time_main(main)?;
     // `Iso8601_time.is_extended`: "True if this time uses '-', ':' separators".
     // A value counts as extended when every separator position it actually has
     // is written with a separator (so `hh`, `Z` and `±hh`, which have none, do
-    // not disqualify it) — see the `parse_date` is_extended NOTE.
+    // not disqualify it) — see the `scan_date` is_extended NOTE.
     let extended = body_is_extended(split_fraction_lexeme(main).0) && timezone_is_extended(tz);
     Some(ParsedTime {
         hour,
@@ -346,8 +374,9 @@ fn timezone_is_extended(tz: &str) -> bool {
     tz.contains(':') || tz.len() <= 3
 }
 
-/// Parse the time-of-day part (no timezone) in extended or compact form.
-fn parse_time_main(main: &str) -> Option<TimeParts> {
+/// Decompose the time-of-day part (no timezone) in extended or compact form,
+/// lexically only — see [`scan_time`].
+fn scan_time_main(main: &str) -> Option<TimeParts> {
     // Separate an optional fractional-seconds tail introduced by '.' or ','.
     let (body, frac) = split_fraction(main);
     let (hour, minute, second) = if body.contains(':') {
@@ -381,13 +410,7 @@ fn parse_time_main(main: &str) -> Option<TimeParts> {
             _ => return None,
         }
     };
-    // A fractional part is only meaningful on a present second.
-    let fractional_second = match frac {
-        Some(f) if second.is_some() => Some(f),
-        Some(_) => return None,
-        None => None,
-    };
-    validate_time(hour, minute, second, fractional_second)
+    Some((hour, minute, second, frac))
 }
 
 /// Split a trailing `(.|,)digits` fractional part off the time body, returning
@@ -450,8 +473,10 @@ fn validate_time(
     {
         return None; // leap second `:60` rejected per valid_second
     }
+    // `Fractional_second_valid`: a fraction is significant only on a present
+    // second, and lies in `[0.0, 1.0)` (`valid_fractional_second`).
     if let Some(f) = fractional_second
-        && !(f.is_finite() && (0.0..1.0).contains(&f))
+        && (second.is_none() || !(f.is_finite() && (0.0..1.0).contains(&f)))
     {
         return None; // includes the NaN split_fraction uses to flag malformed input
     }
@@ -522,6 +547,23 @@ pub(crate) fn parse_date_time(s: &str) -> Option<ParsedDateTime> {
     } else {
         Some(ParsedDateTime {
             date: parse_date(s)?,
+            time: None,
+        })
+    }
+}
+
+/// Decompose a date/time LEXICALLY, without the component-validity checks — see
+/// [`scan_date`] and [`scan_time`], which it composes on the same `T` split as
+/// [`parse_date_time`].
+pub(crate) fn scan_date_time(s: &str) -> Option<ParsedDateTime> {
+    if let Some((d, t)) = s.split_once('T') {
+        Some(ParsedDateTime {
+            date: scan_date(d)?,
+            time: Some(scan_time(t)?),
+        })
+    } else {
+        Some(ParsedDateTime {
+            date: scan_date(s)?,
             time: None,
         })
     }
@@ -1336,6 +1378,41 @@ mod tests {
         assert!((month - 2_628_288.0).abs() < 1e-6);
         assert_eq!(EXACT_SECONDS_IN_AVERAGE_YEAR, 31_556_736);
         assert_eq!(EXACT_SECONDS_IN_AVERAGE_MONTH, 2_628_288);
+    }
+
+    /// The lenient scanners accept EXACTLY what the strict parsers accept, plus
+    /// the values whose only defect is a class invariant — which is what lets
+    /// the `*_impl.rs` validators name the rule a bad value breaks.
+    #[test]
+    fn the_scanners_extend_the_parsers_only_where_an_invariant_decides() {
+        for good in ["2020", "2020-06", "2020-06-15", "20200615", "202006"] {
+            assert_eq!(scan_date(good), parse_date(good), "{good:?}");
+        }
+        for good in [
+            "12",
+            "12:00",
+            "12:00:00",
+            "120000",
+            "12:00:00.5",
+            "120000,25Z",
+        ] {
+            assert_eq!(scan_time(good), parse_time(good), "{good:?}");
+        }
+        for bad in ["2020-W01", "not-a-date", "2020-6-15", ""] {
+            assert!(scan_date(bad).is_none(), "{bad:?} is not the production");
+        }
+        // Calendar- and component-invalid values still decompose.
+        assert!(parse_date("2021-02-29").is_none() && scan_date("2021-02-29").is_some());
+        assert!(parse_date("2020-13-01").is_none() && scan_date("2020-13-01").is_some());
+        assert!(parse_time("24:00:00").is_none() && scan_time("24:00:00").is_some());
+        assert!(parse_time("12:00:60").is_none() && scan_time("12:00:60").is_some());
+        // A fraction with no second to carry it: refused by the parser (the
+        // `Fractional_second_valid` clause), kept by the scanner.
+        assert!(parse_time("12:00.5").is_none());
+        assert_eq!(
+            scan_time("12:00.5").and_then(|t| t.fractional_second),
+            Some(0.5)
+        );
     }
 
     #[test]

--- a/tools/openehr-codegen/templates/openehr-base/foundation_types/time/iso8601_time_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-base/foundation_types/time/iso8601_time_impl.rs
@@ -18,6 +18,27 @@
 //!   definite forms exist for a time — 'year' and 'month' cannot land on a clock
 //!   face, so `Iso8601_time` declares no `add_nominal`).
 //!
+//! Invariants — the FIVE entries the class table declares under §Invariants,
+//! plus one rule of our own naming:
+//! - `Hour_valid`, `Minute_valid`, `Second_valid` and
+//!   `Fractional_second_valid` — checked, each under its own name (shared with
+//!   `Iso8601_date_time`, which re-declares all four verbatim).
+//! - `Partial_validity` (`minute_unknown implies second_unknown`) —
+//!   structurally satisfied: no accepted form writes a second without a minute.
+//! - `Value_lexical_form_valid` — OUR OWN name, because the class table
+//!   declares none: a value that is not the `valid_iso8601_time` production at
+//!   all has no components, so every declared invariant holds vacuously.
+//!
+//! NOTE: `Hour_valid` is `valid_hour (hour, minute, second)`, whose
+//! postcondition also admits `h = Hours_in_day and m = 0 and s = 0`; this class
+//! and `master06` §Primitive Time Types both forbid `24:00:00` "anywhere", so
+//! the invariant is enforced as `hour < 24`.
+//!
+//! NOTE: the timezone's own bounds are `Iso8601_timezone`'s invariants
+//! (`org.openehr.base.foundation_types.iso8601_timezone.adoc` §Invariants), a
+//! class an `Iso8601_time` carries only as a lexeme, so an out-of-range offset
+//! is reported as a lexical-form failure rather than under one of them.
+//!
 //! NOTE: arithmetic needs every component, and the openEHR spec says nothing
 //! about computing on a PARTIAL time (`hh`, `hh:mm`) — a partial (or
 //! unparseable) operand yields `None`, the same undecidable answer this
@@ -50,9 +71,10 @@ use super::iso8601_duration::Iso8601Duration;
 use super::iso8601_parse::{
     EXACT_SECONDS_IN_DAY, EXACT_SECONDS_IN_HOUR, EXACT_SECONDS_IN_MINUTE, ExactSeconds, ParsedTime,
     as_extended_time, hms_from_seconds_of_day, parse_time, range_before, render_duration,
-    render_time_extended, time_completion_range,
+    render_time_extended, scan_time, time_completion_range,
 };
 use super::iso8601_time::Iso8601Time;
+use crate::validate::{InvariantViolation, Validate};
 
 impl Iso8601Time {
     /// Parsed components, or `None` when `value` is not a valid ISO 8601 time.
@@ -253,6 +275,55 @@ impl PartialOrd for Iso8601Time {
             return Some(Ordering::Equal); // consistent with the derived PartialEq
         }
         cmp_time(&self.parsed()?, &other.parsed()?)
+    }
+}
+
+/// The uniform violation for one named invariant, on the class reporting it —
+/// `Iso8601_time`, or `Iso8601_date_time` where it re-declares the same rule.
+fn failed(invariant: &str, type_name: &str) -> InvariantViolation {
+    InvariantViolation::here(format!("Invariant {invariant} failed on type {type_name}"))
+}
+
+/// Appends the time-component invariant violations of a scanned value.
+///
+/// The rules are `Hour_valid`, `Minute_valid`, `Second_valid` and
+/// `Fractional_second_valid`, reported on `type_name`. `Iso8601_date_time`
+/// declares the same four under the same names with the same expressions, so
+/// both classes report through this one body.
+pub(crate) fn push_time_component_violations(
+    t: &ParsedTime,
+    type_name: &str,
+    out: &mut Vec<InvariantViolation>,
+) {
+    // Hour_valid — `24:00:00` is forbidden anywhere (module NOTE).
+    if t.hour >= 24 {
+        out.push(failed("Hour_valid", type_name));
+    }
+    // Minute_valid / Second_valid: `valid_minute (m)` is `m < Minutes_in_hour`
+    // and `valid_second (s)` is `s < Seconds_in_minute`, each on a present
+    // component (the implication is vacuous on an absent one).
+    if t.minute.is_some_and(|m| m >= 60) {
+        out.push(failed("Minute_valid", type_name));
+    }
+    if t.second.is_some_and(|s| s >= 60) {
+        out.push(failed("Second_valid", type_name));
+    }
+    // Fractional_second_valid: significant only alongside a present second, and
+    // `valid_fractional_second (fs)` is `fs >= 0.0 and fs < 1.0`.
+    if let Some(f) = t.fractional_second
+        && (t.second.is_none() || !(0.0..1.0).contains(&f))
+    {
+        out.push(failed("Fractional_second_valid", type_name));
+    }
+}
+
+impl Validate for Iso8601Time {
+    fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
+        let Some(t) = scan_time(&self.value) else {
+            out.push(failed("Value_lexical_form_valid", "Iso8601_time"));
+            return;
+        };
+        push_time_component_violations(&t, "Iso8601_time", out);
     }
 }
 
@@ -562,6 +633,59 @@ mod tests {
     }
 
     // ── partial / malformed operands ─────────────────────────────────────────
+
+    // ── invariants ───────────────────────────────────────────────────────────
+
+    /// Every invalid value names the `iso8601_time.adoc` §Invariants entry it
+    /// breaks, rather than merely failing to parse.
+    #[test]
+    fn invalid_times_name_the_invariant_they_break() {
+        for (bad, invariant) in [
+            // Hour_valid — including the `24:00:00` openEHR deviation.
+            ("24:00:00", "Hour_valid"),
+            ("25:30", "Hour_valid"),
+            ("990000", "Hour_valid"),
+            // Minute_valid / Second_valid.
+            ("12:60:00", "Minute_valid"),
+            ("12:00:60", "Second_valid"),
+            // Fractional_second_valid: a fraction with no second to carry it.
+            ("12:00.5", "Fractional_second_valid"),
+            // Our own lexical rule: not the valid_iso8601_time production.
+            ("nonsense", "Value_lexical_form_valid"),
+            ("12:00:00+15:00", "Value_lexical_form_valid"),
+            ("12:0:00", "Value_lexical_form_valid"),
+            ("", "Value_lexical_form_valid"),
+        ] {
+            let v = time(bad).invariants();
+            let expected = format!("Invariant {invariant} failed on type Iso8601_time");
+            assert!(
+                v.iter().any(|m| m.message == expected),
+                "{bad:?} should report {invariant}, got {v:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn valid_times_including_every_partial_form_report_nothing() {
+        for good in [
+            "12",
+            "12:00",
+            "12:00:00",
+            "1200",
+            "120000",
+            "12:00:00.5",
+            "12:00:00,25",
+            "23:59:59",
+            "00:00:00Z",
+            "12:00:00+02:00",
+            "120000-0500",
+        ] {
+            assert!(
+                time(good).invariants().is_empty(),
+                "{good:?} is a valid Iso8601_time"
+            );
+        }
+    }
 
     #[test]
     fn partial_and_malformed_values_have_no_arithmetic() {

--- a/tools/openehr-codegen/templates/openehr-base/resource/authored_resource_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-base/resource/authored_resource_impl.rs
@@ -1,11 +1,39 @@
-//! Hand-written spec functions of `AUTHORED_RESOURCE`.
+//! Hand-written spec functions + invariants of `AUTHORED_RESOURCE`.
 //!
 //! Spec: `BASE/docs/UML/classes/org.openehr.base.resource.authored_resource.adoc`
-//! §Functions, and `BASE/docs/resource/master02-resource_package.adoc`
-//! §Natural Languages and Translation ("The languages_available function
-//! provides a complete list of languages in the resource").
+//! §Functions and §Invariants, and
+//! `BASE/docs/resource/master02-resource_package.adoc` §Natural Languages and
+//! Translation ("The languages_available function provides a complete list of
+//! languages in the resource").
+//!
+//! Invariants — the FOUR entries the class table declares:
+//! - `Translations_valid` and `Description_valid` — checked, each under its
+//!   own name.
+//! - `Languages_available_valid` (`languages_available.has
+//!   (original_language)`) — structurally satisfied: `languages_available`
+//!   opens with the original language.
+//! - `Original_language_valid` — a terminology boundary, see the NOTE below.
+//!
+//! NOTE: `Original_language_valid`
+//! (`code_set (Code_set_id_languages).has_code (original_language.as_string)`)
+//! is not enforced here: the languages code set lives in the terminology
+//! service, which `openehr-base` has no dependency on.
+//!
+//! NOTE: `Description_valid`'s literal form would reject the resource's own
+//! ORIGINAL-language detail, which `master02-resource_package.adoc` §Meta-data
+//! requires each translated resource to keep, so it is read as "every detail
+//! language is the original language or a declared translation".
+//!
+//! NOTE: `Translations_valid` spells its second clause `translations.has
+//! (original_language.code_string)` over a list "keyed by language code" whose
+//! §Attributes text says the original language "does not appear in this list",
+//! so it is read as the KEY test its sibling clause spells `has_key`.
 
 use crate::v1_3::resource::authored_resource::AuthoredResource;
+use crate::v1_3::resource::resource_description_item::ResourceDescriptionItem;
+use crate::v1_3::resource::translation_details::TranslationDetails;
+use crate::validate::{InvariantViolation, Validate};
+use std::collections::BTreeMap;
 
 impl AuthoredResource {
     /// `AUTHORED_RESOURCE.languages_available`: the total list of languages
@@ -24,50 +52,114 @@ impl AuthoredResource {
     }
 }
 
+/// The uniform violation for one named invariant of this class.
+fn failed(invariant: &str) -> InvariantViolation {
+    InvariantViolation::here(format!(
+        "Invariant {invariant} failed on type AUTHORED_RESOURCE"
+    ))
+}
+
+/// Appends `Description_valid` when any description detail is written in a
+/// language the resource declares neither as its original nor as a translation.
+fn push_description_violation(
+    details: &BTreeMap<String, ResourceDescriptionItem>,
+    original_language: &str,
+    translations: &BTreeMap<String, TranslationDetails>,
+    out: &mut Vec<InvariantViolation>,
+) {
+    let undeclared = details.values().any(|item| {
+        let language = item.language.code_string.as_str();
+        language != original_language && !translations.contains_key(language)
+    });
+    if undeclared {
+        out.push(failed("Description_valid"));
+    }
+}
+
+impl Validate for AuthoredResource {
+    fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
+        // Both declared rules are `translations /= Void implies …`, so a
+        // resource with no translation list satisfies each vacuously.
+        let Some(translations) = &self.translations else {
+            return;
+        };
+        let original_language = self.original_language.code_string.as_str();
+        if translations.is_empty() || translations.contains_key(original_language) {
+            out.push(failed("Translations_valid"));
+        }
+        if let Some(details) = self.description.as_ref().and_then(|d| d.details.as_ref()) {
+            push_description_violation(details, original_language, translations, out);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::v1_3::foundation_types::terminology::terminology_code::TerminologyCode;
-    use crate::v1_3::resource::authored_resource::AuthoredResource;
-    use crate::v1_3::resource::translation_details::TranslationDetails;
+
+    /// An ISO 639-1 language code as a `TERMINOLOGY_CODE`.
+    fn language_code(code: &str) -> TerminologyCode {
+        TerminologyCode {
+            terminology_id: "ISO_639-1".to_owned(),
+            terminology_version: None,
+            code_string: code.to_owned(),
+            uri: None,
+        }
+    }
+
+    /// A `translations` list keyed by the given language codes.
+    fn translation_map(languages: &[&str]) -> BTreeMap<String, TranslationDetails> {
+        languages
+            .iter()
+            .map(|lang| {
+                (
+                    (*lang).to_owned(),
+                    TranslationDetails {
+                        language: language_code(lang),
+                        author: BTreeMap::new(),
+                        accreditation: None,
+                        other_details: None,
+                        version_last_translated: None,
+                        other_contributors: None,
+                    },
+                )
+            })
+            .collect()
+    }
+
+    /// A `description.details` list keyed by the given language codes.
+    fn details_map(languages: &[&str]) -> BTreeMap<String, ResourceDescriptionItem> {
+        languages
+            .iter()
+            .map(|lang| {
+                (
+                    (*lang).to_owned(),
+                    ResourceDescriptionItem {
+                        language: language_code(lang),
+                        purpose: "purpose".to_owned(),
+                        keywords: None,
+                        use_: None,
+                        misuse: None,
+                        original_resource_uri: None,
+                        other_details: None,
+                    },
+                )
+            })
+            .collect()
+    }
 
     fn resource(translations: &[&str]) -> AuthoredResource {
         AuthoredResource {
             uid: None,
-            original_language: TerminologyCode {
-                terminology_id: "ISO_639-1".to_owned(),
-                terminology_version: None,
-                code_string: "en".to_owned(),
-                uri: None,
-            },
+            original_language: language_code("en"),
             description: None,
             is_controlled: None,
             annotations: None,
             translations: if translations.is_empty() {
                 None
             } else {
-                Some(
-                    translations
-                        .iter()
-                        .map(|lang| {
-                            (
-                                (*lang).to_owned(),
-                                TranslationDetails {
-                                    language: TerminologyCode {
-                                        terminology_id: "ISO_639-1".to_owned(),
-                                        terminology_version: None,
-                                        code_string: (*lang).to_owned(),
-                                        uri: None,
-                                    },
-                                    author: std::collections::BTreeMap::new(),
-                                    accreditation: None,
-                                    other_details: None,
-                                    version_last_translated: None,
-                                    other_contributors: None,
-                                },
-                            )
-                        })
-                        .collect(),
-                )
+                Some(translation_map(translations))
             },
         }
     }
@@ -84,5 +176,90 @@ mod tests {
             resource(&["de", "pt"]).languages_available(),
             ["en", "de", "pt"]
         );
+    }
+
+    // ── invariants ───────────────────────────────────────────────────────────
+
+    /// `Translations_valid`: a present list is neither empty nor a re-statement
+    /// of the original language.
+    #[test]
+    fn translations_valid_refuses_an_empty_or_self_naming_list() {
+        for (languages, case) in [
+            (Vec::new(), "an empty list"),
+            (vec!["en"], "the original language alone"),
+            (vec!["de", "en"], "the original language among others"),
+        ] {
+            let mut authored = resource(&[]);
+            authored.translations = Some(translation_map(&languages));
+            let violations = authored.invariants();
+            assert_eq!(violations.len(), 1, "{case}");
+            assert_eq!(
+                violations[0].message,
+                "Invariant Translations_valid failed on type AUTHORED_RESOURCE",
+                "{case}"
+            );
+        }
+    }
+
+    /// The state `Translations_valid` exists to prevent: `languages_available`
+    /// reports the original language twice.
+    #[test]
+    fn a_self_naming_translation_list_duplicates_a_language() {
+        let mut authored = resource(&[]);
+        authored.translations = Some(translation_map(&["en"]));
+        assert_eq!(authored.languages_available(), ["en", "en"]);
+        assert!(!authored.invariants().is_empty());
+    }
+
+    #[test]
+    fn a_valid_translation_list_reports_nothing() {
+        // No list at all: both rules are vacuous.
+        assert!(resource(&[]).invariants().is_empty());
+        assert!(resource(&["de", "pt"]).invariants().is_empty());
+    }
+
+    /// `Description_valid`: a detail written in a language the resource
+    /// declares nowhere.
+    #[test]
+    fn description_valid_refuses_a_detail_in_an_undeclared_language() {
+        // NOTE: BASE 1.2.0's RESOURCE_DESCRIPTION declares a different field set
+        // from 1.3.0's, so a whole-value fixture is not writable in a generation
+        // twin — the rule is asserted on the core every generation shares.
+        let mut violations = Vec::new();
+        push_description_violation(
+            &details_map(&["en", "fr"]),
+            "en",
+            &translation_map(&["de"]),
+            &mut violations,
+        );
+        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            violations[0].message,
+            "Invariant Description_valid failed on type AUTHORED_RESOURCE"
+        );
+    }
+
+    /// The accepting twin, including the ORIGINAL-language detail the literal
+    /// invariant text would have rejected (module NOTE).
+    #[test]
+    fn description_valid_accepts_the_original_language_and_every_translation() {
+        for details in [
+            details_map(&["en"]),
+            details_map(&["en", "de"]),
+            details_map(&["en", "de", "pt"]),
+            details_map(&[]),
+        ] {
+            let mut violations = Vec::new();
+            push_description_violation(
+                &details,
+                "en",
+                &translation_map(&["de", "pt"]),
+                &mut violations,
+            );
+            assert!(
+                violations.is_empty(),
+                "{details:?} declares only known languages"
+            );
+        }
     }
 }

--- a/tools/openehr-codegen/templates/openehr-rm/common/change_control/versioned_object_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/common/change_control/versioned_object_impl.rs
@@ -4,7 +4,7 @@
 //!
 //! Spec: RM
 //! `docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.common.versioned_object.adoc`
-//! §Functions declares fourteen operations on a version container:
+//! §Functions declares sixteen operations on a version container:
 //! `version_count`, `all_version_ids`, `all_versions`, `has_version_at_time`,
 //! `has_version_id`, `version_with_id`, `is_original_version`,
 //! `version_at_time`, `revision_history`, `latest_version`,

--- a/tools/openehr-codegen/templates/openehr-rm/common/directory/folder_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/common/directory/folder_impl.rs
@@ -4,9 +4,10 @@
 //! (`RM/docs/UML/classes/org.openehr.rm.common.folder.adoc`) carries
 //! Description / Inherit / Attributes rows and no Invariants section, and the
 //! vendored BMM class definition likewise has no `invariants` member. So the
-//! only invariant that applies to a `FOLDER` is the one it inherits from
-//! `LOCATABLE` — `Archetype_node_id_valid`
-//! (`…common.locatable.adoc` §Invariants) — and that is all this impl runs.
+//! `FOLDER` inherits three from `LOCATABLE` (`…common.locatable.adoc`
+//! §Invariants): `Archetype_node_id_valid`, which this impl runs; `Links_valid`,
+//! structural (`links` is `Option<NonEmptyVec<Link>>`); and `Archetyped_valid`,
+//! whose enforceable arm runs per node in the `openehr-its` instance pass.
 
 use crate::v1_2::common::directory::folder::Folder;
 use openehr_base::validate::{InvariantViolation, Validate};

--- a/tools/openehr-codegen/templates/openehr-rm/common/generic/attestation_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/common/generic/attestation_impl.rs
@@ -13,11 +13,9 @@
 //! - `Reason_valid` (a `DV_CODED_TEXT` `reason` must code to the openEHR
 //!   `attestation reason` group) — terminology-bound likewise, and realized in
 //!   the same binding table.
-//! - `Items_valid` (`items /= Void implies not items.is_empty`) — the BMM
-//!   `List` emits as a `Vec`, so absent and present-but-empty are one value
-//!   here and the rule has nothing to distinguish; it is realized where the
-//!   raw wire body still separates them, on the application's
-//!   attestation-completion path (a `422`).
+//! - `Items_valid` (`items /= Void implies not items.is_empty`) — structural:
+//!   `items` is `Option<NonEmptyVec<DvEhrUri>>`, whose `Deserialize` refuses an
+//!   empty list at the door, so a violating value cannot be built or read.
 
 use crate::v1_2::common::generic::attestation::Attestation;
 use openehr_base::validate::{InvariantViolation, Validate};

--- a/tools/openehr-codegen/templates/openehr-rm/common/generic/party_identified_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/common/generic/party_identified_impl.rs
@@ -7,10 +7,9 @@
 //!   /= Void` — realized here, through the generated `party_identified_core`.
 //! - `Name_valid`: `name /= Void implies not name.is_empty` — same core.
 //! - `Identifiers_valid`: `identifiers /= Void implies not
-//!   identifiers.is_empty` — realized here, through the generated
-//!   `nonempty_list_core`: the optional-container emission shape
-//!   (`Option<Vec<T>>`) makes present-but-empty a distinct value, so the rule
-//!   has something to judge.
+//!   identifiers.is_empty` — structural: `identifiers` is
+//!   `Option<NonEmptyVec<DvIdentifier>>`, whose `Deserialize` refuses an empty
+//!   list, so a violating value cannot be built or read.
 
 use crate::v1_2::common::generic::party_identified::PartyIdentifiedData;
 use openehr_base::validate::{InvariantViolation, Validate};

--- a/tools/openehr-codegen/templates/openehr-rm/common/generic/party_related_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/common/generic/party_related_impl.rs
@@ -5,9 +5,8 @@
 //! `…org.openehr.rm.common.party_identified.adoc` §Invariants:
 //!
 //! - inherited `Basic_validity` and `Name_valid` — realized here, through the
-//!   generated `party_identified_core` (the inherited `Identifiers_valid` is
-//!   unrealizable on the typed node for the reason given in
-//!   `party_identified_impl`).
+//!   generated `party_identified_core`; the inherited `Identifiers_valid` is
+//!   structural, for the reason given in `party_identified_impl`.
 //! - `Relationship_valid`: `terminology (Terminology_id_openehr)
 //!   .has_code_for_group_id (Group_id_subject_relationship,
 //!   relationship.defining_code)` — terminology-bound, so it needs a bundle

--- a/tools/openehr-codegen/templates/openehr-rm/common/generic/revision_history_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/common/generic/revision_history_impl.rs
@@ -16,13 +16,9 @@
 //! … there may also be further attestations"
 //! (`…org.openehr.rm.common.revision_history_item.adoc` §Attributes).
 //!
-//! NOTE: the spec types both functions `1..1`, but the BMM `List` attributes
-//! they walk emit as `Vec`, so a value with no items — or an item with no
-//! audits, which `REVISION_HISTORY_ITEM.Audit_valid` (`not audits.is_empty`)
-//! forbids — is representable in the Rust type and not in the spec model. Each
-//! function therefore returns an `Option`, `None` exactly on that
-//! spec-unrepresentable input, so a caller can never read a fabricated id or
-//! instant out of an empty history.
+//! NOTE: both functions are `1..1` and stay total — `items` and
+//! `REVISION_HISTORY_ITEM.audits` are `NonEmptyVec`, so the empty cases the
+//! spec model forbids are unrepresentable rather than merely rejected.
 
 use crate::v1_2::common::generic::audit_details::AuditDetails;
 use crate::v1_2::common::generic::revision_history::RevisionHistory;
@@ -43,12 +39,11 @@ impl RevisionHistory {
     /// date/time of the most recent item — the `time_committed` of that item's
     /// FIRST audit, which is its commit audit — as its `String` value.
     ///
-    /// Returns `None` when the history holds no items, or the most recent item
-    /// carries no audit (`REVISION_HISTORY_ITEM.Audit_valid` forbids the
-    /// latter; see the module docs).
+    /// Returns `None` only when `items` has no last element — `NonEmptyVec`
+    /// offers no total `last`, unlike the `head` the audits are read through.
     #[must_use]
     pub fn most_recent_version_time_committed(&self) -> Option<&str> {
-        self.items.last()?.audits.first().map(|a| match a {
+        Some(match self.items.last()?.audits.head() {
             AuditDetails::AuditDetails(d) => d.time_committed.value.as_str(),
             AuditDetails::Attestation(a) => a.time_committed.value.as_str(),
         })

--- a/tools/openehr-codegen/templates/openehr-rm/common/resource/authored_resource_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/common/resource/authored_resource_impl.rs
@@ -13,6 +13,10 @@
 //! `Original_language_valid` stays with the terminology binding table;
 //! `Translations_valid`/`Description_valid` are cross-member map rules over
 //! `translations`, realized where a whole authored resource is ingested.
+//! `Languages_available_valid` (`languages_available.has (original_language)`)
+//! constrains the derived `languages_available()` function, which builds its
+//! result from `original_language` — so it holds by that function's own
+//! definition, the same venue as `Current_revision_valid`.
 
 use crate::v1_2::common::resource::authored_resource::AuthoredResource;
 use openehr_base::validate::{InvariantViolation, Validate};

--- a/tools/openehr-codegen/templates/openehr-rm/integration/generic_entry_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/integration/generic_entry_impl.rs
@@ -4,7 +4,8 @@
 //! `org.openehr.rm.integration.generic_entry.adoc` — GENERIC_ENTRY carries
 //! only the generic `data: ITEM` (1..1, enforced structurally by the typed
 //! deserialize) plus the inherited LOCATABLE duties
-//! (`Archetype_node_id_valid`).
+//! (`Archetype_node_id_valid`; the sibling `Links_valid` is structural and
+//! `Archetyped_valid` runs in the `openehr-its` instance pass).
 
 use crate::v1_2::integration::generic_entry::GenericEntry;
 use openehr_base::validate::{InvariantViolation, Validate};

--- a/tools/openehr-codegen/templates/openehr-rm/paths.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/paths.rs
@@ -185,8 +185,14 @@ impl CmpOp {
 }
 
 /// The right-hand literal of a general comparison conjunct: a single-quoted
-/// string (compared lexically — ISO 8601 date/time strings order temporally)
-/// or an unquoted number (compared numerically).
+/// string (compared byte-lexically) or an unquoted number (compared
+/// numerically).
+///
+/// BASE `master11-paths.adoc` §Predicate Expressions defines the predicate
+/// SYNTAX only, so the evaluation rule is our own design. A lexical compare
+/// coincides with temporal order only for identically-formatted, same-offset,
+/// fully-specified ISO-8601 values — master11's own example literal is
+/// day-first, where it does not.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CmpLiteral {
     /// A `'…'` string literal.
@@ -1082,9 +1088,11 @@ impl fmt::Display for VersionLocator {
 /// A parsed `top_level_structure_locator`: an optional `EHR` attribute name and
 /// an optional versioned-object reference.
 ///
-/// Master11 writes locators as `compositions/<uid-or-OVID>` or `directory`; the
-/// CNF `DV_EHR_URI` fixtures also use the attribute-less short form where the
-/// versioned-object id follows the `ehr_id` directly (both are accepted here).
+/// Master11 writes locators as `compositions/<uid-or-OVID>` or `directory`.
+///
+/// The attribute-less short form — the versioned-object id following the
+/// `ehr_id` directly — is ALSO accepted, and no released form defines it: no
+/// openEHR spec governs that acceptance, it is our own extension (#2270).
 #[derive(Debug, Clone, PartialEq)]
 pub struct TopLevelLocator {
     /// The `EHR` attribute name (`compositions`, `directory`, …), if present.

--- a/tools/openehr-codegen/templates/openehr-rm/validate.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/validate.rs
@@ -643,10 +643,9 @@ fn is_valid_tz(tz: &str) -> bool {
     // Max_timezone_hour = 14, Min_timezone_hour = 12): `+` offsets go to
     // +14:00, `-` offsets only to -12:00 (reject `-13:00`).
     //
-    // NOTE (corpus adjudication): the invariants literally require
-    // `hour > 0` when signed, but the canonical corpus + CNF data sets carry
-    // `+00:00`/`-00:00` UTC forms in 42 files — the corpus outranks the prose
-    // reading, so hour 0 is accepted with either sign (≡ `Z`).
+    // NOTE: hour 0 is accepted with either sign — `iso8601_timezone.adoc`
+    // §Description gives `hh` as "`00` - `23`" and §Functions defines `is_gmt`
+    // as "timezone `+0000`", which the `hour > 0` invariants would forbid.
     let max_hour = if tz.starts_with('+') { 14 } else { 12 };
     if rest.contains(':') {
         matches!(rest.split(':').collect::<Vec<_>>().as_slice(),
@@ -661,15 +660,12 @@ fn is_valid_tz(tz: &str) -> bool {
 }
 
 fn is_valid_time_core(s: &str) -> bool {
-    // A trailing decimal fraction (after '.' or ',') is legal ONLY on the
-    // seconds component: "partial date/times with fractional minutes or hours
-    // … in openEHR, only fractional seconds are supported" (BASE
-    // `foundation_types/master06-time_types.adoc` §"ISO 8601 semantics not
-    // included in these types"). A fractional hour ("10.5") or fractional
-    // minute ("10:05.5") is therefore rejected — a fraction is accepted only
-    // when the base carries full `HH:MM:SS` (seconds present). This mirrors the
-    // seconds-only fraction rule the duration path enforces
-    // (`parse_duration_components`).
+    // NOTE: a decimal fraction is legal only on seconds — BASE
+    // `master06-time_types.adoc`: "only fractional seconds are supported".
+    //
+    // NOTE: seconds are `0..=59` per `time_definitions.adoc` §Functions
+    // `valid_second` (`Post: … s < Seconds_in_minute`) — the machine-checkable
+    // clause, which BASE's own reader also took over the `00`-`60` prose.
     let (base, frac) = match s.split_once(['.', ',']) {
         Some((b, f)) => (b, Some(f)),
         None => (s, None),
@@ -684,7 +680,7 @@ fn is_valid_time_core(s: &str) -> bool {
         match base.split(':').collect::<Vec<_>>().as_slice() {
             [h] => !has_frac && in_range(h, 0, 23),
             [h, m] => !has_frac && in_range(h, 0, 23) && in_range(m, 0, 59),
-            [h, m, sec] => in_range(h, 0, 23) && in_range(m, 0, 59) && in_range(sec, 0, 60),
+            [h, m, sec] => in_range(h, 0, 23) && in_range(m, 0, 59) && in_range(sec, 0, 59),
             _ => false,
         }
     } else {
@@ -696,7 +692,7 @@ fn is_valid_time_core(s: &str) -> bool {
             6 => {
                 in_range(part(base, 0..2), 0, 23)
                     && in_range(part(base, 2..4), 0, 59)
-                    && in_range(part(base, 4..6), 0, 60)
+                    && in_range(part(base, 4..6), 0, 59)
             }
             _ => false,
         }
@@ -908,6 +904,25 @@ mod tests {
         assert!(!is_valid_iso_duration("PT"));
     }
 
+    /// This validator and BASE's `Iso8601Time` reader must accept the same
+    /// strings: `valid_second` bounds seconds below 60, and a value that passes
+    /// here but not there is stored with no magnitude and no arithmetic.
+    #[test]
+    fn time_validity_agrees_with_the_base_reader() {
+        for value in ["10:30:00", "10:30:59", "23:59:59", "10:30:60", "103060", "25:00:00"] {
+            let base = openehr_base::v1_3::foundation_types::time::iso8601_time::Iso8601Time {
+                value: value.to_owned(),
+            }
+            .hour()
+            .is_some();
+            assert_eq!(
+                is_valid_iso_time(value),
+                base,
+                "{value:?}: the RM validator and the BASE reader disagree",
+            );
+        }
+    }
+
     /// This validator and BASE's `Iso8601Duration` reader must accept the same
     /// strings, or a value passes `Value_valid`, gets stored, and then has no
     /// arithmetic. `P1Y1Y` validated here while BASE refused it and
@@ -962,17 +977,12 @@ mod tests {
         assert!(!is_valid_iso_duration("PT2H14,5M"));
     }
 
-    // NOTE: the `_type`-dispatch tests (fast/typed equivalence, corpus, mutation
-    // battery) live in `openehr-its/tests/it/rm_validation.rs`, where the tiers
-    // are reachable through the COMPOSED wire entry points — the fast path
-    // (`try_fast_validate`) and the typed table
-    // (`typed_dispatch::dispatch_typed`) both live in this crate, but the
-    // generated five-crate structural fallthrough they are composed with can
-    // only exist downstream. The ISO-8601 helper tests below stay with the
-    // helpers they exercise.
+    // NOTE: the `_type`-dispatch tests live in
+    // `openehr-its/tests/it/rm_validation.rs`, where the tiers are reachable
+    // through the composed wire entry points.
 
     /// BASE `Iso8601_timezone`: `+` offsets reach +14:00, `-` offsets stop at
-    /// -12:00; ±00:00 accepted per the corpus (see `is_valid_tz`).
+    /// -12:00; ±00:00 is accepted (see `is_valid_tz`).
     #[test]
     fn timezone_bounds_are_asymmetric() {
         assert!(is_valid_iso_time("10:00:00+14:00"));

--- a/tools/openehr-codegen/templates/openehr-rm/validate/terminology.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/validate/terminology.rs
@@ -376,12 +376,22 @@ pub fn slots_for(rm_type: &str) -> &'static [Slot] {
             invariant: "Change_type_valid",
             binding: Binding::Group(Group::AuditChangeType),
         }],
-        // attestation.adoc: Reason_valid (attestation_reason group).
-        "ATTESTATION" => &[Slot {
-            field: "reason",
-            invariant: "Reason_valid",
-            binding: Binding::Group(Group::AttestationReason),
-        }],
+        // attestation.adoc: Reason_valid (attestation_reason group), PLUS the
+        // Change_type_valid it inherits from AUDIT_DETAILS — this table is keyed
+        // on the exact wire `_type`, so an ancestor's slot reaches a descendant
+        // only by being repeated here.
+        "ATTESTATION" => &[
+            Slot {
+                field: "reason",
+                invariant: "Reason_valid",
+                binding: Binding::Group(Group::AttestationReason),
+            },
+            Slot {
+                field: "change_type",
+                invariant: "Change_type_valid",
+                binding: Binding::Group(Group::AuditChangeType),
+            },
+        ],
         // party_related.adoc: Relationship_valid (subject_relationship group).
         "PARTY_RELATED" => &[Slot {
             field: "relationship",
@@ -484,6 +494,54 @@ pub fn validate_rm_terminology(ty: &str, value: &Value, out: &mut Vec<InvariantV
                 slot.field,
                 format!("Invariant {} failed on type {ty}", slot.invariant),
             ));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// This table is keyed on the exact wire `_type`, so an invariant declared
+    /// on an ancestor reaches a descendant only by being repeated. `ATTESTATION`
+    /// inherits `AUDIT_DETAILS`, so an out-of-group `change_type` must be
+    /// refused on both — it was accepted on `ATTESTATION` while the identical
+    /// `AUDIT_DETAILS` node was refused.
+    #[test]
+    fn an_inherited_coded_invariant_reaches_the_descendant() {
+        let node = serde_json::json!({
+            "change_type": {
+                "value": "creation",
+                "defining_code": {
+                    "terminology_id": { "value": "openehr" },
+                    "code_string": "9999"
+                }
+            }
+        });
+        for ty in ["AUDIT_DETAILS", "ATTESTATION"] {
+            let mut out = Vec::new();
+            validate_rm_terminology(ty, &node, &mut out);
+            assert!(
+                out.iter()
+                    .any(|v| v.message == format!("Invariant Change_type_valid failed on type {ty}")),
+                "{ty}: an out-of-group change_type must be refused, got {out:?}",
+            );
+        }
+
+        // The accepting twin: a code the group does carry raises nothing.
+        let valid = serde_json::json!({
+            "change_type": {
+                "value": "creation",
+                "defining_code": {
+                    "terminology_id": { "value": "openehr" },
+                    "code_string": "249"
+                }
+            }
+        });
+        for ty in ["AUDIT_DETAILS", "ATTESTATION"] {
+            let mut out = Vec::new();
+            validate_rm_terminology(ty, &valid, &mut out);
+            assert!(out.is_empty(), "{ty}: a valid change_type raises nothing, got {out:?}");
         }
     }
 }


### PR DESCRIPTION
Audit findings from #2252 / #2255 / #2256, implemented across three crates by two workers plus me. **2783 tests pass.**

Closes #2261, #2264, #2265, #2266, #2267.

## The recurring shape: two readers, one value

`DV_TIME` of `10:30:60` passed `Value_valid` and was stored — then `Iso8601Time` refused it, so `add`/`diff` produced nothing while `DV_ORDERED` ordering used the RM-local reader. Same defect class as the duration fix in #2263, in a different pair.

`valid_second`'s post-condition (`s < Seconds_in_minute`) is the machine-checkable clause and the one BASE already took; the `00`-`60` prose on the same page is the contradiction. A test now asserts the two readers accept identical strings.

## `ATTESTATION` never checked a rule its own doc claimed it did

The slot table is keyed on the exact wire `_type`, so an ancestor's slot reaches a descendant **only by being repeated**. An out-of-group `change_type` was accepted on `ATTESTATION` and refused on the identical `AUDIT_DETAILS`.

The pinned slot-count test caught the addition and told me to re-pin deliberately — which is exactly what it is for.

## `AUTHORED_RESOURCE` and the four ISO-8601 types had no `Validate` at all

~17 declared invariants, enforced only by the RM wrappers. Implementing them required splitting each parser into a **lenient scanner** plus the validity gate: `parse_date` collapses every invariant into `None`, so a validator built on it could only ever say "not a date". Now `2021-02-29` still decomposes far enough to name `Day_valid`. `parse_*` behaviour is byte-identical, pinned by a scanner-vs-parser agreement test.

## LANG: a value silently becoming zero

An out-of-range BMM enumeration item value became `0` via `unwrap_or_default`, mapping two distinct names onto one value — while `value_literal` still held the truth, making it invisible unless you compared both fields. Now a typed refusal.

`type_conforms_to` ignored the algorithm's `BMM_GENERIC_CLASS` guard, so `Interval<Integer>` vs `Interval<Ordered>` over a *non-generic* `Interval` reported a conformance the spec denies.

## The guard that could not see the emitter

`comment-style.sh` skipped any file **containing** `@generated` — so the entire emitter, which *emits* that banner, was exempt. Keying on the header exposed **16 violations**, including a 45-line NOTE that contained a duplicated paragraph (someone edited and left both).

All 16 fixed. The container-shape adjudication moved to the crate's `CLAUDE.md` §Container shapes, which is where `comments.md` says design decisions belong — rather than being deleted or relocated into a `///` to dodge the budget.

## Two issue claims I did NOT implement, on the evidence

- **`DV_PROPORTION.is_integral`** stays the value test. The `precision = 0` reading (the spec's own "i.e.") makes `Fraction_validity` demand every fraction *declare* a precision, so a valid `1/2` stating none becomes invalid. Both readings make one invariant vacuous; only that one rejects good data.
- **A `P_BMM` constant with no value** is a collected finding, not a refusal. All three released LANG schemas exercise that case (`BMM_DEFINITIONS.Bmm_internal_version`), and `P_BMM_CONSTANT.value` is `0..1` — refusing it would invent a prohibition, the mirror image of leniency.

## Filed rather than silently deferred

**#2270** (the attribute-less `ehr:` locator is our own extension — keep or refuse is a decision), **#2271** (two OPT emitter facets carried as raw text). Both referenced from the code that defers to them.

## Verification

2783 workspace tests; clippy clean at `-D warnings`; `comment-style`, `spec-citations`, `default-style`, `typed-status` all green; both generations stamped from one template each. Crates bumped to `0.0.25`.