### PR TITLE
fix(base): TERMINOLOGY_ID refused values on an invariant nothing declares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -673,6 +673,16 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **A `TERMINOLOGY_ID` is no longer refused for its lexical form.** The CDR
+  rejected composition values such as `snomed_ct(3.1)` and `SNOMED CT` with
+  `Invariant Value_valid failed on type TERMINOLOGY_ID` — an invariant the
+  released BASE model does not declare anywhere: the class table carries no
+  Invariants row and the machine-readable model no `invariants` key. Released
+  QUERY 1.1.0 settles it from the other side by publishing
+  `terminology_id/value='snomed_ct(3.1)'` in its own normative example, which
+  the enforced production forbade. Values that were being rejected at commit
+  are now accepted.
+
 - **Five CI gates ran without gating anything.** Branch protection routes
   through a single aggregate check, which is what lets jobs be added or renamed
   without editing repository settings — but a job missing from that check's

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5486,7 +5486,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "indexmap 2.14.0",
  "openehr-am",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "serde",
  "serde_json",
@@ -5530,7 +5530,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "async-trait",
  "axum",
@@ -5559,7 +5559,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "assert_fs",
  "chumsky",
@@ -5573,7 +5573,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "chumsky",
  "logos",
@@ -5582,7 +5582,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "insta",
  "jsonschema",
@@ -5600,7 +5600,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-adl"
-version = "0.0.26"
+version = "0.0.27"
 description = "openEHR ADL 2.4.0: hand-written ADL2/cADL/ODIN parser, AOM2 validation catalogue, specialisation flattener, OPT2 generator, and ADL 1.4→2 conversion over the generated openehr_am::v2_4::aom2 model"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,10 +16,10 @@ include = ["src/**", "README.md", "LICENSE-MIT"]
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)
-openehr-base = { path = "../openehr-base", version = "0.0.26" }   # VersionStatus for the parsed HRID
-openehr-am = { path = "../openehr-am", version = "0.0.26" }       # v2_4 ArchetypeHrid (the identification target type)
-openehr-rm = { path = "../openehr-rm", version = "0.0.26" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
-openehr-lang = { path = "../openehr-lang", version = "0.0.26" }   # openehr_lang::odin — the ODIN section parser
+openehr-base = { path = "../openehr-base", version = "0.0.27" }   # VersionStatus for the parsed HRID
+openehr-am = { path = "../openehr-am", version = "0.0.27" }       # v2_4 ArchetypeHrid (the identification target type)
+openehr-rm = { path = "../openehr-rm", version = "0.0.27" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
+openehr-lang = { path = "../openehr-lang", version = "0.0.27" }   # openehr_lang::odin — the ODIN section parser
 uuid.workspace = true        # meta uid/build_uid (AUTHORED_ARCHETYPE.uid: Uuid)
 indexmap.workspace = true    # OdinValue::Object body (insertion-ordered map)
 

--- a/crates/openehr-am/Cargo.toml
+++ b/crates/openehr-am/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-am"
-version = "0.0.26"
+version = "0.0.27"
 description = "openEHR AM Archetype Model, generated from BMM: generations v1_4 (AM 1.4.0, ADL 1.4) and v2_4 (AM 2.4.0, ADL 2; current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,8 +13,8 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.26" }
-openehr-lang = { path = "../openehr-lang", version = "0.0.26" }
+openehr-base = { path = "../openehr-base", version = "0.0.27" }
+openehr-lang = { path = "../openehr-lang", version = "0.0.27" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also carries the untyped `Value` fields the generator

--- a/crates/openehr-base/Cargo.toml
+++ b/crates/openehr-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-base"
-version = "0.0.26"
+version = "0.0.27"
 description = "openEHR BASE foundation + base types, generated from BMM: generations v1_2 (BASE 1.2.0) and v1_3 (BASE 1.3.0, current)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-base/src/v1_2/base_types/identification/terminology_id_impl.rs
+++ b/crates/openehr-base/src/v1_2/base_types/identification/terminology_id_impl.rs
@@ -7,6 +7,15 @@
 //! Spec: BASE 1.3.0
 //! `docs/specs/openehr/BASE/docs/UML/classes/org.openehr.base.base_types.terminology_id.adoc`.
 //! Lexical form: `name [ '(' version ')' ]`, e.g. `SNOMED-CT`, `ICD10AM(3rd_ed)`.
+//!
+//! That lexical form is DESCRIPTIVE. The class table carries no `Invariants`
+//! row and the BMM no `invariants` key — unlike its sibling `VERSION_TREE_ID`,
+//! which declares seven — so this type constrains no value and there is no
+//! `Validate` impl below. Released QUERY 1.1.0
+//! (`docs/specs/openehr/QUERY/docs/AQL/master03-syntax.adoc` §Node predicate)
+//! publishes `terminology_id/value='snomed_ct(3.1)'`, which the master05
+//! §Syntaxes production forbids: enforcing it refused openEHR's own example
+//! (#2314).
 
 use super::terminology_id::TerminologyId;
 
@@ -32,6 +41,16 @@ impl TerminologyId {
             .and_then(|(_, rest)| rest.strip_suffix(')'))
             .unwrap_or("")
     }
+}
+
+impl crate::validate::Validate for TerminologyId {
+    /// Declares nothing, because the class declares nothing.
+    ///
+    /// The impl exists because the RM validation walk requires every visited
+    /// type to implement the trait, not because there is a constraint to
+    /// express: see the module documentation for why the lexical form is not
+    /// one.
+    fn validate_invariants(&self, _out: &mut Vec<crate::validate::InvariantViolation>) {}
 }
 
 #[cfg(test)]
@@ -64,109 +83,27 @@ mod tests {
         assert_eq!(t.name(), "ICD10AM");
         assert_eq!(t.version_id(), "");
     }
-}
 
-/// Lexical validity per BASE base_types master05 §Syntaxes:
-/// `terminology_id = name-str, [ '(', name-str, ')' ]` with
-/// `name-str = letter, { letter | digit | '_' | '-' | '/' | '+' }`.
-///
-/// The name is `name-str` exactly: an interior space, and the `:` and `.` of a
-/// URI, are all outside it.
-///
-/// NOTE: the version part drops `name-str`'s leading-letter requirement,
-/// because every example the same chapter gives — `ICD9(1999)`,
-/// `ICD10AM(3rd_ed)`, `ICD10AM(4th_ed)` (§Terminology Identifiers) — starts its
-/// version with a digit, so reading `name-str` there would refuse the released
-/// text's own identifiers (#2283).
-#[must_use]
-pub(crate) fn is_valid_terminology_id(value: &str) -> bool {
-    /// The `name-str` body: `letter | digit | '_' | '-' | '/' | '+'`.
-    fn body(s: &str) -> bool {
-        !s.is_empty()
-            && s.chars()
-                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '/' | '+'))
-    }
-    /// `name-str = letter, { letter | digit | '_' | '-' | '/' | '+' }`.
-    fn name_str(s: &str) -> bool {
-        s.starts_with(|c: char| c.is_ascii_alphabetic()) && body(s)
-    }
-    match value.split_once('(') {
-        None => name_str(value),
-        Some((name, rest)) => rest
-            .strip_suffix(')')
-            .is_some_and(|version| name_str(name) && body(version)),
-    }
-}
-
-impl crate::validate::Validate for TerminologyId {
-    fn validate_invariants(&self, out: &mut Vec<crate::validate::InvariantViolation>) {
-        if !is_valid_terminology_id(&self.value) {
-            out.push(crate::validate::InvariantViolation::here(
-                "Invariant Value_valid failed on type TERMINOLOGY_ID (the master05 \
-                 §Syntaxes production `terminology_id = name-str, [ '(', name-str, \
-                 ')' ]`, where a name-str starts with a letter and continues with \
-                 letters, digits, '_', '-', '/' or '+')",
-            ));
-        }
-    }
-}
-
-#[cfg(test)]
-mod validity_tests {
-    use super::*;
-
-    /// The accepted forms are the production's, and they cover every
-    /// terminology this implementation actually carries.
+    /// The accessors read every shape a released component publishes as a
+    /// `TERMINOLOGY_ID.value`, including the two the withdrawn production
+    /// refused (#2314).
     #[test]
-    fn terminology_id_follows_the_name_str_production() {
-        for ok in [
-            "openehr",
-            "local",
-            "x",
-            "ISO_639-1",
-            "ISO_3166-1",
-            "IANA_character-sets",
-            "IANA_media-types",
-            "SNOMED-CT",
-            "ICD10",
-            "Unicode",
-            // The chapter's own versioned examples (§Terminology Identifiers).
-            "ICD9(1999)",
-            "ICD10AM(3rd_ed)",
-            "ICD10AM(4th_ed)",
-            // The production admits '/' and '+' in a name-str.
-            "some/terminology+ext",
-        ] {
-            assert!(is_valid_terminology_id(ok), "{ok:?} must be valid");
-        }
-    }
+    fn released_shapes_decompose() {
+        // QUERY 1.1.0 `master03-syntax.adoc:239` spells this as a
+        // `terminology_id/value` in the canonical node-predicate expansion.
+        let dotted = tid("snomed_ct(3.1)");
+        assert_eq!(dotted.name(), "snomed_ct");
+        assert_eq!(dotted.version_id(), "3.1");
 
-    /// Every refusal is asserted, so a silently loosened reader is a failing
-    /// build rather than a quiet drift (`.claude/rules/spec-adherence.md`).
-    #[test]
-    fn terminology_id_refuses_what_the_production_forbids() {
-        for bad in [
-            "",
-            // An interior space: the spec's own example is `SNOMED-CT`.
-            "SNOMED CT",
-            "SNOMED CT ",
-            // A URI: master05 admits neither ':' nor '.' in a name-str.
-            "http://snomed.info/sct",
-            "https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1010.2",
-            // name-str must START with a letter.
-            "1CD10",
-            "_leading",
-            // An unclosed or empty version group.
-            "x(",
-            "ICD10AM(3rd_ed",
-            "ICD10AM()",
-            // The version drops only the leading-letter rule, not the character
-            // class.
-            "ICD10AM(3rd ed)",
-            "ICD10AM(1999.1)",
-            "bad\u{7}id",
-        ] {
-            assert!(!is_valid_terminology_id(bad), "{bad:?} must be invalid");
-        }
+        // An interior space is a name like any other now that nothing
+        // constrains the value.
+        let spaced = tid("SNOMED CT");
+        assert_eq!(spaced.name(), "SNOMED CT");
+        assert_eq!(spaced.version_id(), "");
+
+        // A URI has no version group, so it decomposes to itself.
+        let uri = tid("http://snomed.info/sct");
+        assert_eq!(uri.name(), "http://snomed.info/sct");
+        assert_eq!(uri.version_id(), "");
     }
 }

--- a/crates/openehr-base/src/v1_3/base_types/identification/terminology_id_impl.rs
+++ b/crates/openehr-base/src/v1_3/base_types/identification/terminology_id_impl.rs
@@ -7,6 +7,15 @@
 //! Spec: BASE 1.3.0
 //! `docs/specs/openehr/BASE/docs/UML/classes/org.openehr.base.base_types.terminology_id.adoc`.
 //! Lexical form: `name [ '(' version ')' ]`, e.g. `SNOMED-CT`, `ICD10AM(3rd_ed)`.
+//!
+//! That lexical form is DESCRIPTIVE. The class table carries no `Invariants`
+//! row and the BMM no `invariants` key — unlike its sibling `VERSION_TREE_ID`,
+//! which declares seven — so this type constrains no value and there is no
+//! `Validate` impl below. Released QUERY 1.1.0
+//! (`docs/specs/openehr/QUERY/docs/AQL/master03-syntax.adoc` §Node predicate)
+//! publishes `terminology_id/value='snomed_ct(3.1)'`, which the master05
+//! §Syntaxes production forbids: enforcing it refused openEHR's own example
+//! (#2314).
 
 use super::terminology_id::TerminologyId;
 
@@ -32,6 +41,16 @@ impl TerminologyId {
             .and_then(|(_, rest)| rest.strip_suffix(')'))
             .unwrap_or("")
     }
+}
+
+impl crate::validate::Validate for TerminologyId {
+    /// Declares nothing, because the class declares nothing.
+    ///
+    /// The impl exists because the RM validation walk requires every visited
+    /// type to implement the trait, not because there is a constraint to
+    /// express: see the module documentation for why the lexical form is not
+    /// one.
+    fn validate_invariants(&self, _out: &mut Vec<crate::validate::InvariantViolation>) {}
 }
 
 #[cfg(test)]
@@ -64,109 +83,27 @@ mod tests {
         assert_eq!(t.name(), "ICD10AM");
         assert_eq!(t.version_id(), "");
     }
-}
 
-/// Lexical validity per BASE base_types master05 §Syntaxes:
-/// `terminology_id = name-str, [ '(', name-str, ')' ]` with
-/// `name-str = letter, { letter | digit | '_' | '-' | '/' | '+' }`.
-///
-/// The name is `name-str` exactly: an interior space, and the `:` and `.` of a
-/// URI, are all outside it.
-///
-/// NOTE: the version part drops `name-str`'s leading-letter requirement,
-/// because every example the same chapter gives — `ICD9(1999)`,
-/// `ICD10AM(3rd_ed)`, `ICD10AM(4th_ed)` (§Terminology Identifiers) — starts its
-/// version with a digit, so reading `name-str` there would refuse the released
-/// text's own identifiers (#2283).
-#[must_use]
-pub(crate) fn is_valid_terminology_id(value: &str) -> bool {
-    /// The `name-str` body: `letter | digit | '_' | '-' | '/' | '+'`.
-    fn body(s: &str) -> bool {
-        !s.is_empty()
-            && s.chars()
-                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '/' | '+'))
-    }
-    /// `name-str = letter, { letter | digit | '_' | '-' | '/' | '+' }`.
-    fn name_str(s: &str) -> bool {
-        s.starts_with(|c: char| c.is_ascii_alphabetic()) && body(s)
-    }
-    match value.split_once('(') {
-        None => name_str(value),
-        Some((name, rest)) => rest
-            .strip_suffix(')')
-            .is_some_and(|version| name_str(name) && body(version)),
-    }
-}
-
-impl crate::validate::Validate for TerminologyId {
-    fn validate_invariants(&self, out: &mut Vec<crate::validate::InvariantViolation>) {
-        if !is_valid_terminology_id(&self.value) {
-            out.push(crate::validate::InvariantViolation::here(
-                "Invariant Value_valid failed on type TERMINOLOGY_ID (the master05 \
-                 §Syntaxes production `terminology_id = name-str, [ '(', name-str, \
-                 ')' ]`, where a name-str starts with a letter and continues with \
-                 letters, digits, '_', '-', '/' or '+')",
-            ));
-        }
-    }
-}
-
-#[cfg(test)]
-mod validity_tests {
-    use super::*;
-
-    /// The accepted forms are the production's, and they cover every
-    /// terminology this implementation actually carries.
+    /// The accessors read every shape a released component publishes as a
+    /// `TERMINOLOGY_ID.value`, including the two the withdrawn production
+    /// refused (#2314).
     #[test]
-    fn terminology_id_follows_the_name_str_production() {
-        for ok in [
-            "openehr",
-            "local",
-            "x",
-            "ISO_639-1",
-            "ISO_3166-1",
-            "IANA_character-sets",
-            "IANA_media-types",
-            "SNOMED-CT",
-            "ICD10",
-            "Unicode",
-            // The chapter's own versioned examples (§Terminology Identifiers).
-            "ICD9(1999)",
-            "ICD10AM(3rd_ed)",
-            "ICD10AM(4th_ed)",
-            // The production admits '/' and '+' in a name-str.
-            "some/terminology+ext",
-        ] {
-            assert!(is_valid_terminology_id(ok), "{ok:?} must be valid");
-        }
-    }
+    fn released_shapes_decompose() {
+        // QUERY 1.1.0 `master03-syntax.adoc:239` spells this as a
+        // `terminology_id/value` in the canonical node-predicate expansion.
+        let dotted = tid("snomed_ct(3.1)");
+        assert_eq!(dotted.name(), "snomed_ct");
+        assert_eq!(dotted.version_id(), "3.1");
 
-    /// Every refusal is asserted, so a silently loosened reader is a failing
-    /// build rather than a quiet drift (`.claude/rules/spec-adherence.md`).
-    #[test]
-    fn terminology_id_refuses_what_the_production_forbids() {
-        for bad in [
-            "",
-            // An interior space: the spec's own example is `SNOMED-CT`.
-            "SNOMED CT",
-            "SNOMED CT ",
-            // A URI: master05 admits neither ':' nor '.' in a name-str.
-            "http://snomed.info/sct",
-            "https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1010.2",
-            // name-str must START with a letter.
-            "1CD10",
-            "_leading",
-            // An unclosed or empty version group.
-            "x(",
-            "ICD10AM(3rd_ed",
-            "ICD10AM()",
-            // The version drops only the leading-letter rule, not the character
-            // class.
-            "ICD10AM(3rd ed)",
-            "ICD10AM(1999.1)",
-            "bad\u{7}id",
-        ] {
-            assert!(!is_valid_terminology_id(bad), "{bad:?} must be invalid");
-        }
+        // An interior space is a name like any other now that nothing
+        // constrains the value.
+        let spaced = tid("SNOMED CT");
+        assert_eq!(spaced.name(), "SNOMED CT");
+        assert_eq!(spaced.version_id(), "");
+
+        // A URI has no version group, so it decomposes to itself.
+        let uri = tid("http://snomed.info/sct");
+        assert_eq!(uri.name(), "http://snomed.info/sct");
+        assert_eq!(uri.version_id(), "");
     }
 }

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-its"
-version = "0.0.26"
+version = "0.0.27"
 description = "openEHR ITS (Implementation Technology Specifications): canonical JSON + canonical XML serialization of the RM, the generated ITS-REST 1.1.0 API contract, OPT 1.4 and AOM2 archetype XML codecs, and the Simplified Formats (FLAT / STRUCTURED / Web Template)"
 edition.workspace = true
 rust-version.workspace = true
@@ -41,14 +41,14 @@ regex = { workspace = true, optional = true }
 fancy-regex = { workspace = true, optional = true }
 # The generated XML (de)serializers impl the crate's ToXml/FromXml traits for the
 # RM/BASE spec types, so these are real (non-dev) deps.
-openehr-base = { path = "../openehr-base", version = "0.0.26", optional = true }
-openehr-rm = { path = "../openehr-rm", version = "0.0.26", optional = true }
+openehr-base = { path = "../openehr-base", version = "0.0.27", optional = true }
+openehr-rm = { path = "../openehr-rm", version = "0.0.27", optional = true }
 # The native canonical-JSON codec (`json_codec/generated`, emit-json) implements
 # `ToJson` for EVERY generated spec type the `OpenEhrType` derive covers, so it
 # spans all five spec crates (not just the RM/BASE the XML codec needs).
-openehr-lang = { path = "../openehr-lang", version = "0.0.26", optional = true }
-openehr-am = { path = "../openehr-am", version = "0.0.26", optional = true }
-openehr-term = { path = "../openehr-term", version = "0.0.26", optional = true }
+openehr-lang = { path = "../openehr-lang", version = "0.0.27", optional = true }
+openehr-am = { path = "../openehr-am", version = "0.0.27", optional = true }
+openehr-term = { path = "../openehr-term", version = "0.0.27", optional = true }
 
 # `full` — every ITS surface (canonical JSON/XML, the generated ITS-REST
 # contract, `opt14`, Simplified Formats). ON BY DEFAULT, so every consumer sees

--- a/crates/openehr-its/tests/it/validation.rs
+++ b/crates/openehr-its/tests/it/validation.rs
@@ -232,21 +232,26 @@ fn missing_mandatory_composer_is_rejected() {
     );
 }
 
-/// The invalid twin of the corpus adjudication above: a vendored composition
-/// carrying `TERMINOLOGY_ID` `"SNOMED CT"` is REFUSED, at the path that holds
-/// it.
+/// A vendored composition carrying `TERMINOLOGY_ID` `"SNOMED CT"` is ACCEPTED,
+/// because the class constrains no value.
 ///
-/// Keeping the refusal asserted is what stops the reader being loosened back:
-/// the interior space is outside the `terminology_id` production (BASE
-/// `base_types/master05-identification_package.adoc` §Syntaxes), and the same
-/// chapter spells the terminology `"SNOMED-CT"`.
+/// This assertion was inverted deliberately (#2314). It previously required
+/// the interior space to be REFUSED, citing the `terminology_id` production in
+/// BASE `base_types/master05-identification_package.adoc` §Syntaxes. That
+/// production is prose in a chapter: `TERMINOLOGY_ID`'s own class table
+/// declares no `Invariants` row and the BMM no `invariants` key — unlike its
+/// sibling `VERSION_TREE_ID`, which declares seven — so enforcing it invented a
+/// prohibition the model does not contain. Released QUERY 1.1.0
+/// (`docs/specs/openehr/QUERY/docs/AQL/master03-syntax.adoc` §Node predicate)
+/// settles it from the other side by publishing
+/// `terminology_id/value='snomed_ct(3.1)'`, which that same production forbids.
 #[test]
-fn snomed_ct_with_a_space_is_refused() {
+fn a_terminology_id_with_a_space_is_accepted() {
     let wts = web_templates();
     let msgs = validate("ehrb_adbm_op_consult_record.json", &wts);
     assert!(
-        msgs.iter().any(|m| m.path.ends_with("/terminology_id")),
-        "the space in \"SNOMED CT\" must be refused at its terminology_id path, got {msgs:?}"
+        !msgs.iter().any(|m| m.path.ends_with("/terminology_id")),
+        "no violation may be raised against a terminology_id, got {msgs:?}"
     );
 }
 

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-lang"
-version = "0.0.26"
+version = "0.0.27"
 description = "openEHR LANG BMM/P_BMM object model, generated from BMM: generations v1_0 (LANG 1.0.0) and v1_1 (LANG 1.1.0, current; the stable BMM v2.x unit beside the paused BMM3 unit), plus hand-written ODIN/BEL/EL readers"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["parser-implementations", "data-structures"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.26" }
+openehr-base = { path = "../openehr-base", version = "0.0.27" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the
 # generated types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) —
 # never a derive. `serde_json` also carries the untyped `Value` fields the

--- a/crates/openehr-query/Cargo.toml
+++ b/crates/openehr-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-query"
-version = "0.0.26"
+version = "0.0.27"
 description = "openEHR QUERY (AQL 1.1.0): hand-written lexer, parser, typed AST and canonical printer from the official grammar (no ANTLR runtime)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-rm"
-version = "0.0.26"
+version = "0.0.27"
 description = "openEHR RM Reference Model, generated from BMM: generations v1_1 (RM 1.1.0) and v1_2 (RM 1.2.0, current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,11 +13,11 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.26" }
+openehr-base = { path = "../openehr-base", version = "0.0.27" }
 # The terminology-backed RM class invariants (`validate::terminology`) resolve
 # openEHR terminology groups + code sets against the vendored TERM 3.1.0 bundle.
 # `openehr-term` itself depends only on `openehr-base`, so this is acyclic.
-openehr-term = { path = "../openehr-term", version = "0.0.26" }
+openehr-term = { path = "../openehr-term", version = "0.0.27" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also backs the untyped `Value` RM representation used by

--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-term"
-version = "0.0.26"
+version = "0.0.27"
 description = "openEHR TERM terminology data model, generated from BMM (generation v3_1 = TERM 3.1.0), plus the embedded official terminology XML bundle"
 edition.workspace = true
 rust-version.workspace = true
@@ -29,7 +29,7 @@ include = [
 ]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.26" }
+openehr-base = { path = "../openehr-base", version = "0.0.27" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive.

--- a/tools/openehr-codegen/templates/openehr-base/base_types/identification/terminology_id_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-base/base_types/identification/terminology_id_impl.rs
@@ -7,6 +7,15 @@
 //! Spec: BASE 1.3.0
 //! `docs/specs/openehr/BASE/docs/UML/classes/org.openehr.base.base_types.terminology_id.adoc`.
 //! Lexical form: `name [ '(' version ')' ]`, e.g. `SNOMED-CT`, `ICD10AM(3rd_ed)`.
+//!
+//! That lexical form is DESCRIPTIVE. The class table carries no `Invariants`
+//! row and the BMM no `invariants` key — unlike its sibling `VERSION_TREE_ID`,
+//! which declares seven — so this type constrains no value and there is no
+//! `Validate` impl below. Released QUERY 1.1.0
+//! (`docs/specs/openehr/QUERY/docs/AQL/master03-syntax.adoc` §Node predicate)
+//! publishes `terminology_id/value='snomed_ct(3.1)'`, which the master05
+//! §Syntaxes production forbids: enforcing it refused openEHR's own example
+//! (#2314).
 
 use super::terminology_id::TerminologyId;
 
@@ -32,6 +41,16 @@ impl TerminologyId {
             .and_then(|(_, rest)| rest.strip_suffix(')'))
             .unwrap_or("")
     }
+}
+
+impl crate::validate::Validate for TerminologyId {
+    /// Declares nothing, because the class declares nothing.
+    ///
+    /// The impl exists because the RM validation walk requires every visited
+    /// type to implement the trait, not because there is a constraint to
+    /// express: see the module documentation for why the lexical form is not
+    /// one.
+    fn validate_invariants(&self, _out: &mut Vec<crate::validate::InvariantViolation>) {}
 }
 
 #[cfg(test)]
@@ -64,109 +83,27 @@ mod tests {
         assert_eq!(t.name(), "ICD10AM");
         assert_eq!(t.version_id(), "");
     }
-}
 
-/// Lexical validity per BASE base_types master05 §Syntaxes:
-/// `terminology_id = name-str, [ '(', name-str, ')' ]` with
-/// `name-str = letter, { letter | digit | '_' | '-' | '/' | '+' }`.
-///
-/// The name is `name-str` exactly: an interior space, and the `:` and `.` of a
-/// URI, are all outside it.
-///
-/// NOTE: the version part drops `name-str`'s leading-letter requirement,
-/// because every example the same chapter gives — `ICD9(1999)`,
-/// `ICD10AM(3rd_ed)`, `ICD10AM(4th_ed)` (§Terminology Identifiers) — starts its
-/// version with a digit, so reading `name-str` there would refuse the released
-/// text's own identifiers (#2283).
-#[must_use]
-pub(crate) fn is_valid_terminology_id(value: &str) -> bool {
-    /// The `name-str` body: `letter | digit | '_' | '-' | '/' | '+'`.
-    fn body(s: &str) -> bool {
-        !s.is_empty()
-            && s.chars()
-                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '/' | '+'))
-    }
-    /// `name-str = letter, { letter | digit | '_' | '-' | '/' | '+' }`.
-    fn name_str(s: &str) -> bool {
-        s.starts_with(|c: char| c.is_ascii_alphabetic()) && body(s)
-    }
-    match value.split_once('(') {
-        None => name_str(value),
-        Some((name, rest)) => rest
-            .strip_suffix(')')
-            .is_some_and(|version| name_str(name) && body(version)),
-    }
-}
-
-impl crate::validate::Validate for TerminologyId {
-    fn validate_invariants(&self, out: &mut Vec<crate::validate::InvariantViolation>) {
-        if !is_valid_terminology_id(&self.value) {
-            out.push(crate::validate::InvariantViolation::here(
-                "Invariant Value_valid failed on type TERMINOLOGY_ID (the master05 \
-                 §Syntaxes production `terminology_id = name-str, [ '(', name-str, \
-                 ')' ]`, where a name-str starts with a letter and continues with \
-                 letters, digits, '_', '-', '/' or '+')",
-            ));
-        }
-    }
-}
-
-#[cfg(test)]
-mod validity_tests {
-    use super::*;
-
-    /// The accepted forms are the production's, and they cover every
-    /// terminology this implementation actually carries.
+    /// The accessors read every shape a released component publishes as a
+    /// `TERMINOLOGY_ID.value`, including the two the withdrawn production
+    /// refused (#2314).
     #[test]
-    fn terminology_id_follows_the_name_str_production() {
-        for ok in [
-            "openehr",
-            "local",
-            "x",
-            "ISO_639-1",
-            "ISO_3166-1",
-            "IANA_character-sets",
-            "IANA_media-types",
-            "SNOMED-CT",
-            "ICD10",
-            "Unicode",
-            // The chapter's own versioned examples (§Terminology Identifiers).
-            "ICD9(1999)",
-            "ICD10AM(3rd_ed)",
-            "ICD10AM(4th_ed)",
-            // The production admits '/' and '+' in a name-str.
-            "some/terminology+ext",
-        ] {
-            assert!(is_valid_terminology_id(ok), "{ok:?} must be valid");
-        }
-    }
+    fn released_shapes_decompose() {
+        // QUERY 1.1.0 `master03-syntax.adoc:239` spells this as a
+        // `terminology_id/value` in the canonical node-predicate expansion.
+        let dotted = tid("snomed_ct(3.1)");
+        assert_eq!(dotted.name(), "snomed_ct");
+        assert_eq!(dotted.version_id(), "3.1");
 
-    /// Every refusal is asserted, so a silently loosened reader is a failing
-    /// build rather than a quiet drift (`.claude/rules/spec-adherence.md`).
-    #[test]
-    fn terminology_id_refuses_what_the_production_forbids() {
-        for bad in [
-            "",
-            // An interior space: the spec's own example is `SNOMED-CT`.
-            "SNOMED CT",
-            "SNOMED CT ",
-            // A URI: master05 admits neither ':' nor '.' in a name-str.
-            "http://snomed.info/sct",
-            "https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1010.2",
-            // name-str must START with a letter.
-            "1CD10",
-            "_leading",
-            // An unclosed or empty version group.
-            "x(",
-            "ICD10AM(3rd_ed",
-            "ICD10AM()",
-            // The version drops only the leading-letter rule, not the character
-            // class.
-            "ICD10AM(3rd ed)",
-            "ICD10AM(1999.1)",
-            "bad\u{7}id",
-        ] {
-            assert!(!is_valid_terminology_id(bad), "{bad:?} must be invalid");
-        }
+        // An interior space is a name like any other now that nothing
+        // constrains the value.
+        let spaced = tid("SNOMED CT");
+        assert_eq!(spaced.name(), "SNOMED CT");
+        assert_eq!(spaced.version_id(), "");
+
+        // A URI has no version group, so it decomposes to itself.
+        let uri = tid("http://snomed.info/sct");
+        assert_eq!(uri.name(), "http://snomed.info/sct");
+        assert_eq!(uri.version_id(), "");
     }
 }


### PR DESCRIPTION
Five of the eight CNF failures come from one invented prohibition. The CDR rejected compositions with:

```
Invariant Value_valid failed on type TERMINOLOGY_ID
```

**No such invariant exists.** Verified first-hand in all three places it could live, rather than taken from the triage report:

| Source | Result |
|---|---|
| `BASE/…/org.openehr.base.base_types.terminology_id.adoc` | **no `*Invariants*` row at all** |
| the vendored BMM (the codegen input) | **no `invariants` key**; ancestor `OBJECT_ID` declares none either |
| control — `VERSION_TREE_ID`, sibling, lexical form described identically | **7 invariants**, `Value_valid` among them |

The class's only statement about its value sits inside the DESCRIPTION cell — *"Lexical form: `name [ '(' version ')' ]`"*. That is prose in a chapter; `validate_invariants` implements **model invariants**. Enforcing prose there invents a prohibition, which `.claude/rules/spec-adherence.md` treats as the same defect class as leniency: *"strict means exact, in both directions."*

## A released component publishes what we refused

Independently decisive. Released QUERY 1.1.0, `docs/specs/openehr/QUERY/docs/AQL/master03-syntax.adoc:239`, gives as the normative canonical expansion of the node-predicate shortcut:

```
[archetype_node_id=at0002 and name/defining_code/code_string='313267000' and name/defining_code/terminology_id/value='snomed_ct(3.1)']
```

`.` is outside `name-str`. The production we enforced refused **openEHR's own published example**.

That also makes upstream report **#2283 under-derived**: it asserts the production is "unambiguous" and lists `ICD10AM(1999.1)` among correct refusals — a reading that refuses the AQL example above. #2283 relaxed only the version's leading-letter rule, one rule too narrow, and missed that the class declares nothing at all.

## What changed

The `Validate` impl **stays, empty**. The RM validation walk requires every visited type to implement the trait (`fast.rs`, `typed_dispatch.rs` both call it), so removing it does not compile. What is withdrawn is the *claim*, not the participation — and the impl says so.

The test that asserted the refusal is **inverted, not deleted**, and carries the derivation inline. A refusal may only be weakened with a docs-text-grounded adjudication and a gate updated to assert the new expected outcome; deleting it would have removed the record of why it ever existed.

## Verification

- `cargo nextest run --workspace` → **4915 passed, 0 failed**, 6 skipped
- clippy clean on the exact CI lane, `cargo fmt` clean
- `codegen-drift` clean — the fix is in `tools/openehr-codegen/templates/`, regenerated with the **full** emit set, and both stamped generation copies (`v1_2`, `v1_3`) moved together
- `comment-style --all` and `spdx-headers` (2470 files) green
- eight crates bumped lockstep to `0.0.27` with their internal requirements

Exactly one test failed before the flip, and it was the one asserting the withdrawn refusal.

## Not claimed here

This does not close #2032. The five terminology rows should clear, but that is a prediction until a conformance run says so — and three of the eight failures were the PGP cluster, fixed separately in #2315.

Closes #2314.