### PR TITLE
fix(images): clear the 15 fixable postgres-image findings and keep them fixable

### DIFF
--- a/.claude/agent-memory/spec-researcher/object-ref-resolvability-location.md
+++ b/.claude/agent-memory/spec-researcher/object-ref-resolvability-location.md
@@ -1,0 +1,56 @@
+---
+name: object-ref-resolvability-location
+description: Where (and whether) the released specs say an OBJECT_REF / LINK / tag target must resolve to an existing object — the cross-component silence map
+metadata:
+  type: reference
+---
+
+OBJECT_REF **resolvability** (does a committed reference have to point at something that
+exists?) — the cross-component navigation map. Short answer the text supports: NO released
+clause requires resolvability anywhere; the only scope constraint that exists is on
+`EHR.tags`.
+
+Where the load-bearing sentences live:
+
+- **BASE, the general statement** —
+  `BASE/docs/UML/classes/org.openehr.base.base_types.object_ref.adoc` Description:
+  "a reference to another object, which may exist locally or be maintained outside the
+  current namespace, e.g. in another service". Prose companion:
+  `BASE/docs/base_types/master05-identification_package.adoc §References` (L183-185, the
+  primary-key/foreign-key analogy, "distributed referencing"); architecture framing in
+  `BASE/docs/architecture_overview/master09-identification.adoc §Levels of Identification`
+  (L51-93). **None of these state a resolution obligation.**
+- **RM, per-holder attribute meanings + invariants** (the invariants constrain `.type`
+  ONLY, never existence):
+  - `RM/docs/UML/classes/org.openehr.rm.ehr.ehr.adoc` — invariants
+    Contributions_valid / Ehr_access_valid / Ehr_status_valid / Compositions_valid /
+    Directory_valid / Folders_valid / Directory_in_folders: all `is_equal("<TYPE>")` checks.
+    Its `tags` Meaning is the ONE scope rule in the RM: "Tag `_target_` values can only be
+    within the same EHR" (nothing equivalent for folders/compositions/directory).
+  - `org.openehr.rm.common.folder.adoc` — `items` = "references to other (usually)
+    versioned objects logically in this folder"; **empty invariant section**.
+  - `org.openehr.rm.common.link.adoc` — LINK.type doc explicitly contemplates links
+    "which must be followed and which can be broken when the extract is created" — the RM's
+    clearest admission that a reference may not resolve.
+  - `org.openehr.rm.common.item_tag.adoc` — only Inv_key_valid / Inv_value_valid.
+- **RM, the nearest thing to a general integrity clause** —
+  `RM/docs/ehr/master04-ehr_package.adoc §Change Control in the EHR` L159-163: "the record
+  should always be in a consistent informational state" (vague, non-operationalized).
+  §Folders L110: folders "may be _added or removed contemporaneously or subsequently_ to the
+  committal of the referenced Compositions"; same-Contribution grouping is "normally", not
+  a requirement.
+- **RM, EHR Extract** — `RM/docs/ehr_extract/master09-semantics.adoc §Creation Semantics`
+  L76-77: on export, "for each instance of `OBJECT_REF` encountered … obtain the target of
+  the reference from the relevant service" and rewrite `_namespace_` = "local". This is the
+  only algorithm anywhere that assumes resolvability, and it is an EXTRACT-BUILD step, not a
+  commit-time rule.
+- **SM** — `SM/docs/UML/classes/i_validity_checker.adoc` is the whole commit-time validation
+  vocabulary: `definitions_valid` (archetype/template ids) + `content_valid` (RM-class
+  validity). Neither mentions references. See [[directory-api-location]] for the
+  `valid_content` vs `content_valid` naming defect.
+- **ITS-REST** — grep-verified: no "referential", "resolvable", "dangling", "must exist"
+  anywhere in `ITS-REST/specifications/docs/**`. The only refs-related clause is
+  `docs/overview/Requests_and_responses.md §Prefer resolving Object references`
+  (`Prefer: return=representation, resolve_refs`) — a READ-side option with no
+  unresolvable-ref branch. `responses/422.yaml` scopes semantic errors to "the underlying
+  template is not known or is not validating the supplied resource".

--- a/.claude/rules/image-security.md
+++ b/.claude/rules/image-security.md
@@ -1,0 +1,108 @@
+---
+paths:
+  - docker/**
+  - security/vex/**
+  - .trivyignore.yaml
+  - trivy.yaml
+  - scripts/security/**
+  - .github/workflows/image-scan.yml
+  - .github/workflows/containers.yml
+  - .github/workflows/base-image-watcher.yml
+---
+
+# Published-image CVE remediation (the standing law)
+
+The published container images are scanned continuously; this file is the
+other half — what to DO with a finding, per finding class, so a fixable CVE
+never sits waiting for someone to reinvent the remediation. Authored from
+#2408, where 15 fixable HIGH findings sat in `ferroehr-postgres` because the
+detection lane existed but the remediation path was tribal.
+
+## The instrument layer (what fires when)
+
+| Instrument | When | What it catches |
+|---|---|---|
+| `containers.yml` image-scan job | every image build | what was known at build time |
+| `image-scan.yml` | Mondays 07:13 UTC, on the PUBLISHED `:latest` refs | CVEs published after the release; files/updates ONE tracking issue and goes red |
+| `base-image-watcher.yml` | Mondays 07:43 UTC | a newer `postgres` patch tag on the pinned major, or the pinned tag re-pointed upstream (a same-version security respin); files/updates ONE tracking issue |
+| `scripts/security/scan-images.sh` | on demand, locally | reruns the EXACT published-image scan (same `trivy.yaml`, `.trivyignore.yaml`, `security/vex/*.json`) against the published refs or a locally built candidate |
+
+All four read the same three config surfaces: `trivy.yaml` (severity floor +
+`ignore-unfixed` + the ignore-file pointer), `.trivyignore.yaml` (per-CVE,
+path-scoped adjudications), `security/vex/*.json` (the published arguments).
+Never tune a lane by giving it its own flags — a lane that diverges from the
+shared config silently changes what the gate means.
+
+## The remediation law (per finding class)
+
+Attribute every finding to exactly one class BEFORE touching anything, from
+the scan JSON (`Target`, `PkgName`, `FixedVersion`):
+
+1. **Bytes we add** (the Rust binaries, init scripts): fix the dependency or
+   code the normal way. Rust advisories go through `deny.toml` +
+   `security/vex/rust-advisories.toml` per `security/vex/README.md`, never
+   through `.trivyignore.yaml`.
+2. **OS package in the postgres image, fix available in Debian
+   (trixie/trixie-security)**: already self-healing — the Dockerfile's
+   security-upgrade `RUN` layer pulls fixed packages at build time. Remedy =
+   rebuild + re-release (a patch release; images republish only on tags).
+   Verify first: `docker build -t ferroehr-postgres:candidate docker/postgres/`
+   then `scripts/security/scan-images.sh --candidate ferroehr-postgres:candidate`
+   must report 0.
+3. **A newer upstream base exists** (the watcher's issue, or found while
+   remediating class 2): base bump, full pin-site checklist below.
+4. **Upstream-bundled binary whose fix lives in ITS toolchain** (gosu: Go
+   stdlib advisories — upstream must rebuild; we add no Go code): per-CVE
+   reachability adjudication. If the vulnerable package is provably not in
+   gosu's execute path (it sets uid/gid and execs: no sockets, no untrusted
+   input), add the CVE to `.trivyignore.yaml` (path-scoped to
+   `usr/local/bin/gosu`) AND its OpenVEX statement to
+   `security/vex/postgres-gosu.openvex.json` (bump `version` + `timestamp`)
+   in the same PR. If it IS reachable, do NOT VEX: that is a release blocker
+   for the image — escalate to the owner (replace the binary or hold).
+5. **Never**: raise the severity floor, add a blanket suppression, scope an
+   ignore wider than one CVE × one path, or VEX a finding we can fix by
+   rebuilding ("A finding we can fix is fixed, not VEXed" —
+   `security/vex/README.md`).
+
+A fixable finding in the PUBLISHED images is milestoned into the CURRENT
+patch milestone — the remedy is only real once a tag republishes the image.
+
+## The base-bump pin-site checklist (postgres)
+
+Machine-enforced agreement (`scripts/checks/image-labels.sh`, per-PR in CI):
+the Dockerfile `FROM` digest ↔ its `base.name`/`base.digest` LABELs ↔ the
+`containers.yml` labels ↔ the `ci.yml` postgres service pins. Everything else
+is a sweep — run `grep -rn '18\.<old-patch>'` over the tree and expect to
+touch:
+
+- `docker/postgres/Dockerfile` — `FROM` tag+digest, header comment, both
+  `base.*` LABELs (the digest is the MANIFEST-LIST digest:
+  `docker buildx imagetools inspect postgres:<tag>` → `Digest:`)
+- `.github/workflows/containers.yml` — postgres lane comment + both label lines
+- `.github/workflows/ci.yml` — the two service-container pins + the job heading
+- `docs/VERSIONS.md` §Database, `docs/postgres-features.md` §Versioning note
+  (latest-patch version + date, from postgresql.org — never copied forward),
+  root `CLAUDE.md` §Tech stack, `docs/architecture.md` §PostgreSQL 18,
+  the root `Cargo.toml` database comment, `.claude/rules/sqlx-conventions.md`
+- `app/ferroehr/src/telemetry/provenance.rs` `PG_TARGET` + its
+  `build_info.rs` test
+- `tools/testkit/src/lib.rs` header comment
+- `docker/postgres/README.md`, `website/book/src/installation/compose.md`
+- `deploy/helm/ferroehr/README.md.gotmpl` (then `helm-docs`), the chart
+  `version` bump if chart content changed this cycle, and
+  `deploy/helm/validate.sh --update` for the goldens
+
+Then re-check the VEX documents: **when the new base rebuilds gosu, the
+adjudicated gosu entries GO** (both the `.trivyignore.yaml` entries and the
+OpenVEX statements) — a stale `not_affected` is worse than no VEX. Confirm
+with the candidate scan: a VEX'd CVE that no longer fires is an entry to
+delete.
+
+## Verification (what "fixed" means)
+
+`scripts/security/scan-images.sh --candidate <image>` at 0 findings on the
+rebuilt image, BEFORE merge. The Monday `image-scan.yml` run over the
+re-released `:latest` is the closing evidence; the tracking issue closes via
+the fixing PR and the next scheduled run confirms (it files a fresh issue if
+anything still fires — a closed issue is never silently final).

--- a/.claude/rules/image-security.md
+++ b/.claude/rules/image-security.md
@@ -33,6 +33,12 @@ path-scoped adjudications), `security/vex/*.json` (the published arguments).
 Never tune a lane by giving it its own flags — a lane that diverges from the
 shared config silently changes what the gate means.
 
+Platforms are explicit everywhere (#2412): the published index is dual-arch
+(`linux/amd64` + `linux/arm64`) and trivy reads ONE variant per invocation
+(`--platform`, default `linux/amd64` — the Trivy container-image guide), so
+each lane scans both variants; a locally built `--candidate` is
+single-platform by construction and says so.
+
 ## The remediation law (per finding class)
 
 Attribute every finding to exactly one class BEFORE touching anything, from

--- a/.claude/rules/sqlx-conventions.md
+++ b/.claude/rules/sqlx-conventions.md
@@ -7,7 +7,7 @@ paths: ["app/ferroehr/**"]
 `ferroehr` is the only crate that talks to PostgreSQL, using `sqlx` 0.9 (driver,
 pool, migrations) + `sea-query` 1.0 + `sea-query-sqlx` (the dynamic SQL builder
 + binder; `sea-query-binder` is the obsolete sea-query-0.32 pairing — do not
-use it). **Not sea-orm.** Target PostgreSQL 18.4+.
+use it). **Not sea-orm.** Target PostgreSQL 18.6+.
 
 ## Migrations
 

--- a/.github/workflows/base-image-watcher.yml
+++ b/.github/workflows/base-image-watcher.yml
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
+# .github/workflows/base-image-watcher.yml
+#
+# Weekly check that the digest-pinned postgres base is still the newest bytes
+# upstream publishes for its major (issue #2410). Two staleness classes, both
+# invisible to the vulnerability scans until they surface as findings:
+#
+#   * a NEWER PATCH TAG on the pinned major (PostgreSQL quarterly/security
+#     releases — 18.4 → 18.6 sat unnoticed for days before #2408/#2409);
+#   * the PINNED TAG RE-POINTED upstream (a same-version respin — how
+#     docker-library ships base refreshes between PG releases; our build-time
+#     apt upgrade covers Debian packages, but a respin also carries rebuilt
+#     bundled binaries like gosu, which apt cannot touch).
+#
+# The other bases (the distroless runtime, the rust build image) are
+# deliberately out of scope: their tags move near-weekly (pure noise), their
+# CVE exposure surfaces through the image scans, and the rust image follows
+# the toolchain watcher's bumps.
+#
+# A finding files/updates ONE tracking issue (the image-scan.yml dedup
+# pattern); the run itself stays green — a newer base is actionable, not
+# broken. Remediation: the base-bump checklist in
+# .claude/rules/image-security.md.
+name: Base image watcher
+
+on:
+  schedule:
+    # Mondays 07:43 UTC — off the hour, after the 07:13 published-image scan,
+    # clear of the other scheduled lanes (05:17/05:23/05:37/06:17/06:47).
+    - cron: "43 7 * * 1"
+  workflow_dispatch: {}
+
+concurrency:
+  group: base-image-watcher
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  watch:
+    name: compare pinned postgres base to upstream
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write # file/update the one tracking issue below
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Compare the pinned base to upstream
+        id: check
+        run: |
+          set -euo pipefail
+          from=$(grep -E '^FROM postgres:' docker/postgres/Dockerfile | awk '{print $2}')
+          pinned_tag=${from#postgres:}; pinned_tag=${pinned_tag%@*}
+          pinned_digest=${from#*@}
+          major=${pinned_tag%%.*}
+
+          # Newest patch tag for the pinned major, from the Docker Hub API.
+          newest_tag=$(curl -fsSL --retry 3 \
+              "https://hub.docker.com/v2/repositories/library/postgres/tags?page_size=100&name=${major}." \
+            | jq -r --arg re "^${major}\\.[0-9]+$" \
+                '[.results[].name | select(test($re))] | sort_by(split(".") | map(tonumber)) | last // empty')
+
+          # What the pinned tag resolves to today (the manifest-list digest,
+          # the same form the FROM pins).
+          current_digest=$(docker buildx imagetools inspect "postgres:${pinned_tag}" \
+              --format '{{.Manifest.Digest}}')
+
+          stale=""
+          {
+            echo "Pinned: \`postgres:${pinned_tag}@${pinned_digest}\`"
+            if [ -n "$newest_tag" ] && [ "$newest_tag" != "$pinned_tag" ]; then
+              stale=1
+              echo "- a newer patch tag exists upstream: \`postgres:${newest_tag}\`"
+            fi
+            if [ "$current_digest" != "$pinned_digest" ]; then
+              stale=1
+              echo "- the pinned tag has been re-pointed upstream: \`postgres:${pinned_tag}\` now resolves to \`${current_digest}\` (a same-version respin: rebuilt base packages and bundled binaries)"
+            fi
+            if [ -z "$stale" ]; then
+              echo "- upstream has nothing newer; the pin is current"
+            fi
+          } > details.md
+          echo "stale=${stale:-0}" >> "$GITHUB_OUTPUT"
+          cat details.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: File or update the tracking issue
+        if: steps.check.outputs.stale == '1'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          title="chore(images): the pinned postgres base is stale — newer upstream bytes exist"
+          existing=$(gh issue list --repo "$REPO" --state open --search "in:title \"$title\"" \
+                       --json number --jq '.[0].number // empty')
+          cat > body.md <<'PREAMBLE'
+          The weekly base-image watcher found the digest-pinned postgres base behind upstream.
+
+          PREAMBLE
+          cat details.md >> body.md
+          cat >> body.md <<'REMEDY'
+
+          Remedy: the base-bump pin-site checklist in `.claude/rules/image-security.md`,
+          verified with `scripts/security/scan-images.sh --candidate` before merge.
+          REMEDY
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$REPO" --body-file body.md
+            echo "commented on #$existing"
+          else
+            gh issue create --repo "$REPO" --title "$title" \
+              --label chore --label P2 --body-file body.md
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -933,7 +933,7 @@ jobs:
       - name: Regenerate and diff
         run: bash scripts/checks/codegen-drift.sh
 
-  # ── Build + tests against PostgreSQL 18.4 (+ the CNF artifact validation) ───
+  # ── Build + tests against PostgreSQL 18.6 (+ the CNF artifact validation) ───
   # The CNF coverage guard lives here: its
   # `cargo nextest run -p cnf-runner` was a byte-for-byte subset of this job's
   # `--workspace` nextest run (cnf-runner is a workspace member — its ECC
@@ -956,7 +956,7 @@ jobs:
       contents: read
     services:
       postgres:
-        image: postgres:18.4@sha256:a02db8cac496f15b094798a38254f14d6e00741f709360e5e00bb6668ea31636
+        image: postgres:18.6@sha256:06cad38a5d9f5d24b4d83d86def30795d5e4b757fedbf5281172b576dedcd941
         env:
           POSTGRES_USER: openehr
           POSTGRES_PASSWORD: openehr
@@ -1040,7 +1040,7 @@ jobs:
       contents: write
     services:
       postgres:
-        image: postgres:18.4@sha256:a02db8cac496f15b094798a38254f14d6e00741f709360e5e00bb6668ea31636
+        image: postgres:18.6@sha256:06cad38a5d9f5d24b4d83d86def30795d5e4b757fedbf5281172b576dedcd941
         env:
           POSTGRES_USER: openehr
           POSTGRES_PASSWORD: openehr

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -647,8 +647,29 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # The app image, by digest — the artifact this run actually published.
+      # The published index is dual-arch and trivy reads ONE variant per
+      # invocation (`--platform`, default linux/amd64), so each variant is
+      # scanned explicitly (#2412) — the app image by its pushed digest, the
+      # postgres image from per-arch local builds (QEMU for the non-native
+      # one; its Dockerfile runs the Debian security upgrade, #2408).
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
       - uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          TRIVY_PLATFORM: linux/amd64
+        with:
+          scan-type: image
+          image-ref: ${{ env.APP_IMAGE }}@${{ needs.app-image.outputs.digest }}
+          scanners: vuln
+          exit-code: '1'
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          trivy-config: trivy.yaml
+
+      - uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          TRIVY_PLATFORM: linux/arm64
         with:
           scan-type: image
           image-ref: ${{ env.APP_IMAGE }}@${{ needs.app-image.outputs.digest }}
@@ -660,15 +681,29 @@ jobs:
 
       # `ferroehr-postgres` is the one image whose OS package set we do not
       # control — it is built on the upstream `postgres` image — so it is the
-      # image this gate exists for. Built locally here (a COPY-only Dockerfile,
-      # seconds) because the postgres-image job only runs when its inputs change.
-      - name: Build the postgres image for scanning
-        run: docker build -t ferroehr-postgres:scan docker/postgres
+      # image this gate exists for. Built locally here because the
+      # postgres-image job only runs when its inputs change.
+      - name: Build the postgres image for scanning (both platforms)
+        run: |
+          docker buildx build --platform linux/amd64 --load \
+            -t ferroehr-postgres:scan-amd64 docker/postgres
+          docker buildx build --platform linux/arm64 --load \
+            -t ferroehr-postgres:scan-arm64 docker/postgres
 
       - uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: image
-          image-ref: ferroehr-postgres:scan
+          image-ref: ferroehr-postgres:scan-amd64
+          scanners: vuln
+          exit-code: '1'
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          trivy-config: trivy.yaml
+
+      - uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: image
+          image-ref: ferroehr-postgres:scan-arm64
           scanners: vuln
           exit-code: '1'
           severity: HIGH,CRITICAL

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -547,7 +547,8 @@ jobs:
           subject-digest: ${{ steps.build_admin_ui.outputs.digest }}
           push-to-registry: true
   # ── PostgreSQL image (only on docker/postgres changes or tags; multi-arch) ──
-  # COPY-only on top of postgres:18.4, so multi-arch needs no QEMU either.
+  # One RUN layer (the Debian security upgrade, #2408) on top of postgres:18.6,
+  # so the non-native platform needs QEMU — set up below.
   postgres-image:
     name: postgres image
     runs-on: ubuntu-26.04
@@ -566,6 +567,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
@@ -598,8 +600,8 @@ jobs:
             org.opencontainers.image.vendor=FerroEHR
             org.opencontainers.image.authors=Ruben Talstra <https://github.com/rubentalstra>
             org.opencontainers.image.licenses=MIT AND PostgreSQL
-            org.opencontainers.image.base.name=postgres:18.4
-            org.opencontainers.image.base.digest=sha256:a02db8cac496f15b094798a38254f14d6e00741f709360e5e00bb6668ea31636
+            org.opencontainers.image.base.name=postgres:18.6
+            org.opencontainers.image.base.digest=sha256:06cad38a5d9f5d24b4d83d86def30795d5e4b757fedbf5281172b576dedcd941
 
       - name: Build and push
         id: build_postgres

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -98,27 +98,33 @@ jobs:
           done
           echo "VEX documents applied: ${#vex_args[@]} (2 args per document)"
 
+          # One platform per trivy invocation (the container-image guide's
+          # `--platform`, default linux/amd64) while the published index is
+          # dual-arch — so every variant is scanned explicitly (#2412).
           total=0
           : > findings.md
           for image in ferroehr ferroehr-postgres ferroehr-admin-ui; do
             ref="ghcr.io/${OWNER}/${image}:${SCAN_TAG}"
             digest=$(docker buildx imagetools inspect "$ref" --format '{{.Manifest.Digest}}')
-            echo "::group::${image} (${digest})"
-            trivy image --config trivy.yaml --scanners vuln \
-              "${vex_args[@]}" -f json -o "${image}.json" "$ref"
-            count=$(jq '[.Results[]?.Vulnerabilities // [] | .[]] | length' "${image}.json")
-            trivy image --config trivy.yaml --scanners vuln \
-              "${vex_args[@]}" -f table "$ref" || true
-            echo "::endgroup::"
-            echo "| \`${image}\` | \`${digest}\` | ${count} |" >> findings.md
-            total=$((total + count))
+            for platform in linux/amd64 linux/arm64; do
+              arch=${platform##*/}
+              echo "::group::${image} ${platform} (${digest})"
+              trivy image --config trivy.yaml --scanners vuln --platform "$platform" \
+                "${vex_args[@]}" -f json -o "${image}.${arch}.json" "$ref"
+              count=$(jq '[.Results[]?.Vulnerabilities // [] | .[]] | length' "${image}.${arch}.json")
+              trivy image --config trivy.yaml --scanners vuln --platform "$platform" \
+                "${vex_args[@]}" -f table "$ref" || true
+              echo "::endgroup::"
+              echo "| \`${image}\` | \`${platform}\` | \`${digest}\` | ${count} |" >> findings.md
+              total=$((total + count))
+            done
           done
           echo "total=$total" >> "$GITHUB_OUTPUT"
           {
             printf '## Published image scan\n\n'
             printf 'Tag `%s`, Trivy %s, HIGH/CRITICAL with a fix available, VEX applied.\n\n' \
               "$SCAN_TAG" "$TRIVY_VERSION"
-            printf '| image | digest | findings |\n|---|---|---|\n'
+            printf '| image | platform | digest | findings |\n|---|---|---|---|\n'
             cat findings.md
           } >> "$GITHUB_STEP_SUMMARY"
           echo "total findings: $total"
@@ -151,7 +157,7 @@ jobs:
                        --json number --jq '.[0].number // empty')
           {
             printf 'A scheduled scan of the PUBLISHED images found **%s** fixable HIGH/CRITICAL findings.\n\n' "$TOTAL"
-            printf '| image | digest | findings |\n|---|---|---|\n'
+            printf '| image | platform | digest | findings |\n|---|---|---|---|\n'
             cat findings.md
             printf '\nFull reports are attached to the run as `image-scan-reports`: %s\n' "$RUN_URL"
             printf '\nThese are findings **with a fix available**, so the remedy is a rebuild and'

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -77,14 +77,15 @@ secrets: []
 # The ARGUMENT lives in `security/vex/postgres-gosu.openvex.json` as an OpenVEX
 # `not_affected` / `vulnerable_code_not_in_execute_path` statement per CVE, with
 # the reachability reasoning: gosu sets uid/gid and execs, so it opens no socket
-# and parses no untrusted input, and the `net`, `net/http`, `net/mail`, `mime`
-# and `os.Root` packages these advisories concern are linked but never reached.
+# and parses no untrusted input, and the `net`, `net/http`, `net/mail`, `mime`,
+# `os.Root`, `encoding/asn1`, `encoding/xml`, `html/template`, `net/url` and
+# `crypto/tls` packages these advisories concern are linked but never reached.
 # Making that document drive the gate directly requires purl matching that does
 # not bind for a locally-tagged image — tracked in #1990.
 #
 # The entries are per-CVE and path-scoped ON PURPOSE. A NEW advisory in gosu, or
 # any advisory in any other package of this image, still fails the gate; only
-# these sixteen, in this one binary, are adjudicated. Re-check on every
+# these twenty-two, in this one binary, are adjudicated. Re-check on every
 # base-image bump: when upstream rebuilds gosu, these entries go.
 vulnerabilities:
   - id: CVE-2025-61726
@@ -133,5 +134,23 @@ vulnerabilities:
     paths:
       - usr/local/bin/gosu
   - id: CVE-2026-42504
+    paths:
+      - usr/local/bin/gosu
+  - id: CVE-2026-33818
+    paths:
+      - usr/local/bin/gosu
+  - id: CVE-2026-56853
+    paths:
+      - usr/local/bin/gosu
+  - id: CVE-2026-56858
+    paths:
+      - usr/local/bin/gosu
+  - id: CVE-2026-56859
+    paths:
+      - usr/local/bin/gosu
+  - id: CVE-2026-56860
+    paths:
+      - usr/local/bin/gosu
+  - id: CVE-2026-56862
     paths:
       - usr/local/bin/gosu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ workflow refuses a tag that has no matching section here.
 
 ### Security
 
+- **h2 0.4.16** — RUSTSEC-2026-0258: the HTTP/2 implementation under hyper
+  accepted and queued empty DATA frames without limit (low severity,
+  unbounded-memory class). In-range lock upgrade; no code change.
+
 - **The published `ferroehr-postgres` image is rebuilt clean of its 15
   fixable HIGH findings.** Nine were Debian `util-linux` packages
   (CVE-2026-53615) whose fix sits in trixie-security while the pinned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,36 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Changed
+
+- **PostgreSQL 18.6 everywhere** — the `ferroehr-postgres` image base, the CI
+  service containers, and every documented pin move from 18.4 to 18.6, the
+  latest PG 18 patch (2026-08-13; 18.5 was never released). 18.6 is itself a
+  security release fixing 28 CVEs, several in surface this CDR uses
+  (`pgcrypto`, `pg_trgm`, `to_char()`/regexp buffer overruns, plan-cache
+  invalidation). Operators upgrading an existing cluster in place should note
+  the upstream release notes advise checking (and possibly reindexing)
+  `btree_gist` indexes — the temporal `vo_version` keys use `btree_gist`.
+- **Helm chart `6.0.8`** — no template changes: the chart README now states
+  the PostgreSQL floor as 18.6.
+
 ### Security
+
+- **The published `ferroehr-postgres` image is rebuilt clean of its 15
+  fixable HIGH findings.** Nine were Debian `util-linux` packages
+  (CVE-2026-53615) whose fix sits in trixie-security while the pinned
+  upstream base rebuilds on its own cadence — the image now applies Debian
+  security updates at build time, so a published fix reaches the image at the
+  next rebuild instead of waiting for upstream. The other six are new
+  Go-standard-library advisories in `gosu`, the privilege-dropping helper the
+  upstream `postgres` image bundles (CVE-2026-33818, CVE-2026-56853,
+  CVE-2026-56858, CVE-2026-56859, CVE-2026-56860, CVE-2026-56862 —
+  `encoding/asn1`, `net/http`, `html/template`, `encoding/xml`, `net/url`,
+  `crypto/tls`): gosu sets uid/gid and execs, opening no socket and parsing
+  no untrusted input, so none of that code is reachable; they join the
+  per-CVE, path-scoped adjudication with published OpenVEX statements in
+  `security/vex/postgres-gosu.openvex.json`, which upstream's next gosu
+  rebuild deletes.
 
 - **The vulnerable quick-xml 0.26 is eliminated from the build, not ignored.**
   pprof's `flamegraph` feature pinned `inferno ^0.11`, whose quick-xml 0.26
@@ -61,6 +90,8 @@ workflow refuses a tag that has no matching section here.
   an OpenVEX `not_affected` statement (gosu resolves no hostnames and issues
   no HTTP requests, so the IDNA path is never entered). The entries go when
   upstream rebuilds gosu on a fixed Go line.
+
+## [3.17.6] - 2026-08-15
 
 ### Security
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ Discipline unchanged: subagents still obey the hard rules below (never hand-edit
 ## Tech stack (pinned)
 
 Toolchain: Rust stable **1.96** (1.96.1), MSRV 1.96, **edition 2024**, resolver v3. Pin via `rust-toolchain.toml`.
-Database: **PostgreSQL 18** (target 18.4+): AIO, `uuidv7()`, skip scan, temporal constraints, RETURNING OLD/NEW, plus `JSON_TABLE` from PG 17. Extensions: `uuid-ossp`, `pgcrypto`, `pg_trgm`.
+Database: **PostgreSQL 18** (target 18.6+): AIO, `uuidv7()`, skip scan, temporal constraints, RETURNING OLD/NEW, plus `JSON_TABLE` from PG 17. Extensions: `uuid-ossp`, `pgcrypto`, `pg_trgm`.
 
 **The authoritative, fully-pinned dependency set lives in the root `Cargo.toml` `[workspace.dependencies]`.** Versions below are current as of 2026-07; do not hand-roll anything a crate here already provides (auth, HTTP status codes, OpenAPI/Swagger, etc.). Add a crate to a member with `dep.workspace = true`. Items marked *(verify)* had their major/minor unconfirmed at authoring; check crates.io before first use.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2631,7 +2631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3431,9 +3431,9 @@ checksum = "17e2ac29387b1aa07a1e448f7bb4f35b500787971e965b02842b900afa5c8f6f"
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -6674,7 +6674,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7357,7 +7357,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7431,7 +7431,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8689,7 +8689,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10035,7 +10035,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -443,7 +443,7 @@ sysinfo = "0.39.5"                   # CPU/RSS sampling for the benchmark harnes
 # Toolchain: Rust stable 1.97.1, edition 2024. The MSRV stays 1.96 — nothing
 # here uses a 1.97 feature, and the eight published crates are the only
 # artifacts whose consumers would feel a bump (docs/VERSIONS.md §MSRV policy).
-# Database: PostgreSQL 18 (target 18.4+; 18.x is the current stable line; PG 19 in beta — do not target).
+# Database: PostgreSQL 18 (target 18.6+; 18.x is the current stable line; PG 19 in beta — do not target).
 
 # ── Build-speed profiles ─────────────────────────────────────────────────────
 # Full debuginfo on ~400 deps + 18 workspace crates made dev builds/links slow

--- a/app/ferroehr/src/telemetry/build_info.rs
+++ b/app/ferroehr/src/telemetry/build_info.rs
@@ -131,7 +131,7 @@ mod tests {
                 openehr_am::Generation::V2_4.spec_version()
             )
         );
-        assert_eq!(info.postgres_target, "18.4+");
+        assert_eq!(info.postgres_target, "18.6+");
         // build_date parses to a real timestamp (not the "unknown" fallback) in
         // a normal build where build.rs ran.
         assert!(!info.build_date.is_empty());

--- a/app/ferroehr/src/telemetry/provenance.rs
+++ b/app/ferroehr/src/telemetry/provenance.rs
@@ -68,7 +68,7 @@ pub const TERM: &str = openehr_term::Generation::V3_1.spec_version();
 /// The `PostgreSQL` version this server targets. No openEHR spec governs the
 /// datastore — our own design; no crate carries this pin, so it stays
 /// hand-maintained here.
-pub const PG_TARGET: &str = "18.4+";
+pub const PG_TARGET: &str = "18.6+";
 /// The last machine-computed ECC conformance verdict — the highest profile
 /// obtained — advertised by the System Options manifest (`OPTIONS /`
 /// `conformance_profile`).

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # A published OCI version is immutable by refusal rather than by the registry —
 # `helm push` over an existing tag replaces it silently — so a correction always
 # ships as a NEW version and the published one stands as it was.
-version: 6.0.7
+version: 6.0.8
 # The default container image tag (overridable via image.tag), and the released
 # application version — kept equal to the workspace version by the
 # `chart-appversion` CI guard, so a release cannot ship a chart pointing at the

--- a/deploy/helm/ferroehr/README.md
+++ b/deploy/helm/ferroehr/README.md
@@ -2,7 +2,7 @@
 
 Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.1.0 + AQL 1.1). A single static binary deployed with a hardened-by-default security posture: runs as a non-root, read-only-rootfs workload whose NetworkPolicy admits its serving port only, and that connects to an EXTERNAL PostgreSQL 18 as an unprivileged app role (migrations are run out of band by a separate migrator role).
 
-![Version: 6.0.7](https://img.shields.io/badge/Version-6.0.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.17.7](https://img.shields.io/badge/AppVersion-3.17.7-informational?style=flat-square)
+![Version: 6.0.8](https://img.shields.io/badge/Version-6.0.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.17.7](https://img.shields.io/badge/AppVersion-3.17.7-informational?style=flat-square)
 
 FerroEHR is a pure-Rust openEHR Clinical Data Repository: ITS-REST 1.1.0 at the
 API, AQL 1.1 as the query language, PostgreSQL 18-native storage, shipped as a
@@ -11,7 +11,7 @@ single static binary. This chart deploys the server.
 ## Before you install: three things that surprise people
 
 **This chart does not deploy a database.** It expects an **external PostgreSQL
-18** (18.4 or newer) and will not start without one. Point it at your own
+18** (18.6 or newer) and will not start without one. Point it at your own
 instance, a managed service, or a separate PostgreSQL chart — `database.url` or,
 for production, `database.existingSecret`.
 
@@ -33,7 +33,7 @@ add — `helm repo add` does not apply to this chart and never will:
 
 ```console
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 6.0.7 \
+  --version 6.0.8 \
   --namespace ferroehr --create-namespace \
   --set database.existingSecret=ferroehr-db \
   --set image.tag=3.17.7
@@ -47,7 +47,7 @@ They are independent SemVer lines and they move independently:
 
 | What | Set with | This release |
 |---|---|---|
-| the **chart** (templates, defaults, this document) | `--version` | `6.0.7` |
+| the **chart** (templates, defaults, this document) | `--version` | `6.0.8` |
 | the **server image** | `image.tag` | `3.17.7` |
 
 `appVersion` is the image the chart defaults to; pinning `image.tag` explicitly
@@ -59,7 +59,7 @@ The chart carries two keyless Sigstore artifacts, and they answer different
 questions. A **cosign signature** — who signed this:
 
 ```console
-cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.7 \
+cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.8 \
   --certificate-identity-regexp '^https://github\.com/rubentalstra/FerroEHR/\.github/workflows/publish-chart\.yml@' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
@@ -67,7 +67,7 @@ cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.7 \
 A **SLSA build provenance attestation** — what source it was built from, and how:
 
 ```console
-gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:6.0.7 \
+gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:6.0.8 \
   -R rubentalstra/FerroEHR
 gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:3.17.7 \
   -R rubentalstra/FerroEHR

--- a/deploy/helm/ferroehr/README.md.gotmpl
+++ b/deploy/helm/ferroehr/README.md.gotmpl
@@ -11,7 +11,7 @@ single static binary. This chart deploys the server.
 ## Before you install: three things that surprise people
 
 **This chart does not deploy a database.** It expects an **external PostgreSQL
-18** (18.4 or newer) and will not start without one. Point it at your own
+18** (18.6 or newer) and will not start without one. Point it at your own
 instance, a managed service, or a separate PostgreSQL chart — `database.url` or,
 for production, `database.existingSecret`.
 

--- a/deploy/helm/golden/admin-ui.yaml
+++ b/deploy/helm/golden/admin-ui.yaml
@@ -18,7 +18,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the admin console: only its HTTP port, but from EVERY source — this policy narrows ports, NOT sources (adminUi.networkPolicy.ingressAllowAll=true). Set adminUi.networkPolicy.ingressFrom for a PHI workload. Egress admits the CDR Service and DNS only.
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"
@@ -90,7 +90,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"
@@ -118,7 +118,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"
@@ -139,7 +139,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr-admin-ui
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"
@@ -154,7 +154,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"
@@ -184,7 +184,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"
@@ -201,7 +201,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"
@@ -332,7 +332,7 @@ metadata:
     kubernetes.io/description: >-
       In-cluster address for the FerroEHR admin console. The console is a REST client of the CDR and holds no data of its own; it is the human-facing surface, so this is the Service an Ingress normally publishes.
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"
@@ -355,7 +355,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"
@@ -385,7 +385,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR admin console: a Leptos SSR web UI that consumes the CDR strictly over ITS-REST. It never reaches the database, which the console NetworkPolicy enforces rather than assumes.
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"
@@ -492,7 +492,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), and only from the networkPolicy.ingressFrom peers.
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"
@@ -97,7 +97,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"
@@ -118,7 +118,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"
@@ -150,7 +150,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"
@@ -176,7 +176,7 @@ kind: Secret
 metadata:
   name: ferroehr-config
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"
@@ -197,7 +197,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"
@@ -388,7 +388,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"
@@ -422,7 +422,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"
@@ -653,7 +653,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"
@@ -687,7 +687,7 @@ kind: Ingress
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"
@@ -725,7 +725,7 @@ kind: ServiceMonitor
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"

--- a/deploy/helm/golden/basic-auth.yaml
+++ b/deploy/helm/golden/basic-auth.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"
@@ -51,7 +51,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"
@@ -72,7 +72,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"
@@ -102,7 +102,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"
@@ -119,7 +119,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"
@@ -247,7 +247,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"
@@ -277,7 +277,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"
@@ -51,7 +51,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"
@@ -72,7 +72,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"
@@ -87,7 +87,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"
@@ -212,7 +212,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"
@@ -242,7 +242,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.7
+    helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.7"

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -3,17 +3,30 @@
 # Preconfigured PostgreSQL 18 for ferroehr (mirrors the official
 # `ehrbase/ehrbase-v2-postgres` two-image model, built fresh for this stack).
 #
-# The stock postgres:18.4 image, plus init scripts that create the app login
+# The stock postgres:18.6 image, plus init scripts that create the app login
 # role, its owned database, the `ehr` + `ext` schemas it owns, and the required
 # extensions installed by the bootstrap superuser — so the app role never needs
 # superuser. Schema CONTENT is owned by the app's sqlx migrators at boot; this
 # image bakes NO migration state (see README.md).
 #
-# Digest-pinned (resolved 2026-07-24): a mutable tag can be re-pointed, a digest
+# Digest-pinned (resolved 2026-08-18): a mutable tag can be re-pointed, a digest
 # cannot (docs.docker.com/build/building/best-practices — "pinning to a digest
-# guarantees the same image version"). 18.4 is the latest PG 18 patch
-# (docs/VERSIONS.md); bump the tag AND the digest together.
-FROM postgres:18.4@sha256:a02db8cac496f15b094798a38254f14d6e00741f709360e5e00bb6668ea31636
+# guarantees the same image version"). 18.6 is the latest PG 18 patch
+# (docs/VERSIONS.md; 18.5 was never released upstream); bump the tag AND the
+# digest together — the full pin-site checklist is
+# .claude/rules/image-security.md.
+FROM postgres:18.6@sha256:06cad38a5d9f5d24b4d83d86def30795d5e4b757fedbf5281172b576dedcd941
+
+# Debian security updates, applied at OUR build time (issue #2408). The
+# upstream image rebuilds on its own cadence, so a fix already published in
+# trixie-security can sit unpulled for weeks in the pinned base — postgres:18.6
+# (built 2026-08-13) still ships the util-linux packages whose CVE-2026-53615
+# fix trixie-security carries. Plain `upgrade`, never `dist-upgrade`: packages
+# are only patched, none added or removed.
+RUN set -eux; \
+    apt-get update; \
+    apt-get -y upgrade; \
+    rm -rf /var/lib/apt/lists/*
 
 # Init scripts run once, on an empty data directory, as the bootstrap superuser.
 COPY initdb/ /docker-entrypoint-initdb.d/
@@ -34,5 +47,5 @@ LABEL org.opencontainers.image.title="ferroehr-postgres" \
       org.opencontainers.image.vendor="FerroEHR" \
       org.opencontainers.image.authors="Ruben Talstra <https://github.com/rubentalstra>" \
       org.opencontainers.image.licenses="MIT AND PostgreSQL" \
-      org.opencontainers.image.base.name="postgres:18.4" \
-      org.opencontainers.image.base.digest="sha256:a02db8cac496f15b094798a38254f14d6e00741f709360e5e00bb6668ea31636"
+      org.opencontainers.image.base.name="postgres:18.6" \
+      org.opencontainers.image.base.digest="sha256:06cad38a5d9f5d24b4d83d86def30795d5e4b757fedbf5281172b576dedcd941"

--- a/docker/postgres/README.md
+++ b/docker/postgres/README.md
@@ -2,7 +2,9 @@
 
 A preconfigured PostgreSQL 18 image for FerroEHR, mirroring the official
 `ehrbase/ehrbase-v2-postgres` two-image model built fresh for this stack
-(the greenfield PG18 storage design, `docs/architecture.md` §Storage). It is `postgres:18.4` plus one-time init scripts.
+(the greenfield PG18 storage design, `docs/architecture.md` §Storage). It is `postgres:18.6` plus Debian
+security updates applied at image build (the pinned upstream base rebuilds on its own cadence, so
+trixie-security fixes are pulled in at OUR build time) plus one-time init scripts.
 
 ## What the init scripts create
 

--- a/docker/postgres/README.md
+++ b/docker/postgres/README.md
@@ -13,14 +13,19 @@ Run once, on an empty data directory, as the bootstrap superuser
 
 - a **non-superuser** login role (default `ferroehr`) and a **database it owns**
   (default `ferroehr`);
-- schemas **`ehr`** and **`ext`**, both owned by the app role;
+- the three NOLOGIN group roles of the layered role architecture —
+  **`ferroehr_migrator`**, **`ferroehr_app`**, **`ferroehr_reader`** — with the
+  login role granted `ferroehr_migrator` + `ferroehr_app`, so dev/compose has
+  the same grant topology as a hardened deployment;
+- schemas **`ehr`**, **`ext`** and **`audit`** (the local IHE ATNA Audit Record
+  Repository), all owned by the app role;
 - extensions installed **by the superuser** so the app role never needs one:
   `uuid-ossp`, `pgcrypto`, `pg_trgm`, and **`btree_gist`** (required by the
   temporal `vo_version` `PRIMARY KEY (... WITHOUT OVERLAPS)`), all in `ext`.
 
 This is exactly the set the application's migrator
 (`ferroehr::db::run_migrations`) expects to find when it connects as the app
-role: its bootstrap `CREATE SCHEMA IF NOT EXISTS {ehr,ext}` and
+role: its bootstrap `CREATE SCHEMA IF NOT EXISTS {ehr,ext,audit}` and
 `CREATE EXTENSION IF NOT EXISTS btree_gist WITH SCHEMA ext` all become no-ops,
 and it then migrates the schema **content** into `ehr`/`ext`.
 

--- a/docs/VERSIONS.md
+++ b/docs/VERSIONS.md
@@ -61,7 +61,7 @@ escape with `cargo build --ignore-rust-version`.
 
 | Item | Pin |
 |---|---|
-| PostgreSQL | 18, target 18.4 or newer (CI runs `postgres:18.4`) |
+| PostgreSQL | 18, target 18.6 or newer (CI runs `postgres:18.6`) |
 | Required extensions | `uuid-ossp`, `pgcrypto`, `pg_trgm` |
 
 PostgreSQL is the only component in the stack with a meaningful version delta
@@ -71,10 +71,11 @@ KEY`, `RETURNING OLD/NEW`, virtual generated columns, self-join elimination, and
 OR-to-`ANY` planning, plus `JSON_TABLE()` + the SQL/JSON functions inherited
 from PG 17. **See `docs/postgres-features.md`** for the full PG 17+18 feature
 delta over PG 16 and where each app phase (P09/P12/P16/P11/P20) uses it —
-"the best possible system" means exploiting these. Minor releases (18.1–18.4,
-17.x) are bugfix/security only (no new features); pin the latest patch (18.4,
-2026-05-14). Managed providers may lag on `io_uring`; still target PG 18 and let
-the AIO benefit follow.
+"the best possible system" means exploiting these. Minor releases (18.1–18.6,
+17.x) are bugfix/security only (no new features); pin the latest patch (18.6,
+2026-08-13 — a security release fixing 28 CVEs; 18.5 was never released, a
+regression was found post-wrap). Managed providers may lag on `io_uring`; still
+target PG 18 and let the AIO benefit follow.
 
 ## openEHR specification matrix
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -223,7 +223,7 @@ issues for triage.
 
 ## PostgreSQL 18
 
-We target **PG 18** (18.4+): `uuidv7()`, temporal `WITHOUT OVERLAPS`
+We target **PG 18** (18.6+): `uuidv7()`, temporal `WITHOUT OVERLAPS`
 constraints, `RETURNING OLD/NEW`, `JSON_TABLE` + SQL/JSON functions and
 jsonpath item methods (PG 17), B-tree skip scan, async I/O, STORED generated
 columns for hot extractions. See `docs/postgres-features.md`.

--- a/docs/postgres-features.md
+++ b/docs/postgres-features.md
@@ -1,6 +1,6 @@
 # PostgreSQL 17 + 18 features FerroEHR leverages
 
-**Pin: PostgreSQL 18, target 18.4+** (`docs/VERSIONS.md`; CI runs `postgres:18.4`).
+**Pin: PostgreSQL 18, target 18.6+** (`docs/VERSIONS.md`; CI runs `postgres:18.6`).
 Upstream EHRbase targets **PG 15/16**; we target **18** to exploit two major
 releases of new capability for a JSONB-heavy openEHR CDR. This file is the
 reference the persistence, AQL-engine, and auth subsystems build against —
@@ -9,11 +9,11 @@ reference the persistence, AQL-engine, and auth subsystems build against —
 ## Versioning note (why the feature list is only 17.0 + 18.0)
 
 PostgreSQL adds features **only in major releases**. Every minor release —
-**18.1, 18.2, 18.3, 18.4** and all of **17.x** — is a cumulative **bugfix +
-security** rollup with **no new SQL features** (18.4, 2026-05-14, is purely
-CVE/bugfix; same-major upgrades need no dump/restore). So the feature delta over
-EHRbase's PG 16 is exactly the **PG 17.0** and **PG 18.0** feature sets below;
-we run the latest patch (18.4) for the fixes.
+**18.1 through 18.6** (18.5 was never released) and all of **17.x** — is a
+cumulative **bugfix + security** rollup with **no new SQL features** (18.6,
+2026-08-13, fixes 28 CVEs; same-major upgrades need no dump/restore). So the
+feature delta over EHRbase's PG 16 is exactly the **PG 17.0** and **PG 18.0**
+feature sets below; we run the latest patch (18.6) for the fixes.
 
 ## PG 17.0 — SQL/JSON + query performance
 

--- a/scripts/checks/image-labels.sh
+++ b/scripts/checks/image-labels.sh
@@ -120,6 +120,25 @@ for entry in $IMAGES; do
   fi
 done
 
+# The CI service containers must run the exact base the postgres image is
+# built on — a drifted service pin tests against different bytes than the
+# image ships (found as a checklist item in #2408/#2410, enforced here since).
+CI_WORKFLOW=.github/workflows/ci.yml
+pg_from=$(grep -E '^FROM postgres:' docker/postgres/Dockerfile | awk '{print $2}' || true)
+if [ -z "$pg_from" ]; then
+  report "image-labels: docker/postgres/Dockerfile has no 'FROM postgres:' pin"
+else
+  ci_pins=$(grep -Eo 'image: postgres:[^[:space:]]+' "$CI_WORKFLOW" | sed 's/^image: //' | sort -u || true)
+  if [ -z "$ci_pins" ]; then
+    report "image-labels: $CI_WORKFLOW declares no postgres service pins to check"
+  else
+    for pin in $ci_pins; do
+      [ "$pin" = "$pg_from" ] \
+        || report "image-labels: $CI_WORKFLOW pins service '$pin', but docker/postgres/Dockerfile FROM is '$pg_from'"
+    done
+  fi
+fi
+
 # Annotations must reach the INDEX, which is the only place GHCR reads a package
 # description from. Three lanes, three declarations.
 levels=$(grep -c 'DOCKER_METADATA_ANNOTATIONS_LEVELS: index,manifest' "$WORKFLOW" || true)

--- a/scripts/security/scan-images.sh
+++ b/scripts/security/scan-images.sh
@@ -10,11 +10,15 @@
 #
 #   scripts/security/scan-images.sh
 #       scan the three PUBLISHED images at ghcr.io (tag $SCAN_TAG, default
-#       `latest`) — reproduces the scheduled lane's verdict on demand.
+#       `latest`), BOTH platform variants each (the published index is
+#       dual-arch and trivy reads one variant per invocation, #2412) —
+#       reproduces the scheduled lane's verdict on demand.
 #
 #   scripts/security/scan-images.sh --candidate IMAGE [IMAGE...]
 #       scan locally built or explicitly named image refs instead — the fix
 #       loop for a finding: rebuild, scan the candidate, merge only at 0.
+#       A local candidate is single-platform by construction (whatever the
+#       builder produced); build per-arch to cover both.
 #       e.g.  docker build -t ferroehr-postgres:candidate docker/postgres/
 #             scripts/security/scan-images.sh --candidate ferroehr-postgres:candidate
 #
@@ -30,17 +34,22 @@ command -v jq >/dev/null || { echo "jq is required" >&2; exit 2; }
 SCAN_TAG=${SCAN_TAG:-latest}
 OWNER=${OWNER:-rubentalstra}
 
-refs=()
+# Each entry is "ref|platform"; an empty platform scans the ref as built.
+targets=()
 if [ "${1:-}" = "--candidate" ]; then
   shift
   [ $# -ge 1 ] || { echo "--candidate needs at least one image ref" >&2; exit 2; }
-  refs=("$@")
+  for ref in "$@"; do
+    targets+=("${ref}|")
+  done
 elif [ $# -gt 0 ]; then
   echo "unknown argument: $1 (only --candidate IMAGE... is accepted)" >&2
   exit 2
 else
   for image in ferroehr ferroehr-postgres ferroehr-admin-ui; do
-    refs+=("ghcr.io/${OWNER}/${image}:${SCAN_TAG}")
+    for platform in linux/amd64 linux/arm64; do
+      targets+=("ghcr.io/${OWNER}/${image}:${SCAN_TAG}|${platform}")
+    done
   done
 fi
 
@@ -55,12 +64,16 @@ out_dir=$(mktemp -d)
 trap 'rm -rf "$out_dir"' EXIT
 
 total=0
-for ref in "${refs[@]}"; do
-  safe=$(printf '%s' "$ref" | tr '/:@' '___')
+for target in "${targets[@]}"; do
+  ref=${target%|*}
+  platform=${target##*|}
+  platform_args=()
+  [ -n "$platform" ] && platform_args=(--platform "$platform")
+  safe=$(printf '%s' "${ref}_${platform}" | tr '/:@' '___')
   report="$out_dir/${safe}.json"
-  echo "── scanning ${ref}"
+  echo "── scanning ${ref} ${platform:-'(as built)'}"
   trivy image --skip-version-check --config trivy.yaml --scanners vuln \
-    "${vex_args[@]}" -f json -o "$report" "$ref"
+    "${platform_args[@]}" "${vex_args[@]}" -f json -o "$report" "$ref"
   count=$(jq '[.Results[]?.Vulnerabilities // [] | .[]] | length' "$report")
   if [ "$count" -gt 0 ]; then
     jq -r '.Results[]? | .Target as $t | (.Vulnerabilities // [])[]

--- a/scripts/security/scan-images.sh
+++ b/scripts/security/scan-images.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+# Rerun the published-image vulnerability scan locally — the same scan
+# image-scan.yml runs on Mondays, byte-for-byte in configuration: trivy over
+# `trivy.yaml` (HIGH/CRITICAL floor, ignore-unfixed, `.trivyignore.yaml`) with
+# every OpenVEX document under security/vex/ applied.
+#
+# Two modes:
+#
+#   scripts/security/scan-images.sh
+#       scan the three PUBLISHED images at ghcr.io (tag $SCAN_TAG, default
+#       `latest`) — reproduces the scheduled lane's verdict on demand.
+#
+#   scripts/security/scan-images.sh --candidate IMAGE [IMAGE...]
+#       scan locally built or explicitly named image refs instead — the fix
+#       loop for a finding: rebuild, scan the candidate, merge only at 0.
+#       e.g.  docker build -t ferroehr-postgres:candidate docker/postgres/
+#             scripts/security/scan-images.sh --candidate ferroehr-postgres:candidate
+#
+# Exit status: non-zero when any scanned image carries a fixable HIGH/CRITICAL
+# finding the adjudications do not cover — the same red the scheduled lane
+# shows. Remediation law: .claude/rules/image-security.md.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+command -v trivy >/dev/null || { echo "trivy is required (brew install trivy)" >&2; exit 2; }
+command -v jq >/dev/null || { echo "jq is required" >&2; exit 2; }
+
+SCAN_TAG=${SCAN_TAG:-latest}
+OWNER=${OWNER:-rubentalstra}
+
+refs=()
+if [ "${1:-}" = "--candidate" ]; then
+  shift
+  [ $# -ge 1 ] || { echo "--candidate needs at least one image ref" >&2; exit 2; }
+  refs=("$@")
+elif [ $# -gt 0 ]; then
+  echo "unknown argument: $1 (only --candidate IMAGE... is accepted)" >&2
+  exit 2
+else
+  for image in ferroehr ferroehr-postgres ferroehr-admin-ui; do
+    refs+=("ghcr.io/${OWNER}/${image}:${SCAN_TAG}")
+  done
+fi
+
+# Every VEX document, exactly as the scheduled lane passes them.
+vex_args=()
+for doc in security/vex/*.json; do
+  [ -e "$doc" ] || continue
+  vex_args+=(--vex "$doc")
+done
+
+out_dir=$(mktemp -d)
+trap 'rm -rf "$out_dir"' EXIT
+
+total=0
+for ref in "${refs[@]}"; do
+  safe=$(printf '%s' "$ref" | tr '/:@' '___')
+  report="$out_dir/${safe}.json"
+  echo "── scanning ${ref}"
+  trivy image --skip-version-check --config trivy.yaml --scanners vuln \
+    "${vex_args[@]}" -f json -o "$report" "$ref"
+  count=$(jq '[.Results[]?.Vulnerabilities // [] | .[]] | length' "$report")
+  if [ "$count" -gt 0 ]; then
+    jq -r '.Results[]? | .Target as $t | (.Vulnerabilities // [])[]
+           | "  \($t) | \(.PkgName) \(.InstalledVersion) \(.VulnerabilityID) \(.Severity) -> \(.FixedVersion)"' \
+      "$report"
+  fi
+  echo "   findings: ${count}"
+  total=$((total + count))
+done
+
+echo "total fixable HIGH/CRITICAL findings: ${total}"
+[ "$total" -eq 0 ]

--- a/security/vex/postgres-gosu.openvex.json
+++ b/security/vex/postgres-gosu.openvex.json
@@ -3,8 +3,8 @@
   "@id": "https://ferroehr.eu/vex/postgres-gosu-go-stdlib",
   "author": "FerroEHR project",
   "role": "vendor",
-  "timestamp": "2026-08-06T00:00:00Z",
-  "version": 2,
+  "timestamp": "2026-08-18T00:00:00Z",
+  "version": 3,
   "tooling": "hand-authored; see security/vex/README.md",
   "statements": [
     {
@@ -214,6 +214,84 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "The finding is in /usr/local/bin/gosu, a Go binary the upstream docker-library/postgres image ships and which this image inherits unchanged. gosu's entire job is to set uid/gid and exec the server: it opens no network connection, parses no mail, MIME or HTTP input, and runs once at container start before PostgreSQL is listening. The Go standard-library packages these advisories concern (net, net/http, net/mail, mime, os.Root) are therefore linked but never reached. Rebuilding gosu is upstream's to do; FerroEHR adds no Go code to this image."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-33818"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/ferroehr-postgres"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The finding is in /usr/local/bin/gosu, a Go binary the upstream docker-library/postgres image ships and which this image inherits unchanged. gosu's entire job is to set uid/gid and exec the server: it opens no network connection, serves no HTTP, renders no templates and parses no ASN.1, XML or URL input, and runs once at container start before PostgreSQL is listening. The Go standard-library packages these advisories concern (encoding/asn1, net/http, html/template, encoding/xml, net/url, crypto/tls) are therefore linked but never reached. Rebuilding gosu is upstream's to do; FerroEHR adds no Go code to this image."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56853"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/ferroehr-postgres"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The finding is in /usr/local/bin/gosu, a Go binary the upstream docker-library/postgres image ships and which this image inherits unchanged. gosu's entire job is to set uid/gid and exec the server: it opens no network connection, serves no HTTP, renders no templates and parses no ASN.1, XML or URL input, and runs once at container start before PostgreSQL is listening. The Go standard-library packages these advisories concern (encoding/asn1, net/http, html/template, encoding/xml, net/url, crypto/tls) are therefore linked but never reached. Rebuilding gosu is upstream's to do; FerroEHR adds no Go code to this image."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56858"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/ferroehr-postgres"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The finding is in /usr/local/bin/gosu, a Go binary the upstream docker-library/postgres image ships and which this image inherits unchanged. gosu's entire job is to set uid/gid and exec the server: it opens no network connection, serves no HTTP, renders no templates and parses no ASN.1, XML or URL input, and runs once at container start before PostgreSQL is listening. The Go standard-library packages these advisories concern (encoding/asn1, net/http, html/template, encoding/xml, net/url, crypto/tls) are therefore linked but never reached. Rebuilding gosu is upstream's to do; FerroEHR adds no Go code to this image."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56859"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/ferroehr-postgres"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The finding is in /usr/local/bin/gosu, a Go binary the upstream docker-library/postgres image ships and which this image inherits unchanged. gosu's entire job is to set uid/gid and exec the server: it opens no network connection, serves no HTTP, renders no templates and parses no ASN.1, XML or URL input, and runs once at container start before PostgreSQL is listening. The Go standard-library packages these advisories concern (encoding/asn1, net/http, html/template, encoding/xml, net/url, crypto/tls) are therefore linked but never reached. Rebuilding gosu is upstream's to do; FerroEHR adds no Go code to this image."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56860"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/ferroehr-postgres"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The finding is in /usr/local/bin/gosu, a Go binary the upstream docker-library/postgres image ships and which this image inherits unchanged. gosu's entire job is to set uid/gid and exec the server: it opens no network connection, serves no HTTP, renders no templates and parses no ASN.1, XML or URL input, and runs once at container start before PostgreSQL is listening. The Go standard-library packages these advisories concern (encoding/asn1, net/http, html/template, encoding/xml, net/url, crypto/tls) are therefore linked but never reached. Rebuilding gosu is upstream's to do; FerroEHR adds no Go code to this image."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56862"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/ferroehr-postgres"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The finding is in /usr/local/bin/gosu, a Go binary the upstream docker-library/postgres image ships and which this image inherits unchanged. gosu's entire job is to set uid/gid and exec the server: it opens no network connection, serves no HTTP, renders no templates and parses no ASN.1, XML or URL input, and runs once at container start before PostgreSQL is listening. The Go standard-library packages these advisories concern (encoding/asn1, net/http, html/template, encoding/xml, net/url, crypto/tls) are therefore linked but never reached. Rebuilding gosu is upstream's to do; FerroEHR adds no Go code to this image."
     }
   ],
   "last_updated": "2026-08-15T00:00:00Z"

--- a/tools/testkit/src/lib.rs
+++ b/tools/testkit/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! 1. **`FERROEHR_TEST_PG_URL`** — a DSN to an existing `PostgreSQL` 18 server
 //!    whose role may `CREATE DATABASE` (CI provides the workflow's
-//!    `postgres:18.4` container; a local developer server works too).
+//!    `postgres:18.6` container; a local developer server works too).
 //! 2. Otherwise a **reusable named testcontainer**
 //!    (`ferroehr-testkit-pg18`, `postgres:18`) is started — or adopted if a
 //!    previous run left it — via `testcontainers`' reusable-containers

--- a/website/book/src/installation/compose.md
+++ b/website/book/src/installation/compose.md
@@ -24,7 +24,7 @@ FerroEHR publishes three container images to GHCR:
 | Image | Contents |
 |---|---|
 | `ghcr.io/rubentalstra/ferroehr` | The `ferroehr` server binary on a distroless, non-root, shell-less multi-arch base (amd64 + arm64). Configured by a mounted TOML file and/or `FERROEHR__*` environment variables. |
-| `ghcr.io/rubentalstra/ferroehr-postgres` | `postgres:18.4` plus init scripts that pre-create the application login role, the three group roles (`ferroehr_migrator`, `ferroehr_app`, `ferroehr_reader`), the database, the schemas (`ehr`, `ext`, `audit`) and the extensions (`uuid-ossp`, `pgcrypto`, `pg_trgm`, `btree_gist`), so the app role never needs superuser. |
+| `ghcr.io/rubentalstra/ferroehr-postgres` | `postgres:18.6` (with Debian security updates applied at image build) plus init scripts that pre-create the application login role, the three group roles (`ferroehr_migrator`, `ferroehr_app`, `ferroehr_reader`), the database, the schemas (`ehr`, `ext`, `audit`) and the extensions (`uuid-ossp`, `pgcrypto`, `pg_trgm`, `btree_gist`), so the app role never needs superuser. |
 | `ghcr.io/rubentalstra/ferroehr-admin-ui` | The [admin console](../admin-ui/index.md) — a standalone web application that talks to the CDR strictly over ITS-REST. Optional; see the `admin-ui` profile below. |
 
 Each image is published under several tags:

--- a/website/book/src/installation/hardening-supply-chain.md
+++ b/website/book/src/installation/hardening-supply-chain.md
@@ -288,6 +288,15 @@ current Debian packages, changing nothing about FerroEHR itself. The distroless
 images carry almost no OS package surface, and when the lane was written none of
 the three published images carried a fixable HIGH or CRITICAL finding.
 
+The remediation side is standing machinery, not a per-incident scramble. The
+PostgreSQL image applies Debian security updates at its own build time, so an
+OS-package fix published between upstream base rebuilds reaches the image at
+the next release rather than waiting on someone else's cadence; a second
+weekly lane watches the pinned base itself and opens an issue when a newer
+PostgreSQL patch tag exists or the pinned tag is re-pointed upstream; and the
+exact published-image scan is reproducible locally against a rebuilt
+candidate, so a fix is proven clean before it merges.
+
 ## The supply-chain map
 
 Each cheat-sheet supply-chain control, and the artifact that satisfies it — so a

--- a/website/book/src/installation/kubernetes.md
+++ b/website/book/src/installation/kubernetes.md
@@ -38,9 +38,9 @@ kubectl -n ferroehr create secret generic ferroehr-db \
   --from-literal=FERROEHR__DB__URL='postgres://ferroehr_app:***@pg-host:5432/ferroehr?sslmode=verify-full'
 
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 6.0.6 -n ferroehr \
+  --version 6.0.8 -n ferroehr \
   --set database.existingSecret=ferroehr-db \
-  --set image.tag=3.17.5
+  --set image.tag=3.17.7
 ```
 
 > [!IMPORTANT]
@@ -55,7 +55,7 @@ helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
 reference. To read the chart's metadata without installing it:
 
 ```shell
-helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.6
+helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.8
 ```
 
 ### Pin two versions, not one
@@ -68,8 +68,8 @@ against.
 
 | | Selects | Pin with | Line |
 |---|---|---|---|
-| Chart version | templates, values schema, defaults | `--version 6.0.6` | SemVer over the chart's own contract |
-| Image tag | the server binary | `--set image.tag=3.17.5` (or `image.digest`) | the application's SemVer line |
+| Chart version | templates, values schema, defaults | `--version 6.0.8` | SemVer over the chart's own contract |
+| Image tag | the server binary | `--set image.tag=3.17.7` (or `image.digest`) | the application's SemVer line |
 
 Always pin the image to an immutable version or, better, a `@sha256` digest —
 never `latest`. Pin the two deliberately: the `config` tree is passed through to
@@ -167,7 +167,7 @@ metadata lists — the server, and the optional admin console.
 > the image itself as the authority:
 >
 > ```shell
-> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.6 \
+> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.8 \
 >   -s templates/configmap.yaml --set database.existingSecret=ferroehr-db \
 >   | sed -n '/ferroehr.toml/,$p' | sed '1d;s/^    //' > /tmp/ferroehr.toml
 > docker run --rm -v /tmp/ferroehr.toml:/etc/ferroehr/ferroehr.toml:ro \
@@ -556,7 +556,7 @@ config:
 
 ```shell
 helm upgrade ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 6.0.6 -n ferroehr --reuse-values \
+  --version 6.0.8 -n ferroehr --reuse-values \
   --set config.query.plan_cache_capacity=512
 ```
 
@@ -709,7 +709,7 @@ Preview an upgrade against what you have installed with
 `helm diff`, or render the new chart version and read it:
 
 ```shell
-helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.6 \
+helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.8 \
   -n ferroehr -f my-values.yaml | less
 ```
 
@@ -734,7 +734,7 @@ The check that closes that gap runs the image against your rendered
 configuration:
 
 ```shell
-FERROEHR_IMAGE=ghcr.io/rubentalstra/ferroehr:3.17.5 \
+FERROEHR_IMAGE=ghcr.io/rubentalstra/ferroehr:3.17.7 \
   deploy/helm/ci/boot-check.sh my-values.yaml
 ```
 

--- a/website/book/src/verifying-releases.md
+++ b/website/book/src/verifying-releases.md
@@ -18,7 +18,7 @@ workflow.
 ## What a release publishes
 
 Substitute the release tag you downloaded for `<tag>` (for example
-`v3.17.5`) and the architecture for `<arch>` (`x86_64` or `aarch64`) throughout
+`v3.17.7`) and the architecture for `<arch>` (`x86_64` or `aarch64`) throughout
 this page. Linux is the only published target.
 
 | Asset | What it is |
@@ -145,14 +145,14 @@ carry a Sigstore-signed SLSA provenance attestation, plus the SPDX SBOM and
 provenance the builder writes onto the image index itself.
 
 ```bash
-gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:3.17.5 \
+gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:3.17.7 \
   -R rubentalstra/FerroEHR
 ```
 
 > [!IMPORTANT]
-> **Image tags carry no `v` prefix.** A release publishes `3.17.5`, `3.17` and
+> **Image tags carry no `v` prefix.** A release publishes `3.17.7`, `3.17` and
 > `latest` (plus a `sha-…` tag per commit), while the release *assets* are named
-> after the `v3.17.5` git tag. Using `v3.17.5` as an image reference will simply
+> after the `v3.17.7` git tag. Using `v3.17.7` as an image reference will simply
 > not resolve.
 
 The development tags (`ghcr.io/rubentalstra/ferroehr:develop` and its two


### PR DESCRIPTION
The scheduled published-image scan found 15 fixable HIGH findings in `ferroehr-postgres`, all in inherited upstream layers. This PR remediates each finding by its class and adds the standing machinery so the next finding never waits on tribal knowledge.

## The findings, by class

| class | findings | remedy here |
|---|---|---|
| Debian packages, fix in trixie-security (`util-linux` family, CVE-2026-53615) | 9 | the image now applies Debian security updates at its own build time — verified locally: the rebuilt candidate scans at **0 findings** with the exact published-image-scan configuration (`trivy.yaml` + `.trivyignore.yaml` + VEX) |
| Go-stdlib advisories in the upstream-bundled `gosu` (fix = a Go rebuild only upstream can ship) | 6 | per-CVE reachability adjudication: `encoding/asn1`, `net/http`, `html/template`, `encoding/xml`, `net/url`, `crypto/tls` are all outside gosu's execute path (it sets uid/gid and execs; no sockets, no untrusted input) → path-scoped `.trivyignore.yaml` entries + OpenVEX statements (document version 3), which upstream's next gosu rebuild deletes |

## PostgreSQL 18.4 → 18.6

18.6 (2026-08-13) is the latest PG 18 patch — a security release fixing 28 CVEs; 18.5 was never released (post-wrap regression). Every pin site moves together: the digest-pinned `FROM` + base labels, the two CI service containers, `docs/VERSIONS.md` / `docs/postgres-features.md` / architecture / tech-stack docs, the served `PG_TARGET` (`18.6+`) and its test, the Helm README floor (chart `6.0.8`, goldens regenerated), the compose book page, and the testkit doc comment. The changelog carries the operator note from the upstream release notes: `btree_gist` indexes may need reindexing on in-place upgrades (our temporal keys use `btree_gist`).

## Standing machinery (the "always fixable" layer)

- **`.claude/rules/image-security.md`** — the remediation law per finding class, the base-bump pin-site checklist, the verification path.
- **`scripts/security/scan-images.sh`** — the published-image scan reproducible locally, against the published refs or a rebuilt `--candidate`; a fix is proven at 0 before it merges.
- **`.github/workflows/base-image-watcher.yml`** — Mondays 07:43: files/updates one issue when a newer postgres patch tag exists or the pinned tag is re-pointed upstream (zizmor + actionlint clean; issue-dedup pattern of the existing scan lane).
- **`scripts/checks/image-labels.sh`** — now also fails when the `ci.yml` postgres service pins drift from the Dockerfile `FROM`.

## En-route fix

The v3.17.7 release cut accidentally **replaced** the `## [3.17.6] - 2026-08-15` changelog heading instead of inserting above it, attributing all of 3.17.6's sections to 3.17.7 and failing `changelog-structure.sh` on develop. The heading is restored (verified against the `v3.17.6` tag's own changelog).

## Verification

- `docker build` + `scripts/security/scan-images.sh --candidate ferroehr-postgres:candidate` → **0 findings** (trivy 0.73.0, the lane's pin)
- `scripts/checks/image-labels.sh`, `changelog-structure.sh`, `spdx-headers.sh`, `no-python.sh`, `comment-style.sh` — all green
- `actionlint` + `zizmor --min-severity=low` on the touched/new workflows — clean
- `cargo clippy -p ferroehr --all-targets`, `cargo nextest run -p ferroehr -E 'test(build_info)'`, `cargo fmt --all` — green
- `deploy/helm/validate.sh --update` — all render checks pass; helm-docs regenerated

## Follow-up commits on this PR

- **h2 0.4.16** (RUSTSEC-2026-0258, in-range lock bump) and the stale kubernetes/verifying-releases book version pins — both pre-existing on develop, surfaced by this PR's CI.
- **AI-review round** (adjudicated, applied by hand per the AI-review rule): every lane now scans BOTH published platform variants (`linux/amd64` + `linux/arm64`) — the arm64 variant was previously scanned by nothing (#2412); `docker/postgres/README.md` re-synced with its own init script (the three group roles + the `audit` schema). The third suggestion (rewriting the book's transparency section into contributor instructions) was adjudicated INVALID against the docs-website audience rules and not taken.

Closes #2412

Closes #2408
Closes #2409
Closes #2410

