### PR TITLE
build(toolchain): move to Rust 1.97.1

### DIFF
--- a/.claude/rules/fuzzing.md
+++ b/.claude/rules/fuzzing.md
@@ -75,7 +75,7 @@ crashes, the bug is in the parser until proven otherwise. Specifically:
   explicitly. Do not remove it, and do not "fix" a recurrence by disabling the
   sanitizer — the sanitizer is the instrument.
 - **`fuzz/` is its own workspace on purpose.** cargo-fuzz needs nightly; the CDR
-  workspace is pinned stable 1.96. Never add `fuzz` to the root workspace
+  workspace is pinned stable 1.97. Never add `fuzz` to the root workspace
   members, and never let a `cargo build`/`clippy`/`nextest` over `crates/*`,
   `app/*`, `tools/*` reach it.
 - **A scheduled-only lane rots silently.** This one sat broken for nights

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -112,7 +112,7 @@ Never park tests for crate X under crate Y's `tests/` directory.
   plumbing failures should propagate with `?`, not `.unwrap()`.
   **`clippy::panic_in_result_fn` (deny, workspace-wide) fires on this shape
   and clippy offers NO `allow-…-in-tests` knob for it** (verified
-  empirically on the pinned 1.96 toolchain: `allow-panic-in-tests = true` is
+  empirically on the pinned 1.97 toolchain (re-verified at the 1.96→1.97 bump): `allow-panic-in-tests = true` is
   already set and the lint still fires inside a `#[test] fn -> Result<…>`
   that asserts; the clippy lint-configuration page lists no option for this
   lint —

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -576,7 +576,7 @@ jobs:
       - uses: taiki-e/install-action@91ddec75689c4c78665b598d188dc821c5a43e5c # v2.85.9
         with:
           tool: cargo-hack
-      - run: cargo hack check --rust-version --workspace --locked
+      - run: cargo hack check --rust-version --workspace --locked --all-targets
 
   # ── Generated code must stay in sync with the vendored specs ──
   codegen-drift:
@@ -1035,7 +1035,7 @@ jobs:
     # runner: glibc compatibility runs forward only, so a runner image with a
     # newer glibc than the runtime image ships yields a binary that image
     # cannot load.
-    container: rust:1.96.1-slim-trixie@sha256:31ee7fc65186be7e0e0ccb3f2ca305f14e4739e7642a1ae65753aa5d7b874523
+    container: rust:1.97.1-slim-trixie@sha256:3b2879047d42784ca9403ad20c51ed3df361a50f1df96f5777d39b4e33aa65cd
     env:
       # Fixed build timestamp — reproducible, and the precondition for the
       # compile to be cacheable at all (see the block above; build.rs honours
@@ -1072,7 +1072,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: bin/amd64/ferroehr
-          key: ui-e2e-server-bin-1.96.1-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', '.cargo/**', 'crates/**', 'app/ferroehr/**', 'app/ferroehr-rest/**', 'app/ferroehr-server/**', 'tools/**') }}
+          key: ui-e2e-server-bin-1.97.1-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', '.cargo/**', 'crates/**', 'app/ferroehr/**', 'app/ferroehr-rest/**', 'app/ferroehr-server/**', 'tools/**') }}
       # Registry cache only, for the reason the ui-e2e job spells out below:
       # rust-cache's key hashes every manifest, so a lockfile bump rotates a
       # whole target archive and pays a cold build, while sccache degrades to
@@ -1148,7 +1148,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ui-e2e-console-stage
-          key: ui-e2e-console-1.96.1-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', '.cargo/**', 'crates/**', 'app/ferroehr-admin-ui/**') }}
+          key: ui-e2e-console-1.97.1-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', '.cargo/**', 'crates/**', 'app/ferroehr-admin-ui/**') }}
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         if: steps.console-cache.outputs.cache-hit != 'true'
         with:

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -170,7 +170,7 @@ jobs:
     # Digest-pinned, not tag-pinned: a tag is mutable, so a re-run of an
     # already-reviewed commit could build against different bytes. The index
     # digest (not a per-platform one) so both runner architectures resolve.
-    container: rust:1.96.1-slim-trixie@sha256:31ee7fc65186be7e0e0ccb3f2ca305f14e4739e7642a1ae65753aa5d7b874523
+    container: rust:1.97.1-slim-trixie@sha256:3b2879047d42784ca9403ad20c51ed3df361a50f1df96f5777d39b4e33aa65cd
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -380,7 +380,7 @@ jobs:
     # Digest-pinned, not tag-pinned: a tag is mutable, so a re-run of an
     # already-reviewed commit could build against different bytes. The index
     # digest (not a per-platform one) so both runner architectures resolve.
-    container: rust:1.96.1-slim-trixie@sha256:31ee7fc65186be7e0e0ccb3f2ca305f14e4739e7642a1ae65753aa5d7b874523
+    container: rust:1.97.1-slim-trixie@sha256:3b2879047d42784ca9403ad20c51ed3df361a50f1df96f5777d39b4e33aa65cd
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ workflow refuses a tag that has no matching section here.
 ## [Unreleased]
 
 
+### Changed
+
+- **The Rust toolchain moves to 1.97.1.** It carries an LLVM miscompilation
+  fix whose underlying bug has been present since at least 1.87 — the pinned
+  1.96.1 sat inside that window. The MSRV stays 1.96: nothing here uses a 1.97
+  feature, and the published crates are the only artifacts whose consumers
+  would feel a bump.
+
 ### Added
 
 - **`Time_Definitions`'s eleven validity functions are now public** on

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -434,7 +434,9 @@ sysinfo = "0.39.5"                   # CPU/RSS sampling for the benchmark harnes
 #   cargo-nextest, cargo-audit, cargo-deny, cargo-machete, cargo-hakari,
 #   cargo-llvm-cov, sccache ; linker: mold (Linux).
 #
-# Toolchain: Rust stable 1.96 (1.96.1 current), edition 2024.
+# Toolchain: Rust stable 1.97.1, edition 2024. The MSRV stays 1.96 — nothing
+# here uses a 1.97 feature, and the eight published crates are the only
+# artifacts whose consumers would feel a bump (docs/VERSIONS.md §MSRV policy).
 # Database: PostgreSQL 18 (target 18.4+; 18.x is the current stable line; PG 19 in beta — do not target).
 
 # ── Build-speed profiles ─────────────────────────────────────────────────────

--- a/app/ferroehr/tests/it/service_admin.rs
+++ b/app/ferroehr/tests/it/service_admin.rs
@@ -780,12 +780,12 @@ async fn physical_party_delete_cascades_relationships_and_spares_partner() {
         vo_version_rows(pool, &r3).await > 0,
         "unrelated r3 survives"
     );
-    assert!(
+    assert_eq!(
         svc.party_get(PartyKind::Person, p2.clone(), None)
             .await
             .expect("p2 still readable")
-            .body["_type"]
-            == "PERSON"
+            .body["_type"],
+        "PERSON"
     );
 
     // No orphaned audit rows were left behind (audits swept in the cascade).

--- a/app/ferroehr/tests/it/service_ehr.rs
+++ b/app/ferroehr/tests/it/service_ehr.rs
@@ -1070,7 +1070,7 @@ async fn revision_history_lists_every_version() {
     let items = history["items"].as_array().expect("items");
     assert_eq!(items.len(), 2, "two versions after one update");
     assert_eq!(items[0]["_type"], "REVISION_HISTORY_ITEM");
-    assert!(items[0]["audits"][0]["_type"] == "AUDIT_DETAILS");
+    assert_eq!(items[0]["audits"][0]["_type"], "AUDIT_DETAILS");
 }
 
 #[tokio::test]

--- a/crates/openehr-adl/src/flatten.rs
+++ b/crates/openehr-adl/src/flatten.rs
@@ -606,11 +606,7 @@ fn resolve_object_mut<'a>(
         // with a copy of its target structure resolved in the snapshot.
         let children = attributes[attr_pos].children.as_mut()?;
         if let CObject::CComplexObjectProxy(proxy) = &children[child_pos] {
-            if let Some(expanded) = expand_proxy(&snapshot, proxy) {
-                children[child_pos] = expanded;
-            } else {
-                return None;
-            }
+            children[child_pos] = expand_proxy(&snapshot, proxy)?;
         }
         current = match &mut children[child_pos] {
             CObject::CComplexObject(CComplexObject::CComplexObject(d)) => d,

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,17 +19,17 @@
 # The RUST_VERSION toolchain is single-sourced from rust-toolchain.toml; CI
 # cross-checks the ARG against its `channel` so they never drift.
 
-ARG RUST_VERSION=1.96.1
+ARG RUST_VERSION=1.97.1
 ARG CARGO_CHEF_VERSION=0.1.77
 
 # ── chef: the builder toolchain + cargo-chef, a cached base for planner/builder ─
-# Digest-pinned rust:1.96.1-slim-trixie (Debian 13, glibc 2.41), resolved
+# Digest-pinned rust:1.97.1-slim-trixie (Debian 13, glibc 2.41), resolved
 # 2026-07-24. The builder and the cc-debian13 runtime below share the Debian 13
 # generation so the binary links the exact glibc it runs against. Pinning by
 # digest (not the mutable tag) guarantees a reproducible base
 # (docs.docker.com/build/building/best-practices — "pinning to a digest
 # guarantees the same image version").
-FROM rust:${RUST_VERSION}-slim-trixie@sha256:31ee7fc65186be7e0e0ccb3f2ca305f14e4739e7642a1ae65753aa5d7b874523 AS chef
+FROM rust:${RUST_VERSION}-slim-trixie@sha256:3b2879047d42784ca9403ad20c51ed3df361a50f1df96f5777d39b4e33aa65cd AS chef
 ARG CARGO_CHEF_VERSION
 # cargo-chef pinned by version, installed behind a cargo-registry cache mount so
 # the download is not repeated on rebuilds (docs.docker.com/build/cache/optimize

--- a/docker/admin-ui/Dockerfile
+++ b/docker/admin-ui/Dockerfile
@@ -23,17 +23,17 @@
 # (that compiles a vendored OpenSSL C tree — ~10 min per cold build); the same
 # prebuilt path the CI workflows use.
 
-ARG RUST_VERSION=1.96.1
+ARG RUST_VERSION=1.97.1
 ARG CARGO_CHEF_VERSION=0.1.77
 ARG CARGO_LEPTOS_VERSION=0.3.7
 ARG WASM_BINDGEN_VERSION=0.2.126
 ARG TAILWIND_VERSION=v4.3.3
 
 # ── chef: builder toolchain + cargo-chef (cached base for planner/builder) ─────
-# Digest-pinned rust:1.96.1-slim-trixie (Debian 13, glibc 2.41), resolved
+# Digest-pinned rust:1.97.1-slim-trixie (Debian 13, glibc 2.41), resolved
 # 2026-07-24 — same base + rationale as docker/Dockerfile
 # (docs.docker.com/build/building/best-practices — pin by digest).
-FROM rust:${RUST_VERSION}-slim-trixie@sha256:31ee7fc65186be7e0e0ccb3f2ca305f14e4739e7642a1ae65753aa5d7b874523 AS chef
+FROM rust:${RUST_VERSION}-slim-trixie@sha256:3b2879047d42784ca9403ad20c51ed3df361a50f1df96f5777d39b4e33aa65cd AS chef
 ARG CARGO_CHEF_VERSION
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     cargo install cargo-chef --version ${CARGO_CHEF_VERSION} --locked

--- a/docs/VERSIONS.md
+++ b/docs/VERSIONS.md
@@ -39,8 +39,8 @@ releases never ride the product version.
 
 | Item | Pin |
 |---|---|
-| Rust toolchain | stable 1.96 (1.96.1) |
-| MSRV | 1.96 |
+| Rust toolchain | stable 1.97 (1.97.1) |
+| MSRV | 1.96 |  <!-- deliberately behind the toolchain: see the MSRV bump policy below -->
 | Edition | 2024 |
 | Cargo resolver | v3 |
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.96.1"
+channel = "1.97.1"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 profile = "default"


### PR DESCRIPTION
Closes #2241.

## Why, honestly

1.97.1 carries an LLVM miscompilation fix whose underlying bug *"has been present since at least Rust 1.87"* — so the pinned 1.96.1 sat **inside** that window.

Nothing here has been traced to it. The argument is exposure, not a reproduction. But a miscompilation is the silent wrong answer this repository legislates against everywhere else, and it is the one the compiler produces on its own.

## The digest was re-resolved, not edited

The CI and container images are **digest-pinned**. Bumping the tag while keeping the old digest silently keeps the old toolchain — the failure that looks like success.

The index digest is the right form, and I confirmed that before trusting it: `docker buildx imagetools inspect rust:1.96.1-slim-trixie` returns `sha256:31ee7fc6…`, which is **exactly the pin already in the tree**. The same command gives `sha256:3b287904…` for 1.97.1.

Moved: `rust-toolchain.toml`, both Dockerfiles (`ARG` + base digest), `ci.yml`, `containers.yml`, `Cargo.toml`, `docs/VERSIONS.md`, and a stale pin claim in `fuzzing.md`.

## MSRV stays at 1.96 — a decision, and a verified one

Nothing here uses a 1.97 feature, and the eight published crates are the only artifacts whose consumers would feel a bump. `cargo hack check --rust-version` still passes on 1.96 — including with `--all-targets`.

**That flag is new.** The Cargo book's own MSRV recipe passes `--all-targets`; our job did not, so tests and benches were never MSRV-checked. It passes with it, so the check is now the stricter official form.

## Two new lints, fixed rather than allowed

- `question_mark` — an `if let`/`else` block that already returned `None`, now `?`.
- `manual_assert_eq` — two `assert!(a == b)` sites, which is what `testing.md` already asks for.

This is exactly what the Cargo book warns about: *"CI can fail due to new toolchain versions because there are limited compatibility guarantees around warnings."* Fine in a dedicated PR; not fine as a surprise on unrelated work — hence **#2278**, which files the automation the same passage recommends (a scheduled job that PRs the bump).

## Re-verified, not carried forward

`testing.md` records an empirical claim that `allow-panic-in-tests` does not suppress `panic_in_result_fn`. I re-checked it on 1.97 with a fresh probe crate rather than assuming it survived the bump — it still holds, and the note now says which toolchain it was verified on.

## Verification, all on 1.97.1

2791 tests pass; clippy clean at `-D warnings` across the workspace **and** the admin-ui SSR lane; rustdoc clean with `RUSTDOCFLAGS=-D warnings`; `cargo fmt --check` clean; MSRV job green on 1.96 with `--all-targets`.