### PR TITLE
docs(security): custom FOSSA policies are not on this plan, so the gate stays off

### DIFF
--- a/security/fossa-adjudications.md
+++ b/security/fossa-adjudications.md
@@ -82,8 +82,17 @@ backwards, and both stock distribution templates do it.
 `wit-bindgen` — plus `symbolic-demangle` again under
 `apache-2.0-runtime-library-exception`.
 
-These are resolved by allowing the exception forms in the policy, not by
-dismissing seven findings one at a time.
+The clean fix would be to approve those two licence forms in the policy, so the
+rule stops firing at all. **That is not available on this plan**: custom
+policies are a paid feature, and the stock templates cannot be edited. Both
+distribution templates flag these forms, so switching between them does not help
+either — verified by switching, after which the count did not move.
+
+They are therefore dismissed per finding, which treats the symptom and leaves
+the rule in place. Expect them to reappear when any of those crates changes
+version, because the resolution attaches to the finding rather than to the
+policy that produced it. That recurrence is a property of the tool on this
+plan, not a sign anything regressed.
 
 ## Real, and accepted with a reason
 
@@ -116,11 +125,19 @@ an older copy arriving transitively. Trace it with
 `.github/workflows/fossa.yml` sets `run-tests: false`, so the lane analyses and
 publishes but does not fail the build.
 
-Of twenty findings, ten are false positives and seven are permissive licences
-the stock policy flags in error. Gating today would fail the build for reasons
-no author could act on — and a gate that is permanently red is one people learn
-to merge past, which costs more than the gate was ever worth.
+Of the original twenty findings, ten were false positives and seven are
+permissive licences the stock policy flags in error. Gating on that would fail
+the build for reasons no author could act on, and a permanently red gate is one
+people learn to merge past — which costs more than the gate was ever worth.
 
-The order is: correct the policy, resolve the findings above, and only then
-decide whether to gate. Flipping `run-tests` before that would be enabling a
-check whose first act is to be wrong.
+The plan does not offer custom policies, and that is the deciding fact rather
+than a detail. A gate is only worth having if the rule behind it can be
+corrected when it is wrong; here it cannot. Every recurrence of the seven
+permissive findings would have to be dismissed by hand, and each dismissal is a
+judgement call made under pressure to get a build green — which is exactly the
+condition under which a real finding gets waved through with the noise.
+
+So `run-tests` stays `false`, and this is a settled position rather than a
+deferral: the lane analyses, publishes and is read, and `cargo deny` remains
+the gating advisory check, because its rules live in this repository where they
+can be fixed.


### PR DESCRIPTION
The file I merged an hour ago gave advice that **cannot be followed**. It said the seven permissive Apache-with-exception findings are

> "resolved by allowing the exception forms in the policy, not by dismissing seven findings one at a time"

Custom policies are a **paid feature** on this plan, and the stock templates cannot be edited. Both distribution templates flag those forms, so switching between them does not help either — verified by actually switching the project to **Single-Binary Distribution**, after which the count did not move (9, unchanged).

That switch was still right on its own merits: it **denies** `GPL-2.0-only` where the previous template merely flagged it, which is the correct posture for a statically linked Rust binary where a release tarball is one executable with every dependency inside it.

## Why this settles the gating question rather than deferring it

I had written that the order was "correct the policy, then decide whether to gate". The policy cannot be corrected, so the decision is due now.

**A gate is worth having only if the rule behind it can be fixed when it is wrong.** Here it cannot. Every recurrence of a permissive finding — and they will recur, since a per-finding dismissal attaches to the finding rather than to the rule that produced it — would have to be dismissed by hand, under time pressure to get a build green. That is precisely the condition under which a real finding gets waved through along with the noise.

So `run-tests: false` is now a **settled position, not a deferral**: the lane analyses, publishes and is read, and `cargo deny` stays the gating advisory check — because its rules live in this repository, where they can be corrected.

## Current state

```
20 → 9 open
  6× Apache-2.0 WITH LLVM-exception     ← dismissed per finding; will recur on version bumps
  1× apache-2.0-runtime-library-exception
  1× CVE-2023-49092 (rsa)               ← reasoning in this file, needs pasting into FOSSA
  1× ordered-float outdated             ← maintenance, not licensing
```

All ten false positives and all three genuinely-real findings are resolved.