### PR TITLE
fix(render): comparison run dates render in UTC, immune to the committer's midnight

### DIFF
--- a/scripts/render/comparison.sh
+++ b/scripts/render/comparison.sh
@@ -37,10 +37,15 @@ count() { jq "[(.cases // .outcomes)[] | select(.status == \"$2\")] | length" "$
 # --follow --diff-filter=AM: a rename of the artifact directory (a lane rename)
 # must not restamp a measured run with the rename's date — only a commit that
 # ADDED or MODIFIED the record is a run.
+# The date is rendered in UTC, never the committer's own zone (%cs): a commit
+# made just past local midnight would otherwise regenerate a DIFFERENT day
+# than the one rendered before it was committed, and the regenerate-and-diff
+# gate turns that into a permanent drift failure baked into the tag's tree.
 run_date() {
   local d
-  d=$(git log --follow --diff-filter=AM -1 --format=%cs -- "$1/results.json" 2>/dev/null || true)
-  [ -n "$d" ] || d=$(date -r "$1/results.json" +%Y-%m-%d)
+  d=$(TZ=UTC git log --follow --diff-filter=AM -1 --date=format-local:%Y-%m-%d \
+    --format=%cd -- "$1/results.json" 2>/dev/null || true)
+  [ -n "$d" ] || d=$(TZ=UTC date -r "$1/results.json" +%Y-%m-%d)
   echo "$d"
 }
 rs_date=$(run_date "$RS")


### PR DESCRIPTION
The v3.17.6 tag and every Docs run since the release merge fail the party-documents drift gate on ONE line: `COMPARISON.md`'s Run date row. `run_date` formatted the baseline commit's date with `%cs` — the committer's own timezone — so the baseline commit made at 00:0x CEST (22:0x UTC, Aug 14) regenerates as `2026-08-15` against the committed `2026-08-14` that was rendered minutes earlier under the uncommitted-file mtime fallback. A midnight-adjacent commit therefore bakes a permanent drift failure into the tag's own tree.

Fix: format the same clock-free commit date in UTC (`TZ=UTC --date=format-local:%Y-%m-%d`), mtime fallback likewise. Verified: `bash scripts/render/comparison.sh` now reproduces the committed COMPARISON.md byte-identically (empty diff), so the develop Docs deploy goes green on merge.

The frozen v3.17.6 site cut failed on the tag and cannot be re-run from the tag's immutable tree; the frozen version will be cut manually from the fixed tree (same content) after this merges.

CI-only render-tooling fix, no user-visible behaviour: `no-changelog`.