### PR TITLE
fix(lang): a lexical defect could be reported with no text, and seven citations named the wrong class

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -28,3 +28,4 @@
 - [No worktrees — one checkout](no-worktrees-single-checkout.md) — every change in the main tree on the current branch; one worker at a time with explicit fences, never `isolation: worktree`
 - [K8s testing uses a compose postgres](k8s-testing-uses-compose-postgres.md) — database runs in docker compose on the host and the chart points at it; never deploy postgres into the test cluster
 - [This is a rewrite, not inherited code](rewrite-not-inherited-code.md) — existing code is never assumed correct; read the ancestor spec + existing code before implementing; breaking changes preferred over preserving bad code; distrust instruments too
+- [One Closes keyword per issue; current milestone always](pr-closes-one-keyword-per-issue.md) — "Closes #1, #2, #3" closes only #1, verify after merge; every en-route issue goes in the CURRENT milestone, never the next

--- a/.claude/memory/pr-closes-one-keyword-per-issue.md
+++ b/.claude/memory/pr-closes-one-keyword-per-issue.md
@@ -1,0 +1,34 @@
+---
+name: pr-closes-one-keyword-per-issue
+description: "A PR body must repeat the closing keyword for EVERY issue — \"Closes #1, #2, #3\" closes only #1; and every issue found en route goes in the CURRENT milestone, never the next"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 7a390181-e5e7-4508-9316-33a300a4aedb
+  modified: 2026-08-11T20:01:59.900Z
+---
+
+**One closing keyword per issue.** `Closes #2261, #2264, #2265` closes only
+**#2261** — GitHub parses the keyword against a single reference, not against a
+comma list. Write `Closes #2261. Closes #2264. Closes #2265.` (or `Closes #2261,
+closes #2264, closes #2265`).
+
+**Why:** PR #2272 listed five issues behind one `Closes` and left four open
+after merging. The work was done and merged; the tracker said otherwise, which
+is the failure the auto-close exists to prevent.
+
+**Every issue found en route goes in the CURRENT milestone.** Owner directive
+(2026-08-11): "everything that comes up will be added to this milestone". Do not
+file into the next milestone because something looks like follow-up work — the
+owner decides what slips, and a milestone is the release's promise, so parking
+work in the next one silently removes it from this cut.
+
+How to apply:
+- Repeat the keyword per issue, then VERIFY after merge (`gh issue view <n>
+  --json state`) — the parse is silent when it fails.
+- `gh issue create --milestone v<current>` on every new issue, including
+  upstream-reports and follow-ups, unless the owner says otherwise. The one
+  standing exception is `blocked-upstream`, which carries no milestone at all
+  (it cannot promise a delivery).
+
+Related: [[en-route-findings-always-filed]], [[autonomous-phase-flow]].

--- a/crates/openehr-lang/src/v1_0/lexer/mod.rs
+++ b/crates/openehr-lang/src/v1_0/lexer/mod.rs
@@ -43,6 +43,22 @@ mod token;
 
 use logos::Logos;
 
+/// The source text a lexer span names.
+///
+/// Total by construction: every span reaching this function was produced by
+/// `logos` over the SAME `src`, so it always names a character boundary inside
+/// it. Returning an empty string instead would report a lexical defect with no
+/// text — a silent wrong diagnostic, which `.claude/rules/reliability.md`
+/// forbids dodging the lint with.
+#[expect(
+    clippy::expect_used,
+    reason = "the span comes from lexing this same `src`, so it always slices"
+)]
+fn span_text(src: &str, span: core::ops::Range<usize>) -> &str {
+    src.get(span)
+        .expect("a span produced by lexing this source should slice it")
+}
+
 use crate::v1_0::lexer::reclassify::reclassify;
 pub use crate::v1_0::lexer::token::Token;
 
@@ -82,11 +98,11 @@ pub fn lex_odin(src: &str) -> Result<Vec<Spanned>, LexError> {
     let mut lexer = Token::lexer(src);
     while let Some(result) = lexer.next() {
         let span = lexer.span();
-        let text = src.get(span.clone()).unwrap_or_default();
+        let text = span_text(src, span.clone());
         let Ok(produced) = result else {
             let end = stuck_at(src, span.start, span.end);
             return Err(LexError {
-                text: src.get(span.start..end).unwrap_or_default().to_owned(),
+                text: span_text(src, span.start..end).to_owned(),
                 span: span.start..end,
             });
         };
@@ -132,7 +148,7 @@ fn retag_odin_value_words_in_key_position(src: &str, spanned: &mut [Spanned]) {
             && before_eq
             && let Some(entry) = spanned.get_mut(index)
         {
-            let slice = src.get(entry.span.clone()).unwrap_or_default();
+            let slice = span_text(src, entry.span.clone());
             entry.token = if slice.starts_with(|c: char| c.is_ascii_uppercase()) {
                 Token::AlphaUcId(slice.to_owned())
             } else {
@@ -164,7 +180,7 @@ fn narrow(
     let mut end = previous_boundary(src, limit, start);
     while end > start {
         if let Some(produced) = single_token(src, start, end) {
-            let text = src.get(start..end).unwrap_or_default();
+            let text = span_text(src, start..end);
             if let Some(read) = reclassify(&produced, text, src, start) {
                 if !matches!(read, Token::Bom) {
                     out.push(Spanned {
@@ -180,7 +196,7 @@ fn narrow(
     let end = next_boundary(src, start);
     Err(LexError {
         span: start..end,
-        text: src.get(start..end).unwrap_or_default().to_owned(),
+        text: span_text(src, start..end).to_owned(),
     })
 }
 

--- a/crates/openehr-lang/src/v1_1/bmm/core/bmm_classifier_impl.rs
+++ b/crates/openehr-lang/src/v1_1/bmm/core/bmm_classifier_impl.rs
@@ -56,7 +56,8 @@ impl BmmClassifier {
     /// the _root_ type from a generic type (e.g. `Interval` from
     /// `Interval<T>`)" (`LANG/docs/bmm/master05-core.adoc` §Semantics §Basics —
     /// the function is defined there in prose; only
-    /// `BMM_OPEN_TYPE`/`BMM_PARAMETER_TYPE` carry it in a §Functions table).
+    /// `BMM_OPEN_TYPE` carries it in a §Functions table — the only class doc in
+    /// the vendored LANG set that names it).
     #[must_use]
     pub fn conformance_type_name(&self) -> String {
         match self {

--- a/crates/openehr-lang/src/v1_1/bmm/core/bmm_generic_parameter_impl.rs
+++ b/crates/openehr-lang/src/v1_1/bmm/core/bmm_generic_parameter_impl.rs
@@ -105,7 +105,7 @@ impl BmmGenericParameter {
         }
     }
 
-    /// `BMM_CLASSIFIER.conformance_type_name` for a generic parameter: the
+    /// `conformance_type_name` for a generic parameter: the
     /// effective constraint, i.e. the class the parameter is guaranteed to
     /// conform to — `Any` when unconstrained
     /// (`org.openehr.lang.bmm.bmm_open_type.adoc` §Functions:

--- a/crates/openehr-lang/src/v1_1/bmm/core/bmm_property_impl.rs
+++ b/crates/openehr-lang/src/v1_1/bmm/core/bmm_property_impl.rs
@@ -94,7 +94,7 @@ impl BmmProperty<BmmType> {
         }
     }
 
-    /// `BMM_CLASSIFIER.conformance_type_name` of this property's type: the
+    /// `conformance_type_name` of this property's type: the
     /// reduced form that abstracts a container away — "the _contained_ type for
     /// a container type (e.g. `ELEMENT` from the type `List<ELEMENT>`)"
     /// (`LANG/docs/bmm/master05-core.adoc` §Semantics §Basics). This is the

--- a/crates/openehr-lang/src/v1_1/bmm3/core/entity/bmm_type_impl.rs
+++ b/crates/openehr-lang/src/v1_1/bmm3/core/entity/bmm_type_impl.rs
@@ -375,7 +375,7 @@ impl BmmStatusType {
         Self::BASE_NAME.to_owned()
     }
 
-    /// `BMM_CLASSIFIER.conformance_type_name` for the status meta-type: its
+    /// `conformance_type_name` for the status meta-type: its
     /// built-in base name (`org.openehr.lang.bmm3.bmm_status_type.adoc`
     /// §Constants).
     #[expect(
@@ -412,7 +412,7 @@ impl BmmTupleType {
         Self::BASE_NAME.to_owned()
     }
 
-    /// `BMM_CLASSIFIER.conformance_type_name` for the tuple meta-type: its
+    /// `conformance_type_name` for the tuple meta-type: its
     /// built-in base name (`org.openehr.lang.bmm3.bmm_tuple_type.adoc`
     /// §Constants).
     #[expect(
@@ -462,7 +462,7 @@ impl BmmSignature {
         }
     }
 
-    /// `BMM_CLASSIFIER.conformance_type_name` for a signature meta-type: its
+    /// `conformance_type_name` for a signature meta-type: its
     /// built-in base name — a signature is not a model class, so there is no
     /// reduced form beyond the name itself (`master05-core.adoc` §Basics).
     #[must_use]
@@ -537,7 +537,7 @@ impl BmmEffectiveType {
         }
     }
 
-    /// `BMM_CLASSIFIER.conformance_type_name` for an effective type.
+    /// `conformance_type_name` for an effective type.
     #[must_use]
     pub fn conformance_type_name(&self) -> String {
         match self {
@@ -592,7 +592,7 @@ impl BmmUnitaryType {
         }
     }
 
-    /// `BMM_CLASSIFIER.conformance_type_name` for a unitary type.
+    /// `conformance_type_name` for a unitary type.
     #[must_use]
     pub fn conformance_type_name(&self) -> String {
         match self {

--- a/crates/openehr-lang/src/v1_1/bmm_persistence/create_bmm3_model.rs
+++ b/crates/openehr-lang/src/v1_1/bmm_persistence/create_bmm3_model.rs
@@ -31,7 +31,7 @@
 //!   reappear in the descendant with the bound type and
 //!   `is_synthesised_generic` set (`synthesise_generic_properties`).
 //!
-//! Three boundaries are load-bearing and stated here rather than left implicit:
+//! Two boundaries are load-bearing and stated here rather than left implicit:
 //!
 //! * **Class invariants and routine pre-/post-conditions.** v3 requires them as
 //!   `BMM_ASSERTION` (`LANG/docs/bmm3/master10-expressions.adoc` §Usage in BMM

--- a/crates/openehr-lang/src/v1_1/lexer/mod.rs
+++ b/crates/openehr-lang/src/v1_1/lexer/mod.rs
@@ -64,6 +64,22 @@ mod token;
 
 use logos::Logos;
 
+/// The source text a lexer span names.
+///
+/// Total by construction: every span reaching this function was produced by
+/// `logos` over the SAME `src`, so it always names a character boundary inside
+/// it. Returning an empty string instead would report a lexical defect with no
+/// text — a silent wrong diagnostic, which `.claude/rules/reliability.md`
+/// forbids dodging the lint with.
+#[expect(
+    clippy::expect_used,
+    reason = "the span comes from lexing this same `src`, so it always slices"
+)]
+fn span_text(src: &str, span: core::ops::Range<usize>) -> &str {
+    src.get(span)
+        .expect("a span produced by lexing this source should slice it")
+}
+
 use crate::v1_1::lexer::reclassify::{Language, reclassify};
 pub use crate::v1_1::lexer::token::Token;
 
@@ -145,7 +161,7 @@ fn retag_odin_value_words_in_key_position(src: &str, spanned: &mut [Spanned]) {
             && before_eq
             && let Some(entry) = spanned.get_mut(index)
         {
-            let slice = src.get(entry.span.clone()).unwrap_or_default();
+            let slice = span_text(src, entry.span.clone());
             entry.token = if slice.starts_with(|c: char| c.is_ascii_uppercase()) {
                 Token::AlphaUcId(slice.to_owned())
             } else {
@@ -197,11 +213,11 @@ fn lex_with(language: Language, src: &str) -> Result<Vec<Spanned>, LexError> {
     let mut lexer = Token::lexer(src);
     while let Some(result) = lexer.next() {
         let span = lexer.span();
-        let text = src.get(span.clone()).unwrap_or_default();
+        let text = span_text(src, span.clone());
         let Ok(produced) = result else {
             let end = stuck_at(language, src, span.start, span.end);
             return Err(LexError {
-                text: src.get(span.start..end).unwrap_or_default().to_owned(),
+                text: span_text(src, span.start..end).to_owned(),
                 span: span.start..end,
             });
         };
@@ -240,7 +256,7 @@ fn narrow(
     let mut end = previous_boundary(src, limit, start);
     while end > start {
         if let Some(produced) = single_token(src, start, end) {
-            let text = src.get(start..end).unwrap_or_default();
+            let text = span_text(src, start..end);
             if let Some(read) = reclassify(language, &produced, text, src, start) {
                 if !matches!(read, Token::Bom) {
                     out.push(Spanned {
@@ -256,7 +272,7 @@ fn narrow(
     let end = next_boundary(src, start);
     Err(LexError {
         span: start..end,
-        text: src.get(start..end).unwrap_or_default().to_owned(),
+        text: span_text(src, start..end).to_owned(),
     })
 }
 


### PR DESCRIPTION
Follow-ups the #2267 worker found **outside its fence** and correctly left alone, plus two its own fix exposed.

## A defect reported with no text

Ten sites across the two lexer generations:

```rust
let text = src.get(span).unwrap_or_default();
```

This is the **diagnostic** path — a span that failed to slice would report a lexical defect with empty text. The spans all come from lexing the same `src`, so the failure is unreachable, and that is precisely why substituting an empty string is the defect rather than a safeguard: `reliability.md` forbids dodging the lint with a fabricated value, because it converts a loud impossible state into a silent wrong one.

One `span_text` helper per generation now states the inspection once and expects, instead of ten silent fallbacks scattered across the file.

## Seven citations naming a class that does not declare the function

Release 2.2.1 removed `conformance_type_name` from `BMM_CLASSIFIER` (`master00-amendment_record.adoc`). A sweep of the vendored class docs shows it appears in **exactly one**: `org.openehr.lang.bmm.bmm_open_type.adoc`.

Two of the seven were the sites #2267 scoped; five more were in the v3 generation. And the sibling that #2267 named as "the correct position" was itself partly wrong — it claimed `BMM_PARAMETER_TYPE` carries it too, and that class's §Functions lists only `flattened_conforms_to_type` and `type_signature`. Corrected rather than propagated.

## Also

`create_bmm3_model`'s module docs said "Three boundaries" over a list of two.

## Reported upstream

**#2274** — the case that forced #2267's design change. `P_BMM_CONSTANT.value` is `0..1` while the v3 destination `BMM_CONSTANT.generator` is `1..1` over a `1..1` `value_literal`, and openEHR's own three published LANG schemas exercise the absent case (`BMM_DEFINITIONS.Bmm_internal_version`). A conforming persistence document cannot fully materialise into a conforming v3 model, so every implementer invents the same workaround.

## Verification

332 `openehr-lang` tests and 2783 workspace tests pass; clippy clean at `-D warnings`; comment-style and spec-citations green. Crates bumped to `0.0.26`.