### PR TITLE
feat(signing,fhir,crates,ci): RSA advisory, FHIR gate bypass closed, attributed packages, recipe-aware filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,28 @@ jobs:
   # jobs. GitHub treats a skipped required check as satisfied, so branch
   # protection is unaffected; a workflow-gating bug surfaces on the next
   # code-touching PR, which is acceptable.
+  #
+  # TWO NARROW EXCEPTIONS to "not build-relevant" (#2373), both instances of
+  # the rule the admin_ui/helm/chart_boot filters below already state — a
+  # change to a job's own recipe exercises the job it changes:
+  #   * `workflows` — this file. A workflow-only PR skipped EVERY cargo lane,
+  #     including the lane whose recipe it was editing, so a narrowed clippy
+  #     invocation or a dropped feature combination went in unexercised. It
+  #     re-triggers the four RECIPE-BEARING cargo lanes (clippy,
+  #     feature-combos, deny, test) rather than every cargo lane: those four
+  #     encode WHICH surface is verified — which crates, which features, which
+  #     flags, which extra guard scripts — so an edit there can NARROW what CI
+  #     checks while every lane still reports green. The single-command lanes
+  #     (fmt, doc, msrv, codegen-drift, unused-deps) run one canonical
+  #     whole-workspace command with no surface to narrow; a broken edit there
+  #     fails that lane outright on the next code-touching PR, which is the
+  #     same trade-off the paragraph above already accepts.
+  #   * `vex` — the VEX gates that run inside the `deny` job
+  #     (`vex-reachability.sh` reads the generated OpenVEX document,
+  #     `advisory-exceptions.sh` reads `deny.toml`) plus the two check scripts
+  #     themselves. `deny.toml` is already in the code allowlist; the VEX
+  #     documents and those scripts are not, so a `security/vex/**`-only PR
+  #     skipped the job that enforces them (#2370).
   changes:
     name: change detection
     runs-on: ubuntu-latest
@@ -72,6 +94,8 @@ jobs:
       helm: ${{ steps.filter.outputs.helm }}
       chart_boot: ${{ steps.filter.outputs.chart_boot }}
       deploy: ${{ steps.filter.outputs.deploy }}
+      workflows: ${{ steps.filter.outputs.workflows }}
+      vex: ${{ steps.filter.outputs.vex }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -105,6 +129,8 @@ jobs:
               echo "helm=true"
               echo "chart_boot=true"
               echo "deploy=true"
+              echo "workflows=true"
+              echo "vex=true"
             } >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -122,6 +148,8 @@ jobs:
               echo "helm=false"
               echo "chart_boot=false"
               echo "deploy=false"
+              echo "workflows=false"
+              echo "vex=false"
             } >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -189,6 +217,28 @@ jobs:
             echo "chart_boot=true" >> "$GITHUB_OUTPUT"
           else
             echo "chart_boot=false" >> "$GITHUB_OUTPUT"
+          fi
+          # Recipe gate (#2373): this workflow itself. Consumed by the four
+          # cargo lanes whose recipe decides WHAT is verified — clippy,
+          # feature-combos, deny and test — each of which ORs it into its
+          # `if:` beside `code`. Deliberately narrower than adding this file to
+          # the `code` allowlist, which would re-run every cargo job on a
+          # comment fix; deliberately wider than nothing, which is what let a
+          # workflow-only PR edit a lane's recipe without ever running it.
+          if echo "$changed" | grep -qE '^\.github/workflows/ci\.yml$' ; then
+            echo "workflows=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "workflows=false" >> "$GITHUB_OUTPUT"
+          fi
+          # VEX gate (#2370): the published OpenVEX documents and the two
+          # checks that read them, all enforced INSIDE the `deny` job. Only
+          # `deny.toml` is in the code allowlist, so without this a PR editing
+          # a VEX justification or its check script skipped the job that would
+          # have refused it.
+          if echo "$changed" | grep -qE '^(security/vex/|scripts/checks/(vex-reachability|advisory-exceptions)\.sh$)' ; then
+            echo "vex=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "vex=false" >> "$GITHUB_OUTPUT"
           fi
 
   # ── Required for code changes: formatting ───────────────────────────────────
@@ -493,6 +543,12 @@ jobs:
       # travel. This is the check that can.
       - name: First-party Rust source carries its SPDX header
         run: bash scripts/checks/spdx-headers.sh
+      # A vendored tree's PROVENANCE.md is the repository's record and does not
+      # travel with the package built from it. This is the check that the
+      # attribution INSIDE a published crate still names the revision the
+      # repository vendors.
+      - name: Packaged third-party bytes carry a pinned attribution
+        run: bash scripts/checks/packaged-attribution.sh
 
   # The compose hardening properties (cap_drop ALL, no-new-privileges, no
   # privileged, no seccomp=unconfined, loopback-only publishing). This gate
@@ -642,7 +698,10 @@ jobs:
   deny:
     name: cargo-deny
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    # `vex` because this job is where the two VEX gates run (#2370);
+    # `workflows` because its recipe — those two extra steps — is authored
+    # here (#2373).
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.vex == 'true' || needs.changes.outputs.workflows == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -712,7 +771,10 @@ jobs:
   clippy:
     name: clippy
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    # The three lanes below (workspace-minus-console, console ssr, console
+    # wasm hydrate) are this file's own recipe, so a change to it runs them
+    # (#2373).
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.workflows == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -756,7 +818,8 @@ jobs:
   feature-combos:
     name: clippy (slim server feature combos)
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    # The three feature sets ARE the test, and they are declared here (#2373).
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.workflows == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     permissions:
@@ -875,7 +938,9 @@ jobs:
   test:
     name: build & test (pg18)
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    # The service container, its pinned image, the env the suite runs against
+    # and the trailing CNF `validate` step are all this file's recipe (#2373).
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.workflows == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,15 +62,26 @@ workflow refuses a tag that has no matching section here.
   non-required, so a broker outage reports `DEGRADED` (the outbox retains
   messages) and never fails readiness. Previously a PHI-bearing outbound
   stream could be down with nothing on the health surface saying so.
+- **A boot advisory for RSA OpenPGP signing keys.** With
+  `signing.mode = "pgp"` and an RSA key, every signature is an RSA
+  private-key operation — the operation the Marvin timing sidechannel
+  (RUSTSEC-2023-0071) concerns, with no fixed `rsa` release. Boot now emits
+  a prominent warning naming the advisory and the Ed25519/ECC rotation path
+  (`signing.retired_key_paths` keeps history verifying); deliberately not a
+  refusal, because signatures are immutable committed facts an operator must
+  stay able to verify. The signing configuration page carries the guidance.
 
 ### Changed
 
-- **The `openehr-*` crates move to `0.0.28`, and `openehr-term` declares every
-  license its bytes are under.** The published `openehr-term` package ships
-  openEHR's verbatim terminology XML (CC-BY-SA 3.0) but declared only
-  `MIT AND Apache-2.0`; the expression is now
-  `MIT AND Apache-2.0 AND CC-BY-SA-3.0` and the license text travels in the
-  package. The other seven crates audited clean; all eight bump in lockstep.
+- **The `openehr-*` crates move to `0.0.29`, declaring and attributing every
+  third-party byte they ship.** `openehr-term` ships openEHR's verbatim
+  terminology XML (CC-BY-SA 3.0) but declared only `MIT AND Apache-2.0`; the
+  expression now names all three licenses and the text travels in the
+  package. The published `openehr-its` package carries attribution for the
+  openEHR JSON Schema it ships (pinned commit, upstream path, license, in
+  the README), and a new guard fails any crate packaging third-party bytes
+  whose pinned attribution does not travel. The other crates audited clean;
+  all eight bump in lockstep.
 - **The documentation site was read end-to-end against the tree and
   rewritten.** Every page's substantive claims were verified against the
   code, the chart, the workflows and the committed conformance artifacts;
@@ -84,6 +95,10 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **The FHIR read façade and outbound emitter respect the spec-profile read
+  gate.** Both read stored bodies around the gated versioning seam, so a
+  development-only body was mapped to FHIR under the `stable` profile with
+  no refusal; both now go through the gated read, mutation-proven.
 - **The boot banner follows the resolved log format.** With the default
   `log.format = "auto"` in a container (stdout not a terminal), logs render
   as JSON but the multi-line ASCII banner still printed first, handing every

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5486,7 +5486,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "indexmap 2.14.0",
  "openehr-am",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "serde",
  "serde_json",
@@ -5530,7 +5530,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "async-trait",
  "axum",
@@ -5559,7 +5559,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "assert_fs",
  "chumsky",
@@ -5573,7 +5573,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "chumsky",
  "logos",
@@ -5582,7 +5582,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "insta",
  "jsonschema",
@@ -5600,7 +5600,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -219,3 +219,19 @@ path = "docs/specs/openehr/CNF/tests/platform/robot/I_EHR_COMPOSITION/get_compos
 precedence = "override"
 SPDX-FileCopyrightText = "openEHR Foundation"
 SPDX-License-Identifier = "CC-BY-SA-3.0"
+
+# ── Our own provenance records inside the vendored trees ────────────────────
+# The PROVENANCE.md files are FIRST-PARTY prose about the upstream material,
+# not upstream bytes; the tree globs above would mis-attribute them to the
+# openEHR Foundation (`override` means no in-file header could correct it,
+# and openehr-term ships its record in the published package under that
+# declaration). Placed LAST: a later matching annotation wins.
+[[annotations]]
+path = [
+  "crates/openehr-its/schemas/json/PROVENANCE.md",
+  "crates/openehr-its/schemas/xml/PROVENANCE.md",
+  "crates/openehr-term/assets/PROVENANCE.md",
+]
+precedence = "override"
+SPDX-FileCopyrightText = "FerroEHR contributors"
+SPDX-License-Identifier = "MIT"

--- a/app/ferroehr/src/extensions/fhir/ingest.rs
+++ b/app/ferroehr/src/extensions/fhir/ingest.rs
@@ -17,7 +17,6 @@ use crate::service::error::{ServiceError, Violation, internal_fault};
 use crate::service::query::request::AqlQueryRequest;
 use crate::service::response::ServiceResponse;
 use crate::service::status::{CallStatusType, SmError};
-use crate::storage::version_repo;
 
 use ferroehr_ext::fhir::mapping::FhirMappingDefinition;
 
@@ -30,9 +29,10 @@ use ferroehr_ext::fhir::mapping::FhirMappingDefinition;
 /// COMPOSITION c` chain — a COMPOSITION variable's own `c/uid/value` is a
 /// (null) RM leaf on the AQL read path (the reassembled body carries no uid),
 /// whereas the VERSION variable's uid is the engine-synthesized object-version
-/// id. The COMPOSITION body is then loaded through the versioned read seam
-/// ([`version_repo::read::read_version_by_ordinal`]) by that uid, keeping the façade
-/// on the query seam and reusing the same read seam the outbound emitter uses.
+/// id. The COMPOSITION body is then loaded through the GATED versioned read
+/// seam ([`crate::versioning::read::read_version_by_ordinal`]) by that uid,
+/// keeping the façade on the query seam and reusing the same read seam the
+/// outbound emitter uses.
 const FHIR_SEARCH_AQL: &str = "SELECT v/uid/value FROM EHR e \
      CONTAINS VERSION v CONTAINS COMPOSITION c \
      WHERE c/archetype_details/template_id/value = $templateId";
@@ -308,9 +308,13 @@ impl FerroEhrService {
                 ) else {
                     continue;
                 };
-                let Some(read) =
-                    version_repo::read::read_version_by_ordinal(&self.pool, vo_id, sys_version)
-                        .await?
+                let Some(read) = crate::versioning::read::read_version_by_ordinal(
+                    &self.pool,
+                    self.spec_profile,
+                    vo_id,
+                    sys_version,
+                )
+                .await?
                 else {
                     continue;
                 };
@@ -358,14 +362,15 @@ impl FerroEhrService {
     /// Returns an empty vec (nothing to emit) when the version is absent, a
     /// logical delete (a deleted COMPOSITION has no content to map — a FHIR
     /// delete notification is out of the starter scope), carries no template,
-    /// or its template has no enabled mapping. Reuses the versioned read seam
-    /// ([`version_repo::read::read_version_by_ordinal`]) and the reverse transform.
+    /// or its template has no enabled mapping. Reuses the gated versioned read
+    /// seam ([`crate::versioning::read::read_version_by_ordinal`]) and the
+    /// reverse transform.
     ///
     /// NOTE: the template is read from the COMPOSITION itself (as the
-    /// read façade's AQL also does), NOT from `vo_version.template_id` — that
-    /// column is currently left NULL on the commit path, so relying on it would
-    /// emit nothing. Deriving it from the canonical body avoids touching the
-    /// versioning path.
+    /// read façade's AQL also does), NOT from `vo_version.template_id` — the
+    /// canonical body is the authoritative carrier
+    /// (`archetype_details.template_id`), and deriving from it keeps this
+    /// reader independent of the envelope column's population rules.
     ///
     /// # Errors
     /// A database failure on the version/mapping/subject reads, or
@@ -379,8 +384,13 @@ impl FerroEhrService {
         sys_version: i32,
     ) -> Result<Vec<(String, String, Value)>, ServiceError> {
         // Load the exact committed version; skip absent / logically-deleted ones.
-        let Some(read) =
-            version_repo::read::read_version_by_ordinal(&self.pool, vo_id, sys_version).await?
+        let Some(read) = crate::versioning::read::read_version_by_ordinal(
+            &self.pool,
+            self.spec_profile,
+            vo_id,
+            sys_version,
+        )
+        .await?
         else {
             return Ok(Vec::new());
         };

--- a/app/ferroehr/src/service/admin/dump_load.rs
+++ b/app/ferroehr/src/service/admin/dump_load.rs
@@ -1333,6 +1333,9 @@ impl FerroEhrService {
             // A deleted version has no node rows; its body stays `null`. An
             // export covers the WHOLE repository, so the content is read across
             // both storage tiers (`crate::storage::version_repo::tier`).
+            // NOTE: no openEHR spec governs the `spec_profile` gate — our own
+            // design/extension: a dump replicates stored bytes for restore
+            // rather than serving an RM body, so it reads ungated.
             let body = if lifecycle_state == DELETED_LIFECYCLE {
                 Value::Null
             } else {

--- a/app/ferroehr/src/service/ehr/validation.rs
+++ b/app/ferroehr/src/service/ehr/validation.rs
@@ -341,6 +341,9 @@ pub(in crate::service) async fn check_versioned_composition_invariants(
     vo_id: VoId,
     canonical: &Value,
 ) -> Result<(), ServiceError> {
+    // NOTE: no openEHR spec governs the `spec_profile` gate — our own
+    // design/extension: this write-path read compares two root fields and
+    // serves nothing, so it stays ungated.
     let Some(first) = crate::storage::node_repo::first_version_root(tx, vo_id).await? else {
         // No stored content version (e.g. every prior version deleted) — no
         // first-version root to compare against.

--- a/app/ferroehr/src/versioning/signature/key.rs
+++ b/app/ferroehr/src/versioning/signature/key.rs
@@ -16,6 +16,8 @@ use pgp::composed::{
     ArmorOptions, Deserializable, DetachedSignature, SignedPublicKey, SignedSecretKey,
 };
 use pgp::crypto::hash::HashAlgorithm;
+use pgp::crypto::public_key::PublicKeyAlgorithm;
+use pgp::types::KeyDetails as _;
 use pgp::types::Password;
 use rand::rngs::OsRng;
 
@@ -171,7 +173,35 @@ impl PgpKey {
         // Fail-closed: a real signature proves the passphrase unlocks the key
         // and it can actually sign.
         key.sign(b"ferroehr-signing boot check")?;
+        if let Some(algorithm) = key.key_algorithm_warning() {
+            warn_rsa_signing_key(algorithm);
+        }
         Ok(key)
+    }
+
+    /// The public-key algorithm of the component that actually signs — the
+    /// signing subkey when the certificate carries one, else the primary key
+    /// (the same choice [`Self::sign`] makes).
+    fn signing_algorithm(&self) -> PublicKeyAlgorithm {
+        match self
+            .signing_subkey
+            .and_then(|index| self.secret.secret_subkeys.get(index))
+        {
+            Some(subkey) => subkey.key.algorithm(),
+            None => self.secret.primary_key.algorithm(),
+        }
+    }
+
+    /// Returns the signing algorithm of this key when it is one whose
+    /// PRIVATE-key operations carry the Marvin timing sidechannel, `None` for a
+    /// key that keeps `rsa` off the signing path.
+    ///
+    /// The classification is a pure seam over [`Self::signing_algorithm`]; the
+    /// boot loader turns a `Some` into the operator-facing warning
+    /// ([`warn_rsa_signing_key`]).
+    pub(crate) fn key_algorithm_warning(&self) -> Option<PublicKeyAlgorithm> {
+        let algorithm = self.signing_algorithm();
+        rsa_family(algorithm).then_some(algorithm)
     }
 
     /// Produce an ASCII-armored RFC 4880 detached signature over `data`.
@@ -215,6 +245,35 @@ impl PgpKey {
     }
 }
 
+/// Whether `algorithm` signs with RSA, in any of the three spellings RFC 9580
+/// §9.1 registers (`RSA`, plus the deprecated sign-only and encrypt-only
+/// codepoints an older certificate can still carry).
+fn rsa_family(algorithm: PublicKeyAlgorithm) -> bool {
+    matches!(
+        algorithm,
+        PublicKeyAlgorithm::RSA | PublicKeyAlgorithm::RSASign | PublicKeyAlgorithm::RSAEncrypt
+    )
+}
+
+/// Warns that the configured signing key performs RSA private-key operations.
+///
+/// A warning rather than a boot refusal: an operator whose corpus is already
+/// RSA-signed must keep the key configured to verify that history (a
+/// `VERSION.signature` is an immutable committed fact — RM common
+/// `master06-change_control_package.adoc` §Digital Signature), so refusing the
+/// key would strand them with no read path at all.
+fn warn_rsa_signing_key(algorithm: PublicKeyAlgorithm) {
+    tracing::warn!(
+        key_algorithm = ?algorithm,
+        advisory = "RUSTSEC-2023-0071",
+        "the configured OpenPGP signing key is RSA, so every signature is an RSA private-key \
+         operation — the operation the Marvin timing sidechannel (RUSTSEC-2023-0071 / \
+         CVE-2023-49092) concerns, and the `rsa` crate has no fixed release. Rotate to an Ed25519 \
+         (or other ECC) signing key and keep this certificate in `signing.retired_key_paths` so \
+         versions already signed keep verifying."
+    );
+}
+
 /// Verify `sig` against every component of one certificate — the primary key
 /// and each of its subkeys.
 ///
@@ -236,4 +295,41 @@ fn verify_against_certificate(
         .public_subkeys
         .iter()
         .any(|subkey| sig.verify(subkey, data).is_ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every RFC 9580 §9.1 RSA codepoint classifies as RSA — including the two
+    /// deprecated single-purpose ones, which an older certificate still uses
+    /// and which sign with exactly the same private-key operation.
+    #[test]
+    fn every_rsa_codepoint_is_classified_as_rsa() {
+        for algorithm in [
+            PublicKeyAlgorithm::RSA,
+            PublicKeyAlgorithm::RSASign,
+            PublicKeyAlgorithm::RSAEncrypt,
+        ] {
+            assert!(rsa_family(algorithm), "{algorithm:?} must classify as RSA");
+        }
+    }
+
+    /// The algorithms that keep `rsa` off the signing path raise no advisory.
+    #[test]
+    fn elliptic_curve_algorithms_raise_no_advisory() {
+        for algorithm in [
+            PublicKeyAlgorithm::Ed25519,
+            PublicKeyAlgorithm::Ed448,
+            PublicKeyAlgorithm::EdDSALegacy,
+            PublicKeyAlgorithm::ECDSA,
+            PublicKeyAlgorithm::ECDH,
+            PublicKeyAlgorithm::X25519,
+        ] {
+            assert!(
+                !rsa_family(algorithm),
+                "{algorithm:?} performs no RSA private-key operation"
+            );
+        }
+    }
 }

--- a/app/ferroehr/tests/it/service_spec_profile.rs
+++ b/app/ferroehr/tests/it/service_spec_profile.rs
@@ -309,3 +309,169 @@ async fn archive_and_restore_preserve_the_stamp() {
         .await
         .expect("the restored object reads under the development profile");
 }
+
+// ── The FHIR read façade goes through the same gate ──────────────────────────
+
+/// The OPT the FHIR mapping binds to, and its ids.
+const OPT_REL: &str = "tests/resources/service/knowledge/opt/minimal_evaluation.opt";
+const TEMPLATE_ID: &str = "minimal_evaluation.en.v1";
+const ROOT_ARCHETYPE: &str = "openEHR-EHR-COMPOSITION.minimal.v1";
+/// The FHIR subject external id both compositions hang off.
+const SUBJECT: &str = "p-42";
+
+/// Read a test resource anchored at the crate manifest directory.
+fn fixture(rel: &str) -> String {
+    let path = format!("{}/{rel}", env!("CARGO_MANIFEST_DIR"));
+    std::fs::read_to_string(&path).expect("read the OPT fixture")
+}
+
+/// The FHIR mapping bound to the minimal-evaluation template.
+fn mapping_body() -> Value {
+    json!({
+        "name": "spec-profile-observation",
+        "definition": {
+            "resource_type": "Observation",
+            "template_id": TEMPLATE_ID,
+            "subject": {
+                "reference_path": "subject.reference",
+                "namespace": "fhir",
+                "strip_prefix": "Patient/"
+            },
+            "context": {
+                "ctx/language": "en", "ctx/territory": "US",
+                "ctx/composer_name": "fhir-connector", "ctx/time": "2026-02-03T04:05:06Z"
+            },
+            "entries": [
+                { "openehr_path": "minimal/minimal:0/quantity",
+                  "fhir_path": "valueQuantity.value",
+                  "transform": { "kind": "quantity", "unit_path": "valueQuantity.unit" } }
+            ]
+        }
+    })
+}
+
+/// The inbound FHIR resource whose ingest produces the CLEAN, template-bound
+/// COMPOSITION the façade also reverse-maps.
+fn observation() -> Value {
+    json!({
+        "resourceType": "Observation",
+        "id": "spec-profile-obs-1",
+        "status": "final",
+        "subject": { "reference": format!("Patient/{SUBJECT}") },
+        "valueQuantity": { "value": 118, "unit": "kg" }
+    })
+}
+
+/// The development-only COMPOSITION planted under the mapped template's root
+/// archetype, so the façade's template-bound query reaches it.
+fn development_only_under_template() -> Value {
+    let mut body = development_only_composition();
+    let root = body.as_object_mut().expect("the fixture is a JSON object");
+    root.insert("archetype_node_id".to_owned(), json!(ROOT_ARCHETYPE));
+    root.insert(
+        "archetype_details".to_owned(),
+        json!({
+            "_type": "ARCHETYPED",
+            "archetype_id": { "_type": "ARCHETYPE_ID", "value": ROOT_ARCHETYPE },
+            "rm_version": "1.2.0"
+        }),
+    );
+    body
+}
+
+/// Stamp `template_id` onto a stored COMPOSITION's root node fragment.
+///
+/// The façade's AQL matches on `archetype_details/template_id/value`, and a
+/// COMPOSITION declaring a template is validated against it at commit — so a
+/// body carrying template-foreign content (the `GENERIC_ENTRY` this module's
+/// docs describe) can only reach the store the way this fixture puts it there.
+/// `archetype_details` is not a structure node, so it lives in the root row's
+/// canonical fragment (`num = 0`).
+async fn stamp_template_on_stored_root(pool: &sqlx::PgPool, vo_id: VoId) {
+    let affected = sqlx::query(
+        "UPDATE node SET data = jsonb_set(data, '{archetype_details,template_id}', $2, true) \
+         WHERE vo_id = $1 AND num = 0",
+    )
+    .bind(vo_id)
+    .bind(json!({ "_type": "TEMPLATE_ID", "value": TEMPLATE_ID }))
+    .execute(pool)
+    .await
+    .expect("stamp the template id on the stored root node")
+    .rows_affected();
+    assert_eq!(affected, 1, "exactly one root node row is stamped");
+}
+
+/// The FHIR read façade loads full stored bodies, so it takes the same
+/// `spec_profile` gate every other served read takes: under `stable` a
+/// development-only body is the `409`-class conflict, and no resource is
+/// mapped from it.
+#[tokio::test]
+async fn the_fhir_read_facade_is_gated_by_the_spec_profile() {
+    let db = testkit::db().await.expect("testkit database");
+    let svc = FerroEhrService::new(db.pool());
+    svc.template_adl14_upload(fixture(OPT_REL))
+        .await
+        .expect("ingest the OPT");
+    svc.fhir_mapping_create(mapping_body())
+        .await
+        .expect("create the FHIR mapping");
+
+    // One EHR carrying two COMPOSITIONs of the mapped template: the clean one
+    // an inbound FHIR ingest commits, and a development-only one.
+    let ehr_id = svc
+        .create_ehr_for_subject(
+            ferroehr::service::ehr_index::types::SubjectRef::person(SUBJECT, "fhir"),
+            None,
+        )
+        .await
+        .expect("create the subject's EHR");
+    svc.fhir_ingest("Observation".to_owned(), None, observation())
+        .await
+        .expect("the inbound ingest commits the clean composition");
+    let planted = svc
+        .create_composition(ehr_id, create_version(&development_only_under_template()))
+        .await
+        .expect("the development profile commits the development-only body");
+    assert_eq!(
+        stamp(&db.pool(), planted.vo_id).await,
+        Some(false),
+        "the planted body is stamped NOT stable-compatible at commit"
+    );
+    stamp_template_on_stored_root(&db.pool(), planted.vo_id).await;
+
+    // Under the profile that accepted it, the façade serves the Bundle.
+    let bundle = svc
+        .fhir_search("Observation".to_owned(), ehr_id.to_string(), None)
+        .await
+        .expect("the development profile serves the façade");
+    assert_eq!(
+        bundle["total"].as_u64(),
+        Some(2),
+        "both stored compositions of the mapped template are in the Bundle: {bundle}"
+    );
+    assert!(
+        bundle["entry"].as_array().is_some_and(|entries| entries
+            .iter()
+            .any(|e| e["resource"]["valueQuantity"]["value"].as_f64() == Some(118.0))),
+        "the clean composition still reverse-maps its value: {bundle}"
+    );
+
+    // Under `stable` the same façade refuses rather than mapping a body the
+    // released generations do not define.
+    let refused = stable_service(db.pool())
+        .fhir_search("Observation".to_owned(), ehr_id.to_string(), None)
+        .await;
+    let Err(SmError {
+        status: CallStatusType::Conflict,
+        message,
+        ..
+    }) = refused
+    else {
+        panic!("the stable profile must refuse the FHIR read, got {refused:?}");
+    };
+    assert!(message.contains("stable"), "{message}");
+    assert!(
+        message.contains(&planted.vo_id.to_string()),
+        "the refusal names the offending version: {message}"
+    );
+}

--- a/app/ferroehr/tests/it/signing_pgp.rs
+++ b/app/ferroehr/tests/it/signing_pgp.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 //! `OpenPGP`-mode integration tests: sign→verify round-trip with a
-//! generated key, tamper detection, armor-parse failures, and the fail-closed
-//! boot validation (missing path, garbled key, wrong passphrase).
+//! generated key, tamper detection, armor-parse failures, the fail-closed
+//! boot validation (missing path, garbled key, wrong passphrase), and the
+//! boot advisory an RSA signing key raises.
 //!
 //! Keys are generated in-test via rPGP so there is no vendored key fixture.
 
@@ -15,8 +16,10 @@
               fixture indexing are the intended shape here (the Rust Book ch11)"
 )]
 
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 
 use ferroehr::versioning::signature::config::{Mode, SigningConfig, VerifyOnRead};
 use ferroehr::versioning::signature::key::KeyError;
@@ -26,6 +29,9 @@ use pgp::composed::{
     ArmorOptions, KeyType, SecretKeyParamsBuilder, SignedSecretKey, SubkeyParamsBuilder,
 };
 use rand::rngs::OsRng;
+use tracing::field::{Field, Visit};
+use tracing_subscriber::layer::{Context, Layer};
+use tracing_subscriber::prelude::*;
 
 /// A short openEHR-canonical-form-like string to sign in the tests.
 const CANONICAL: &str = r#"{"_type":"ORIGINAL_VERSION","uid":{"value":"a::b::1"}}"#;
@@ -371,5 +377,117 @@ fn a_subkey_signature_verifies_against_the_certificate_that_retains_it() {
         rotated.verify(CANONICAL, &signature),
         Verdict::PgpValid,
         "a subkey signature must verify against a retained certificate, not just the active one"
+    );
+}
+
+// ── The RSA signing-key boot advisory ───────────────────────────────────────
+
+/// One captured `tracing` event: its level and its rendered field values.
+#[derive(Debug, Clone)]
+struct CapturedEvent {
+    level: tracing::Level,
+    fields: BTreeMap<String, String>,
+}
+
+/// A layer collecting every event emitted while it is the default subscriber.
+#[derive(Clone, Default)]
+struct EventCapture {
+    events: Arc<Mutex<Vec<CapturedEvent>>>,
+}
+
+impl<S: tracing::Subscriber> Layer<S> for EventCapture {
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        let mut visitor = FieldVisitor::default();
+        event.record(&mut visitor);
+        self.events.lock().expect("lock").push(CapturedEvent {
+            level: *event.metadata().level(),
+            fields: visitor.0,
+        });
+    }
+}
+
+/// Collects field name → rendered value.
+#[derive(Default)]
+struct FieldVisitor(BTreeMap<String, String>);
+
+impl Visit for FieldVisitor {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.0.insert(field.name().to_owned(), value.to_owned());
+    }
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.0.insert(field.name().to_owned(), format!("{value:?}"));
+    }
+}
+
+/// Build a `pgp`-mode signer with a capturing subscriber installed, returning
+/// every event the key load emitted.
+fn boot_events(armored_key: &str) -> Vec<CapturedEvent> {
+    let capture = EventCapture::default();
+    let events = Arc::clone(&capture.events);
+    let subscriber = tracing_subscriber::registry().with(capture);
+    {
+        let _guard = tracing::subscriber::set_default(subscriber);
+        pgp_signer(armored_key, None).expect("build signer");
+    }
+    events.lock().expect("lock").clone()
+}
+
+/// Generate an armored RSA-2048 `OpenPGP` secret key (rPGP refuses anything
+/// smaller as insecure).
+fn generate_rsa_key() -> String {
+    let mut builder = SecretKeyParamsBuilder::default();
+    builder
+        .key_type(KeyType::Rsa(2048))
+        .can_sign(true)
+        .primary_user_id("ferroehr-signing rsa <rsa@ferroehr.local>".into());
+    let params = builder.build().expect("build RSA key params");
+    let key: SignedSecretKey = params.generate(OsRng).expect("generate RSA key");
+    key.to_armored_string(ArmorOptions::default())
+        .expect("armor RSA key")
+}
+
+/// An RSA signing key BOOTS — the operator with an RSA-signed corpus keeps a
+/// read path — and raises a prominent warning naming the advisory and the
+/// remedy.
+#[test]
+fn an_rsa_signing_key_boots_with_a_prominent_advisory() {
+    let warnings: Vec<CapturedEvent> = boot_events(&generate_rsa_key())
+        .into_iter()
+        .filter(|e| e.level == tracing::Level::WARN)
+        .collect();
+    let advisory = warnings
+        .iter()
+        .find(|e| {
+            e.fields
+                .get("advisory")
+                .is_some_and(|a| a == "RUSTSEC-2023-0071")
+        })
+        .unwrap_or_else(|| panic!("no RSA advisory among the boot events: {warnings:?}"));
+    let message = advisory.fields.get("message").expect("a message field");
+    assert!(
+        message.contains("RSA"),
+        "the warning names the key algorithm: {message}"
+    );
+    assert!(
+        message.contains("Ed25519"),
+        "the warning names the recommended replacement: {message}"
+    );
+    assert!(
+        message.contains("retired_key_paths"),
+        "the warning points at the rotation mechanism that keeps history verifying: {message}"
+    );
+}
+
+/// An Ed25519 key keeps `rsa` off the signing path entirely, so it raises no
+/// advisory at all.
+#[test]
+fn an_ed25519_signing_key_raises_no_advisory() {
+    let advisories: Vec<CapturedEvent> = boot_events(&generate_key(None))
+        .into_iter()
+        .filter(|e| e.fields.contains_key("advisory"))
+        .collect();
+    assert!(
+        advisories.is_empty(),
+        "an ECC signing key must boot silently, got {advisories:?}"
     );
 }

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-adl"
-version = "0.0.28"
+version = "0.0.29"
 description = "openEHR ADL 2.4.0: hand-written ADL2/cADL/ODIN parser, AOM2 validation catalogue, specialisation flattener, OPT2 generator, and ADL 1.4→2 conversion over the generated openehr_am::v2_4::aom2 model"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,10 +16,10 @@ include = ["src/**", "README.md", "LICENSE-MIT"]
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)
-openehr-base = { path = "../openehr-base", version = "0.0.28" }   # VersionStatus for the parsed HRID
-openehr-am = { path = "../openehr-am", version = "0.0.28" }       # v2_4 ArchetypeHrid (the identification target type)
-openehr-rm = { path = "../openehr-rm", version = "0.0.28" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
-openehr-lang = { path = "../openehr-lang", version = "0.0.28" }   # openehr_lang::odin — the ODIN section parser
+openehr-base = { path = "../openehr-base", version = "0.0.29" }   # VersionStatus for the parsed HRID
+openehr-am = { path = "../openehr-am", version = "0.0.29" }       # v2_4 ArchetypeHrid (the identification target type)
+openehr-rm = { path = "../openehr-rm", version = "0.0.29" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
+openehr-lang = { path = "../openehr-lang", version = "0.0.29" }   # openehr_lang::odin — the ODIN section parser
 uuid.workspace = true        # meta uid/build_uid (AUTHORED_ARCHETYPE.uid: Uuid)
 indexmap.workspace = true    # OdinValue::Object body (insertion-ordered map)
 

--- a/crates/openehr-am/Cargo.toml
+++ b/crates/openehr-am/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-am"
-version = "0.0.28"
+version = "0.0.29"
 description = "openEHR AM Archetype Model, generated from BMM: generations v1_4 (AM 1.4.0, ADL 1.4) and v2_4 (AM 2.4.0, ADL 2; current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,8 +13,8 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.28" }
-openehr-lang = { path = "../openehr-lang", version = "0.0.28" }
+openehr-base = { path = "../openehr-base", version = "0.0.29" }
+openehr-lang = { path = "../openehr-lang", version = "0.0.29" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also carries the untyped `Value` fields the generator

--- a/crates/openehr-base/Cargo.toml
+++ b/crates/openehr-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-base"
-version = "0.0.28"
+version = "0.0.29"
 description = "openEHR BASE foundation + base types, generated from BMM: generations v1_2 (BASE 1.2.0) and v1_3 (BASE 1.3.0, current)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-its"
-version = "0.0.28"
+version = "0.0.29"
 description = "openEHR ITS (Implementation Technology Specifications): canonical JSON + canonical XML serialization of the RM, the generated ITS-REST 1.1.0 API contract, OPT 1.4 and AOM2 archetype XML codecs, and the Simplified Formats (FLAT / STRUCTURED / Web Template)"
 edition.workspace = true
 rust-version.workspace = true
@@ -41,14 +41,14 @@ regex = { workspace = true, optional = true }
 fancy-regex = { workspace = true, optional = true }
 # The generated XML (de)serializers impl the crate's ToXml/FromXml traits for the
 # RM/BASE spec types, so these are real (non-dev) deps.
-openehr-base = { path = "../openehr-base", version = "0.0.28", optional = true }
-openehr-rm = { path = "../openehr-rm", version = "0.0.28", optional = true }
+openehr-base = { path = "../openehr-base", version = "0.0.29", optional = true }
+openehr-rm = { path = "../openehr-rm", version = "0.0.29", optional = true }
 # The native canonical-JSON codec (`json_codec/generated`, emit-json) implements
 # `ToJson` for EVERY generated spec type the `OpenEhrType` derive covers, so it
 # spans all five spec crates (not just the RM/BASE the XML codec needs).
-openehr-lang = { path = "../openehr-lang", version = "0.0.28", optional = true }
-openehr-am = { path = "../openehr-am", version = "0.0.28", optional = true }
-openehr-term = { path = "../openehr-term", version = "0.0.28", optional = true }
+openehr-lang = { path = "../openehr-lang", version = "0.0.29", optional = true }
+openehr-am = { path = "../openehr-am", version = "0.0.29", optional = true }
+openehr-term = { path = "../openehr-term", version = "0.0.29", optional = true }
 
 # `full` — every ITS surface (canonical JSON/XML, the generated ITS-REST
 # contract, `opt14`, Simplified Formats). ON BY DEFAULT, so every consumer sees

--- a/crates/openehr-its/README.md
+++ b/crates/openehr-its/README.md
@@ -56,6 +56,27 @@ package version.
 
 Rust 1.96 (edition 2024).
 
+## Attribution — the embedded openEHR artifact
+
+Exactly one third-party file travels inside this package:
+
+- **Packaged path:** `schemas/json/openehr_rm_1.1.0_all.json`
+- **Upstream:** [`openEHR/specifications-ITS-JSON`](https://github.com/openEHR/specifications-ITS-JSON),
+  path `components/openehr_rm_1.1.0_all.json`, commit
+  `5acae056248e917a4b4c56f7e712f4fcfeb616a6` (`master` — ITS-JSON is
+  DEVELOPMENT status and has no numbered release)
+- **Copyright:** openEHR Foundation; redistributed **verbatim** under
+  Apache-2.0 ([`LICENSE-APACHE-2.0`](LICENSE-APACHE-2.0),
+  <https://github.com/openEHR/specifications-ITS-JSON/blob/master/LICENSE>)
+- **Role here:** the consolidated ITS-JSON RM 1.1.0 JSON Schema, embedded as
+  `openehr_its::json::RM_SCHEMA_JSON` and used as the validation oracle for
+  canonical-JSON output — it is not a code source.
+
+If you redistribute this crate, that file and this attribution travel with it.
+The rest of the vendored ITS-JSON tree, and the ITS-XML XSDs and ITS-REST
+OpenAPI documents the generated code was emitted from, stay in the repository
+and are not packaged.
+
 ## License
 
 Licensed as **MIT AND Apache-2.0**:
@@ -63,7 +84,9 @@ Licensed as **MIT AND Apache-2.0**:
 - The Rust code and hand-written parts are MIT ([`LICENSE-MIT`](LICENSE-MIT)).
 - The package embeds material derived from the official openEHR
   machine-readable specification artifacts, which openEHR publishes under
-  Apache-2.0 ([`LICENSE-APACHE-2.0`](LICENSE-APACHE-2.0)) — the generated codecs/contract derive from the vendored ITS XSD/OpenAPI/BMM artifacts, and the package embeds the official ITS-JSON RM schema (`schemas/json/`).
+  Apache-2.0 ([`LICENSE-APACHE-2.0`](LICENSE-APACHE-2.0)) — the generated
+  codecs/contract derive from the vendored ITS XSD/OpenAPI/BMM artifacts, and
+  the package embeds the official ITS-JSON RM schema attributed above.
 
 ## Part of FerroEHR
 

--- a/crates/openehr-its/schemas/json/PROVENANCE.md
+++ b/crates/openehr-its/schemas/json/PROVENANCE.md
@@ -30,6 +30,12 @@ self-tagging; there are no JSON structs to generate. `openehr-its::json` reads
 `openehr_rm_1.1.0_all.json` (via `include_str!`) to validate canonical-JSON
 output in the fidelity gate (`tests/`).
 
+That one file — and only that one — is also PACKAGED in the published
+`openehr-its` crate, so its attribution has to travel with the package rather
+than with this tree: the crate's `README.md` carries it, pinned to the same
+commit as above, and `scripts/checks/packaged-attribution.sh` fails the build
+if the two ever disagree. Re-vendoring moves both.
+
 ## Known version divergence (adjudicated, machine-pinned — #1697)
 
 ITS-JSON tops out at RM 1.1.0 while our generated RM is 1.2.0 (from BMM), and

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-lang"
-version = "0.0.28"
+version = "0.0.29"
 description = "openEHR LANG BMM/P_BMM object model, generated from BMM: generations v1_0 (LANG 1.0.0) and v1_1 (LANG 1.1.0, current; the stable BMM v2.x unit beside the paused BMM3 unit), plus hand-written ODIN/BEL/EL readers"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["parser-implementations", "data-structures"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.28" }
+openehr-base = { path = "../openehr-base", version = "0.0.29" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the
 # generated types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) —
 # never a derive. `serde_json` also carries the untyped `Value` fields the

--- a/crates/openehr-query/Cargo.toml
+++ b/crates/openehr-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-query"
-version = "0.0.28"
+version = "0.0.29"
 description = "openEHR QUERY (AQL 1.1.0): hand-written lexer, parser, typed AST and canonical printer from the official grammar (no ANTLR runtime)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-rm"
-version = "0.0.28"
+version = "0.0.29"
 description = "openEHR RM Reference Model, generated from BMM: generations v1_1 (RM 1.1.0) and v1_2 (RM 1.2.0, current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,11 +13,11 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.28" }
+openehr-base = { path = "../openehr-base", version = "0.0.29" }
 # The terminology-backed RM class invariants (`validate::terminology`) resolve
 # openEHR terminology groups + code sets against the vendored TERM 3.1.0 bundle.
 # `openehr-term` itself depends only on `openehr-base`, so this is acyclic.
-openehr-term = { path = "../openehr-term", version = "0.0.28" }
+openehr-term = { path = "../openehr-term", version = "0.0.29" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also backs the untyped `Value` RM representation used by

--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-term"
-version = "0.0.28"
+version = "0.0.29"
 description = "openEHR TERM terminology data model, generated from BMM (generation v3_1 = TERM 3.1.0), plus the embedded official terminology XML bundle"
 edition.workspace = true
 rust-version.workspace = true
@@ -34,7 +34,7 @@ include = [
 ]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.28" }
+openehr-base = { path = "../openehr-base", version = "0.0.29" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive.

--- a/scripts/checks/packaged-attribution.sh
+++ b/scripts/checks/packaged-attribution.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+# A crate that PACKAGES third-party bytes carries that material's attribution
+# INSIDE the package, pinned to the revision the repository records.
+#
+# The per-tree `PROVENANCE.md` is the repository's record and does not travel:
+# it describes the whole vendored tree, and for `openehr-its` that tree is 784
+# schema files while the published package ships exactly one of them. So the
+# packaged attribution is a SECOND statement of the same pin — which is
+# precisely the shape that drifts, because a re-vendor updates the provenance
+# record and can leave the packaged text quoting a revision nobody vendors any
+# more. This gate makes that a failing build instead.
+#
+# Two mechanical assertions per row; neither judges prose:
+#   1. the upstream revision recorded in the provenance file appears verbatim
+#      in the packaged attribution file;
+#   2. that attribution file is itself in the crate's `include` list, so it
+#      actually reaches a consumer.
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# crate | provenance record (repository) | packaged attribution
+readonly -a ROWS=(
+  "crates/openehr-its|schemas/json/PROVENANCE.md|README.md"
+  "crates/openehr-term|assets/PROVENANCE.md|assets/PROVENANCE.md"
+)
+
+fail=0
+note() { echo "packaged-attribution: $*" >&2; fail=1; }
+
+for row in "${ROWS[@]}"; do
+  IFS='|' read -r crate provenance attribution <<<"$row"
+  manifest="$crate/Cargo.toml"
+  for required in "$crate/$provenance" "$crate/$attribution" "$manifest"; do
+    [ -f "$required" ] || { note "missing $required"; continue 2; }
+  done
+
+  revision=$(grep -oE '[0-9a-f]{40}' "$crate/$provenance" | head -1 || true)
+  if [ -z "$revision" ]; then
+    note "$crate/$provenance records no 40-hex upstream commit — the packaged attribution has nothing to pin to"
+    continue
+  fi
+  if ! grep -qF -- "$revision" "$crate/$attribution"; then
+    note "$crate/$attribution does not name the upstream commit $revision recorded in $crate/$provenance — the attribution that travels with the package would point at a revision this repository no longer vendors"
+  fi
+
+  # The `include` list is a TOML array that may span lines; the attribution
+  # file is matched by its exact path, so a glob covering it (never the case
+  # today) would have to be spelled out here deliberately.
+  if ! sed -n '/^include *= *\[/,/\]/p' "$manifest" | grep -qF -- "\"$attribution\""; then
+    note "$manifest does not \`include\` $attribution — the attribution would not travel in the published package"
+  fi
+done
+
+[ "$fail" -eq 0 ] || {
+  echo >&2
+  echo "Attribution for redistributed third-party material must be inside the" >&2
+  echo "published artifact, not only in the repository it was built from." >&2
+  exit 1
+}
+
+echo "ok: ${#ROWS[@]} crates package third-party bytes, each with a pinned attribution that travels"

--- a/website/book/src/crates.md
+++ b/website/book/src/crates.md
@@ -20,8 +20,8 @@ vendored specification text.
 
 ```toml
 [dependencies]
-openehr-rm = "0.0.28"
-openehr-its = "0.0.28"
+openehr-rm = "0.0.29"
+openehr-its = "0.0.29"
 ```
 
 All eight are **edition 2024** with an MSRV of **Rust 1.96**, and all eight
@@ -104,7 +104,7 @@ enforces instead of carrying a second one:
 
 ```toml
 [dependencies]
-openehr-its = { version = "0.0.28", default-features = false }
+openehr-its = { version = "0.0.29", default-features = false }
 ```
 
 ## Releases
@@ -125,7 +125,10 @@ their own Rust sources, the README, and the MIT text. Five of the crates that
 embed material derived from the official openEHR machine-readable artifacts —
 generated types carrying specification documentation text, and the vendored
 ITS-JSON schema — declare **`MIT AND Apache-2.0`** and ship both license texts
-in the package.
+in the package. `openehr-its` is the one of them that packages a third-party
+file as bytes rather than as generated code, so its README carries that file's
+attribution — upstream repository, the exact vendored commit, and the license —
+inside the package, where it travels with any redistribution.
 
 `openehr-term` carries a third term, because it embeds a different kind of
 openEHR material: the official terminology XML (the five language bundles, the

--- a/website/book/src/installation/config-auth.md
+++ b/website/book/src/installation/config-auth.md
@@ -362,6 +362,30 @@ takes a comma-separated list
 > `pgp` mode **fails closed at boot** if the key is missing or unusable — the
 > server will not start. Verify the key and passphrase before switching modes.
 
+### Choose an Ed25519 (or other ECC) signing key
+
+Any OpenPGP key algorithm is accepted, but an **RSA** signing key makes every
+commit perform an RSA private-key operation — the operation the Marvin timing
+sidechannel concerns (RUSTSEC-2023-0071 / CVE-2023-49092), for which the
+underlying `rsa` crate has no fixed release. An Ed25519 or ECDSA key keeps that
+code off the signing path entirely.
+
+The server does **not** refuse an RSA key: a repository whose history is
+already RSA-signed needs that key to keep verifying, and signatures are
+immutable committed facts that cannot be re-issued. Instead it logs a warning
+at boot naming the advisory. To clear it:
+
+1. Generate a new signing key: `gpg --quick-generate-key "…" ed25519 sign`, and
+   export the armored secret key to `key_path`.
+2. Export the **public** half of the old certificate and add it to
+   `retired_key_paths`, so versions signed with it still verify (see above).
+3. Restart. New versions are signed with Ed25519; old ones keep verifying.
+
+Rotation inside one certificate is cheaper still: add an Ed25519 **signing
+subkey** to the existing certificate and the server signs with it
+automatically, with no `retired_key_paths` entry needed — the certificate keeps
+the previous subkey, so past signatures continue to verify.
+
 **On Kubernetes**, `digest` mode needs nothing — it is the default. `pgp` mode
 needs the key as a file and its passphrase as a secret, both of which the chart
 mounts for you:


### PR DESCRIPTION
Closes #2369
Closes #2371
Closes #2373
Closes #2381

**#2371 — the RSA signing configuration announces itself.** With `signing.mode = "pgp"` and an RSA key, every signature is an RSA private-key operation — the Marvin (RUSTSEC-2023-0071) operation, no fixed `rsa` release. Boot now emits a prominent structured warning naming the advisory and the Ed25519/ECC rotation path. Adjudicated as a warning, not a refusal: a `VERSION.signature` is an immutable committed fact (RM common master06 §Digital Signature), so an operator with an RSA-signed corpus must stay able to verify it. The classifier covers all three RFC 9580 RSA codepoints and reads the component that actually signs (an RSA primary with an Ed25519 signing subkey correctly raises nothing); real-key boot tests pin both directions; the signing page carries the rotation recipe.

**#2381 — the last serving read path outside the profile gate is closed.** Both FHIR ingest sites now go through the gated versioning read (mutation-proven: reverting the profile at the façade site re-produces the exact defect — a development-only body mapped to FHIR under `stable`). The full sweep of direct storage readers: dump (replicates bytes for restore — justified, NOTE'd), validation (write-path root fields — justified, NOTE'd), and AQL whole-object projection — which turns out to serve the same ungated bodies on the busiest read path, filed as #2386 with the feasible join named. #2387 tracks pinning dump→load stamp honesty.

**#2369 — attribution travels with the published bytes.** `openehr-its`'s packaged openEHR JSON Schema gains a pinned attribution in the crate README (chosen over a second provenance file, which the REUSE `override` glob would have mis-attributed to the openEHR Foundation — that mis-attribution itself is now fixed with a last-position annotation, verified against `reuse spdx` output). A new `packaged-attribution.sh` guard fails any crate whose pinned attribution stops travelling, proven in both directions. Lockstep bump to `0.0.29`; whole-workspace publish dry-run green with the attribution in the packaged bytes. En route: packaged test code references fixtures the package does not carry — #2385.

**#2373 — a recipe edit exercises the lanes it can narrow.** Two new `changes` outputs: `ci.yml` triggers clippy, feature-combos, deny and test (the lanes that encode *which surface* is verified and can be narrowed silently); `security/vex/**` + the two VEX gate scripts trigger the deny job that runs them. Single-command lanes stay untriggered with the rationale stated in the filter header; the conclusion aggregation is unchanged and `ci-conclusion-complete.sh` reports all 42 jobs gating.

## Verification

clippy (all lanes touched crates) clean; `cargo nextest run -p ferroehr` 909 passed; rustdoc gate clean; `reuse lint` compliant with the resolved attribution verified via `reuse spdx`; publish dry-run all eight crates; packaged-attribution + licensing + SPDX guards green; actionlint/zizmor/ci-conclusion-complete green; docs-claims/typed-status/comment-style/default-style/changelog-structure green.