### PR TITLE
test(cnf): the Entry-package wire twins

### DIFF
--- a/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
@@ -7,12 +7,12 @@ Runner: cnf-runner 3.17.8 · verification pack: passed
 
 | Status | Count |
 | --- | --- |
-| passed | 1041 |
+| passed | 1043 |
 | failed | 0 |
 | errored | 0 |
 | skipped | 0 |
 | not_applicable | 38 |
-| total | 1079 |
+| total | 1081 |
 
 ## By chapter
 
@@ -20,12 +20,12 @@ Grouping is the published per-chapter chart's taxonomy: chapters with their band
 
 | Chapter / band | passed | failed | errored | cited n/a |
 | --- | --- | --- | --- | --- |
-| **EHR** | 460 | 0 | 0 | 18 |
+| **EHR** | 462 | 0 | 0 | 18 |
 | — EHR resource | 25 | 0 | 0 | 2 |
 | — EHR_STATUS | 46 | 0 | 0 | 5 |
 | — COMPOSITION | 138 | 0 | 0 | 0 |
 | — DIRECTORY | 79 | 0 | 0 | 6 |
-| — CONTRIBUTION | 104 | 0 | 0 | 5 |
+| — CONTRIBUTION | 106 | 0 | 0 | 5 |
 | — Item tags | 62 | 0 | 0 | 0 |
 | — Revision history | 6 | 0 | 0 | 0 |
 | **Definitions** | 97 | 0 | 0 | 10 |
@@ -86,7 +86,7 @@ Selected gating cases per claimed capability. `inconclusive` counts cases whose 
 | EhrStatus | pass | 44 | 0 | 0 | 5 |
 | CompositionOps | pass | 59 | 0 | 0 | 0 |
 | DirectoryOps | pass | 77 | 0 | 0 | 8 |
-| ChangeSets | pass | 97 | 0 | 0 | 5 |
+| ChangeSets | pass | 99 | 0 | 0 | 5 |
 | Versioning | pass | 73 | 0 | 0 | 0 |
 | ArchetypeValidation | pass | 125 | 0 | 0 | 0 |
 | PartyOperations | pass | 86 | 0 | 0 | 4 |
@@ -175,7 +175,7 @@ Percentiles re-derive from the embedded HDR V2 histograms; the class verdict is 
 
 ## Honesty
 
-Coverage: 1041 of 1079 selected cases driven.
+Coverage: 1043 of 1081 selected cases driven.
 
 Not-executed verdicts (each cited):
 

--- a/docs/conformance/ferroehr/badge.json
+++ b/docs/conformance/ferroehr/badge.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "openEHR conformance",
-  "message": "CORE+STANDARD PASS · 1041/1041 cases",
+  "message": "CORE+STANDARD PASS · 1043/1043 cases",
   "color": "brightgreen"
 }

--- a/docs/conformance/ferroehr/results.json
+++ b/docs/conformance/ferroehr/results.json
@@ -2215,6 +2215,12 @@
       "rows_total": 1
     },
     {
+      "case": "I_EHR_CONTRIBUTION.commit_contribution-entry_family_invalid",
+      "status": "passed",
+      "rows_driven": 4,
+      "rows_total": 4
+    },
+    {
       "case": "I_EHR_CONTRIBUTION.commit_contribution-event_composition",
       "status": "passed",
       "rows_driven": 1,
@@ -2276,6 +2282,12 @@
     },
     {
       "case": "I_EHR_CONTRIBUTION.commit_contribution-incomplete_wrong_data",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_CONTRIBUTION.commit_contribution-instruction_rich",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1

--- a/docs/conformance/ferroehr/verdicts.json
+++ b/docs/conformance/ferroehr/verdicts.json
@@ -268,7 +268,7 @@
     [
       "ChangeSets",
       {
-        "passed": 97,
+        "passed": 99,
         "failed": 0,
         "inconclusive": 0,
         "unevidenced": 5
@@ -588,9 +588,9 @@
     }
   ],
   "coverage": {
-    "selected": 1079,
-    "driven": 1041,
-    "passed": 1041,
+    "selected": 1081,
+    "driven": 1043,
+    "passed": 1043,
     "failed": 0,
     "inconclusive": 0
   }

--- a/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
+++ b/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
@@ -3697,3 +3697,50 @@ cnf.composition.history_open_cat.persistent:
   validity: { verdict: valid }
   template_id: "history_open_cat.en.v1"
   provenance: "derived 2026-08-20 (issue #2486) from cnf.composition.history_open_cat.event with only the category swapped to openehr::431|persistent| — VALID standalone (431 is a composition_category member and the archetype leaves category unconstrained); the defect exists only relative to an event-category container's first version, which is exactly what the update-seam case exercises (VERSIONED_COMPOSITION.Persistent_validity)"
+cnf.composition.maximal.instruction_rich:
+  source: fixtures/contribution/composition.maximal.instruction_rich.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity: { verdict: valid }
+  template_id: "test_all_types.en.v1"
+  provenance: "derived 2026-08-20 (issue #2488) from cnf.composition.maximal by adding every never-committed instruction-family trimming: ISM_TRANSITION.transition (536|plan step|, matching the planned state) + careflow_step (a local archetype term) + reason, ACTION.instruction_details (LOCATABLE_REF instruction_id + activity_id), INSTRUCTION.expiry_time and wf_definition (a DV_PARSABLE; the chapter fixes no formalism — master08 §Clinical Workflow Definition: any syntax may currently be used)"
+cnf.composition.maximal.bad_ism_state:
+  source: fixtures/contribution/composition.maximal.bad_ism_state.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "an ISM_TRANSITION whose current_state code 999 is outside the instruction states group"
+    spec_ref: "RM UML/classes/org.openehr.rm.composition.ism_transition.adoc §Invariants Current_state_valid (has_code_for_group_id(Group_id_instruction_states, current_state.defining_code))"
+  template_id: "test_all_types.en.v1"
+  provenance: "derived 2026-08-20 (issue #2488) from cnf.composition.maximal with exactly one defect: the state code 526 swapped to 999 (the maximal OPT leaves the ISM state archetype-open, so the terminology invariant is the only violation)"
+cnf.composition.maximal.bad_ism_transition:
+  source: fixtures/contribution/composition.maximal.bad_ism_transition.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "an ISM_TRANSITION whose transition code 999 is outside the instruction transitions group"
+    spec_ref: "RM UML/classes/org.openehr.rm.composition.ism_transition.adoc §Invariants Transition_valid (transition /= Void implies has_code_for_group_id(Group_id_instruction_transitions, transition.defining_code))"
+  template_id: "test_all_types.en.v1"
+  provenance: "derived 2026-08-20 (issue #2488): exactly one defect — an out-of-group transition added to the otherwise-valid ISM_TRANSITION"
+cnf.composition.maximal.empty_action_archetype_id:
+  source: fixtures/contribution/composition.maximal.empty_action_archetype_id.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "an ACTIVITY whose mandatory action_archetype_id is the empty string"
+    spec_ref: "RM UML/classes/org.openehr.rm.composition.activity.adoc §Invariants Action_archetype_id_valid (not action_archetype_id.is_empty)"
+  template_id: "test_all_types.en.v1"
+  provenance: "derived 2026-08-20 (issue #2488): exactly one defect — action_archetype_id \"\""
+cnf.composition.maximal.empty_activity_id:
+  source: fixtures/contribution/composition.maximal.empty_activity_id.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "an INSTRUCTION_DETAILS whose mandatory activity_id is the empty string"
+    spec_ref: "RM UML/classes/org.openehr.rm.composition.instruction_details.adoc §Invariants Activity_path_valid (not activity_id.is_empty)"
+  template_id: "test_all_types.en.v1"
+  provenance: "derived 2026-08-20 (issue #2488): exactly one defect — an otherwise-valid instruction_details (well-formed LOCATABLE_REF instruction_id) added to the ACTION with activity_id \"\""

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.maximal.bad_ism_state.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.maximal.bad_ism_state.json
@@ -1,0 +1,850 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Test all types"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.test_all_types.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "test_all_types.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.test_all_types.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "UY"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "external_ref": {
+      "_type": "PARTY_REF",
+      "id": {
+        "_type": "HIER_OBJECT_ID",
+        "value": "b7c07d35-fa06-4280-8e65-eabdfbe64fdc"
+      },
+      "namespace": "DEMOGRAPHIC",
+      "type": "PERSON"
+    },
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2019-01-28T21:22:49,294+00:00"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "primary nursing care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "229"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Test all types"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.test_all_types.v1",
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2019-01-28T21:22:49,326+00:00"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Cualquier evento"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2019-01-28T21:22:49,332+00:00"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Arbol"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "text"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_TEXT",
+                    "value": "At,ffwkm.xsuDu,LNtqXEQJzxNMXTjyKVzQojaNTidAxLLZRbWWoGnfOIMUM.XxakRgJxExjtjBPirOxu,nUnPdIegLQbhNDKNRqGbFuvXrXYuNPXwnELoIsYMKgFEWHnR.XSBuESAamCrjJMssGgI.QOOyzatFlaXbiVaUBxzSdkOscZza,IumnYWoxwekcSAYSJiILhmKEOUWdoElCavaQPNNpGcxHEGASUMSAkFuu jZdWcysffi.QLeVONn"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "coded text"
+                  },
+                  "archetype_node_id": "at0005",
+                  "value": {
+                    "_type": "DV_CODED_TEXT",
+                    "value": "value1",
+                    "defining_code": {
+                      "_type": "CODE_PHRASE",
+                      "terminology_id": {
+                        "_type": "TERMINOLOGY_ID",
+                        "value": "local"
+                      },
+                      "code_string": "at0006"
+                    }
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "coded text terminology"
+                  },
+                  "archetype_node_id": "at0006",
+                  "value": {
+                    "_type": "DV_CODED_TEXT",
+                    "value": ".HCXbqCyQtseLkDyKS,QLpOdDZxrEJ",
+                    "defining_code": {
+                      "_type": "CODE_PHRASE",
+                      "terminology_id": {
+                        "_type": "TERMINOLOGY_ID",
+                        "value": "SNOMED-CT"
+                      },
+                      "code_string": "1004034"
+                    }
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "quantity"
+                  },
+                  "archetype_node_id": "at0007",
+                  "value": {
+                    "_type": "DV_QUANTITY",
+                    "magnitude": 636.3397240638733,
+                    "units": "mg"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "count"
+                  },
+                  "archetype_node_id": "at0008",
+                  "value": {
+                    "_type": "DV_COUNT",
+                    "magnitude": 10
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "date"
+                  },
+                  "archetype_node_id": "at0009",
+                  "value": {
+                    "_type": "DV_DATE",
+                    "value": "20190114"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "datetime"
+                  },
+                  "archetype_node_id": "at0010",
+                  "value": {
+                    "_type": "DV_DATE_TIME",
+                    "value": "2019-01-28T21:22:49,426+00:00"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "datetime any"
+                  },
+                  "archetype_node_id": "at0011",
+                  "value": {
+                    "_type": "DV_DATE_TIME",
+                    "value": "2019-01-28T21:22:49,427+00:00"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "time"
+                  },
+                  "archetype_node_id": "at0012",
+                  "value": {
+                    "_type": "DV_TIME",
+                    "value": "18:36:49"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "ordinal"
+                  },
+                  "archetype_node_id": "at0013",
+                  "value": {
+                    "_type": "DV_ORDINAL",
+                    "value": 0,
+                    "symbol": {
+                      "_type": "DV_CODED_TEXT",
+                      "value": "ord1",
+                      "defining_code": {
+                        "_type": "CODE_PHRASE",
+                        "terminology_id": {
+                          "_type": "TERMINOLOGY_ID",
+                          "value": "local"
+                        },
+                        "code_string": "at0014"
+                      }
+                    }
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "boolean"
+                  },
+                  "archetype_node_id": "at0017",
+                  "value": {
+                    "_type": "DV_BOOLEAN",
+                    "value": true
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "duration any"
+                  },
+                  "archetype_node_id": "at0018",
+                  "value": {
+                    "_type": "DV_DURATION",
+                    "value": "PT30M"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "parsable any"
+                  },
+                  "archetype_node_id": "at0020",
+                  "value": {
+                    "_type": "DV_PARSABLE",
+                    "value": "20170629",
+                    "formalism": "ISO8601"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "identifier"
+                  },
+                  "archetype_node_id": "at0021",
+                  "value": {
+                    "_type": "DV_IDENTIFIER",
+                    "issuer": "Hospital de Clinicas",
+                    "assigner": "Hospital de Clinicas",
+                    "id": "55175056",
+                    "type": "LOCALID"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "proportion any"
+                  },
+                  "archetype_node_id": "at0022",
+                  "value": {
+                    "_type": "DV_PROPORTION",
+                    "numerator": 1.5,
+                    "denominator": 1.0,
+                    "type": 1,
+                    "precision": 1
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.test_all_types.v1"
+        },
+        "rm_version": "1.0.2"
+      }
+    },
+    {
+      "_type": "EVALUATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Test all types"
+      },
+      "archetype_node_id": "openEHR-EHR-EVALUATION.test_all_types.v1",
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "ITEM_TREE",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Arbol"
+        },
+        "archetype_node_id": "at0001",
+        "items": [
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "uri"
+            },
+            "archetype_node_id": "at0002",
+            "null_flavour": {
+              "_type": "DV_CODED_TEXT",
+              "value": "no information",
+              "defining_code": {
+                "_type": "CODE_PHRASE",
+                "terminology_id": {
+                  "_type": "TERMINOLOGY_ID",
+                  "value": "openehr"
+                },
+                "code_string": "271"
+              }
+            }
+          },
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "interval count"
+            },
+            "archetype_node_id": "at0003",
+            "value": {
+              "_type": "DV_INTERVAL",
+              "lower": {
+                "_type": "DV_COUNT",
+                "magnitude": 123
+              },
+              "upper": {
+                "_type": "DV_COUNT",
+                "magnitude": 234
+              },
+              "lower_unbounded": false,
+              "upper_unbounded": false
+            }
+          },
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "interval quantity"
+            },
+            "archetype_node_id": "at0004",
+            "value": {
+              "_type": "DV_INTERVAL",
+              "lower": {
+                "_type": "DV_QUANTITY",
+                "magnitude": 123.123,
+                "units": "mm[H20]"
+              },
+              "upper": {
+                "_type": "DV_QUANTITY",
+                "magnitude": 234.234,
+                "units": "mm[H20]"
+              },
+              "lower_unbounded": false,
+              "upper_unbounded": false
+            }
+          },
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "interval datetime"
+            },
+            "archetype_node_id": "at0005",
+            "value": {
+              "_type": "DV_INTERVAL",
+              "lower": {
+                "_type": "DV_DATE_TIME",
+                "value": "2019-01-28T21:22:49,426+00:00"
+              },
+              "upper": {
+                "_type": "DV_DATE_TIME",
+                "value": "2019-01-28T21:22:49,426+00:00"
+              },
+              "lower_unbounded": false,
+              "upper_unbounded": false
+            }
+          },
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "choice"
+            },
+            "archetype_node_id": "at0009",
+            "value": {
+              "_type": "DV_QUANTITY",
+              "magnitude": 148.01210165023804,
+              "units": "mm[H20]"
+            }
+          },
+          {
+            "_type": "CLUSTER",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "cluster 1"
+            },
+            "archetype_node_id": "at0006",
+            "items": [
+              {
+                "_type": "CLUSTER",
+                "name": {
+                  "_type": "DV_TEXT",
+                  "value": "cluster 2"
+                },
+                "archetype_node_id": "at0007",
+                "items": [
+                  {
+                    "_type": "CLUSTER",
+                    "name": {
+                      "_type": "DV_TEXT",
+                      "value": "cluster 3"
+                    },
+                    "archetype_node_id": "at0008",
+                    "items": [
+                      {
+                        "_type": "ELEMENT",
+                        "name": {
+                          "_type": "DV_TEXT",
+                          "value": "text 2"
+                        },
+                        "archetype_node_id": "at0010",
+                        "value": {
+                          "_type": "DV_TEXT",
+                          "value": "FViqRjKtFGXm ,iPOYGPuYNjqqVYifvxzvbOlMnuidJvvdYByUiDUgQIBkyOcJtgZcRKdFmyo .TrsPDcaXtFeqLlnZgqdTxb.,LGavIsdXKcBhTWd,PElsLCymSIGcfRrObkevpucVkThYTAZZxcikhpGVaQ.UbyrkwewgarEn gLmIWGLqFZBFYLcBje.GwiYMBoHEEVymGCkyXUyosuq,CNvWsuUnHdVEjEuxGSEwBDEVgwWrXWOYWUCIhos"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-EVALUATION.test_all_types.v1"
+        },
+        "rm_version": "1.0.2"
+      }
+    },
+    {
+      "_type": "SECTION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Test all types"
+      },
+      "archetype_node_id": "openEHR-EHR-SECTION.test_all_types.v1",
+      "items": [
+        {
+          "_type": "SECTION",
+          "name": {
+            "_type": "DV_TEXT",
+            "value": "section 2"
+          },
+          "archetype_node_id": "at0001",
+          "items": [
+            {
+              "_type": "SECTION",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "section 3"
+              },
+              "archetype_node_id": "at0002",
+              "items": [
+                {
+                  "_type": "INSTRUCTION",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "Test all types"
+                  },
+                  "archetype_node_id": "openEHR-EHR-INSTRUCTION.test_all_types.v1",
+                  "language": {
+                    "_type": "CODE_PHRASE",
+                    "terminology_id": {
+                      "_type": "TERMINOLOGY_ID",
+                      "value": "ISO_639-1"
+                    },
+                    "code_string": "en"
+                  },
+                  "encoding": {
+                    "_type": "CODE_PHRASE",
+                    "terminology_id": {
+                      "_type": "TERMINOLOGY_ID",
+                      "value": "IANA_character-sets"
+                    },
+                    "code_string": "UTF-8"
+                  },
+                  "subject": {
+                    "_type": "PARTY_SELF"
+                  },
+                  "narrative": {
+                    "_type": "DV_TEXT",
+                    "value": "WAZotVojPPlPDKcOwCqQGlJjRdMC.ujKPgVAmyWABEoOgtrRSznogUWokmqmfgxjZOYmUEAcyvmnfz,KhtTC FrpwevrLJFNiJKzkzOwfOPRFQJjRmQCTW,ewdqvscogOkayvONWrOTPcCFnZsUod CAQ fuhLaBA.pFWdEyzyFgDODbueIlUjIGBdnIDDpMfjzWivfUDSEvTUsncmCgPdHnpONCuNGXUwFTaiSHHHJBZYssxGne.BLIbBQzXhG"
+                  },
+                  "activities": [
+                    {
+                      "_type": "ACTIVITY",
+                      "name": {
+                        "_type": "DV_TEXT",
+                        "value": "Current Activity"
+                      },
+                      "archetype_node_id": "at0001",
+                      "description": {
+                        "_type": "ITEM_LIST",
+                        "name": {
+                          "_type": "DV_TEXT",
+                          "value": "List"
+                        },
+                        "archetype_node_id": "at0002",
+                        "items": [
+                          {
+                            "_type": "ELEMENT",
+                            "name": {
+                              "_type": "DV_TEXT",
+                              "value": "partial date"
+                            },
+                            "archetype_node_id": "at0003",
+                            "value": {
+                              "_type": "DV_DATE",
+                              "value": "20190114"
+                            }
+                          },
+                          {
+                            "_type": "ELEMENT",
+                            "name": {
+                              "_type": "DV_TEXT",
+                              "value": "partial datetime"
+                            },
+                            "archetype_node_id": "at0004",
+                            "value": {
+                              "_type": "DV_DATE_TIME",
+                              "value": "2019-01-28T21:22:49,426+00:00"
+                            }
+                          }
+                        ]
+                      },
+                      "timing": {
+                        "_type": "DV_PARSABLE",
+                        "value": "P1D",
+                        "formalism": "ISO8601"
+                      },
+                      "action_archetype_id": "openEHR-EHR-ACTION\\.test_all_types\\.v1"
+                    }
+                  ],
+                  "archetype_details": {
+                    "_type": "ARCHETYPED",
+                    "archetype_id": {
+                      "_type": "ARCHETYPE_ID",
+                      "value": "openEHR-EHR-INSTRUCTION.test_all_types.v1"
+                    },
+                    "rm_version": "1.0.2"
+                  }
+                },
+                {
+                  "_type": "ACTION",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "Test all types"
+                  },
+                  "archetype_node_id": "openEHR-EHR-ACTION.test_all_types.v1",
+                  "language": {
+                    "_type": "CODE_PHRASE",
+                    "terminology_id": {
+                      "_type": "TERMINOLOGY_ID",
+                      "value": "ISO_639-1"
+                    },
+                    "code_string": "en"
+                  },
+                  "encoding": {
+                    "_type": "CODE_PHRASE",
+                    "terminology_id": {
+                      "_type": "TERMINOLOGY_ID",
+                      "value": "IANA_character-sets"
+                    },
+                    "code_string": "UTF-8"
+                  },
+                  "subject": {
+                    "_type": "PARTY_SELF"
+                  },
+                  "time": {
+                    "_type": "DV_DATE_TIME",
+                    "value": "2019-01-28T21:22:50,154+00:00"
+                  },
+                  "description": {
+                    "_type": "ITEM_TREE",
+                    "name": {
+                      "_type": "DV_TEXT",
+                      "value": "Arbol"
+                    },
+                    "archetype_node_id": "at0001",
+                    "items": [
+                      {
+                        "_type": "CLUSTER",
+                        "name": {
+                          "_type": "DV_TEXT",
+                          "value": "Test all types"
+                        },
+                        "archetype_node_id": "openEHR-EHR-CLUSTER.test_all_types.v1",
+                        "items": [
+                          {
+                            "_type": "CLUSTER",
+                            "name": {
+                              "_type": "DV_TEXT",
+                              "value": "cluster 5"
+                            },
+                            "archetype_node_id": "at0001",
+                            "items": [
+                              {
+                                "_type": "CLUSTER",
+                                "name": {
+                                  "_type": "DV_TEXT",
+                                  "value": "cluster 6"
+                                },
+                                "archetype_node_id": "at0002",
+                                "items": [
+                                  {
+                                    "_type": "ELEMENT",
+                                    "name": {
+                                      "_type": "DV_TEXT",
+                                      "value": "boolean 2"
+                                    },
+                                    "archetype_node_id": "at0003",
+                                    "value": {
+                                      "_type": "DV_BOOLEAN",
+                                      "value": true
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ],
+                        "archetype_details": {
+                          "_type": "ARCHETYPED",
+                          "archetype_id": {
+                            "_type": "ARCHETYPE_ID",
+                            "value": "openEHR-EHR-CLUSTER.test_all_types.v1"
+                          },
+                          "rm_version": "1.0.2"
+                        }
+                      }
+                    ]
+                  },
+                  "ism_transition": {
+                    "_type": "ISM_TRANSITION",
+                    "current_state": {
+                      "_type": "DV_CODED_TEXT",
+                      "value": "bogus state",
+                      "defining_code": {
+                        "_type": "CODE_PHRASE",
+                        "terminology_id": {
+                          "_type": "TERMINOLOGY_ID",
+                          "value": "openehr"
+                        },
+                        "code_string": "999"
+                      }
+                    }
+                  },
+                  "archetype_details": {
+                    "_type": "ARCHETYPED",
+                    "archetype_id": {
+                      "_type": "ARCHETYPE_ID",
+                      "value": "openEHR-EHR-ACTION.test_all_types.v1"
+                    },
+                    "rm_version": "1.0.2"
+                  }
+                }
+              ]
+            },
+            {
+              "_type": "ADMIN_ENTRY",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Test all types"
+              },
+              "archetype_node_id": "openEHR-EHR-ADMIN_ENTRY.test_all_types.v1",
+              "language": {
+                "_type": "CODE_PHRASE",
+                "terminology_id": {
+                  "_type": "TERMINOLOGY_ID",
+                  "value": "ISO_639-1"
+                },
+                "code_string": "en"
+              },
+              "encoding": {
+                "_type": "CODE_PHRASE",
+                "terminology_id": {
+                  "_type": "TERMINOLOGY_ID",
+                  "value": "IANA_character-sets"
+                },
+                "code_string": "UTF-8"
+              },
+              "subject": {
+                "_type": "PARTY_SELF"
+              },
+              "data": {
+                "_type": "ITEM_SINGLE",
+                "name": {
+                  "_type": "DV_TEXT",
+                  "value": "single"
+                },
+                "archetype_node_id": "at0001",
+                "item": {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "count 3"
+                  },
+                  "archetype_node_id": "at0002",
+                  "value": {
+                    "_type": "DV_COUNT",
+                    "magnitude": 123
+                  }
+                }
+              },
+              "archetype_details": {
+                "_type": "ARCHETYPED",
+                "archetype_id": {
+                  "_type": "ARCHETYPE_ID",
+                  "value": "openEHR-EHR-ADMIN_ENTRY.test_all_types.v1"
+                },
+                "rm_version": "1.0.2"
+              }
+            }
+          ]
+        }
+      ],
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-SECTION.test_all_types.v1"
+        },
+        "rm_version": "1.0.2"
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.maximal.bad_ism_transition.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.maximal.bad_ism_transition.json
@@ -1,0 +1,862 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Test all types"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.test_all_types.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "test_all_types.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.test_all_types.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "UY"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "external_ref": {
+      "_type": "PARTY_REF",
+      "id": {
+        "_type": "HIER_OBJECT_ID",
+        "value": "b7c07d35-fa06-4280-8e65-eabdfbe64fdc"
+      },
+      "namespace": "DEMOGRAPHIC",
+      "type": "PERSON"
+    },
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2019-01-28T21:22:49,294+00:00"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "primary nursing care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "229"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Test all types"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.test_all_types.v1",
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2019-01-28T21:22:49,326+00:00"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Cualquier evento"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2019-01-28T21:22:49,332+00:00"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Arbol"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "text"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_TEXT",
+                    "value": "At,ffwkm.xsuDu,LNtqXEQJzxNMXTjyKVzQojaNTidAxLLZRbWWoGnfOIMUM.XxakRgJxExjtjBPirOxu,nUnPdIegLQbhNDKNRqGbFuvXrXYuNPXwnELoIsYMKgFEWHnR.XSBuESAamCrjJMssGgI.QOOyzatFlaXbiVaUBxzSdkOscZza,IumnYWoxwekcSAYSJiILhmKEOUWdoElCavaQPNNpGcxHEGASUMSAkFuu jZdWcysffi.QLeVONn"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "coded text"
+                  },
+                  "archetype_node_id": "at0005",
+                  "value": {
+                    "_type": "DV_CODED_TEXT",
+                    "value": "value1",
+                    "defining_code": {
+                      "_type": "CODE_PHRASE",
+                      "terminology_id": {
+                        "_type": "TERMINOLOGY_ID",
+                        "value": "local"
+                      },
+                      "code_string": "at0006"
+                    }
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "coded text terminology"
+                  },
+                  "archetype_node_id": "at0006",
+                  "value": {
+                    "_type": "DV_CODED_TEXT",
+                    "value": ".HCXbqCyQtseLkDyKS,QLpOdDZxrEJ",
+                    "defining_code": {
+                      "_type": "CODE_PHRASE",
+                      "terminology_id": {
+                        "_type": "TERMINOLOGY_ID",
+                        "value": "SNOMED-CT"
+                      },
+                      "code_string": "1004034"
+                    }
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "quantity"
+                  },
+                  "archetype_node_id": "at0007",
+                  "value": {
+                    "_type": "DV_QUANTITY",
+                    "magnitude": 636.3397240638733,
+                    "units": "mg"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "count"
+                  },
+                  "archetype_node_id": "at0008",
+                  "value": {
+                    "_type": "DV_COUNT",
+                    "magnitude": 10
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "date"
+                  },
+                  "archetype_node_id": "at0009",
+                  "value": {
+                    "_type": "DV_DATE",
+                    "value": "20190114"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "datetime"
+                  },
+                  "archetype_node_id": "at0010",
+                  "value": {
+                    "_type": "DV_DATE_TIME",
+                    "value": "2019-01-28T21:22:49,426+00:00"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "datetime any"
+                  },
+                  "archetype_node_id": "at0011",
+                  "value": {
+                    "_type": "DV_DATE_TIME",
+                    "value": "2019-01-28T21:22:49,427+00:00"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "time"
+                  },
+                  "archetype_node_id": "at0012",
+                  "value": {
+                    "_type": "DV_TIME",
+                    "value": "18:36:49"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "ordinal"
+                  },
+                  "archetype_node_id": "at0013",
+                  "value": {
+                    "_type": "DV_ORDINAL",
+                    "value": 0,
+                    "symbol": {
+                      "_type": "DV_CODED_TEXT",
+                      "value": "ord1",
+                      "defining_code": {
+                        "_type": "CODE_PHRASE",
+                        "terminology_id": {
+                          "_type": "TERMINOLOGY_ID",
+                          "value": "local"
+                        },
+                        "code_string": "at0014"
+                      }
+                    }
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "boolean"
+                  },
+                  "archetype_node_id": "at0017",
+                  "value": {
+                    "_type": "DV_BOOLEAN",
+                    "value": true
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "duration any"
+                  },
+                  "archetype_node_id": "at0018",
+                  "value": {
+                    "_type": "DV_DURATION",
+                    "value": "PT30M"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "parsable any"
+                  },
+                  "archetype_node_id": "at0020",
+                  "value": {
+                    "_type": "DV_PARSABLE",
+                    "value": "20170629",
+                    "formalism": "ISO8601"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "identifier"
+                  },
+                  "archetype_node_id": "at0021",
+                  "value": {
+                    "_type": "DV_IDENTIFIER",
+                    "issuer": "Hospital de Clinicas",
+                    "assigner": "Hospital de Clinicas",
+                    "id": "55175056",
+                    "type": "LOCALID"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "proportion any"
+                  },
+                  "archetype_node_id": "at0022",
+                  "value": {
+                    "_type": "DV_PROPORTION",
+                    "numerator": 1.5,
+                    "denominator": 1.0,
+                    "type": 1,
+                    "precision": 1
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.test_all_types.v1"
+        },
+        "rm_version": "1.0.2"
+      }
+    },
+    {
+      "_type": "EVALUATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Test all types"
+      },
+      "archetype_node_id": "openEHR-EHR-EVALUATION.test_all_types.v1",
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "ITEM_TREE",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Arbol"
+        },
+        "archetype_node_id": "at0001",
+        "items": [
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "uri"
+            },
+            "archetype_node_id": "at0002",
+            "null_flavour": {
+              "_type": "DV_CODED_TEXT",
+              "value": "no information",
+              "defining_code": {
+                "_type": "CODE_PHRASE",
+                "terminology_id": {
+                  "_type": "TERMINOLOGY_ID",
+                  "value": "openehr"
+                },
+                "code_string": "271"
+              }
+            }
+          },
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "interval count"
+            },
+            "archetype_node_id": "at0003",
+            "value": {
+              "_type": "DV_INTERVAL",
+              "lower": {
+                "_type": "DV_COUNT",
+                "magnitude": 123
+              },
+              "upper": {
+                "_type": "DV_COUNT",
+                "magnitude": 234
+              },
+              "lower_unbounded": false,
+              "upper_unbounded": false
+            }
+          },
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "interval quantity"
+            },
+            "archetype_node_id": "at0004",
+            "value": {
+              "_type": "DV_INTERVAL",
+              "lower": {
+                "_type": "DV_QUANTITY",
+                "magnitude": 123.123,
+                "units": "mm[H20]"
+              },
+              "upper": {
+                "_type": "DV_QUANTITY",
+                "magnitude": 234.234,
+                "units": "mm[H20]"
+              },
+              "lower_unbounded": false,
+              "upper_unbounded": false
+            }
+          },
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "interval datetime"
+            },
+            "archetype_node_id": "at0005",
+            "value": {
+              "_type": "DV_INTERVAL",
+              "lower": {
+                "_type": "DV_DATE_TIME",
+                "value": "2019-01-28T21:22:49,426+00:00"
+              },
+              "upper": {
+                "_type": "DV_DATE_TIME",
+                "value": "2019-01-28T21:22:49,426+00:00"
+              },
+              "lower_unbounded": false,
+              "upper_unbounded": false
+            }
+          },
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "choice"
+            },
+            "archetype_node_id": "at0009",
+            "value": {
+              "_type": "DV_QUANTITY",
+              "magnitude": 148.01210165023804,
+              "units": "mm[H20]"
+            }
+          },
+          {
+            "_type": "CLUSTER",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "cluster 1"
+            },
+            "archetype_node_id": "at0006",
+            "items": [
+              {
+                "_type": "CLUSTER",
+                "name": {
+                  "_type": "DV_TEXT",
+                  "value": "cluster 2"
+                },
+                "archetype_node_id": "at0007",
+                "items": [
+                  {
+                    "_type": "CLUSTER",
+                    "name": {
+                      "_type": "DV_TEXT",
+                      "value": "cluster 3"
+                    },
+                    "archetype_node_id": "at0008",
+                    "items": [
+                      {
+                        "_type": "ELEMENT",
+                        "name": {
+                          "_type": "DV_TEXT",
+                          "value": "text 2"
+                        },
+                        "archetype_node_id": "at0010",
+                        "value": {
+                          "_type": "DV_TEXT",
+                          "value": "FViqRjKtFGXm ,iPOYGPuYNjqqVYifvxzvbOlMnuidJvvdYByUiDUgQIBkyOcJtgZcRKdFmyo .TrsPDcaXtFeqLlnZgqdTxb.,LGavIsdXKcBhTWd,PElsLCymSIGcfRrObkevpucVkThYTAZZxcikhpGVaQ.UbyrkwewgarEn gLmIWGLqFZBFYLcBje.GwiYMBoHEEVymGCkyXUyosuq,CNvWsuUnHdVEjEuxGSEwBDEVgwWrXWOYWUCIhos"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-EVALUATION.test_all_types.v1"
+        },
+        "rm_version": "1.0.2"
+      }
+    },
+    {
+      "_type": "SECTION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Test all types"
+      },
+      "archetype_node_id": "openEHR-EHR-SECTION.test_all_types.v1",
+      "items": [
+        {
+          "_type": "SECTION",
+          "name": {
+            "_type": "DV_TEXT",
+            "value": "section 2"
+          },
+          "archetype_node_id": "at0001",
+          "items": [
+            {
+              "_type": "SECTION",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "section 3"
+              },
+              "archetype_node_id": "at0002",
+              "items": [
+                {
+                  "_type": "INSTRUCTION",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "Test all types"
+                  },
+                  "archetype_node_id": "openEHR-EHR-INSTRUCTION.test_all_types.v1",
+                  "language": {
+                    "_type": "CODE_PHRASE",
+                    "terminology_id": {
+                      "_type": "TERMINOLOGY_ID",
+                      "value": "ISO_639-1"
+                    },
+                    "code_string": "en"
+                  },
+                  "encoding": {
+                    "_type": "CODE_PHRASE",
+                    "terminology_id": {
+                      "_type": "TERMINOLOGY_ID",
+                      "value": "IANA_character-sets"
+                    },
+                    "code_string": "UTF-8"
+                  },
+                  "subject": {
+                    "_type": "PARTY_SELF"
+                  },
+                  "narrative": {
+                    "_type": "DV_TEXT",
+                    "value": "WAZotVojPPlPDKcOwCqQGlJjRdMC.ujKPgVAmyWABEoOgtrRSznogUWokmqmfgxjZOYmUEAcyvmnfz,KhtTC FrpwevrLJFNiJKzkzOwfOPRFQJjRmQCTW,ewdqvscogOkayvONWrOTPcCFnZsUod CAQ fuhLaBA.pFWdEyzyFgDODbueIlUjIGBdnIDDpMfjzWivfUDSEvTUsncmCgPdHnpONCuNGXUwFTaiSHHHJBZYssxGne.BLIbBQzXhG"
+                  },
+                  "activities": [
+                    {
+                      "_type": "ACTIVITY",
+                      "name": {
+                        "_type": "DV_TEXT",
+                        "value": "Current Activity"
+                      },
+                      "archetype_node_id": "at0001",
+                      "description": {
+                        "_type": "ITEM_LIST",
+                        "name": {
+                          "_type": "DV_TEXT",
+                          "value": "List"
+                        },
+                        "archetype_node_id": "at0002",
+                        "items": [
+                          {
+                            "_type": "ELEMENT",
+                            "name": {
+                              "_type": "DV_TEXT",
+                              "value": "partial date"
+                            },
+                            "archetype_node_id": "at0003",
+                            "value": {
+                              "_type": "DV_DATE",
+                              "value": "20190114"
+                            }
+                          },
+                          {
+                            "_type": "ELEMENT",
+                            "name": {
+                              "_type": "DV_TEXT",
+                              "value": "partial datetime"
+                            },
+                            "archetype_node_id": "at0004",
+                            "value": {
+                              "_type": "DV_DATE_TIME",
+                              "value": "2019-01-28T21:22:49,426+00:00"
+                            }
+                          }
+                        ]
+                      },
+                      "timing": {
+                        "_type": "DV_PARSABLE",
+                        "value": "P1D",
+                        "formalism": "ISO8601"
+                      },
+                      "action_archetype_id": "openEHR-EHR-ACTION\\.test_all_types\\.v1"
+                    }
+                  ],
+                  "archetype_details": {
+                    "_type": "ARCHETYPED",
+                    "archetype_id": {
+                      "_type": "ARCHETYPE_ID",
+                      "value": "openEHR-EHR-INSTRUCTION.test_all_types.v1"
+                    },
+                    "rm_version": "1.0.2"
+                  }
+                },
+                {
+                  "_type": "ACTION",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "Test all types"
+                  },
+                  "archetype_node_id": "openEHR-EHR-ACTION.test_all_types.v1",
+                  "language": {
+                    "_type": "CODE_PHRASE",
+                    "terminology_id": {
+                      "_type": "TERMINOLOGY_ID",
+                      "value": "ISO_639-1"
+                    },
+                    "code_string": "en"
+                  },
+                  "encoding": {
+                    "_type": "CODE_PHRASE",
+                    "terminology_id": {
+                      "_type": "TERMINOLOGY_ID",
+                      "value": "IANA_character-sets"
+                    },
+                    "code_string": "UTF-8"
+                  },
+                  "subject": {
+                    "_type": "PARTY_SELF"
+                  },
+                  "time": {
+                    "_type": "DV_DATE_TIME",
+                    "value": "2019-01-28T21:22:50,154+00:00"
+                  },
+                  "description": {
+                    "_type": "ITEM_TREE",
+                    "name": {
+                      "_type": "DV_TEXT",
+                      "value": "Arbol"
+                    },
+                    "archetype_node_id": "at0001",
+                    "items": [
+                      {
+                        "_type": "CLUSTER",
+                        "name": {
+                          "_type": "DV_TEXT",
+                          "value": "Test all types"
+                        },
+                        "archetype_node_id": "openEHR-EHR-CLUSTER.test_all_types.v1",
+                        "items": [
+                          {
+                            "_type": "CLUSTER",
+                            "name": {
+                              "_type": "DV_TEXT",
+                              "value": "cluster 5"
+                            },
+                            "archetype_node_id": "at0001",
+                            "items": [
+                              {
+                                "_type": "CLUSTER",
+                                "name": {
+                                  "_type": "DV_TEXT",
+                                  "value": "cluster 6"
+                                },
+                                "archetype_node_id": "at0002",
+                                "items": [
+                                  {
+                                    "_type": "ELEMENT",
+                                    "name": {
+                                      "_type": "DV_TEXT",
+                                      "value": "boolean 2"
+                                    },
+                                    "archetype_node_id": "at0003",
+                                    "value": {
+                                      "_type": "DV_BOOLEAN",
+                                      "value": true
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ],
+                        "archetype_details": {
+                          "_type": "ARCHETYPED",
+                          "archetype_id": {
+                            "_type": "ARCHETYPE_ID",
+                            "value": "openEHR-EHR-CLUSTER.test_all_types.v1"
+                          },
+                          "rm_version": "1.0.2"
+                        }
+                      }
+                    ]
+                  },
+                  "ism_transition": {
+                    "_type": "ISM_TRANSITION",
+                    "current_state": {
+                      "_type": "DV_CODED_TEXT",
+                      "value": "planned",
+                      "defining_code": {
+                        "_type": "CODE_PHRASE",
+                        "terminology_id": {
+                          "_type": "TERMINOLOGY_ID",
+                          "value": "openehr"
+                        },
+                        "code_string": "526"
+                      }
+                    },
+                    "transition": {
+                      "_type": "DV_CODED_TEXT",
+                      "value": "bogus transition",
+                      "defining_code": {
+                        "_type": "CODE_PHRASE",
+                        "terminology_id": {
+                          "_type": "TERMINOLOGY_ID",
+                          "value": "openehr"
+                        },
+                        "code_string": "999"
+                      }
+                    }
+                  },
+                  "archetype_details": {
+                    "_type": "ARCHETYPED",
+                    "archetype_id": {
+                      "_type": "ARCHETYPE_ID",
+                      "value": "openEHR-EHR-ACTION.test_all_types.v1"
+                    },
+                    "rm_version": "1.0.2"
+                  }
+                }
+              ]
+            },
+            {
+              "_type": "ADMIN_ENTRY",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Test all types"
+              },
+              "archetype_node_id": "openEHR-EHR-ADMIN_ENTRY.test_all_types.v1",
+              "language": {
+                "_type": "CODE_PHRASE",
+                "terminology_id": {
+                  "_type": "TERMINOLOGY_ID",
+                  "value": "ISO_639-1"
+                },
+                "code_string": "en"
+              },
+              "encoding": {
+                "_type": "CODE_PHRASE",
+                "terminology_id": {
+                  "_type": "TERMINOLOGY_ID",
+                  "value": "IANA_character-sets"
+                },
+                "code_string": "UTF-8"
+              },
+              "subject": {
+                "_type": "PARTY_SELF"
+              },
+              "data": {
+                "_type": "ITEM_SINGLE",
+                "name": {
+                  "_type": "DV_TEXT",
+                  "value": "single"
+                },
+                "archetype_node_id": "at0001",
+                "item": {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "count 3"
+                  },
+                  "archetype_node_id": "at0002",
+                  "value": {
+                    "_type": "DV_COUNT",
+                    "magnitude": 123
+                  }
+                }
+              },
+              "archetype_details": {
+                "_type": "ARCHETYPED",
+                "archetype_id": {
+                  "_type": "ARCHETYPE_ID",
+                  "value": "openEHR-EHR-ADMIN_ENTRY.test_all_types.v1"
+                },
+                "rm_version": "1.0.2"
+              }
+            }
+          ]
+        }
+      ],
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-SECTION.test_all_types.v1"
+        },
+        "rm_version": "1.0.2"
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.maximal.empty_action_archetype_id.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.maximal.empty_action_archetype_id.json
@@ -1,0 +1,850 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Test all types"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.test_all_types.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "test_all_types.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.test_all_types.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "UY"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "external_ref": {
+      "_type": "PARTY_REF",
+      "id": {
+        "_type": "HIER_OBJECT_ID",
+        "value": "b7c07d35-fa06-4280-8e65-eabdfbe64fdc"
+      },
+      "namespace": "DEMOGRAPHIC",
+      "type": "PERSON"
+    },
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2019-01-28T21:22:49,294+00:00"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "primary nursing care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "229"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Test all types"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.test_all_types.v1",
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2019-01-28T21:22:49,326+00:00"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Cualquier evento"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2019-01-28T21:22:49,332+00:00"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Arbol"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "text"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_TEXT",
+                    "value": "At,ffwkm.xsuDu,LNtqXEQJzxNMXTjyKVzQojaNTidAxLLZRbWWoGnfOIMUM.XxakRgJxExjtjBPirOxu,nUnPdIegLQbhNDKNRqGbFuvXrXYuNPXwnELoIsYMKgFEWHnR.XSBuESAamCrjJMssGgI.QOOyzatFlaXbiVaUBxzSdkOscZza,IumnYWoxwekcSAYSJiILhmKEOUWdoElCavaQPNNpGcxHEGASUMSAkFuu jZdWcysffi.QLeVONn"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "coded text"
+                  },
+                  "archetype_node_id": "at0005",
+                  "value": {
+                    "_type": "DV_CODED_TEXT",
+                    "value": "value1",
+                    "defining_code": {
+                      "_type": "CODE_PHRASE",
+                      "terminology_id": {
+                        "_type": "TERMINOLOGY_ID",
+                        "value": "local"
+                      },
+                      "code_string": "at0006"
+                    }
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "coded text terminology"
+                  },
+                  "archetype_node_id": "at0006",
+                  "value": {
+                    "_type": "DV_CODED_TEXT",
+                    "value": ".HCXbqCyQtseLkDyKS,QLpOdDZxrEJ",
+                    "defining_code": {
+                      "_type": "CODE_PHRASE",
+                      "terminology_id": {
+                        "_type": "TERMINOLOGY_ID",
+                        "value": "SNOMED-CT"
+                      },
+                      "code_string": "1004034"
+                    }
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "quantity"
+                  },
+                  "archetype_node_id": "at0007",
+                  "value": {
+                    "_type": "DV_QUANTITY",
+                    "magnitude": 636.3397240638733,
+                    "units": "mg"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "count"
+                  },
+                  "archetype_node_id": "at0008",
+                  "value": {
+                    "_type": "DV_COUNT",
+                    "magnitude": 10
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "date"
+                  },
+                  "archetype_node_id": "at0009",
+                  "value": {
+                    "_type": "DV_DATE",
+                    "value": "20190114"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "datetime"
+                  },
+                  "archetype_node_id": "at0010",
+                  "value": {
+                    "_type": "DV_DATE_TIME",
+                    "value": "2019-01-28T21:22:49,426+00:00"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "datetime any"
+                  },
+                  "archetype_node_id": "at0011",
+                  "value": {
+                    "_type": "DV_DATE_TIME",
+                    "value": "2019-01-28T21:22:49,427+00:00"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "time"
+                  },
+                  "archetype_node_id": "at0012",
+                  "value": {
+                    "_type": "DV_TIME",
+                    "value": "18:36:49"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "ordinal"
+                  },
+                  "archetype_node_id": "at0013",
+                  "value": {
+                    "_type": "DV_ORDINAL",
+                    "value": 0,
+                    "symbol": {
+                      "_type": "DV_CODED_TEXT",
+                      "value": "ord1",
+                      "defining_code": {
+                        "_type": "CODE_PHRASE",
+                        "terminology_id": {
+                          "_type": "TERMINOLOGY_ID",
+                          "value": "local"
+                        },
+                        "code_string": "at0014"
+                      }
+                    }
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "boolean"
+                  },
+                  "archetype_node_id": "at0017",
+                  "value": {
+                    "_type": "DV_BOOLEAN",
+                    "value": true
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "duration any"
+                  },
+                  "archetype_node_id": "at0018",
+                  "value": {
+                    "_type": "DV_DURATION",
+                    "value": "PT30M"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "parsable any"
+                  },
+                  "archetype_node_id": "at0020",
+                  "value": {
+                    "_type": "DV_PARSABLE",
+                    "value": "20170629",
+                    "formalism": "ISO8601"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "identifier"
+                  },
+                  "archetype_node_id": "at0021",
+                  "value": {
+                    "_type": "DV_IDENTIFIER",
+                    "issuer": "Hospital de Clinicas",
+                    "assigner": "Hospital de Clinicas",
+                    "id": "55175056",
+                    "type": "LOCALID"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "proportion any"
+                  },
+                  "archetype_node_id": "at0022",
+                  "value": {
+                    "_type": "DV_PROPORTION",
+                    "numerator": 1.5,
+                    "denominator": 1.0,
+                    "type": 1,
+                    "precision": 1
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.test_all_types.v1"
+        },
+        "rm_version": "1.0.2"
+      }
+    },
+    {
+      "_type": "EVALUATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Test all types"
+      },
+      "archetype_node_id": "openEHR-EHR-EVALUATION.test_all_types.v1",
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "ITEM_TREE",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Arbol"
+        },
+        "archetype_node_id": "at0001",
+        "items": [
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "uri"
+            },
+            "archetype_node_id": "at0002",
+            "null_flavour": {
+              "_type": "DV_CODED_TEXT",
+              "value": "no information",
+              "defining_code": {
+                "_type": "CODE_PHRASE",
+                "terminology_id": {
+                  "_type": "TERMINOLOGY_ID",
+                  "value": "openehr"
+                },
+                "code_string": "271"
+              }
+            }
+          },
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "interval count"
+            },
+            "archetype_node_id": "at0003",
+            "value": {
+              "_type": "DV_INTERVAL",
+              "lower": {
+                "_type": "DV_COUNT",
+                "magnitude": 123
+              },
+              "upper": {
+                "_type": "DV_COUNT",
+                "magnitude": 234
+              },
+              "lower_unbounded": false,
+              "upper_unbounded": false
+            }
+          },
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "interval quantity"
+            },
+            "archetype_node_id": "at0004",
+            "value": {
+              "_type": "DV_INTERVAL",
+              "lower": {
+                "_type": "DV_QUANTITY",
+                "magnitude": 123.123,
+                "units": "mm[H20]"
+              },
+              "upper": {
+                "_type": "DV_QUANTITY",
+                "magnitude": 234.234,
+                "units": "mm[H20]"
+              },
+              "lower_unbounded": false,
+              "upper_unbounded": false
+            }
+          },
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "interval datetime"
+            },
+            "archetype_node_id": "at0005",
+            "value": {
+              "_type": "DV_INTERVAL",
+              "lower": {
+                "_type": "DV_DATE_TIME",
+                "value": "2019-01-28T21:22:49,426+00:00"
+              },
+              "upper": {
+                "_type": "DV_DATE_TIME",
+                "value": "2019-01-28T21:22:49,426+00:00"
+              },
+              "lower_unbounded": false,
+              "upper_unbounded": false
+            }
+          },
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "choice"
+            },
+            "archetype_node_id": "at0009",
+            "value": {
+              "_type": "DV_QUANTITY",
+              "magnitude": 148.01210165023804,
+              "units": "mm[H20]"
+            }
+          },
+          {
+            "_type": "CLUSTER",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "cluster 1"
+            },
+            "archetype_node_id": "at0006",
+            "items": [
+              {
+                "_type": "CLUSTER",
+                "name": {
+                  "_type": "DV_TEXT",
+                  "value": "cluster 2"
+                },
+                "archetype_node_id": "at0007",
+                "items": [
+                  {
+                    "_type": "CLUSTER",
+                    "name": {
+                      "_type": "DV_TEXT",
+                      "value": "cluster 3"
+                    },
+                    "archetype_node_id": "at0008",
+                    "items": [
+                      {
+                        "_type": "ELEMENT",
+                        "name": {
+                          "_type": "DV_TEXT",
+                          "value": "text 2"
+                        },
+                        "archetype_node_id": "at0010",
+                        "value": {
+                          "_type": "DV_TEXT",
+                          "value": "FViqRjKtFGXm ,iPOYGPuYNjqqVYifvxzvbOlMnuidJvvdYByUiDUgQIBkyOcJtgZcRKdFmyo .TrsPDcaXtFeqLlnZgqdTxb.,LGavIsdXKcBhTWd,PElsLCymSIGcfRrObkevpucVkThYTAZZxcikhpGVaQ.UbyrkwewgarEn gLmIWGLqFZBFYLcBje.GwiYMBoHEEVymGCkyXUyosuq,CNvWsuUnHdVEjEuxGSEwBDEVgwWrXWOYWUCIhos"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-EVALUATION.test_all_types.v1"
+        },
+        "rm_version": "1.0.2"
+      }
+    },
+    {
+      "_type": "SECTION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Test all types"
+      },
+      "archetype_node_id": "openEHR-EHR-SECTION.test_all_types.v1",
+      "items": [
+        {
+          "_type": "SECTION",
+          "name": {
+            "_type": "DV_TEXT",
+            "value": "section 2"
+          },
+          "archetype_node_id": "at0001",
+          "items": [
+            {
+              "_type": "SECTION",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "section 3"
+              },
+              "archetype_node_id": "at0002",
+              "items": [
+                {
+                  "_type": "INSTRUCTION",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "Test all types"
+                  },
+                  "archetype_node_id": "openEHR-EHR-INSTRUCTION.test_all_types.v1",
+                  "language": {
+                    "_type": "CODE_PHRASE",
+                    "terminology_id": {
+                      "_type": "TERMINOLOGY_ID",
+                      "value": "ISO_639-1"
+                    },
+                    "code_string": "en"
+                  },
+                  "encoding": {
+                    "_type": "CODE_PHRASE",
+                    "terminology_id": {
+                      "_type": "TERMINOLOGY_ID",
+                      "value": "IANA_character-sets"
+                    },
+                    "code_string": "UTF-8"
+                  },
+                  "subject": {
+                    "_type": "PARTY_SELF"
+                  },
+                  "narrative": {
+                    "_type": "DV_TEXT",
+                    "value": "WAZotVojPPlPDKcOwCqQGlJjRdMC.ujKPgVAmyWABEoOgtrRSznogUWokmqmfgxjZOYmUEAcyvmnfz,KhtTC FrpwevrLJFNiJKzkzOwfOPRFQJjRmQCTW,ewdqvscogOkayvONWrOTPcCFnZsUod CAQ fuhLaBA.pFWdEyzyFgDODbueIlUjIGBdnIDDpMfjzWivfUDSEvTUsncmCgPdHnpONCuNGXUwFTaiSHHHJBZYssxGne.BLIbBQzXhG"
+                  },
+                  "activities": [
+                    {
+                      "_type": "ACTIVITY",
+                      "name": {
+                        "_type": "DV_TEXT",
+                        "value": "Current Activity"
+                      },
+                      "archetype_node_id": "at0001",
+                      "description": {
+                        "_type": "ITEM_LIST",
+                        "name": {
+                          "_type": "DV_TEXT",
+                          "value": "List"
+                        },
+                        "archetype_node_id": "at0002",
+                        "items": [
+                          {
+                            "_type": "ELEMENT",
+                            "name": {
+                              "_type": "DV_TEXT",
+                              "value": "partial date"
+                            },
+                            "archetype_node_id": "at0003",
+                            "value": {
+                              "_type": "DV_DATE",
+                              "value": "20190114"
+                            }
+                          },
+                          {
+                            "_type": "ELEMENT",
+                            "name": {
+                              "_type": "DV_TEXT",
+                              "value": "partial datetime"
+                            },
+                            "archetype_node_id": "at0004",
+                            "value": {
+                              "_type": "DV_DATE_TIME",
+                              "value": "2019-01-28T21:22:49,426+00:00"
+                            }
+                          }
+                        ]
+                      },
+                      "timing": {
+                        "_type": "DV_PARSABLE",
+                        "value": "P1D",
+                        "formalism": "ISO8601"
+                      },
+                      "action_archetype_id": ""
+                    }
+                  ],
+                  "archetype_details": {
+                    "_type": "ARCHETYPED",
+                    "archetype_id": {
+                      "_type": "ARCHETYPE_ID",
+                      "value": "openEHR-EHR-INSTRUCTION.test_all_types.v1"
+                    },
+                    "rm_version": "1.0.2"
+                  }
+                },
+                {
+                  "_type": "ACTION",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "Test all types"
+                  },
+                  "archetype_node_id": "openEHR-EHR-ACTION.test_all_types.v1",
+                  "language": {
+                    "_type": "CODE_PHRASE",
+                    "terminology_id": {
+                      "_type": "TERMINOLOGY_ID",
+                      "value": "ISO_639-1"
+                    },
+                    "code_string": "en"
+                  },
+                  "encoding": {
+                    "_type": "CODE_PHRASE",
+                    "terminology_id": {
+                      "_type": "TERMINOLOGY_ID",
+                      "value": "IANA_character-sets"
+                    },
+                    "code_string": "UTF-8"
+                  },
+                  "subject": {
+                    "_type": "PARTY_SELF"
+                  },
+                  "time": {
+                    "_type": "DV_DATE_TIME",
+                    "value": "2019-01-28T21:22:50,154+00:00"
+                  },
+                  "description": {
+                    "_type": "ITEM_TREE",
+                    "name": {
+                      "_type": "DV_TEXT",
+                      "value": "Arbol"
+                    },
+                    "archetype_node_id": "at0001",
+                    "items": [
+                      {
+                        "_type": "CLUSTER",
+                        "name": {
+                          "_type": "DV_TEXT",
+                          "value": "Test all types"
+                        },
+                        "archetype_node_id": "openEHR-EHR-CLUSTER.test_all_types.v1",
+                        "items": [
+                          {
+                            "_type": "CLUSTER",
+                            "name": {
+                              "_type": "DV_TEXT",
+                              "value": "cluster 5"
+                            },
+                            "archetype_node_id": "at0001",
+                            "items": [
+                              {
+                                "_type": "CLUSTER",
+                                "name": {
+                                  "_type": "DV_TEXT",
+                                  "value": "cluster 6"
+                                },
+                                "archetype_node_id": "at0002",
+                                "items": [
+                                  {
+                                    "_type": "ELEMENT",
+                                    "name": {
+                                      "_type": "DV_TEXT",
+                                      "value": "boolean 2"
+                                    },
+                                    "archetype_node_id": "at0003",
+                                    "value": {
+                                      "_type": "DV_BOOLEAN",
+                                      "value": true
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ],
+                        "archetype_details": {
+                          "_type": "ARCHETYPED",
+                          "archetype_id": {
+                            "_type": "ARCHETYPE_ID",
+                            "value": "openEHR-EHR-CLUSTER.test_all_types.v1"
+                          },
+                          "rm_version": "1.0.2"
+                        }
+                      }
+                    ]
+                  },
+                  "ism_transition": {
+                    "_type": "ISM_TRANSITION",
+                    "current_state": {
+                      "_type": "DV_CODED_TEXT",
+                      "value": "planned",
+                      "defining_code": {
+                        "_type": "CODE_PHRASE",
+                        "terminology_id": {
+                          "_type": "TERMINOLOGY_ID",
+                          "value": "openehr"
+                        },
+                        "code_string": "526"
+                      }
+                    }
+                  },
+                  "archetype_details": {
+                    "_type": "ARCHETYPED",
+                    "archetype_id": {
+                      "_type": "ARCHETYPE_ID",
+                      "value": "openEHR-EHR-ACTION.test_all_types.v1"
+                    },
+                    "rm_version": "1.0.2"
+                  }
+                }
+              ]
+            },
+            {
+              "_type": "ADMIN_ENTRY",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Test all types"
+              },
+              "archetype_node_id": "openEHR-EHR-ADMIN_ENTRY.test_all_types.v1",
+              "language": {
+                "_type": "CODE_PHRASE",
+                "terminology_id": {
+                  "_type": "TERMINOLOGY_ID",
+                  "value": "ISO_639-1"
+                },
+                "code_string": "en"
+              },
+              "encoding": {
+                "_type": "CODE_PHRASE",
+                "terminology_id": {
+                  "_type": "TERMINOLOGY_ID",
+                  "value": "IANA_character-sets"
+                },
+                "code_string": "UTF-8"
+              },
+              "subject": {
+                "_type": "PARTY_SELF"
+              },
+              "data": {
+                "_type": "ITEM_SINGLE",
+                "name": {
+                  "_type": "DV_TEXT",
+                  "value": "single"
+                },
+                "archetype_node_id": "at0001",
+                "item": {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "count 3"
+                  },
+                  "archetype_node_id": "at0002",
+                  "value": {
+                    "_type": "DV_COUNT",
+                    "magnitude": 123
+                  }
+                }
+              },
+              "archetype_details": {
+                "_type": "ARCHETYPED",
+                "archetype_id": {
+                  "_type": "ARCHETYPE_ID",
+                  "value": "openEHR-EHR-ADMIN_ENTRY.test_all_types.v1"
+                },
+                "rm_version": "1.0.2"
+              }
+            }
+          ]
+        }
+      ],
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-SECTION.test_all_types.v1"
+        },
+        "rm_version": "1.0.2"
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.maximal.empty_activity_id.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.maximal.empty_activity_id.json
@@ -1,0 +1,863 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Test all types"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.test_all_types.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "test_all_types.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.test_all_types.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "UY"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "external_ref": {
+      "_type": "PARTY_REF",
+      "id": {
+        "_type": "HIER_OBJECT_ID",
+        "value": "b7c07d35-fa06-4280-8e65-eabdfbe64fdc"
+      },
+      "namespace": "DEMOGRAPHIC",
+      "type": "PERSON"
+    },
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2019-01-28T21:22:49,294+00:00"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "primary nursing care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "229"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Test all types"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.test_all_types.v1",
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2019-01-28T21:22:49,326+00:00"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Cualquier evento"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2019-01-28T21:22:49,332+00:00"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Arbol"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "text"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_TEXT",
+                    "value": "At,ffwkm.xsuDu,LNtqXEQJzxNMXTjyKVzQojaNTidAxLLZRbWWoGnfOIMUM.XxakRgJxExjtjBPirOxu,nUnPdIegLQbhNDKNRqGbFuvXrXYuNPXwnELoIsYMKgFEWHnR.XSBuESAamCrjJMssGgI.QOOyzatFlaXbiVaUBxzSdkOscZza,IumnYWoxwekcSAYSJiILhmKEOUWdoElCavaQPNNpGcxHEGASUMSAkFuu jZdWcysffi.QLeVONn"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "coded text"
+                  },
+                  "archetype_node_id": "at0005",
+                  "value": {
+                    "_type": "DV_CODED_TEXT",
+                    "value": "value1",
+                    "defining_code": {
+                      "_type": "CODE_PHRASE",
+                      "terminology_id": {
+                        "_type": "TERMINOLOGY_ID",
+                        "value": "local"
+                      },
+                      "code_string": "at0006"
+                    }
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "coded text terminology"
+                  },
+                  "archetype_node_id": "at0006",
+                  "value": {
+                    "_type": "DV_CODED_TEXT",
+                    "value": ".HCXbqCyQtseLkDyKS,QLpOdDZxrEJ",
+                    "defining_code": {
+                      "_type": "CODE_PHRASE",
+                      "terminology_id": {
+                        "_type": "TERMINOLOGY_ID",
+                        "value": "SNOMED-CT"
+                      },
+                      "code_string": "1004034"
+                    }
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "quantity"
+                  },
+                  "archetype_node_id": "at0007",
+                  "value": {
+                    "_type": "DV_QUANTITY",
+                    "magnitude": 636.3397240638733,
+                    "units": "mg"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "count"
+                  },
+                  "archetype_node_id": "at0008",
+                  "value": {
+                    "_type": "DV_COUNT",
+                    "magnitude": 10
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "date"
+                  },
+                  "archetype_node_id": "at0009",
+                  "value": {
+                    "_type": "DV_DATE",
+                    "value": "20190114"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "datetime"
+                  },
+                  "archetype_node_id": "at0010",
+                  "value": {
+                    "_type": "DV_DATE_TIME",
+                    "value": "2019-01-28T21:22:49,426+00:00"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "datetime any"
+                  },
+                  "archetype_node_id": "at0011",
+                  "value": {
+                    "_type": "DV_DATE_TIME",
+                    "value": "2019-01-28T21:22:49,427+00:00"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "time"
+                  },
+                  "archetype_node_id": "at0012",
+                  "value": {
+                    "_type": "DV_TIME",
+                    "value": "18:36:49"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "ordinal"
+                  },
+                  "archetype_node_id": "at0013",
+                  "value": {
+                    "_type": "DV_ORDINAL",
+                    "value": 0,
+                    "symbol": {
+                      "_type": "DV_CODED_TEXT",
+                      "value": "ord1",
+                      "defining_code": {
+                        "_type": "CODE_PHRASE",
+                        "terminology_id": {
+                          "_type": "TERMINOLOGY_ID",
+                          "value": "local"
+                        },
+                        "code_string": "at0014"
+                      }
+                    }
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "boolean"
+                  },
+                  "archetype_node_id": "at0017",
+                  "value": {
+                    "_type": "DV_BOOLEAN",
+                    "value": true
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "duration any"
+                  },
+                  "archetype_node_id": "at0018",
+                  "value": {
+                    "_type": "DV_DURATION",
+                    "value": "PT30M"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "parsable any"
+                  },
+                  "archetype_node_id": "at0020",
+                  "value": {
+                    "_type": "DV_PARSABLE",
+                    "value": "20170629",
+                    "formalism": "ISO8601"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "identifier"
+                  },
+                  "archetype_node_id": "at0021",
+                  "value": {
+                    "_type": "DV_IDENTIFIER",
+                    "issuer": "Hospital de Clinicas",
+                    "assigner": "Hospital de Clinicas",
+                    "id": "55175056",
+                    "type": "LOCALID"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "proportion any"
+                  },
+                  "archetype_node_id": "at0022",
+                  "value": {
+                    "_type": "DV_PROPORTION",
+                    "numerator": 1.5,
+                    "denominator": 1.0,
+                    "type": 1,
+                    "precision": 1
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.test_all_types.v1"
+        },
+        "rm_version": "1.0.2"
+      }
+    },
+    {
+      "_type": "EVALUATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Test all types"
+      },
+      "archetype_node_id": "openEHR-EHR-EVALUATION.test_all_types.v1",
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "ITEM_TREE",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Arbol"
+        },
+        "archetype_node_id": "at0001",
+        "items": [
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "uri"
+            },
+            "archetype_node_id": "at0002",
+            "null_flavour": {
+              "_type": "DV_CODED_TEXT",
+              "value": "no information",
+              "defining_code": {
+                "_type": "CODE_PHRASE",
+                "terminology_id": {
+                  "_type": "TERMINOLOGY_ID",
+                  "value": "openehr"
+                },
+                "code_string": "271"
+              }
+            }
+          },
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "interval count"
+            },
+            "archetype_node_id": "at0003",
+            "value": {
+              "_type": "DV_INTERVAL",
+              "lower": {
+                "_type": "DV_COUNT",
+                "magnitude": 123
+              },
+              "upper": {
+                "_type": "DV_COUNT",
+                "magnitude": 234
+              },
+              "lower_unbounded": false,
+              "upper_unbounded": false
+            }
+          },
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "interval quantity"
+            },
+            "archetype_node_id": "at0004",
+            "value": {
+              "_type": "DV_INTERVAL",
+              "lower": {
+                "_type": "DV_QUANTITY",
+                "magnitude": 123.123,
+                "units": "mm[H20]"
+              },
+              "upper": {
+                "_type": "DV_QUANTITY",
+                "magnitude": 234.234,
+                "units": "mm[H20]"
+              },
+              "lower_unbounded": false,
+              "upper_unbounded": false
+            }
+          },
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "interval datetime"
+            },
+            "archetype_node_id": "at0005",
+            "value": {
+              "_type": "DV_INTERVAL",
+              "lower": {
+                "_type": "DV_DATE_TIME",
+                "value": "2019-01-28T21:22:49,426+00:00"
+              },
+              "upper": {
+                "_type": "DV_DATE_TIME",
+                "value": "2019-01-28T21:22:49,426+00:00"
+              },
+              "lower_unbounded": false,
+              "upper_unbounded": false
+            }
+          },
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "choice"
+            },
+            "archetype_node_id": "at0009",
+            "value": {
+              "_type": "DV_QUANTITY",
+              "magnitude": 148.01210165023804,
+              "units": "mm[H20]"
+            }
+          },
+          {
+            "_type": "CLUSTER",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "cluster 1"
+            },
+            "archetype_node_id": "at0006",
+            "items": [
+              {
+                "_type": "CLUSTER",
+                "name": {
+                  "_type": "DV_TEXT",
+                  "value": "cluster 2"
+                },
+                "archetype_node_id": "at0007",
+                "items": [
+                  {
+                    "_type": "CLUSTER",
+                    "name": {
+                      "_type": "DV_TEXT",
+                      "value": "cluster 3"
+                    },
+                    "archetype_node_id": "at0008",
+                    "items": [
+                      {
+                        "_type": "ELEMENT",
+                        "name": {
+                          "_type": "DV_TEXT",
+                          "value": "text 2"
+                        },
+                        "archetype_node_id": "at0010",
+                        "value": {
+                          "_type": "DV_TEXT",
+                          "value": "FViqRjKtFGXm ,iPOYGPuYNjqqVYifvxzvbOlMnuidJvvdYByUiDUgQIBkyOcJtgZcRKdFmyo .TrsPDcaXtFeqLlnZgqdTxb.,LGavIsdXKcBhTWd,PElsLCymSIGcfRrObkevpucVkThYTAZZxcikhpGVaQ.UbyrkwewgarEn gLmIWGLqFZBFYLcBje.GwiYMBoHEEVymGCkyXUyosuq,CNvWsuUnHdVEjEuxGSEwBDEVgwWrXWOYWUCIhos"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-EVALUATION.test_all_types.v1"
+        },
+        "rm_version": "1.0.2"
+      }
+    },
+    {
+      "_type": "SECTION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Test all types"
+      },
+      "archetype_node_id": "openEHR-EHR-SECTION.test_all_types.v1",
+      "items": [
+        {
+          "_type": "SECTION",
+          "name": {
+            "_type": "DV_TEXT",
+            "value": "section 2"
+          },
+          "archetype_node_id": "at0001",
+          "items": [
+            {
+              "_type": "SECTION",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "section 3"
+              },
+              "archetype_node_id": "at0002",
+              "items": [
+                {
+                  "_type": "INSTRUCTION",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "Test all types"
+                  },
+                  "archetype_node_id": "openEHR-EHR-INSTRUCTION.test_all_types.v1",
+                  "language": {
+                    "_type": "CODE_PHRASE",
+                    "terminology_id": {
+                      "_type": "TERMINOLOGY_ID",
+                      "value": "ISO_639-1"
+                    },
+                    "code_string": "en"
+                  },
+                  "encoding": {
+                    "_type": "CODE_PHRASE",
+                    "terminology_id": {
+                      "_type": "TERMINOLOGY_ID",
+                      "value": "IANA_character-sets"
+                    },
+                    "code_string": "UTF-8"
+                  },
+                  "subject": {
+                    "_type": "PARTY_SELF"
+                  },
+                  "narrative": {
+                    "_type": "DV_TEXT",
+                    "value": "WAZotVojPPlPDKcOwCqQGlJjRdMC.ujKPgVAmyWABEoOgtrRSznogUWokmqmfgxjZOYmUEAcyvmnfz,KhtTC FrpwevrLJFNiJKzkzOwfOPRFQJjRmQCTW,ewdqvscogOkayvONWrOTPcCFnZsUod CAQ fuhLaBA.pFWdEyzyFgDODbueIlUjIGBdnIDDpMfjzWivfUDSEvTUsncmCgPdHnpONCuNGXUwFTaiSHHHJBZYssxGne.BLIbBQzXhG"
+                  },
+                  "activities": [
+                    {
+                      "_type": "ACTIVITY",
+                      "name": {
+                        "_type": "DV_TEXT",
+                        "value": "Current Activity"
+                      },
+                      "archetype_node_id": "at0001",
+                      "description": {
+                        "_type": "ITEM_LIST",
+                        "name": {
+                          "_type": "DV_TEXT",
+                          "value": "List"
+                        },
+                        "archetype_node_id": "at0002",
+                        "items": [
+                          {
+                            "_type": "ELEMENT",
+                            "name": {
+                              "_type": "DV_TEXT",
+                              "value": "partial date"
+                            },
+                            "archetype_node_id": "at0003",
+                            "value": {
+                              "_type": "DV_DATE",
+                              "value": "20190114"
+                            }
+                          },
+                          {
+                            "_type": "ELEMENT",
+                            "name": {
+                              "_type": "DV_TEXT",
+                              "value": "partial datetime"
+                            },
+                            "archetype_node_id": "at0004",
+                            "value": {
+                              "_type": "DV_DATE_TIME",
+                              "value": "2019-01-28T21:22:49,426+00:00"
+                            }
+                          }
+                        ]
+                      },
+                      "timing": {
+                        "_type": "DV_PARSABLE",
+                        "value": "P1D",
+                        "formalism": "ISO8601"
+                      },
+                      "action_archetype_id": "openEHR-EHR-ACTION\\.test_all_types\\.v1"
+                    }
+                  ],
+                  "archetype_details": {
+                    "_type": "ARCHETYPED",
+                    "archetype_id": {
+                      "_type": "ARCHETYPE_ID",
+                      "value": "openEHR-EHR-INSTRUCTION.test_all_types.v1"
+                    },
+                    "rm_version": "1.0.2"
+                  }
+                },
+                {
+                  "_type": "ACTION",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "Test all types"
+                  },
+                  "archetype_node_id": "openEHR-EHR-ACTION.test_all_types.v1",
+                  "language": {
+                    "_type": "CODE_PHRASE",
+                    "terminology_id": {
+                      "_type": "TERMINOLOGY_ID",
+                      "value": "ISO_639-1"
+                    },
+                    "code_string": "en"
+                  },
+                  "encoding": {
+                    "_type": "CODE_PHRASE",
+                    "terminology_id": {
+                      "_type": "TERMINOLOGY_ID",
+                      "value": "IANA_character-sets"
+                    },
+                    "code_string": "UTF-8"
+                  },
+                  "subject": {
+                    "_type": "PARTY_SELF"
+                  },
+                  "time": {
+                    "_type": "DV_DATE_TIME",
+                    "value": "2019-01-28T21:22:50,154+00:00"
+                  },
+                  "description": {
+                    "_type": "ITEM_TREE",
+                    "name": {
+                      "_type": "DV_TEXT",
+                      "value": "Arbol"
+                    },
+                    "archetype_node_id": "at0001",
+                    "items": [
+                      {
+                        "_type": "CLUSTER",
+                        "name": {
+                          "_type": "DV_TEXT",
+                          "value": "Test all types"
+                        },
+                        "archetype_node_id": "openEHR-EHR-CLUSTER.test_all_types.v1",
+                        "items": [
+                          {
+                            "_type": "CLUSTER",
+                            "name": {
+                              "_type": "DV_TEXT",
+                              "value": "cluster 5"
+                            },
+                            "archetype_node_id": "at0001",
+                            "items": [
+                              {
+                                "_type": "CLUSTER",
+                                "name": {
+                                  "_type": "DV_TEXT",
+                                  "value": "cluster 6"
+                                },
+                                "archetype_node_id": "at0002",
+                                "items": [
+                                  {
+                                    "_type": "ELEMENT",
+                                    "name": {
+                                      "_type": "DV_TEXT",
+                                      "value": "boolean 2"
+                                    },
+                                    "archetype_node_id": "at0003",
+                                    "value": {
+                                      "_type": "DV_BOOLEAN",
+                                      "value": true
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ],
+                        "archetype_details": {
+                          "_type": "ARCHETYPED",
+                          "archetype_id": {
+                            "_type": "ARCHETYPE_ID",
+                            "value": "openEHR-EHR-CLUSTER.test_all_types.v1"
+                          },
+                          "rm_version": "1.0.2"
+                        }
+                      }
+                    ]
+                  },
+                  "ism_transition": {
+                    "_type": "ISM_TRANSITION",
+                    "current_state": {
+                      "_type": "DV_CODED_TEXT",
+                      "value": "planned",
+                      "defining_code": {
+                        "_type": "CODE_PHRASE",
+                        "terminology_id": {
+                          "_type": "TERMINOLOGY_ID",
+                          "value": "openehr"
+                        },
+                        "code_string": "526"
+                      }
+                    }
+                  },
+                  "archetype_details": {
+                    "_type": "ARCHETYPED",
+                    "archetype_id": {
+                      "_type": "ARCHETYPE_ID",
+                      "value": "openEHR-EHR-ACTION.test_all_types.v1"
+                    },
+                    "rm_version": "1.0.2"
+                  },
+                  "instruction_details": {
+                    "_type": "INSTRUCTION_DETAILS",
+                    "instruction_id": {
+                      "_type": "LOCATABLE_REF",
+                      "id": {
+                        "_type": "OBJECT_VERSION_ID",
+                        "value": "11111111-1111-4111-8111-111111111111::cnf.example.org::1"
+                      },
+                      "namespace": "local",
+                      "type": "INSTRUCTION"
+                    },
+                    "activity_id": ""
+                  }
+                }
+              ]
+            },
+            {
+              "_type": "ADMIN_ENTRY",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Test all types"
+              },
+              "archetype_node_id": "openEHR-EHR-ADMIN_ENTRY.test_all_types.v1",
+              "language": {
+                "_type": "CODE_PHRASE",
+                "terminology_id": {
+                  "_type": "TERMINOLOGY_ID",
+                  "value": "ISO_639-1"
+                },
+                "code_string": "en"
+              },
+              "encoding": {
+                "_type": "CODE_PHRASE",
+                "terminology_id": {
+                  "_type": "TERMINOLOGY_ID",
+                  "value": "IANA_character-sets"
+                },
+                "code_string": "UTF-8"
+              },
+              "subject": {
+                "_type": "PARTY_SELF"
+              },
+              "data": {
+                "_type": "ITEM_SINGLE",
+                "name": {
+                  "_type": "DV_TEXT",
+                  "value": "single"
+                },
+                "archetype_node_id": "at0001",
+                "item": {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "count 3"
+                  },
+                  "archetype_node_id": "at0002",
+                  "value": {
+                    "_type": "DV_COUNT",
+                    "magnitude": 123
+                  }
+                }
+              },
+              "archetype_details": {
+                "_type": "ARCHETYPED",
+                "archetype_id": {
+                  "_type": "ARCHETYPE_ID",
+                  "value": "openEHR-EHR-ADMIN_ENTRY.test_all_types.v1"
+                },
+                "rm_version": "1.0.2"
+              }
+            }
+          ]
+        }
+      ],
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-SECTION.test_all_types.v1"
+        },
+        "rm_version": "1.0.2"
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.maximal.instruction_rich.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/contribution/composition.maximal.instruction_rich.json
@@ -1,0 +1,902 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Test all types"
+  },
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.test_all_types.v1"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "test_all_types.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.test_all_types.v1",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "UY"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "value": "event",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "external_ref": {
+      "_type": "PARTY_REF",
+      "id": {
+        "_type": "HIER_OBJECT_ID",
+        "value": "b7c07d35-fa06-4280-8e65-eabdfbe64fdc"
+      },
+      "namespace": "DEMOGRAPHIC",
+      "type": "PERSON"
+    },
+    "name": "Dr. House"
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2019-01-28T21:22:49,294+00:00"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "value": "primary nursing care",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "229"
+      }
+    }
+  },
+  "content": [
+    {
+      "_type": "OBSERVATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Test all types"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.test_all_types.v1",
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "HISTORY",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2019-01-28T21:22:49,326+00:00"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Cualquier evento"
+            },
+            "archetype_node_id": "at0002",
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2019-01-28T21:22:49,332+00:00"
+            },
+            "data": {
+              "_type": "ITEM_TREE",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Arbol"
+              },
+              "archetype_node_id": "at0003",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "text"
+                  },
+                  "archetype_node_id": "at0004",
+                  "value": {
+                    "_type": "DV_TEXT",
+                    "value": "At,ffwkm.xsuDu,LNtqXEQJzxNMXTjyKVzQojaNTidAxLLZRbWWoGnfOIMUM.XxakRgJxExjtjBPirOxu,nUnPdIegLQbhNDKNRqGbFuvXrXYuNPXwnELoIsYMKgFEWHnR.XSBuESAamCrjJMssGgI.QOOyzatFlaXbiVaUBxzSdkOscZza,IumnYWoxwekcSAYSJiILhmKEOUWdoElCavaQPNNpGcxHEGASUMSAkFuu jZdWcysffi.QLeVONn"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "coded text"
+                  },
+                  "archetype_node_id": "at0005",
+                  "value": {
+                    "_type": "DV_CODED_TEXT",
+                    "value": "value1",
+                    "defining_code": {
+                      "_type": "CODE_PHRASE",
+                      "terminology_id": {
+                        "_type": "TERMINOLOGY_ID",
+                        "value": "local"
+                      },
+                      "code_string": "at0006"
+                    }
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "coded text terminology"
+                  },
+                  "archetype_node_id": "at0006",
+                  "value": {
+                    "_type": "DV_CODED_TEXT",
+                    "value": ".HCXbqCyQtseLkDyKS,QLpOdDZxrEJ",
+                    "defining_code": {
+                      "_type": "CODE_PHRASE",
+                      "terminology_id": {
+                        "_type": "TERMINOLOGY_ID",
+                        "value": "SNOMED-CT"
+                      },
+                      "code_string": "1004034"
+                    }
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "quantity"
+                  },
+                  "archetype_node_id": "at0007",
+                  "value": {
+                    "_type": "DV_QUANTITY",
+                    "magnitude": 636.3397240638733,
+                    "units": "mg"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "count"
+                  },
+                  "archetype_node_id": "at0008",
+                  "value": {
+                    "_type": "DV_COUNT",
+                    "magnitude": 10
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "date"
+                  },
+                  "archetype_node_id": "at0009",
+                  "value": {
+                    "_type": "DV_DATE",
+                    "value": "20190114"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "datetime"
+                  },
+                  "archetype_node_id": "at0010",
+                  "value": {
+                    "_type": "DV_DATE_TIME",
+                    "value": "2019-01-28T21:22:49,426+00:00"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "datetime any"
+                  },
+                  "archetype_node_id": "at0011",
+                  "value": {
+                    "_type": "DV_DATE_TIME",
+                    "value": "2019-01-28T21:22:49,427+00:00"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "time"
+                  },
+                  "archetype_node_id": "at0012",
+                  "value": {
+                    "_type": "DV_TIME",
+                    "value": "18:36:49"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "ordinal"
+                  },
+                  "archetype_node_id": "at0013",
+                  "value": {
+                    "_type": "DV_ORDINAL",
+                    "value": 0,
+                    "symbol": {
+                      "_type": "DV_CODED_TEXT",
+                      "value": "ord1",
+                      "defining_code": {
+                        "_type": "CODE_PHRASE",
+                        "terminology_id": {
+                          "_type": "TERMINOLOGY_ID",
+                          "value": "local"
+                        },
+                        "code_string": "at0014"
+                      }
+                    }
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "boolean"
+                  },
+                  "archetype_node_id": "at0017",
+                  "value": {
+                    "_type": "DV_BOOLEAN",
+                    "value": true
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "duration any"
+                  },
+                  "archetype_node_id": "at0018",
+                  "value": {
+                    "_type": "DV_DURATION",
+                    "value": "PT30M"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "parsable any"
+                  },
+                  "archetype_node_id": "at0020",
+                  "value": {
+                    "_type": "DV_PARSABLE",
+                    "value": "20170629",
+                    "formalism": "ISO8601"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "identifier"
+                  },
+                  "archetype_node_id": "at0021",
+                  "value": {
+                    "_type": "DV_IDENTIFIER",
+                    "issuer": "Hospital de Clinicas",
+                    "assigner": "Hospital de Clinicas",
+                    "id": "55175056",
+                    "type": "LOCALID"
+                  }
+                },
+                {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "proportion any"
+                  },
+                  "archetype_node_id": "at0022",
+                  "value": {
+                    "_type": "DV_PROPORTION",
+                    "numerator": 1.5,
+                    "denominator": 1.0,
+                    "type": 1,
+                    "precision": 1
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.test_all_types.v1"
+        },
+        "rm_version": "1.0.2"
+      }
+    },
+    {
+      "_type": "EVALUATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Test all types"
+      },
+      "archetype_node_id": "openEHR-EHR-EVALUATION.test_all_types.v1",
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "ITEM_TREE",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Arbol"
+        },
+        "archetype_node_id": "at0001",
+        "items": [
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "uri"
+            },
+            "archetype_node_id": "at0002",
+            "null_flavour": {
+              "_type": "DV_CODED_TEXT",
+              "value": "no information",
+              "defining_code": {
+                "_type": "CODE_PHRASE",
+                "terminology_id": {
+                  "_type": "TERMINOLOGY_ID",
+                  "value": "openehr"
+                },
+                "code_string": "271"
+              }
+            }
+          },
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "interval count"
+            },
+            "archetype_node_id": "at0003",
+            "value": {
+              "_type": "DV_INTERVAL",
+              "lower": {
+                "_type": "DV_COUNT",
+                "magnitude": 123
+              },
+              "upper": {
+                "_type": "DV_COUNT",
+                "magnitude": 234
+              },
+              "lower_unbounded": false,
+              "upper_unbounded": false
+            }
+          },
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "interval quantity"
+            },
+            "archetype_node_id": "at0004",
+            "value": {
+              "_type": "DV_INTERVAL",
+              "lower": {
+                "_type": "DV_QUANTITY",
+                "magnitude": 123.123,
+                "units": "mm[H20]"
+              },
+              "upper": {
+                "_type": "DV_QUANTITY",
+                "magnitude": 234.234,
+                "units": "mm[H20]"
+              },
+              "lower_unbounded": false,
+              "upper_unbounded": false
+            }
+          },
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "interval datetime"
+            },
+            "archetype_node_id": "at0005",
+            "value": {
+              "_type": "DV_INTERVAL",
+              "lower": {
+                "_type": "DV_DATE_TIME",
+                "value": "2019-01-28T21:22:49,426+00:00"
+              },
+              "upper": {
+                "_type": "DV_DATE_TIME",
+                "value": "2019-01-28T21:22:49,426+00:00"
+              },
+              "lower_unbounded": false,
+              "upper_unbounded": false
+            }
+          },
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "choice"
+            },
+            "archetype_node_id": "at0009",
+            "value": {
+              "_type": "DV_QUANTITY",
+              "magnitude": 148.01210165023804,
+              "units": "mm[H20]"
+            }
+          },
+          {
+            "_type": "CLUSTER",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "cluster 1"
+            },
+            "archetype_node_id": "at0006",
+            "items": [
+              {
+                "_type": "CLUSTER",
+                "name": {
+                  "_type": "DV_TEXT",
+                  "value": "cluster 2"
+                },
+                "archetype_node_id": "at0007",
+                "items": [
+                  {
+                    "_type": "CLUSTER",
+                    "name": {
+                      "_type": "DV_TEXT",
+                      "value": "cluster 3"
+                    },
+                    "archetype_node_id": "at0008",
+                    "items": [
+                      {
+                        "_type": "ELEMENT",
+                        "name": {
+                          "_type": "DV_TEXT",
+                          "value": "text 2"
+                        },
+                        "archetype_node_id": "at0010",
+                        "value": {
+                          "_type": "DV_TEXT",
+                          "value": "FViqRjKtFGXm ,iPOYGPuYNjqqVYifvxzvbOlMnuidJvvdYByUiDUgQIBkyOcJtgZcRKdFmyo .TrsPDcaXtFeqLlnZgqdTxb.,LGavIsdXKcBhTWd,PElsLCymSIGcfRrObkevpucVkThYTAZZxcikhpGVaQ.UbyrkwewgarEn gLmIWGLqFZBFYLcBje.GwiYMBoHEEVymGCkyXUyosuq,CNvWsuUnHdVEjEuxGSEwBDEVgwWrXWOYWUCIhos"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-EVALUATION.test_all_types.v1"
+        },
+        "rm_version": "1.0.2"
+      }
+    },
+    {
+      "_type": "SECTION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Test all types"
+      },
+      "archetype_node_id": "openEHR-EHR-SECTION.test_all_types.v1",
+      "items": [
+        {
+          "_type": "SECTION",
+          "name": {
+            "_type": "DV_TEXT",
+            "value": "section 2"
+          },
+          "archetype_node_id": "at0001",
+          "items": [
+            {
+              "_type": "SECTION",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "section 3"
+              },
+              "archetype_node_id": "at0002",
+              "items": [
+                {
+                  "_type": "INSTRUCTION",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "Test all types"
+                  },
+                  "archetype_node_id": "openEHR-EHR-INSTRUCTION.test_all_types.v1",
+                  "language": {
+                    "_type": "CODE_PHRASE",
+                    "terminology_id": {
+                      "_type": "TERMINOLOGY_ID",
+                      "value": "ISO_639-1"
+                    },
+                    "code_string": "en"
+                  },
+                  "encoding": {
+                    "_type": "CODE_PHRASE",
+                    "terminology_id": {
+                      "_type": "TERMINOLOGY_ID",
+                      "value": "IANA_character-sets"
+                    },
+                    "code_string": "UTF-8"
+                  },
+                  "subject": {
+                    "_type": "PARTY_SELF"
+                  },
+                  "narrative": {
+                    "_type": "DV_TEXT",
+                    "value": "WAZotVojPPlPDKcOwCqQGlJjRdMC.ujKPgVAmyWABEoOgtrRSznogUWokmqmfgxjZOYmUEAcyvmnfz,KhtTC FrpwevrLJFNiJKzkzOwfOPRFQJjRmQCTW,ewdqvscogOkayvONWrOTPcCFnZsUod CAQ fuhLaBA.pFWdEyzyFgDODbueIlUjIGBdnIDDpMfjzWivfUDSEvTUsncmCgPdHnpONCuNGXUwFTaiSHHHJBZYssxGne.BLIbBQzXhG"
+                  },
+                  "activities": [
+                    {
+                      "_type": "ACTIVITY",
+                      "name": {
+                        "_type": "DV_TEXT",
+                        "value": "Current Activity"
+                      },
+                      "archetype_node_id": "at0001",
+                      "description": {
+                        "_type": "ITEM_LIST",
+                        "name": {
+                          "_type": "DV_TEXT",
+                          "value": "List"
+                        },
+                        "archetype_node_id": "at0002",
+                        "items": [
+                          {
+                            "_type": "ELEMENT",
+                            "name": {
+                              "_type": "DV_TEXT",
+                              "value": "partial date"
+                            },
+                            "archetype_node_id": "at0003",
+                            "value": {
+                              "_type": "DV_DATE",
+                              "value": "20190114"
+                            }
+                          },
+                          {
+                            "_type": "ELEMENT",
+                            "name": {
+                              "_type": "DV_TEXT",
+                              "value": "partial datetime"
+                            },
+                            "archetype_node_id": "at0004",
+                            "value": {
+                              "_type": "DV_DATE_TIME",
+                              "value": "2019-01-28T21:22:49,426+00:00"
+                            }
+                          }
+                        ]
+                      },
+                      "timing": {
+                        "_type": "DV_PARSABLE",
+                        "value": "P1D",
+                        "formalism": "ISO8601"
+                      },
+                      "action_archetype_id": "openEHR-EHR-ACTION\\.test_all_types\\.v1"
+                    }
+                  ],
+                  "archetype_details": {
+                    "_type": "ARCHETYPED",
+                    "archetype_id": {
+                      "_type": "ARCHETYPE_ID",
+                      "value": "openEHR-EHR-INSTRUCTION.test_all_types.v1"
+                    },
+                    "rm_version": "1.0.2"
+                  },
+                  "expiry_time": {
+                    "_type": "DV_DATE_TIME",
+                    "value": "2027-01-01T00:00:00Z"
+                  },
+                  "wf_definition": {
+                    "_type": "DV_PARSABLE",
+                    "value": "plan { step prescribe; }",
+                    "formalism": "cnf-demo-wf"
+                  }
+                },
+                {
+                  "_type": "ACTION",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "Test all types"
+                  },
+                  "archetype_node_id": "openEHR-EHR-ACTION.test_all_types.v1",
+                  "language": {
+                    "_type": "CODE_PHRASE",
+                    "terminology_id": {
+                      "_type": "TERMINOLOGY_ID",
+                      "value": "ISO_639-1"
+                    },
+                    "code_string": "en"
+                  },
+                  "encoding": {
+                    "_type": "CODE_PHRASE",
+                    "terminology_id": {
+                      "_type": "TERMINOLOGY_ID",
+                      "value": "IANA_character-sets"
+                    },
+                    "code_string": "UTF-8"
+                  },
+                  "subject": {
+                    "_type": "PARTY_SELF"
+                  },
+                  "time": {
+                    "_type": "DV_DATE_TIME",
+                    "value": "2019-01-28T21:22:50,154+00:00"
+                  },
+                  "description": {
+                    "_type": "ITEM_TREE",
+                    "name": {
+                      "_type": "DV_TEXT",
+                      "value": "Arbol"
+                    },
+                    "archetype_node_id": "at0001",
+                    "items": [
+                      {
+                        "_type": "CLUSTER",
+                        "name": {
+                          "_type": "DV_TEXT",
+                          "value": "Test all types"
+                        },
+                        "archetype_node_id": "openEHR-EHR-CLUSTER.test_all_types.v1",
+                        "items": [
+                          {
+                            "_type": "CLUSTER",
+                            "name": {
+                              "_type": "DV_TEXT",
+                              "value": "cluster 5"
+                            },
+                            "archetype_node_id": "at0001",
+                            "items": [
+                              {
+                                "_type": "CLUSTER",
+                                "name": {
+                                  "_type": "DV_TEXT",
+                                  "value": "cluster 6"
+                                },
+                                "archetype_node_id": "at0002",
+                                "items": [
+                                  {
+                                    "_type": "ELEMENT",
+                                    "name": {
+                                      "_type": "DV_TEXT",
+                                      "value": "boolean 2"
+                                    },
+                                    "archetype_node_id": "at0003",
+                                    "value": {
+                                      "_type": "DV_BOOLEAN",
+                                      "value": true
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ],
+                        "archetype_details": {
+                          "_type": "ARCHETYPED",
+                          "archetype_id": {
+                            "_type": "ARCHETYPE_ID",
+                            "value": "openEHR-EHR-CLUSTER.test_all_types.v1"
+                          },
+                          "rm_version": "1.0.2"
+                        }
+                      }
+                    ]
+                  },
+                  "ism_transition": {
+                    "_type": "ISM_TRANSITION",
+                    "current_state": {
+                      "_type": "DV_CODED_TEXT",
+                      "value": "planned",
+                      "defining_code": {
+                        "_type": "CODE_PHRASE",
+                        "terminology_id": {
+                          "_type": "TERMINOLOGY_ID",
+                          "value": "openehr"
+                        },
+                        "code_string": "526"
+                      }
+                    },
+                    "transition": {
+                      "_type": "DV_CODED_TEXT",
+                      "value": "plan step",
+                      "defining_code": {
+                        "_type": "CODE_PHRASE",
+                        "terminology_id": {
+                          "_type": "TERMINOLOGY_ID",
+                          "value": "openehr"
+                        },
+                        "code_string": "536"
+                      }
+                    },
+                    "careflow_step": {
+                      "_type": "DV_CODED_TEXT",
+                      "value": "Prescribe",
+                      "defining_code": {
+                        "_type": "CODE_PHRASE",
+                        "terminology_id": {
+                          "_type": "TERMINOLOGY_ID",
+                          "value": "local"
+                        },
+                        "code_string": "at0005"
+                      }
+                    },
+                    "reason": [
+                      {
+                        "_type": "DV_TEXT",
+                        "value": "routine planning step"
+                      }
+                    ]
+                  },
+                  "archetype_details": {
+                    "_type": "ARCHETYPED",
+                    "archetype_id": {
+                      "_type": "ARCHETYPE_ID",
+                      "value": "openEHR-EHR-ACTION.test_all_types.v1"
+                    },
+                    "rm_version": "1.0.2"
+                  },
+                  "instruction_details": {
+                    "_type": "INSTRUCTION_DETAILS",
+                    "instruction_id": {
+                      "_type": "LOCATABLE_REF",
+                      "id": {
+                        "_type": "OBJECT_VERSION_ID",
+                        "value": "11111111-1111-4111-8111-111111111111::cnf.example.org::1"
+                      },
+                      "namespace": "local",
+                      "type": "INSTRUCTION"
+                    },
+                    "activity_id": "activities[at0001]"
+                  }
+                }
+              ]
+            },
+            {
+              "_type": "ADMIN_ENTRY",
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Test all types"
+              },
+              "archetype_node_id": "openEHR-EHR-ADMIN_ENTRY.test_all_types.v1",
+              "language": {
+                "_type": "CODE_PHRASE",
+                "terminology_id": {
+                  "_type": "TERMINOLOGY_ID",
+                  "value": "ISO_639-1"
+                },
+                "code_string": "en"
+              },
+              "encoding": {
+                "_type": "CODE_PHRASE",
+                "terminology_id": {
+                  "_type": "TERMINOLOGY_ID",
+                  "value": "IANA_character-sets"
+                },
+                "code_string": "UTF-8"
+              },
+              "subject": {
+                "_type": "PARTY_SELF"
+              },
+              "data": {
+                "_type": "ITEM_SINGLE",
+                "name": {
+                  "_type": "DV_TEXT",
+                  "value": "single"
+                },
+                "archetype_node_id": "at0001",
+                "item": {
+                  "_type": "ELEMENT",
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "count 3"
+                  },
+                  "archetype_node_id": "at0002",
+                  "value": {
+                    "_type": "DV_COUNT",
+                    "magnitude": 123
+                  }
+                }
+              },
+              "archetype_details": {
+                "_type": "ARCHETYPED",
+                "archetype_id": {
+                  "_type": "ARCHETYPE_ID",
+                  "value": "openEHR-EHR-ADMIN_ENTRY.test_all_types.v1"
+                },
+                "rm_version": "1.0.2"
+              }
+            }
+          ]
+        }
+      ],
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-SECTION.test_all_types.v1"
+        },
+        "rm_version": "1.0.2"
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-entry_family_invalid.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-entry_family_invalid.yaml
@@ -1,0 +1,40 @@
+# The Entry-package refusal twins (RM EHR ch.8, issue #2488): four
+# falsifiable instruction-family invariants with no prior wire case, one
+# defect per row (the maximal OPT leaves the ISM nodes archetype-open, so
+# each named RM rule is the only violation). The accepting twin is
+# commit_contribution-instruction_rich.
+id: I_EHR_CONTRIBUTION.commit_contribution-entry_family_invalid
+kind: functional
+component: EHR_CONTRIBUTION
+sm_operation: I_EHR_CONTRIBUTION.commit_contribution
+capabilities: [ChangeSets]
+profiles: [CORE]
+test_purpose: "A committed instruction-family value violating its invariants — an out-of-group ISM state or transition code, an empty action_archetype_id, or an empty INSTRUCTION_DETAILS activity_id — is refused as invalid content, and no version is created."
+description: "commit compositions with Entry-package instruction-family defects"
+spec_refs:
+  - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
+  - "RM UML/classes/org.openehr.rm.composition.ism_transition.adoc §Invariants (Current_state_valid, Transition_valid)"
+  - "RM UML/classes/org.openehr.rm.composition.activity.adoc §Invariants (Action_archetype_id_valid) + org.openehr.rm.composition.instruction_details.adoc §Invariants (Activity_path_valid)"
+  - "ITS-REST overview Requests_and_responses.md §HTTP status codes (the semantic 422 branch)"
+applies: { rm: ">=1.0.2" }
+requires:
+  server: any
+  templates: [cnf.opt.maximal]
+  ehr: { commits: none }
+parameters:
+  iteration: reset_per_row
+  fixture_set:
+    - { data_set: cnf.composition.maximal.bad_ism_state, expected: validation_failed, defect: "ISM state code 999 outside the instruction states group (Current_state_valid)" }
+    - { data_set: cnf.composition.maximal.bad_ism_transition, expected: validation_failed, defect: "ISM transition code 999 outside the instruction transitions group (Transition_valid)" }
+    - { data_set: cnf.composition.maximal.empty_action_archetype_id, expected: validation_failed, defect: "empty ACTIVITY.action_archetype_id (Action_archetype_id_valid)" }
+    - { data_set: cnf.composition.maximal.empty_activity_id, expected: validation_failed, defect: "empty INSTRUCTION_DETAILS.activity_id (Activity_path_valid)" }
+flow:
+  - step: 1
+    call: commit_contribution
+    with:
+      versions: "${ds:fixture}"
+      audit: { change_type: creation, committer: { name: "conformance tester" } }
+    expect: "${fixture.expected}"
+postconditions:
+  - assert: version
+    count: 0

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-instruction_rich.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-instruction_rich.yaml
@@ -1,0 +1,49 @@
+# The instruction family's rich accepting twin (RM EHR ch.8, issue #2488):
+# the never-committed trimmings in one instance — ISM_TRANSITION.transition +
+# careflow_step + reason, ACTION.instruction_details, INSTRUCTION.expiry_time
+# + wf_definition. The refusal directions live in
+# commit_contribution-entry_family_invalid.
+id: I_EHR_CONTRIBUTION.commit_contribution-instruction_rich
+kind: functional
+component: EHR_CONTRIBUTION
+sm_operation: I_EHR_CONTRIBUTION.commit_contribution
+capabilities: [ChangeSets]
+profiles: [CORE]
+test_purpose: >-
+  Committing a composition whose instruction family carries every optional
+  trimming — a full ISM_TRANSITION (state, in-group transition, local
+  careflow step, reasons), an ACTION with INSTRUCTION_DETAILS, and an
+  INSTRUCTION with expiry_time and a parsable wf_definition — succeeds and
+  creates version 1.
+description: "commit a composition with the full instruction-family trimmings"
+spec_refs:
+  - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
+  - "RM UML/classes/org.openehr.rm.composition.ism_transition.adoc §Attributes (transition, careflow_step, reason) + org.openehr.rm.composition.instruction_details.adoc §Attributes (instruction_id, activity_id)"
+  - "RM ehr/master08-entry_package.adoc §Clinical Workflow Definition (wf_definition: any syntax may currently be used) + §Careflow Process to State Machine Mapping"
+applies: { rm: ">=1.0.2" }
+requires:
+  server: any
+  templates: [cnf.opt.maximal]
+  ehr: { commits: none }
+parameters:
+  iteration: reset_per_row
+  fixture_set:
+    - { data_set: cnf.composition.maximal.instruction_rich, expected: created, defect: "full ISM_TRANSITION + INSTRUCTION_DETAILS + expiry_time + wf_definition" }
+flow:
+  - step: 1
+    call: commit_contribution
+    with:
+      ehr_id: "${ehr_id}"
+      versions:
+        - { data: "${ds:fixture}", change_type: creation }
+    expect: "${fixture.expected}"
+    capture:
+      version_uids: created.version_uids[]
+    assert:
+      - { assert: version, for_each: "${version_uids}", change_type: CREATE, uid_pattern: "<uuid>::<system>::1" }
+postconditions:
+  - assert: state
+    text: >-
+      The EHR holds one new VERSION<COMPOSITION> whose instruction-family
+      trimmings are stored and served unchanged.
+    verified_by: I_EHR_COMPOSITION.get_composition_latest

--- a/tools/cnf-runner/artifacts/vocab/capability_matrix.yaml
+++ b/tools/cnf-runner/artifacts/vocab/capability_matrix.yaml
@@ -1,278 +1,50 @@
 # The capability -> family -> tier matrix: CNF profiles master03-profiles.adoc
 # capability x tier tables as data, plus the CNF 2.0 Security family proposal
-# (our own extension). OPTIONS = the book's catch-all pseudo-profile =>
-# required: false on OPTIONS rows.
-#
-# Claim-completeness columns (owner 2026-07-28; all enforced by `cnf-runner
-# validate`, never by review):
+# (our own extension). OPTIONS rows are required: false.
+# Columns (all enforced by cnf-runner validate):
 #   min_cases          verdict-bearing case-count FLOOR; ratchets UP only.
-#   realization        released-wire (default) | extension (routes no openEHR
-#                      spec governs — never `required`).
+#   realization        released-wire (default) | extension (never required).
 #   evidence_exception register entry adjudicating an all-excused capability.
 #   workload_exclusion register entry adjudicating a claimed capability the
 #                      measured hospital simulation does not exercise.
-# Workload exclusions are PERMANENT reasons of two kinds only: destructive
-# mid-measurement, or no-request-to-send (no wire, no served route); a stale
-# exclusion is a `workload-coverage` finding.
-# Derivation narratives live in the ambiguity register entries each row
-# points at (and the owner rulings on the tracker); comments here stay one
-# line per row. The nine unclaimed SM rows become re-claimable the day the
-# product serves their operations on declared extension routes (the
-# PartyRelationshipOperations pattern).
+# Derivation narratives live in the ambiguity register and on the tracker.
 Adl14ArchetypeProvisioning: { family: Platform, tier: CORE, required: false, realization: extension, min_cases: 13, workload_exclusion: { register: AMB-170, reason: "definition administration, not a sustainable per-patient arrival: archetype provisioning is a design-time operation a hospital simulation would not repeatedly drive (the same family reason the ADL2/OPT provisioning rows carry journeys for is satisfied by the definition-poll journey; this row's own upload/delete churn would grow the definition store unboundedly through a measured hold)" }, source: "CNF profiles master03-profiles.adoc §Functional (Definitions: ADL 1.4 Archetype provisioning)" }
 Adl14OptProvisioning: { family: Platform, tier: CORE, required: true, min_cases: 26, source: "CNF profiles master03-profiles.adoc §Functional (Definitions: ADL 1.4 OPT provisioning)" }
-# (c) NO RELEASED WIRE — verified first-hand 2026-07-28: the released
-# definition.openapi.yaml surfaces only OPT wire under /definition/template/adl2
-# (list / upload / get / example / the deprecated version GET); there is no ADL 2
-# archetype-provisioning path and the docs text names none. AND NO SERVED ROUTE:
-# this product mounts nothing for artefact-generic ADL 2 provisioning. Claim
-# withdrawn from the ferroehr statement.
-# REALIZED ON THE EXTENSION SURFACE (#637, 2026-07-29) — the row carried an
-# evidence_exception while ITS-REST 1.1.0 surfaced no ADL 2 archetype/artefact
-# wire AND this product served none either. It now serves five routes
-# (/definition/archetype/adl2[/count], /definition/artefact/adl2[/count],
-# DELETE /definition/artefact/adl2/{id}; the `adl2-archetype` served_extensions
-# family), the five SM operations carry EXTENSION bindings onto them, and the
-# battery is EXECUTED. The exception is therefore GONE.
-#
-# The row carries NO `realization: extension` marker, and that is a derived
-# fact rather than an oversight: `delete_artefact-existing` verifies its own
-# postcondition by reading the artefact back through the RELEASED
-# get_artefact (GET /definition/template/adl2/{id} -> 404), so the battery is
-# genuinely MIXED — four cases drive extension routes only, two touch released
-# wire — and `check_realization_markers` reserves the marker for a battery
-# whose every case is extension-only. Weakening that read-back to an
-# extension-only probe to earn the marker would trade real evidence for a
-# label.
-#
-# The workload_exclusion is gone too: the `integration_poll` journey now polls
-# the ADL 2 archetype store (`archetype_adl2_list`), so the measured
-# hospital simulation exercises the capability.
 Adl2ArchetypeProvisioning: { family: Platform, tier: OPTIONS, required: false, min_cases: 10, source: "CNF profiles master03-profiles.adoc §Functional (Definitions: ADL 2 Archetype provisioning)" }
 Adl2OptProvisioning: { family: Platform, tier: OPTIONS, required: false, min_cases: 30, source: "CNF profiles master03-profiles.adoc §Functional (Definitions: ADL 2 OPT provisioning)" }
-# Example generation split from OPT provisioning (#545, 2026-07-28): the /example sub-resource is SHOULD-level surface — the CNF profiles book has no ex (register: AMB-115).
 TemplateExamples: { family: Platform, tier: OPTIONS, required: false, min_cases: 3, source: "ITS-REST specifications/operations/definition_template_adl1.4_example_get.yaml NOTE + register AMB-115 (no CNF profiles row exists for example generation)" }
 QueryProvisioning: { family: Platform, tier: STANDARD, required: true, min_cases: 27, source: "CNF profiles master03-profiles.adoc §Functional (Definitions: Query provisioning)" }
 EhrOperations: { family: Platform, tier: CORE, required: true, min_cases: 24, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: EHR Operations)" }
 EhrStatus: { family: Platform, tier: CORE, required: true, min_cases: 49, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: EHR Status)" }
 CompositionOps: { family: Platform, tier: CORE, required: true, min_cases: 59, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Composition Operations)" }
 DirectoryOps: { family: Platform, tier: STANDARD, required: true, min_cases: 85, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Directory Operations)" }
-# Floor raised 89 -> 90: the third axis of the master06 §Logical Deletion
-# procedure — a delete member whose own declared lifecycle_state contradicts
-# the deletion it performs (the two data axes were already covered).
-# Floor raised 91 -> 93 (2026-08-20): the History-package twins (issue
-# #2471) — the master06 instance-figure acceptance case plus the
-# three-invariant refusal family under the open history template.
-# Raised 93 -> 94 (2026-08-20): the DV_IDENTIFIER empty-id refusal twin
-# (issue #2474, Id_valid — the present-but-empty branch beside the
-# CONT-DV_IDENTIFIER matrix's missing-id row).
-# Raised 94 -> 96 (2026-08-20): the Text-package twins (issue #2476) — the
-# deprecated-forms acceptance case (DV_PARAGRAPH + legacy formatting +
-# hyperlink) plus the four-invariant refusal family.
-# Raised 96 -> 98 (2026-08-20): the Quantity-package twins (issue #2478) —
-# the fully-trimmed DV_QUANTITY acceptance case plus the ten-invariant
-# refusal family.
-# Raised 98 -> 100 (2026-08-20): the time-specification twins (issue
-# #2480) — the PIVL/GTS acceptance case plus the formalism refusal.
-# Raised 100 -> 102 (2026-08-20): the Encapsulated-package twins (issue
-# #2482) — the rich multimedia/parsable acceptance case plus the
-# five-invariant refusal family.
-ChangeSets: { family: Platform, tier: CORE, required: true, min_cases: 102, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Change sets)" }
-# Raised 72 -> 73 (2026-08-20): the Persistent_validity cross-version
-# category-flip refusal (issue #2486).
+ChangeSets: { family: Platform, tier: CORE, required: true, min_cases: 104, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Change sets)" }
 Versioning: { family: Platform, tier: CORE, required: true, min_cases: 73, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Versioning)" }
-# Floor raised 121 -> 125 (2026-07-29): the four commit-time CONSTRAINT
-# BINDING cases (member accepted / non-member refused / unresolvable under each
-# declared posture). BASE architecture_overview master12 §"Binding Terminology
-# Value-sets to Archetypes" makes the bound query's result the permitted value
-# set, so resolving it at ingestion is archetype-constraint validation like any
-# other — it just reaches an external terminology query server to do it.
 ArchetypeValidation: { family: Platform, tier: CORE, required: true, min_cases: 125, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Archetype Validation)" }
 PartyOperations: { family: Platform, tier: OPTIONS, required: false, min_cases: 90, source: "CNF profiles master03-profiles.adoc §Functional (Demographic Persistence: Party Operations)" }
-# REALIZATION DERIVED FIRST-HAND 2026-07-28 (#623), outcome (b): the RELEASED
-# wire does not exist — the ITS-REST docs text never names a PARTY_RELATIONSHIP
-# resource and specifications/demographic.openapi.yaml declares no
-# /demographic/party_relationship* path (PartyRelationship.yaml is a schema
-# only, the by-value member of PARTY.relationships) — but this product SERVES
-# all six SM relationship operations on its own declared extension routes, so
-# the battery is EXECUTED there instead of excused. The evidence_exception is
-# therefore GONE and the row is `realization: extension`, which the matrix model
-# forbids from ever being `required`: the capability is certified as product
-# function, and no openEHR profile tier or ITS-REST wire-conformance claim rests
-# on it (owner ruling 2026-07-28).
 PartyRelationshipOperations: { family: Platform, tier: OPTIONS, required: false, realization: extension, min_cases: 19, source: "CNF profiles master03-profiles.adoc §Functional (Demographic Persistence: Party Relationship Operations)" }
-# REALIZED ON RELEASED WIRE (#624, 2026-07-28) — the row carried `min_cases: 0`
-# and no battery. The realization is the party commit seam: the released
-# demographic create operations validate the committed PARTY against the
-# archetyped demographic model, and a violation is the released 422
-# (ITS-REST overview Requests_and_responses.md §HTTP status codes: "The request
-# was well-formed but was unable to be followed due to semantic errors"). The
-# battery is the demographic twin of the CONT- family: the archetype-root rules
-# (RM demographic party.adoc §Is_archetype_root + RM common locatable.adoc
-# §Archetyped_valid and §archetype_node_id), the present-implies-non-empty
-# cardinality rules on PARTY/ACTOR/ROLE, the PARTY_IDENTITY value-type and
-# mandatory-attribute rules, and the accept case that proves the validator
-# passes fully archetyped content rather than refusing what it does not
-# recognize. Exercised by the measured workload through the demographic
-# admission journey's party commits — the validator runs on every commit, the
-# same reasoning that maps ArchetypeValidation onto CompositionCommit.
 DemographicArchetypeValidation: { family: Platform, tier: OPTIONS, required: false, min_cases: 11, source: "CNF profiles master03-profiles.adoc §Functional (Demographic Persistence: Archetype validation)" }
-# Floor raised 19 -> 30 (2026-07-30): the AQL master03 language battery — LIKE wildcards, EXISTS/NOT EXISTS, NOT CONTAINS, the AND/OR containment operat (register: AMB-174).
 AqlBasic: { family: Platform, tier: STANDARD, required: true, min_cases: 35, source: "CNF profiles master03-profiles.adoc §Functional (Querying: AQL basic)" }
-# Floor raised 2 -> 3 (2026-07-30): the DISTINCT x LIMIT ordering case
-# (duplicates filtered before LIMIT applies — master03-syntax §LIMIT) joins the
-# two LIMIT cases.
 AqlAdvanced: { family: Platform, tier: OPTIONS, required: false, min_cases: 3, source: "CNF profiles master03-profiles.adoc §Functional (Querying: AQL advanced)" }
-# Floor raised 1 -> 5 (2026-07-29): the four EXTERNAL-terminology-server cases (Boolean validate resolving true and false, the expand filter over commit (register: AMB-30).
 AqlTerminology: { family: Platform, tier: OPTIONS, required: false, min_cases: 6, source: "CNF profiles master03-profiles.adoc §Functional (Querying: AQL & terminology)" }
-# (c) NO RELEASED WIRE — verified first-hand 2026-07-28: the released
-# admin.openapi.yaml declares exactly two paths, /admin/ehr/{ehr_id} and
-# /admin/ehr/all{?ehr_id*}, so none of the SM I_ADMIN_SERVICE reporting
-# operations (list_contributions / contribution_count /
-# versioned_composition_count / composition_version_count) has a wire. AND NO
-# SERVED ROUTE: the product's admin extension family is exactly template
-# delete, stored-query-version delete and the redacted config read (declared in
-# vocab/wire_surface.yaml `admin-extension-routes`) — the statistics methods are
-# service-layer only (`ferroehr::service::admin::statistics`). Claim withdrawn.
-# REALIZED ON THE EXTENSION SURFACE (#637, 2026-07-29) — ITS-REST 1.1.0
-# realizes only admin_ehr_delete/admin_ehr_delete_all of the SM Admin surface,
-# but this product serves the four SM reporting calls under /admin/report/
-# (the `admin-activity-report` served_extensions family) and the whole battery
-# is EXECUTED there. The evidence_exception is GONE and the row is
-# `realization: extension`, which may never be `required`.
-# The workload_exclusion is gone too: the `audit_review` journey now reads the
-# contribution count (`admin_contribution_report`), so the measured hospital
-# simulation exercises the capability.
 ActivityReport: { family: Platform, tier: OPTIONS, required: false, realization: extension, min_cases: 15, source: "CNF profiles master03-profiles.adoc §Functional (Admin: Activity Report)" }
 PhysicalDeletion: { family: Platform, tier: OPTIONS, required: false, min_cases: 11, workload_exclusion: { register: AMB-170, reason: "destructive mid-measurement: the released admin operations erase an EHR and its whole version history outright, so every arrival would shrink the population-anchored corpus the measured window is bound to and the earned class would no longer describe the declared volumetric class" }, source: "CNF profiles master03-profiles.adoc §Functional (Admin: Physical Deletion)" }
-# REALIZED ON THE EXTENSION SURFACE (#659, 2026-07-29) — the LAST admin excuse standing after the #637 wave, and for a reason of its own rather than "no (register: AMB-33).
 EhrDumpLoad: { family: Platform, tier: OPTIONS, required: false, realization: extension, min_cases: 15, workload_exclusion: { register: AMB-170, reason: "one-shot by nature: export_ehrs dumps the WHOLE repository to a file system and load_ehrs reads a whole archive back, so neither is a per-patient interaction a hospital simulation could sustain - a repeated arrival would re-dump the entire population-anchored corpus the measured window is bound to, and the load half would additionally grow it. The exclusion is about the SHAPE of the operation, not about routing, so it stands now that the routes exist" }, source: "CNF profiles master03-profiles.adoc §Functional (Admin: EHR Dump/Load)" }
-# REALIZED ON RELEASED WIRE (#624, 2026-07-28) — the row carried `min_cases: 0`
-# and no battery. Derived first-hand: the SM Admin chapter
-# (SM openehr_platform master15-admin_service.adoc — I_ADMIN_SERVICE,
-# I_ADMIN_ARCHIVE, I_ADMIN_DUMP_LOAD) declares NO bulk-load operation (the only
-# load-shaped one, I_ADMIN_DUMP_LOAD.load_ehrs, is the separate EhrDumpLoad
-# book row and reads a file-system archive), and the released admin API
-# declares only /admin/ehr/{ehr_id} and /admin/ehr/all. So the load itself is
-# the realization, and it is entirely RELEASED wire: a population created and
-# filled through the ordinary EHR + COMPOSITION operations — the same path this
-# runner seeds its scale corpora on. The battery covers the two axes of a
-# loaded corpus (population breadth, per-EHR depth) and the two ways a bulk
-# load fails (identity collision, content bleed), asserting count + integrity
-# through the query surface and per-container reads. N stays small: this is the
-# FUNCTIONAL catalogue, not the measured instrument.
 BulkEhrLoad: { family: Platform, tier: OPTIONS, required: false, min_cases: 2, workload_exclusion: { register: AMB-170, reason: "the bulk load IS every measured run's own seeding phase: the scale corpus is loaded strictly through the public API before the window opens, so the capability is exercised per-run by the seeder - as a sustained ARRIVAL it would be a second population grower distorting the population-anchored envelope, the same one-shot family as a whole-server dump/load" }, source: "CNF profiles master03-profiles.adoc §Functional (Admin: Bulk EHR load)" }
-# (c) NO RELEASED WIRE (the two-path admin API above) and NO SERVED ROUTE — the
-# SM I_ADMIN_ARCHIVE archive_ehrs operation is service-layer only
-# (`ferroehr::service::admin::archive`). Claim withdrawn 2026-07-28 (#623).
-# REALIZED ON THE EXTENSION SURFACE (#637, 2026-07-29) — the product serves
-# POST /admin/archive/ehrs (the `admin-archive` served_extensions family), the
-# SM archive_ehrs carries an EXTENSION binding onto it, and both cases are
-# EXECUTED. The evidence_exception is GONE and the row is
-# `realization: extension`. The workload_exclusion SURVIVES but its reason is
-# re-derived: the old one ("no request exists to send") lapsed the day the
-# route landed; the live reason is the destructive/one-shot family.
 EhrArchive: { family: Platform, tier: OPTIONS, required: false, realization: extension, min_cases: 7, workload_exclusion: { register: AMB-170, reason: "destructive mid-measurement: archiving is a lifecycle transition applied to a named set of EHRs, so every arrival would move part of the population-anchored corpus the measured window is bound to into the archival tier - the earned class would no longer describe the declared volumetric class. The same one-shot/destructive family as physical deletion, and unlike the read-only extension routes the simulation now polls" }, source: "CNF profiles master03-profiles.adoc §Functional (Admin: EHR Archive)" }
-# (c) NO RELEASED WIRE (the two-path admin API above) and NO SERVED ROUTE — the
-# SM I_ADMIN_ARCHIVE archive_parties operation is service-layer only
-# (`ferroehr::service::admin::archive`). Claim withdrawn 2026-07-28 (#623).
-# REALIZED ON THE EXTENSION SURFACE (#637, 2026-07-29) — the product serves
-# POST /admin/archive/parties (the `admin-archive` served_extensions family),
-# the SM archive_parties carries an EXTENSION binding onto it, and both cases
-# are EXECUTED (the success case provisions its party through the new
-# `requires.party` precondition, so its FLOW stays extension-only). The
-# evidence_exception is GONE, the row is `realization: extension`, and the
-# workload_exclusion reason is re-derived to the destructive/one-shot family.
 DemographicArchive: { family: Platform, tier: OPTIONS, required: false, realization: extension, min_cases: 8, workload_exclusion: { register: AMB-170, reason: "destructive mid-measurement: archiving is a lifecycle transition applied to a named set of parties, so every arrival would move part of the demographic population the measured window is bound to into the archival tier - the same one-shot/destructive family as physical deletion and the EHR archive half" }, source: "CNF profiles master03-profiles.adoc §Functional (Admin: Demographic Archive)" }
-# REALIZED ON THE EXTENSION SURFACE (#659, 2026-07-29). The released absence is
-# CONFIRMED unchanged first-hand: seven API groups (overview, system, ehr,
-# demographic, query, definition, admin) and no message/extract/tdd group in
-# either the docs text or the OAS. What changed is OUR side — the product serves
-# the four SM EHR-Extract operations under /message/ (the `message-extract`
-# served_extensions family), they carry EXTENSION bindings, and the whole
-# battery is EXECUTED. The evidence_exception is GONE and the row is
-# `realization: extension`, which may never be `required`.
-#
-# The battery also stopped being documentary in a second sense. Its corpus was
-# spec-SHAPED but semantically unexecutable — a manifest naming neither ehr_id
-# nor subject_id, an EXTRACT with empty chapters and no EHR_STATUS container —
-# so it could never have been posted anywhere. Every fixture is re-authored
-# EXECUTABLE (corpus/MANIFEST.yaml §MESSAGING), and the cases whose subject is
-# a runner-minted id build their EXTRACT_SPEC inline, because a corpus entry is
-# static bytes with no reference substitution.
-#
-# The workload_exclusion is GONE: the `integration_poll` journey now exports an
-# EHR as EXTRACTs (`ehr_extract_export`), so the measured hospital simulation
-# exercises the capability.
 EhrExtract: { family: Platform, tier: OPTIONS, required: false, realization: extension, min_cases: 32, source: "CNF profiles master03-profiles.adoc §Functional (Messaging: EHR Extract)" }
-# REALIZED ON THE EXTENSION SURFACE (#659, 2026-07-29) — no MESSAGE group exists
-# in the release (CONFIRMED unchanged first-hand), but the product serves
-# import_tdd + import_tdds under /message/tdd/ (the `message-tdd`
-# served_extensions family) and the battery is EXECUTED. The evidence_exception
-# is GONE and the row is `realization: extension`.
-#
-# Its corpus is now the OFFICIAL CNF TDD data set rather than a hand-shaped
-# stand-in naming a template no corpus entry provisions: the two valid
-# documents are the vendored persistent_minimal / nested instances (root `uid`
-# removed — a version identifier is the committing system's, RM common master06
-# §Version Identification), and each owning case provisions the naming template
-# through `requires.templates`.
-#
-# The workload_exclusion is GONE: the `documentation` journey now imports a TDD
-# (`tdd_import`), so the measured simulation exercises the capability.
 Tds: { family: Platform, tier: OPTIONS, required: false, realization: extension, min_cases: 16, source: "CNF profiles master03-profiles.adoc §Functional (Messaging: TDS)" }
 DefinitionApi: { family: Platform, tier: CORE, required: true, min_cases: 1, source: "CNF profiles master03-profiles.adoc §Functional (REST APIs: DEFINITION API)" }
 EhrApi: { family: Platform, tier: CORE, required: true, min_cases: 2, source: "CNF profiles master03-profiles.adoc §Functional (REST APIs: EHR API)" }
-# REPORTING QUALIFIER, release-pinned (group-12 audit, 2026-07-27) — carried on
-# the capability row because the report/statement renderers take their scope
-# text from this matrix and no other artifact carries per-API scope wording.
-# It qualifies REPORTING only: it is never a verdict modifier, and it is not an
-# ambiguity (requirement force is unaffected — the BCP-14 clause of ITS-REST
-# `docs/overview/Preface.md` §Requirements is not state-qualified, so every
-# MUST/SHOULD on this API binds exactly as elsewhere).
 DemographicApi: { family: Platform, tier: OPTIONS, required: false, min_cases: 63, source: "CNF profiles master03-profiles.adoc §Functional (REST APIs: DEMOGRAPHIC API). SCOPE: the openEHR DEMOGRAPHIC API is DEVELOPMENT-state in the pinned release — ITS-REST docs/demographic/Description.md §Status verbatim: \"This specification is in the `DEVELOPMENT` state\" — and ITS-REST docs/overview/Preface.md §Conformance is literally \"tbd.\", so openEHR publishes no conformance criteria for this API. Claims here are pinned to ITS-REST Release-1.1.0 and derived from the released operation/RM/SM text, not from a conformance clause" }
 QueryApi: { family: Platform, tier: STANDARD, required: true, min_cases: 22, source: "CNF profiles master03-profiles.adoc §Functional (REST APIs: QUERY API)" }
 AdminApi: { family: Platform, tier: OPTIONS, required: false, min_cases: 8, workload_exclusion: { register: AMB-170, reason: "destructive mid-measurement: the released ADMIN API of ITS-REST 1.1.0 is exactly admin_ehr_delete and admin_ehr_delete_all, so the only wire this claim covers is the same corpus-erasing pair PhysicalDeletion excludes (the further /admin routes this server mounts are extensions no claim rests on)" }, source: "CNF profiles master03-profiles.adoc §Functional (REST APIs: ADMIN API). SCOPE: the openEHR ADMIN API is DEVELOPMENT-state in the pinned release — ITS-REST docs/admin/Description.md §Status verbatim: \"This specification is in the `DEVELOPMENT` state\" — and ITS-REST docs/overview/Preface.md §Conformance is literally \"tbd.\", so openEHR publishes no conformance criteria for this API. Claims here are pinned to ITS-REST Release-1.1.0 and cover exactly the two released operations (admin_ehr_delete, admin_ehr_delete_all), derived from the released operation/RM/SM text, not from a conformance clause; the further /admin routes this server mounts are our own extensions and no claim rests on them" }
-# REALIZED ON THE EXTENSION SURFACE (#659, 2026-07-29). The CNF Profiles book
-# lists a MESSAGE API row and ITS-REST 1.1.0 publishes no such API group, so
-# there is still NO released API to conform to — but this product now mounts a
-# message resource of its own (`/message/**`, the `message-extract` +
-# `message-tdd` served_extensions families), so the row has something real to
-# gate. The evidence_exception is GONE and the row is `realization: extension`:
-# what it certifies is that the product answers on the message surface it
-# DECLARES, never that it conforms to an openEHR MESSAGE API — there is none.
-#
-# The workload_exclusion goes with EhrExtract's: the `integration_poll` journey
-# drives the same extension surface.
 MessageApi: { family: Platform, tier: OPTIONS, required: false, realization: extension, min_cases: 4, source: "CNF profiles master03-profiles.adoc §Functional (REST APIs: MESSAGE API)" }
-# TIER BY ANALOGY, release-pinned — the CNF Profiles book has NO SYSTEM row (its
-# REST-APIs table lists six: DEFINITION, EHR, DEMOGRAPHIC, QUERY, ADMIN,
-# MESSAGE), so the tier below is ours, not a book row — the same footing as
-# SmartAppLaunch. OPTIONS and required:false because no released MUST binds a
-# service to serve the API: the one released sentence about the method is the
-# descriptive §HTTP Methods table row, carrying no RFC 2119 keyword. The API's
-# STABLE state does not change that (a stable specification of a descriptive
-# row is still descriptive), so the capability may never gate CORE or STANDARD.
 SystemApi: { family: Platform, tier: OPTIONS, required: false, min_cases: 1, source: "ITS-REST docs/system/Description.md §Status (\"This specification is in the `STABLE` state\") + docs/overview/Requests_and_responses.md §HTTP Methods (\"OPTIONS | Describe the communication options for the target resource\"). SCOPE: the CNF Profiles book has no SYSTEM row, so the tier is ours by analogy with the other non-book API capabilities, and the claim covers exactly what the released docs text assigns — a 200 answer carrying Allow on the API base path. The manifest BODY and the resource path are described by no released sentence (register AMB-160), so no claim rests on them" }
-# TIER BY THE RELEASE'S OWN WORDS — the ITEM_TAG surface is OPTIONAL, stated
-# outright: ITS-REST docs/overview/Requests_and_responses.md §openehr-item-tag
-# and openehr-version-item-tag, "If the server does not support ITEM_TAGs,
-# these headers will also be unsupported." A capability a conformant service
-# may simply not have can never gate CORE or STANDARD, so OPTIONS +
-# required:false — the same footing SystemApi and SmartAppLaunch sit on (the
-# CNF Profiles book has no ITEM_TAG row either; its REST-APIs table lists six
-# API groups and its Functional table no tag capability). The tag routes live
-# INSIDE the EHR and DEMOGRAPHIC API groups, so this capability is deliberately
-# NOT EhrApi/DemographicApi: a service that answers every EHR-API operation and
-# no tag route is conformant, and folding tags into EhrApi (CORE, required)
-# would claim otherwise.
-# Floor raised 63 -> 66: the three UpdateItemTag write-schema strictness cases
-# (an undeclared member; a non-string `value`; a non-string `target_path` —
-# register AMB-205).
 ItemTags: { family: Platform, tier: OPTIONS, required: false, min_cases: 66, source: "ITS-REST docs/overview/Requests_and_responses.md §openehr-item-tag and openehr-version-item-tag (\"Both headers act as convenient wrappers around the dedicated ITEM_TAG operations\"; \"If the server does not support ITEM_TAGs, these headers will also be unsupported\") + the twenty-three released tag operations (specifications/operations/{ehr,demographic}_tags_get.yaml, {composition,ehr_status}_tags_{get,update,delete}.yaml, {person,agent,group,organisation,role}_tags_{get,update,delete}.yaml) + RM common master07-tags.adoc (the ITEM_TAG class the routes serve). SCOPE: the CNF Profiles book has no ITEM_TAG row, so the tier is ours by analogy with the other non-book capabilities; the operations have no SM interface at all (register AMB-161) and the catalogue anchors them under the reserved I_ITS_REST_ITEM_TAGS pseudo-interface. The editorial defects of the released tag surface are registered (AMB-91..97, AMB-137, AMB-138) and no claim rests on anything they leave unassigned" }
 Signing: { family: Platform, tier: STANDARD, required: false, min_cases: 13, source: "CNF profiles master03-profiles.adoc §Non-Functional (Security & Privacy: Signing); RM common (ORIGINAL_VERSION.signature)" }
 SimplifiedFormats: { family: Platform, tier: OPTIONS, required: false, min_cases: 75, source: "ITS-REST simplified_formats (SHOULD-level: OPTIONS profile, never gates CORE/STANDARD)" }
-# REPORTING QUALIFIER, release-pinned (group-15 audit) — the same DEVELOPMENT-state scope wording DemographicApi/AdminApi carry, plus the two facts uniq (register: AMB-151).
 SmartAppLaunch: { family: Platform, tier: OPTIONS, required: false, min_cases: 3, source: "ITS-REST docs/smart_app_launch (SMART on openEHR). SCOPE: the specification is DEVELOPMENT-state in the pinned release — manifest_vars.adoc verbatim: \":spec_status: DEVELOPMENT\" — it is prose-only (no OpenAPI group, no schemas), it carries exactly ONE RFC 2119 uppercase keyword in all nine chapters (master06 §Deprecated Flows, \"MUST NOT be used\"), the vendored CNF corpus never mentions it, and ITS-REST docs/overview/Preface.md §Conformance is literally \"tbd.\", so openEHR publishes no conformance criteria for it. Claims here are pinned to ITS-REST Release-1.1.0, are config-gated on the SMART resource-server role being enabled, and cover exactly the CDR's enforceable share — the /.well-known/smart-configuration document (master04 §Service Discovery + §Services + §Capabilities), the master08 §Resource Scopes grammar, and the 403-on-scope-deny discipline (overview Requests_and_responses.md §Authentication and authorization). The launch flows (master07), token issuance and grant prohibitions (master06), registration (master03) and the application typology (master05) are Authorization-Server behaviour and no claim rests on them" }
 EhrDemographicSeparation: { family: Security, tier: SEC-BASIC, required: true, min_cases: 1, source: "CNF 2.0 proposal (Security family; 2017 schedule Security BASIC lineage); RM ehr (EHR_STATUS.subject external refs / PARTY_SELF)" }
 AuthenticatedAccess: { family: Security, tier: SEC-BASIC, required: true, min_cases: 2, source: "CNF 2.0 proposal (Security family; 2017 schedule Security BASIC lineage); ITS-REST overview Requests_and_responses (HTTP status codes: 401)" }


### PR DESCRIPTION
Closes #2488

The wire-coverage finding of the EHR ch.8 (Entry package, #928) audit, plus the owner-ordered capability-matrix comment cleanup.

**Refusal family** (`commit_contribution-entry_family_invalid`), one defect per row derived from `cnf.composition.maximal` (whose OPT leaves the ISM nodes archetype-open — single-cause):

| Row | Rule |
|---|---|
| ISM state code 999 | `Current_state_valid` (instruction states group) |
| ISM transition code 999 | `Transition_valid` (instruction transitions group) |
| `action_archetype_id: ""` | `Action_archetype_id_valid` |
| `INSTRUCTION_DETAILS.activity_id: ""` | `Activity_path_valid` |

**Accepting twin** (`commit_contribution-instruction_rich`): the never-committed trimmings in one instance — full ISM_TRANSITION (in-group `536|plan step|`, a local careflow step, reasons), `ACTION.instruction_details` (LOCATABLE_REF + activity path), `INSTRUCTION.expiry_time` and a parsable `wf_definition` (master08 §Clinical Workflow Definition: "any syntax may currently be used"). ChangeSets floor 102→104.

**Also**: the capability matrix's 241-line change-narration comment ledger is stripped to a 10-line column key (owner order; values untouched, git history carries the raises).

Fresh pipeline: **1043 passed / 0 failed / 0 errored — CORE+STANDARD PASS, 1043/1043**; `cnf-runner validate` 1082 cases 0 findings; the 348-test battery green.