### PR TITLE
fix(rm): ITEM_TABLE.as_hierarchy — the §4.2 row encoding wins the intra-document contradiction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **`ITEM_TABLE.as_hierarchy` produces the specified row encoding.** The
+  `openehr-rm` function previously emitted a column transpose (following a
+  contradictory one-line summary in the class table); it now encodes one
+  `CLUSTER` per row renamed to the stringified row number, as the RM's own
+  ISO 13606 encoding rules, class description and instance figure define
+  (the contradiction is reported upstream).
+
 - **`validate` and `upload` can no longer disagree about a template.** The
   ADL 1.4 OPT validation endpoint now answers with the same artefact-validity
   catalogue the upload enforces, so a template that would be refused on

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5501,7 +5501,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.32"
+version = "0.0.33"
 dependencies = [
  "indexmap 2.14.0",
  "openehr-am",
@@ -5517,7 +5517,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.32"
+version = "0.0.33"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -5527,7 +5527,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.32"
+version = "0.0.33"
 dependencies = [
  "serde",
  "serde_json",
@@ -5546,7 +5546,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.32"
+version = "0.0.33"
 dependencies = [
  "async-trait",
  "axum",
@@ -5575,7 +5575,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.32"
+version = "0.0.33"
 dependencies = [
  "assert_fs",
  "chumsky",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.32"
+version = "0.0.33"
 dependencies = [
  "chumsky",
  "logos",
@@ -5598,7 +5598,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.32"
+version = "0.0.33"
 dependencies = [
  "insta",
  "jsonschema",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.32"
+version = "0.0.33"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-adl"
-version = "0.0.32"
+version = "0.0.33"
 description = "openEHR ADL 2.4.0: hand-written ADL2/cADL/ODIN parser, AOM2 validation catalogue, specialisation flattener, OPT2 generator, and ADL 1.4→2 conversion over the generated openehr_am::v2_4::aom2 model"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,11 +16,11 @@ include = ["src/**", "README.md", "LICENSE-MIT"]
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)
-openehr-base = { path = "../openehr-base", version = "0.0.32" }   # VersionStatus for the parsed HRID
-openehr-am = { path = "../openehr-am", version = "0.0.32" }       # v2_4 ArchetypeHrid (the identification target type)
-openehr-rm = { path = "../openehr-rm", version = "0.0.32" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
-openehr-lang = { path = "../openehr-lang", version = "0.0.32" }   # openehr_lang::odin — the ODIN section parser
-openehr-term = { path = "../openehr-term", version = "0.0.32" }   # the languages code set for the RM resource-meta rows
+openehr-base = { path = "../openehr-base", version = "0.0.33" }   # VersionStatus for the parsed HRID
+openehr-am = { path = "../openehr-am", version = "0.0.33" }       # v2_4 ArchetypeHrid (the identification target type)
+openehr-rm = { path = "../openehr-rm", version = "0.0.33" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
+openehr-lang = { path = "../openehr-lang", version = "0.0.33" }   # openehr_lang::odin — the ODIN section parser
+openehr-term = { path = "../openehr-term", version = "0.0.33" }   # the languages code set for the RM resource-meta rows
 uuid.workspace = true        # meta uid/build_uid (AUTHORED_ARCHETYPE.uid: Uuid)
 indexmap.workspace = true    # OdinValue::Object body (insertion-ordered map)
 

--- a/crates/openehr-am/Cargo.toml
+++ b/crates/openehr-am/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-am"
-version = "0.0.32"
+version = "0.0.33"
 description = "openEHR AM Archetype Model, generated from BMM: generations v1_4 (AM 1.4.0, ADL 1.4) and v2_4 (AM 2.4.0, ADL 2; current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,8 +13,8 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.32" }
-openehr-lang = { path = "../openehr-lang", version = "0.0.32" }
+openehr-base = { path = "../openehr-base", version = "0.0.33" }
+openehr-lang = { path = "../openehr-lang", version = "0.0.33" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also carries the untyped `Value` fields the generator

--- a/crates/openehr-base/Cargo.toml
+++ b/crates/openehr-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-base"
-version = "0.0.32"
+version = "0.0.33"
 description = "openEHR BASE foundation + base types, generated from BMM: generations v1_2 (BASE 1.2.0) and v1_3 (BASE 1.3.0, current)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-its"
-version = "0.0.32"
+version = "0.0.33"
 description = "openEHR ITS (Implementation Technology Specifications): canonical JSON + canonical XML serialization of the RM, the generated ITS-REST 1.1.0 API contract, OPT 1.4 and AOM2 archetype XML codecs, and the Simplified Formats (FLAT / STRUCTURED / Web Template)"
 edition.workspace = true
 rust-version.workspace = true
@@ -41,14 +41,14 @@ regex = { workspace = true, optional = true }
 fancy-regex = { workspace = true, optional = true }
 # The generated XML (de)serializers impl the crate's ToXml/FromXml traits for the
 # RM/BASE spec types, so these are real (non-dev) deps.
-openehr-base = { path = "../openehr-base", version = "0.0.32", optional = true }
-openehr-rm = { path = "../openehr-rm", version = "0.0.32", optional = true }
+openehr-base = { path = "../openehr-base", version = "0.0.33", optional = true }
+openehr-rm = { path = "../openehr-rm", version = "0.0.33", optional = true }
 # The native canonical-JSON codec (`json_codec/generated`, emit-json) implements
 # `ToJson` for EVERY generated spec type the `OpenEhrType` derive covers, so it
 # spans all five spec crates (not just the RM/BASE the XML codec needs).
-openehr-lang = { path = "../openehr-lang", version = "0.0.32", optional = true }
-openehr-am = { path = "../openehr-am", version = "0.0.32", optional = true }
-openehr-term = { path = "../openehr-term", version = "0.0.32", optional = true }
+openehr-lang = { path = "../openehr-lang", version = "0.0.33", optional = true }
+openehr-am = { path = "../openehr-am", version = "0.0.33", optional = true }
+openehr-term = { path = "../openehr-term", version = "0.0.33", optional = true }
 
 # `full` — every ITS surface (canonical JSON/XML, the generated ITS-REST
 # contract, `opt14`, Simplified Formats). ON BY DEFAULT, so every consumer sees

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-lang"
-version = "0.0.32"
+version = "0.0.33"
 description = "openEHR LANG BMM/P_BMM object model, generated from BMM: generations v1_0 (LANG 1.0.0) and v1_1 (LANG 1.1.0, current; the stable BMM v2.x unit beside the paused BMM3 unit), plus hand-written ODIN/BEL/EL readers"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["parser-implementations", "data-structures"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.32" }
+openehr-base = { path = "../openehr-base", version = "0.0.33" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the
 # generated types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) —
 # never a derive. `serde_json` also carries the untyped `Value` fields the

--- a/crates/openehr-query/Cargo.toml
+++ b/crates/openehr-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-query"
-version = "0.0.32"
+version = "0.0.33"
 description = "openEHR QUERY (AQL 1.1.0): hand-written lexer, parser, typed AST and canonical printer from the official grammar (no ANTLR runtime)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-rm"
-version = "0.0.32"
+version = "0.0.33"
 description = "openEHR RM Reference Model, generated from BMM: generations v1_1 (RM 1.1.0) and v1_2 (RM 1.2.0, current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,11 +13,11 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.32" }
+openehr-base = { path = "../openehr-base", version = "0.0.33" }
 # The terminology-backed RM class invariants (`validate::terminology`) resolve
 # openEHR terminology groups + code sets against the vendored TERM 3.1.0 bundle.
 # `openehr-term` itself depends only on `openehr-base`, so this is acyclic.
-openehr-term = { path = "../openehr-term", version = "0.0.32" }
+openehr-term = { path = "../openehr-term", version = "0.0.33" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also backs the untyped `Value` RM representation used by

--- a/crates/openehr-rm/src/v1_1/data_structures/item_structure/item_table_impl.rs
+++ b/crates/openehr-rm/src/v1_1/data_structures/item_structure/item_table_impl.rs
@@ -195,41 +195,48 @@ impl ItemTable {
     /// This table as a CEN EN13606-compatible hierarchy, or `None` for a table
     /// with no cells.
     ///
-    /// Spec: `item_table.adoc` §Functions `as_hierarchy` — "Generate a CEN
-    /// EN13606-compatible hierarchy consisting of a single `CLUSTER` containing
-    /// the `CLUSTERs` representing the COLUMNS of this table."
+    /// Spec: `master04-item_structure_package.adoc` §ISO 13606 Encoding Rules
+    /// — ITEM_TABLE: "Each row is encoded as a Cluster containing a number of
+    /// `ELEMENTs`, each corresponding to the value of a column in that row";
+    /// the `ELEMENT` names are the column names (already true of the physical
+    /// rows, which `Row_regularity` pins); "The names of the containing
+    /// `CLUSTER` of each row is the stringified number of the row in the
+    /// overall table" (one-based, matching [`Self::ith_row`]).
     ///
-    /// The hierarchy is therefore a TRANSPOSE of the stored form, which is
-    /// row-per-`CLUSTER`: one `CLUSTER` per column, named with the column name,
-    /// holding that column's cell from each row in row order. An empty table
-    /// has no columns to build from, and `CLUSTER.items` is `1..*`, so there is
-    /// no hierarchy to return rather than an ill-formed one.
+    /// NOTE: the class table's `as_hierarchy` Meaning sentence says "the
+    /// `CLUSTERs` representing the columns", contradicting §ISO 13606
+    /// Encoding Rules, §Description ("Cluster-per-row encoding") and the
+    /// normative instance figure — the row encoding those three define wins;
+    /// the void-cell rule is guaranteed by the physical row regularity.
+    ///
+    /// An empty table has no rows to encode, and `CLUSTER.items` is `1..*`,
+    /// so there is no hierarchy to return rather than an ill-formed one.
     #[must_use]
     pub fn as_hierarchy(&self) -> Option<Cluster> {
         let rows = self.rows.as_deref()?;
-        let names = self.column_names();
-        let columns: Vec<Item> = names
-            .into_iter()
+        let encoded: Vec<Item> = rows
+            .iter()
             .enumerate()
-            .filter_map(|(index, name)| {
-                let cells: Vec<Item> = rows
-                    .iter()
-                    .filter_map(|row| row.items.get(index).cloned())
-                    .collect();
-                Some(Item::Cluster(column_cluster(
-                    name,
-                    &self.archetype_node_id,
-                    cells,
-                )?))
+            .map(|(index, row)| {
+                let mut renamed = row.clone();
+                renamed.name = DvText::DvText(crate::v1_1::data_types::text::dv_text::DvTextData {
+                    value: (index + 1).to_string(),
+                    hyperlink: None,
+                    formatting: None,
+                    mappings: None,
+                    language: None,
+                    encoding: None,
+                });
+                Item::Cluster(renamed)
             })
             .collect();
-        column_cluster(self.name.clone(), &self.archetype_node_id, columns)
+        row_cluster(self.name.clone(), &self.archetype_node_id, encoded)
     }
 }
 
 /// A `CLUSTER` over `items`, or `None` when there are none — `CLUSTER.items` is
 /// `1..*`, so an empty one is not a `CLUSTER`.
-fn column_cluster(name: DvText, archetype_node_id: &str, items: Vec<Item>) -> Option<Cluster> {
+fn row_cluster(name: DvText, archetype_node_id: &str, items: Vec<Item>) -> Option<Cluster> {
     Some(Cluster {
         name,
         archetype_node_id: archetype_node_id.to_owned(),
@@ -667,25 +674,42 @@ mod tests {
         assert!(acuity.element_at_cell_ij(3, 1).is_none());
     }
 
-    /// `as_hierarchy` is a TRANSPOSE: "a single CLUSTER containing the CLUSTERs
-    /// representing the COLUMNS of this table", while the stored form is one
-    /// CLUSTER per row.
+    /// §ISO 13606 Encoding Rules — ITEM_TABLE: each row a `CLUSTER` of the
+    /// row's `ELEMENTs`, renamed to the stringified one-based row number;
+    /// the row-vs-column contradiction with the class table's Meaning
+    /// sentence is adjudicated to this encoding (the Description's
+    /// "Cluster-per-row" and the normative instance figure corroborate).
     #[test]
-    fn as_hierarchy_transposes_rows_into_columns() {
+    fn as_hierarchy_encodes_rows_with_stringified_names() {
         let hierarchy = acuity().as_hierarchy().expect("a table with cells");
         assert_eq!(text_of(&hierarchy.name), "table");
-        assert_eq!(hierarchy.items.len(), 2, "one CLUSTER per column");
+        assert_eq!(hierarchy.items.len(), 2, "one CLUSTER per row");
 
-        let Item::Cluster(site) = &hierarchy.items[0] else {
-            panic!("a column is a CLUSTER");
+        let Item::Cluster(first) = &hierarchy.items[0] else {
+            panic!("a row is a CLUSTER");
         };
-        assert_eq!(text_of(&site.name), "site");
-        assert_eq!(site.items.len(), 2, "one cell per row");
         assert_eq!(
-            site.items.iter().filter_map(cell_text).collect::<Vec<_>>(),
-            ["left eye", "right eye"],
-            "in row order"
+            text_of(&first.name),
+            "1",
+            "stringified one-based row number"
         );
+        assert_eq!(first.items.len(), 2, "the row's ELEMENTs, one per column");
+        assert_eq!(
+            first
+                .items
+                .iter()
+                .map(|item| match item {
+                    Item::Element(element) => text_of(&element.name),
+                    Item::Cluster(cluster) => text_of(&cluster.name),
+                })
+                .collect::<Vec<_>>(),
+            ["site", "result"],
+            "ELEMENT names are the column names"
+        );
+        let Item::Cluster(second) = &hierarchy.items[1] else {
+            panic!("a row is a CLUSTER");
+        };
+        assert_eq!(text_of(&second.name), "2");
 
         assert!(
             table(vec![]).as_hierarchy().is_none(),

--- a/crates/openehr-rm/src/v1_2/data_structures/item_structure/item_table_impl.rs
+++ b/crates/openehr-rm/src/v1_2/data_structures/item_structure/item_table_impl.rs
@@ -195,41 +195,48 @@ impl ItemTable {
     /// This table as a CEN EN13606-compatible hierarchy, or `None` for a table
     /// with no cells.
     ///
-    /// Spec: `item_table.adoc` §Functions `as_hierarchy` — "Generate a CEN
-    /// EN13606-compatible hierarchy consisting of a single `CLUSTER` containing
-    /// the `CLUSTERs` representing the COLUMNS of this table."
+    /// Spec: `master04-item_structure_package.adoc` §ISO 13606 Encoding Rules
+    /// — ITEM_TABLE: "Each row is encoded as a Cluster containing a number of
+    /// `ELEMENTs`, each corresponding to the value of a column in that row";
+    /// the `ELEMENT` names are the column names (already true of the physical
+    /// rows, which `Row_regularity` pins); "The names of the containing
+    /// `CLUSTER` of each row is the stringified number of the row in the
+    /// overall table" (one-based, matching [`Self::ith_row`]).
     ///
-    /// The hierarchy is therefore a TRANSPOSE of the stored form, which is
-    /// row-per-`CLUSTER`: one `CLUSTER` per column, named with the column name,
-    /// holding that column's cell from each row in row order. An empty table
-    /// has no columns to build from, and `CLUSTER.items` is `1..*`, so there is
-    /// no hierarchy to return rather than an ill-formed one.
+    /// NOTE: the class table's `as_hierarchy` Meaning sentence says "the
+    /// `CLUSTERs` representing the columns", contradicting §ISO 13606
+    /// Encoding Rules, §Description ("Cluster-per-row encoding") and the
+    /// normative instance figure — the row encoding those three define wins;
+    /// the void-cell rule is guaranteed by the physical row regularity.
+    ///
+    /// An empty table has no rows to encode, and `CLUSTER.items` is `1..*`,
+    /// so there is no hierarchy to return rather than an ill-formed one.
     #[must_use]
     pub fn as_hierarchy(&self) -> Option<Cluster> {
         let rows = self.rows.as_deref()?;
-        let names = self.column_names();
-        let columns: Vec<Item> = names
-            .into_iter()
+        let encoded: Vec<Item> = rows
+            .iter()
             .enumerate()
-            .filter_map(|(index, name)| {
-                let cells: Vec<Item> = rows
-                    .iter()
-                    .filter_map(|row| row.items.get(index).cloned())
-                    .collect();
-                Some(Item::Cluster(column_cluster(
-                    name,
-                    &self.archetype_node_id,
-                    cells,
-                )?))
+            .map(|(index, row)| {
+                let mut renamed = row.clone();
+                renamed.name = DvText::DvText(crate::v1_2::data_types::text::dv_text::DvTextData {
+                    value: (index + 1).to_string(),
+                    hyperlink: None,
+                    formatting: None,
+                    mappings: None,
+                    language: None,
+                    encoding: None,
+                });
+                Item::Cluster(renamed)
             })
             .collect();
-        column_cluster(self.name.clone(), &self.archetype_node_id, columns)
+        row_cluster(self.name.clone(), &self.archetype_node_id, encoded)
     }
 }
 
 /// A `CLUSTER` over `items`, or `None` when there are none — `CLUSTER.items` is
 /// `1..*`, so an empty one is not a `CLUSTER`.
-fn column_cluster(name: DvText, archetype_node_id: &str, items: Vec<Item>) -> Option<Cluster> {
+fn row_cluster(name: DvText, archetype_node_id: &str, items: Vec<Item>) -> Option<Cluster> {
     Some(Cluster {
         name,
         archetype_node_id: archetype_node_id.to_owned(),
@@ -667,25 +674,42 @@ mod tests {
         assert!(acuity.element_at_cell_ij(3, 1).is_none());
     }
 
-    /// `as_hierarchy` is a TRANSPOSE: "a single CLUSTER containing the CLUSTERs
-    /// representing the COLUMNS of this table", while the stored form is one
-    /// CLUSTER per row.
+    /// §ISO 13606 Encoding Rules — ITEM_TABLE: each row a `CLUSTER` of the
+    /// row's `ELEMENTs`, renamed to the stringified one-based row number;
+    /// the row-vs-column contradiction with the class table's Meaning
+    /// sentence is adjudicated to this encoding (the Description's
+    /// "Cluster-per-row" and the normative instance figure corroborate).
     #[test]
-    fn as_hierarchy_transposes_rows_into_columns() {
+    fn as_hierarchy_encodes_rows_with_stringified_names() {
         let hierarchy = acuity().as_hierarchy().expect("a table with cells");
         assert_eq!(text_of(&hierarchy.name), "table");
-        assert_eq!(hierarchy.items.len(), 2, "one CLUSTER per column");
+        assert_eq!(hierarchy.items.len(), 2, "one CLUSTER per row");
 
-        let Item::Cluster(site) = &hierarchy.items[0] else {
-            panic!("a column is a CLUSTER");
+        let Item::Cluster(first) = &hierarchy.items[0] else {
+            panic!("a row is a CLUSTER");
         };
-        assert_eq!(text_of(&site.name), "site");
-        assert_eq!(site.items.len(), 2, "one cell per row");
         assert_eq!(
-            site.items.iter().filter_map(cell_text).collect::<Vec<_>>(),
-            ["left eye", "right eye"],
-            "in row order"
+            text_of(&first.name),
+            "1",
+            "stringified one-based row number"
         );
+        assert_eq!(first.items.len(), 2, "the row's ELEMENTs, one per column");
+        assert_eq!(
+            first
+                .items
+                .iter()
+                .map(|item| match item {
+                    Item::Element(element) => text_of(&element.name),
+                    Item::Cluster(cluster) => text_of(&cluster.name),
+                })
+                .collect::<Vec<_>>(),
+            ["site", "result"],
+            "ELEMENT names are the column names"
+        );
+        let Item::Cluster(second) = &hierarchy.items[1] else {
+            panic!("a row is a CLUSTER");
+        };
+        assert_eq!(text_of(&second.name), "2");
 
         assert!(
             table(vec![]).as_hierarchy().is_none(),

--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-term"
-version = "0.0.32"
+version = "0.0.33"
 description = "openEHR TERM terminology data model, generated from BMM (generation v3_1 = TERM 3.1.0), plus the embedded official terminology XML bundle"
 edition.workspace = true
 rust-version.workspace = true
@@ -34,7 +34,7 @@ include = [
 ]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.32" }
+openehr-base = { path = "../openehr-base", version = "0.0.33" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive.

--- a/tools/cnf-runner/artifacts/registers/ambiguities.yaml
+++ b/tools/cnf-runner/artifacts/registers/ambiguities.yaml
@@ -9256,3 +9256,36 @@ AMB-212:
     ADL source seam, where translations exist. valid_opt answers with the
     same artefact catalogue upload_opt enforces, so the two never diverge.
   disposition: fixed_handling
+AMB-213:
+  ambiguity: >-
+    The RM data_structures document contradicts itself about
+    ITEM_TABLE.as_hierarchy's shape. §ISO 13606 Encoding Rules — ITEM_TABLE
+    defines the encoding by ROWS ("Each row is encoded as a Cluster
+    containing a number of ELEMENTs, each corresponding to the value of a
+    column in that row"; the ELEMENT names are the column names; "The names
+    of the containing CLUSTER of each row is the stringified number of the
+    row in the overall table"; a void cell is an ELEMENT with null_flavour
+    set), and both the class Description ("Implemented using Cluster-per-row
+    encoding") and the normative instance figure (three at0010|row| CLUSTERs)
+    corroborate rows — while the same class table's as_hierarchy Meaning
+    sentence alone says "a single CLUSTER containing the CLUSTERs
+    representing the columns of this table".
+  source: >-
+    RM docs/data_structures/master04-item_structure_package.adoc §ISO 13606
+    Encoding Rules — ITEM_TABLE + §Instance Structures
+    (diagrams/instance_item_table.svg); RM
+    UML/classes/org.openehr.rm.data_structures.item_table.adoc §Description +
+    §Functions as_hierarchy.
+  handling: >-
+    Fixed handling (issue #2464): the row encoding wins — the dedicated
+    encoding rules, corroborated by the Description's physical form and the
+    normative figure, against one summary sentence. as_hierarchy produces the
+    outer CLUSTER over per-row CLUSTERs, each row's ELEMENTs replicated
+    (names already the column names per the physical row regularity), each
+    row CLUSTER renamed to the stringified ONE-based row number (the base
+    ith_row already uses); the void-cell rule is guaranteed by the physical
+    Row_regularity check; an empty table yields no hierarchy
+    (CLUSTER.items 1..*). The Meaning sentence is treated as an editorial
+    defect and reported upstream.
+  disposition: fixed_handling
+  upstream_issue: 2465

--- a/tools/openehr-codegen/templates/openehr-rm/data_structures/item_structure/item_table_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/data_structures/item_structure/item_table_impl.rs
@@ -195,41 +195,48 @@ impl ItemTable {
     /// This table as a CEN EN13606-compatible hierarchy, or `None` for a table
     /// with no cells.
     ///
-    /// Spec: `item_table.adoc` §Functions `as_hierarchy` — "Generate a CEN
-    /// EN13606-compatible hierarchy consisting of a single `CLUSTER` containing
-    /// the `CLUSTERs` representing the COLUMNS of this table."
+    /// Spec: `master04-item_structure_package.adoc` §ISO 13606 Encoding Rules
+    /// — ITEM_TABLE: "Each row is encoded as a Cluster containing a number of
+    /// `ELEMENTs`, each corresponding to the value of a column in that row";
+    /// the `ELEMENT` names are the column names (already true of the physical
+    /// rows, which `Row_regularity` pins); "The names of the containing
+    /// `CLUSTER` of each row is the stringified number of the row in the
+    /// overall table" (one-based, matching [`Self::ith_row`]).
     ///
-    /// The hierarchy is therefore a TRANSPOSE of the stored form, which is
-    /// row-per-`CLUSTER`: one `CLUSTER` per column, named with the column name,
-    /// holding that column's cell from each row in row order. An empty table
-    /// has no columns to build from, and `CLUSTER.items` is `1..*`, so there is
-    /// no hierarchy to return rather than an ill-formed one.
+    /// NOTE: the class table's `as_hierarchy` Meaning sentence says "the
+    /// `CLUSTERs` representing the columns", contradicting §ISO 13606
+    /// Encoding Rules, §Description ("Cluster-per-row encoding") and the
+    /// normative instance figure — the row encoding those three define wins;
+    /// the void-cell rule is guaranteed by the physical row regularity.
+    ///
+    /// An empty table has no rows to encode, and `CLUSTER.items` is `1..*`,
+    /// so there is no hierarchy to return rather than an ill-formed one.
     #[must_use]
     pub fn as_hierarchy(&self) -> Option<Cluster> {
         let rows = self.rows.as_deref()?;
-        let names = self.column_names();
-        let columns: Vec<Item> = names
-            .into_iter()
+        let encoded: Vec<Item> = rows
+            .iter()
             .enumerate()
-            .filter_map(|(index, name)| {
-                let cells: Vec<Item> = rows
-                    .iter()
-                    .filter_map(|row| row.items.get(index).cloned())
-                    .collect();
-                Some(Item::Cluster(column_cluster(
-                    name,
-                    &self.archetype_node_id,
-                    cells,
-                )?))
+            .map(|(index, row)| {
+                let mut renamed = row.clone();
+                renamed.name = DvText::DvText(crate::v1_2::data_types::text::dv_text::DvTextData {
+                    value: (index + 1).to_string(),
+                    hyperlink: None,
+                    formatting: None,
+                    mappings: None,
+                    language: None,
+                    encoding: None,
+                });
+                Item::Cluster(renamed)
             })
             .collect();
-        column_cluster(self.name.clone(), &self.archetype_node_id, columns)
+        row_cluster(self.name.clone(), &self.archetype_node_id, encoded)
     }
 }
 
 /// A `CLUSTER` over `items`, or `None` when there are none — `CLUSTER.items` is
 /// `1..*`, so an empty one is not a `CLUSTER`.
-fn column_cluster(name: DvText, archetype_node_id: &str, items: Vec<Item>) -> Option<Cluster> {
+fn row_cluster(name: DvText, archetype_node_id: &str, items: Vec<Item>) -> Option<Cluster> {
     Some(Cluster {
         name,
         archetype_node_id: archetype_node_id.to_owned(),
@@ -667,25 +674,42 @@ mod tests {
         assert!(acuity.element_at_cell_ij(3, 1).is_none());
     }
 
-    /// `as_hierarchy` is a TRANSPOSE: "a single CLUSTER containing the CLUSTERs
-    /// representing the COLUMNS of this table", while the stored form is one
-    /// CLUSTER per row.
+    /// §ISO 13606 Encoding Rules — ITEM_TABLE: each row a `CLUSTER` of the
+    /// row's `ELEMENTs`, renamed to the stringified one-based row number;
+    /// the row-vs-column contradiction with the class table's Meaning
+    /// sentence is adjudicated to this encoding (the Description's
+    /// "Cluster-per-row" and the normative instance figure corroborate).
     #[test]
-    fn as_hierarchy_transposes_rows_into_columns() {
+    fn as_hierarchy_encodes_rows_with_stringified_names() {
         let hierarchy = acuity().as_hierarchy().expect("a table with cells");
         assert_eq!(text_of(&hierarchy.name), "table");
-        assert_eq!(hierarchy.items.len(), 2, "one CLUSTER per column");
+        assert_eq!(hierarchy.items.len(), 2, "one CLUSTER per row");
 
-        let Item::Cluster(site) = &hierarchy.items[0] else {
-            panic!("a column is a CLUSTER");
+        let Item::Cluster(first) = &hierarchy.items[0] else {
+            panic!("a row is a CLUSTER");
         };
-        assert_eq!(text_of(&site.name), "site");
-        assert_eq!(site.items.len(), 2, "one cell per row");
         assert_eq!(
-            site.items.iter().filter_map(cell_text).collect::<Vec<_>>(),
-            ["left eye", "right eye"],
-            "in row order"
+            text_of(&first.name),
+            "1",
+            "stringified one-based row number"
         );
+        assert_eq!(first.items.len(), 2, "the row's ELEMENTs, one per column");
+        assert_eq!(
+            first
+                .items
+                .iter()
+                .map(|item| match item {
+                    Item::Element(element) => text_of(&element.name),
+                    Item::Cluster(cluster) => text_of(&cluster.name),
+                })
+                .collect::<Vec<_>>(),
+            ["site", "result"],
+            "ELEMENT names are the column names"
+        );
+        let Item::Cluster(second) = &hierarchy.items[1] else {
+            panic!("a row is a CLUSTER");
+        };
+        assert_eq!(text_of(&second.name), "2");
 
         assert!(
             table(vec![]).as_hierarchy().is_none(),


### PR DESCRIPTION
The Data structures ch.4 audit (#907, section #2461) caught `ITEM_TABLE.as_hierarchy` implementing the class table's lone "columns" Meaning sentence, against the three agreeing definitions in the same released document: §ISO 13606 Encoding Rules (rows, with the ELEMENT-name and stringified-row-number rules), the class Description ("Implemented using Cluster-per-row encoding"), and the normative instance figure (three `at0010|row|` CLUSTERs).

Adjudication (register AMB-213; upstream report #2465): the row encoding wins. The template now emits the outer CLUSTER over per-row CLUSTERs — each row's ELEMENTs replicated (names already the column names, held by the physical `Row_regularity` check), each row CLUSTER renamed to its stringified one-based number (the base `ith_row` already uses) — with the empty-table `None` unchanged (`CLUSTER.items 1..*`). The old transpose-pinning gate is flipped to the adjudicated expectation and the row shape is pinned in both generations; `data_structure_impl`'s dispatch is untouched.

Walked records for all four ch.4 sections are on #2460–#2463; every declared function of the five class tables verified realized (the twelve ITEM_TABLE functions included). Spec crates bumped lockstep to 0.0.33; changelog entry added.

Closes #2464