### PR TITLE
fix(telemetry,ci): one db_pool_connections instrument; the slim feature graph gets a CI lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -731,6 +731,44 @@ jobs:
       - run: cargo clippy --locked -p ferroehr-admin-ui --all-targets --features ssr -- -D warnings
       - run: cargo clippy --locked -p ferroehr-admin-ui --target wasm32-unknown-unknown --features hydrate -- -D warnings
 
+  # ── The slim server: the optional-integration features, subtracted ──────────
+  # The clippy job above compiles the workspace with --all-features, so nothing
+  # in CI ever built the server WITHOUT the optional integrations: every
+  # `require_disabled` refusal path, every `#[cfg(not(feature = …))]` block and
+  # the additive feature wiring of #1890 were compiled by no lane at all. That
+  # is how a wrong gate on the FHIR outbound emitter stayed latent until #2358,
+  # where `--features events` without `fhir` did not compile.
+  #
+  # Three feature sets, each a real deployment shape: the slim CDR, and each
+  # single integration enabled on top of it. `fhir` pulls `events` in by its own
+  # feature edge, so the `events`-only lane is the one that proves the gates are
+  # not silently coupled the other way. clippy, not check: the deny-tier lints
+  # must cover the gated code too. No tests — the feature graphs are compile
+  # properties, and the test job owns behaviour.
+  feature-combos:
+    name: clippy (slim server feature combos)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      # rust-cache, for the reason the clippy job states: sccache cannot cache
+      # clippy-driver invocations (mozilla/sccache#539). This job's cache entry
+      # is its own (rust-cache keys on the job), which is what it must be — the
+      # target dir here holds a different feature graph than the clippy job's.
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          components: clippy
+          cache-save-if: ${{ github.ref == 'refs/heads/develop' }}
+      - run: cargo clippy --locked -p ferroehr-server --no-default-features --all-targets -- -D warnings
+      - run: cargo clippy --locked -p ferroehr-server --no-default-features --features events --all-targets -- -D warnings
+      - run: cargo clippy --locked -p ferroehr-server --no-default-features --features fhir --all-targets -- -D warnings
+
   # ── Rustdoc: intra-doc links + doc lints are inert unless rustdoc runs ──────
   # [workspace.lints.rustdoc] levels apply to every `cargo doc`; the -D
   # warnings env additionally promotes the warn-tier doc lints in CI
@@ -1886,6 +1924,7 @@ jobs:
       - deny
       - vex
       - clippy
+      - feature-combos
       - doc
       - msrv
       - codegen-drift

--- a/app/ferroehr/src/telemetry/metrics.rs
+++ b/app/ferroehr/src/telemetry/metrics.rs
@@ -59,7 +59,7 @@ pub const AUTH_FAILURES: &str = "auth_failures";
 pub const AUTHZ_CEDAR_DECISIONS: &str = "authz_cedar_decisions";
 /// Remote-PDP authorization calls (`result`).
 pub const AUTHZ_REMOTE_PDP_CALLS: &str = "authz_remote_pdp_calls";
-/// Database pool connections (`state`).
+/// Database pool connections (`state`), sampled as a gauge.
 pub const DB_POOL_CONNECTIONS: &str = "db_pool_connections";
 /// Database connection-acquire latency.
 pub const DB_POOL_ACQUIRE_DURATION: &str = "db_pool_acquire_duration";
@@ -171,8 +171,6 @@ pub struct Metrics {
     pub authz_cedar_decisions: Counter<u64>,
     /// Remote-PDP authorization calls.
     pub authz_remote_pdp_calls: Counter<u64>,
-    /// Database pool connections by state.
-    pub db_pool_connections: UpDownCounter<i64>,
     /// Database connection-acquire latency, seconds.
     pub db_pool_acquire_duration: Histogram<f64>,
     /// Service transactions by outcome.
@@ -253,10 +251,6 @@ impl Metrics {
             authz_remote_pdp_calls: meter
                 .u64_counter(AUTHZ_REMOTE_PDP_CALLS)
                 .with_description("Remote-PDP authorization calls by result")
-                .build(),
-            db_pool_connections: meter
-                .i64_up_down_counter(DB_POOL_CONNECTIONS)
-                .with_description("Connection pool connections by state")
                 .build(),
             db_pool_acquire_duration: meter
                 .f64_histogram(DB_POOL_ACQUIRE_DURATION)
@@ -555,6 +549,7 @@ mod tests {
         .expect("the Prometheus reader should build");
         let meter = provider.meter(SCOPE);
         let instruments = Metrics::new(&meter);
+        let pool = crate::telemetry::samplers::pool_gauge(&meter);
 
         // A family reaches the exposition only once it carries a measurement.
         instruments.http_active_requests.add(1, &[]);
@@ -564,9 +559,8 @@ mod tests {
         instruments
             .aql_queries
             .add(1, &[KeyValue::new("outcome", "ok")]);
-        instruments
-            .db_pool_connections
-            .add(1, &[KeyValue::new("state", "in_use")]);
+        pool.record(2, &[KeyValue::new("state", "idle")]);
+        pool.record(1, &[KeyValue::new("state", "in_use")]);
 
         let rendered = render(&registry).expect("the exposition should encode");
         for (instrument, exported) in CONSOLE_RENDERED_NAMES {
@@ -588,6 +582,68 @@ mod tests {
                 "the exporter renders no sample line for {exported}: {rendered}"
             );
         }
+    }
+
+    /// One instrument, one kind.
+    ///
+    /// `db_pool_connections` is created solely by the sampler, as a gauge. A
+    /// second instrument of a different kind under the same name on the same
+    /// meter is an `OpenTelemetry` duplicate-instrument conflict, and the pull
+    /// surface would then expose whichever stream won — the console's
+    /// `db_pool_connections{state="in_use"}` tile reads that family verbatim.
+    #[test]
+    fn the_pool_gauge_is_the_only_db_pool_connections_stream() {
+        use opentelemetry::metrics::MeterProvider as _;
+
+        let (provider, registry) = build_provider(
+            opentelemetry_sdk::Resource::builder().build(),
+            None::<opentelemetry_sdk::metrics::PeriodicReader<opentelemetry_otlp::MetricExporter>>,
+        )
+        .expect("the Prometheus reader should build");
+        let meter = provider.meter(SCOPE);
+        // The whole shipped instrument set plus the sampler's gauge, on one
+        // meter, exactly as the server creates them.
+        let _instruments = Metrics::new(&meter);
+        let pool = crate::telemetry::samplers::pool_gauge(&meter);
+        pool.record(2, &[KeyValue::new("state", "idle")]);
+        pool.record(1, &[KeyValue::new("state", "in_use")]);
+
+        let rendered = render(&registry).expect("the exposition should encode");
+        assert_eq!(
+            rendered.matches("# TYPE db_pool_connections ").count(),
+            1,
+            "db_pool_connections must render as exactly one family: {rendered}"
+        );
+        assert!(
+            rendered.contains("# TYPE db_pool_connections gauge"),
+            "db_pool_connections must render as a gauge: {rendered}"
+        );
+        for state in ["idle", "in_use"] {
+            let label = format!("state=\"{state}\"");
+            assert!(
+                rendered.lines().any(|line| {
+                    line.starts_with("db_pool_connections{") && line.contains(&label)
+                }),
+                "db_pool_connections carries no {label} sample: {rendered}"
+            );
+        }
+
+        // A second instrument kind under this name folds its stream into the
+        // same family, so one label set renders twice — which Prometheus
+        // rejects as a duplicate sample, losing the whole scrape.
+        let mut label_sets: Vec<&str> = rendered
+            .lines()
+            .filter(|line| line.starts_with("db_pool_connections{"))
+            .filter_map(|line| line.split_once('}').map(|(labels, _)| labels))
+            .collect();
+        let emitted = label_sets.len();
+        label_sets.sort_unstable();
+        label_sets.dedup();
+        assert_eq!(
+            label_sets.len(),
+            emitted,
+            "db_pool_connections renders a label set more than once: {rendered}"
+        );
     }
 
     /// The bucket ladders must be sorted and free of duplicates, or the

--- a/app/ferroehr/src/telemetry/samplers.rs
+++ b/app/ferroehr/src/telemetry/samplers.rs
@@ -28,6 +28,19 @@ use super::metrics::{
 /// How often the sampler reads gauges + runs recorder upkeep.
 const SAMPLE_INTERVAL: Duration = Duration::from_secs(5);
 
+/// Creates the pool-connections gauge on `meter`.
+///
+/// The one place [`DB_POOL_CONNECTIONS`] becomes an instrument: same name with a
+/// second instrument kind on one meter is an `OpenTelemetry` duplicate-instrument
+/// conflict, and the pull surface would then expose whichever stream won.
+#[must_use]
+pub(super) fn pool_gauge(meter: &Meter) -> opentelemetry::metrics::Gauge<u64> {
+    meter
+        .u64_gauge(DB_POOL_CONNECTIONS)
+        .with_description("Connection pool connections by state")
+        .build()
+}
+
 /// Acquire a pooled connection, recording the wait on
 /// [`DB_POOL_ACQUIRE_DURATION`](crate::telemetry::metrics::DB_POOL_ACQUIRE_DURATION). Use in place of `pool.acquire()` on measured
 /// hot paths.
@@ -105,7 +118,7 @@ struct OtelGauges {
 impl OtelGauges {
     fn new(meter: &Meter) -> Self {
         Self {
-            pool: meter.u64_gauge(DB_POOL_CONNECTIONS).build(),
+            pool: pool_gauge(meter),
             workers: meter.u64_gauge(TOKIO_WORKERS).build(),
             global_queue_depth: meter.u64_gauge(TOKIO_GLOBAL_QUEUE_DEPTH).build(),
             alive_tasks: meter.u64_gauge(TOKIO_ALIVE_TASKS).build(),

--- a/app/ferroehr/tests/it/telemetry.rs
+++ b/app/ferroehr/tests/it/telemetry.rs
@@ -7,7 +7,7 @@
 //! a live collector), and readiness reflecting a DOWN database.
 
 use ferroehr::telemetry::health::{Health, HealthIndicator, HealthStatus};
-use ferroehr::telemetry::metrics::histogram_views;
+use ferroehr::telemetry::metrics::{DB_POOL_CONNECTIONS, histogram_views};
 
 /// The histogram bucket ladders as a stable text table, so a re-bucketing is
 /// reviewed deliberately: `OTel`'s defaults are not ours, and a silently changed
@@ -77,7 +77,7 @@ async fn otlp_metrics_push_pipeline_smoke() {
         .build();
 
     let meter = provider.meter("ferroehr");
-    let gauge = meter.u64_gauge("db_pool_connections").build();
+    let gauge = meter.u64_gauge(DB_POOL_CONNECTIONS).build();
     gauge.record(3, &[KeyValue::new("state", "idle")]);
 
     provider.force_flush().expect("flush");
@@ -88,7 +88,7 @@ async fn otlp_metrics_push_pipeline_smoke() {
     );
     let has_gauge = metrics.iter().any(|rm| {
         rm.scope_metrics()
-            .any(|sm| sm.metrics().any(|m| m.name() == "db_pool_connections"))
+            .any(|sm| sm.metrics().any(|m| m.name() == DB_POOL_CONNECTIONS))
     });
     assert!(has_gauge, "db_pool_connections not present in the export");
 }


### PR DESCRIPTION
Closes #2366
Closes #2367

**#2366 — the duplicate instrument was scrape-breaking, not just ambiguous.** `db_pool_connections` was created twice on one meter — an `i64_up_down_counter` field nothing ever recorded into (grep-proven dead across app/, crates/, tools/) beside the `u64_gauge` the pool sampler writes. The mutation test showed the exporter folds both into one gauge family and renders the same label set twice — a duplicate sample a Prometheus scrape rejects outright, so reviving the dead stream could cost the console the whole scrape, not one tile. The dead field is removed, `samplers::pool_gauge` is the single creation site for the name, and a mutation-proven test pins one family + label-set uniqueness (failed `2 != 3` under the reintroduced conflict, passes after). The console-facing rendered name is unchanged; the naming pin test now records through the real gauge.

**#2367 — the additive-feature design is finally compiled by something.** A `feature-combos` lane clippy-checks `ferroehr-server` at `--no-default-features`, `--features events`, and `--features fhir` with `-D warnings` — the events-only lane is the load-bearing one (fhir implies events, so only events-without-fhir proves the gates aren't coupled backwards; #2358's wrong gate stayed latent for exactly this gap). Pins, permissions, cache policy and `--locked` copied from the existing clippy job; registered in the `conclusion` aggregate (the `ci-conclusion-complete.sh` guard verifies both directions and reports all 42 jobs gating). All three commands proven green locally with timings. En route: a workflow-only PR cannot run the cargo lane it edits — filed as #2373.

No user-visible behaviour changes (the dead instrument never rendered; the lane is CI-only) — `no-changelog`.

## Verification

`cargo clippy -p ferroehr --all-targets --all-features -- -D warnings` clean; full `-p ferroehr` suite 892 passed; the three slim-lane clippy commands green; `actionlint` + `zizmor` + `ci-conclusion-complete.sh` green; dependents re-checked (the removed field was pub).