### PR TITLE
chore(supply-chain): record the FOSSA schema decisions, and stop claiming Zenodo

### DIFF
--- a/.claude/rules/changelog.md
+++ b/.claude/rules/changelog.md
@@ -67,12 +67,15 @@ optional:
   overwrite a published chart version. GitHub releases are immutable by the
   platform; container tags are immutable only because our lane enforces it.
 
-- **The tag also produces an archived artifact.** Zenodo is connected to this
-  repository, so publishing a release makes Zenodo take the zipball and mint a
-  DOI from `.zenodo.json`. That deposit is immutable — whatever the metadata
-  says at publish time is what the DOI carries — so the metadata is verified
-  BEFORE the cut, never after. A badge cites the CONCEPT DOI; a version DOI
-  freezes on whichever release was current the day it was added.
+- **The tag does NOT produce an archived artifact — Zenodo is not connected.**
+  Measured after the v3.17.4 cut: the Zenodo API returned zero records for this
+  project while a control query returned results, so the absence is real and
+  not an indexing lag. This entry previously asserted the integration as fact,
+  which is exactly how a cut passes believing it archived something when it did
+  not. `.zenodo.json` is generated and valid, so the metadata half is ready and
+  only the connection is missing. Two properties govern it if it is ever
+  enabled: a deposit is IMMUTABLE, so the metadata is verified before the cut
+  and never after; and enabling it archives the NEXT release, never a past one.
 - **After the tag:** close the `vX.Y.Z` milestone (`gh api … milestones/N
   -f state=closed`) and make sure the NEXT milestone exists so triage always
   has a target. The milestone's closed-issue list + the changelog section

--- a/.fossa.yml
+++ b/.fossa.yml
@@ -38,6 +38,26 @@
 #     obligation attaches.
 version: 3
 
+# WHAT IS DELIBERATELY NOT SET HERE, and why (#2334). The v3 schema offers a
+# dozen more fields; every one left out is a decision, not an oversight.
+#
+#   project.name/.link/.jiraProjectKey/.policy/.team  — documented CREATE-ONLY.
+#     This project already exists, so setting them would be inert at best. The
+#     project is selected by the workflow's `project:` input, which is one
+#     place rather than half here and half there; unpinned, the CLI names it
+#     after the git remote and files results under a project literally called
+#     "https://github.com/rubentalstra/FerroEHR", which is how a duplicate
+#     appeared beside the hosted integration's.
+#   revision.branch/.commit  — passed by the workflow, which is the only place
+#     that knows the event. `github.head_ref || github.ref_name` there keeps a
+#     pull request off the `<PR>/merge` ref it would otherwise record under.
+#   vendoredDependencies  — nothing in this repository is scanned as a vendored
+#     DEPENDENCY: the vendored trees are specification text and test corpora,
+#     excluded below, not code this software links.
+#   server  — the default endpoint is correct; recorded as checked.
+#   telemetry  — left at the default deliberately rather than silently.
+#   maven/gradle blocks  — not applicable; this is a Cargo workspace.
+
 targets:
   only:
     - type: cargo


### PR DESCRIPTION
Two corrections of the same kind — a document asserting something the repository does not do.

## The release procedure claimed Zenodo archiving that does not happen

`.claude/rules/changelog.md` said:

> **The tag also produces an archived artifact.** Zenodo is connected to this repository, so publishing a release makes Zenodo take the zipball and mint a DOI from `.zenodo.json`.

Measured after the v3.17.4 cut:

```
GET https://zenodo.org/api/records?q=FerroEHR      → hits.total = 0
GET https://zenodo.org/api/records?q=rubentalstra  → hits.total = 0
control query                                      → 1,260,637 hits
```

The absence is real, not an indexing lag. A release procedure that asserts an archival step it does not perform is precisely how a cut passes believing an artifact was archived when none was — the same shape as the five gates that ran without gating and the asset guard that matched by substring.

The entry now says what is true, and keeps the two properties that would govern it if it were ever enabled: a deposit is **immutable**, so metadata is verified before the cut; and enabling it archives the **next** release, never a past one. `.zenodo.json` is generated and valid, so only the connection is missing.

## `.fossa.yml` used three fields and inherited the rest

Every remaining field in the v3 schema is now recorded as a decision with its reason:

| Field | Decision |
|---|---|
| `project.name/.link/.jiraProjectKey/.policy/.team` | **create-only** — inert against a project that already exists; selection stays in the workflow's `project:` input, one place rather than half in each |
| `revision.branch/.commit` | the workflow's, because only it knows the event — `github.head_ref \|\| github.ref_name` keeps a PR off the `<PR>/merge` ref |
| `vendoredDependencies` | nothing to act on — the vendored trees are specification text and corpora, not linked code |
| `server` | default correct, recorded as checked |
| `telemetry` | left at default **deliberately** rather than silently |
| `maven`/`gradle` | not applicable to a Cargo workspace |

A default that was chosen reads the same as one that was inherited, until someone has to change it. Verified the file still parses: `version: 3`, `targets.only[0].type: cargo`, 13 exclusions intact.

Refs #2334.