### PR TITLE
feat(citation): the Zenodo DOI is live — badge, a deposit shape the integration honours, and corrected records

### DIFF
--- a/.claude/rules/changelog.md
+++ b/.claude/rules/changelog.md
@@ -67,15 +67,23 @@ optional:
   overwrite a published chart version. GitHub releases are immutable by the
   platform; container tags are immutable only because our lane enforces it.
 
-- **The tag does NOT produce an archived artifact — Zenodo is not connected.**
-  Measured after the v3.17.4 cut: the Zenodo API returned zero records for this
-  project while a control query returned results, so the absence is real and
-  not an indexing lag. This entry previously asserted the integration as fact,
-  which is exactly how a cut passes believing it archived something when it did
-  not. `.zenodo.json` is generated and valid, so the metadata half is ready and
-  only the connection is missing. Two properties govern it if it is ever
-  enabled: a deposit is IMMUTABLE, so the metadata is verified before the cut
-  and never after; and enabling it archives the NEXT release, never a past one.
+- **The tag DOES produce an archived artifact — Zenodo is connected**
+  (measured 2026-08-15: the v3.17.6 release archived as version DOI
+  10.5281/zenodo.21940280 under concept DOI 10.5281/zenodo.21940279, the
+  README badge's target). Two properties govern every cut: the deposit's
+  FILES freeze at publication (record METADATA stays owner-editable in the
+  Zenodo UI, files never), so `.zenodo.json` is verified before the tag and
+  never after; and the metadata file only counts if Zenodo actually reads
+  it — the v3.17.6 deposit IGNORED the then-committed InvenioRDM-record-shape
+  file and archived GitHub's raw repo metadata (the full contributor list as
+  creators), so `.zenodo.json` is rendered in the FLAT LEGACY DEPOSIT shape
+  the help page documents
+  (<https://help.zenodo.org/docs/github/describe-software/zenodo-json/>),
+  generated from `CITATION.cff` by `scripts/render/zenodo-json.sh` and
+  drift-checked by the `citation-guard` job. Whether a given deposit honoured
+  the file is confirmed on the published record (its creators/title must be
+  ours, not GitHub's), not assumed. The v3.17.6 record's own wrong metadata
+  is only correctable by the owner in the Zenodo UI.
 - **After the tag:** close the `vX.Y.Z` milestone (`gh api … milestones/N
   -f state=closed`) and make sure the NEXT milestone exists so triage always
   has a target. The milestone's closed-issue list + the changelog section

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,250 +1,103 @@
 {
-  "access": {
-    "record": "public",
-    "files": "public"
-  },
-  "custom_fields": {
-    "code:codeRepository": "https://github.com/rubentalstra/FerroEHR",
-    "code:programmingLanguage": [
-      {
-        "id": "rust",
-        "title": {
-          "en": "Rust"
-        }
-      },
-      {
-        "id": "sql",
-        "title": {
-          "en": "SQL"
-        }
-      }
-    ],
-    "code:developmentStatus": {
-      "id": "active",
-      "title": {
-        "en": "Active"
-      }
+  "upload_type": "software",
+  "access_right": "open",
+  "language": "eng",
+  "title": "FerroEHR",
+  "description": "<p>A pure-Rust, openEHR-specification-conformant clinical data repository (CDR): ITS-REST 1.1.0 REST API, AQL 1.1 query language, and the openEHR RM 1.2.0 reference model on PostgreSQL-18-native storage. The openEHR specification layer is generated from the official machine-readable specifications, and conformance is machine-verified per release by a built-in CNF conformance runner.</p>",
+  "publication_date": "2026-08-15",
+  "version": "3.17.6",
+  "creators": [
+    {
+      "name": "Talstra, Ruben",
+      "orcid": "0009-0009-2758-0141"
     }
-  },
-  "metadata": {
-    "resource_type": {
-      "id": "software"
+  ],
+  "license": "mit",
+  "keywords": [
+    "openEHR",
+    "clinical data repository",
+    "CDR",
+    "electronic health records",
+    "EHR",
+    "AQL",
+    "health informatics",
+    "healthcare interoperability",
+    "ITS-REST",
+    "Rust",
+    "PostgreSQL"
+  ],
+  "references": [
+    "openEHR Reference Model (RM) Release 1.1.0. openEHR International. https://specifications.openehr.org/releases/RM/Release-1.1.0",
+    "openEHR Archetype Query Language (AQL), QUERY Release 1.1.0. openEHR International. https://specifications.openehr.org/releases/QUERY/Release-1.1.0",
+    "openEHR REST API (ITS-REST) Release 1.1.0. openEHR International. https://specifications.openehr.org/releases/ITS-REST/Release-1.1.0",
+    "openEHR Archetype Model (AM) Release 2.3.0. openEHR International. https://specifications.openehr.org/releases/AM/Release-2.3.0"
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "https://ferroehr.eu/",
+      "relation": "isDocumentedBy",
+      "resource_type": "publication-softwaredocumentation"
     },
-    "title": "FerroEHR",
-    "description": "<p>A pure-Rust, openEHR-specification-conformant clinical data repository (CDR): ITS-REST 1.1.0 REST API, AQL 1.1 query language, and the openEHR RM 1.2.0 reference model on PostgreSQL-18-native storage. The openEHR specification layer is generated from the official machine-readable specifications, and conformance is machine-verified per release by a built-in CNF conformance runner.</p>",
-    "publication_date": "2026-08-15",
-    "version": "3.17.6",
-    "creators": [
-      {
-        "person_or_org": {
-          "type": "personal",
-          "given_name": "Ruben",
-          "family_name": "Talstra",
-          "name": "Talstra, Ruben",
-          "identifiers": [
-            {
-              "scheme": "orcid",
-              "identifier": "0009-0009-2758-0141"
-            }
-          ]
-        }
-      }
-    ],
-    "languages": [
-      {
-        "id": "eng",
-        "title": {
-          "en": "English"
-        }
-      }
-    ],
-    "rights": [
-      {
-        "id": "mit"
-      }
-    ],
-    "subjects": [
-      {
-        "subject": "openEHR"
-      },
-      {
-        "subject": "clinical data repository"
-      },
-      {
-        "subject": "CDR"
-      },
-      {
-        "subject": "electronic health records"
-      },
-      {
-        "subject": "EHR"
-      },
-      {
-        "subject": "AQL"
-      },
-      {
-        "subject": "health informatics"
-      },
-      {
-        "subject": "healthcare interoperability"
-      },
-      {
-        "subject": "ITS-REST"
-      },
-      {
-        "subject": "Rust"
-      },
-      {
-        "subject": "PostgreSQL"
-      }
-    ],
-    "references": [
-      {
-        "reference": "openEHR Reference Model (RM) Release 1.1.0. openEHR International. https://specifications.openehr.org/releases/RM/Release-1.1.0"
-      },
-      {
-        "reference": "openEHR Archetype Query Language (AQL), QUERY Release 1.1.0. openEHR International. https://specifications.openehr.org/releases/QUERY/Release-1.1.0"
-      },
-      {
-        "reference": "openEHR REST API (ITS-REST) Release 1.1.0. openEHR International. https://specifications.openehr.org/releases/ITS-REST/Release-1.1.0"
-      },
-      {
-        "reference": "openEHR Archetype Model (AM) Release 2.3.0. openEHR International. https://specifications.openehr.org/releases/AM/Release-2.3.0"
-      }
-    ],
-    "related_identifiers": [
-      {
-        "identifier": "https://ferroehr.eu/",
-        "scheme": "url",
-        "relation_type": {
-          "id": "isdocumentedby"
-        },
-        "resource_type": {
-          "id": "publication-softwaredocumentation"
-        }
-      },
-      {
-        "identifier": "https://specifications.openehr.org/releases/RM/Release-1.1.0",
-        "scheme": "url",
-        "relation_type": {
-          "id": "isderivedfrom"
-        }
-      },
-      {
-        "identifier": "https://specifications.openehr.org/releases/ITS-REST/Release-1.1.0",
-        "scheme": "url",
-        "relation_type": {
-          "id": "isderivedfrom"
-        }
-      },
-      {
-        "identifier": "https://specifications.openehr.org/releases/QUERY/Release-1.1.0",
-        "scheme": "url",
-        "relation_type": {
-          "id": "isderivedfrom"
-        }
-      },
-      {
-        "identifier": "https://specifications.openehr.org/releases/AM/Release-2.3.0",
-        "scheme": "url",
-        "relation_type": {
-          "id": "isderivedfrom"
-        }
-      },
-      {
-        "identifier": "https://crates.io/crates/openehr-base",
-        "scheme": "url",
-        "relation_type": {
-          "id": "haspart"
-        },
-        "resource_type": {
-          "id": "software"
-        }
-      },
-      {
-        "identifier": "https://crates.io/crates/openehr-rm",
-        "scheme": "url",
-        "relation_type": {
-          "id": "haspart"
-        },
-        "resource_type": {
-          "id": "software"
-        }
-      },
-      {
-        "identifier": "https://crates.io/crates/openehr-am",
-        "scheme": "url",
-        "relation_type": {
-          "id": "haspart"
-        },
-        "resource_type": {
-          "id": "software"
-        }
-      },
-      {
-        "identifier": "https://crates.io/crates/openehr-term",
-        "scheme": "url",
-        "relation_type": {
-          "id": "haspart"
-        },
-        "resource_type": {
-          "id": "software"
-        }
-      },
-      {
-        "identifier": "https://crates.io/crates/openehr-lang",
-        "scheme": "url",
-        "relation_type": {
-          "id": "haspart"
-        },
-        "resource_type": {
-          "id": "software"
-        }
-      },
-      {
-        "identifier": "https://crates.io/crates/openehr-query",
-        "scheme": "url",
-        "relation_type": {
-          "id": "haspart"
-        },
-        "resource_type": {
-          "id": "software"
-        }
-      },
-      {
-        "identifier": "https://crates.io/crates/openehr-its",
-        "scheme": "url",
-        "relation_type": {
-          "id": "haspart"
-        },
-        "resource_type": {
-          "id": "software"
-        }
-      },
-      {
-        "identifier": "https://crates.io/crates/openehr-adl",
-        "scheme": "url",
-        "relation_type": {
-          "id": "haspart"
-        },
-        "resource_type": {
-          "id": "software"
-        }
-      }
-    ],
-    "additional_descriptions": [
-      {
-        "type": {
-          "id": "technical-info"
-        },
-        "description": "<p>Implements the openEHR specifications at these pinned versions: Reference Model 1.2.0, BASE 1.3.0, Archetype Model 1.4.0 and 2.4.0, Terminology 3.1.0, AQL (QUERY) 1.1.0, ITS-REST 1.1.0 and ITS-XML. The specification layer is generated from the official machine-readable specifications rather than hand-written, and conformance is measured per release by a built-in openEHR CNF conformance runner whose results are committed alongside the source. Requires PostgreSQL 18.</p>"
-      },
-      {
-        "type": {
-          "id": "notes"
-        },
-        "description": "<p>Licensing: the recorded licence covers this project&rsquo;s own code. Vendored third-party material keeps its upstream terms &mdash; Apache-2.0 for the openEHR machine-readable artifacts and test corpora, CC-BY-SA-3.0 for the openEHR specification text and CKM-derived clinical models &mdash; each recorded in the PROVENANCE.md of the tree that carries it.</p>"
-      }
-    ]
-  }
+    {
+      "identifier": "https://github.com/rubentalstra/FerroEHR",
+      "relation": "isSupplementTo"
+    },
+    {
+      "identifier": "https://specifications.openehr.org/releases/RM/Release-1.1.0",
+      "relation": "isDerivedFrom"
+    },
+    {
+      "identifier": "https://specifications.openehr.org/releases/ITS-REST/Release-1.1.0",
+      "relation": "isDerivedFrom"
+    },
+    {
+      "identifier": "https://specifications.openehr.org/releases/QUERY/Release-1.1.0",
+      "relation": "isDerivedFrom"
+    },
+    {
+      "identifier": "https://specifications.openehr.org/releases/AM/Release-2.3.0",
+      "relation": "isDerivedFrom"
+    },
+    {
+      "identifier": "https://crates.io/crates/openehr-base",
+      "relation": "hasPart",
+      "resource_type": "software"
+    },
+    {
+      "identifier": "https://crates.io/crates/openehr-rm",
+      "relation": "hasPart",
+      "resource_type": "software"
+    },
+    {
+      "identifier": "https://crates.io/crates/openehr-am",
+      "relation": "hasPart",
+      "resource_type": "software"
+    },
+    {
+      "identifier": "https://crates.io/crates/openehr-term",
+      "relation": "hasPart",
+      "resource_type": "software"
+    },
+    {
+      "identifier": "https://crates.io/crates/openehr-lang",
+      "relation": "hasPart",
+      "resource_type": "software"
+    },
+    {
+      "identifier": "https://crates.io/crates/openehr-query",
+      "relation": "hasPart",
+      "resource_type": "software"
+    },
+    {
+      "identifier": "https://crates.io/crates/openehr-its",
+      "relation": "hasPart",
+      "resource_type": "software"
+    },
+    {
+      "identifier": "https://crates.io/crates/openehr-adl",
+      "relation": "hasPart",
+      "resource_type": "software"
+    }
+  ],
+  "notes": "Implements the openEHR specifications at these pinned versions: Reference Model 1.2.0, BASE 1.3.0, Archetype Model 1.4.0 and 2.4.0, Terminology 3.1.0, AQL (QUERY) 1.1.0, ITS-REST 1.1.0 and ITS-XML. The specification layer is generated from the official machine-readable specifications rather than hand-written, and conformance is measured per release by a built-in openEHR CNF conformance runner whose results are committed alongside the source. Requires PostgreSQL 18. Licensing: the recorded licence covers this project's own code; vendored third-party material keeps its upstream terms — Apache-2.0 for the openEHR machine-readable artifacts and test corpora, CC-BY-SA-3.0 for the openEHR specification text and CKM-derived clinical models — each recorded in the PROVENANCE.md of the tree that carries it."
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,17 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
-## [3.17.6] - 2026-08-15
+### Added
+
+- **Releases archive to Zenodo with a citable DOI.** Every release tag now
+  deposits a snapshot under the concept DOI
+  [10.5281/zenodo.21940279](https://doi.org/10.5281/zenodo.21940279) (the
+  README badge; it always resolves to the latest archived version — v3.17.6
+  is 10.5281/zenodo.21940280). The deposit metadata is generated from
+  `CITATION.cff` in the flat legacy shape Zenodo's GitHub integration
+  documents, after the first deposit demonstrably ignored the
+  InvenioRDM-record-shape file and archived raw repository metadata instead;
+  the concept DOI is recorded in `CITATION.cff` for citation managers.
 
 ### Security
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -20,6 +20,10 @@ authors:
     orcid: "https://orcid.org/0009-0009-2758-0141"
 repository-code: "https://github.com/rubentalstra/FerroEHR"
 url: "https://ferroehr.eu/"
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.21940279
+    description: "The concept DOI of the Zenodo software archive; resolves to the latest archived release."
 license: MIT
 keywords:
   - openEHR

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ ITS-REST 1.1.0 &nbsp;·&nbsp; AQL 1.1 &nbsp;·&nbsp; RM 1.2.0 **+ 1.1.0** &nbsp;
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13982/badge)](https://www.bestpractices.dev/projects/13982)
 [![GHCR](https://img.shields.io/badge/ghcr.io-ferroehr-2496ED.svg?logo=docker&logoColor=white)](https://github.com/rubentalstra/FerroEHR/pkgs/container/ferroehr)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/ferroehr)](https://artifacthub.io/packages/search?repo=ferroehr)
+[![DOI](https://zenodo.org/badge/1286429270.svg)](https://doi.org/10.5281/zenodo.21940279)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 [![openEHR CNF conformance](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Frubentalstra%2Fferroehr%2Fdevelop%2Fdocs%2Fconformance%2Fferroehr%2Fbadge.json)](docs/conformance/ferroehr/CONFORMANCE_REPORT.md)

--- a/scripts/render/zenodo-json.sh
+++ b/scripts/render/zenodo-json.sh
@@ -15,12 +15,17 @@
 # file is GENERATED: CITATION.cff stays the single source for every fact both
 # carry, and `citation-guard` runs this script in --check mode.
 #
-# The output is the InvenioRDM RECORD shape, not the flat legacy deposit shape
-# the help page documents. Zenodo runs on InvenioRDM now and the GitHub
-# integration accepts this form — verified against a live GitHub-archived
-# record whose .zenodo.json is this shape and whose published record carries
-# the custom_fields it declares. The legacy shape cannot say what language a
-# piece of software is written in.
+# The output is the FLAT LEGACY DEPOSIT shape the help page documents — not
+# the InvenioRDM record shape this script previously emitted. Measured
+# first-hand on this repository's own first GitHub-archived deposit
+# (10.5281/zenodo.21940280, v3.17.6, read 2026-08-15): the record-shape file
+# was IGNORED entirely and the deposit fell back to GitHub's raw repo
+# metadata (title "rubentalstra/FerroEHR: v3.17.6", the full 29-name
+# contributor list as creators), refuting the earlier claim that the
+# integration accepts the record shape. The help page's complete example
+# (read 2026-08-15) is the authority for the field spellings used below:
+# flat top-level keys, `license` as a lowercase id, camelCase
+# `related_identifiers[].relation`, creators as {name, orcid, affiliation}.
 #
 # Usage:
 #   scripts/render/zenodo-json.sh            # write .zenodo.json
@@ -63,9 +68,10 @@ cff_list() {
   ' "$CFF" | jq -R . | jq -s .
 }
 
-# `authors` → InvenioRDM `creators`. The ORCID is emitted as the BARE
-# identifier: CITATION.cff stores the full https://orcid.org/… URL, and passing
-# that through yields a record with no linked ORCID at all.
+# `authors` → legacy-deposit `creators` ({name, orcid, affiliation}). The
+# ORCID is emitted as the BARE identifier: CITATION.cff stores the full
+# https://orcid.org/… URL, and passing that through yields a record with no
+# linked ORCID at all.
 cff_creators() {
   awk '
     /^authors:[ \t]*$/ { grab = 1; next }
@@ -86,21 +92,9 @@ cff_creators() {
          capture("^(?<k>[^:]+):[[:space:]]*(?<v>.*)$")
          | {(.k): (.v | sub("^\"";"") | sub("\"$";""))}
        ) | add) as $a
-      | {
-          person_or_org: (
-            {
-              type: "personal",
-              given_name: $a["given-names"],
-              family_name: $a["family-names"],
-              name: ($a["family-names"] + ", " + $a["given-names"]),
-            }
-            + (if $a.orcid
-               then {identifiers: [{scheme: "orcid",
-                                    identifier: ($a.orcid | split("/") | last)}]}
-               else {} end)
-          ),
-        }
-      + (if $a.affiliation then {affiliations: [{name: $a.affiliation}]} else {} end)
+      | { name: ($a["family-names"] + ", " + $a["given-names"]) }
+      + (if $a.orcid then {orcid: ($a.orcid | split("/") | last)} else {} end)
+      + (if $a.affiliation then {affiliation: $a.affiliation} else {} end)
     )'
 }
 
@@ -127,57 +121,36 @@ rendered="$(
     --argjson specs    "$SPECS" \
     --argjson crates   "$CRATES" \
 '{
-  access: { record: "public", files: "public" },
-
-  # The complete set of software custom fields Zenodo actually carries,
-  # established by enumerating the custom_fields of the 100 newest software
-  # records: code:codeRepository, code:programmingLanguage,
-  # code:developmentStatus. code:operatingSystem, code:runtimePlatform,
-  # code:softwareRequirements and code:license returned ZERO records and do not
-  # exist — nothing here invents them.
-  custom_fields: {
-    "code:codeRepository": $repo,
-    "code:programmingLanguage": [
-      { id: "rust", title: { en: "Rust" } },
-      { id: "sql",  title: { en: "SQL"  } }
-    ],
-    "code:developmentStatus": { id: "active", title: { en: "Active" } }
-  },
-
-  metadata: {
-    resource_type: { id: "software" },
-    title: $title,
-    description: ("<p>" + $abstract + "</p>"),
-    publication_date: $released,
-    version: $version,
-    creators: $creators,
-    languages: [ { id: "eng", title: { en: "English" } } ],
-    rights: [ { id: $license } ],
-    subjects: ($keywords | map({ subject: . })),
-    references: [
-      { reference: "openEHR Reference Model (RM) Release 1.1.0. openEHR International. https://specifications.openehr.org/releases/RM/Release-1.1.0" },
-      { reference: "openEHR Archetype Query Language (AQL), QUERY Release 1.1.0. openEHR International. https://specifications.openehr.org/releases/QUERY/Release-1.1.0" },
-      { reference: "openEHR REST API (ITS-REST) Release 1.1.0. openEHR International. https://specifications.openehr.org/releases/ITS-REST/Release-1.1.0" },
-      { reference: "openEHR Archetype Model (AM) Release 2.3.0. openEHR International. https://specifications.openehr.org/releases/AM/Release-2.3.0" }
-    ],
-    related_identifiers: (
-      [ { identifier: $site, scheme: "url",
-          relation_type: { id: "isdocumentedby" },
-          resource_type: { id: "publication-softwaredocumentation" } } ]
-      + ($specs | map({ identifier: ., scheme: "url",
-                        relation_type: { id: "isderivedfrom" } }))
-      + ($crates | map({ identifier: ("https://crates.io/crates/" + .),
-                         scheme: "url",
-                         relation_type: { id: "haspart" },
-                         resource_type: { id: "software" } }))
-    ),
-    additional_descriptions: [
-      { type: { id: "technical-info" },
-        description: "<p>Implements the openEHR specifications at these pinned versions: Reference Model 1.2.0, BASE 1.3.0, Archetype Model 1.4.0 and 2.4.0, Terminology 3.1.0, AQL (QUERY) 1.1.0, ITS-REST 1.1.0 and ITS-XML. The specification layer is generated from the official machine-readable specifications rather than hand-written, and conformance is measured per release by a built-in openEHR CNF conformance runner whose results are committed alongside the source. Requires PostgreSQL 18.</p>" },
-      { type: { id: "notes" },
-        description: "<p>Licensing: the recorded licence covers this project&rsquo;s own code. Vendored third-party material keeps its upstream terms &mdash; Apache-2.0 for the openEHR machine-readable artifacts and test corpora, CC-BY-SA-3.0 for the openEHR specification text and CKM-derived clinical models &mdash; each recorded in the PROVENANCE.md of the tree that carries it.</p>" }
-    ]
-  }
+  # The flat legacy deposit shape — every key spelled as the help page
+  # example spells it. No `doi` key on purpose: Zenodo mints the version DOI
+  # itself, and a supplied one would collide with the minting.
+  upload_type: "software",
+  access_right: "open",
+  language: "eng",
+  title: $title,
+  description: ("<p>" + $abstract + "</p>"),
+  publication_date: $released,
+  version: $version,
+  creators: $creators,
+  license: $license,
+  keywords: $keywords,
+  references: [
+    "openEHR Reference Model (RM) Release 1.1.0. openEHR International. https://specifications.openehr.org/releases/RM/Release-1.1.0",
+    "openEHR Archetype Query Language (AQL), QUERY Release 1.1.0. openEHR International. https://specifications.openehr.org/releases/QUERY/Release-1.1.0",
+    "openEHR REST API (ITS-REST) Release 1.1.0. openEHR International. https://specifications.openehr.org/releases/ITS-REST/Release-1.1.0",
+    "openEHR Archetype Model (AM) Release 2.3.0. openEHR International. https://specifications.openehr.org/releases/AM/Release-2.3.0"
+  ],
+  related_identifiers: (
+    [ { identifier: $site,
+        relation: "isDocumentedBy",
+        resource_type: "publication-softwaredocumentation" },
+      { identifier: $repo, relation: "isSupplementTo" } ]
+    + ($specs | map({ identifier: ., relation: "isDerivedFrom" }))
+    + ($crates | map({ identifier: ("https://crates.io/crates/" + .),
+                       relation: "hasPart",
+                       resource_type: "software" }))
+  ),
+  notes: "Implements the openEHR specifications at these pinned versions: Reference Model 1.2.0, BASE 1.3.0, Archetype Model 1.4.0 and 2.4.0, Terminology 3.1.0, AQL (QUERY) 1.1.0, ITS-REST 1.1.0 and ITS-XML. The specification layer is generated from the official machine-readable specifications rather than hand-written, and conformance is measured per release by a built-in openEHR CNF conformance runner whose results are committed alongside the source. Requires PostgreSQL 18. Licensing: the recorded licence covers this project'\''s own code; vendored third-party material keeps its upstream terms — Apache-2.0 for the openEHR machine-readable artifacts and test corpora, CC-BY-SA-3.0 for the openEHR specification text and CKM-derived clinical models — each recorded in the PROVENANCE.md of the tree that carries it."
 }'
 )"
 


### PR DESCRIPTION
Closes #2398

Zenodo's GitHub integration is connected and archived the v3.17.6 release first-hand: concept DOI **[10.5281/zenodo.21940279](https://doi.org/10.5281/zenodo.21940279)** (always the latest archived version), version DOI 10.5281/zenodo.21940280.

## What landed

- **README**: the DOI badge (`zenodo.org/badge/1286429270.svg` → the concept DOI), beside the GHCR/Artifact Hub badges.
- **CITATION.cff**: the concept DOI recorded under `identifiers` (CFF 1.2.0 shape), so citation managers resolve it; it deliberately does NOT flow into the rendered deposit — Zenodo mints each version DOI itself.
- **The deposit shape, corrected by measurement.** The published v3.17.6 record shows Zenodo IGNORED our committed InvenioRDM-record-shape `.zenodo.json` and archived GitHub's raw repository metadata instead — title `rubentalstra/FerroEHR: v3.17.6`, creators = the full 29-name contributor list including upstream EHRbase contributors and `Snyk bot` — refuting the render script's own 'verified against a live record' shape claim. `scripts/render/zenodo-json.sh` now emits the **flat legacy deposit shape** the official help page documents (field spellings taken from the page's complete example, read first-hand: flat top-level keys, lowercase `license`, camelCase `related_identifiers[].relation`, creators as `{name, orcid, affiliation}`). Same `CITATION.cff` source, same `citation-guard` drift check; `--check` is green.
- **`.claude/rules/changelog.md` §Zenodo** rewritten from the stale 'not connected' measurement to the connected reality: deposits happen on every release tag; the deposit's FILES freeze at publication while record metadata stays owner-editable in the Zenodo UI (the v3.17.6 record's wrong metadata is only correctable there); `.zenodo.json` is verified before the tag; and whether a deposit honoured the file is confirmed on the published record, never assumed.
- **Changelog**: an `[Unreleased]` Added entry for the DOI.

## Verification

- `bash scripts/render/zenodo-json.sh --check` — green (regenerated output committed).
- Deposit metadata contains no `doi` key (Zenodo mints), `upload_type: software`, `license: mit`, creators/ORCID from CITATION.cff.
- The next release tag is the live test: the published record's title/creators must be ours — the rewritten rule says to confirm exactly that at the cut.