### PR TITLE
test(cnf): the DV_IDENTIFIER empty-id refusal twin

### DIFF
--- a/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
@@ -7,12 +7,12 @@ Runner: cnf-runner 3.17.8 · verification pack: passed
 
 | Status | Count |
 | --- | --- |
-| passed | 1031 |
+| passed | 1032 |
 | failed | 0 |
 | errored | 0 |
 | skipped | 0 |
 | not_applicable | 38 |
-| total | 1069 |
+| total | 1070 |
 
 ## By chapter
 
@@ -20,12 +20,12 @@ Grouping is the published per-chapter chart's taxonomy: chapters with their band
 
 | Chapter / band | passed | failed | errored | cited n/a |
 | --- | --- | --- | --- | --- |
-| **EHR** | 450 | 0 | 0 | 18 |
+| **EHR** | 451 | 0 | 0 | 18 |
 | — EHR resource | 25 | 0 | 0 | 2 |
 | — EHR_STATUS | 46 | 0 | 0 | 5 |
 | — COMPOSITION | 137 | 0 | 0 | 0 |
 | — DIRECTORY | 79 | 0 | 0 | 6 |
-| — CONTRIBUTION | 95 | 0 | 0 | 5 |
+| — CONTRIBUTION | 96 | 0 | 0 | 5 |
 | — Item tags | 62 | 0 | 0 | 0 |
 | — Revision history | 6 | 0 | 0 | 0 |
 | **Definitions** | 97 | 0 | 0 | 10 |
@@ -86,7 +86,7 @@ Selected gating cases per claimed capability. `inconclusive` counts cases whose 
 | EhrStatus | pass | 44 | 0 | 0 | 5 |
 | CompositionOps | pass | 59 | 0 | 0 | 0 |
 | DirectoryOps | pass | 77 | 0 | 0 | 8 |
-| ChangeSets | pass | 88 | 0 | 0 | 5 |
+| ChangeSets | pass | 89 | 0 | 0 | 5 |
 | Versioning | pass | 72 | 0 | 0 | 0 |
 | ArchetypeValidation | pass | 125 | 0 | 0 | 0 |
 | PartyOperations | pass | 86 | 0 | 0 | 4 |
@@ -175,7 +175,7 @@ Percentiles re-derive from the embedded HDR V2 histograms; the class verdict is 
 
 ## Honesty
 
-Coverage: 1031 of 1069 selected cases driven.
+Coverage: 1032 of 1070 selected cases driven.
 
 Not-executed verdicts (each cited):
 

--- a/docs/conformance/ferroehr/badge.json
+++ b/docs/conformance/ferroehr/badge.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "openEHR conformance",
-  "message": "CORE+STANDARD PASS · 1031/1031 cases",
+  "message": "CORE+STANDARD PASS · 1032/1032 cases",
   "color": "brightgreen"
 }

--- a/docs/conformance/ferroehr/results.json
+++ b/docs/conformance/ferroehr/results.json
@@ -2227,6 +2227,12 @@
       "rows_total": 1
     },
     {
+      "case": "I_EHR_CONTRIBUTION.commit_contribution-identifier_empty_id",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_CONTRIBUTION.commit_contribution-imported_version_member",
       "status": "passed",
       "rows_driven": 1,

--- a/docs/conformance/ferroehr/verdicts.json
+++ b/docs/conformance/ferroehr/verdicts.json
@@ -268,7 +268,7 @@
     [
       "ChangeSets",
       {
-        "passed": 88,
+        "passed": 89,
         "failed": 0,
         "inconclusive": 0,
         "unevidenced": 5
@@ -588,9 +588,9 @@
     }
   ],
   "coverage": {
-    "selected": 1069,
-    "driven": 1031,
-    "passed": 1031,
+    "selected": 1070,
+    "driven": 1032,
+    "passed": 1032,
     "failed": 0,
     "inconclusive": 0
   }

--- a/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
+++ b/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
@@ -3438,3 +3438,13 @@ cnf.composition.history_open.off_period_offset:
     spec_ref: "RM UML/classes/org.openehr.rm.data_structures.history.adoc §Invariants Period_consistency (is_periodic implies events.for_all(e | e.offset.to_seconds.mod(period.to_seconds) = 0))"
   template_id: "history_open.en.v1"
   provenance: "derived 2026-08-20 from cnf.composition.history_open.interval_events with exactly one defect: the period kept at PT5M and the second event retimed to 08:07:00 (both events POINT_EVENTs of the same ITEM_TREE shape, so the off-period offset is the only violation)"
+cnf.composition.history_open.empty_identifier_id:
+  source: fixtures/contribution/composition.history_open.empty_identifier_id.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "an ELEMENT valued DV_IDENTIFIER whose mandatory id is the empty string"
+    spec_ref: "RM UML/classes/org.openehr.rm.data_types.dv_identifier.adoc §Invariants Id_valid (not id.is_empty)"
+  template_id: "history_open.en.v1"
+  provenance: "derived 2026-08-20 (issue #2474) from cnf.composition.history_open.interval_events with exactly one defect: aperiodic, one POINT_EVENT whose single ELEMENT value is a DV_IDENTIFIER with id \"\" — the open ITEM_STRUCTURE slot admits the element, so Id_valid is the only violation (the missing-id branch is already pinned by the CONT-DV_IDENTIFIER matrix's rm_schema row; this is the present-but-empty twin)"

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.empty_identifier_id.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.empty_identifier_id.json
@@ -1,0 +1,156 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "history_open.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "NL"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2026-02-03T08:00:00Z"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "secondary medical care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "232"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Open history"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.history_open.v1",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.history_open.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2026-02-03T08:00:00Z"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Initial event"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2026-02-03T08:00:00Z"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Any structure"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "RWE id"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_IDENTIFIER",
+                    "id": ""
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-identifier_empty_id.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-identifier_empty_id.yaml
@@ -1,0 +1,38 @@
+# The DV_IDENTIFIER Id_valid refusal twin (RM data_types ch.4, issue #2474):
+# the accepting twin is the populated DV_IDENTIFIER inside
+# cnf.composition.maximal (committed green by
+# commit_contribution-valid_composition); the missing-id branch is pinned by
+# the CONT-DV_IDENTIFIER matrix's rm_schema row. This row pins the
+# present-but-EMPTY id — a distinct RM invariant refusal, single-cause under
+# the open history_open.en.v1 template.
+id: I_EHR_CONTRIBUTION.commit_contribution-identifier_empty_id
+kind: functional
+component: EHR_CONTRIBUTION
+sm_operation: I_EHR_CONTRIBUTION.commit_contribution
+capabilities: [ChangeSets]
+profiles: [CORE]
+test_purpose: "A committed DV_IDENTIFIER whose mandatory id is the empty string is refused as invalid content (Id_valid: not id.is_empty), and no version is created."
+description: "commit a composition carrying a DV_IDENTIFIER with an empty id"
+spec_refs:
+  - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
+  - "RM UML/classes/org.openehr.rm.data_types.dv_identifier.adoc §Invariants (Id_valid: not id.is_empty)"
+  - "ITS-REST overview Requests_and_responses.md §HTTP status codes (the semantic 422 branch)"
+applies: { rm: ">=1.0.2" }
+requires:
+  server: any
+  templates: [cnf.opt.history_open.v1]
+  ehr: { commits: none }
+parameters:
+  iteration: reset_per_row
+  fixture_set:
+    - { data_set: cnf.composition.history_open.empty_identifier_id, expected: validation_failed, defect: "DV_IDENTIFIER.id is the empty string (Id_valid)" }
+flow:
+  - step: 1
+    call: commit_contribution
+    with:
+      versions: "${ds:fixture}"
+      audit: { change_type: creation, committer: { name: "conformance tester" } }
+    expect: "${fixture.expected}"
+postconditions:
+  - assert: version
+    count: 0

--- a/tools/cnf-runner/artifacts/vocab/capability_matrix.yaml
+++ b/tools/cnf-runner/artifacts/vocab/capability_matrix.yaml
@@ -63,7 +63,10 @@ DirectoryOps: { family: Platform, tier: STANDARD, required: true, min_cases: 85,
 # Floor raised 91 -> 93 (2026-08-20): the History-package twins (issue
 # #2471) — the master06 instance-figure acceptance case plus the
 # three-invariant refusal family under the open history template.
-ChangeSets: { family: Platform, tier: CORE, required: true, min_cases: 93, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Change sets)" }
+# Raised 93 -> 94 (2026-08-20): the DV_IDENTIFIER empty-id refusal twin
+# (issue #2474, Id_valid — the present-but-empty branch beside the
+# CONT-DV_IDENTIFIER matrix's missing-id row).
+ChangeSets: { family: Platform, tier: CORE, required: true, min_cases: 94, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Change sets)" }
 Versioning: { family: Platform, tier: CORE, required: true, min_cases: 72, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Versioning)" }
 # Floor raised 121 -> 125 (2026-07-29): the four commit-time CONSTRAINT
 # BINDING cases (member accepted / non-member refused / unresolvable under each


### PR DESCRIPTION
Closes #2474

The wire-coverage finding of the ch.4 (Basic package) audit (#912): `DV_IDENTIFIER.Id_valid` (`not id.is_empty`, `org.openehr.rm.data_types.dv_identifier.adoc` §Invariants) is enforced (`dv_identifier_core`, typed + fast path, register-pinned) but nothing exercised it on the wire — the CONT-DV_IDENTIFIER matrix pins the MISSING id (rm_schema mandatory) and the C_STRING constraints, and a present-but-empty id is a distinct RM refusal.

One single-defect fixture (an ELEMENT valued `DV_IDENTIFIER` with `id: ""`) under the ch.6 open template — the archetype admits the element, so `Id_valid` is the only violation — expected `validation_failed` with version count 0. The accepting twin is the populated DV_IDENTIFIER inside `cnf.composition.maximal` (commits green in the B.2 set). ChangeSets floor 93→94.

Fresh pipeline: **1032 passed / 0 failed / 0 errored — CORE+STANDARD PASS, 1032/1032**; `cnf-runner validate` 1071 cases 0 findings; the 348-test battery green.