### PR TITLE
docs(changelog): the chart 6.0.4 bump is user-visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Helm chart is `6.0.4`.** The v3.17.5 cut moved the chart's
+  `appVersion` to 3.17.5 without moving the chart's own version, and 6.0.3
+  was already published — a published chart version is immutable, so the
+  publish lane refused rather than replacing it. Install with
+  `--version 6.0.4` to get the 3.17.5 application image by default.
+
 ## [3.17.5] - 2026-08-13
 
 ### Security


### PR DESCRIPTION
Two things, one entry.

**It is the entry the chart bump should have carried.** I labelled #2350 `no-changelog`, which was wrong — a chart version is what an operator types after `--version`, so it is user-visible under the changelog rule's own definition, which names deployment artifacts explicitly.

**It also unblocks the chart publish.** On a `workflow_dispatch` the annotation step reads `## [Unreleased]` for the Artifact Hub changes list, and that section is empty by construction immediately after a release cut:

```
the '## [Unreleased]' section lists no changes
##[error]Process completed with exit code 1
```

That refusal is right: publishing with an empty changes annotation would tell Artifact Hub nothing changed, when 6.0.4 is exactly the version that fixes the problem.

Worth noting the chain, since it is three guards in a row all being correct — `chart-version-guard` caught the missing bump on the release PR, the publish lane refused to overwrite an immutable published version, and the annotation step refused to publish a release note that says nothing. The only wrong step was mine, overriding the first one.