### PR TITLE
ci: make the licence gate real, and make every gate actually gate

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -62,13 +62,16 @@ paths:
     # Fuzzing seeds: copies of the corpora above, kept for crash reproduction.
     - ./fuzz/seeds
 
-# A licence this project must never ship goes here rather than living only in a
-# reviewer's memory. These are the two copyleft families that would conflict
-# with the MIT licence of this project's own code; a match inside our own
-# sources is a finding worth stopping for, and the exclusions above mean a hit
-# can only come from code we wrote.
-customLicenseSearch:
-  - matchCriteria: "GNU (Affero )?General Public License"
-    name: "GPL-family licence text in first-party source"
-  - matchCriteria: "Server Side Public License"
-    name: "SSPL text in first-party source"
+# NO customLicenseSearch HERE, for two measured reasons (run 2026-08-12, CLI
+# 3.17.16). It uploaded nothing — `archiveAndLicenseUpload is not enabled in
+# this organization` failed the whole lane after a successful analysis — and,
+# more importantly, it did not honour the `paths.exclude` list above: every one
+# of its seven hits was inside a tree excluded on line 42ff, i.e. exactly the
+# third-party material this file exists to keep out of the results. The search
+# filters are a separate setting (`vendoredDependencies.licenseScanPathFilters`)
+# and the two lists do not compose the way the layout suggests.
+#
+# The forbidden-licence check therefore lives where it can be proven instead:
+# `scripts/checks/first-party-license-text.sh`, run by the `license-text` CI
+# job. It shares this file's exclusion list, needs no FOSSA plan, and fails the
+# build rather than filing a dashboard finding nobody is paged for.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,6 +407,26 @@ jobs:
       - name: No copyleft licence text in first-party source
         run: bash scripts/checks/first-party-license-text.sh
 
+  # The compose hardening properties (cap_drop ALL, no-new-privileges, no
+  # privileged, no seccomp=unconfined, loopback-only publishing). This gate
+  # existed and ran nowhere, while `docker-compose.yml` and the operations
+  # chapter both told readers it "enforces that on every compose artifact" — a
+  # documented guard that does not fire is worse than none, because the docs and
+  # the reviewer both believe it did.
+  compose-hardening:
+    name: compose-hardening
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Compose artifacts stay hardened
+        run: bash scripts/checks/compose-hardening.sh
+
   # RFC 0201: an error carries its cause. No clippy lint covers this, so the
   # gate is a per-tree ratchet — the flattened-site counts may only fall while
   # the #2034 sweep runs.
@@ -1730,6 +1750,7 @@ jobs:
       - no-python
       - license-text
       - spec-citations
+      - compose-hardening
       - deny
       - clippy
       - doc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,6 +330,13 @@ jobs:
             rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 \
             -color
 
+      # actionlint validates each job in isolation and cannot know that this
+      # repository routes branch protection through a single `conclusion` check,
+      # which makes a job missing from its `needs` list run without gating
+      # anything.
+      - name: Every CI job gates the merge
+        run: bash scripts/checks/ci-conclusion-complete.sh
+
   # Comment-style guard (.claude/rules/comments.md, RFC 505/1574): block
   # comments, TODO(#N) form, NOTE/essay line budgets — over the WHOLE tree
   # hand-written .rs files. Diff-scoped until the legacy essay sweep (#1870)
@@ -381,6 +388,24 @@ jobs:
           persist-credentials: false
       - name: No Python invocations or sources
         run: bash scripts/checks/no-python.sh
+
+  # This project's own code is MIT, so a GPL-family or SSPL grant inside a file
+  # we wrote is a licence conflict. It lives here rather than in `.fossa.yml`
+  # because FOSSA's customLicenseSearch could not upload on this org's plan and
+  # did not honour that file's path exclusions (measured 2026-08-12).
+  license-text:
+    name: license-text
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: No copyleft licence text in first-party source
+        run: bash scripts/checks/first-party-license-text.sh
 
   # RFC 0201: an error carries its cause. No clippy lint covers this, so the
   # gate is a per-tree ratchet — the flattened-site counts may only fall while
@@ -1701,6 +1726,10 @@ jobs:
       - docs-claims
       - sql-string-building
       - error-hygiene
+      - error-source-chain
+      - no-python
+      - license-text
+      - spec-citations
       - deny
       - clippy
       - doc
@@ -1722,6 +1751,7 @@ jobs:
       - crate-version
       - chart-version
       - chart-appversion
+      - chart-boot
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions: {}

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -4,11 +4,14 @@
 # scans server-side with its own credentials and does NOT read `.fossa.yml`
 # (that file is the CLI's — https://docs.fossa.com/docs/cli/references/files/fossa-yml).
 # Everything the committed configuration decides — that the dependency surface
-# is the Cargo graph, that the vendored openEHR specification text and third-
-# party test corpora are not ours to license, and the customLicenseSearch rules
-# that flag GPL-family text in FIRST-PARTY source — applies only when the CLI
+# is the Cargo graph, and that the vendored openEHR specification text and
+# third-party test corpora are not ours to license — applies only when the CLI
 # runs. Without this lane the config is decoration and the dashboard reports
 # somebody else's licence as if it were ours.
+#
+# The forbidden-licence check is NOT here; it is
+# `scripts/checks/first-party-license-text.sh`, run by the `license-text` CI
+# job. `.fossa.yml` records why.
 #
 # ANALYSE-ONLY, DELIBERATELY. `run-tests` stays false: `fossa test` would fail
 # the build on a policy verdict, and this repository redistributes vendored
@@ -63,8 +66,7 @@ jobs:
       - name: Ensure the Cargo lockfile is present
         run: cargo generate-lockfile --locked || cargo generate-lockfile
 
-      - id: fossa
-        uses: fossas/fossa-action@29693cc50323968e039056be419b32989fc5880c # v2.0.0
+      - uses: fossas/fossa-action@29693cc50323968e039056be419b32989fc5880c # v2.0.0
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}
           # PINNING THE CLI IS NOT OPTIONAL HERE. The action's own README says
@@ -80,26 +82,10 @@ jobs:
           # results off the branch's history.
           branch: ${{ github.ref_name }}
           run-tests: false
-          # An SPDX attribution report of everything the dependency graph
-          # carries. This project already publishes a CycloneDX SBOM of the
-          # cargo graph per release binary; that answers "what is in the
-          # artifact", while this answers "what are we obliged to attribute" —
-          # a different question, and the one that matters for a product
-          # redistributing third-party material.
-          generate-report: spdx
-
-      # The report is a step OUTPUT, so it exists only for the length of this
-      # job unless something writes it down. Read through the environment
-      # rather than interpolated into the shell: report text is arbitrary
-      # third-party content (dependency names, licence bodies) and must never
-      # be parsed as script.
-      - name: Write the attribution report
-        env:
-          REPORT: ${{ steps.fossa.outputs.report }}
-        run: printf '%s' "$REPORT" > fossa-attribution.spdx.json
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: fossa-attribution-report
-          path: fossa-attribution.spdx.json
-          if-no-files-found: error
+          # NO `generate-report` HERE. It needs a READ-scoped token and fails
+          # with "Invalid API token type" on the push-only one this repository
+          # deliberately uses (measured 2026-08-12). Report generation is not
+          # worth widening a CI credential from write-only to read: a token that
+          # cannot read the organization's data is a smaller blast radius than
+          # an SPDX attribution file is a convenience. Pull the report from the
+          # dashboard when it is wanted.

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -53,7 +53,7 @@ jobs:
       # (https://docs.fossa.com/docs/project-setup/supported-languages/rust),
       # so it needs a toolchain. Pinned by rust-toolchain.toml; no cache is
       # restored, because nothing here consumes build output.
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.15.2
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -613,6 +613,25 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **Five CI gates ran without gating anything.** Branch protection routes
+  through a single aggregate check, which is what lets jobs be added or renamed
+  without editing repository settings — but a job missing from that check's
+  dependency list still runs, still goes red, and still merges. The compose
+  hardening guard, the error cause-chain ratchet, the no-Python rule, the
+  spec-citation check and the chart boot check were all in that state. All are
+  wired in, and a new guard fails the build when a job is missing from the list
+  in either direction, so the next one cannot slip through silently. The compose
+  guard is the one worth calling out: `docker-compose.yml` and the operations
+  chapter both told readers it enforced on every compose artifact, and it had
+  never run.
+
+- **The forbidden-licence check now actually runs.** It was configured as a
+  FOSSA `customLicenseSearch`, which could not upload on this organization's
+  plan and did not honour the configured path exclusions — every one of its
+  findings came from vendored third-party trees rather than from this project's
+  own code. It is now a local check that shares the same exclusion list and
+  fails the build.
+
 - **An uploaded operational template no longer silently loses its slot
   constraints.** A slot assertion was rendered into ADL by writing the raw
   numeric operator code the OPT XML encodes — text the assertion parser cannot

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5485,7 +5485,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "indexmap 2.14.0",
  "openehr-am",
@@ -5500,7 +5500,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "serde",
  "serde_json",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "async-trait",
  "axum",
@@ -5558,7 +5558,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "assert_fs",
  "chumsky",
@@ -5572,7 +5572,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "chumsky",
  "logos",
@@ -5581,7 +5581,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "insta",
  "jsonschema",
@@ -5599,7 +5599,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-adl"
-version = "0.0.24"
+version = "0.0.25"
 description = "openEHR ADL 2.4.0: hand-written ADL2/cADL/ODIN parser, AOM2 validation catalogue, specialisation flattener, OPT2 generator, and ADL 1.4→2 conversion over the generated openehr_am::v2_4::aom2 model"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,10 +16,10 @@ include = ["src/**", "README.md", "LICENSE-MIT"]
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)
-openehr-base = { path = "../openehr-base", version = "0.0.24" }   # VersionStatus for the parsed HRID
-openehr-am = { path = "../openehr-am", version = "0.0.24" }       # v2_4 ArchetypeHrid (the identification target type)
-openehr-rm = { path = "../openehr-rm", version = "0.0.24" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
-openehr-lang = { path = "../openehr-lang", version = "0.0.24" }   # openehr_lang::odin — the ODIN section parser
+openehr-base = { path = "../openehr-base", version = "0.0.25" }   # VersionStatus for the parsed HRID
+openehr-am = { path = "../openehr-am", version = "0.0.25" }       # v2_4 ArchetypeHrid (the identification target type)
+openehr-rm = { path = "../openehr-rm", version = "0.0.25" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
+openehr-lang = { path = "../openehr-lang", version = "0.0.25" }   # openehr_lang::odin — the ODIN section parser
 uuid.workspace = true        # meta uid/build_uid (AUTHORED_ARCHETYPE.uid: Uuid)
 indexmap.workspace = true    # OdinValue::Object body (insertion-ordered map)
 

--- a/crates/openehr-adl/src/aom/interval.rs
+++ b/crates/openehr-adl/src/aom/interval.rs
@@ -33,8 +33,8 @@ impl Bounds {
         Self { lower, upper }
     }
 
-    /// The [`MultiplicityInterval`] this bound denotes, the inverse of
-    /// [`bounds`].
+    /// The [`MultiplicityInterval`] this bound denotes, the inverse of the
+    /// crate-internal `bounds` reader.
     #[must_use]
     pub fn to_multiplicity_interval(self) -> MultiplicityInterval {
         MultiplicityInterval {

--- a/crates/openehr-adl/src/validate/conformance.rs
+++ b/crates/openehr-adl/src/validate/conformance.rs
@@ -5,7 +5,7 @@
 //! `docs/specs/openehr/AM/docs/AOM2/master04.5-constraint_model-class_definitions.adoc`
 //! §Conformance Semantics). This module is what the phase-2 specialisation
 //! validator adds on top of them: the tri-state
-//! [`ValueConformance`]/[`TupleConformance`] verdicts its issue codes need, the
+//! `ValueConformance`/`TupleConformance` verdicts its issue codes need, the
 //! VSONCO collective-occurrences computation, the VSONT meta-type rule, and the
 //! ADL 1.4 effective-value accessors.
 //!

--- a/crates/openehr-adl/src/validate/flat.rs
+++ b/crates/openehr-adl/src/validate/flat.rs
@@ -374,8 +374,10 @@ fn check_node_id_unique(
 /// one parent node share a path and two distinct nodes do not.
 ///
 /// A code that is NEW at its level (`[id0.32]`) specialises nothing —
-/// [`crate::codes::is_redefined_code`] is false for it — so it is left alone and
-/// two independently-added nodes never collapse onto each other.
+/// [`AdlCodeDefinitionsData::is_redefined_code`] is false for it — so it is left
+/// alone and two independently-added nodes never collapse onto each other.
+///
+/// [`AdlCodeDefinitionsData::is_redefined_code`]: openehr_am::v2_4::aom2::definitions::adl_code_definitions::AdlCodeDefinitionsData::is_redefined_code
 fn specialisation_root_path(path: &str) -> String {
     let mut out = String::with_capacity(path.len());
     let mut rest = path;

--- a/crates/openehr-am/Cargo.toml
+++ b/crates/openehr-am/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-am"
-version = "0.0.24"
+version = "0.0.25"
 description = "openEHR AM Archetype Model, generated from BMM: generations v1_4 (AM 1.4.0, ADL 1.4) and v2_4 (AM 2.4.0, ADL 2; current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,8 +13,8 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.24" }
-openehr-lang = { path = "../openehr-lang", version = "0.0.24" }
+openehr-base = { path = "../openehr-base", version = "0.0.25" }
+openehr-lang = { path = "../openehr-lang", version = "0.0.25" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also carries the untyped `Value` fields the generator

--- a/crates/openehr-base/Cargo.toml
+++ b/crates/openehr-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-base"
-version = "0.0.24"
+version = "0.0.25"
 description = "openEHR BASE foundation + base types, generated from BMM: generations v1_2 (BASE 1.2.0) and v1_3 (BASE 1.3.0, current)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-its"
-version = "0.0.24"
+version = "0.0.25"
 description = "openEHR ITS (Implementation Technology Specifications): canonical JSON + canonical XML serialization of the RM, the generated ITS-REST 1.1.0 API contract, OPT 1.4 and AOM2 archetype XML codecs, and the Simplified Formats (FLAT / STRUCTURED / Web Template)"
 edition.workspace = true
 rust-version.workspace = true
@@ -41,14 +41,14 @@ regex = { workspace = true, optional = true }
 fancy-regex = { workspace = true, optional = true }
 # The generated XML (de)serializers impl the crate's ToXml/FromXml traits for the
 # RM/BASE spec types, so these are real (non-dev) deps.
-openehr-base = { path = "../openehr-base", version = "0.0.24", optional = true }
-openehr-rm = { path = "../openehr-rm", version = "0.0.24", optional = true }
+openehr-base = { path = "../openehr-base", version = "0.0.25", optional = true }
+openehr-rm = { path = "../openehr-rm", version = "0.0.25", optional = true }
 # The native canonical-JSON codec (`json_codec/generated`, emit-json) implements
 # `ToJson` for EVERY generated spec type the `OpenEhrType` derive covers, so it
 # spans all five spec crates (not just the RM/BASE the XML codec needs).
-openehr-lang = { path = "../openehr-lang", version = "0.0.24", optional = true }
-openehr-am = { path = "../openehr-am", version = "0.0.24", optional = true }
-openehr-term = { path = "../openehr-term", version = "0.0.24", optional = true }
+openehr-lang = { path = "../openehr-lang", version = "0.0.25", optional = true }
+openehr-am = { path = "../openehr-am", version = "0.0.25", optional = true }
+openehr-term = { path = "../openehr-term", version = "0.0.25", optional = true }
 
 # `full` — every ITS surface (canonical JSON/XML, the generated ITS-REST
 # contract, `opt14`, Simplified Formats). ON BY DEFAULT, so every consumer sees

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-lang"
-version = "0.0.24"
+version = "0.0.25"
 description = "openEHR LANG BMM/P_BMM object model, generated from BMM: generations v1_0 (LANG 1.0.0) and v1_1 (LANG 1.1.0, current; the stable BMM v2.x unit beside the paused BMM3 unit), plus hand-written ODIN/BEL/EL readers"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["parser-implementations", "data-structures"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.24" }
+openehr-base = { path = "../openehr-base", version = "0.0.25" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the
 # generated types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) —
 # never a derive. `serde_json` also carries the untyped `Value` fields the

--- a/crates/openehr-query/Cargo.toml
+++ b/crates/openehr-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-query"
-version = "0.0.24"
+version = "0.0.25"
 description = "openEHR QUERY (AQL 1.1.0): hand-written lexer, parser, typed AST and canonical printer from the official grammar (no ANTLR runtime)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-rm"
-version = "0.0.24"
+version = "0.0.25"
 description = "openEHR RM Reference Model, generated from BMM: generations v1_1 (RM 1.1.0) and v1_2 (RM 1.2.0, current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,11 +13,11 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.24" }
+openehr-base = { path = "../openehr-base", version = "0.0.25" }
 # The terminology-backed RM class invariants (`validate::terminology`) resolve
 # openEHR terminology groups + code sets against the vendored TERM 3.1.0 bundle.
 # `openehr-term` itself depends only on `openehr-base`, so this is acyclic.
-openehr-term = { path = "../openehr-term", version = "0.0.24" }
+openehr-term = { path = "../openehr-term", version = "0.0.25" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also backs the untyped `Value` RM representation used by

--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-term"
-version = "0.0.24"
+version = "0.0.25"
 description = "openEHR TERM terminology data model, generated from BMM (generation v3_1 = TERM 3.1.0), plus the embedded official terminology XML bundle"
 edition.workspace = true
 rust-version.workspace = true
@@ -29,7 +29,7 @@ include = [
 ]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.24" }
+openehr-base = { path = "../openehr-base", version = "0.0.25" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,13 +70,21 @@ ENV REVISION=${REVISION}
 # The binary is pure-Rust (rustls, no OpenSSL); the slim base needs no extra
 # system libraries. Deps are already compiled by `chef cook`, so this step only
 # builds the workspace's own crates.
-# --jobs 2: the generated spec crates carry every emitted generation
-# (#1936/#1942), and two of those rustc invocations in parallel with the app
-# crates exceed a default Docker VM's memory at opt-level 3 (observed: SIGKILL
-# compiling openehr-its in a 7.7 GB VM, 2026-08-05). Capping build parallelism
-# changes no shipped byte — it only serializes compilation.
+# Build parallelism is capped, and tunable. The generated spec crates carry
+# every emitted generation (#1936/#1942), so a single rustc invocation on one of
+# them at opt-level 3 holds gigabytes; running several alongside the app crates
+# exhausts a small Docker VM and the kernel kills the compiler. That has now
+# been observed twice at two different caps — SIGKILL on openehr-its at the
+# default parallelism (7.7 GB VM, 2026-08-05), and again at `--jobs 2` once the
+# spec-function work landed — so the number is a property of the machine, not a
+# constant to keep re-tuning in this file.
+#
+# `--build-arg CARGO_BUILD_JOBS=1` builds on a memory-constrained host. It costs
+# wall-clock and changes no shipped byte: parallelism only decides how many
+# translation units compile at once.
+ARG CARGO_BUILD_JOBS=2
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-    cargo build --release --locked --jobs 2 -p ferroehr-server \
+    cargo build --release --locked --jobs "${CARGO_BUILD_JOBS}" -p ferroehr-server \
     && cp target/release/ferroehr /usr/local/bin/ferroehr \
     && strip /usr/local/bin/ferroehr
 

--- a/docker/sut-ferroehr.yml
+++ b/docker/sut-ferroehr.yml
@@ -106,6 +106,10 @@ services:
       target: runtime-from-source
       args:
         REVISION: ${REVISION:-}
+        # Lower to 1 on a memory-constrained Docker VM: the release build of
+        # the generated spec crates is what exhausts it, and serializing
+        # compilation changes no shipped byte (docker/Dockerfile).
+        CARGO_BUILD_JOBS: ${CARGO_BUILD_JOBS:-2}
     depends_on:
       ferroehr-postgres:
         condition: service_healthy

--- a/scripts/checks/ci-conclusion-complete.sh
+++ b/scripts/checks/ci-conclusion-complete.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Every CI job must be reachable from the `conclusion` gate.
+#
+# Branch protection points at `conclusion` alone, on purpose: that is what lets
+# jobs be added, renamed or path-gated without editing repository settings. The
+# cost of that design is that a job missing from `conclusion.needs` still RUNS
+# and still goes red, while merging stays green — a gate that looks enforced and
+# is not.
+#
+# That is not hypothetical: on 2026-08-12 four gates (`chart-boot`,
+# `error-source-chain`, `no-python`, `spec-citations`) were found running
+# without gating anything. This check exists so the next one fails loudly.
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+readonly WORKFLOW='.github/workflows/ci.yml'
+
+# Job keys are the only two-space-indented `name:` lines under `jobs:`.
+jobs=$(yq -o=json '.jobs | keys' "$WORKFLOW" | jq -r '.[]' | grep -vx 'conclusion' | sort)
+needs=$(yq -o=json '.jobs.conclusion.needs' "$WORKFLOW" | jq -r '.[]' | sort)
+
+if missing=$(comm -23 <(echo "$jobs") <(echo "$needs")) && [[ -n "$missing" ]]; then
+  echo "error: CI jobs that do not gate the merge" >&2
+  echo >&2
+  echo "$missing" | sed 's/^/  - /' >&2
+  echo >&2
+  echo "Branch protection requires only the 'conclusion' check, so a job absent" >&2
+  echo "from its 'needs' list can fail without blocking a merge. Add each job" >&2
+  echo "above to jobs.conclusion.needs in $WORKFLOW." >&2
+  exit 1
+fi
+
+# The mirror direction: a needs entry naming a job that no longer exists makes
+# `conclusion` fail permanently on an unresolvable dependency.
+if stale=$(comm -13 <(echo "$jobs") <(echo "$needs")) && [[ -n "$stale" ]]; then
+  echo "error: conclusion.needs names jobs that do not exist" >&2
+  echo "$stale" | sed 's/^/  - /' >&2
+  exit 1
+fi
+
+echo "ok: all $(echo "$jobs" | wc -l | tr -d ' ') CI jobs gate the merge"

--- a/scripts/checks/first-party-license-text.sh
+++ b/scripts/checks/first-party-license-text.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Refuses copyleft licence TEXT inside this project's own source.
+#
+# This project's own code is MIT (.claude/rules/reliability.md §C-PERMISSIVE).
+# A GPL-family or SSPL grant appearing in a file WE wrote is a licence conflict
+# that no reviewer reliably catches by eye, so it is checked here.
+#
+# WHY THIS IS LOCAL AND NOT `customLicenseSearch` IN .fossa.yml: that feature was
+# tried and removed on 2026-08-12 (CLI 3.17.16). It could not upload at all
+# (`archiveAndLicenseUpload is not enabled in this organization`, failing the
+# lane after a clean analysis), and it did not honour the `paths.exclude` list —
+# all seven of its hits were inside vendored third-party trees that list already
+# excludes. A gate that reads the wrong files and cannot report is worse than no
+# gate; this one shares that exclusion list and fails the build.
+#
+# Third-party material is EXCLUDED, not exempted: it is redistributed verbatim
+# under terms recorded in each tree's PROVENANCE.md. Its licences are facts
+# about somebody else's work, and flagging them here would say this project
+# adopted them.
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# The forbidden grants. Copyleft families incompatible with shipping MIT source.
+readonly PATTERN='GNU (Affero |Lesser )?General Public License|Server Side Public License'
+
+# Mirrors .fossa.yml `paths.exclude`, plus build/VCS output. Keep the two in
+# step: a tree vendored into one and not the other is a silent coverage hole.
+readonly -a EXCLUDED=(
+  ':(exclude)docs/specs/openehr/**'
+  ':(exclude)crates/openehr-term/assets/**'
+  ':(exclude)crates/openehr-its/schemas/**'
+  ':(exclude)crates/openehr-adl/vendor/**'
+  ':(exclude)crates/openehr-lang/vendor/**'
+  ':(exclude)tools/openehr-codegen/vendor/**'
+  ':(exclude)crates/openehr-adl/tests/corpus/**'
+  ':(exclude)crates/openehr-its/tests/vendor/**'
+  ':(exclude)crates/openehr-its/tests/fixtures/**'
+  ':(exclude)crates/openehr-lang/tests/vendor/**'
+  ':(exclude)crates/openehr-term/tests/**'
+  ':(exclude)tools/cnf-runner/artifacts/corpus/**'
+  ':(exclude)fuzz/seeds/**'
+)
+
+# Files that legitimately NAME these licences without granting them: the licence
+# texts this project redistributes, the rules that adjudicate them, this gate,
+# and the dependency policy that denies them. A match here is prose ABOUT a
+# licence, which is the opposite of a violation.
+readonly -a PROSE=(
+  ':(exclude)LICENSE-APACHE-2.0'
+  ':(exclude)LICENSE-CC-BY-SA-3.0'
+  ':(exclude)LICENSE-CC-BY-SA-4.0'
+  ':(exclude).claude/**'
+  ':(exclude)scripts/checks/first-party-license-text.sh'
+  ':(exclude)deny.toml'
+  ':(exclude).fossa.yml'
+  ':(exclude)CHANGELOG.md'
+)
+
+# `git grep` over TRACKED files only, so an untracked local scratch file can
+# never fail somebody's build, and target/ is skipped without naming it.
+if matches=$(git grep -InE "$PATTERN" -- . "${EXCLUDED[@]}" "${PROSE[@]}"); then
+  echo "error: copyleft licence text in first-party source" >&2
+  echo >&2
+  echo "$matches" >&2
+  echo >&2
+  echo "This project's own code is MIT. A GPL-family or SSPL grant here is a" >&2
+  echo "licence conflict. If the file is vendored third-party material, add its" >&2
+  echo "tree to BOTH the exclusion list in this script and paths.exclude in" >&2
+  echo ".fossa.yml, and record its terms in that tree's PROVENANCE.md." >&2
+  exit 1
+fi
+
+echo "ok: no copyleft licence text in first-party source"


### PR DESCRIPTION
Four red lanes on develop. One of them was hiding something worth more than the fix.

## Four gates were running without gating anything

Branch protection routes through the single `conclusion` check — deliberately, because that is what lets jobs be added, renamed or path-gated without editing repository settings. The cost of that design is that a job missing from `conclusion.needs` still **runs**, still goes **red**, and still **merges**.

Four were in exactly that state:

| job | what it enforces |
|---|---|
| `chart-boot` | the chart's rendered defaults actually boot the `appVersion` image |
| `error-source-chain` | the RFC 0201 cause-chain ratchet |
| `no-python` | the no-Python hard rule |
| `spec-citations` | spec-citation validity |

All four are wired in, plus the new `license-text`. `scripts/checks/ci-conclusion-complete.sh` now fails when a job is missing from the list — and in the mirror direction too, since a `needs` entry naming a deleted job makes `conclusion` permanently unresolvable. **All 36 jobs gate.**

## FOSSA analysed cleanly, then failed to upload

```
Error: archiveAndLicenseUpload is not enabled in this organization.
```

`customLicenseSearch` needs an org feature this plan does not have, so the lane died *after* a successful analysis. The more interesting half: **it did not honour `paths.exclude`.** All seven of its hits were inside vendored trees that file already excludes — so the comment I wrote claiming "a hit can only come from code we wrote" was flatly wrong, and the run disproved it. The search filters are a separate setting (`vendoredDependencies.licenseScanPathFilters`) and the two lists do not compose the way the layout suggests.

A check that reads the wrong files and cannot report is worse than no check, so it moves to `scripts/checks/first-party-license-text.sh`: same exclusion list, no FOSSA plan required, fails the build rather than filing a dashboard finding nobody is paged for.

Mutation-proven in three directions:

- clean tree → passes
- a GPL grant planted in `app/ferroehr/src` → **caught**
- the same text inside an excluded vendored tree → **correctly ignored**

## Two of my own mistakes

The `setup-rust-toolchain` pin in `fossa.yml` carried a stale `# v1.15.2` comment against a SHA that is really **v1.17.0** — the version every other workflow states. zizmor's `ref-version-mismatch` caught it, which is the audit doing its job.

Three `openehr-adl` doc links pointed at private or non-existent items: `bounds` and the two conformance verdict enums are `pub(crate)`, and `crate::codes::is_redefined_code` never existed — that function is realized on `AdlCodeDefinitionsData` in `openehr-am`.

## Deliberately NOT in this PR

The `docs` lane is also red, on the conformance-assets drift gate. Regenerating those SVGs is a one-line fix and I am not taking it, because the drift is the symptom of something else: the committed baseline went from **1014 passed / 0 failed** to **1006 passed / 8 failed** in #2293. Regenerating would publish the regression as the record and silence the signal that caught it.

The 8 failures are in spec-adjudicated triage now (5 terminology, 3 PGP signing), and they belong to #2032, the milestone's closing gate.

Closes #2301.
Refs #2298.