### PR TITLE
fix(release): the SPDX SBOM identifies itself as ferroehr, not "."

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,14 +140,28 @@ jobs:
           # `dir:.` catalogues the checked-out release commit, so the document
           # describes the tree the release was cut from rather than a graph
           # resolved afterwards.
-          syft scan "dir:." --output "spdx-json=ferroehr-${TAG}.spdx.json"
-          # Refuse to attach a document that is not SPDX, rather than shipping a
-          # file that looks like an SBOM and is not.
+          #
+          # --source-name/--source-version, or the document names itself after
+          # the scanned directory: v3.17.4 shipped an SBOM whose `name` was
+          # literally "." (#2335). A consumer ingesting several SBOMs lists them
+          # by name, and one called "." is indistinguishable from any other
+          # directory scan.
+          syft scan "dir:." \
+            --source-name ferroehr --source-version "${TAG#v}" \
+            --output "spdx-json=ferroehr-${TAG}.spdx.json"
+          # Refuse to attach a document that is not SPDX, or that does not
+          # identify itself — either one ships a file that looks like an SBOM
+          # and answers no question a consumer can ask of it.
           version="$(jq -r '.spdxVersion' "ferroehr-${TAG}.spdx.json")"
           case "$version" in
             SPDX-*) ;;
             *) echo "::error::generated SBOM is not SPDX (spdxVersion=${version})"; exit 1 ;;
           esac
+          name="$(jq -r '.name' "ferroehr-${TAG}.spdx.json")"
+          if [ "$name" != "ferroehr" ]; then
+            echo "::error::SPDX document names itself '${name}', expected 'ferroehr'"
+            exit 1
+          fi
           count="$(jq '.packages | length' "ferroehr-${TAG}.spdx.json")"
           [ "$count" -gt 0 ] || { echo "::error::the SPDX SBOM lists no packages"; exit 1; }
           echo "SPDX ${version}, ${count} packages"


### PR DESCRIPTION
v3.17.4 shipped a repository SBOM whose document `name` was literally `.`:

```json
{ "spdxVersion": "SPDX-2.3", "dataLicense": "CC0-1.0", "name": "." }
```

syft names the document after the scanned target, and the target was `dir:.`. The package data was complete — 1277 packages — so nothing was missing; the document's own **identity** was wrong. It matters because consumers list SBOMs by name, and one called `.` is indistinguishable from any other directory scan.

## Verified, not assumed

The flags were checked against the binary itself rather than documentation:

```
$ syft:v1.50.0 scan --help
      --source-name string      set the name of the target being analyzed
      --source-version string   set the version of the target being analyzed
```

Then reproduced both ways on a throwaway crate:

| | document `name` |
|---|---|
| `syft scan dir:.` (what v3.17.4 ran) | **`.`** |
| `syft scan dir:. --source-name ferroehr --source-version 3.17.5` | **`ferroehr`** |

The version lands too — the described package carries `versionInfo: 3.17.5`.

## Also: a guard

A document that does not identify itself now fails the release, beside the existing check that refuses a non-SPDX file. Both failures ship something that *looks* like an SBOM and answers no question a consumer can ask of it — and release assets are immutable once published, so both belong before the publish rather than after.

`actionlint` clean, `zizmor --min-severity=low` no findings.

Closes #2335.