### PR TITLE
test(cnf): the Quantity-package wire twins

### DIFF
--- a/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
@@ -7,12 +7,12 @@ Runner: cnf-runner 3.17.8 · verification pack: passed
 
 | Status | Count |
 | --- | --- |
-| passed | 1034 |
+| passed | 1036 |
 | failed | 0 |
 | errored | 0 |
 | skipped | 0 |
 | not_applicable | 38 |
-| total | 1072 |
+| total | 1074 |
 
 ## By chapter
 
@@ -20,12 +20,12 @@ Grouping is the published per-chapter chart's taxonomy: chapters with their band
 
 | Chapter / band | passed | failed | errored | cited n/a |
 | --- | --- | --- | --- | --- |
-| **EHR** | 453 | 0 | 0 | 18 |
+| **EHR** | 455 | 0 | 0 | 18 |
 | — EHR resource | 25 | 0 | 0 | 2 |
 | — EHR_STATUS | 46 | 0 | 0 | 5 |
 | — COMPOSITION | 137 | 0 | 0 | 0 |
 | — DIRECTORY | 79 | 0 | 0 | 6 |
-| — CONTRIBUTION | 98 | 0 | 0 | 5 |
+| — CONTRIBUTION | 100 | 0 | 0 | 5 |
 | — Item tags | 62 | 0 | 0 | 0 |
 | — Revision history | 6 | 0 | 0 | 0 |
 | **Definitions** | 97 | 0 | 0 | 10 |
@@ -86,7 +86,7 @@ Selected gating cases per claimed capability. `inconclusive` counts cases whose 
 | EhrStatus | pass | 44 | 0 | 0 | 5 |
 | CompositionOps | pass | 59 | 0 | 0 | 0 |
 | DirectoryOps | pass | 77 | 0 | 0 | 8 |
-| ChangeSets | pass | 91 | 0 | 0 | 5 |
+| ChangeSets | pass | 93 | 0 | 0 | 5 |
 | Versioning | pass | 72 | 0 | 0 | 0 |
 | ArchetypeValidation | pass | 125 | 0 | 0 | 0 |
 | PartyOperations | pass | 86 | 0 | 0 | 4 |
@@ -175,7 +175,7 @@ Percentiles re-derive from the embedded HDR V2 histograms; the class verdict is 
 
 ## Honesty
 
-Coverage: 1034 of 1072 selected cases driven.
+Coverage: 1036 of 1074 selected cases driven.
 
 Not-executed verdicts (each cited):
 

--- a/docs/conformance/ferroehr/badge.json
+++ b/docs/conformance/ferroehr/badge.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "openEHR conformance",
-  "message": "CORE+STANDARD PASS · 1034/1034 cases",
+  "message": "CORE+STANDARD PASS · 1036/1036 cases",
   "color": "brightgreen"
 }

--- a/docs/conformance/ferroehr/results.json
+++ b/docs/conformance/ferroehr/results.json
@@ -2404,6 +2404,18 @@
       "rows_total": 1
     },
     {
+      "case": "I_EHR_CONTRIBUTION.commit_contribution-quantity_family_invalid",
+      "status": "passed",
+      "rows_driven": 10,
+      "rows_total": 10
+    },
+    {
+      "case": "I_EHR_CONTRIBUTION.commit_contribution-quantity_rich",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_CONTRIBUTION.commit_contribution-return_identifier",
       "status": "passed",
       "rows_driven": 1,

--- a/docs/conformance/ferroehr/verdicts.json
+++ b/docs/conformance/ferroehr/verdicts.json
@@ -268,7 +268,7 @@
     [
       "ChangeSets",
       {
-        "passed": 91,
+        "passed": 93,
         "failed": 0,
         "inconclusive": 0,
         "unevidenced": 5
@@ -588,9 +588,9 @@
     }
   ],
   "coverage": {
-    "selected": 1072,
-    "driven": 1034,
-    "passed": 1034,
+    "selected": 1074,
+    "driven": 1036,
+    "passed": 1036,
     "failed": 0,
     "inconclusive": 0
   }

--- a/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
+++ b/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
@@ -3495,3 +3495,110 @@ cnf.composition.history_open.empty_code_string:
     spec_ref: "RM UML/classes/org.openehr.rm.data_types.code_phrase.adoc §Invariants Code_string_valid (not code_string.is_empty)"
   template_id: "history_open.en.v1"
   provenance: "derived 2026-08-20 (issue #2476) from cnf.composition.history_open.interval_events with exactly one defect: one DV_TEXT ELEMENT carrying a single well-formed mapping (match '=') whose target code_string is \"\" — the target path carries no terminology-group check, so Code_string_valid is the only violation"
+cnf.composition.history_open.quantity_rich:
+  source: fixtures/contribution/composition.history_open.quantity_rich.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity: { verdict: valid }
+  template_id: "history_open.en.v1"
+  provenance: "authored 2026-08-20 (issue #2478): the quantity family's rich accepting instance — a DV_QUANTITY carrying every optional trimming (magnitude_status ~, percent accuracy 5, precision 1, units_system + units_display_name, normal_status N, a containing normal_range 90..130, an other_reference_ranges critical entry) beside a valid percent DV_PROPORTION — the accepting twin of the cnf.composition.history_open quantity refusal rows"
+cnf.composition.history_open.bad_magnitude_status:
+  source: fixtures/contribution/composition.history_open.bad_magnitude_status.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "a DV_QUANTITY whose magnitude_status !! is outside = < > <= >= ~"
+    spec_ref: "RM UML/classes/org.openehr.rm.data_types.dv_quantified.adoc §Invariants Magnitude_status_valid (valid_magnitude_status)"
+  template_id: "history_open.en.v1"
+  provenance: "derived 2026-08-20 (issue #2478) from cnf.composition.history_open.interval_events with exactly one defect: magnitude_status \"!!\""
+cnf.composition.history_open.accuracy_zero_percent:
+  source: fixtures/contribution/composition.history_open.accuracy_zero_percent.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "a DV_QUANTITY with accuracy 0 while accuracy_is_percent is true"
+    spec_ref: "RM UML/classes/org.openehr.rm.data_types.dv_amount.adoc §Invariants Accuracy_is_percent_validity (accuracy = 0 implies not accuracy_is_percent)"
+  template_id: "history_open.en.v1"
+  provenance: "derived 2026-08-20 (issue #2478): exactly one defect — accuracy 0.0 with accuracy_is_percent true (0 is a valid percentage, so Accuracy_validity stays quiet)"
+cnf.composition.history_open.accuracy_percent_out_of_range:
+  source: fixtures/contribution/composition.history_open.accuracy_percent_out_of_range.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "a DV_QUANTITY whose percent accuracy 250 is outside 0..100"
+    spec_ref: "RM UML/classes/org.openehr.rm.data_types.dv_amount.adoc §Invariants Accuracy_validity (accuracy_is_percent implies valid_percentage(accuracy))"
+  template_id: "history_open.en.v1"
+  provenance: "derived 2026-08-20 (issue #2478): exactly one defect — accuracy 250.0 with accuracy_is_percent true (non-zero, so Accuracy_is_percent_validity stays quiet)"
+cnf.composition.history_open.fraction_non_integral:
+  source: fixtures/contribution/composition.history_open.fraction_non_integral.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "a pk_fraction DV_PROPORTION whose numerator 1.5 is not integral"
+    spec_ref: "RM UML/classes/org.openehr.rm.data_types.dv_proportion.adoc §Invariants Fraction_validity ((type = pk_fraction or type = pk_integer_fraction) implies is_integral)"
+  template_id: "history_open.en.v1"
+  provenance: "derived 2026-08-20 (issue #2478): exactly one defect — type 3 with numerator 1.5 (Is_integral_validity is register-excluded as the same defect, so the core reports Fraction_validity once)"
+cnf.composition.history_open.unitary_bad_denominator:
+  source: fixtures/contribution/composition.history_open.unitary_bad_denominator.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "a pk_unitary DV_PROPORTION whose denominator is 2, not 1"
+    spec_ref: "RM UML/classes/org.openehr.rm.data_types.dv_proportion.adoc §Invariants Unitary_validity (type = pk_unitary implies denominator = 1)"
+  template_id: "history_open.en.v1"
+  provenance: "derived 2026-08-20 (issue #2478): exactly one defect — type 1 with denominator 2.0"
+cnf.composition.history_open.percent_bad_denominator:
+  source: fixtures/contribution/composition.history_open.percent_bad_denominator.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "a pk_percent DV_PROPORTION whose denominator is 500, not 100"
+    spec_ref: "RM UML/classes/org.openehr.rm.data_types.dv_proportion.adoc §Invariants Percent_validity (type = pk_percent implies denominator = 100)"
+  template_id: "history_open.en.v1"
+  provenance: "derived 2026-08-20 (issue #2478): exactly one defect — type 2 with denominator 500.0"
+cnf.composition.history_open.zero_denominator:
+  source: fixtures/contribution/composition.history_open.zero_denominator.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "a DV_PROPORTION whose denominator is 0.0"
+    spec_ref: "RM UML/classes/org.openehr.rm.data_types.dv_proportion.adoc §Invariants Valid_denominator (denominator /= 0.0)"
+  template_id: "history_open.en.v1"
+  provenance: "derived 2026-08-20 (issue #2478): exactly one defect — type 0 (ratio, any values legal) with denominator 0.0"
+cnf.composition.history_open.bad_normal_status:
+  source: fixtures/contribution/composition.history_open.bad_normal_status.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "a DV_QUANTITY whose normal_status code XX is no member of the normal statuses code set"
+    spec_ref: "RM UML/classes/org.openehr.rm.data_types.dv_ordered.adoc §Invariants Normal_status_validity (code_set(Code_set_id_normal_statuses).has_code(normal_status))"
+  template_id: "history_open.en.v1"
+  provenance: "derived 2026-08-20 (issue #2478): exactly one defect — normal_status openehr_normal_statuses::XX"
+cnf.composition.history_open.status_range_inconsistent:
+  source: fixtures/contribution/composition.history_open.status_range_inconsistent.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "a DV_QUANTITY of magnitude 50 declaring normal_status N beside a normal_range 100..200 that does not contain it"
+    spec_ref: "RM UML/classes/org.openehr.rm.data_types.dv_ordered.adoc §Invariants Normal_range_and_status_consistency ((normal_range /= Void and normal_status /= Void) implies (normal_status.code_string.is_equal(N) xor not normal_range.has(self)))"
+  template_id: "history_open.en.v1"
+  provenance: "derived 2026-08-20 (issue #2478): exactly one defect — the N status contradicts the out-of-range value (the status code is set-valid and the range limits are comparable and ordered, so the consistency xor is the only violation)"
+cnf.composition.history_open.nonsimple_reference_range:
+  source: fixtures/contribution/composition.history_open.nonsimple_reference_range.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "an other_reference_ranges entry whose range lower limit itself carries a normal_range (a non-simple limit)"
+    spec_ref: "RM UML/classes/org.openehr.rm.data_types.reference_range.adoc §Invariants Range_is_simple ((range.lower_unbounded or else range.lower.is_simple) and (range.upper_unbounded or else range.upper.is_simple))"
+  template_id: "history_open.en.v1"
+  provenance: "derived 2026-08-20 (issue #2478): exactly one defect — the critical range's lower DV_QUANTITY carries its own (internally consistent, contained) normal_range, so Range_is_simple is the only violation"

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.accuracy_percent_out_of_range.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.accuracy_percent_out_of_range.json
@@ -1,0 +1,159 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "history_open.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "NL"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2026-02-03T08:00:00Z"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "secondary medical care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "232"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Open history"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.history_open.v1",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.history_open.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2026-02-03T08:00:00Z"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Initial event"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2026-02-03T08:00:00Z"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Any structure"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "q"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_QUANTITY",
+                    "magnitude": 120.0,
+                    "units": "mm[Hg]",
+                    "accuracy": 250.0,
+                    "accuracy_is_percent": true
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.accuracy_zero_percent.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.accuracy_zero_percent.json
@@ -1,0 +1,159 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "history_open.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "NL"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2026-02-03T08:00:00Z"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "secondary medical care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "232"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Open history"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.history_open.v1",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.history_open.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2026-02-03T08:00:00Z"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Initial event"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2026-02-03T08:00:00Z"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Any structure"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "q"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_QUANTITY",
+                    "magnitude": 120.0,
+                    "units": "mm[Hg]",
+                    "accuracy": 0.0,
+                    "accuracy_is_percent": true
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.bad_magnitude_status.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.bad_magnitude_status.json
@@ -1,0 +1,158 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "history_open.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "NL"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2026-02-03T08:00:00Z"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "secondary medical care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "232"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Open history"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.history_open.v1",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.history_open.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2026-02-03T08:00:00Z"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Initial event"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2026-02-03T08:00:00Z"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Any structure"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "q"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_QUANTITY",
+                    "magnitude": 120.0,
+                    "units": "mm[Hg]",
+                    "magnitude_status": "!!"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.bad_normal_status.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.bad_normal_status.json
@@ -1,0 +1,165 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "history_open.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "NL"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2026-02-03T08:00:00Z"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "secondary medical care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "232"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Open history"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.history_open.v1",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.history_open.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2026-02-03T08:00:00Z"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Initial event"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2026-02-03T08:00:00Z"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Any structure"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "q"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_QUANTITY",
+                    "magnitude": 120.0,
+                    "units": "mm[Hg]",
+                    "normal_status": {
+                      "_type": "CODE_PHRASE",
+                      "terminology_id": {
+                        "_type": "TERMINOLOGY_ID",
+                        "value": "openehr_normal_statuses"
+                      },
+                      "code_string": "XX"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.fraction_non_integral.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.fraction_non_integral.json
@@ -1,0 +1,158 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "history_open.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "NL"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2026-02-03T08:00:00Z"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "secondary medical care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "232"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Open history"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.history_open.v1",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.history_open.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2026-02-03T08:00:00Z"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Initial event"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2026-02-03T08:00:00Z"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Any structure"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "q"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_PROPORTION",
+                    "numerator": 1.5,
+                    "denominator": 2.0,
+                    "type": 3
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.nonsimple_reference_range.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.nonsimple_reference_range.json
@@ -1,0 +1,195 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "history_open.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "NL"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2026-02-03T08:00:00Z"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "secondary medical care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "232"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Open history"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.history_open.v1",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.history_open.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2026-02-03T08:00:00Z"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Initial event"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2026-02-03T08:00:00Z"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Any structure"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "q"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_QUANTITY",
+                    "magnitude": 120.0,
+                    "units": "mm[Hg]",
+                    "other_reference_ranges": [
+                      {
+                        "_type": "REFERENCE_RANGE",
+                        "meaning": {
+                          "_type": "DV_TEXT",
+                          "value": "critical"
+                        },
+                        "range": {
+                          "_type": "DV_INTERVAL",
+                          "lower": {
+                            "_type": "DV_QUANTITY",
+                            "magnitude": 180.0,
+                            "units": "mm[Hg]",
+                            "normal_range": {
+                              "_type": "DV_INTERVAL",
+                              "lower": {
+                                "_type": "DV_QUANTITY",
+                                "magnitude": 170.0,
+                                "units": "mm[Hg]"
+                              },
+                              "upper": {
+                                "_type": "DV_QUANTITY",
+                                "magnitude": 190.0,
+                                "units": "mm[Hg]"
+                              },
+                              "lower_unbounded": false,
+                              "upper_unbounded": false,
+                              "lower_included": true,
+                              "upper_included": true
+                            }
+                          },
+                          "lower_unbounded": false,
+                          "upper_unbounded": true,
+                          "lower_included": true,
+                          "upper_included": false
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.percent_bad_denominator.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.percent_bad_denominator.json
@@ -1,0 +1,158 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "history_open.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "NL"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2026-02-03T08:00:00Z"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "secondary medical care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "232"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Open history"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.history_open.v1",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.history_open.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2026-02-03T08:00:00Z"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Initial event"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2026-02-03T08:00:00Z"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Any structure"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "q"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_PROPORTION",
+                    "numerator": 14.5,
+                    "denominator": 500.0,
+                    "type": 2
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.quantity_rich.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.quantity_rich.json
@@ -1,0 +1,224 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "history_open.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "NL"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2026-02-03T08:00:00Z"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "secondary medical care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "232"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Open history"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.history_open.v1",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.history_open.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2026-02-03T08:00:00Z"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Initial event"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2026-02-03T08:00:00Z"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Any structure"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "BP mean"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_QUANTITY",
+                    "magnitude_status": "~",
+                    "accuracy": 5.0,
+                    "accuracy_is_percent": true,
+                    "magnitude": 120.5,
+                    "precision": 1,
+                    "units": "mm[Hg]",
+                    "units_system": "http://unitsofmeasure.org",
+                    "units_display_name": "mmHg",
+                    "normal_status": {
+                      "_type": "CODE_PHRASE",
+                      "terminology_id": {
+                        "_type": "TERMINOLOGY_ID",
+                        "value": "openehr_normal_statuses"
+                      },
+                      "code_string": "N"
+                    },
+                    "normal_range": {
+                      "_type": "DV_INTERVAL",
+                      "lower": {
+                        "_type": "DV_QUANTITY",
+                        "magnitude": 90.0,
+                        "units": "mm[Hg]"
+                      },
+                      "upper": {
+                        "_type": "DV_QUANTITY",
+                        "magnitude": 130.0,
+                        "units": "mm[Hg]"
+                      },
+                      "lower_unbounded": false,
+                      "upper_unbounded": false,
+                      "lower_included": true,
+                      "upper_included": true
+                    },
+                    "other_reference_ranges": [
+                      {
+                        "_type": "REFERENCE_RANGE",
+                        "meaning": {
+                          "_type": "DV_TEXT",
+                          "value": "critical"
+                        },
+                        "range": {
+                          "_type": "DV_INTERVAL",
+                          "lower": {
+                            "_type": "DV_QUANTITY",
+                            "magnitude": 180.0,
+                            "units": "mm[Hg]"
+                          },
+                          "lower_unbounded": false,
+                          "upper_unbounded": true,
+                          "lower_included": true,
+                          "upper_included": false
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "RDW"
+                  },
+                  "archetype_node_id": "at0005",
+                  "value": {
+                    "_type": "DV_PROPORTION",
+                    "numerator": 14.5,
+                    "denominator": 100.0,
+                    "type": 2,
+                    "precision": 1
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.status_range_inconsistent.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.status_range_inconsistent.json
@@ -1,0 +1,182 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "history_open.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "NL"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2026-02-03T08:00:00Z"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "secondary medical care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "232"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Open history"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.history_open.v1",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.history_open.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2026-02-03T08:00:00Z"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Initial event"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2026-02-03T08:00:00Z"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Any structure"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "q"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_QUANTITY",
+                    "magnitude": 50.0,
+                    "units": "mm[Hg]",
+                    "normal_status": {
+                      "_type": "CODE_PHRASE",
+                      "terminology_id": {
+                        "_type": "TERMINOLOGY_ID",
+                        "value": "openehr_normal_statuses"
+                      },
+                      "code_string": "N"
+                    },
+                    "normal_range": {
+                      "_type": "DV_INTERVAL",
+                      "lower": {
+                        "_type": "DV_QUANTITY",
+                        "magnitude": 100.0,
+                        "units": "mm[Hg]"
+                      },
+                      "upper": {
+                        "_type": "DV_QUANTITY",
+                        "magnitude": 200.0,
+                        "units": "mm[Hg]"
+                      },
+                      "lower_unbounded": false,
+                      "upper_unbounded": false,
+                      "lower_included": true,
+                      "upper_included": true
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.unitary_bad_denominator.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.unitary_bad_denominator.json
@@ -1,0 +1,158 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "history_open.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "NL"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2026-02-03T08:00:00Z"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "secondary medical care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "232"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Open history"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.history_open.v1",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.history_open.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2026-02-03T08:00:00Z"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Initial event"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2026-02-03T08:00:00Z"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Any structure"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "q"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_PROPORTION",
+                    "numerator": 3.0,
+                    "denominator": 2.0,
+                    "type": 1
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.zero_denominator.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.zero_denominator.json
@@ -1,0 +1,158 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "history_open.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "NL"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2026-02-03T08:00:00Z"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "secondary medical care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "232"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Open history"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.history_open.v1",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.history_open.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2026-02-03T08:00:00Z"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Initial event"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2026-02-03T08:00:00Z"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Any structure"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "q"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_PROPORTION",
+                    "numerator": 1.0,
+                    "denominator": 0.0,
+                    "type": 0
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-quantity_family_invalid.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-quantity_family_invalid.yaml
@@ -1,0 +1,49 @@
+# The Quantity-package refusal twins (RM data_types ch.6, issue #2478): ten
+# falsifiable RM consistency invariants with no prior wire case, one defect
+# per row under the open history_open.en.v1 template (the archetype admits
+# each element, so the named RM rule is the only violation — the existing
+# CONT-DV_PROPORTION rows reject on archetype C_INTEGER.list narrowing,
+# never on these rules). The accepting twin is
+# commit_contribution-quantity_rich.
+id: I_EHR_CONTRIBUTION.commit_contribution-quantity_family_invalid
+kind: functional
+component: EHR_CONTRIBUTION
+sm_operation: I_EHR_CONTRIBUTION.commit_contribution
+capabilities: [ChangeSets]
+profiles: [CORE]
+test_purpose: "A committed quantity value violating the family's consistency rules — an out-of-set magnitude_status, contradictory or out-of-range percent accuracy, a proportion breaking its kind's arithmetic rule or a zero denominator, a non-simple reference-range limit, an out-of-set normal_status, or an N status contradicting its own normal_range — is refused as invalid content, and no version is created."
+description: "commit compositions with Quantity-package invariant defects"
+spec_refs:
+  - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
+  - "RM UML/classes/org.openehr.rm.data_types.dv_quantified.adoc §Invariants (Magnitude_status_valid) + org.openehr.rm.data_types.dv_amount.adoc §Invariants (Accuracy_is_percent_validity, Accuracy_validity)"
+  - "RM UML/classes/org.openehr.rm.data_types.dv_proportion.adoc §Invariants (Fraction_validity, Unitary_validity, Percent_validity, Valid_denominator)"
+  - "RM UML/classes/org.openehr.rm.data_types.dv_ordered.adoc §Invariants (Normal_status_validity, Normal_range_and_status_consistency) + org.openehr.rm.data_types.reference_range.adoc §Invariants (Range_is_simple)"
+  - "ITS-REST overview Requests_and_responses.md §HTTP status codes (the semantic 422 branch)"
+applies: { rm: ">=1.0.2" }
+requires:
+  server: any
+  templates: [cnf.opt.history_open.v1]
+  ehr: { commits: none }
+parameters:
+  iteration: reset_per_row
+  fixture_set:
+    - { data_set: cnf.composition.history_open.bad_magnitude_status, expected: validation_failed, defect: "magnitude_status '!!' outside = < > <= >= ~ (Magnitude_status_valid)" }
+    - { data_set: cnf.composition.history_open.accuracy_zero_percent, expected: validation_failed, defect: "accuracy 0 with accuracy_is_percent true (Accuracy_is_percent_validity)" }
+    - { data_set: cnf.composition.history_open.accuracy_percent_out_of_range, expected: validation_failed, defect: "percent accuracy 250 outside 0..100 (Accuracy_validity)" }
+    - { data_set: cnf.composition.history_open.fraction_non_integral, expected: validation_failed, defect: "pk_fraction with a non-integral numerator (Fraction_validity)" }
+    - { data_set: cnf.composition.history_open.unitary_bad_denominator, expected: validation_failed, defect: "pk_unitary with denominator 2 (Unitary_validity)" }
+    - { data_set: cnf.composition.history_open.percent_bad_denominator, expected: validation_failed, defect: "pk_percent with denominator 500 (Percent_validity)" }
+    - { data_set: cnf.composition.history_open.zero_denominator, expected: validation_failed, defect: "denominator 0.0 (Valid_denominator)" }
+    - { data_set: cnf.composition.history_open.nonsimple_reference_range, expected: validation_failed, defect: "a reference-range limit carrying its own normal_range (Range_is_simple)" }
+    - { data_set: cnf.composition.history_open.bad_normal_status, expected: validation_failed, defect: "normal_status XX outside the normal statuses code set (Normal_status_validity)" }
+    - { data_set: cnf.composition.history_open.status_range_inconsistent, expected: validation_failed, defect: "normal_status N beside a normal_range not containing the value (Normal_range_and_status_consistency)" }
+flow:
+  - step: 1
+    call: commit_contribution
+    with:
+      versions: "${ds:fixture}"
+      audit: { change_type: creation, committer: { name: "conformance tester" } }
+    expect: "${fixture.expected}"
+postconditions:
+  - assert: version
+    count: 0

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-quantity_rich.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-quantity_rich.yaml
@@ -1,0 +1,52 @@
+# The quantity family's rich accepting twin (RM data_types ch.6, issue
+# #2478): one committed DV_QUANTITY carrying every optional trimming the
+# class tables declare — magnitude_status "~", percent accuracy, precision,
+# units_system + units_display_name (the RM 1.2.0 additions), normal_status
+# N with a containing normal_range, an other_reference_ranges entry — beside
+# a valid percent DV_PROPORTION. The refusal directions live in
+# commit_contribution-quantity_family_invalid.
+id: I_EHR_CONTRIBUTION.commit_contribution-quantity_rich
+kind: functional
+component: EHR_CONTRIBUTION
+sm_operation: I_EHR_CONTRIBUTION.commit_contribution
+capabilities: [ChangeSets]
+profiles: [CORE]
+test_purpose: >-
+  Committing a DV_QUANTITY that exercises every optional quantity feature —
+  magnitude_status, percent accuracy, precision, units_system,
+  units_display_name, a consistent normal_status + normal_range pair and an
+  other_reference_ranges entry — together with a valid percent DV_PROPORTION
+  succeeds and creates version 1.
+description: "commit a composition carrying a fully-trimmed DV_QUANTITY + a percent DV_PROPORTION"
+spec_refs:
+  - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
+  - "RM UML/classes/org.openehr.rm.data_types.dv_quantity.adoc §Attributes (magnitude, precision, units, units_system, units_display_name) + org.openehr.rm.data_types.dv_ordered.adoc §Attributes (normal_status, normal_range, other_reference_ranges)"
+  - "RM UML/classes/org.openehr.rm.data_types.dv_proportion.adoc §Invariants (Percent_validity satisfied: type = pk_percent, denominator = 100)"
+applies: { rm: ">=1.0.2" }
+requires:
+  server: any
+  templates: [cnf.opt.history_open.v1]
+  ehr: { commits: none }
+parameters:
+  iteration: reset_per_row
+  fixture_set:
+    - { data_set: cnf.composition.history_open.quantity_rich, expected: created, defect: "fully-trimmed DV_QUANTITY + valid percent DV_PROPORTION" }
+flow:
+  - step: 1
+    call: commit_contribution
+    with:
+      ehr_id: "${ehr_id}"
+      versions:
+        - { data: "${ds:fixture}", change_type: creation }
+    expect: "${fixture.expected}"
+    capture:
+      version_uids: created.version_uids[]
+    assert:
+      - { assert: version, for_each: "${version_uids}", change_type: CREATE, uid_pattern: "<uuid>::<system>::1" }
+postconditions:
+  - assert: state
+    text: >-
+      The EHR holds one new VERSION<COMPOSITION> whose quantity trimmings
+      (magnitude_status, accuracy, ranges, units fields) are stored and
+      served unchanged.
+    verified_by: I_EHR_COMPOSITION.get_composition_latest

--- a/tools/cnf-runner/artifacts/vocab/capability_matrix.yaml
+++ b/tools/cnf-runner/artifacts/vocab/capability_matrix.yaml
@@ -69,7 +69,10 @@ DirectoryOps: { family: Platform, tier: STANDARD, required: true, min_cases: 85,
 # Raised 94 -> 96 (2026-08-20): the Text-package twins (issue #2476) — the
 # deprecated-forms acceptance case (DV_PARAGRAPH + legacy formatting +
 # hyperlink) plus the four-invariant refusal family.
-ChangeSets: { family: Platform, tier: CORE, required: true, min_cases: 96, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Change sets)" }
+# Raised 96 -> 98 (2026-08-20): the Quantity-package twins (issue #2478) —
+# the fully-trimmed DV_QUANTITY acceptance case plus the ten-invariant
+# refusal family.
+ChangeSets: { family: Platform, tier: CORE, required: true, min_cases: 98, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Change sets)" }
 Versioning: { family: Platform, tier: CORE, required: true, min_cases: 72, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Versioning)" }
 # Floor raised 121 -> 125 (2026-07-29): the four commit-time CONSTRAINT
 # BINDING cases (member accepted / non-member refused / unresolvable under each


### PR DESCRIPTION
Closes #2478

The wire-coverage finding of the ch.6 (Quantity package) audit (#914): the quantity family's RM register is fully enforced, but TEN falsifiable consistency invariants had no catalogue case — the existing CONT-DV_PROPORTION rows reject on archetype `C_INTEGER.list` narrowing, never on the RM rules.

**Refusal family** (`commit_contribution-quantity_family_invalid`), one defect per row under the open template, each expected `validation_failed` with version count 0:

| Row | Rule |
|---|---|
| magnitude_status `!!` | `Magnitude_status_valid` |
| accuracy 0 + percent | `Accuracy_is_percent_validity` |
| percent accuracy 250 | `Accuracy_validity` |
| pk_fraction numerator 1.5 | `Fraction_validity` |
| pk_unitary denominator 2 | `Unitary_validity` |
| pk_percent denominator 500 | `Percent_validity` |
| denominator 0.0 | `Valid_denominator` |
| range limit with its own normal_range | `Range_is_simple` |
| normal_status `XX` | `Normal_status_validity` |
| status N, value outside its normal_range | `Normal_range_and_status_consistency` |

**Accepting twin** (`commit_contribution-quantity_rich`): a DV_QUANTITY carrying every optional trimming (magnitude_status `~`, percent accuracy 5, precision, `units_system`/`units_display_name` — the RM 1.2.0 additions —, N status with a containing 90..130 normal_range, an other_reference_ranges critical entry) beside a valid percent DV_PROPORTION. ChangeSets floor 96→98.

Fresh pipeline: **1036 passed / 0 failed / 0 errored — CORE+STANDARD PASS, 1036/1036**; `cnf-runner validate` 1075 cases 0 findings; the 348-test battery green.