### PR TITLE
chore(legal): shell, SQL and YAML carry their licensing too

### DIFF
--- a/.claude/hooks/block_dangerous.sh
+++ b/.claude/hooks/block_dangerous.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # .claude/hooks/block_dangerous.sh
 #
 # Claude Code PreToolUse hook (matcher: Bash). Blocks destructive commands:

--- a/.claude/hooks/cnf_attribution_guard.sh
+++ b/.claude/hooks/cnf_attribution_guard.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # .claude/hooks/cnf_attribution_guard.sh
 #
 # Claude Code PreToolUse hook (matcher: Write|Edit|NotebookEdit). NON-BLOCKING

--- a/.claude/hooks/crate_version_bump_guard.sh
+++ b/.claude/hooks/crate_version_bump_guard.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # .claude/hooks/crate_version_bump_guard.sh
 #
 # Claude Code PreToolUse hook (matcher: Bash). Blocks `git push` when the

--- a/.claude/hooks/inject_phase_context.sh
+++ b/.claude/hooks/inject_phase_context.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # .claude/hooks/inject_phase_context.sh
 #
 # Claude Code SessionStart hook: prints the open GitHub issue list (the

--- a/.claude/hooks/no_attribution_guard.sh
+++ b/.claude/hooks/no_attribution_guard.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # .claude/hooks/no_attribution_guard.sh
 #
 # Claude Code PreToolUse hook (matcher: Bash).

--- a/.claude/hooks/phase_gate.sh
+++ b/.claude/hooks/phase_gate.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # .claude/hooks/phase_gate.sh
 #
 # Claude Code Stop hook: blocks ending a session in which no commit was made

--- a/.claude/hooks/protect_vendored_specs.sh
+++ b/.claude/hooks/protect_vendored_specs.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # .claude/hooks/protect_vendored_specs.sh
 #
 # Claude Code PreToolUse hook (matcher: Write|Edit|NotebookEdit). Mechanical

--- a/.claude/hooks/rust_fmt_clippy.sh
+++ b/.claude/hooks/rust_fmt_clippy.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # .claude/hooks/rust_fmt_clippy.sh
 #
 # Claude Code PostToolUse hook (matcher: Write|Edit).

--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fossas/fossa-cli/master/docs/references/files/fossa-yml.schema.json
 #
 # FOSSA CLI v3 configuration.

--- a/.fossabot.yml
+++ b/.fossabot.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # yaml-language-server: $schema=https://api.fossabot.fossa.com/schemas/fossabot-config.v1.json
 #
 # Fossabot — automated dependency-upgrade pull requests.

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # These are supported funding model platforms
 
 github: [rubentalstra]

--- a/.github/ISSUE_TEMPLATE/defect.yml
+++ b/.github/ISSUE_TEMPLATE/defect.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 name: Bug Report
 description: Report a defect in FerroEHR (wrong wire behaviour, a crash, a conformance divergence)
 labels: ["bug"]

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 name: Enhancement Request
 description: Request new or extended functionality in FerroEHR
 labels: ["enhancement"]

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 name: Task
 description: A general work item (maintenance, research, tooling, docs)
 labels: ["chore"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # .github/dependabot.yml
 version: 2
 updates:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # .github/workflows/ci.yml
 name: CI
 
@@ -395,6 +398,22 @@ jobs:
   # did not honour that file's path exclusions (measured 2026-08-12).
   # LICENSE, REUSE.toml and the codegen header constant must agree on the
   # copyright holder. They did not, and nothing compared them (#2325).
+  # Shell, SQL and YAML carry their licence in the file too, so a copied
+  # migration or script travels with it (#2326).
+  spdx-headers-text:
+    name: spdx-headers-text
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Shell, SQL and YAML state their licensing
+        run: bash scripts/checks/spdx-headers-text.sh
+
   copyright-holder:
     name: copyright-holder
     if: github.event_name == 'pull_request'
@@ -1854,6 +1873,7 @@ jobs:
       - no-python
       - license-text
       - copyright-holder
+      - spdx-headers-text
       - licensing
       - spec-citations
       - compose-hardening

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # CodeQL code scanning (security analysis).
 #
 # Enables GitHub code scanning so security alerts exist — the prerequisite for

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # .github/workflows/containers.yml
 #
 # Container images, built for speed:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # .github/workflows/docs.yml — build + deploy the documentation website.
 # Rust-only toolchain, vendored static assets, no Node/Python build step for
 # the site render.

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # Licence + dependency analysis via the FOSSA CLI (tracker issue #2298).
 #
 # WHY THIS LANE EXISTS, and not just the GitHub App: the hosted integration

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # Scheduled libFuzzer campaigns over the parsers that read attacker-controlled
 # bytes off the REST wire (the harnesses live in `fuzz/`).
 #

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # .github/workflows/image-scan.yml
 #
 # Scheduled vulnerability scan of the PUBLISHED container images (issue #2086;

--- a/.github/workflows/latest-deps.yml
+++ b/.github/workflows/latest-deps.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # .github/workflows/latest-deps.yml — scheduled latest-dependencies check.
 #
 # Cargo.toml pins caret ranges; Cargo.lock freezes CI to known-good versions

--- a/.github/workflows/link-check-external.yml
+++ b/.github/workflows/link-check-external.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # External link reachability — reported, never a merge gate (issue #2287).
 #
 # WHY THIS IS NOT IN THE PR PATH. Whether a third-party host answers a CI

--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # .github/workflows/publish-chart.yml
 #
 # Publishes the Helm chart to GHCR as an OCI artifact (issues #2104–#2106).

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # .github/workflows/publish-crates.yml
 #
 # Publishes the eight `crates/*` openEHR spec crates to crates.io

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # The release build, as a REUSABLE workflow — the SLSA v1.0 Build Level 3 lane.
 #
 # WHY THIS IS A SEPARATE FILE, which is the whole point of it. SLSA Build L3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # .github/workflows/release.yml
 #
 # Releases are changelog-driven (Keep a Changelog 1.1.0, CHANGELOG.md):

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # OpenSSF Scorecard — an INDEPENDENT score of this repository's security posture.
 #
 # It is here for the same reason the conformance numbers are computed by a runner

--- a/.github/workflows/spec-release-watcher.yml
+++ b/.github/workflows/spec-release-watcher.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # openEHR RELEASE watcher (tracker issue #179) — the companion of
 # spec-update-watcher.yml: that workflow tracks individual completed spec
 # changes; this one guarantees a component RELEASE is never missed (the

--- a/.github/workflows/spec-update-watcher.yml
+++ b/.github/workflows/spec-update-watcher.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # Scheduled openEHR spec-update watcher (tracker issue #137; the full
 # live-verified design dossier is recorded on that issue — the mechanism
 # notes live in scripts/watch/spec-update.sh itself).

--- a/.github/workflows/toolchain-watcher.yml
+++ b/.github/workflows/toolchain-watcher.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # Scheduled Rust toolchain watcher (tracker issue #2278).
 #
 # The Cargo book's CI guidance asks for exactly this

--- a/app/ferroehr/migrations/audit/0001_baseline.sql
+++ b/app/ferroehr/migrations/audit/0001_baseline.sql
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: FerroEHR contributors
+-- SPDX-License-Identifier: MIT
+
 -- audit schema baseline: the local IHE ATNA Audit Record Repository.
 --
 -- NOTE: no openEHR spec governs audit storage mechanics — our own

--- a/app/ferroehr/migrations/audit/0002_audit_chain.sql
+++ b/app/ferroehr/migrations/audit/0002_audit_chain.sql
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: FerroEHR contributors
+-- SPDX-License-Identifier: MIT
+
 -- Tamper evidence for the local IHE ATNA Audit Record Repository, plus the
 -- least-privilege grants that make the `audit` schema usable by a role that
 -- holds no DDL rights.

--- a/app/ferroehr/migrations/ehr/0001_baseline.sql
+++ b/app/ferroehr/migrations/ehr/0001_baseline.sql
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: FerroEHR contributors
+-- SPDX-License-Identifier: MIT
+
 -- ehr schema: the greenfield PG18-native CDR schema.
 --
 -- BASELINE. openEHR defines NO SQL schema — the relational layout here is our

--- a/app/ferroehr/migrations/ehr/0002_event_outbox.sql
+++ b/app/ferroehr/migrations/ehr/0002_event_outbox.sql
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: FerroEHR contributors
+-- SPDX-License-Identifier: MIT
+
 -- ehr schema: the contribution-outbox eventing table.
 --
 -- Append-only on the baseline (0001). One transactional outbox row is

--- a/app/ferroehr/migrations/ehr/0003_event_subscription.sql
+++ b/app/ferroehr/migrations/ehr/0003_event_subscription.sql
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: FerroEHR contributors
+-- SPDX-License-Identifier: MIT
+
 -- ehr schema: the event-filter subscription store (an extension — no openEHR
 -- spec governs eventing; "Event
 -- Trigger" parity).

--- a/app/ferroehr/migrations/ehr/0004_multitenancy.sql
+++ b/app/ferroehr/migrations/ehr/0004_multitenancy.sql
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: FerroEHR contributors
+-- SPDX-License-Identifier: MIT
+
 -- ehr schema: multi-tenancy — tenant registry + tenant_id scoping + RLS FORCE
 -- (an extension — no openEHR spec governs multi-tenancy; E2).
 --

--- a/app/ferroehr/migrations/ehr/0005_fhir_mapping.sql
+++ b/app/ferroehr/migrations/ehr/0005_fhir_mapping.sql
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: FerroEHR contributors
+-- SPDX-License-Identifier: MIT
+
 -- ehr schema: the FHIR-connector mapping store (an extension — no openEHR
 -- spec governs FHIR interop; E3 — FHIR R4
 -- connectors, "mapping-as-data").

--- a/app/ferroehr/migrations/ehr/0006_fhir_outbound_cursor.sql
+++ b/app/ferroehr/migrations/ehr/0006_fhir_outbound_cursor.sql
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: FerroEHR contributors
+-- SPDX-License-Identifier: MIT
+
 -- ehr schema: the FHIR **outbound** emitter's delivery cursor (an extension —
 -- no openEHR spec governs FHIR interop;
 -- 4a — event-driven FHIR resource emission).

--- a/app/ferroehr/migrations/ehr/0007_cold_archive_tier.sql
+++ b/app/ferroehr/migrations/ehr/0007_cold_archive_tier.sql
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: FerroEHR contributors
+-- SPDX-License-Identifier: MIT
+
 -- ehr schema: the COLD archival storage tier realizing SM I_ADMIN_ARCHIVE's
 -- "Move selected EHRs to archival storage" as an actual physical move.
 --

--- a/app/ferroehr/migrations/ext/0001_openehr_functions.sql
+++ b/app/ferroehr/migrations/ext/0001_openehr_functions.sql
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: FerroEHR contributors
+-- SPDX-License-Identifier: MIT
+
 -- ext schema: openEHR support functions + the cluster role/grant baseline
 -- (openEHR-semantics helper functions; no openEHR spec governs SQL helpers —
 -- they realize the cited RM/QUERY semantics).

--- a/app/ferroehr/migrations/ext/0002_tenant_context.sql
+++ b/app/ferroehr/migrations/ext/0002_tenant_context.sql
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: FerroEHR contributors
+-- SPDX-License-Identifier: MIT
+
 -- ext schema: multi-tenancy session context (an extension — no openEHR spec
 -- governs multi-tenancy; E2).
 --

--- a/app/ferroehr/tests/resources/config/application-test.yml
+++ b/app/ferroehr/tests/resources/config/application-test.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 
 security:
   auth-type: oauth

--- a/app/ferroehr/tests/resources/service/application.yml
+++ b/app/ferroehr/tests/resources/service/application.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # Copyright (c) 2024 Vitasystems GmbH.
 #
 # This file is part of Project EHRbase

--- a/deploy/helm/artifacthub-changes.sh
+++ b/deploy/helm/artifacthub-changes.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 #
 # Derive the per-release Artifact Hub annotations from CHANGELOG.md, so the hub
 # listing has ONE source of truth rather than a second changelog that drifts.

--- a/deploy/helm/artifacthub-repo.yml
+++ b/deploy/helm/artifacthub-repo.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # Artifact Hub repository metadata — the ownership token for the chart's listing
 # (https://artifacthub.io/docs/topics/repositories/).
 #

--- a/deploy/helm/ci/boot-check.sh
+++ b/deploy/helm/ci/boot-check.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 #
 # Boot every committed values overlay against a real ferroehr image.
 #

--- a/deploy/helm/validate.sh
+++ b/deploy/helm/validate.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 #
 # Validate the ferroehr Helm chart:
 #   1. helm lint      — default + all-features value sets (must be clean)

--- a/docker-compose.keycloak.yml
+++ b/docker-compose.keycloak.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # FerroEHR quickstart, OIDC variant — a STANDALONE overlay on docker-compose.yml
 # (the same pattern as docker-compose.observability.yml). Download BOTH files
 # into one directory and run:

--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # Observability overlay for the FerroEHR quickstart — STANDALONE, like
 # docker-compose.keycloak.yml: download it beside docker-compose.yml and run
 #

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # Repo-development override — merged automatically onto docker-compose.yml by
 # any bare `docker compose` invocation run from a repo checkout
 # (docs.docker.com/compose/how-tos/multiple-compose-files — "the override

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # FerroEHR quickstart — a STANDALONE file: download it anywhere and run
 #
 #   docker compose up

--- a/docker/admin-ui/e2e-env.yml
+++ b/docker/admin-ui/e2e-env.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # Compose override for the image-mode E2E run (scripts/ui-e2e.sh with
 # UI_E2E_IMAGE=1): the composed console image receives the same OIDC test
 # wiring the host-mode harness passes as process env. The issuer uses the

--- a/docker/observability/alerts.yml
+++ b/docker/observability/alerts.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # Alert starter pack — documented, not imposed. Load into a Prometheus/Grafana
 # alerting instance and calibrate every threshold against real traffic: these
 # rules exist to be tuned, and a rule that never fires in your deployment is a

--- a/docker/postgres/initdb/10-ferroehr-init.sh
+++ b/docker/postgres/initdb/10-ferroehr-init.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Preconfigure the ferroehr database. Runs once, as the bootstrap superuser
 # (POSTGRES_USER), on first initialisation of an empty data directory.
 #

--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # End-to-end smoke test for the two container images (amd64), run against the
 # TRUE end-user artifact: the standalone docker-compose.yml, pinned with an
 # explicit -f so a repo checkout's docker-compose.override.yml never merges in.

--- a/docker/sut-ehrbase.yml
+++ b/docker/sut-ehrbase.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # Upstream EHRbase as a CNF system-under-test — composed ONLY by
 # `CONF_SUT=ehrbase scripts/conformance.sh` (issue #232: the public CDR
 # comparison re-based on the CNF 2.0 pipeline). Fresh volumes per run (the

--- a/docker/sut-ferroehr.yml
+++ b/docker/sut-ferroehr.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # The ferroehr CNF SUT stack (compose BASE — self-contained, like
 # docker/sut-ehrbase.yml): the conformance lanes compose THIS file, never
 # the end-user quickstart docker-compose.yml, so the quickstart artifact and

--- a/docker/sut-measurement.yml
+++ b/docker/sut-measurement.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # The MEASUREMENT posture overlay — composed on top of docker/sut-ferroehr.yml
 # only for the measured-performance (`cnf-runner perf`) and step-load
 # (`cnf-runner stress`) lanes, which scripts/conformance.sh selects when

--- a/docker/sut-pgp-parallel.yml
+++ b/docker/sut-pgp-parallel.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # CNF parallel pgp deployment (compose OVERLAY, stacks LAST).
 #
 # The conformance pipeline runs BOTH claimed version-signing modes in the ONE

--- a/docker/sut-signing-pgp.yml
+++ b/docker/sut-signing-pgp.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # CNF pgp-mode signing variant (compose OVERLAY).
 #
 # Reconfigures the ferroehr SUT to sign committed VERSIONs with an OpenPGP

--- a/docker/sut-smart.yml
+++ b/docker/sut-smart.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # CNF SMART on openEHR lane (compose OVERLAY).
 #
 # Boots the ferroehr SUT in the SMART *resource-server* role so the three

--- a/docker/sut-terminology-failclosed.yml
+++ b/docker/sut-terminology-failclosed.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # CNF external-terminology lane (compose OVERLAY) — the fail-CLOSED posture.
 #
 # `[terminology.external] fail_on_error` decides what a deployment does with a

--- a/docker/sut-terminology.yml
+++ b/docker/sut-terminology.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
 # CNF external-terminology lane (compose OVERLAY) — the fail-OPEN posture.
 #
 # Switches on the `[terminology.external]` providers that docker/ferroehr.dev.toml

--- a/docker/terminology/seed.sh
+++ b/docker/terminology/seed.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Seed the composed FHIR R4 terminology server with the CNF test terminologies.
 #
 # Runs as a one-shot init container of the `terminology` compose profile, after

--- a/fuzz/seeds.sh
+++ b/fuzz/seeds.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Populate fuzz/seeds/<target>/ from the corpora already committed in this
 # repository, as SYMLINKS — the archetype and template packs are ~100 MB, are
 # provenance-stamped where they live, and are never copied.

--- a/scripts/checks/access-provenance.sh
+++ b/scripts/checks/access-provenance.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Access-layer provenance guard (owner directive 2026-08-06, issue #1963).
 #
 # The authentication/authorization layer is OUR OWN DESIGN, grounded in the IETF

--- a/scripts/checks/changelog-structure.sh
+++ b/scripts/checks/changelog-structure.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Changelog structure guard (Keep a Changelog 1.1.0).
 #
 # Fails when any release section of CHANGELOG.md (including [Unreleased])

--- a/scripts/checks/ci-conclusion-complete.sh
+++ b/scripts/checks/ci-conclusion-complete.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Every CI job must be reachable from the `conclusion` gate.
 #
 # Branch protection points at `conclusion` alone, on purpose: that is what lets

--- a/scripts/checks/codegen-drift.sh
+++ b/scripts/checks/codegen-drift.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Regenerate every codegen output and fail if any drifted from the vendored
 # specs (BMM → spec crates; the ITS XML/REST surfaces).
 #

--- a/scripts/checks/comment-style.sh
+++ b/scripts/checks/comment-style.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Comment-style guard (.claude/rules/comments.md — RFC 505 / RFC 1574).
 #
 # Checks HAND-WRITTEN .rs files (files carrying the `@generated` marker are

--- a/scripts/checks/compose-hardening.sh
+++ b/scripts/checks/compose-hardening.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Compose hardening guard (OWASP Docker Security Cheat Sheet; issues #1993–#2001).
 #
 # The Kubernetes path is hardened by `deploy/helm/ferroehr/values.yaml`, which a

--- a/scripts/checks/compose-image-tags.sh
+++ b/scripts/checks/compose-image-tags.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Compose image-tag guard (the CITATION.cff / Helm appVersion pattern).
 #
 # The standalone quickstart docker-compose.yml pulls the PUBLISHED images by an

--- a/scripts/checks/conformance-numbers.sh
+++ b/scripts/checks/conformance-numbers.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # The stale-numbers gate (CI, docs workflow): fails the build if a hand-typed
 # conformance OR performance claim appears in the site SOURCES. Conformance
 # numbers/verdicts and performance rates/latencies on the website are derived

--- a/scripts/checks/copyright-holder.sh
+++ b/scripts/checks/copyright-holder.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # One copyright holder, stated identically everywhere it is stated.
 #
 # `LICENSE` said "Ruben Talstra" while `REUSE.toml`, the codegen header constant

--- a/scripts/checks/default-style.sh
+++ b/scripts/checks/default-style.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Default-value style guard (owner directive 2026-08-06; the shape of RFC 3681,
 # https://rust-lang.github.io/rfcs/3681-default-field-values.html).
 #

--- a/scripts/checks/docs-claims.sh
+++ b/scripts/checks/docs-claims.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Docs-claim guard: a documented KEY must exist in the thing it documents.
 #
 # The v3.17.4 book sweep found five substantive defects that had shipped to the

--- a/scripts/checks/error-hygiene.sh
+++ b/scripts/checks/error-hygiene.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Error-body hygiene guard (OWASP REST Security Cheat Sheet, issue #2021):
 # "Do not pass technical details (e.g. call stacks or other internal hints) to
 # the client."

--- a/scripts/checks/error-source-chain.sh
+++ b/scripts/checks/error-source-chain.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # RFC 0201: an error carries its cause (#2034).
 #
 # `Error::source` is part of the `Error` contract, and `map_err(|e| V(e.to_string()))`

--- a/scripts/checks/first-party-license-text.sh
+++ b/scripts/checks/first-party-license-text.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Refuses copyleft licence TEXT inside this project's own source.
 #
 # This project's own code is MIT (.claude/rules/reliability.md §C-PERMISSIVE).

--- a/scripts/checks/image-labels.sh
+++ b/scripts/checks/image-labels.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Image-metadata guard: the OCI annotation keys are declared once, correctly, and
 # the two places that declare them agree.
 #

--- a/scripts/checks/licensing-declarations.sh
+++ b/scripts/checks/licensing-declarations.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # The licensing declarations, the licence texts and the licensing chapter must
 # describe the same set of licences.
 #

--- a/scripts/checks/no-python.sh
+++ b/scripts/checks/no-python.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # No Python in this repository (owner hard rule, 2026-08-10).
 #
 # The tooling languages are bash and Rust. Python is banned everywhere —

--- a/scripts/checks/spdx-headers-text.sh
+++ b/scripts/checks/spdx-headers-text.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Every first-party shell, SQL and YAML file states its licensing INSIDE itself.
 #
 # The sibling gate `spdx-headers.sh` does this for Rust. This one exists rather

--- a/scripts/checks/spdx-headers-text.sh
+++ b/scripts/checks/spdx-headers-text.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Every first-party shell, SQL and YAML file states its licensing INSIDE itself.
+#
+# The sibling gate `spdx-headers.sh` does this for Rust. This one exists rather
+# than extending it because the two populations differ in three ways at once:
+# the comment syntax (`#` and `--`, not `//`), the placement (a shebang must
+# stay on line 1), and the licensing (these files are plain MIT — none carries
+# openEHR specification text, so the dual-licence rule the Rust gate applies to
+# the published spec crates has nothing to act on here). One gate with a mode
+# matrix would be harder to read than two that each do one thing.
+#
+# WHY HEADERS AT ALL, when `REUSE.toml` already covers the tree by glob: a glob
+# declaration does not travel with a copied file. REUSE 3.3 exists for exactly
+# that property. The sharpest case here is `app/ferroehr/migrations/*.sql` — a
+# migration lifted into another project is precisely the kind of file that gets
+# copied, and it would arrive with no licence statement at all.
+#
+# SCOPE: tracked `.sh`, `.sql`, `.yml`. Vendored trees and third-party corpora
+# are excluded, not exempted — a header there would assert something about
+# somebody else's file. `.yaml` is deliberately NOT covered: that population is
+# the CNF catalogue (data, thousands of files), and the Helm templates, where a
+# `#` comment renders into `helm template` output and would change what users
+# see.
+#
+# Usage:
+#   scripts/checks/spdx-headers-text.sh          # verify
+#   scripts/checks/spdx-headers-text.sh --fix    # insert missing headers
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+mode="${1:-}"
+case "$mode" in
+'' | --fix) ;;
+*)
+  echo "usage: $0 [--fix]" >&2
+  exit 2
+  ;;
+esac
+
+# The tags below are DATA this gate compares against, not this file's own
+# licensing, and `reuse lint` reads a tag wherever it appears — the
+# specification's own remedy for a file that quotes the syntax it checks.
+# REUSE-IgnoreStart
+readonly COPYRIGHT='SPDX-FileCopyrightText: FerroEHR contributors'
+readonly LICENSE='SPDX-License-Identifier: MIT'
+# REUSE-IgnoreEnd
+
+# Vendored and third-party trees: their licensing is recorded in each tree's
+# PROVENANCE.md and must not be overwritten by an assertion of ours. Kept in
+# step with .fossa.yml and scripts/checks/first-party-license-text.sh.
+readonly EXCLUDED='^(docs/specs|crates/[^/]+/vendor|crates/[^/]+/tests/vendor|crates/openehr-adl/tests/corpus|crates/openehr-its/tests/fixtures|crates/openehr-term/tests|crates/openehr-term/assets|crates/openehr-its/schemas|tools/openehr-codegen/vendor|tools/cnf-runner/artifacts|fuzz/seeds|LICENSES)/'
+
+# The comment leader for a path's file type.
+comment_prefix() {
+  case "$1" in
+  *.sql) printf -- '--' ;;
+  *) printf '#' ;;
+  esac
+}
+
+fail=0
+fixed=0
+checked=0
+
+while IFS= read -r f; do
+  [ -f "$f" ] || continue
+  checked=$((checked + 1))
+  prefix=$(comment_prefix "$f")
+
+  # Read a window, not line 1: a shebang legitimately precedes the header.
+  if head -n 8 "$f" | grep -qF "$LICENSE"; then
+    continue
+  fi
+
+  if [ "$mode" != --fix ]; then
+    echo "$f: no $LICENSE in the first 8 lines" >&2
+    fail=1
+    continue
+  fi
+
+  # A shebang must stay on line 1, or the file stops being executable by the
+  # interpreter it names.
+  if head -n 1 "$f" | grep -q '^#!'; then
+    {
+      head -n 1 "$f"
+      printf '%s %s\n%s %s\n' "$prefix" "$COPYRIGHT" "$prefix" "$LICENSE"
+      tail -n +2 "$f"
+    } >"$f.spdx.tmp"
+  else
+    {
+      printf '%s %s\n%s %s\n\n' "$prefix" "$COPYRIGHT" "$prefix" "$LICENSE"
+      cat "$f"
+    } >"$f.spdx.tmp"
+  fi
+  # Preserve the executable bit: a stamped script that stops being runnable is
+  # a worse defect than a missing header.
+  chmod --reference="$f" "$f.spdx.tmp" 2>/dev/null || chmod "$(stat -f '%A' "$f")" "$f.spdx.tmp"
+  mv "$f.spdx.tmp" "$f"
+  fixed=$((fixed + 1))
+done < <(git ls-files '*.sh' '*.sql' '*.yml' | grep -vE "$EXCLUDED")
+
+if [ "$mode" = --fix ]; then
+  echo "spdx-headers-text: $fixed header(s) inserted across $checked file(s)."
+  exit 0
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "spdx-headers-text: files without a licence header (run --fix)." >&2
+  exit 1
+fi
+echo "spdx-headers-text: OK ($checked files)."

--- a/scripts/checks/spdx-headers.sh
+++ b/scripts/checks/spdx-headers.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Every first-party Rust source file states its licensing INSIDE itself.
 #
 # `REUSE.toml` already covers the whole tree by glob and `reuse lint` proves it

--- a/scripts/checks/spec-citations.sh
+++ b/scripts/checks/spec-citations.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Every openEHR spec file a comment cites must exist under docs/specs/openehr/.
 #
 # The vendored spec text is the oracle (.claude/rules/spec-adherence.md), and a

--- a/scripts/checks/sql-string-building.sh
+++ b/scripts/checks/sql-string-building.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # String-built-SQL guard for every layer that builds SQL at runtime.
 #
 # The AQL engine builds SQL dynamically from attacker-controlled query text, so

--- a/scripts/checks/typed-status.sh
+++ b/scripts/checks/typed-status.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Typed-status guard (owner directive 2026-08-06).
 #
 # An HTTP status is compared as a TYPE, never as a number:

--- a/scripts/checks/vex-advisories.sh
+++ b/scripts/checks/vex-advisories.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # The VEX drift gate: the published OpenVEX document must be exactly what the
 # generator produces from `deny.toml` + `security/vex/rust-advisories.toml`.
 #

--- a/scripts/conformance.sh
+++ b/scripts/conformance.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # openEHR CNF 2.0 conformance pipeline — the acceptance instrument.
 #
 # Drives the CNF reference runner (tools/cnf-runner) end to end: bring up the

--- a/scripts/deploy-probe-k8s.sh
+++ b/scripts/deploy-probe-k8s.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # The deployment-conformance harness, Kubernetes platform (#2178).
 #
 # The compose harness (scripts/deploy-probe.sh) measures whether the software

--- a/scripts/deploy-probe.sh
+++ b/scripts/deploy-probe.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # The deployment-conformance harness (#2178).
 #
 # `cnf-runner` exists because "we believe the REST surface is conformant" was

--- a/scripts/deploy-probes/compose.sh
+++ b/scripts/deploy-probes/compose.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # The Docker Compose probe family.
 #
 # Every probe here observes at the FAR END — a blob in the bucket, a claim in a

--- a/scripts/deploy-probes/events.sh
+++ b/scripts/deploy-probes/events.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # The events / AMQP outbox probe family (#2178, #2158).
 #
 # Two claims are made about this integration and neither had been demonstrated

--- a/scripts/deploy-probes/fhir.sh
+++ b/scripts/deploy-probes/fhir.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # The FHIR probe family (#2178, #2158).
 #
 # FHIR is two integrations behind one config block, and they have OPPOSITE

--- a/scripts/deploy-probes/kubernetes.sh
+++ b/scripts/deploy-probes/kubernetes.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # The Kubernetes probe family (#2178's second platform).
 #
 # The compose family answers "does the software work when it is deployed". This

--- a/scripts/deploy-probes/lib.sh
+++ b/scripts/deploy-probes/lib.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Shared probe vocabulary for the deployment-conformance harness.
 #
 # The instrument's whole point is that a red row is ACTIONABLE, so every

--- a/scripts/deploy-probes/observability.sh
+++ b/scripts/deploy-probes/observability.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # The observability probe family (#2162, #2173, #2175).
 #
 # The far end here is deliberately awkward to reach, and that is the point. The

--- a/scripts/deploy-probes/oidc.sh
+++ b/scripts/deploy-probes/oidc.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # The OIDC / Keycloak probe family.
 #
 # Driven through the PUBLISHED quickstart overlay and the recipe the book gives

--- a/scripts/deploy-probes/signing.sh
+++ b/scripts/deploy-probes/signing.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # The VERSION-signing probe family (#2163).
 #
 # `[signing]` is on by default in `digest` mode with read-time verification

--- a/scripts/deploy-probes/signing_pgp.sh
+++ b/scripts/deploy-probes/signing_pgp.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # The PGP signing probe family (#2163's second mode).
 #
 # #2163 is explicit that the PGP path must be exercised "with a real key,

--- a/scripts/deploy-probes/tenancy.sh
+++ b/scripts/deploy-probes/tenancy.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # The multi-tenancy probe family (#2178, #2158).
 #
 # Tenancy is off by default, and its claim is the strongest one this server

--- a/scripts/deploy-probes/terminology.sh
+++ b/scripts/deploy-probes/terminology.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # The terminology probe family (#2178, #2158) — against a REAL terminology
 # server, with REAL content.
 #

--- a/scripts/generate-ckm-examples.sh
+++ b/scripts/generate-ckm-examples.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Generate the committed example skeletons for the CKM journey template
 # pack: upload every vendored OPT to a running ferroehr SUT, fetch its
 # example composition (the ITS-REST "Get example data by template"

--- a/scripts/gh/project.sh
+++ b/scripts/gh/project.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # scripts/gh/project.sh — the deterministic GitHub Projects (v2) board helper.
 #
 # WHY THIS EXISTS: the public roadmap board is a GitHub Project (v2), and its

--- a/scripts/gh/rel.sh
+++ b/scripts/gh/rel.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # scripts/gh/rel.sh — the deterministic GitHub issue-relationship helper.
 #
 # WHY THIS EXISTS: `gh` has NO native subcommand for sub-issues or issue

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # scripts/install-hooks.sh
 #
 # Installs the repo's tracked git hooks by pointing git at .githooks/.

--- a/scripts/profile.sh
+++ b/scripts/profile.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Profiling harness: run ONE capacity step
 # of the hospital-day workload against the composed ferroehr stack and dump
 # the PostgreSQL statement profile + the AQL dashboard plans into a committed

--- a/scripts/render/comparison.sh
+++ b/scripts/render/comparison.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Render the public comparison page's content (tracker issue #147) from the
 # COMMITTED runner artifacts — the same no-hand-typed-numbers discipline as
 # scripts/render/conformance-stats.sh (CI: scripts/checks/conformance-numbers.sh).

--- a/scripts/render/conformance-assets.sh
+++ b/scripts/render/conformance-assets.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Regenerate the published conformance visuals (the capability heat grid +
 # the per-chapter outcome bars) FROM the committed party artifacts — the
 # render-perf-assets.sh pattern for functional conformance: deterministic,

--- a/scripts/render/conformance-stats.sh
+++ b/scripts/render/conformance-stats.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Derive every website conformance claim from the committed CNF artifacts
 # (docs/conformance/ferroehr/: results.json + verdicts.json) at BUILD time —
 # the site sources carry no hand-typed conformance numbers (enforced by

--- a/scripts/render/perf-assets.sh
+++ b/scripts/render/perf-assets.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Render the published performance SVG assets FROM the committed measurement
 # records (docs/conformance/<sut>/results.json measurements block, plus the
 # stress report when one exists) via `cnf-runner perf-assets`. Deterministic

--- a/scripts/render/zenodo-json.sh
+++ b/scripts/render/zenodo-json.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Render `.zenodo.json` from `CITATION.cff` (#2210).
 #
 # Zenodo's own rule makes this file necessary and dangerous in one sentence:

--- a/scripts/security/vex-generate.sh
+++ b/scripts/security/vex-generate.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Generate the Rust-dependency OpenVEX document.
 #
 #   security/vex/rust-advisories.toml  (the reasoning)

--- a/scripts/site/assemble-oas.sh
+++ b/scripts/site/assemble-oas.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Copy the 7 documentation OAS bundles into the served copy; --check fails on drift.
 #
 # The served specs are a byte copy of the vendored `-html` ITS-REST bundles

--- a/scripts/site/build.sh
+++ b/scripts/site/build.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Assemble the full Pages site tree into ./_site, exactly as CI does — so
 # "works on my machine" == the deployed layout (URL scheme, frozen versions,
 # and workflow all match the Docs CI job).

--- a/scripts/site/cut-version.sh
+++ b/scripts/site/cut-version.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Cut a frozen documentation version onto the docs-dist orphan branch.
 # "generate once, never rebuild".
 #

--- a/scripts/ui-e2e.sh
+++ b/scripts/ui-e2e.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Admin-console E2E harness: compose up the CDR stack +
 # Keycloak, build + run the console on the host, start chromedriver, run the
 # e2e journeys via nextest, tear down. Mirrors scripts/conformance.sh.

--- a/scripts/vendor/adl-grammars.sh
+++ b/scripts/vendor/adl-grammars.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Vendor the AM component's normative ADL/cADL ANTLR4 grammars, VERSION-SCOPED.
 #
 # Layout (the multi-generation foundation, #1936/#1946): the grammar files are

--- a/scripts/vendor/adl2-archetypes.sh
+++ b/scripts/vendor/adl2-archetypes.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Vendor the official openEHR ADL 2 archetype libraries — the ADL 2.4 half of
 # the two-dialect archetype corpus.
 #

--- a/scripts/vendor/ckm-archetypes.sh
+++ b/scripts/vendor/ckm-archetypes.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Vendor the official openEHR CKM archetype library — the ADL 1.4 half of the
 # two-dialect archetype corpus.
 #

--- a/scripts/vendor/ckm-templates.sh
+++ b/scripts/vendor/ckm-templates.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Vendor the official openEHR CKM template library as OPT 1.4 XML.
 #
 # Source: the public openEHR Clinical Knowledge Manager REST API

--- a/scripts/vendor/lang-grammars.sh
+++ b/scripts/vendor/lang-grammars.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Vendor the LANG component's normative ANTLR4 grammars, VERSION-SCOPED.
 #
 # Layout (the multi-generation foundation, #1936/#1942): each LANG component

--- a/scripts/vendor/openehr-sdk-json.sh
+++ b/scripts/vendor/openehr-sdk-json.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Vendor the real-world openEHR canonical-JSON corpus that grounds the
 # `openehr-its` fidelity gates (read -> re-serialize -> equality +
 # ITS-JSON schema validation).

--- a/scripts/vendor/spec-docs.sh
+++ b/scripts/vendor/spec-docs.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # Vendors the openEHR specification *documentation* (the normative spec text)
 # into docs/specs/openehr/, pinned per docs/VERSIONS.md. Text formats only
 # (adoc/md/txt/csv/json/yaml) — bitmap images, UML .xmi, XSDs, and other

--- a/scripts/watch/spec-release.sh
+++ b/scripts/watch/spec-release.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # openEHR RELEASE watcher (tracker issue #179) — the companion of
 # scripts/watch/spec-update.sh: that one tracks individual completed spec
 # CHANGES; this one makes sure a component RELEASE event is never missed

--- a/scripts/watch/spec-update.sh
+++ b/scripts/watch/spec-update.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
 # openEHR spec-update watcher (tracker issue #137; design dossier: recorded on tracker issue #137
 # — every mechanism live-verified 2026-07-20). Three detection sources; A and B
 # file ONE GitHub issue per completed upstream spec change, C maintains ONE


### PR DESCRIPTION
#2318 stamped every first-party Rust source. Three populations were left without one: **75 shell scripts, 11 SQL migrations, 41 YAML files**.

## Why the migrations are the point

A migration lifted out of `app/ferroehr/migrations/` into another project is exactly the kind of file that gets copied — and it arrived carrying no licence statement at all. `REUSE.toml` keeps the *repository* compliant, but a glob declaration does not travel with a copied file, which is the entire property REUSE 3.3 exists for.

## A sibling gate, not an extension

The Rust gate is 149 careful lines that hardcode `//` and prepend at line 1. These populations differ in three ways at once:

- **comment syntax** — `#` and `--`
- **placement** — a shebang must stay on line 1 or the script stops being executable by the interpreter it names
- **licensing** — none of these files carries openEHR specification text, so the dual-licence rule the Rust gate applies to the published spec crates has nothing to act on

One gate with a mode matrix would read worse than two that each do one thing.

## `.yaml` is excluded deliberately, and not for scale

The Helm templates are `.yaml`, and a `#` comment there **renders into `helm template` output** — stamping them would change what users see and move the golden renders. The rest of that population is the CNF catalogue, which is data rather than code. Both reasons are written into the gate's own header so the scope is not mistaken for an oversight.

## Verified beyond "the gate passes"

| check | result |
|---|---|
| `actionlint` over all workflows | clean |
| `docker compose config` | parses |
| every stamped gate script still executes | 6/6 ok |
| executable bit survives the rewrite | preserved |

Mutation-proven three ways: a stripped SQL header **fails**, a new unheadered script **fails**, a vendored file is **not** flagged.

41 CI jobs now gate the merge.

Closes #2326.