### PR TITLE
release: v3.17.5

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -33,7 +33,7 @@
     "title": "FerroEHR",
     "description": "<p>A pure-Rust, openEHR-specification-conformant clinical data repository (CDR): ITS-REST 1.1.0 REST API, AQL 1.1 query language, and the openEHR RM 1.2.0 reference model on PostgreSQL-18-native storage. The openEHR specification layer is generated from the official machine-readable specifications, and conformance is machine-verified per release by a built-in CNF conformance runner.</p>",
     "publication_date": "2026-08-13",
-    "version": "3.17.4",
+    "version": "3.17.5",
     "creators": [
       {
         "person_or_org": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+## [3.17.5] - 2026-08-13
+
 ### Security
 
 - **The `ferroehr-postgres` image moves to a rebuilt PostgreSQL 18.4 base.** The
@@ -6531,7 +6533,8 @@ but has not yet run in production.
   seccomp, default-deny NetworkPolicy) and golden-render validation.
 
 
-[unreleased]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.4...HEAD
+[unreleased]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.5...HEAD
+[3.17.5]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.4...v3.17.5
 [3.17.4]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.3...v3.17.4
 [3.17.3]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.2...v3.17.3
 [3.17.2]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.1...v3.17.2

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,5 +33,5 @@ keywords:
   - ITS-REST
   - Rust
   - PostgreSQL
-version: 3.17.4
+version: 3.17.5
 date-released: 2026-08-13

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "cnf-runner"
-version = "3.17.4"
+version = "3.17.5"
 dependencies = [
  "assert_fs",
  "base64 0.23.1",
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "docs-meta"
-version = "3.17.4"
+version = "3.17.5"
 
 [[package]]
 name = "dotenvy"
@@ -2663,7 +2663,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ferroehr"
-version = "3.17.4"
+version = "3.17.5"
 dependencies = [
  "argon2",
  "assert_fs",
@@ -2735,7 +2735,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-admin-ui"
-version = "3.17.4"
+version = "3.17.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -2777,7 +2777,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-ext"
-version = "3.17.4"
+version = "3.17.5"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2801,7 +2801,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-rest"
-version = "3.17.4"
+version = "3.17.5"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -2860,7 +2860,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-server"
-version = "3.17.4"
+version = "3.17.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -5521,7 +5521,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-codegen"
-version = "3.17.4"
+version = "3.17.5"
 dependencies = [
  "roxmltree",
  "serde_json",
@@ -8744,7 +8744,7 @@ dependencies = [
 
 [[package]]
 name = "testkit"
-version = "3.17.4"
+version = "3.17.5"
 dependencies = [
  "ferroehr",
  "jiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "3"
 members = ["crates/*", "app/*", "tools/*"]
 
 [workspace.package]
-version = "3.17.4"
+version = "3.17.5"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT"

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -25,7 +25,7 @@ version: 6.0.3
 # previous image. It is NOT a promise that this tag accepts the chart's current
 # `config` defaults: values track development between releases, so the publish
 # lane re-checks the pairing against the image itself.
-appVersion: "3.17.4"
+appVersion: "3.17.5"
 
 # A COMPATIBILITY floor, and a real one: 1.36 is the release where the newest
 # field this chart renders became stable.
@@ -135,7 +135,7 @@ annotations:
   # scan while leaving the false claim in place, so it is deliberately not used.
   artifacthub.io/images: |
     - name: ferroehr
-      image: ghcr.io/rubentalstra/ferroehr:3.17.4
+      image: ghcr.io/rubentalstra/ferroehr:3.17.5
       platforms:
         - linux/amd64
         - linux/arm64
@@ -144,7 +144,7 @@ annotations:
     # visible to anyone considering it. See #2193: this chart cannot deploy it
     # yet, so today the entry advertises intent rather than chart behaviour.
     - name: ferroehr-admin-ui
-      image: ghcr.io/rubentalstra/ferroehr-admin-ui:3.17.4
+      image: ghcr.io/rubentalstra/ferroehr-admin-ui:3.17.5
       platforms:
         - linux/amd64
         - linux/arm64

--- a/deploy/helm/ferroehr/README.md
+++ b/deploy/helm/ferroehr/README.md
@@ -2,7 +2,7 @@
 
 Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.1.0 + AQL 1.1). A single static binary deployed with a hardened-by-default security posture: runs as a non-root, read-only-rootfs, default-deny-ingress workload that connects to an EXTERNAL PostgreSQL 18 as an unprivileged app role (migrations are run out of band by a separate migrator role).
 
-![Version: 6.0.3](https://img.shields.io/badge/Version-6.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.17.4](https://img.shields.io/badge/AppVersion-3.17.4-informational?style=flat-square)
+![Version: 6.0.3](https://img.shields.io/badge/Version-6.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.17.5](https://img.shields.io/badge/AppVersion-3.17.5-informational?style=flat-square)
 
 FerroEHR is a pure-Rust openEHR Clinical Data Repository: ITS-REST 1.1.0 at the
 API, AQL 1.1 as the query language, PostgreSQL 18-native storage, shipped as a
@@ -36,7 +36,7 @@ helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
   --version 6.0.3 \
   --namespace ferroehr --create-namespace \
   --set database.existingSecret=ferroehr-db \
-  --set image.tag=3.17.4
+  --set image.tag=3.17.5
 ```
 
 OCI registries require Helm 3.8 or newer.
@@ -48,7 +48,7 @@ They are independent SemVer lines and they move independently:
 | What | Set with | This release |
 |---|---|---|
 | the **chart** (templates, defaults, this document) | `--version` | `6.0.3` |
-| the **server image** | `image.tag` | `3.17.4` |
+| the **server image** | `image.tag` | `3.17.5` |
 
 `appVersion` is the image the chart defaults to; pinning `image.tag` explicitly
 is what keeps an upgrade of one from silently moving the other.
@@ -69,7 +69,7 @@ A **SLSA build provenance attestation** — what source it was built from, and h
 ```console
 gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:6.0.3 \
   -R rubentalstra/FerroEHR
-gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:3.17.4 \
+gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:3.17.5 \
   -R rubentalstra/FerroEHR
 ```
 

--- a/deploy/helm/golden/admin-ui.yaml
+++ b/deploy/helm/golden/admin-ui.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -72,7 +72,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -100,7 +100,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -121,7 +121,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -136,7 +136,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 automountServiceAccountToken: false
@@ -166,7 +166,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -183,7 +183,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -314,7 +314,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -337,7 +337,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -367,7 +367,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -403,7 +403,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: admin-ui
-          image: "ghcr.io/rubentalstra/ferroehr-admin-ui:3.17.4"
+          image: "ghcr.io/rubentalstra/ferroehr-admin-ui:3.17.5"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -474,7 +474,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -522,7 +522,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:3.17.4"
+          image: "ghcr.io/rubentalstra/ferroehr:3.17.5"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -18,7 +18,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -92,7 +92,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -113,7 +113,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -145,7 +145,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -171,7 +171,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -192,7 +192,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -383,7 +383,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -417,7 +417,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -467,7 +467,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:3.17.4"
+          image: "ghcr.io/rubentalstra/ferroehr:3.17.5"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -648,7 +648,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -682,7 +682,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -720,7 +720,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     release: kube-prometheus-stack

--- a/deploy/helm/golden/basic-auth.yaml
+++ b/deploy/helm/golden/basic-auth.yaml
@@ -18,7 +18,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -46,7 +46,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -67,7 +67,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 automountServiceAccountToken: false
@@ -97,7 +97,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -114,7 +114,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -242,7 +242,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -272,7 +272,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -320,7 +320,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:3.17.4"
+          image: "ghcr.io/rubentalstra/ferroehr:3.17.5"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -18,7 +18,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -46,7 +46,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -67,7 +67,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 automountServiceAccountToken: false
@@ -82,7 +82,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -207,7 +207,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -237,7 +237,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.4"
+    app.kubernetes.io/version: "3.17.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -285,7 +285,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:3.17.4"
+          image: "ghcr.io/rubentalstra/ferroehr:3.17.5"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@
 
 services:
   ferroehr-postgres:
-    image: ${FERROEHR_POSTGRES_IMAGE:-ghcr.io/rubentalstra/ferroehr-postgres:3.17.4}
+    image: ${FERROEHR_POSTGRES_IMAGE:-ghcr.io/rubentalstra/ferroehr-postgres:3.17.5}
     # Docker's default 64MB /dev/shm starves PostgreSQL's dynamic shared
     # memory under load (parallel workers error `could not resize shared
     # memory segment … No space left on device`); measured runs share this
@@ -151,7 +151,7 @@ services:
       start_period: 10s
 
   ferroehr:
-    image: ${FERROEHR_IMAGE:-ghcr.io/rubentalstra/ferroehr:3.17.4}
+    image: ${FERROEHR_IMAGE:-ghcr.io/rubentalstra/ferroehr:3.17.5}
     depends_on:
       ferroehr-postgres:
         condition: service_healthy
@@ -249,7 +249,7 @@ services:
   # FERROEHR_ADMIN__AUTH__OIDC__* variables at your identity provider.
   ferroehr-admin-ui:
     profiles: [admin-ui]
-    image: ${FERROEHR_ADMIN_UI_IMAGE:-ghcr.io/rubentalstra/ferroehr-admin-ui:3.17.4}
+    image: ${FERROEHR_ADMIN_UI_IMAGE:-ghcr.io/rubentalstra/ferroehr-admin-ui:3.17.5}
     depends_on:
       ferroehr:
         condition: service_healthy


### PR DESCRIPTION
The v3.17.5 milestone reached zero open issues. It was a **verification** milestone — its job was to check what the v3.17.4 cut actually produced — so most of what it carries is invisible to an operator.

One thing is not, and it is why this is a release rather than a milestone quietly closed: **the `ferroehr-postgres` image moves to a rebuilt PostgreSQL 18.4 base**, which changes the bytes an operator pulls.

## What the milestone established

For the record rather than the changelog, since none of it changes behaviour:

- The v3.17.4 signing assets **verify offline** against downloaded copies — checksum, attestation, and a provenance digest that agrees with both. The verification was also confirmed *capable of failing*: one altered byte, or the wrong repository, is rejected.
- **`Signed-Releases` moved 0 → 2** on a Scorecard run after the cut. It is 2 rather than 10 because the check reads the last five releases and only one carries these assets.
- The release-tag ruleset **admitted a signed tag on the live path** — the rule evaluating, which no settings read-back can show.
- **REUSE 3.3 at 13560/13560**, with headers now on shell, SQL and YAML as well as Rust.

## Two corrections that matter more than their size

**The SPDX SBOM named itself `.`** rather than the project, because syft takes the document name from the scan target. This release's own lane fixes it — so v3.17.5's SBOM will identify itself where v3.17.4's did not. A fix shipping in the release that repairs the previous release's artifact.

**The release procedure asserted that Zenodo archives every tag.** It does not — the API returns zero records for this project against a control returning 1.26M. The entry now states the true position. A procedure that claims an archival step it never performs is how a cut passes believing an artifact was archived.

## Versions

| What | To | Note |
|---|---|---|
| workspace | `3.17.5` | + `Cargo.lock` |
| chart `appVersion` | `3.17.5` | |
| chart's own version | `6.0.3` — **unchanged** | no packaged chart content changed |
| spec crates | `0.0.27` — **unchanged** | no packaged crate content changed |
| `CITATION.cff`, `.zenodo.json` | `3.17.5` | zenodo regenerated, never hand-edited |
| compose image tags | `3.17.5` | |

## Verified before opening

`helm validate` all render checks passed · `compose-image-tags` · `image-labels` · `copyright-holder` · `spdx-headers-text` (128 files) · `ci-conclusion-complete` (41 jobs) — and workspace / `CITATION.cff` / `.zenodo.json` all agree on `3.17.5`.

## After the merge

Tag `v3.17.5` on the **merge commit**. This will be the second run of the signing lane, and the first of the corrected SBOM naming — both worth watching rather than assuming.