### PR TITLE
refactor(rm): one ISO-8601 grammar, not two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,21 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
+- **`Time_Definitions`'s eleven validity functions are now public** on
+  `openehr-base` — `valid_year`, `valid_month`, `valid_day`, `valid_hour`,
+  `valid_minute`, `valid_second`, `valid_fractional_second`, `days_in_month`,
+  and the four `valid_iso8601_*` string predicates. They had no realization
+  anywhere despite being declared by the spec.
+
+### Changed
+
+- **One ISO-8601 grammar, not two.** `openehr-rm` validated dates, times,
+  date-times and durations with its own hand-written reader while depending on
+  the `openehr-base` one that owns them. The two drifted twice and both drifts
+  shipped, each letting a value pass validation and then behave as invalid.
+  The RM side now calls the spec functions; 341 lines of duplicate grammar are
+  gone.
+
 - **`ITEM_TABLE`'s twelve accessors** on the published spec crates — `row_count`,
   `column_count`, `row_names`, `column_names`, `ith_row`, `named_row`,
   `has_row_with_name`, `has_column_with_name`, `has_row_with_key`,

--- a/crates/openehr-base/src/v1_2/foundation_types/time/mod.rs
+++ b/crates/openehr-base/src/v1_2/foundation_types/time/mod.rs
@@ -15,3 +15,4 @@ pub mod iso8601_date_time_impl;
 pub mod iso8601_duration_impl;
 pub mod iso8601_parse;
 pub mod iso8601_time_impl;
+pub mod time_definitions;

--- a/crates/openehr-base/src/v1_2/foundation_types/time/time_definitions.rs
+++ b/crates/openehr-base/src/v1_2/foundation_types/time/time_definitions.rs
@@ -1,0 +1,195 @@
+// @generated-from-template templates/openehr-base/foundation_types/time/time_definitions.rs — DO NOT EDIT; edit the source and re-run `openehr-codegen -- emit`.
+//! `Time_Definitions` — the released validity functions, publicly.
+//!
+//! Spec: `docs/specs/openehr/BASE/docs/UML/classes/org.openehr.base.foundation_types.time_definitions.adoc`
+//! §Functions. The class is a constant holder the emitter maps rather than
+//! emits, so its constants already live in `iso8601_parse`; its eleven `valid_*`
+//! functions had no home at all, which also made them invisible to the
+//! unrealized-function ratchet (a mapped class is out of that projection's
+//! scope by construction).
+//!
+//! This is the one public surface for "is this string a valid ISO-8601 X" in
+//! the workspace. `openehr-rm` used to answer it with a second, hand-written
+//! grammar; the two drifted twice, and both drifts shipped (#2273).
+
+use crate::v1_2::foundation_types::time::iso8601_parse;
+
+/// True if `y >= 0`.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_year` —
+/// `Post: Result = y >= 0`.
+#[must_use]
+pub fn valid_year(y: i64) -> bool {
+    y >= 0
+}
+
+/// True if `m >= 1 and m <= Months_in_year`.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_month`.
+#[must_use]
+pub fn valid_month(m: i64) -> bool {
+    (1..=12).contains(&m)
+}
+
+/// True if `d >= 1 and d <= days_in_month (m, y)`.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_day`. The month and year are
+/// checked first: `days_in_month` is undefined for a month outside `1..=12`, so
+/// the post-condition cannot be evaluated without them.
+#[must_use]
+pub fn valid_day(y: i64, m: i64, d: i64) -> bool {
+    let Some(length) = days_in_month(y, m) else {
+        return false;
+    };
+    valid_year(y) && valid_month(m) && d >= 1 && d <= i64::from(length)
+}
+
+/// True if `(h >= 0 and h < Hours_in_day) or (h = Hours_in_day and m = 0 and
+/// s = 0)`.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_hour`.
+///
+/// NOTE: the second clause admits `24:00:00`, which `iso8601_time.adoc`
+/// §Description and `master06-time_types.adoc` forbid "anywhere" — a released
+/// contradiction, resolved toward the prohibition (#2276).
+#[must_use]
+pub fn valid_hour(h: i64, m: i64, s: i64) -> bool {
+    (0..24).contains(&h) && valid_minute(m) && valid_second(s)
+}
+
+/// True if `m >= 0 and m < Minutes_in_hour`.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_minute`.
+#[must_use]
+pub fn valid_minute(m: i64) -> bool {
+    (0..60).contains(&m)
+}
+
+/// True if `s >= 0 and s < Seconds_in_minute`.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_second` —
+/// `Post: Result = s >= 0 and s < Seconds_in_minute`. The `valid_iso8601_time`
+/// Meaning column's "`ss` is `00` - `60`" on the same page is the contradiction;
+/// this post-condition is the machine-checkable clause.
+#[must_use]
+pub fn valid_second(s: i64) -> bool {
+    (0..60).contains(&s)
+}
+
+/// True if `fs >= 0.0 and fs < 1.0`.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_fractional_second`.
+#[must_use]
+pub fn valid_fractional_second(fs: f64) -> bool {
+    fs.is_finite() && (0.0..1.0).contains(&fs)
+}
+
+/// True if `s` is a valid ISO-8601 date.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_iso8601_date`.
+#[must_use]
+pub fn valid_iso8601_date(s: &str) -> bool {
+    iso8601_parse::parse_date(s).is_some()
+}
+
+/// True if `s` is a valid ISO-8601 time.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_iso8601_time`.
+#[must_use]
+pub fn valid_iso8601_time(s: &str) -> bool {
+    iso8601_parse::parse_time(s).is_some()
+}
+
+/// True if `s` is a valid ISO-8601 date-time.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_iso8601_date_time`.
+#[must_use]
+pub fn valid_iso8601_date_time(s: &str) -> bool {
+    iso8601_parse::parse_date_time(s).is_some()
+}
+
+/// True if `s` is a valid ISO-8601 duration.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_iso8601_duration`.
+#[must_use]
+pub fn valid_iso8601_duration(s: &str) -> bool {
+    iso8601_parse::parse_duration(s).is_some()
+}
+
+/// The number of days in month `m` of year `y`, or `None` when the pair names
+/// no month of the calendar.
+///
+/// Spec: `time_definitions.adoc` §Functions `days_in_month`.
+#[must_use]
+pub fn days_in_month(y: i64, m: i64) -> Option<u32> {
+    let (Ok(year), Ok(month)) = (u32::try_from(y), u32::try_from(m)) else {
+        return None;
+    };
+    iso8601_parse::days_in_month(year, month)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Each numeric predicate is its own post-condition, at the boundary.
+    #[test]
+    fn the_numeric_predicates_are_their_post_conditions() {
+        assert!(valid_year(0) && valid_year(2024));
+        assert!(!valid_year(-1));
+
+        assert!(valid_month(1) && valid_month(12));
+        assert!(!valid_month(0) && !valid_month(13));
+
+        assert!(valid_minute(0) && valid_minute(59));
+        assert!(!valid_minute(60) && !valid_minute(-1));
+
+        assert!(valid_second(0) && valid_second(59));
+        assert!(
+            !valid_second(60),
+            "the post-condition is `s < Seconds_in_minute`"
+        );
+
+        assert!(valid_fractional_second(0.0) && valid_fractional_second(0.999));
+        assert!(!valid_fractional_second(1.0) && !valid_fractional_second(-0.1));
+        assert!(!valid_fractional_second(f64::NAN));
+    }
+
+    /// `valid_day` is defined via `days_in_month (m, y)`, so it answers the
+    /// leap year and refuses a month it cannot evaluate.
+    #[test]
+    fn valid_day_follows_the_month_length() {
+        assert!(valid_day(2024, 2, 29), "2024 is a leap year");
+        assert!(!valid_day(2023, 2, 29));
+        assert!(valid_day(2024, 1, 31) && !valid_day(2024, 4, 31));
+        assert!(!valid_day(2024, 0, 1), "no month to measure");
+        assert!(!valid_day(2024, 1, 0));
+    }
+
+    /// `24:00:00` is refused: the released `valid_hour` post-condition admits
+    /// it while the `Iso8601_time` class forbids it anywhere (#2276).
+    #[test]
+    fn the_twenty_fourth_hour_is_refused() {
+        assert!(valid_hour(23, 59, 59));
+        assert!(!valid_hour(24, 0, 0));
+        assert!(!valid_hour(-1, 0, 0));
+    }
+
+    /// The four string predicates are the one public answer to "is this a valid
+    /// ISO-8601 X" — the same readers every accessor and every arithmetic
+    /// function in this crate already uses.
+    #[test]
+    fn the_string_predicates_agree_with_the_readers() {
+        assert!(valid_iso8601_date("2024-02-29") && !valid_iso8601_date("2023-02-29"));
+        assert!(valid_iso8601_time("10:30:59") && !valid_iso8601_time("10:30:60"));
+        assert!(
+            valid_iso8601_date_time("2024-02-29T10:30:00")
+                && !valid_iso8601_date_time("2024-02-30T10:30:00")
+        );
+        assert!(valid_iso8601_duration("P1Y2M3DT4H5M6S"));
+        assert!(
+            !valid_iso8601_duration("P1Y1Y"),
+            "a repeated designator is not a duration"
+        );
+    }
+}

--- a/crates/openehr-base/src/v1_3/foundation_types/time/mod.rs
+++ b/crates/openehr-base/src/v1_3/foundation_types/time/mod.rs
@@ -15,3 +15,4 @@ pub mod iso8601_date_time_impl;
 pub mod iso8601_duration_impl;
 pub mod iso8601_parse;
 pub mod iso8601_time_impl;
+pub mod time_definitions;

--- a/crates/openehr-base/src/v1_3/foundation_types/time/time_definitions.rs
+++ b/crates/openehr-base/src/v1_3/foundation_types/time/time_definitions.rs
@@ -1,0 +1,195 @@
+// @generated-from-template templates/openehr-base/foundation_types/time/time_definitions.rs — DO NOT EDIT; edit the source and re-run `openehr-codegen -- emit`.
+//! `Time_Definitions` — the released validity functions, publicly.
+//!
+//! Spec: `docs/specs/openehr/BASE/docs/UML/classes/org.openehr.base.foundation_types.time_definitions.adoc`
+//! §Functions. The class is a constant holder the emitter maps rather than
+//! emits, so its constants already live in `iso8601_parse`; its eleven `valid_*`
+//! functions had no home at all, which also made them invisible to the
+//! unrealized-function ratchet (a mapped class is out of that projection's
+//! scope by construction).
+//!
+//! This is the one public surface for "is this string a valid ISO-8601 X" in
+//! the workspace. `openehr-rm` used to answer it with a second, hand-written
+//! grammar; the two drifted twice, and both drifts shipped (#2273).
+
+use crate::v1_3::foundation_types::time::iso8601_parse;
+
+/// True if `y >= 0`.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_year` —
+/// `Post: Result = y >= 0`.
+#[must_use]
+pub fn valid_year(y: i64) -> bool {
+    y >= 0
+}
+
+/// True if `m >= 1 and m <= Months_in_year`.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_month`.
+#[must_use]
+pub fn valid_month(m: i64) -> bool {
+    (1..=12).contains(&m)
+}
+
+/// True if `d >= 1 and d <= days_in_month (m, y)`.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_day`. The month and year are
+/// checked first: `days_in_month` is undefined for a month outside `1..=12`, so
+/// the post-condition cannot be evaluated without them.
+#[must_use]
+pub fn valid_day(y: i64, m: i64, d: i64) -> bool {
+    let Some(length) = days_in_month(y, m) else {
+        return false;
+    };
+    valid_year(y) && valid_month(m) && d >= 1 && d <= i64::from(length)
+}
+
+/// True if `(h >= 0 and h < Hours_in_day) or (h = Hours_in_day and m = 0 and
+/// s = 0)`.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_hour`.
+///
+/// NOTE: the second clause admits `24:00:00`, which `iso8601_time.adoc`
+/// §Description and `master06-time_types.adoc` forbid "anywhere" — a released
+/// contradiction, resolved toward the prohibition (#2276).
+#[must_use]
+pub fn valid_hour(h: i64, m: i64, s: i64) -> bool {
+    (0..24).contains(&h) && valid_minute(m) && valid_second(s)
+}
+
+/// True if `m >= 0 and m < Minutes_in_hour`.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_minute`.
+#[must_use]
+pub fn valid_minute(m: i64) -> bool {
+    (0..60).contains(&m)
+}
+
+/// True if `s >= 0 and s < Seconds_in_minute`.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_second` —
+/// `Post: Result = s >= 0 and s < Seconds_in_minute`. The `valid_iso8601_time`
+/// Meaning column's "`ss` is `00` - `60`" on the same page is the contradiction;
+/// this post-condition is the machine-checkable clause.
+#[must_use]
+pub fn valid_second(s: i64) -> bool {
+    (0..60).contains(&s)
+}
+
+/// True if `fs >= 0.0 and fs < 1.0`.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_fractional_second`.
+#[must_use]
+pub fn valid_fractional_second(fs: f64) -> bool {
+    fs.is_finite() && (0.0..1.0).contains(&fs)
+}
+
+/// True if `s` is a valid ISO-8601 date.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_iso8601_date`.
+#[must_use]
+pub fn valid_iso8601_date(s: &str) -> bool {
+    iso8601_parse::parse_date(s).is_some()
+}
+
+/// True if `s` is a valid ISO-8601 time.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_iso8601_time`.
+#[must_use]
+pub fn valid_iso8601_time(s: &str) -> bool {
+    iso8601_parse::parse_time(s).is_some()
+}
+
+/// True if `s` is a valid ISO-8601 date-time.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_iso8601_date_time`.
+#[must_use]
+pub fn valid_iso8601_date_time(s: &str) -> bool {
+    iso8601_parse::parse_date_time(s).is_some()
+}
+
+/// True if `s` is a valid ISO-8601 duration.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_iso8601_duration`.
+#[must_use]
+pub fn valid_iso8601_duration(s: &str) -> bool {
+    iso8601_parse::parse_duration(s).is_some()
+}
+
+/// The number of days in month `m` of year `y`, or `None` when the pair names
+/// no month of the calendar.
+///
+/// Spec: `time_definitions.adoc` §Functions `days_in_month`.
+#[must_use]
+pub fn days_in_month(y: i64, m: i64) -> Option<u32> {
+    let (Ok(year), Ok(month)) = (u32::try_from(y), u32::try_from(m)) else {
+        return None;
+    };
+    iso8601_parse::days_in_month(year, month)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Each numeric predicate is its own post-condition, at the boundary.
+    #[test]
+    fn the_numeric_predicates_are_their_post_conditions() {
+        assert!(valid_year(0) && valid_year(2024));
+        assert!(!valid_year(-1));
+
+        assert!(valid_month(1) && valid_month(12));
+        assert!(!valid_month(0) && !valid_month(13));
+
+        assert!(valid_minute(0) && valid_minute(59));
+        assert!(!valid_minute(60) && !valid_minute(-1));
+
+        assert!(valid_second(0) && valid_second(59));
+        assert!(
+            !valid_second(60),
+            "the post-condition is `s < Seconds_in_minute`"
+        );
+
+        assert!(valid_fractional_second(0.0) && valid_fractional_second(0.999));
+        assert!(!valid_fractional_second(1.0) && !valid_fractional_second(-0.1));
+        assert!(!valid_fractional_second(f64::NAN));
+    }
+
+    /// `valid_day` is defined via `days_in_month (m, y)`, so it answers the
+    /// leap year and refuses a month it cannot evaluate.
+    #[test]
+    fn valid_day_follows_the_month_length() {
+        assert!(valid_day(2024, 2, 29), "2024 is a leap year");
+        assert!(!valid_day(2023, 2, 29));
+        assert!(valid_day(2024, 1, 31) && !valid_day(2024, 4, 31));
+        assert!(!valid_day(2024, 0, 1), "no month to measure");
+        assert!(!valid_day(2024, 1, 0));
+    }
+
+    /// `24:00:00` is refused: the released `valid_hour` post-condition admits
+    /// it while the `Iso8601_time` class forbids it anywhere (#2276).
+    #[test]
+    fn the_twenty_fourth_hour_is_refused() {
+        assert!(valid_hour(23, 59, 59));
+        assert!(!valid_hour(24, 0, 0));
+        assert!(!valid_hour(-1, 0, 0));
+    }
+
+    /// The four string predicates are the one public answer to "is this a valid
+    /// ISO-8601 X" — the same readers every accessor and every arithmetic
+    /// function in this crate already uses.
+    #[test]
+    fn the_string_predicates_agree_with_the_readers() {
+        assert!(valid_iso8601_date("2024-02-29") && !valid_iso8601_date("2023-02-29"));
+        assert!(valid_iso8601_time("10:30:59") && !valid_iso8601_time("10:30:60"));
+        assert!(
+            valid_iso8601_date_time("2024-02-29T10:30:00")
+                && !valid_iso8601_date_time("2024-02-30T10:30:00")
+        );
+        assert!(valid_iso8601_duration("P1Y2M3DT4H5M6S"));
+        assert!(
+            !valid_iso8601_duration("P1Y1Y"),
+            "a repeated designator is not a duration"
+        );
+    }
+}

--- a/crates/openehr-rm/src/v1_1/data_types/quantity/date_time/dv_date_impl.rs
+++ b/crates/openehr-rm/src/v1_1/data_types/quantity/date_time/dv_date_impl.rs
@@ -18,7 +18,7 @@ use crate::v1_1::data_types::quantity::dv_absolute_quantity_impl::{
 use crate::v1_1::data_types::quantity::dv_amount_impl::CombinedAccuracy;
 use crate::v1_1::data_types::quantity::dv_ordered::DvOrdered;
 use crate::v1_1::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
-use crate::v1_1::validate::is_valid_iso_date;
+use crate::v1_1::validate::valid_iso8601_date;
 use openehr_base::v1_2::foundation_types::time::iso8601_date::Iso8601Date;
 use openehr_base::v1_2::foundation_types::time::iso8601_duration::Iso8601Duration;
 use openehr_base::validate::{InvariantViolation, Validate};
@@ -124,7 +124,7 @@ impl Validate for DvDate {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
         crate::v1_1::validate::generated::temporal_value_core(
             "DV_DATE",
-            is_valid_iso_date(&self.value),
+            valid_iso8601_date(&self.value),
             out,
         );
         crate::v1_1::validate::generated::magnitude_status_core(

--- a/crates/openehr-rm/src/v1_1/data_types/quantity/date_time/dv_date_time_impl.rs
+++ b/crates/openehr-rm/src/v1_1/data_types/quantity/date_time/dv_date_time_impl.rs
@@ -13,7 +13,7 @@ use crate::v1_1::data_types::quantity::dv_absolute_quantity_impl::{
 use crate::v1_1::data_types::quantity::dv_amount_impl::CombinedAccuracy;
 use crate::v1_1::data_types::quantity::dv_ordered::DvOrdered;
 use crate::v1_1::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
-use crate::v1_1::validate::is_valid_iso_date_time;
+use crate::v1_1::validate::valid_iso8601_date_time;
 use openehr_base::v1_2::foundation_types::time::iso8601_date_time::Iso8601DateTime;
 use openehr_base::v1_2::foundation_types::time::iso8601_duration::Iso8601Duration;
 use openehr_base::validate::{InvariantViolation, Validate};
@@ -97,7 +97,7 @@ impl Validate for DvDateTime {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
         crate::v1_1::validate::generated::temporal_value_core(
             "DV_DATE_TIME",
-            is_valid_iso_date_time(&self.value),
+            valid_iso8601_date_time(&self.value),
             out,
         );
         crate::v1_1::validate::generated::magnitude_status_core(

--- a/crates/openehr-rm/src/v1_1/data_types/quantity/date_time/dv_duration_impl.rs
+++ b/crates/openehr-rm/src/v1_1/data_types/quantity/date_time/dv_duration_impl.rs
@@ -12,7 +12,7 @@ use crate::v1_1::data_types::quantity::dv_amount_impl::{
 };
 use crate::v1_1::data_types::quantity::dv_ordered::DvOrdered;
 use crate::v1_1::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
-use crate::v1_1::validate::is_valid_iso_duration;
+use crate::v1_1::validate::valid_iso8601_duration;
 use openehr_base::v1_2::foundation_types::time::iso8601_duration::Iso8601Duration;
 use openehr_base::validate::{InvariantViolation, Validate};
 
@@ -135,7 +135,7 @@ impl Validate for DvDuration {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
         crate::v1_1::validate::generated::temporal_value_core(
             "DV_DURATION",
-            is_valid_iso_duration(&self.value),
+            valid_iso8601_duration(&self.value),
             out,
         );
         crate::v1_1::validate::generated::dv_amount_core(

--- a/crates/openehr-rm/src/v1_1/data_types/quantity/date_time/dv_time_impl.rs
+++ b/crates/openehr-rm/src/v1_1/data_types/quantity/date_time/dv_time_impl.rs
@@ -13,7 +13,7 @@ use crate::v1_1::data_types::quantity::dv_absolute_quantity_impl::{
 use crate::v1_1::data_types::quantity::dv_amount_impl::CombinedAccuracy;
 use crate::v1_1::data_types::quantity::dv_ordered::DvOrdered;
 use crate::v1_1::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
-use crate::v1_1::validate::is_valid_iso_time;
+use crate::v1_1::validate::valid_iso8601_time;
 use openehr_base::v1_2::foundation_types::time::iso8601_duration::Iso8601Duration;
 use openehr_base::v1_2::foundation_types::time::iso8601_time::Iso8601Time;
 use openehr_base::validate::{InvariantViolation, Validate};
@@ -97,7 +97,7 @@ impl Validate for DvTime {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
         crate::v1_1::validate::generated::temporal_value_core(
             "DV_TIME",
-            is_valid_iso_time(&self.value),
+            valid_iso8601_time(&self.value),
             out,
         );
         crate::v1_1::validate::generated::magnitude_status_core(

--- a/crates/openehr-rm/src/v1_1/data_types/quantity/dv_ordered_impl.rs
+++ b/crates/openehr-rm/src/v1_1/data_types/quantity/dv_ordered_impl.rs
@@ -48,7 +48,7 @@ use crate::v1_1::data_types::quantity::dv_proportion::DvProportion;
 use crate::v1_1::data_types::quantity::dv_quantity::DvQuantity;
 use crate::v1_1::data_types::quantity::dv_scale::DvScale;
 use crate::v1_1::validate::{
-    is_valid_iso_date, is_valid_iso_date_time, is_valid_iso_duration, is_valid_iso_time,
+    valid_iso8601_date, valid_iso8601_date_time, valid_iso8601_duration, valid_iso8601_time,
 };
 
 // ── BASE Time_definitions constants (nominal durations) ─────────────────────
@@ -78,7 +78,7 @@ fn parse_u32(s: &str) -> Option<u32> {
 /// Decompose an openEHR ISO-8601 date (extended or compact) into (y, m, d),
 /// defaulting missing parts to 1.
 fn date_parts(s: &str) -> Option<(i64, u32, u32)> {
-    if !is_valid_iso_date(s) {
+    if !valid_iso8601_date(s) {
         return None;
     }
     let (y, m, d) = if s.contains('-') {
@@ -195,7 +195,7 @@ fn time_core_seconds(s: &str) -> Option<f64> {
 /// start-of-day origin).
 #[must_use]
 pub(crate) fn iso_time_magnitude_seconds(s: &str) -> Option<f64> {
-    if !is_valid_iso_time(s) {
+    if !valid_iso8601_time(s) {
         return None;
     }
     let (core, _tz) = split_tz(s);
@@ -206,7 +206,7 @@ pub(crate) fn iso_time_magnitude_seconds(s: &str) -> Option<f64> {
 /// `DV_DATE_TIME.magnitude`); a stated timezone offset is normalised to UTC.
 #[must_use]
 pub(crate) fn iso_date_time_magnitude_seconds(s: &str) -> Option<f64> {
-    if !is_valid_iso_date_time(s) {
+    if !valid_iso8601_date_time(s) {
         return None;
     }
     #[expect(
@@ -231,7 +231,7 @@ pub(crate) fn iso_date_time_magnitude_seconds(s: &str) -> Option<f64> {
 /// `-` negates the whole value (openEHR deviation).
 #[must_use]
 pub(crate) fn iso_duration_to_seconds(s: &str) -> Option<f64> {
-    if !is_valid_iso_duration(s) {
+    if !valid_iso8601_duration(s) {
         return None;
     }
     let (sign, body) = match s.strip_prefix('-') {

--- a/crates/openehr-rm/src/v1_1/data_types/time_specification/dv_periodic_time_specification_impl.rs
+++ b/crates/openehr-rm/src/v1_1/data_types/time_specification/dv_periodic_time_specification_impl.rs
@@ -8,7 +8,7 @@
 
 use crate::v1_1::data_types::quantity::date_time::dv_duration::DvDuration;
 use crate::v1_1::data_types::time_specification::dv_periodic_time_specification::DvPeriodicTimeSpecification;
-use crate::v1_1::validate::is_valid_iso_duration;
+use crate::v1_1::validate::valid_iso8601_duration;
 use openehr_base::validate::{InvariantViolation, Validate};
 
 impl DvPeriodicTimeSpecification {
@@ -121,7 +121,7 @@ const INSTITUTION_SPECIFIED: &str = "IST";
 /// nobody. A difference in neither form has no duration.
 fn iso_duration(difference: &str) -> Option<String> {
     let difference = difference.trim();
-    if is_valid_iso_duration(difference) {
+    if valid_iso8601_duration(difference) {
         return Some(difference.to_owned());
     }
     let boundary = difference.find(|c: char| !c.is_ascii_digit() && c != '-')?;

--- a/crates/openehr-rm/src/v1_1/validate.rs
+++ b/crates/openehr-rm/src/v1_1/validate.rs
@@ -535,270 +535,14 @@ pub(crate) fn valid_proportion_kind(k: i32) -> bool {
 
 // The DV_DATE / DV_TIME / DV_DATE_TIME / DV_DURATION `Value_valid` invariants
 // are `valid_iso8601_date` / `_time` / `_date_time` / `_duration` (each class
-// page's §Invariants); their accepted complete, compact and partial forms are
-// enumerated in BASE `…foundation_types.time_definitions.adoc` §Functions,
-// including that page's stated exception allowing a `W` designator alongside
-// the others in a duration. `value` is a `String` here, so those grammars are
-// checked at runtime rather than guaranteed by a parsed temporal type.
+// page's §Invariants), and those are BASE `Time_Definitions` functions — so
+// this crate calls them rather than re-deriving the grammar. It used to carry
+// its own reader; the two drifted twice and both drifts shipped (#2273), each
+// time letting a value pass validation, commit, and then behave as invalid.
 
-fn all_digits(s: &str) -> bool {
-    !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit())
-}
-
-/// The byte sub-range of `s`, or `""` when the range is out of bounds or lands
-/// off a UTF-8 boundary.
-///
-/// The compact ISO 8601 forms below extract fixed byte windows only after an
-/// exact-length + all-ASCII-digits test, so the empty fallback is unreachable
-/// there; it exists so the extraction can never panic (a `""` window fails
-/// every `in_range`/`valid_day` predicate, i.e. it rejects rather than aborts).
-fn part(s: &str, range: std::ops::Range<usize>) -> &str {
-    s.get(range).unwrap_or_default()
-}
-
-fn digits_n(s: &str, n: usize) -> bool {
-    s.len() == n && all_digits(s)
-}
-
-fn in_range(s: &str, lo: u32, hi: u32) -> bool {
-    s.len() == 2 && all_digits(s) && s.parse::<u32>().is_ok_and(|v| (lo..=hi).contains(&v))
-}
-
-/// `true` for a Gregorian leap year: divisible by 4, except centuries not
-/// divisible by 400 (BASE `Time_definitions`; the calendar `days_in_month`
-/// depends on it).
-fn is_leap_year(year: u32) -> bool {
-    (year.is_multiple_of(4) && !year.is_multiple_of(100)) || year.is_multiple_of(400)
-}
-
-/// Calendar days in a given month of a given year — the `days_in_month (m, y)`
-/// the BASE `Time_definitions.valid_day` postcondition dispatches through
-/// (`docs/specs/openehr/BASE/docs/UML/classes/org.openehr.base.foundation_types.time_definitions.adoc`
-/// lines 95–103). Returns `0` for a month outside `1..=12` (caller has already
-/// range-checked the month, so that branch is defensive).
-fn days_in_month(year: u32, month: u32) -> u32 {
-    match month {
-        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
-        4 | 6 | 9 | 11 => 30,
-        2 if is_leap_year(year) => 29,
-        2 => 28,
-        _ => 0,
-    }
-}
-
-/// A calendar-valid two-digit day for the 4-digit `y` / 2-digit `m` strings:
-/// `d` is `01`..`days_in_month(m, y)` — the BASE `Iso8601_date` invariant
-/// `Day_valid: not day_unknown implies valid_day (year, month, day)` with
-/// `valid_day (y, m, d) = (d >= 1 and d <= days_in_month (m, y))`
-/// (`org.openehr.base.foundation_types.iso8601_date.adoc` line 107;
-/// `time_definitions.adoc` line 102). This is calendar-exact — it rejects
-/// `2021-02-31`, `2021-04-31`, and `2021-02-29` (non-leap) while accepting
-/// `2020-02-29` (leap).
-fn valid_day(y: &str, m: &str, d: &str) -> bool {
-    if d.len() != 2 || !all_digits(d) {
-        return false;
-    }
-    let (Ok(year), Ok(month), Ok(day)) = (y.parse::<u32>(), m.parse::<u32>(), d.parse::<u32>())
-    else {
-        return false;
-    };
-    (1..=days_in_month(year, month)).contains(&day)
-}
-
-/// A valid openEHR ISO-8601 date: `YYYY`, `YYYY-MM`, `YYYY-MM-DD`, or the
-/// compact `YYYYMM` / `YYYYMMDD` forms. Day validity is **calendar-exact**
-/// (month lengths + leap years) per BASE `Iso8601_date.Day_valid`, not a bare
-/// `1..=31` range.
-#[must_use]
-pub(crate) fn is_valid_iso_date(s: &str) -> bool {
-    if s.contains('-') {
-        match s.split('-').collect::<Vec<_>>().as_slice() {
-            [y] => digits_n(y, 4),
-            [y, m] => digits_n(y, 4) && in_range(m, 1, 12),
-            [y, m, d] => digits_n(y, 4) && in_range(m, 1, 12) && valid_day(y, m, d),
-            _ => false,
-        }
-    } else {
-        match s.len() {
-            4 => all_digits(s),
-            6 => all_digits(s) && in_range(part(s, 4..6), 1, 12),
-            8 => {
-                all_digits(s)
-                    && in_range(part(s, 4..6), 1, 12)
-                    && valid_day(part(s, 0..4), part(s, 4..6), part(s, 6..8))
-            }
-            _ => false,
-        }
-    }
-}
-
-fn is_valid_tz(tz: &str) -> bool {
-    if tz.is_empty() || tz == "Z" {
-        return true;
-    }
-    let Some(rest) = tz.strip_prefix(['+', '-']) else {
-        return false;
-    };
-    // BASE `Iso8601_timezone` bounds are ASYMMETRIC (`iso8601_timezone.adoc`
-    // Max_hour_valid / Min_hour_valid; `time_definitions.adoc`
-    // Max_timezone_hour = 14, Min_timezone_hour = 12): `+` offsets go to
-    // +14:00, `-` offsets only to -12:00 (reject `-13:00`).
-    //
-    // NOTE: hour 0 is accepted with either sign — `iso8601_timezone.adoc`
-    // §Description gives `hh` as "`00` - `23`" and §Functions defines `is_gmt`
-    // as "timezone `+0000`", which the `hour > 0` invariants would forbid.
-    let max_hour = if tz.starts_with('+') { 14 } else { 12 };
-    if rest.contains(':') {
-        matches!(rest.split(':').collect::<Vec<_>>().as_slice(),
-            [h, m] if in_range(h, 0, max_hour) && in_range(m, 0, 59))
-    } else {
-        match rest.len() {
-            2 => in_range(rest, 0, max_hour),
-            4 => in_range(part(rest, 0..2), 0, max_hour) && in_range(part(rest, 2..4), 0, 59),
-            _ => false,
-        }
-    }
-}
-
-fn is_valid_time_core(s: &str) -> bool {
-    // NOTE: a decimal fraction is legal only on seconds — BASE
-    // `master06-time_types.adoc`: "only fractional seconds are supported".
-    //
-    // NOTE: seconds are `0..=59` per `time_definitions.adoc` §Functions
-    // `valid_second` (`Post: … s < Seconds_in_minute`) — the machine-checkable
-    // clause, which BASE's own reader also took over the `00`-`60` prose.
-    let (base, frac) = match s.split_once(['.', ',']) {
-        Some((b, f)) => (b, Some(f)),
-        None => (s, None),
-    };
-    if let Some(f) = frac
-        && !all_digits(f)
-    {
-        return false;
-    }
-    let has_frac = frac.is_some();
-    if base.contains(':') {
-        match base.split(':').collect::<Vec<_>>().as_slice() {
-            [h] => !has_frac && in_range(h, 0, 23),
-            [h, m] => !has_frac && in_range(h, 0, 23) && in_range(m, 0, 59),
-            [h, m, sec] => in_range(h, 0, 23) && in_range(m, 0, 59) && in_range(sec, 0, 59),
-            _ => false,
-        }
-    } else {
-        match base.len() {
-            2 => !has_frac && in_range(base, 0, 23),
-            4 => {
-                !has_frac && in_range(part(base, 0..2), 0, 23) && in_range(part(base, 2..4), 0, 59)
-            }
-            6 => {
-                in_range(part(base, 0..2), 0, 23)
-                    && in_range(part(base, 2..4), 0, 59)
-                    && in_range(part(base, 4..6), 0, 59)
-            }
-            _ => false,
-        }
-    }
-}
-
-/// A valid openEHR ISO-8601 time: `HH`, `HH:MM`, `HH:MM:SS[.fff]` (and the
-/// compact `HHMM` / `HHMMSS` forms), with an optional `Z` / `±HH[:MM]` timezone.
-#[must_use]
-pub(crate) fn is_valid_iso_time(s: &str) -> bool {
-    // Split off a trailing timezone (`Z`, or a `+`/`-` offset that is not the
-    // fractional separator). Scan from the end for `Z`/`+`/`-`.
-    if let Some(stripped) = s.strip_suffix('Z') {
-        return is_valid_time_core(stripped);
-    }
-    if let Some((core, tz)) = s.rfind(['+', '-']).and_then(|pos| s.split_at_checked(pos)) {
-        return is_valid_time_core(core) && is_valid_tz(tz);
-    }
-    is_valid_time_core(s)
-}
-
-/// A valid openEHR ISO-8601 date-time: a date, then (if a time component is
-/// present) `T` and a time. A `T`-less value is accepted as a date-only partial.
-#[must_use]
-pub(crate) fn is_valid_iso_date_time(s: &str) -> bool {
-    match s.split_once('T') {
-        Some((date, time)) => is_valid_iso_date(date) && is_valid_iso_time(time),
-        None => is_valid_iso_date(s),
-    }
-}
-
-fn parse_duration_components(s: &str, allowed: &[u8], any: &mut bool) -> bool {
-    let bytes = s.as_bytes();
-    let mut i = 0;
-    // `allowed` is the production's own order (`YMWD`, then `HMS`), so a
-    // designator's index in it IS its slot: requiring the slot to advance
-    // strictly enforces both "in order" and "at most once" in one test.
-    // Without it `P1Y1Y` validated here while BASE's reader refused the same
-    // string and `iso_duration_to_seconds` summed BOTH years — one value, three
-    // in-tree answers, none of them the spec's.
-    let mut last_slot: isize = -1;
-    while i < bytes.len() {
-        let start = i;
-        while bytes.get(i).is_some_and(u8::is_ascii_digit) {
-            i += 1;
-        }
-        let mut has_fraction = false;
-        if matches!(bytes.get(i), Some(b'.' | b',')) {
-            has_fraction = true;
-            i += 1;
-            while bytes.get(i).is_some_and(u8::is_ascii_digit) {
-                i += 1;
-            }
-        }
-        // No number, or a number with no designator after it.
-        let Some(&designator) = bytes.get(i) else {
-            return false;
-        };
-        if i == start {
-            return false;
-        }
-        let Some(slot) = allowed.iter().position(|d| *d == designator) else {
-            return false;
-        };
-        let slot = slot.cast_signed();
-        if slot <= last_slot {
-            return false;
-        }
-        last_slot = slot;
-        // BASE `master06-time_types.adoc` §Primitive Time Types: "in openEHR,
-        // only fractional seconds are supported" — a decimal fraction is only
-        // permitted on the seconds ('S') component, never on Y/M/W/D/H/M.
-        if has_fraction && designator != b'S' {
-            return false;
-        }
-        i += 1;
-        *any = true;
-    }
-    true
-}
-
-/// A valid openEHR ISO-8601 duration: optional leading sign, `P`, then one or
-/// more `nY nM nW nD` components and an optional `T nH nM nS` part (openEHR
-/// permits the sign and a `W` designator mixed with the others).
-#[must_use]
-pub(crate) fn is_valid_iso_duration(s: &str) -> bool {
-    let s = s.strip_prefix(['+', '-']).unwrap_or(s);
-    let Some(rest) = s.strip_prefix('P') else {
-        return false;
-    };
-    let (date_part, time_part) = match rest.split_once('T') {
-        Some((d, t)) => (d, Some(t)),
-        None => (rest, None),
-    };
-    let mut any = false;
-    if !parse_duration_components(date_part, b"YMWD", &mut any) {
-        return false;
-    }
-    if let Some(t) = time_part
-        && (t.is_empty() || !parse_duration_components(t, b"HMS", &mut any))
-    {
-        return false;
-    }
-    any
-}
+pub(crate) use openehr_base::v1_2::foundation_types::time::time_definitions::{
+    valid_iso8601_date, valid_iso8601_date_time, valid_iso8601_duration, valid_iso8601_time,
+};
 
 #[cfg(test)]
 mod tests {
@@ -806,14 +550,14 @@ mod tests {
 
     #[test]
     fn iso_date_forms() {
-        assert!(is_valid_iso_date("2021"));
-        assert!(is_valid_iso_date("2021-05"));
-        assert!(is_valid_iso_date("2021-05-17"));
-        assert!(is_valid_iso_date("20210517"));
-        assert!(!is_valid_iso_date("2021-13"));
-        assert!(!is_valid_iso_date("2021-05-32"));
-        assert!(!is_valid_iso_date("not-a-date"));
-        assert!(!is_valid_iso_date(""));
+        assert!(valid_iso8601_date("2021"));
+        assert!(valid_iso8601_date("2021-05"));
+        assert!(valid_iso8601_date("2021-05-17"));
+        assert!(valid_iso8601_date("20210517"));
+        assert!(!valid_iso8601_date("2021-13"));
+        assert!(!valid_iso8601_date("2021-05-32"));
+        assert!(!valid_iso8601_date("not-a-date"));
+        assert!(!valid_iso8601_date(""));
     }
 
     /// BASE `Iso8601_date.Day_valid` (`valid_day = d <= days_in_month(m, y)`,
@@ -822,44 +566,44 @@ mod tests {
     #[test]
     fn iso_date_day_is_calendar_exact() {
         // 31-day months accept 31; 30-day months reject it.
-        assert!(is_valid_iso_date("2021-01-31"));
-        assert!(is_valid_iso_date("2021-12-31"));
-        assert!(!is_valid_iso_date("2021-04-31")); // April has 30 days
-        assert!(!is_valid_iso_date("2021-06-31"));
-        assert!(!is_valid_iso_date("2021-09-31"));
-        assert!(!is_valid_iso_date("2021-11-31"));
-        assert!(is_valid_iso_date("2021-04-30"));
+        assert!(valid_iso8601_date("2021-01-31"));
+        assert!(valid_iso8601_date("2021-12-31"));
+        assert!(!valid_iso8601_date("2021-04-31")); // April has 30 days
+        assert!(!valid_iso8601_date("2021-06-31"));
+        assert!(!valid_iso8601_date("2021-09-31"));
+        assert!(!valid_iso8601_date("2021-11-31"));
+        assert!(valid_iso8601_date("2021-04-30"));
 
         // February: 28 in a common year, 29 in a leap year, never 30/31.
-        assert!(!is_valid_iso_date("2021-02-31"));
-        assert!(!is_valid_iso_date("2021-02-30"));
-        assert!(!is_valid_iso_date("2021-02-29")); // 2021 is not a leap year
-        assert!(is_valid_iso_date("2021-02-28"));
-        assert!(is_valid_iso_date("2020-02-29")); // 2020 divisible by 4
-        assert!(is_valid_iso_date("2000-02-29")); // 2000 divisible by 400
-        assert!(!is_valid_iso_date("1900-02-29")); // 1900 century, not /400
+        assert!(!valid_iso8601_date("2021-02-31"));
+        assert!(!valid_iso8601_date("2021-02-30"));
+        assert!(!valid_iso8601_date("2021-02-29")); // 2021 is not a leap year
+        assert!(valid_iso8601_date("2021-02-28"));
+        assert!(valid_iso8601_date("2020-02-29")); // 2020 divisible by 4
+        assert!(valid_iso8601_date("2000-02-29")); // 2000 divisible by 400
+        assert!(!valid_iso8601_date("1900-02-29")); // 1900 century, not /400
 
         // Day 00 is never valid.
-        assert!(!is_valid_iso_date("2021-05-00"));
+        assert!(!valid_iso8601_date("2021-05-00"));
 
         // Compact form is held to the same calendar rule.
-        assert!(!is_valid_iso_date("20210431"));
-        assert!(!is_valid_iso_date("20210229"));
-        assert!(is_valid_iso_date("20200229"));
-        assert!(is_valid_iso_date("20210131"));
+        assert!(!valid_iso8601_date("20210431"));
+        assert!(!valid_iso8601_date("20210229"));
+        assert!(valid_iso8601_date("20200229"));
+        assert!(valid_iso8601_date("20210131"));
     }
 
     #[test]
     fn iso_time_forms() {
-        assert!(is_valid_iso_time("10"));
-        assert!(is_valid_iso_time("10:30"));
-        assert!(is_valid_iso_time("10:30:59"));
-        assert!(is_valid_iso_time("10:30:59.250"));
-        assert!(is_valid_iso_time("10:30:59Z"));
-        assert!(is_valid_iso_time("10:30:59+01:00"));
-        assert!(!is_valid_iso_time("25:00"));
-        assert!(!is_valid_iso_time("10:61"));
-        assert!(!is_valid_iso_time("abc"));
+        assert!(valid_iso8601_time("10"));
+        assert!(valid_iso8601_time("10:30"));
+        assert!(valid_iso8601_time("10:30:59"));
+        assert!(valid_iso8601_time("10:30:59.250"));
+        assert!(valid_iso8601_time("10:30:59Z"));
+        assert!(valid_iso8601_time("10:30:59+01:00"));
+        assert!(!valid_iso8601_time("25:00"));
+        assert!(!valid_iso8601_time("10:61"));
+        assert!(!valid_iso8601_time("abc"));
     }
 
     /// BASE `foundation_types/master06-time_types.adoc` §"ISO 8601 semantics
@@ -870,39 +614,39 @@ mod tests {
     #[test]
     fn iso_time_fraction_only_on_seconds() {
         // Fractional seconds (period or comma) is the sole permitted case.
-        assert!(is_valid_iso_time("10:30:59.250"));
-        assert!(is_valid_iso_time("10:30:59,5"));
-        assert!(is_valid_iso_time("103059.250")); // compact HHMMSS
-        assert!(is_valid_iso_time("10:30:59.5+01:00")); // fraction before timezone
+        assert!(valid_iso8601_time("10:30:59.250"));
+        assert!(valid_iso8601_time("10:30:59,5"));
+        assert!(valid_iso8601_time("103059.250")); // compact HHMMSS
+        assert!(valid_iso8601_time("10:30:59.5+01:00")); // fraction before timezone
         // A fractional hour or minute is rejected in every base form.
-        assert!(!is_valid_iso_time("10.5")); // fractional hour
-        assert!(!is_valid_iso_time("10:05.5")); // fractional minute (extended)
-        assert!(!is_valid_iso_time("1005.5")); // fractional minute (compact HHMM)
-        assert!(!is_valid_iso_time("10,5")); // fractional hour, comma
+        assert!(!valid_iso8601_time("10.5")); // fractional hour
+        assert!(!valid_iso8601_time("10:05.5")); // fractional minute (extended)
+        assert!(!valid_iso8601_time("1005.5")); // fractional minute (compact HHMM)
+        assert!(!valid_iso8601_time("10,5")); // fractional hour, comma
     }
 
     #[test]
     fn iso_date_time_forms() {
-        assert!(is_valid_iso_date_time("2021-05-17T10:30:00"));
-        assert!(is_valid_iso_date_time("2021-05-17T10:30:00+02:00"));
-        assert!(is_valid_iso_date_time("2021-05-17"));
-        assert!(!is_valid_iso_date_time("2021-05-17T99:00"));
-        assert!(!is_valid_iso_date_time("nope"));
+        assert!(valid_iso8601_date_time("2021-05-17T10:30:00"));
+        assert!(valid_iso8601_date_time("2021-05-17T10:30:00+02:00"));
+        assert!(valid_iso8601_date_time("2021-05-17"));
+        assert!(!valid_iso8601_date_time("2021-05-17T99:00"));
+        assert!(!valid_iso8601_date_time("nope"));
     }
 
     #[test]
     fn iso_duration_forms() {
-        assert!(is_valid_iso_duration("P1Y"));
-        assert!(is_valid_iso_duration("P1Y2M10D"));
-        assert!(is_valid_iso_duration("PT2H30M"));
-        assert!(is_valid_iso_duration("P1Y2M10DT2H30M"));
-        assert!(is_valid_iso_duration("P2W"));
-        assert!(is_valid_iso_duration("-P1D"));
-        assert!(is_valid_iso_duration("PT0.5S"));
-        assert!(!is_valid_iso_duration("P"));
-        assert!(!is_valid_iso_duration("1Y"));
-        assert!(!is_valid_iso_duration("P1X"));
-        assert!(!is_valid_iso_duration("PT"));
+        assert!(valid_iso8601_duration("P1Y"));
+        assert!(valid_iso8601_duration("P1Y2M10D"));
+        assert!(valid_iso8601_duration("PT2H30M"));
+        assert!(valid_iso8601_duration("P1Y2M10DT2H30M"));
+        assert!(valid_iso8601_duration("P2W"));
+        assert!(valid_iso8601_duration("-P1D"));
+        assert!(valid_iso8601_duration("PT0.5S"));
+        assert!(!valid_iso8601_duration("P"));
+        assert!(!valid_iso8601_duration("1Y"));
+        assert!(!valid_iso8601_duration("P1X"));
+        assert!(!valid_iso8601_duration("PT"));
     }
 
     /// This validator and BASE's `Iso8601Time` reader must accept the same
@@ -919,7 +663,7 @@ mod tests {
             .hour()
             .is_some();
             assert_eq!(
-                is_valid_iso_time(value),
+                valid_iso8601_time(value),
                 base,
                 "{value:?}: the RM validator and the BASE reader disagree",
             );
@@ -954,7 +698,7 @@ mod tests {
                 .to_seconds()
                 .is_some();
             assert_eq!(
-                is_valid_iso_duration(value),
+                valid_iso8601_duration(value),
                 base,
                 "{value:?}: the RM validator and the BASE reader disagree",
             );
@@ -968,17 +712,17 @@ mod tests {
     #[test]
     fn iso_duration_fraction_only_on_seconds() {
         // Fraction on seconds (period or comma) is the sole permitted case.
-        assert!(is_valid_iso_duration("PT2H30M0.5S"));
-        assert!(is_valid_iso_duration("PT0,5S"));
+        assert!(valid_iso8601_duration("PT2H30M0.5S"));
+        assert!(valid_iso8601_duration("PT0,5S"));
         // Fraction on any other component is rejected.
-        assert!(!is_valid_iso_duration("P1Y3M4DT2.5H"));
-        assert!(!is_valid_iso_duration("PT2H14.5M"));
-        assert!(!is_valid_iso_duration("P1.5Y"));
-        assert!(!is_valid_iso_duration("P1.5M"));
-        assert!(!is_valid_iso_duration("P1.5W"));
-        assert!(!is_valid_iso_duration("P1.5D"));
-        assert!(!is_valid_iso_duration("PT1.5H"));
-        assert!(!is_valid_iso_duration("PT2H14,5M"));
+        assert!(!valid_iso8601_duration("P1Y3M4DT2.5H"));
+        assert!(!valid_iso8601_duration("PT2H14.5M"));
+        assert!(!valid_iso8601_duration("P1.5Y"));
+        assert!(!valid_iso8601_duration("P1.5M"));
+        assert!(!valid_iso8601_duration("P1.5W"));
+        assert!(!valid_iso8601_duration("P1.5D"));
+        assert!(!valid_iso8601_duration("PT1.5H"));
+        assert!(!valid_iso8601_duration("PT2H14,5M"));
     }
 
     // NOTE: the `_type`-dispatch tests live in
@@ -989,16 +733,16 @@ mod tests {
     /// -12:00; ±00:00 is accepted (see `is_valid_tz`).
     #[test]
     fn timezone_bounds_are_asymmetric() {
-        assert!(is_valid_iso_time("10:00:00+14:00"));
-        assert!(is_valid_iso_time("10:00:00-12:00"));
-        assert!(is_valid_iso_time("10:00:00+00:00"));
-        assert!(is_valid_iso_time("10:00:00-00:00"));
+        assert!(valid_iso8601_time("10:00:00+14:00"));
+        assert!(valid_iso8601_time("10:00:00-12:00"));
+        assert!(valid_iso8601_time("10:00:00+00:00"));
+        assert!(valid_iso8601_time("10:00:00-00:00"));
         assert!(
-            !is_valid_iso_time("10:00:00+15:00"),
+            !valid_iso8601_time("10:00:00+15:00"),
             "+15 exceeds Max_timezone_hour"
         );
         assert!(
-            !is_valid_iso_time("10:00:00-13:00"),
+            !valid_iso8601_time("10:00:00-13:00"),
             "-13 exceeds Min_timezone_hour"
         );
     }

--- a/crates/openehr-rm/src/v1_1/validate/fast.rs
+++ b/crates/openehr-rm/src/v1_1/validate/fast.rs
@@ -82,7 +82,7 @@ use serde_json::{Map, Value};
 use crate::v1_1::model::{Container, RmClass};
 use crate::v1_1::validate::generated;
 use crate::v1_1::validate::{
-    is_valid_iso_date, is_valid_iso_date_time, is_valid_iso_duration, is_valid_iso_time,
+    valid_iso8601_date, valid_iso8601_date_time, valid_iso8601_duration, valid_iso8601_time,
 };
 use openehr_base::validate::{InvariantViolation, Validate};
 
@@ -451,7 +451,7 @@ fn run_invariants(ty: &str, obj: &Map<String, Value>, out: &mut Vec<InvariantVio
                 let Some(value) = str_of(obj, "value") else {
                     return false;
                 };
-                generated::temporal_value_core(ty, is_valid_iso_duration(value), out);
+                generated::temporal_value_core(ty, valid_iso8601_duration(value), out);
             }
             generated::dv_amount_core(
                 ty,
@@ -466,9 +466,9 @@ fn run_invariants(ty: &str, obj: &Map<String, Value>, out: &mut Vec<InvariantVio
                 return false;
             };
             let valid = match ty {
-                "DV_DATE" => is_valid_iso_date(value),
-                "DV_TIME" => is_valid_iso_time(value),
-                _ => is_valid_iso_date_time(value),
+                "DV_DATE" => valid_iso8601_date(value),
+                "DV_TIME" => valid_iso8601_time(value),
+                _ => valid_iso8601_date_time(value),
             };
             generated::temporal_value_core(ty, valid, out);
             generated::magnitude_status_core(ty, str_of(obj, "magnitude_status"), out);

--- a/crates/openehr-rm/src/v1_2/data_types/quantity/date_time/dv_date_impl.rs
+++ b/crates/openehr-rm/src/v1_2/data_types/quantity/date_time/dv_date_impl.rs
@@ -18,7 +18,7 @@ use crate::v1_2::data_types::quantity::dv_absolute_quantity_impl::{
 use crate::v1_2::data_types::quantity::dv_amount_impl::CombinedAccuracy;
 use crate::v1_2::data_types::quantity::dv_ordered::DvOrdered;
 use crate::v1_2::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
-use crate::v1_2::validate::is_valid_iso_date;
+use crate::v1_2::validate::valid_iso8601_date;
 use openehr_base::v1_3::foundation_types::time::iso8601_date::Iso8601Date;
 use openehr_base::v1_3::foundation_types::time::iso8601_duration::Iso8601Duration;
 use openehr_base::validate::{InvariantViolation, Validate};
@@ -124,7 +124,7 @@ impl Validate for DvDate {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
         crate::v1_2::validate::generated::temporal_value_core(
             "DV_DATE",
-            is_valid_iso_date(&self.value),
+            valid_iso8601_date(&self.value),
             out,
         );
         crate::v1_2::validate::generated::magnitude_status_core(

--- a/crates/openehr-rm/src/v1_2/data_types/quantity/date_time/dv_date_time_impl.rs
+++ b/crates/openehr-rm/src/v1_2/data_types/quantity/date_time/dv_date_time_impl.rs
@@ -13,7 +13,7 @@ use crate::v1_2::data_types::quantity::dv_absolute_quantity_impl::{
 use crate::v1_2::data_types::quantity::dv_amount_impl::CombinedAccuracy;
 use crate::v1_2::data_types::quantity::dv_ordered::DvOrdered;
 use crate::v1_2::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
-use crate::v1_2::validate::is_valid_iso_date_time;
+use crate::v1_2::validate::valid_iso8601_date_time;
 use openehr_base::v1_3::foundation_types::time::iso8601_date_time::Iso8601DateTime;
 use openehr_base::v1_3::foundation_types::time::iso8601_duration::Iso8601Duration;
 use openehr_base::validate::{InvariantViolation, Validate};
@@ -97,7 +97,7 @@ impl Validate for DvDateTime {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
         crate::v1_2::validate::generated::temporal_value_core(
             "DV_DATE_TIME",
-            is_valid_iso_date_time(&self.value),
+            valid_iso8601_date_time(&self.value),
             out,
         );
         crate::v1_2::validate::generated::magnitude_status_core(

--- a/crates/openehr-rm/src/v1_2/data_types/quantity/date_time/dv_duration_impl.rs
+++ b/crates/openehr-rm/src/v1_2/data_types/quantity/date_time/dv_duration_impl.rs
@@ -12,7 +12,7 @@ use crate::v1_2::data_types::quantity::dv_amount_impl::{
 };
 use crate::v1_2::data_types::quantity::dv_ordered::DvOrdered;
 use crate::v1_2::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
-use crate::v1_2::validate::is_valid_iso_duration;
+use crate::v1_2::validate::valid_iso8601_duration;
 use openehr_base::v1_3::foundation_types::time::iso8601_duration::Iso8601Duration;
 use openehr_base::validate::{InvariantViolation, Validate};
 
@@ -135,7 +135,7 @@ impl Validate for DvDuration {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
         crate::v1_2::validate::generated::temporal_value_core(
             "DV_DURATION",
-            is_valid_iso_duration(&self.value),
+            valid_iso8601_duration(&self.value),
             out,
         );
         crate::v1_2::validate::generated::dv_amount_core(

--- a/crates/openehr-rm/src/v1_2/data_types/quantity/date_time/dv_time_impl.rs
+++ b/crates/openehr-rm/src/v1_2/data_types/quantity/date_time/dv_time_impl.rs
@@ -13,7 +13,7 @@ use crate::v1_2::data_types::quantity::dv_absolute_quantity_impl::{
 use crate::v1_2::data_types::quantity::dv_amount_impl::CombinedAccuracy;
 use crate::v1_2::data_types::quantity::dv_ordered::DvOrdered;
 use crate::v1_2::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
-use crate::v1_2::validate::is_valid_iso_time;
+use crate::v1_2::validate::valid_iso8601_time;
 use openehr_base::v1_3::foundation_types::time::iso8601_duration::Iso8601Duration;
 use openehr_base::v1_3::foundation_types::time::iso8601_time::Iso8601Time;
 use openehr_base::validate::{InvariantViolation, Validate};
@@ -97,7 +97,7 @@ impl Validate for DvTime {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
         crate::v1_2::validate::generated::temporal_value_core(
             "DV_TIME",
-            is_valid_iso_time(&self.value),
+            valid_iso8601_time(&self.value),
             out,
         );
         crate::v1_2::validate::generated::magnitude_status_core(

--- a/crates/openehr-rm/src/v1_2/data_types/quantity/dv_ordered_impl.rs
+++ b/crates/openehr-rm/src/v1_2/data_types/quantity/dv_ordered_impl.rs
@@ -48,7 +48,7 @@ use crate::v1_2::data_types::quantity::dv_proportion::DvProportion;
 use crate::v1_2::data_types::quantity::dv_quantity::DvQuantity;
 use crate::v1_2::data_types::quantity::dv_scale::DvScale;
 use crate::v1_2::validate::{
-    is_valid_iso_date, is_valid_iso_date_time, is_valid_iso_duration, is_valid_iso_time,
+    valid_iso8601_date, valid_iso8601_date_time, valid_iso8601_duration, valid_iso8601_time,
 };
 
 // ── BASE Time_definitions constants (nominal durations) ─────────────────────
@@ -78,7 +78,7 @@ fn parse_u32(s: &str) -> Option<u32> {
 /// Decompose an openEHR ISO-8601 date (extended or compact) into (y, m, d),
 /// defaulting missing parts to 1.
 fn date_parts(s: &str) -> Option<(i64, u32, u32)> {
-    if !is_valid_iso_date(s) {
+    if !valid_iso8601_date(s) {
         return None;
     }
     let (y, m, d) = if s.contains('-') {
@@ -195,7 +195,7 @@ fn time_core_seconds(s: &str) -> Option<f64> {
 /// start-of-day origin).
 #[must_use]
 pub(crate) fn iso_time_magnitude_seconds(s: &str) -> Option<f64> {
-    if !is_valid_iso_time(s) {
+    if !valid_iso8601_time(s) {
         return None;
     }
     let (core, _tz) = split_tz(s);
@@ -206,7 +206,7 @@ pub(crate) fn iso_time_magnitude_seconds(s: &str) -> Option<f64> {
 /// `DV_DATE_TIME.magnitude`); a stated timezone offset is normalised to UTC.
 #[must_use]
 pub(crate) fn iso_date_time_magnitude_seconds(s: &str) -> Option<f64> {
-    if !is_valid_iso_date_time(s) {
+    if !valid_iso8601_date_time(s) {
         return None;
     }
     #[expect(
@@ -231,7 +231,7 @@ pub(crate) fn iso_date_time_magnitude_seconds(s: &str) -> Option<f64> {
 /// `-` negates the whole value (openEHR deviation).
 #[must_use]
 pub(crate) fn iso_duration_to_seconds(s: &str) -> Option<f64> {
-    if !is_valid_iso_duration(s) {
+    if !valid_iso8601_duration(s) {
         return None;
     }
     let (sign, body) = match s.strip_prefix('-') {

--- a/crates/openehr-rm/src/v1_2/data_types/time_specification/dv_periodic_time_specification_impl.rs
+++ b/crates/openehr-rm/src/v1_2/data_types/time_specification/dv_periodic_time_specification_impl.rs
@@ -8,7 +8,7 @@
 
 use crate::v1_2::data_types::quantity::date_time::dv_duration::DvDuration;
 use crate::v1_2::data_types::time_specification::dv_periodic_time_specification::DvPeriodicTimeSpecification;
-use crate::v1_2::validate::is_valid_iso_duration;
+use crate::v1_2::validate::valid_iso8601_duration;
 use openehr_base::validate::{InvariantViolation, Validate};
 
 impl DvPeriodicTimeSpecification {
@@ -121,7 +121,7 @@ const INSTITUTION_SPECIFIED: &str = "IST";
 /// nobody. A difference in neither form has no duration.
 fn iso_duration(difference: &str) -> Option<String> {
     let difference = difference.trim();
-    if is_valid_iso_duration(difference) {
+    if valid_iso8601_duration(difference) {
         return Some(difference.to_owned());
     }
     let boundary = difference.find(|c: char| !c.is_ascii_digit() && c != '-')?;

--- a/crates/openehr-rm/src/v1_2/validate.rs
+++ b/crates/openehr-rm/src/v1_2/validate.rs
@@ -535,270 +535,14 @@ pub(crate) fn valid_proportion_kind(k: i32) -> bool {
 
 // The DV_DATE / DV_TIME / DV_DATE_TIME / DV_DURATION `Value_valid` invariants
 // are `valid_iso8601_date` / `_time` / `_date_time` / `_duration` (each class
-// page's §Invariants); their accepted complete, compact and partial forms are
-// enumerated in BASE `…foundation_types.time_definitions.adoc` §Functions,
-// including that page's stated exception allowing a `W` designator alongside
-// the others in a duration. `value` is a `String` here, so those grammars are
-// checked at runtime rather than guaranteed by a parsed temporal type.
+// page's §Invariants), and those are BASE `Time_Definitions` functions — so
+// this crate calls them rather than re-deriving the grammar. It used to carry
+// its own reader; the two drifted twice and both drifts shipped (#2273), each
+// time letting a value pass validation, commit, and then behave as invalid.
 
-fn all_digits(s: &str) -> bool {
-    !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit())
-}
-
-/// The byte sub-range of `s`, or `""` when the range is out of bounds or lands
-/// off a UTF-8 boundary.
-///
-/// The compact ISO 8601 forms below extract fixed byte windows only after an
-/// exact-length + all-ASCII-digits test, so the empty fallback is unreachable
-/// there; it exists so the extraction can never panic (a `""` window fails
-/// every `in_range`/`valid_day` predicate, i.e. it rejects rather than aborts).
-fn part(s: &str, range: std::ops::Range<usize>) -> &str {
-    s.get(range).unwrap_or_default()
-}
-
-fn digits_n(s: &str, n: usize) -> bool {
-    s.len() == n && all_digits(s)
-}
-
-fn in_range(s: &str, lo: u32, hi: u32) -> bool {
-    s.len() == 2 && all_digits(s) && s.parse::<u32>().is_ok_and(|v| (lo..=hi).contains(&v))
-}
-
-/// `true` for a Gregorian leap year: divisible by 4, except centuries not
-/// divisible by 400 (BASE `Time_definitions`; the calendar `days_in_month`
-/// depends on it).
-fn is_leap_year(year: u32) -> bool {
-    (year.is_multiple_of(4) && !year.is_multiple_of(100)) || year.is_multiple_of(400)
-}
-
-/// Calendar days in a given month of a given year — the `days_in_month (m, y)`
-/// the BASE `Time_definitions.valid_day` postcondition dispatches through
-/// (`docs/specs/openehr/BASE/docs/UML/classes/org.openehr.base.foundation_types.time_definitions.adoc`
-/// lines 95–103). Returns `0` for a month outside `1..=12` (caller has already
-/// range-checked the month, so that branch is defensive).
-fn days_in_month(year: u32, month: u32) -> u32 {
-    match month {
-        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
-        4 | 6 | 9 | 11 => 30,
-        2 if is_leap_year(year) => 29,
-        2 => 28,
-        _ => 0,
-    }
-}
-
-/// A calendar-valid two-digit day for the 4-digit `y` / 2-digit `m` strings:
-/// `d` is `01`..`days_in_month(m, y)` — the BASE `Iso8601_date` invariant
-/// `Day_valid: not day_unknown implies valid_day (year, month, day)` with
-/// `valid_day (y, m, d) = (d >= 1 and d <= days_in_month (m, y))`
-/// (`org.openehr.base.foundation_types.iso8601_date.adoc` line 107;
-/// `time_definitions.adoc` line 102). This is calendar-exact — it rejects
-/// `2021-02-31`, `2021-04-31`, and `2021-02-29` (non-leap) while accepting
-/// `2020-02-29` (leap).
-fn valid_day(y: &str, m: &str, d: &str) -> bool {
-    if d.len() != 2 || !all_digits(d) {
-        return false;
-    }
-    let (Ok(year), Ok(month), Ok(day)) = (y.parse::<u32>(), m.parse::<u32>(), d.parse::<u32>())
-    else {
-        return false;
-    };
-    (1..=days_in_month(year, month)).contains(&day)
-}
-
-/// A valid openEHR ISO-8601 date: `YYYY`, `YYYY-MM`, `YYYY-MM-DD`, or the
-/// compact `YYYYMM` / `YYYYMMDD` forms. Day validity is **calendar-exact**
-/// (month lengths + leap years) per BASE `Iso8601_date.Day_valid`, not a bare
-/// `1..=31` range.
-#[must_use]
-pub(crate) fn is_valid_iso_date(s: &str) -> bool {
-    if s.contains('-') {
-        match s.split('-').collect::<Vec<_>>().as_slice() {
-            [y] => digits_n(y, 4),
-            [y, m] => digits_n(y, 4) && in_range(m, 1, 12),
-            [y, m, d] => digits_n(y, 4) && in_range(m, 1, 12) && valid_day(y, m, d),
-            _ => false,
-        }
-    } else {
-        match s.len() {
-            4 => all_digits(s),
-            6 => all_digits(s) && in_range(part(s, 4..6), 1, 12),
-            8 => {
-                all_digits(s)
-                    && in_range(part(s, 4..6), 1, 12)
-                    && valid_day(part(s, 0..4), part(s, 4..6), part(s, 6..8))
-            }
-            _ => false,
-        }
-    }
-}
-
-fn is_valid_tz(tz: &str) -> bool {
-    if tz.is_empty() || tz == "Z" {
-        return true;
-    }
-    let Some(rest) = tz.strip_prefix(['+', '-']) else {
-        return false;
-    };
-    // BASE `Iso8601_timezone` bounds are ASYMMETRIC (`iso8601_timezone.adoc`
-    // Max_hour_valid / Min_hour_valid; `time_definitions.adoc`
-    // Max_timezone_hour = 14, Min_timezone_hour = 12): `+` offsets go to
-    // +14:00, `-` offsets only to -12:00 (reject `-13:00`).
-    //
-    // NOTE: hour 0 is accepted with either sign — `iso8601_timezone.adoc`
-    // §Description gives `hh` as "`00` - `23`" and §Functions defines `is_gmt`
-    // as "timezone `+0000`", which the `hour > 0` invariants would forbid.
-    let max_hour = if tz.starts_with('+') { 14 } else { 12 };
-    if rest.contains(':') {
-        matches!(rest.split(':').collect::<Vec<_>>().as_slice(),
-            [h, m] if in_range(h, 0, max_hour) && in_range(m, 0, 59))
-    } else {
-        match rest.len() {
-            2 => in_range(rest, 0, max_hour),
-            4 => in_range(part(rest, 0..2), 0, max_hour) && in_range(part(rest, 2..4), 0, 59),
-            _ => false,
-        }
-    }
-}
-
-fn is_valid_time_core(s: &str) -> bool {
-    // NOTE: a decimal fraction is legal only on seconds — BASE
-    // `master06-time_types.adoc`: "only fractional seconds are supported".
-    //
-    // NOTE: seconds are `0..=59` per `time_definitions.adoc` §Functions
-    // `valid_second` (`Post: … s < Seconds_in_minute`) — the machine-checkable
-    // clause, which BASE's own reader also took over the `00`-`60` prose.
-    let (base, frac) = match s.split_once(['.', ',']) {
-        Some((b, f)) => (b, Some(f)),
-        None => (s, None),
-    };
-    if let Some(f) = frac
-        && !all_digits(f)
-    {
-        return false;
-    }
-    let has_frac = frac.is_some();
-    if base.contains(':') {
-        match base.split(':').collect::<Vec<_>>().as_slice() {
-            [h] => !has_frac && in_range(h, 0, 23),
-            [h, m] => !has_frac && in_range(h, 0, 23) && in_range(m, 0, 59),
-            [h, m, sec] => in_range(h, 0, 23) && in_range(m, 0, 59) && in_range(sec, 0, 59),
-            _ => false,
-        }
-    } else {
-        match base.len() {
-            2 => !has_frac && in_range(base, 0, 23),
-            4 => {
-                !has_frac && in_range(part(base, 0..2), 0, 23) && in_range(part(base, 2..4), 0, 59)
-            }
-            6 => {
-                in_range(part(base, 0..2), 0, 23)
-                    && in_range(part(base, 2..4), 0, 59)
-                    && in_range(part(base, 4..6), 0, 59)
-            }
-            _ => false,
-        }
-    }
-}
-
-/// A valid openEHR ISO-8601 time: `HH`, `HH:MM`, `HH:MM:SS[.fff]` (and the
-/// compact `HHMM` / `HHMMSS` forms), with an optional `Z` / `±HH[:MM]` timezone.
-#[must_use]
-pub(crate) fn is_valid_iso_time(s: &str) -> bool {
-    // Split off a trailing timezone (`Z`, or a `+`/`-` offset that is not the
-    // fractional separator). Scan from the end for `Z`/`+`/`-`.
-    if let Some(stripped) = s.strip_suffix('Z') {
-        return is_valid_time_core(stripped);
-    }
-    if let Some((core, tz)) = s.rfind(['+', '-']).and_then(|pos| s.split_at_checked(pos)) {
-        return is_valid_time_core(core) && is_valid_tz(tz);
-    }
-    is_valid_time_core(s)
-}
-
-/// A valid openEHR ISO-8601 date-time: a date, then (if a time component is
-/// present) `T` and a time. A `T`-less value is accepted as a date-only partial.
-#[must_use]
-pub(crate) fn is_valid_iso_date_time(s: &str) -> bool {
-    match s.split_once('T') {
-        Some((date, time)) => is_valid_iso_date(date) && is_valid_iso_time(time),
-        None => is_valid_iso_date(s),
-    }
-}
-
-fn parse_duration_components(s: &str, allowed: &[u8], any: &mut bool) -> bool {
-    let bytes = s.as_bytes();
-    let mut i = 0;
-    // `allowed` is the production's own order (`YMWD`, then `HMS`), so a
-    // designator's index in it IS its slot: requiring the slot to advance
-    // strictly enforces both "in order" and "at most once" in one test.
-    // Without it `P1Y1Y` validated here while BASE's reader refused the same
-    // string and `iso_duration_to_seconds` summed BOTH years — one value, three
-    // in-tree answers, none of them the spec's.
-    let mut last_slot: isize = -1;
-    while i < bytes.len() {
-        let start = i;
-        while bytes.get(i).is_some_and(u8::is_ascii_digit) {
-            i += 1;
-        }
-        let mut has_fraction = false;
-        if matches!(bytes.get(i), Some(b'.' | b',')) {
-            has_fraction = true;
-            i += 1;
-            while bytes.get(i).is_some_and(u8::is_ascii_digit) {
-                i += 1;
-            }
-        }
-        // No number, or a number with no designator after it.
-        let Some(&designator) = bytes.get(i) else {
-            return false;
-        };
-        if i == start {
-            return false;
-        }
-        let Some(slot) = allowed.iter().position(|d| *d == designator) else {
-            return false;
-        };
-        let slot = slot.cast_signed();
-        if slot <= last_slot {
-            return false;
-        }
-        last_slot = slot;
-        // BASE `master06-time_types.adoc` §Primitive Time Types: "in openEHR,
-        // only fractional seconds are supported" — a decimal fraction is only
-        // permitted on the seconds ('S') component, never on Y/M/W/D/H/M.
-        if has_fraction && designator != b'S' {
-            return false;
-        }
-        i += 1;
-        *any = true;
-    }
-    true
-}
-
-/// A valid openEHR ISO-8601 duration: optional leading sign, `P`, then one or
-/// more `nY nM nW nD` components and an optional `T nH nM nS` part (openEHR
-/// permits the sign and a `W` designator mixed with the others).
-#[must_use]
-pub(crate) fn is_valid_iso_duration(s: &str) -> bool {
-    let s = s.strip_prefix(['+', '-']).unwrap_or(s);
-    let Some(rest) = s.strip_prefix('P') else {
-        return false;
-    };
-    let (date_part, time_part) = match rest.split_once('T') {
-        Some((d, t)) => (d, Some(t)),
-        None => (rest, None),
-    };
-    let mut any = false;
-    if !parse_duration_components(date_part, b"YMWD", &mut any) {
-        return false;
-    }
-    if let Some(t) = time_part
-        && (t.is_empty() || !parse_duration_components(t, b"HMS", &mut any))
-    {
-        return false;
-    }
-    any
-}
+pub(crate) use openehr_base::v1_3::foundation_types::time::time_definitions::{
+    valid_iso8601_date, valid_iso8601_date_time, valid_iso8601_duration, valid_iso8601_time,
+};
 
 #[cfg(test)]
 mod tests {
@@ -806,14 +550,14 @@ mod tests {
 
     #[test]
     fn iso_date_forms() {
-        assert!(is_valid_iso_date("2021"));
-        assert!(is_valid_iso_date("2021-05"));
-        assert!(is_valid_iso_date("2021-05-17"));
-        assert!(is_valid_iso_date("20210517"));
-        assert!(!is_valid_iso_date("2021-13"));
-        assert!(!is_valid_iso_date("2021-05-32"));
-        assert!(!is_valid_iso_date("not-a-date"));
-        assert!(!is_valid_iso_date(""));
+        assert!(valid_iso8601_date("2021"));
+        assert!(valid_iso8601_date("2021-05"));
+        assert!(valid_iso8601_date("2021-05-17"));
+        assert!(valid_iso8601_date("20210517"));
+        assert!(!valid_iso8601_date("2021-13"));
+        assert!(!valid_iso8601_date("2021-05-32"));
+        assert!(!valid_iso8601_date("not-a-date"));
+        assert!(!valid_iso8601_date(""));
     }
 
     /// BASE `Iso8601_date.Day_valid` (`valid_day = d <= days_in_month(m, y)`,
@@ -822,44 +566,44 @@ mod tests {
     #[test]
     fn iso_date_day_is_calendar_exact() {
         // 31-day months accept 31; 30-day months reject it.
-        assert!(is_valid_iso_date("2021-01-31"));
-        assert!(is_valid_iso_date("2021-12-31"));
-        assert!(!is_valid_iso_date("2021-04-31")); // April has 30 days
-        assert!(!is_valid_iso_date("2021-06-31"));
-        assert!(!is_valid_iso_date("2021-09-31"));
-        assert!(!is_valid_iso_date("2021-11-31"));
-        assert!(is_valid_iso_date("2021-04-30"));
+        assert!(valid_iso8601_date("2021-01-31"));
+        assert!(valid_iso8601_date("2021-12-31"));
+        assert!(!valid_iso8601_date("2021-04-31")); // April has 30 days
+        assert!(!valid_iso8601_date("2021-06-31"));
+        assert!(!valid_iso8601_date("2021-09-31"));
+        assert!(!valid_iso8601_date("2021-11-31"));
+        assert!(valid_iso8601_date("2021-04-30"));
 
         // February: 28 in a common year, 29 in a leap year, never 30/31.
-        assert!(!is_valid_iso_date("2021-02-31"));
-        assert!(!is_valid_iso_date("2021-02-30"));
-        assert!(!is_valid_iso_date("2021-02-29")); // 2021 is not a leap year
-        assert!(is_valid_iso_date("2021-02-28"));
-        assert!(is_valid_iso_date("2020-02-29")); // 2020 divisible by 4
-        assert!(is_valid_iso_date("2000-02-29")); // 2000 divisible by 400
-        assert!(!is_valid_iso_date("1900-02-29")); // 1900 century, not /400
+        assert!(!valid_iso8601_date("2021-02-31"));
+        assert!(!valid_iso8601_date("2021-02-30"));
+        assert!(!valid_iso8601_date("2021-02-29")); // 2021 is not a leap year
+        assert!(valid_iso8601_date("2021-02-28"));
+        assert!(valid_iso8601_date("2020-02-29")); // 2020 divisible by 4
+        assert!(valid_iso8601_date("2000-02-29")); // 2000 divisible by 400
+        assert!(!valid_iso8601_date("1900-02-29")); // 1900 century, not /400
 
         // Day 00 is never valid.
-        assert!(!is_valid_iso_date("2021-05-00"));
+        assert!(!valid_iso8601_date("2021-05-00"));
 
         // Compact form is held to the same calendar rule.
-        assert!(!is_valid_iso_date("20210431"));
-        assert!(!is_valid_iso_date("20210229"));
-        assert!(is_valid_iso_date("20200229"));
-        assert!(is_valid_iso_date("20210131"));
+        assert!(!valid_iso8601_date("20210431"));
+        assert!(!valid_iso8601_date("20210229"));
+        assert!(valid_iso8601_date("20200229"));
+        assert!(valid_iso8601_date("20210131"));
     }
 
     #[test]
     fn iso_time_forms() {
-        assert!(is_valid_iso_time("10"));
-        assert!(is_valid_iso_time("10:30"));
-        assert!(is_valid_iso_time("10:30:59"));
-        assert!(is_valid_iso_time("10:30:59.250"));
-        assert!(is_valid_iso_time("10:30:59Z"));
-        assert!(is_valid_iso_time("10:30:59+01:00"));
-        assert!(!is_valid_iso_time("25:00"));
-        assert!(!is_valid_iso_time("10:61"));
-        assert!(!is_valid_iso_time("abc"));
+        assert!(valid_iso8601_time("10"));
+        assert!(valid_iso8601_time("10:30"));
+        assert!(valid_iso8601_time("10:30:59"));
+        assert!(valid_iso8601_time("10:30:59.250"));
+        assert!(valid_iso8601_time("10:30:59Z"));
+        assert!(valid_iso8601_time("10:30:59+01:00"));
+        assert!(!valid_iso8601_time("25:00"));
+        assert!(!valid_iso8601_time("10:61"));
+        assert!(!valid_iso8601_time("abc"));
     }
 
     /// BASE `foundation_types/master06-time_types.adoc` §"ISO 8601 semantics
@@ -870,39 +614,39 @@ mod tests {
     #[test]
     fn iso_time_fraction_only_on_seconds() {
         // Fractional seconds (period or comma) is the sole permitted case.
-        assert!(is_valid_iso_time("10:30:59.250"));
-        assert!(is_valid_iso_time("10:30:59,5"));
-        assert!(is_valid_iso_time("103059.250")); // compact HHMMSS
-        assert!(is_valid_iso_time("10:30:59.5+01:00")); // fraction before timezone
+        assert!(valid_iso8601_time("10:30:59.250"));
+        assert!(valid_iso8601_time("10:30:59,5"));
+        assert!(valid_iso8601_time("103059.250")); // compact HHMMSS
+        assert!(valid_iso8601_time("10:30:59.5+01:00")); // fraction before timezone
         // A fractional hour or minute is rejected in every base form.
-        assert!(!is_valid_iso_time("10.5")); // fractional hour
-        assert!(!is_valid_iso_time("10:05.5")); // fractional minute (extended)
-        assert!(!is_valid_iso_time("1005.5")); // fractional minute (compact HHMM)
-        assert!(!is_valid_iso_time("10,5")); // fractional hour, comma
+        assert!(!valid_iso8601_time("10.5")); // fractional hour
+        assert!(!valid_iso8601_time("10:05.5")); // fractional minute (extended)
+        assert!(!valid_iso8601_time("1005.5")); // fractional minute (compact HHMM)
+        assert!(!valid_iso8601_time("10,5")); // fractional hour, comma
     }
 
     #[test]
     fn iso_date_time_forms() {
-        assert!(is_valid_iso_date_time("2021-05-17T10:30:00"));
-        assert!(is_valid_iso_date_time("2021-05-17T10:30:00+02:00"));
-        assert!(is_valid_iso_date_time("2021-05-17"));
-        assert!(!is_valid_iso_date_time("2021-05-17T99:00"));
-        assert!(!is_valid_iso_date_time("nope"));
+        assert!(valid_iso8601_date_time("2021-05-17T10:30:00"));
+        assert!(valid_iso8601_date_time("2021-05-17T10:30:00+02:00"));
+        assert!(valid_iso8601_date_time("2021-05-17"));
+        assert!(!valid_iso8601_date_time("2021-05-17T99:00"));
+        assert!(!valid_iso8601_date_time("nope"));
     }
 
     #[test]
     fn iso_duration_forms() {
-        assert!(is_valid_iso_duration("P1Y"));
-        assert!(is_valid_iso_duration("P1Y2M10D"));
-        assert!(is_valid_iso_duration("PT2H30M"));
-        assert!(is_valid_iso_duration("P1Y2M10DT2H30M"));
-        assert!(is_valid_iso_duration("P2W"));
-        assert!(is_valid_iso_duration("-P1D"));
-        assert!(is_valid_iso_duration("PT0.5S"));
-        assert!(!is_valid_iso_duration("P"));
-        assert!(!is_valid_iso_duration("1Y"));
-        assert!(!is_valid_iso_duration("P1X"));
-        assert!(!is_valid_iso_duration("PT"));
+        assert!(valid_iso8601_duration("P1Y"));
+        assert!(valid_iso8601_duration("P1Y2M10D"));
+        assert!(valid_iso8601_duration("PT2H30M"));
+        assert!(valid_iso8601_duration("P1Y2M10DT2H30M"));
+        assert!(valid_iso8601_duration("P2W"));
+        assert!(valid_iso8601_duration("-P1D"));
+        assert!(valid_iso8601_duration("PT0.5S"));
+        assert!(!valid_iso8601_duration("P"));
+        assert!(!valid_iso8601_duration("1Y"));
+        assert!(!valid_iso8601_duration("P1X"));
+        assert!(!valid_iso8601_duration("PT"));
     }
 
     /// This validator and BASE's `Iso8601Time` reader must accept the same
@@ -919,7 +663,7 @@ mod tests {
             .hour()
             .is_some();
             assert_eq!(
-                is_valid_iso_time(value),
+                valid_iso8601_time(value),
                 base,
                 "{value:?}: the RM validator and the BASE reader disagree",
             );
@@ -954,7 +698,7 @@ mod tests {
                 .to_seconds()
                 .is_some();
             assert_eq!(
-                is_valid_iso_duration(value),
+                valid_iso8601_duration(value),
                 base,
                 "{value:?}: the RM validator and the BASE reader disagree",
             );
@@ -968,17 +712,17 @@ mod tests {
     #[test]
     fn iso_duration_fraction_only_on_seconds() {
         // Fraction on seconds (period or comma) is the sole permitted case.
-        assert!(is_valid_iso_duration("PT2H30M0.5S"));
-        assert!(is_valid_iso_duration("PT0,5S"));
+        assert!(valid_iso8601_duration("PT2H30M0.5S"));
+        assert!(valid_iso8601_duration("PT0,5S"));
         // Fraction on any other component is rejected.
-        assert!(!is_valid_iso_duration("P1Y3M4DT2.5H"));
-        assert!(!is_valid_iso_duration("PT2H14.5M"));
-        assert!(!is_valid_iso_duration("P1.5Y"));
-        assert!(!is_valid_iso_duration("P1.5M"));
-        assert!(!is_valid_iso_duration("P1.5W"));
-        assert!(!is_valid_iso_duration("P1.5D"));
-        assert!(!is_valid_iso_duration("PT1.5H"));
-        assert!(!is_valid_iso_duration("PT2H14,5M"));
+        assert!(!valid_iso8601_duration("P1Y3M4DT2.5H"));
+        assert!(!valid_iso8601_duration("PT2H14.5M"));
+        assert!(!valid_iso8601_duration("P1.5Y"));
+        assert!(!valid_iso8601_duration("P1.5M"));
+        assert!(!valid_iso8601_duration("P1.5W"));
+        assert!(!valid_iso8601_duration("P1.5D"));
+        assert!(!valid_iso8601_duration("PT1.5H"));
+        assert!(!valid_iso8601_duration("PT2H14,5M"));
     }
 
     // NOTE: the `_type`-dispatch tests live in
@@ -989,16 +733,16 @@ mod tests {
     /// -12:00; ±00:00 is accepted (see `is_valid_tz`).
     #[test]
     fn timezone_bounds_are_asymmetric() {
-        assert!(is_valid_iso_time("10:00:00+14:00"));
-        assert!(is_valid_iso_time("10:00:00-12:00"));
-        assert!(is_valid_iso_time("10:00:00+00:00"));
-        assert!(is_valid_iso_time("10:00:00-00:00"));
+        assert!(valid_iso8601_time("10:00:00+14:00"));
+        assert!(valid_iso8601_time("10:00:00-12:00"));
+        assert!(valid_iso8601_time("10:00:00+00:00"));
+        assert!(valid_iso8601_time("10:00:00-00:00"));
         assert!(
-            !is_valid_iso_time("10:00:00+15:00"),
+            !valid_iso8601_time("10:00:00+15:00"),
             "+15 exceeds Max_timezone_hour"
         );
         assert!(
-            !is_valid_iso_time("10:00:00-13:00"),
+            !valid_iso8601_time("10:00:00-13:00"),
             "-13 exceeds Min_timezone_hour"
         );
     }

--- a/crates/openehr-rm/src/v1_2/validate/fast.rs
+++ b/crates/openehr-rm/src/v1_2/validate/fast.rs
@@ -82,7 +82,7 @@ use serde_json::{Map, Value};
 use crate::v1_2::model::{Container, RmClass};
 use crate::v1_2::validate::generated;
 use crate::v1_2::validate::{
-    is_valid_iso_date, is_valid_iso_date_time, is_valid_iso_duration, is_valid_iso_time,
+    valid_iso8601_date, valid_iso8601_date_time, valid_iso8601_duration, valid_iso8601_time,
 };
 use openehr_base::validate::{InvariantViolation, Validate};
 
@@ -451,7 +451,7 @@ fn run_invariants(ty: &str, obj: &Map<String, Value>, out: &mut Vec<InvariantVio
                 let Some(value) = str_of(obj, "value") else {
                     return false;
                 };
-                generated::temporal_value_core(ty, is_valid_iso_duration(value), out);
+                generated::temporal_value_core(ty, valid_iso8601_duration(value), out);
             }
             generated::dv_amount_core(
                 ty,
@@ -466,9 +466,9 @@ fn run_invariants(ty: &str, obj: &Map<String, Value>, out: &mut Vec<InvariantVio
                 return false;
             };
             let valid = match ty {
-                "DV_DATE" => is_valid_iso_date(value),
-                "DV_TIME" => is_valid_iso_time(value),
-                _ => is_valid_iso_date_time(value),
+                "DV_DATE" => valid_iso8601_date(value),
+                "DV_TIME" => valid_iso8601_time(value),
+                _ => valid_iso8601_date_time(value),
             };
             generated::temporal_value_core(ty, valid, out);
             generated::magnitude_status_core(ty, str_of(obj, "magnitude_status"), out);

--- a/tools/openehr-codegen/templates/openehr-base/foundation_types/time/time_definitions.rs
+++ b/tools/openehr-codegen/templates/openehr-base/foundation_types/time/time_definitions.rs
@@ -1,0 +1,194 @@
+//! `Time_Definitions` — the released validity functions, publicly.
+//!
+//! Spec: `docs/specs/openehr/BASE/docs/UML/classes/org.openehr.base.foundation_types.time_definitions.adoc`
+//! §Functions. The class is a constant holder the emitter maps rather than
+//! emits, so its constants already live in `iso8601_parse`; its eleven `valid_*`
+//! functions had no home at all, which also made them invisible to the
+//! unrealized-function ratchet (a mapped class is out of that projection's
+//! scope by construction).
+//!
+//! This is the one public surface for "is this string a valid ISO-8601 X" in
+//! the workspace. `openehr-rm` used to answer it with a second, hand-written
+//! grammar; the two drifted twice, and both drifts shipped (#2273).
+
+use crate::v1_3::foundation_types::time::iso8601_parse;
+
+/// True if `y >= 0`.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_year` —
+/// `Post: Result = y >= 0`.
+#[must_use]
+pub fn valid_year(y: i64) -> bool {
+    y >= 0
+}
+
+/// True if `m >= 1 and m <= Months_in_year`.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_month`.
+#[must_use]
+pub fn valid_month(m: i64) -> bool {
+    (1..=12).contains(&m)
+}
+
+/// True if `d >= 1 and d <= days_in_month (m, y)`.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_day`. The month and year are
+/// checked first: `days_in_month` is undefined for a month outside `1..=12`, so
+/// the post-condition cannot be evaluated without them.
+#[must_use]
+pub fn valid_day(y: i64, m: i64, d: i64) -> bool {
+    let Some(length) = days_in_month(y, m) else {
+        return false;
+    };
+    valid_year(y) && valid_month(m) && d >= 1 && d <= i64::from(length)
+}
+
+/// True if `(h >= 0 and h < Hours_in_day) or (h = Hours_in_day and m = 0 and
+/// s = 0)`.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_hour`.
+///
+/// NOTE: the second clause admits `24:00:00`, which `iso8601_time.adoc`
+/// §Description and `master06-time_types.adoc` forbid "anywhere" — a released
+/// contradiction, resolved toward the prohibition (#2276).
+#[must_use]
+pub fn valid_hour(h: i64, m: i64, s: i64) -> bool {
+    (0..24).contains(&h) && valid_minute(m) && valid_second(s)
+}
+
+/// True if `m >= 0 and m < Minutes_in_hour`.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_minute`.
+#[must_use]
+pub fn valid_minute(m: i64) -> bool {
+    (0..60).contains(&m)
+}
+
+/// True if `s >= 0 and s < Seconds_in_minute`.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_second` —
+/// `Post: Result = s >= 0 and s < Seconds_in_minute`. The `valid_iso8601_time`
+/// Meaning column's "`ss` is `00` - `60`" on the same page is the contradiction;
+/// this post-condition is the machine-checkable clause.
+#[must_use]
+pub fn valid_second(s: i64) -> bool {
+    (0..60).contains(&s)
+}
+
+/// True if `fs >= 0.0 and fs < 1.0`.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_fractional_second`.
+#[must_use]
+pub fn valid_fractional_second(fs: f64) -> bool {
+    fs.is_finite() && (0.0..1.0).contains(&fs)
+}
+
+/// True if `s` is a valid ISO-8601 date.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_iso8601_date`.
+#[must_use]
+pub fn valid_iso8601_date(s: &str) -> bool {
+    iso8601_parse::parse_date(s).is_some()
+}
+
+/// True if `s` is a valid ISO-8601 time.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_iso8601_time`.
+#[must_use]
+pub fn valid_iso8601_time(s: &str) -> bool {
+    iso8601_parse::parse_time(s).is_some()
+}
+
+/// True if `s` is a valid ISO-8601 date-time.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_iso8601_date_time`.
+#[must_use]
+pub fn valid_iso8601_date_time(s: &str) -> bool {
+    iso8601_parse::parse_date_time(s).is_some()
+}
+
+/// True if `s` is a valid ISO-8601 duration.
+///
+/// Spec: `time_definitions.adoc` §Functions `valid_iso8601_duration`.
+#[must_use]
+pub fn valid_iso8601_duration(s: &str) -> bool {
+    iso8601_parse::parse_duration(s).is_some()
+}
+
+/// The number of days in month `m` of year `y`, or `None` when the pair names
+/// no month of the calendar.
+///
+/// Spec: `time_definitions.adoc` §Functions `days_in_month`.
+#[must_use]
+pub fn days_in_month(y: i64, m: i64) -> Option<u32> {
+    let (Ok(year), Ok(month)) = (u32::try_from(y), u32::try_from(m)) else {
+        return None;
+    };
+    iso8601_parse::days_in_month(year, month)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Each numeric predicate is its own post-condition, at the boundary.
+    #[test]
+    fn the_numeric_predicates_are_their_post_conditions() {
+        assert!(valid_year(0) && valid_year(2024));
+        assert!(!valid_year(-1));
+
+        assert!(valid_month(1) && valid_month(12));
+        assert!(!valid_month(0) && !valid_month(13));
+
+        assert!(valid_minute(0) && valid_minute(59));
+        assert!(!valid_minute(60) && !valid_minute(-1));
+
+        assert!(valid_second(0) && valid_second(59));
+        assert!(
+            !valid_second(60),
+            "the post-condition is `s < Seconds_in_minute`"
+        );
+
+        assert!(valid_fractional_second(0.0) && valid_fractional_second(0.999));
+        assert!(!valid_fractional_second(1.0) && !valid_fractional_second(-0.1));
+        assert!(!valid_fractional_second(f64::NAN));
+    }
+
+    /// `valid_day` is defined via `days_in_month (m, y)`, so it answers the
+    /// leap year and refuses a month it cannot evaluate.
+    #[test]
+    fn valid_day_follows_the_month_length() {
+        assert!(valid_day(2024, 2, 29), "2024 is a leap year");
+        assert!(!valid_day(2023, 2, 29));
+        assert!(valid_day(2024, 1, 31) && !valid_day(2024, 4, 31));
+        assert!(!valid_day(2024, 0, 1), "no month to measure");
+        assert!(!valid_day(2024, 1, 0));
+    }
+
+    /// `24:00:00` is refused: the released `valid_hour` post-condition admits
+    /// it while the `Iso8601_time` class forbids it anywhere (#2276).
+    #[test]
+    fn the_twenty_fourth_hour_is_refused() {
+        assert!(valid_hour(23, 59, 59));
+        assert!(!valid_hour(24, 0, 0));
+        assert!(!valid_hour(-1, 0, 0));
+    }
+
+    /// The four string predicates are the one public answer to "is this a valid
+    /// ISO-8601 X" — the same readers every accessor and every arithmetic
+    /// function in this crate already uses.
+    #[test]
+    fn the_string_predicates_agree_with_the_readers() {
+        assert!(valid_iso8601_date("2024-02-29") && !valid_iso8601_date("2023-02-29"));
+        assert!(valid_iso8601_time("10:30:59") && !valid_iso8601_time("10:30:60"));
+        assert!(
+            valid_iso8601_date_time("2024-02-29T10:30:00")
+                && !valid_iso8601_date_time("2024-02-30T10:30:00")
+        );
+        assert!(valid_iso8601_duration("P1Y2M3DT4H5M6S"));
+        assert!(
+            !valid_iso8601_duration("P1Y1Y"),
+            "a repeated designator is not a duration"
+        );
+    }
+}

--- a/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/date_time/dv_date_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/date_time/dv_date_impl.rs
@@ -17,7 +17,7 @@ use crate::v1_2::data_types::quantity::dv_absolute_quantity_impl::{
 use crate::v1_2::data_types::quantity::dv_amount_impl::CombinedAccuracy;
 use crate::v1_2::data_types::quantity::dv_ordered::DvOrdered;
 use crate::v1_2::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
-use crate::v1_2::validate::is_valid_iso_date;
+use crate::v1_2::validate::valid_iso8601_date;
 use openehr_base::v1_3::foundation_types::time::iso8601_date::Iso8601Date;
 use openehr_base::v1_3::foundation_types::time::iso8601_duration::Iso8601Duration;
 use openehr_base::validate::{InvariantViolation, Validate};
@@ -123,7 +123,7 @@ impl Validate for DvDate {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
         crate::v1_2::validate::generated::temporal_value_core(
             "DV_DATE",
-            is_valid_iso_date(&self.value),
+            valid_iso8601_date(&self.value),
             out,
         );
         crate::v1_2::validate::generated::magnitude_status_core(

--- a/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/date_time/dv_date_time_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/date_time/dv_date_time_impl.rs
@@ -12,7 +12,7 @@ use crate::v1_2::data_types::quantity::dv_absolute_quantity_impl::{
 use crate::v1_2::data_types::quantity::dv_amount_impl::CombinedAccuracy;
 use crate::v1_2::data_types::quantity::dv_ordered::DvOrdered;
 use crate::v1_2::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
-use crate::v1_2::validate::is_valid_iso_date_time;
+use crate::v1_2::validate::valid_iso8601_date_time;
 use openehr_base::v1_3::foundation_types::time::iso8601_date_time::Iso8601DateTime;
 use openehr_base::v1_3::foundation_types::time::iso8601_duration::Iso8601Duration;
 use openehr_base::validate::{InvariantViolation, Validate};
@@ -96,7 +96,7 @@ impl Validate for DvDateTime {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
         crate::v1_2::validate::generated::temporal_value_core(
             "DV_DATE_TIME",
-            is_valid_iso_date_time(&self.value),
+            valid_iso8601_date_time(&self.value),
             out,
         );
         crate::v1_2::validate::generated::magnitude_status_core(

--- a/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/date_time/dv_duration_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/date_time/dv_duration_impl.rs
@@ -11,7 +11,7 @@ use crate::v1_2::data_types::quantity::dv_amount_impl::{
 };
 use crate::v1_2::data_types::quantity::dv_ordered::DvOrdered;
 use crate::v1_2::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
-use crate::v1_2::validate::is_valid_iso_duration;
+use crate::v1_2::validate::valid_iso8601_duration;
 use openehr_base::v1_3::foundation_types::time::iso8601_duration::Iso8601Duration;
 use openehr_base::validate::{InvariantViolation, Validate};
 
@@ -134,7 +134,7 @@ impl Validate for DvDuration {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
         crate::v1_2::validate::generated::temporal_value_core(
             "DV_DURATION",
-            is_valid_iso_duration(&self.value),
+            valid_iso8601_duration(&self.value),
             out,
         );
         crate::v1_2::validate::generated::dv_amount_core(

--- a/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/date_time/dv_time_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/date_time/dv_time_impl.rs
@@ -12,7 +12,7 @@ use crate::v1_2::data_types::quantity::dv_absolute_quantity_impl::{
 use crate::v1_2::data_types::quantity::dv_amount_impl::CombinedAccuracy;
 use crate::v1_2::data_types::quantity::dv_ordered::DvOrdered;
 use crate::v1_2::data_types::quantity::dv_ordered_impl::push_normal_range_consistency;
-use crate::v1_2::validate::is_valid_iso_time;
+use crate::v1_2::validate::valid_iso8601_time;
 use openehr_base::v1_3::foundation_types::time::iso8601_duration::Iso8601Duration;
 use openehr_base::v1_3::foundation_types::time::iso8601_time::Iso8601Time;
 use openehr_base::validate::{InvariantViolation, Validate};
@@ -96,7 +96,7 @@ impl Validate for DvTime {
     fn validate_invariants(&self, out: &mut Vec<InvariantViolation>) {
         crate::v1_2::validate::generated::temporal_value_core(
             "DV_TIME",
-            is_valid_iso_time(&self.value),
+            valid_iso8601_time(&self.value),
             out,
         );
         crate::v1_2::validate::generated::magnitude_status_core(

--- a/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/dv_ordered_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/data_types/quantity/dv_ordered_impl.rs
@@ -47,7 +47,7 @@ use crate::v1_2::data_types::quantity::dv_proportion::DvProportion;
 use crate::v1_2::data_types::quantity::dv_quantity::DvQuantity;
 use crate::v1_2::data_types::quantity::dv_scale::DvScale;
 use crate::v1_2::validate::{
-    is_valid_iso_date, is_valid_iso_date_time, is_valid_iso_duration, is_valid_iso_time,
+    valid_iso8601_date, valid_iso8601_date_time, valid_iso8601_duration, valid_iso8601_time,
 };
 
 // ── BASE Time_definitions constants (nominal durations) ─────────────────────
@@ -77,7 +77,7 @@ fn parse_u32(s: &str) -> Option<u32> {
 /// Decompose an openEHR ISO-8601 date (extended or compact) into (y, m, d),
 /// defaulting missing parts to 1.
 fn date_parts(s: &str) -> Option<(i64, u32, u32)> {
-    if !is_valid_iso_date(s) {
+    if !valid_iso8601_date(s) {
         return None;
     }
     let (y, m, d) = if s.contains('-') {
@@ -194,7 +194,7 @@ fn time_core_seconds(s: &str) -> Option<f64> {
 /// start-of-day origin).
 #[must_use]
 pub(crate) fn iso_time_magnitude_seconds(s: &str) -> Option<f64> {
-    if !is_valid_iso_time(s) {
+    if !valid_iso8601_time(s) {
         return None;
     }
     let (core, _tz) = split_tz(s);
@@ -205,7 +205,7 @@ pub(crate) fn iso_time_magnitude_seconds(s: &str) -> Option<f64> {
 /// `DV_DATE_TIME.magnitude`); a stated timezone offset is normalised to UTC.
 #[must_use]
 pub(crate) fn iso_date_time_magnitude_seconds(s: &str) -> Option<f64> {
-    if !is_valid_iso_date_time(s) {
+    if !valid_iso8601_date_time(s) {
         return None;
     }
     #[expect(
@@ -230,7 +230,7 @@ pub(crate) fn iso_date_time_magnitude_seconds(s: &str) -> Option<f64> {
 /// `-` negates the whole value (openEHR deviation).
 #[must_use]
 pub(crate) fn iso_duration_to_seconds(s: &str) -> Option<f64> {
-    if !is_valid_iso_duration(s) {
+    if !valid_iso8601_duration(s) {
         return None;
     }
     let (sign, body) = match s.strip_prefix('-') {

--- a/tools/openehr-codegen/templates/openehr-rm/data_types/time_specification/dv_periodic_time_specification_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/data_types/time_specification/dv_periodic_time_specification_impl.rs
@@ -7,7 +7,7 @@
 
 use crate::v1_2::data_types::quantity::date_time::dv_duration::DvDuration;
 use crate::v1_2::data_types::time_specification::dv_periodic_time_specification::DvPeriodicTimeSpecification;
-use crate::v1_2::validate::is_valid_iso_duration;
+use crate::v1_2::validate::valid_iso8601_duration;
 use openehr_base::validate::{InvariantViolation, Validate};
 
 impl DvPeriodicTimeSpecification {
@@ -120,7 +120,7 @@ const INSTITUTION_SPECIFIED: &str = "IST";
 /// nobody. A difference in neither form has no duration.
 fn iso_duration(difference: &str) -> Option<String> {
     let difference = difference.trim();
-    if is_valid_iso_duration(difference) {
+    if valid_iso8601_duration(difference) {
         return Some(difference.to_owned());
     }
     let boundary = difference.find(|c: char| !c.is_ascii_digit() && c != '-')?;

--- a/tools/openehr-codegen/templates/openehr-rm/validate.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/validate.rs
@@ -534,270 +534,14 @@ pub(crate) fn valid_proportion_kind(k: i32) -> bool {
 
 // The DV_DATE / DV_TIME / DV_DATE_TIME / DV_DURATION `Value_valid` invariants
 // are `valid_iso8601_date` / `_time` / `_date_time` / `_duration` (each class
-// page's §Invariants); their accepted complete, compact and partial forms are
-// enumerated in BASE `…foundation_types.time_definitions.adoc` §Functions,
-// including that page's stated exception allowing a `W` designator alongside
-// the others in a duration. `value` is a `String` here, so those grammars are
-// checked at runtime rather than guaranteed by a parsed temporal type.
+// page's §Invariants), and those are BASE `Time_Definitions` functions — so
+// this crate calls them rather than re-deriving the grammar. It used to carry
+// its own reader; the two drifted twice and both drifts shipped (#2273), each
+// time letting a value pass validation, commit, and then behave as invalid.
 
-fn all_digits(s: &str) -> bool {
-    !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit())
-}
-
-/// The byte sub-range of `s`, or `""` when the range is out of bounds or lands
-/// off a UTF-8 boundary.
-///
-/// The compact ISO 8601 forms below extract fixed byte windows only after an
-/// exact-length + all-ASCII-digits test, so the empty fallback is unreachable
-/// there; it exists so the extraction can never panic (a `""` window fails
-/// every `in_range`/`valid_day` predicate, i.e. it rejects rather than aborts).
-fn part(s: &str, range: std::ops::Range<usize>) -> &str {
-    s.get(range).unwrap_or_default()
-}
-
-fn digits_n(s: &str, n: usize) -> bool {
-    s.len() == n && all_digits(s)
-}
-
-fn in_range(s: &str, lo: u32, hi: u32) -> bool {
-    s.len() == 2 && all_digits(s) && s.parse::<u32>().is_ok_and(|v| (lo..=hi).contains(&v))
-}
-
-/// `true` for a Gregorian leap year: divisible by 4, except centuries not
-/// divisible by 400 (BASE `Time_definitions`; the calendar `days_in_month`
-/// depends on it).
-fn is_leap_year(year: u32) -> bool {
-    (year.is_multiple_of(4) && !year.is_multiple_of(100)) || year.is_multiple_of(400)
-}
-
-/// Calendar days in a given month of a given year — the `days_in_month (m, y)`
-/// the BASE `Time_definitions.valid_day` postcondition dispatches through
-/// (`docs/specs/openehr/BASE/docs/UML/classes/org.openehr.base.foundation_types.time_definitions.adoc`
-/// lines 95–103). Returns `0` for a month outside `1..=12` (caller has already
-/// range-checked the month, so that branch is defensive).
-fn days_in_month(year: u32, month: u32) -> u32 {
-    match month {
-        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
-        4 | 6 | 9 | 11 => 30,
-        2 if is_leap_year(year) => 29,
-        2 => 28,
-        _ => 0,
-    }
-}
-
-/// A calendar-valid two-digit day for the 4-digit `y` / 2-digit `m` strings:
-/// `d` is `01`..`days_in_month(m, y)` — the BASE `Iso8601_date` invariant
-/// `Day_valid: not day_unknown implies valid_day (year, month, day)` with
-/// `valid_day (y, m, d) = (d >= 1 and d <= days_in_month (m, y))`
-/// (`org.openehr.base.foundation_types.iso8601_date.adoc` line 107;
-/// `time_definitions.adoc` line 102). This is calendar-exact — it rejects
-/// `2021-02-31`, `2021-04-31`, and `2021-02-29` (non-leap) while accepting
-/// `2020-02-29` (leap).
-fn valid_day(y: &str, m: &str, d: &str) -> bool {
-    if d.len() != 2 || !all_digits(d) {
-        return false;
-    }
-    let (Ok(year), Ok(month), Ok(day)) = (y.parse::<u32>(), m.parse::<u32>(), d.parse::<u32>())
-    else {
-        return false;
-    };
-    (1..=days_in_month(year, month)).contains(&day)
-}
-
-/// A valid openEHR ISO-8601 date: `YYYY`, `YYYY-MM`, `YYYY-MM-DD`, or the
-/// compact `YYYYMM` / `YYYYMMDD` forms. Day validity is **calendar-exact**
-/// (month lengths + leap years) per BASE `Iso8601_date.Day_valid`, not a bare
-/// `1..=31` range.
-#[must_use]
-pub(crate) fn is_valid_iso_date(s: &str) -> bool {
-    if s.contains('-') {
-        match s.split('-').collect::<Vec<_>>().as_slice() {
-            [y] => digits_n(y, 4),
-            [y, m] => digits_n(y, 4) && in_range(m, 1, 12),
-            [y, m, d] => digits_n(y, 4) && in_range(m, 1, 12) && valid_day(y, m, d),
-            _ => false,
-        }
-    } else {
-        match s.len() {
-            4 => all_digits(s),
-            6 => all_digits(s) && in_range(part(s, 4..6), 1, 12),
-            8 => {
-                all_digits(s)
-                    && in_range(part(s, 4..6), 1, 12)
-                    && valid_day(part(s, 0..4), part(s, 4..6), part(s, 6..8))
-            }
-            _ => false,
-        }
-    }
-}
-
-fn is_valid_tz(tz: &str) -> bool {
-    if tz.is_empty() || tz == "Z" {
-        return true;
-    }
-    let Some(rest) = tz.strip_prefix(['+', '-']) else {
-        return false;
-    };
-    // BASE `Iso8601_timezone` bounds are ASYMMETRIC (`iso8601_timezone.adoc`
-    // Max_hour_valid / Min_hour_valid; `time_definitions.adoc`
-    // Max_timezone_hour = 14, Min_timezone_hour = 12): `+` offsets go to
-    // +14:00, `-` offsets only to -12:00 (reject `-13:00`).
-    //
-    // NOTE: hour 0 is accepted with either sign — `iso8601_timezone.adoc`
-    // §Description gives `hh` as "`00` - `23`" and §Functions defines `is_gmt`
-    // as "timezone `+0000`", which the `hour > 0` invariants would forbid.
-    let max_hour = if tz.starts_with('+') { 14 } else { 12 };
-    if rest.contains(':') {
-        matches!(rest.split(':').collect::<Vec<_>>().as_slice(),
-            [h, m] if in_range(h, 0, max_hour) && in_range(m, 0, 59))
-    } else {
-        match rest.len() {
-            2 => in_range(rest, 0, max_hour),
-            4 => in_range(part(rest, 0..2), 0, max_hour) && in_range(part(rest, 2..4), 0, 59),
-            _ => false,
-        }
-    }
-}
-
-fn is_valid_time_core(s: &str) -> bool {
-    // NOTE: a decimal fraction is legal only on seconds — BASE
-    // `master06-time_types.adoc`: "only fractional seconds are supported".
-    //
-    // NOTE: seconds are `0..=59` per `time_definitions.adoc` §Functions
-    // `valid_second` (`Post: … s < Seconds_in_minute`) — the machine-checkable
-    // clause, which BASE's own reader also took over the `00`-`60` prose.
-    let (base, frac) = match s.split_once(['.', ',']) {
-        Some((b, f)) => (b, Some(f)),
-        None => (s, None),
-    };
-    if let Some(f) = frac
-        && !all_digits(f)
-    {
-        return false;
-    }
-    let has_frac = frac.is_some();
-    if base.contains(':') {
-        match base.split(':').collect::<Vec<_>>().as_slice() {
-            [h] => !has_frac && in_range(h, 0, 23),
-            [h, m] => !has_frac && in_range(h, 0, 23) && in_range(m, 0, 59),
-            [h, m, sec] => in_range(h, 0, 23) && in_range(m, 0, 59) && in_range(sec, 0, 59),
-            _ => false,
-        }
-    } else {
-        match base.len() {
-            2 => !has_frac && in_range(base, 0, 23),
-            4 => {
-                !has_frac && in_range(part(base, 0..2), 0, 23) && in_range(part(base, 2..4), 0, 59)
-            }
-            6 => {
-                in_range(part(base, 0..2), 0, 23)
-                    && in_range(part(base, 2..4), 0, 59)
-                    && in_range(part(base, 4..6), 0, 59)
-            }
-            _ => false,
-        }
-    }
-}
-
-/// A valid openEHR ISO-8601 time: `HH`, `HH:MM`, `HH:MM:SS[.fff]` (and the
-/// compact `HHMM` / `HHMMSS` forms), with an optional `Z` / `±HH[:MM]` timezone.
-#[must_use]
-pub(crate) fn is_valid_iso_time(s: &str) -> bool {
-    // Split off a trailing timezone (`Z`, or a `+`/`-` offset that is not the
-    // fractional separator). Scan from the end for `Z`/`+`/`-`.
-    if let Some(stripped) = s.strip_suffix('Z') {
-        return is_valid_time_core(stripped);
-    }
-    if let Some((core, tz)) = s.rfind(['+', '-']).and_then(|pos| s.split_at_checked(pos)) {
-        return is_valid_time_core(core) && is_valid_tz(tz);
-    }
-    is_valid_time_core(s)
-}
-
-/// A valid openEHR ISO-8601 date-time: a date, then (if a time component is
-/// present) `T` and a time. A `T`-less value is accepted as a date-only partial.
-#[must_use]
-pub(crate) fn is_valid_iso_date_time(s: &str) -> bool {
-    match s.split_once('T') {
-        Some((date, time)) => is_valid_iso_date(date) && is_valid_iso_time(time),
-        None => is_valid_iso_date(s),
-    }
-}
-
-fn parse_duration_components(s: &str, allowed: &[u8], any: &mut bool) -> bool {
-    let bytes = s.as_bytes();
-    let mut i = 0;
-    // `allowed` is the production's own order (`YMWD`, then `HMS`), so a
-    // designator's index in it IS its slot: requiring the slot to advance
-    // strictly enforces both "in order" and "at most once" in one test.
-    // Without it `P1Y1Y` validated here while BASE's reader refused the same
-    // string and `iso_duration_to_seconds` summed BOTH years — one value, three
-    // in-tree answers, none of them the spec's.
-    let mut last_slot: isize = -1;
-    while i < bytes.len() {
-        let start = i;
-        while bytes.get(i).is_some_and(u8::is_ascii_digit) {
-            i += 1;
-        }
-        let mut has_fraction = false;
-        if matches!(bytes.get(i), Some(b'.' | b',')) {
-            has_fraction = true;
-            i += 1;
-            while bytes.get(i).is_some_and(u8::is_ascii_digit) {
-                i += 1;
-            }
-        }
-        // No number, or a number with no designator after it.
-        let Some(&designator) = bytes.get(i) else {
-            return false;
-        };
-        if i == start {
-            return false;
-        }
-        let Some(slot) = allowed.iter().position(|d| *d == designator) else {
-            return false;
-        };
-        let slot = slot.cast_signed();
-        if slot <= last_slot {
-            return false;
-        }
-        last_slot = slot;
-        // BASE `master06-time_types.adoc` §Primitive Time Types: "in openEHR,
-        // only fractional seconds are supported" — a decimal fraction is only
-        // permitted on the seconds ('S') component, never on Y/M/W/D/H/M.
-        if has_fraction && designator != b'S' {
-            return false;
-        }
-        i += 1;
-        *any = true;
-    }
-    true
-}
-
-/// A valid openEHR ISO-8601 duration: optional leading sign, `P`, then one or
-/// more `nY nM nW nD` components and an optional `T nH nM nS` part (openEHR
-/// permits the sign and a `W` designator mixed with the others).
-#[must_use]
-pub(crate) fn is_valid_iso_duration(s: &str) -> bool {
-    let s = s.strip_prefix(['+', '-']).unwrap_or(s);
-    let Some(rest) = s.strip_prefix('P') else {
-        return false;
-    };
-    let (date_part, time_part) = match rest.split_once('T') {
-        Some((d, t)) => (d, Some(t)),
-        None => (rest, None),
-    };
-    let mut any = false;
-    if !parse_duration_components(date_part, b"YMWD", &mut any) {
-        return false;
-    }
-    if let Some(t) = time_part
-        && (t.is_empty() || !parse_duration_components(t, b"HMS", &mut any))
-    {
-        return false;
-    }
-    any
-}
+pub(crate) use openehr_base::v1_3::foundation_types::time::time_definitions::{
+    valid_iso8601_date, valid_iso8601_date_time, valid_iso8601_duration, valid_iso8601_time,
+};
 
 #[cfg(test)]
 mod tests {
@@ -805,14 +549,14 @@ mod tests {
 
     #[test]
     fn iso_date_forms() {
-        assert!(is_valid_iso_date("2021"));
-        assert!(is_valid_iso_date("2021-05"));
-        assert!(is_valid_iso_date("2021-05-17"));
-        assert!(is_valid_iso_date("20210517"));
-        assert!(!is_valid_iso_date("2021-13"));
-        assert!(!is_valid_iso_date("2021-05-32"));
-        assert!(!is_valid_iso_date("not-a-date"));
-        assert!(!is_valid_iso_date(""));
+        assert!(valid_iso8601_date("2021"));
+        assert!(valid_iso8601_date("2021-05"));
+        assert!(valid_iso8601_date("2021-05-17"));
+        assert!(valid_iso8601_date("20210517"));
+        assert!(!valid_iso8601_date("2021-13"));
+        assert!(!valid_iso8601_date("2021-05-32"));
+        assert!(!valid_iso8601_date("not-a-date"));
+        assert!(!valid_iso8601_date(""));
     }
 
     /// BASE `Iso8601_date.Day_valid` (`valid_day = d <= days_in_month(m, y)`,
@@ -821,44 +565,44 @@ mod tests {
     #[test]
     fn iso_date_day_is_calendar_exact() {
         // 31-day months accept 31; 30-day months reject it.
-        assert!(is_valid_iso_date("2021-01-31"));
-        assert!(is_valid_iso_date("2021-12-31"));
-        assert!(!is_valid_iso_date("2021-04-31")); // April has 30 days
-        assert!(!is_valid_iso_date("2021-06-31"));
-        assert!(!is_valid_iso_date("2021-09-31"));
-        assert!(!is_valid_iso_date("2021-11-31"));
-        assert!(is_valid_iso_date("2021-04-30"));
+        assert!(valid_iso8601_date("2021-01-31"));
+        assert!(valid_iso8601_date("2021-12-31"));
+        assert!(!valid_iso8601_date("2021-04-31")); // April has 30 days
+        assert!(!valid_iso8601_date("2021-06-31"));
+        assert!(!valid_iso8601_date("2021-09-31"));
+        assert!(!valid_iso8601_date("2021-11-31"));
+        assert!(valid_iso8601_date("2021-04-30"));
 
         // February: 28 in a common year, 29 in a leap year, never 30/31.
-        assert!(!is_valid_iso_date("2021-02-31"));
-        assert!(!is_valid_iso_date("2021-02-30"));
-        assert!(!is_valid_iso_date("2021-02-29")); // 2021 is not a leap year
-        assert!(is_valid_iso_date("2021-02-28"));
-        assert!(is_valid_iso_date("2020-02-29")); // 2020 divisible by 4
-        assert!(is_valid_iso_date("2000-02-29")); // 2000 divisible by 400
-        assert!(!is_valid_iso_date("1900-02-29")); // 1900 century, not /400
+        assert!(!valid_iso8601_date("2021-02-31"));
+        assert!(!valid_iso8601_date("2021-02-30"));
+        assert!(!valid_iso8601_date("2021-02-29")); // 2021 is not a leap year
+        assert!(valid_iso8601_date("2021-02-28"));
+        assert!(valid_iso8601_date("2020-02-29")); // 2020 divisible by 4
+        assert!(valid_iso8601_date("2000-02-29")); // 2000 divisible by 400
+        assert!(!valid_iso8601_date("1900-02-29")); // 1900 century, not /400
 
         // Day 00 is never valid.
-        assert!(!is_valid_iso_date("2021-05-00"));
+        assert!(!valid_iso8601_date("2021-05-00"));
 
         // Compact form is held to the same calendar rule.
-        assert!(!is_valid_iso_date("20210431"));
-        assert!(!is_valid_iso_date("20210229"));
-        assert!(is_valid_iso_date("20200229"));
-        assert!(is_valid_iso_date("20210131"));
+        assert!(!valid_iso8601_date("20210431"));
+        assert!(!valid_iso8601_date("20210229"));
+        assert!(valid_iso8601_date("20200229"));
+        assert!(valid_iso8601_date("20210131"));
     }
 
     #[test]
     fn iso_time_forms() {
-        assert!(is_valid_iso_time("10"));
-        assert!(is_valid_iso_time("10:30"));
-        assert!(is_valid_iso_time("10:30:59"));
-        assert!(is_valid_iso_time("10:30:59.250"));
-        assert!(is_valid_iso_time("10:30:59Z"));
-        assert!(is_valid_iso_time("10:30:59+01:00"));
-        assert!(!is_valid_iso_time("25:00"));
-        assert!(!is_valid_iso_time("10:61"));
-        assert!(!is_valid_iso_time("abc"));
+        assert!(valid_iso8601_time("10"));
+        assert!(valid_iso8601_time("10:30"));
+        assert!(valid_iso8601_time("10:30:59"));
+        assert!(valid_iso8601_time("10:30:59.250"));
+        assert!(valid_iso8601_time("10:30:59Z"));
+        assert!(valid_iso8601_time("10:30:59+01:00"));
+        assert!(!valid_iso8601_time("25:00"));
+        assert!(!valid_iso8601_time("10:61"));
+        assert!(!valid_iso8601_time("abc"));
     }
 
     /// BASE `foundation_types/master06-time_types.adoc` §"ISO 8601 semantics
@@ -869,39 +613,39 @@ mod tests {
     #[test]
     fn iso_time_fraction_only_on_seconds() {
         // Fractional seconds (period or comma) is the sole permitted case.
-        assert!(is_valid_iso_time("10:30:59.250"));
-        assert!(is_valid_iso_time("10:30:59,5"));
-        assert!(is_valid_iso_time("103059.250")); // compact HHMMSS
-        assert!(is_valid_iso_time("10:30:59.5+01:00")); // fraction before timezone
+        assert!(valid_iso8601_time("10:30:59.250"));
+        assert!(valid_iso8601_time("10:30:59,5"));
+        assert!(valid_iso8601_time("103059.250")); // compact HHMMSS
+        assert!(valid_iso8601_time("10:30:59.5+01:00")); // fraction before timezone
         // A fractional hour or minute is rejected in every base form.
-        assert!(!is_valid_iso_time("10.5")); // fractional hour
-        assert!(!is_valid_iso_time("10:05.5")); // fractional minute (extended)
-        assert!(!is_valid_iso_time("1005.5")); // fractional minute (compact HHMM)
-        assert!(!is_valid_iso_time("10,5")); // fractional hour, comma
+        assert!(!valid_iso8601_time("10.5")); // fractional hour
+        assert!(!valid_iso8601_time("10:05.5")); // fractional minute (extended)
+        assert!(!valid_iso8601_time("1005.5")); // fractional minute (compact HHMM)
+        assert!(!valid_iso8601_time("10,5")); // fractional hour, comma
     }
 
     #[test]
     fn iso_date_time_forms() {
-        assert!(is_valid_iso_date_time("2021-05-17T10:30:00"));
-        assert!(is_valid_iso_date_time("2021-05-17T10:30:00+02:00"));
-        assert!(is_valid_iso_date_time("2021-05-17"));
-        assert!(!is_valid_iso_date_time("2021-05-17T99:00"));
-        assert!(!is_valid_iso_date_time("nope"));
+        assert!(valid_iso8601_date_time("2021-05-17T10:30:00"));
+        assert!(valid_iso8601_date_time("2021-05-17T10:30:00+02:00"));
+        assert!(valid_iso8601_date_time("2021-05-17"));
+        assert!(!valid_iso8601_date_time("2021-05-17T99:00"));
+        assert!(!valid_iso8601_date_time("nope"));
     }
 
     #[test]
     fn iso_duration_forms() {
-        assert!(is_valid_iso_duration("P1Y"));
-        assert!(is_valid_iso_duration("P1Y2M10D"));
-        assert!(is_valid_iso_duration("PT2H30M"));
-        assert!(is_valid_iso_duration("P1Y2M10DT2H30M"));
-        assert!(is_valid_iso_duration("P2W"));
-        assert!(is_valid_iso_duration("-P1D"));
-        assert!(is_valid_iso_duration("PT0.5S"));
-        assert!(!is_valid_iso_duration("P"));
-        assert!(!is_valid_iso_duration("1Y"));
-        assert!(!is_valid_iso_duration("P1X"));
-        assert!(!is_valid_iso_duration("PT"));
+        assert!(valid_iso8601_duration("P1Y"));
+        assert!(valid_iso8601_duration("P1Y2M10D"));
+        assert!(valid_iso8601_duration("PT2H30M"));
+        assert!(valid_iso8601_duration("P1Y2M10DT2H30M"));
+        assert!(valid_iso8601_duration("P2W"));
+        assert!(valid_iso8601_duration("-P1D"));
+        assert!(valid_iso8601_duration("PT0.5S"));
+        assert!(!valid_iso8601_duration("P"));
+        assert!(!valid_iso8601_duration("1Y"));
+        assert!(!valid_iso8601_duration("P1X"));
+        assert!(!valid_iso8601_duration("PT"));
     }
 
     /// This validator and BASE's `Iso8601Time` reader must accept the same
@@ -916,7 +660,7 @@ mod tests {
             .hour()
             .is_some();
             assert_eq!(
-                is_valid_iso_time(value),
+                valid_iso8601_time(value),
                 base,
                 "{value:?}: the RM validator and the BASE reader disagree",
             );
@@ -950,7 +694,7 @@ mod tests {
             .to_seconds()
             .is_some();
             assert_eq!(
-                is_valid_iso_duration(value),
+                valid_iso8601_duration(value),
                 base,
                 "{value:?}: the RM validator and the BASE reader disagree",
             );
@@ -964,17 +708,17 @@ mod tests {
     #[test]
     fn iso_duration_fraction_only_on_seconds() {
         // Fraction on seconds (period or comma) is the sole permitted case.
-        assert!(is_valid_iso_duration("PT2H30M0.5S"));
-        assert!(is_valid_iso_duration("PT0,5S"));
+        assert!(valid_iso8601_duration("PT2H30M0.5S"));
+        assert!(valid_iso8601_duration("PT0,5S"));
         // Fraction on any other component is rejected.
-        assert!(!is_valid_iso_duration("P1Y3M4DT2.5H"));
-        assert!(!is_valid_iso_duration("PT2H14.5M"));
-        assert!(!is_valid_iso_duration("P1.5Y"));
-        assert!(!is_valid_iso_duration("P1.5M"));
-        assert!(!is_valid_iso_duration("P1.5W"));
-        assert!(!is_valid_iso_duration("P1.5D"));
-        assert!(!is_valid_iso_duration("PT1.5H"));
-        assert!(!is_valid_iso_duration("PT2H14,5M"));
+        assert!(!valid_iso8601_duration("P1Y3M4DT2.5H"));
+        assert!(!valid_iso8601_duration("PT2H14.5M"));
+        assert!(!valid_iso8601_duration("P1.5Y"));
+        assert!(!valid_iso8601_duration("P1.5M"));
+        assert!(!valid_iso8601_duration("P1.5W"));
+        assert!(!valid_iso8601_duration("P1.5D"));
+        assert!(!valid_iso8601_duration("PT1.5H"));
+        assert!(!valid_iso8601_duration("PT2H14,5M"));
     }
 
     // NOTE: the `_type`-dispatch tests live in
@@ -985,16 +729,16 @@ mod tests {
     /// -12:00; ±00:00 is accepted (see `is_valid_tz`).
     #[test]
     fn timezone_bounds_are_asymmetric() {
-        assert!(is_valid_iso_time("10:00:00+14:00"));
-        assert!(is_valid_iso_time("10:00:00-12:00"));
-        assert!(is_valid_iso_time("10:00:00+00:00"));
-        assert!(is_valid_iso_time("10:00:00-00:00"));
+        assert!(valid_iso8601_time("10:00:00+14:00"));
+        assert!(valid_iso8601_time("10:00:00-12:00"));
+        assert!(valid_iso8601_time("10:00:00+00:00"));
+        assert!(valid_iso8601_time("10:00:00-00:00"));
         assert!(
-            !is_valid_iso_time("10:00:00+15:00"),
+            !valid_iso8601_time("10:00:00+15:00"),
             "+15 exceeds Max_timezone_hour"
         );
         assert!(
-            !is_valid_iso_time("10:00:00-13:00"),
+            !valid_iso8601_time("10:00:00-13:00"),
             "-13 exceeds Min_timezone_hour"
         );
     }

--- a/tools/openehr-codegen/templates/openehr-rm/validate/fast.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/validate/fast.rs
@@ -81,7 +81,7 @@ use serde_json::{Map, Value};
 use crate::v1_2::model::{Container, RmClass};
 use crate::v1_2::validate::generated;
 use crate::v1_2::validate::{
-    is_valid_iso_date, is_valid_iso_date_time, is_valid_iso_duration, is_valid_iso_time,
+    valid_iso8601_date, valid_iso8601_date_time, valid_iso8601_duration, valid_iso8601_time,
 };
 use openehr_base::validate::{InvariantViolation, Validate};
 
@@ -450,7 +450,7 @@ fn run_invariants(ty: &str, obj: &Map<String, Value>, out: &mut Vec<InvariantVio
                 let Some(value) = str_of(obj, "value") else {
                     return false;
                 };
-                generated::temporal_value_core(ty, is_valid_iso_duration(value), out);
+                generated::temporal_value_core(ty, valid_iso8601_duration(value), out);
             }
             generated::dv_amount_core(
                 ty,
@@ -465,9 +465,9 @@ fn run_invariants(ty: &str, obj: &Map<String, Value>, out: &mut Vec<InvariantVio
                 return false;
             };
             let valid = match ty {
-                "DV_DATE" => is_valid_iso_date(value),
-                "DV_TIME" => is_valid_iso_time(value),
-                _ => is_valid_iso_date_time(value),
+                "DV_DATE" => valid_iso8601_date(value),
+                "DV_TIME" => valid_iso8601_time(value),
+                _ => valid_iso8601_date_time(value),
             };
             generated::temporal_value_core(ty, valid, out);
             generated::magnitude_status_core(ty, str_of(obj, "magnitude_status"), out);


### PR DESCRIPTION
Closes #2273. **341 lines deleted, 85 added.**

## The root cause behind two shipped defects

`openehr-rm` validated dates, times, date-times and durations with its **own hand-written reader** — while depending on the `openehr-base` crate that owns that grammar. Two definitions of one thing, maintained by hand.

They drifted twice, and both drifts shipped:

| value | what happened |
|---|---|
| `P1Y1Y` | passed RM validation, committed, ordering summed **two years**, arithmetic returned nothing |
| `10:30:60` | passed RM validation, committed, `add`/`diff` produced nothing |

Both were patched symptomatically on both sides (#2263, #2272). This removes the source rather than waiting for the third.

## The delegation target is the spec's own

`Time_Definitions` §Functions declares `valid_iso8601_date` / `_time` / `_date_time` / `_duration` — which is *literally what a `Value_valid` invariant cites*.

Those functions had **no realization anywhere**. And because the emitter maps `Time_Definitions` as a constant holder rather than emitting it, that gap was **structurally invisible to the unrealized-function ratchet** — which is why nothing ever reported eleven missing spec functions. All eleven are now public on `openehr-base`, each carrying its released post-condition, over the readers every accessor in that crate already uses.

So this closes a real spec gap *and* removes the duplication, because they were the same problem seen from two sides.

## The RM callers use the spec names

`is_valid_iso_date` → `valid_iso8601_date`, etc. Import renaming is banned by `rust-style.md`, and the spec name is the better one anyway — it is what the invariant says.

## The agreement tests stay, and now pass trivially

The acceptance criteria asked for exactly this: the tests from #2263 and #2272 assert that the two readers accept identical strings. They are kept, not deleted — they asserted a property that had to be maintained by hand, and it now holds by construction. A test that becomes trivially true is the *evidence* the duplication is gone.

## Two released contradictions recorded, not transcribed

- `valid_hour`'s post-condition admits `24:00:00` while `Iso8601_time` forbids it anywhere → resolved toward the prohibition, reported as **#2276**.
- `valid_iso8601_time`'s prose allows `ss` to `60` while `valid_second` requires `< 60` → already resolved toward the post-condition in #2264.

## Verification

562 `openehr-rm` and 2791 workspace tests pass; clippy clean at `-D warnings`; comment-style and spec-citations green. Crates bumped to `0.0.27`.