### PR TITLE
ci(licensing): record FOSSA revisions against branches, not merge refs

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -82,10 +82,15 @@ jobs:
           # "https://github.com/rubentalstra/FerroEHR". A stable name keeps the
           # dashboard, the badge and this lane pointing at one place.
           project: FerroEHR
-          # `github.ref_name` is the branch on a push and the PR number on a
-          # pull_request, which is what FOSSA's own example uses to keep a PR's
-          # results off the branch's history.
-          branch: ${{ github.ref_name }}
+          # The SOURCE branch, never the merge ref. `github.ref_name` is the
+          # branch on a push but `<PR>/merge` on a pull_request — a ref no
+          # branch corresponds to — so FOSSA recorded revisions under names
+          # like `2315/merge` and its project view landed on a merge ref from a
+          # pull request that had closed hours earlier. FOSSA's CI guidance is
+          # to analyse "a published branch, or pass the revision explicitly"
+          # (https://docs.fossa.com/docs/project-setup/cicd-scanning); a merge
+          # ref is neither.
+          branch: ${{ github.head_ref || github.ref_name }}
           run-tests: false
           # NO `generate-report` HERE. It needs a READ-scoped token and fails
           # with "Invalid API token type" on the push-only one this repository


### PR DESCRIPTION
`github.ref_name` is the branch on a `push` but **`<PR>/merge`** on a `pull_request` — a ref no branch corresponds to.

The consequence was visible on the dashboard: revisions filed under names like `2315/merge`, and the project's current view sitting on a merge ref from a pull request that had **closed nineteen hours earlier**, while `develop` scans existed the whole time.

`github.head_ref || github.ref_name` resolves correctly for both events:

| event | `head_ref` | result |
|---|---|---|
| push to `develop` | empty | `develop` |
| pull request | the source branch | the source branch |

This is what FOSSA's CI guidance asks for — analyse *"a published branch, or pass the revision explicitly"* (<https://docs.fossa.com/docs/project-setup/cicd-scanning>). A merge ref is neither.

`actionlint` clean, `zizmor --min-severity=low` no findings.

Refs #2334 — the remaining items there are the schema fields to decide deliberately, the project's visibility and default branch, and triaging the 20 findings before deciding whether the lane should gate.