### PR TITLE
chore(security): adjudicate CVE-2026-39821 in the postgres image's bundled gosu

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -84,7 +84,7 @@ secrets: []
 #
 # The entries are per-CVE and path-scoped ON PURPOSE. A NEW advisory in gosu, or
 # any advisory in any other package of this image, still fails the gate; only
-# these fifteen, in this one binary, are adjudicated. Re-check on every
+# these sixteen, in this one binary, are adjudicated. Re-check on every
 # base-image bump: when upstream rebuilds gosu, these entries go.
 vulnerabilities:
   - id: CVE-2025-61726
@@ -118,6 +118,9 @@ vulnerabilities:
     paths:
       - usr/local/bin/gosu
   - id: CVE-2026-39820
+    paths:
+      - usr/local/bin/gosu
+  - id: CVE-2026-39821
     paths:
       - usr/local/bin/gosu
   - id: CVE-2026-39822

--- a/security/vex/postgres-gosu.openvex.json
+++ b/security/vex/postgres-gosu.openvex.json
@@ -4,7 +4,7 @@
   "author": "FerroEHR project",
   "role": "vendor",
   "timestamp": "2026-08-06T00:00:00Z",
-  "version": 1,
+  "version": 2,
   "tooling": "hand-authored; see security/vex/README.md",
   "statements": [
     {
@@ -152,6 +152,19 @@
     },
     {
       "vulnerability": {
+        "name": "CVE-2026-39821"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/ferroehr-postgres"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The finding is in /usr/local/bin/gosu, a Go binary the upstream docker-library/postgres image ships and which this image inherits unchanged. gosu's entire job is to set uid/gid and exec the server: it opens no network connection, parses no mail, MIME or HTTP input, and runs once at container start before PostgreSQL is listening. The Go standard-library packages these advisories concern (net, net/http, net/mail, mime, os.Root) are therefore linked but never reached. Rebuilding gosu is upstream's to do; FerroEHR adds no Go code to this image. CVE-2026-39821 specifically concerns golang.org/x/net/idna Punycode label processing reached through net/http hostname handling; gosu resolves no hostnames and issues no HTTP requests, so the IDNA path is never entered."
+    },
+    {
+      "vulnerability": {
         "name": "CVE-2026-39822"
       },
       "products": [
@@ -202,5 +215,6 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "The finding is in /usr/local/bin/gosu, a Go binary the upstream docker-library/postgres image ships and which this image inherits unchanged. gosu's entire job is to set uid/gid and exec the server: it opens no network connection, parses no mail, MIME or HTTP input, and runs once at container start before PostgreSQL is listening. The Go standard-library packages these advisories concern (net, net/http, net/mail, mime, os.Root) are therefore linked but never reached. Rebuilding gosu is upstream's to do; FerroEHR adds no Go code to this image."
     }
-  ]
+  ],
+  "last_updated": "2026-08-15T00:00:00Z"
 }


### PR DESCRIPTION
Closes #2397

The v3.17.6 tag's Containers run failed at the image vulnerability scan on exactly one new HIGH: **CVE-2026-39821** (Go stdlib, `golang.org/x/net/idna` Punycode label processing via net/http) matching `/usr/local/bin/gosu` — the privilege-dropping helper the upstream `docker-library/postgres` image ships and `ferroehr-postgres` inherits unchanged. Verified first-hand that no rebuilt upstream exists: the live `postgres:18.4` manifest digest is byte-identical to our pin (`a02db8ca…`), the same digest that scanned green on the v3.17.5 cut — the advisory is newer than the image.

This is the sixteenth member of the already-adjudicated gosu Go-stdlib family: gosu sets uid/gid and execs once at container start — it opens no socket, resolves no hostnames, issues no HTTP requests, so the IDNA path the CVE concerns is linked but never entered. Handled exactly like the fifteen before it:

- a per-CVE, path-scoped entry in `.trivyignore.yaml` (a NEW gosu advisory or any advisory in any other package still fails the gate)
- an OpenVEX `not_affected` / `vulnerable_code_not_in_execute_path` statement in `security/vex/postgres-gosu.openvex.json` (version 2, last_updated stamped) carrying the IDNA-specific reachability reasoning
- the removal trigger stands in both files: the entries go when upstream rebuilds gosu on a fixed Go line (re-checked at every base-image bump)

**Mutation-proven locally** against the `ferroehr-postgres:scan` image (same base digest) with the repo's own `trivy.yaml`: without the entry the scan reports exactly `Total: 1 (HIGH: 1)` — CVE-2026-39821 — and with it, zero findings, exit 0.

Scanner-exception bookkeeping only, no shipped behaviour: `no-changelog`.