### PR TITLE
test(cnf): the time-specification wire twins

### DIFF
--- a/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
@@ -7,12 +7,12 @@ Runner: cnf-runner 3.17.8 · verification pack: passed
 
 | Status | Count |
 | --- | --- |
-| passed | 1036 |
+| passed | 1038 |
 | failed | 0 |
 | errored | 0 |
 | skipped | 0 |
 | not_applicable | 38 |
-| total | 1074 |
+| total | 1076 |
 
 ## By chapter
 
@@ -20,12 +20,12 @@ Grouping is the published per-chapter chart's taxonomy: chapters with their band
 
 | Chapter / band | passed | failed | errored | cited n/a |
 | --- | --- | --- | --- | --- |
-| **EHR** | 455 | 0 | 0 | 18 |
+| **EHR** | 457 | 0 | 0 | 18 |
 | — EHR resource | 25 | 0 | 0 | 2 |
 | — EHR_STATUS | 46 | 0 | 0 | 5 |
 | — COMPOSITION | 137 | 0 | 0 | 0 |
 | — DIRECTORY | 79 | 0 | 0 | 6 |
-| — CONTRIBUTION | 100 | 0 | 0 | 5 |
+| — CONTRIBUTION | 102 | 0 | 0 | 5 |
 | — Item tags | 62 | 0 | 0 | 0 |
 | — Revision history | 6 | 0 | 0 | 0 |
 | **Definitions** | 97 | 0 | 0 | 10 |
@@ -86,7 +86,7 @@ Selected gating cases per claimed capability. `inconclusive` counts cases whose 
 | EhrStatus | pass | 44 | 0 | 0 | 5 |
 | CompositionOps | pass | 59 | 0 | 0 | 0 |
 | DirectoryOps | pass | 77 | 0 | 0 | 8 |
-| ChangeSets | pass | 93 | 0 | 0 | 5 |
+| ChangeSets | pass | 95 | 0 | 0 | 5 |
 | Versioning | pass | 72 | 0 | 0 | 0 |
 | ArchetypeValidation | pass | 125 | 0 | 0 | 0 |
 | PartyOperations | pass | 86 | 0 | 0 | 4 |
@@ -175,7 +175,7 @@ Percentiles re-derive from the embedded HDR V2 histograms; the class verdict is 
 
 ## Honesty
 
-Coverage: 1036 of 1074 selected cases driven.
+Coverage: 1038 of 1076 selected cases driven.
 
 Not-executed verdicts (each cited):
 

--- a/docs/conformance/ferroehr/badge.json
+++ b/docs/conformance/ferroehr/badge.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "openEHR conformance",
-  "message": "CORE+STANDARD PASS · 1036/1036 cases",
+  "message": "CORE+STANDARD PASS · 1038/1038 cases",
   "color": "brightgreen"
 }

--- a/docs/conformance/ferroehr/results.json
+++ b/docs/conformance/ferroehr/results.json
@@ -2391,6 +2391,12 @@
       "rows_total": 1
     },
     {
+      "case": "I_EHR_CONTRIBUTION.commit_contribution-periodic_bad_formalism",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_CONTRIBUTION.commit_contribution-persistent_composition",
       "status": "passed",
       "rows_driven": 1,
@@ -2432,6 +2438,12 @@
       "status": "passed",
       "rows_driven": 4,
       "rows_total": 4
+    },
+    {
+      "case": "I_EHR_CONTRIBUTION.commit_contribution-time_specifications",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
     },
     {
       "case": "I_EHR_CONTRIBUTION.commit_contribution-two_commits_second_creation",

--- a/docs/conformance/ferroehr/verdicts.json
+++ b/docs/conformance/ferroehr/verdicts.json
@@ -268,7 +268,7 @@
     [
       "ChangeSets",
       {
-        "passed": 93,
+        "passed": 95,
         "failed": 0,
         "inconclusive": 0,
         "unevidenced": 5
@@ -588,9 +588,9 @@
     }
   ],
   "coverage": {
-    "selected": 1074,
-    "driven": 1036,
-    "passed": 1036,
+    "selected": 1076,
+    "driven": 1038,
+    "passed": 1038,
     "failed": 0,
     "inconclusive": 0
   }

--- a/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
+++ b/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
@@ -3602,3 +3602,20 @@ cnf.composition.history_open.nonsimple_reference_range:
     spec_ref: "RM UML/classes/org.openehr.rm.data_types.reference_range.adoc §Invariants Range_is_simple ((range.lower_unbounded or else range.lower.is_simple) and (range.upper_unbounded or else range.upper.is_simple))"
   template_id: "history_open.en.v1"
   provenance: "derived 2026-08-20 (issue #2478): exactly one defect — the critical range's lower DV_QUANTITY carries its own (internally consistent, contained) normal_range, so Range_is_simple is the only violation"
+cnf.composition.history_open.time_specifications:
+  source: fixtures/contribution/composition.history_open.time_specifications.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity: { verdict: valid }
+  template_id: "history_open.en.v1"
+  provenance: "authored 2026-08-20 (issue #2480): the time_specification package's first committed instances — a DV_PERIODIC_TIME_SPECIFICATION whose DV_PARSABLE carries the chapter's own §Phase-linked example ([200004181100;200004181110]/(7d)@DW, formalism HL7:PIVL) beside a DV_GENERAL_TIME_SPECIFICATION (the same phase-linked spec is a valid GTS factor per §General Time Specification Syntax, formalism HL7:GTS)"
+cnf.composition.history_open.periodic_bad_formalism:
+  source: fixtures/contribution/composition.history_open.periodic_bad_formalism.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "a DV_PERIODIC_TIME_SPECIFICATION whose value.formalism is HL7:GTS, not HL7:PIVL or HL7:EIVL"
+    spec_ref: "RM UML/classes/org.openehr.rm.data_types.dv_periodic_time_specification.adoc §Invariants Value_valid (value.formalism.is_equal(HL7:PIVL) or value.formalism.is_equal(HL7:EIVL))"
+  template_id: "history_open.en.v1"
+  provenance: "derived 2026-08-20 (issue #2480) from cnf.composition.history_open.time_specifications with exactly one defect: the periodic specification's formalism swapped to HL7:GTS (the parsable value itself stays well-formed, so Value_valid is the only violation)"

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.periodic_bad_formalism.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.periodic_bad_formalism.json
@@ -1,0 +1,160 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "history_open.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "NL"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2026-02-03T08:00:00Z"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "secondary medical care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "232"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Open history"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.history_open.v1",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.history_open.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2026-02-03T08:00:00Z"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Initial event"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2026-02-03T08:00:00Z"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Any structure"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "dosing schedule"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_PERIODIC_TIME_SPECIFICATION",
+                    "value": {
+                      "_type": "DV_PARSABLE",
+                      "value": "[200004181100;200004181110]/(7d)@DW",
+                      "formalism": "HL7:GTS"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.time_specifications.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.time_specifications.json
@@ -1,0 +1,176 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "history_open.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "NL"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2026-02-03T08:00:00Z"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "secondary medical care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "232"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Open history"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.history_open.v1",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.history_open.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2026-02-03T08:00:00Z"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Initial event"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2026-02-03T08:00:00Z"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Any structure"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "dosing schedule"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_PERIODIC_TIME_SPECIFICATION",
+                    "value": {
+                      "_type": "DV_PARSABLE",
+                      "value": "[200004181100;200004181110]/(7d)@DW",
+                      "formalism": "HL7:PIVL"
+                    }
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "general schedule"
+                  },
+                  "archetype_node_id": "at0005",
+                  "value": {
+                    "_type": "DV_GENERAL_TIME_SPECIFICATION",
+                    "value": {
+                      "_type": "DV_PARSABLE",
+                      "value": "[200004181100;200004181110]/(7d)@DW",
+                      "formalism": "HL7:GTS"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-periodic_bad_formalism.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-periodic_bad_formalism.yaml
@@ -1,0 +1,37 @@
+# The time-specification refusal twin (RM data_types ch.8, issue #2480):
+# DV_PERIODIC_TIME_SPECIFICATION.Value_valid constrains ONLY the formalism
+# (HL7:PIVL or HL7:EIVL) — syntax extraction is function behaviour, not a
+# refusal — so the single-defect row swaps the formalism to HL7:GTS on an
+# otherwise well-formed parsable. The accepting twin is
+# commit_contribution-time_specifications.
+id: I_EHR_CONTRIBUTION.commit_contribution-periodic_bad_formalism
+kind: functional
+component: EHR_CONTRIBUTION
+sm_operation: I_EHR_CONTRIBUTION.commit_contribution
+capabilities: [ChangeSets]
+profiles: [CORE]
+test_purpose: "A committed DV_PERIODIC_TIME_SPECIFICATION whose value.formalism is neither HL7:PIVL nor HL7:EIVL is refused as invalid content, and no version is created."
+description: "commit a composition with a periodic time specification carrying a foreign formalism"
+spec_refs:
+  - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
+  - "RM UML/classes/org.openehr.rm.data_types.dv_periodic_time_specification.adoc §Invariants (Value_valid: value.formalism.is_equal(HL7:PIVL) or value.formalism.is_equal(HL7:EIVL))"
+  - "ITS-REST overview Requests_and_responses.md §HTTP status codes (the semantic 422 branch)"
+applies: { rm: ">=1.0.2" }
+requires:
+  server: any
+  templates: [cnf.opt.history_open.v1]
+  ehr: { commits: none }
+parameters:
+  iteration: reset_per_row
+  fixture_set:
+    - { data_set: cnf.composition.history_open.periodic_bad_formalism, expected: validation_failed, defect: "formalism HL7:GTS on a DV_PERIODIC_TIME_SPECIFICATION (Value_valid)" }
+flow:
+  - step: 1
+    call: commit_contribution
+    with:
+      versions: "${ds:fixture}"
+      audit: { change_type: creation, committer: { name: "conformance tester" } }
+    expect: "${fixture.expected}"
+postconditions:
+  - assert: version
+    count: 0

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-time_specifications.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-time_specifications.yaml
@@ -1,0 +1,47 @@
+# The time-specification accepting twin (RM data_types ch.8, issue #2480):
+# the package's first committed instances — the chapter's own §Phase-linked
+# example as a DV_PERIODIC_TIME_SPECIFICATION (formalism HL7:PIVL) beside a
+# DV_GENERAL_TIME_SPECIFICATION (the same spec is a valid GTS factor). The
+# refusal direction lives in commit_contribution-periodic_bad_formalism.
+id: I_EHR_CONTRIBUTION.commit_contribution-time_specifications
+kind: functional
+component: EHR_CONTRIBUTION
+sm_operation: I_EHR_CONTRIBUTION.commit_contribution
+capabilities: [ChangeSets]
+profiles: [CORE]
+test_purpose: >-
+  Committing a composition carrying a DV_PERIODIC_TIME_SPECIFICATION
+  (HL7:PIVL phase-linked value) and a DV_GENERAL_TIME_SPECIFICATION (HL7:GTS)
+  succeeds and creates version 1.
+description: "commit a composition carrying periodic + general time specifications"
+spec_refs:
+  - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
+  - "RM data_types/master08-time_specification_package.adoc §Phase-linked Time Specification Syntax (the [interval]/(difference)@alignment example) + §General Time Specification Syntax (a phase_linked_time_spec is a GTS factor)"
+  - "RM UML/classes/org.openehr.rm.data_types.dv_periodic_time_specification.adoc §Invariants (Value_valid satisfied: formalism HL7:PIVL)"
+applies: { rm: ">=1.0.2" }
+requires:
+  server: any
+  templates: [cnf.opt.history_open.v1]
+  ehr: { commits: none }
+parameters:
+  iteration: reset_per_row
+  fixture_set:
+    - { data_set: cnf.composition.history_open.time_specifications, expected: created, defect: "PIVL periodic + GTS general time specifications" }
+flow:
+  - step: 1
+    call: commit_contribution
+    with:
+      ehr_id: "${ehr_id}"
+      versions:
+        - { data: "${ds:fixture}", change_type: creation }
+    expect: "${fixture.expected}"
+    capture:
+      version_uids: created.version_uids[]
+    assert:
+      - { assert: version, for_each: "${version_uids}", change_type: CREATE, uid_pattern: "<uuid>::<system>::1" }
+postconditions:
+  - assert: state
+    text: >-
+      The EHR holds one new VERSION<COMPOSITION> whose time-specification
+      values (parsable value + formalism) are stored and served unchanged.
+    verified_by: I_EHR_COMPOSITION.get_composition_latest

--- a/tools/cnf-runner/artifacts/vocab/capability_matrix.yaml
+++ b/tools/cnf-runner/artifacts/vocab/capability_matrix.yaml
@@ -72,7 +72,9 @@ DirectoryOps: { family: Platform, tier: STANDARD, required: true, min_cases: 85,
 # Raised 96 -> 98 (2026-08-20): the Quantity-package twins (issue #2478) —
 # the fully-trimmed DV_QUANTITY acceptance case plus the ten-invariant
 # refusal family.
-ChangeSets: { family: Platform, tier: CORE, required: true, min_cases: 98, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Change sets)" }
+# Raised 98 -> 100 (2026-08-20): the time-specification twins (issue
+# #2480) — the PIVL/GTS acceptance case plus the formalism refusal.
+ChangeSets: { family: Platform, tier: CORE, required: true, min_cases: 100, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Change sets)" }
 Versioning: { family: Platform, tier: CORE, required: true, min_cases: 72, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Versioning)" }
 # Floor raised 121 -> 125 (2026-07-29): the four commit-time CONSTRAINT
 # BINDING cases (member accepted / non-member refused / unresolvable under each


### PR DESCRIPTION
Closes #2480

The wire-coverage finding of the ch.8 (Time specification) audit (#916): the package had ZERO catalogue coverage — no committed DV_PERIODIC_TIME_SPECIFICATION or DV_GENERAL_TIME_SPECIFICATION anywhere, and the one falsifiable invariant had no refusal case.

**Accepting twin** (`commit_contribution-time_specifications`): the chapter's own §Phase-linked example (`[200004181100;200004181110]/(7d)@DW`) committed as a DV_PERIODIC_TIME_SPECIFICATION (formalism `HL7:PIVL`) beside a DV_GENERAL_TIME_SPECIFICATION (the same spec is a valid GTS `factor` per §General Time Specification Syntax).

**Refusal twin** (`commit_contribution-periodic_bad_formalism`): the formalism swapped to `HL7:GTS` — `Value_valid` constrains ONLY the formalism (`HL7:PIVL` or `HL7:EIVL`; syntax extraction is function behaviour), so that is the single defect. Expected `validation_failed`, version count 0. ChangeSets floor 98→100.

Fresh pipeline: **1038 passed / 0 failed / 0 errored — CORE+STANDARD PASS, 1038/1038**; `cnf-runner validate` 1077 cases 0 findings; the 348-test battery green.