### PR TITLE
ci: run FOSSA through the CLI so the committed configuration governs

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -1,0 +1,73 @@
+# Licence + dependency analysis via the FOSSA CLI (tracker issue #2298).
+#
+# WHY THIS LANE EXISTS, and not just the GitHub App: the hosted integration
+# scans server-side with its own credentials and does NOT read `.fossa.yml`
+# (that file is the CLI's — https://docs.fossa.com/docs/cli/references/files/fossa-yml).
+# Everything the committed configuration decides — that the dependency surface
+# is the Cargo graph, that the vendored openEHR specification text and third-
+# party test corpora are not ours to license, and the customLicenseSearch rules
+# that flag GPL-family text in FIRST-PARTY source — applies only when the CLI
+# runs. Without this lane the config is decoration and the dashboard reports
+# somebody else's licence as if it were ours.
+#
+# ANALYSE-ONLY, DELIBERATELY. `run-tests` stays false: `fossa test` would fail
+# the build on a policy verdict, and this repository redistributes vendored
+# material under CC-BY-SA and a tri-licensed test corpus. A gate that goes red
+# on somebody else's licence teaches people to merge past a red gate, which is
+# the failure this whole thread started with. Results are published and read on
+# the dashboard; flipping this to a gate is a deliberate decision to make once
+# the six known findings are resolved, not a default to inherit.
+#
+# The API key is a PUSH-ONLY token: `fossa analyze` "Works with a push-only API
+# token" (https://docs.fossa.com/docs/cli/references/subcommands/analyze), so
+# the secret carries no read scope it does not need.
+name: FOSSA
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+  workflow_dispatch:
+
+# Every job grants its own minimum; nothing is inherited.
+permissions: {}
+
+concurrency:
+  group: fossa-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: fossa analyze
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # FOSSA's Rust analyzer runs `cargo generate-lockfile` then
+      # `cargo metadata --format-version 1`
+      # (https://docs.fossa.com/docs/project-setup/supported-languages/rust),
+      # so it needs a toolchain. Pinned by rust-toolchain.toml; no cache is
+      # restored, because nothing here consumes build output.
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.15.2
+        with:
+          cache: false
+
+      # The lockfile is committed, but generate it defensively: the analyzer
+      # documents it as its first step, and a missing lockfile would otherwise
+      # surface as an empty dependency graph rather than an error.
+      - name: Ensure the Cargo lockfile is present
+        run: cargo generate-lockfile --locked || cargo generate-lockfile
+
+      - uses: fossas/fossa-action@29693cc50323968e039056be419b32989fc5880c # v2.0.0
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+          # `github.ref_name` is the branch on a push and the PR number on a
+          # pull_request, which is what FOSSA's own example uses to keep a PR's
+          # results off the branch's history.
+          branch: ${{ github.ref_name }}
+          run-tests: false

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -63,11 +63,43 @@ jobs:
       - name: Ensure the Cargo lockfile is present
         run: cargo generate-lockfile --locked || cargo generate-lockfile
 
-      - uses: fossas/fossa-action@29693cc50323968e039056be419b32989fc5880c # v2.0.0
+      - id: fossa
+        uses: fossas/fossa-action@29693cc50323968e039056be419b32989fc5880c # v2.0.0
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}
+          # PINNING THE CLI IS NOT OPTIONAL HERE. The action's own README says
+          # "This Action will always use the latest version of FOSSA CLI", so a
+          # SHA-pinned action still downloads a moving tool at runtime — the
+          # analysis would change under us with no commit in this repository.
+          # That is precisely what the reliability rule's pinning requirement
+          # exists to stop, and pinning the action alone only looks like
+          # compliance. Bump deliberately, like every other pin.
+          pinned-cli-version: v3.17.16
           # `github.ref_name` is the branch on a push and the PR number on a
           # pull_request, which is what FOSSA's own example uses to keep a PR's
           # results off the branch's history.
           branch: ${{ github.ref_name }}
           run-tests: false
+          # An SPDX attribution report of everything the dependency graph
+          # carries. This project already publishes a CycloneDX SBOM of the
+          # cargo graph per release binary; that answers "what is in the
+          # artifact", while this answers "what are we obliged to attribute" —
+          # a different question, and the one that matters for a product
+          # redistributing third-party material.
+          generate-report: spdx
+
+      # The report is a step OUTPUT, so it exists only for the length of this
+      # job unless something writes it down. Read through the environment
+      # rather than interpolated into the shell: report text is arbitrary
+      # third-party content (dependency names, licence bodies) and must never
+      # be parsed as script.
+      - name: Write the attribution report
+        env:
+          REPORT: ${{ steps.fossa.outputs.report }}
+        run: printf '%s' "$REPORT" > fossa-attribution.spdx.json
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fossa-attribution-report
+          path: fossa-attribution.spdx.json
+          if-no-files-found: error


### PR DESCRIPTION
`.fossa.yml` landed with the licensing work and **nothing has ever read it.**

The project is scanned by the hosted GitHub integration (`Package manager: Git`, `Depth: Direct`), which analyses server-side with its own credentials and does not open that file — it is the CLI's (<https://docs.fossa.com/docs/cli/references/files/fossa-yml>). So the Cargo-only target, the vendored-tree exclusions and the `customLicenseSearch` rules have all been inert, and the dashboard has been reporting openEHR's specification text and a tri-licensed test corpus as though they were ours to license.

## Why analyse-only

`run-tests` is deliberately `false`. `fossa test` fails the build on a policy verdict, and this repository legitimately redistributes CC-BY-SA specification text, CC-BY-SA 4.0 clinical models, and an MPL-1.1-elected test corpus. **A gate that goes red on somebody else's licence teaches people to merge past a red gate** — which is exactly the failure this whole thread started with.

Results publish to the dashboard and are read there. Turning this into a gate is a decision to take deliberately once the six known findings are resolved, not a default inherited from an example.

## Token scope

The secret is a **push-only** token. `fossa analyze` documents that as sufficient (<https://docs.fossa.com/docs/cli/references/subcommands/analyze>: *"Works with a push-only API token"*), so it carries no read scope it does not need.

To answer the question that prompted this: the GitHub App installation does **not** authenticate the CLI. They are separate paths — the App scans server-side and ignores the config; the CLI runs on our runner and pushes up, so it needs its own key.

## Security posture

Every property the `zizmor` job enforces, verified rather than assumed:

- Both `uses:` pinned to full commit SHAs with the version in a trailing comment. Each SHA was dereferenced from its annotated release tag (`fossa-action` v2.0.0 → `29693cc`) and then **checked to belong to the repository named in front of it** — the `impostor-commit` class, which zizmor cannot verify in offline mode.
- `permissions: {}` at workflow level; the one job takes `contents: read`.
- `persist-credentials: false` on checkout.
- No context value reaches a `run:` block. `github.ref_name` is passed as an action *input*, not interpolated into a shell.
- No build cache restored — nothing here consumes build output.

`actionlint` (exit 0) and `zizmor --min-severity=low` (no findings) are both clean on the file.

## The Rust analyzer's requirements

FOSSA's Rust support runs `cargo generate-lockfile` then `cargo metadata --format-version 1` (<https://docs.fossa.com/docs/project-setup/supported-languages/rust>), so the job installs the pinned toolchain. The lockfile is committed, but the step runs defensively: a missing lockfile would otherwise surface as an empty dependency graph rather than an error.

Worth knowing when reading the results — from the same page, FOSSA *"does not currently understand default or missing features"* and treats optional dependencies like Java optionals. Its view of our graph is therefore **wider** than what actually compiles; `cargo deny` remains the precise instrument for what we ship.

## Requires

A `FOSSA_API_KEY` repository secret (push-only). Until it exists this job will fail on the analyze step — which is the honest failure mode, rather than silently reporting nothing.

Refs #2298.