### PR TITLE
fix(cnf): verify a signature made by the certificate's signing subkey

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -77,6 +77,11 @@ jobs:
           # exists to stop, and pinning the action alone only looks like
           # compliance. Bump deliberately, like every other pin.
           pinned-cli-version: v3.17.16
+          # Pinned, or the CLI derives the project name from the git remote and
+          # files results under a project literally named
+          # "https://github.com/rubentalstra/FerroEHR". A stable name keeps the
+          # dashboard, the badge and this lane pointing at one place.
+          project: FerroEHR
           # `github.ref_name` is the branch on a push and the PR number on a
           # pull_request, which is what FOSSA's own example uses to keep a PR's
           # results off the branch's history.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1423,6 +1423,7 @@ dependencies = [
  "jsonwebtoken",
  "pgp",
  "quick-xml 0.41.0",
+ "rand 0.8.7",
  "regex",
  "reqwest 0.13.4",
  "semver",

--- a/tools/cnf-runner/Cargo.toml
+++ b/tools/cnf-runner/Cargo.toml
@@ -65,6 +65,11 @@ jsonwebtoken = { workspace = true }
 
 [dev-dependencies]
 assert_fs = { workspace = true }
+# NOT the workspace rand (0.10). `pgp 0.20`'s signing call takes an RNG from
+# rand 0.8's rand_core generation, so the types must come from that major or
+# they do not unify. `app/ferroehr` pins it identically and for the same
+# reason; this is a deliberate crate-level pin, not drift.
+rand = "0.8"
 
 [lints]
 workspace = true

--- a/tools/cnf-runner/src/exec/signature.rs
+++ b/tools/cnf-runner/src/exec/signature.rs
@@ -123,7 +123,21 @@ fn verify_pgp(
         .map_err(|e| format!("pgp public key: {e}"))?;
     let (sig, _) = DetachedSignature::from_string(signature_armored)
         .map_err(|e| format!("pgp signature: {e}"))?;
-    Ok(sig.verify(&key, bytes).is_ok())
+
+    // A signature by a signing-flagged SUBKEY is a signature by the
+    // certificate: RFC 9580 §10.1 defines a transferable public key as a
+    // primary key plus its subkeys, and §5.2.3.29 key flag 0x02 marks a key as
+    // usable to sign data. `rpgp`'s `VerifyingKey for SignedPublicKey` consults
+    // `primary_key` alone, so verifying only against it refuses a signature the
+    // declared certificate legitimately covers — which is a verifier defect,
+    // never a finding about the system under test.
+    if sig.verify(&key, bytes).is_ok() {
+        return Ok(true);
+    }
+    Ok(key
+        .public_subkeys
+        .iter()
+        .any(|subkey| sig.verify(subkey, bytes).is_ok()))
 }
 
 #[cfg(test)]
@@ -162,6 +176,61 @@ mod tests {
         // A tampered envelope (different data) must fail against the old digest.
         let env2 = json!({ "_type": "ORIGINAL_VERSION", "data": { "b": 3, "a": 1 } });
         assert!(!verify(&env2, &good, &digest_mode()).unwrap());
+    }
+
+    // A signature made by the certificate's signing SUBKEY must verify.
+    //
+    // The corpus certificate carries one, the server signs with it by
+    // capability, and `rpgp` verifies against the primary key alone — so a
+    // verifier written the obvious way reports a conformant server as
+    // unverifiable. Three CNF rows failed exactly that way, unnoticed because
+    // nothing pinned which key component signs.
+    #[test]
+    #[expect(
+        clippy::panic_in_result_fn,
+        reason = "test assertions in the Book's Result-returning test shape"
+    )]
+    fn subkey_signature_verifies_against_the_certificate() -> Result<(), Box<dyn std::error::Error>>
+    {
+        use pgp::composed::{
+            ArmorOptions, Deserializable as _, DetachedSignature, SignedSecretKey,
+        };
+        use pgp::crypto::hash::HashAlgorithm;
+        use pgp::types::Password;
+        use rand::rngs::OsRng;
+
+        let keys = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("artifacts/corpus/keys");
+        let (secret, _) = SignedSecretKey::from_string(&std::fs::read_to_string(
+            keys.join("cnf-signing.sec.asc"),
+        )?)?;
+        let public_armored = std::fs::read_to_string(keys.join("cnf-signing.pub.asc"))?;
+
+        // Pick the subkey by CAPABILITY, the way the server does — an
+        // encryption subkey signing would be a key-usage violation.
+        let subkey = secret
+            .secret_subkeys
+            .iter()
+            .find(|sub| sub.signatures.iter().any(|sig| sig.key_flags().sign()))
+            .ok_or("the corpus certificate carries no signing subkey")?;
+
+        let data = b"ferroehr-cnf subkey verification";
+        let sig = DetachedSignature::sign_binary_data(
+            OsRng,
+            &subkey.key,
+            &Password::empty(),
+            HashAlgorithm::Sha256,
+            &data[..],
+        )?
+        .to_armored_string(ArmorOptions::default())?;
+
+        assert!(
+            verify_pgp(data, &sig, &public_armored)?,
+            "a signature by the certificate's signing subkey must verify"
+        );
+        // The negative direction: a different payload must still fail, so the
+        // subkey fallback cannot pass by accepting everything.
+        assert!(!verify_pgp(b"tampered", &sig, &public_armored)?);
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
Three `SIG-VERSION-*-pgp` rows reported a conformant server as unverifiable. **The fault was the verifier, not the server**, and that attribution is what the triage protocol exists to establish before anything is changed.

## The derivation

RFC 9580 §10.1 defines a transferable public key as a primary key **plus its subkeys**, and §5.2.3.29 key flag `0x02` marks a key as usable to sign data. The corpus certificate carries a signing subkey, the server selects it by capability, and the signature it produces is therefore a signature *by that certificate*.

`rpgp`'s `VerifyingKey for SignedPublicKey` consults `primary_key` alone:

```rust
impl VerifyingKey for SignedPublicKey {
    fn verify(&self, hash: HashAlgorithm, data: &[u8], sig: &SignatureBytes) -> Result<()> {
        self.primary_key.verify(hash, data, sig)   // public_subkeys never consulted
    }
}
```

So the runner refused a signature the declared certificate legitimately covers.

## Why this is the verifier and not the SUT

Two pieces of in-run evidence, neither requiring a SUT to reproduce:

- The **digest twins** of all three cases passed in the same run. The runner reconstructs exactly the bytes the server signed, so the canonical form (RFC 8785 JCS of the version minus `signature`) agrees byte-for-byte. Canonicalization is not the fault.
- rpgp returned `Ok(false)`, not `Err` — which proves the armored detached signature **parsed**. The server emitted a real signature; the verifier simply could not match it to a key it was willing to look at.

`SIG-VERSION-client_supplied_verbatim-pgp` also passed on the same `sut_pgp` instance, so the deployment was up and the key had loaded — `PgpKey::load` is fail-closed and performs a real test signature at boot, so it could not have started otherwise.

## The application already had this right

`app/ferroehr/src/versioning/signature/key.rs` carries `verify_against_certificate` with a doc comment naming this exact rpgp behaviour. The runner never got the same treatment — the two verifiers had drifted, and only the one with no test noticed nothing.

## The gap that let it through

The signer changed from primary key to subkey in `7a8a8c9a3`, and **no case pinned which key component signs**, so the change was invisible to the acceptance instrument until an unrelated re-run. There is now a test that signs with the subkey exactly as the server does — selecting it by capability, not position, since an encryption subkey signing would be a key-usage violation.

Mutation-proven in both directions:

| verifier | result |
|---|---|
| primary-key-only (the old code) | **FAIL** |
| primary + subkeys (this change) | **PASS** |

It also asserts a tampered payload still fails, so the fallback cannot pass by accepting everything.

## Two smaller things

`rand` is pinned to `0.8` in the dev-dependencies rather than taken from the workspace (`0.10`): pgp 0.20's signing call takes an RNG from that generation's `rand_core` and the types do not otherwise unify. `app/ferroehr` pins it identically, for the same reason, with the same note.

The FOSSA project name is now pinned. Unpinned, the CLI derives it from the git remote and files results under a project literally named `https://github.com/rubentalstra/FerroEHR` — which is how a duplicate project appeared beside the hosted integration's.

Refs #2032.