### PR TITLE
chore(supply-chain): close the enterprise supply-chain and project-maturity gaps

### DIFF
--- a/.claude/agent-memory/cnf-triage/MEMORY.md
+++ b/.claude/agent-memory/cnf-triage/MEMORY.md
@@ -41,3 +41,6 @@
 - [OAS `required:` ≠ non-empty array](oas-required-does-not-forbid-empty-arrays.md) — `Clstr.yaml required: [items]` is satisfied by `[]`; only the BMM cardinality grounds an empty-list refusal
 - [Authz class is EXPLICIT SM deferral](authz-class-is-explicit-sm-deferral.md) — a role 403 is never the app bin; SM master02 §Functional Style also grounds driving semantics cases as an authorized principal
 - [Definition-delete routes are Admin (#2071)](definition-delete-routes-are-admin-class.md) — the class move stands; 5 red rows = catalogue bin (`on: admin`), plus the readonly/uncased-branch fallout
+- [TERMINOLOGY_ID has no declared invariant](terminology-id-value-has-no-invariant.md) — BASE declares no Invariants row; master05's production is refuted by its own examples AND released QUERY `snomed_ct(3.1)`
+- [PGP subkey signature the runner cannot verify](pgp-subkey-signature-runner-cannot-verify.md) — RUNNER bin: rpgp 0.20 `SignedPublicKey::verify` is primary-only; the app signs with the `[S]` subkey since 7a8a8c9a3
+- [Baseline commit = where the run was RECORDED](baseline-commit-is-where-the-run-was-recorded.md) — diff the whole range since the previous results.json, never trust a handed-down "prime suspect"

--- a/.claude/agent-memory/cnf-triage/baseline-commit-is-where-the-run-was-recorded.md
+++ b/.claude/agent-memory/cnf-triage/baseline-commit-is-where-the-run-was-recorded.md
@@ -1,0 +1,24 @@
+---
+name: baseline-commit-is-where-the-run-was-recorded
+description: A results.json regression is attributed to the commit that RE-RAN the pipeline, not the commit that caused it — always diff the range since the previous baseline
+metadata:
+  type: feedback
+---
+
+`docs/conformance/ferroehr/results.json` is regenerated only when someone runs
+`scripts/conformance.sh`, not per PR. So "the regression landed in commit X" is
+almost always false: X is where the run was RECORDED.
+
+**Why:** on 2026-08-12 the 8 red rows were handed over as "landed in 11ee41ea7
+(#2293), the prime suspect". `git log --oneline 6ffd14ed6..11ee41ea7 --
+docs/conformance/ferroehr/results.json` shows 11ee41ea7 is the ONLY commit in
+the range that touched it — and the range is **145 commits**. Neither cluster's
+cause was in #2293: the terminology cluster came from bdf68d3f1 (#2282) and the
+PGP cluster from 7a8a8c9a3, both earlier in the range.
+
+**How to apply:** step 0 of any regression triage is
+`git log --oneline <prev-baseline>..<red-baseline> -- docs/conformance/<sut>/results.json`
+to establish the true suspect RANGE, then
+`git diff <prev>..<red> -- <the module the failure implicates>` to find the one
+semantic change. Never accept a handed-down "prime suspect" commit without
+that check.

--- a/.claude/agent-memory/cnf-triage/pgp-subkey-signature-runner-cannot-verify.md
+++ b/.claude/agent-memory/cnf-triage/pgp-subkey-signature-runner-cannot-verify.md
@@ -1,0 +1,40 @@
+---
+name: pgp-subkey-signature-runner-cannot-verify
+description: RUNNER bin — rpgp 0.20 SignedPublicKey::verify is primary-key-only, so the runner rejects the app's (conformant) signing-subkey signature
+metadata:
+  type: project
+---
+
+Confirmed 2026-08-12: all three `SIG-VERSION-*-pgp` cases asserting
+`verifiable: true` fail with "signature: does not verify over the agreed
+canonical form"; every digest twin and every mode-agnostic pgp case passes.
+
+The chain, all read first-hand:
+
+1. `app/ferroehr/src/versioning/signature/key.rs:157-160` selects a
+   signing-capable SUBKEY by RFC 9580 §5.2.3.29 key flag 0x02 and signs with it
+   (`:181-195`). Landed in **7a8a8c9a3** (2026-08-07) — AFTER the last green
+   baseline; before it the primary key signed.
+2. The committed test certificate HAS one: `gpg --show-keys
+   tools/cnf-runner/artifacts/corpus/keys/cnf-signing.sec.asc` →
+   `sec [SCEAR] C87EEF94…` + `ssb [S] 376C44DE…`. The ixit's
+   `instances.sut_pgp.signing.public_key` is byte-identical to the committed
+   `.pub.asc`, i.e. the same certificate.
+3. **Pinned `pgp` 0.20.0, `src/composed/signed_key/public.rs:200-204`:**
+   `impl VerifyingKey for SignedPublicKey { fn verify(..) { self.primary_key.verify(..) } }`
+   — `public_subkeys` is never consulted.
+4. `tools/cnf-runner/src/exec/signature.rs:126` is
+   `sig.verify(&key, bytes).is_ok()` on the primary `SignedPublicKey` → `Ok(false)`.
+
+The app already has the correct shape:
+`key.rs::verify_against_certificate` (`:224-236`) tries the primary key then
+every subkey. The runner needs the same walk.
+
+Not environmental: `PgpKey::load` is fail-closed at boot (a test signature), so
+the pgp deployment could not have started with a missing/unusable key, and
+`SIG-VERSION-client_supplied_verbatim-pgp` passed on the same instance in the
+same run. `Ok(false)` (not `Err`) also proves the armor PARSED.
+
+**How to apply:** a `-pgp` verifiable failure with the digest twin green is
+never a canonicalization bug — the digest case proves the JCS bytes agree. Look
+at which key component signed.

--- a/.claude/agent-memory/cnf-triage/terminology-id-value-has-no-invariant.md
+++ b/.claude/agent-memory/cnf-triage/terminology-id-value-has-no-invariant.md
@@ -1,0 +1,52 @@
+---
+name: terminology-id-value-has-no-invariant
+description: BASE declares NO Invariants row on TERMINOLOGY_ID; the master05 §Syntaxes production is self-refuted by its own examples and by released QUERY `snomed_ct(3.1)`
+metadata:
+  type: project
+---
+
+Confirmed first-hand 2026-08-12 while triaging the 5-row terminology cluster
+(build 11ee41ea7; the enforcement landed in bdf68d3f1 / issue #2258).
+
+**The released model does not declare the invariant the app enforces.**
+`BASE/docs/UML/classes/org.openehr.base.base_types.terminology_id.adoc` has NO
+`*Invariants*` row at all — its only value statement is the description line
+"Lexical form: `name [ '(' version ')' ]`". The sibling
+`…version_tree_id.adoc`, whose lexical form is described the same way, DOES
+carry an Invariants row — and even there `Value_valid` is only
+`not value.is_empty`. The BMM mirrors this exactly
+(`openehr_base_1.3.0.bmm.json`: `VERSION_TREE_ID.invariants` = 7 entries,
+`TERMINOLOGY_ID` has no `invariants` key; same for ARCHETYPE_ID, TEMPLATE_ID,
+GENERIC_ID, OBJECT_VERSION_ID, HIER_OBJECT_ID). Neither released ITS
+constrains the value beyond `string` (ITS-JSON
+`openehr_rm_1.1.0_all.json` `TERMINOLOGY_ID.properties.value: {type: string}`;
+ITS-XML `BaseTypes.xsd` `TERMINOLOGY_ID` = bare `xs:extension base="OBJECT_ID"`).
+
+**The production is refuted by released text, twice.**
+`master05-identification_package.adoc:273/277`
+`terminology_id = name-str, [ '(', name-str, ')' ]`,
+`name-str = letter, { letter | digit | '_' | '-' | '/' | '+' }`.
+(a) Its own §Terminology Identifiers examples `ICD9(1999)`, `ICD10AM(3rd_ed)`,
+`ICD10AM(4th_ed)` all start the version with a digit (upstream report #2283).
+(b) **RELEASED QUERY 1.1.0** `docs/AQL/master03-syntax.adoc:239` publishes
+`name/defining_code/terminology_id/value='snomed_ct(3.1)'` as the canonical
+expansion of the node-predicate shortcut — `.` is outside `name-str`, so #2283's
+"one rule wide" relaxation is one rule too narrow. #2283 does not mention this.
+
+**Split reading that survives the released text:** the NAME part's production is
+NOT contradicted by any released example (`SNOMED-CT`, `ICD10`, `ICD9`,
+`ICD10AM` all conform), so refusing an interior space is defensible; the VERSION
+part's character class is contradicted; and a URI-form id
+(`http://…/CodeSystem/x`) is released-SILENT — grep of RM/BASE/QUERY/TERM/
+ITS-REST finds no URI spelled as a `terminology_id` value (the `http://snomed.info/sct`
+occurrences in QUERY §TERMINOLOGY are function arguments and `code_string`
+operands, never a TERMINOLOGY_ID).
+
+**How to apply:** any red row reading "expected `created`, observed
+`validation_failed`" on a fixture whose CODE_PHRASE names an external
+terminology — check the TERMINOLOGY_ID value against
+`crates/openehr-base/src/v1_3/base_types/identification/terminology_id_impl.rs`
+`is_valid_terminology_id` first. Fix path is the TEMPLATE
+`tools/openehr-codegen/templates/openehr-base/base_types/identification/terminology_id_impl.rs`
++ `openehr-codegen -- emit` (both stamped copies are
+`@generated-from-template`). See [[cnf-red-2026-08-12-terminology-id-grammar]].

--- a/.claude/rules/reliability.md
+++ b/.claude/rules/reliability.md
@@ -192,8 +192,14 @@ chapters, the Clippy book, and the Cargo/rustdoc books.)
   `From`/`TryFrom` over ad-hoc `to_x()` where the conversion is total/
   fallible, getters without `get_` prefixes. (Tier 3 via pedantic +
   review; `avoid-breaking-exported-api = false` in `clippy.toml` keeps the
-  API-shape lints live — every crate is `publish = false`, so there is no
-  external semver surface to protect.)
+  API-shape lints live. The justification is NOT "nothing publishes" — the
+  eight `openehr-*` crates publish to crates.io — it is the line they publish
+  on: `0.0.x`, where cargo treats every patch as its own compatibility set
+  (https://doc.rust-lang.org/cargo/reference/semver.html), so no consumer
+  version range spans a break, and any packaged-content change already bumps
+  all eight in the same PR. The `ferroehr-*` crates remain unpublished.
+  Re-adjudicate if the line graduates past `0.x` — the same trigger the
+  C-STABLE entry below carries.)
 - **Blocking never hides in async**: no `std::sync` locks held across
   `.await` (clippy `await_holding_lock`, tier 3 — active via `clippy::all`),
   no synchronous I/O on the runtime; `spawn_blocking` for the rare

--- a/.claude/rules/reliability.md
+++ b/.claude/rules/reliability.md
@@ -305,10 +305,14 @@ chapters, the Clippy book, and the Cargo/rustdoc books.)
   code is MIT-licensed; vendored third-party material keeps its upstream
   terms — Apache-2.0 for the openEHR machine-readable artifacts and the
   vendored test corpora (`LICENSE-APACHE-2.0`), CC-BY-SA 3.0 for the openEHR
-  spec docs text (`LICENSE-CC-BY-SA-3.0`), and CC-BY-SA **4.0** for the
-  CKM-derived clinical models (`LICENSE-CC-BY-SA-4.0`), which is what their
-  own per-file `licence` metadata declares — one version per corpus, never a
-  single version standing for both. The vendored ADL2 regression corpus
+  spec docs text (`LICENSE-CC-BY-SA-3.0`), and BOTH CC-BY-SA **4.0** and
+  CC-BY-SA **3.0** for the CKM-derived clinical models — corrected 2026-08-12
+  by a first-hand count over the vendored corpus, which finds 4.0 in the
+  majority and several hundred 3.0 files beside it, so the earlier "one
+  version per corpus" claim was false in the direction it warned about. Each
+  archetype's own `licence` metadata is the authority for that file;
+  `REUSE.toml` declares the trees as `CC-BY-SA-3.0 AND CC-BY-SA-4.0` because
+  neither version alone is a true statement about them. The vendored ADL2 regression corpus
   additionally carries three ISO 13606 BMM reference models offered under an
   MPL 1.1 / GPL 2.0 / LGPL 2.1 tri-license; **we take them under MPL 1.1**, so
   no GPL or LGPL obligation attaches (the election is recorded in that

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,70 @@
+# Code owners — who is asked to review a change, per area.
+#
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Read this file honestly: FerroEHR has ONE maintainer, so every line below
+# names the same person. That is not review theatre, and it is not a claim of
+# capacity the project does not have — it does two real things.
+#
+#   1. It makes ownership EXPLICIT rather than assumed, which is what a
+#      procurement review asks for and what a second maintainer inherits on
+#      day one: the areas are already carved, so adding a person is a one-line
+#      change per area rather than a structural decision under time pressure.
+#   2. Combined with `require_code_owner_review` on the default-branch ruleset,
+#      it is what makes a pull request from an account WITHOUT write access
+#      unmergeable until an owner has looked at it. GitHub does not count a
+#      pull request author's own review, so this constrains outside
+#      contributions without pretending the maintainer reviews himself.
+#
+# A LATER PATTERN WINS. The catch-all comes first and every specific area
+# overrides it, so ordering here is load-bearing.
+#
+# MAINTAINERS.md is the roster and the access-continuity record; GOVERNANCE.md
+# is the decision process. This file is only the routing table.
+
+*                                   @rubentalstra
+
+# ── The generated openEHR specification layer ───────────────────────────────
+# Changes here are almost never hand-written: they come out of the code
+# generator, and a hand edit to a `// @generated` file is a defect by itself.
+/crates/                            @rubentalstra
+/tools/openehr-codegen/             @rubentalstra
+
+# The vendored specification text and the machine-readable artifacts are the
+# conformance oracle. They change only by re-running a vendoring script.
+/docs/specs/                        @rubentalstra
+
+# ── The application ─────────────────────────────────────────────────────────
+/app/                               @rubentalstra
+
+# ── The conformance instrument ──────────────────────────────────────────────
+# The catalogue and the runner decide what "conformant" means for this
+# project, so a change here changes the acceptance bar itself.
+/tools/cnf-runner/                  @rubentalstra
+/docs/conformance/                  @rubentalstra
+
+# ── Supply chain, CI and release ────────────────────────────────────────────
+# Everything that decides what gets built, signed and published.
+/.github/                           @rubentalstra
+/scripts/                           @rubentalstra
+/deny.toml                          @rubentalstra
+/security/                          @rubentalstra
+/REUSE.toml                         @rubentalstra
+/LICENSES/                          @rubentalstra
+
+# ── Deployment artifacts an operator actually runs ──────────────────────────
+/deploy/                            @rubentalstra
+/docker/                            @rubentalstra
+/docker-compose.yml                 @rubentalstra
+/docker-compose.keycloak.yml        @rubentalstra
+/docker-compose.observability.yml   @rubentalstra
+/docker-compose.override.yml        @rubentalstra
+
+# ── Policy and legal ────────────────────────────────────────────────────────
+/SECURITY.md                        @rubentalstra
+/GOVERNANCE.md                      @rubentalstra
+/MAINTAINERS.md                     @rubentalstra
+/SUPPORT.md                         @rubentalstra
+/CODE_OF_CONDUCT.md                 @rubentalstra
+/LICENSE                            @rubentalstra
+/.github/CODEOWNERS                 @rubentalstra

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,53 @@ updates:
         patterns: ["serde*"]
     commit-message:
       prefix: "deps"          # plain conventional prefix; no attribution
+  # The fuzz harnesses are their OWN Cargo workspace with their own lock file
+  # (`fuzz/Cargo.toml` opens with an empty `[workspace]` table precisely so the
+  # root workspace never sees them). A `cargo` entry at `/` therefore reaches
+  # none of it — Dependabot resolves the manifest at the directory it is given
+  # and nothing above or below. The harnesses compile on the pull-request path,
+  # so an unbumped dependency there breaks CI rather than rotting quietly, but
+  # it would still never receive a security bump.
+  #
+  # Separate entries for one ecosystem are supported as long as the directories
+  # do not overlap, which `/` and `/fuzz` do not:
+  # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+  - package-ecosystem: "cargo"
+    directory: "/fuzz"
+    schedule:
+      interval: "weekly"
+    # The same window as the root cargo entry: these dependencies execute in a
+    # build, and the harnesses link the crates under test.
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+  # The three container base images are pinned by digest, which is what earns
+  # the Scorecard `Pinned-Dependencies` score — and is also why they never
+  # receive a patch unless something proposes one. Without this entry the
+  # weekly published-image scan keeps FINDING base-layer CVEs in the clinical
+  # images while nothing offers the fix.
+  #
+  # `directories` (plural) takes a list and supports globbing; `directory`
+  # (singular) takes one path and does not. Each entry points at the directory
+  # holding a Dockerfile, per the options reference above.
+  - package-ecosystem: "docker"
+    directories:
+      - "/docker"
+      - "/docker/postgres"
+      - "/docker/admin-ui"
+    schedule:
+      interval: "weekly"
+    # Between the cargo and actions windows. A base image ships in the product,
+    # like a crate — but a base-image digest bump is reviewed against a build
+    # and a Trivy scan before it can merge, which a crate bump is not.
+    cooldown:
+      default-days: 5
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,6 +407,53 @@ jobs:
       - name: No copyleft licence text in first-party source
         run: bash scripts/checks/first-party-license-text.sh
 
+  # REUSE 3.3 compliance: every file in the tree has machine-readable licensing
+  # that SURVIVES the file being copied out of it — which is the expected case
+  # for a repository whose premise is that people build on it and ship it, and
+  # which redistributes material under six distinct licences.
+  #
+  # The per-tree `PROVENANCE.md` arrangement is accurate but travels with the
+  # tree, not with the file. `REUSE.toml` closes that gap by glob, touching no
+  # vendored file — which matters, because hand-editing vendored material is
+  # forbidden here.
+  licensing:
+    name: licensing
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: reuse lint
+        # The OFFICIAL image, digest-pinned — the same construction the
+        # actionlint job uses and for the same reasons: `reuse` is distributed
+        # as a Python package, which this repository does not install, and the
+        # published container is the one distribution that needs neither a
+        # Python toolchain in CI nor an unpinned installer script.
+        run: |
+          docker run --rm \
+            -v "$PWD:/data" --workdir /data \
+            fsfe/reuse:6.2.0@sha256:85462a75c0f8efda09ddd190b92816b70e7662577c8427429e11e1b9f25a992e \
+            lint
+      # `reuse lint` proves the declarations are COMPLETE. It cannot know that
+      # this project also publishes a human-readable licensing chapter, which is
+      # what a procurement reviewer actually reads and what drifts.
+      - name: Install yq
+        env:
+          YQ_VERSION: v4.53.3
+          YQ_SHA256: fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+          echo "${YQ_SHA256}  /tmp/yq" | sha256sum -c -
+          sudo install -m 0755 /tmp/yq /usr/local/bin/yq
+          yq --version
+      - name: The declarations, the texts and the chapter agree
+        run: bash scripts/checks/licensing-declarations.sh
+
   # The compose hardening properties (cap_drop ALL, no-new-privileges, no
   # privileged, no seccomp=unconfined, loopback-only publishing). This gate
   # existed and ran nowhere, while `docker-compose.yml` and the operations
@@ -571,6 +618,42 @@ jobs:
         with:
           tool: cargo-deny
       - run: cargo deny check
+
+  # The published VEX document must be exactly what `deny.toml` plus the prose
+  # file generate. Every advisory the gate ACCEPTS carries a machine-readable
+  # justification a downstream scanner can ingest — otherwise the argument
+  # exists only in a TOML comment nobody downstream reads, and a hospital's
+  # scanner sees unexplained findings on a clinical artifact.
+  #
+  # Ungated on `changes.code`: `deny.toml` is in the code allowlist, but the
+  # prose file and the generator are not, and a prose-only edit must still be
+  # checked.
+  vex:
+    name: vex
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      # `deny.toml` and the prose file are TOML, which jq cannot read. Pinned by
+      # version and verified by checksum, like the chart lane's copy: this
+      # binary decides whether the gate passes.
+      - name: Install yq
+        env:
+          YQ_VERSION: v4.53.3
+          YQ_SHA256: fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+          echo "${YQ_SHA256}  /tmp/yq" | sha256sum -c -
+          sudo install -m 0755 /tmp/yq /usr/local/bin/yq
+          yq --version
+      - name: Every accepted advisory has a published VEX justification
+        run: bash scripts/checks/vex-advisories.sh
 
   clippy:
     name: clippy
@@ -1749,9 +1832,11 @@ jobs:
       - error-source-chain
       - no-python
       - license-text
+      - licensing
       - spec-citations
       - compose-hardening
       - deny
+      - vex
       - clippy
       - doc
       - msrv

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -87,10 +87,30 @@ jobs:
           TAG: ${{ inputs.tag }}
           TARGET: ${{ inputs.target }}
         run: |
+          set -euo pipefail
           out="ferroehr-${TAG}-${TARGET}.tar.gz"
           strip target/release/ferroehr
           tar -C target/release -czf "$out" ferroehr
           echo "ASSET=$out" >> "$GITHUB_ENV"
+          # A plain checksum beside the tarball. Everything else this lane
+          # publishes needs `gh` or `cosign` installed and a network path to
+          # Sigstore; this is the only verification available to an operator
+          # who has neither — `sha256sum -c <file>.sha256sum` in a locked-down
+          # environment, which is exactly the environment a clinical deployment
+          # tends to be. containerd ships one per artifact for the same reason.
+          #
+          # It is NOT a signature and is not claimed as one: it detects a
+          # corrupt or truncated download, not a substituted release. Only the
+          # Sigstore bundle answers "who built this", and OpenSSF Scorecard's
+          # signature probe agrees — it matches `.asc`, `.minisig`, `.sig`,
+          # `.sign`, `.sto` and `.sigstore.json`, and no checksum suffix
+          # (v5.5.0 `probes/releasesAreSigned`).
+          #
+          # The file records the BARE filename, so `sha256sum -c` works in
+          # whatever directory the downloader put the two files in.
+          sha256sum "$out" > "${out}.sha256sum"
+          cat "${out}.sha256sum"
+          echo "CHECKSUM=${out}.sha256sum" >> "$GITHUB_ENV"
 
       # A CycloneDX SBOM of the Rust dependency graph — a different document from
       # the container SBOMs BuildKit emits, answering a different question. The
@@ -113,6 +133,15 @@ jobs:
           set -euo pipefail
           # Scoped to the binary-producing crate, so the document describes the
           # artifact being released rather than the whole workspace.
+          #
+          # `--spec-version 1.5` is the HIGHEST cargo-cyclonedx emits: its
+          # `--spec-version` accepts 1.3, 1.4 or 1.5 and defaults to 1.3, so
+          # this flag is not cosmetic — dropping it would silently downgrade
+          # every release to 1.3. CycloneDX 1.6 exists but this generator
+          # cannot produce it; bump the moment it can. 1.5 carries the fields
+          # that make the document actionable (purls, hashes, and the
+          # direct-versus-transitive `dependencies` graph), and every consumer
+          # that reads 1.6 reads 1.5.
           cargo cyclonedx \
             --manifest-path app/ferroehr-server/Cargo.toml \
             --format json --describe binaries --spec-version 1.5
@@ -193,6 +222,7 @@ jobs:
           tag_name: ${{ inputs.tag }}
           files: |
             ${{ env.ASSET }}
+            ${{ env.CHECKSUM }}
             ${{ env.SBOM }}
             ${{ env.PROVENANCE_BUNDLE_ASSET }}
             ${{ env.SBOM_BUNDLE_ASSET }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,53 @@ jobs:
           fi
         env:
           TAG: ${{ steps.tag.outputs.tag }}
+
+      # An SPDX SBOM of the REPOSITORY, generated from the release commit.
+      #
+      # This is the third SBOM this project publishes and it is not redundant
+      # with the other two — they answer different questions for different
+      # readers, and both reviews happen for a clinical deployment:
+      #
+      #   * the CycloneDX `.cdx.json` per binary (release-build.yml) carries the
+      #     cargo dependency GRAPH with direct-versus-transitive edges and purls,
+      #     which is what a vulnerability tool consumes;
+      #   * the SPDX SBOM BuildKit attaches to each container image index
+      #     (containers.yml) describes the image's OS layer;
+      #   * this one is the ATTRIBUTION document for the source tree — the
+      #     licence-obligation view a legal or procurement reviewer of a
+      #     four-licence redistribution asks for.
+      #
+      # It existed nowhere a consumer could reach before: the licence-scanning
+      # lane deliberately generates no report (its token is push-only), so there
+      # was no repository SBOM at all.
+      #
+      # SPDX also satisfies the CISA/NTIA minimum-element data fields directly:
+      # supplier, component name, version, other unique identifiers (purl),
+      # dependency relationships, SBOM author and timestamp
+      # (https://www.cisa.gov/sbom).
+      - uses: taiki-e/install-action@7f4eb899022d8fe70b20c4f3de697aa85c309026 # v2.85.11
+        with:
+          tool: syft@1.50.0
+      - name: Generate the repository SPDX SBOM
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # `dir:.` catalogues the checked-out release commit, so the document
+          # describes the tree the release was cut from rather than a graph
+          # resolved afterwards.
+          syft scan "dir:." --output "spdx-json=ferroehr-${TAG}.spdx.json"
+          # Refuse to attach a document that is not SPDX, rather than shipping a
+          # file that looks like an SBOM and is not.
+          version="$(jq -r '.spdxVersion' "ferroehr-${TAG}.spdx.json")"
+          case "$version" in
+            SPDX-*) ;;
+            *) echo "::error::generated SBOM is not SPDX (spdxVersion=${version})"; exit 1 ;;
+          esac
+          count="$(jq '.packages | length' "ferroehr-${TAG}.spdx.json")"
+          [ "$count" -gt 0 ] || { echo "::error::the SPDX SBOM lists no packages"; exit 1; }
+          echo "SPDX ${version}, ${count} packages"
+
       # Created as a DRAFT, and finalized only after every asset is attached.
       #
       # Release immutability is enabled on this repository: once a release is
@@ -129,6 +176,7 @@ jobs:
             docker-compose.yml
             docker-compose.keycloak.yml
             docker-compose.observability.yml
+            ferroehr-${{ steps.tag.outputs.tag }}.spdx.json
           # Releases publish as OFFICIAL releases (owner sign-off
           # 2026-07-31, superseding the 2026-07-11 always-prerelease rule);
           # only an explicitly suffixed tag (v3.16.0-rc1, ...) is a
@@ -204,18 +252,34 @@ jobs:
           # document and its attestation bundle are checked too: a release
           # publishing without them is unfixable (immutability), and the only
           # remedy would be another version.
+          #
+          # `grep -Fxq` — fixed string, whole line. A substring match passed as
+          # soon as any longer asset name contained the expected one, so
+          # ".tar.gz" was satisfied by ".tar.gz.sigstore.json" alone and a
+          # missing tarball would have shipped.
           missing=""
           for arch in x86_64 aarch64; do
             for suffix in \
               ".tar.gz" \
+              ".tar.gz.sha256sum" \
               ".tar.gz.sigstore.json" \
               ".tar.gz.sbom.sigstore.json" \
               ".tar.gz.intoto.jsonl" \
               ".cdx.json"; do
               printf '%s\n' "$assets" \
-                | grep -q "ferroehr-${TAG}-${arch}-unknown-linux-gnu${suffix}" \
+                | grep -Fxq "ferroehr-${TAG}-${arch}-unknown-linux-gnu${suffix}" \
                 || missing="$missing ferroehr-${TAG}-${arch}-unknown-linux-gnu${suffix}"
             done
+          done
+          # The release-wide assets the draft job attached: the repository SPDX
+          # SBOM and the quickstart compose files a downloader runs without
+          # cloning.
+          for asset in \
+            "ferroehr-${TAG}.spdx.json" \
+            "docker-compose.yml" \
+            "docker-compose.keycloak.yml" \
+            "docker-compose.observability.yml"; do
+            printf '%s\n' "$assets" | grep -Fxq "$asset" || missing="$missing $asset"
           done
           [ -z "$missing" ] || {
             echo "::error::the draft is missing assets, so it will not be published:$missing"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,51 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
+- **A published threat model.** A new
+  [Threat model](https://ferroehr.eu/docs/latest/threat-model.html) chapter
+  names the actors, the protected assets and eight trust boundaries, and for
+  each boundary states the control that holds **and the residual risk that
+  survives it** — plus an explicit list of what FerroEHR does not defend
+  against, so silence is never read as coverage. It exists because the parts of
+  this system that protect patient data are precisely the parts no openEHR
+  specification governs: the five-stage authorization order, multi-tenancy
+  isolation, the audit trail and the archive tier are all this project's own
+  design, and until now every deployer had to reconstruct them from
+  configuration prose.
+- **Governance, maintainer and support documents.** `GOVERNANCE.md` (how
+  decisions are made and how to become a maintainer), `MAINTAINERS.md` (the
+  roster, every publishing identity, and what happens if the holder is
+  unavailable), `SUPPORT.md` (question versus defect versus vulnerability), and
+  a `CODEOWNERS` file routing review per area. All four state the current
+  single-maintainer reality plainly rather than describing a process that does
+  not exist.
+- **A published support and end-of-life policy.** `SECURITY.md` now states
+  which versions receive security fixes (only the newest), when a version stops
+  receiving them (the moment a newer release exists), and how a fix reaches
+  you — covering the server, the Helm chart and the published crates, which
+  follow separate version lines. The same policy is reachable from the
+  Operations chapter's upgrade guidance, where an operator planning change
+  control actually looks.
+- **Machine-readable licensing (REUSE 3.3).** A `LICENSES/` directory carries
+  the full text of every licence any file in this tree is offered under, named
+  by SPDX identifier, and a root `REUSE.toml` declares by glob which files are
+  offered under which — so licensing now survives a file being copied out of
+  the repository, which per-tree provenance files could not do. No vendored
+  file was modified. Two positions are represented rather than flattened: the
+  MPL 1.1 election under a tri-licensed corpus, and one upstream file whose own
+  header contradicts its repository's licence. `reuse lint` and a
+  declarations-versus-documentation check both gate the merge.
+- **A published VEX document for the Rust dependency advisories.** Every
+  advisory the `cargo deny` gate accepts now carries an
+  [OpenVEX](https://openvex.dev) statement with a controlled-vocabulary
+  justification and a checkable impact statement, at
+  `security/vex/rust-advisories.openvex.json`, so a downstream scanner ingests
+  the argument instead of reporting unexplained findings. It also covers the
+  advisory that only a `Cargo.lock`-reading scanner reports for a crate this
+  project's feature set never compiles. The document is generated from
+  `deny.toml` joined with the published reasoning, and CI fails if the two
+  disagree in either direction — an advisory cannot be accepted without its
+  justification reaching you.
 - **About 190 openEHR spec functions are now callable on the generated types.**
   The Reference Model, Archetype Model, BASE and LANG classes declare functions
   the specifications define — `ITEM_LIST.ith_item`, `DV_QUANTIFIED.magnitude`,
@@ -964,6 +1009,42 @@ workflow refuses a tag that has no matching section here.
 
 ### Security
 
+- **Release tags are now protected by a ruleset.** Three lanes publish off a
+  raw tag push — the release, the Helm chart, and the documentation version
+  cut — and until now the tags driving them could be created, moved or deleted
+  freely. A `release-tags` ruleset on `refs/tags/v*` blocks tag deletion and
+  non-fast-forward tag updates and requires signatures, codifying the signed-tag
+  practice the project already followed. Release immutability protects the
+  window *after* a release is published; this protects the window in which a tag
+  drives a build, an image push and a chart publish. `SECURITY.md` now records
+  the full expected repository security posture, with the two read-back commands
+  that detect a settings reset.
+- **Every release tarball now ships a `.sha256sum`.** It is the only
+  verification available to an operator with neither `gh` nor `cosign`
+  installed, which is what a locked-down clinical environment tends to be. The
+  documentation is explicit that a checksum detects a corrupt download and not a
+  substituted release — only the Sigstore bundle answers "who built this".
+- **A release now carries an SPDX SBOM of the repository**, generated from the
+  release commit, alongside the per-binary CycloneDX SBOM and the per-image
+  SPDX SBOM. The three answer different questions — what is inside the binary I
+  am about to run, what am I redistributing and under what terms, and what is in
+  the image's OS layer — and the security chapter now says which is which, so a
+  reader picks the right one instead of assuming they are redundant. The
+  CycloneDX specification version (1.5, the highest the generator emits) is
+  recorded with its reason.
+- **The release asset-completeness guard now matches asset names exactly.** It
+  compared by substring, so the check for the `.tar.gz` was satisfied by
+  `.tar.gz.sigstore.json` alone and a release missing its actual tarball would
+  have been published — unfixably, since publishing freezes a release. It now
+  requires a whole-line match, and additionally checks the checksum, the
+  repository SBOM and the quickstart compose files.
+- **Dependabot now covers the fuzz workspace and the container base images.**
+  The fuzz harnesses are a separate Cargo workspace with their own lock file
+  that a `cargo` entry at the repository root could never reach, so they were
+  receiving no security bumps. The three base images are digest-pinned, which
+  is correct for reproducibility and means they never receive a patch unless
+  something proposes one — so the weekly image scan kept finding CVEs in the
+  clinical images while nothing offered the fix.
 - The admin console's `Content-Security-Policy` no longer allows inline scripts.
   `script-src` is now `'self' 'wasm-unsafe-eval' 'nonce-…'`, where the nonce is
   freshly generated for every response and stamped on the only inline script the

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,132 @@
+# Governance
+
+How decisions get made in FerroEHR, who makes them, and how that changes.
+
+This document describes the project as it actually operates. Where the honest
+description is "one person decides", it says so — a governance document that
+describes a committee that does not meet is worse than none, because it invites
+a reviewer to rely on a control that is not there.
+
+## Current structure: benevolent dictator, one maintainer
+
+FerroEHR has a single maintainer ([MAINTAINERS.md](MAINTAINERS.md)) who holds
+final say on every decision: what gets built, what gets merged, what gets
+released, and what the project refuses to do. There is no steering committee,
+no technical oversight body, no foundation, and no vote.
+
+This is the standard structure for a project of this age and size, and it has
+the standard trade-off: decisions are fast and coherent, and the project's
+resilience is one person's. The second half of that sentence is treated as a
+finding rather than a footnote — see
+[MAINTAINERS.md § If the maintainer is unavailable](MAINTAINERS.md#if-the-maintainer-is-unavailable).
+
+## Where decisions are recorded
+
+The tracker is the record. There is no separate design-document layer, and
+that is deliberate: an architecture decision record that outlives the code it
+justified becomes a false authority, so this project keeps decisions in the
+places that cannot drift out of sync with the tree.
+
+| Kind of decision | Where it lives |
+|---|---|
+| What to work on next | a [GitHub issue](https://github.com/rubentalstra/FerroEHR/issues); the open list is the worklist |
+| Direction and status, publicly | the [FerroEHR Roadmap project board](https://github.com/rubentalstra/FerroEHR/projects), a view over the tracker |
+| Why a change looks the way it does | the pull request description that landed it, and the issue's closing comment |
+| What a release contains | [`CHANGELOG.md`](CHANGELOG.md) and the `vX.Y.Z` milestone |
+| Standing architectural rules | [`docs/architecture.md`](docs/architecture.md) and the `CLAUDE.md` files |
+| What conformance means | the committed artifacts under `docs/conformance/`, produced by the CNF runner |
+
+A decision that exists only in a conversation is not a decision this project
+made.
+
+## How a change gets in
+
+1. **An issue carries the contract** — what is wrong or missing, and the
+   acceptance criteria that settle it.
+2. **A pull request implements it** on a conventional-type branch, declaring
+   `Closes #N`.
+3. **The gates run.** They are not advisory and there is no override: format,
+   clippy at `-D warnings`, the full test suite, the codegen drift check, the
+   licence and advisory gates, the workflow security audit, the comment and
+   documentation-claim guards, the Helm golden renders, and the browser
+   battery. The complete list is [`.github/workflows/ci.yml`](.github/workflows/ci.yml);
+   the merge gate is the single `conclusion` check, and a CI job that does not
+   feed it fails its own guard.
+4. **The maintainer merges.** A pull request from an account without write
+   access additionally requires a code-owner approval before it can merge
+   ([`.github/CODEOWNERS`](.github/CODEOWNERS)).
+
+**On required review, stated plainly.** The maintainer's own changes are not
+independently reviewed by a second human, because there is no second human.
+Requiring two approvals of oneself would be a control that reports "reviewed"
+without anyone having reviewed, and this project would rather report the truth
+and let a deployer weigh it. What stands in for review here is machine
+enforcement: the gates above, an automated reviewer on every pull request
+([`.coderabbit.yaml`](.coderabbit.yaml)) whose findings are advisory and never
+outrank the specifications or these rules, and the conformance suite as an
+external acceptance instrument.
+
+## The specifications are the authority, not the maintainer
+
+The one place the maintainer explicitly does *not* have final say is
+specification conformance. The vendored openEHR specification text under
+`docs/specs/openehr/` is the oracle for every wire-visible behaviour, and a
+conformance failure is attributed against it — never against what the
+implementation happens to do, and never against another CDR's behaviour. Where
+the specifications are silent, the decision is the project's own and must be
+labelled as such wherever it is written down.
+
+If you believe the implementation contradicts the specification, that is not a
+matter of taste and it is not the maintainer's call: cite the section and open
+an issue. Those are the reports this project most wants.
+
+## Becoming a maintainer
+
+The route is open and it is the ordinary one:
+
+1. **Contribute.** Sustained, merged, self-directed work — not a headcount of
+   pull requests, but the point at which review stops finding things.
+2. **Show judgement in the areas that matter here.** The signal is
+   specification discipline: reading the normative text first-hand, citing it,
+   refusing to resolve a question from another implementation's behaviour, and
+   being honest when the specification is silent.
+3. **Ask, or be asked.** Either direction is normal. Open an issue, or say so
+   on a pull request.
+
+The maintainer decides, and says yes or no with a reason on the tracker rather
+than by silence. A new maintainer receives write access, a row in
+[MAINTAINERS.md](MAINTAINERS.md), and their handle in
+[`.github/CODEOWNERS`](.github/CODEOWNERS) for the areas they own. Publishing
+identities move separately and only where the identity permits a second holder;
+that table is in MAINTAINERS.md and is kept truthful.
+
+## What this project will not do
+
+Recorded here so the questions do not have to be re-litigated in each pull
+request:
+
+- **No contributor licence agreement, and no copyright assignment.** You keep
+  your copyright; the licence stays MIT for everyone including the maintainer.
+  This is a deliberate position, not an oversight.
+- **No re-modelling of the openEHR specification by hand.** The specification
+  crates are generated from the machine-readable artifacts; a change goes into
+  the generator.
+- **No weakening a test, a gate or an expectation to make a build green.** A
+  red gate is information.
+- **No claim the project cannot demonstrate.** Conformance numbers come from
+  committed run artifacts, performance numbers from measured runs, and
+  security controls from configuration a reader can check. If a claim has no
+  evidence behind it, it does not get written.
+
+## Code of conduct
+
+[`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) applies to every space this project
+occupies. Enforcement is the maintainer's, at the contact address given there.
+
+## Changing this document
+
+Governance changes are pull requests against this file, like anything else, and
+they take effect when they merge. If the structure described here stops being
+true — a second maintainer joins, a legal entity forms, a decision body is
+created — this file changes in the same pull request that makes it true, not
+afterwards.

--- a/LICENSES/AGPL-3.0-only.txt
+++ b/LICENSES/AGPL-3.0-only.txt
@@ -1,0 +1,235 @@
+GNU AFFERO GENERAL PUBLIC LICENSE
+Version 3, 19 November 2007
+
+Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+                            Preamble
+
+The GNU Affero General Public License is a free, copyleft license for software and other kinds of works, specifically designed to ensure cooperation with the community in the case of network server software.
+
+The licenses for most software and other practical works are designed to take away your freedom to share and change the works.  By contrast, our General Public Licenses are intended to guarantee your freedom to share and change all versions of a program--to make sure it remains free software for all its users.
+
+When we speak of free software, we are referring to freedom, not price.  Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for them if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs, and that you know you can do these things.
+
+Developers that use our General Public Licenses protect your rights with two steps: (1) assert copyright on the software, and (2) offer you this License which gives you legal permission to copy, distribute and/or modify the software.
+
+A secondary benefit of defending all users' freedom is that improvements made in alternate versions of the program, if they receive widespread use, become available for other developers to incorporate.  Many developers of free software are heartened and encouraged by the resulting cooperation.  However, in the case of software used on network servers, this result may fail to come about. The GNU General Public License permits making a modified version and letting the public access it on a server without ever releasing its source code to the public.
+
+The GNU Affero General Public License is designed specifically to ensure that, in such cases, the modified source code becomes available to the community.  It requires the operator of a network server to provide the source code of the modified version running there to the users of that server.  Therefore, public use of a modified version, on a publicly accessible server, gives the public access to the source code of the modified version.
+
+An older license, called the Affero General Public License and published by Affero, was designed to accomplish similar goals.  This is a different license, not a version of the Affero GPL, but Affero has released a new version of the Affero GPL which permits relicensing under this license.
+
+The precise terms and conditions for copying, distribution and modification follow.
+
+                       TERMS AND CONDITIONS
+
+0. Definitions.
+
+"This License" refers to version 3 of the GNU Affero General Public License.
+
+"Copyright" also means copyright-like laws that apply to other kinds of works, such as semiconductor masks.
+
+"The Program" refers to any copyrightable work licensed under this License.  Each licensee is addressed as "you".  "Licensees" and "recipients" may be individuals or organizations.
+
+To "modify" a work means to copy from or adapt all or part of the work in a fashion requiring copyright permission, other than the making of an exact copy.  The resulting work is called a "modified version" of the earlier work or a work "based on" the earlier work.
+
+A "covered work" means either the unmodified Program or a work based on the Program.
+
+To "propagate" a work means to do anything with it that, without permission, would make you directly or secondarily liable for infringement under applicable copyright law, except executing it on a computer or modifying a private copy.  Propagation includes copying, distribution (with or without modification), making available to the public, and in some countries other activities as well.
+
+To "convey" a work means any kind of propagation that enables other parties to make or receive copies.  Mere interaction with a user through a computer network, with no transfer of a copy, is not conveying.
+
+An interactive user interface displays "Appropriate Legal Notices" to the extent that it includes a convenient and prominently visible feature that (1) displays an appropriate copyright notice, and (2) tells the user that there is no warranty for the work (except to the extent that warranties are provided), that licensees may convey the work under this License, and how to view a copy of this License.  If the interface presents a list of user commands or options, such as a menu, a prominent item in the list meets this criterion.
+
+1. Source Code.
+The "source code" for a work means the preferred form of the work for making modifications to it.  "Object code" means any non-source form of a work.
+
+A "Standard Interface" means an interface that either is an official standard defined by a recognized standards body, or, in the case of interfaces specified for a particular programming language, one that is widely used among developers working in that language.
+
+The "System Libraries" of an executable work include anything, other than the work as a whole, that (a) is included in the normal form of packaging a Major Component, but which is not part of that Major Component, and (b) serves only to enable use of the work with that Major Component, or to implement a Standard Interface for which an implementation is available to the public in source code form.  A "Major Component", in this context, means a major essential component (kernel, window system, and so on) of the specific operating system (if any) on which the executable work runs, or a compiler used to produce the work, or an object code interpreter used to run it.
+
+The "Corresponding Source" for a work in object code form means all the source code needed to generate, install, and (for an executable work) run the object code and to modify the work, including scripts to control those activities.  However, it does not include the work's System Libraries, or general-purpose tools or generally available free programs which are used unmodified in performing those activities but which are not part of the work.  For example, Corresponding Source includes interface definition files associated with source files for the work, and the source code for shared libraries and dynamically linked subprograms that the work is specifically designed to require, such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+The Corresponding Source need not include anything that users can regenerate automatically from other parts of the Corresponding Source.
+
+The Corresponding Source for a work in source code form is that same work.
+
+2. Basic Permissions.
+All rights granted under this License are granted for the term of copyright on the Program, and are irrevocable provided the stated conditions are met.  This License explicitly affirms your unlimited permission to run the unmodified Program.  The output from running a covered work is covered by this License only if the output, given its content, constitutes a covered work.  This License acknowledges your rights of fair use or other equivalent, as provided by copyright law.
+
+You may make, run and propagate covered works that you do not convey, without conditions so long as your license otherwise remains in force.  You may convey covered works to others for the sole purpose of having them make modifications exclusively for you, or provide you with facilities for running those works, provided that you comply with the terms of this License in conveying all material for which you do not control copyright.  Those thus making or running the covered works for you must do so exclusively on your behalf, under your direction and control, on terms that prohibit them from making any copies of your copyrighted material outside their relationship with you.
+
+Conveying under any other circumstances is permitted solely under the conditions stated below.  Sublicensing is not allowed; section 10 makes it unnecessary.
+
+3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+No covered work shall be deemed part of an effective technological measure under any applicable law fulfilling obligations under article 11 of the WIPO copyright treaty adopted on 20 December 1996, or similar laws prohibiting or restricting circumvention of such measures.
+
+When you convey a covered work, you waive any legal power to forbid circumvention of technological measures to the extent such circumvention is effected by exercising rights under this License with respect to the covered work, and you disclaim any intention to limit operation or modification of the work as a means of enforcing, against the work's users, your or third parties' legal rights to forbid circumvention of technological measures.
+
+4. Conveying Verbatim Copies.
+You may convey verbatim copies of the Program's source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice; keep intact all notices stating that this License and any non-permissive terms added in accord with section 7 apply to the code; keep intact all notices of the absence of any warranty; and give all recipients a copy of this License along with the Program.
+
+You may charge any price or no price for each copy that you convey, and you may offer support or warranty protection for a fee.
+
+5. Conveying Modified Source Versions.
+You may convey a work based on the Program, or the modifications to produce it from the Program, in the form of source code under the terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is released under this License and any conditions added under section 7.  This requirement modifies the requirement in section 4 to "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this License to anyone who comes into possession of a copy.  This License will therefore apply, along with any applicable section 7 additional terms, to the whole of the work, and all its parts, regardless of how they are packaged.  This License gives no permission to license the work in any other way, but it does not invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display Appropriate Legal Notices; however, if the Program has interactive interfaces that do not display Appropriate Legal Notices, your work need not make them do so.
+
+A compilation of a covered work with other separate and independent works, which are not by their nature extensions of the covered work, and which are not combined with it such as to form a larger program, in or on a volume of a storage or distribution medium, is called an "aggregate" if the compilation and its resulting copyright are not used to limit the access or legal rights of the compilation's users beyond what the individual works permit.  Inclusion of a covered work in an aggregate does not cause this License to apply to the other parts of the aggregate.
+
+6. Conveying Non-Source Forms.
+You may convey a covered work in object code form under the terms of sections 4 and 5, provided that you also convey the machine-readable Corresponding Source under the terms of this License, in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by the Corresponding Source fixed on a durable physical medium customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by a written offer, valid for at least three years and valid for as long as you offer spare parts or customer support for that product model, to give anyone who possesses the object code either (1) a copy of the Corresponding Source for all the software in the product that is covered by this License, on a durable physical medium customarily used for software interchange, for a price no more than your reasonable cost of physically performing this conveying of source, or (2) access to copy the Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the written offer to provide the Corresponding Source.  This alternative is allowed only occasionally and noncommercially, and only if you received the object code with such an offer, in accord with subsection 6b.
+
+    d) Convey the object code by offering access from a designated place (gratis or for a charge), and offer equivalent access to the Corresponding Source in the same way through the same place at no further charge.  You need not require recipients to copy the Corresponding Source along with the object code.  If the place to copy the object code is a network server, the Corresponding Source may be on a different server (operated by you or a third party) that supports equivalent copying facilities, provided you maintain clear directions next to the object code saying where to find the Corresponding Source.  Regardless of what server hosts the Corresponding Source, you remain obligated to ensure that it is available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided you inform other peers where the object code and Corresponding Source of the work are being offered to the general public at no charge under subsection 6d.
+
+A separable portion of the object code, whose source code is excluded from the Corresponding Source as a System Library, need not be included in conveying the object code work.
+
+A "User Product" is either (1) a "consumer product", which means any tangible personal property which is normally used for personal, family, or household purposes, or (2) anything designed or sold for incorporation into a dwelling.  In determining whether a product is a consumer product, doubtful cases shall be resolved in favor of coverage.  For a particular product received by a particular user, "normally used" refers to a typical or common use of that class of product, regardless of the status of the particular user or of the way in which the particular user actually uses, or expects or is expected to use, the product.  A product is a consumer product regardless of whether the product has substantial commercial, industrial or non-consumer uses, unless such uses represent the only significant mode of use of the product.
+
+"Installation Information" for a User Product means any methods, procedures, authorization keys, or other information required to install and execute modified versions of a covered work in that User Product from a modified version of its Corresponding Source.  The information must suffice to ensure that the continued functioning of the modified object code is in no case prevented or interfered with solely because modification has been made.
+
+If you convey an object code work under this section in, or with, or specifically for use in, a User Product, and the conveying occurs as part of a transaction in which the right of possession and use of the User Product is transferred to the recipient in perpetuity or for a fixed term (regardless of how the transaction is characterized), the Corresponding Source conveyed under this section must be accompanied by the Installation Information.  But this requirement does not apply if neither you nor any third party retains the ability to install modified object code on the User Product (for example, the work has been installed in ROM).
+
+The requirement to provide Installation Information does not include a requirement to continue to provide support service, warranty, or updates for a work that has been modified or installed by the recipient, or for the User Product in which it has been modified or installed.  Access to a network may be denied when the modification itself materially and adversely affects the operation of the network or violates the rules and protocols for communication across the network.
+
+Corresponding Source conveyed, and Installation Information provided, in accord with this section must be in a format that is publicly documented (and with an implementation available to the public in source code form), and must require no special password or key for unpacking, reading or copying.
+
+7. Additional Terms.
+"Additional permissions" are terms that supplement the terms of this License by making exceptions from one or more of its conditions. Additional permissions that are applicable to the entire Program shall be treated as though they were included in this License, to the extent that they are valid under applicable law.  If additional permissions apply only to part of the Program, that part may be used separately under those permissions, but the entire Program remains governed by this License without regard to the additional permissions.
+
+When you convey a copy of a covered work, you may at your option remove any additional permissions from that copy, or from any part of it.  (Additional permissions may be written to require their own removal in certain cases when you modify the work.)  You may place additional permissions on material, added by you to a covered work, for which you have or can give appropriate copyright permission.
+
+Notwithstanding any other provision of this License, for material you add to a covered work, you may (if authorized by the copyright holders of that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or author attributions in that material or in the Appropriate Legal Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or requiring that modified versions of such material be marked in reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that material by anyone who conveys the material (or modified versions of it) with contractual assumptions of liability to the recipient, for any liability that these contractual assumptions directly impose on those licensors and authors.
+
+All other non-permissive additional terms are considered "further restrictions" within the meaning of section 10.  If the Program as you received it, or any part of it, contains a notice stating that it is governed by this License along with a term that is a further restriction, you may remove that term.  If a license document contains a further restriction but permits relicensing or conveying under this License, you may add to a covered work material governed by the terms of that license document, provided that the further restriction does not survive such relicensing or conveying.
+
+If you add terms to a covered work in accord with this section, you must place, in the relevant source files, a statement of the additional terms that apply to those files, or a notice indicating where to find the applicable terms.
+
+Additional terms, permissive or non-permissive, may be stated in the form of a separately written license, or stated as exceptions; the above requirements apply either way.
+
+8. Termination.
+
+You may not propagate or modify a covered work except as expressly provided under this License.  Any attempt otherwise to propagate or modify it is void, and will automatically terminate your rights under this License (including any patent licenses granted under the third paragraph of section 11).
+
+However, if you cease all violation of this License, then your license from a particular copyright holder is reinstated (a) provisionally, unless and until the copyright holder explicitly and finally terminates your license, and (b) permanently, if the copyright holder fails to notify you of the violation by some reasonable means prior to 60 days after the cessation.
+
+Moreover, your license from a particular copyright holder is reinstated permanently if the copyright holder notifies you of the violation by some reasonable means, this is the first time you have received notice of violation of this License (for any work) from that copyright holder, and you cure the violation prior to 30 days after your receipt of the notice.
+
+Termination of your rights under this section does not terminate the licenses of parties who have received copies or rights from you under this License.  If your rights have been terminated and not permanently reinstated, you do not qualify to receive new licenses for the same material under section 10.
+
+9. Acceptance Not Required for Having Copies.
+
+You are not required to accept this License in order to receive or run a copy of the Program.  Ancillary propagation of a covered work occurring solely as a consequence of using peer-to-peer transmission to receive a copy likewise does not require acceptance.  However, nothing other than this License grants you permission to propagate or modify any covered work.  These actions infringe copyright if you do not accept this License.  Therefore, by modifying or propagating a covered work, you indicate your acceptance of this License to do so.
+
+10. Automatic Licensing of Downstream Recipients.
+
+Each time you convey a covered work, the recipient automatically receives a license from the original licensors, to run, modify and propagate that work, subject to this License.  You are not responsible for enforcing compliance by third parties with this License.
+
+An "entity transaction" is a transaction transferring control of an organization, or substantially all assets of one, or subdividing an organization, or merging organizations.  If propagation of a covered work results from an entity transaction, each party to that transaction who receives a copy of the work also receives whatever licenses to the work the party's predecessor in interest had or could give under the previous paragraph, plus a right to possession of the Corresponding Source of the work from the predecessor in interest, if the predecessor has it or can get it with reasonable efforts.
+
+You may not impose any further restrictions on the exercise of the rights granted or affirmed under this License.  For example, you may not impose a license fee, royalty, or other charge for exercise of rights granted under this License, and you may not initiate litigation (including a cross-claim or counterclaim in a lawsuit) alleging that any patent claim is infringed by making, using, selling, offering for sale, or importing the Program or any portion of it.
+
+11. Patents.
+
+A "contributor" is a copyright holder who authorizes use under this License of the Program or a work on which the Program is based.  The work thus licensed is called the contributor's "contributor version".
+
+A contributor's "essential patent claims" are all patent claims owned or controlled by the contributor, whether already acquired or hereafter acquired, that would be infringed by some manner, permitted by this License, of making, using, or selling its contributor version, but do not include claims that would be infringed only as a consequence of further modification of the contributor version.  For purposes of this definition, "control" includes the right to grant patent sublicenses in a manner consistent with the requirements of this License.
+
+Each contributor grants you a non-exclusive, worldwide, royalty-free patent license under the contributor's essential patent claims, to make, use, sell, offer for sale, import and otherwise run, modify and propagate the contents of its contributor version.
+
+In the following three paragraphs, a "patent license" is any express agreement or commitment, however denominated, not to enforce a patent (such as an express permission to practice a patent or covenant not to sue for patent infringement).  To "grant" such a patent license to a party means to make such an agreement or commitment not to enforce a patent against the party.
+
+If you convey a covered work, knowingly relying on a patent license, and the Corresponding Source of the work is not available for anyone to copy, free of charge and under the terms of this License, through a publicly available network server or other readily accessible means, then you must either (1) cause the Corresponding Source to be so available, or (2) arrange to deprive yourself of the benefit of the patent license for this particular work, or (3) arrange, in a manner consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have actual knowledge that, but for the patent license, your conveying the covered work in a country, or your recipient's use of the covered work in a country, would infringe one or more identifiable patents in that country that you have reason to believe are valid.
+
+If, pursuant to or in connection with a single transaction or arrangement, you convey, or propagate by procuring conveyance of, a covered work, and grant a patent license to some of the parties receiving the covered work authorizing them to use, propagate, modify or convey a specific copy of the covered work, then the patent license you grant is automatically extended to all recipients of the covered work and works based on it.
+
+A patent license is "discriminatory" if it does not include within the scope of its coverage, prohibits the exercise of, or is conditioned on the non-exercise of one or more of the rights that are specifically granted under this License.  You may not convey a covered work if you are a party to an arrangement with a third party that is in the business of distributing software, under which you make payment to the third party based on the extent of your activity of conveying the work, and under which the third party grants, to any of the parties who would receive the covered work from you, a discriminatory patent license (a) in connection with copies of the covered work conveyed by you (or copies made from those copies), or (b) primarily for and in connection with specific products or compilations that contain the covered work, unless you entered into that arrangement, or that patent license was granted, prior to 28 March 2007.
+
+Nothing in this License shall be construed as excluding or limiting any implied license or other defenses to infringement that may otherwise be available to you under applicable patent law.
+
+12. No Surrender of Others' Freedom.
+
+If conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License.  If you cannot convey a covered work so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you to collect a royalty for further conveying from those to whom you convey the Program, the only way you could satisfy both those terms and this License would be to refrain entirely from conveying the Program.
+
+13. Remote Network Interaction; Use with the GNU General Public License.
+
+Notwithstanding any other provision of this License, if you modify the Program, your modified version must prominently offer all users interacting with it remotely through a computer network (if your version supports such interaction) an opportunity to receive the Corresponding Source of your version by providing access to the Corresponding Source from a network server at no charge, through some standard or customary means of facilitating copying of software.  This Corresponding Source shall include the Corresponding Source for any work covered by version 3 of the GNU General Public License that is incorporated pursuant to the following paragraph.
+
+Notwithstanding any other provision of this License, you have permission to link or combine any covered work with a work licensed under version 3 of the GNU General Public License into a single combined work, and to convey the resulting work.  The terms of this License will continue to apply to the part which is the covered work, but the work with which it is combined will remain governed by version 3 of the GNU General Public License.
+
+14. Revised Versions of this License.
+
+The Free Software Foundation may publish revised and/or new versions of the GNU Affero General Public License from time to time.  Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program specifies that a certain numbered version of the GNU Affero General Public License "or any later version" applies to it, you have the option of following the terms and conditions either of that numbered version or of any later version published by the Free Software Foundation.  If the Program does not specify a version number of the GNU Affero General Public License, you may choose any version ever published by the Free Software Foundation.
+
+If the Program specifies that a proxy can decide which future versions of the GNU Affero General Public License can be used, that proxy's public statement of acceptance of a version permanently authorizes you to choose that version for the Program.
+
+Later license versions may give you additional or different permissions.  However, no additional obligations are imposed on any author or copyright holder as a result of your choosing to follow a later version.
+
+15. Disclaimer of Warranty.
+
+THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+16. Limitation of Liability.
+
+IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+17. Interpretation of Sections 15 and 16.
+
+If the disclaimer of warranty and limitation of liability provided above cannot be given local legal effect according to their terms, reviewing courts shall apply local law that most closely approximates an absolute waiver of all civil liability in connection with the Program, unless a warranty or assumption of liability accompanies a copy of the Program in return for a fee.
+
+END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest possible use to the public, the best way to achieve this is to make it free software which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program.  It is safest to attach them to the start of each source file to most effectively state the exclusion of warranty; and each file should have at least the "copyright" line and a pointer to where the full notice is found.
+
+     <one line to give the program's name and a brief idea of what it does.>
+     Copyright (C) <year>  <name of author>
+
+     This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+     This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details.
+
+     You should have received a copy of the GNU Affero General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If your software can interact with users remotely through a computer network, you should also make sure that it provides a way for users to get its source.  For example, if your program is a web application, its interface could display a "Source" link that leads users to an archive of the code.  There are many ways you could offer source, and different solutions will be better for different programs; see section 13 for the specific requirements.
+
+You should also get your employer (if you work as a programmer) or school, if any, to sign a "copyright disclaimer" for the program, if necessary. For more information on this, and how to apply and follow the GNU AGPL, see <http://www.gnu.org/licenses/>.

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Ruben Talstra
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSES/CC-BY-SA-3.0.txt
+++ b/LICENSES/CC-BY-SA-3.0.txt
@@ -1,0 +1,359 @@
+Creative Commons Legal Code
+
+Attribution-ShareAlike 3.0 Unported
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS LICENSE DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE INFORMATION PROVIDED, AND DISCLAIMS LIABILITY FOR
+    DAMAGES RESULTING FROM ITS USE.
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS CREATIVE
+COMMONS PUBLIC LICENSE ("CCPL" OR "LICENSE"). THE WORK IS PROTECTED BY
+COPYRIGHT AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS
+AUTHORIZED UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HERE, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. TO THE EXTENT THIS LICENSE MAY
+BE CONSIDERED TO BE A CONTRACT, THE LICENSOR GRANTS YOU THE RIGHTS
+CONTAINED HERE IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS.
+
+1. Definitions
+
+ a. "Adaptation" means a work based upon the Work, or upon the Work and
+    other pre-existing works, such as a translation, adaptation,
+    derivative work, arrangement of music or other alterations of a
+    literary or artistic work, or phonogram or performance and includes
+    cinematographic adaptations or any other form in which the Work may be
+    recast, transformed, or adapted including in any form recognizably
+    derived from the original, except that a work that constitutes a
+    Collection will not be considered an Adaptation for the purpose of
+    this License. For the avoidance of doubt, where the Work is a musical
+    work, performance or phonogram, the synchronization of the Work in
+    timed-relation with a moving image ("synching") will be considered an
+    Adaptation for the purpose of this License.
+ b. "Collection" means a collection of literary or artistic works, such as
+    encyclopedias and anthologies, or performances, phonograms or
+    broadcasts, or other works or subject matter other than works listed
+    in Section 1(f) below, which, by reason of the selection and
+    arrangement of their contents, constitute intellectual creations, in
+    which the Work is included in its entirety in unmodified form along
+    with one or more other contributions, each constituting separate and
+    independent works in themselves, which together are assembled into a
+    collective whole. A work that constitutes a Collection will not be
+    considered an Adaptation (as defined below) for the purposes of this
+    License.
+ c. "Creative Commons Compatible License" means a license that is listed
+    at https://creativecommons.org/compatiblelicenses that has been
+    approved by Creative Commons as being essentially equivalent to this
+    License, including, at a minimum, because that license: (i) contains
+    terms that have the same purpose, meaning and effect as the License
+    Elements of this License; and, (ii) explicitly permits the relicensing
+    of adaptations of works made available under that license under this
+    License or a Creative Commons jurisdiction license with the same
+    License Elements as this License.
+ d. "Distribute" means to make available to the public the original and
+    copies of the Work or Adaptation, as appropriate, through sale or
+    other transfer of ownership.
+ e. "License Elements" means the following high-level license attributes
+    as selected by Licensor and indicated in the title of this License:
+    Attribution, ShareAlike.
+ f. "Licensor" means the individual, individuals, entity or entities that
+    offer(s) the Work under the terms of this License.
+ g. "Original Author" means, in the case of a literary or artistic work,
+    the individual, individuals, entity or entities who created the Work
+    or if no individual or entity can be identified, the publisher; and in
+    addition (i) in the case of a performance the actors, singers,
+    musicians, dancers, and other persons who act, sing, deliver, declaim,
+    play in, interpret or otherwise perform literary or artistic works or
+    expressions of folklore; (ii) in the case of a phonogram the producer
+    being the person or legal entity who first fixes the sounds of a
+    performance or other sounds; and, (iii) in the case of broadcasts, the
+    organization that transmits the broadcast.
+ h. "Work" means the literary and/or artistic work offered under the terms
+    of this License including without limitation any production in the
+    literary, scientific and artistic domain, whatever may be the mode or
+    form of its expression including digital form, such as a book,
+    pamphlet and other writing; a lecture, address, sermon or other work
+    of the same nature; a dramatic or dramatico-musical work; a
+    choreographic work or entertainment in dumb show; a musical
+    composition with or without words; a cinematographic work to which are
+    assimilated works expressed by a process analogous to cinematography;
+    a work of drawing, painting, architecture, sculpture, engraving or
+    lithography; a photographic work to which are assimilated works
+    expressed by a process analogous to photography; a work of applied
+    art; an illustration, map, plan, sketch or three-dimensional work
+    relative to geography, topography, architecture or science; a
+    performance; a broadcast; a phonogram; a compilation of data to the
+    extent it is protected as a copyrightable work; or a work performed by
+    a variety or circus performer to the extent it is not otherwise
+    considered a literary or artistic work.
+ i. "You" means an individual or entity exercising rights under this
+    License who has not previously violated the terms of this License with
+    respect to the Work, or who has received express permission from the
+    Licensor to exercise rights under this License despite a previous
+    violation.
+ j. "Publicly Perform" means to perform public recitations of the Work and
+    to communicate to the public those public recitations, by any means or
+    process, including by wire or wireless means or public digital
+    performances; to make available to the public Works in such a way that
+    members of the public may access these Works from a place and at a
+    place individually chosen by them; to perform the Work to the public
+    by any means or process and the communication to the public of the
+    performances of the Work, including by public digital performance; to
+    broadcast and rebroadcast the Work by any means including signs,
+    sounds or images.
+ k. "Reproduce" means to make copies of the Work by any means including
+    without limitation by sound or visual recordings and the right of
+    fixation and reproducing fixations of the Work, including storage of a
+    protected performance or phonogram in digital form or other electronic
+    medium.
+
+2. Fair Dealing Rights. Nothing in this License is intended to reduce,
+limit, or restrict any uses free from copyright or rights arising from
+limitations or exceptions that are provided for in connection with the
+copyright protection under copyright law or other applicable laws.
+
+3. License Grant. Subject to the terms and conditions of this License,
+Licensor hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license to
+exercise the rights in the Work as stated below:
+
+ a. to Reproduce the Work, to incorporate the Work into one or more
+    Collections, and to Reproduce the Work as incorporated in the
+    Collections;
+ b. to create and Reproduce Adaptations provided that any such Adaptation,
+    including any translation in any medium, takes reasonable steps to
+    clearly label, demarcate or otherwise identify that changes were made
+    to the original Work. For example, a translation could be marked "The
+    original work was translated from English to Spanish," or a
+    modification could indicate "The original work has been modified.";
+ c. to Distribute and Publicly Perform the Work including as incorporated
+    in Collections; and,
+ d. to Distribute and Publicly Perform Adaptations.
+ e. For the avoidance of doubt:
+
+     i. Non-waivable Compulsory License Schemes. In those jurisdictions in
+        which the right to collect royalties through any statutory or
+        compulsory licensing scheme cannot be waived, the Licensor
+        reserves the exclusive right to collect such royalties for any
+        exercise by You of the rights granted under this License;
+    ii. Waivable Compulsory License Schemes. In those jurisdictions in
+        which the right to collect royalties through any statutory or
+        compulsory licensing scheme can be waived, the Licensor waives the
+        exclusive right to collect such royalties for any exercise by You
+        of the rights granted under this License; and,
+   iii. Voluntary License Schemes. The Licensor waives the right to
+        collect royalties, whether individually or, in the event that the
+        Licensor is a member of a collecting society that administers
+        voluntary licensing schemes, via that society, from any exercise
+        by You of the rights granted under this License.
+
+The above rights may be exercised in all media and formats whether now
+known or hereafter devised. The above rights include the right to make
+such modifications as are technically necessary to exercise the rights in
+other media and formats. Subject to Section 8(f), all rights not expressly
+granted by Licensor are hereby reserved.
+
+4. Restrictions. The license granted in Section 3 above is expressly made
+subject to and limited by the following restrictions:
+
+ a. You may Distribute or Publicly Perform the Work only under the terms
+    of this License. You must include a copy of, or the Uniform Resource
+    Identifier (URI) for, this License with every copy of the Work You
+    Distribute or Publicly Perform. You may not offer or impose any terms
+    on the Work that restrict the terms of this License or the ability of
+    the recipient of the Work to exercise the rights granted to that
+    recipient under the terms of the License. You may not sublicense the
+    Work. You must keep intact all notices that refer to this License and
+    to the disclaimer of warranties with every copy of the Work You
+    Distribute or Publicly Perform. When You Distribute or Publicly
+    Perform the Work, You may not impose any effective technological
+    measures on the Work that restrict the ability of a recipient of the
+    Work from You to exercise the rights granted to that recipient under
+    the terms of the License. This Section 4(a) applies to the Work as
+    incorporated in a Collection, but this does not require the Collection
+    apart from the Work itself to be made subject to the terms of this
+    License. If You create a Collection, upon notice from any Licensor You
+    must, to the extent practicable, remove from the Collection any credit
+    as required by Section 4(c), as requested. If You create an
+    Adaptation, upon notice from any Licensor You must, to the extent
+    practicable, remove from the Adaptation any credit as required by
+    Section 4(c), as requested.
+ b. You may Distribute or Publicly Perform an Adaptation only under the
+    terms of: (i) this License; (ii) a later version of this License with
+    the same License Elements as this License; (iii) a Creative Commons
+    jurisdiction license (either this or a later license version) that
+    contains the same License Elements as this License (e.g.,
+    Attribution-ShareAlike 3.0 US)); (iv) a Creative Commons Compatible
+    License. If you license the Adaptation under one of the licenses
+    mentioned in (iv), you must comply with the terms of that license. If
+    you license the Adaptation under the terms of any of the licenses
+    mentioned in (i), (ii) or (iii) (the "Applicable License"), you must
+    comply with the terms of the Applicable License generally and the
+    following provisions: (I) You must include a copy of, or the URI for,
+    the Applicable License with every copy of each Adaptation You
+    Distribute or Publicly Perform; (II) You may not offer or impose any
+    terms on the Adaptation that restrict the terms of the Applicable
+    License or the ability of the recipient of the Adaptation to exercise
+    the rights granted to that recipient under the terms of the Applicable
+    License; (III) You must keep intact all notices that refer to the
+    Applicable License and to the disclaimer of warranties with every copy
+    of the Work as included in the Adaptation You Distribute or Publicly
+    Perform; (IV) when You Distribute or Publicly Perform the Adaptation,
+    You may not impose any effective technological measures on the
+    Adaptation that restrict the ability of a recipient of the Adaptation
+    from You to exercise the rights granted to that recipient under the
+    terms of the Applicable License. This Section 4(b) applies to the
+    Adaptation as incorporated in a Collection, but this does not require
+    the Collection apart from the Adaptation itself to be made subject to
+    the terms of the Applicable License.
+ c. If You Distribute, or Publicly Perform the Work or any Adaptations or
+    Collections, You must, unless a request has been made pursuant to
+    Section 4(a), keep intact all copyright notices for the Work and
+    provide, reasonable to the medium or means You are utilizing: (i) the
+    name of the Original Author (or pseudonym, if applicable) if supplied,
+    and/or if the Original Author and/or Licensor designate another party
+    or parties (e.g., a sponsor institute, publishing entity, journal) for
+    attribution ("Attribution Parties") in Licensor's copyright notice,
+    terms of service or by other reasonable means, the name of such party
+    or parties; (ii) the title of the Work if supplied; (iii) to the
+    extent reasonably practicable, the URI, if any, that Licensor
+    specifies to be associated with the Work, unless such URI does not
+    refer to the copyright notice or licensing information for the Work;
+    and (iv) , consistent with Ssection 3(b), in the case of an
+    Adaptation, a credit identifying the use of the Work in the Adaptation
+    (e.g., "French translation of the Work by Original Author," or
+    "Screenplay based on original Work by Original Author"). The credit
+    required by this Section 4(c) may be implemented in any reasonable
+    manner; provided, however, that in the case of a Adaptation or
+    Collection, at a minimum such credit will appear, if a credit for all
+    contributing authors of the Adaptation or Collection appears, then as
+    part of these credits and in a manner at least as prominent as the
+    credits for the other contributing authors. For the avoidance of
+    doubt, You may only use the credit required by this Section for the
+    purpose of attribution in the manner set out above and, by exercising
+    Your rights under this License, You may not implicitly or explicitly
+    assert or imply any connection with, sponsorship or endorsement by the
+    Original Author, Licensor and/or Attribution Parties, as appropriate,
+    of You or Your use of the Work, without the separate, express prior
+    written permission of the Original Author, Licensor and/or Attribution
+    Parties.
+ d. Except as otherwise agreed in writing by the Licensor or as may be
+    otherwise permitted by applicable law, if You Reproduce, Distribute or
+    Publicly Perform the Work either by itself or as part of any
+    Adaptations or Collections, You must not distort, mutilate, modify or
+    take other derogatory action in relation to the Work which would be
+    prejudicial to the Original Author's honor or reputation. Licensor
+    agrees that in those jurisdictions (e.g. Japan), in which any exercise
+    of the right granted in Section 3(b) of this License (the right to
+    make Adaptations) would be deemed to be a distortion, mutilation,
+    modification or other derogatory action prejudicial to the Original
+    Author's honor and reputation, the Licensor will waive or not assert,
+    as appropriate, this Section, to the fullest extent permitted by the
+    applicable national law, to enable You to reasonably exercise Your
+    right under Section 3(b) of this License (right to make Adaptations)
+    but not otherwise.
+
+5. Representations, Warranties and Disclaimer
+
+UNLESS OTHERWISE MUTUALLY AGREED TO BY THE PARTIES IN WRITING, LICENSOR
+OFFERS THE WORK AS-IS AND MAKES NO REPRESENTATIONS OR WARRANTIES OF ANY
+KIND CONCERNING THE WORK, EXPRESS, IMPLIED, STATUTORY OR OTHERWISE,
+INCLUDING, WITHOUT LIMITATION, WARRANTIES OF TITLE, MERCHANTIBILITY,
+FITNESS FOR A PARTICULAR PURPOSE, NONINFRINGEMENT, OR THE ABSENCE OF
+LATENT OR OTHER DEFECTS, ACCURACY, OR THE PRESENCE OF ABSENCE OF ERRORS,
+WHETHER OR NOT DISCOVERABLE. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION
+OF IMPLIED WARRANTIES, SO SUCH EXCLUSION MAY NOT APPLY TO YOU.
+
+6. Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE
+LAW, IN NO EVENT WILL LICENSOR BE LIABLE TO YOU ON ANY LEGAL THEORY FOR
+ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY DAMAGES
+ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK, EVEN IF LICENSOR HAS
+BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+7. Termination
+
+ a. This License and the rights granted hereunder will terminate
+    automatically upon any breach by You of the terms of this License.
+    Individuals or entities who have received Adaptations or Collections
+    from You under this License, however, will not have their licenses
+    terminated provided such individuals or entities remain in full
+    compliance with those licenses. Sections 1, 2, 5, 6, 7, and 8 will
+    survive any termination of this License.
+ b. Subject to the above terms and conditions, the license granted here is
+    perpetual (for the duration of the applicable copyright in the Work).
+    Notwithstanding the above, Licensor reserves the right to release the
+    Work under different license terms or to stop distributing the Work at
+    any time; provided, however that any such election will not serve to
+    withdraw this License (or any other license that has been, or is
+    required to be, granted under the terms of this License), and this
+    License will continue in full force and effect unless terminated as
+    stated above.
+
+8. Miscellaneous
+
+ a. Each time You Distribute or Publicly Perform the Work or a Collection,
+    the Licensor offers to the recipient a license to the Work on the same
+    terms and conditions as the license granted to You under this License.
+ b. Each time You Distribute or Publicly Perform an Adaptation, Licensor
+    offers to the recipient a license to the original Work on the same
+    terms and conditions as the license granted to You under this License.
+ c. If any provision of this License is invalid or unenforceable under
+    applicable law, it shall not affect the validity or enforceability of
+    the remainder of the terms of this License, and without further action
+    by the parties to this agreement, such provision shall be reformed to
+    the minimum extent necessary to make such provision valid and
+    enforceable.
+ d. No term or provision of this License shall be deemed waived and no
+    breach consented to unless such waiver or consent shall be in writing
+    and signed by the party to be charged with such waiver or consent.
+ e. This License constitutes the entire agreement between the parties with
+    respect to the Work licensed here. There are no understandings,
+    agreements or representations with respect to the Work not specified
+    here. Licensor shall not be bound by any additional provisions that
+    may appear in any communication from You. This License may not be
+    modified without the mutual written agreement of the Licensor and You.
+ f. The rights granted under, and the subject matter referenced, in this
+    License were drafted utilizing the terminology of the Berne Convention
+    for the Protection of Literary and Artistic Works (as amended on
+    September 28, 1979), the Rome Convention of 1961, the WIPO Copyright
+    Treaty of 1996, the WIPO Performances and Phonograms Treaty of 1996
+    and the Universal Copyright Convention (as revised on July 24, 1971).
+    These rights and subject matter take effect in the relevant
+    jurisdiction in which the License terms are sought to be enforced
+    according to the corresponding provisions of the implementation of
+    those treaty provisions in the applicable national law. If the
+    standard suite of rights granted under applicable copyright law
+    includes additional rights not granted under this License, such
+    additional rights are deemed to be included in the License; this
+    License is not intended to restrict the license of any rights under
+    applicable law.
+
+
+Creative Commons Notice
+
+    Creative Commons is not a party to this License, and makes no warranty
+    whatsoever in connection with the Work. Creative Commons will not be
+    liable to You or any party on any legal theory for any damages
+    whatsoever, including without limitation any general, special,
+    incidental or consequential damages arising in connection to this
+    license. Notwithstanding the foregoing two (2) sentences, if Creative
+    Commons has expressly identified itself as the Licensor hereunder, it
+    shall have all rights and obligations of Licensor.
+
+    Except for the limited purpose of indicating to the public that the
+    Work is licensed under the CCPL, Creative Commons does not authorize
+    the use by either party of the trademark "Creative Commons" or any
+    related trademark or logo of Creative Commons without the prior
+    written consent of Creative Commons. Any permitted use will be in
+    compliance with Creative Commons' then-current trademark usage
+    guidelines, as may be published on its website or otherwise made
+    available upon request from time to time. For the avoidance of doubt,
+    this trademark restriction does not form part of the License.
+
+    Creative Commons may be contacted at https://creativecommons.org/.

--- a/LICENSES/CC-BY-SA-4.0.txt
+++ b/LICENSES/CC-BY-SA-4.0.txt
@@ -1,0 +1,428 @@
+Attribution-ShareAlike 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution-ShareAlike 4.0 International Public
+License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution-ShareAlike 4.0 International Public License ("Public
+License"). To the extent this Public License may be interpreted as a
+contract, You are granted the Licensed Rights in consideration of Your
+acceptance of these terms and conditions, and the Licensor grants You
+such rights in consideration of benefits the Licensor receives from
+making the Licensed Material available under these terms and
+conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. BY-SA Compatible License means a license listed at
+     creativecommons.org/compatiblelicenses, approved by Creative
+     Commons as essentially the equivalent of this Public License.
+
+  d. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  e. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  f. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  g. License Elements means the license attributes listed in the name
+     of a Creative Commons Public License. The License Elements of this
+     Public License are Attribution and ShareAlike.
+
+  h. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  i. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  j. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  k. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  l. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  m. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. Additional offer from the Licensor -- Adapted Material.
+               Every recipient of Adapted Material from You
+               automatically receives an offer from the Licensor to
+               exercise the Licensed Rights in the Adapted Material
+               under the conditions of the Adapter's License You apply.
+
+            c. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+  b. ShareAlike.
+
+     In addition to the conditions in Section 3(a), if You Share
+     Adapted Material You produce, the following conditions also apply.
+
+       1. The Adapter's License You apply must be a Creative Commons
+          license with the same License Elements, this version or
+          later, or a BY-SA Compatible License.
+
+       2. You must include the text of, or the URI or hyperlink to, the
+          Adapter's License You apply. You may satisfy this condition
+          in any reasonable manner based on the medium, means, and
+          context in which You Share Adapted Material.
+
+       3. You may not offer or impose any additional or different terms
+          or conditions on, or apply any Effective Technological
+          Measures to, Adapted Material that restrict exercise of the
+          rights granted under the Adapter's License You apply.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material,
+     including for purposes of Section 3(b); and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.
+

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ruben Talstra
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSES/MPL-1.1.txt
+++ b/LICENSES/MPL-1.1.txt
@@ -1,0 +1,143 @@
+Mozilla Public License Version 1.1
+
+1. Definitions.
+
+     1.0.1. "Commercial Use" means distribution or otherwise making the Covered Code available to a third party.
+
+     1.1. "Contributor" means each entity that creates or contributes to the creation of Modifications.
+
+     1.2. "Contributor Version" means the combination of the Original Code, prior Modifications used by a Contributor, and the Modifications made by that particular Contributor.
+
+     1.3. "Covered Code" means the Original Code or Modifications or the combination of the Original Code and Modifications, in each case including portions thereof.
+
+     1.4. "Electronic Distribution Mechanism" means a mechanism generally accepted in the software development community for the electronic transfer of data.
+
+     1.5. "Executable" means Covered Code in any form other than Source Code.
+
+     1.6. "Initial Developer" means the individual or entity identified as the Initial Developer in the Source Code notice required by Exhibit A.
+
+     1.7. "Larger Work" means a work which combines Covered Code or portions thereof with code not governed by the terms of this License.
+
+     1.8. "License" means this document.
+
+     1.8.1. "Licensable" means having the right to grant, to the maximum extent possible, whether at the time of the initial grant or subsequently acquired, any and all of the rights conveyed herein.
+
+     1.9. "Modifications" means any addition to or deletion from the substance or structure of either the Original Code or any previous Modifications. When Covered Code is released as a series of files, a Modification is:
+Any addition to or deletion from the contents of a file containing Original Code or previous Modifications.
+Any new file that contains any part of the Original Code or previous Modifications.
+
+     1.10. "Original Code" means Source Code of computer software code which is described in the Source Code notice required by Exhibit A as Original Code, and which, at the time of its release under this License is not already Covered Code governed by this License.
+
+     1.10.1. "Patent Claims" means any patent claim(s), now owned or hereafter acquired, including without limitation, method, process, and apparatus claims, in any patent Licensable by grantor.
+
+     1.11. "Source Code" means the preferred form of the Covered Code for making modifications to it, including all modules it contains, plus any associated interface definition files, scripts used to control compilation and installation of an Executable, or source code differential comparisons against either the Original Code or another well known, available Covered Code of the Contributor's choice. The Source Code can be in a compressed or archival form, provided the appropriate decompression or de-archiving software is widely available for no charge.
+
+     1.12. "You" (or "Your") means an individual or a legal entity exercising rights under, and complying with all of the terms of, this License or a future version of this License issued under Section 6.1. For legal entities, "You" includes any entity which controls, is controlled by, or is under common control with You. For purposes of this definition, "control" means (a) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (b) ownership of more than fifty percent (50%) of the outstanding shares or beneficial ownership of such entity.
+
+2. Source Code License.
+
+     2.1. The Initial Developer Grant. The Initial Developer hereby grants You a world-wide, royalty-free, non-exclusive license, subject to third party intellectual property claims:
+
+          a. under intellectual property rights (other than patent or trademark) Licensable by Initial Developer to use, reproduce, modify, display, perform, sublicense and distribute the Original Code (or portions thereof) with or without Modifications, and/or as part of a Larger Work; and
+          b. under Patents Claims infringed by the making, using or selling of Original Code, to make, have made, use, practice, sell, and offer for sale, and/or otherwise dispose of the Original Code (or portions thereof).
+          c. the licenses granted in this Section 2.1 (a) and (b) are effective on the date Initial Developer first distributes Original Code under the terms of this License.
+          d. Notwithstanding Section 2.1 (b) above, no patent license is granted: 1) for code that You delete from the Original Code; 2) separate from the Original Code; or 3) for infringements caused by: i) the modification of the Original Code or ii) the combination of the Original Code with other software or devices.
+
+     2.2. Contributor Grant. Subject to third party intellectual property claims, each Contributor hereby grants You a world-wide, royalty-free, non-exclusive license
+
+          a. under intellectual property rights (other than patent or trademark) Licensable by Contributor, to use, reproduce, modify, display, perform, sublicense and distribute the Modifications created by such Contributor (or portions thereof) either on an unmodified basis, with other Modifications, as Covered Code and/or as part of a Larger Work; and
+          b. under Patent Claims infringed by the making, using, or selling of Modifications made by that Contributor either alone and/or in combination with its Contributor Version (or portions of such combination), to make, use, sell, offer for sale, have made, and/or otherwise dispose of: 1) Modifications made by that Contributor (or portions thereof); and 2) the combination of Modifications made by that Contributor with its Contributor Version (or portions of such combination).
+          c. the licenses granted in Sections 2.2 (a) and 2.2 (b) are effective on the date Contributor first makes Commercial Use of the Covered Code.
+          d. Notwithstanding Section 2.2 (b) above, no patent license is granted: 1) for any code that Contributor has deleted from the Contributor Version; 2) separate from the Contributor Version; 3) for infringements caused by: i) third party modifications of Contributor Version or ii) the combination of Modifications made by that Contributor with other software (except as part of the Contributor Version) or other devices; or 4) under Patent Claims infringed by Covered Code in the absence of Modifications made by that Contributor.
+
+3. Distribution Obligations.
+
+     3.1. Application of License. The Modifications which You create or to which You contribute are governed by the terms of this License, including without limitation Section 2.2. The Source Code version of Covered Code may be distributed only under the terms of this License or a future version of this License released under Section 6.1, and You must include a copy of this License with every copy of the Source Code You distribute. You may not offer or impose any terms on any Source Code version that alters or restricts the applicable version of this License or the recipients' rights hereunder. However, You may include an additional document offering the additional rights described in Section 3.5.
+
+     3.2. Availability of Source Code. Any Modification which You create or to which You contribute must be made available in Source Code form under the terms of this License either on the same media as an Executable version or via an accepted Electronic Distribution Mechanism to anyone to whom you made an Executable version available; and if made available via Electronic Distribution Mechanism, must remain available for at least twelve (12) months after the date it initially became available, or at least six (6) months after a subsequent version of that particular Modification has been made available to such recipients. You are responsible for ensuring that the Source Code version remains available even if the Electronic Distribution Mechanism is maintained by a third party.
+
+     3.3. Description of Modifications. You must cause all Covered Code to which You contribute to contain a file documenting the changes You made to create that Covered Code and the date of any change. You must include a prominent statement that the Modification is derived, directly or indirectly, from Original Code provided by the Initial Developer and including the name of the Initial Developer in (a) the Source Code, and (b) in any notice in an Executable version or related documentation in which You describe the origin or ownership of the Covered Code.
+
+     3.4. Intellectual Property Matters
+
+          (a) Third Party Claims
+          If Contributor has knowledge that a license under a third party's intellectual property rights is required to exercise the rights granted by such Contributor under Sections 2.1 or 2.2, Contributor must include a text file with the Source Code distribution titled "LEGAL" which describes the claim and the party making the claim in sufficient detail that a recipient will know whom to contact. If Contributor obtains such knowledge after the Modification is made available as described in Section 3.2, Contributor shall promptly modify the LEGAL file in all copies Contributor makes available thereafter and shall take other steps (such as notifying appropriate mailing lists or newsgroups) reasonably calculated to inform those who received the Covered Code that new knowledge has been obtained.
+
+          (b) Contributor APIs
+          If Contributor's Modifications include an application programming interface and Contributor has knowledge of patent licenses which are reasonably necessary to implement that API, Contributor must also include this information in the LEGAL file.
+
+          (c) Representations.
+          Contributor represents that, except as disclosed pursuant to Section 3.4 (a) above, Contributor believes that Contributor's Modifications are Contributor's original creation(s) and/or Contributor has sufficient rights to grant the rights conveyed by this License.
+
+     3.5. Required Notices. You must duplicate the notice in Exhibit A in each file of the Source Code. If it is not possible to put such notice in a particular Source Code file due to its structure, then You must include such notice in a location (such as a relevant directory) where a user would be likely to look for such a notice. If You created one or more Modification(s) You may add your name as a Contributor to the notice described in Exhibit A. You must also duplicate this License in any documentation for the Source Code where You describe recipients' rights or ownership rights relating to Covered Code. You may choose to offer, and to charge a fee for, warranty, support, indemnity or liability obligations to one or more recipients of Covered Code. However, You may do so only on Your own behalf, and not on behalf of the Initial Developer or any Contributor. You must make it absolutely clear than any such warranty, support, indemnity or liability obligation is offered by You alone, and You hereby agree to indemnify the Initial Developer and every Contributor for any liability incurred by the Initial Developer or such Contributor as a result of warranty, support, indemnity or liability terms You offer.
+
+     3.6. Distribution of Executable Versions. You may distribute Covered Code in Executable form only if the requirements of Sections 3.1, 3.2, 3.3, 3.4 and 3.5 have been met for that Covered Code, and if You include a notice stating that the Source Code version of the Covered Code is available under the terms of this License, including a description of how and where You have fulfilled the obligations of Section 3.2. The notice must be conspicuously included in any notice in an Executable version, related documentation or collateral in which You describe recipients' rights relating to the Covered Code. You may distribute the Executable version of Covered Code or ownership rights under a license of Your choice, which may contain terms different from this License, provided that You are in compliance with the terms of this License and that the license for the Executable version does not attempt to limit or alter the recipient's rights in the Source Code version from the rights set forth in this License. If You distribute the Executable version under a different license You must make it absolutely clear that any terms which differ from this License are offered by You alone, not by the Initial Developer or any Contributor. You hereby agree to indemnify the Initial Developer and every Contributor for any liability incurred by the Initial Developer or such Contributor as a result of any such terms You offer.
+
+     3.7. Larger Works. You may create a Larger Work by combining Covered Code with other code not governed by the terms of this License and distribute the Larger Work as a single product. In such a case, You must make sure the requirements of this License are fulfilled for the Covered Code.
+
+4. Inability to Comply Due to Statute or Regulation.
+
+If it is impossible for You to comply with any of the terms of this License with respect to some or all of the Covered Code due to statute, judicial order, or regulation then You must: (a) comply with the terms of this License to the maximum extent possible; and (b) describe the limitations and the code they affect. Such description must be included in the LEGAL file described in Section 3.4 and must be included with all distributions of the Source Code. Except to the extent prohibited by statute or regulation, such description must be sufficiently detailed for a recipient of ordinary skill to be able to understand it.
+
+5. Application of this License.
+This License applies to code to which the Initial Developer has attached the notice in Exhibit A and to related Covered Code.
+
+6. Versions of the License.
+
+     6.1. New Versions
+     Netscape Communications Corporation ("Netscape") may publish revised and/or new versions of the License from time to time. Each version will be given a distinguishing version number.
+
+     6.2. Effect of New Versions
+     Once Covered Code has been published under a particular version of the License, You may always continue to use it under the terms of that version. You may also choose to use such Covered Code under the terms of any subsequent version of the License published by Netscape. No one other than Netscape has the right to modify the terms applicable to Covered Code created under this License.
+
+     6.3. Derivative Works
+     If You create or use a modified version of this License (which you may only do in order to apply it to code which is not already Covered Code governed by this License), You must (a) rename Your license so that the phrases "Mozilla", "MOZILLAPL", "MOZPL", "Netscape", "MPL", "NPL" or any confusingly similar phrase do not appear in your license (except to note that your license differs from this License) and (b) otherwise make it clear that Your version of the license contains terms which differ from the Mozilla Public License and Netscape Public License. (Filling in the name of the Initial Developer, Original Code or Contributor in the notice described in Exhibit A shall not of themselves be deemed to be modifications of this License.)
+
+7. DISCLAIMER OF WARRANTY
+COVERED CODE IS PROVIDED UNDER THIS LICENSE ON AN "AS IS" BASIS, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, WITHOUT LIMITATION, WARRANTIES THAT THE COVERED CODE IS FREE OF DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE OR NON-INFRINGING. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE COVERED CODE IS WITH YOU. SHOULD ANY COVERED CODE PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT THE INITIAL DEVELOPER OR ANY OTHER CONTRIBUTOR) ASSUME THE COST OF ANY NECESSARY SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO USE OF ANY COVERED CODE IS AUTHORIZED HEREUNDER EXCEPT UNDER THIS DISCLAIMER.
+
+8. Termination
+
+     8.1. This License and the rights granted hereunder will terminate automatically if You fail to comply with terms herein and fail to cure such breach within 30 days of becoming aware of the breach. All sublicenses to the Covered Code which are properly granted shall survive any termination of this License. Provisions which, by their nature, must remain in effect beyond the termination of this License shall survive.
+
+     8.2. If You initiate litigation by asserting a patent infringement claim (excluding declatory judgment actions) against Initial Developer or a Contributor (the Initial Developer or Contributor against whom You file such action is referred to as "Participant") alleging that:
+
+          a. such Participant's Contributor Version directly or indirectly infringes any patent, then any and all rights granted by such Participant to You under Sections 2.1 and/or 2.2 of this License shall, upon 60 days notice from Participant terminate prospectively, unless if within 60 days after receipt of notice You either: (i) agree in writing to pay Participant a mutually agreeable reasonable royalty for Your past and future use of Modifications made by such Participant, or (ii) withdraw Your litigation claim with respect to the Contributor Version against such Participant. If within 60 days of notice, a reasonable royalty and payment arrangement are not mutually agreed upon in writing by the parties or the litigation claim is not withdrawn, the rights granted by Participant to You under Sections 2.1 and/or 2.2 automatically terminate at the expiration of the 60 day notice period specified above.
+          b. any software, hardware, or device, other than such Participant's Contributor Version, directly or indirectly infringes any patent, then any rights granted to You by such Participant under Sections 2.1(b) and 2.2(b) are revoked effective as of the date You first made, used, sold, distributed, or had made, Modifications made by that Participant.
+
+     8.3. If You assert a patent infringement claim against Participant alleging that such Participant's Contributor Version directly or indirectly infringes any patent where such claim is resolved (such as by license or settlement) prior to the initiation of patent infringement litigation, then the reasonable value of the licenses granted by such Participant under Sections 2.1 or 2.2 shall be taken into account in determining the amount or value of any payment or license.
+
+     8.4. In the event of termination under Sections 8.1 or 8.2 above, all end user license agreements (excluding distributors and resellers) which have been validly granted by You or any distributor hereunder prior to termination shall survive termination.
+
+9. LIMITATION OF LIABILITY
+UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER TORT (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL YOU, THE INITIAL DEVELOPER, ANY OTHER CONTRIBUTOR, OR ANY DISTRIBUTOR OF COVERED CODE, OR ANY SUPPLIER OF ANY OF SUCH PARTIES, BE LIABLE TO ANY PERSON FOR ANY INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF GOODWILL, WORK STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER COMMERCIAL DAMAGES OR LOSSES, EVEN IF SUCH PARTY SHALL HAVE BEEN INFORMED OF THE POSSIBILITY OF SUCH DAMAGES. THIS LIMITATION OF LIABILITY SHALL NOT APPLY TO LIABILITY FOR DEATH OR PERSONAL INJURY RESULTING FROM SUCH PARTY'S NEGLIGENCE TO THE EXTENT APPLICABLE LAW PROHIBITS SUCH LIMITATION. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR LIMITATION OF INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THIS EXCLUSION AND LIMITATION MAY NOT APPLY TO YOU.
+
+10. U.S. government end users
+The Covered Code is a "commercial item," as that term is defined in 48 C.F.R. 2.101 (Oct. 1995), consisting of "commercial computer software" and "commercial computer software documentation," as such terms are used in 48 C.F.R. 12.212 (Sept. 1995). Consistent with 48 C.F.R. 12.212 and 48 C.F.R. 227.7202-1 through 227.7202-4 (June 1995), all U.S. Government End Users acquire Covered Code with only those rights set forth herein.
+
+11. Miscellaneous
+This License represents the complete agreement concerning subject matter hereof. If any provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary to make it enforceable. This License shall be governed by California law provisions (except to the extent applicable law, if any, provides otherwise), excluding its conflict-of-law provisions. With respect to disputes in which at least one party is a citizen of, or an entity chartered or registered to do business in the United States of America, any litigation relating to this License shall be subject to the jurisdiction of the Federal Courts of the Northern District of California, with venue lying in Santa Clara County, California, with the losing party responsible for costs, including without limitation, court costs and reasonable attorneys' fees and expenses. The application of the United Nations Convention on Contracts for the International Sale of Goods is expressly excluded. Any law or regulation which provides that the language of a contract shall be construed against the drafter shall not apply to this License.
+
+12. Responsibility for claims
+As between Initial Developer and the Contributors, each party is responsible for claims and damages arising, directly or indirectly, out of its utilization of rights under this License and You agree to work with Initial Developer and Contributors to distribute such responsibility on an equitable basis. Nothing herein is intended or shall be deemed to constitute any admission of liability.
+
+13. Multiple-licensed code
+Initial Developer may designate portions of the Covered Code as "Multiple-Licensed". "Multiple-Licensed" means that the Initial Developer permits you to utilize portions of the Covered Code under Your choice of the MPL or the alternative licenses, if any, specified by the Initial Developer in the file described in Exhibit A.
+
+Exhibit A - Mozilla Public License.
+
+"The contents of this file are subject to the Mozilla Public License Version 1.1 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.mozilla.org/MPL/
+
+Software distributed under the License is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the specific language governing rights and limitations under the License.
+
+The Original Code is ______________________________________.
+
+The Initial Developer of the Original Code is ________________________.
+Portions created by ______________________ are Copyright (C) ______
+_______________________. All Rights Reserved.
+
+Contributor(s): ______________________________________.
+
+Alternatively, the contents of this file may be used under the terms of the _____ license (the  "[___] License"), in which case the provisions of [______] License are applicable instead of those above. If you wish to allow use of your version of this file only under the terms of the [____] License and not to allow others to use your version of this file under the MPL, indicate your decision by deleting the provisions above and replace them with the notice and other provisions required by the [___] License. If you do not delete the provisions above, a recipient may use your version of this file under either the MPL or the [___] License."
+
+NOTE: The text of this Exhibit A may differ slightly from the text of the notices in the Source Code files of the Original Code. You should use the text of this Exhibit A rather than the text found in the Original Code Source Code for Your Modifications.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,85 @@
+# Maintainers and access continuity
+
+This file is the roster and the honest answer to the question an enterprise
+procurement review asks about any software that holds patient data: *what
+happens if the people who can ship a fix are unavailable?*
+
+It is deliberately not aspirational. Everything below describes the project as
+it is on the day you read it in git history, not a structure the project hopes
+to grow into.
+
+## Roster
+
+| Person | GitHub | Role | Since |
+|---|---|---|---|
+| Ruben Talstra | [@rubentalstra](https://github.com/rubentalstra) | Maintainer (sole) | 2026-07-01 |
+
+**The bus factor of this project is one.** There is exactly one person with
+write access to the repository (`GET /repos/rubentalstra/FerroEHR/collaborators`
+returns one login), one person who can publish a release, and one person who
+can accept a pull request. No second maintainer exists, no organisation stands
+behind the project, and no legal entity is a party to it.
+
+Everything else in this file follows from that sentence, and no wording
+elsewhere in the repository should be read as softening it. The path out is in
+[GOVERNANCE.md](GOVERNANCE.md) — becoming a maintainer is a defined route, not
+an invitation-only one — and it is open.
+
+## Publishing identities and where they live
+
+These are the credentials and configured identities that can put bytes in front
+of a user. Naming them is the point: an inventory nobody has written down is an
+inventory nobody can hand over.
+
+| Identity | What it publishes | Held by | Recovery if the holder is unavailable |
+|---|---|---|---|
+| The GitHub account `rubentalstra` | everything — the repository, releases, issues, settings | the maintainer | none: the repository is user-owned, so GitHub's account-recovery process is the only route, and it is between GitHub and the account holder |
+| The OpenPGP commit- and tag-signing key | the verified signature on every commit and every release tag | the maintainer, on his own hardware | none: the private key is not escrowed. A successor would publish a new key and re-establish trust from a signed statement on the repository; historical signatures stay verifiable regardless |
+| crates.io Trusted Publisher (OIDC) | the eight `openehr-*` crates | configured per crate on crates.io against this repository, the `publish-crates.yml` workflow and the `crates-io` environment — **no long-lived token exists anywhere** | the crates.io owner list is the recovery surface, and it is the maintainer's account. A successor with repository write access can run the lane, but only after crates.io ownership moves |
+| `GITHUB_TOKEN` (ephemeral, per workflow run) | the GHCR container images, the Helm chart, the GitHub release | GitHub, minted per run; nothing is stored | not applicable — there is no credential to lose |
+| The `FOSSA_API_KEY` repository secret | nothing; it uploads a licence analysis | the repository | not applicable — a lost key costs a scan, not a release |
+| Zenodo | the archived release deposit and its DOI | the Zenodo account linked to the GitHub account | tied to GitHub account recovery |
+| The `ferroehr.eu` domain and GitHub Pages | the documentation site | the maintainer (registrar account) | none: registrar account recovery only |
+
+**The honest reading of that table:** with a single exception, every
+publishing identity terminates at one person's GitHub account or one person's
+hardware. Trusted Publishing removes the *stored secret* risk — there is no
+crates.io token to leak — but it does not distribute the *authority*, which is
+still one account's. That is the residual risk, and it is stated rather than
+mitigated because no mitigation is currently available to a one-person project
+without a legal entity behind it.
+
+## If the maintainer is unavailable
+
+There is no succession plan that a document can create. What exists instead:
+
+- **Nothing already published disappears.** Releases are immutable and their
+  assets stay downloadable; published crates cannot be unpublished (only
+  yanked, which needs the owner anyway); published chart versions are never
+  overwritten by policy and the lane refuses to; the Zenodo DOI is permanent.
+  A deployment already running is not affected by maintainer availability.
+- **Nothing new ships.** No release, no security fix, no chart version, no
+  crate publish. The support window in [SECURITY.md](SECURITY.md) — only the
+  newest release is supported — becomes, in that situation, no supported
+  release at all.
+- **The work is not lost.** The licence is MIT, the history is public, every
+  gate is a committed script and every design decision is in the tree or on
+  the tracker. A fork is a complete and legitimate continuation, and the
+  project's position is that it should be taken rather than waited on.
+- **A vulnerability report has a fallback.** If a private report receives no
+  acknowledgement within the window [SECURITY.md](SECURITY.md) commits to, the
+  policy already tells you to escalate publicly, and publishing becomes your
+  call. That path does not depend on the maintainer.
+
+If you depend on this software in a clinical setting and that position is not
+acceptable to you — it reasonably may not be — the mitigation is on your side
+of the boundary: pin a version, keep a fork you can build, and budget for
+maintaining it. That is a truthful answer, and it is more useful than a
+continuity plan with nobody behind it.
+
+## Adding a maintainer
+
+The route is in [GOVERNANCE.md](GOVERNANCE.md). When someone takes it, this
+file gains a row, [`.github/CODEOWNERS`](.github/CODEOWNERS) gains their handle
+on the areas they own, and the table above gains a second holder wherever the
+identity permits one. Those three edits are the whole mechanism.

--- a/README.md
+++ b/README.md
@@ -558,12 +558,25 @@ specification text this project treats as its oracle is vendored in-repo and
 pinned per component, so every conformance decision cites a file you can
 read.
 
-## Contributing and security
+## Contributing, governance and security
 
 Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) and the
 [Code of Conduct](CODE_OF_CONDUCT.md). Please report suspected
 vulnerabilities privately per the [security policy](SECURITY.md), not in
 public issues.
+
+| Document | Answers |
+|---|---|
+| [SUPPORT.md](SUPPORT.md) | where to ask a question, report a defect, or report a vulnerability — they are not the same place |
+| [GOVERNANCE.md](GOVERNANCE.md) | who decides, how a change gets in, and how to become a maintainer |
+| [MAINTAINERS.md](MAINTAINERS.md) | who the maintainers are, which publishing identities exist, and what happens if they are unavailable |
+| [SECURITY.md](SECURITY.md) | how to report a vulnerability, what you can expect back, and **which versions receive security fixes** |
+| [Threat model](https://ferroehr.eu/docs/latest/threat-model.html) | the trust boundaries, the control at each, the residual risk that survives it, and what is explicitly not defended against |
+
+Two of those are worth reading before a procurement decision rather than
+after: the project has **one maintainer**, and **only the newest release
+receives security fixes**. Both are stated plainly in the documents above
+rather than left to be discovered.
 
 ## Acknowledgments and license
 
@@ -597,9 +610,16 @@ public issues.
 |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
 | **FerroEHR's own code** — the application, the tooling, and the generated crates                                                                                                                      | [MIT](LICENSE)                                                                          |
 | openEHR **machine-readable artifacts** (BMM, XSDs, OpenAPI, JSON Schemas — the `specifications-ITS-*` repos) and the vendored **test corpora** (archie, Better `web-template-tests`, the EHRbase SDK) | [Apache-2.0](LICENSE-APACHE-2.0)                                                        |
-| openEHR **specification text** (vendored for conformance work) and **CKM-derived clinical models**                                                                                                    | [CC-BY-SA 3.0](LICENSE-CC-BY-SA-3.0); clinical models carry per-file `licence` metadata |
+| openEHR **specification text** (vendored for conformance work)                                                                                                                                        | [CC-BY-SA 3.0](LICENSE-CC-BY-SA-3.0)                                                    |
+| **CKM-derived clinical models** (test corpora)                                                                                                                                                        | per-file `licence` metadata — a mix of [CC-BY-SA 4.0](LICENSES/CC-BY-SA-4.0.txt) and [CC-BY-SA 3.0](LICENSE-CC-BY-SA-3.0) |
 
 Each vendored tree documents its exact origin and license in a
-`PROVENANCE.md`, with the upstream `LICENSE` vendored alongside. The full
-reckoning is on the documentation site's
+`PROVENANCE.md`, with the upstream `LICENSE` vendored alongside — and the
+whole tree is additionally declared in the machine-readable
+[REUSE 3.3](https://reuse.software/spec-3.3/) form
+([`REUSE.toml`](REUSE.toml) + [`LICENSES/`](LICENSES)), so licensing survives
+a file being copied out of the repository. Two positions the summary table
+above deliberately does not flatten — an MPL 1.1 election under a tri-licensed
+corpus, and one upstream file whose own header contradicts its repository's
+license — are set out with the rest on the documentation site's
 [Licensing & legal](https://ferroehr.eu/docs/latest/licensing.html) page.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,221 @@
+# REUSE Specification 3.3 — https://reuse.software/spec-3.3/
+#
+# WHAT THIS ADDS that the existing arrangement did not. Licensing here has
+# always been recorded per vendored tree, by a `PROVENANCE.md` naming the
+# upstream source, the pinned revision and the licence, with the upstream
+# `LICENSE` vendored alongside. That is accurate and it stays. What it does not
+# do is SURVIVE A FILE LEAVING THIS REPOSITORY — the property REUSE exists for,
+# that licensing "is preserved when the file is copied and reused by third
+# parties". Someone who lifts one archetype out of a test corpus takes a
+# CC-BY-SA file; someone who vendors one generated crate source file takes a
+# file whose dual-licence position is stated only in a manifest they did not
+# copy. This repository redistributes material under six distinct licences and
+# its stated premise is that people build on it and ship it, so downstream
+# file-level redistribution is the expected case, not the edge case.
+#
+# WHY THE DECLARATIONS ARE HERE RATHER THAN IN THE FILES. `REUSE.toml`
+# expresses licensing in bulk by glob, which is what makes this tractable
+# without touching a single vendored file — and hand-editing vendored material
+# is forbidden by this project's own corpus discipline, so a header sweep over
+# the third-party trees was never an option.
+#
+# HOW THE TABLES COMPOSE, because the ordering below is load-bearing: "If a
+# Covered File is covered by multiple [[annotations]] tables in the same
+# REUSE.toml file, then exclusively the LAST matching table in the file is used"
+# (spec 3.3). So the first table is the catch-all and every later table narrows
+# it. Move one and you change what it declares.
+#
+# PRECEDENCE, likewise from the spec: `closest` associates licensing found
+# INSIDE the file (a comment header or a `.license` sidecar) and falls back to
+# the table only when the file carries none; `override` ignores anything closer.
+# First-party globs use `closest`, so adding a real SPDX header to a source file
+# is an improvement that takes effect immediately and never contradicts this
+# file. Vendored globs use `override` where the upstream tree's terms are
+# settled by its `PROVENANCE.md` rather than by any per-file marking.
+
+version = 1
+
+# ── Catch-all: everything in this repository is FerroEHR's own, MIT ──────────
+# Narrowed by every table below. `closest` means a file carrying its own SPDX
+# header wins over this declaration.
+[[annotations]]
+path = "**"
+precedence = "closest"
+SPDX-FileCopyrightText = "FerroEHR contributors"
+SPDX-License-Identifier = "MIT"
+
+# ── The published spec crates: MIT AND Apache-2.0 ───────────────────────────
+# Their own manifests already declare `MIT AND Apache-2.0` and ship both texts
+# in the package, because the emitted Rust is this project's while the
+# specification documentation text, terminology XML and JSON Schema carried
+# inside it are openEHR's. Declaring only MIT here would flatten exactly the
+# dual position the crates were careful to state. The vendored inputs and
+# assets INSIDE these crates are narrowed further below.
+[[annotations]]
+path = [
+  "crates/openehr-base/**",
+  "crates/openehr-rm/**",
+  "crates/openehr-am/**",
+  "crates/openehr-lang/**",
+  "crates/openehr-term/**",
+  "crates/openehr-its/**",
+]
+precedence = "closest"
+SPDX-FileCopyrightText = ["FerroEHR contributors", "openEHR Foundation"]
+SPDX-License-Identifier = "MIT AND Apache-2.0"
+
+# ── openEHR machine-readable artifacts — Apache-2.0 ─────────────────────────
+# The BMM meta-models, XML Schemas, OpenAPI documents, JSON Schemas and ANTLR
+# grammars the code generator and the codecs consume. Vendored verbatim by a
+# committed script; each tree's PROVENANCE.md names the exact upstream commit.
+[[annotations]]
+path = [
+  "tools/openehr-codegen/vendor/**",
+  "crates/openehr-its/schemas/**",
+  "crates/openehr-its/vendor/**",
+  "crates/openehr-adl/vendor/**",
+  "crates/openehr-lang/vendor/**",
+]
+precedence = "override"
+SPDX-FileCopyrightText = "openEHR Foundation"
+SPDX-License-Identifier = "Apache-2.0"
+
+# ── openEHR specification TEXT — CC-BY-SA-3.0 ───────────────────────────────
+# The conformance oracle: the normative documentation, redistributed verbatim
+# with attribution. Reference and test material, never part of the compiled
+# server.
+[[annotations]]
+path = "docs/specs/openehr/**"
+precedence = "override"
+SPDX-FileCopyrightText = "openEHR Foundation"
+SPDX-License-Identifier = "CC-BY-SA-3.0"
+
+# The AQL grammar and the TERM computable assets come from the same
+# specification repositories under the same terms.
+[[annotations]]
+path = [
+  "crates/openehr-query/vendor/**",
+  "crates/openehr-term/assets/**",
+]
+precedence = "override"
+SPDX-FileCopyrightText = "openEHR Foundation"
+SPDX-License-Identifier = "CC-BY-SA-3.0"
+
+# One file inside that tree contradicts its own repository. `PropertyUnitData.xsd`
+# carries an ADL Designer / ADL2-tools header offering it under the GNU Affero
+# General Public License, inside an upstream repository whose LICENSE is
+# CC-BY-SA-3.0. The contradiction is upstream's and is not ours to resolve, so
+# it is declared here at the MORE RESTRICTIVE of the two readings — the one the
+# file's own text asserts — rather than quietly absorbed into the tree
+# declaration above. No obligation propagates to anything shipped: the file is
+# excluded from the published crate by that crate's `include`, so it reaches no
+# consumer.
+[[annotations]]
+path = "crates/openehr-term/assets/schema/PropertyUnitData.xsd"
+precedence = "override"
+SPDX-FileCopyrightText = "2013-2014 Marand d.o.o."
+SPDX-License-Identifier = "AGPL-3.0-only"
+
+# ── Third-party test corpora — Apache-2.0 ───────────────────────────────────
+# archie fixtures (Nedap), Better `web-template-tests`, EHRbase SDK
+# canonical-JSON data (vitasystems), and the openEHR reference-model BMM set
+# archie ships. Each tree's PROVENANCE.md names its upstream and licence.
+[[annotations]]
+path = [
+  "crates/openehr-its/tests/vendor/**",
+  "crates/openehr-its/tests/fixtures/**",
+  "crates/openehr-lang/tests/vendor/**",
+  "crates/openehr-adl/tests/corpus/rm/**",
+]
+precedence = "override"
+SPDX-FileCopyrightText = ["Nedap Healthcare", "Better Ltd", "vitasystems GmbH", "openEHR Foundation"]
+SPDX-License-Identifier = "Apache-2.0"
+
+# Three BMM reference models inside that set are offered by their authors under
+# a Mozilla Public License 1.1 / GPL 2.0 / LGPL 2.1 TRI-LICENCE. This project
+# TAKES THEM UNDER MPL-1.1 — the election is recorded in that corpus's
+# PROVENANCE.md — so no GPL or LGPL obligation attaches to anything here.
+# Declaring the tri-licence as a disjunction would misrepresent a choice that
+# has already been made and recorded.
+[[annotations]]
+path = [
+  "crates/openehr-adl/tests/corpus/rm/referencemodels/bmm/ISO_13606/2008/BMM/cen_EN13606_0.95.bmm",
+  "crates/openehr-adl/tests/corpus/rm/referencemodels/bmm/ISO_13606/2008/BMM/cen_ts14796_0.90.bmm",
+  "crates/openehr-adl/tests/corpus/rm/referencemodels/bmm/openEHR/components/RM/rejected/openehr_ehr_extract_999.bmm",
+]
+precedence = "override"
+SPDX-FileCopyrightText = "the respective model authors"
+SPDX-License-Identifier = "MPL-1.1"
+
+# ── Clinical models (archetypes, templates) ─────────────────────────────────
+# The ADL2 archetype library and the CKM-derived clinical models. These carry
+# their licence INSIDE themselves — every archetype's own `description` block
+# has a `licence` field — so for this material licensing already survives
+# copying, and these declarations exist to make the same fact machine-readable
+# at the tree level.
+#
+# The corpora are MIXED at file level and the SPDX expression says so rather
+# than picking a winner: a first-hand count over the CKM corpus finds both
+# CC-BY-SA-4.0 (the majority) and CC-BY-SA-3.0 (several hundred files) — so
+# neither version alone is a true statement about the tree, and `AND` names
+# both sets of obligations a redistributor takes on. The per-file `licence`
+# metadata remains the authority for any individual file.
+[[annotations]]
+path = [
+  "tools/cnf-runner/artifacts/corpus/**",
+  "crates/openehr-adl/tests/corpus/**",
+]
+precedence = "override"
+SPDX-FileCopyrightText = ["openEHR Foundation", "the respective archetype authors"]
+SPDX-License-Identifier = "CC-BY-SA-3.0 AND CC-BY-SA-4.0"
+
+# The BMM reference-model subtree inside the ADL2 corpus is code-adjacent
+# material under different terms, so the two tables above are re-applied after
+# the broad clinical-model glob that would otherwise have swallowed them —
+# the last matching table wins, so these must come last.
+[[annotations]]
+path = "crates/openehr-adl/tests/corpus/rm/**"
+precedence = "override"
+SPDX-FileCopyrightText = ["Nedap Healthcare", "openEHR Foundation"]
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = [
+  "crates/openehr-adl/tests/corpus/rm/referencemodels/bmm/ISO_13606/2008/BMM/cen_EN13606_0.95.bmm",
+  "crates/openehr-adl/tests/corpus/rm/referencemodels/bmm/ISO_13606/2008/BMM/cen_ts14796_0.90.bmm",
+  "crates/openehr-adl/tests/corpus/rm/referencemodels/bmm/openEHR/components/RM/rejected/openehr_ehr_extract_999.bmm",
+]
+precedence = "override"
+SPDX-FileCopyrightText = "the respective model authors"
+SPDX-License-Identifier = "MPL-1.1"
+
+# ── Fuzzing seeds ───────────────────────────────────────────────────────────
+# Copies of the corpora above, kept so a recorded crash stays reproducible.
+# They inherit whatever their source carried; the union is declared because a
+# seed's origin is not recoverable from its filename.
+[[annotations]]
+path = "fuzz/seeds/**"
+precedence = "override"
+SPDX-FileCopyrightText = ["openEHR Foundation", "the respective archetype authors", "FerroEHR contributors"]
+SPDX-License-Identifier = "Apache-2.0 AND CC-BY-SA-3.0 AND CC-BY-SA-4.0 AND MIT"
+
+# ── Self-hosted KaTeX assets — MIT ──────────────────────────────────────────
+# The documentation site pre-renders maths at build time and self-hosts the
+# stylesheet and fonts; provenance is in website/book/KATEX-PROVENANCE.md.
+[[annotations]]
+path = "website/book/src/katex/**"
+precedence = "override"
+SPDX-FileCopyrightText = "KaTeX contributors"
+SPDX-License-Identifier = "MIT"
+
+# ── One vendored file whose NAME contains a newline character ───────────────
+# `docs/specs/openehr/CNF/.../I_EHR_COMPOSITION.get_composition_version-bad_ehr\n.robot`
+# is tracked with a literal U+000A inside its filename — an upstream defect in
+# the vendored CNF suite, not something this repository may rename (hand-editing
+# a vendored tree is forbidden; the fix belongs upstream). Glob matching over a
+# newline-bearing path does not reach it, so it is named explicitly.
+[[annotations]]
+path = "docs/specs/openehr/CNF/tests/platform/robot/I_EHR_COMPOSITION/get_composition/I_EHR_COMPOSITION.get_composition_version-bad_ehr\n.robot"
+precedence = "override"
+SPDX-FileCopyrightText = "openEHR Foundation"
+SPDX-License-Identifier = "CC-BY-SA-3.0"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,8 +5,38 @@ and handled with priority.
 
 ## Supported versions
 
-The project is pre-release. Security fixes land on `develop` and in the next
-tagged release; there are no maintenance branches yet.
+**Only the most recent release is supported.** There are no maintenance
+branches, no long-term-support line, and no backports. This is a deliberate
+policy for the current release cadence, not an omission — and it is stated
+here rather than left to inference, because an operator running a clinical
+deployment under change control has to plan around it.
+
+| Artifact | Version line | What is supported |
+|---|---|---|
+| The server (GitHub releases, container images) | product SemVer, `3.x` | the newest `vX.Y.Z` tag, and nothing older |
+| The Helm chart (`oci://ghcr.io/rubentalstra/charts`) | its own SemVer, independent of the server | the newest published chart version |
+| The `openehr-*` crates (crates.io) | their own lockstep `0.0.x` line | the newest published version of all eight |
+
+**How a security fix reaches you.** The fix lands on `develop` and ships in the
+next tagged release. That is normally the next *patch* on the current minor —
+so a fix does not oblige you to take new behaviour — but the project does not
+promise it: if the fix is only correct alongside a behavioural change, the
+release carrying it is the release carrying the change, and the changelog
+entry says so. A chart-only fix ships as a new chart version through the same
+publish lane between server releases.
+
+**When a version stops receiving fixes: the moment a newer release exists.**
+A release is never retro-fitted — GitHub release immutability means a
+published release's assets and tag cannot be modified at all, so the only
+remedy for any defect is a new version. If you are not on the newest release,
+you are receiving no security fixes, and the action is to upgrade.
+
+**If you need something stronger than that** — a supported line you can stay
+on, a backport window, a deprecation notice period — it does not exist today
+and cannot be conjured by a policy document. Say so on the tracker; a
+maintenance line is a commitment that needs people behind it, and the
+[governance and continuity](GOVERNANCE.md) position records honestly how many
+there currently are.
 
 ## Reporting a vulnerability
 
@@ -70,6 +100,36 @@ credit costs you nothing and changes nothing about how the report is handled.
   [`security/vex/`](security/vex/), with the justification and an impact
   statement you can check. If you think one of those arguments is wrong, that is
   a valid report.
+
+## Repository security settings — the posture of record
+
+Settings live in GitHub, not in the tree, so they can be changed without a
+commit and reset without anyone noticing. This table is the record of what the
+posture is **supposed** to be; read it back with
+`gh api repos/rubentalstra/FerroEHR --jq '.security_and_analysis'` and
+`gh api repos/rubentalstra/FerroEHR/rulesets`, and treat a divergence as a
+finding.
+
+| Setting | Expected | Why |
+|---|---|---|
+| Secret scanning | enabled | the baseline detector |
+| Push protection | enabled | refuses the commit rather than filing an alert after the fact |
+| Secret scanning — **non-provider patterns** | enabled | the credential classes this repository is most likely to leak are not provider tokens: private keys, database URLs with an embedded password, HTTP basic-auth URLs, generic high-entropy secrets. The chart mounts a config volume carrying a private key, the OIDC configuration takes an HMAC secret with an enforced entropy floor, and the platform library ships a signing module |
+| Secret scanning — **validity checks** | enabled | the difference between "rotate this eventually" and "this credential is live right now" |
+| Dependabot security updates | enabled | advisory-driven bumps, exempt from the update cooldowns |
+| Private vulnerability reporting | enabled | the reporting route this document points at |
+| Ruleset `develop` (default branch) | active — no deletion, no force-push, signed commits, pull request required, `conclusion` status check required | the merge gate |
+| Ruleset `protect-main` | active — no deletion, no force-push, pull request required | |
+| Ruleset `release-tags` (`refs/tags/v*`) | active — no tag deletion, no non-fast-forward tag update, signatures required | three lanes publish off a raw tag push (the release, the Helm chart, the documentation version cut). Release immutability protects the window *after* a release is published; this protects the window in which a tag drives a build, an image push and a chart publish |
+
+> [!NOTE]
+> Two of these are **not yet true**: `secret_scanning_non_provider_patterns`
+> and `secret_scanning_validity_checks` both read `disabled`. Both are
+> accepted-and-ignored by `PATCH /repos/{owner}/{repo}` — the request returns
+> `200` and changes nothing — so they have to be switched on in the repository
+> Settings UI (*Settings → Code security → Secret Protection*). The table above
+> states the intended posture; this note is what makes the gap visible rather
+> than implied.
 
 ### Reporting a vulnerability in Kubernetes itself
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,79 @@
+# Getting help
+
+Three destinations, and they are not interchangeable. Picking the right one is
+the difference between an answer and a thread nobody is paged for.
+
+## I have a question
+
+**[GitHub Discussions](https://github.com/rubentalstra/FerroEHR/discussions)** —
+how to configure something, whether an approach fits, what an openEHR concept
+means in this implementation, why a design is the way it is.
+
+Read first, because the answer is often already written and is more precise
+than a reply:
+
+- **[The documentation site](https://ferroehr.eu/)** — installation, the
+  configuration reference, the API walkthroughs, AQL, templates, security and
+  multi-tenancy, operations. Start at
+  [Getting started](https://ferroehr.eu/docs/latest/getting-started.html).
+- **[The API reference](https://ferroehr.eu/api/)** — the OpenAPI document the
+  server itself generates, so it describes the surface that actually exists.
+- **[`docs/architecture.md`](docs/architecture.md)** — the design, in one file.
+
+There is no commercial support offering, no service-level agreement, and no
+paid tier. Answers come when the maintainer is at a keyboard
+([MAINTAINERS.md](MAINTAINERS.md) is honest about how many keyboards that is).
+
+## I found a defect
+
+**[Open an issue](https://github.com/rubentalstra/FerroEHR/issues/new/choose)**
+— something is wrong, missing, or contradicts the openEHR specifications.
+
+The reports that get fixed fastest carry:
+
+- the version (`ferroehr --version`, or the image tag), and how it is deployed;
+- the request and the response, verbatim — method, path, headers,
+  bodies — or the AQL and the result set;
+- what the openEHR specification says should have happened, with the
+  file and section from `docs/specs/openehr/` if you have it. A citation turns
+  a disagreement into a defect.
+
+**A specification-conformance report is not a nuisance report — it is the most
+valuable kind here.** The implementation is never presumed correct because it
+was written to the specification; the specification text is the authority and
+the implementation is the usual culprit.
+
+## I found a vulnerability
+
+**Do not open a public issue.** Follow [SECURITY.md](SECURITY.md): report
+privately through
+[GitHub private vulnerability reporting](https://github.com/rubentalstra/FerroEHR/security/advisories/new).
+
+That document also carries what you can expect in return — an acknowledgement
+window, an assessment window, coordinated disclosure, safe harbour for good-faith
+research, and credit by default — plus what to do if the acknowledgement does
+not arrive.
+
+**A vulnerability in Kubernetes itself, or in a database, broker or terminology
+server you deployed alongside FerroEHR, goes to that project**, not here.
+SECURITY.md § *Reporting a vulnerability in Kubernetes itself* has the routing.
+
+## I want to change something
+
+[CONTRIBUTING.md](CONTRIBUTING.md) is the practical guide — setup, the gates
+every pull request must pass, and the hard rules. [GOVERNANCE.md](GOVERNANCE.md)
+is how the decision gets made and how someone becomes a maintainer.
+
+## What you are entitled to
+
+Nothing, and that is worth saying rather than implying. FerroEHR is MIT-licensed
+software provided as-is, by volunteers, with no warranty — read the
+[LICENSE](LICENSE), which says exactly that in the language that binds.
+Everything above describes what the project *intends* to do, and the intent is
+sincere; none of it is a contractual commitment, and only the security-report
+windows in SECURITY.md are stated as promises at all.
+
+Only the newest release receives fixes ([SECURITY.md § Supported
+versions](SECURITY.md#supported-versions)). If your deployment needs a stronger
+guarantee than a single-maintainer project can give, the honest options are to
+fork and maintain, or to fund the capacity that would change the answer.

--- a/clippy.toml
+++ b/clippy.toml
@@ -13,8 +13,15 @@ allow-indexing-slicing-in-tests = true  # clippy::indexing_slicing
 check-incompatible-msrv-in-tests = true # clippy::incompatible_msrv reaches tests too
 # allow-dbg-in-tests stays false (default): dbg! is never committed, tests included
 
-# ── every crate is publish = false: there is no external semver surface, so the
-#    ~15 API-shape lints this option suppresses report real findings instead ──
+# ── the ~15 API-shape lints this option suppresses report real findings here ──
+#    The eight `openehr-*` crates DO publish to crates.io, so "no external API"
+#    is not the reason. The reason is the line they publish on: `0.0.x`, where
+#    cargo treats every patch as its own compatibility set
+#    (https://doc.rust-lang.org/cargo/reference/semver.html), so no consumer
+#    range spans a break — and any packaged-content change already bumps all
+#    eight in the same pull request. The `ferroehr-*` crates are unpublished.
+#    Nothing downstream is protected by hiding an API-shape finding, so they
+#    stay visible. Re-adjudicate if the line ever graduates past `0.x`.
 avoid-breaking-exported-api = false
 
 # ── clippy::doc_markdown domain vocabulary (".." appends to the defaults) ────

--- a/deny.toml
+++ b/deny.toml
@@ -92,8 +92,13 @@ exceptions = [
 [bans]
 multiple-versions = "warn"
 wildcards = "deny"
-# Internal path-only deps carry an implicit "*" version; all crates are
-# publish = false, so path-only is fine and stays denied for external deps.
+# Internal path-only deps carry an implicit "*" version. The `ferroehr-*`
+# application crates and the tools are unpublished and depend on the spec
+# crates by bare path, which is fine and never reaches a registry. The eight
+# PUBLISHED `openehr-*` crates do not rely on this: cargo refuses to package a
+# path dependency without a version requirement, so each of their internal deps
+# carries an explicit `version = "0.0.x"` bumped in lockstep. External wildcards
+# stay denied either way.
 allow-wildcard-paths = true
 # Deny known-unmaintained or footgun crates here as they surface.
 deny = []

--- a/scripts/checks/first-party-license-text.sh
+++ b/scripts/checks/first-party-license-text.sh
@@ -50,6 +50,21 @@ readonly -a PROSE=(
   ':(exclude)LICENSE-APACHE-2.0'
   ':(exclude)LICENSE-CC-BY-SA-3.0'
   ':(exclude)LICENSE-CC-BY-SA-4.0'
+  # The REUSE 3.3 licence directory is the same category as the root licence
+  # texts above: quoted legal text this project REDISTRIBUTES so that a
+  # downstream copier can read the terms of the file they took, never a grant
+  # over anything written here. REUSE requires the full text of every licence
+  # any file in the tree is offered under, and one vendored file carries an
+  # upstream AGPL header — so an AGPL text has to be present for the tree to be
+  # compliant at all.
+  #
+  # This does not open a hole where the gate used to be: a licence text that
+  # belongs to no file now fails `scripts/checks/licensing-declarations.sh`,
+  # which refuses any text in LICENSES/ that REUSE.toml does not use. The
+  # control moved to the place that can judge it.
+  ':(exclude)LICENSES/**'
+  ':(exclude)REUSE.toml'
+  ':(exclude)website/book/src/licensing.md'
   ':(exclude).claude/**'
   ':(exclude)scripts/checks/first-party-license-text.sh'
   ':(exclude)deny.toml'

--- a/scripts/checks/licensing-declarations.sh
+++ b/scripts/checks/licensing-declarations.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# The licensing declarations, the licence texts and the licensing chapter must
+# describe the same set of licences.
+#
+# `reuse lint` already proves that every file in the tree carries licensing
+# information and that no licence text is orphaned. What it cannot check is the
+# thing this repository actually gets wrong over time: the human-readable
+# licensing chapter drifting away from the machine-readable declarations, so a
+# compliance reviewer reading the site and a scanner reading `REUSE.toml` are
+# told different things.
+#
+# Three assertions, all mechanical:
+#   1. every SPDX identifier used in REUSE.toml has its text in LICENSES/;
+#   2. every text in LICENSES/ is used by REUSE.toml (no orphan);
+#   3. every SPDX identifier used in REUSE.toml is named in the licensing
+#      chapter, so a licence cannot enter the tree without the page that
+#      explains the tree acquiring it.
+#
+# What it deliberately does NOT check: whether the chapter's PROSE about a
+# licence is correct. No tool can judge that, and a check that pretended to
+# would be the kind of unenforced rule `.claude/rules/reliability.md` refuses.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+readonly REUSE_TOML='REUSE.toml'
+readonly LICENSES_DIR='LICENSES'
+readonly CHAPTER='website/book/src/licensing.md'
+
+for required in "$REUSE_TOML" "$CHAPTER"; do
+  [ -f "$required" ] || { echo "error: missing $required" >&2; exit 1; }
+done
+[ -d "$LICENSES_DIR" ] || { echo "error: missing $LICENSES_DIR/" >&2; exit 1; }
+command -v yq >/dev/null || { echo "error: yq is required" >&2; exit 1; }
+
+# Every identifier named in an SPDX expression. Expressions here are `AND`/`OR`
+# joins of plain identifiers — no parentheses, no `WITH` — so splitting on the
+# operators is exact rather than an approximation of a parser.
+declared=$(
+  yq -p toml -o json '[.annotations[]."SPDX-License-Identifier"] | flatten' "$REUSE_TOML" \
+    | jq -r '.[]' \
+    | tr ' ' '\n' \
+    | grep -vxE 'AND|OR' \
+    | grep -v '^$' \
+    | sort -u
+)
+texts=$(find "$LICENSES_DIR" -maxdepth 1 -type f -name '*.txt' -exec basename {} .txt \; | sort)
+
+fail=0
+note() { echo "licensing-declarations: $*" >&2; fail=1; }
+
+while read -r id; do
+  [ -n "$id" ] || continue
+  note "REUSE.toml declares '$id' but $LICENSES_DIR/$id.txt does not exist — REUSE requires the full text of every licence the tree is offered under"
+done < <(comm -23 <(echo "$declared") <(echo "$texts"))
+
+while read -r id; do
+  [ -n "$id" ] || continue
+  note "$LICENSES_DIR/$id.txt is present but nothing in REUSE.toml is offered under '$id' — delete the text, or declare the files that need it"
+done < <(comm -13 <(echo "$declared") <(echo "$texts"))
+
+# The chapter names licences the way a reader does ("CC-BY-SA 3.0"), so both the
+# SPDX spelling and the spaced human spelling count as a mention.
+while read -r id; do
+  [ -n "$id" ] || continue
+  human=${id%-only}
+  human=$(printf '%s' "$human" | sed -E 's/^(CC-BY-SA)-([0-9])/\1 \2/; s/^(MPL|AGPL|Apache|GPL|LGPL)-([0-9])/\1 \2/')
+  if ! grep -qF -- "$id" "$CHAPTER" && ! grep -qF -- "$human" "$CHAPTER"; then
+    note "'$id' is declared in REUSE.toml but named nowhere in $CHAPTER — the licensing chapter must account for every licence this tree redistributes under"
+  fi
+done < <(echo "$declared")
+
+[ "$fail" -eq 0 ] || {
+  echo >&2
+  echo "The machine-readable declarations (REUSE.toml + LICENSES/) and the" >&2
+  echo "licensing chapter are the same statement in two registers; they may" >&2
+  echo "never disagree about WHICH licences apply." >&2
+  exit 1
+}
+
+echo "ok: $(echo "$declared" | wc -l | tr -d ' ') licences declared, texted and documented"

--- a/scripts/checks/vex-advisories.sh
+++ b/scripts/checks/vex-advisories.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# The VEX drift gate: the published OpenVEX document must be exactly what the
+# generator produces from `deny.toml` + `security/vex/rust-advisories.toml`.
+#
+# Two failure modes it exists to catch, both of which have precedent in this
+# repository's history of second lists that nothing read:
+#
+#   1. An advisory is accepted in `deny.toml` and no justification is published,
+#      so a downstream scanner sees an unexplained finding while the argument
+#      sits in a TOML comment nobody downstream reads. (The generator refuses;
+#      this gate is where that refusal reaches CI.)
+#   2. The JSON is hand-edited, or the prose changes without regeneration, and
+#      the published document quietly stops matching the gate it claims to
+#      describe.
+#
+# Mutation-proven in both directions: adding an ignore to `deny.toml` without a
+# prose entry fails, and touching one byte of the generated JSON fails.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+readonly OUT='security/vex/rust-advisories.openvex.json'
+
+[ -f "$OUT" ] || {
+  echo "error: $OUT does not exist — run scripts/security/vex-generate.sh" >&2
+  exit 1
+}
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# The generator carries the id-set agreement and the OpenVEX vocabulary checks
+# and exits non-zero on any of them, so running it IS half this gate.
+bash scripts/security/vex-generate.sh --stdout > "$work/expected.json"
+
+if ! diff -u "$OUT" "$work/expected.json" > "$work/diff.txt"; then
+  echo "error: $OUT is not what the generator produces" >&2
+  echo >&2
+  sed 's/^/  /' "$work/diff.txt" >&2
+  echo >&2
+  echo "The document is GENERATED — never hand-edit it. Change deny.toml or" >&2
+  echo "security/vex/rust-advisories.toml, then run:" >&2
+  echo "  bash scripts/security/vex-generate.sh" >&2
+  exit 1
+fi
+
+# Every OTHER document under security/vex/ is hand-authored (they describe
+# inherited container layers, where nothing in this repository resolves the
+# finding). They still have to be well-formed OpenVEX, so a typo does not ship
+# as a document a consumer's parser rejects.
+for doc in security/vex/*.openvex.json; do
+  jq -e '
+    (has("@context") and has("@id") and has("author") and has("timestamp")
+     and has("version") and (.statements | type == "array" and length > 0))
+    and (.statements | all(
+      has("vulnerability") and has("products") and has("status")
+      and (.status | IN("not_affected", "affected", "fixed", "under_investigation"))
+      and (if .status == "not_affected" then
+             (.justification | IN(
+               "component_not_present", "vulnerable_code_not_present",
+               "vulnerable_code_not_in_execute_path",
+               "vulnerable_code_cannot_be_controlled_by_adversary",
+               "inline_mitigations_already_exist"))
+           else true end)))
+  ' "$doc" > /dev/null || {
+    echo "error: $doc is not a well-formed OpenVEX document" >&2
+    echo "  (https://github.com/openvex/spec/blob/main/OPENVEX-SPEC.md)" >&2
+    exit 1
+  }
+done
+
+echo "ok: $(ls security/vex/*.openvex.json | wc -l | tr -d ' ') VEX documents well-formed; $OUT matches deny.toml"

--- a/scripts/security/vex-generate.sh
+++ b/scripts/security/vex-generate.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Generate the Rust-dependency OpenVEX document.
+#
+#   security/vex/rust-advisories.toml  (the reasoning)
+# + deny.toml [advisories].ignore      (the authoritative id set)
+# → security/vex/rust-advisories.openvex.json
+#
+# The ids come from the advisory GATE, never from the prose file, so the
+# published document and the thing that actually fails a build cannot drift
+# apart: this script refuses to emit anything if the two sets disagree in
+# either direction, or if a lock-file-only entry has been added to the gate's
+# ignore list.
+#
+# Output is byte-deterministic — statements sorted by advisory id, the document
+# timestamp taken from the TOML rather than the clock — so the drift check can
+# regenerate and diff.
+#
+# OpenVEX specification: https://github.com/openvex/spec/blob/main/OPENVEX-SPEC.md
+#
+# Usage: scripts/security/vex-generate.sh [--write | --stdout]
+#   --write   (default) overwrite security/vex/rust-advisories.openvex.json
+#   --stdout  print the document instead, changing nothing on disk
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+readonly PROSE='security/vex/rust-advisories.toml'
+readonly GATE='deny.toml'
+readonly OUT='security/vex/rust-advisories.openvex.json'
+
+mode="${1:---write}"
+case "$mode" in
+  --write | --stdout) ;;
+  *)
+    echo "usage: $0 [--write | --stdout]" >&2
+    exit 2
+    ;;
+esac
+
+for tool in yq jq; do
+  command -v "$tool" >/dev/null || { echo "vex-generate: $tool is required" >&2; exit 1; }
+done
+for required in "$PROSE" "$GATE"; do
+  [ -f "$required" ] || { echo "vex-generate: missing $required" >&2; exit 1; }
+done
+
+# The controlled vocabularies, so a typo in the prose file fails here instead of
+# producing a document a consumer's parser rejects.
+readonly VALID_STATUS='not_affected affected fixed under_investigation'
+readonly VALID_JUSTIFICATION='component_not_present vulnerable_code_not_present vulnerable_code_not_in_execute_path vulnerable_code_cannot_be_controlled_by_adversary inline_mitigations_already_exist'
+
+prose_json="$(yq -p toml -o json '.' "$PROSE")"
+gate_ids="$(yq -p toml -o json '[.advisories.ignore[].id]' "$GATE" | jq -r '.[]' | sort)"
+accepted_ids="$(jq -r '(.accepted // [])[].id' <<<"$prose_json" | sort)"
+lockfile_ids="$(jq -r '(.lockfile_only // [])[].id' <<<"$prose_json" | sort)"
+
+fail=0
+note() { echo "vex-generate: $*" >&2; fail=1; }
+
+# ── the two-way agreement that makes one list impossible to forget ──────────
+while read -r id; do
+  [ -n "$id" ] || continue
+  note "deny.toml accepts $id but $PROSE has no [[accepted]] entry for it — every accepted advisory needs a published justification"
+done < <(comm -23 <(echo "$gate_ids") <(echo "$accepted_ids"))
+
+while read -r id; do
+  [ -n "$id" ] || continue
+  note "$PROSE claims $id is accepted but deny.toml does not ignore it — a VEX statement for an advisory the gate still fails on is a false claim"
+done < <(comm -13 <(echo "$gate_ids") <(echo "$accepted_ids"))
+
+# A lock-file-only entry that has been added to the gate is either a real
+# acceptance (move it to [[accepted]]) or the ignore that deny.toml's header
+# explicitly refuses to carry.
+while read -r id; do
+  [ -n "$id" ] || continue
+  note "$id is listed as [[lockfile_only]] but deny.toml now ignores it — move it to [[accepted]], or drop the ignore"
+done < <(comm -12 <(echo "$gate_ids") <(echo "$lockfile_ids"))
+
+# ── vocabulary + completeness of every statement ────────────────────────────
+while read -r entry; do
+  [ -n "$entry" ] || continue
+  id="$(jq -r '.id // ""' <<<"$entry")"
+  for field in crate status justification impact; do
+    value="$(jq -r --arg f "$field" '.[$f] // ""' <<<"$entry")"
+    [ -n "$value" ] || note "${id:-<no id>}: missing '$field'"
+  done
+  status="$(jq -r '.status // ""' <<<"$entry")"
+  justification="$(jq -r '.justification // ""' <<<"$entry")"
+  grep -qw -- "$status" <<<"$VALID_STATUS" \
+    || note "$id: status '$status' is not an OpenVEX status ($VALID_STATUS)"
+  if [ "$status" = "not_affected" ]; then
+    grep -qw -- "$justification" <<<"$VALID_JUSTIFICATION" \
+      || note "$id: justification '$justification' is not in the OpenVEX vocabulary ($VALID_JUSTIFICATION)"
+  fi
+done < <(jq -c '((.accepted // []) + (.lockfile_only // []))[]' <<<"$prose_json")
+
+[ "$fail" -eq 0 ] || exit 1
+
+document="$(jq -S '
+  .document as $d
+  | (((.accepted // []) + (.lockfile_only // [])) | sort_by(.id)) as $entries
+  | {
+      "@context": "https://openvex.dev/ns/v0.2.0",
+      "@id": $d.id,
+      author: $d.author,
+      role: $d.role,
+      timestamp: $d.timestamp,
+      version: $d.version,
+      tooling: "scripts/security/vex-generate.sh from security/vex/rust-advisories.toml + deny.toml",
+      statements: [
+        $entries[] | . as $e | {
+          vulnerability: ({ name: $e.id }
+            + (if ($e.aliases // []) | length > 0 then { aliases: $e.aliases } else {} end)),
+          products: [
+            $d.products[] | { "@id": ., subcomponents: [ { "@id": ("pkg:cargo/" + $e.crate) } ] }
+          ],
+          status: $e.status,
+          justification: $e.justification,
+          impact_statement: $e.impact,
+        }
+      ],
+    }
+' <<<"$prose_json")"
+
+# jq -S sorts object keys alphabetically, which is what makes the output
+# byte-stable across jq versions; the statement ORDER is fixed above by id.
+if [ "$mode" = "--stdout" ]; then
+  printf '%s\n' "$document"
+else
+  printf '%s\n' "$document" > "$OUT"
+  echo "ok: wrote $OUT ($(jq '.statements | length' <<<"$document") statements)"
+fi

--- a/security/vex/README.md
+++ b/security/vex/README.md
@@ -26,6 +26,44 @@ re-evaluate.
 
 ## Documents
 
-| File | Subject |
-|---|---|
-| `postgres-gosu.openvex.json` | Go standard-library advisories in `/usr/local/bin/gosu`, the privilege-dropping helper the upstream `postgres` image ships. Not reachable: gosu sets uid/gid and execs, opening no socket and parsing no untrusted input. |
+| File | Subject | Authored |
+|---|---|---|
+| `postgres-gosu.openvex.json` | Go standard-library advisories in `/usr/local/bin/gosu`, the privilege-dropping helper the upstream `postgres` image ships. Not reachable: gosu sets uid/gid and execs, opening no socket and parsing no untrusted input. | by hand |
+| `rust-advisories.openvex.json` | The Rust dependency advisories: the five accepted by the advisory gate, plus the one a lock-file-reading scanner reports for a crate our feature set never compiles. | **generated** |
+
+## The generated document
+
+`rust-advisories.openvex.json` is produced by
+`scripts/security/vex-generate.sh` from two inputs, and must never be edited by
+hand:
+
+- **`deny.toml`** `[advisories].ignore` — the authoritative set of advisory
+  ids. It is the gate that actually decides whether a build passes, so it is
+  the only place the id list may live.
+- **`security/vex/rust-advisories.toml`** — the reasoning: the OpenVEX
+  `status`, the controlled-vocabulary `justification`, and the
+  `impact_statement` for each id.
+
+Two lists that must agree is exactly the shape this repository has already been
+bitten by (a second advisory ignore list at `.cargo/audit.toml` that nothing
+read and that had drifted to a different set of ids). So the generator refuses
+to emit anything unless the two sets match in **both** directions, and
+`scripts/checks/vex-advisories.sh` — the `vex` CI job — regenerates the
+document and fails on any difference. Adding an ignore to `deny.toml` without
+publishing its justification is a red build, not an oversight nobody notices.
+
+To change a statement: edit `rust-advisories.toml` (and `deny.toml` if the id
+set changes), bump the document's `version` and `timestamp`, then run
+`bash scripts/security/vex-generate.sh`.
+
+### Why lock-file-only findings are in there
+
+The last section of `rust-advisories.toml` carries advisories `cargo-deny`
+never raises — because it resolves cargo FEATURES — but which a scanner reading
+`Cargo.lock` alone does report. Those are precisely the findings that reach a
+downstream consumer with no explanation attached anywhere in this repository,
+which is the reason a published VEX document is worth more here than a comment.
+They are deliberately absent from `deny.toml`'s ignore list: an ignore for an
+advisory the gate never raises records nothing and would start applying
+silently if the tool ever became lock-file-based. The generator enforces that
+too.

--- a/security/vex/rust-advisories.openvex.json
+++ b/security/vex/rust-advisories.openvex.json
@@ -1,0 +1,172 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://ferroehr.eu/vex/rust-dependency-advisories",
+  "author": "FerroEHR project",
+  "role": "vendor",
+  "statements": [
+    {
+      "impact_statement": "The Marvin timing sidechannel leaks information about an RSA PRIVATE key through the timing of private-key operations. FerroEHR holds no RSA private key and performs no RSA private-key operation. The crate is reached only through `openidconnect` in the OIDC authentication path, where the sole RSA operation is verifying an RS256 signature on an ID token using the identity provider's PUBLIC key. There is no secret in that computation for a timing observation to recover. No upstream fix exists — `rsa` has no patched release — so this is not a deferred upgrade; the exposure is absent rather than accepted. Re-evaluate if a release beyond rsa 0.9 ships, or if this codebase ever performs an RSA decryption or signing operation.",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "products": [
+        {
+          "@id": "pkg:cargo/ferroehr-server",
+          "subcomponents": [
+            {
+              "@id": "pkg:cargo/rsa"
+            }
+          ]
+        },
+        {
+          "@id": "pkg:oci/ferroehr",
+          "subcomponents": [
+            {
+              "@id": "pkg:cargo/rsa"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "vulnerability": {
+        "aliases": [
+          "CVE-2023-49092",
+          "GHSA-c38w-74pg-36hr",
+          "GHSA-4grx-2x9w-596c"
+        ],
+        "name": "RUSTSEC-2023-0071"
+      }
+    },
+    {
+      "impact_statement": "An UNMAINTAINED-crate advisory, not a vulnerability: the author archived the repository and RustSec records no flaw and no patched version. `paste` is a procedural macro that pastes tokens at compile time, reached through `utoipa-axum` 0.2.0 — the latest release of the official utoipa axum bindings, for which no paste-free version exists. Like every proc-macro it runs inside the compiler and links into nothing that ships, so it is absent from the artifacts this document describes. Re-evaluate on the next `utoipa-axum` release.",
+      "justification": "vulnerable_code_not_present",
+      "products": [
+        {
+          "@id": "pkg:cargo/ferroehr-server",
+          "subcomponents": [
+            {
+              "@id": "pkg:cargo/paste"
+            }
+          ]
+        },
+        {
+          "@id": "pkg:oci/ferroehr",
+          "subcomponents": [
+            {
+              "@id": "pkg:cargo/paste"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "vulnerability": {
+        "name": "RUSTSEC-2024-0436"
+      }
+    },
+    {
+      "impact_statement": "An UNMAINTAINED-crate advisory, not a vulnerability: RustSec records no flaw and no patched version, only that the author has stated the crate is no longer maintained. `proc-macro-error2` is a procedural-macro dependency of `leptos_macro` 0.8, used by the admin console. A proc-macro executes in the COMPILER during the build and its code is not linked into any shipped artifact, so it is absent from both the server binary and the container image this document describes. It goes away when Leptos drops it upstream; re-evaluate at the next Leptos bump.",
+      "justification": "vulnerable_code_not_present",
+      "products": [
+        {
+          "@id": "pkg:cargo/ferroehr-server",
+          "subcomponents": [
+            {
+              "@id": "pkg:cargo/proc-macro-error2"
+            }
+          ]
+        },
+        {
+          "@id": "pkg:oci/ferroehr",
+          "subcomponents": [
+            {
+              "@id": "pkg:cargo/proc-macro-error2"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "vulnerability": {
+        "name": "RUSTSEC-2026-0173"
+      }
+    },
+    {
+      "impact_statement": "Quadratic run time when a start tag is checked for duplicate attribute names (denial of service). The affected version, quick-xml 0.40.1, enters the graph only through `object_store` 0.14.0 — the S3 multimedia offload — which is the latest release and requires `quick-xml ^0.40`, so no fixed version is reachable. The parser in that path reads S3 API RESPONSES from the endpoint the operator configured, a semi-trusted peer inside the deployment's own trust boundary; it never sees a request body, an AQL query, or any other client-supplied bytes. FerroEHR's own canonical-XML surface — the one that does parse client input — is built on quick-xml 0.41, which carries the fix. Re-evaluate on the next `object_store` release.",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "products": [
+        {
+          "@id": "pkg:cargo/ferroehr-server",
+          "subcomponents": [
+            {
+              "@id": "pkg:cargo/quick-xml"
+            }
+          ]
+        },
+        {
+          "@id": "pkg:oci/ferroehr",
+          "subcomponents": [
+            {
+              "@id": "pkg:cargo/quick-xml"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "vulnerability": {
+        "name": "RUSTSEC-2026-0194"
+      }
+    },
+    {
+      "impact_statement": "Unbounded namespace-declaration allocation in `NsReader`, enabling memory-exhaustion denial of service. Same reachability as RUSTSEC-2026-0194 and the same argument: quick-xml 0.40.1 is pulled only by `object_store` 0.14.0 (the latest release, requiring `quick-xml ^0.40`) for the S3 multimedia offload, where it parses responses from the operator-configured object-store endpoint and never client input. The client-facing canonical-XML codec uses quick-xml 0.41, which is patched. Re-evaluate on the next `object_store` release.",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "products": [
+        {
+          "@id": "pkg:cargo/ferroehr-server",
+          "subcomponents": [
+            {
+              "@id": "pkg:cargo/quick-xml"
+            }
+          ]
+        },
+        {
+          "@id": "pkg:oci/ferroehr",
+          "subcomponents": [
+            {
+              "@id": "pkg:cargo/quick-xml"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "vulnerability": {
+        "name": "RUSTSEC-2026-0195"
+      }
+    },
+    {
+      "impact_statement": "Insufficient archive validation causing out-of-bounds reads in archives containing `Rc`/`Arc` (patched in rkyv 0.8.17). `rkyv` is NOT COMPILED into any FerroEHR artifact. `rust_decimal` declares both `rkyv ^0.8.13` and `rkyv ^0.7.46` as OPTIONAL dependencies; this project enables neither feature, and `cargo tree --workspace --all-features` resolves zero `rkyv` nodes. `Cargo.lock` nonetheless pins 0.7.46, because a lock file records the union of every dependency any feature combination could pull and `^0.7.46` cannot resolve above the vulnerable range — so the entry can only leave the lock file when `rust_decimal` drops that requirement upstream. A scanner that reads the lock file therefore reports it; `cargo deny`, which resolves features, does not. Where the two disagree in that direction, the feature-resolving tool is the more precise instrument.",
+      "justification": "component_not_present",
+      "products": [
+        {
+          "@id": "pkg:cargo/ferroehr-server",
+          "subcomponents": [
+            {
+              "@id": "pkg:cargo/rkyv"
+            }
+          ]
+        },
+        {
+          "@id": "pkg:oci/ferroehr",
+          "subcomponents": [
+            {
+              "@id": "pkg:cargo/rkyv"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "vulnerability": {
+        "name": "RUSTSEC-2026-0235"
+      }
+    }
+  ],
+  "timestamp": "2026-08-12T00:00:00Z",
+  "tooling": "scripts/security/vex-generate.sh from security/vex/rust-advisories.toml + deny.toml",
+  "version": 1
+}

--- a/security/vex/rust-advisories.toml
+++ b/security/vex/rust-advisories.toml
@@ -1,0 +1,166 @@
+# The prose half of the Rust-dependency VEX document.
+#
+# `security/vex/rust-advisories.openvex.json` is GENERATED from this file joined
+# with `deny.toml`, by `scripts/security/vex-generate.sh`. Never hand-edit the
+# JSON — `scripts/checks/vex-advisories.sh` regenerates it and fails on any
+# difference.
+#
+# WHY TWO FILES RATHER THAN ONE. The set of accepted advisory ids has exactly
+# one authority — the `[advisories].ignore` array in `deny.toml`, which is the
+# gate that actually decides whether a build passes. Duplicating that list here
+# would create the second list this repository has already been bitten by (a
+# stale `.cargo/audit.toml` nothing read). So the ids come from `deny.toml` and
+# only the reasoning lives here, and the generator REFUSES to run if the two
+# sets disagree in either direction.
+#
+# The OpenVEX vocabulary is not free text: `status` and `justification` are
+# controlled fields from the specification
+# (https://github.com/openvex/spec/blob/main/OPENVEX-SPEC.md). A justification
+# must be one of `component_not_present`, `vulnerable_code_not_present`,
+# `vulnerable_code_not_in_execute_path`,
+# `vulnerable_code_cannot_be_controlled_by_adversary`,
+# `inline_mitigations_already_exist` — and the `impact` below has to actually
+# argue for the one chosen. "Low risk" is not a justification.
+#
+# Aliases are transcribed from the advisory's own RustSec entry
+# (https://rustsec.org/advisories/) so a scanner keyed on a CVE or GHSA
+# identifier rather than a RUSTSEC one still matches the statement.
+
+[document]
+# A stable IRI for the document, and a timestamp that is HAND-SET rather than
+# taken from the clock: the generator must be deterministic, or the drift check
+# would fail on every run. Bump `version` and `timestamp` together whenever a
+# statement changes.
+id = "https://ferroehr.eu/vex/rust-dependency-advisories"
+author = "FerroEHR project"
+role = "vendor"
+timestamp = "2026-08-12T00:00:00Z"
+version = 1
+
+# What the statements are about: the released server binary and the container
+# image built from it. Both carry the same Cargo dependency graph, which is the
+# graph every advisory below concerns.
+products = [
+  "pkg:cargo/ferroehr-server",
+  "pkg:oci/ferroehr",
+]
+
+# ── Accepted by the advisory gate ───────────────────────────────────────────
+# Every id here MUST appear in `deny.toml`'s `[advisories].ignore`, and every id
+# there MUST appear here. The generator enforces both directions.
+
+[[accepted]]
+id = "RUSTSEC-2023-0071"
+crate = "rsa"
+aliases = ["CVE-2023-49092", "GHSA-c38w-74pg-36hr", "GHSA-4grx-2x9w-596c"]
+status = "not_affected"
+justification = "vulnerable_code_cannot_be_controlled_by_adversary"
+impact = """
+The Marvin timing sidechannel leaks information about an RSA PRIVATE key \
+through the timing of private-key operations. FerroEHR holds no RSA private \
+key and performs no RSA private-key operation. The crate is reached only \
+through `openidconnect` in the OIDC authentication path, where the sole RSA \
+operation is verifying an RS256 signature on an ID token using the identity \
+provider's PUBLIC key. There is no secret in that computation for a timing \
+observation to recover. No upstream fix exists — `rsa` has no patched release \
+— so this is not a deferred upgrade; the exposure is absent rather than \
+accepted. Re-evaluate if a release beyond rsa 0.9 ships, or if this codebase \
+ever performs an RSA decryption or signing operation.\
+"""
+
+[[accepted]]
+id = "RUSTSEC-2026-0194"
+crate = "quick-xml"
+status = "not_affected"
+justification = "vulnerable_code_cannot_be_controlled_by_adversary"
+impact = """
+Quadratic run time when a start tag is checked for duplicate attribute names \
+(denial of service). The affected version, quick-xml 0.40.1, enters the graph \
+only through `object_store` 0.14.0 — the S3 multimedia offload — which is the \
+latest release and requires `quick-xml ^0.40`, so no fixed version is \
+reachable. The parser in that path reads S3 API RESPONSES from the endpoint \
+the operator configured, a semi-trusted peer inside the deployment's own \
+trust boundary; it never sees a request body, an AQL query, or any other \
+client-supplied bytes. FerroEHR's own canonical-XML surface — the one that \
+does parse client input — is built on quick-xml 0.41, which carries the fix. \
+Re-evaluate on the next `object_store` release.\
+"""
+
+[[accepted]]
+id = "RUSTSEC-2026-0195"
+crate = "quick-xml"
+status = "not_affected"
+justification = "vulnerable_code_cannot_be_controlled_by_adversary"
+impact = """
+Unbounded namespace-declaration allocation in `NsReader`, enabling \
+memory-exhaustion denial of service. Same reachability as RUSTSEC-2026-0194 \
+and the same argument: quick-xml 0.40.1 is pulled only by `object_store` \
+0.14.0 (the latest release, requiring `quick-xml ^0.40`) for the S3 \
+multimedia offload, where it parses responses from the operator-configured \
+object-store endpoint and never client input. The client-facing canonical-XML \
+codec uses quick-xml 0.41, which is patched. Re-evaluate on the next \
+`object_store` release.\
+"""
+
+[[accepted]]
+id = "RUSTSEC-2026-0173"
+crate = "proc-macro-error2"
+status = "not_affected"
+justification = "vulnerable_code_not_present"
+impact = """
+An UNMAINTAINED-crate advisory, not a vulnerability: RustSec records no flaw \
+and no patched version, only that the author has stated the crate is no longer \
+maintained. `proc-macro-error2` is a procedural-macro dependency of \
+`leptos_macro` 0.8, used by the admin console. A proc-macro executes in the \
+COMPILER during the build and its code is not linked into any shipped \
+artifact, so it is absent from both the server binary and the container image \
+this document describes. It goes away when Leptos drops it upstream; \
+re-evaluate at the next Leptos bump.\
+"""
+
+[[accepted]]
+id = "RUSTSEC-2024-0436"
+crate = "paste"
+status = "not_affected"
+justification = "vulnerable_code_not_present"
+impact = """
+An UNMAINTAINED-crate advisory, not a vulnerability: the author archived the \
+repository and RustSec records no flaw and no patched version. `paste` is a \
+procedural macro that pastes tokens at compile time, reached through \
+`utoipa-axum` 0.2.0 — the latest release of the official utoipa axum \
+bindings, for which no paste-free version exists. Like every proc-macro it \
+runs inside the compiler and links into nothing that ships, so it is absent \
+from the artifacts this document describes. Re-evaluate on the next \
+`utoipa-axum` release.\
+"""
+
+# ── Reported by lock-file scanners only ─────────────────────────────────────
+# Advisories `cargo-deny` never raises, because it resolves FEATURES, while a
+# scanner reading `Cargo.lock` alone cannot. These must NOT be in `deny.toml`'s
+# ignore list — an ignore for an advisory the gate never raises records nothing
+# and would start applying silently if the tool ever became lock-file-based —
+# and the generator refuses if one appears there.
+#
+# This section is the whole reason a consumer needs this document: it is
+# precisely the class of finding that reaches a downstream scanner and has no
+# explanation attached anywhere in the repository.
+
+[[lockfile_only]]
+id = "RUSTSEC-2026-0235"
+crate = "rkyv"
+status = "not_affected"
+justification = "component_not_present"
+impact = """
+Insufficient archive validation causing out-of-bounds reads in archives \
+containing `Rc`/`Arc` (patched in rkyv 0.8.17). `rkyv` is NOT COMPILED into \
+any FerroEHR artifact. `rust_decimal` declares both `rkyv ^0.8.13` and \
+`rkyv ^0.7.46` as OPTIONAL dependencies; this project enables neither feature, \
+and `cargo tree --workspace --all-features` resolves zero `rkyv` nodes. \
+`Cargo.lock` nonetheless pins 0.7.46, because a lock file records the union of \
+every dependency any feature combination could pull and `^0.7.46` cannot \
+resolve above the vulnerable range — so the entry can only leave the lock file \
+when `rust_decimal` drops that requirement upstream. A scanner that reads the \
+lock file therefore reports it; `cargo deny`, which resolves features, does \
+not. Where the two disagree in that direction, the feature-resolving tool is \
+the more precise instrument.\
+"""

--- a/tools/cnf-runner/artifacts/corpus/archetypes/ckm/PROVENANCE.md
+++ b/tools/cnf-runner/artifacts/corpus/archetypes/ckm/PROVENANCE.md
@@ -32,10 +32,16 @@ a skip. Never delete a refused file: that drops the negative case
 ## Licensing
 
 CKM publishes no repository-level license; each archetype carries its
-own `description` > `licence` metadata (predominantly CC-BY-SA 3.0
-where stated — see the individual file). Vendored verbatim, so the
-authorship and licence metadata ride along in every file; root
-reference copy: `LICENSE-CC-BY-SA-3.0`.
+own `description` > `licence` metadata, and the corpus is **mixed**:
+a count over this directory on 2026-08-12 found **1266 files under
+CC-BY-SA 4.0 and 546 under CC-BY-SA 3.0**. The earlier wording here —
+"predominantly CC-BY-SA 3.0" — was the wrong way round, and no single
+version is a true statement about the tree. Read the individual file;
+its own metadata is the authority. Vendored verbatim, so the authorship
+and licence metadata ride along in every file; root reference copies:
+`LICENSE-CC-BY-SA-3.0` and `LICENSE-CC-BY-SA-4.0`
+(`LICENSES/CC-BY-SA-3.0.txt`, `LICENSES/CC-BY-SA-4.0.txt`), and
+`REUSE.toml` declares this tree as `CC-BY-SA-3.0 AND CC-BY-SA-4.0`.
 
 ## Inventory
 

--- a/tools/cnf-runner/artifacts/corpus/templates/ckm/PROVENANCE.md
+++ b/tools/cnf-runner/artifacts/corpus/templates/ckm/PROVENANCE.md
@@ -27,10 +27,14 @@ under `full/` with its own provenance file.
 ## Licensing
 
 CKM publishes no repository-level license; each OPT embeds its source
-archetypes' `licence` metadata (predominantly CC-BY-SA 3.0 where
-stated — see the individual file). Vendored verbatim, so authorship
-and licence metadata ride along; root reference copy:
-`LICENSE-CC-BY-SA-3.0`.
+archetypes' `licence` metadata, and the corpus is **mixed**: a count
+over this directory on 2026-08-12 found **114 files carrying CC-BY-SA
+4.0 and 10 carrying CC-BY-SA 3.0**. The earlier wording here —
+"predominantly CC-BY-SA 3.0" — was the wrong way round. Read the
+individual file; its own metadata is the authority. Vendored verbatim,
+so authorship and licence metadata ride along; root reference copies:
+`LICENSE-CC-BY-SA-3.0` and `LICENSE-CC-BY-SA-4.0`, and `REUSE.toml`
+declares this tree as `CC-BY-SA-3.0 AND CC-BY-SA-4.0`.
 
 | cid | slug | display name | status | modified | journey role |
 |---|---|---|---|---|---|

--- a/website/book/src/SUMMARY.md
+++ b/website/book/src/SUMMARY.md
@@ -27,6 +27,7 @@
   - [FHIR connectors](beyond-core/fhir.md)
   - [S3 multimedia](beyond-core/s3-multimedia.md)
 - [Security & multi-tenancy](security.md)
+  - [Threat model](threat-model.md)
   - [Enterprise identity providers](identity-providers.md)
   - [SMART App Launch](smart-app-launch.md)
   - [Audit trail (IHE ATNA)](audit.md)

--- a/website/book/src/licensing.md
+++ b/website/book/src/licensing.md
@@ -35,14 +35,74 @@ license:
 
 | Material | Source | License |
 |---|---|---|
-| openEHR machine-readable artifacts (BMM meta-models, XML Schemas, OpenAPI, JSON Schemas) | the openEHR `specifications-ITS-*` repositories | [Apache-2.0](https://github.com/rubentalstra/FerroEHR/blob/develop/LICENSE-APACHE-2.0) |
-| openEHR specification text (the conformance reference) | the openEHR `specifications-*` repositories | [CC-BY-SA 3.0](https://github.com/rubentalstra/FerroEHR/blob/develop/LICENSE-CC-BY-SA-3.0) |
-| Clinical models (archetypes and templates) from the openEHR Clinical Knowledge Manager and the openEHR ADL archetype library | ckm.openehr.org, `openEHR/adl-archetypes` | per-file `licence` metadata, predominantly CC-BY-SA 3.0 |
+| openEHR machine-readable artifacts (BMM meta-models, XML Schemas, OpenAPI, JSON Schemas, ANTLR grammars) | the openEHR `specifications-ITS-*` repositories | [Apache-2.0](https://github.com/rubentalstra/FerroEHR/blob/develop/LICENSES/Apache-2.0.txt) |
+| openEHR specification text (the conformance reference) | the openEHR `specifications-*` repositories | [CC-BY-SA 3.0](https://github.com/rubentalstra/FerroEHR/blob/develop/LICENSES/CC-BY-SA-3.0.txt) |
+| Clinical models (archetypes and templates) from the openEHR Clinical Knowledge Manager and the openEHR ADL archetype library | ckm.openehr.org, `openEHR/adl-archetypes` | per-file `licence` metadata — a **mix** of [CC-BY-SA 4.0](https://github.com/rubentalstra/FerroEHR/blob/develop/LICENSES/CC-BY-SA-4.0.txt) and [CC-BY-SA 3.0](https://github.com/rubentalstra/FerroEHR/blob/develop/LICENSES/CC-BY-SA-3.0.txt) |
 | Test corpora (archie fixtures, Better `web-template-tests`, EHRbase SDK canonical-JSON data) | Nedap, Better Ltd, vitasystems | Apache-2.0 |
+| Three ISO 13606 / rejected-extract BMM reference models inside the archie corpus | offered by their authors under MPL 1.1 / GPL 2.0 / LGPL 2.1 | taken under [MPL 1.1](https://github.com/rubentalstra/FerroEHR/blob/develop/LICENSES/MPL-1.1.txt) — see the election below |
+| One terminology schema file, `PropertyUnitData.xsd` | ADL Designer / ADL2-tools, via the openEHR TERM assets | [AGPL 3.0](https://github.com/rubentalstra/FerroEHR/blob/develop/LICENSES/AGPL-3.0-only.txt) — see the contradiction below |
 
 Every vendored tree in the repository carries a `PROVENANCE.md` naming its
 exact upstream source, pinned revision, and license, with the upstream
 `LICENSE` file vendored alongside where the source publishes one.
+
+**The clinical-model corpora are mixed, and the table says so on purpose.** A
+first-hand count over the vendored CKM material finds both CC-BY-SA 4.0 (the
+majority) and CC-BY-SA 3.0 (several hundred files), so no single version is a
+true statement about the tree. Each archetype carries its own `licence` field
+inside its `description` block, and that per-file metadata is the authority for
+any individual file — which also means licensing for this material already
+survives being copied out of the repository.
+
+**Two positions worth stating explicitly**, because both are the kind of thing
+a compliance review finds and a summary table hides:
+
+- **The MPL election.** Three BMM reference models in the archie corpus
+  (`cen_EN13606_0.95.bmm`, `cen_ts14796_0.90.bmm`,
+  `openehr_ehr_extract_999.bmm`) are offered by their authors under a
+  tri-license: MPL 1.1, GPL 2.0, or LGPL 2.1. This project **takes them under
+  MPL 1.1**, a file-scoped weak copyleft. The election is recorded in that
+  corpus's `PROVENANCE.md`, so **no GPL or LGPL obligation attaches to
+  anything here**.
+- **One upstream contradiction, not resolved by us.**
+  `crates/openehr-term/assets/schema/PropertyUnitData.xsd` carries an ADL
+  Designer / ADL2-tools header offering it under the GNU Affero General Public
+  License, inside an upstream repository whose own `LICENSE` is CC-BY-SA 3.0.
+  Both cannot be right, the contradiction is upstream's, and re-licensing
+  someone else's file is not ours to do — so it is declared at the **more
+  restrictive** of the two readings, the one the file's own text asserts. No
+  obligation reaches a consumer: the file is excluded from the published crate
+  by that crate's `include`, so it ships in nothing.
+
+## Machine-readable licensing (REUSE 3.3)
+
+The `PROVENANCE.md` arrangement above is accurate, and it stays. What it does
+not do is survive a file leaving this repository — someone who lifts a single
+archetype out of a test corpus takes a CC-BY-SA file bearing no marking they
+copied. Since the stated premise of this project is that people build on it,
+ship it and sell it, downstream file-level redistribution is the expected case.
+
+So licensing is **also** published in the machine-readable form the
+[REUSE Specification 3.3](https://reuse.software/spec-3.3/) defines:
+
+- **[`LICENSES/`](https://github.com/rubentalstra/FerroEHR/tree/develop/LICENSES)**
+  holds the full text of every license any file in the tree is offered under,
+  named by SPDX identifier: `MIT`, `Apache-2.0`, `CC-BY-SA-3.0`,
+  `CC-BY-SA-4.0`, `MPL-1.1`, `AGPL-3.0-only`.
+- **[`REUSE.toml`](https://github.com/rubentalstra/FerroEHR/blob/develop/REUSE.toml)**
+  declares, by glob, which files are offered under which — including the two
+  positions above, represented rather than flattened.
+
+It is expressed by glob rather than by per-file headers for the vendored trees
+for a reason that is not convenience: **no vendored file may be edited**, so a
+header sweep over third-party material was never available. `REUSE.toml` is the
+mechanism that makes the declaration complete without touching one.
+
+Both halves are gated in CI: `reuse lint` must report the project compliant,
+and a second check fails the build if the set of licenses declared in
+`REUSE.toml`, the texts present in `LICENSES/`, and the licenses named on this
+page ever stop agreeing. This page cannot drift away from the declarations
+silently.
 
 The CC-BY-SA specification text and clinical models are redistributed
 **verbatim, with attribution** — they are reference and test material, not

--- a/website/book/src/operations.md
+++ b/website/book/src/operations.md
@@ -252,6 +252,29 @@ why they are written as your checklist rather than as our claim.
   API. The default 30-second termination grace period covers the server's
   short shutdown drain of the audit and event outboxes.
 
+### How long the version you pinned is supported
+
+Plan the upgrade cadence around this, because it is short and it is deliberate:
+
+- **Only the most recent release receives security fixes.** There are no
+  maintenance branches, no long-term-support line, and no backports. A version
+  stops receiving fixes the moment a newer release exists.
+- **A fix normally arrives as the next patch** on the current minor, so taking
+  it does not oblige you to take new behaviour — but that is the usual case,
+  not a promise. Where a fix is only correct alongside a behavioural change,
+  the release carrying it carries the change, and the changelog entry says so.
+- **A published release is never repaired in place.** Release immutability
+  means the assets and the tag of a published release cannot be modified at
+  all, so the remedy for any defect is a new version.
+- **The Helm chart and the published crates follow their own version lines**,
+  each supported at its newest published version only. A chart-only fix ships
+  as a new chart version between server releases.
+
+The consequence for change control: budget for taking every release, or budget
+for maintaining a fork. There is no third option, and the full policy — with
+the reasoning and what to do if you need something stronger — is
+[SECURITY.md](https://github.com/rubentalstra/FerroEHR/blob/develop/SECURITY.md#supported-versions).
+
 ## Observability
 
 `tracing` is the single instrumentation API. From it, three signal families

--- a/website/book/src/security.md
+++ b/website/book/src/security.md
@@ -8,6 +8,12 @@ security surfaces you configure when you deploy FerroEHR: **authentication**
 (recording what happened). Each is independently configurable, and each is
 described here in terms of the environment variables you actually set.
 
+This chapter tells you **how to configure each control**. The
+[Threat model](threat-model.md) is its companion and tells you **what remains
+true after each control has done its job** — the trust boundaries, the residual
+risk at each, and what this software explicitly does not defend against. Read
+that one before you decide a control is sufficient for your deployment.
+
 <!-- toc -->
 
 Configuration follows the same pattern throughout: the server reads defaults,
@@ -455,21 +461,28 @@ Two properties worth knowing because they are not obvious:
 
 ## Verifying what you pulled
 
-Artifacts published from `3.17.4` onward carry **signed** build provenance and an
-SBOM, so you can establish that a binary or image came from this repository's
-build and see what went into it. Provenance was already being generated before —
+Release artifacts carry **signed** build provenance, SBOMs and a checksum, so
+you can establish that a binary or image came from this repository's build and
+see what went into it. Provenance was already being generated before —
 BuildKit's SLSA statement on each image index — but unsigned, which means readable
-and not verifiable. It is signed through Sigstore from this release on.
+and not verifiable. It is signed through Sigstore.
 
 > [!IMPORTANT]
-> Signing landed in the publishing lanes during the `3.17.4` cycle, so **`3.17.3`
-> and every earlier tag carry no attestation**: the commands below answer
-> `HTTP 404: Not Found` for them. That is the honest state, not a verification
-> failure — there is nothing to verify, because those artifacts were built before
-> the lane signed anything. The development images
-> (`ghcr.io/rubentalstra/ferroehr:develop` and its two siblings) are signed and
-> verify now; the release-tag, release-binary and chart forms below start
-> answering at the `3.17.4` cut.
+> **No published release carries these assets yet.** The signing lane landed
+> after the `v3.17.3` cut (2026-08-05), which is the newest release at the time
+> of writing, so `v3.17.3` and every earlier tag have exactly two assets each
+> and the release-binary commands below answer `HTTP 404: Not Found` for them.
+> That is the honest state, not a verification failure — there is nothing to
+> verify, because those artifacts were built before the lane signed anything.
+> The development images (`ghcr.io/rubentalstra/ferroehr:develop` and its two
+> siblings) **are** signed and verify today; the release-binary and chart forms
+> below begin answering at the next cut, at which point this note is removed and
+> the commands are re-run against the real assets rather than assumed correct.
+>
+> Every command below writes `<tag>` where a release tag goes. Substitute the
+> tag you actually downloaded — the examples deliberately name no specific
+> version, so that this page cannot drift into quoting a release that does not
+> exist.
 
 **An image** — signed and verifying today on the development tag:
 
@@ -499,7 +512,7 @@ PGP `.prov`, so `helm install --verify` does not apply — deliberately, since a
 **A release binary:**
 
 ```bash
-gh attestation verify ferroehr-v3.17.4-x86_64-unknown-linux-gnu.tar.gz   -R rubentalstra/FerroEHR
+gh attestation verify ferroehr-<tag>-x86_64-unknown-linux-gnu.tar.gz -R rubentalstra/FerroEHR
 ```
 
 **A release binary, without reaching GitHub.** Each release also carries its
@@ -508,8 +521,8 @@ the bundle — useful on an air-gapped host, and the only form in which the
 signature travels with the download:
 
 ```bash
-gh attestation verify ferroehr-v3.17.4-x86_64-unknown-linux-gnu.tar.gz \
-  --bundle ferroehr-v3.17.4-x86_64-unknown-linux-gnu.tar.gz.sigstore.json \
+gh attestation verify ferroehr-<tag>-x86_64-unknown-linux-gnu.tar.gz \
+  --bundle ferroehr-<tag>-x86_64-unknown-linux-gnu.tar.gz.sigstore.json \
   --repo rubentalstra/FerroEHR
 ```
 
@@ -517,14 +530,35 @@ The `*.sbom.sigstore.json` asset beside it is the same thing for the SBOM
 attestation, so "which dependency graph was this binary built from" is
 verifiable offline too.
 
-Each release also attaches a **CycloneDX SBOM of the Rust dependency graph**
-(`*.cdx.json`), which is a different document from the SPDX SBOM on the image
-index and answers a different question. The image SBOM sees the OS layer — which
-is what matters for `ferroehr-postgres`, built on the upstream `postgres` image.
-The CycloneDX one enumerates the cargo graph: every component with a
-`pkg:cargo/…` purl and licence, most with checksums, and the **dependency edges**,
-so "is this crate a direct dependency or something four levels down" is a question
-the document can answer rather than a flat list you have to guess from.
+**With neither `gh` nor `cosign` installed.** Every release tarball ships a
+plain `.sha256sum` beside it, which is the only verification available in a
+locked-down environment — and a locked-down environment is what a clinical
+deployment tends to be:
+
+```bash
+sha256sum -c ferroehr-<tag>-x86_64-unknown-linux-gnu.tar.gz.sha256sum
+```
+
+Be clear about what that buys: a checksum detects a **corrupt or truncated
+download**, not a substituted release, because an attacker who can replace the
+tarball can replace the checksum beside it. Only the Sigstore bundle answers
+"who built this". The checksum is a floor, not a substitute.
+
+### Three SBOMs, three questions
+
+A release involves three SBOM documents. They are not redundant — they describe
+different things for different readers, and both reviews genuinely happen for a
+clinical deployment:
+
+| Document | Where | Format | Answers |
+|---|---|---|---|
+| `ferroehr-<tag>-<target>.cdx.json` | a release asset, one per architecture | CycloneDX 1.5 | *what is inside the binary I am about to run?* Every cargo component with a `pkg:cargo/…` purl and licence, most with checksums, and the **dependency edges** — so "is this crate direct or four levels down" is answerable rather than guessed. This is what a vulnerability scanner consumes. |
+| `ferroehr-<tag>.spdx.json` | a release asset, one per release | SPDX | *what am I redistributing, and under what terms?* The attribution and licence-obligation view of the source tree at the release commit — the document a legal or procurement reviewer of a four-licence redistribution asks for. |
+| the image SBOM | attached to each container image index | SPDX | *what is in the image's OS layer?* Which is what matters for `ferroehr-postgres`, built on the upstream `postgres` image. |
+
+CycloneDX 1.5 is the highest version the generator emits (`cargo-cyclonedx`
+accepts 1.3, 1.4 or 1.5 and defaults to 1.3, so the release lane sets it
+explicitly); it carries everything 1.6 consumers read.
 
 ### What SLSA level each artifact reaches, and what is still not claimed
 
@@ -548,7 +582,7 @@ has no steps at all, which is what makes the property hard to lose by accident.
 The consumer-visible benefit is that you can **require** that signer:
 
 ```bash
-gh attestation verify ferroehr-v3.17.4-x86_64-unknown-linux-gnu.tar.gz \
+gh attestation verify ferroehr-<tag>-x86_64-unknown-linux-gnu.tar.gz \
   -R rubentalstra/FerroEHR \
   --signer-workflow rubentalstra/FerroEHR/.github/workflows/release-build.yml
 ```
@@ -561,11 +595,35 @@ than ours, and nothing here asserts a reproducible or hermetic build — those a
 separate SLSA tracks this project does not address. Naming the boundary is worth
 more than rounding a level up.
 
-Where a scanner reports a finding in an inherited upstream layer that we have
-argued is not reachable, the argument is published as an
-[OpenVEX](https://openvex.dev) document under `security/vex/` — with the
-justification and an impact statement you can check, rather than an ignore entry
-that records only the verdict.
+### Findings a scanner will report, and why they are not what they look like
+
+Run a scanner over a FerroEHR artifact and it will report findings. Every one
+this project has assessed and accepted is published as an
+[OpenVEX](https://openvex.dev) document under
+[`security/vex/`](https://github.com/rubentalstra/FerroEHR/tree/develop/security/vex),
+carrying a controlled-vocabulary justification and an impact statement you can
+check — rather than an ignore entry that records only the verdict. Point your
+tooling at them (`trivy --vex`, and most SCA platforms take an OpenVEX feed).
+
+| Document | Covers |
+|---|---|
+| `rust-advisories.openvex.json` | the Rust dependency advisories: the five the advisory gate accepts, plus one that only a `Cargo.lock`-reading scanner reports |
+| `postgres-gosu.openvex.json` | Go standard-library findings in the `gosu` helper the upstream `postgres` image ships |
+
+The Rust document is **generated** from `deny.toml` — the gate that actually
+decides whether a build passes — joined with the published reasoning, and a CI
+job fails if the two disagree in either direction. So an advisory cannot be
+accepted without a justification reaching you, and a justification cannot claim
+something the gate does not do.
+
+One asymmetry worth knowing, because it produces findings that are real reports
+of nothing. `Cargo.lock` records the union of every dependency any feature
+combination *could* pull, so a scanner reading the lock file alone reports
+crates this project's feature set never compiles. `cargo deny` resolves
+features and does not. Where the two disagree in that direction the
+feature-resolving tool is the more precise instrument — and the VEX document
+carries that argument for the specific crate it currently applies to, so you do
+not have to take our word for it in prose.
 
 ## Multi-tenancy
 

--- a/website/book/src/threat-model.md
+++ b/website/book/src/threat-model.md
@@ -1,0 +1,360 @@
+# Threat model
+
+This chapter says what FerroEHR defends against, how, and — more usefully —
+**what remains true after the control has done its job**. It exists because the
+parts of this system that actually protect patient data are the parts no
+external specification governs: openEHR's REST specification makes
+authentication a `SHOULD` and mandates no scheme, and the Service Model places
+authorization out of band, so only the 401-versus-403 split is
+specification-grounded. Everything finer is this project's own design, and a
+design nobody has written down asks every deployer to reconstruct it privately.
+
+<!-- toc -->
+
+## What this is, and what it is not
+
+This is an **attack-surface and trust-boundary analysis with named residual
+risk**. Boundaries are enumerated, the control at each is stated, and the risk
+that survives the control is stated beside it.
+
+It is **not** a certification, an audit report, or an assurance case in the
+formal sense, and it does not make FerroEHR compliant with anything. It is also
+not a substitute for your own analysis: your deployment introduces boundaries
+this document cannot see — your identity provider's token policy, your
+network, your operators, your backups. The value here is that you do not have
+to reverse-engineer *our* half of it from configuration prose.
+
+Read it alongside [Security & multi-tenancy](security.md) (how each control is
+configured), [Audit trail](audit.md) (what is recorded), [Operations](operations.md)
+(the deployment surface) and [Cluster hardening](installation/kubernetes-hardening.md)
+(what the platform owes).
+
+**Where this document and the code disagree, the code is right and this
+document is a defect** — report it.
+
+## Assets
+
+What an attacker wants, in the order the loss hurts:
+
+| Asset | Where it lives | Why it matters |
+|---|---|---|
+| **Clinical payload** — compositions, EHR status, folders, demographics | the `node` and `vo_version` tables, and the cold-archive mirrors | this is PHI; disclosure is the primary harm and it is not undoable |
+| **The audit trail** | the `audit` schema, plus any configured forwarding sink | it is the evidence that everything else happened; an attacker who can edit it can make an access disappear |
+| **Version history and its integrity** | `vo_version`, `contribution`, attestations | an openEHR record's value is that it is *append-only and attributable*; a silently rewritten prior version is worse than a deleted one |
+| **Signing keys** | the configured signing key material for commit attestation | forging an attestation forges provenance of clinical content |
+| **Bearer credentials and password hashes** | tokens in flight; Argon2id PHC hashes at rest | a stolen token is an authenticated clinical caller until it expires |
+| **Tenant separation** | the `ferroehr.tenant_id` session setting and the row-level-security policies | in a multi-tenant deployment, one tenant reading another is a breach of two organisations at once |
+| **Availability** | the whole stack | a CDR that is down is a clinical system that is down; denial of service is a patient-safety issue here, not an inconvenience |
+
+## Actors
+
+| Actor | Reaches | Assumed capability |
+|---|---|---|
+| **Unauthenticated caller** | the listening port | can send arbitrary bytes, replay anything observed, and probe every route |
+| **Authenticated clinical caller** | the openEHR API within their grants | holds a valid token; may be a legitimate user acting outside their remit, or a compromised client |
+| **Admin / management caller** | the admin, management and messaging surfaces | can delete physically, archive, dump and load; the most dangerous *authorized* actor |
+| **Tenant peer** | their own tenant's API | a legitimate tenant of a shared deployment, trying to reach another's rows |
+| **Database** | everything stored | trusted for confidentiality, but assumed to be a place where a mistake is permanent |
+| **Terminology server (FHIR R4B)** | called out to at validation and commit time | operator-configured; semi-trusted — it answers our questions and can lie |
+| **Object store (S3)** | called out to for multimedia | operator-configured; semi-trusted, and its responses are parsed |
+| **Message broker (AMQP)** | receives change events | operator-configured; a sink for data, so a confidentiality boundary |
+| **Identity provider** | issues the tokens everything else believes | fully trusted by construction; if it is compromised, no control below it holds |
+| **Cluster / host operator** | the process, its memory, its filesystem, its secrets | fully trusted; outside the software's reach |
+
+## Trust boundaries
+
+```mermaid
+flowchart LR
+  subgraph Untrusted
+    U[Unauthenticated caller]
+    C[Clinical client]
+    A[Admin client]
+  end
+  subgraph Deployment["Deployment boundary (operator-controlled)"]
+    subgraph Server["FerroEHR process"]
+      B1["B1 network + protocol"]
+      B2["B2 authentication"]
+      B3["B3 authorization<br/>EHR_ACCESS - RBAC - ABAC - SMART"]
+      B4["B4 content validation"]
+      B5["B5 tenant scoping"]
+    end
+    DB[("B6 PostgreSQL")]
+    AUD[("B7 audit store")]
+  end
+  subgraph External["Semi-trusted peers"]
+    IDP[Identity provider]
+    TS[Terminology server]
+    S3[Object store]
+    MQ[Message broker]
+  end
+  U --> B1
+  C --> B1
+  A --> B1
+  B1 --> B2
+  B2 --> B3
+  B3 --> B4
+  B4 --> B5
+  B5 --> DB
+  B5 --> AUD
+  B2 -.verifies tokens from.-> IDP
+  B4 -.asks.-> TS
+  B4 -.stores blobs.-> S3
+  B5 -.publishes.-> MQ
+```
+
+Each boundary below names the control that holds and the risk that remains.
+
+### B1 — Network and protocol
+
+**Control.** TLS terminates either at the server (`rustls`) or in front of it.
+Request bodies are size-limited, requests are timed out, and a `tower_governor`
+rate limit is available. Panics are caught and become a clean `500` rather than
+a dropped connection, and release builds run with overflow checks on so an
+arithmetic mistake is a loud panic rather than a silently wrong number. Response
+security headers are set. Every parser that reads attacker-controlled bytes —
+canonical JSON, canonical XML, AQL, ADL — has a libFuzzer harness compiled on
+the pull-request path, and a crash is fixed in the crate, never in the harness.
+
+**Residual risk.**
+
+- **Fuzzing finds crashes; it does not prove their absence.** The harnesses
+  cover the parsers we identified as reachable. A parser reached by a path we
+  did not enumerate is not covered by anything.
+- **Rate limiting is off unless you turn it on**, and it is per-process. A
+  multi-replica deployment behind a load balancer divides the effective limit by
+  the replica count; it is not a distributed limiter.
+- **Algorithmic complexity in query execution is not bounded by the limiter.**
+  A syntactically small AQL query can be an expensive one. Statement timeouts at
+  the database are the backstop, and they are the operator's to set.
+- **TLS termination in front of the server is the operator's**; nothing in the
+  software can tell whether the hop behind the proxy is encrypted.
+
+### B2 — Authentication
+
+**Control.** Two mechanisms: HTTP Basic against Argon2id PHC hashes with a
+verified-credential cache, and OAuth2/OIDC bearer tokens validated against the
+issuer. Configuration is validated **at boot**, not on the first request: a
+mandatory audience list, an `https` issuer, an algorithm set bound to its key
+source, an HMAC entropy floor, and the OWASP Argon2id parameter floor. A
+malformed `Authorization` header is a `400`, not a `401` — the server never read
+a credential. An unreachable issuer is a `503`, never a silent pass.
+
+**Residual risk.**
+
+- **A valid token is a valid caller.** FerroEHR verifies signature, audience,
+  issuer and expiry; it does not and cannot know whether the human behind the
+  token is who the token says. Token theft is defended against by your identity
+  provider's lifetimes and binding, not by us.
+- **There is no token binding, no proof-of-possession and no replay window.** A
+  bearer token replayed from another network location is accepted.
+- **The identity provider is unconditionally trusted.** A compromised issuer,
+  or an attacker who can mint tokens with the right audience, defeats every
+  authorization stage below — all of which read their inputs from claims.
+- **Basic authentication has no session, no lockout and no second factor.** It
+  is intended for machine callers and small deployments; the Argon2id cost is
+  the only brake on offline cracking if a hash leaks.
+
+### B3 — Authorization
+
+**Control.** Five stages, each of which can only *narrow* what the previous one
+allowed — which is what makes an optional stage safe to leave off:
+
+1. **Authentication** produces a principal or a typed refusal.
+2. **`EHR_ACCESS`** is always on and unconditional, from the openEHR Reference
+   Model's own gateway clause.
+3. **RBAC** checks the coarse operation class (public / clinical / admin /
+   management) against roles taken from the RFC 9068 claim carriers. An OAuth2
+   scope is deliberately not treated as a role. The read-only restriction
+   overrides any grant.
+4. **ABAC** (off by default) evaluates subject and resource attributes through
+   embedded Cedar or an external policy decision point, fanning multi-valued
+   attributes out as a cartesian product with all-must-permit and short-circuit
+   deny.
+5. **SMART scopes** (off by default) are AND-composed onto the ABAC decision.
+
+Deny-by-default throughout, and **fail-closed in both senses**: no stage permits
+by omission (an unconfigured resource kind on the external PDP denies, and the
+missing rule is a boot error), and a stage that cannot *decide* is never read as
+a decision — an unreachable issuer is `503`, a policy server answering `5xx` or a
+Cedar policy that errors during evaluation is a fail-closed `500`. Silence is
+never consent, and a broken control never looks like a policy outcome.
+
+**Residual risk.**
+
+- **Coarse by default.** With ABAC off — the default — authorization is
+  role-level and `EHR_ACCESS`-level. Any authenticated clinical caller can reach
+  any EHR that `EHR_ACCESS` does not restrict. If your model is "a clinician may
+  read only their own patients", that is ABAC, and you must turn it on and write
+  the policy.
+- **Policy is only as good as the attributes.** Every decision is made from
+  claims the identity provider asserted. A wrong `organization` claim produces a
+  correct decision on a false premise.
+- **The external PDP is a network dependency in the request path.** Fail-closed
+  means an outage is an outage: correct, and an availability risk you should
+  size.
+- **Authorization is enforced at the API.** Anything with a direct database
+  connection is past it entirely; see B6.
+- **A legitimate caller acting outside their remit is not prevented, only
+  recorded.** That is what the audit trail is for, and detection is not
+  prevention.
+
+### B4 — Content validation and outbound calls
+
+**Control.** Committed content is validated against the operational template
+(the WebTemplate walker), the Reference Model's own invariants — machine-derived
+from the specification's meta-model rather than hand-written — and terminology
+bindings. Canonical JSON is read by a **strict** reader that refuses undeclared
+and duplicate keys. Outbound terminology, object-store and broker calls go only
+to operator-configured endpoints.
+
+**Residual risk.**
+
+- **The terminology server is trusted to answer honestly.** A compromised or
+  misconfigured one can permit a code that should have been refused. It is a
+  correctness boundary, and a clinical-safety one.
+- **A response parsed from a semi-trusted peer is still parsed.** The S3 path
+  carries a `quick-xml` version with two denial-of-service advisories that no
+  reachable release fixes; the exposure is limited to responses from the
+  endpoint the operator configured, which is exactly the argument published as
+  a machine-readable [VEX document](https://github.com/rubentalstra/FerroEHR/tree/develop/security/vex)
+  rather than left in a comment.
+- **Multimedia blobs are stored, not inspected.** FerroEHR is not an antivirus
+  and does not pretend to be; a malicious blob is delivered faithfully to
+  whatever opens it.
+- **Validation does not make content true.** A well-formed composition asserting
+  a clinically wrong fact is stored, correctly.
+
+### B5 — Tenant scoping
+
+**Control.** Off by default; when off the server is byte-for-byte
+single-tenant. When on, the tenant is resolved from a configured JWT claim and
+applied as a PostgreSQL session setting that drives **`FORCE ROW LEVEL
+SECURITY`** policies on every tenant-scoped table, including the cold-archive
+mirrors. Isolation is fail-safe: an absent or unresolvable tenant runs against a
+reserved default rather than guessing, and a cross-tenant access is an empty
+result set rather than a `403` that would leak the existence of another tenant's
+data.
+
+**Residual risk.**
+
+- **`FERROEHR__TENANCY__HEADER` is a tenant selector a client controls.** It is
+  a development affordance and there is no way to make it safe in production.
+  If it is set, tenancy is not a boundary. Leave it unset.
+- **A missing claim degrades quietly to the default tenant.** That is the
+  fail-safe choice, and its cost is that a misconfigured claim path looks like
+  "tenancy is doing nothing" rather than failing loudly.
+- **Row-level security binds a connection, not a request.** The scoping is
+  applied per connection from a shared pool; a defect in that plumbing is a
+  cross-tenant read, which is why it is enforced by the database rather than by
+  application `WHERE` clauses — the database refuses even if the query forgets.
+- **Tenancy separates rows, not resources.** One tenant's expensive query
+  competes with another's for the same CPU, connections and disk. It is not a
+  noisy-neighbour control.
+
+### B6 — The database
+
+**Control.** The application connects with a least-privilege role; migrations
+are applied by a separate, more privileged one. `FORCE ROW LEVEL SECURITY`
+means even a table owner is subject to the policies. Version history is
+temporal (`PRIMARY KEY … WITHOUT OVERLAPS`) rather than overwritten, so a prior
+version is a row that exists, not one that was replaced. Every write emits a
+contribution and an audit record in the same transaction.
+
+**Residual risk.**
+
+- **Anyone with a database connection is past every control in B1–B5.** That is
+  the single largest residual risk in this system, and it is inherent: FerroEHR
+  enforces authorization at the API. Protect the credentials and the network
+  path accordingly.
+- **Encryption at rest is the operator's.** FerroEHR does not encrypt clinical
+  payload before it reaches PostgreSQL; the payload is queryable JSONB, which is
+  what makes AQL possible and is incompatible with application-level encryption
+  of the same fields.
+- **A superuser can rewrite history.** The temporal design makes accidental
+  overwrite structurally hard; it does not defend against someone with `UPDATE`
+  on the tables. The audit chain (B7) is the detection layer.
+- **Backups carry PHI with none of these controls.** A restored dump is a
+  complete copy of everything.
+
+### B7 — The audit trail
+
+**Control.** Every access is recorded in both official renderings (DICOM PS3.15
+and FHIR `AuditEvent`/BALP) into a local Audit Record Repository, on by default,
+with optional syslog and ATX:FHIR-Feed forwarding. Records are **hash-chained**,
+so `SELECT * FROM audit.verify_audit_chain()` names any record that was altered
+or removed. ITI-81 is the retrieval side; ITI-19 mutual TLS is available for
+node authentication.
+
+**Residual risk.**
+
+- **Tamper *evidence*, not tamper *proof*.** The chain proves alteration
+  happened; it does not prevent it. An attacker with write access to the audit
+  schema can rewrite the chain from the point of compromise forward — which is
+  precisely why forwarding to an off-box sink matters, and why the sink should
+  not be writable by the same identity.
+- **A local repository shares the blast radius of the thing it audits.** If the
+  database is lost, so is the local audit trail.
+- **The trail records what the server saw.** A read performed directly against
+  the database appears nowhere in it.
+- **Audit records are themselves sensitive.** They name patients, subjects and
+  actions; ITI-81 retrieval is a PHI-disclosure surface and is authorized like
+  any other.
+
+### B8 — The supply chain
+
+**Control.** Releases are built by a reusable workflow that satisfies SLSA v1.0
+Build L3, signed through Sigstore with a signer identity a consumer can pin,
+carrying a CycloneDX dependency SBOM, a SPDX repository SBOM, in-toto
+provenance and a plain `sha256sum`. Container base images are digest-pinned and
+scanned weekly. Every action is pinned to a commit SHA, workflows are audited by
+`zizmor` on every pull request, and accepted advisories carry published VEX
+justifications. Commits and tags are signed and the tags are protected by a
+ruleset.
+
+**Residual risk.**
+
+- **Provenance proves *where* an artifact was built, not that the source was
+  good.** Build L3 says these bytes came from this workflow at this commit. It
+  says nothing about what that commit contained.
+- **The build is not hermetic and not reproducible.** Those are separate SLSA
+  tracks this project does not address. A dependency resolved at build time is
+  trusted to be what the lock file names.
+- **Review capacity is one person.** No second human is structurally required
+  between an idea and a released binary; the mitigation is machine enforcement
+  and it is honestly recorded in
+  [GOVERNANCE.md](https://github.com/rubentalstra/FerroEHR/blob/develop/GOVERNANCE.md).
+- **Only the newest release receives fixes.** There is no maintenance branch to
+  backport to; see [SECURITY.md](https://github.com/rubentalstra/FerroEHR/blob/develop/SECURITY.md).
+
+## What is explicitly NOT defended against
+
+Silence is never coverage, so these are stated rather than left to inference.
+
+- **A compromised identity provider.** Everything downstream reads claims it
+  asserted.
+- **A compromised host, container runtime, or cluster operator.** Process memory
+  holds decrypted PHI and key material by necessity.
+- **Anyone with direct database credentials.**
+- **A malicious maintainer, or a compromise of the maintainer's account or
+  signing key.** The bus factor is one; see
+  [MAINTAINERS.md](https://github.com/rubentalstra/FerroEHR/blob/develop/MAINTAINERS.md).
+- **Physical access, side channels, and speculative-execution attacks.**
+- **Traffic analysis.** Request sizes, timings and error-code patterns can leak
+  the existence of records; nothing pads or delays.
+- **A legitimate user's authorized misuse**, beyond recording it.
+- **Denial of service by a resource-holding authorized caller** — an expensive
+  query, a large commit, a slow client. Rate limiting is coarse and off by
+  default; database and container limits are the operator's.
+- **Data remanence.** Physical deletion removes rows; it does not scrub
+  filesystem blocks, WAL segments, replicas or backups.
+- **Clinical correctness.** FerroEHR validates structure, invariants and
+  terminology bindings. It does not know whether a recorded fact is true, and
+  no control here is a substitute for clinical governance.
+
+## Reporting a finding
+
+If you believe a control is weaker than stated here, or a residual risk is
+missing, that is a valid security report — including when the defect is in this
+document rather than in the code. Follow
+[SECURITY.md](https://github.com/rubentalstra/FerroEHR/blob/develop/SECURITY.md):
+report privately, never as a public issue.


### PR DESCRIPTION
Closes #2305
Closes #2306
Closes #2307
Closes #2308
Closes #2313

Eleven sub-issues of #2302. Five close here. Four are partially delivered and say
so below; two need a repository setting only the owner can flip, with the exact
steps posted on their issues. Nothing is claimed that was not observed.

## What closes

### #2305 — threat model

A new `website/book/src/threat-model.md` chapter, linked from the security
chapter and the README. It names the actors, the assets in the order the loss
hurts, and eight trust boundaries; for each boundary it states the control **and
the residual risk that survives it**, which is the part the existing
configuration prose could not give a reader. It ends with an explicit
not-defended-against list, so silence is never read as coverage, and with the
rule that where the document and the code disagree the code is right and the
document is a defect.

Grounded first-hand rather than from the issue text: the five-stage evaluation
order and its fail-closed semantics from `docs/architecture.md`; tenant isolation
read from `app/ferroehr/migrations/ehr/0004_multitenancy.sql` (`FORCE ROW LEVEL
SECURITY` driven by the `ferroehr.tenant_id` session setting) and
`app/ferroehr/src/extensions/tenancy.rs`; the audit chain from the audit chapter;
the supply-chain boundary from the release lanes in this same PR.

### #2306 — support window and end-of-life

`SECURITY.md` § Supported versions replaced. Only the newest release is
supported; there are no maintenance branches and no backports; a version stops
receiving fixes the moment a newer release exists; a fix normally arrives as the
next patch but that is not promised. Covers the server, the Helm chart and the
crates on their separate version lines, and closes with what to do if that is not
enough. The same policy is repeated in the Operations chapter's upgrade guidance,
where an operator planning change control actually looks.

### #2307 — VEX for the accepted advisories

`security/vex/rust-advisories.openvex.json`, **generated** by
`scripts/security/vex-generate.sh` from `deny.toml` (the id set — the gate that
actually decides whether a build passes) joined with
`security/vex/rust-advisories.toml` (the prose). The generator refuses to emit
anything if the two disagree in either direction, and `vex-advisories.sh` — the
new `vex` CI job — regenerates and diffs, so a hand edit fails too.

Justifications match the real arguments and come from the OpenVEX vocabulary:
`vulnerable_code_cannot_be_controlled_by_adversary` for `rsa` (verification-only,
no private keys held) and the two `quick-xml` advisories (parses
operator-configured S3 responses, never client input);
`vulnerable_code_not_present` for the two proc-macro advisories, which link into
nothing shipped. It also carries `RUSTSEC-2026-0235` (`rkyv`,
`component_not_present`), which `cargo-deny` never raises and a
`Cargo.lock`-reading scanner does — the class of finding that reaches a consumer
with no explanation anywhere in the repository, and the reason publishing this is
worth anything.

Mutation-proven, five ways, each failing and the restored tree passing: an
accepted advisory with no prose entry; a prose entry the gate no longer ignores;
one hand-edited byte in the JSON; a lock-file-only entry added to the gate; an
out-of-vocabulary justification.

### #2308 — Dependabot coverage

A second `cargo` entry at `/fuzz` (separate workspace, separate lock file, which
a `/` entry cannot reach) and a `docker` entry over the three Dockerfile
directories. Verified against the current options reference: separate entries per
ecosystem are supported while directories do not overlap; `directories` (plural)
takes a list where `directory` does not; and `cooldown` applies to version
updates only, never to security updates — which is what makes the windows safe.

### #2313 — drifted claims

`clippy.toml`, `.claude/rules/reliability.md` and `deny.toml` all justified a
decision with "every crate is `publish = false`". False since the eight
`openehr-*` crates started publishing. The lint decision is unchanged because the
real reason is better: they publish on `0.0.x`, where cargo treats every patch as
its own compatibility set, so no consumer range spans a break. The `deny.toml`
variant was doubly wrong — cargo refuses to package a path dependency without a
version, which is why the published crates carry explicit lockstep versions and
do not rely on `allow-wildcard-paths` at all.

The security chapter's verification examples named `v3.17.4`, which does not
exist. They now write `<tag>`, and the in-page caveat states the real position:
no published release carries these assets yet, the newest is `v3.17.3` from
2026-08-05, and the commands are to be re-run against real assets at the next
cut.

## What is partially delivered

### #2303 — signed releases (the lane still has to run)

Implemented now:

- **`.sha256sum` per tarball.** The only verification available with neither `gh`
  nor `cosign` installed. Documented as detecting a corrupt download and **not** a
  substituted release. Checked against Scorecard's actual probe source before
  claiming anything: `probes/releasesAreSigned` matches `.asc`, `.minisig`,
  `.sig`, `.sign`, `.sto`, `.sigstore.json` and `probes/releasesHaveProvenance`
  matches `.intoto.jsonl` — no checksum suffix, so the checksum earns no score and
  is not sold as if it did. The existing `.sigstore.json` and `.intoto.jsonl`
  assets are what will move `Signed-Releases`.
- **The `finalize-release` guard, read carefully as asked — and it had a real
  defect.** The names do agree, but the comparison was `grep -q` on a
  **substring**, so the check for `.tar.gz` was satisfied by
  `.tar.gz.sigstore.json` alone: a draft missing its actual tarball would have
  been published, unfixably. Now `grep -Fxq`, whole-line, plus the checksum, the
  repository SBOM and the compose files.

Not closable here: the lane has never executed, and only a real cut can satisfy
"confirmed to have run and passed", "verified against a release that exists" and
"a subsequent Scorecard run reports non-zero". Those three acceptance boxes, and
#2313's task to re-run each documented command against real assets, belong to the
next release cut.

### #2311 — REUSE

`LICENSES/` (six texts, SPDX-named) and a root `REUSE.toml`. `reuse lint` reports
the project **compliant with version 3.3** — 13551/13551 files with copyright and
licence information — and it gates the merge via the official image, digest-pinned
like the actionlint one. **No vendored file was modified**, which is why the glob
form was the only available mechanism.

Both recorded positions are represented rather than flattened: the three
tri-licensed ISO 13606 BMM models are declared `MPL-1.1` per the existing
election, and `PropertyUnitData.xsd` — an AGPL header inside a CC-BY-SA-3.0
repository — is declared at the more restrictive of the two readings, the one the
file's own text asserts.

A second gate, `licensing-declarations.sh`, fails the build when `REUSE.toml`,
`LICENSES/` and the licensing chapter stop agreeing about which licences apply
(three mutations proven). The copyleft gate needed one adjustment and got it
without weakening: `LICENSES/**` joins the PROSE list beside the root licence
texts it is the same category as, and a licence text belonging to no file now
fails the new gate instead — re-proven that a GPL grant dropped into
`app/ferroehr/src` still fails.

**Left open:** SPDX headers in first-party source. Sub-issue #2318 carries it,
because it is a ~2500-file mechanical change that must go through the
`openehr-codegen` emitter for the 1471 generated files, forces a full
regeneration and a lockstep bump of all eight published crates, and does not
belong in a pull request that also lands governance documents and release-lane
changes. Note that for the case the issue actually motivates — an archetype
lifted out of a corpus — headers were never available: vendored files may not be
edited, which is exactly why `REUSE.toml` is the answer there.

### #2312 — SBOM to a consumer

A release now carries `ferroehr-<tag>.spdx.json`, generated by syft (pinned
1.50.0) from the checked-out release commit, attached to the draft and required by
the completeness guard. The security chapter gains a table saying which of the
three SBOMs answers which question, so a reader picks one instead of assuming they
are redundant. The CycloneDX version is recorded with its reason: 1.5 is the
**highest** `cargo-cyclonedx` emits (it accepts 1.3/1.4/1.5 and defaults to 1.3),
so the flag is load-bearing and 1.6 is simply not reachable from this generator.

**The issue's premise is wrong and the tree is the authority.** It says "the SPDX
attribution report the licence-scanning lane already generates is uploaded as a
workflow artifact". No such report exists: `generate-report` was deliberately
removed from `fossa.yml` (measured 2026-08-12) because it needs a read-scoped
token this repository does not issue, and the reasoning is in that file. So there
was no SPDX SBOM anywhere, not one stuck in a workflow artifact — hence a
generator rather than a re-upload. The remaining criterion needs a cut, like
#2303.

### #2304 — governance

`GOVERNANCE.md`, `MAINTAINERS.md`, `SUPPORT.md`, `.github/CODEOWNERS`, and a
README section. They state the single-maintainer reality plainly: bus factor one,
no organisation, no legal entity, and a publishing-identity table whose recovery
column reads "none" for most rows because that is true. `GOVERNANCE.md` says
outright that the maintainer's own changes get no independent human review and
that machine enforcement stands in for it, rather than describing a review process
that does not happen.

**Left open — needs the owner:** the two ruleset criteria. The `PUT` on the
`develop` ruleset was refused by this session's permission layer. The exact call
is on the issue.

## What needs the owner

- **#2309 — done in part, verification outstanding.** The `release-tags` ruleset
  (id `20755150`) was **created and is active**: `refs/tags/v*`, blocking deletion
  and non-fast-forward updates and requiring signatures. The criterion "verified by
  attempting a disallowed tag operation" is **not** met — the only safe probe
  needed a ruleset edit that was refused, and no destructive probe was run against
  a real release tag. Steps on the issue.
- **#2310 — blocked on a UI toggle.** `secret_scanning_non_provider_patterns` and
  `secret_scanning_validity_checks` are still `disabled`. `PATCH
  /repos/{owner}/{repo}` **accepts and silently ignores** both, together and
  individually, returning `200` with the values unchanged — verified three times.
  They have to be switched on in Settings. `SECURITY.md` now carries the full
  expected repository security posture as a table with the read-back commands, and
  marks these two as not-yet-true rather than describing them as if they were.

## Verification

Run on this branch, results as observed:

- `cargo fmt --all` — clean; zero `.rs` files changed by this PR.
- `cargo clippy --workspace --exclude ferroehr-admin-ui --all-targets --all-features -- -D warnings` — exit 0.
- `bash scripts/checks/ci-conclusion-complete.sh` — `ok: all 39 CI jobs gate the merge` (the two new jobs, `vex` and `licensing`, are in `conclusion.needs`).
- `bash scripts/checks/no-python.sh` — clean. `reuse` reaches CI as the official container, never a Python install.
- `SHELLCHECK_OPTS='-e SC2016' actionlint` — no output.
- `zizmor --min-severity=low .github/workflows/` — `No findings to report`.
- `reuse lint` — `compliant with version 3.3`, 13551/13551.
- `vex-advisories.sh`, `licensing-declarations.sh`, `first-party-license-text.sh`, `docs-claims.sh --all`, `comment-style.sh --all` (2462 files), `changelog-structure.sh` — all pass.
- Every new gate mutation-proven in both directions; the mutations are listed per issue above.
- All commits GPG-verified.

## Findings for the tracker

1. **A tracked filename contains a literal newline.**
   `docs/specs/openehr/CNF/tests/platform/robot/I_EHR_COMPOSITION/get_composition/I_EHR_COMPOSITION.get_composition_version-bad_ehr\n.robot`
   — confirmed by dumping `git ls-files -z`. Glob matching does not reach it, so
   `REUSE.toml` has to name it explicitly. Upstream's defect, arriving through the
   vendoring script; a candidate `upstream-report`.
2. **`target/` is 71 GB**, well past the ~30 GB `cargo clean` threshold. Not
   cleaned: another session shares this tree and the cache is warm.
3. **The ADL2 library's licence claim is unverified.** Two PROVENANCE files say
   "predominantly CC-BY-SA 3.0 where stated" for corpora whose archetypes write
   `Creative Commons CC-BY-SA` with the version only in a URL. The CKM claims were
   measurably wrong and are fixed in this PR; this one was left alone rather than
   guessed at.
