### PR TITLE
test(cnf): the ELEMENT null-family refusal twins

### DIFF
--- a/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
@@ -7,12 +7,12 @@ Runner: cnf-runner 3.17.8 · verification pack: passed
 
 | Status | Count |
 | --- | --- |
-| passed | 1028 |
+| passed | 1029 |
 | failed | 0 |
 | errored | 0 |
 | skipped | 0 |
 | not_applicable | 38 |
-| total | 1066 |
+| total | 1067 |
 
 ## By chapter
 
@@ -20,12 +20,12 @@ Grouping is the published per-chapter chart's taxonomy: chapters with their band
 
 | Chapter / band | passed | failed | errored | cited n/a |
 | --- | --- | --- | --- | --- |
-| **EHR** | 447 | 0 | 0 | 18 |
+| **EHR** | 448 | 0 | 0 | 18 |
 | — EHR resource | 25 | 0 | 0 | 2 |
 | — EHR_STATUS | 46 | 0 | 0 | 5 |
 | — COMPOSITION | 137 | 0 | 0 | 0 |
 | — DIRECTORY | 79 | 0 | 0 | 6 |
-| — CONTRIBUTION | 92 | 0 | 0 | 5 |
+| — CONTRIBUTION | 93 | 0 | 0 | 5 |
 | — Item tags | 62 | 0 | 0 | 0 |
 | — Revision history | 6 | 0 | 0 | 0 |
 | **Definitions** | 97 | 0 | 0 | 10 |
@@ -86,7 +86,7 @@ Selected gating cases per claimed capability. `inconclusive` counts cases whose 
 | EhrStatus | pass | 44 | 0 | 0 | 5 |
 | CompositionOps | pass | 59 | 0 | 0 | 0 |
 | DirectoryOps | pass | 77 | 0 | 0 | 8 |
-| ChangeSets | pass | 85 | 0 | 0 | 5 |
+| ChangeSets | pass | 86 | 0 | 0 | 5 |
 | Versioning | pass | 72 | 0 | 0 | 0 |
 | ArchetypeValidation | pass | 125 | 0 | 0 | 0 |
 | PartyOperations | pass | 86 | 0 | 0 | 4 |
@@ -175,7 +175,7 @@ Percentiles re-derive from the embedded HDR V2 histograms; the class verdict is 
 
 ## Honesty
 
-Coverage: 1028 of 1066 selected cases driven.
+Coverage: 1029 of 1067 selected cases driven.
 
 Not-executed verdicts (each cited):
 

--- a/docs/conformance/ferroehr/badge.json
+++ b/docs/conformance/ferroehr/badge.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "openEHR conformance",
-  "message": "CORE+STANDARD PASS · 1028/1028 cases",
+  "message": "CORE+STANDARD PASS · 1029/1029 cases",
   "color": "brightgreen"
 }

--- a/docs/conformance/ferroehr/results.json
+++ b/docs/conformance/ferroehr/results.json
@@ -2179,6 +2179,12 @@
       "rows_total": 12
     },
     {
+      "case": "I_EHR_CONTRIBUTION.commit_contribution-element_null_family_invalid",
+      "status": "passed",
+      "rows_driven": 3,
+      "rows_total": 3
+    },
+    {
       "case": "I_EHR_CONTRIBUTION.commit_contribution-empty",
       "status": "passed",
       "rows_driven": 1,

--- a/docs/conformance/ferroehr/verdicts.json
+++ b/docs/conformance/ferroehr/verdicts.json
@@ -268,7 +268,7 @@
     [
       "ChangeSets",
       {
-        "passed": 85,
+        "passed": 86,
         "failed": 0,
         "inconclusive": 0,
         "unevidenced": 5
@@ -588,9 +588,9 @@
     }
   ],
   "coverage": {
-    "selected": 1066,
-    "driven": 1028,
-    "passed": 1028,
+    "selected": 1067,
+    "driven": 1029,
+    "passed": 1029,
     "failed": 0,
     "inconclusive": 0
   }

--- a/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
+++ b/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
@@ -3364,3 +3364,33 @@ cnf.archetype.adl14.translation_restates_original:
     defect: "a translations entry re-states the original language en"
     spec_ref: "RM UML/classes/org.openehr.rm.common.authored_resource.adoc §Invariants Translations_valid (not translations.has(orginal_language.code_string) — the spec's own spelling); the RM resource package governs AOM 1.4 meta-data (RM common master08-resource_package.adoc front-matter NOTE)"
   provenance: "derived 2026-08-19 from cnf.archetype.adl14.medication with exactly one edit: an [\"en\"] entry inserted into the existing translations section"
+cnf.composition.null_family.value_and_flavour:
+  source: fixtures/contribution/composition.obs_admin.null_family.value_and_flavour.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "the at0004 ELEMENT carries BOTH a value and a null_flavour"
+    spec_ref: "RM UML/classes/org.openehr.rm.data_structures.element.adoc §Invariants Inv_null_flavour_indicated (is_null() xor null_flavour = Void)"
+  template_id: "obs_admin.en.v2"
+  provenance: "derived 2026-08-20 from cnf.composition.null_flavour with exactly one edit: a template-legal DV_TEXT value added to the null ELEMENT, so the xor is the only defect"
+cnf.composition.null_family.orphan_null_reason:
+  source: fixtures/contribution/composition.obs_admin.null_family.orphan_null_reason.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "a null_reason on a VALUED at0004 ELEMENT (is_null() is false)"
+    spec_ref: "RM UML/classes/org.openehr.rm.data_structures.element.adoc §Invariants Inv_null_reason_valid (null_reason /= Void implies is_null())"
+  template_id: "obs_admin.en.v2"
+  provenance: "derived 2026-08-20 from cnf.composition.obs_admin.coded_text_on_text with exactly one edit: a null_reason added beside the present value"
+cnf.composition.null_family.out_of_group_flavour:
+  source: fixtures/contribution/composition.obs_admin.null_family.out_of_group_flavour.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "the null ELEMENT's null_flavour code 999 is outside the openEHR null flavours group"
+    spec_ref: "RM UML/classes/org.openehr.rm.data_structures.element.adoc §Invariants Inv_null_flavour_valid (terminology(Terminology_id_openehr).has_code_for_group_id(Group_id_null_flavour, null_flavour.defining_code))"
+  template_id: "obs_admin.en.v2"
+  provenance: "derived 2026-08-20 from cnf.composition.null_flavour with exactly one edit: the 271 code swapped to the out-of-group 999 (value text adjusted to avoid a rubric mismatch masking the group defect)"

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.obs_admin.null_family.orphan_null_reason.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.obs_admin.null_family.orphan_null_reason.json
@@ -1,0 +1,244 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "obs_admin.en.v2"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "UY"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "external_ref": {
+      "_type": "PARTY_REF",
+      "id": {
+        "_type": "HIER_OBJECT_ID",
+        "value": "781ef163-d503-4653-9449-40e59a97e1d1"
+      },
+      "namespace": "DEMOGRAPHIC",
+      "type": "PERSON"
+    },
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2019-04-16T21:08:14,127+00:00"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "primary nursing care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "229"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Minimal"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.minimal.v1",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.minimal.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2019-04-16T21:08:14,129+00:00"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Cualquier evento"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2019-04-16T21:08:14,130+00:00"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Arbol"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "text"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_CODED_TEXT",
+                    "value": "a text",
+                    "defining_code": {
+                      "terminology_id": {
+                        "value": "snomed ct"
+                      },
+                      "code_string": "23423423242"
+                    }
+                  },
+                  "null_reason": {
+                    "_type": "DV_TEXT",
+                    "value": "patient refused to say"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_type": "ADMIN_ENTRY",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Minimal"
+      },
+      "archetype_node_id": "openEHR-EHR-ADMIN_ENTRY.minimal.v1",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-ADMIN_ENTRY.minimal.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "ITEM_TREE",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Arbol"
+        },
+        "archetype_node_id": "at0001",
+        "items": [
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "ordinal"
+            },
+            "archetype_node_id": "at0002",
+            "value": {
+              "_type": "DV_ORDINAL",
+              "value": 1,
+              "symbol": {
+                "_type": "DV_CODED_TEXT",
+                "value": "ord1",
+                "defining_code": {
+                  "_type": "CODE_PHRASE",
+                  "terminology_id": {
+                    "_type": "TERMINOLOGY_ID",
+                    "value": "local"
+                  },
+                  "code_string": "at0003"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.obs_admin.null_family.out_of_group_flavour.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.obs_admin.null_family.out_of_group_flavour.json
@@ -1,0 +1,239 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "obs_admin.en.v2"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "UY"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "external_ref": {
+      "_type": "PARTY_REF",
+      "id": {
+        "_type": "HIER_OBJECT_ID",
+        "value": "781ef163-d503-4653-9449-40e59a97e1d1"
+      },
+      "namespace": "DEMOGRAPHIC",
+      "type": "PERSON"
+    },
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2019-04-16T21:08:14,127+00:00"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "primary nursing care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "229"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Minimal"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.minimal.v1",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.minimal.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2019-04-16T21:08:14,129+00:00"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Cualquier evento"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2019-04-16T21:08:14,130+00:00"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Arbol"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "text"
+                  },
+                  "archetype_node_id": "at0004",
+                  "null_flavour": {
+                    "value": "bogus flavour",
+                    "defining_code": {
+                      "terminology_id": {
+                        "value": "openehr"
+                      },
+                      "code_string": "999"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_type": "ADMIN_ENTRY",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Minimal"
+      },
+      "archetype_node_id": "openEHR-EHR-ADMIN_ENTRY.minimal.v1",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-ADMIN_ENTRY.minimal.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "ITEM_TREE",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Arbol"
+        },
+        "archetype_node_id": "at0001",
+        "items": [
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "ordinal"
+            },
+            "archetype_node_id": "at0002",
+            "value": {
+              "_type": "DV_ORDINAL",
+              "value": 1,
+              "symbol": {
+                "_type": "DV_CODED_TEXT",
+                "value": "ord1",
+                "defining_code": {
+                  "_type": "CODE_PHRASE",
+                  "terminology_id": {
+                    "_type": "TERMINOLOGY_ID",
+                    "value": "local"
+                  },
+                  "code_string": "at0003"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.obs_admin.null_family.value_and_flavour.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.obs_admin.null_family.value_and_flavour.json
@@ -1,0 +1,243 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "obs_admin.en.v2"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "UY"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "external_ref": {
+      "_type": "PARTY_REF",
+      "id": {
+        "_type": "HIER_OBJECT_ID",
+        "value": "781ef163-d503-4653-9449-40e59a97e1d1"
+      },
+      "namespace": "DEMOGRAPHIC",
+      "type": "PERSON"
+    },
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2019-04-16T21:08:14,127+00:00"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "primary nursing care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "229"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Minimal"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.minimal.v1",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.minimal.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2019-04-16T21:08:14,129+00:00"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Cualquier evento"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2019-04-16T21:08:14,130+00:00"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Arbol"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "text"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_TEXT",
+                    "value": "a text"
+                  },
+                  "null_flavour": {
+                    "value": "no information",
+                    "defining_code": {
+                      "terminology_id": {
+                        "value": "openehr"
+                      },
+                      "code_string": "271"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_type": "ADMIN_ENTRY",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Minimal"
+      },
+      "archetype_node_id": "openEHR-EHR-ADMIN_ENTRY.minimal.v1",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-ADMIN_ENTRY.minimal.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "ITEM_TREE",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Arbol"
+        },
+        "archetype_node_id": "at0001",
+        "items": [
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "ordinal"
+            },
+            "archetype_node_id": "at0002",
+            "value": {
+              "_type": "DV_ORDINAL",
+              "value": 1,
+              "symbol": {
+                "_type": "DV_CODED_TEXT",
+                "value": "ord1",
+                "defining_code": {
+                  "_type": "CODE_PHRASE",
+                  "terminology_id": {
+                    "_type": "TERMINOLOGY_ID",
+                    "value": "local"
+                  },
+                  "code_string": "at0003"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-element_null_family_invalid.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-element_null_family_invalid.yaml
@@ -1,0 +1,39 @@
+# The ELEMENT null-family refusal twins (RM data_structures ch.5): the
+# accepting twin is cnf.composition.null_flavour (a valid null ELEMENT,
+# driven by commit_contribution-valid_composition); these rows pin the three
+# refusals, one defect each. The invariants are per-node RM class rules, so
+# the refusal is the semantic 422 the composition seams answer for invalid
+# content.
+id: I_EHR_CONTRIBUTION.commit_contribution-element_null_family_invalid
+kind: functional
+component: EHR_CONTRIBUTION
+sm_operation: I_EHR_CONTRIBUTION.commit_contribution
+capabilities: [ChangeSets]
+profiles: [CORE]
+test_purpose: "A committed ELEMENT violating the null family — a value beside a null_flavour, a null_reason on a valued node, or an out-of-group null_flavour code — is refused as invalid content, and no version is created."
+description: "commit compositions with ELEMENT null-family defects"
+spec_refs:
+  - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
+  - "RM UML/classes/org.openehr.rm.data_structures.element.adoc §Invariants (Inv_null_flavour_indicated, Inv_null_reason_valid, Inv_null_flavour_valid)"
+  - "ITS-REST overview Requests_and_responses.md §HTTP status codes (the semantic 422 branch)"
+applies: { rm: ">=1.0.2" }
+requires:
+  server: any
+  templates: [cnf.opt.obs_admin.v2]
+  ehr: { commits: none }
+parameters:
+  iteration: reset_per_row
+  fixture_set:
+    - { data_set: cnf.composition.null_family.value_and_flavour, expected: validation_failed, defect: "value AND null_flavour on one ELEMENT (Inv_null_flavour_indicated)" }
+    - { data_set: cnf.composition.null_family.orphan_null_reason, expected: validation_failed, defect: "null_reason on a valued ELEMENT (Inv_null_reason_valid)" }
+    - { data_set: cnf.composition.null_family.out_of_group_flavour, expected: validation_failed, defect: "null_flavour code outside the openEHR null flavours group (Inv_null_flavour_valid)" }
+flow:
+  - step: 1
+    call: commit_contribution
+    with:
+      versions: "${ds:fixture}"
+      audit: { change_type: creation, committer: { name: "conformance tester" } }
+    expect: "${fixture.expected}"
+postconditions:
+  - assert: version
+    count: 0

--- a/tools/cnf-runner/artifacts/vocab/capability_matrix.yaml
+++ b/tools/cnf-runner/artifacts/vocab/capability_matrix.yaml
@@ -60,7 +60,7 @@ DirectoryOps: { family: Platform, tier: STANDARD, required: true, min_cases: 85,
 # Floor raised 89 -> 90: the third axis of the master06 §Logical Deletion
 # procedure — a delete member whose own declared lifecycle_state contradicts
 # the deletion it performs (the two data axes were already covered).
-ChangeSets: { family: Platform, tier: CORE, required: true, min_cases: 90, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Change sets)" }
+ChangeSets: { family: Platform, tier: CORE, required: true, min_cases: 91, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Change sets)" }
 Versioning: { family: Platform, tier: CORE, required: true, min_cases: 72, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Versioning)" }
 # Floor raised 121 -> 125 (2026-07-29): the four commit-time CONSTRAINT
 # BINDING cases (member accepted / non-member refused / unresolvable under each


### PR DESCRIPTION
Closes #2469

Adds the three missing refusal twins for the ELEMENT null family at the commit seam — the wire coverage half of the ch.5 (Representation package) audit. Each fixture carries exactly one defect against one falsifiable invariant from `docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.data_structures.element.adoc` §Invariants:

| Fixture | Defect | Invariant |
|---|---|---|
| `…null_family.value_and_flavour` | a DV_TEXT value added to the null ELEMENT that carries `null_flavour` | `Inv_null_flavour_indicated` (`is_null() xor null_flavour = Void`) |
| `…null_family.orphan_null_reason` | `null_reason` beside a present value | `Inv_null_reason_valid` (`null_reason /= Void implies is_null()`) |
| `…null_family.out_of_group_flavour` | flavour code 999 outside the `null flavours` group | `Inv_null_flavour_valid` (terminology group check) |

One case (`I_EHR_CONTRIBUTION.commit_contribution-element_null_family_invalid`), three rows, each expected `validation_failed` with a post-condition version count of 0. The valid twins already exist (`cnf.composition.null_flavour` commits green), so both directions of the family are now pinned. ChangeSets floor 90→91.

Fresh pipeline run: **1029 passed / 0 failed / 0 errored (CORE+STANDARD PASS, 1029/1029)** — the new case passed on all three rows; baseline artifacts ratchet by exactly this case.