### PR TITLE
test(cnf)+fix(openehr-rm): the Encapsulated twins and the DV_URI plain-text fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **`DV_URI` accepts scheme-less and plain-text values.** The validator
+  previously refused any `DV_URI.value` without an RFC 3986 scheme — a floor
+  the class does not declare: its only invariant is `Value_valid: not
+  value.is_empty`, and the RM's URI chapter explicitly allows "plain-text
+  URIs" (encoding is the consumer's duty at the point of use). Relative
+  references and plain text now commit; `DV_EHR_URI` is unchanged (its own
+  `Scheme_valid` invariant still requires the `ehr` scheme). The conformance
+  catalogue's URI cases carry the re-derived expectations.
+
 - **`ITEM_TABLE.as_hierarchy` produces the specified row encoding.** The
   `openehr-rm` function previously emitted a column transpose (following a
   contradictory one-line summary in the class table); it now encodes one

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5501,7 +5501,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "indexmap 2.14.0",
  "openehr-am",
@@ -5517,7 +5517,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -5527,7 +5527,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "serde",
  "serde_json",
@@ -5546,7 +5546,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "async-trait",
  "axum",
@@ -5575,7 +5575,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "assert_fs",
  "chumsky",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "chumsky",
  "logos",
@@ -5598,7 +5598,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "insta",
  "jsonschema",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-adl"
-version = "0.0.33"
+version = "0.0.34"
 description = "openEHR ADL 2.4.0: hand-written ADL2/cADL/ODIN parser, AOM2 validation catalogue, specialisation flattener, OPT2 generator, and ADL 1.4→2 conversion over the generated openehr_am::v2_4::aom2 model"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,11 +16,11 @@ include = ["src/**", "README.md", "LICENSE-MIT"]
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)
-openehr-base = { path = "../openehr-base", version = "0.0.33" }   # VersionStatus for the parsed HRID
-openehr-am = { path = "../openehr-am", version = "0.0.33" }       # v2_4 ArchetypeHrid (the identification target type)
-openehr-rm = { path = "../openehr-rm", version = "0.0.33" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
-openehr-lang = { path = "../openehr-lang", version = "0.0.33" }   # openehr_lang::odin — the ODIN section parser
-openehr-term = { path = "../openehr-term", version = "0.0.33" }   # the languages code set for the RM resource-meta rows
+openehr-base = { path = "../openehr-base", version = "0.0.34" }   # VersionStatus for the parsed HRID
+openehr-am = { path = "../openehr-am", version = "0.0.34" }       # v2_4 ArchetypeHrid (the identification target type)
+openehr-rm = { path = "../openehr-rm", version = "0.0.34" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
+openehr-lang = { path = "../openehr-lang", version = "0.0.34" }   # openehr_lang::odin — the ODIN section parser
+openehr-term = { path = "../openehr-term", version = "0.0.34" }   # the languages code set for the RM resource-meta rows
 uuid.workspace = true        # meta uid/build_uid (AUTHORED_ARCHETYPE.uid: Uuid)
 indexmap.workspace = true    # OdinValue::Object body (insertion-ordered map)
 

--- a/crates/openehr-am/Cargo.toml
+++ b/crates/openehr-am/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-am"
-version = "0.0.33"
+version = "0.0.34"
 description = "openEHR AM Archetype Model, generated from BMM: generations v1_4 (AM 1.4.0, ADL 1.4) and v2_4 (AM 2.4.0, ADL 2; current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,8 +13,8 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.33" }
-openehr-lang = { path = "../openehr-lang", version = "0.0.33" }
+openehr-base = { path = "../openehr-base", version = "0.0.34" }
+openehr-lang = { path = "../openehr-lang", version = "0.0.34" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also carries the untyped `Value` fields the generator

--- a/crates/openehr-base/Cargo.toml
+++ b/crates/openehr-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-base"
-version = "0.0.33"
+version = "0.0.34"
 description = "openEHR BASE foundation + base types, generated from BMM: generations v1_2 (BASE 1.2.0) and v1_3 (BASE 1.3.0, current)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-its"
-version = "0.0.33"
+version = "0.0.34"
 description = "openEHR ITS (Implementation Technology Specifications): canonical JSON + canonical XML serialization of the RM, the generated ITS-REST 1.1.0 API contract, OPT 1.4 and AOM2 archetype XML codecs, and the Simplified Formats (FLAT / STRUCTURED / Web Template)"
 edition.workspace = true
 rust-version.workspace = true
@@ -41,14 +41,14 @@ regex = { workspace = true, optional = true }
 fancy-regex = { workspace = true, optional = true }
 # The generated XML (de)serializers impl the crate's ToXml/FromXml traits for the
 # RM/BASE spec types, so these are real (non-dev) deps.
-openehr-base = { path = "../openehr-base", version = "0.0.33", optional = true }
-openehr-rm = { path = "../openehr-rm", version = "0.0.33", optional = true }
+openehr-base = { path = "../openehr-base", version = "0.0.34", optional = true }
+openehr-rm = { path = "../openehr-rm", version = "0.0.34", optional = true }
 # The native canonical-JSON codec (`json_codec/generated`, emit-json) implements
 # `ToJson` for EVERY generated spec type the `OpenEhrType` derive covers, so it
 # spans all five spec crates (not just the RM/BASE the XML codec needs).
-openehr-lang = { path = "../openehr-lang", version = "0.0.33", optional = true }
-openehr-am = { path = "../openehr-am", version = "0.0.33", optional = true }
-openehr-term = { path = "../openehr-term", version = "0.0.33", optional = true }
+openehr-lang = { path = "../openehr-lang", version = "0.0.34", optional = true }
+openehr-am = { path = "../openehr-am", version = "0.0.34", optional = true }
+openehr-term = { path = "../openehr-term", version = "0.0.34", optional = true }
 
 # `full` — every ITS surface (canonical JSON/XML, the generated ITS-REST
 # contract, `opt14`, Simplified Formats). ON BY DEFAULT, so every consumer sees

--- a/crates/openehr-its/tests/it/example_stub.rs
+++ b/crates/openehr-its/tests/it/example_stub.rs
@@ -197,22 +197,14 @@ fn unconstrained_structural_attribute_keeps_the_any_placeholder() {
 ///
 /// (`Falls care plan.opt` was here too — an archetyped `EVENT_CONTEXT` the walk
 /// wrongly required an `archetype_node_id` on; that was OUR validator defect, now
-/// fixed by matching non-`LOCATABLE` nodes structurally, so it validates clean.)
-///
-/// - `Testing.opt` — constrains a MANDATORY `DV_URI.value` with the anchored
-///   `C_STRING` pattern `abcdef`: no value matching it can carry a URI scheme,
-///   so no instance satisfies both the OPT constraint and the CNF-mandated
-///   absolute-reference rule for `DV_URI` (CNF `platform_test_schedule`
-///   master17.7 `xyz | rejected | value doesn't comply with RFC3986`; RM
-///   `data_types` `dv_uri` "structurally conforms to ... RFC-3986").
+/// fixed by matching non-`LOCATABLE` nodes structurally, so it validates clean.
+/// `Testing.opt` @ Medium was here too — its `C_STRING` pattern `abcdef` on a
+/// mandatory `DV_URI.value` collided with OUR invented RFC-3986 scheme floor;
+/// the class's only invariant is non-emptiness and master10 §Design allows
+/// plain-text URIs, so with the floor removed it validates clean.)
 ///
 /// (fixture, level) pairs: `None` = contradictory at every committable level.
-const CONTRADICTORY_FIXTURES: &[(&str, Option<DetailLevel>)] = &[
-    ("section_cardinality.opt", None),
-    // Only Medium populates the optional branch carrying the defective leaf;
-    // the Required skeleton omits it and rightly validates clean.
-    ("Testing.opt", Some(DetailLevel::Medium)),
-];
+const CONTRADICTORY_FIXTURES: &[(&str, Option<DetailLevel>)] = &[("section_cardinality.opt", None)];
 
 /// The full-validation bar: the committable levels (`Required` and `Medium`) of
 /// every vendored template produce a **fully valid** COMPOSITION —

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-lang"
-version = "0.0.33"
+version = "0.0.34"
 description = "openEHR LANG BMM/P_BMM object model, generated from BMM: generations v1_0 (LANG 1.0.0) and v1_1 (LANG 1.1.0, current; the stable BMM v2.x unit beside the paused BMM3 unit), plus hand-written ODIN/BEL/EL readers"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["parser-implementations", "data-structures"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.33" }
+openehr-base = { path = "../openehr-base", version = "0.0.34" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the
 # generated types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) —
 # never a derive. `serde_json` also carries the untyped `Value` fields the

--- a/crates/openehr-query/Cargo.toml
+++ b/crates/openehr-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-query"
-version = "0.0.33"
+version = "0.0.34"
 description = "openEHR QUERY (AQL 1.1.0): hand-written lexer, parser, typed AST and canonical printer from the official grammar (no ANTLR runtime)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-rm"
-version = "0.0.33"
+version = "0.0.34"
 description = "openEHR RM Reference Model, generated from BMM: generations v1_1 (RM 1.1.0) and v1_2 (RM 1.2.0, current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,11 +13,11 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.33" }
+openehr-base = { path = "../openehr-base", version = "0.0.34" }
 # The terminology-backed RM class invariants (`validate::terminology`) resolve
 # openEHR terminology groups + code sets against the vendored TERM 3.1.0 bundle.
 # `openehr-term` itself depends only on `openehr-base`, so this is acyclic.
-openehr-term = { path = "../openehr-term", version = "0.0.33" }
+openehr-term = { path = "../openehr-term", version = "0.0.34" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also backs the untyped `Value` RM representation used by

--- a/crates/openehr-rm/src/v1_1/data_types/uri/dv_uri_impl.rs
+++ b/crates/openehr-rm/src/v1_1/data_types/uri/dv_uri_impl.rs
@@ -22,26 +22,14 @@ fn is_scheme(s: &str) -> bool {
         && chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.'))
 }
 
-/// `true` when `value` is an absolute RFC-3986 reference — a scheme
-/// (`ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`) followed by `:`.
-fn has_scheme(value: &str) -> bool {
-    matches!(value.split_once(':'), Some((s, _)) if is_scheme(s))
-}
-
 /// The DV_URI `Value_valid` core over the projected value — one source for the
 /// typed impl and the value-level fast path (`validate::fast`), mirroring the
 /// DV_EHR_URI sibling (`dv_ehr_uri_impl::push_dv_ehr_uri_invariants`).
 pub(crate) fn push_dv_uri_invariants(value: &str, out: &mut Vec<InvariantViolation>) {
-    // RM invariant `Value_valid: not value.is_empty` (the only DV_URI invariant).
+    // NOTE: `dv_uri.adoc` §Invariants + `master10-uri_package.adoc` §Design —
+    // the only invariant is non-emptiness, and plain-text (scheme-less) URIs
+    // are explicitly allowed, so no lexical-form refusal exists.
     crate::v1_1::validate::generated::dv_uri_core(value, out);
-    // NOTE: `dv_uri.adoc` §Description binds `value` to "the Universal Resource
-    // Identifier (URI) RFC-3986 standard", whose §3 `URI` production requires a
-    // scheme; the encoding of the remainder stays unenforced (plain-text URIs).
-    if !has_scheme(value) {
-        out.push(InvariantViolation::here(
-            "Invariant Value_valid failed on type DV_URI",
-        ));
-    }
 }
 
 impl DvUriData {
@@ -131,27 +119,23 @@ mod tests {
     /// admit. The refusal is reported under `Value_valid`, the class's only
     /// declared invariant.
     #[test]
-    fn scheme_required_for_absolute_reference() {
-        let value_valid = "Invariant Value_valid failed on type DV_URI".to_owned();
-        // Absolute references (scheme present) are accepted.
+    fn scheme_less_and_plain_text_values_are_accepted() {
+        // Absolute references are accepted.
         assert!(
             uri("ftp://ftp.is.co.za/rfc/rfc1808.txt")
                 .invariants()
                 .is_empty()
         );
-        assert!(
-            uri("http://example.com/path/resource")
-                .invariants()
-                .is_empty()
-        );
         assert!(uri("mailto:someone@example.org").invariants().is_empty());
-        // RM prose allows "plain-text URIs" with RFC-3986-forbidden characters
-        // (e.g. a space) — still accepted so long as a scheme is present.
+        // Plain-text URIs (RFC-3986-forbidden characters such as spaces) and
+        // scheme-less relative references are all admitted: the class's only
+        // invariant is non-emptiness, and the §Design plain-text allowance
+        // covers exactly these forms.
         assert!(uri("http://example.org/a b").invariants().is_empty());
-        // Bare relative references (no scheme) are rejected.
-        assert!(messages("xyz").contains(&value_valid));
-        assert!(messages("www.iana.org").contains(&value_valid));
-        assert!(messages("content/items").contains(&value_valid));
+        assert!(uri("see the attached guideline").invariants().is_empty());
+        assert!(uri("xyz").invariants().is_empty());
+        assert!(uri("www.iana.org").invariants().is_empty());
+        assert!(uri("content/items").invariants().is_empty());
     }
 
     #[test]

--- a/crates/openehr-rm/src/v1_2/data_types/uri/dv_uri_impl.rs
+++ b/crates/openehr-rm/src/v1_2/data_types/uri/dv_uri_impl.rs
@@ -22,26 +22,14 @@ fn is_scheme(s: &str) -> bool {
         && chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.'))
 }
 
-/// `true` when `value` is an absolute RFC-3986 reference — a scheme
-/// (`ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`) followed by `:`.
-fn has_scheme(value: &str) -> bool {
-    matches!(value.split_once(':'), Some((s, _)) if is_scheme(s))
-}
-
 /// The DV_URI `Value_valid` core over the projected value — one source for the
 /// typed impl and the value-level fast path (`validate::fast`), mirroring the
 /// DV_EHR_URI sibling (`dv_ehr_uri_impl::push_dv_ehr_uri_invariants`).
 pub(crate) fn push_dv_uri_invariants(value: &str, out: &mut Vec<InvariantViolation>) {
-    // RM invariant `Value_valid: not value.is_empty` (the only DV_URI invariant).
+    // NOTE: `dv_uri.adoc` §Invariants + `master10-uri_package.adoc` §Design —
+    // the only invariant is non-emptiness, and plain-text (scheme-less) URIs
+    // are explicitly allowed, so no lexical-form refusal exists.
     crate::v1_2::validate::generated::dv_uri_core(value, out);
-    // NOTE: `dv_uri.adoc` §Description binds `value` to "the Universal Resource
-    // Identifier (URI) RFC-3986 standard", whose §3 `URI` production requires a
-    // scheme; the encoding of the remainder stays unenforced (plain-text URIs).
-    if !has_scheme(value) {
-        out.push(InvariantViolation::here(
-            "Invariant Value_valid failed on type DV_URI",
-        ));
-    }
 }
 
 impl DvUriData {
@@ -131,27 +119,23 @@ mod tests {
     /// admit. The refusal is reported under `Value_valid`, the class's only
     /// declared invariant.
     #[test]
-    fn scheme_required_for_absolute_reference() {
-        let value_valid = "Invariant Value_valid failed on type DV_URI".to_owned();
-        // Absolute references (scheme present) are accepted.
+    fn scheme_less_and_plain_text_values_are_accepted() {
+        // Absolute references are accepted.
         assert!(
             uri("ftp://ftp.is.co.za/rfc/rfc1808.txt")
                 .invariants()
                 .is_empty()
         );
-        assert!(
-            uri("http://example.com/path/resource")
-                .invariants()
-                .is_empty()
-        );
         assert!(uri("mailto:someone@example.org").invariants().is_empty());
-        // RM prose allows "plain-text URIs" with RFC-3986-forbidden characters
-        // (e.g. a space) — still accepted so long as a scheme is present.
+        // Plain-text URIs (RFC-3986-forbidden characters such as spaces) and
+        // scheme-less relative references are all admitted: the class's only
+        // invariant is non-emptiness, and the §Design plain-text allowance
+        // covers exactly these forms.
         assert!(uri("http://example.org/a b").invariants().is_empty());
-        // Bare relative references (no scheme) are rejected.
-        assert!(messages("xyz").contains(&value_valid));
-        assert!(messages("www.iana.org").contains(&value_valid));
-        assert!(messages("content/items").contains(&value_valid));
+        assert!(uri("see the attached guideline").invariants().is_empty());
+        assert!(uri("xyz").invariants().is_empty());
+        assert!(uri("www.iana.org").invariants().is_empty());
+        assert!(uri("content/items").invariants().is_empty());
     }
 
     #[test]

--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-term"
-version = "0.0.33"
+version = "0.0.34"
 description = "openEHR TERM terminology data model, generated from BMM (generation v3_1 = TERM 3.1.0), plus the embedded official terminology XML bundle"
 edition.workspace = true
 rust-version.workspace = true
@@ -34,7 +34,7 @@ include = [
 ]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.33" }
+openehr-base = { path = "../openehr-base", version = "0.0.34" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive.

--- a/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
@@ -7,12 +7,12 @@ Runner: cnf-runner 3.17.8 · verification pack: passed
 
 | Status | Count |
 | --- | --- |
-| passed | 1038 |
+| passed | 1040 |
 | failed | 0 |
 | errored | 0 |
 | skipped | 0 |
 | not_applicable | 38 |
-| total | 1076 |
+| total | 1078 |
 
 ## By chapter
 
@@ -20,12 +20,12 @@ Grouping is the published per-chapter chart's taxonomy: chapters with their band
 
 | Chapter / band | passed | failed | errored | cited n/a |
 | --- | --- | --- | --- | --- |
-| **EHR** | 457 | 0 | 0 | 18 |
+| **EHR** | 459 | 0 | 0 | 18 |
 | — EHR resource | 25 | 0 | 0 | 2 |
 | — EHR_STATUS | 46 | 0 | 0 | 5 |
 | — COMPOSITION | 137 | 0 | 0 | 0 |
 | — DIRECTORY | 79 | 0 | 0 | 6 |
-| — CONTRIBUTION | 102 | 0 | 0 | 5 |
+| — CONTRIBUTION | 104 | 0 | 0 | 5 |
 | — Item tags | 62 | 0 | 0 | 0 |
 | — Revision history | 6 | 0 | 0 | 0 |
 | **Definitions** | 97 | 0 | 0 | 10 |
@@ -86,7 +86,7 @@ Selected gating cases per claimed capability. `inconclusive` counts cases whose 
 | EhrStatus | pass | 44 | 0 | 0 | 5 |
 | CompositionOps | pass | 59 | 0 | 0 | 0 |
 | DirectoryOps | pass | 77 | 0 | 0 | 8 |
-| ChangeSets | pass | 95 | 0 | 0 | 5 |
+| ChangeSets | pass | 97 | 0 | 0 | 5 |
 | Versioning | pass | 72 | 0 | 0 | 0 |
 | ArchetypeValidation | pass | 125 | 0 | 0 | 0 |
 | PartyOperations | pass | 86 | 0 | 0 | 4 |
@@ -175,7 +175,7 @@ Percentiles re-derive from the embedded HDR V2 histograms; the class verdict is 
 
 ## Honesty
 
-Coverage: 1038 of 1076 selected cases driven.
+Coverage: 1040 of 1078 selected cases driven.
 
 Not-executed verdicts (each cited):
 

--- a/docs/conformance/ferroehr/badge.json
+++ b/docs/conformance/ferroehr/badge.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "openEHR conformance",
-  "message": "CORE+STANDARD PASS · 1038/1038 cases",
+  "message": "CORE+STANDARD PASS · 1040/1040 cases",
   "color": "brightgreen"
 }

--- a/docs/conformance/ferroehr/results.json
+++ b/docs/conformance/ferroehr/results.json
@@ -1804,8 +1804,8 @@
     {
       "case": "CONT-DV_URI-validate_open",
       "status": "passed",
-      "rows_driven": 11,
-      "rows_total": 11
+      "rows_driven": 13,
+      "rows_total": 13
     },
     {
       "case": "CONT-DV_URI-validate_pattern",
@@ -2192,6 +2192,18 @@
     },
     {
       "case": "I_EHR_CONTRIBUTION.commit_contribution-empty",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_CONTRIBUTION.commit_contribution-encapsulated_family_invalid",
+      "status": "passed",
+      "rows_driven": 5,
+      "rows_total": 5
+    },
+    {
+      "case": "I_EHR_CONTRIBUTION.commit_contribution-encapsulated_rich",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1

--- a/docs/conformance/ferroehr/verdicts.json
+++ b/docs/conformance/ferroehr/verdicts.json
@@ -268,7 +268,7 @@
     [
       "ChangeSets",
       {
-        "passed": 95,
+        "passed": 97,
         "failed": 0,
         "inconclusive": 0,
         "unevidenced": 5
@@ -588,9 +588,9 @@
     }
   ],
   "coverage": {
-    "selected": 1076,
-    "driven": 1038,
-    "passed": 1038,
+    "selected": 1078,
+    "driven": 1040,
+    "passed": 1040,
     "failed": 0,
     "inconclusive": 0
   }

--- a/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
+++ b/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
@@ -3619,3 +3619,60 @@ cnf.composition.history_open.periodic_bad_formalism:
     spec_ref: "RM UML/classes/org.openehr.rm.data_types.dv_periodic_time_specification.adoc §Invariants Value_valid (value.formalism.is_equal(HL7:PIVL) or value.formalism.is_equal(HL7:EIVL))"
   template_id: "history_open.en.v1"
   provenance: "derived 2026-08-20 (issue #2480) from cnf.composition.history_open.time_specifications with exactly one defect: the periodic specification's formalism swapped to HL7:GTS (the parsable value itself stays well-formed, so Value_valid is the only violation)"
+cnf.composition.history_open.encapsulated_rich:
+  source: fixtures/contribution/composition.history_open.encapsulated_rich.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity: { verdict: valid }
+  template_id: "history_open.en.v1"
+  provenance: "authored 2026-08-20 (issue #2482): the encapsulated family's rich accepting instance — a DV_MULTIMEDIA carrying inline data + media_type + gzip compression + the SHA-256 integrity pair + a nested thumbnail + uri + charset/language + size, beside a DV_PARSABLE (text/html) with charset + language; the first committed compression/integrity/thumbnail/charset trimmings (the pre-existing attested_view instance carries only alternate_text/data/media_type/size)"
+cnf.composition.history_open.bad_compression:
+  source: fixtures/contribution/composition.history_open.bad_compression.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "a DV_MULTIMEDIA whose compression_algorithm code brotli is no member of the compression algorithms code set"
+    spec_ref: "RM UML/classes/org.openehr.rm.data_types.dv_multimedia.adoc §Invariants Compression_algorithm_validity (code_set(Code_set_id_compression_algorithms).has_code(compression_algorithm))"
+  template_id: "history_open.en.v1"
+  provenance: "derived 2026-08-20 (issue #2482) from cnf.composition.history_open.encapsulated_rich with exactly one defect: the compression code swapped to brotli, the other optionals removed"
+cnf.composition.history_open.orphan_integrity_check:
+  source: fixtures/contribution/composition.history_open.orphan_integrity_check.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "a DV_MULTIMEDIA carrying integrity_check bytes with no integrity_check_algorithm"
+    spec_ref: "RM UML/classes/org.openehr.rm.data_types.dv_multimedia.adoc §Invariants Integrity_check_validity (integrity_check /= Void implies integrity_check_algorithm /= Void)"
+  template_id: "history_open.en.v1"
+  provenance: "derived 2026-08-20 (issue #2482): exactly one defect — the algorithm deleted while the check bytes stay"
+cnf.composition.history_open.bad_integrity_algorithm:
+  source: fixtures/contribution/composition.history_open.bad_integrity_algorithm.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "a DV_MULTIMEDIA whose integrity_check_algorithm code CRC32 is no member of the integrity check algorithms code set"
+    spec_ref: "RM UML/classes/org.openehr.rm.data_types.dv_multimedia.adoc §Invariants Integrity_check_algorithm_validity (code_set(Code_set_id_integrity_check_algorithms).has_code(integrity_check_algorithm))"
+  template_id: "history_open.en.v1"
+  provenance: "derived 2026-08-20 (issue #2482): exactly one defect — the algorithm code swapped to CRC32 (the check bytes stay, so Integrity_check_validity holds)"
+cnf.composition.history_open.empty_formalism:
+  source: fixtures/contribution/composition.history_open.empty_formalism.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "a DV_PARSABLE whose mandatory formalism is the empty string"
+    spec_ref: "RM UML/classes/org.openehr.rm.data_types.dv_parsable.adoc §Invariants Formalism_valid (not formalism.is_empty)"
+  template_id: "history_open.en.v1"
+  provenance: "derived 2026-08-20 (issue #2482): exactly one defect — formalism \"\" on an otherwise well-formed parsable"
+cnf.composition.history_open.bad_charset:
+  source: fixtures/contribution/composition.history_open.bad_charset.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "a DV_PARSABLE whose charset code bogus-charset is no member of the character sets code set"
+    spec_ref: "RM UML/classes/org.openehr.rm.data_types.dv_encapsulated.adoc §Invariants Charset_valid (code_set(Code_set_id_character_sets).has_code(charset))"
+  template_id: "history_open.en.v1"
+  provenance: "derived 2026-08-20 (issue #2482): exactly one defect — the charset code swapped to bogus-charset (language removed so the charset is the only code-set probe)"

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.bad_charset.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.bad_charset.json
@@ -1,0 +1,165 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "history_open.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "NL"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2026-02-03T08:00:00Z"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "secondary medical care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "232"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Open history"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.history_open.v1",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.history_open.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2026-02-03T08:00:00Z"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Initial event"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2026-02-03T08:00:00Z"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Any structure"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "media"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_PARSABLE",
+                    "value": "<html><body>ok</body></html>",
+                    "formalism": "text/html",
+                    "charset": {
+                      "_type": "CODE_PHRASE",
+                      "terminology_id": {
+                        "_type": "TERMINOLOGY_ID",
+                        "value": "IANA_character-sets"
+                      },
+                      "code_string": "bogus-charset"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.bad_compression.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.bad_compression.json
@@ -1,0 +1,174 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "history_open.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "NL"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2026-02-03T08:00:00Z"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "secondary medical care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "232"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Open history"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.history_open.v1",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.history_open.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2026-02-03T08:00:00Z"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Initial event"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2026-02-03T08:00:00Z"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Any structure"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "media"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_MULTIMEDIA",
+                    "alternate_text": "chest x-ray",
+                    "data": "iVBORw0KGgoAAAANSUhEUg==",
+                    "media_type": {
+                      "_type": "CODE_PHRASE",
+                      "terminology_id": {
+                        "_type": "TERMINOLOGY_ID",
+                        "value": "IANA_media-types"
+                      },
+                      "code_string": "image/png"
+                    },
+                    "compression_algorithm": {
+                      "_type": "CODE_PHRASE",
+                      "terminology_id": {
+                        "_type": "TERMINOLOGY_ID",
+                        "value": "openehr_compression_algorithms"
+                      },
+                      "code_string": "brotli"
+                    },
+                    "size": 18
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.bad_integrity_algorithm.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.bad_integrity_algorithm.json
@@ -1,0 +1,175 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "history_open.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "NL"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2026-02-03T08:00:00Z"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "secondary medical care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "232"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Open history"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.history_open.v1",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.history_open.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2026-02-03T08:00:00Z"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Initial event"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2026-02-03T08:00:00Z"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Any structure"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "media"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_MULTIMEDIA",
+                    "alternate_text": "chest x-ray",
+                    "data": "iVBORw0KGgoAAAANSUhEUg==",
+                    "media_type": {
+                      "_type": "CODE_PHRASE",
+                      "terminology_id": {
+                        "_type": "TERMINOLOGY_ID",
+                        "value": "IANA_media-types"
+                      },
+                      "code_string": "image/png"
+                    },
+                    "integrity_check": "3q2+7w==",
+                    "integrity_check_algorithm": {
+                      "_type": "CODE_PHRASE",
+                      "terminology_id": {
+                        "_type": "TERMINOLOGY_ID",
+                        "value": "openehr_integrity_check_algorithms"
+                      },
+                      "code_string": "CRC32"
+                    },
+                    "size": 18
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.empty_formalism.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.empty_formalism.json
@@ -1,0 +1,157 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "history_open.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "NL"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2026-02-03T08:00:00Z"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "secondary medical care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "232"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Open history"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.history_open.v1",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.history_open.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2026-02-03T08:00:00Z"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Initial event"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2026-02-03T08:00:00Z"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Any structure"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "media"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_PARSABLE",
+                    "value": "<html><body>ok</body></html>",
+                    "formalism": ""
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.encapsulated_rich.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.encapsulated_rich.json
@@ -1,0 +1,245 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "history_open.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "NL"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2026-02-03T08:00:00Z"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "secondary medical care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "232"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Open history"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.history_open.v1",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.history_open.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2026-02-03T08:00:00Z"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Initial event"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2026-02-03T08:00:00Z"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Any structure"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "media"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_MULTIMEDIA",
+                    "alternate_text": "chest x-ray",
+                    "uri": {
+                      "_type": "DV_URI",
+                      "value": "https://pacs.example.test/study/42"
+                    },
+                    "data": "iVBORw0KGgoAAAANSUhEUg==",
+                    "media_type": {
+                      "_type": "CODE_PHRASE",
+                      "terminology_id": {
+                        "_type": "TERMINOLOGY_ID",
+                        "value": "IANA_media-types"
+                      },
+                      "code_string": "image/png"
+                    },
+                    "compression_algorithm": {
+                      "_type": "CODE_PHRASE",
+                      "terminology_id": {
+                        "_type": "TERMINOLOGY_ID",
+                        "value": "openehr_compression_algorithms"
+                      },
+                      "code_string": "gzip"
+                    },
+                    "integrity_check": "3q2+7w==",
+                    "integrity_check_algorithm": {
+                      "_type": "CODE_PHRASE",
+                      "terminology_id": {
+                        "_type": "TERMINOLOGY_ID",
+                        "value": "openehr_integrity_check_algorithms"
+                      },
+                      "code_string": "SHA-256"
+                    },
+                    "thumbnail": {
+                      "_type": "DV_MULTIMEDIA",
+                      "data": "iVBORw0KGgo=",
+                      "media_type": {
+                        "_type": "CODE_PHRASE",
+                        "terminology_id": {
+                          "_type": "TERMINOLOGY_ID",
+                          "value": "IANA_media-types"
+                        },
+                        "code_string": "image/png"
+                      },
+                      "size": 12
+                    },
+                    "charset": {
+                      "_type": "CODE_PHRASE",
+                      "terminology_id": {
+                        "_type": "TERMINOLOGY_ID",
+                        "value": "IANA_character-sets"
+                      },
+                      "code_string": "UTF-8"
+                    },
+                    "language": {
+                      "_type": "CODE_PHRASE",
+                      "terminology_id": {
+                        "_type": "TERMINOLOGY_ID",
+                        "value": "ISO_639-1"
+                      },
+                      "code_string": "en"
+                    },
+                    "size": 18
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "markup"
+                  },
+                  "archetype_node_id": "at0005",
+                  "value": {
+                    "_type": "DV_PARSABLE",
+                    "value": "<html><body>ok</body></html>",
+                    "formalism": "text/html",
+                    "charset": {
+                      "_type": "CODE_PHRASE",
+                      "terminology_id": {
+                        "_type": "TERMINOLOGY_ID",
+                        "value": "IANA_character-sets"
+                      },
+                      "code_string": "UTF-8"
+                    },
+                    "language": {
+                      "_type": "CODE_PHRASE",
+                      "terminology_id": {
+                        "_type": "TERMINOLOGY_ID",
+                        "value": "ISO_639-1"
+                      },
+                      "code_string": "en"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.orphan_integrity_check.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.history_open.orphan_integrity_check.json
@@ -1,0 +1,167 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "history_open.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "NL"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2026-02-03T08:00:00Z"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "secondary medical care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "232"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Open history"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.history_open.v1",
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.history_open.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2026-02-03T08:00:00Z"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Initial event"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2026-02-03T08:00:00Z"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Any structure"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "media"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_MULTIMEDIA",
+                    "alternate_text": "chest x-ray",
+                    "data": "iVBORw0KGgoAAAANSUhEUg==",
+                    "media_type": {
+                      "_type": "CODE_PHRASE",
+                      "terminology_id": {
+                        "_type": "TERMINOLOGY_ID",
+                        "value": "IANA_media-types"
+                      },
+                      "code_string": "image/png"
+                    },
+                    "integrity_check": "3q2+7w==",
+                    "size": 18
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/registers/ambiguities.yaml
+++ b/tools/cnf-runner/artifacts/registers/ambiguities.yaml
@@ -9108,11 +9108,19 @@ AMB-209:
     it has no stopping point — every format-constrained leaf (ISO 8601
     durations, terminology codes, archetype ids) would migrate to 400 with
     it, collapsing the 422 branch that `responses/422.yaml` explicitly
-    provides for content that converted. Pinned by row 1 of
-    `CONT-DV_URI-validate_open` and row 1 of `CONT-DV_EHR_URI-validate_open`,
-    whose authored `violates` clause is a `rm_schema:` entry about a VALUE's
-    form and therefore does NOT carry the `mandatory` word the
-    content-table refusal split keys on (schedule/content/README.md).
+    provides for content that converted. RE-GROUNDED (issue #2484): the
+    DV_URI lexical-refusal class this entry originally pinned no longer
+    exists — the ch.10 audit found the RFC-3986 floor was an invented
+    prohibition (the class's only invariant is `Value_valid: not
+    value.is_empty` and master10 §Design explicitly allows scheme-less
+    plain-text URIs), so `CONT-DV_URI-validate_open` now ACCEPTS those
+    values and `CONT-DV_EHR_URI-validate_open` refuses a scheme-less value
+    on its real `Scheme_valid` invariant. The convertibility boundary this
+    entry fixes SURVIVES for every value-form refusal that genuinely exists
+    (the `iso8601(...)`, `rm_invariant(...)` and terminology-code rows all
+    refuse 422, never 400), and the runner's parse/semantic discriminator
+    (`run.rs::refused_at_parse`, keying `rm_schema:` + `mandatory`) keeps
+    exactly that line.
   disposition: fixed_handling
 
 AMB-210:
@@ -9313,3 +9321,26 @@ AMB-214:
     INTERVAL_EVENT; the editorial defect is reported upstream.
   disposition: fixed_handling
   upstream_issue: 2472
+AMB-215:
+  ambiguity: >-
+    The Encapsulated-package chapter's own examples table names an
+    integrity-check algorithm code the terminology code set does not
+    define: the "inline JPG with SHA-2 hash" row sets
+    integrity_check_algorithm = "openehr::SHA-2", while the integrity
+    check algorithms code set enumerates the SHA-2 FAMILY members
+    (SHA-1, SHA-224, SHA-256, SHA-384, SHA-512, ...) and has no SHA-2
+    member — so an instance following the example is refused by the
+    class's own Integrity_check_algorithm_validity.
+  source: >-
+    RM docs/data_types/master09-encapsulated_package.adoc §Examples; RM
+    UML/classes/org.openehr.rm.data_types.dv_multimedia.adoc §Invariants
+    Integrity_check_algorithm_validity; the openEHR terminology integrity
+    check algorithms code set (crates/openehr-term/assets).
+  handling: >-
+    Fixed handling (issue #2483): the invariant + code set win — SHA-2 is
+    refused as out-of-set, the example row is illustrative prose with no
+    normative force against the invariant, and the catalogue commits
+    SHA-256 in the accepting instance while pinning the out-of-set refusal
+    (issue #2482). The example defect is reported upstream.
+  disposition: fixed_handling
+  upstream_issue: 2483

--- a/tools/cnf-runner/artifacts/schedule/content/CONT-DV_EHR_URI-validate_open.yaml
+++ b/tools/cnf-runner/artifacts/schedule/content/CONT-DV_EHR_URI-validate_open.yaml
@@ -4,11 +4,11 @@ component: CONTENT
 rm_class: DV_EHR_URI
 capabilities: [ArchetypeValidation]
 profiles: [CORE]
-test_purpose: "A committed DV_EHR_URI is accepted iff value is a present RFC 3986 URI whose scheme is 'ehr'."
-description: "DV_EHR_URI open: RFC3986 + scheme='ehr' invariant"
+test_purpose: "A committed DV_EHR_URI is accepted iff value is present and its scheme is 'ehr' (Scheme_valid) \u2014 a scheme-less value has no 'ehr' scheme and is refused by that invariant, not by any RFC-3986 lexical floor."
+description: "DV_EHR_URI open: the scheme='ehr' invariant"
 spec_refs:
   - "CNF platform_test_schedule master17.7 \u00a7CONT-DV_EHR_URI-validate_open"
-  - "RM data_types \u00a7DV_EHR_URI"
+  - "RM UML/classes/org.openehr.rm.data_types.dv_ehr_uri.adoc \u00a7Invariants (Scheme_valid: scheme.is_equal(Ehr_scheme))"
   - "AM AOM1.4 \u00a7C_STRING"
 constraint_context:
   template: cnf.tpl.dv_ehr_uri_open
@@ -17,7 +17,10 @@ decision_table:
   columns: ["value", "expected", "violates"]
   rows:
     - [null, "rejected", ["rm_schema: value is mandatory"]]
-    - ["xyz", "rejected", ["rm_schema: value is not a valid RFC 3986 URI"]]
+    # Re-grounded 2026-08-20: a scheme-less value refuses on Scheme_valid (its
+    # scheme is not 'ehr'), never on an RFC-3986 lexical floor DV_URI does not
+    # declare (the DV_URI sibling case carries the acceptance adjudication).
+    - ["xyz", "rejected", ["rm_invariant(Scheme_valid): URI scheme is not 'ehr'"]]
     - ["ftp://ftp.is.co.za/rfc/rfc1808.txt", "rejected", ["rm_invariant(Scheme_valid): URI scheme is not 'ehr'"]]
     - ["http://www.ietf.org/rfc/rfc2396.txt", "rejected", ["rm_invariant(Scheme_valid): URI scheme is not 'ehr'"]]
     - ["ldap://[2001:db8::7]/c=GB?objectClass?one", "rejected", ["rm_invariant(Scheme_valid): URI scheme is not 'ehr'"]]

--- a/tools/cnf-runner/artifacts/schedule/content/CONT-DV_URI-validate_open.yaml
+++ b/tools/cnf-runner/artifacts/schedule/content/CONT-DV_URI-validate_open.yaml
@@ -4,11 +4,12 @@ component: CONTENT
 rm_class: DV_URI
 capabilities: [ArchetypeValidation]
 profiles: [CORE]
-test_purpose: "A committed DV_URI is accepted iff value is present and is an RFC 3986-compliant URI."
-description: "DV_URI open: only non-RFC3986 or missing values are rejected"
+test_purpose: "A committed DV_URI is accepted iff value is present and non-empty \u2014 scheme-less relative references and plain-text URIs included (the class's only invariant is Value_valid: not value.is_empty, and master10 \u00a7Design explicitly allows plain-text URIs, placing the RFC-3986 encoding duty on downstream use)."
+description: "DV_URI open: only missing or empty values are rejected"
 spec_refs:
   - "CNF platform_test_schedule master17.7 \u00a7CONT-DV_URI-validate_open"
-  - "RM data_types \u00a7DV_URI"
+  - "RM UML/classes/org.openehr.rm.data_types.dv_uri.adoc \u00a7Invariants (Value_valid: not value.is_empty \u2014 the only declared invariant) + \u00a7Description (plain-text URIs allowed)"
+  - "RM data_types/master10-uri_package.adoc \u00a7Design (plain-text URIs \u2026 are allowed \u2026 must be RFC-3986 encoded prior to use)"
   - "AM AOM1.4 \u00a7C_STRING"
 constraint_context:
   template: cnf.tpl.dv_uri_open
@@ -17,7 +18,13 @@ decision_table:
   columns: ["value", "expected", "violates"]
   rows:
     - [null, "rejected", ["rm_schema: value is mandatory"]]
-    - ["xyz", "rejected", ["rm_schema: value is not a valid RFC 3986 URI"]]
+    - ["", "rejected", ["rm_invariant(Value_valid): value must be non-empty"]]
+    # Adjudicated 2026-08-20 (the fix issue carries the derivation): the former
+    # rejected row enforced an RFC-3986 floor the class does not declare \u2014 the
+    # only invariant is non-emptiness and the plain-text allowance admits
+    # scheme-less values, so relative references and plain text accept.
+    - ["xyz", "accepted", []]
+    - ["see the attached guideline", "accepted", []]
     - ["ftp://ftp.is.co.za/rfc/rfc1808.txt", "accepted", []]
     - ["http://www.ietf.org/rfc/rfc2396.txt", "accepted", []]
     - ["ldap://[2001:db8::7]/c=GB?objectClass?one", "accepted", []]

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-encapsulated_family_invalid.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-encapsulated_family_invalid.yaml
@@ -1,0 +1,40 @@
+# The Encapsulated-package refusal twins (RM data_types ch.9, issue #2482):
+# five falsifiable invariants with no prior wire case, one defect per row
+# under the open history_open.en.v1 template. The accepting twin is
+# commit_contribution-encapsulated_rich.
+id: I_EHR_CONTRIBUTION.commit_contribution-encapsulated_family_invalid
+kind: functional
+component: EHR_CONTRIBUTION
+sm_operation: I_EHR_CONTRIBUTION.commit_contribution
+capabilities: [ChangeSets]
+profiles: [CORE]
+test_purpose: "A committed encapsulated value violating the family — an out-of-set compression or integrity-check algorithm, integrity bytes without their algorithm, an empty parsable formalism, or an out-of-set charset — is refused as invalid content, and no version is created."
+description: "commit compositions with Encapsulated-package invariant defects"
+spec_refs:
+  - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
+  - "RM UML/classes/org.openehr.rm.data_types.dv_multimedia.adoc §Invariants (Compression_algorithm_validity, Integrity_check_validity, Integrity_check_algorithm_validity)"
+  - "RM UML/classes/org.openehr.rm.data_types.dv_parsable.adoc §Invariants (Formalism_valid) + org.openehr.rm.data_types.dv_encapsulated.adoc §Invariants (Charset_valid)"
+  - "ITS-REST overview Requests_and_responses.md §HTTP status codes (the semantic 422 branch)"
+applies: { rm: ">=1.0.2" }
+requires:
+  server: any
+  templates: [cnf.opt.history_open.v1]
+  ehr: { commits: none }
+parameters:
+  iteration: reset_per_row
+  fixture_set:
+    - { data_set: cnf.composition.history_open.bad_compression, expected: validation_failed, defect: "compression code brotli outside the compression algorithms code set (Compression_algorithm_validity)" }
+    - { data_set: cnf.composition.history_open.orphan_integrity_check, expected: validation_failed, defect: "integrity_check bytes without integrity_check_algorithm (Integrity_check_validity)" }
+    - { data_set: cnf.composition.history_open.bad_integrity_algorithm, expected: validation_failed, defect: "integrity algorithm CRC32 outside its code set (Integrity_check_algorithm_validity)" }
+    - { data_set: cnf.composition.history_open.empty_formalism, expected: validation_failed, defect: "empty DV_PARSABLE formalism (Formalism_valid)" }
+    - { data_set: cnf.composition.history_open.bad_charset, expected: validation_failed, defect: "charset bogus-charset outside the character sets code set (Charset_valid)" }
+flow:
+  - step: 1
+    call: commit_contribution
+    with:
+      versions: "${ds:fixture}"
+      audit: { change_type: creation, committer: { name: "conformance tester" } }
+    expect: "${fixture.expected}"
+postconditions:
+  - assert: version
+    count: 0

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-encapsulated_rich.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-encapsulated_rich.yaml
@@ -1,0 +1,49 @@
+# The encapsulated family's rich accepting twin (RM data_types ch.9, issue
+# #2482): the first committed compression / integrity-pair / thumbnail /
+# charset trimmings — the pre-existing attested_view DV_MULTIMEDIA carries
+# only alternate_text/data/media_type/size. The refusal directions live in
+# commit_contribution-encapsulated_family_invalid.
+id: I_EHR_CONTRIBUTION.commit_contribution-encapsulated_rich
+kind: functional
+component: EHR_CONTRIBUTION
+sm_operation: I_EHR_CONTRIBUTION.commit_contribution
+capabilities: [ChangeSets]
+profiles: [CORE]
+test_purpose: >-
+  Committing a DV_MULTIMEDIA carrying inline data, media_type, gzip
+  compression, the SHA-256 integrity pair, a nested thumbnail, uri,
+  charset/language and size — beside a DV_PARSABLE with charset and
+  language — succeeds and creates version 1.
+description: "commit a composition carrying a fully-trimmed DV_MULTIMEDIA + DV_PARSABLE"
+spec_refs:
+  - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
+  - "RM UML/classes/org.openehr.rm.data_types.dv_multimedia.adoc §Attributes (uri, data, media_type, compression_algorithm, integrity_check, integrity_check_algorithm, thumbnail, size) + org.openehr.rm.data_types.dv_encapsulated.adoc §Attributes (charset, language)"
+  - "RM UML/classes/org.openehr.rm.data_types.dv_parsable.adoc §Invariants (Formalism_valid satisfied: text/html)"
+applies: { rm: ">=1.0.2" }
+requires:
+  server: any
+  templates: [cnf.opt.history_open.v1]
+  ehr: { commits: none }
+parameters:
+  iteration: reset_per_row
+  fixture_set:
+    - { data_set: cnf.composition.history_open.encapsulated_rich, expected: created, defect: "fully-trimmed DV_MULTIMEDIA (incl. thumbnail recursion) + DV_PARSABLE with charset/language" }
+flow:
+  - step: 1
+    call: commit_contribution
+    with:
+      ehr_id: "${ehr_id}"
+      versions:
+        - { data: "${ds:fixture}", change_type: creation }
+    expect: "${fixture.expected}"
+    capture:
+      version_uids: created.version_uids[]
+    assert:
+      - { assert: version, for_each: "${version_uids}", change_type: CREATE, uid_pattern: "<uuid>::<system>::1" }
+postconditions:
+  - assert: state
+    text: >-
+      The EHR holds one new VERSION<COMPOSITION> whose multimedia trimmings
+      (compression, integrity pair, thumbnail, charset/language) are stored
+      and served unchanged.
+    verified_by: I_EHR_COMPOSITION.get_composition_latest

--- a/tools/cnf-runner/artifacts/vocab/capability_matrix.yaml
+++ b/tools/cnf-runner/artifacts/vocab/capability_matrix.yaml
@@ -74,7 +74,10 @@ DirectoryOps: { family: Platform, tier: STANDARD, required: true, min_cases: 85,
 # refusal family.
 # Raised 98 -> 100 (2026-08-20): the time-specification twins (issue
 # #2480) — the PIVL/GTS acceptance case plus the formalism refusal.
-ChangeSets: { family: Platform, tier: CORE, required: true, min_cases: 100, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Change sets)" }
+# Raised 100 -> 102 (2026-08-20): the Encapsulated-package twins (issue
+# #2482) — the rich multimedia/parsable acceptance case plus the
+# five-invariant refusal family.
+ChangeSets: { family: Platform, tier: CORE, required: true, min_cases: 102, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Change sets)" }
 Versioning: { family: Platform, tier: CORE, required: true, min_cases: 72, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Versioning)" }
 # Floor raised 121 -> 125 (2026-07-29): the four commit-time CONSTRAINT
 # BINDING cases (member accepted / non-member refused / unresolvable under each

--- a/tools/openehr-codegen/templates/openehr-rm/data_types/uri/dv_uri_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/data_types/uri/dv_uri_impl.rs
@@ -22,26 +22,14 @@ fn is_scheme(s: &str) -> bool {
         && chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.'))
 }
 
-/// `true` when `value` is an absolute RFC-3986 reference — a scheme
-/// (`ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`) followed by `:`.
-fn has_scheme(value: &str) -> bool {
-    matches!(value.split_once(':'), Some((s, _)) if is_scheme(s))
-}
-
 /// The DV_URI `Value_valid` core over the projected value — one source for the
 /// typed impl and the value-level fast path (`validate::fast`), mirroring the
 /// DV_EHR_URI sibling (`dv_ehr_uri_impl::push_dv_ehr_uri_invariants`).
 pub(crate) fn push_dv_uri_invariants(value: &str, out: &mut Vec<InvariantViolation>) {
-    // RM invariant `Value_valid: not value.is_empty` (the only DV_URI invariant).
+    // NOTE: `dv_uri.adoc` §Invariants + `master10-uri_package.adoc` §Design —
+    // the only invariant is non-emptiness, and plain-text (scheme-less) URIs
+    // are explicitly allowed, so no lexical-form refusal exists.
     crate::v1_2::validate::generated::dv_uri_core(value, out);
-    // NOTE: `dv_uri.adoc` §Description binds `value` to "the Universal Resource
-    // Identifier (URI) RFC-3986 standard", whose §3 `URI` production requires a
-    // scheme; the encoding of the remainder stays unenforced (plain-text URIs).
-    if !has_scheme(value) {
-        out.push(InvariantViolation::here(
-            "Invariant Value_valid failed on type DV_URI",
-        ));
-    }
 }
 
 impl DvUriData {
@@ -131,27 +119,23 @@ mod tests {
     /// admit. The refusal is reported under `Value_valid`, the class's only
     /// declared invariant.
     #[test]
-    fn scheme_required_for_absolute_reference() {
-        let value_valid = "Invariant Value_valid failed on type DV_URI".to_owned();
-        // Absolute references (scheme present) are accepted.
+    fn scheme_less_and_plain_text_values_are_accepted() {
+        // Absolute references are accepted.
         assert!(
             uri("ftp://ftp.is.co.za/rfc/rfc1808.txt")
                 .invariants()
                 .is_empty()
         );
-        assert!(
-            uri("http://example.com/path/resource")
-                .invariants()
-                .is_empty()
-        );
         assert!(uri("mailto:someone@example.org").invariants().is_empty());
-        // RM prose allows "plain-text URIs" with RFC-3986-forbidden characters
-        // (e.g. a space) — still accepted so long as a scheme is present.
+        // Plain-text URIs (RFC-3986-forbidden characters such as spaces) and
+        // scheme-less relative references are all admitted: the class's only
+        // invariant is non-emptiness, and the §Design plain-text allowance
+        // covers exactly these forms.
         assert!(uri("http://example.org/a b").invariants().is_empty());
-        // Bare relative references (no scheme) are rejected.
-        assert!(messages("xyz").contains(&value_valid));
-        assert!(messages("www.iana.org").contains(&value_valid));
-        assert!(messages("content/items").contains(&value_valid));
+        assert!(uri("see the attached guideline").invariants().is_empty());
+        assert!(uri("xyz").invariants().is_empty());
+        assert!(uri("www.iana.org").invariants().is_empty());
+        assert!(uri("content/items").invariants().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Closes #2482
Closes #2484

Two entangled units from the ch.9/ch.10 audits — the ch.10 catalogue correction red-runs without the app fix, so they ship together.

## The Encapsulated-package wire twins (#2482, ch.9 — #917)

Five falsifiable invariants had no case: `Compression_algorithm_validity`, `Integrity_check_validity`, `Integrity_check_algorithm_validity`, `Formalism_valid`, `Charset_valid` — each now a single-defect refusal row under the open template. The accepting twin is one rich instance carrying the corpus's **first committed** compression, integrity pair, nested thumbnail, uri and charset/language trimmings, beside a DV_PARSABLE with charset+language. En route: master09's own §Examples row uses `openehr::SHA-2` — a code its code set does not define (the set enumerates the family's members) — registered **AMB-215**, reported upstream as #2483. ChangeSets floor 100→102.

## The DV_URI plain-text fix (#2484, ch.10 — #918, P1)

`dv_uri_impl` (a generation-twin template) refused any scheme-less `DV_URI.value` — a floor the class never declares. The only invariant is `Value_valid: not value.is_empty`, and both the class Description and `master10` §Design **explicitly allow** plain-text URIs (encoding is the consumer's duty at use). An invented prohibition is the leniency mirror (spec-adherence hard rule). Confirmed twice, independently:

1. The spec-derived catalogue rows red-ran against the unfixed validator exactly as predicted (`CONT-DV_URI-validate_open` rows: expected created, observed validation_failed).
2. The `example_stub` gate's `Testing.opt` adjudication — a real CKM template whose `C_STRING` pattern `abcdef` can never carry a scheme — was "spec-contradictory" ONLY because of the floor, validates clean without it, and the gate itself demanded the stale entry go.

`DV_EHR_URI` unchanged (`Scheme_valid` is a real invariant; scheme-less/foreign-scheme values keep refusing, now grounded on it). AMB-209 re-grounded (its 400-vs-422 convertibility boundary survives for genuinely refused value-form classes). Lockstep crate bump 0.0.33→0.0.34; changelog entry.

## Verification

Fresh pipeline over the combined tree: **1040 passed / 0 failed / 0 errored — CORE+STANDARD PASS, 1040/1040** (the two previously-red URI rows now green through the fixed validator). `cnf-runner validate` 1079 cases 0 findings; workspace nextest **4987/4987**; wide clippy clean; the 348-test battery green; codegen drift clean by construction (template + regenerated output together).