### PR TITLE
fix(citation): the Zenodo isSupplementTo is the tag tree, never the repo root

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -39,8 +39,9 @@
       "resource_type": "publication-softwaredocumentation"
     },
     {
-      "identifier": "https://github.com/rubentalstra/FerroEHR",
-      "relation": "isSupplementTo"
+      "identifier": "https://github.com/rubentalstra/FerroEHR/tree/v3.17.7",
+      "relation": "isSupplementTo",
+      "resource_type": "software"
     },
     {
       "identifier": "https://specifications.openehr.org/releases/RM/Release-1.1.0",

--- a/scripts/render/zenodo-json.sh
+++ b/scripts/render/zenodo-json.sh
@@ -141,10 +141,19 @@ rendered="$(
     "openEHR Archetype Model (AM) Release 2.3.0. openEHR International. https://specifications.openehr.org/releases/AM/Release-2.3.0"
   ],
   related_identifiers: (
+    # A supplied related_identifiers list REPLACES the ones the GitHub
+    # integration would add (measured on the v3.17.7 record, #2404), and the
+    # record page derives its "Available in GitHub" link from the
+    # isSupplementTo entry — so this entry must BE the stock tag-tree link,
+    # never the repo root. The version here is the tag by construction: the
+    # release cut bumps CITATION.cff in the PR the tag is cut from, and
+    # citation-guard pins it to the workspace version.
     [ { identifier: $site,
         relation: "isDocumentedBy",
         resource_type: "publication-softwaredocumentation" },
-      { identifier: $repo, relation: "isSupplementTo" } ]
+      { identifier: ($repo + "/tree/v" + $version),
+        relation: "isSupplementTo",
+        resource_type: "software" } ]
     + ($specs | map({ identifier: ., relation: "isDerivedFrom" }))
     + ($crates | map({ identifier: ("https://crates.io/crates/" + .),
                        relation: "hasPart",


### PR DESCRIPTION
Closes #2404

**The defect** (user-reported on the v3.17.7 record): the record's *Available in GitHub* link goes to the repository root instead of the tagged tree. Three-way evidence from the records API: the v3.17.6 record (stock integration metadata) carries exactly one related identifier — `isSupplementTo → …/tree/v3.17.6` (`resource_type: software`) — which is the link the record page's GitHub button follows; the v3.17.7 record's identifiers are EXACTLY the list our `.zenodo.json` rendered, integration entry absent; therefore a supplied `related_identifiers` list replaces the integration's own, and the repo-root `isSupplementTo` #2400 introduced displaced the tag link.

**The fix**: render the stock link ourselves — `<repository-code>/tree/v<version>`, `resource_type: software` — correct at every tag by construction (`citation-guard` pins CITATION.cff's version to the workspace version, and the release cut bumps both in the PR the tag is cut from). Comment in the script records the measured replace-semantics with the issue reference.

**Because one defect earns a full audit**, every other field of the new legacy shape was verified against the live v3.17.7 record: title `FerroEHR`, version, publication_date, `license: mit` (accepted, mapped to `mit-license`), `access_right: open`, `language: eng`, creators with the **linked ORCID**, all 11 keywords, the abstract description, all 4 references, and the notes text including the shell-escaped apostrophe (`project's own code` arrived intact). The GitHub link was the one defect.

The published v3.17.7 record's link is owner-editable in the Zenodo UI (metadata only; files frozen). The next release's record is the live confirmation. Render-tooling only: `no-changelog`.