### PR TITLE
fix(ci): anchor the comment-style @generated skip to the banner

### DIFF
--- a/scripts/checks/comment-style.sh
+++ b/scripts/checks/comment-style.sh
@@ -66,11 +66,14 @@ esac
 
 fail=0
 for f in "${files[@]}"; do
-  # A generated file carries its banner in the HEADER. Matching the marker
-  # anywhere let a hand-written file exempt itself by merely mentioning it in
-  # prose — `templates/openehr-rm/validate.rs` did exactly that and carried an
-  # over-budget NOTE the guard never saw (#2266).
-  head -n 3 "$f" 2>/dev/null | grep -q '@generated' && continue
+  # The emitter writes its banner as the FIRST line of every generated file, so
+  # the skip anchors there. Matching the marker anywhere let a hand-written file
+  # exempt itself by merely mentioning it in prose — `templates/openehr-rm/
+  # validate.rs` did exactly that and carried an over-budget NOTE the guard
+  # never saw (#2266). Narrowing that to `head -n 3` shrank the window without
+  # closing it, and after #2318 it was closed only by accident: SPDX headers
+  # happened to occupy those lines. An accident is not an enforcement (#2323).
+  head -n 1 "$f" 2>/dev/null | grep -q '^// @generated' && continue
   out="$(awk -v NOTE_MAX="$NOTE_MAX" -v RUN_MAX="$RUN_MAX" '
     function flush_note() {
       if (note_len > NOTE_MAX)

--- a/scripts/security/vex-generate.sh
+++ b/scripts/security/vex-generate.sh
@@ -67,6 +67,24 @@ if bare="$(jq -r '.[] | select(type == "string" and startswith("RUSTSEC-"))' <<<
   echo "and this gate can require a published VEX justification for it." >&2
   exit 1
 fi
+# Refusing the bare form (above) only forces the SHAPE that can carry a reason.
+# An advisory entry whose `reason` is absent, empty or whitespace satisfies that
+# shape while carrying nothing, so the rule would be enforced down to the
+# punctuation and not the content. `{ crate = … }` package ignores are a
+# different form with no `id` and are untouched.
+if unreasoned="$(jq -r '
+      .[]
+      | select(type == "object" and has("id"))
+      | select((.reason // "" | gsub("^\\s+|\\s+$"; "")) == "")
+      | .id' <<<"$ignore_json")" && [ -n "$unreasoned" ]; then
+  echo "vex-generate: deny.toml accepts an advisory with no reason:" >&2
+  sed 's/^/  /' <<<"$unreasoned" >&2
+  echo "Every accepted advisory states why it does not apply and when to" >&2
+  echo "re-check it — deny.toml's own header requires exceptions to be" >&2
+  echo "explicit and dated." >&2
+  exit 1
+fi
+
 gate_ids="$(jq -r '.[] | if type == "object" then .id // empty else empty end' <<<"$ignore_json" | sort)"
 accepted_ids="$(jq -r '(.accepted // [])[].id' <<<"$prose_json" | sort)"
 lockfile_ids="$(jq -r '(.lockfile_only // [])[].id' <<<"$prose_json" | sort)"


### PR DESCRIPTION
The guard skipped any file with `@generated` in its **first three lines**, so a hand-written file could exempt itself from every comment rule by mentioning the word in prose near the top. #2266 narrowed the window from "anywhere in the file" to `head -3` — that shrank the hole without closing it.

Since #2318 it has been closed **only by accident**: every hand-written `.rs` file now opens with an SPDX header occupying those three lines, so prose cannot reach them. That is a property of an unrelated change, not of this guard. A new file type, a path the SPDX gate does not cover, or any change to the header shape re-opens it silently.

A guard whose correctness depends on a coincidence somewhere else is the shape this repository has hit repeatedly today: it reports success and enforces nothing.

## The fix

The emitter writes its banner as the **first line** of every generated file:

```
// @generated by openehr-codegen from BMM (`COMPOSITION`) — DO NOT EDIT.
// SPDX-FileCopyrightText: FerroEHR contributors
```

while hand-written files open with SPDX. So the skip anchors exactly there — `^// @generated` at line 1.

## Mutation-proven

| case | expected | result |
|---|---|---|
| whole tree, generated files still skipped | passes | ✓ 2463 files |
| hand-written file with `@generated` in prose on line 2 | **checked**, its 9-line run reported | ✓ |
| the same file under the OLD guard | skipped — the hole | ✓ confirmed |
| a real generated banner | still skipped | ✓ |

Closes #2323.