### PR TITLE
chore(legal): one copyright holder, and the FOSSA badge that reads our config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,6 +393,22 @@ jobs:
   # we wrote is a licence conflict. It lives here rather than in `.fossa.yml`
   # because FOSSA's customLicenseSearch could not upload on this org's plan and
   # did not honour that file's path exclusions (measured 2026-08-12).
+  # LICENSE, REUSE.toml and the codegen header constant must agree on the
+  # copyright holder. They did not, and nothing compared them (#2325).
+  copyright-holder:
+    name: copyright-holder
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: One copyright holder, stated identically everywhere
+        run: bash scripts/checks/copyright-holder.sh
+
   license-text:
     name: license-text
     if: github.event_name == 'pull_request'
@@ -1837,6 +1853,7 @@ jobs:
       - error-source-chain
       - no-python
       - license-text
+      - copyright-holder
       - licensing
       - spec-citations
       - compose-hardening

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Ruben Talstra
+Copyright (c) 2026 FerroEHR contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ ITS-REST 1.1.0 &nbsp;·&nbsp; AQL 1.1 &nbsp;·&nbsp; RM 1.2.0 **+ 1.1.0** &nbsp;
 [![Containers](https://github.com/rubentalstra/FerroEHR/actions/workflows/containers.yml/badge.svg?branch=develop)](https://github.com/rubentalstra/FerroEHR/actions/workflows/containers.yml)
 [![CodeQL](https://github.com/rubentalstra/FerroEHR/actions/workflows/codeql.yml/badge.svg?branch=develop)](https://github.com/rubentalstra/FerroEHR/actions/workflows/codeql.yml)
 [![GitHub Release](https://img.shields.io/github/release/rubentalstra/FerroEHR.svg?logo=github)](https://github.com/rubentalstra/FerroEHR/releases/latest)
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Frubentalstra%2FFerroEHR.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Frubentalstra%2FFerroEHR?ref=badge_shield)
+[![FOSSA Status](https://app.fossa.com/api/projects/custom%2B63718%2FFerroEHR.svg?type=shield)](https://app.fossa.com/projects/custom%2B63718%2FFerroEHR?ref=badge_shield)
 
 [![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Frubentalstra%2Fferroehr%2Fbadges%2Fcoverage.json)](https://github.com/rubentalstra/FerroEHR/actions/workflows/ci.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/rubentalstra/FerroEHR/badge)](https://scorecard.dev/viewer/?uri=github.com/rubentalstra/FerroEHR)
@@ -581,7 +581,7 @@ rather than left to be discovered.
 ## Acknowledgments and license
 
 
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Frubentalstra%2FFerroEHR.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Frubentalstra%2FFerroEHR?ref=badge_large)
+[![FOSSA Status](https://app.fossa.com/api/projects/custom%2B63718%2FFerroEHR.svg?type=large)](https://app.fossa.com/projects/custom%2B63718%2FFerroEHR?ref=badge_large)
 
 ### Acknowledgments
 

--- a/scripts/checks/copyright-holder.sh
+++ b/scripts/checks/copyright-holder.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# One copyright holder, stated identically everywhere it is stated.
+#
+# `LICENSE` said "Ruben Talstra" while `REUSE.toml`, the codegen header constant
+# and 2470 file headers said "FerroEHR contributors". Both are defensible
+# positions; asserting both means a downstream redistributor reading a file
+# header and a lawyer reading LICENSE come away with different answers about who
+# holds the copyright — the exact ambiguity per-file licensing exists to remove.
+#
+# The divergence survived because nothing compared the three sources. This does.
+#
+# NOT compared: `CITATION.cff` authors and `.zenodo.json` creators. Those record
+# AUTHORSHIP for citation, which is a different datum from the copyright holder
+# and is correctly a named person.
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+readonly HOLDER='FerroEHR contributors'
+
+fail=0
+check() {
+  local what="$1" found="$2"
+  if [ "$found" != "$HOLDER" ]; then
+    echo "error: $what states the copyright holder as:" >&2
+    echo "         ${found:-<not found>}" >&2
+    echo "       every source must state: $HOLDER" >&2
+    fail=1
+  fi
+}
+
+# `LICENSE` — the MIT notice line.
+check "LICENSE" \
+  "$(sed -n 's/^Copyright (c) [0-9]\{4\} //p' LICENSE | head -1)"
+
+# `REUSE.toml` — the first-party annotation (the openEHR Foundation appears as a
+# SECOND holder on vendored-derived files, which is a different statement).
+check "REUSE.toml" \
+  "$(sed -n 's/^SPDX-FileCopyrightText = "\(.*\)"$/\1/p' REUSE.toml | head -1)"
+
+# The emitter constant every generated header is stamped from.
+check "tools/openehr-codegen/src/render/spdx.rs" \
+  "$(sed -n 's/^pub(crate) const PROJECT_COPYRIGHT: &str = "\(.*\)";$/\1/p' \
+       tools/openehr-codegen/src/render/spdx.rs | head -1)"
+
+if [ "$fail" -ne 0 ]; then
+  echo >&2
+  echo "Changing the holder means changing ALL of them together, plus the file" >&2
+  echo "headers (re-run the codegen emit set for the generated half)." >&2
+  exit 1
+fi
+
+echo "ok: one copyright holder — $HOLDER"


### PR DESCRIPTION
Two statements that ship inside a released tarball and disagreed with themselves.

## The copyright holder

`LICENSE` said `Ruben Talstra`; `REUSE.toml`, the codegen header constant and **2470 file headers** said `FerroEHR contributors`. Both positions are defensible — having both is not. A redistributor reading a file header and a lawyer reading `LICENSE` come away with different answers about who holds the copyright, which is the exact ambiguity per-file licensing exists to remove.

**"FerroEHR contributors" wins**, so `LICENSE` is what changes:

- it is what 2470 files, `REUSE.toml` and the emitter already say — one edit rather than 2472
- `CONTRIBUTING.md` takes **no CLA** and leaves contributors their own copyright, so the plural collective is the accurate statement
- it stays true as the contributor set grows; a personal name becomes wrong on the first outside patch

`CITATION.cff` is deliberately untouched — authorship for citation is a different datum from the copyright holder, and is correctly a named person with an ORCID.

The divergence survived because **nothing compared the sources**. `scripts/checks/copyright-holder.sh` now does, wired into `conclusion.needs` (40 jobs gate). Mutation-proven from both ends: diverging `LICENSE` fails, diverging the emitter constant fails, and it names which source disagrees.

## The FOSSA badges

The README's four badges pointed at `git+github.com/rubentalstra/FerroEHR` — the **hosted** project, which does not read `.fossa.yml`. So the badge a visitor saw was generated from the scan that ignores every exclusion in that file: the vendored openEHR specification text, the CKM clinical models, the tri-licensed ISO 13606 models.

They now point at `custom+63718/FerroEHR`, the CLI project whose results are the configured ones. Both badge types verified serving (HTTP 200) before the swap.

Still needs a UI action, tracked on #2298: the hosted integration should be disconnected, or it keeps maintaining the misleading project regardless of what the badges reference.

---

Closes #2325.
Closes #2298.

(Separate lines deliberately — GitHub honours only the first issue in a comma-joined list.)