### PR TITLE
ci(docs): full-history checkout for the drift gate; the mtime date fallback refuses under CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,6 +44,14 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # Full history: the party-documents drift gate regenerates
+          # COMPARISON.md, whose run dates derive from the conformance
+          # artifacts' COMMIT dates (scripts/render/comparison.sh). On a
+          # shallow checkout that git log is empty and the mtime fallback
+          # stamps the CHECKOUT day — green only on the baseline's own UTC
+          # day, red every day after (#2402; it failed both the v3.17.6 and
+          # v3.17.7 tag runs).
+          fetch-depth: 0
       # The deployed site is rebuilt in the deploy job, which restores no build
       # cache; this job publishes only a pull-request diagnostic artifact.
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0 # zizmor: ignore[cache-poisoning]

--- a/scripts/render/comparison.sh
+++ b/scripts/render/comparison.sh
@@ -45,7 +45,18 @@ run_date() {
   local d
   d=$(TZ=UTC git log --follow --diff-filter=AM -1 --date=format-local:%Y-%m-%d \
     --format=%cd -- "$1/results.json" 2>/dev/null || true)
-  [ -n "$d" ] || d=$(TZ=UTC date -r "$1/results.json" +%Y-%m-%d)
+  if [ -z "$d" ]; then
+    # The mtime fallback exists ONLY for a local, not-yet-committed
+    # regeneration. Under CI an empty git log means a SHALLOW checkout, and
+    # the fallback would stamp the checkout day — which the drift gate then
+    # reads as a one-line date change (#2402, red on both tag runs). Fail
+    # naming the cause instead.
+    if [ -n "${GITHUB_ACTIONS:-}" ]; then
+      echo "::error::run_date: git log found no commit for $1/results.json — a shallow checkout; give the job fetch-depth: 0" >&2
+      exit 1
+    fi
+    d=$(TZ=UTC date -r "$1/results.json" +%Y-%m-%d)
+  fi
   echo "$d"
 }
 rs_date=$(run_date "$RS")


### PR DESCRIPTION
Closes #2402

The Docs `build` job's default depth-1 checkout made `run_date`'s `git log` empty, so the mtime fallback stamped the CHECKOUT day and the party-documents drift gate compared today's date against the committed run date — green only on the baseline's own UTC day, red every day after. It failed both the v3.17.6 and v3.17.7 tag runs (the first masked by the `%cs` timezone defect #2395 fixed; the second with the UTC fix already in the tree, proving the second half of the defect).

Two halves:
- the `build` job checks out with `fetch-depth: 0` (comment cites #2402), so the run date derives from the artifact's commit history and the render is deterministic on any day;
- `run_date`'s mtime fallback — legitimate only for a local, not-yet-committed regeneration — now exits loudly under `GITHUB_ACTIONS`, naming fetch-depth as the cause, so a future shallow checkout fails with the diagnosis instead of a confusing one-line date drift.

Mutation-proven: a simulated CI+shallow invocation fails with the ::error:: message (rc=1); the local render still reproduces the committed COMPARISON.md byte-identically. The frozen `/docs/v3.17.7/` will be cut manually from the fixed tree, the tag's own run being unrepeatable. CI-only: `no-changelog`.