### PR TITLE
ci: gate the workflows on actionlint, not just zizmor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,6 +287,39 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: zizmor --min-severity=low .github/workflows/
 
+  # actionlint (github.com/rhysd/actionlint) is the CORRECTNESS half of the pair
+  # above: zizmor audits security posture, actionlint checks that the workflow
+  # is well-formed at all — `${{ }}` expressions that cannot evaluate, `needs:`
+  # naming a job that does not exist, unknown runner labels, and shellcheck over
+  # every embedded `run:` block. A committed `.github/actionlint.yaml` (the
+  # runner-label roster) existed here long before this job did, so the tool was
+  # being run by hand and never gated.
+  #
+  # Ungated on the `changes` filter for the same reason zizmor is: that filter
+  # excludes `.github/`.
+  workflow-lint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: taiki-e/install-action@91ddec75689c4c78665b598d188dc821c5a43e5c # v2.85.9
+        with:
+          tool: actionlint@1.7.12
+      - name: Lint .github/workflows
+        # SC2016 ("expressions don't expand in single quotes") is excluded, and
+        # only it: every occurrence in this repo is a `printf` format string or a
+        # `jq` filter, where single quotes are the CORRECT idiom precisely
+        # because the shell must not expand `%s` or `$`. Nothing else is
+        # suppressed — the run is clean at actionlint's own default severity.
+        env:
+          SHELLCHECK_OPTS: "-e SC2016"
+        run: actionlint
+
   # Comment-style guard (.claude/rules/comments.md, RFC 505/1574): block
   # comments, TODO(#N) form, NOTE/essay line budgets — over the WHOLE tree
   # hand-written .rs files. Diff-scoped until the legacy essay sweep (#1870)
@@ -1652,6 +1685,7 @@ jobs:
       - fmt
       - no-attribution
       - workflow-audit
+      - workflow-lint
       - comment-style
       - default-style
       - docs-claims

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,18 +307,28 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: taiki-e/install-action@91ddec75689c4c78665b598d188dc821c5a43e5c # v2.85.9
-        with:
-          tool: actionlint@1.7.12
       - name: Lint .github/workflows
+        # The OFFICIAL image, digest-pinned. actionlint is a Go binary, so
+        # `taiki-e/install-action` does not carry it and its cargo-binstall
+        # fallback cannot ("actionlint is not found" — it is not a crate). The
+        # upstream alternative is `curl | bash` off `main`, which is exactly the
+        # unpinned fetch this repository's pinning rule exists to forbid. The
+        # image is also the only distribution that BUNDLES shellcheck, which
+        # half of actionlint's value depends on: "The image contains actionlint
+        # executable and all dependencies (shellcheck and pyflakes)"
+        # (https://github.com/rhysd/actionlint/blob/main/docs/usage.md).
+        #
         # SC2016 ("expressions don't expand in single quotes") is excluded, and
         # only it: every occurrence in this repo is a `printf` format string or a
         # `jq` filter, where single quotes are the CORRECT idiom precisely
         # because the shell must not expand `%s` or `$`. Nothing else is
         # suppressed — the run is clean at actionlint's own default severity.
-        env:
-          SHELLCHECK_OPTS: "-e SC2016"
-        run: actionlint
+        run: |
+          docker run --rm \
+            -v "$PWD:/repo" --workdir /repo \
+            -e SHELLCHECK_OPTS='-e SC2016' \
+            rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 \
+            -color
 
   # Comment-style guard (.claude/rules/comments.md, RFC 505/1574): block
   # comments, TODO(#N) form, NOTE/essay line budgets — over the WHOLE tree


### PR DESCRIPTION
`.github/actionlint.yaml` — the runner-label roster actionlint needs to accept `ubuntu-26.04` — has been committed here since well before any job ran the tool. So someone ran actionlint by hand, kept its config, and it was never promoted to a gate.

The two tools do not overlap. zizmor audits **security posture** (unpinned actions, excessive permissions, template injection, credential persistence). actionlint checks the workflow is **well-formed at all**: `${{ }}` expressions that cannot evaluate, `needs:` naming a job that does not exist, unknown runner labels, and shellcheck over every embedded `run:` block. `.claude/rules/reliability.md` says the build pipeline is code and is analysed like code; half of that analysis was missing.

## The 12 findings, and why exactly one code is excluded

Running it reported 12 issues, every one the same class:

```
image-scan.yml:88   SC2016 Expressions don't expand in single quotes
publish-chart.yml:557 SC2016 …
```

All of them are `printf` format strings or a `jq` filter:

```bash
printf '## Chart %s is published, and this run failed after that\n\n' "$VERSION"
--json number --jq '.[0].number // empty'
```

Single quotes there are the **correct** idiom — the shell must not expand `%s` or `$`, that is the entire point. So `SC2016` is excluded via `SHELLCHECK_OPTS`, with the reason recorded at the step, and nothing else is suppressed. The run is clean at actionlint's own default severity rather than by lowering it.

## Mutation-proven

A gate nobody has seen fail is a gate nobody knows works. Two deliberate defects, each reported by name:

```
needs: a-job-that-does-not-exist
  → job "conclusion" needs job "a-job-that-does-not-exist" which does not exist in this workflow [job-needs]

runs-on: ubuntu-nonexistent-99
  → label "ubuntu-nonexistent-99" is unknown … [runner-label]
```

Removing both returns the run to exit 0.

## Shape

Mirrors the `zizmor` job it sits beside: pinned to a SHA via `taiki-e/install-action`, `permissions: contents: read` only, `persist-credentials: false`, no context value in a `run:` block. It is deliberately **not** gated on the `changes` filter — that filter excludes `.github/`, so a workflow-only pull request would otherwise skip the one check that reads workflows, which is the same reasoning already recorded for zizmor. Added to the `conclusion` job's `needs:` so it is required rather than advisory.

Self-checked: `actionlint` and `zizmor --min-severity=low` both clean on the edited file.

Closes #2280.