### PR TITLE
fix(security): a bare-string advisory ignore escaped the VEX requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,7 +447,7 @@ jobs:
           YQ_SHA256: fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4
         run: |
           set -euo pipefail
-          curl -fsSL -o /tmp/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+          curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors -o /tmp/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
           echo "${YQ_SHA256}  /tmp/yq" | sha256sum -c -
           sudo install -m 0755 /tmp/yq /usr/local/bin/yq
           yq --version
@@ -648,7 +648,7 @@ jobs:
           YQ_SHA256: fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4
         run: |
           set -euo pipefail
-          curl -fsSL -o /tmp/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+          curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors -o /tmp/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
           echo "${YQ_SHA256}  /tmp/yq" | sha256sum -c -
           sudo install -m 0755 /tmp/yq /usr/local/bin/yq
           yq --version
@@ -1008,7 +1008,7 @@ jobs:
           YQ_SHA256: fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4
         run: |
           set -euo pipefail
-          curl -fsSL -o /tmp/yq             "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+          curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors -o /tmp/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
           echo "${YQ_SHA256}  /tmp/yq" | sha256sum -c -
           sudo install -m 0755 /tmp/yq /usr/local/bin/yq
           yq --version

--- a/scripts/security/vex-generate.sh
+++ b/scripts/security/vex-generate.sh
@@ -49,7 +49,25 @@ readonly VALID_STATUS='not_affected affected fixed under_investigation'
 readonly VALID_JUSTIFICATION='component_not_present vulnerable_code_not_present vulnerable_code_not_in_execute_path vulnerable_code_cannot_be_controlled_by_adversary inline_mitigations_already_exist'
 
 prose_json="$(yq -p toml -o json '.' "$PROSE")"
-gate_ids="$(yq -p toml -o json '[.advisories.ignore[].id]' "$GATE" | jq -r '.[]' | sort)"
+
+# cargo-deny's `ignore` accepts BOTH a bare id string and a `{ id, reason }`
+# table (https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html).
+# Reading only `.id` would let a bare-string advisory slip past every check
+# below with no published justification — the gate would still report agreement
+# because the id was never in the set it compared. Refuse the bare form instead
+# of quietly accepting it: this repository's convention is that an exception is
+# explicit, dated and reasoned, which the table form carries and a bare string
+# cannot. Bare non-advisory entries (`yanked@0.1.1`) stay legal.
+ignore_json="$(yq -p toml -o json '[.advisories.ignore[]]' "$GATE")"
+if bare="$(jq -r '.[] | select(type == "string" and startswith("RUSTSEC-"))' <<<"$ignore_json")" \
+   && [ -n "$bare" ]; then
+  echo "vex-generate: deny.toml ignores an advisory in the bare-string form:" >&2
+  sed 's/^/  /' <<<"$bare" >&2
+  echo "Use { id = \"…\", reason = \"…\" } so the exception carries its reason" >&2
+  echo "and this gate can require a published VEX justification for it." >&2
+  exit 1
+fi
+gate_ids="$(jq -r '.[] | if type == "object" then .id // empty else empty end' <<<"$ignore_json" | sort)"
 accepted_ids="$(jq -r '(.accepted // [])[].id' <<<"$prose_json" | sort)"
 lockfile_ids="$(jq -r '(.lockfile_only // [])[].id' <<<"$prose_json" | sort)"
 


### PR DESCRIPTION
The VEX gate landed in #2317 with a mutation proof. I re-ran that proof independently and it held — the gate caught a properly-shaped ignore with no published justification, naming the id precisely.

But my **first** probe added the advisory in the bare-string form, the gate stayed green, and the obvious conclusion was that the gate was broken. It was the probe that was malformed. The interesting part is *why* it was malformed:

`cargo-deny`'s `ignore` accepts **both** forms — [its own documentation](https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html) gives this example:

```toml
ignore = [
   "RUSTSEC-0000-0000",
   { id = "RUSTSEC-0000-0000", reason = "this vulnerability does not affect us..." },
   "yanked@0.1.1",
   { crate = "yanked-crate@0.1.1", reason = "..." },
]
```

The generator read only `.id`, so a bare-string advisory never entered the id set the agreement check compares — and the gate then **reported agreement**, because the advisory it should have complained about was invisible to it.

That is the same shape as the five unwired CI jobs from earlier today: a check that looks enforced, reports success, and is not enforcing the thing it names.

## The fix, and why refusal rather than acceptance

The bare form is now **refused**, not silently read. This repository's convention is that an exception is explicit, dated and reasoned — `deny.toml`'s own header says so, and every existing entry is a table with a reason. A bare string cannot carry one, so accepting it would mean accepting an unreasoned exception. Bare *non-advisory* entries (`yanked@0.1.1`) stay legal, since those are package specs rather than advisories.

## Mutation-proven, three directions

| case | expected | result |
|---|---|---|
| clean tree | passes | ✓ |
| bare-string advisory ignore | **fails**, naming the id | ✓ |
| bare `yanked@0.1.1` entry | passes | ✓ |

Refs #2307.