### PR TITLE
fix: errors carry their cause, and an ehr: URI names the attribute it addresses

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,9 +200,18 @@ jobs:
           set -euo pipefail
           assets="$(gh release view "$TAG" --json assets --jq '.assets[].name')"
           echo "$assets"
+          # Every suffix release-build.yml uploads per architecture. The SBOM
+          # document and its attestation bundle are checked too: a release
+          # publishing without them is unfixable (immutability), and the only
+          # remedy would be another version.
           missing=""
           for arch in x86_64 aarch64; do
-            for suffix in ".tar.gz" ".tar.gz.sigstore.json" ".tar.gz.intoto.jsonl"; do
+            for suffix in \
+              ".tar.gz" \
+              ".tar.gz.sigstore.json" \
+              ".tar.gz.sbom.sigstore.json" \
+              ".tar.gz.intoto.jsonl" \
+              ".cdx.json"; do
               printf '%s\n' "$assets" \
                 | grep -q "ferroehr-${TAG}-${arch}-unknown-linux-gnu${suffix}" \
                 || missing="$missing ferroehr-${TAG}-${arch}-unknown-linux-gnu${suffix}"

--- a/.github/workflows/toolchain-watcher.yml
+++ b/.github/workflows/toolchain-watcher.yml
@@ -1,0 +1,391 @@
+# Scheduled Rust toolchain watcher (tracker issue #2278).
+#
+# The Cargo book's CI guidance asks for exactly this
+# (https://doc.rust-lang.org/cargo/guide/continuous-integration.html):
+# "CI can fail due to new toolchain versions because there are limited
+# compatibility guarantees around warnings. Consider pinning the toolchain
+# version with an automated job that creates a PR to upgrade the toolchain on
+# new releases." We already pin; this lane is the second half.
+#
+# It is a PR, never a push. The point is that a human sees the new lints — the
+# 1.96 -> 1.97.1 move introduced two pedantic lints that fail instantly under
+# -D warnings, which is fine on a dedicated PR and not fine as a surprise on
+# somebody else's.
+#
+# THE DIGEST IS RE-RESOLVED, NEVER COPIED. Bumping the `rust:X-<variant>` tag
+# while keeping the previous @sha256 pin silently keeps the OLD toolchain in
+# every container-based job — a failure that looks like success. The index
+# digest is read back from the registry for the new tag and every pin site
+# moves together, and a residual-pin check refuses to open a PR that missed one.
+#
+# THE MSRV IS A SEPARATE DATUM AND DOES NOT MOVE (docs/VERSIONS.md §MSRV bump
+# policy). This lane never writes `rust-version`; it asserts the line is
+# byte-identical after its edits. If the new toolchain makes the declared MSRV
+# unbuildable, ci.yml's `msrv` job (`cargo hack check --rust-version`) fails on
+# this PR — loudly, and without the MSRV having been moved to hide it.
+#
+# PREREQUISITE — the TOOLCHAIN_BUMP_TOKEN secret. Two properties of
+# GITHUB_TOKEN make it insufficient here, both documented and neither
+# work-aroundable: it has no `workflows` permission, so a ref update carrying
+# .github/workflows/** is refused outright; and events it raises start no
+# workflow run, so a PR opened with it arrives with no checks — which is
+# precisely the "a human sees the new lints" property this lane exists for
+# (docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication).
+# A fine-grained PAT or GitHub App installation token with contents:write,
+# pull-requests:write and workflows:write satisfies both. Without it the lane
+# still opens a PR for every pin it CAN move, says so in the PR body, and then
+# fails the job — degraded and loud, never silently partial.
+#
+# NOTE: GitHub disables scheduled workflows after 60 days without repository
+# activity — re-enable from the Actions tab if that ever happens.
+name: Toolchain watcher
+
+on:
+  schedule:
+    # Mondays 07:43 UTC — off the hour, and clear of every other scheduled
+    # lane (fuzz 02:41, latest-deps 05:17, codeql 05:23, scorecard 05:37,
+    # spec watchers 06:17/06:47, image-scan 07:13).
+    - cron: "43 7 * * 1"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Resolve the bump and print the diff without creating a branch or PR"
+        type: boolean
+        default: false
+      force_version:
+        description: "Rehearsal: bump to this exact version instead of the one discovered upstream (e.g. 1.97.0). Empty = use upstream."
+        type: string
+        default: ""
+
+permissions: {}
+
+concurrency:
+  group: toolchain-watcher
+  cancel-in-progress: false
+
+jobs:
+  watch:
+    name: watch
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write # create the blob/tree/commit and the branch ref
+      pull-requests: write # open the bump PR
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # ── Discover ────────────────────────────────────────────────────────
+      # The release channel manifest is the official, machine-readable source
+      # of what "stable" currently is; it is what rustup itself resolves
+      # against. It is TOML, so it is read with awk + sed rather than jq.
+      - name: Discover the newest stable Rust release
+        id: discover
+        env:
+          FORCE_VERSION: ${{ inputs.force_version }}
+        run: |
+          set -euo pipefail
+
+          current=$(awk -F'"' '/^[[:space:]]*channel[[:space:]]*=/ { print $2; exit }' rust-toolchain.toml)
+          if ! printf '%s' "$current" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::rust-toolchain.toml channel is '$current', not an exact x.y.z pin. This lane only moves exact pins."
+            exit 1
+          fi
+
+          if [ -n "${FORCE_VERSION:-}" ]; then
+            latest="$FORCE_VERSION"
+            echo "rehearsal: forced target version $latest"
+          else
+            manifest=$(mktemp)
+            curl -fsSL --retry 3 --retry-delay 5 --max-time 120 \
+              https://static.rust-lang.org/dist/channel-rust-stable.toml -o "$manifest"
+            # [pkg.rust] version = "1.97.1 (<commit> <date>)" — take the first
+            # `version` inside that table and stop at the next table header, so
+            # a sibling package's version can never be picked up by mistake.
+            latest=$(awk '
+              /^\[pkg\.rust\]$/          { inside = 1; next }
+              inside && /^\[/            { exit }
+              inside && /^version[ ]*=/  { print; exit }
+            ' "$manifest" | sed -E 's/^version[ ]*=[ ]*"([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+          fi
+
+          if ! printf '%s' "$latest" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Could not read a x.y.z stable version from the release channel manifest (got '$latest'). The manifest shape may have changed."
+            exit 1
+          fi
+
+          echo "pinned=$current  upstream-stable=$latest"
+          echo "old_version=$current" >> "$GITHUB_OUTPUT"
+          echo "new_version=$latest" >> "$GITHUB_OUTPUT"
+
+          if [ "$current" = "$latest" ]; then
+            echo "bump=0" >> "$GITHUB_OUTPUT"
+            echo "::notice::Toolchain pin $current is the newest stable release. Nothing to do."
+          else
+            echo "bump=1" >> "$GITHUB_OUTPUT"
+            echo "::notice::New stable Rust $latest (pinned: $current)."
+          fi
+
+      # ── Re-resolve the base-image digest ────────────────────────────────
+      # The image VARIANT is read out of docker/Dockerfile rather than spelled
+      # here, so a future base change (trixie -> whatever) is followed
+      # automatically instead of silently pinning the wrong flavour.
+      - name: Re-resolve the base-image digest for the new tag
+        id: image
+        if: steps.discover.outputs.bump == '1'
+        env:
+          NEW_VERSION: ${{ steps.discover.outputs.new_version }}
+        run: |
+          set -euo pipefail
+
+          variant=$(sed -nE 's/^FROM rust:[^-]*-([A-Za-z0-9._-]+)@sha256:[0-9a-f]{64}.*/\1/p' docker/Dockerfile | head -1)
+          if [ -z "$variant" ]; then
+            echo "::error::No digest-pinned 'FROM rust:...-<variant>@sha256:...' line in docker/Dockerfile. The base-image shape changed; this lane needs updating."
+            exit 1
+          fi
+
+          image="rust:${NEW_VERSION}-${variant}"
+          echo "resolving $image"
+          if ! inspect=$(docker buildx imagetools inspect "$image" 2>&1); then
+            echo "$inspect"
+            echo "::error::$image is not published yet. The toolchain released but the official image has not landed; this lane will pick it up on the next run rather than pin a stale digest."
+            exit 1
+          fi
+          digest=$(printf '%s\n' "$inspect" | awk '$1 == "Digest:" { print $2; exit }')
+          if ! printf '%s' "$digest" | grep -qE '^sha256:[0-9a-f]{64}$'; then
+            echo "::error::Could not read an index digest for $image (got '$digest')."
+            exit 1
+          fi
+
+          echo "variant=$variant" >> "$GITHUB_OUTPUT"
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+          echo "$image -> $digest"
+
+      # ── Move every pin ──────────────────────────────────────────────────
+      - name: Move every toolchain pin
+        id: edit
+        if: steps.discover.outputs.bump == '1'
+        env:
+          OLD_VERSION: ${{ steps.discover.outputs.old_version }}
+          NEW_VERSION: ${{ steps.discover.outputs.new_version }}
+          VARIANT: ${{ steps.image.outputs.variant }}
+          NEW_DIGEST: ${{ steps.image.outputs.digest }}
+        run: |
+          set -euo pipefail
+
+          # The MSRV line, captured before anything is written, so the
+          # "does not move the MSRV" property is asserted rather than assumed.
+          msrv_before=$(grep -E '^rust-version[[:space:]]*=' Cargo.toml)
+
+          old_re=$(printf '%s' "$OLD_VERSION" | sed 's/\./\\./g')
+          new_minor=${NEW_VERSION%.*}
+
+          # 1. The channel pin itself.
+          sed -i -E "s|^([[:space:]]*channel[[:space:]]*=[[:space:]]*\").*(\")|\1${NEW_VERSION}\2|" rust-toolchain.toml
+
+          # 2. The two Dockerfiles: the build arg, the digest-pinned FROM, and
+          #    the prose that names the same tag.
+          for f in docker/Dockerfile docker/admin-ui/Dockerfile; do
+            sed -i -E "s|^ARG RUST_VERSION=.*|ARG RUST_VERSION=${NEW_VERSION}|" "$f"
+            sed -i -E "s|^(FROM rust:[^@]*@)sha256:[0-9a-f]{64}|\1${NEW_DIGEST}|" "$f"
+            sed -i -E "s|rust:${old_re}-|rust:${NEW_VERSION}-|g" "$f"
+          done
+
+          # 3. The workflow `container:` images and the cache keys that carry
+          #    the toolchain version. A blanket replace of the exact old
+          #    version inside these two files is deliberate: it also catches
+          #    cache keys added since this lane was written, which a list of
+          #    known line numbers would silently miss.
+          for f in .github/workflows/ci.yml .github/workflows/containers.yml; do
+            sed -i -E "s|(rust:[^@[:space:]]*@)sha256:[0-9a-f]{64}|\1${NEW_DIGEST}|g" "$f"
+            sed -i -E "s|${old_re}|${NEW_VERSION}|g" "$f"
+          done
+
+          # 4. The prose pins. Anchored substitutions only — a loose replace in
+          #    Cargo.toml could reach a dependency version.
+          sed -i -E "s#^\| Rust toolchain \|.*\|#| Rust toolchain | stable ${new_minor} (${NEW_VERSION}) |#" docs/VERSIONS.md
+          sed -i -E "s|^# Toolchain: Rust stable [0-9]+\.[0-9]+\.[0-9]+,|# Toolchain: Rust stable ${NEW_VERSION},|" Cargo.toml
+          sed -i -E "s|uses a [0-9]+\.[0-9]+ feature|uses a ${new_minor} feature|" Cargo.toml
+
+          # 5. The changelog entry, inserted into the existing [Unreleased]
+          #    '### Changed' subsection when there is one — a second '### Changed'
+          #    in the same release section is refused by
+          #    scripts/checks/changelog-structure.sh.
+          entry="- **The Rust toolchain moves to ${NEW_VERSION}.** The pinned channel, both container base images (digest re-resolved) and the CI job containers move together; the MSRV is unchanged."
+          awk -v entry="$entry" '
+            state == 0 && /^## \[Unreleased\]/            { print; state = 1; next }
+            state == 1 && /^### Changed[[:space:]]*$/     { print; print ""; print entry; state = 2; next }
+            state == 1 && /^## \[/                        { print "### Changed"; print ""; print entry; print ""; print; state = 2; next }
+                                                          { print }
+            END { if (state == 1) { print "### Changed"; print ""; print entry } }
+          ' CHANGELOG.md > CHANGELOG.md.new
+          mv CHANGELOG.md.new CHANGELOG.md
+
+          # ── The properties that make this safe to merge ────────────────────
+
+          msrv_after=$(grep -E '^rust-version[[:space:]]*=' Cargo.toml)
+          if [ "$msrv_before" != "$msrv_after" ]; then
+            echo "::error::The MSRV line changed ('$msrv_before' -> '$msrv_after'). It is a separate datum with its own policy and this lane must never move it."
+            exit 1
+          fi
+
+          # No pin left behind. A residual old version in any of these files is
+          # exactly the half-bump this lane exists to prevent, so it fails here
+          # rather than opening a PR that looks complete.
+          residual=$(grep -Fn "$OLD_VERSION" \
+            rust-toolchain.toml docker/Dockerfile docker/admin-ui/Dockerfile \
+            .github/workflows/ci.yml .github/workflows/containers.yml || true)
+          if [ -n "$residual" ]; then
+            echo "$residual"
+            echo "::error::A pin still names $OLD_VERSION after the rewrite. A new pin site appeared that this lane does not know about — add it above."
+            exit 1
+          fi
+
+          # And every digest-pinned rust image now carries the RE-RESOLVED
+          # digest. Stated as "none may differ" rather than "N must match", so
+          # a pin site added later is covered without editing this check.
+          pinned=$(grep -nE 'rust:[^@[:space:]]*@sha256:[0-9a-f]{64}' \
+            docker/Dockerfile docker/admin-ui/Dockerfile \
+            .github/workflows/ci.yml .github/workflows/containers.yml || true)
+          stale=$(printf '%s\n' "$pinned" | grep -v '^$' | grep -Fv "$NEW_DIGEST" || true)
+          if [ -n "$stale" ]; then
+            echo "$stale"
+            echo "::error::A digest-pinned rust image still carries the previous digest. Bumping the tag while keeping the old digest silently keeps the old toolchain — refusing to open a partial bump."
+            exit 1
+          fi
+          n_pinned=$(printf '%s\n' "$pinned" | awk 'NF { n++ } END { print n + 0 }')
+          echo "digest-pinned rust references, all re-resolved: $n_pinned"
+          if [ "$n_pinned" -lt 1 ]; then
+            echo "::error::No digest-pinned rust image was found at all. The base-image shape changed; this lane needs updating."
+            exit 1
+          fi
+
+          if ! git diff --quiet; then
+            git diff --name-only | tee changed-files.txt
+            echo "changed=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::The version differs but no file changed. The pin sites moved; this lane needs updating."
+            exit 1
+          fi
+
+          {
+            echo "### Rust ${OLD_VERSION} -> ${NEW_VERSION}"
+            echo
+            echo "Base image: \`rust:${NEW_VERSION}-${VARIANT}\` at \`${NEW_DIGEST}\`"
+            echo
+            echo '```diff'
+            git diff
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # ── Open the PR ─────────────────────────────────────────────────────
+      # The commit is created through the Git Data REST API, never local git
+      # plumbing: API commits made with a repository token are signed by GitHub
+      # and show Verified (owner hard rule 2026-08-01 — CI pushes only verified
+      # commits; docs.github.com/en/rest/git/commits, "Signature verification").
+      # The mechanism is the same one ci.yml uses for the coverage badge; the
+      # difference is that this one carries a parent and a base tree, because it
+      # lands on a real branch rather than an orphan ref.
+      - name: Open the toolchain bump PR
+        if: steps.edit.outputs.changed == '1' && inputs.dry_run != true
+        env:
+          # A fine-grained PAT or App token when one is configured, the
+          # workflow token otherwise. Two things need the former: GITHUB_TOKEN
+          # cannot write .github/workflows/** (it has no `workflows`
+          # permission), and events it raises do not start workflow runs — so a
+          # PR opened with it arrives with no checks, which defeats the purpose
+          # of seeing the new lints before they land.
+          GH_TOKEN: ${{ secrets.TOOLCHAIN_BUMP_TOKEN || github.token }}
+          HAVE_TOKEN: ${{ secrets.TOOLCHAIN_BUMP_TOKEN != '' && '1' || '0' }}
+          REPO: ${{ github.repository }}
+          BASE_BRANCH: ${{ github.event.repository.default_branch || 'develop' }}
+          OLD_VERSION: ${{ steps.discover.outputs.old_version }}
+          NEW_VERSION: ${{ steps.discover.outputs.new_version }}
+          VARIANT: ${{ steps.image.outputs.variant }}
+          NEW_DIGEST: ${{ steps.image.outputs.digest }}
+        run: |
+          set -euo pipefail
+
+          branch="chore/rust-toolchain-${NEW_VERSION}"
+
+          # Dedup across states, the spec-watcher pattern: an open PR means the
+          # bump is already filed, and a closed one means a human said no. Both
+          # are answers, and re-opening either weekly would be noise.
+          existing=$(gh pr list --repo "$REPO" --head "$branch" --state all \
+                       --json number,state --jq '.[0] | select(. != null) | "#\(.number) (\(.state))"')
+          if [ -n "$existing" ]; then
+            echo "::notice::A PR for $branch already exists: $existing. Nothing to do."
+            exit 0
+          fi
+
+          files=$(grep -v '^$' changed-files.txt || true)
+          if [ -z "$files" ]; then
+            echo "::error::No changed files were recorded. The rewrite step did not hand anything to commit."
+            exit 1
+          fi
+          if [ "$HAVE_TOKEN" != "1" ]; then
+            # The workflow token cannot write workflow files: the ref update is
+            # refused outright, which would lose the whole PR. Drop them from
+            # the commit so the rest still lands, and let the reader know.
+            files=$(printf '%s\n' "$files" | grep -v '^\.github/workflows/' || true)
+          fi
+
+          base_sha=$(gh api "repos/${REPO}/git/ref/heads/${BASE_BRANCH}" --jq .object.sha)
+          base_tree=$(gh api "repos/${REPO}/git/commits/${base_sha}" --jq .tree.sha)
+
+          tree_args=()
+          while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            blob=$(gh api "repos/${REPO}/git/blobs" \
+                     -f encoding=base64 -f content="$(base64 -w0 "$f")" --jq .sha)
+            tree_args+=( -f "tree[][path]=$f" -f "tree[][mode]=100644" \
+                         -f "tree[][type]=blob" -f "tree[][sha]=$blob" )
+            echo "staged $f ($blob)"
+          done <<< "$files"
+
+          tree=$(gh api "repos/${REPO}/git/trees" \
+                   -f "base_tree=${base_tree}" "${tree_args[@]}" --jq .sha)
+          commit=$(gh api "repos/${REPO}/git/commits" \
+                     -f "message=build(toolchain): move to Rust ${NEW_VERSION}" \
+                     -f "tree=${tree}" -f "parents[]=${base_sha}" --jq .sha)
+          gh api "repos/${REPO}/git/refs" \
+            -f "ref=refs/heads/${branch}" -f "sha=${commit}" --jq .ref
+
+          {
+            echo "The Cargo book asks for this job by name (Continuous Integration, \"Checking for warnings\"): the toolchain is pinned, and an automated job opens the upgrade PR so new-toolchain lint churn arrives on its own branch instead of on somebody else's."
+            echo
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Previous pin | \`${OLD_VERSION}\` |"
+            echo "| New stable | \`${NEW_VERSION}\` |"
+            echo "| Base image | \`rust:${NEW_VERSION}-${VARIANT}\` |"
+            echo "| Index digest | \`${NEW_DIGEST}\` |"
+            echo
+            echo "The digest was **re-resolved from the registry** for the new tag, not carried over. Copying it forward would keep the old toolchain in every container-based job while every version string claimed otherwise."
+            echo
+            echo "## What to check before merging"
+            echo
+            echo "- **New lints.** A minor release routinely adds lints that fail instantly under \`-D warnings\` with the pedantic table. That churn belongs on this PR."
+            echo "- **The MSRV did not move**, and must not: it is a separate datum with its own policy (\`docs/VERSIONS.md\` §MSRV bump policy). If \`cargo hack check --rust-version\` is red here, the fix is a deliberate MSRV decision in its own PR, never a quiet bump inside this one."
+            echo "- **The digest is the index digest** of \`rust:${NEW_VERSION}-${VARIANT}\`, verifiable with \`docker buildx imagetools inspect rust:${NEW_VERSION}-${VARIANT}\`."
+            if [ "$HAVE_TOKEN" != "1" ]; then
+              echo
+              echo "## This bump is INCOMPLETE"
+              echo
+              echo "No \`TOOLCHAIN_BUMP_TOKEN\` secret is configured, so this commit could not include \`.github/workflows/ci.yml\` or \`.github/workflows/containers.yml\`: the workflow token has no \`workflows\` permission and the ref update is refused. Their \`container:\` pins and cache keys still name \`${OLD_VERSION}\` and must be moved by hand to \`rust:${NEW_VERSION}-${VARIANT}@${NEW_DIGEST}\` before this merges — the toolchain-pin check in both files fails until they are."
+              echo
+              echo "Checks also do not start by themselves on a PR opened with the workflow token. Close and reopen this PR to raise them."
+            fi
+          } > pr-body.md
+
+          url=$(gh pr create --repo "$REPO" --base "$BASE_BRANCH" --head "$branch" \
+                  --title "build(toolchain): move to Rust ${NEW_VERSION}" \
+                  --body-file pr-body.md)
+          echo "::notice::Opened $url"
+          echo "$url" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$HAVE_TOKEN" != "1" ]; then
+            echo "::error::Opened an INCOMPLETE bump PR. Configure a TOOLCHAIN_BUMP_TOKEN secret (a fine-grained PAT or GitHub App installation token with contents:write, pull-requests:write and workflows:write) so this lane can move the workflow pins and so its PRs start their own checks."
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,15 +15,6 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
-
-### Changed
-
-- **The Rust toolchain moves to 1.97.1.** It carries an LLVM miscompilation
-  fix whose underlying bug has been present since at least 1.87 — the pinned
-  1.96.1 sat inside that window. The MSRV stays 1.96: nothing here uses a 1.97
-  feature, and the published crates are the only artifacts whose consumers
-  would feel a bump.
-
 ### Added
 
 - **`Time_Definitions`'s eleven validity functions are now public** on
@@ -33,6 +24,37 @@ workflow refuses a tag that has no matching section here.
   anywhere despite being declared by the spec.
 
 ### Changed
+
+- **An `ehr:` URI must name the `EHR` attribute it addresses.** The server
+  accepted a short form that put the versioned-object id straight after the
+  EHR id (`ehr:/<ehr_id>/<uid>::SYSTEM::1`); no released spec defines it. BASE
+  `master11-paths` enumerates the locator's values — they "come from attribute
+  names of the class `EHR` … namely `compositions`, `directory` etc." — and
+  every example carries one. The short form is now refused; write
+  `ehr:/<ehr_id>/compositions/<uid>::SYSTEM::1` instead. This affects any
+  `DV_EHR_URI` value stored in a `LINK` or elsewhere that used the short form.
+
+- **A refused log-filter swap now answers `400` or `503`, not always `400`.**
+  `POST`/`DELETE /management/loggers` carried one flattened error string, so a
+  reload layer that had gone away was reported as if the caller had written bad
+  directives. The two faults are now distinct types: unparseable directives stay
+  `400`, a subscriber whose reload handle is gone is `503`.
+
+- **Errors carry their cause across the remaining request-path seams.** Six
+  sites in the platform library — Web Template building, FHIR terminology
+  decoding, the log-filter seam, and admin dump/load payload reading — flattened
+  their cause into a message, so nothing downstream could match on it. Each now
+  carries a typed source (RFC 0201). The sites that remain are structural and
+  say so at the site: `prometheus::Error` has no source-bearing variant, and the
+  console's error types must be serializable (server-fn boundary) or
+  `Clone + Eq` (reactive-signal storage), which no underlying error is.
+
+- **The Rust toolchain moves to 1.97.1.** It carries an LLVM miscompilation
+  fix whose underlying bug has been present since at least 1.87 — the pinned
+  1.96.1 sat inside that window. The MSRV stays 1.96: nothing here uses a 1.97
+  feature, and the published crates are the only artifacts whose consumers
+  would feel a bump.
+
 
 - **One ISO-8601 grammar, not two.** `openehr-rm` validated dates, times,
   date-times and durations with its own hand-written reader while depending on
@@ -330,7 +352,6 @@ workflow refuses a tag that has no matching section here.
 - Container scanning in CI: image vulnerability scanning, Dockerfile lint, and secret plus misconfiguration scanning over the tree. Adjudicated exceptions carry their reasoning — for an unreachable finding in an inherited upstream layer, as a published OpenVEX document under `security/vex/`.
 - Boot warnings for two deliberate weakenings that are easy to leave switched on: `cors_permissive`, and authentication enabled on a **plaintext** listener bound to a routable address.
 
-### Changed
 
 - **Every import from `openehr-its` now names the module that defines it.** The
   crate's nine convenience re-exports are gone, so consumers write
@@ -541,7 +562,6 @@ workflow refuses a tag that has no matching section here.
 - `openehr-lang` now models generations by COMPONENT VERSION like every other spec crate: one `openehr_lang::v1_1` generation holding the version's published specifications side by side — the STABLE, tool-implemented BMM v2.x model (`bmm`/`bmm_persistence`/`beom`, on the prelude) beside the PAUSED BMM3 model (`bmm3`, full-path only) — together with the hand-written ODIN/BEL/EL readers and the shared lexer for that version's notations (all previously crate-root modules). The released LANG 1.0.0 machine-readable BMM is recorded as unusable for code generation (no `includes`, unnamed `BMM_CLASS`/`BMM_PACKAGE`, an explicitly obsolete package; BMM is TRIAL in that release), so no 1.0.0 generation exists until upstream republishes usable artifacts.
 - The published `openehr-*` spec crates now expose every BMM generation under a version-named top module — `openehr_base::v1_3`, `openehr_rm::v1_2`, `openehr_lang::v2`/`v3` (replacing `bmm`/`bmm_persistence`/`beom` and `bmm3` at the crate root), `openehr_am::v1_4`/`v2_4` (replacing `am14`/`am24`), `openehr_term::v3_1` — with a new per-crate `Generation` enum (derived `Default` marking the current generation, `spec_version()`/`as_str()`, `FromStr`/`Display`) and the crate prelude re-exporting the current generation only. Import paths into these crates change accordingly; the served wire formats are unchanged.
 
-
 ### Removed
 
 - **`authz.rbac.management_access` and `management.access_default` are gone**
@@ -563,44 +583,6 @@ workflow refuses a tag that has no matching section here.
 
 
 - The generated `openehr-*` spec crates no longer carry a crate-level `SPEC_VERSION` constant: a multi-generation crate has no single implemented spec version, and a fixed crate-root pin would contradict a configured non-current generation. The ONLY pin authority is the emitted `Generation` enum (per-variant `const fn spec_version()`; the derived `Default` variant is the current generation) — the generation modules carry no version constant either; the hand-written single-spec crates (`openehr-its`, `openehr-query`, `openehr-adl`) keep their literal constant.
-
-
-### Security
-
-- The admin console's `Content-Security-Policy` no longer allows inline scripts.
-  `script-src` is now `'self' 'wasm-unsafe-eval' 'nonce-…'`, where the nonce is
-  freshly generated for every response and stamped on the only inline script the
-  console emits — Leptos's hydration bootstrap and its resource-serialization
-  chunks. An injected inline script no longer runs. `style-src` keeps
-  `'unsafe-inline'`, because the console's component library creates its
-  stylesheets in the browser through the DOM without a nonce attribute; adding a
-  nonce there would suppress the inline allowance under CSP Level 3 and leave the
-  console unstyled, so the allowance stays with its reason recorded rather than
-  being traded for a policy that looks stricter and works worse.
-
-- The error-body hygiene check now also covers Service Model faults
-  (`SmError::exception` and `exception`-coded call statuses), which are a
-  second route to a `500` response body it previously did not inspect. Three
-  boot-time terminology and subject-proxy failures were rewritten to keep the
-  underlying diagnostic out of the message and carry it as an error cause
-  instead, so it reaches the server log and never a client.
-
-- Every one of the 20 GitHub Actions referenced by the build, test, release and publish pipelines is now pinned to a full commit SHA instead of a mutable tag, so a retagged or compromised upstream release can no longer change what runs against the tokens that publish this project's releases, container images and crates. Each pin carries its human-readable version in a trailing comment and was verified to belong to the named repository.
-- 38 of the 40 repository checkouts in CI no longer leave the job's API token in `.git/config` for the rest of the job (`persist-credentials: false`), so a later step — a third-party action, a build script, an uploaded artifact — can no longer pick it up and push with it. The two exceptions are the documentation jobs that genuinely use git against the remote, and both are now annotated with the reason.
-- All nine workflows now start from `permissions: {}` and grant each job only what that job actually uses, so write access to releases, packages, issues or Pages exists in the four jobs that publish and nowhere else. Previously a single workflow-level grant applied to every job in the file — `contents: write` to all of `release.yml`, `packages: write` to all of `containers.yml` — and `codeql.yml` declared nothing at all and inherited the repository default.
-- The release tarballs and the crates.io uploads are now built with no compile cache at all, so a published artifact can only contain bytes produced from the tag being released. Both lanes were silently restoring one: the toolchain action they use enables caching by default, which the release job's own comment already assumed it did not.
-- The per-architecture release tarballs are now built from the exact commit the release notes were read from, resolved once and passed on as a SHA, instead of each job resolving the release tag separately. A tag that moved between the two jobs could previously publish assets that did not match the release they were attached to.
-- The build pipeline is now itself statically analysed on every pull request: a new `zizmor` gate audits the workflow definitions, and CodeQL analyses them as source alongside the Rust code. The properties above therefore cannot silently regress — an unpinned action, a checkout keeping its credential without a recorded reason, or a context value spliced into a shell command each fail the build.
-
-- **The PGP signing private key is no longer world-readable inside the pod.**
-  The `secrets` volume was projected at `0440`, but the sibling `config` volume
-  carried no mode and so defaulted to `0644` — and that volume holds every
-  `config.files` entry, whose documented use includes the PGP signing private
-  key (`signing.key_path`), mutual-TLS PEMs and a JWKS blob, plus `ferroehr.toml`
-  itself when the configuration holds a secret the chart cannot route out. Now
-  `0440`, matching the secrets volume. Verified on a live cluster: the applied
-  `defaultMode` is 288 (0440) and both server pods read their configuration and
-  became Ready.
 
 ### Fixed
 
@@ -885,6 +867,42 @@ workflow refuses a tag that has no matching section here.
 - Configuring both a symmetric secret (`auth.oidc.hmac_secret`/`_file`) and a static JWKS (`auth.oidc.jwks_json`/`_file`) is now a boot-time configuration error naming both keys. Previously the server silently used the symmetric secret and ignored the JWKS.
 - An unreachable or unresponsive OAuth2/OIDC issuer no longer stalls bearer-token requests or hammers the issuer with outbound connections. The client that fetches the issuer's discovery document and JWKS now carries explicit timeouts, and a failed fetch is remembered briefly, so bearer requests during an issuer outage are refused fast instead of each one opening a fresh connection and waiting for the operating system's TCP timeout. Three new `[auth.oidc]` keys tune this (they apply only when signing keys come from discovery — that is, when neither `hmac_secret` nor `jwks_json` is set): `connect_timeout_ms` (default `3000`), `request_timeout_ms` (default `5000`), and `negative_cache_ttl_seconds` (default `10`, `0` disables). Successfully fetched keys keep their existing five-minute lifetime, and recovery is automatic once the negative entry expires.
 
+### Security
+
+- The admin console's `Content-Security-Policy` no longer allows inline scripts.
+  `script-src` is now `'self' 'wasm-unsafe-eval' 'nonce-…'`, where the nonce is
+  freshly generated for every response and stamped on the only inline script the
+  console emits — Leptos's hydration bootstrap and its resource-serialization
+  chunks. An injected inline script no longer runs. `style-src` keeps
+  `'unsafe-inline'`, because the console's component library creates its
+  stylesheets in the browser through the DOM without a nonce attribute; adding a
+  nonce there would suppress the inline allowance under CSP Level 3 and leave the
+  console unstyled, so the allowance stays with its reason recorded rather than
+  being traded for a policy that looks stricter and works worse.
+
+- The error-body hygiene check now also covers Service Model faults
+  (`SmError::exception` and `exception`-coded call statuses), which are a
+  second route to a `500` response body it previously did not inspect. Three
+  boot-time terminology and subject-proxy failures were rewritten to keep the
+  underlying diagnostic out of the message and carry it as an error cause
+  instead, so it reaches the server log and never a client.
+
+- Every one of the 20 GitHub Actions referenced by the build, test, release and publish pipelines is now pinned to a full commit SHA instead of a mutable tag, so a retagged or compromised upstream release can no longer change what runs against the tokens that publish this project's releases, container images and crates. Each pin carries its human-readable version in a trailing comment and was verified to belong to the named repository.
+- 38 of the 40 repository checkouts in CI no longer leave the job's API token in `.git/config` for the rest of the job (`persist-credentials: false`), so a later step — a third-party action, a build script, an uploaded artifact — can no longer pick it up and push with it. The two exceptions are the documentation jobs that genuinely use git against the remote, and both are now annotated with the reason.
+- All nine workflows now start from `permissions: {}` and grant each job only what that job actually uses, so write access to releases, packages, issues or Pages exists in the four jobs that publish and nowhere else. Previously a single workflow-level grant applied to every job in the file — `contents: write` to all of `release.yml`, `packages: write` to all of `containers.yml` — and `codeql.yml` declared nothing at all and inherited the repository default.
+- The release tarballs and the crates.io uploads are now built with no compile cache at all, so a published artifact can only contain bytes produced from the tag being released. Both lanes were silently restoring one: the toolchain action they use enables caching by default, which the release job's own comment already assumed it did not.
+- The per-architecture release tarballs are now built from the exact commit the release notes were read from, resolved once and passed on as a SHA, instead of each job resolving the release tag separately. A tag that moved between the two jobs could previously publish assets that did not match the release they were attached to.
+- The build pipeline is now itself statically analysed on every pull request: a new `zizmor` gate audits the workflow definitions, and CodeQL analyses them as source alongside the Rust code. The properties above therefore cannot silently regress — an unpinned action, a checkout keeping its credential without a recorded reason, or a context value spliced into a shell command each fail the build.
+
+- **The PGP signing private key is no longer world-readable inside the pod.**
+  The `secrets` volume was projected at `0440`, but the sibling `config` volume
+  carried no mode and so defaulted to `0644` — and that volume holds every
+  `config.files` entry, whose documented use includes the PGP signing private
+  key (`signing.key_path`), mutual-TLS PEMs and a JWKS blob, plus `ferroehr.toml`
+  itself when the configuration holds a secret the chart cannot route out. Now
+  `0440`, matching the secrets volume. Verified on a live cluster: the applied
+  `defaultMode` is 288 (0440) and both server pods read their configuration and
+  became Ready.
 
 ## [3.17.3] - 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -586,6 +586,32 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **AQL archetype subsumption works again for ADL 2 identifiers.** A query
+  naming a parent archetype is supposed to match data created with its
+  specialisations. For an AOM2-era identifier — `openEHR-EHR-OBSERVATION
+  .lipid_panel.v1.0.0`, the form an ADL 2 archetype actually carries — it did
+  not: the predicate read the identifier through a decomposition that accepts
+  only the single-part `.v1` version, silently fell back to matching the whole
+  identifier string, and left the index built for the subsumption query unused.
+  The answer was narrower than the spec requires, with no error. Both eras'
+  forms are now read through the same decomposition the lineage index is built
+  from.
+
+- **`TERMINOLOGY_ID` now enforces its grammar.** A value was accepted if it was
+  merely non-empty and printable, so `"SNOMED CT"` and
+  `"http://snomed.info/sct"` passed. The identifier is now the production BASE
+  `base_types` master05 §Syntaxes states. The version part in parentheses
+  admits a leading digit, because every example the same chapter gives
+  (`ICD9(1999)`, `ICD10AM(3rd_ed)`) starts with one — reported upstream, since
+  the grammar as written refuses openEHR's own identifiers.
+
+- **A Web Template no longer reports a query string as a terminology.** A
+  `C_CODE_REFERENCE` whose reference-set URI carries parameters —
+  `terminology:NSI?subset=doctor_category&language=en-GB` — had the entire
+  remainder copied into the input's `terminology` field, which is a terminology
+  identifier. Only the identifying part is taken now, for both the bare form
+  the conformance templates use and the addressed form AQL documents.
+
 - **The release lane would have shipped a release with no binaries.** GitHub
   release immutability is now enabled, which freezes a release's assets the
   moment it is published — and the binaries, SBOMs and Sigstore bundles are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -586,6 +586,14 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **An operational template whose archetype id carries an ADL 2 version is
+  accepted again.** Uploading an OPT whose root id is
+  `openEHR-EHR-COMPOSITION.minimal.v1.0.0` was refused as a malformed archetype
+  identifier (`VARID`), even though deployed OPT 1.4 exports carry exactly that
+  form and the validator documented the tolerance. The check had been routed
+  through a grammar whose version production is single-part by definition, so
+  the tolerance it described could never fire.
+
 - **AQL archetype subsumption works again for ADL 2 identifiers.** A query
   naming a parent archetype is supposed to match data created with its
   specialisations. For an AOM2-era identifier — `openEHR-EHR-OBSERVATION

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5485,7 +5485,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "indexmap 2.14.0",
  "openehr-am",
@@ -5500,7 +5500,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "serde",
  "serde_json",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "async-trait",
  "axum",
@@ -5558,7 +5558,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "assert_fs",
  "chumsky",
@@ -5572,7 +5572,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "chumsky",
  "logos",
@@ -5581,7 +5581,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "insta",
  "jsonschema",
@@ -5599,7 +5599,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5485,7 +5485,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "indexmap 2.14.0",
  "openehr-am",
@@ -5500,7 +5500,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "serde",
  "serde_json",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "async-trait",
  "axum",
@@ -5558,7 +5558,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "assert_fs",
  "chumsky",
@@ -5572,7 +5572,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "chumsky",
  "logos",
@@ -5581,7 +5581,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "insta",
  "jsonschema",
@@ -5599,7 +5599,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5485,7 +5485,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "indexmap 2.14.0",
  "openehr-am",
@@ -5500,7 +5500,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "serde",
  "serde_json",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "async-trait",
  "axum",
@@ -5558,7 +5558,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "assert_fs",
  "chumsky",
@@ -5572,7 +5572,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "chumsky",
  "logos",
@@ -5581,7 +5581,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "insta",
  "jsonschema",
@@ -5599,7 +5599,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/app/ferroehr-admin-ui/src/builder/lift.rs
+++ b/app/ferroehr-admin-ui/src/builder/lift.rs
@@ -47,6 +47,10 @@ const TEMPLATE_PATH: &str = "/archetype_details/template_id/value";
 /// tells the reader what to do about it (edit it as raw AQL, or run it on the
 /// stored-query runner). Never crosses a server-fn boundary — the lift is pure
 /// and runs on whichever target holds the AQL.
+///
+/// NOTE: `NotAql` carries the parse failure as text because the refusal is held
+/// in an `RwSignal` and compared, so the type must be `Clone + Eq` (Leptos book
+/// `reactivity/working_with_signals`) — which the parser's error is not.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum LiftError {
     /// The stored text is not valid AQL at all.

--- a/app/ferroehr-admin-ui/src/error.rs
+++ b/app/ferroehr-admin-ui/src/error.rs
@@ -3,6 +3,12 @@
 //! strings.
 //!
 //! Implements `FromServerFnError` per the Leptos book (`server/25`).
+//!
+//! NOTE: the variants carry their cause as text because this type crosses the
+//! server-fn boundary — `FromServerFnError` requires `Serialize`/`Deserialize`
+//! (Leptos book `server/25`), which no underlying `reqwest` or parser error
+//! implements, so an `#[source]` here would be unrepresentable rather than
+//! merely inconvenient.
 
 use serde::{Deserialize, Serialize};
 

--- a/app/ferroehr-admin-ui/tests/it/common/mod.rs
+++ b/app/ferroehr-admin-ui/tests/it/common/mod.rs
@@ -234,6 +234,42 @@ impl Harness {
         }
     }
 
+    /// Explicit wait on an `XPath` that additionally requires the element to be
+    /// CLICKABLE — displayed and enabled — before returning it.
+    ///
+    /// A control the console disables until its form is valid is already
+    /// PRESENT, so [`Self::wait_xpath`] hands it back and the click is
+    /// INTERCEPTED by whatever sits above it. That is an error rather than a
+    /// lost interaction, so the re-click loop other journeys use for
+    /// pre-hydration clicks does not cover it — the condition has to be part of
+    /// the wait.
+    ///
+    /// # Panics
+    /// When the element never becomes clickable.
+    pub(crate) async fn wait_clickable_xpath(&self, xpath: &str) -> WebElement {
+        match self
+            .driver
+            .query(By::XPath(xpath))
+            .and_clickable()
+            .wait(Duration::from_secs(15), Duration::from_millis(200))
+            .first()
+            .await
+        {
+            Ok(element) => element,
+            Err(e) => {
+                let url = self
+                    .driver
+                    .current_url()
+                    .await
+                    .map(|u| u.to_string())
+                    .unwrap_or_default();
+                let path = format!("{}/{}-fail.png", self.shots_dir, self.journey);
+                drop(self.driver.screenshot(std::path::Path::new(&path)).await);
+                panic!("waiting for xpath `{xpath}` to become clickable at {url}: {e}");
+            }
+        }
+    }
+
     /// Wait until the current URL contains `fragment` (redirect chains).
     ///
     /// # Panics

--- a/app/ferroehr-admin-ui/tests/it/e2e_admin_ops.rs
+++ b/app/ferroehr-admin-ui/tests/it/e2e_admin_ops.rs
@@ -121,12 +121,27 @@ async fn ensure_template(h: &Harness, fixture: &str, template_id: &str) {
     if h.driver.find(By::Css(row_delete.clone())).await.is_ok() {
         return;
     }
-    h.wait_css("input[type=file]")
-        .await
-        .send_keys(&fixture_opt_path(fixture))
-        .await
-        .expect("upload the fixture OPT via the hidden file input");
-    h.wait_css(&row_delete).await;
+    // The file input's `on:change` is a hydrated listener, and the waits above
+    // only prove the SSR'd list rendered — so a `send_keys` landing before
+    // hydration is simply LOST, exactly like the login submit. Re-send until
+    // the row appears. A repeat after an upload that DID land cannot happen:
+    // the row is re-checked before every attempt.
+    for _ in 0..4 {
+        h.wait_css("input[type=file]")
+            .await
+            .send_keys(&fixture_opt_path(fixture))
+            .await
+            .expect("upload the fixture OPT via the hidden file input");
+        for _ in 0..40 {
+            if h.driver.find(By::Css(row_delete.clone())).await.is_ok() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+    }
+    panic!(
+        "`{template_id}` never appeared after uploading `{fixture}` (pre-hydration uploads exhausted)"
+    );
 }
 
 /// Poll until no element matches `css` (the assert-gone half of every journey).

--- a/app/ferroehr-admin-ui/tests/it/e2e_browse.rs
+++ b/app/ferroehr-admin-ui/tests/it/e2e_browse.rs
@@ -75,14 +75,25 @@ async fn ensure_template_present(h: &Harness) -> bool {
         return false;
     }
     let path = fixture_opt_path();
-    h.wait_css("input[type=file]")
-        .await
-        .send_keys(&path)
-        .await
-        .expect("upload fixture OPT via the hidden file input");
-    // The new row (its detail anchor) appears once the list refetches.
-    h.wait_css(TEMPLATE_LINK).await;
-    true
+    // The change event that drives the upload is a HYDRATED listener, and the
+    // waits above only prove the SSR'd list rendered — a `send_keys` landing
+    // before hydration is simply lost (the login-submit precedent). Re-send
+    // until the row's detail anchor appears; the anchor is re-checked before
+    // every attempt, so an upload that did land is never repeated.
+    for _ in 0..4 {
+        h.wait_css("input[type=file]")
+            .await
+            .send_keys(&path)
+            .await
+            .expect("upload fixture OPT via the hidden file input");
+        for _ in 0..40 {
+            if h.driver.find(By::Css(TEMPLATE_LINK)).await.is_ok() {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+    }
+    panic!("the fixture template never appeared after upload (pre-hydration uploads exhausted)");
 }
 
 /// Expand every collapsed disclosure in the visible catalog tree so the deep

--- a/app/ferroehr-admin-ui/tests/it/e2e_chart.rs
+++ b/app/ferroehr-admin-ui/tests/it/e2e_chart.rs
@@ -114,7 +114,10 @@ async fn results_chart_groups_series_and_toggles_them() {
         .send_keys(CHART_AQL)
         .await
         .expect("type the AQL");
-    h.wait_xpath("//button[normalize-space(.)='Run']")
+    // Run stays DISABLED until the editor's content reaches the signal, so the
+    // wait has to include the condition — a click on the disabled button is
+    // intercepted by the toolbar above it, not merely lost.
+    h.wait_clickable_xpath("//button[normalize-space(.)='Run']")
         .await
         .click()
         .await

--- a/app/ferroehr-admin-ui/tests/it/e2e_docs_shots.rs
+++ b/app/ferroehr-admin-ui/tests/it/e2e_docs_shots.rs
@@ -409,7 +409,9 @@ async fn capture_documentation_screenshots() {
         )
         .await
         .expect("type the AQL");
-    h.wait_xpath("//button[normalize-space(.)='Run']")
+    // Run is disabled until the typed AQL reaches the signal; a click before
+    // then is intercepted by the toolbar, so the wait carries the condition.
+    h.wait_clickable_xpath("//button[normalize-space(.)='Run']")
         .await
         .click()
         .await

--- a/app/ferroehr-rest/src/extensions/management/logger_routes.rs
+++ b/app/ferroehr-rest/src/extensions/management/logger_routes.rs
@@ -12,7 +12,7 @@ use axum::response::{IntoResponse, Response};
 use http::StatusCode;
 use serde::{Deserialize, Serialize};
 
-use ferroehr::telemetry::log_reload::LogReload;
+use ferroehr::telemetry::log_reload::{FilterReloadError, LogReload};
 
 #[derive(Debug, Serialize)]
 pub(super) struct LoggersView {
@@ -46,7 +46,7 @@ pub(super) fn set(reload: &LogReload, body: &SetFilter) -> Response {
     match reload.set(&body.filter) {
         Ok(()) => (StatusCode::OK, Json(view(reload))).into_response(),
         Err(e) => (
-            StatusCode::BAD_REQUEST,
+            refusal_status(&e),
             Json(serde_json::json!({ "error": format!("invalid filter: {e}") })),
         )
             .into_response(),
@@ -58,9 +58,18 @@ pub(super) fn reset(reload: &LogReload) -> Response {
     match reload.reset() {
         Ok(()) => (StatusCode::OK, Json(view(reload))).into_response(),
         Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
+            refusal_status(&e),
             Json(serde_json::json!({ "error": format!("reset failed: {e}") })),
         )
             .into_response(),
+    }
+}
+
+/// The two arms of a refused filter swap are two different faults: directives
+/// the caller wrote wrong are a `400`, a reload layer that is gone is a `503`.
+fn refusal_status(e: &FilterReloadError) -> StatusCode {
+    match e {
+        FilterReloadError::Directives(_) => StatusCode::BAD_REQUEST,
+        FilterReloadError::Handle(_) => StatusCode::SERVICE_UNAVAILABLE,
     }
 }

--- a/app/ferroehr/src/aql/lineage.rs
+++ b/app/ferroehr/src/aql/lineage.rs
@@ -67,14 +67,60 @@ impl ArchetypeKey {
     /// (an at/id-code, an arbitrary string).
     #[must_use]
     pub fn from_hrid(hrid: &str) -> Option<Self> {
-        let parsed = parse_hrid(hrid).ok()?;
-        let major: i32 = parsed.release_version.split('.').next()?.parse().ok()?;
-        let entity = format!(
-            "{}-{}-{}",
-            parsed.rm_publisher, parsed.rm_package, parsed.rm_class
-        );
-        Some(Self::new(&entity, &parsed.concept_id, major))
+        decompose_hrid(hrid).map(|q| q.key)
     }
+}
+
+/// An archetype identifier decomposed for matching.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueriedArchetype {
+    /// The interface key the identifier resolves to.
+    pub key: ArchetypeKey,
+    /// True when the version is the ADL 1.4 major-only form (`.v1`) rather
+    /// than the AOM2-era physical form (`.v1.0.0`).
+    ///
+    /// Only in the 1.4 form do the `-` segments of a `domain_concept` carry
+    /// specialisation (AM `AOM2` master07.05 §Physical Archetype Identifier),
+    /// so a concept-prefix match is meaningful there and nowhere else.
+    pub legacy_form: bool,
+}
+
+/// Decompose an archetype HRID in either era's form.
+///
+/// This is the ONE reading of an archetype identifier in the query path: the
+/// lineage index and the SQL predicate both go through it, so a form one of
+/// them accepts cannot be a form the other silently declines.
+///
+/// `None` when the text is not an archetype HRID at all (an at/id-code, an
+/// arbitrary string).
+#[must_use]
+pub fn decompose_hrid(hrid: &str) -> Option<QueriedArchetype> {
+    let parsed = parse_hrid(hrid).ok()?;
+    let major: i32 = parsed.release_version.split('.').next()?.parse().ok()?;
+    let entity = format!(
+        "{}-{}-{}",
+        parsed.rm_publisher, parsed.rm_package, parsed.rm_class
+    );
+    Some(QueriedArchetype {
+        key: ArchetypeKey::new(&entity, &parsed.concept_id, major),
+        legacy_form: version_is_major_only(hrid),
+    })
+}
+
+/// True when the identifier's own text carries a major-only version (`.v1`)
+/// rather than the physical `.v1.0.0` form.
+///
+/// The distinction has to come from the source text: `parse_hrid` normalises
+/// every version to `major.minor.patch`, so a parsed `.v1` and a parsed
+/// `.v1.0.0` are indistinguishable afterwards — and it is exactly `.v1` that
+/// licenses the ADL 1.4 concept-prefix match.
+fn version_is_major_only(hrid: &str) -> bool {
+    let Some(version) = hrid.rsplit_once(".v").map(|(_, v)| v) else {
+        return false;
+    };
+    // A `-rc`/`-alpha`/`-beta` build suffix is not part of the version number.
+    let numeric = version.split('-').next().unwrap_or_default();
+    !numeric.is_empty() && !numeric.contains('.')
 }
 
 /// The stored specialisation graph: for every archetype identity, the stored

--- a/app/ferroehr/src/aql/sql/expr.rs
+++ b/app/ferroehr/src/aql/sql/expr.rs
@@ -18,11 +18,10 @@ use std::fmt::Write as _;
 use sea_query::extension::postgres::PgFunc;
 use sea_query::{Alias, BinOper, Expr, ExprTrait as _, Func, Value};
 
-use openehr_base::prelude::ArchetypeId;
 use openehr_query::lexer::CompOp;
 
 use crate::aql::ir::{Coercion, EhrField, LeafPath, PathTarget, TypeSet, TypedLit, VersionField};
-use crate::aql::lineage::{ArchetypeKey, ArchetypeLineage};
+use crate::aql::lineage::{ArchetypeLineage, decompose_hrid};
 
 /// A typed `"alias"."column"` reference.
 pub(super) fn col(alias: &str, column: &str) -> Expr {
@@ -227,17 +226,14 @@ pub(super) fn aql_like_to_sql(pattern: &str) -> String {
 // `archetype_node_id` string equality; we implement BASE/AM subsumption instead,
 // since a parent archetype must retrieve its children (master10).
 pub(super) fn archetype_predicate(node: &str, value: &str, lineage: &ArchetypeLineage) -> Expr {
-    let Ok(id) = value.parse::<ArchetypeId>() else {
+    // Both eras' identifier forms are read here, through the SAME decomposition
+    // the lineage index is built with — a form one side accepts and the other
+    // declines would silently narrow the answer instead of erroring.
+    let Some(decomposed) = decompose_hrid(value) else {
         return archetype_equality(node, value);
     };
-    let Ok(major) = id.major_version().parse::<i32>() else {
-        return archetype_equality(node, value);
-    };
-    let queried = ArchetypeKey::new(id.qualified_rm_entity(), id.domain_concept(), major);
-    // An ADL 1.4-form id carries a major-only version; a `.vMAJOR.MINOR.PATCH`
-    // version marks the AOM2-era physical form (AM `AOM2` master07.05), whose
-    // `-` segments carry no lineage.
-    let legacy_form = !id.version_id().contains('.');
+    let queried = decomposed.key;
+    let legacy_form = decomposed.legacy_form;
 
     // The matching set, grouped by the (entity, major) interface boundary each
     // member is scoped to. `BTreeMap`/`BTreeSet` keep the emitted SQL
@@ -427,6 +423,33 @@ mod tests {
             !sql.contains("LIKE"),
             "no `-`-prefix heuristic for an AOM2-era identifier: {sql}"
         );
+    }
+
+    /// A value that is no archetype identifier at all falls back to plain
+    /// equality on the whole `archetype` column.
+    ///
+    /// Asserted so the fallback stays REACHABLE and honest: an `at`-code or a
+    /// free string names no interface, so there is nothing to subsume over —
+    /// but if the decomposition ever started accepting these, the predicate
+    /// would silently widen instead of matching what was asked for.
+    #[test]
+    fn a_non_identifier_falls_back_to_equality() {
+        for value in [
+            "at0001",
+            "id3",
+            "not an archetype",
+            "openEHR-EHR-OBSERVATION",
+        ] {
+            let sql = archetype_predicate_sql(value, &ArchetypeLineage::default());
+            assert!(
+                sql.contains(r#""n"."archetype""#),
+                "{value:?} names no interface, so it matches the whole id: {sql}"
+            );
+            assert!(
+                !sql.contains("arch_concept"),
+                "{value:?} must not reach the subsumption columns: {sql}"
+            );
+        }
     }
 
     /// A stored specialisation family widens the matching set to `= ANY(…)`

--- a/app/ferroehr/src/service/admin/dump_load.rs
+++ b/app/ferroehr/src/service/admin/dump_load.rs
@@ -793,34 +793,43 @@ fn version_document(kind: &str, envelope: &Value) -> Result<String, ServiceError
     }
 }
 
+/// Why a `versions/*.xml` entry could not be read back into a payload.
+#[derive(Debug, thiserror::Error)]
+enum VersionPayloadError {
+    /// The entry is not a readable canonical-XML `ORIGINAL_VERSION`.
+    #[error("{0}")]
+    Xml(#[from] openehr_its::xml::runtime::XmlError),
+    /// The document parsed, but carries no `data` to restore.
+    #[error("the ORIGINAL_VERSION document carries no `data`")]
+    NoData,
+    /// The record names a versioned-object kind with no canonical-XML type.
+    #[error("no canonical-XML payload type for versioned-object kind {0}")]
+    UnknownKind(String),
+}
+
 /// Read one `versions/*.xml` entry back into the version's canonical-JSON
 /// payload — the inverse of [`version_document_of`].
 ///
 /// # Errors
-/// The parse failure as a human-readable message; the caller turns it into the
-/// record's [`DumpLoadFailReport`].
-fn version_payload_of<T: FromXml + Serialize>(xml: &str) -> Result<Value, String> {
-    let typed: OriginalVersion<T> =
-        openehr_its::xml::from_canonical_xml(xml).map_err(|e| e.to_string())?;
-    let data = typed
-        .data
-        .ok_or_else(|| "the ORIGINAL_VERSION document carries no `data`".to_owned())?;
+/// [`VersionPayloadError`]; the caller renders it into the record's
+/// [`DumpLoadFailReport`].
+fn version_payload_of<T: FromXml + Serialize>(xml: &str) -> Result<Value, VersionPayloadError> {
+    let typed: OriginalVersion<T> = openehr_its::xml::from_canonical_xml(xml)?;
+    let data = typed.data.ok_or(VersionPayloadError::NoData)?;
     Ok(openehr_its::json::to_canonical_value(&data))
 }
 
 /// [`version_payload_of`] dispatched on the record's stored kind.
 ///
 /// # Errors
-/// The parse failure as a human-readable message.
-fn version_payload(kind: &str, xml: &str) -> Result<Value, String> {
+/// [`VersionPayloadError`].
+fn version_payload(kind: &str, xml: &str) -> Result<Value, VersionPayloadError> {
     match kind {
         "COMPOSITION" => version_payload_of::<Composition>(xml),
         "EHR_STATUS" => version_payload_of::<EhrStatus>(xml),
         "EHR_ACCESS" => version_payload_of::<EhrAccess>(xml),
         "FOLDER" => version_payload_of::<Folder>(xml),
-        other => Err(format!(
-            "no canonical-XML payload type for versioned-object kind {other}"
-        )),
+        other => Err(VersionPayloadError::UnknownKind(other.to_owned())),
     }
 }
 

--- a/app/ferroehr/src/service/ehr/uri.rs
+++ b/app/ferroehr/src/service/ehr/uri.rs
@@ -128,7 +128,8 @@ impl FerroEhrService {
             // version, an exact OBJECT_VERSION_ID selects that version
             // (master11 §"Top-level Structure Locator").
             resolve_object_ref(object)?
-        } else if let Some(attribute) = &locator.attribute {
+        } else {
+            let attribute = &locator.attribute;
             // An attribute with no id addresses the EHR's single current object
             // of that kind (e.g. `directory`, `ehr_status`). `directory` (and a
             // bare `folders`, whose only spec-pinned member is `folders.item(1)`
@@ -168,10 +169,6 @@ impl FerroEhrService {
                 }
             };
             (vo_id, None)
-        } else {
-            return Err(ServiceError::precondition(
-                "ehr: URI locator identifies no top-level structure".to_owned(),
-            ));
         };
 
         let read = match version {

--- a/app/ferroehr/src/service/terminology/fhir.rs
+++ b/app/ferroehr/src/service/terminology/fhir.rs
@@ -636,14 +636,27 @@ impl Expansion {
     }
 }
 
+/// Why a FHIR terminology response body could not be decoded.
+#[derive(Debug, thiserror::Error)]
+enum DecodeError {
+    /// The body is not the FHIR resource the operation returns.
+    #[cfg(feature = "fhir")]
+    #[error("{0}")]
+    Fhir(#[from] ferroehr_ext::fhir::terminology::TerminologyDecodeError),
+    /// A slim build has no FHIR model to decode with. Unreachable:
+    /// [`FhirTerminologyProvider::new`] refuses a configured provider at boot.
+    #[cfg(not(feature = "fhir"))]
+    #[error("this binary was built without the `fhir` cargo feature")]
+    FeatureAbsent,
+}
+
 /// Decode a FHIR terminology response body into the reduced form the service
 /// consumes, via the typed R4B model in the extension crate.
 #[cfg(feature = "fhir")]
-fn decode(kind: ResponseKind, body: &[u8]) -> Result<DecodedResponse, String> {
+fn decode(kind: ResponseKind, body: &[u8]) -> Result<DecodedResponse, DecodeError> {
     match kind {
         ResponseKind::Parameters => {
-            let view = ferroehr_ext::fhir::terminology::decode_parameters(body)
-                .map_err(|e| e.to_string())?;
+            let view = ferroehr_ext::fhir::terminology::decode_parameters(body)?;
             Ok(DecodedResponse::Parameters(ParameterValues {
                 booleans: view.booleans,
                 codes: view.codes,
@@ -651,8 +664,7 @@ fn decode(kind: ResponseKind, body: &[u8]) -> Result<DecodedResponse, String> {
             }))
         }
         ResponseKind::ValueSet => {
-            let members = ferroehr_ext::fhir::terminology::decode_expansion(body)
-                .map_err(|e| e.to_string())?;
+            let members = ferroehr_ext::fhir::terminology::decode_expansion(body)?;
             let mut expansion = Expansion::default();
             for member in &members {
                 collect(member, &mut expansion);
@@ -702,8 +714,8 @@ fn collect(member: &ferroehr_ext::fhir::terminology::ExpansionMember, out: &mut 
 /// A slim build decodes no FHIR responses. Unreachable:
 /// [`FhirTerminologyProvider::new`] refuses a configured provider at boot.
 #[cfg(not(feature = "fhir"))]
-fn decode(_kind: ResponseKind, _body: &[u8]) -> Result<DecodedResponse, String> {
-    Err("this binary was built without the `fhir` cargo feature".to_owned())
+fn decode(_kind: ResponseKind, _body: &[u8]) -> Result<DecodedResponse, DecodeError> {
+    Err(DecodeError::FeatureAbsent)
 }
 
 #[cfg(test)]

--- a/app/ferroehr/src/telemetry/layers.rs
+++ b/app/ferroehr/src/telemetry/layers.rs
@@ -16,7 +16,7 @@ use std::io::IsTerminal;
 use std::path::Path;
 use std::sync::Arc;
 
-use crate::telemetry::log_reload::{ApplyFilter, LogReload, ReadFilter};
+use crate::telemetry::log_reload::{ApplyFilter, FilterReloadError, LogReload, ReadFilter};
 use opentelemetry_sdk::trace::SdkTracer;
 use tracing_subscriber::layer::{Layered, SubscriberExt};
 use tracing_subscriber::util::SubscriberInitExt;
@@ -82,9 +82,10 @@ pub(super) fn init_subscriber(
             .unwrap_or_default()
     });
 
-    let apply: ApplyFilter = Arc::new(move |directives: &str| -> Result<(), String> {
-        let new_filter = EnvFilter::try_new(directives).map_err(|e| e.to_string())?;
-        reload_handle.reload(new_filter).map_err(|e| e.to_string())
+    let apply: ApplyFilter = Arc::new(move |directives: &str| -> Result<(), FilterReloadError> {
+        let new_filter = EnvFilter::try_new(directives)?;
+        reload_handle.reload(new_filter)?;
+        Ok(())
     });
 
     Ok((LogReload::new(boot_filter, read, apply), flame_flush))

--- a/app/ferroehr/src/telemetry/log_reload.rs
+++ b/app/ferroehr/src/telemetry/log_reload.rs
@@ -16,7 +16,22 @@ use std::sync::Arc;
 /// Reads the effective filter directives from the subscriber's reload handle.
 pub type ReadFilter = Arc<dyn Fn() -> String + Send + Sync>;
 /// Applies a new filter directive set to the subscriber's reload handle.
-pub type ApplyFilter = Arc<dyn Fn(&str) -> Result<(), String> + Send + Sync>;
+pub type ApplyFilter = Arc<dyn Fn(&str) -> Result<(), FilterReloadError> + Send + Sync>;
+
+/// Why a runtime log-filter swap did not take effect.
+///
+/// The two arms are the two distinguishable outcomes the `POST` handler must
+/// tell apart: bad directives are the caller's fault (`400`), a refused reload
+/// is the subscriber's (`503`).
+#[derive(Debug, thiserror::Error)]
+pub enum FilterReloadError {
+    /// The submitted directives are not a valid `env-filter` expression.
+    #[error("the filter directives are not valid: {0}")]
+    Directives(#[from] tracing_subscriber::filter::ParseError),
+    /// The subscriber's reload layer refused the new filter — it is gone.
+    #[error("the subscriber's reload handle refused the new filter: {0}")]
+    Handle(#[from] tracing_subscriber::reload::Error),
+}
 
 /// A type-erased handle onto the subscriber's reloadable `EnvFilter`.
 #[derive(Clone)]
@@ -58,20 +73,21 @@ impl LogReload {
         (self.read)()
     }
 
-    /// Swap the live filter. Returns an error message if `filter` does not
-    /// parse as an `EnvFilter` directive set.
+    /// Swap the live filter.
     ///
     /// # Errors
-    /// Returns the parse/apply error message.
-    pub fn set(&self, filter: &str) -> Result<(), String> {
+    /// [`FilterReloadError::Directives`] if `filter` is not a valid
+    /// `EnvFilter` directive set, [`FilterReloadError::Handle`] if the
+    /// subscriber's reload layer is gone.
+    pub fn set(&self, filter: &str) -> Result<(), FilterReloadError> {
         (self.apply)(filter)
     }
 
     /// Reset the live filter to the boot filter.
     ///
     /// # Errors
-    /// Returns the apply error message.
-    pub fn reset(&self) -> Result<(), String> {
+    /// [`FilterReloadError::Handle`] if the subscriber's reload layer is gone.
+    pub fn reset(&self) -> Result<(), FilterReloadError> {
         let boot = Arc::clone(&self.boot_filter);
         (self.apply)(&boot)
     }
@@ -92,9 +108,7 @@ mod tests {
             boot,
             Arc::new(move || read_state.lock().expect("lock").clone()),
             Arc::new(move |f: &str| {
-                if f.contains("!!bad") {
-                    return Err("parse error".to_owned());
-                }
+                tracing_subscriber::EnvFilter::try_new(f)?;
                 *apply_state.lock().expect("lock") = f.to_owned();
                 Ok(())
             }),

--- a/app/ferroehr/src/telemetry/metrics.rs
+++ b/app/ferroehr/src/telemetry/metrics.rs
@@ -413,6 +413,8 @@ pub fn render(registry: &prometheus::Registry) -> Result<String, prometheus::Err
     let encoder = prometheus::TextEncoder::new();
     let mut buf = Vec::new();
     encoder.encode(&registry.gather(), &mut buf)?;
+    // NOTE: `prometheus::Error` is the registry's own error space and carries
+    // no source-bearing variant, so the cause can only travel as its message.
     String::from_utf8(buf).map_err(|e| prometheus::Error::Msg(e.to_string()))
 }
 

--- a/app/ferroehr/src/templates/runtime.rs
+++ b/app/ferroehr/src/templates/runtime.rs
@@ -171,7 +171,7 @@ impl FerroEhrService {
         self.web_templates
             .get_or_build(key, || {
                 let opt = openehr_its::opt14::from_xml(xml)
-                    .map_err(|e| openehr_its::flat::error::FlatError::OptParse(e.to_string()))?;
+                    .map_err(openehr_its::flat::error::FlatError::OptParse)?;
                 openehr_its::flat::webtemplate::builder::build_web_template(&opt)
             })
             .await

--- a/app/ferroehr/src/validation/opt/invariants.rs
+++ b/app/ferroehr/src/validation/opt/invariants.rs
@@ -20,7 +20,6 @@
 
 use std::collections::HashSet;
 
-use openehr_base::prelude::ArchetypeId;
 use openehr_its::opt14::types::{
     ArchetypeInternalRef, ArchetypeSlot, Assertion, CObject, ConstraintRef, ExprItem,
     Intervalofinteger,
@@ -129,11 +128,10 @@ pub(super) fn check_archetype_id(id: &str, rm_type_name: &str) -> Result<(), Rul
 
 /// Archetype-identifier shape for uploaded artefacts:
 /// `rm_originator-rm_name-rm_entity.domain_concept.v<version>` (BASE `base_types`
-/// master05 §Syntaxes), decided by the BASE parser
-/// ([`ArchetypeId`]) plus the OPT-ingest narrowing below. Tolerances beyond the
-/// strict BASE `name-str` grammar,
-/// both adjudicated against real published templates (never against CNF valid
-/// fixtures, which all conform strictly):
+/// master05 §Syntaxes), read here rather than through the BASE parser, whose
+/// grammar is narrower than an uploaded OPT's identifiers on both axes below.
+/// Tolerances beyond that grammar, each adjudicated against real published
+/// templates (never against CNF valid fixtures, which all conform strictly):
 ///
 /// - the version may be multi-part numeric (`v1.0.0`) — the ADL2-era archetype
 ///   HRID form appears in deployed OPT 1.4 exports (the vendored
@@ -148,26 +146,27 @@ fn is_archetype_id_shaped(id: &str) -> bool {
         chars.next().is_some_and(|c| c.is_ascii_alphabetic())
             && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
     }
-    // The lexical form itself is BASE's — `ARCHETYPE_ID::from_str` splits on
-    // the trailing `.v` and the RM qualifier and enforces the three-part
-    // qualifier; the axes are then read back through its typed accessors, so
-    // this function never re-implements the grammar. What it adds on top is the
-    // OPT-ingest NARROWING documented above (numeric multi-part version, ASCII
-    // concept charset), which BASE deliberately leaves open.
-    let Ok(parsed) = id.parse::<ArchetypeId>() else {
+    // The split is done here rather than through `ARCHETYPE_ID::from_str`,
+    // because BASE's `version_id` production is single-part by definition
+    // (`'0' | non-zero-digit, [ number ]`, master05 §Syntaxes) — it REFUSES the
+    // `v1.0.0` this function's own tolerances exist to accept, so routing
+    // through it would make both documented tolerances unreachable.
+    let Some((qualified_and_concept, version)) = id.rsplit_once(".v") else {
         return false;
     };
-    let version = parsed.version_id();
-    let version_ok = version
-        .split('.')
-        .all(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()))
-        && version.split('.').count() <= 3;
-    let entity_parts: Vec<&str> = parsed.qualified_rm_entity().split('-').collect();
+    let Some((qualified, concept)) = qualified_and_concept.split_once('.') else {
+        return false;
+    };
+    let version_ok = version.split('.').count() <= 3
+        && version
+            .split('.')
+            .all(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()));
+    let entity_parts: Vec<&str> = qualified.split('-').collect();
     let entity_ok = entity_parts.len() == 3 && entity_parts.iter().all(|p| alphanum_str(p));
-    let concept_ok = parsed
-        .domain_concept()
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '(' | ')' | '.'));
+    let concept_ok = !concept.is_empty()
+        && concept
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '(' | ')' | '.'));
     version_ok && entity_ok && concept_ok
 }
 

--- a/app/ferroehr/tests/it/service_aql_terminology.rs
+++ b/app/ferroehr/tests/it/service_aql_terminology.rs
@@ -286,9 +286,13 @@ async fn terminology_expand_fhir_merges_expansion_codes() {
     let ehr = create_ehr(&svc).await;
 
     // SNOMED-coded leaves (non-openEHR terminology → not RM-terminology-checked).
-    create_coded(&svc, &ehr, "member", "http://snomed.info/sct", "442031002").await;
-    create_coded(&svc, &ehr, "child", "http://snomed.info/sct", "11713004").await;
-    create_coded(&svc, &ehr, "non-member", "http://snomed.info/sct", "999999").await;
+    // The terminology is spelled the way BASE `base_types` master05 spells it,
+    // not as the FHIR system URI: a `TERMINOLOGY_ID` is a `name-str`, and the
+    // URI belongs in the value-set argument below. The match is on
+    // `code_string`, so the spelling is not what this test measures.
+    create_coded(&svc, &ehr, "member", "SNOMED-CT", "442031002").await;
+    create_coded(&svc, &ehr, "child", "SNOMED-CT", "11713004").await;
+    create_coded(&svc, &ehr, "non-member", "SNOMED-CT", "999999").await;
 
     let aql = format!(
         "SELECT c/name/value \

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-adl"
-version = "0.0.19"
+version = "0.0.20"
 description = "openEHR ADL 2.4.0: hand-written ADL2/cADL/ODIN parser, AOM2 validation catalogue, specialisation flattener, OPT2 generator, and ADL 1.4→2 conversion over the generated openehr_am::v2_4::aom2 model"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,10 +16,10 @@ include = ["src/**", "README.md", "LICENSE-MIT"]
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)
-openehr-base = { path = "../openehr-base", version = "0.0.19" }   # VersionStatus for the parsed HRID
-openehr-am = { path = "../openehr-am", version = "0.0.19" }       # v2_4 ArchetypeHrid (the identification target type)
-openehr-rm = { path = "../openehr-rm", version = "0.0.19" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
-openehr-lang = { path = "../openehr-lang", version = "0.0.19" }   # openehr_lang::odin — the ODIN section parser
+openehr-base = { path = "../openehr-base", version = "0.0.20" }   # VersionStatus for the parsed HRID
+openehr-am = { path = "../openehr-am", version = "0.0.20" }       # v2_4 ArchetypeHrid (the identification target type)
+openehr-rm = { path = "../openehr-rm", version = "0.0.20" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
+openehr-lang = { path = "../openehr-lang", version = "0.0.20" }   # openehr_lang::odin — the ODIN section parser
 uuid.workspace = true        # meta uid/build_uid (AUTHORED_ARCHETYPE.uid: Uuid)
 indexmap.workspace = true    # OdinValue::Object body (insertion-ordered map)
 

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-adl"
-version = "0.0.20"
+version = "0.0.21"
 description = "openEHR ADL 2.4.0: hand-written ADL2/cADL/ODIN parser, AOM2 validation catalogue, specialisation flattener, OPT2 generator, and ADL 1.4→2 conversion over the generated openehr_am::v2_4::aom2 model"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,10 +16,10 @@ include = ["src/**", "README.md", "LICENSE-MIT"]
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)
-openehr-base = { path = "../openehr-base", version = "0.0.20" }   # VersionStatus for the parsed HRID
-openehr-am = { path = "../openehr-am", version = "0.0.20" }       # v2_4 ArchetypeHrid (the identification target type)
-openehr-rm = { path = "../openehr-rm", version = "0.0.20" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
-openehr-lang = { path = "../openehr-lang", version = "0.0.20" }   # openehr_lang::odin — the ODIN section parser
+openehr-base = { path = "../openehr-base", version = "0.0.21" }   # VersionStatus for the parsed HRID
+openehr-am = { path = "../openehr-am", version = "0.0.21" }       # v2_4 ArchetypeHrid (the identification target type)
+openehr-rm = { path = "../openehr-rm", version = "0.0.21" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
+openehr-lang = { path = "../openehr-lang", version = "0.0.21" }   # openehr_lang::odin — the ODIN section parser
 uuid.workspace = true        # meta uid/build_uid (AUTHORED_ARCHETYPE.uid: Uuid)
 indexmap.workspace = true    # OdinValue::Object body (insertion-ordered map)
 

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-adl"
-version = "0.0.21"
+version = "0.0.22"
 description = "openEHR ADL 2.4.0: hand-written ADL2/cADL/ODIN parser, AOM2 validation catalogue, specialisation flattener, OPT2 generator, and ADL 1.4→2 conversion over the generated openehr_am::v2_4::aom2 model"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,10 +16,10 @@ include = ["src/**", "README.md", "LICENSE-MIT"]
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)
-openehr-base = { path = "../openehr-base", version = "0.0.21" }   # VersionStatus for the parsed HRID
-openehr-am = { path = "../openehr-am", version = "0.0.21" }       # v2_4 ArchetypeHrid (the identification target type)
-openehr-rm = { path = "../openehr-rm", version = "0.0.21" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
-openehr-lang = { path = "../openehr-lang", version = "0.0.21" }   # openehr_lang::odin — the ODIN section parser
+openehr-base = { path = "../openehr-base", version = "0.0.22" }   # VersionStatus for the parsed HRID
+openehr-am = { path = "../openehr-am", version = "0.0.22" }       # v2_4 ArchetypeHrid (the identification target type)
+openehr-rm = { path = "../openehr-rm", version = "0.0.22" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
+openehr-lang = { path = "../openehr-lang", version = "0.0.22" }   # openehr_lang::odin — the ODIN section parser
 uuid.workspace = true        # meta uid/build_uid (AUTHORED_ARCHETYPE.uid: Uuid)
 indexmap.workspace = true    # OdinValue::Object body (insertion-ordered map)
 

--- a/crates/openehr-am/Cargo.toml
+++ b/crates/openehr-am/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-am"
-version = "0.0.19"
+version = "0.0.20"
 description = "openEHR AM Archetype Model, generated from BMM: generations v1_4 (AM 1.4.0, ADL 1.4) and v2_4 (AM 2.4.0, ADL 2; current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,8 +13,8 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.19" }
-openehr-lang = { path = "../openehr-lang", version = "0.0.19" }
+openehr-base = { path = "../openehr-base", version = "0.0.20" }
+openehr-lang = { path = "../openehr-lang", version = "0.0.20" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also carries the untyped `Value` fields the generator

--- a/crates/openehr-am/Cargo.toml
+++ b/crates/openehr-am/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-am"
-version = "0.0.21"
+version = "0.0.22"
 description = "openEHR AM Archetype Model, generated from BMM: generations v1_4 (AM 1.4.0, ADL 1.4) and v2_4 (AM 2.4.0, ADL 2; current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,8 +13,8 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.21" }
-openehr-lang = { path = "../openehr-lang", version = "0.0.21" }
+openehr-base = { path = "../openehr-base", version = "0.0.22" }
+openehr-lang = { path = "../openehr-lang", version = "0.0.22" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also carries the untyped `Value` fields the generator

--- a/crates/openehr-am/Cargo.toml
+++ b/crates/openehr-am/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-am"
-version = "0.0.20"
+version = "0.0.21"
 description = "openEHR AM Archetype Model, generated from BMM: generations v1_4 (AM 1.4.0, ADL 1.4) and v2_4 (AM 2.4.0, ADL 2; current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,8 +13,8 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.20" }
-openehr-lang = { path = "../openehr-lang", version = "0.0.20" }
+openehr-base = { path = "../openehr-base", version = "0.0.21" }
+openehr-lang = { path = "../openehr-lang", version = "0.0.21" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also carries the untyped `Value` fields the generator

--- a/crates/openehr-base/Cargo.toml
+++ b/crates/openehr-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-base"
-version = "0.0.20"
+version = "0.0.21"
 description = "openEHR BASE foundation + base types, generated from BMM: generations v1_2 (BASE 1.2.0) and v1_3 (BASE 1.3.0, current)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-base/Cargo.toml
+++ b/crates/openehr-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-base"
-version = "0.0.21"
+version = "0.0.22"
 description = "openEHR BASE foundation + base types, generated from BMM: generations v1_2 (BASE 1.2.0) and v1_3 (BASE 1.3.0, current)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-base/Cargo.toml
+++ b/crates/openehr-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-base"
-version = "0.0.19"
+version = "0.0.20"
 description = "openEHR BASE foundation + base types, generated from BMM: generations v1_2 (BASE 1.2.0) and v1_3 (BASE 1.3.0, current)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-base/src/v1_2/base_types/identification/terminology_id_impl.rs
+++ b/crates/openehr-base/src/v1_2/base_types/identification/terminology_id_impl.rs
@@ -64,33 +64,34 @@ mod tests {
 }
 
 /// Lexical validity per BASE base_types master05 §Syntaxes:
-/// `terminology_id = name-str [ '(' name-str ')' ]` with
-/// `name-str = letter { letter | digit | '_' | '-' | '/' | '+' }`.
+/// `terminology_id = name-str, [ '(', name-str, ')' ]` with
+/// `name-str = letter, { letter | digit | '_' | '-' | '/' | '+' }`.
 ///
-/// This check is LOOSER than that production, which is a known divergence
-/// tracked on its own issue rather than a reading of the spec: master05
-/// §"Terminology Identifiers" only gives EXAMPLES ("Examples of terminology
-/// identifiers include: `SNOMED-CT`, `ICD9(1999)`") and names UMLS as "the best
-/// authoritative source for the name part", while real integrations identify
-/// terminologies by URI (`http://snomed.info/sct`), which `name-str` forbids.
+/// The name is `name-str` exactly: an interior space, and the `:` and `.` of a
+/// URI, are all outside it.
+///
+/// NOTE: the version part drops `name-str`'s leading-letter requirement,
+/// because every example the same chapter gives — `ICD9(1999)`,
+/// `ICD10AM(3rd_ed)`, `ICD10AM(4th_ed)` (§Terminology Identifiers) — starts its
+/// version with a digit, so reading `name-str` there would refuse the released
+/// text's own identifiers (#2283).
 #[must_use]
 pub(crate) fn is_valid_terminology_id(value: &str) -> bool {
-    // TODO(#2258): enforce the master05 §Syntaxes `name-str` production, or
-    // register the URI form as an adjudicated acceptance — the current check is
-    // well-formedness only: non-empty, printable, not ending in whitespace,
-    // with a non-empty `(version)` suffix when one is present.
-    fn name_ok(s: &str) -> bool {
-        !s.is_empty() && !s.ends_with(' ') && s.chars().all(|c| !c.is_control())
+    /// The `name-str` body: `letter | digit | '_' | '-' | '/' | '+'`.
+    fn body(s: &str) -> bool {
+        !s.is_empty()
+            && s.chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '/' | '+'))
     }
-    match (value.split_once('('), value.contains("://")) {
-        // URI-form ids are taken whole (any parentheses belong to the URI).
-        (_, true) | (None, false) => name_ok(value),
-        (Some((name, rest)), false) => {
-            name_ok(name.trim_end())
-                && rest
-                    .strip_suffix(')')
-                    .is_some_and(|version| !version.is_empty())
-        }
+    /// `name-str = letter, { letter | digit | '_' | '-' | '/' | '+' }`.
+    fn name_str(s: &str) -> bool {
+        s.starts_with(|c: char| c.is_ascii_alphabetic()) && body(s)
+    }
+    match value.split_once('(') {
+        None => name_str(value),
+        Some((name, rest)) => rest
+            .strip_suffix(')')
+            .is_some_and(|version| name_str(name) && body(version)),
     }
 }
 
@@ -98,9 +99,10 @@ impl crate::validate::Validate for TerminologyId {
     fn validate_invariants(&self, out: &mut Vec<crate::validate::InvariantViolation>) {
         if !is_valid_terminology_id(&self.value) {
             out.push(crate::validate::InvariantViolation::here(
-                "Invariant Value_valid failed on type TERMINOLOGY_ID (a non-empty \
-                 printable name, optionally with a non-empty '(version)' suffix — \
-                 BASE base_types master05 §Syntaxes + §Terminology Identifiers)",
+                "Invariant Value_valid failed on type TERMINOLOGY_ID (the master05 \
+                 §Syntaxes production `terminology_id = name-str, [ '(', name-str, \
+                 ')' ]`, where a name-str starts with a letter and continues with \
+                 letters, digits, '_', '-', '/' or '+')",
             ));
         }
     }
@@ -110,22 +112,57 @@ impl crate::validate::Validate for TerminologyId {
 mod validity_tests {
     use super::*;
 
+    /// The accepted forms are the production's, and they cover every
+    /// terminology this implementation actually carries.
     #[test]
-    fn terminology_id_lexical_form() {
+    fn terminology_id_follows_the_name_str_production() {
         for ok in [
             "openehr",
-            "ISO_639-1",
-            "SNOMED CT",
-            "ICD10AM(3rd_ed)",
             "local",
-            // §Terminology Identifiers opens the space ("not limited to");
-            // FHIR system URIs are the integration reality.
+            "x",
+            "ISO_639-1",
+            "ISO_3166-1",
+            "IANA_character-sets",
+            "IANA_media-types",
+            "SNOMED-CT",
+            "ICD10",
+            "Unicode",
+            // The chapter's own versioned examples (§Terminology Identifiers).
+            "ICD9(1999)",
+            "ICD10AM(3rd_ed)",
+            "ICD10AM(4th_ed)",
+            // The production admits '/' and '+' in a name-str.
+            "some/terminology+ext",
+        ] {
+            assert!(is_valid_terminology_id(ok), "{ok:?} must be valid");
+        }
+    }
+
+    /// Every refusal is asserted, so a silently loosened reader is a failing
+    /// build rather than a quiet drift (`.claude/rules/spec-adherence.md`).
+    #[test]
+    fn terminology_id_refuses_what_the_production_forbids() {
+        for bad in [
+            "",
+            // An interior space: the spec's own example is `SNOMED-CT`.
+            "SNOMED CT",
+            "SNOMED CT ",
+            // A URI: master05 admits neither ':' nor '.' in a name-str.
             "http://snomed.info/sct",
             "https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1010.2",
+            // name-str must START with a letter.
+            "1CD10",
+            "_leading",
+            // An unclosed or empty version group.
+            "x(",
+            "ICD10AM(3rd_ed",
+            "ICD10AM()",
+            // The version drops only the leading-letter rule, not the character
+            // class.
+            "ICD10AM(3rd ed)",
+            "ICD10AM(1999.1)",
+            "bad\u{7}id",
         ] {
-            assert!(is_valid_terminology_id(ok), "{ok} must be valid");
-        }
-        for bad in ["", "SNOMED CT ", "x(", "bad\u{7}id"] {
             assert!(!is_valid_terminology_id(bad), "{bad:?} must be invalid");
         }
     }

--- a/crates/openehr-base/src/v1_3/base_types/identification/terminology_id_impl.rs
+++ b/crates/openehr-base/src/v1_3/base_types/identification/terminology_id_impl.rs
@@ -64,33 +64,34 @@ mod tests {
 }
 
 /// Lexical validity per BASE base_types master05 §Syntaxes:
-/// `terminology_id = name-str [ '(' name-str ')' ]` with
-/// `name-str = letter { letter | digit | '_' | '-' | '/' | '+' }`.
+/// `terminology_id = name-str, [ '(', name-str, ')' ]` with
+/// `name-str = letter, { letter | digit | '_' | '-' | '/' | '+' }`.
 ///
-/// This check is LOOSER than that production, which is a known divergence
-/// tracked on its own issue rather than a reading of the spec: master05
-/// §"Terminology Identifiers" only gives EXAMPLES ("Examples of terminology
-/// identifiers include: `SNOMED-CT`, `ICD9(1999)`") and names UMLS as "the best
-/// authoritative source for the name part", while real integrations identify
-/// terminologies by URI (`http://snomed.info/sct`), which `name-str` forbids.
+/// The name is `name-str` exactly: an interior space, and the `:` and `.` of a
+/// URI, are all outside it.
+///
+/// NOTE: the version part drops `name-str`'s leading-letter requirement,
+/// because every example the same chapter gives — `ICD9(1999)`,
+/// `ICD10AM(3rd_ed)`, `ICD10AM(4th_ed)` (§Terminology Identifiers) — starts its
+/// version with a digit, so reading `name-str` there would refuse the released
+/// text's own identifiers (#2283).
 #[must_use]
 pub(crate) fn is_valid_terminology_id(value: &str) -> bool {
-    // TODO(#2258): enforce the master05 §Syntaxes `name-str` production, or
-    // register the URI form as an adjudicated acceptance — the current check is
-    // well-formedness only: non-empty, printable, not ending in whitespace,
-    // with a non-empty `(version)` suffix when one is present.
-    fn name_ok(s: &str) -> bool {
-        !s.is_empty() && !s.ends_with(' ') && s.chars().all(|c| !c.is_control())
+    /// The `name-str` body: `letter | digit | '_' | '-' | '/' | '+'`.
+    fn body(s: &str) -> bool {
+        !s.is_empty()
+            && s.chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '/' | '+'))
     }
-    match (value.split_once('('), value.contains("://")) {
-        // URI-form ids are taken whole (any parentheses belong to the URI).
-        (_, true) | (None, false) => name_ok(value),
-        (Some((name, rest)), false) => {
-            name_ok(name.trim_end())
-                && rest
-                    .strip_suffix(')')
-                    .is_some_and(|version| !version.is_empty())
-        }
+    /// `name-str = letter, { letter | digit | '_' | '-' | '/' | '+' }`.
+    fn name_str(s: &str) -> bool {
+        s.starts_with(|c: char| c.is_ascii_alphabetic()) && body(s)
+    }
+    match value.split_once('(') {
+        None => name_str(value),
+        Some((name, rest)) => rest
+            .strip_suffix(')')
+            .is_some_and(|version| name_str(name) && body(version)),
     }
 }
 
@@ -98,9 +99,10 @@ impl crate::validate::Validate for TerminologyId {
     fn validate_invariants(&self, out: &mut Vec<crate::validate::InvariantViolation>) {
         if !is_valid_terminology_id(&self.value) {
             out.push(crate::validate::InvariantViolation::here(
-                "Invariant Value_valid failed on type TERMINOLOGY_ID (a non-empty \
-                 printable name, optionally with a non-empty '(version)' suffix — \
-                 BASE base_types master05 §Syntaxes + §Terminology Identifiers)",
+                "Invariant Value_valid failed on type TERMINOLOGY_ID (the master05 \
+                 §Syntaxes production `terminology_id = name-str, [ '(', name-str, \
+                 ')' ]`, where a name-str starts with a letter and continues with \
+                 letters, digits, '_', '-', '/' or '+')",
             ));
         }
     }
@@ -110,22 +112,57 @@ impl crate::validate::Validate for TerminologyId {
 mod validity_tests {
     use super::*;
 
+    /// The accepted forms are the production's, and they cover every
+    /// terminology this implementation actually carries.
     #[test]
-    fn terminology_id_lexical_form() {
+    fn terminology_id_follows_the_name_str_production() {
         for ok in [
             "openehr",
-            "ISO_639-1",
-            "SNOMED CT",
-            "ICD10AM(3rd_ed)",
             "local",
-            // §Terminology Identifiers opens the space ("not limited to");
-            // FHIR system URIs are the integration reality.
+            "x",
+            "ISO_639-1",
+            "ISO_3166-1",
+            "IANA_character-sets",
+            "IANA_media-types",
+            "SNOMED-CT",
+            "ICD10",
+            "Unicode",
+            // The chapter's own versioned examples (§Terminology Identifiers).
+            "ICD9(1999)",
+            "ICD10AM(3rd_ed)",
+            "ICD10AM(4th_ed)",
+            // The production admits '/' and '+' in a name-str.
+            "some/terminology+ext",
+        ] {
+            assert!(is_valid_terminology_id(ok), "{ok:?} must be valid");
+        }
+    }
+
+    /// Every refusal is asserted, so a silently loosened reader is a failing
+    /// build rather than a quiet drift (`.claude/rules/spec-adherence.md`).
+    #[test]
+    fn terminology_id_refuses_what_the_production_forbids() {
+        for bad in [
+            "",
+            // An interior space: the spec's own example is `SNOMED-CT`.
+            "SNOMED CT",
+            "SNOMED CT ",
+            // A URI: master05 admits neither ':' nor '.' in a name-str.
             "http://snomed.info/sct",
             "https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1010.2",
+            // name-str must START with a letter.
+            "1CD10",
+            "_leading",
+            // An unclosed or empty version group.
+            "x(",
+            "ICD10AM(3rd_ed",
+            "ICD10AM()",
+            // The version drops only the leading-letter rule, not the character
+            // class.
+            "ICD10AM(3rd ed)",
+            "ICD10AM(1999.1)",
+            "bad\u{7}id",
         ] {
-            assert!(is_valid_terminology_id(ok), "{ok} must be valid");
-        }
-        for bad in ["", "SNOMED CT ", "x(", "bad\u{7}id"] {
             assert!(!is_valid_terminology_id(bad), "{bad:?} must be invalid");
         }
     }

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-its"
-version = "0.0.19"
+version = "0.0.20"
 description = "openEHR ITS (Implementation Technology Specifications): canonical JSON + canonical XML serialization of the RM, the generated ITS-REST 1.1.0 API contract, OPT 1.4 and AOM2 archetype XML codecs, and the Simplified Formats (FLAT / STRUCTURED / Web Template)"
 edition.workspace = true
 rust-version.workspace = true
@@ -41,14 +41,14 @@ regex = { workspace = true, optional = true }
 fancy-regex = { workspace = true, optional = true }
 # The generated XML (de)serializers impl the crate's ToXml/FromXml traits for the
 # RM/BASE spec types, so these are real (non-dev) deps.
-openehr-base = { path = "../openehr-base", version = "0.0.19", optional = true }
-openehr-rm = { path = "../openehr-rm", version = "0.0.19", optional = true }
+openehr-base = { path = "../openehr-base", version = "0.0.20", optional = true }
+openehr-rm = { path = "../openehr-rm", version = "0.0.20", optional = true }
 # The native canonical-JSON codec (`json_codec/generated`, emit-json) implements
 # `ToJson` for EVERY generated spec type the `OpenEhrType` derive covers, so it
 # spans all five spec crates (not just the RM/BASE the XML codec needs).
-openehr-lang = { path = "../openehr-lang", version = "0.0.19", optional = true }
-openehr-am = { path = "../openehr-am", version = "0.0.19", optional = true }
-openehr-term = { path = "../openehr-term", version = "0.0.19", optional = true }
+openehr-lang = { path = "../openehr-lang", version = "0.0.20", optional = true }
+openehr-am = { path = "../openehr-am", version = "0.0.20", optional = true }
+openehr-term = { path = "../openehr-term", version = "0.0.20", optional = true }
 
 # `full` — every ITS surface (canonical JSON/XML, the generated ITS-REST
 # contract, `opt14`, Simplified Formats). ON BY DEFAULT, so every consumer sees

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-its"
-version = "0.0.21"
+version = "0.0.22"
 description = "openEHR ITS (Implementation Technology Specifications): canonical JSON + canonical XML serialization of the RM, the generated ITS-REST 1.1.0 API contract, OPT 1.4 and AOM2 archetype XML codecs, and the Simplified Formats (FLAT / STRUCTURED / Web Template)"
 edition.workspace = true
 rust-version.workspace = true
@@ -41,14 +41,14 @@ regex = { workspace = true, optional = true }
 fancy-regex = { workspace = true, optional = true }
 # The generated XML (de)serializers impl the crate's ToXml/FromXml traits for the
 # RM/BASE spec types, so these are real (non-dev) deps.
-openehr-base = { path = "../openehr-base", version = "0.0.21", optional = true }
-openehr-rm = { path = "../openehr-rm", version = "0.0.21", optional = true }
+openehr-base = { path = "../openehr-base", version = "0.0.22", optional = true }
+openehr-rm = { path = "../openehr-rm", version = "0.0.22", optional = true }
 # The native canonical-JSON codec (`json_codec/generated`, emit-json) implements
 # `ToJson` for EVERY generated spec type the `OpenEhrType` derive covers, so it
 # spans all five spec crates (not just the RM/BASE the XML codec needs).
-openehr-lang = { path = "../openehr-lang", version = "0.0.21", optional = true }
-openehr-am = { path = "../openehr-am", version = "0.0.21", optional = true }
-openehr-term = { path = "../openehr-term", version = "0.0.21", optional = true }
+openehr-lang = { path = "../openehr-lang", version = "0.0.22", optional = true }
+openehr-am = { path = "../openehr-am", version = "0.0.22", optional = true }
+openehr-term = { path = "../openehr-term", version = "0.0.22", optional = true }
 
 # `full` — every ITS surface (canonical JSON/XML, the generated ITS-REST
 # contract, `opt14`, Simplified Formats). ON BY DEFAULT, so every consumer sees

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-its"
-version = "0.0.20"
+version = "0.0.21"
 description = "openEHR ITS (Implementation Technology Specifications): canonical JSON + canonical XML serialization of the RM, the generated ITS-REST 1.1.0 API contract, OPT 1.4 and AOM2 archetype XML codecs, and the Simplified Formats (FLAT / STRUCTURED / Web Template)"
 edition.workspace = true
 rust-version.workspace = true
@@ -41,14 +41,14 @@ regex = { workspace = true, optional = true }
 fancy-regex = { workspace = true, optional = true }
 # The generated XML (de)serializers impl the crate's ToXml/FromXml traits for the
 # RM/BASE spec types, so these are real (non-dev) deps.
-openehr-base = { path = "../openehr-base", version = "0.0.20", optional = true }
-openehr-rm = { path = "../openehr-rm", version = "0.0.20", optional = true }
+openehr-base = { path = "../openehr-base", version = "0.0.21", optional = true }
+openehr-rm = { path = "../openehr-rm", version = "0.0.21", optional = true }
 # The native canonical-JSON codec (`json_codec/generated`, emit-json) implements
 # `ToJson` for EVERY generated spec type the `OpenEhrType` derive covers, so it
 # spans all five spec crates (not just the RM/BASE the XML codec needs).
-openehr-lang = { path = "../openehr-lang", version = "0.0.20", optional = true }
-openehr-am = { path = "../openehr-am", version = "0.0.20", optional = true }
-openehr-term = { path = "../openehr-term", version = "0.0.20", optional = true }
+openehr-lang = { path = "../openehr-lang", version = "0.0.21", optional = true }
+openehr-am = { path = "../openehr-am", version = "0.0.21", optional = true }
+openehr-term = { path = "../openehr-term", version = "0.0.21", optional = true }
 
 # `full` — every ITS surface (canonical JSON/XML, the generated ITS-REST
 # contract, `opt14`, Simplified Formats). ON BY DEFAULT, so every consumer sees

--- a/crates/openehr-its/src/flat/error.rs
+++ b/crates/openehr-its/src/flat/error.rs
@@ -15,7 +15,7 @@ pub enum FlatError {
 
     /// An OPT 1.4 XML document failed to parse.
     #[error("failed to parse OPT 1.4 XML: {0}")]
-    OptParse(String),
+    OptParse(#[from] crate::xml::runtime::XmlError),
 
     /// A value could not be serialized to JSON.
     #[error("failed to serialize to JSON: {0}")]

--- a/crates/openehr-its/src/flat/webtemplate/inputs.rs
+++ b/crates/openehr-its/src/flat/webtemplate/inputs.rs
@@ -216,14 +216,27 @@ fn external_terminology_inputs(terminology: Option<&str>) -> Vec<WebTemplateInpu
     vec![code, value]
 }
 
+/// The TERMINOLOGY_ID a `C_CODE_REFERENCE.referenceSetUri` names.
+///
+/// The Web Template `terminology` field carries a terminology identifier
+/// (`ITS-REST/specifications/schemas/web_template/Input3.yaml`, example
+/// `openehr`), so only the identifying part of the URI belongs in it. The
+/// bare form is `terminology:SNOMED-CT`
+/// (`CNF/tests/platform/robot/_resources/test_data_sets/valid_templates/`);
+/// the addressed form carries an authority, a path and a query —
+/// `terminology://snomed-ct/hierarchy?rootConceptId=50043002`
+/// (`QUERY/docs/AQL/master03-syntax.adoc`) — where the terminology is the
+/// authority and the rest selects within it.
 fn reference_set_uri(uri: &str) -> Option<String> {
     if uri.is_empty() {
-        None
-    } else if let Some(rest) = uri.strip_prefix("terminology:") {
-        Some(rest.to_owned())
-    } else {
-        Some(uri.to_owned())
+        return None;
     }
+    let Some(rest) = uri.strip_prefix("terminology:") else {
+        return Some(uri.to_owned());
+    };
+    let rest = rest.strip_prefix("//").unwrap_or(rest);
+    let id = rest.split(['/', '?', '#']).next().unwrap_or("");
+    (!id.is_empty()).then(|| id.to_owned())
 }
 
 fn coded_values(

--- a/crates/openehr-its/tests/it/validation.rs
+++ b/crates/openehr-its/tests/it/validation.rs
@@ -151,12 +151,19 @@ fn kinds(msgs: &[ValidationMessage]) -> Vec<ValidationKind> {
 ///   defect on its `/content[0]` OBSERVATION (an
 ///   `openEHR-EHR-COMPOSITION.*` `archetype_id` claimed by a non-COMPOSITION
 ///   node), violating the same identity rule.
+/// - `ehrb_adbm_op_consult_record.json` — carries the `TERMINOLOGY_ID` value
+///   `"SNOMED CT"`, whose interior space is outside the `terminology_id`
+///   production (BASE `base_types/master05-identification_package.adoc`
+///   §Syntaxes: `terminology_id = name-str, [ '(', name-str, ')' ]`,
+///   `name-str = letter, { letter | digit | '_' | '-' | '/' | '+' }`). The same
+///   chapter's §Terminology Identifiers spells the terminology `"SNOMED-CT"`,
+///   which the production admits. The refusal is pinned by
+///   [`snomed_ct_with_a_space_is_refused`].
 const CLEAN_COMPOSITIONS: &[&str] = &[
     "choice_validation_test.json",
     "compo_corona.json",
     "demo_vitals_352.json",
     "dvquantity_choice.json",
-    "ehrb_adbm_op_consult_record.json",
     "interval_partial_date.json",
     "ips_canonical.json",
     "minimal_with_optional_attribute.json",
@@ -218,6 +225,24 @@ fn missing_mandatory_composer_is_rejected() {
         msgs.iter()
             .any(|m| m.message.to_lowercase().contains("composer") || m.path == "/"),
         "the violation should reference the missing mandatory composer: {msgs:?}"
+    );
+}
+
+/// The invalid twin of the corpus adjudication above: a vendored composition
+/// carrying `TERMINOLOGY_ID` `"SNOMED CT"` is REFUSED, at the path that holds
+/// it.
+///
+/// Keeping the refusal asserted is what stops the reader being loosened back:
+/// the interior space is outside the `terminology_id` production (BASE
+/// `base_types/master05-identification_package.adoc` §Syntaxes), and the same
+/// chapter spells the terminology `"SNOMED-CT"`.
+#[test]
+fn snomed_ct_with_a_space_is_refused() {
+    let wts = web_templates();
+    let msgs = validate("ehrb_adbm_op_consult_record.json", &wts);
+    assert!(
+        msgs.iter().any(|m| m.path.ends_with("/terminology_id")),
+        "the space in \"SNOMED CT\" must be refused at its terminology_id path, got {msgs:?}"
     );
 }
 

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-lang"
-version = "0.0.20"
+version = "0.0.21"
 description = "openEHR LANG BMM/P_BMM object model, generated from BMM: generations v1_0 (LANG 1.0.0) and v1_1 (LANG 1.1.0, current; the stable BMM v2.x unit beside the paused BMM3 unit), plus hand-written ODIN/BEL/EL readers"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["parser-implementations", "data-structures"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.20" }
+openehr-base = { path = "../openehr-base", version = "0.0.21" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the
 # generated types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) —
 # never a derive. `serde_json` also carries the untyped `Value` fields the

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-lang"
-version = "0.0.19"
+version = "0.0.20"
 description = "openEHR LANG BMM/P_BMM object model, generated from BMM: generations v1_0 (LANG 1.0.0) and v1_1 (LANG 1.1.0, current; the stable BMM v2.x unit beside the paused BMM3 unit), plus hand-written ODIN/BEL/EL readers"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["parser-implementations", "data-structures"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.19" }
+openehr-base = { path = "../openehr-base", version = "0.0.20" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the
 # generated types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) —
 # never a derive. `serde_json` also carries the untyped `Value` fields the

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-lang"
-version = "0.0.21"
+version = "0.0.22"
 description = "openEHR LANG BMM/P_BMM object model, generated from BMM: generations v1_0 (LANG 1.0.0) and v1_1 (LANG 1.1.0, current; the stable BMM v2.x unit beside the paused BMM3 unit), plus hand-written ODIN/BEL/EL readers"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["parser-implementations", "data-structures"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.21" }
+openehr-base = { path = "../openehr-base", version = "0.0.22" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the
 # generated types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) —
 # never a derive. `serde_json` also carries the untyped `Value` fields the

--- a/crates/openehr-lang/src/v1_1/escape.rs
+++ b/crates/openehr-lang/src/v1_1/escape.rs
@@ -1,4 +1,5 @@
-//! The `master03` string-escape decoder — one home for ODIN, BEL and cADL.
+// @generated-from-template templates/openehr-lang/escape.rs — DO NOT EDIT; edit the source and re-run `openehr-codegen -- emit`.
+//! The `master03` string-escape decoder — one home for this generation.
 //!
 //! `LANG/docs/odin/master03-basics.adoc` §File Encoding (verbatim twin:
 //! `AM/docs/ADL2/master03-file_encoding.adoc` §File Encoding) defines the
@@ -47,6 +48,9 @@
 //! digits opening with anything else are read as the 4-digit form followed by
 //! literal hex text, so a plain `A` never changes meaning because hex
 //! characters happen to follow it.
+//!
+//! NOTE: `master03-basics.adoc` is byte-identical in Release-1.0.0 (verified
+//! first-hand 2026-08-05), so one decoder is correct for every generation.
 
 /// A `master03` escape-sequence defect.
 ///
@@ -206,10 +210,9 @@ pub fn validate(inner: &str) -> Result<(), EscapeError> {
 ///
 /// The delimiters are `master03`'s (`LANG/docs/odin/master03-basics` §Special
 /// Character Sequences: `\"` is the escape *because* `"` delimits), and every
-/// reader of a `master03` string literal — the ODIN parser, the BEL parser and
-/// the cADL parser — strips them the same way, so the rule lives here once. A
-/// slice that is not delimited is decoded as-is rather than losing a
-/// character.
+/// reader of a `master03` string literal strips them the same way — whichever
+/// readers this generation carries — so the rule lives here once. A slice that
+/// is not delimited is decoded as-is rather than losing a character.
 ///
 /// # Errors
 /// As [`decode`].

--- a/crates/openehr-lang/src/v1_1/position.rs
+++ b/crates/openehr-lang/src/v1_1/position.rs
@@ -1,9 +1,13 @@
-//! Source-text position arithmetic — one home for every LANG-family parser.
+// @generated-from-template templates/openehr-lang/position.rs — DO NOT EDIT; edit the source and re-run `openehr-codegen -- emit`.
+//! Source-text position arithmetic — one home for this generation's parsers.
 //!
-//! ODIN, BEL and the ADL/cADL front end all report defects at a byte offset in
-//! the source they were handed and all need to present that offset to a human
-//! as a line and column. The mapping is a property of the text, not of any one
-//! grammar, so it lives here once rather than being re-derived per parser.
+//! Every reader in the LANG family reports defects at a byte offset in the
+//! source it was handed, and needs to present that offset to a human as a line
+//! and column. Which readers a generation carries differs — Release-1.0.0
+//! defines an ODIN-only grammar set, the 1.1.0 line adds BEL and the ADL/cADL
+//! front end — but the mapping is a property of the TEXT, not of any one
+//! grammar, so it lives here once rather than being re-derived per parser or
+//! per generation.
 
 /// The 1-based line and column of a byte `offset` in `src`, counting COLUMNS
 /// IN CHARACTERS.

--- a/crates/openehr-query/Cargo.toml
+++ b/crates/openehr-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-query"
-version = "0.0.20"
+version = "0.0.21"
 description = "openEHR QUERY (AQL 1.1.0): hand-written lexer, parser, typed AST and canonical printer from the official grammar (no ANTLR runtime)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-query/Cargo.toml
+++ b/crates/openehr-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-query"
-version = "0.0.19"
+version = "0.0.20"
 description = "openEHR QUERY (AQL 1.1.0): hand-written lexer, parser, typed AST and canonical printer from the official grammar (no ANTLR runtime)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-query/Cargo.toml
+++ b/crates/openehr-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-query"
-version = "0.0.21"
+version = "0.0.22"
 description = "openEHR QUERY (AQL 1.1.0): hand-written lexer, parser, typed AST and canonical printer from the official grammar (no ANTLR runtime)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-rm"
-version = "0.0.21"
+version = "0.0.22"
 description = "openEHR RM Reference Model, generated from BMM: generations v1_1 (RM 1.1.0) and v1_2 (RM 1.2.0, current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,11 +13,11 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.21" }
+openehr-base = { path = "../openehr-base", version = "0.0.22" }
 # The terminology-backed RM class invariants (`validate::terminology`) resolve
 # openEHR terminology groups + code sets against the vendored TERM 3.1.0 bundle.
 # `openehr-term` itself depends only on `openehr-base`, so this is acyclic.
-openehr-term = { path = "../openehr-term", version = "0.0.21" }
+openehr-term = { path = "../openehr-term", version = "0.0.22" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also backs the untyped `Value` RM representation used by

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-rm"
-version = "0.0.19"
+version = "0.0.20"
 description = "openEHR RM Reference Model, generated from BMM: generations v1_1 (RM 1.1.0) and v1_2 (RM 1.2.0, current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,11 +13,11 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.19" }
+openehr-base = { path = "../openehr-base", version = "0.0.20" }
 # The terminology-backed RM class invariants (`validate::terminology`) resolve
 # openEHR terminology groups + code sets against the vendored TERM 3.1.0 bundle.
 # `openehr-term` itself depends only on `openehr-base`, so this is acyclic.
-openehr-term = { path = "../openehr-term", version = "0.0.19" }
+openehr-term = { path = "../openehr-term", version = "0.0.20" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also backs the untyped `Value` RM representation used by

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-rm"
-version = "0.0.20"
+version = "0.0.21"
 description = "openEHR RM Reference Model, generated from BMM: generations v1_1 (RM 1.1.0) and v1_2 (RM 1.2.0, current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,11 +13,11 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.20" }
+openehr-base = { path = "../openehr-base", version = "0.0.21" }
 # The terminology-backed RM class invariants (`validate::terminology`) resolve
 # openEHR terminology groups + code sets against the vendored TERM 3.1.0 bundle.
 # `openehr-term` itself depends only on `openehr-base`, so this is acyclic.
-openehr-term = { path = "../openehr-term", version = "0.0.20" }
+openehr-term = { path = "../openehr-term", version = "0.0.21" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also backs the untyped `Value` RM representation used by

--- a/crates/openehr-rm/src/v1_1/paths.rs
+++ b/crates/openehr-rm/src/v1_1/paths.rs
@@ -1086,18 +1086,19 @@ impl fmt::Display for VersionLocator {
     }
 }
 
-/// A parsed `top_level_structure_locator`: an optional `EHR` attribute name and
-/// an optional versioned-object reference.
+/// A parsed `top_level_structure_locator`: an `EHR` attribute name and an
+/// optional versioned-object reference.
 ///
 /// Master11 writes locators as `compositions/<uid-or-OVID>` or `directory`.
-///
-/// The attribute-less short form — the versioned-object id following the
-/// `ehr_id` directly — is ALSO accepted, and no released form defines it: no
-/// openEHR spec governs that acceptance, it is our own extension (#2270).
+/// The attribute is not optional: BASE `master11-paths` §"EHR Reference URIs"
+/// enumerates the locator's values — "The possible values for
+/// `top_level_structure_locator` come from attribute names of the class `EHR`
+/// … namely `compositions`, `directory` etc." — so a versioned-object id
+/// standing where the attribute belongs does not name a top-level structure.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TopLevelLocator {
-    /// The `EHR` attribute name (`compositions`, `directory`, …), if present.
-    pub attribute: Option<String>,
+    /// The `EHR` attribute name (`compositions`, `directory`, …).
+    pub attribute: String,
     /// The versioned-object reference, if present (absent for e.g. `directory`).
     pub object: Option<VersionLocator>,
 }
@@ -1195,9 +1196,7 @@ impl fmt::Display for EhrUri {
             parts.push(ehr.to_string());
         }
         if let Some(loc) = &self.locator {
-            if let Some(attr) = &loc.attribute {
-                parts.push(attr.clone());
-            }
+            parts.push(loc.attribute.clone());
             if let Some(obj) = &loc.object {
                 parts.push(obj.to_string());
             }
@@ -1278,18 +1277,18 @@ fn parse_locator_and_path(
     if segs.is_empty() {
         return Ok((None, None));
     }
-    let (attribute, rest): (Option<String>, &[&str]) = match segs.split_first() {
-        Some((&first, tail)) if is_ehr_locator_attribute(first) => (Some(first.to_owned()), tail),
-        _ => (None, segs.as_slice()),
-    };
+    let (first, rest) = segs.split_at(1);
+    // The locator's first segment is an `EHR` attribute name — master11
+    // §"EHR Reference URIs" enumerates the possible values, so anything else
+    // (a bare versioned-object id included) names no top-level structure.
+    let first = first.first().copied().unwrap_or_default();
+    if !is_ehr_locator_attribute(first) {
+        return Err(EhrUriError::UnrecognisedLocator(first.to_owned()));
+    }
+    let attribute = first.to_owned();
     let (object, item_segs): (Option<VersionLocator>, &[&str]) = match rest.split_first() {
         Some((&head, tail)) if looks_like_version_id(head) => {
             (Some(parse_version_locator(head)?), tail)
-        }
-        Some((&head, _)) if attribute.is_none() => {
-            // No `EHR` attribute name and no version id → nothing identifies a
-            // top-level structure.
-            return Err(EhrUriError::UnrecognisedLocator(head.to_owned()));
         }
         _ => (None, rest),
     };
@@ -1765,28 +1764,61 @@ mod tests {
         s.parse().unwrap()
     }
 
-    /// The exact CNF `DV_EHR_URI` §"validate_open" accepted fixtures
-    /// (`master17.7-content_tc_data_types-uri.adoc`) must all parse.
+    /// The CNF `DV_EHR_URI` §"validate_open" fixtures
+    /// (`master17.7-content_tc_data_types-uri.adoc`), adjudicated against the
+    /// released grammar.
+    ///
+    /// Each fixture that reaches beyond the EHR omits the `EHR` attribute name,
+    /// putting the versioned-object id directly after the `ehr_id`. BASE
+    /// `master11-paths.adoc` §"EHR Reference URIs" enumerates the locator's
+    /// values ("come from attribute names of the class `EHR` … namely
+    /// `compositions`, `directory` etc.") and every example in
+    /// §"Top-level Structure Locator" and §"Item URIs" carries one, so those
+    /// fixtures are refused and their attribute-bearing twins accepted. The CNF
+    /// material is a stalled guide, never the oracle — the released spec wins.
     #[test]
-    fn cnf_dv_ehr_uri_fixtures_parse() {
+    fn cnf_dv_ehr_uri_fixtures_are_adjudicated() {
         const EHR: &str = "89c0752e-0815-47d7-8b3c-b3aaea2cea7a";
-        let accepted = [
+        const OVID: &str = "031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1";
+        const ITEM: &str = "context/other_context[at0001]/items[archetype_id=openEHR-EHR-CLUSTER.sample_symptom.v1]/items[at0034]/items[at0021]/value";
+
+        // The EHR-only fixtures name no top-level structure and stay accepted.
+        for s in [
             format!("ehr:/{EHR}"),
-            format!("ehr:/{EHR}/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1"),
-            format!(
-                "ehr:/{EHR}/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1/context/other_context[at0001]/items[archetype_id=openEHR-EHR-CLUSTER.sample_symptom.v1]/items[at0034]/items[at0021]/value"
-            ),
             format!("ehr://CLOUD_EHRSERVER/{EHR}"),
-            format!(
-                "ehr://CLOUD_EHRSERVER/{EHR}/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1"
-            ),
-            format!(
-                "ehr://CLOUD_EHRSERVER/{EHR}/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1/context/other_context[at0001]/items[archetype_id=openEHR-EHR-CLUSTER.sample_symptom.v1]/items[at0034]/items[at0021]/value"
-            ),
-        ];
-        for s in accepted {
+        ] {
             assert!(s.parse::<EhrUri>().is_ok(), "should parse: {s}");
         }
+
+        // Every locator-bearing fixture, in both twins.
+        for (invalid, valid) in [
+            (
+                format!("ehr:/{EHR}/{OVID}"),
+                format!("ehr:/{EHR}/compositions/{OVID}"),
+            ),
+            (
+                format!("ehr:/{EHR}/{OVID}/{ITEM}"),
+                format!("ehr:/{EHR}/compositions/{OVID}/{ITEM}"),
+            ),
+            (
+                format!("ehr://CLOUD_EHRSERVER/{EHR}/{OVID}"),
+                format!("ehr://CLOUD_EHRSERVER/{EHR}/compositions/{OVID}"),
+            ),
+            (
+                format!("ehr://CLOUD_EHRSERVER/{EHR}/{OVID}/{ITEM}"),
+                format!("ehr://CLOUD_EHRSERVER/{EHR}/compositions/{OVID}/{ITEM}"),
+            ),
+        ] {
+            assert!(
+                matches!(
+                    invalid.parse::<EhrUri>(),
+                    Err(EhrUriError::UnrecognisedLocator(_))
+                ),
+                "the attribute-less locator names no top-level structure: {invalid}"
+            );
+            assert!(valid.parse::<EhrUri>().is_ok(), "should parse: {valid}");
+        }
+
         // Non-`ehr` schemes are rejected structurally.
         assert!(matches!(
             "ftp://ftp.is.co.za/rfc/rfc1808.txt".parse::<EhrUri>(),
@@ -1808,12 +1840,22 @@ mod tests {
         assert_eq!(u.locator, None);
         assert_eq!(u.item_path, None);
 
-        // Attribute-less short form (CNF): the OVID follows the ehr_id directly.
+        // The locator's attribute is mandatory (master11 §"EHR Reference URIs"
+        // enumerates the values), so an OVID directly after the ehr_id names no
+        // top-level structure.
+        assert!(matches!(
+            format!("ehr:/{EHR}/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1")
+                .parse::<EhrUri>(),
+            Err(EhrUriError::UnrecognisedLocator(_))
+        ));
+
+        // The same version, located: an exact OBJECT_VERSION_ID under
+        // `compositions` (master11 §"Top-level Structure Locator").
         let u = ehr_uri(&format!(
-            "ehr:/{EHR}/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1"
+            "ehr:/{EHR}/compositions/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1"
         ));
         let loc = u.locator.unwrap();
-        assert_eq!(loc.attribute, None);
+        assert_eq!(loc.attribute, "compositions");
         match loc.object.unwrap() {
             VersionLocator::Version(ovid) => {
                 assert_eq!(
@@ -1830,7 +1872,7 @@ mod tests {
             "ehr:/347a5490-55ee-4da9-b91a-9bba710f730e/compositions/87284370-2d4b-4e3d-a3f3-f303d2f4f34b",
         );
         let loc = u.locator.unwrap();
-        assert_eq!(loc.attribute.as_deref(), Some("compositions"));
+        assert_eq!(loc.attribute, "compositions");
         assert!(matches!(
             loc.object,
             Some(VersionLocator::VersionedObject(_))
@@ -1839,7 +1881,7 @@ mod tests {
         // `directory` attribute, no uid.
         let u = ehr_uri("ehr:/347a5490-55ee-4da9-b91a-9bba710f730e/directory");
         let loc = u.locator.unwrap();
-        assert_eq!(loc.attribute.as_deref(), Some("directory"));
+        assert_eq!(loc.attribute, "directory");
         assert_eq!(loc.object, None);
 
         // Authority form.
@@ -1850,7 +1892,7 @@ mod tests {
         // Relative forms carry no ehr_id.
         let u = ehr_uri("ehr:directory");
         assert_eq!(u.ehr_id, None);
-        assert_eq!(u.locator.unwrap().attribute.as_deref(), Some("directory"));
+        assert_eq!(u.locator.unwrap().attribute, "directory");
         let u = ehr_uri(
             "ehr:compositions/87284370-2d4b-4e3d-a3f3-f303d2f4f34b/content[openEHR-EHR-SECTION.vital_signs.v1]",
         );
@@ -1864,10 +1906,10 @@ mod tests {
         // Forms whose predicates need no normalisation round-trip byte-exactly.
         for s in [
             format!("ehr:/{EHR}"),
-            format!("ehr:/{EHR}/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1"),
+            format!("ehr:/{EHR}/compositions/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1"),
             format!("ehr://CLOUD_EHRSERVER/{EHR}"),
             format!(
-                "ehr://CLOUD_EHRSERVER/{EHR}/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1"
+                "ehr://CLOUD_EHRSERVER/{EHR}/compositions/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1"
             ),
             "ehr:directory".to_owned(),
         ] {
@@ -1880,7 +1922,7 @@ mod tests {
         // The item-path form normalises `[archetype_id=…]` to the bare shortcut,
         // so it round-trips *structurally* (parse == parse∘format∘parse) even
         // when not byte-identical.
-        let s = "ehr:/89c0752e-0815-47d7-8b3c-b3aaea2cea7a/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1/context/other_context[at0001]/items[archetype_id=openEHR-EHR-CLUSTER.sample_symptom.v1]/items[at0034]/items[at0021]/value";
+        let s = "ehr:/89c0752e-0815-47d7-8b3c-b3aaea2cea7a/compositions/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1/context/other_context[at0001]/items[archetype_id=openEHR-EHR-CLUSTER.sample_symptom.v1]/items[at0034]/items[at0021]/value";
         let u = ehr_uri(s);
         let reparsed: EhrUri = u.to_string().parse().unwrap();
         assert_eq!(u, reparsed);

--- a/crates/openehr-rm/src/v1_2/paths.rs
+++ b/crates/openehr-rm/src/v1_2/paths.rs
@@ -1086,18 +1086,19 @@ impl fmt::Display for VersionLocator {
     }
 }
 
-/// A parsed `top_level_structure_locator`: an optional `EHR` attribute name and
-/// an optional versioned-object reference.
+/// A parsed `top_level_structure_locator`: an `EHR` attribute name and an
+/// optional versioned-object reference.
 ///
 /// Master11 writes locators as `compositions/<uid-or-OVID>` or `directory`.
-///
-/// The attribute-less short form — the versioned-object id following the
-/// `ehr_id` directly — is ALSO accepted, and no released form defines it: no
-/// openEHR spec governs that acceptance, it is our own extension (#2270).
+/// The attribute is not optional: BASE `master11-paths` §"EHR Reference URIs"
+/// enumerates the locator's values — "The possible values for
+/// `top_level_structure_locator` come from attribute names of the class `EHR`
+/// … namely `compositions`, `directory` etc." — so a versioned-object id
+/// standing where the attribute belongs does not name a top-level structure.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TopLevelLocator {
-    /// The `EHR` attribute name (`compositions`, `directory`, …), if present.
-    pub attribute: Option<String>,
+    /// The `EHR` attribute name (`compositions`, `directory`, …).
+    pub attribute: String,
     /// The versioned-object reference, if present (absent for e.g. `directory`).
     pub object: Option<VersionLocator>,
 }
@@ -1195,9 +1196,7 @@ impl fmt::Display for EhrUri {
             parts.push(ehr.to_string());
         }
         if let Some(loc) = &self.locator {
-            if let Some(attr) = &loc.attribute {
-                parts.push(attr.clone());
-            }
+            parts.push(loc.attribute.clone());
             if let Some(obj) = &loc.object {
                 parts.push(obj.to_string());
             }
@@ -1278,18 +1277,18 @@ fn parse_locator_and_path(
     if segs.is_empty() {
         return Ok((None, None));
     }
-    let (attribute, rest): (Option<String>, &[&str]) = match segs.split_first() {
-        Some((&first, tail)) if is_ehr_locator_attribute(first) => (Some(first.to_owned()), tail),
-        _ => (None, segs.as_slice()),
-    };
+    let (first, rest) = segs.split_at(1);
+    // The locator's first segment is an `EHR` attribute name — master11
+    // §"EHR Reference URIs" enumerates the possible values, so anything else
+    // (a bare versioned-object id included) names no top-level structure.
+    let first = first.first().copied().unwrap_or_default();
+    if !is_ehr_locator_attribute(first) {
+        return Err(EhrUriError::UnrecognisedLocator(first.to_owned()));
+    }
+    let attribute = first.to_owned();
     let (object, item_segs): (Option<VersionLocator>, &[&str]) = match rest.split_first() {
         Some((&head, tail)) if looks_like_version_id(head) => {
             (Some(parse_version_locator(head)?), tail)
-        }
-        Some((&head, _)) if attribute.is_none() => {
-            // No `EHR` attribute name and no version id → nothing identifies a
-            // top-level structure.
-            return Err(EhrUriError::UnrecognisedLocator(head.to_owned()));
         }
         _ => (None, rest),
     };
@@ -1765,28 +1764,61 @@ mod tests {
         s.parse().unwrap()
     }
 
-    /// The exact CNF `DV_EHR_URI` §"validate_open" accepted fixtures
-    /// (`master17.7-content_tc_data_types-uri.adoc`) must all parse.
+    /// The CNF `DV_EHR_URI` §"validate_open" fixtures
+    /// (`master17.7-content_tc_data_types-uri.adoc`), adjudicated against the
+    /// released grammar.
+    ///
+    /// Each fixture that reaches beyond the EHR omits the `EHR` attribute name,
+    /// putting the versioned-object id directly after the `ehr_id`. BASE
+    /// `master11-paths.adoc` §"EHR Reference URIs" enumerates the locator's
+    /// values ("come from attribute names of the class `EHR` … namely
+    /// `compositions`, `directory` etc.") and every example in
+    /// §"Top-level Structure Locator" and §"Item URIs" carries one, so those
+    /// fixtures are refused and their attribute-bearing twins accepted. The CNF
+    /// material is a stalled guide, never the oracle — the released spec wins.
     #[test]
-    fn cnf_dv_ehr_uri_fixtures_parse() {
+    fn cnf_dv_ehr_uri_fixtures_are_adjudicated() {
         const EHR: &str = "89c0752e-0815-47d7-8b3c-b3aaea2cea7a";
-        let accepted = [
+        const OVID: &str = "031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1";
+        const ITEM: &str = "context/other_context[at0001]/items[archetype_id=openEHR-EHR-CLUSTER.sample_symptom.v1]/items[at0034]/items[at0021]/value";
+
+        // The EHR-only fixtures name no top-level structure and stay accepted.
+        for s in [
             format!("ehr:/{EHR}"),
-            format!("ehr:/{EHR}/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1"),
-            format!(
-                "ehr:/{EHR}/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1/context/other_context[at0001]/items[archetype_id=openEHR-EHR-CLUSTER.sample_symptom.v1]/items[at0034]/items[at0021]/value"
-            ),
             format!("ehr://CLOUD_EHRSERVER/{EHR}"),
-            format!(
-                "ehr://CLOUD_EHRSERVER/{EHR}/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1"
-            ),
-            format!(
-                "ehr://CLOUD_EHRSERVER/{EHR}/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1/context/other_context[at0001]/items[archetype_id=openEHR-EHR-CLUSTER.sample_symptom.v1]/items[at0034]/items[at0021]/value"
-            ),
-        ];
-        for s in accepted {
+        ] {
             assert!(s.parse::<EhrUri>().is_ok(), "should parse: {s}");
         }
+
+        // Every locator-bearing fixture, in both twins.
+        for (invalid, valid) in [
+            (
+                format!("ehr:/{EHR}/{OVID}"),
+                format!("ehr:/{EHR}/compositions/{OVID}"),
+            ),
+            (
+                format!("ehr:/{EHR}/{OVID}/{ITEM}"),
+                format!("ehr:/{EHR}/compositions/{OVID}/{ITEM}"),
+            ),
+            (
+                format!("ehr://CLOUD_EHRSERVER/{EHR}/{OVID}"),
+                format!("ehr://CLOUD_EHRSERVER/{EHR}/compositions/{OVID}"),
+            ),
+            (
+                format!("ehr://CLOUD_EHRSERVER/{EHR}/{OVID}/{ITEM}"),
+                format!("ehr://CLOUD_EHRSERVER/{EHR}/compositions/{OVID}/{ITEM}"),
+            ),
+        ] {
+            assert!(
+                matches!(
+                    invalid.parse::<EhrUri>(),
+                    Err(EhrUriError::UnrecognisedLocator(_))
+                ),
+                "the attribute-less locator names no top-level structure: {invalid}"
+            );
+            assert!(valid.parse::<EhrUri>().is_ok(), "should parse: {valid}");
+        }
+
         // Non-`ehr` schemes are rejected structurally.
         assert!(matches!(
             "ftp://ftp.is.co.za/rfc/rfc1808.txt".parse::<EhrUri>(),
@@ -1808,12 +1840,22 @@ mod tests {
         assert_eq!(u.locator, None);
         assert_eq!(u.item_path, None);
 
-        // Attribute-less short form (CNF): the OVID follows the ehr_id directly.
+        // The locator's attribute is mandatory (master11 §"EHR Reference URIs"
+        // enumerates the values), so an OVID directly after the ehr_id names no
+        // top-level structure.
+        assert!(matches!(
+            format!("ehr:/{EHR}/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1")
+                .parse::<EhrUri>(),
+            Err(EhrUriError::UnrecognisedLocator(_))
+        ));
+
+        // The same version, located: an exact OBJECT_VERSION_ID under
+        // `compositions` (master11 §"Top-level Structure Locator").
         let u = ehr_uri(&format!(
-            "ehr:/{EHR}/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1"
+            "ehr:/{EHR}/compositions/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1"
         ));
         let loc = u.locator.unwrap();
-        assert_eq!(loc.attribute, None);
+        assert_eq!(loc.attribute, "compositions");
         match loc.object.unwrap() {
             VersionLocator::Version(ovid) => {
                 assert_eq!(
@@ -1830,7 +1872,7 @@ mod tests {
             "ehr:/347a5490-55ee-4da9-b91a-9bba710f730e/compositions/87284370-2d4b-4e3d-a3f3-f303d2f4f34b",
         );
         let loc = u.locator.unwrap();
-        assert_eq!(loc.attribute.as_deref(), Some("compositions"));
+        assert_eq!(loc.attribute, "compositions");
         assert!(matches!(
             loc.object,
             Some(VersionLocator::VersionedObject(_))
@@ -1839,7 +1881,7 @@ mod tests {
         // `directory` attribute, no uid.
         let u = ehr_uri("ehr:/347a5490-55ee-4da9-b91a-9bba710f730e/directory");
         let loc = u.locator.unwrap();
-        assert_eq!(loc.attribute.as_deref(), Some("directory"));
+        assert_eq!(loc.attribute, "directory");
         assert_eq!(loc.object, None);
 
         // Authority form.
@@ -1850,7 +1892,7 @@ mod tests {
         // Relative forms carry no ehr_id.
         let u = ehr_uri("ehr:directory");
         assert_eq!(u.ehr_id, None);
-        assert_eq!(u.locator.unwrap().attribute.as_deref(), Some("directory"));
+        assert_eq!(u.locator.unwrap().attribute, "directory");
         let u = ehr_uri(
             "ehr:compositions/87284370-2d4b-4e3d-a3f3-f303d2f4f34b/content[openEHR-EHR-SECTION.vital_signs.v1]",
         );
@@ -1864,10 +1906,10 @@ mod tests {
         // Forms whose predicates need no normalisation round-trip byte-exactly.
         for s in [
             format!("ehr:/{EHR}"),
-            format!("ehr:/{EHR}/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1"),
+            format!("ehr:/{EHR}/compositions/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1"),
             format!("ehr://CLOUD_EHRSERVER/{EHR}"),
             format!(
-                "ehr://CLOUD_EHRSERVER/{EHR}/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1"
+                "ehr://CLOUD_EHRSERVER/{EHR}/compositions/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1"
             ),
             "ehr:directory".to_owned(),
         ] {
@@ -1880,7 +1922,7 @@ mod tests {
         // The item-path form normalises `[archetype_id=…]` to the bare shortcut,
         // so it round-trips *structurally* (parse == parse∘format∘parse) even
         // when not byte-identical.
-        let s = "ehr:/89c0752e-0815-47d7-8b3c-b3aaea2cea7a/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1/context/other_context[at0001]/items[archetype_id=openEHR-EHR-CLUSTER.sample_symptom.v1]/items[at0034]/items[at0021]/value";
+        let s = "ehr:/89c0752e-0815-47d7-8b3c-b3aaea2cea7a/compositions/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1/context/other_context[at0001]/items[archetype_id=openEHR-EHR-CLUSTER.sample_symptom.v1]/items[at0034]/items[at0021]/value";
         let u = ehr_uri(s);
         let reparsed: EhrUri = u.to_string().parse().unwrap();
         assert_eq!(u, reparsed);

--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-term"
-version = "0.0.19"
+version = "0.0.20"
 description = "openEHR TERM terminology data model, generated from BMM (generation v3_1 = TERM 3.1.0), plus the embedded official terminology XML bundle"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["data-structures", "science"]
 include = ["src/**", "assets/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.19" }
+openehr-base = { path = "../openehr-base", version = "0.0.20" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive.

--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-term"
-version = "0.0.20"
+version = "0.0.21"
 description = "openEHR TERM terminology data model, generated from BMM (generation v3_1 = TERM 3.1.0), plus the embedded official terminology XML bundle"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["data-structures", "science"]
 include = ["src/**", "assets/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.20" }
+openehr-base = { path = "../openehr-base", version = "0.0.21" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive.

--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-term"
-version = "0.0.21"
+version = "0.0.22"
 description = "openEHR TERM terminology data model, generated from BMM (generation v3_1 = TERM 3.1.0), plus the embedded official terminology XML bundle"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["data-structures", "science"]
 include = ["src/**", "assets/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.21" }
+openehr-base = { path = "../openehr-base", version = "0.0.22" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive.

--- a/scripts/checks/error-source-chain.sh
+++ b/scripts/checks/error-source-chain.sh
@@ -27,9 +27,23 @@
 set -euo pipefail
 cd "$(dirname "$0")/../.." || exit 1
 
-# Trees still being swept. Each is a COUNT, and a count may only go DOWN:
-# the sweep is judgement-per-site (#2034), so this pins progress rather than
-# demanding a big-bang change.
+# The sweep (#2034) is CLOSED: every remaining site below was judged and carries
+# its `// NOTE:` reason at the site or on its error type. Each budget is a COUNT
+# that may only go DOWN — a new flattened site fails the gate, and lowering a
+# budget needs the same judgement the sweep applied.
+#
+# What survives, and why each one is structural rather than unfinished:
+#
+#   app/ferroehr           `prometheus::Error` has no source-bearing variant.
+#   app/ferroehr-ext       `fhir_model`'s builder error is a dependency type
+#                          (RFC 1105 — see the site's NOTE).
+#   app/ferroehr-admin-ui  `AdminUiError` crosses the server-fn boundary, so
+#                          `FromServerFnError` requires Serialize/Deserialize;
+#                          `LiftError` is held in an `RwSignal`, so it must be
+#                          Clone + Eq. No underlying error is any of those.
+#
+# A line that ALSO calls `.with_source(e)` is not flattened — it carries the
+# cause and stringifies only for the message — so the count excludes it.
 #
 # `tools/*` is NOT swept, and that is an adjudication rather than an omission —
 # both trees fall under the shapes #2034 itself names as legitimate:
@@ -46,7 +60,7 @@ cd "$(dirname "$0")/../.." || exit 1
 # Both stay out of the budget list so the gate measures the request path, where
 # a status code is chosen BY TYPE and a flattened cause actually costs something.
 declare -a BUDGETS=(
-  "app/ferroehr:9"
+  "app/ferroehr:1"
   "app/ferroehr-ext:1"
   "app/ferroehr-admin-ui:6"
 )
@@ -56,7 +70,7 @@ for entry in "${BUDGETS[@]}"; do
   tree="${entry%%:*}"
   budget="${entry##*:}"
   count="$(grep -rn 'map_err(|e| .*to_string())' "$tree" 2>/dev/null \
-           | grep -vc '/tests/' || true)"
+           | grep -v '/tests/' | grep -vc 'with_source' || true)"
   count="${count:-0}"
   printf '%-26s %3s flattened (budget %s)\n' "$tree" "$count" "$budget"
   if [ "$count" -gt "$budget" ]; then

--- a/tools/openehr-codegen/src/load/xsd.rs
+++ b/tools/openehr-codegen/src/load/xsd.rs
@@ -47,14 +47,11 @@ pub(crate) struct XsdType {
 #[derive(Clone)]
 pub(crate) struct XsdAttr {
     pub name: String,
-    /// The declared `type` of the XSD attribute, loaded for completeness: the
-    /// emitters type an attribute from the BMM property it corresponds to, not
-    /// from the schema, so nothing reads this yet.
-    #[expect(
-        dead_code,
-        reason = "the LOAD stage records the XSD attribute declaration in full; \
-                  attribute typing comes from the BMM side of the merge"
-    )]
+    /// The declared `type` of the XSD attribute.
+    ///
+    /// The emitters type an attribute from the BMM property it corresponds to
+    /// rather than from the schema; this is read by the closure invariants,
+    /// which ask what a slot's declared type is.
     pub type_name: String,
     pub required: bool,
 }

--- a/tools/openehr-codegen/src/render/emit_opt.rs
+++ b/tools/openehr-codegen/src/render/emit_opt.rs
@@ -551,9 +551,9 @@ impl<'a> OptModel<'a> {
             // it). It is emitted as the plain shape a document has to present —
             // never dropped, which would leave a dangling field type.
             //
-            // NOTE: such a type is NOT added to the variant set of the enums it
-            // descends from — `XsdModel::descendants` reports concrete subtypes
-            // only, which is the XSD rule for `xsi:type` (#2271).
+            // NOTE: such a type is NOT a variant of the enums it descends from —
+            // the XSD `xsi:type` rule — while its concrete descendants all are,
+            // which `the_concrete_only_variant_reading_loses_no_document_shape` pins.
             if ty.is_abstract && !self.enum_specs.contains(spec) {
                 let _ = writeln!(
                     b,

--- a/tools/openehr-codegen/src/testsupport.rs
+++ b/tools/openehr-codegen/src/testsupport.rs
@@ -1726,3 +1726,96 @@ fn rust_bodies_by_stem(dir: &std::path::Path) -> Result<BTreeMap<String, String>
     }
     Ok(out)
 }
+
+/// A place where the concrete-only `xsi:type` reading would LOSE a document
+/// shape: a concrete type a slot must be able to carry that is missing from
+/// the variant set emitted for that slot.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct LostVariant {
+    /// The emission closure (`opt14`, `aom2`, `aom2_model`).
+    pub closure: String,
+    /// The slot's declared type — the dispatch enum's base.
+    pub declared: String,
+    /// The abstract type sitting between `declared` and the lost variant.
+    pub via_abstract: String,
+    /// The type at fault.
+    pub lost: String,
+    /// Which of the two properties broke.
+    pub problem: &'static str,
+}
+
+/// Every concrete type an XSD-driven closure's dispatch enums would fail to
+/// carry, reading `xsi:type` variants as CONCRETE descendants only.
+///
+/// A type declared `abstract` is not a legal `xsi:type` value, so it is
+/// correctly absent from a slot's variant set — but each of its CONCRETE
+/// descendants is legal there and must be present. The two facts are
+/// independent: the second is what guarantees the concrete-only reading
+/// discards no document shape, and it is the one worth checking, because the
+/// closures are full of slots typed above an abstract type (`EXPR_ITEM` over
+/// `EXPR_OPERATOR`, `C_OBJECT` over `C_DOMAIN_TYPE`, `OBJECT_ID` over
+/// `UID_BASED_ID`) rather than free of them (#2271).
+///
+/// # Errors
+/// When a closure's schema files cannot be read or parsed.
+pub fn lost_dispatch_variants() -> Result<Vec<LostVariant>, Error> {
+    let its = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../crates/openehr-its");
+    let v1_all = its.join("schemas/xml/its-xml-1.0.2-nsv1/ALL");
+    let aom2 = its.join("schemas/xml/its-xml-1.0.2-nsv1/AOM2");
+    let closures = [
+        ("opt14", crate::load::xsd::am_files_v1(&v1_all)),
+        ("aom2", crate::load::xsd::aom2_files(&aom2)),
+        ("aom2_model", crate::load::xsd::aom2_model_files(&aom2)),
+    ];
+
+    let mut out = Vec::new();
+    for (name, files) in closures {
+        let model = crate::load::xsd::XsdModel::parse_files(&files).map_err(Error::from)?;
+        let slot_types: BTreeSet<String> = model
+            .types
+            .values()
+            .flat_map(|owner| {
+                let (attrs, elems) = model.flattened(&owner.name);
+                attrs
+                    .into_iter()
+                    .map(|a| a.type_name)
+                    .chain(elems.into_iter().map(|e| e.type_name))
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+
+        for declared in &slot_types {
+            let variants: BTreeSet<String> = model.descendants(declared).into_iter().collect();
+            for abstract_ty in model.types.values().filter(|t| t.is_abstract) {
+                if !model.is_a(&abstract_ty.name, declared) {
+                    continue;
+                }
+                // The abstract type itself is correctly absent; every concrete
+                // type BELOW it is a shape a document can present at this slot.
+                for concrete in model.descendants(&abstract_ty.name) {
+                    if !variants.contains(&concrete) {
+                        out.push(LostVariant {
+                            closure: name.to_owned(),
+                            declared: declared.clone(),
+                            via_abstract: abstract_ty.name.clone(),
+                            lost: concrete,
+                            problem: "a concrete descendant is missing from the variant set",
+                        });
+                    }
+                }
+                if variants.contains(&abstract_ty.name) {
+                    out.push(LostVariant {
+                        closure: name.to_owned(),
+                        declared: declared.clone(),
+                        via_abstract: abstract_ty.name.clone(),
+                        lost: abstract_ty.name.clone(),
+                        problem: "an abstract type appears as an xsi:type variant",
+                    });
+                }
+            }
+        }
+    }
+    out.sort();
+    out.dedup();
+    Ok(out)
+}

--- a/tools/openehr-codegen/templates/openehr-base/base_types/identification/terminology_id_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-base/base_types/identification/terminology_id_impl.rs
@@ -63,33 +63,34 @@ mod tests {
 }
 
 /// Lexical validity per BASE base_types master05 §Syntaxes:
-/// `terminology_id = name-str [ '(' name-str ')' ]` with
-/// `name-str = letter { letter | digit | '_' | '-' | '/' | '+' }`.
+/// `terminology_id = name-str, [ '(', name-str, ')' ]` with
+/// `name-str = letter, { letter | digit | '_' | '-' | '/' | '+' }`.
 ///
-/// This check is LOOSER than that production, which is a known divergence
-/// tracked on its own issue rather than a reading of the spec: master05
-/// §"Terminology Identifiers" only gives EXAMPLES ("Examples of terminology
-/// identifiers include: `SNOMED-CT`, `ICD9(1999)`") and names UMLS as "the best
-/// authoritative source for the name part", while real integrations identify
-/// terminologies by URI (`http://snomed.info/sct`), which `name-str` forbids.
+/// The name is `name-str` exactly: an interior space, and the `:` and `.` of a
+/// URI, are all outside it.
+///
+/// NOTE: the version part drops `name-str`'s leading-letter requirement,
+/// because every example the same chapter gives — `ICD9(1999)`,
+/// `ICD10AM(3rd_ed)`, `ICD10AM(4th_ed)` (§Terminology Identifiers) — starts its
+/// version with a digit, so reading `name-str` there would refuse the released
+/// text's own identifiers (#2283).
 #[must_use]
 pub(crate) fn is_valid_terminology_id(value: &str) -> bool {
-    // TODO(#2258): enforce the master05 §Syntaxes `name-str` production, or
-    // register the URI form as an adjudicated acceptance — the current check is
-    // well-formedness only: non-empty, printable, not ending in whitespace,
-    // with a non-empty `(version)` suffix when one is present.
-    fn name_ok(s: &str) -> bool {
-        !s.is_empty() && !s.ends_with(' ') && s.chars().all(|c| !c.is_control())
+    /// The `name-str` body: `letter | digit | '_' | '-' | '/' | '+'`.
+    fn body(s: &str) -> bool {
+        !s.is_empty()
+            && s.chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '/' | '+'))
     }
-    match (value.split_once('('), value.contains("://")) {
-        // URI-form ids are taken whole (any parentheses belong to the URI).
-        (_, true) | (None, false) => name_ok(value),
-        (Some((name, rest)), false) => {
-            name_ok(name.trim_end())
-                && rest
-                    .strip_suffix(')')
-                    .is_some_and(|version| !version.is_empty())
-        }
+    /// `name-str = letter, { letter | digit | '_' | '-' | '/' | '+' }`.
+    fn name_str(s: &str) -> bool {
+        s.starts_with(|c: char| c.is_ascii_alphabetic()) && body(s)
+    }
+    match value.split_once('(') {
+        None => name_str(value),
+        Some((name, rest)) => rest
+            .strip_suffix(')')
+            .is_some_and(|version| name_str(name) && body(version)),
     }
 }
 
@@ -97,9 +98,10 @@ impl crate::validate::Validate for TerminologyId {
     fn validate_invariants(&self, out: &mut Vec<crate::validate::InvariantViolation>) {
         if !is_valid_terminology_id(&self.value) {
             out.push(crate::validate::InvariantViolation::here(
-                "Invariant Value_valid failed on type TERMINOLOGY_ID (a non-empty \
-                 printable name, optionally with a non-empty '(version)' suffix — \
-                 BASE base_types master05 §Syntaxes + §Terminology Identifiers)",
+                "Invariant Value_valid failed on type TERMINOLOGY_ID (the master05 \
+                 §Syntaxes production `terminology_id = name-str, [ '(', name-str, \
+                 ')' ]`, where a name-str starts with a letter and continues with \
+                 letters, digits, '_', '-', '/' or '+')",
             ));
         }
     }
@@ -109,22 +111,57 @@ impl crate::validate::Validate for TerminologyId {
 mod validity_tests {
     use super::*;
 
+    /// The accepted forms are the production's, and they cover every
+    /// terminology this implementation actually carries.
     #[test]
-    fn terminology_id_lexical_form() {
+    fn terminology_id_follows_the_name_str_production() {
         for ok in [
             "openehr",
-            "ISO_639-1",
-            "SNOMED CT",
-            "ICD10AM(3rd_ed)",
             "local",
-            // §Terminology Identifiers opens the space ("not limited to");
-            // FHIR system URIs are the integration reality.
+            "x",
+            "ISO_639-1",
+            "ISO_3166-1",
+            "IANA_character-sets",
+            "IANA_media-types",
+            "SNOMED-CT",
+            "ICD10",
+            "Unicode",
+            // The chapter's own versioned examples (§Terminology Identifiers).
+            "ICD9(1999)",
+            "ICD10AM(3rd_ed)",
+            "ICD10AM(4th_ed)",
+            // The production admits '/' and '+' in a name-str.
+            "some/terminology+ext",
+        ] {
+            assert!(is_valid_terminology_id(ok), "{ok:?} must be valid");
+        }
+    }
+
+    /// Every refusal is asserted, so a silently loosened reader is a failing
+    /// build rather than a quiet drift (`.claude/rules/spec-adherence.md`).
+    #[test]
+    fn terminology_id_refuses_what_the_production_forbids() {
+        for bad in [
+            "",
+            // An interior space: the spec's own example is `SNOMED-CT`.
+            "SNOMED CT",
+            "SNOMED CT ",
+            // A URI: master05 admits neither ':' nor '.' in a name-str.
             "http://snomed.info/sct",
             "https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1010.2",
+            // name-str must START with a letter.
+            "1CD10",
+            "_leading",
+            // An unclosed or empty version group.
+            "x(",
+            "ICD10AM(3rd_ed",
+            "ICD10AM()",
+            // The version drops only the leading-letter rule, not the character
+            // class.
+            "ICD10AM(3rd ed)",
+            "ICD10AM(1999.1)",
+            "bad\u{7}id",
         ] {
-            assert!(is_valid_terminology_id(ok), "{ok} must be valid");
-        }
-        for bad in ["", "SNOMED CT ", "x(", "bad\u{7}id"] {
             assert!(!is_valid_terminology_id(bad), "{bad:?} must be invalid");
         }
     }

--- a/tools/openehr-codegen/templates/openehr-lang/escape.rs
+++ b/tools/openehr-codegen/templates/openehr-lang/escape.rs
@@ -1,4 +1,3 @@
-// @generated-from-template templates/openehr-lang/escape.rs — DO NOT EDIT; edit the source and re-run `openehr-codegen -- emit`.
 //! The `master03` string-escape decoder — one home for this generation.
 //!
 //! `LANG/docs/odin/master03-basics.adoc` §File Encoding (verbatim twin:

--- a/tools/openehr-codegen/templates/openehr-lang/position.rs
+++ b/tools/openehr-codegen/templates/openehr-lang/position.rs
@@ -1,4 +1,3 @@
-// @generated-from-template templates/openehr-lang/position.rs — DO NOT EDIT; edit the source and re-run `openehr-codegen -- emit`.
 //! Source-text position arithmetic — one home for this generation's parsers.
 //!
 //! Every reader in the LANG family reports defects at a byte offset in the

--- a/tools/openehr-codegen/templates/openehr-rm/paths.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/paths.rs
@@ -1085,18 +1085,19 @@ impl fmt::Display for VersionLocator {
     }
 }
 
-/// A parsed `top_level_structure_locator`: an optional `EHR` attribute name and
-/// an optional versioned-object reference.
+/// A parsed `top_level_structure_locator`: an `EHR` attribute name and an
+/// optional versioned-object reference.
 ///
 /// Master11 writes locators as `compositions/<uid-or-OVID>` or `directory`.
-///
-/// The attribute-less short form — the versioned-object id following the
-/// `ehr_id` directly — is ALSO accepted, and no released form defines it: no
-/// openEHR spec governs that acceptance, it is our own extension (#2270).
+/// The attribute is not optional: BASE `master11-paths` §"EHR Reference URIs"
+/// enumerates the locator's values — "The possible values for
+/// `top_level_structure_locator` come from attribute names of the class `EHR`
+/// … namely `compositions`, `directory` etc." — so a versioned-object id
+/// standing where the attribute belongs does not name a top-level structure.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TopLevelLocator {
-    /// The `EHR` attribute name (`compositions`, `directory`, …), if present.
-    pub attribute: Option<String>,
+    /// The `EHR` attribute name (`compositions`, `directory`, …).
+    pub attribute: String,
     /// The versioned-object reference, if present (absent for e.g. `directory`).
     pub object: Option<VersionLocator>,
 }
@@ -1194,9 +1195,7 @@ impl fmt::Display for EhrUri {
             parts.push(ehr.to_string());
         }
         if let Some(loc) = &self.locator {
-            if let Some(attr) = &loc.attribute {
-                parts.push(attr.clone());
-            }
+            parts.push(loc.attribute.clone());
             if let Some(obj) = &loc.object {
                 parts.push(obj.to_string());
             }
@@ -1277,18 +1276,18 @@ fn parse_locator_and_path(
     if segs.is_empty() {
         return Ok((None, None));
     }
-    let (attribute, rest): (Option<String>, &[&str]) = match segs.split_first() {
-        Some((&first, tail)) if is_ehr_locator_attribute(first) => (Some(first.to_owned()), tail),
-        _ => (None, segs.as_slice()),
-    };
+    let (first, rest) = segs.split_at(1);
+    // The locator's first segment is an `EHR` attribute name — master11
+    // §"EHR Reference URIs" enumerates the possible values, so anything else
+    // (a bare versioned-object id included) names no top-level structure.
+    let first = first.first().copied().unwrap_or_default();
+    if !is_ehr_locator_attribute(first) {
+        return Err(EhrUriError::UnrecognisedLocator(first.to_owned()));
+    }
+    let attribute = first.to_owned();
     let (object, item_segs): (Option<VersionLocator>, &[&str]) = match rest.split_first() {
         Some((&head, tail)) if looks_like_version_id(head) => {
             (Some(parse_version_locator(head)?), tail)
-        }
-        Some((&head, _)) if attribute.is_none() => {
-            // No `EHR` attribute name and no version id → nothing identifies a
-            // top-level structure.
-            return Err(EhrUriError::UnrecognisedLocator(head.to_owned()));
         }
         _ => (None, rest),
     };
@@ -1764,28 +1763,61 @@ mod tests {
         s.parse().unwrap()
     }
 
-    /// The exact CNF `DV_EHR_URI` §"validate_open" accepted fixtures
-    /// (`master17.7-content_tc_data_types-uri.adoc`) must all parse.
+    /// The CNF `DV_EHR_URI` §"validate_open" fixtures
+    /// (`master17.7-content_tc_data_types-uri.adoc`), adjudicated against the
+    /// released grammar.
+    ///
+    /// Each fixture that reaches beyond the EHR omits the `EHR` attribute name,
+    /// putting the versioned-object id directly after the `ehr_id`. BASE
+    /// `master11-paths.adoc` §"EHR Reference URIs" enumerates the locator's
+    /// values ("come from attribute names of the class `EHR` … namely
+    /// `compositions`, `directory` etc.") and every example in
+    /// §"Top-level Structure Locator" and §"Item URIs" carries one, so those
+    /// fixtures are refused and their attribute-bearing twins accepted. The CNF
+    /// material is a stalled guide, never the oracle — the released spec wins.
     #[test]
-    fn cnf_dv_ehr_uri_fixtures_parse() {
+    fn cnf_dv_ehr_uri_fixtures_are_adjudicated() {
         const EHR: &str = "89c0752e-0815-47d7-8b3c-b3aaea2cea7a";
-        let accepted = [
+        const OVID: &str = "031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1";
+        const ITEM: &str = "context/other_context[at0001]/items[archetype_id=openEHR-EHR-CLUSTER.sample_symptom.v1]/items[at0034]/items[at0021]/value";
+
+        // The EHR-only fixtures name no top-level structure and stay accepted.
+        for s in [
             format!("ehr:/{EHR}"),
-            format!("ehr:/{EHR}/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1"),
-            format!(
-                "ehr:/{EHR}/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1/context/other_context[at0001]/items[archetype_id=openEHR-EHR-CLUSTER.sample_symptom.v1]/items[at0034]/items[at0021]/value"
-            ),
             format!("ehr://CLOUD_EHRSERVER/{EHR}"),
-            format!(
-                "ehr://CLOUD_EHRSERVER/{EHR}/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1"
-            ),
-            format!(
-                "ehr://CLOUD_EHRSERVER/{EHR}/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1/context/other_context[at0001]/items[archetype_id=openEHR-EHR-CLUSTER.sample_symptom.v1]/items[at0034]/items[at0021]/value"
-            ),
-        ];
-        for s in accepted {
+        ] {
             assert!(s.parse::<EhrUri>().is_ok(), "should parse: {s}");
         }
+
+        // Every locator-bearing fixture, in both twins.
+        for (invalid, valid) in [
+            (
+                format!("ehr:/{EHR}/{OVID}"),
+                format!("ehr:/{EHR}/compositions/{OVID}"),
+            ),
+            (
+                format!("ehr:/{EHR}/{OVID}/{ITEM}"),
+                format!("ehr:/{EHR}/compositions/{OVID}/{ITEM}"),
+            ),
+            (
+                format!("ehr://CLOUD_EHRSERVER/{EHR}/{OVID}"),
+                format!("ehr://CLOUD_EHRSERVER/{EHR}/compositions/{OVID}"),
+            ),
+            (
+                format!("ehr://CLOUD_EHRSERVER/{EHR}/{OVID}/{ITEM}"),
+                format!("ehr://CLOUD_EHRSERVER/{EHR}/compositions/{OVID}/{ITEM}"),
+            ),
+        ] {
+            assert!(
+                matches!(
+                    invalid.parse::<EhrUri>(),
+                    Err(EhrUriError::UnrecognisedLocator(_))
+                ),
+                "the attribute-less locator names no top-level structure: {invalid}"
+            );
+            assert!(valid.parse::<EhrUri>().is_ok(), "should parse: {valid}");
+        }
+
         // Non-`ehr` schemes are rejected structurally.
         assert!(matches!(
             "ftp://ftp.is.co.za/rfc/rfc1808.txt".parse::<EhrUri>(),
@@ -1807,12 +1839,22 @@ mod tests {
         assert_eq!(u.locator, None);
         assert_eq!(u.item_path, None);
 
-        // Attribute-less short form (CNF): the OVID follows the ehr_id directly.
+        // The locator's attribute is mandatory (master11 §"EHR Reference URIs"
+        // enumerates the values), so an OVID directly after the ehr_id names no
+        // top-level structure.
+        assert!(matches!(
+            format!("ehr:/{EHR}/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1")
+                .parse::<EhrUri>(),
+            Err(EhrUriError::UnrecognisedLocator(_))
+        ));
+
+        // The same version, located: an exact OBJECT_VERSION_ID under
+        // `compositions` (master11 §"Top-level Structure Locator").
         let u = ehr_uri(&format!(
-            "ehr:/{EHR}/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1"
+            "ehr:/{EHR}/compositions/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1"
         ));
         let loc = u.locator.unwrap();
-        assert_eq!(loc.attribute, None);
+        assert_eq!(loc.attribute, "compositions");
         match loc.object.unwrap() {
             VersionLocator::Version(ovid) => {
                 assert_eq!(
@@ -1829,7 +1871,7 @@ mod tests {
             "ehr:/347a5490-55ee-4da9-b91a-9bba710f730e/compositions/87284370-2d4b-4e3d-a3f3-f303d2f4f34b",
         );
         let loc = u.locator.unwrap();
-        assert_eq!(loc.attribute.as_deref(), Some("compositions"));
+        assert_eq!(loc.attribute, "compositions");
         assert!(matches!(
             loc.object,
             Some(VersionLocator::VersionedObject(_))
@@ -1838,7 +1880,7 @@ mod tests {
         // `directory` attribute, no uid.
         let u = ehr_uri("ehr:/347a5490-55ee-4da9-b91a-9bba710f730e/directory");
         let loc = u.locator.unwrap();
-        assert_eq!(loc.attribute.as_deref(), Some("directory"));
+        assert_eq!(loc.attribute, "directory");
         assert_eq!(loc.object, None);
 
         // Authority form.
@@ -1849,7 +1891,7 @@ mod tests {
         // Relative forms carry no ehr_id.
         let u = ehr_uri("ehr:directory");
         assert_eq!(u.ehr_id, None);
-        assert_eq!(u.locator.unwrap().attribute.as_deref(), Some("directory"));
+        assert_eq!(u.locator.unwrap().attribute, "directory");
         let u = ehr_uri(
             "ehr:compositions/87284370-2d4b-4e3d-a3f3-f303d2f4f34b/content[openEHR-EHR-SECTION.vital_signs.v1]",
         );
@@ -1863,10 +1905,10 @@ mod tests {
         // Forms whose predicates need no normalisation round-trip byte-exactly.
         for s in [
             format!("ehr:/{EHR}"),
-            format!("ehr:/{EHR}/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1"),
+            format!("ehr:/{EHR}/compositions/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1"),
             format!("ehr://CLOUD_EHRSERVER/{EHR}"),
             format!(
-                "ehr://CLOUD_EHRSERVER/{EHR}/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1"
+                "ehr://CLOUD_EHRSERVER/{EHR}/compositions/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1"
             ),
             "ehr:directory".to_owned(),
         ] {
@@ -1879,7 +1921,7 @@ mod tests {
         // The item-path form normalises `[archetype_id=…]` to the bare shortcut,
         // so it round-trips *structurally* (parse == parse∘format∘parse) even
         // when not byte-identical.
-        let s = "ehr:/89c0752e-0815-47d7-8b3c-b3aaea2cea7a/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1/context/other_context[at0001]/items[archetype_id=openEHR-EHR-CLUSTER.sample_symptom.v1]/items[at0034]/items[at0021]/value";
+        let s = "ehr:/89c0752e-0815-47d7-8b3c-b3aaea2cea7a/compositions/031f2513-b9ef-47b2-bbef-8db24ae68c2f::EHRSERVER::1/context/other_context[at0001]/items[archetype_id=openEHR-EHR-CLUSTER.sample_symptom.v1]/items[at0034]/items[at0021]/value";
         let u = ehr_uri(s);
         let reparsed: EhrUri = u.to_string().parse().unwrap();
         assert_eq!(u, reparsed);

--- a/tools/openehr-codegen/tests/it/emitter_invariants.rs
+++ b/tools/openehr-codegen/tests/it/emitter_invariants.rs
@@ -1333,3 +1333,27 @@ fn hand_written_twins_are_templates() {
         );
     }
 }
+
+/// Reading `xsi:type` variants as CONCRETE descendants only discards no
+/// document shape.
+///
+/// A type declared `abstract` is not a legal `xsi:type` value, so it is
+/// correctly absent from a slot's dispatch enum. What has to hold alongside
+/// that is the other half: every CONCRETE type below such an abstract type is
+/// legal at the slot and must be a variant.
+///
+/// The closures are full of slots typed above an abstract type — `EXPR_ITEM`
+/// over `EXPR_OPERATOR`, `C_OBJECT` over `C_DOMAIN_TYPE`, `OBJECT_ID` over
+/// `UID_BASED_ID` — so this is a live property, not a vacuous one, and a
+/// re-vendoring that broke either half would otherwise surface as a document
+/// that silently fails to parse (#2271).
+#[test]
+fn the_concrete_only_variant_reading_loses_no_document_shape() {
+    let lost = testsupport::lost_dispatch_variants().expect("closures readable");
+    assert_eq!(
+        lost,
+        Vec::new(),
+        "the emitted xsi:type variant sets no longer cover every concrete shape a \
+         document can present (or admit an abstract type as a variant)"
+    );
+}


### PR DESCRIPTION
Three tracker items and one repair that was blocking every PR.

## `CHANGELOG.md` was structurally invalid (repair)

`[Unreleased]` carried **three** `### Changed` headers, and
`scripts/checks/changelog-structure.sh` runs unconditionally — the
`no-changelog` label waives the *entry* requirement, never the structure check.
So `changelog-guard` was red on every pull request against `develop`.

The three sections are merged into one, and the subsections put in Keep a
Changelog order (Added, Changed, Removed, Fixed, Security). The rewrite is pure
reordering, proven rather than asserted: an order-insensitive diff of every
non-blank, non-header line is empty.

## Errors carry their cause (closes #2034)

The sweep's guard was already a ratchet at 16 remaining sites. Each one was
judged, and they split three ways.

**Six were real and are fixed** — the cause is now a typed source:

| seam | was | now |
|---|---|---|
| Web Template build | `FlatError::OptParse(String)` | `#[from] XmlError` |
| FHIR terminology decode (×2) | `Result<_, String>` | `DecodeError`, `#[from]` the extension crate's decode error |
| runtime log-filter swap (×2) | `Result<(), String>` | `FilterReloadError` |
| admin dump/load payload read | `Result<_, String>` | `VersionPayloadError` |

The log-filter one is user-visible. `POST`/`DELETE /management/loggers` had a
single flattened string, so a subscriber whose reload layer had gone away was
reported as if the *caller* had written bad directives. Those are two different
faults and now answer differently: unparseable directives `400`, a missing
reload handle `503`.

**Two were never defects.** `extensions/fhir/ingest.rs:586` and `:598` already
read `.with_source(e)` — they carry the cause and stringify only for the
message. The guard's grep matched the `to_string()` and counted them anyway, so
it now excludes any line that also calls `with_source`.

**Eight are structural**, and each says so where it lives rather than in a
tracker comment:

- `prometheus::Error` has no source-bearing variant, and it is the registry's
  own error space.
- `fhir_model`'s builder error is a dependency type (RFC 1105 — already noted).
- `AdminUiError` crosses the server-fn boundary, so `FromServerFnError`
  requires `Serialize`/`Deserialize` (Leptos book `server/25`); `LiftError` is
  held in an `RwSignal` and compared, so it must be `Clone + Eq`. No
  `reqwest::Error` or parser error is any of those — an `#[source]` there is
  unrepresentable, not merely inconvenient.

The guard's header now records the sweep as closed and lists what survives and
why, so the next reader does not re-open a settled question.

## An `ehr:` URI must name the `EHR` attribute it addresses (closes #2270)

The server accepted `ehr:/<ehr_id>/<uid>::SYSTEM::1` — the versioned-object id
directly after the EHR id, with no attribute. The original justification was
that the CNF `DV_EHR_URI` fixtures use that shape, which
`.claude/rules/spec-adherence.md` rules out as a ground: stalled CNF material is
"corroboration at most, decision never".

The released grammar is not silent here, it **enumerates**. BASE
`master11-paths.adoc` §"EHR Reference URIs": *"The possible values for
`top_level_structure_locator` come from attribute names of the class `EHR` …
namely `compositions`, `directory` etc."* Every example in §"Top-level Structure
Locator" and §"Item URIs" carries one, and RM
`data_types/master10-uri_package.adoc` §"DV_EHR_URI Syntax" lists the same
forms. Under §NEVER LAX that makes the acceptance leniency, so it is refused.

`TopLevelLocator.attribute` stops being an `Option<String>` and becomes a
`String`: the state the spec does not define is now unrepresentable rather than
merely rejected, which is what removed the "identifies no top-level structure"
branch from the service resolver entirely.

Both twins are kept, per `testing.md`. Every CNF fixture is asserted in **both**
directions — the attribute-less form refused with `UnrecognisedLocator`, the
attribute-bearing form parsed — so a future loosening fails the build instead of
passing quietly.

**Breaking for stored data**: a `DV_EHR_URI` in a `LINK` that used the short
form no longer resolves. The changelog says so and gives the replacement.

## The toolchain bump lane (closes #2278)

The Cargo book's CI chapter asks for exactly this: *"Consider pinning the
toolchain version with an automated job that creates a PR to upgrade the
toolchain on new releases."* We already pin; this is the second half.

Weekly, plus `workflow_dispatch` with a `force_version` rehearsal input. It
reads the newest stable from the official channel manifest, and if it differs
from `rust-toolchain.toml` it moves every pin site together and opens a PR.

Two properties are the point:

- **The container digest is re-resolved, never copied.** Bumping the
  `rust:X-slim-trixie` tag while keeping the old `@sha256` silently keeps the
  *old* toolchain in every container job — a failure that looks like success.
  Three refusals block a partial bump: any residual old version, any rust image
  still on the old digest, and an unpublished tag.
- **The MSRV is a separate datum and the lane never writes it.** If the new
  toolchain breaks the declared MSRV, `ci.yml`'s `msrv` job fails *on that PR*
  rather than the MSRV being quietly moved to hide it.

Commits go through the Git Data API — the same mechanism `ci.yml`'s badge step
uses — because every commit here must be verified; there is no `git commit` in
the lane. Every `uses:` is SHA-pinned, `permissions: {}` at workflow level,
`persist-credentials: false`, and no context value reaches a `run:` block.
`actionlint`, `zizmor --min-severity=low` with online audits, `shellcheck` and
`no-python.sh` are all clean on it.

**It needs a `TOOLCHAIN_BUMP_TOKEN` secret to work fully.** `GITHUB_TOKEN` has
no `workflows` permission, so a ref update carrying `.github/workflows/**` is
refused outright, and events it raises start no workflow run — so its PR would
arrive with no checks, defeating the whole purpose. Without the secret the lane
degrades loudly, never silently: it opens a PR for the pins it can move, states
which two it could not and what to set them to, then fails the job.

## Filed, not fixed here

- **#2281** — three tests in `aql/sql/expr.rs` are red on `develop` and are
  *not* stale. `ARCHETYPE_ID` correctly refuses the three-part
  `.vMAJOR.MINOR.PATCH` version (BASE master05 defines the single-part form
  only), so every AOM2-era identifier falls through to plain equality and
  archetype subsumption stops widening — with `idx_node_arch_subsume`, an index
  built for exactly that predicate, going unused. A narrower AQL answer, not an
  error. Verified first-hand and left failing rather than edited.
- **#2280** — `.github/actionlint.yaml` is committed but actionlint was never
  wired into CI. zizmor audits security posture; actionlint checks correctness.

## Verification

`cargo fmt --all --check`, `clippy --workspace --exclude ferroehr-admin-ui
--all-targets --all-features`, and `-p ferroehr --no-default-features` (the slim
build that exercises the other half of the `DecodeError` cfg) are all clean.
`comment-style`, `typed-status`, `default-style`, `spec-citations`,
`changelog-structure` and `error-source-chain` pass. The spec crates are bumped
in lockstep to `0.0.20`, since `openehr-its`'s packaged content changed.

`nextest -p openehr-rm -p openehr-its` is green. `-p ferroehr --lib` fails only
the three #2281 tests, which fail identically on a clean `develop` checkout —
confirmed by stashing this branch and re-running them.

---

## Second commit: what the first one's CI turned up

`build & test (pg18)` and `ui-e2e` both went red, and neither was noise.

### AQL archetype subsumption was broken for every ADL 2 identifier (closes #2281)

The three `aql/sql/expr.rs` tests that fail on `develop` are not stale — they
describe behaviour the storage schema was purpose-built for, and it was gone.

`archetype_predicate` read the queried identifier with
`value.parse::<ArchetypeId>()`. That door is correct to refuse
`.vMAJOR.MINOR.PATCH` (BASE `base_types/master05` §Syntaxes defines
`version_id = '0' | non-zero-digit, [ number ]` — single-part only; the
three-part version belongs to the AM `ARCHETYPE_HRID`). But the *lineage index*
it matches against is built with `ArchetypeKey::from_hrid`, which reads **both**
eras through `openehr_adl::hrid::parse_hrid`.

Two readers, one value, different answers — so an ADL 2 identifier indexed one
way was queried another, fell through to plain equality on the whole
`archetype` column, and `idx_node_arch_subsume` went unused. A query for a
parent archetype stopped matching its specialisations. No error, just a
narrower answer.

Both sides now go through one `decompose_hrid`, and the doc comment says why
that matters.

One subtlety the fix had to get right: `parse_hrid` normalises every version to
`major.minor.patch`, so a parsed `.v1` and a parsed `.v1.0.0` are
indistinguishable afterwards — and it is exactly `.v1` that licenses the ADL 1.4
concept-prefix match (`AOM2` master07.05: the `-` segments carry specialisation
only in the 1.4 form). The legacy-form flag therefore reads the source text, not
the parsed value.

A new test pins the equality fallback for values that are no identifier at all
(`at0001`, `id3`, a free string), so the fallback stays reachable and asserted
rather than becoming dead code.

### `TERMINOLOGY_ID` keeps to its grammar (closes #2258)

The check was well-formedness only — non-empty, printable, no trailing space —
where §Syntaxes states a production. Worse, the justification shipped in the
published crate cited a phrase (*"include, but are not limited to"*) that
appears nowhere in the vendored specs, and invoked a "CNF-outranks-prose rule"
that is the inverse of ours.

It is now the production. Two things came out of enforcing it.

**The spec contradicts itself, and it is filed (#2283).** `name-str` must start
with a letter, and the version part is a `name-str` — yet all three examples the
same chapter gives (`ICD9(1999)`, `ICD10AM(3rd_ed)`, `ICD10AM(4th_ed)`) start
their version with a digit. Reading the grammar literally refuses openEHR's own
identifiers. The version part therefore drops the leading-letter rule and
nothing else: `ICD10AM(3rd ed)` and `ICD10AM(1999.1)` stay refused, so the
relaxation is exactly one rule wide.

**Two real defects the lenient reader had been hiding:**

1. A `C_CODE_REFERENCE` reference-set URI with parameters —
   `terminology:NSI?subset=doctor_category&language=en-GB` — had its **entire**
   remainder copied into the Web Template input's `terminology` field, which is
   a terminology identifier (`ITS-REST .../web_template/Input3.yaml`, example
   `openehr`). The conformance templates use the bare form
   (`terminology:SNOMED-CT`) and AQL master03 shows the addressed form
   (`terminology://snomed-ct/hierarchy?rootConceptId=…`) where the terminology
   is the authority; the query selects *within* a terminology and was never part
   of its name. Only the identifying part is taken now.
2. The vendored openEHR SDK corpus carries `"SNOMED CT"` with a space, where the
   spec spells it `"SNOMED-CT"`. That is a corpus defect, not a spec one, so it
   is adjudicated in the gate the way `testing.md` requires — moved out of
   `CLEAN_COMPOSITIONS` with its citation, and the refusal pinned by its own
   test so the reader cannot be loosened back without a failing build. The
   vendored file is untouched.

### The chart E2E journey (the `ui-e2e` failure)

`results_chart_groups_series_and_toggles_them` clicked **Run** while it was
still `disabled`, and the click was *intercepted* by the toolbar above it.

That is a different failure mode from the pre-hydration lost click the other
journeys handle with a bounded re-click loop: a lost click is a no-op, an
intercepted one is a WebDriver error, so the condition has to be part of the
wait. The harness gains `wait_clickable_xpath` (thirtyfour's `and_clickable`,
same 15 s budget and same failure-screenshot evidence as the existing waits),
and both `Run` sites use it. The `Save` sites were already correct — they guard
on `is_enabled()` — which is what identified the two `Run` ones as the outliers.

No test was weakened, ignored, or retried to get here.

### Versions

The spec crates go to `0.0.21` in lockstep: `openehr-base` and `openehr-its`
both changed packaged content again in this commit.

---

## Third commit: what the full suite turned up

The second commit's CI failed two tests. Running the exact CI command locally
(`cargo nextest run --workspace --exclude ferroehr-admin-ui --all-features`)
reproduced both — I had only run `--lib` before, which is why they were missed.

### An OPT with an ADL 2 archetype id was refused (closes #2284)

`varid_tolerates_multipart_version_and_tooling_names` also fails on a clean
`develop` checkout — verified by stashing and re-running — so it is a
pre-existing defect this PR happened to surface, not a regression it caused.

`is_archetype_id_shaped` decided shape by parsing through `ArchetypeId` and
then applying an OPT-ingest narrowing. Its own doc comment records two
tolerances, each adjudicated against vendored real-world templates:

- a multi-part numeric version (`v1.0.0`), which deployed OPT 1.4 exports carry;
- parenthesised tooling concept names (`t_neurologist_examination(1-17)_lanit`).

`ArchetypeId` refuses `v1.0.0` — BASE `base_types/master05` §Syntaxes defines
`version_id = '0' | non-zero-digit, [ number ]` — so it never reached the
narrowing, and the `version.split('.').count() <= 3` line below it was dead
code. Uploading such a template failed with `VARID`.

This is the **third** instance of one shape in this PR: a value read by two
components under different grammars, where the stricter reader wins silently and
the documented behaviour is quietly unreachable. The other two were the AQL
predicate versus the lineage index, and the Web Template terminology versus the
reference-set URI.

The split now happens in the function, with a comment stating why the BASE
parser is not the door. `varid_malformed_archetype_id` and
`vardt_root_type_mismatch` still pass unedited.

### The FHIR terminology fixture

`terminology_expand_fhir_merges_expansion_codes` passes on `develop` and broke
here, so that one is mine. It used `"http://snomed.info/sct"` as a
`TERMINOLOGY_ID`, which the production this PR now enforces does not admit.

The fixture spells the terminology `SNOMED-CT` — the spelling BASE
`base_types/master05` §Terminology Identifiers itself uses, and still a
non-openEHR terminology, which is the only property the test needed from it. The
value-set URL in the AQL `TERMINOLOGY('expand', …)` argument is unchanged: that
is a FHIR value-set URL, not a terminology identifier. The query matches on
`code_string`, so the test measures exactly what it measured before.

**This is a real behaviour change worth calling out**: a deployment that stores
FHIR system URIs in `CODE_PHRASE.terminology_id` will now have those rejected.
That is what §NEVER LAX directs — the production is explicit, not silent — but
it is the one consequence of #2258 that reaches stored data, and the changelog
says so.

### Verification

`cargo nextest run --workspace --exclude ferroehr-admin-ui --all-features
--no-tests=pass --profile ci` — **4429 tests run, 4429 passed, 6 skipped.**
`cargo fmt --all --check`, workspace clippy, and every style/spec guard clean.

---

## Fourth and fifth commits

### The template-upload journeys race hydration (closes #2285)

`ui-e2e` was red, and it is red on `develop` too — run `31535727748`, the same
journey and the same panic site. Pre-existing, not caused here.

`ensure_template` sends the fixture path to the hidden `input[type=file]` and
then waits once for the row. The upload is driven by that input's `on:change`,
a **hydrated** listener, while the waits before it prove only that the SSR'd
list rendered. A `send_keys` landing in that window is lost, and the single
15-second wait after it can then only time out.

Both uploaders — `e2e_admin_ops::ensure_template` and
`e2e_browse::ensure_template_present` — now re-send until the row appears,
bounded, re-checking the row before each attempt so an upload that did land is
never repeated. This is the pattern `login_basic_as` already documents for the
same race, and the chart journey uses for its Chart toggle; these two were the
sites that never got it.

The chart journey from the previous commit passed on this run.

### `escape.rs` and `position.rs` become generation twins (closes #2269)

`hand_written_twins_are_templates` **does** cover `openehr-lang` — it iterates
`["base", "rm", "am", "term", "lang"]`. The two pairs passed because it compares
for byte identity and each carried a doc-prose delta enumerating its own
generation's readers.

The delta was accurate: Release-1.0.0 defines an ODIN-only grammar set, while
the 1.1.0 line adds BEL and the ADL/cADL front end. It was also the thing
keeping two identical implementations outside the mechanism built to stop them
diverging.

Resolved by unifying the prose, not by a per-generation override — an override
would duplicate a whole file to carry one sentence, which is the duplication the
template mechanism exists to remove. Both docstrings now state the part that is
genuinely generation-invariant (the mapping is a property of the TEXT, not of
any one grammar), and the `master03`-is-byte-identical-in-Release-1.0.0 citation
moves into the single template, where it reads as the reason one decoder serves
every generation.

`templates/openehr-lang/` did not exist; the stamper needed no change
(`stamp_templates` resolves `templates_root.join(comp.crate_name)` and `emit`
runs it for every composition), and neither file referenced a generation path.

Mutation-proven: an identical `twin_probe.rs` in both generations fails the
invariant naming the file; removing it returns it to green.

### The `xsi:type` variant reading is now pinned (#2271 finding 2)

#2271 states the closures contain no slot typed as an ancestor of an abstract
type, so the two readings are indistinguishable. **They are full of them** —
`C_ATTRIBUTE.children` over `C_DOMAIN_TYPE`, `ASSERTION.expression` over
`EXPR_OPERATOR`, `ACCESS_GROUP_REF.id` over `UID_BASED_ID`. That premise was
never true, so "no such slot exists" was never a property worth pinning.

The half that matters is the other one: an abstract type is correctly absent
from a slot's variant set, and every **concrete** type below it must be present
— that is what makes the concrete-only reading discard no document shape. The
new invariant checks both halves across all three XSD closures, and is
mutation-proven (narrowing `descendants` to direct subtypes fails it).

**#2271's finding 1 is decided and recorded on the issue, and stays open.** The
short version: `openehr_am` already generates a typed `OperatorKind`, so binding
to it looked right — until the wire vocabularies turned out to differ. The BMM
enum's values are the constant NAMES (`op_eq`), the XSD facet's are INTEGERS
(`2001`), and the released AM spec publishes no correspondence between them, so
binding would invent one. The decision is to emit over the XSD's own vocabulary
instead. Not implemented here: the loader parses no facets at all today, and the
change turns published `openehr-its` fields from `String` into enums — an
unverified API break is not something to land inside a release cut.

### A stale lint expectation

The new invariant reads `XsdAttr::type_name`, which made a previously-dead field
live and left its `#[expect(dead_code)]` unfulfilled.
`unfulfilled_lint_expectations` is a warning, and every CI lane runs
`-D warnings` — which is why clippy, rustdoc, the build and the drift check all
went red at once. The expectation is gone and the doc says what reads the field.

Caught because the lane was re-run in its exact form
(`cargo clippy … -- -D warnings`); a bare `cargo clippy` had passed, which is
what let it through in the first place.
