### PR TITLE
fix(telemetry,fhir): resolved-format banner, fhir_outbound readiness, correct feature gates

### DIFF
--- a/.claude/agent-memory/cnf-triage/MEMORY.md
+++ b/.claude/agent-memory/cnf-triage/MEMORY.md
@@ -44,3 +44,4 @@
 - [TERMINOLOGY_ID has no declared invariant](terminology-id-value-has-no-invariant.md) — BASE declares no Invariants row; master05's production is refuted by its own examples AND released QUERY `snomed_ct(3.1)`
 - [PGP subkey signature the runner cannot verify](pgp-subkey-signature-runner-cannot-verify.md) — RUNNER bin: rpgp 0.20 `SignedPublicKey::verify` is primary-only; the app signs with the `[S]` subkey since 7a8a8c9a3
 - [Baseline commit = where the run was RECORDED](baseline-commit-is-where-the-run-was-recorded.md) — diff the whole range since the previous results.json, never trust a handed-down "prime suspect"
+- [ehr_id scope is SM-grounded](ehr-id-scope-semantics-is-sm-grounded.md) — SM `_ehr_ids_` defines the effect (AMB-101 overstates the silence); EHRbase 2.34.0 discards both carriers

--- a/.claude/agent-memory/cnf-triage/ehr-id-scope-semantics-is-sm-grounded.md
+++ b/.claude/agent-memory/cnf-triage/ehr-id-scope-semantics-is-sm-grounded.md
@@ -1,0 +1,51 @@
+---
+name: ehr-id-scope-semantics-is-sm-grounded
+description: The query ehr_id/openehr-ehr-id scope's EFFECT is defined by SM i_query_service _ehr_ids_ (not spec-silent); EHRbase 2.34.0 discards both carriers
+metadata:
+  type: project
+---
+
+Adjudicated 2026-08-13 for `execute_ad_hoc_query-empty_db_bare_ehr` on the
+committed EHRbase record (issue #2362).
+
+**The scoping semantics IS released-spec-defined**, contrary to AMB-101's
+"never stated" claim:
+
+- SM `docs/UML/classes/i_query_service.adoc` §I_QUERY_SERVICE Interface,
+  `execute_ad_hoc_query` param `_ehr_ids_`: "Specific set of EHRs on which to
+  execute the query. If none supplied, a full population query will be
+  performed on all EHRs whose status has the `_is_queryable_` flag set to
+  `True`." (+ `.Errors * ehr_id_does_not_exist`).
+- ITS-REST `specifications/docs/query/Query_types.md` §Single EHR queries:
+  single-EHR execution "is achieved by supplying an `ehr_id` query parameter or
+  setting an `openehr-ehr-id` request header".
+- ITS-REST `.../docs/query/Request.md` §Common Headers and Query Parameters:
+  "`ehr_id` - used to execute the query within a single EHR context".
+- Released OAS `query-codegen.openapi.yaml` `components/parameters/ehr_id_Query`:
+  "An optional parameter to execute the query within an EHR context" — optional
+  to SUPPLY, not optional to honour.
+
+The only weakening sentence is Request.md §About the ehr_id parameter ("MAY be
+used by the underlying backend to perform routing, optimizations or similar") —
+about ADDITIONAL backend uses; reading it as permission to ignore a supplied
+scope contradicts §Single EHR queries in the same chapter, and the release
+declares NO branch for "scope unsupported". Caveat to state honestly: parameter
+SUPPORT is a SHOULD ("All query execution requests SHOULD support at least…").
+
+AQL alone cannot supply the constraint: QUERY `master06-writing_AQL.adoc` — an
+unscoped `FROM` (no `ehr_id/value`) IS a population query over all EHRs.
+
+**EHRbase 2.34.0 (reproduced 2026-08-13, docker/sut-ehrbase.yml):** both
+carriers accepted with 200 and DISCARDED. `POST /query/aql?ehr_id=<A>` with
+`SELECT e/ehr_id/value FROM EHR e` returned all 3 EHRs and disclosed
+`meta._executed_aql = "SELECT e/ehr_id/value FROM EHR e LIMIT 100"` (no EHR
+predicate injected); the `openehr-ehr-id` header form rewrote
+`FROM EHR e CONTAINS COMPOSITION c` to `FROM COMPOSITION c`. The AQL-level
+predicate `EHR e[ehr_id/value='A']` DOES scope (1 row) — which is why sibling
+`empty_db` passes and `empty_db_bare_ehr` fails.
+
+The runner never resets between cases (fresh volumes per RUN only), so a bare
+`FROM EHR e` sees every EHR the run minted (548 schedule files carry an
+`ehr:` requirement) — the catalogue realizes the "empty ground" through the
+scope on purpose. Scope-ignoring SUTs therefore also make every
+scoped-count-0 query row pass VACUOUSLY.

--- a/.claude/agent-memory/cnf-triage/upstream-ehrbase-nonconformance.md
+++ b/.claude/agent-memory/cnf-triage/upstream-ehrbase-nonconformance.md
@@ -56,6 +56,11 @@ pack/catalogue toward any of these.
 14. **Admin EHR delete served at `/ferroehr/rest/admin/ehr/{id}`** (204), 404 at
     the released `…/openehr/v1/admin/ehr/{id}` — but SPECITS-80 dates the
     operation to 1.1.0, so it is OUT OF SCOPE for a 1.0.3 party, not a finding.
+15. **The query `ehr_id` scope is DISCARDED on both released carriers** (the
+    `ehr_id` query parameter and the `openehr-ehr-id` header): 200 + a full
+    population result, disclosed by EHRbase's own `meta._executed_aql`. Grounds +
+    reproduction in [[ehr-id-scope-semantics-is-sm-grounded]]; two red rows
+    (`execute_ad_hoc_query-empty_db_bare_ehr`, `-unknown_ehr_scope`).
 
 **CORRECTION to the earlier note:** the item-tag 404s are NOT an upstream
 non-conformance for this party — SPECITS-77 dates ITEM_TAGs to Release-**1.1.0**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Added
+
+- **A `fhir_outbound` readiness indicator.** When the FHIR outbound emitter is
+  enabled, `/health/readiness` now carries its broker-delivery liveness —
+  non-required, so a broker outage reports `DEGRADED` (the outbox retains
+  messages) and never fails readiness. Previously a PHI-bearing outbound
+  stream could be down with nothing on the health surface saying so.
+
 ### Changed
 
 - **The documentation site was read end-to-end against the tree and
@@ -30,6 +38,17 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **The boot banner follows the resolved log format.** With the default
+  `log.format = "auto"` in a container (stdout not a terminal), logs render
+  as JSON but the multi-line ASCII banner still printed first, handing every
+  log collector unparseable lines on each boot. The banner now keys on the
+  same TTY-aware resolution the log layers use: `json`, and `auto` off a
+  terminal, are parseable JSON from the first byte.
+- **Partial feature builds of the server compile again.** The FHIR outbound
+  emitter's wiring was gated on the `events` cargo feature while its module
+  exists only under `fhir`: a `--features events` build (no `fhir`) failed to
+  compile, and a `--features fhir` build never started the emitter. Both
+  gates now sit on `fhir`, which implies `events` at every level.
 - **The Helm chart is `6.0.5`.** Reading the site against the tree corrected
   chart comments and operator-facing messages (the stale distroless base
   name, the secret-routing key list, the config-in-Secret cause in

--- a/app/ferroehr-admin-ui/src/management.rs
+++ b/app/ferroehr-admin-ui/src/management.rs
@@ -61,10 +61,13 @@ type HeadlineMetric = (
 /// The headline metric tiles, in display order.
 ///
 /// Each is a counter or gauge the CDR registers
-/// (`ferroehr::telemetry::prometheus`); a histogram is deliberately absent —
+/// (`ferroehr::telemetry::metrics`); a histogram is deliberately absent —
 /// the CDR's actuator-style detail view folds a histogram's `_bucket`/`_sum`/
 /// `_count` lines into one sample list, so summing it would report a
 /// meaningless number.
+// NOTE: these are the Prometheus exporter's RENDERED names — `_total` is derived
+// from the counter kind, never written on the instrument — and the correspondence
+// is pinned by the CDR's `exporter_renders_the_console_metric_names` test.
 #[cfg(feature = "ssr")]
 const HEADLINE_METRICS: [HeadlineMetric; 4] = [
     ("http_server_active_requests", "In-flight requests", None),

--- a/app/ferroehr-server/Cargo.toml
+++ b/app/ferroehr-server/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 [features]
 # Forward the optional-integration gates (#1890); default mirrors ferroehr's.
 default = ["fhir", "events", "multimedia"]
-fhir = ["ferroehr/fhir", "ferroehr-rest/fhir"]
+fhir = ["ferroehr/fhir", "ferroehr-rest/fhir", "events"]
 events = ["ferroehr/events", "ferroehr-rest/events"]
 multimedia = ["ferroehr/multimedia", "ferroehr-rest/multimedia"]
 

--- a/app/ferroehr-server/src/lib.rs
+++ b/app/ferroehr-server/src/lib.rs
@@ -15,6 +15,7 @@
 //! `anyhow` is fine here: this lib target IS the binary's own logic half,
 //! not a consumable library.
 
+use std::io::IsTerminal as _;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -38,7 +39,7 @@ use uuid::Uuid;
 
 use ferroehr::db;
 use ferroehr::service::FerroEhrService;
-use ferroehr::telemetry::config::{LogFormat, TelemetryConfig};
+use ferroehr::telemetry::config::{LogFormat, ResolvedLogFormat, TelemetryConfig};
 use ferroehr::telemetry::{self, indicators};
 
 /// How long to wait for the audit queue to flush on shutdown.
@@ -221,6 +222,17 @@ async fn healthcheck(url: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Whether the ASCII boot banner prints, given the configured `[log] format`
+/// and whether stdout is a terminal.
+///
+/// Keyed on the RESOLVED rendering rather than the configured value: `format =
+/// "auto"` renders JSON whenever stdout is not a terminal, and a banner ahead of
+/// it would leave a log collector with unparseable first bytes. No openEHR spec
+/// governs logging — our own design.
+fn prints_banner(format: LogFormat, stdout_is_terminal: bool) -> bool {
+    format.resolve(stdout_is_terminal) == ResolvedLogFormat::Pretty
+}
+
 /// Whether a bind address is loopback-only, so a plaintext listener there is
 /// not reachable off the host.
 ///
@@ -277,8 +289,9 @@ async fn serve(config_path: Option<&Path>, overrides: &[(String, String)]) -> an
         otel: config.telemetry.clone(),
     };
 
-    // ASCII banner before telemetry/log init (skipped under `json` logging).
-    if telemetry_config.log.format != LogFormat::Json {
+    // ASCII banner before telemetry/log init, on the same resolved rendering the
+    // log layer installs (so JSON output stays pure from the first byte).
+    if prints_banner(telemetry_config.log.format, std::io::stdout().is_terminal()) {
         ferroehr::banner::print(config.spec_profile);
     }
 
@@ -379,21 +392,12 @@ async fn serve(config_path: Option<&Path>, overrides: &[(String, String)]) -> an
     if let Some(handle) = &events_handle {
         indicators.push(Arc::new(indicators::EventsHealth::new(handle.healthy())));
     }
-    let health = HealthRegistry::new(indicators);
 
     telemetry.start_samplers(pool.clone());
 
     // `/management/env` reports the whole redacted config tree (secrets render
     // `***` by construction of the Secret type).
     let env_snapshot = Arc::new(serde_json::to_value(&config).unwrap_or(serde_json::Value::Null));
-    let observability = Observability {
-        management: config.management.clone(),
-        prometheus: Some(telemetry.registry()),
-        log_reload: Some(telemetry.log_reload()),
-        health,
-        build_info,
-        env_snapshot,
-    };
 
     // Version signing (fail-closed at boot for `pgp` without a usable key).
     let signer =
@@ -502,8 +506,10 @@ async fn serve(config_path: Option<&Path>, overrides: &[(String, String)]) -> an
 
     let service = Arc::new(service);
 
-    // FHIR outbound emitter (off by default; carries PHI).
-    #[cfg(feature = "events")]
+    // FHIR outbound emitter (off by default; carries PHI). Gated on `fhir`:
+    // the outbound module exists only under ferroehr's `fhir` feature (which
+    // itself implies `events` for the broker transport).
+    #[cfg(feature = "fhir")]
     let fhir_outbound_handle = if config.fhir.outbound.enabled {
         tracing::info!(
             exchange = %config.fhir.outbound.exchange,
@@ -517,12 +523,29 @@ async fn serve(config_path: Option<&Path>, overrides: &[(String, String)]) -> an
     } else {
         None
     };
-    #[cfg(not(feature = "events"))]
+    #[cfg(not(feature = "fhir"))]
     if config.fhir.outbound.enabled {
         return Err(anyhow::anyhow!(
-            "fhir.outbound.enabled = true, but this binary was built without the `events` cargo feature"
+            "fhir.outbound.enabled = true, but this binary was built without the `fhir` cargo feature"
         ));
     }
+    #[cfg(feature = "fhir")]
+    if let Some(handle) = &fhir_outbound_handle {
+        indicators.push(Arc::new(indicators::FhirOutboundHealth::new(
+            handle.healthy(),
+        )));
+    }
+
+    // The readiness registry closes over every started subsystem, so it is
+    // assembled after the last optional one (the FHIR outbound emitter).
+    let observability = Observability {
+        management: config.management.clone(),
+        prometheus: Some(telemetry.registry()),
+        log_reload: Some(telemetry.log_reload()),
+        health: HealthRegistry::new(indicators),
+        build_info,
+        env_snapshot,
+    };
 
     // Authorization — only wired when authentication is enabled: the RBAC gate
     // plus the ABAC engine + DB-backed attribute resolvers. A misconfigured
@@ -620,7 +643,7 @@ async fn serve(config_path: Option<&Path>, overrides: &[(String, String)]) -> an
     if let Some(handle) = events_handle {
         handle.shutdown(AUDIT_DRAIN_TIMEOUT).await;
     }
-    #[cfg(feature = "events")]
+    #[cfg(feature = "fhir")]
     if let Some(handle) = fhir_outbound_handle {
         handle.shutdown(AUDIT_DRAIN_TIMEOUT).await;
     }
@@ -729,7 +752,27 @@ fn subject_resolver(pool: PgPool) -> SubjectResolver {
 
 #[cfg(test)]
 mod tests {
-    use super::binds_loopback;
+    use super::{LogFormat, binds_loopback, prints_banner};
+
+    /// The banner follows the RESOLVED rendering: `auto` with stdout piped into
+    /// a log collector renders JSON, so no banner may precede it. The terminal
+    /// state is injected — never probed from the process — so both directions
+    /// are pinned deterministically.
+    #[test]
+    fn the_banner_is_keyed_on_the_resolved_log_format() {
+        assert!(!prints_banner(LogFormat::Auto, false));
+        assert!(prints_banner(LogFormat::Auto, true));
+        for is_terminal in [false, true] {
+            assert!(
+                !prints_banner(LogFormat::Json, is_terminal),
+                "explicit json never prints the banner"
+            );
+            assert!(
+                prints_banner(LogFormat::Pretty, is_terminal),
+                "explicit pretty always prints the banner"
+            );
+        }
+    }
 
     #[test]
     fn loopback_binds_are_recognized() {

--- a/app/ferroehr/src/extensions/fhir/outbound.rs
+++ b/app/ferroehr/src/extensions/fhir/outbound.rs
@@ -67,13 +67,14 @@ pub struct FhirOutboundHandle {
     shutdown: watch::Sender<bool>,
     join: JoinHandle<()>,
     /// Liveness of broker delivery: `true` while emitting succeeds, `false`
-    /// after a publish/transport failure.
-    // TODO(#2358): surface this through a readiness indicator.
+    /// after a publish/transport failure. Surfaced by the `fhir_outbound` health
+    /// indicator (never blocks readiness — degraded-tolerable).
     healthy: Arc<AtomicBool>,
 }
 
 impl FhirOutboundHandle {
-    /// A shared flag reporting whether outbound delivery is currently healthy.
+    /// A shared flag reporting whether outbound delivery is currently healthy,
+    /// for the `fhir_outbound` health indicator.
     #[must_use]
     pub fn healthy(&self) -> Arc<AtomicBool> {
         Arc::clone(&self.healthy)

--- a/app/ferroehr/src/telemetry/config.rs
+++ b/app/ferroehr/src/telemetry/config.rs
@@ -27,6 +27,33 @@ pub enum LogFormat {
     Pretty,
 }
 
+impl LogFormat {
+    /// Resolves this profile against the stdout terminal state, yielding the
+    /// rendering that is actually installed.
+    ///
+    /// The terminal state is a parameter rather than a probe so the `auto` rule
+    /// lives in ONE testable place: the log layer and the boot banner both key
+    /// off the result, and a banner printed ahead of JSON output would make the
+    /// first bytes of stdout unparseable.
+    #[must_use]
+    pub fn resolve(self, stdout_is_terminal: bool) -> ResolvedLogFormat {
+        match self {
+            Self::Pretty => ResolvedLogFormat::Pretty,
+            Self::Auto if stdout_is_terminal => ResolvedLogFormat::Pretty,
+            Self::Json | Self::Auto => ResolvedLogFormat::Json,
+        }
+    }
+}
+
+/// The stdout rendering actually installed, with [`LogFormat::Auto`] decided.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResolvedLogFormat {
+    /// One JSON object per line.
+    Json,
+    /// Human-friendly multi-line text.
+    Pretty,
+}
+
 /// Logging configuration (`[log]`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
@@ -135,5 +162,24 @@ mod tests {
         assert_eq!(c.log.format, LogFormat::Auto);
         assert!(!c.otel.metrics_push);
         assert!(c.otel.flame_file.is_none());
+    }
+
+    /// `auto` follows the terminal state; the explicit profiles ignore it. This
+    /// is the ONE place the rule lives, so the log layer and the boot banner
+    /// cannot disagree about what stdout carries.
+    #[test]
+    fn auto_resolves_off_the_terminal_state() {
+        assert_eq!(LogFormat::Auto.resolve(false), ResolvedLogFormat::Json);
+        assert_eq!(LogFormat::Auto.resolve(true), ResolvedLogFormat::Pretty);
+        for is_terminal in [false, true] {
+            assert_eq!(
+                LogFormat::Json.resolve(is_terminal),
+                ResolvedLogFormat::Json
+            );
+            assert_eq!(
+                LogFormat::Pretty.resolve(is_terminal),
+                ResolvedLogFormat::Pretty
+            );
+        }
     }
 }

--- a/app/ferroehr/src/telemetry/indicators.rs
+++ b/app/ferroehr/src/telemetry/indicators.rs
@@ -141,7 +141,8 @@ pub struct EventsHealth {
 
 impl EventsHealth {
     /// Construct over the publisher's shared health flag
-    /// ([`EventsHandle::healthy`](crate::extensions::events::publisher::EventsHandle::healthy)).
+    /// (`EventsHandle::healthy` — a feature-gated path an intra-doc link
+    /// would break on under `--no-default-features`).
     #[must_use]
     pub fn new(healthy: Arc<AtomicBool>) -> Self {
         Self { healthy }
@@ -167,10 +168,87 @@ impl HealthIndicator for EventsHealth {
     }
 }
 
+/// `fhir_outbound` — reports the FHIR outbound emitter's broker-delivery
+/// health.
+///
+/// Degraded-tolerable (unemitted outbox rows stay past the emitter's cursor, so
+/// delivery lag must not block readiness): a broker outage flips only the
+/// aggregate to `DEGRADED`, never readiness. Registered only when the outbound
+/// emitter is started (`fhir.outbound.enabled`).
+#[derive(Debug)]
+pub struct FhirOutboundHealth {
+    healthy: Arc<AtomicBool>,
+}
+
+impl FhirOutboundHealth {
+    /// Construct over the emitter's shared health flag (the
+    /// `FhirOutboundHandle::healthy` accessor).
+    #[must_use]
+    pub fn new(healthy: Arc<AtomicBool>) -> Self {
+        Self { healthy }
+    }
+}
+
+#[async_trait]
+impl HealthIndicator for FhirOutboundHealth {
+    fn name(&self) -> &'static str {
+        "fhir_outbound"
+    }
+
+    async fn check(&self) -> Health {
+        if self.healthy.load(Ordering::Relaxed) {
+            Health::up()
+        } else {
+            Health::degraded("FHIR outbound broker unavailable; outbox retained")
+        }
+    }
+
+    fn required(&self) -> bool {
+        false
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{DbHealth, MigrationsHealth};
+    use super::{DbHealth, EventsHealth, FhirOutboundHealth, MigrationsHealth};
     use crate::telemetry::health::{HealthIndicator, HealthStatus};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    /// The outbound emitter's shared flag IS the indicator's answer: healthy
+    /// reads UP, a broker failure reads DEGRADED with a detail, and the
+    /// indicator never blocks readiness (the outbox retains the rows).
+    #[tokio::test]
+    async fn fhir_outbound_health_follows_the_shared_flag() {
+        let healthy = Arc::new(AtomicBool::new(true));
+        let indicator = FhirOutboundHealth::new(Arc::clone(&healthy));
+        assert_eq!(indicator.name(), "fhir_outbound");
+        assert!(
+            !indicator.required(),
+            "delivery lag must never take the instance out of rotation"
+        );
+        assert_eq!(indicator.check().await.status, HealthStatus::Up);
+
+        healthy.store(false, Ordering::Relaxed);
+        let degraded = indicator.check().await;
+        assert_eq!(degraded.status, HealthStatus::Degraded);
+        assert!(
+            degraded.detail.is_some_and(|d| d.contains("outbox")),
+            "the degraded detail must say the rows are retained"
+        );
+    }
+
+    /// The outbound indicator mirrors the `events` one it is modelled on: same
+    /// flag-to-status mapping, same non-required posture, distinct names.
+    #[tokio::test]
+    async fn outbound_and_events_indicators_agree_on_shape() {
+        let flag = Arc::new(AtomicBool::new(false));
+        let events = EventsHealth::new(Arc::clone(&flag));
+        let outbound = FhirOutboundHealth::new(flag);
+        assert_ne!(events.name(), outbound.name());
+        assert_eq!(events.required(), outbound.required());
+        assert_eq!(events.check().await.status, outbound.check().await.status);
+    }
 
     /// A failing database probe must report the FACT and nothing else.
     ///

--- a/app/ferroehr/src/telemetry/layers.rs
+++ b/app/ferroehr/src/telemetry/layers.rs
@@ -99,12 +99,9 @@ pub(super) fn init_subscriber(
 /// span's fields for trace↔log correlation.
 fn fmt_layer(format: super::config::LogFormat) -> BoxedLayer {
     use super::config::LogFormat;
-    let json = match format {
-        LogFormat::Json => true,
-        LogFormat::Pretty => false,
-        LogFormat::Auto => !std::io::stdout().is_terminal(),
-    };
-    if json {
+    use super::config::ResolvedLogFormat;
+    let is_terminal = std::io::stdout().is_terminal();
+    if format.resolve(is_terminal) == ResolvedLogFormat::Json {
         fmt::layer()
             .json()
             .with_current_span(true)
@@ -114,7 +111,7 @@ fn fmt_layer(format: super::config::LogFormat) -> BoxedLayer {
         // An explicit `pretty` is a human asking for the colored dev output
         // (e.g. `docker compose` logs, where stdout is a pipe, not a TTY) —
         // force ANSI on. Only `auto`-selected pretty keeps TTY detection.
-        let ansi = matches!(format, LogFormat::Pretty) || std::io::stdout().is_terminal();
+        let ansi = matches!(format, LogFormat::Pretty) || is_terminal;
         // The text format renders `Display` fields and interpolated messages
         // verbatim, so its writer neutralises CR/LF: a value cannot forge a
         // record (OWASP Logging Cheat Sheet §Log Injection —

--- a/app/ferroehr/src/telemetry/metrics.rs
+++ b/app/ferroehr/src/telemetry/metrics.rs
@@ -523,6 +523,73 @@ mod tests {
         }
     }
 
+    /// The admin console's headline tiles and metric deep links, as the pairs
+    /// `(instrument name, the name the Prometheus exporter renders it under)`.
+    ///
+    /// The console reads the rendered view over `/management/metrics`, so the
+    /// right-hand column is the wire contract; it cannot import a constant from
+    /// here (the console never depends on this crate).
+    const CONSOLE_RENDERED_NAMES: [(&str, &str); 4] = [
+        (HTTP_ACTIVE_REQUESTS, "http_server_active_requests"),
+        (COMPOSITIONS_COMMITTED, "compositions_committed_total"),
+        (AQL_QUERIES, "aql_queries_total"),
+        (DB_POOL_CONNECTIONS, "db_pool_connections"),
+    ];
+
+    /// Pins the exporter-derived name of every instrument the admin console
+    /// names as a literal.
+    ///
+    /// The console's `HEADLINE_METRICS` (and its `/operations?metric=…` deep
+    /// links) speak the exporter's rendered name space — `_total` is derived
+    /// from the counter kind, not written on the instrument — and the two name
+    /// spaces meet only here: a renamed instrument or a changed derivation would
+    /// otherwise degrade a console tile to an em-dash in silence.
+    #[test]
+    fn exporter_renders_the_console_metric_names() {
+        use opentelemetry::metrics::MeterProvider as _;
+
+        let (provider, registry) = build_provider(
+            opentelemetry_sdk::Resource::builder().build(),
+            None::<opentelemetry_sdk::metrics::PeriodicReader<opentelemetry_otlp::MetricExporter>>,
+        )
+        .expect("the Prometheus reader should build");
+        let meter = provider.meter(SCOPE);
+        let instruments = Metrics::new(&meter);
+
+        // A family reaches the exposition only once it carries a measurement.
+        instruments.http_active_requests.add(1, &[]);
+        instruments
+            .compositions_committed
+            .add(1, &[KeyValue::new("change_type", "249")]);
+        instruments
+            .aql_queries
+            .add(1, &[KeyValue::new("outcome", "ok")]);
+        instruments
+            .db_pool_connections
+            .add(1, &[KeyValue::new("state", "in_use")]);
+
+        let rendered = render(&registry).expect("the exposition should encode");
+        for (instrument, exported) in CONSOLE_RENDERED_NAMES {
+            assert!(
+                exported.starts_with(instrument),
+                "{exported} is not {instrument} plus an exporter-derived suffix"
+            );
+            assert!(
+                rendered.contains(&format!("# TYPE {exported} ")),
+                "the exporter renders no family named {exported} (instrument \
+                 {instrument}); the console's HEADLINE_METRICS and metric deep \
+                 links consume these rendered spellings verbatim, so a tile \
+                 would silently degrade to an em-dash: {rendered}"
+            );
+            assert!(
+                rendered
+                    .lines()
+                    .any(|line| line.starts_with(&format!("{exported}{{"))),
+                "the exporter renders no sample line for {exported}: {rendered}"
+            );
+        }
+    }
+
     /// The bucket ladders must be sorted and free of duplicates, or the
     /// exporter's cumulative buckets are nonsense.
     #[test]

--- a/website/book/src/installation/config-server.md
+++ b/website/book/src/installation/config-server.md
@@ -282,10 +282,10 @@ filter = "info,ferroehr=info"
 | `filter` | string | `info,ferroehr=info` | Boot log-filter directives; also the value `/management/loggers` resets to. `RUST_LOG` is a recognized lower-priority alias. |
 
 > [!TIP]
-> The ASCII boot banner is printed unless `format` is set explicitly to `json`.
-> Set `json` rather than relying on `auto` wherever every line of stdout must be
-> parseable — `auto` selects JSON *rendering* off a TTY, but the banner is keyed
-> on the configured value, not the resolved one.
+> The ASCII boot banner follows the rendering that is actually installed, not the
+> configured word: it prints for `pretty`, and for `auto` only when stdout is a
+> terminal. Under `json`, and under `auto` off a terminal — a container, a pipe
+> into a log collector — stdout is parseable JSON from the first byte.
 
 ## `[telemetry]`
 

--- a/website/book/src/operations.md
+++ b/website/book/src/operations.md
@@ -440,6 +440,7 @@ Not every indicator blocks readiness, and the distinction is deliberate:
 | `migrations` | this build's schema is present, re-tested on every probe | yes |
 | `audit_sender` | whether ATNA forwarding is enabled | no — reports `DEGRADED`, never `503` |
 | `events` | the event publisher's broker delivery (present only when eventing is enabled) | no — reports `DEGRADED`, never `503`: the outbox buffers while the broker is down |
+| `fhir_outbound` | the FHIR outbound emitter's broker delivery (present only when the emitter is enabled) | no — reports `DEGRADED`, never `503`: unemitted rows are retained and re-emitted |
 
 An instance whose event broker is unreachable therefore keeps taking traffic
 and says so in the body; an instance that cannot reach its database, or whose


### PR DESCRIPTION
Closes #2353
Closes #2358
Closes #2359

Three follow-ups from the #2348 site sweep, plus one latent defect found en route.

**#2353 — the banner corrupted JSON log streams.** Banner suppression keyed on the *configured* `log.format` while rendering resolves `auto` → JSON when stdout is not a terminal — so every container boot with the shipped default printed a multi-line ASCII banner into a JSON stream. One pure resolution function (`LogFormat::resolve(stdout_is_terminal)`) now decides both the rendering and the banner; tests drive the seam with an injected TTY flag (`auto`+non-TTY and `json` → no banner; `auto`+TTY and `pretty` → banner). The config page's `[log]` TIP updated to the fixed behaviour.

**#2358 — a PHI-bearing stream with no health surface.** The FHIR outbound emitter's liveness flag is now a `fhir_outbound` readiness indicator, modelled on `events`: non-required, `DEGRADED` with "outbox retained" on broker failure, registered only when the emitter is enabled. The operations page's readiness table gains the row.

**En route (worker finding, fixed here): the emitter's wiring was gated on the wrong cargo feature.** `#[cfg(feature = "events")]` guarded a module that exists only under `fhir` — a `--features events` build without `fhir` failed to compile (proven, then proven fixed), and a `--features fhir` build never started the emitter. All four sites move to the `fhir` gate and the server's `fhir` feature now implies `events`, mirroring the library. No CI lane builds these combinations, which is how it stayed latent — filed as #2367.

**#2359 — the console's metric names had no pin.** `HEADLINE_METRICS` speaks the Prometheus exporter's rendered name space (`_total` derived, never written on the instrument) while the server registers suffix-less instruments; the crates cannot share a constant (the console is REST-only). The correspondence is now pinned where both name spaces meet: a mutation-proven test beside the instruments renders the exporter output and asserts all four console-consumed names; the constant carries a NOTE naming the test. En route this surfaced #2366 (`db_pool_connections` declared twice with different instrument kinds).

## Verification

`cargo clippy -p ferroehr -p ferroehr-server --all-targets --all-features -- -D warnings` clean; `cargo nextest run -p ferroehr` (891 passed) and `-p ferroehr-server` (17 passed); `cargo check -p ferroehr-server --no-default-features`, `--features events`, `--features fhir` all compile; `docs-claims --all`, comment-style/default-style/typed-status guards green. The console change is comment-only (`no-ui-visual-change`).