### PR TITLE
release: v3.17.4

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -32,8 +32,8 @@
     },
     "title": "FerroEHR",
     "description": "<p>A pure-Rust, openEHR-specification-conformant clinical data repository (CDR): ITS-REST 1.1.0 REST API, AQL 1.1 query language, and the openEHR RM 1.2.0 reference model on PostgreSQL-18-native storage. The openEHR specification layer is generated from the official machine-readable specifications, and conformance is machine-verified per release by a built-in CNF conformance runner.</p>",
-    "publication_date": "2026-08-05",
-    "version": "3.17.3",
+    "publication_date": "2026-08-13",
+    "version": "3.17.4",
     "creators": [
       {
         "person_or_org": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+## [3.17.4] - 2026-08-13
+
 ### Added
 
 - **A published threat model.** A new
@@ -6522,7 +6524,8 @@ but has not yet run in production.
   seccomp, default-deny NetworkPolicy) and golden-render validation.
 
 
-[unreleased]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.3...HEAD
+[unreleased]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.4...HEAD
+[3.17.4]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.3...v3.17.4
 [3.17.3]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.2...v3.17.3
 [3.17.2]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.1...v3.17.2
 [3.17.1]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.0...v3.17.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,5 +33,5 @@ keywords:
   - ITS-REST
   - Rust
   - PostgreSQL
-version: 3.17.3
-date-released: 2026-08-05
+version: 3.17.4
+date-released: 2026-08-13

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "cnf-runner"
-version = "3.17.3"
+version = "3.17.4"
 dependencies = [
  "assert_fs",
  "base64 0.23.0",
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "docs-meta"
-version = "3.17.3"
+version = "3.17.4"
 
 [[package]]
 name = "dotenvy"
@@ -2663,7 +2663,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ferroehr"
-version = "3.17.3"
+version = "3.17.4"
 dependencies = [
  "argon2",
  "assert_fs",
@@ -2735,7 +2735,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-admin-ui"
-version = "3.17.3"
+version = "3.17.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -2777,7 +2777,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-ext"
-version = "3.17.3"
+version = "3.17.4"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -2801,7 +2801,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-rest"
-version = "3.17.3"
+version = "3.17.4"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -2860,7 +2860,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-server"
-version = "3.17.3"
+version = "3.17.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -5521,7 +5521,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-codegen"
-version = "3.17.3"
+version = "3.17.4"
 dependencies = [
  "roxmltree",
  "serde_json",
@@ -8744,7 +8744,7 @@ dependencies = [
 
 [[package]]
 name = "testkit"
-version = "3.17.3"
+version = "3.17.4"
 dependencies = [
  "ferroehr",
  "jiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "3"
 members = ["crates/*", "app/*", "tools/*"]
 
 [workspace.package]
-version = "3.17.3"
+version = "3.17.4"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ ITS-REST 1.1.0 &nbsp;·&nbsp; AQL 1.1 &nbsp;·&nbsp; RM 1.2.0 **+ 1.1.0** &nbsp;
 [![Containers](https://github.com/rubentalstra/FerroEHR/actions/workflows/containers.yml/badge.svg?branch=develop)](https://github.com/rubentalstra/FerroEHR/actions/workflows/containers.yml)
 [![CodeQL](https://github.com/rubentalstra/FerroEHR/actions/workflows/codeql.yml/badge.svg?branch=develop)](https://github.com/rubentalstra/FerroEHR/actions/workflows/codeql.yml)
 [![GitHub Release](https://img.shields.io/github/release/rubentalstra/FerroEHR.svg?logo=github)](https://github.com/rubentalstra/FerroEHR/releases/latest)
-[![FOSSA Status](https://app.fossa.com/api/projects/custom%2B63718%2FFerroEHR.svg?type=shield)](https://app.fossa.com/projects/custom%2B63718%2FFerroEHR?ref=badge_shield)
+[![FOSSA Status](https://app.fossa.com/api/projects/custom%2B63718%2FFerroEHR.svg?type=shield&issueType=license)](https://app.fossa.com/projects/custom%2B63718%2FFerroEHR?ref=badge_shield&issueType=license)
+[![FOSSA Status](https://app.fossa.com/api/projects/custom%2B63718%2FFerroEHR.svg?type=shield&issueType=security)](https://app.fossa.com/projects/custom%2B63718%2FFerroEHR?ref=badge_shield&issueType=security)
 
 [![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Frubentalstra%2Fferroehr%2Fbadges%2Fcoverage.json)](https://github.com/rubentalstra/FerroEHR/actions/workflows/ci.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/rubentalstra/FerroEHR/badge)](https://scorecard.dev/viewer/?uri=github.com/rubentalstra/FerroEHR)
@@ -581,7 +582,7 @@ rather than left to be discovered.
 ## Acknowledgments and license
 
 
-[![FOSSA Status](https://app.fossa.com/api/projects/custom%2B63718%2FFerroEHR.svg?type=large)](https://app.fossa.com/projects/custom%2B63718%2FFerroEHR?ref=badge_large)
+[![FOSSA Status](https://app.fossa.com/api/projects/custom%2B63718%2FFerroEHR.svg?type=large&issueType=license)](https://app.fossa.com/projects/custom%2B63718%2FFerroEHR?ref=badge_large&issueType=license)
 
 ### Acknowledgments
 

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # A published OCI version is immutable by refusal rather than by the registry —
 # `helm push` over an existing tag replaces it silently — so a correction always
 # ships as a NEW version and the published one stands as it was.
-version: 6.0.2
+version: 6.0.3
 # The default container image tag (overridable via image.tag), and the released
 # application version — kept equal to the workspace version by the
 # `chart-appversion` CI guard, so a release cannot ship a chart pointing at the

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -25,7 +25,7 @@ version: 6.0.2
 # previous image. It is NOT a promise that this tag accepts the chart's current
 # `config` defaults: values track development between releases, so the publish
 # lane re-checks the pairing against the image itself.
-appVersion: "3.17.3"
+appVersion: "3.17.4"
 
 # A COMPATIBILITY floor, and a real one: 1.36 is the release where the newest
 # field this chart renders became stable.
@@ -135,7 +135,7 @@ annotations:
   # scan while leaving the false claim in place, so it is deliberately not used.
   artifacthub.io/images: |
     - name: ferroehr
-      image: ghcr.io/rubentalstra/ferroehr:3.17.3
+      image: ghcr.io/rubentalstra/ferroehr:3.17.4
       platforms:
         - linux/amd64
         - linux/arm64
@@ -144,7 +144,7 @@ annotations:
     # visible to anyone considering it. See #2193: this chart cannot deploy it
     # yet, so today the entry advertises intent rather than chart behaviour.
     - name: ferroehr-admin-ui
-      image: ghcr.io/rubentalstra/ferroehr-admin-ui:3.17.3
+      image: ghcr.io/rubentalstra/ferroehr-admin-ui:3.17.4
       platforms:
         - linux/amd64
         - linux/arm64

--- a/deploy/helm/ferroehr/README.md
+++ b/deploy/helm/ferroehr/README.md
@@ -2,7 +2,7 @@
 
 Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.1.0 + AQL 1.1). A single static binary deployed with a hardened-by-default security posture: runs as a non-root, read-only-rootfs, default-deny-ingress workload that connects to an EXTERNAL PostgreSQL 18 as an unprivileged app role (migrations are run out of band by a separate migrator role).
 
-![Version: 6.0.2](https://img.shields.io/badge/Version-6.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.17.4](https://img.shields.io/badge/AppVersion-3.17.4-informational?style=flat-square)
+![Version: 6.0.3](https://img.shields.io/badge/Version-6.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.17.4](https://img.shields.io/badge/AppVersion-3.17.4-informational?style=flat-square)
 
 FerroEHR is a pure-Rust openEHR Clinical Data Repository: ITS-REST 1.1.0 at the
 API, AQL 1.1 as the query language, PostgreSQL 18-native storage, shipped as a
@@ -33,7 +33,7 @@ add — `helm repo add` does not apply to this chart and never will:
 
 ```console
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 6.0.2 \
+  --version 6.0.3 \
   --namespace ferroehr --create-namespace \
   --set database.existingSecret=ferroehr-db \
   --set image.tag=3.17.4
@@ -47,7 +47,7 @@ They are independent SemVer lines and they move independently:
 
 | What | Set with | This release |
 |---|---|---|
-| the **chart** (templates, defaults, this document) | `--version` | `6.0.2` |
+| the **chart** (templates, defaults, this document) | `--version` | `6.0.3` |
 | the **server image** | `image.tag` | `3.17.4` |
 
 `appVersion` is the image the chart defaults to; pinning `image.tag` explicitly
@@ -59,7 +59,7 @@ The chart carries two keyless Sigstore artifacts, and they answer different
 questions. A **cosign signature** — who signed this:
 
 ```console
-cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.2 \
+cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.3 \
   --certificate-identity-regexp '^https://github\.com/rubentalstra/FerroEHR/\.github/workflows/publish-chart\.yml@' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
@@ -67,7 +67,7 @@ cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.2 \
 A **SLSA build provenance attestation** — what source it was built from, and how:
 
 ```console
-gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:6.0.2 \
+gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:6.0.3 \
   -R rubentalstra/FerroEHR
 gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:3.17.4 \
   -R rubentalstra/FerroEHR

--- a/deploy/helm/ferroehr/README.md
+++ b/deploy/helm/ferroehr/README.md
@@ -2,7 +2,7 @@
 
 Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.1.0 + AQL 1.1). A single static binary deployed with a hardened-by-default security posture: runs as a non-root, read-only-rootfs, default-deny-ingress workload that connects to an EXTERNAL PostgreSQL 18 as an unprivileged app role (migrations are run out of band by a separate migrator role).
 
-![Version: 6.0.2](https://img.shields.io/badge/Version-6.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.17.3](https://img.shields.io/badge/AppVersion-3.17.3-informational?style=flat-square)
+![Version: 6.0.2](https://img.shields.io/badge/Version-6.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.17.4](https://img.shields.io/badge/AppVersion-3.17.4-informational?style=flat-square)
 
 FerroEHR is a pure-Rust openEHR Clinical Data Repository: ITS-REST 1.1.0 at the
 API, AQL 1.1 as the query language, PostgreSQL 18-native storage, shipped as a
@@ -36,7 +36,7 @@ helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
   --version 6.0.2 \
   --namespace ferroehr --create-namespace \
   --set database.existingSecret=ferroehr-db \
-  --set image.tag=3.17.3
+  --set image.tag=3.17.4
 ```
 
 OCI registries require Helm 3.8 or newer.
@@ -48,7 +48,7 @@ They are independent SemVer lines and they move independently:
 | What | Set with | This release |
 |---|---|---|
 | the **chart** (templates, defaults, this document) | `--version` | `6.0.2` |
-| the **server image** | `image.tag` | `3.17.3` |
+| the **server image** | `image.tag` | `3.17.4` |
 
 `appVersion` is the image the chart defaults to; pinning `image.tag` explicitly
 is what keeps an upgrade of one from silently moving the other.
@@ -69,7 +69,7 @@ A **SLSA build provenance attestation** — what source it was built from, and h
 ```console
 gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:6.0.2 \
   -R rubentalstra/FerroEHR
-gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:3.17.3 \
+gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:3.17.4 \
   -R rubentalstra/FerroEHR
 ```
 

--- a/deploy/helm/golden/admin-ui.yaml
+++ b/deploy/helm/golden/admin-ui.yaml
@@ -5,7 +5,7 @@ kind: NetworkPolicy
 metadata:
   name: ferroehr-admin-ui
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"
@@ -69,7 +69,7 @@ metadata:
     kubernetes.io/description: >-
       Default-deny ingress for the CDR: only the API port (and the management port when enabled) is admitted. An empty ingressFrom admits every source — narrow it for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"
@@ -97,7 +97,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"
@@ -118,7 +118,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr-admin-ui
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"
@@ -133,7 +133,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"
@@ -163,7 +163,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"
@@ -180,7 +180,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"
@@ -311,7 +311,7 @@ metadata:
     kubernetes.io/description: >-
       In-cluster address for the FerroEHR admin console. The console is a REST client of the CDR and holds no data of its own; it is the human-facing surface, so this is the Service an Ingress normally publishes.
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"
@@ -334,7 +334,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"
@@ -364,7 +364,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR admin console: a Leptos SSR web UI that consumes the CDR strictly over ITS-REST. It never reaches the database, which the console NetworkPolicy enforces rather than assumes.
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"
@@ -471,7 +471,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"

--- a/deploy/helm/golden/admin-ui.yaml
+++ b/deploy/helm/golden/admin-ui.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -72,7 +72,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -100,7 +100,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -121,7 +121,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -136,7 +136,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 automountServiceAccountToken: false
@@ -166,7 +166,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -183,7 +183,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -314,7 +314,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -337,7 +337,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -367,7 +367,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -403,7 +403,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: admin-ui
-          image: "ghcr.io/rubentalstra/ferroehr-admin-ui:3.17.3"
+          image: "ghcr.io/rubentalstra/ferroehr-admin-ui:3.17.4"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -474,7 +474,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -522,7 +522,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:3.17.3"
+          image: "ghcr.io/rubentalstra/ferroehr:3.17.4"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -18,7 +18,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -92,7 +92,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -113,7 +113,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -145,7 +145,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -171,7 +171,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -192,7 +192,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -383,7 +383,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -417,7 +417,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -467,7 +467,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:3.17.3"
+          image: "ghcr.io/rubentalstra/ferroehr:3.17.4"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -648,7 +648,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -682,7 +682,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -720,7 +720,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     release: kube-prometheus-stack

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -15,7 +15,7 @@ metadata:
     kubernetes.io/description: >-
       Default-deny ingress for the CDR: only the API port (and the management port when enabled) is admitted. An empty ingressFrom admits every source — narrow it for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"
@@ -89,7 +89,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"
@@ -110,7 +110,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"
@@ -142,7 +142,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"
@@ -168,7 +168,7 @@ kind: Secret
 metadata:
   name: ferroehr-config
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"
@@ -189,7 +189,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"
@@ -380,7 +380,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"
@@ -414,7 +414,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"
@@ -645,7 +645,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"
@@ -679,7 +679,7 @@ kind: Ingress
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"
@@ -717,7 +717,7 @@ kind: ServiceMonitor
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"

--- a/deploy/helm/golden/basic-auth.yaml
+++ b/deploy/helm/golden/basic-auth.yaml
@@ -15,7 +15,7 @@ metadata:
     kubernetes.io/description: >-
       Default-deny ingress for the CDR: only the API port (and the management port when enabled) is admitted. An empty ingressFrom admits every source — narrow it for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"
@@ -43,7 +43,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"
@@ -64,7 +64,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"
@@ -94,7 +94,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"
@@ -111,7 +111,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"
@@ -239,7 +239,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"
@@ -269,7 +269,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"

--- a/deploy/helm/golden/basic-auth.yaml
+++ b/deploy/helm/golden/basic-auth.yaml
@@ -18,7 +18,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -46,7 +46,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -67,7 +67,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 automountServiceAccountToken: false
@@ -97,7 +97,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -114,7 +114,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -242,7 +242,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -272,7 +272,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -320,7 +320,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:3.17.3"
+          image: "ghcr.io/rubentalstra/ferroehr:3.17.4"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -15,7 +15,7 @@ metadata:
     kubernetes.io/description: >-
       Default-deny ingress for the CDR: only the API port (and the management port when enabled) is admitted. An empty ingressFrom admits every source — narrow it for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"
@@ -43,7 +43,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"
@@ -64,7 +64,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"
@@ -79,7 +79,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"
@@ -204,7 +204,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"
@@ -234,7 +234,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.2
+    helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.4"

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -18,7 +18,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -46,7 +46,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -67,7 +67,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 automountServiceAccountToken: false
@@ -82,7 +82,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -207,7 +207,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -237,7 +237,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.2
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.3"
+    app.kubernetes.io/version: "3.17.4"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -285,7 +285,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:3.17.3"
+          image: "ghcr.io/rubentalstra/ferroehr:3.17.4"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@
 
 services:
   ferroehr-postgres:
-    image: ${FERROEHR_POSTGRES_IMAGE:-ghcr.io/rubentalstra/ferroehr-postgres:3.17.3}
+    image: ${FERROEHR_POSTGRES_IMAGE:-ghcr.io/rubentalstra/ferroehr-postgres:3.17.4}
     # Docker's default 64MB /dev/shm starves PostgreSQL's dynamic shared
     # memory under load (parallel workers error `could not resize shared
     # memory segment … No space left on device`); measured runs share this
@@ -148,7 +148,7 @@ services:
       start_period: 10s
 
   ferroehr:
-    image: ${FERROEHR_IMAGE:-ghcr.io/rubentalstra/ferroehr:3.17.3}
+    image: ${FERROEHR_IMAGE:-ghcr.io/rubentalstra/ferroehr:3.17.4}
     depends_on:
       ferroehr-postgres:
         condition: service_healthy
@@ -246,7 +246,7 @@ services:
   # FERROEHR_ADMIN__AUTH__OIDC__* variables at your identity provider.
   ferroehr-admin-ui:
     profiles: [admin-ui]
-    image: ${FERROEHR_ADMIN_UI_IMAGE:-ghcr.io/rubentalstra/ferroehr-admin-ui:3.17.3}
+    image: ${FERROEHR_ADMIN_UI_IMAGE:-ghcr.io/rubentalstra/ferroehr-admin-ui:3.17.4}
     depends_on:
       ferroehr:
         condition: service_healthy


### PR DESCRIPTION
The v3.17.4 milestone reached **zero open issues**. Everything whose acceptance could only be proven *by* a cut moved to **v3.17.5**, where it is verified against the artifacts this release produces rather than promised in advance — the signing bundles, the SBOM assets, the Zenodo deposit, the Scorecard `Signed-Releases` score, and the tag ruleset's first real refusal.

## The state this release ships in

**Conformance is green at 1014/1014**, restored to its previous high-water mark. It got there by attributing two defects rather than adjusting anything:

- `TERMINOLOGY_ID` was refusing values on an invariant that appears in **neither the class table, nor the BMM, nor the ancestor** — while its sibling `VERSION_TREE_ID` declares seven. One of the refused values, `snomed_ct(3.1)`, is published by released QUERY 1.1.0 in its own normative example.
- The conformance runner verified signatures against a certificate's **primary key alone**, so a signature made by the signing subkey the server selects could not verify. The server was conformant throughout.

Neither was environmental, and neither came from the commit that merely *recorded* the red run — the real causes sat 145 commits apart.

## Version bumps

| What | To | Note |
|---|---|---|
| workspace | `3.17.4` | + `Cargo.lock` |
| chart `appVersion` | `3.17.4` | |
| chart's own version | `6.0.2` — **unchanged** | already bumped three times in-cycle for its breaking changes (3.2.0 → 6.0.2) |
| `CITATION.cff` | `3.17.4`, released `2026-08-13` | |
| `.zenodo.json` | regenerated | never hand-edited — Zenodo ignores `CITATION.cff` when this file exists |
| compose image tags | `3.17.4` | the fallbacks the standalone quickstart pulls |

Chart README regenerated with `helm-docs`; golden renders updated; `deploy/helm/validate.sh` green.

## Verified before opening

`copyright-holder`, `compose-image-tags`, `vex-advisories`, `spdx-headers` (2470 files), `ci-conclusion-complete` (40 jobs) — all green, and workspace / `CITATION.cff` / `.zenodo.json` all agree on `3.17.4`.

## After the merge

Tag `v3.17.4` on the merge commit — **not** on this branch's head. The release lane creates the GitHub release as a draft, attaches the per-arch binaries, SBOMs and Sigstore bundles, checks the asset set is complete, and only then publishes: immutability freezes assets at publish, so the completeness check has to run first.

That asset guard is also newly correct. It compared with `grep -q`, which matches by **substring**, so a check for `…tar.gz` was satisfied by `…tar.gz.sigstore.json` alone — a release missing its binary would have published and been unfixable. It is `grep -Fxq` now, and this is the first cut that exercises it.