### PR TITLE
test(cnf): the Text-package wire twins

### DIFF
--- a/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
@@ -7,12 +7,12 @@ Runner: cnf-runner 3.17.8 · verification pack: passed
 
 | Status | Count |
 | --- | --- |
-| passed | 1032 |
+| passed | 1034 |
 | failed | 0 |
 | errored | 0 |
 | skipped | 0 |
 | not_applicable | 38 |
-| total | 1070 |
+| total | 1072 |
 
 ## By chapter
 
@@ -20,12 +20,12 @@ Grouping is the published per-chapter chart's taxonomy: chapters with their band
 
 | Chapter / band | passed | failed | errored | cited n/a |
 | --- | --- | --- | --- | --- |
-| **EHR** | 451 | 0 | 0 | 18 |
+| **EHR** | 453 | 0 | 0 | 18 |
 | — EHR resource | 25 | 0 | 0 | 2 |
 | — EHR_STATUS | 46 | 0 | 0 | 5 |
 | — COMPOSITION | 137 | 0 | 0 | 0 |
 | — DIRECTORY | 79 | 0 | 0 | 6 |
-| — CONTRIBUTION | 96 | 0 | 0 | 5 |
+| — CONTRIBUTION | 98 | 0 | 0 | 5 |
 | — Item tags | 62 | 0 | 0 | 0 |
 | — Revision history | 6 | 0 | 0 | 0 |
 | **Definitions** | 97 | 0 | 0 | 10 |
@@ -86,7 +86,7 @@ Selected gating cases per claimed capability. `inconclusive` counts cases whose 
 | EhrStatus | pass | 44 | 0 | 0 | 5 |
 | CompositionOps | pass | 59 | 0 | 0 | 0 |
 | DirectoryOps | pass | 77 | 0 | 0 | 8 |
-| ChangeSets | pass | 89 | 0 | 0 | 5 |
+| ChangeSets | pass | 91 | 0 | 0 | 5 |
 | Versioning | pass | 72 | 0 | 0 | 0 |
 | ArchetypeValidation | pass | 125 | 0 | 0 | 0 |
 | PartyOperations | pass | 86 | 0 | 0 | 4 |
@@ -175,7 +175,7 @@ Percentiles re-derive from the embedded HDR V2 histograms; the class verdict is 
 
 ## Honesty
 
-Coverage: 1032 of 1070 selected cases driven.
+Coverage: 1034 of 1072 selected cases driven.
 
 Not-executed verdicts (each cited):
 

--- a/docs/conformance/ferroehr/badge.json
+++ b/docs/conformance/ferroehr/badge.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "openEHR conformance",
-  "message": "CORE+STANDARD PASS · 1032/1032 cases",
+  "message": "CORE+STANDARD PASS · 1034/1034 cases",
   "color": "brightgreen"
 }

--- a/docs/conformance/ferroehr/results.json
+++ b/docs/conformance/ferroehr/results.json
@@ -2149,6 +2149,12 @@
       "rows_total": 1
     },
     {
+      "case": "I_EHR_CONTRIBUTION.commit_contribution-deprecated_text_forms",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_CONTRIBUTION.commit_contribution-ehr_not_modifiable",
       "status": "passed",
       "rows_driven": 1,
@@ -2408,6 +2414,12 @@
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1
+    },
+    {
+      "case": "I_EHR_CONTRIBUTION.commit_contribution-text_family_invalid",
+      "status": "passed",
+      "rows_driven": 4,
+      "rows_total": 4
     },
     {
       "case": "I_EHR_CONTRIBUTION.commit_contribution-two_commits_second_creation",

--- a/docs/conformance/ferroehr/verdicts.json
+++ b/docs/conformance/ferroehr/verdicts.json
@@ -268,7 +268,7 @@
     [
       "ChangeSets",
       {
-        "passed": 89,
+        "passed": 91,
         "failed": 0,
         "inconclusive": 0,
         "unevidenced": 5
@@ -588,9 +588,9 @@
     }
   ],
   "coverage": {
-    "selected": 1070,
-    "driven": 1032,
-    "passed": 1032,
+    "selected": 1072,
+    "driven": 1034,
+    "passed": 1034,
     "failed": 0,
     "inconclusive": 0
   }

--- a/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
+++ b/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
@@ -3448,3 +3448,50 @@ cnf.composition.history_open.empty_identifier_id:
     spec_ref: "RM UML/classes/org.openehr.rm.data_types.dv_identifier.adoc §Invariants Id_valid (not id.is_empty)"
   template_id: "history_open.en.v1"
   provenance: "derived 2026-08-20 (issue #2474) from cnf.composition.history_open.interval_events with exactly one defect: aperiodic, one POINT_EVENT whose single ELEMENT value is a DV_IDENTIFIER with id \"\" — the open ITEM_STRUCTURE slot admits the element, so Id_valid is the only violation (the missing-id branch is already pinned by the CONT-DV_IDENTIFIER matrix's rm_schema row; this is the present-but-empty twin)"
+cnf.composition.history_open.deprecated_text_forms:
+  source: fixtures/contribution/composition.history_open.deprecated_text_forms.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity: { verdict: valid }
+  template_id: "history_open.en.v1"
+  provenance: "authored 2026-08-20 (issue #2476): the three deprecated-but-legal Text forms in one committed instance — an ELEMENT valued DV_PARAGRAPH (master05 §Design: remains legal, should be supported in at least a basic way) whose first DV_TEXT item carries the legacy CSS formatting string and a hyperlink (both deprecated with continued legality, dv_text.adoc §Attributes) — the accepting twins of the paragraph_no_items refusal fixtures"
+cnf.composition.history_open.empty_formatting:
+  source: fixtures/contribution/composition.history_open.empty_formatting.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "a DV_TEXT with a present-but-empty formatting string"
+    spec_ref: "RM UML/classes/org.openehr.rm.data_types.dv_text.adoc §Invariants Formatting_valid (formatting /= void implies not formatting.is_empty)"
+  template_id: "history_open.en.v1"
+  provenance: "derived 2026-08-20 (issue #2476) from cnf.composition.history_open.interval_events with exactly one defect: one DV_TEXT ELEMENT whose formatting is \"\""
+cnf.composition.history_open.bad_encoding:
+  source: fixtures/contribution/composition.history_open.bad_encoding.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "a DV_TEXT whose encoding code bogus-charset is no member of the character sets code set"
+    spec_ref: "RM UML/classes/org.openehr.rm.data_types.dv_text.adoc §Invariants Encoding_valid (encoding /= Void implies code_set(Code_set_id_character_sets).has_code(encoding))"
+  template_id: "history_open.en.v1"
+  provenance: "derived 2026-08-20 (issue #2476) from cnf.composition.history_open.interval_events with exactly one defect: one DV_TEXT ELEMENT carrying encoding IANA_character-sets::bogus-charset"
+cnf.composition.history_open.bad_match:
+  source: fixtures/contribution/composition.history_open.bad_match.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "a TERM_MAPPING whose match character # is outside < = > ?"
+    spec_ref: "RM UML/classes/org.openehr.rm.data_types.term_mapping.adoc §Invariants Match_valid (is_valid_match_code: c = '>' or c = '=' or c = '<' or c = '?')"
+  template_id: "history_open.en.v1"
+  provenance: "derived 2026-08-20 (issue #2476) from cnf.composition.history_open.interval_events with exactly one defect: one DV_TEXT ELEMENT carrying a single mapping whose match is '#' (the target CODE_PHRASE is well-formed, so the match code is the only violation)"
+cnf.composition.history_open.empty_code_string:
+  source: fixtures/contribution/composition.history_open.empty_code_string.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "a mapping target CODE_PHRASE whose code_string is the empty string"
+    spec_ref: "RM UML/classes/org.openehr.rm.data_types.code_phrase.adoc §Invariants Code_string_valid (not code_string.is_empty)"
+  template_id: "history_open.en.v1"
+  provenance: "derived 2026-08-20 (issue #2476) from cnf.composition.history_open.interval_events with exactly one defect: one DV_TEXT ELEMENT carrying a single well-formed mapping (match '=') whose target code_string is \"\" — the target path carries no terminology-group check, so Code_string_valid is the only violation"

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.bad_encoding.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.bad_encoding.json
@@ -1,0 +1,164 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "history_open.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "NL"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2026-02-03T08:00:00Z"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "secondary medical care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "232"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Open history"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.history_open.v1",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.history_open.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2026-02-03T08:00:00Z"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Initial event"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2026-02-03T08:00:00Z"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Any structure"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "note"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_TEXT",
+                    "value": "a note",
+                    "encoding": {
+                      "_type": "CODE_PHRASE",
+                      "terminology_id": {
+                        "_type": "TERMINOLOGY_ID",
+                        "value": "IANA_character-sets"
+                      },
+                      "code_string": "bogus-charset"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.bad_match.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.bad_match.json
@@ -1,0 +1,170 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "history_open.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "NL"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2026-02-03T08:00:00Z"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "secondary medical care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "232"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Open history"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.history_open.v1",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.history_open.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2026-02-03T08:00:00Z"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Initial event"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2026-02-03T08:00:00Z"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Any structure"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "note"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_TEXT",
+                    "value": "arbovirus infection",
+                    "mappings": [
+                      {
+                        "_type": "TERM_MAPPING",
+                        "match": "#",
+                        "target": {
+                          "_type": "CODE_PHRASE",
+                          "terminology_id": {
+                            "_type": "TERMINOLOGY_ID",
+                            "value": "ICD10"
+                          },
+                          "code_string": "A92.8"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.deprecated_text_forms.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.deprecated_text_forms.json
@@ -1,0 +1,170 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "history_open.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "NL"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2026-02-03T08:00:00Z"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "secondary medical care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "232"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Open history"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.history_open.v1",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.history_open.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2026-02-03T08:00:00Z"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Initial event"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2026-02-03T08:00:00Z"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Any structure"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "Report"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_PARAGRAPH",
+                    "items": [
+                      {
+                        "_type": "DV_TEXT",
+                        "value": "Overall findings unremarkable.",
+                        "formatting": "font-weight : bold; font-family : Arial",
+                        "hyperlink": {
+                          "_type": "DV_URI",
+                          "value": "https://example.test/reference"
+                        }
+                      },
+                      {
+                        "_type": "DV_TEXT",
+                        "value": "Follow-up in two weeks."
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.empty_code_string.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.empty_code_string.json
@@ -1,0 +1,170 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "history_open.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "NL"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2026-02-03T08:00:00Z"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "secondary medical care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "232"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Open history"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.history_open.v1",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.history_open.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2026-02-03T08:00:00Z"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Initial event"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2026-02-03T08:00:00Z"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Any structure"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "note"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_TEXT",
+                    "value": "arbovirus infection",
+                    "mappings": [
+                      {
+                        "_type": "TERM_MAPPING",
+                        "match": "=",
+                        "target": {
+                          "_type": "CODE_PHRASE",
+                          "terminology_id": {
+                            "_type": "TERMINOLOGY_ID",
+                            "value": "ICD10"
+                          },
+                          "code_string": ""
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.empty_formatting.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.empty_formatting.json
@@ -1,0 +1,157 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "history_open.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "NL"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2026-02-03T08:00:00Z"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "secondary medical care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "232"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Open history"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.history_open.v1",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.history_open.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2026-02-03T08:00:00Z"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Initial event"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2026-02-03T08:00:00Z"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Any structure"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "note"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_TEXT",
+                    "value": "a note",
+                    "formatting": ""
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-deprecated_text_forms.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-deprecated_text_forms.yaml
@@ -1,0 +1,51 @@
+# The deprecated-but-legal Text forms accepting twin (RM data_types ch.5,
+# issue #2476): DV_PARAGRAPH "remains legal, and should be supported in at
+# least a basic way" (master05 §Formatting and Hyperlinking WARNING), and the
+# legacy CSS formatting string and hyperlink field stay legal beside their
+# deprecation (dv_text.adoc §Attributes). The refusal direction is already
+# pinned by the paragraph_no_items strict-reader twins; this proves the
+# accepting direction commits. Acceptance IS the deprecation's exact wire
+# strength: the commit wire has no findings channel and I_VALIDITY_CHECKER
+# is Boolean by the SM signature, so no Warning channel exists to carry more.
+id: I_EHR_CONTRIBUTION.commit_contribution-deprecated_text_forms
+kind: functional
+component: EHR_CONTRIBUTION
+sm_operation: I_EHR_CONTRIBUTION.commit_contribution
+capabilities: [ChangeSets]
+profiles: [CORE]
+test_purpose: >-
+  Committing a composition carrying the three deprecated-but-legal Text
+  forms — a DV_PARAGRAPH whose items include a DV_TEXT with a legacy CSS
+  formatting string and a hyperlink — succeeds and creates version 1.
+description: "commit a composition carrying DV_PARAGRAPH + legacy formatting + hyperlink"
+spec_refs:
+  - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
+  - "RM data_types/master05-text_package.adoc §Formatting and Hyperlinking (DV_PARAGRAPH remains legal, and should be supported in at least a basic way; the legacy CSS form remains legal; hyperlink deprecated at RM 1.0.4)"
+  - "RM UML/classes/org.openehr.rm.data_types.dv_paragraph.adoc §Invariants (Items_valid: not items.is_empty)"
+applies: { rm: ">=1.0.2" }
+requires:
+  server: any
+  templates: [cnf.opt.history_open.v1]
+  ehr: { commits: none }
+parameters:
+  iteration: reset_per_row
+  fixture_set:
+    - { data_set: cnf.composition.history_open.deprecated_text_forms, expected: created, defect: "DV_PARAGRAPH + legacy CSS formatting + hyperlink, all deprecated-but-legal" }
+flow:
+  - step: 1
+    call: commit_contribution
+    with:
+      ehr_id: "${ehr_id}"
+      versions:
+        - { data: "${ds:fixture}", change_type: creation }
+    expect: "${fixture.expected}"
+    capture:
+      version_uids: created.version_uids[]
+    assert:
+      - { assert: version, for_each: "${version_uids}", change_type: CREATE, uid_pattern: "<uuid>::<system>::1" }
+postconditions:
+  - assert: state
+    text: >-
+      The EHR holds one new VERSION<COMPOSITION> whose DV_PARAGRAPH, legacy
+      formatting string and hyperlink are stored and served unchanged.
+    verified_by: I_EHR_COMPOSITION.get_composition_latest

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-text_family_invalid.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-text_family_invalid.yaml
@@ -1,0 +1,41 @@
+# The Text-package refusal twins (RM data_types ch.5, issue #2476): four
+# falsifiable invariants with no prior wire case, one defect per row under
+# the open history_open.en.v1 template (the archetype admits each element,
+# so the named RM rule is the only violation). Accepting twins: the
+# committed corpus text values everywhere (Valid_value family), and
+# cnf.composition.history_open.deprecated_text_forms for the paragraph path.
+id: I_EHR_CONTRIBUTION.commit_contribution-text_family_invalid
+kind: functional
+component: EHR_CONTRIBUTION
+sm_operation: I_EHR_CONTRIBUTION.commit_contribution
+capabilities: [ChangeSets]
+profiles: [CORE]
+test_purpose: "A committed text value violating the Text family — an empty formatting string, an encoding outside the character sets code set, a match character outside < = > ?, or an empty mapping-target code_string — is refused as invalid content, and no version is created."
+description: "commit compositions with Text-package invariant defects"
+spec_refs:
+  - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
+  - "RM UML/classes/org.openehr.rm.data_types.dv_text.adoc §Invariants (Formatting_valid, Encoding_valid)"
+  - "RM UML/classes/org.openehr.rm.data_types.term_mapping.adoc §Invariants (Match_valid) + org.openehr.rm.data_types.code_phrase.adoc §Invariants (Code_string_valid)"
+  - "ITS-REST overview Requests_and_responses.md §HTTP status codes (the semantic 422 branch)"
+applies: { rm: ">=1.0.2" }
+requires:
+  server: any
+  templates: [cnf.opt.history_open.v1]
+  ehr: { commits: none }
+parameters:
+  iteration: reset_per_row
+  fixture_set:
+    - { data_set: cnf.composition.history_open.empty_formatting, expected: validation_failed, defect: "present-but-empty formatting string (Formatting_valid)" }
+    - { data_set: cnf.composition.history_open.bad_encoding, expected: validation_failed, defect: "encoding code outside the character sets code set (Encoding_valid)" }
+    - { data_set: cnf.composition.history_open.bad_match, expected: validation_failed, defect: "match character '#' outside < = > ? (Match_valid)" }
+    - { data_set: cnf.composition.history_open.empty_code_string, expected: validation_failed, defect: "empty mapping-target code_string (Code_string_valid)" }
+flow:
+  - step: 1
+    call: commit_contribution
+    with:
+      versions: "${ds:fixture}"
+      audit: { change_type: creation, committer: { name: "conformance tester" } }
+    expect: "${fixture.expected}"
+postconditions:
+  - assert: version
+    count: 0

--- a/tools/cnf-runner/artifacts/vocab/capability_matrix.yaml
+++ b/tools/cnf-runner/artifacts/vocab/capability_matrix.yaml
@@ -66,7 +66,10 @@ DirectoryOps: { family: Platform, tier: STANDARD, required: true, min_cases: 85,
 # Raised 93 -> 94 (2026-08-20): the DV_IDENTIFIER empty-id refusal twin
 # (issue #2474, Id_valid — the present-but-empty branch beside the
 # CONT-DV_IDENTIFIER matrix's missing-id row).
-ChangeSets: { family: Platform, tier: CORE, required: true, min_cases: 94, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Change sets)" }
+# Raised 94 -> 96 (2026-08-20): the Text-package twins (issue #2476) — the
+# deprecated-forms acceptance case (DV_PARAGRAPH + legacy formatting +
+# hyperlink) plus the four-invariant refusal family.
+ChangeSets: { family: Platform, tier: CORE, required: true, min_cases: 96, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Change sets)" }
 Versioning: { family: Platform, tier: CORE, required: true, min_cases: 72, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Versioning)" }
 # Floor raised 121 -> 125 (2026-07-29): the four commit-time CONSTRAINT
 # BINDING cases (member accepted / non-member refused / unresolvable under each


### PR DESCRIPTION
Closes #2476

The wire-coverage findings of the ch.5 (Text package) audit (#913), both directions:

**Deprecated-forms accepting twin** (`commit_contribution-deprecated_text_forms`): DV_PARAGRAPH "remains legal, and should be supported in at least a basic way" (master05 §Formatting and Hyperlinking), and the legacy CSS `formatting` string and `hyperlink` field stay legal beside their deprecation — but only the `paragraph_no_items` REFUSAL twins existed. One committed instance now carries all three deprecated forms and must create version 1. Adjudication on deprecation strength (recorded on the case): acceptance IS the exact wire strength — the commit wire has no findings channel and `I_VALIDITY_CHECKER` is Boolean by the SM's own signature, so no Warning-severity channel exists to carry more (unlike the ADL-ingest seam of #1470).

**Refusal family** (`commit_contribution-text_family_invalid`), one defect per row under the open template, each expected `validation_failed` with version count 0:

| Row | Defect | Rule |
|---|---|---|
| empty_formatting | `formatting: ""` | `Formatting_valid` |
| bad_encoding | `IANA_character-sets::bogus-charset` | `Encoding_valid` (character sets code set) |
| bad_match | mapping `match: '#'` | `Match_valid` (`< = > ?`) |
| empty_code_string | mapping target `code_string: ""` | `Code_string_valid` |

Census before this PR: those four invariants had zero catalogue sites (Valid_value, Language_valid, Purpose_valid already covered). ChangeSets floor 94→96.

Fresh pipeline: **1034 passed / 0 failed / 0 errored — CORE+STANDARD PASS, 1034/1034**; `cnf-runner validate` 1073 cases 0 findings; the 348-test battery green.