### PR TITLE
release: v3.17.6

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -32,8 +32,8 @@
     },
     "title": "FerroEHR",
     "description": "<p>A pure-Rust, openEHR-specification-conformant clinical data repository (CDR): ITS-REST 1.1.0 REST API, AQL 1.1 query language, and the openEHR RM 1.2.0 reference model on PostgreSQL-18-native storage. The openEHR specification layer is generated from the official machine-readable specifications, and conformance is machine-verified per release by a built-in CNF conformance runner.</p>",
-    "publication_date": "2026-08-13",
-    "version": "3.17.5",
+    "publication_date": "2026-08-15",
+    "version": "3.17.6",
     "creators": [
       {
         "person_or_org": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+## [3.17.6] - 2026-08-15
+
 ### Security
 
 - **The rsa advisory's published VEX statement was false, and is re-grounded.**
@@ -6673,7 +6675,8 @@ but has not yet run in production.
   seccomp, default-deny NetworkPolicy) and golden-render validation.
 
 
-[unreleased]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.5...HEAD
+[unreleased]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.6...HEAD
+[3.17.6]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.5...v3.17.6
 [3.17.5]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.4...v3.17.5
 [3.17.4]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.3...v3.17.4
 [3.17.3]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.2...v3.17.3

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,5 +33,5 @@ keywords:
   - ITS-REST
   - Rust
   - PostgreSQL
-version: 3.17.5
-date-released: 2026-08-13
+version: 3.17.6
+date-released: 2026-08-15

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "cnf-runner"
-version = "3.17.5"
+version = "3.17.6"
 dependencies = [
  "assert_fs",
  "base64 0.23.1",
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "docs-meta"
-version = "3.17.5"
+version = "3.17.6"
 
 [[package]]
 name = "dotenvy"
@@ -2663,7 +2663,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ferroehr"
-version = "3.17.5"
+version = "3.17.6"
 dependencies = [
  "argon2",
  "assert_fs",
@@ -2735,7 +2735,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-admin-ui"
-version = "3.17.5"
+version = "3.17.6"
 dependencies = [
  "anyhow",
  "axum",
@@ -2777,7 +2777,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-ext"
-version = "3.17.5"
+version = "3.17.6"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2801,7 +2801,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-rest"
-version = "3.17.5"
+version = "3.17.6"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -2860,7 +2860,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-server"
-version = "3.17.5"
+version = "3.17.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -5521,7 +5521,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-codegen"
-version = "3.17.5"
+version = "3.17.6"
 dependencies = [
  "roxmltree",
  "serde_json",
@@ -8744,7 +8744,7 @@ dependencies = [
 
 [[package]]
 name = "testkit"
-version = "3.17.5"
+version = "3.17.6"
 dependencies = [
  "ferroehr",
  "jiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "3"
 members = ["crates/*", "app/*", "tools/*"]
 
 [workspace.package]
-version = "3.17.5"
+version = "3.17.6"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT"

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -26,7 +26,7 @@ version: 6.0.6
 # previous image. It is NOT a promise that this tag accepts the chart's current
 # `config` defaults: values track development between releases, so the publish
 # lane re-checks the pairing against the image itself.
-appVersion: "3.17.5"
+appVersion: "3.17.6"
 
 # A COMPATIBILITY floor, and a real one: 1.36 is the release where the newest
 # field this chart renders became stable.
@@ -136,7 +136,7 @@ annotations:
   # scan while leaving the false claim in place, so it is deliberately not used.
   artifacthub.io/images: |
     - name: ferroehr
-      image: ghcr.io/rubentalstra/ferroehr:3.17.5
+      image: ghcr.io/rubentalstra/ferroehr:3.17.6
       platforms:
         - linux/amd64
         - linux/arm64
@@ -145,7 +145,7 @@ annotations:
     # visible to anyone considering it. See #2193: this chart cannot deploy it
     # yet, so today the entry advertises intent rather than chart behaviour.
     - name: ferroehr-admin-ui
-      image: ghcr.io/rubentalstra/ferroehr-admin-ui:3.17.5
+      image: ghcr.io/rubentalstra/ferroehr-admin-ui:3.17.6
       platforms:
         - linux/amd64
         - linux/arm64

--- a/deploy/helm/ferroehr/README.md
+++ b/deploy/helm/ferroehr/README.md
@@ -2,7 +2,7 @@
 
 Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.1.0 + AQL 1.1). A single static binary deployed with a hardened-by-default security posture: runs as a non-root, read-only-rootfs workload whose NetworkPolicy admits its serving port only, and that connects to an EXTERNAL PostgreSQL 18 as an unprivileged app role (migrations are run out of band by a separate migrator role).
 
-![Version: 6.0.6](https://img.shields.io/badge/Version-6.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.17.5](https://img.shields.io/badge/AppVersion-3.17.5-informational?style=flat-square)
+![Version: 6.0.6](https://img.shields.io/badge/Version-6.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.17.6](https://img.shields.io/badge/AppVersion-3.17.6-informational?style=flat-square)
 
 FerroEHR is a pure-Rust openEHR Clinical Data Repository: ITS-REST 1.1.0 at the
 API, AQL 1.1 as the query language, PostgreSQL 18-native storage, shipped as a
@@ -36,7 +36,7 @@ helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
   --version 6.0.6 \
   --namespace ferroehr --create-namespace \
   --set database.existingSecret=ferroehr-db \
-  --set image.tag=3.17.5
+  --set image.tag=3.17.6
 ```
 
 OCI registries require Helm 3.8 or newer.
@@ -48,7 +48,7 @@ They are independent SemVer lines and they move independently:
 | What | Set with | This release |
 |---|---|---|
 | the **chart** (templates, defaults, this document) | `--version` | `6.0.6` |
-| the **server image** | `image.tag` | `3.17.5` |
+| the **server image** | `image.tag` | `3.17.6` |
 
 `appVersion` is the image the chart defaults to; pinning `image.tag` explicitly
 is what keeps an upgrade of one from silently moving the other.
@@ -69,7 +69,7 @@ A **SLSA build provenance attestation** — what source it was built from, and h
 ```console
 gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:6.0.6 \
   -R rubentalstra/FerroEHR
-gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:3.17.5 \
+gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:3.17.6 \
   -R rubentalstra/FerroEHR
 ```
 

--- a/deploy/helm/golden/admin-ui.yaml
+++ b/deploy/helm/golden/admin-ui.yaml
@@ -21,7 +21,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -93,7 +93,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -121,7 +121,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -142,7 +142,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -157,7 +157,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 automountServiceAccountToken: false
@@ -187,7 +187,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -204,7 +204,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -335,7 +335,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -358,7 +358,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -388,7 +388,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -424,7 +424,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: admin-ui
-          image: "ghcr.io/rubentalstra/ferroehr-admin-ui:3.17.5"
+          image: "ghcr.io/rubentalstra/ferroehr-admin-ui:3.17.6"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -495,7 +495,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -543,7 +543,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:3.17.5"
+          image: "ghcr.io/rubentalstra/ferroehr:3.17.6"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -26,7 +26,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -100,7 +100,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -121,7 +121,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -153,7 +153,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -179,7 +179,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -200,7 +200,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -391,7 +391,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -425,7 +425,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -475,7 +475,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:3.17.5"
+          image: "ghcr.io/rubentalstra/ferroehr:3.17.6"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -656,7 +656,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -690,7 +690,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -728,7 +728,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     release: kube-prometheus-stack

--- a/deploy/helm/golden/basic-auth.yaml
+++ b/deploy/helm/golden/basic-auth.yaml
@@ -26,7 +26,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -54,7 +54,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -75,7 +75,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 automountServiceAccountToken: false
@@ -105,7 +105,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -122,7 +122,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -250,7 +250,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -280,7 +280,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -328,7 +328,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:3.17.5"
+          image: "ghcr.io/rubentalstra/ferroehr:3.17.6"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -26,7 +26,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -54,7 +54,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -75,7 +75,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 automountServiceAccountToken: false
@@ -90,7 +90,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -215,7 +215,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -245,7 +245,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.6
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.5"
+    app.kubernetes.io/version: "3.17.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -293,7 +293,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:3.17.5"
+          image: "ghcr.io/rubentalstra/ferroehr:3.17.6"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,7 @@
 
 services:
   ferroehr-postgres:
-    image: ${FERROEHR_POSTGRES_IMAGE:-ghcr.io/rubentalstra/ferroehr-postgres:3.17.5}
+    image: ${FERROEHR_POSTGRES_IMAGE:-ghcr.io/rubentalstra/ferroehr-postgres:3.17.6}
     # Docker's default 64MB /dev/shm starves PostgreSQL's dynamic shared
     # memory under load (parallel workers error `could not resize shared
     # memory segment … No space left on device`); measured runs share this
@@ -154,7 +154,7 @@ services:
       start_period: 10s
 
   ferroehr:
-    image: ${FERROEHR_IMAGE:-ghcr.io/rubentalstra/ferroehr:3.17.5}
+    image: ${FERROEHR_IMAGE:-ghcr.io/rubentalstra/ferroehr:3.17.6}
     depends_on:
       ferroehr-postgres:
         condition: service_healthy
@@ -252,7 +252,7 @@ services:
   # FERROEHR_ADMIN__AUTH__OIDC__* variables at your identity provider.
   ferroehr-admin-ui:
     profiles: [admin-ui]
-    image: ${FERROEHR_ADMIN_UI_IMAGE:-ghcr.io/rubentalstra/ferroehr-admin-ui:3.17.5}
+    image: ${FERROEHR_ADMIN_UI_IMAGE:-ghcr.io/rubentalstra/ferroehr-admin-ui:3.17.6}
     depends_on:
       ferroehr:
         condition: service_healthy


### PR DESCRIPTION
Cuts **v3.17.6** — the milestone reached zero open issues (the published-surfaces correctness program plus the spec-profile coverage close: the AQL result-assembly gate, the stable-profile conformance lane, the per-carrier scope split, and the honest guard/pin scopes).

Per the release procedure: `[Unreleased]` renamed to `[3.17.6] - 2026-08-15` with a fresh empty section and updated link references; workspace `version` 3.17.6 + `Cargo.lock`; Helm `appVersion` 3.17.6 (+ chart README and the artifacthub image tags) with golden renders regenerated via `deploy/helm/validate.sh --update`; `CITATION.cff` version/date-released with `.zenodo.json` re-rendered; quickstart compose image-tag defaults moved to 3.17.6 (compose-version-guard green locally).

After merge: tag `v3.17.6` on the merge commit, close the milestone, ensure the next one exists, post the board status update.