### PR TITLE
fix(codegen): emit says what it leaves behind

### DIFF
--- a/tools/openehr-codegen/src/cli.rs
+++ b/tools/openehr-codegen/src/cli.rs
@@ -953,8 +953,23 @@ fn write_crate(crate_name: &str, files: &[GenFile]) -> Result<(), Box<dyn std::e
     declare_hand_written_modules(&src, &mut written)?;
     rustfmt(&written)?;
     println!("emitted {} files into {}", files.len(), src.display());
+    eprintln!("{INCOMPLETE_AFTER_EMIT}");
     Ok(())
 }
+
+/// What `emit` alone leaves behind, printed at the end of every run.
+///
+/// `emit` purges each crate's `json_serde.rs` and its declaration, and only
+/// `emit-json` writes them back, so the workspace does not compile in between.
+/// The failure then surfaces far from its cause as unsatisfied
+/// `serde::Serialize` bounds in whichever crate builds first, and the recovery
+/// costs a full rebuild. Saying so at the end of the run is cheaper than
+/// discovering it (#2324).
+const INCOMPLETE_AFTER_EMIT: &str = "\
+note: `emit` alone leaves the workspace UNBUILDABLE — it removes each crate's
+      json_serde.rs, which only `emit-json` writes back. Run the full set:
+        emit-json emit-xml emit-rest emit-opt emit-aom2 emit-rm-model emit-validate
+      or use the /regen-codegen skill, which runs them all plus the drift check.";
 
 /// Whether a file's first line marks it as generated (`// @generated …`).
 fn is_generated_file(path: &Path) -> bool {
@@ -1085,4 +1100,19 @@ fn rustfmt(files: &[PathBuf]) -> Result<(), Box<dyn std::error::Error>> {
         return Err(format!("rustfmt failed with status {status}").into());
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod emit_warning_tests {
+    use super::INCOMPLETE_AFTER_EMIT;
+
+    /// The note must name `emit-json` — the one target that restores what
+    /// `emit` removed. A note that only says "run the others" sends the reader
+    /// back to the documentation the foot-gun already survived (#2324).
+    #[test]
+    fn the_note_names_the_target_that_restores_the_tree() {
+        assert!(INCOMPLETE_AFTER_EMIT.contains("emit-json"));
+        assert!(INCOMPLETE_AFTER_EMIT.contains("json_serde.rs"));
+        assert!(INCOMPLETE_AFTER_EMIT.contains("UNBUILDABLE"));
+    }
 }


### PR DESCRIPTION
`cargo run -p openehr-codegen -- emit` removes each crate's `json_serde.rs` **and its declaration**; only `emit-json` writes them back. Between the two the workspace does not compile, and the failure surfaces far from its cause:

```
the trait bound `Iso8601Date: serde::Serialize` is not satisfied
```

…in whichever crate builds first. Recovering costs a full rebuild. The full set is documented in the crate's `CLAUDE.md` and run by `/regen-codegen`, but nothing in the *tool* said so — so the most obvious invocation of the generator is the one that breaks the tree.

It has now cost time twice in one day, the second time inside a worker whose prompt warned about it explicitly. That is the signal that documentation is not where this belongs.

## What I tried first, and why it is not this PR

Making the purge skip other targets' files. `emit` rebuilds each `lib.rs` from scratch, so the file survived while its declaration did not — 125 errors instead of 125 different errors. Teaching `emit` to declare it then produced `pub mod json_serde;` against `emit-json`'s `mod json_serde;`, and a `codegen-drift` failure.

The two-stage split turns out to be deliberate and documented at `declare_json_serde_module`:

> Both intermediate states are self-consistent: after `emit` neither the module nor its declaration exists, after `emit-json` both do.

So the contract is intentional and my change was contradicting it. This PR makes it **audible** instead.

## What it does

```
note: `emit` alone leaves the workspace UNBUILDABLE — it removes each crate's
      json_serde.rs, which only `emit-json` writes back. Run the full set:
        emit-json emit-xml emit-rest emit-opt emit-aom2 emit-rm-model emit-validate
      or use the /regen-codegen skill, which runs them all plus the drift check.
```

A test pins that the note names `emit-json` specifically — the target that actually puts the files back. A note saying only "run the others" would send the reader to the documentation this foot-gun already survived.

`codegen-drift` clean, clippy clean, `comment-style` clean.

Closes #2324.