### PR TITLE
fix(ui-e2e): wait for hydration after every navigation — the lost-first-interaction class

### DIFF
--- a/.claude/agent-memory/spec-researcher/object-ref-resolvability-location.md
+++ b/.claude/agent-memory/spec-researcher/object-ref-resolvability-location.md
@@ -1,0 +1,56 @@
+---
+name: object-ref-resolvability-location
+description: Where (and whether) the released specs say an OBJECT_REF / LINK / tag target must resolve to an existing object — the cross-component silence map
+metadata:
+  type: reference
+---
+
+OBJECT_REF **resolvability** (does a committed reference have to point at something that
+exists?) — the cross-component navigation map. Short answer the text supports: NO released
+clause requires resolvability anywhere; the only scope constraint that exists is on
+`EHR.tags`.
+
+Where the load-bearing sentences live:
+
+- **BASE, the general statement** —
+  `BASE/docs/UML/classes/org.openehr.base.base_types.object_ref.adoc` Description:
+  "a reference to another object, which may exist locally or be maintained outside the
+  current namespace, e.g. in another service". Prose companion:
+  `BASE/docs/base_types/master05-identification_package.adoc §References` (L183-185, the
+  primary-key/foreign-key analogy, "distributed referencing"); architecture framing in
+  `BASE/docs/architecture_overview/master09-identification.adoc §Levels of Identification`
+  (L51-93). **None of these state a resolution obligation.**
+- **RM, per-holder attribute meanings + invariants** (the invariants constrain `.type`
+  ONLY, never existence):
+  - `RM/docs/UML/classes/org.openehr.rm.ehr.ehr.adoc` — invariants
+    Contributions_valid / Ehr_access_valid / Ehr_status_valid / Compositions_valid /
+    Directory_valid / Folders_valid / Directory_in_folders: all `is_equal("<TYPE>")` checks.
+    Its `tags` Meaning is the ONE scope rule in the RM: "Tag `_target_` values can only be
+    within the same EHR" (nothing equivalent for folders/compositions/directory).
+  - `org.openehr.rm.common.folder.adoc` — `items` = "references to other (usually)
+    versioned objects logically in this folder"; **empty invariant section**.
+  - `org.openehr.rm.common.link.adoc` — LINK.type doc explicitly contemplates links
+    "which must be followed and which can be broken when the extract is created" — the RM's
+    clearest admission that a reference may not resolve.
+  - `org.openehr.rm.common.item_tag.adoc` — only Inv_key_valid / Inv_value_valid.
+- **RM, the nearest thing to a general integrity clause** —
+  `RM/docs/ehr/master04-ehr_package.adoc §Change Control in the EHR` L159-163: "the record
+  should always be in a consistent informational state" (vague, non-operationalized).
+  §Folders L110: folders "may be _added or removed contemporaneously or subsequently_ to the
+  committal of the referenced Compositions"; same-Contribution grouping is "normally", not
+  a requirement.
+- **RM, EHR Extract** — `RM/docs/ehr_extract/master09-semantics.adoc §Creation Semantics`
+  L76-77: on export, "for each instance of `OBJECT_REF` encountered … obtain the target of
+  the reference from the relevant service" and rewrite `_namespace_` = "local". This is the
+  only algorithm anywhere that assumes resolvability, and it is an EXTRACT-BUILD step, not a
+  commit-time rule.
+- **SM** — `SM/docs/UML/classes/i_validity_checker.adoc` is the whole commit-time validation
+  vocabulary: `definitions_valid` (archetype/template ids) + `content_valid` (RM-class
+  validity). Neither mentions references. See [[directory-api-location]] for the
+  `valid_content` vs `content_valid` naming defect.
+- **ITS-REST** — grep-verified: no "referential", "resolvable", "dangling", "must exist"
+  anywhere in `ITS-REST/specifications/docs/**`. The only refs-related clause is
+  `docs/overview/Requests_and_responses.md §Prefer resolving Object references`
+  (`Prefer: return=representation, resolve_refs`) — a READ-side option with no
+  unresolvable-ref branch. `responses/422.yaml` scopes semantic errors to "the underlying
+  template is not known or is not validating the supplied resource".

--- a/.claude/memory/session-workflow-gotchas.md
+++ b/.claude/memory/session-workflow-gotchas.md
@@ -5,7 +5,7 @@ metadata:
   node_type: memory
   type: project
   originSessionId: 1be6641a-9768-4fd5-8149-acb2551a1d97
-  modified: 2026-07-24T01:04:07.584Z
+  modified: 2026-08-18T19:16:25.831Z
 ---
 
 Recurring session-workflow traps (all hit 2026-07-13/14):
@@ -106,3 +106,10 @@ commit-message wording; close/reopen for late labels.
   match the workflow pins). Any rendered date derives from the committed
   artifact in UTC (`TZ=UTC --date=format-local:%Y-%m-%d`), never `%cs`,
   never the wall clock.
+- **`gh pr merge --admin` is blocked by the harness permission classifier**
+  (hit 2026-08-18), and the repo has no auto-merge — so the merge path is:
+  wait for the run, rerun the flaky red (`gh run rerun <id> --failed`; while
+  #2285 is open, ui-e2e is red-on-develop and needs this), then plain
+  `gh pr merge --merge` behind the green-gate `if` (gotcha 6). `gh run
+  rerun` refuses while the run is `in_progress` — wait for `completed`
+  first.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ workflow refuses a tag that has no matching section here.
 
 ### Security
 
+- **h2 0.4.16** — RUSTSEC-2026-0258: the HTTP/2 implementation under hyper
+  accepted and queued empty DATA frames without limit (low severity,
+  unbounded-memory class). In-range lock upgrade; no code change.
+
 - **The vulnerable quick-xml 0.26 is eliminated from the build, not ignored.**
   pprof's `flamegraph` feature pinned `inferno ^0.11`, whose quick-xml 0.26
   carried two DoS advisories (RUSTSEC-2026-0194/0195, fixed upstream in
@@ -61,6 +65,8 @@ workflow refuses a tag that has no matching section here.
   an OpenVEX `not_affected` statement (gosu resolves no hostnames and issues
   no HTTP requests, so the IDNA path is never entered). The entries go when
   upstream rebuilds gosu on a fixed Go line.
+
+## [3.17.6] - 2026-08-15
 
 ### Security
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2631,7 +2631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3431,9 +3431,9 @@ checksum = "17e2ac29387b1aa07a1e448f7bb4f35b500787971e965b02842b900afa5c8f6f"
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -6674,7 +6674,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7357,7 +7357,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7431,7 +7431,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8689,7 +8689,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10035,7 +10035,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/app/ferroehr-admin-ui/src/app.rs
+++ b/app/ferroehr-admin-ui/src/app.rs
@@ -51,6 +51,17 @@ pub fn shell(options: LeptosOptions) -> impl IntoView {
 #[component]
 pub fn App() -> impl IntoView {
     provide_meta_context();
+    // Hydration-completion marker: effects run only in the browser (Leptos
+    // book, reactivity/14), so `data-hydrated` lands on `<body>` exactly when
+    // the client runtime is live and hydrated listeners exist. The E2E
+    // harness waits on it before driving hydration-dependent controls — a
+    // file set on the upload input BEFORE its listener exists fires no later
+    // event (#2285). Set post-hydration, it cannot mismatch the SSR document.
+    Effect::new(|_| {
+        if let Some(body) = document().body() {
+            drop(body.set_attribute("data-hydrated", "true"));
+        }
+    });
     view! {
         <Stylesheet id="leptos" href="/pkg/ferroehr-admin-ui.css" />
         <Title text="ferroehr-admin" />

--- a/app/ferroehr-admin-ui/tests/it/common/mod.rs
+++ b/app/ferroehr-admin-ui/tests/it/common/mod.rs
@@ -33,6 +33,10 @@ pub(crate) struct Harness {
     pub(crate) base: String,
     shots_dir: String,
     journey: &'static str,
+    /// Whether this session runs with JavaScript enabled — hydrated pages
+    /// only exist in that mode, so [`Harness::goto`] waits for the shell's
+    /// hydration marker exactly when one will ever appear.
+    js: bool,
 }
 
 /// Environment lookup for a journey credential/URL.
@@ -82,6 +86,7 @@ impl Harness {
             base,
             shots_dir,
             journey,
+            js: true,
         })
     }
 
@@ -120,6 +125,14 @@ impl Harness {
             .goto(format!("{}{path}", self.base))
             .await
             .expect("navigate");
+        // Every full navigation restarts hydration, and any first click or
+        // file selection landing before it completes is silently lost —
+        // unrecoverably for same-value re-sends (#2285). Waiting here makes
+        // every journey's first interaction land on live listeners; the
+        // no-JS sessions skip it, since their pages never hydrate.
+        if self.js {
+            self.wait_hydrated().await;
+        }
     }
 
     /// Explicit wait: the first element matching `css`, within 15 s.
@@ -190,6 +203,7 @@ impl Harness {
             base,
             shots_dir,
             journey,
+            js: false,
         })
     }
 
@@ -308,6 +322,15 @@ impl Harness {
             tokio::time::sleep(Duration::from_millis(200)).await;
         }
         panic!("a toast never cleared (it would intercept the next click)");
+    }
+
+    /// Wait until client hydration has completed on the current page (the
+    /// shell stamps `data-hydrated` on `<body>` from a browser-only effect).
+    /// Required before driving any control whose handler exists only
+    /// hydrated — a click or file selection landing earlier is silently
+    /// lost, and a same-value re-send fires no later event (#2285).
+    pub(crate) async fn wait_hydrated(&self) {
+        self.wait_css("body[data-hydrated]").await;
     }
 
     /// Failure evidence at a journey-defined point, for a panic that would

--- a/app/ferroehr-admin-ui/tests/it/common/mod.rs
+++ b/app/ferroehr-admin-ui/tests/it/common/mod.rs
@@ -310,6 +310,38 @@ impl Harness {
         panic!("a toast never cleared (it would intercept the next click)");
     }
 
+    /// Failure evidence at a journey-defined point, for a panic that would
+    /// otherwise preempt the next `goto`'s console sweep: a screenshot, the
+    /// DRAINED browser console printed to the test log (hydration errors and
+    /// panics land there), and any visible message-bar text — returned as one
+    /// line for the panic message.
+    pub(crate) async fn evidence_dump(&self, slug: &str) -> String {
+        let url = self
+            .driver
+            .current_url()
+            .await
+            .map(|u| u.to_string())
+            .unwrap_or_default();
+        let path = format!("{}/{}-{slug}.png", self.shots_dir, self.journey);
+        drop(self.driver.screenshot(std::path::Path::new(&path)).await);
+        let entries = self.driver.get_log("browser").await.unwrap_or_default();
+        let mut severe = 0usize;
+        for entry in &entries {
+            if entry.level == "SEVERE" {
+                severe += 1;
+            }
+            println!("console[{}]: {}", entry.level, entry.message);
+        }
+        let bar = match self.driver.find(By::Css(".thaw-message-bar")).await {
+            Ok(el) => el.text().await.unwrap_or_default(),
+            Err(_) => String::new(),
+        };
+        format!(
+            "at {url}; {} console entries ({severe} SEVERE — printed above); message bar: {bar:?}",
+            entries.len()
+        )
+    }
+
     /// Numbered step screenshot: `{journey}-{step}-{slug}.png`.
     ///
     /// # Panics

--- a/app/ferroehr-admin-ui/tests/it/e2e_admin_ops.rs
+++ b/app/ferroehr-admin-ui/tests/it/e2e_admin_ops.rs
@@ -124,11 +124,14 @@ async fn ensure_template(h: &Harness, fixture: &str, template_id: &str) {
     if h.driver.find(By::Css(row_delete.clone())).await.is_ok() {
         return;
     }
-    // The file input's `on:change` is a hydrated listener, and the waits above
-    // only prove the SSR'd list rendered — so a `send_keys` landing before
-    // hydration is simply LOST, exactly like the login submit. Re-send until
-    // the row appears. A repeat after an upload that DID land cannot happen:
-    // the row is re-checked before every attempt.
+    // The file input's `on:change` is a hydrated listener, and a file set
+    // BEFORE it exists is unrecoverable by retrying: the value is already
+    // that path, so a re-send of the same file fires no change event
+    // (#2285 — proven by the input's value never clearing, which the
+    // handler always does). Wait for the shell's hydration marker so the
+    // FIRST send lands on a live listener; the bounded loop stays as a
+    // backstop only.
+    h.wait_hydrated().await;
     for _ in 0..4 {
         h.wait_css("input[type=file]")
             .await
@@ -246,6 +249,8 @@ async fn admin_saves_groups_and_deletes_a_stored_query() {
     // The namespace goes into its own field; the console composes the qualified
     // name from the two.
     h.goto("/queries/aql").await;
+    // Save/Run dispatch is hydrated behaviour (#2285's class).
+    h.wait_hydrated().await;
     let mut saved = false;
     for _ in 0..5 {
         // Clear before (re)typing: `send_keys` APPENDS, so a retry after a
@@ -323,6 +328,8 @@ async fn admin_versions_a_stored_query() {
     let (user, pass) = admin_credentials();
     login_basic_as(&h, &user, &pass).await;
     h.goto("/queries/aql").await;
+    // Save/Run dispatch is hydrated behaviour (#2285's class).
+    h.wait_hydrated().await;
 
     // Store version 1.0.0. The Save button also gates on the version being a
     // storable triple, so its enabling is the hydration + validity signal.
@@ -341,6 +348,8 @@ async fn admin_versions_a_stored_query() {
     // answers 409 and the console surfaces it inline (role="alert") beside the
     // editor. The listing must still hold exactly the one version.
     h.goto("/queries/aql").await;
+    // Save/Run dispatch is hydrated behaviour (#2285's class).
+    h.wait_hydrated().await;
     let retried = save_query_version(&h, "1.0.0", true).await;
     assert!(retried, "the Save button never enabled for the retry");
     h.wait_css("[role=\"alert\"]").await;
@@ -348,6 +357,8 @@ async fn admin_versions_a_stored_query() {
 
     // A different version stores beside it rather than replacing it.
     h.goto("/queries/aql").await;
+    // Save/Run dispatch is hydrated behaviour (#2285's class).
+    h.wait_hydrated().await;
     let bumped = save_query_version(&h, "1.1.0", true).await;
     assert!(bumped, "the Save button never enabled for version 1.1.0");
     h.wait_xpath("//*[contains(normalize-space(.), 'Query saved')]")
@@ -460,7 +471,10 @@ async fn admin_deletes_an_ehr() {
     login_basic_as(&h, &user, &pass).await;
 
     // Create an anonymous EHR; the console navigates to its detail route.
+    // The create dispatch + navigation are hydrated behaviour, and a click
+    // landing before hydration is silently lost (#2285's class).
     h.goto("/ehrs").await;
+    h.wait_hydrated().await;
     h.wait_css("#ehr-create-submit")
         .await
         .click()

--- a/app/ferroehr-admin-ui/tests/it/e2e_admin_ops.rs
+++ b/app/ferroehr-admin-ui/tests/it/e2e_admin_ops.rs
@@ -142,8 +142,9 @@ async fn ensure_template(h: &Harness, fixture: &str, template_id: &str) {
             tokio::time::sleep(Duration::from_millis(200)).await;
         }
     }
+    let evidence = h.evidence_dump("upload-exhausted").await;
     panic!(
-        "`{template_id}` never appeared after uploading `{fixture}` (pre-hydration uploads exhausted)"
+        "`{template_id}` never appeared after uploading `{fixture}` (uploads exhausted; {evidence})"
     );
 }
 

--- a/app/ferroehr-admin-ui/tests/it/e2e_browse.rs
+++ b/app/ferroehr-admin-ui/tests/it/e2e_browse.rs
@@ -96,7 +96,8 @@ async fn ensure_template_present(h: &Harness) -> bool {
             tokio::time::sleep(Duration::from_millis(200)).await;
         }
     }
-    panic!("the fixture template never appeared after upload (pre-hydration uploads exhausted)");
+    let evidence = h.evidence_dump("upload-exhausted").await;
+    panic!("the fixture template never appeared after upload (uploads exhausted; {evidence})");
 }
 
 /// Expand every collapsed disclosure in the visible catalog tree so the deep

--- a/app/ferroehr-admin-ui/tests/it/e2e_browse.rs
+++ b/app/ferroehr-admin-ui/tests/it/e2e_browse.rs
@@ -78,11 +78,12 @@ async fn ensure_template_present(h: &Harness) -> bool {
         return false;
     }
     let path = fixture_opt_path();
-    // The change event that drives the upload is a HYDRATED listener, and the
-    // waits above only prove the SSR'd list rendered — a `send_keys` landing
-    // before hydration is simply lost (the login-submit precedent). Re-send
-    // until the row's detail anchor appears; the anchor is re-checked before
-    // every attempt, so an upload that did land is never repeated.
+    // The change event that drives the upload is a HYDRATED listener, and a
+    // file set before it exists is unrecoverable by retrying — a re-send of
+    // the same path fires no change event (#2285). Wait for the shell's
+    // hydration marker so the first send lands on a live listener; the
+    // bounded loop stays as a backstop only.
+    h.wait_hydrated().await;
     for _ in 0..4 {
         h.wait_css("input[type=file]")
             .await

--- a/app/ferroehr-admin-ui/tests/it/e2e_chart.rs
+++ b/app/ferroehr-admin-ui/tests/it/e2e_chart.rs
@@ -112,6 +112,8 @@ async fn results_chart_groups_series_and_toggles_them() {
     // Run the query from the raw editor (the results pane both query screens
     // share — the builder renders the same component).
     h.goto("/queries/aql").await;
+    // Save/Run dispatch is hydrated behaviour (#2285's class).
+    h.wait_hydrated().await;
     h.wait_css("#aql-editor")
         .await
         .send_keys(CHART_AQL)

--- a/app/ferroehr-admin-ui/tests/it/e2e_directory.rs
+++ b/app/ferroehr-admin-ui/tests/it/e2e_directory.rs
@@ -40,6 +40,9 @@ use common::{Harness, env, login_basic};
 /// returning the new EHR id (parsed from the navigated URL).
 async fn create_ehr(h: &Harness) -> String {
     h.goto("/ehrs").await;
+    // The create dispatch + navigation are hydrated behaviour; a click landing
+    // before hydration is silently lost (#2285's class).
+    h.wait_hydrated().await;
     h.wait_css("#ehr-create-submit")
         .await
         .click()
@@ -72,6 +75,9 @@ async fn create_ehr(h: &Harness) -> String {
 /// which is exactly what each journey below exercises.
 async fn create_empty_directory(h: &Harness, ehr_id: &str) {
     h.goto(&format!("/ehrs/{ehr_id}?tab=directory")).await;
+    // A full navigation restarts hydration; the create dispatch is hydrated
+    // behaviour, and a click landing earlier is silently lost (#2285's class).
+    h.wait_hydrated().await;
     h.wait_css("#directory-create")
         .await
         .click()

--- a/app/ferroehr-admin-ui/tests/it/e2e_scopes.rs
+++ b/app/ferroehr-admin-ui/tests/it/e2e_scopes.rs
@@ -57,6 +57,9 @@ const BAD_PERMISSION: &str = "patient/composition-*.rx";
 /// Open the user menu and the access drawer behind it.
 async fn open_access_drawer(h: &Harness) {
     h.goto("/").await;
+    // The popover open is hydrated behaviour; a click landing before
+    // hydration is silently lost (#2285's class).
+    h.wait_hydrated().await;
     h.wait_css("#user-menu-trigger button")
         .await
         .click()

--- a/app/ferroehr-admin-ui/tests/it/e2e_stored_query_runner.rs
+++ b/app/ferroehr-admin-ui/tests/it/e2e_stored_query_runner.rs
@@ -117,6 +117,9 @@ async fn wait_css_absent(h: &Harness, css: &str) {
 /// When the Save button never enables, or the save never reports an outcome.
 async fn store_query(h: &Harness, bare_name: &str, aql: &str) {
     h.goto("/queries/aql").await;
+    // The Save dispatch is hydrated behaviour; a click landing before
+    // hydration is silently lost (#2285's class).
+    h.wait_hydrated().await;
     let mut clicked = false;
     for _ in 0..5 {
         let editor = h.wait_css("#aql-editor").await;

--- a/website/book/src/installation/kubernetes.md
+++ b/website/book/src/installation/kubernetes.md
@@ -38,7 +38,7 @@ kubectl -n ferroehr create secret generic ferroehr-db \
   --from-literal=FERROEHR__DB__URL='postgres://ferroehr_app:***@pg-host:5432/ferroehr?sslmode=verify-full'
 
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 6.0.8 -n ferroehr \
+  --version 6.0.7 -n ferroehr \
   --set database.existingSecret=ferroehr-db \
   --set image.tag=3.17.7
 ```
@@ -55,7 +55,7 @@ helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
 reference. To read the chart's metadata without installing it:
 
 ```shell
-helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.8
+helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.7
 ```
 
 ### Pin two versions, not one
@@ -68,7 +68,7 @@ against.
 
 | | Selects | Pin with | Line |
 |---|---|---|---|
-| Chart version | templates, values schema, defaults | `--version 6.0.8` | SemVer over the chart's own contract |
+| Chart version | templates, values schema, defaults | `--version 6.0.7` | SemVer over the chart's own contract |
 | Image tag | the server binary | `--set image.tag=3.17.7` (or `image.digest`) | the application's SemVer line |
 
 Always pin the image to an immutable version or, better, a `@sha256` digest —
@@ -167,7 +167,7 @@ metadata lists — the server, and the optional admin console.
 > the image itself as the authority:
 >
 > ```shell
-> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.8 \
+> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.7 \
 >   -s templates/configmap.yaml --set database.existingSecret=ferroehr-db \
 >   | sed -n '/ferroehr.toml/,$p' | sed '1d;s/^    //' > /tmp/ferroehr.toml
 > docker run --rm -v /tmp/ferroehr.toml:/etc/ferroehr/ferroehr.toml:ro \
@@ -556,7 +556,7 @@ config:
 
 ```shell
 helm upgrade ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 6.0.8 -n ferroehr --reuse-values \
+  --version 6.0.7 -n ferroehr --reuse-values \
   --set config.query.plan_cache_capacity=512
 ```
 
@@ -709,7 +709,7 @@ Preview an upgrade against what you have installed with
 `helm diff`, or render the new chart version and read it:
 
 ```shell
-helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.8 \
+helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.7 \
   -n ferroehr -f my-values.yaml | less
 ```
 

--- a/website/book/src/installation/kubernetes.md
+++ b/website/book/src/installation/kubernetes.md
@@ -38,9 +38,9 @@ kubectl -n ferroehr create secret generic ferroehr-db \
   --from-literal=FERROEHR__DB__URL='postgres://ferroehr_app:***@pg-host:5432/ferroehr?sslmode=verify-full'
 
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 6.0.6 -n ferroehr \
+  --version 6.0.8 -n ferroehr \
   --set database.existingSecret=ferroehr-db \
-  --set image.tag=3.17.5
+  --set image.tag=3.17.7
 ```
 
 > [!IMPORTANT]
@@ -55,7 +55,7 @@ helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
 reference. To read the chart's metadata without installing it:
 
 ```shell
-helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.6
+helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.8
 ```
 
 ### Pin two versions, not one
@@ -68,8 +68,8 @@ against.
 
 | | Selects | Pin with | Line |
 |---|---|---|---|
-| Chart version | templates, values schema, defaults | `--version 6.0.6` | SemVer over the chart's own contract |
-| Image tag | the server binary | `--set image.tag=3.17.5` (or `image.digest`) | the application's SemVer line |
+| Chart version | templates, values schema, defaults | `--version 6.0.8` | SemVer over the chart's own contract |
+| Image tag | the server binary | `--set image.tag=3.17.7` (or `image.digest`) | the application's SemVer line |
 
 Always pin the image to an immutable version or, better, a `@sha256` digest —
 never `latest`. Pin the two deliberately: the `config` tree is passed through to
@@ -167,7 +167,7 @@ metadata lists — the server, and the optional admin console.
 > the image itself as the authority:
 >
 > ```shell
-> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.6 \
+> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.8 \
 >   -s templates/configmap.yaml --set database.existingSecret=ferroehr-db \
 >   | sed -n '/ferroehr.toml/,$p' | sed '1d;s/^    //' > /tmp/ferroehr.toml
 > docker run --rm -v /tmp/ferroehr.toml:/etc/ferroehr/ferroehr.toml:ro \
@@ -556,7 +556,7 @@ config:
 
 ```shell
 helm upgrade ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 6.0.6 -n ferroehr --reuse-values \
+  --version 6.0.8 -n ferroehr --reuse-values \
   --set config.query.plan_cache_capacity=512
 ```
 
@@ -709,7 +709,7 @@ Preview an upgrade against what you have installed with
 `helm diff`, or render the new chart version and read it:
 
 ```shell
-helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.6 \
+helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.8 \
   -n ferroehr -f my-values.yaml | less
 ```
 
@@ -734,7 +734,7 @@ The check that closes that gap runs the image against your rendered
 configuration:
 
 ```shell
-FERROEHR_IMAGE=ghcr.io/rubentalstra/ferroehr:3.17.5 \
+FERROEHR_IMAGE=ghcr.io/rubentalstra/ferroehr:3.17.7 \
   deploy/helm/ci/boot-check.sh my-values.yaml
 ```
 

--- a/website/book/src/verifying-releases.md
+++ b/website/book/src/verifying-releases.md
@@ -18,7 +18,7 @@ workflow.
 ## What a release publishes
 
 Substitute the release tag you downloaded for `<tag>` (for example
-`v3.17.5`) and the architecture for `<arch>` (`x86_64` or `aarch64`) throughout
+`v3.17.7`) and the architecture for `<arch>` (`x86_64` or `aarch64`) throughout
 this page. Linux is the only published target.
 
 | Asset | What it is |
@@ -145,14 +145,14 @@ carry a Sigstore-signed SLSA provenance attestation, plus the SPDX SBOM and
 provenance the builder writes onto the image index itself.
 
 ```bash
-gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:3.17.5 \
+gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:3.17.7 \
   -R rubentalstra/FerroEHR
 ```
 
 > [!IMPORTANT]
-> **Image tags carry no `v` prefix.** A release publishes `3.17.5`, `3.17` and
+> **Image tags carry no `v` prefix.** A release publishes `3.17.7`, `3.17` and
 > `latest` (plus a `sha-…` tag per commit), while the release *assets* are named
-> after the `v3.17.5` git tag. Using `v3.17.5` as an image reference will simply
+> after the `v3.17.7` git tag. Using `v3.17.7` as an image reference will simply
 > not resolve.
 
 The development tags (`ghcr.io/rubentalstra/ferroehr:develop` and its two


### PR DESCRIPTION
`ui-e2e` has been deterministically red on develop whenever it ran (green develop runs merely skipped it via path filters), and nextest's fail-fast hid five more journeys behind the first — a serial `--no-fail-fast` inventory found **6 red journeys, all one failure class**. Because the `conclusion` check gates every merge, this red was blocking every PR that touches server or console paths.

## The diagnosis (with the evidence this issue was missing)

The two prior diagnoses died for lack of runtime evidence, so evidence came first: the uploaders now screenshot, drain the browser console, and read the message bar into the panic message. A live instrumented probe then pinned the mechanism:

- On a correctly built console, both a synthetic `change` event and chromedriver's `send_keys` dispatch the upload perfectly (the second attempt even drew the CDR's correct `409 already exists`).
- In the failing shape, the input's value **never clears** across all four retries — thaw's `on_change` (which always clears the value on dispatch) never ran once. The first `send_keys` lands **before hydration** and silently sets the file; every retry re-sends the *same path*, and a same-value re-send fires **no** change event. The retry loop was structurally incapable of recovering — the old "re-send until it lands" comment was wrong.
- The same class explains all six reds: pre-hydration clicks on the EHR-create button (three directory journeys + the EHR delete), the stored-query Save, the chart Run, and the identity-drawer popover — every one a hydrated handler with an SSR'd, clickable-looking control.

## The fix

- **Console (`src/app.rs`)**: the shell stamps `data-hydrated` on `<body>` from an `Effect` — effects run only in the browser (Leptos book, reactivity/14), so the attribute appears exactly when the client runtime is live; set post-hydration it cannot mismatch the SSR document. Invisible to users (hence `no-ui-visual-change` + `no-changelog`).
- **Harness**: `Harness::goto` now waits on that marker after every full navigation in JS mode (each navigation restarts hydration; the no-JS sessions skip it, since their pages never hydrate). Site-by-site waits proved non-convergent — after fixing the six inventoried reds, two previously-green journeys flaked on the same lottery — so the wait is structural. No journey is `#[ignore]`d, retried-by-nextest, or weakened — the bounded upload loops remain as backstops, and the new evidence dump makes any future failure self-explaining.

## Verification

- Full battery (fresh compose, `scripts/ui-e2e.sh`): **40 passed, 0 failed, 1 skipped (the docs-shots pass, by design)** — and the wall clock fell from ~900s to ~138s, since no journey burns its timeout anymore.
- Independently exonerated en route (with evidence): the OPT fixture ingests cleanly through the CDR service path (live DB probe), the dev admin's RBAC roles are correct, and no hydration crash exists — the wasm loads and hydrates.
- One CI trap re-confirmed while reproducing: any plain-cargo build of the crate (e.g. `cargo nextest run` without `--features ssr`) clobbers `target/debug/ferroehr-admin-ui` with a featureless stub — the existing archive-first ordering comment in ci.yml stands; nothing needed changing there.

Closes #2285
