### PR TITLE
release: v3.17.8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,17 +22,15 @@ updates:
       semver-major-days: 14
     open-pull-requests-limit: 10
     groups:
-      # Batch related ecosystems so lockstep crates bump together.
-      opentelemetry:
-        patterns: ["opentelemetry*", "tracing-opentelemetry"]
-      axum-tower:
-        patterns: ["axum*", "tower*", "hyper*"]
-      utoipa:
-        patterns: ["utoipa*"]
-      sea:
-        patterns: ["sea-query*"]
-      serde:
-        patterns: ["serde*"]
+      # ONE weekly PR for every minor/patch bump (#2434 — thirteen open
+      # single-crate PRs at once is review theatre, not review). Lockstep
+      # families (opentelemetry, serde, axum/tower, utoipa, sea-query) bump
+      # together inside it by construction. MAJORS stay individual: a semver
+      # major in shipped code is a real review, and burying one in a batch
+      # is how it gets rubber-stamped.
+      cargo-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
     commit-message:
       prefix: "deps"          # plain conventional prefix; no attribution
   # The fuzz harnesses are their OWN Cargo workspace with their own lock file
@@ -56,6 +54,12 @@ updates:
       default-days: 7
       semver-major-days: 14
     open-pull-requests-limit: 5
+    groups:
+      # The harnesses are dev-only tooling in their own workspace: every
+      # update class rides one weekly PR (#2434) — the harnesses compile on
+      # the PR path, so a breaking bump fails that one PR visibly.
+      fuzz-all:
+        patterns: ["*"]
     commit-message:
       prefix: "deps"
   # The three container base images are pinned by digest, which is what earns
@@ -80,6 +84,11 @@ updates:
     cooldown:
       default-days: 5
     open-pull-requests-limit: 5
+    groups:
+      # The three base images move together in one weekly PR (#2434); each
+      # bump is still reviewed against a build and a Trivy scan before merge.
+      base-images:
+        patterns: ["*"]
     commit-message:
       prefix: "deps"
   - package-ecosystem: "github-actions"
@@ -90,5 +99,11 @@ updates:
     # and these are digest-pinned, so a bump is a reviewed change of digest.
     cooldown:
       default-days: 3
+    groups:
+      # One weekly PR for every action bump (#2434 — one codeql-action release
+      # alone used to open three PRs, one per sub-action). A breaking action
+      # major fails the lanes on that one PR, visibly.
+      actions-all:
+        patterns: ["*"]
     commit-message:
       prefix: "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1284,9 +1284,23 @@ jobs:
           target: runtime-prebuilt
           load: true
           tags: ferroehr:deploy-probe
+      # The database image THIS TREE defines, packaged like the app image —
+      # the compose fallback names the RELEASE tag, which a release PR flips
+      # before that tag's images exist (found on the v3.17.8 cut: every
+      # posture's stack sat on a manifest-unknown postgres pull until the
+      # probe timed out). Native amd64 build; the Dockerfile's security
+      # upgrade runs in minutes.
+      - name: Package the postgres image (base + security updates)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: docker/postgres
+          file: docker/postgres/Dockerfile
+          load: true
+          tags: ferroehr-postgres:deploy-probe
       - name: Probe the deployment
         env:
           FERROEHR_IMAGE: ferroehr:deploy-probe
+          FERROEHR_POSTGRES_IMAGE: ferroehr-postgres:deploy-probe
         run: bash scripts/deploy-probe.sh
       # The RECORD, always — a failed run is exactly when the per-probe layer
       # attribution and the not-exercised ledger are worth reading.

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -4,8 +4,8 @@
   "language": "eng",
   "title": "FerroEHR",
   "description": "<p>A pure-Rust, openEHR-specification-conformant clinical data repository (CDR): ITS-REST 1.1.0 REST API, AQL 1.1 query language, and the openEHR RM 1.2.0 reference model on PostgreSQL-18-native storage. The openEHR specification layer is generated from the official machine-readable specifications, and conformance is machine-verified per release by a built-in CNF conformance runner.</p>",
-  "publication_date": "2026-08-15",
-  "version": "3.17.7",
+  "publication_date": "2026-08-19",
+  "version": "3.17.8",
   "creators": [
     {
       "name": "Talstra, Ruben",
@@ -39,7 +39,7 @@
       "resource_type": "publication-softwaredocumentation"
     },
     {
-      "identifier": "https://github.com/rubentalstra/FerroEHR/tree/v3.17.7",
+      "identifier": "https://github.com/rubentalstra/FerroEHR/tree/v3.17.8",
       "relation": "isSupplementTo",
       "resource_type": "software"
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ workflow refuses a tag that has no matching section here.
 
 ## [3.17.8] - 2026-08-19
 
+### Fixed
+
+- **The quickstart's S3 bucket initializer no longer races the gateway.**
+  `seaweedfs-init` retried nothing: the gateway's healthcheck only proves
+  the S3 port answers, and a single-shot CreateBucket against a still-warming
+  filer could fail once and never run again, leaving every multimedia commit
+  against a missing bucket. The initializer now retries until the bucket is
+  verifiably listable (the same read the deployment probe makes) and exits
+  loudly after 30 attempts — verified over repeated fresh-volume compose
+  cycles.
+
 ### Added
 
 - **Directory folder references that claim this system must now resolve.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,9 @@ workflow refuses a tag that has no matching section here.
   invalidation). Operators upgrading an existing cluster in place should note
   the upstream release notes advise checking (and possibly reindexing)
   `btree_gist` indexes — the temporal `vo_version` keys use `btree_gist`.
-- **Helm chart `6.0.8`** — no template changes: the chart README now states
-  the PostgreSQL floor as 18.6.
+- **Helm chart `6.0.9`** — no template changes: `appVersion` moves to
+  3.17.8 and the chart README states the PostgreSQL floor as 18.6 (6.0.8
+  was cut mid-cycle and never published; the publish lane ships 6.0.9).
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+## [3.17.8] - 2026-08-19
+
 ### Added
 
 - **Directory folder references that claim this system must now resolve.**
@@ -6770,7 +6772,8 @@ but has not yet run in production.
   seccomp, default-deny NetworkPolicy) and golden-render validation.
 
 
-[unreleased]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.7...HEAD
+[unreleased]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.8...HEAD
+[3.17.8]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.7...v3.17.8
 [3.17.7]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.6...v3.17.7
 [3.17.6]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.5...v3.17.6
 [3.17.5]: https://github.com/rubentalstra/FerroEHR/compare/v3.17.4...v3.17.5

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -37,5 +37,5 @@ keywords:
   - ITS-REST
   - Rust
   - PostgreSQL
-version: 3.17.7
-date-released: 2026-08-15
+version: 3.17.8
+date-released: 2026-08-19

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "cnf-runner"
-version = "3.17.7"
+version = "3.17.8"
 dependencies = [
  "assert_fs",
  "base64 0.23.1",
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "docs-meta"
-version = "3.17.7"
+version = "3.17.8"
 
 [[package]]
 name = "dotenvy"
@@ -2683,7 +2683,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ferroehr"
-version = "3.17.7"
+version = "3.17.8"
 dependencies = [
  "argon2",
  "assert_fs",
@@ -2756,7 +2756,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-admin-ui"
-version = "3.17.7"
+version = "3.17.8"
 dependencies = [
  "anyhow",
  "axum",
@@ -2798,7 +2798,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-ext"
-version = "3.17.7"
+version = "3.17.8"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2822,7 +2822,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-rest"
-version = "3.17.7"
+version = "3.17.8"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -2882,7 +2882,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-server"
-version = "3.17.7"
+version = "3.17.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -5536,7 +5536,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-codegen"
-version = "3.17.7"
+version = "3.17.8"
 dependencies = [
  "roxmltree",
  "serde_json",
@@ -8749,7 +8749,7 @@ dependencies = [
 
 [[package]]
 name = "testkit"
-version = "3.17.7"
+version = "3.17.8"
 dependencies = [
  "ferroehr",
  "jiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "3"
 members = ["crates/*", "app/*", "tools/*"]
 
 [workspace.package]
-version = "3.17.7"
+version = "3.17.8"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT"

--- a/app/ferroehr-rest/tests/it/directory_http.rs
+++ b/app/ferroehr-rest/tests/it/directory_http.rs
@@ -109,10 +109,15 @@ fn dv_text(value: &str) -> Value {
 /// A FOLDER `items` member — an `OBJECT_REF` to a COMPOSITION (RM ehr master04
 /// §Folders: Folder structures hold references to `VERSIONED_OBJECT`s, never
 /// content by value).
+///
+/// NOTE: the namespace is a FOREIGN system (register AMB-211, issue #1951): a
+/// reference claiming THIS system must resolve, so a fabricated id rides a
+/// foreign namespace — this suite's subject is the wire mechanics, not
+/// referential validity (covered by `directory_item_refs` + the CNF twins).
 fn composition_ref(id: &str) -> Value {
     json!({
         "_type": "OBJECT_REF",
-        "namespace": "local",
+        "namespace": "another.system.example.org",
         "type": "COMPOSITION",
         "id": { "_type": "HIER_OBJECT_ID", "value": id }
     })

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -26,7 +26,7 @@ version: 6.0.8
 # previous image. It is NOT a promise that this tag accepts the chart's current
 # `config` defaults: values track development between releases, so the publish
 # lane re-checks the pairing against the image itself.
-appVersion: "3.17.7"
+appVersion: "3.17.8"
 
 # A COMPATIBILITY floor, and a real one: 1.36 is the release where the newest
 # field this chart renders became stable.
@@ -136,7 +136,7 @@ annotations:
   # scan while leaving the false claim in place, so it is deliberately not used.
   artifacthub.io/images: |
     - name: ferroehr
-      image: ghcr.io/rubentalstra/ferroehr:3.17.7
+      image: ghcr.io/rubentalstra/ferroehr:3.17.8
       platforms:
         - linux/amd64
         - linux/arm64
@@ -145,7 +145,7 @@ annotations:
     # visible to anyone considering it. See #2193: this chart cannot deploy it
     # yet, so today the entry advertises intent rather than chart behaviour.
     - name: ferroehr-admin-ui
-      image: ghcr.io/rubentalstra/ferroehr-admin-ui:3.17.7
+      image: ghcr.io/rubentalstra/ferroehr-admin-ui:3.17.8
       platforms:
         - linux/amd64
         - linux/arm64

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # A published OCI version is immutable by refusal rather than by the registry —
 # `helm push` over an existing tag replaces it silently — so a correction always
 # ships as a NEW version and the published one stands as it was.
-version: 6.0.8
+version: 6.0.9
 # The default container image tag (overridable via image.tag), and the released
 # application version — kept equal to the workspace version by the
 # `chart-appversion` CI guard, so a release cannot ship a chart pointing at the

--- a/deploy/helm/ferroehr/README.md
+++ b/deploy/helm/ferroehr/README.md
@@ -2,7 +2,7 @@
 
 Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.1.0 + AQL 1.1). A single static binary deployed with a hardened-by-default security posture: runs as a non-root, read-only-rootfs workload whose NetworkPolicy admits its serving port only, and that connects to an EXTERNAL PostgreSQL 18 as an unprivileged app role (migrations are run out of band by a separate migrator role).
 
-![Version: 6.0.8](https://img.shields.io/badge/Version-6.0.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.17.8](https://img.shields.io/badge/AppVersion-3.17.8-informational?style=flat-square)
+![Version: 6.0.9](https://img.shields.io/badge/Version-6.0.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.17.8](https://img.shields.io/badge/AppVersion-3.17.8-informational?style=flat-square)
 
 FerroEHR is a pure-Rust openEHR Clinical Data Repository: ITS-REST 1.1.0 at the
 API, AQL 1.1 as the query language, PostgreSQL 18-native storage, shipped as a
@@ -33,7 +33,7 @@ add — `helm repo add` does not apply to this chart and never will:
 
 ```console
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 6.0.8 \
+  --version 6.0.9 \
   --namespace ferroehr --create-namespace \
   --set database.existingSecret=ferroehr-db \
   --set image.tag=3.17.8
@@ -47,7 +47,7 @@ They are independent SemVer lines and they move independently:
 
 | What | Set with | This release |
 |---|---|---|
-| the **chart** (templates, defaults, this document) | `--version` | `6.0.8` |
+| the **chart** (templates, defaults, this document) | `--version` | `6.0.9` |
 | the **server image** | `image.tag` | `3.17.8` |
 
 `appVersion` is the image the chart defaults to; pinning `image.tag` explicitly
@@ -59,7 +59,7 @@ The chart carries two keyless Sigstore artifacts, and they answer different
 questions. A **cosign signature** — who signed this:
 
 ```console
-cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.8 \
+cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.9 \
   --certificate-identity-regexp '^https://github\.com/rubentalstra/FerroEHR/\.github/workflows/publish-chart\.yml@' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
@@ -67,7 +67,7 @@ cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.8 \
 A **SLSA build provenance attestation** — what source it was built from, and how:
 
 ```console
-gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:6.0.8 \
+gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:6.0.9 \
   -R rubentalstra/FerroEHR
 gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:3.17.8 \
   -R rubentalstra/FerroEHR

--- a/deploy/helm/ferroehr/README.md
+++ b/deploy/helm/ferroehr/README.md
@@ -2,7 +2,7 @@
 
 Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.1.0 + AQL 1.1). A single static binary deployed with a hardened-by-default security posture: runs as a non-root, read-only-rootfs workload whose NetworkPolicy admits its serving port only, and that connects to an EXTERNAL PostgreSQL 18 as an unprivileged app role (migrations are run out of band by a separate migrator role).
 
-![Version: 6.0.8](https://img.shields.io/badge/Version-6.0.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.17.7](https://img.shields.io/badge/AppVersion-3.17.7-informational?style=flat-square)
+![Version: 6.0.8](https://img.shields.io/badge/Version-6.0.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.17.8](https://img.shields.io/badge/AppVersion-3.17.8-informational?style=flat-square)
 
 FerroEHR is a pure-Rust openEHR Clinical Data Repository: ITS-REST 1.1.0 at the
 API, AQL 1.1 as the query language, PostgreSQL 18-native storage, shipped as a
@@ -36,7 +36,7 @@ helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
   --version 6.0.8 \
   --namespace ferroehr --create-namespace \
   --set database.existingSecret=ferroehr-db \
-  --set image.tag=3.17.7
+  --set image.tag=3.17.8
 ```
 
 OCI registries require Helm 3.8 or newer.
@@ -48,7 +48,7 @@ They are independent SemVer lines and they move independently:
 | What | Set with | This release |
 |---|---|---|
 | the **chart** (templates, defaults, this document) | `--version` | `6.0.8` |
-| the **server image** | `image.tag` | `3.17.7` |
+| the **server image** | `image.tag` | `3.17.8` |
 
 `appVersion` is the image the chart defaults to; pinning `image.tag` explicitly
 is what keeps an upgrade of one from silently moving the other.
@@ -69,7 +69,7 @@ A **SLSA build provenance attestation** — what source it was built from, and h
 ```console
 gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:6.0.8 \
   -R rubentalstra/FerroEHR
-gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:3.17.7 \
+gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:3.17.8 \
   -R rubentalstra/FerroEHR
 ```
 

--- a/deploy/helm/golden/admin-ui.yaml
+++ b/deploy/helm/golden/admin-ui.yaml
@@ -18,7 +18,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the admin console: only its HTTP port, but from EVERY source — this policy narrows ports, NOT sources (adminUi.networkPolicy.ingressAllowAll=true). Set adminUi.networkPolicy.ingressFrom for a PHI workload. Egress admits the CDR Service and DNS only.
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"
@@ -90,7 +90,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"
@@ -118,7 +118,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"
@@ -139,7 +139,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr-admin-ui
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"
@@ -154,7 +154,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"
@@ -184,7 +184,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"
@@ -201,7 +201,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"
@@ -332,7 +332,7 @@ metadata:
     kubernetes.io/description: >-
       In-cluster address for the FerroEHR admin console. The console is a REST client of the CDR and holds no data of its own; it is the human-facing surface, so this is the Service an Ingress normally publishes.
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"
@@ -355,7 +355,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"
@@ -385,7 +385,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR admin console: a Leptos SSR web UI that consumes the CDR strictly over ITS-REST. It never reaches the database, which the console NetworkPolicy enforces rather than assumes.
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"
@@ -492,7 +492,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"

--- a/deploy/helm/golden/admin-ui.yaml
+++ b/deploy/helm/golden/admin-ui.yaml
@@ -21,7 +21,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -93,7 +93,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -121,7 +121,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -142,7 +142,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -157,7 +157,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 automountServiceAccountToken: false
@@ -187,7 +187,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -204,7 +204,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -335,7 +335,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -358,7 +358,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -388,7 +388,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -424,7 +424,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: admin-ui
-          image: "ghcr.io/rubentalstra/ferroehr-admin-ui:3.17.7"
+          image: "ghcr.io/rubentalstra/ferroehr-admin-ui:3.17.8"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -495,7 +495,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -543,7 +543,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:3.17.7"
+          image: "ghcr.io/rubentalstra/ferroehr:3.17.8"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -26,7 +26,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -100,7 +100,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -121,7 +121,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -153,7 +153,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -179,7 +179,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -200,7 +200,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -391,7 +391,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -425,7 +425,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -475,7 +475,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:3.17.7"
+          image: "ghcr.io/rubentalstra/ferroehr:3.17.8"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -656,7 +656,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -690,7 +690,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -728,7 +728,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     release: kube-prometheus-stack

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), and only from the networkPolicy.ingressFrom peers.
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"
@@ -97,7 +97,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"
@@ -118,7 +118,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"
@@ -150,7 +150,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"
@@ -176,7 +176,7 @@ kind: Secret
 metadata:
   name: ferroehr-config
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"
@@ -197,7 +197,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"
@@ -388,7 +388,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"
@@ -422,7 +422,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"
@@ -653,7 +653,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"
@@ -687,7 +687,7 @@ kind: Ingress
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"
@@ -725,7 +725,7 @@ kind: ServiceMonitor
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"

--- a/deploy/helm/golden/basic-auth.yaml
+++ b/deploy/helm/golden/basic-auth.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"
@@ -51,7 +51,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"
@@ -72,7 +72,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"
@@ -102,7 +102,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"
@@ -119,7 +119,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"
@@ -247,7 +247,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"
@@ -277,7 +277,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"

--- a/deploy/helm/golden/basic-auth.yaml
+++ b/deploy/helm/golden/basic-auth.yaml
@@ -26,7 +26,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -54,7 +54,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -75,7 +75,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 automountServiceAccountToken: false
@@ -105,7 +105,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -122,7 +122,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -250,7 +250,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -280,7 +280,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -328,7 +328,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:3.17.7"
+          image: "ghcr.io/rubentalstra/ferroehr:3.17.8"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -26,7 +26,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -54,7 +54,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -75,7 +75,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 automountServiceAccountToken: false
@@ -90,7 +90,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -215,7 +215,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -245,7 +245,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.8
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.8"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -293,7 +293,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:3.17.7"
+          image: "ghcr.io/rubentalstra/ferroehr:3.17.8"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"
@@ -51,7 +51,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"
@@ -72,7 +72,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"
@@ -87,7 +87,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"
@@ -212,7 +212,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"
@@ -242,7 +242,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.8
+    helm.sh/chart: ferroehr-6.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "3.17.8"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,7 @@
 
 services:
   ferroehr-postgres:
-    image: ${FERROEHR_POSTGRES_IMAGE:-ghcr.io/rubentalstra/ferroehr-postgres:3.17.7}
+    image: ${FERROEHR_POSTGRES_IMAGE:-ghcr.io/rubentalstra/ferroehr-postgres:3.17.8}
     # Docker's default 64MB /dev/shm starves PostgreSQL's dynamic shared
     # memory under load (parallel workers error `could not resize shared
     # memory segment … No space left on device`); measured runs share this
@@ -154,7 +154,7 @@ services:
       start_period: 10s
 
   ferroehr:
-    image: ${FERROEHR_IMAGE:-ghcr.io/rubentalstra/ferroehr:3.17.7}
+    image: ${FERROEHR_IMAGE:-ghcr.io/rubentalstra/ferroehr:3.17.8}
     depends_on:
       ferroehr-postgres:
         condition: service_healthy
@@ -252,7 +252,7 @@ services:
   # FERROEHR_ADMIN__AUTH__OIDC__* variables at your identity provider.
   ferroehr-admin-ui:
     profiles: [admin-ui]
-    image: ${FERROEHR_ADMIN_UI_IMAGE:-ghcr.io/rubentalstra/ferroehr-admin-ui:3.17.7}
+    image: ${FERROEHR_ADMIN_UI_IMAGE:-ghcr.io/rubentalstra/ferroehr-admin-ui:3.17.8}
     depends_on:
       ferroehr:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -325,15 +325,26 @@ services:
     depends_on:
       seaweedfs:
         condition: service_healthy
-    # --fail-with-body: a non-2xx must fail the service loudly, with the
-    # gateway's own XML error, instead of exiting 0 on an error page.
-    entrypoint: ["curl"]
+    # Retry until the bucket is VERIFIABLY listable, not just until the PUT
+    # returns: the gateway's healthcheck only proves the S3 port answers,
+    # and the filer behind it can still be warming up — a single-shot
+    # CreateBucket against that window failed once and nothing retried
+    # (restart "no"), leaving every multimedia commit against a missing
+    # bucket (#2420; the create is idempotent per the AWS CreateBucket
+    # semantics cited above, so re-PUTting is a no-op). The trailing GET is
+    # the same 200-vs-404 read the deployment probe makes, so this service
+    # exits 0 only in a state the probe accepts, and `up --wait` gates on
+    # that exit.
+    entrypoint: ["sh", "-c"]
     command:
-      - "-sS"
-      - "--fail-with-body"
-      - "-X"
-      - "PUT"
-      - "http://seaweedfs:8333/${FERROEHR__MULTIMEDIA__BUCKET:-openehr-multimedia}"
+      - >-
+        bucket="http://seaweedfs:8333/${FERROEHR__MULTIMEDIA__BUCKET:-openehr-multimedia}";
+        i=0; while [ "$$i" -lt 30 ]; do
+        curl -sS -X PUT "$$bucket" >/dev/null;
+        if curl -sSf -o /dev/null "$$bucket/?max-keys=0"; then exit 0; fi;
+        i=$$((i+1)); sleep 2;
+        done;
+        echo "bucket never became listable after 30 attempts" >&2; exit 1
     restart: "no"
     cap_drop: [ALL]
     security_opt:

--- a/docs/conformance/COMPARISON.md
+++ b/docs/conformance/COMPARISON.md
@@ -19,14 +19,14 @@
 
 | | ferroehr | EHRbase |
 |---|---|---|
-| Product | ferroehr 3.17.5 | ehrbase 2.34.0 |
-| Run date | 2026-08-14 | 2026-08-14 |
+| Product | ferroehr 3.17.7 | ehrbase 2.34.0 |
+| Run date | 2026-08-19 | 2026-08-14 |
 | Party statement | committed with the runner (declares ITS-REST pin, signing, terminology posture) | committed with the runner |
 | Stack | the project's own compose stack, built from the current sources | a dedicated compose stack of the official EHRbase images |
 
 ## Methodology
 
-Both systems execute the **same committed CNF 2.0 catalogue** (1058 case-by-format
+Both systems execute the **same committed CNF 2.0 catalogue** (1060 case-by-format
 executions) through the same reference runner (`tools/cnf-runner`), each on
 fresh volumes with its own committed party set: the ixit names the reachable
 instances (EHRbase declares no readonly principal), and the statement (the
@@ -58,7 +58,7 @@ claimed. The verdict-bearing comparison below is therefore each party's
 
 ## In-scope outcomes
 
-Runs compared: **ferroehr** (run of 2026-08-14) vs **EHRbase
+Runs compared: **ferroehr** (run of 2026-08-19) vs **EHRbase
 2.34.0** (run of 2026-08-14) — the SAME catalogue through the same
 runner, each with its own committed party statement. Per the presentation
 rule, the headline is each party's VERDICT SCOPE (the cases its own
@@ -68,8 +68,8 @@ them.
 
 | | verdict scope (selected) | driven | in-scope passed | in-scope failed | in-scope inconclusive |
 |---|---|---|---|---|---|
-| **ferroehr** | 1058 | 1020 | 1020 | 0 | 0 |
-| **EHRbase** | 617 | 571 | 148 | 148 | 275 |
+| **ferroehr** | 1060 | 1022 | 1022 | 0 | 0 |
+| **EHRbase** | 619 | 571 | 148 | 148 | 275 |
 
 An **inconclusive** row's wire answered outside the operation's bound outcome
 map, or its required ground could not be established (e.g. a refused

--- a/website/book/src/installation/kubernetes.md
+++ b/website/book/src/installation/kubernetes.md
@@ -38,7 +38,7 @@ kubectl -n ferroehr create secret generic ferroehr-db \
   --from-literal=FERROEHR__DB__URL='postgres://ferroehr_app:***@pg-host:5432/ferroehr?sslmode=verify-full'
 
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 6.0.8 -n ferroehr \
+  --version 6.0.9 -n ferroehr \
   --set database.existingSecret=ferroehr-db \
   --set image.tag=3.17.8
 ```
@@ -55,7 +55,7 @@ helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
 reference. To read the chart's metadata without installing it:
 
 ```shell
-helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.8
+helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.9
 ```
 
 ### Pin two versions, not one
@@ -68,7 +68,7 @@ against.
 
 | | Selects | Pin with | Line |
 |---|---|---|---|
-| Chart version | templates, values schema, defaults | `--version 6.0.8` | SemVer over the chart's own contract |
+| Chart version | templates, values schema, defaults | `--version 6.0.9` | SemVer over the chart's own contract |
 | Image tag | the server binary | `--set image.tag=3.17.8` (or `image.digest`) | the application's SemVer line |
 
 Always pin the image to an immutable version or, better, a `@sha256` digest —
@@ -167,7 +167,7 @@ metadata lists — the server, and the optional admin console.
 > the image itself as the authority:
 >
 > ```shell
-> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.8 \
+> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.9 \
 >   -s templates/configmap.yaml --set database.existingSecret=ferroehr-db \
 >   | sed -n '/ferroehr.toml/,$p' | sed '1d;s/^    //' > /tmp/ferroehr.toml
 > docker run --rm -v /tmp/ferroehr.toml:/etc/ferroehr/ferroehr.toml:ro \
@@ -556,7 +556,7 @@ config:
 
 ```shell
 helm upgrade ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 6.0.8 -n ferroehr --reuse-values \
+  --version 6.0.9 -n ferroehr --reuse-values \
   --set config.query.plan_cache_capacity=512
 ```
 
@@ -709,7 +709,7 @@ Preview an upgrade against what you have installed with
 `helm diff`, or render the new chart version and read it:
 
 ```shell
-helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.8 \
+helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.9 \
   -n ferroehr -f my-values.yaml | less
 ```
 

--- a/website/book/src/installation/kubernetes.md
+++ b/website/book/src/installation/kubernetes.md
@@ -40,7 +40,7 @@ kubectl -n ferroehr create secret generic ferroehr-db \
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
   --version 6.0.8 -n ferroehr \
   --set database.existingSecret=ferroehr-db \
-  --set image.tag=3.17.7
+  --set image.tag=3.17.8
 ```
 
 > [!IMPORTANT]
@@ -69,7 +69,7 @@ against.
 | | Selects | Pin with | Line |
 |---|---|---|---|
 | Chart version | templates, values schema, defaults | `--version 6.0.8` | SemVer over the chart's own contract |
-| Image tag | the server binary | `--set image.tag=3.17.7` (or `image.digest`) | the application's SemVer line |
+| Image tag | the server binary | `--set image.tag=3.17.8` (or `image.digest`) | the application's SemVer line |
 
 Always pin the image to an immutable version or, better, a `@sha256` digest —
 never `latest`. Pin the two deliberately: the `config` tree is passed through to
@@ -734,7 +734,7 @@ The check that closes that gap runs the image against your rendered
 configuration:
 
 ```shell
-FERROEHR_IMAGE=ghcr.io/rubentalstra/ferroehr:3.17.7 \
+FERROEHR_IMAGE=ghcr.io/rubentalstra/ferroehr:3.17.8 \
   deploy/helm/ci/boot-check.sh my-values.yaml
 ```
 

--- a/website/book/src/verifying-releases.md
+++ b/website/book/src/verifying-releases.md
@@ -18,7 +18,7 @@ workflow.
 ## What a release publishes
 
 Substitute the release tag you downloaded for `<tag>` (for example
-`v3.17.7`) and the architecture for `<arch>` (`x86_64` or `aarch64`) throughout
+`v3.17.8`) and the architecture for `<arch>` (`x86_64` or `aarch64`) throughout
 this page. Linux is the only published target.
 
 | Asset | What it is |
@@ -145,14 +145,14 @@ carry a Sigstore-signed SLSA provenance attestation, plus the SPDX SBOM and
 provenance the builder writes onto the image index itself.
 
 ```bash
-gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:3.17.7 \
+gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:3.17.8 \
   -R rubentalstra/FerroEHR
 ```
 
 > [!IMPORTANT]
-> **Image tags carry no `v` prefix.** A release publishes `3.17.7`, `3.17` and
+> **Image tags carry no `v` prefix.** A release publishes `3.17.8`, `3.17` and
 > `latest` (plus a `sha-…` tag per commit), while the release *assets* are named
-> after the `v3.17.7` git tag. Using `v3.17.7` as an image reference will simply
+> after the `v3.17.8` git tag. Using `v3.17.8` as an image reference will simply
 > not resolve.
 
 The development tags (`ghcr.io/rubentalstra/ferroehr:develop` and its two


### PR DESCRIPTION
Cuts **v3.17.8** — milestone 28 reached zero open issues (9 closed). The section this promotes from `[Unreleased]`:

- **Added** — directory folder references that claim this system must resolve (422 naming each dangling reference; foreign/`unknown` namespaces pass verbatim; register AMB-211, reported upstream as #2413) — the external report #1951.
- **Changed** — PostgreSQL 18.6 everywhere (the August security release fixing 28 CVEs; 18.5 was never released), with the `btree_gist` reindex advisory for in-place upgrades; Helm chart `6.0.8`.
- **Security** — the published `ferroehr-postgres` image rebuilt clean of its 15 fixable HIGH findings (build-time Debian security updates + six per-CVE gosu adjudications with published OpenVEX statements); `h2 0.4.16` (RUSTSEC-2026-0258); the quick-xml 0.26 elimination.

Mechanics in this PR per the release procedure: changelog rename + fresh `[Unreleased]` + link refs; workspace `version` 3.17.8 (+ lock); chart `appVersion` 3.17.8 + `artifacthub.io/images` tags (+ helm-docs, golden renders — chart `version` stays `6.0.8`, already bumped this cycle); `CITATION.cff` 3.17.8 / 2026-08-19 + the regenerated `.zenodo.json`; the compose fallback tags; the book's version pins. All release guards green locally (changelog-structure, docs-claims, compose-image-tags, image-labels, conformance-numbers).

After merge: signed tag `v3.17.8` on the merge commit (the release workflow publishes from the matching changelog section), milestone 28 closes, and the board gets its status update.

The conformance baseline shipping with this release: **1022 passed, 0 failed — PASS 13/13 capabilities**.


## Also riding the cut (owner direction)

- **#2420 — the quickstart S3 bucket race, fixed at the root**: `seaweedfs-init` now retries until the bucket is *verifiably listable* (the exact 200-vs-404 read the deployment probe makes) and exits loudly after 30 attempts, so `up --wait` gates only on a state the probe accepts. Verified over three fresh-volume compose cycles (bucket 200, init exit 0, every round). This is the intermittent that hit both develop and this PR's deploy-probe.
- **#2434 — dependabot batching**: one weekly PR per ecosystem — all cargo minor/patch bumps together (majors stay individual reviews), the fuzz workspace, the base images, and the actions (one codeql-action release alone used to open three PRs). Cooldowns and limits unchanged. The currently open single-bump PRs will be closed; the next scheduled run re-proposes everything grouped.

Closes #2420
Closes #2434
