### PR TITLE
test(cnf): the FEEDER_AUDIT_DETAILS empty-system-id refusal twin

### DIFF
--- a/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
@@ -7,12 +7,12 @@ Runner: cnf-runner 3.17.8 · verification pack: passed
 
 | Status | Count |
 | --- | --- |
-| passed | 1045 |
+| passed | 1046 |
 | failed | 0 |
 | errored | 0 |
 | skipped | 0 |
 | not_applicable | 38 |
-| total | 1083 |
+| total | 1084 |
 
 ## By chapter
 
@@ -20,12 +20,12 @@ Grouping is the published per-chapter chart's taxonomy: chapters with their band
 
 | Chapter / band | passed | failed | errored | cited n/a |
 | --- | --- | --- | --- | --- |
-| **EHR** | 462 | 0 | 0 | 18 |
+| **EHR** | 463 | 0 | 0 | 18 |
 | — EHR resource | 25 | 0 | 0 | 2 |
 | — EHR_STATUS | 46 | 0 | 0 | 5 |
 | — COMPOSITION | 138 | 0 | 0 | 0 |
 | — DIRECTORY | 79 | 0 | 0 | 6 |
-| — CONTRIBUTION | 106 | 0 | 0 | 5 |
+| — CONTRIBUTION | 107 | 0 | 0 | 5 |
 | — Item tags | 62 | 0 | 0 | 0 |
 | — Revision history | 6 | 0 | 0 | 0 |
 | **Definitions** | 97 | 0 | 0 | 10 |
@@ -86,7 +86,7 @@ Selected gating cases per claimed capability. `inconclusive` counts cases whose 
 | EhrStatus | pass | 44 | 0 | 0 | 5 |
 | CompositionOps | pass | 59 | 0 | 0 | 0 |
 | DirectoryOps | pass | 77 | 0 | 0 | 8 |
-| ChangeSets | pass | 99 | 0 | 0 | 5 |
+| ChangeSets | pass | 100 | 0 | 0 | 5 |
 | Versioning | pass | 73 | 0 | 0 | 0 |
 | ArchetypeValidation | pass | 125 | 0 | 0 | 0 |
 | PartyOperations | pass | 86 | 0 | 0 | 4 |
@@ -175,7 +175,7 @@ Percentiles re-derive from the embedded HDR V2 histograms; the class verdict is 
 
 ## Honesty
 
-Coverage: 1045 of 1083 selected cases driven.
+Coverage: 1046 of 1084 selected cases driven.
 
 Not-executed verdicts (each cited):
 

--- a/docs/conformance/ferroehr/badge.json
+++ b/docs/conformance/ferroehr/badge.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "openEHR conformance",
-  "message": "CORE+STANDARD PASS · 1045/1045 cases",
+  "message": "CORE+STANDARD PASS · 1046/1046 cases",
   "color": "brightgreen"
 }

--- a/docs/conformance/ferroehr/results.json
+++ b/docs/conformance/ferroehr/results.json
@@ -2239,6 +2239,12 @@
       "rows_total": 1
     },
     {
+      "case": "I_EHR_CONTRIBUTION.commit_contribution-feeder_empty_system_id",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_CONTRIBUTION.commit_contribution-full_ehr_status",
       "status": "passed",
       "rows_driven": 1,

--- a/docs/conformance/ferroehr/verdicts.json
+++ b/docs/conformance/ferroehr/verdicts.json
@@ -268,7 +268,7 @@
     [
       "ChangeSets",
       {
-        "passed": 99,
+        "passed": 100,
         "failed": 0,
         "inconclusive": 0,
         "unevidenced": 5
@@ -588,9 +588,9 @@
     }
   ],
   "coverage": {
-    "selected": 1083,
-    "driven": 1045,
-    "passed": 1045,
+    "selected": 1084,
+    "driven": 1046,
+    "passed": 1046,
     "failed": 0,
     "inconclusive": 0
   }

--- a/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
+++ b/tools/cnf-runner/artifacts/corpus/MANIFEST.yaml
@@ -267,6 +267,16 @@ cnf.composition.minimal_event.feeder_audit.v1:
   validity: { verdict: valid }
   template_id: "minimal_evaluation.en.v1"
   provenance: "derived 2026-08-01 from cnf.composition.minimal_event.v1 by attaching FEEDER_AUDIT at the COMPOSITION root and a second one on the interior ELEMENT — the granularity RM common master03-archetyped_package.adoc §Structural Correspondence describes (\"separate FEEDER_AUDIT objects may need to be generated for parts of a Composition\"). The root instance populates every modelled FEEDER_AUDIT attribute: originating_system_item_ids, an inline original_content DV_PARSABLE (§Original Content: \"allows the original content item itself to be either included inline or pointed to\"), originating_system_audit and feeder_system_audit, the former carrying FEEDER_AUDIT_DETAILS.other_details as a small ITEM_TREE (\"Optional attribute to carry any custom meta-data\", feeder_audit_details.adoc §Attributes)"
+cnf.composition.minimal_event.feeder_empty_system_id:
+  source: fixtures/composition/minimal_event.feeder_empty_system_id.json
+  format: canonical-json
+  rm_versions: [">=1.0.2"]
+  validity:
+    verdict: invalid
+    defect: "a FEEDER_AUDIT_DETAILS whose mandatory system_id is the empty string"
+    spec_ref: "RM UML/classes/org.openehr.rm.common.feeder_audit_details.adoc §Invariants System_id_valid (not system_id.is_empty)"
+  template_id: "minimal_evaluation.en.v1"
+  provenance: "derived 2026-08-20 (issue #2493) from cnf.composition.minimal_event.feeder_audit.v1 with exactly one defect: every FEEDER_AUDIT_DETAILS system_id emptied"
 cnf.composition.minimal_event.feeder_audit.v2:
   source: fixtures/composition/minimal_event.feeder_audit.v2.json
   format: canonical-json

--- a/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_event.feeder_empty_system_id.json
+++ b/tools/cnf-runner/artifacts/corpus/fixtures/composition/minimal_event.feeder_empty_system_id.json
@@ -1,0 +1,223 @@
+{
+  "_type": "COMPOSITION",
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Minimal"
+  },
+  "archetype_details": {
+    "archetype_id": {
+      "value": "openEHR-EHR-COMPOSITION.minimal.v1"
+    },
+    "template_id": {
+      "value": "minimal_evaluation.en.v1"
+    },
+    "rm_version": "1.0.2"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.minimal.v1",
+  "feeder_audit": {
+    "_type": "FEEDER_AUDIT",
+    "originating_system_item_ids": [
+      {
+        "_type": "DV_IDENTIFIER",
+        "issuer": "Lab Uruguay",
+        "assigner": "Lab Uruguay",
+        "id": "ACC-2021-0917",
+        "type": "accession"
+      }
+    ],
+    "original_content": {
+      "_type": "DV_PARSABLE",
+      "value": "MSH|^~\\&|LAB|URY|CDR|URY|20210921215231||ORU^R01|MSG0001|P|2.5",
+      "formalism": "HL7v2.5"
+    },
+    "originating_system_audit": {
+      "_type": "FEEDER_AUDIT_DETAILS",
+      "system_id": "",
+      "time": {
+        "value": "2021-09-21T21:50:00-03:00"
+      },
+      "version_id": "final",
+      "other_details": {
+        "_type": "ITEM_TREE",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "feeder meta-data"
+        },
+        "archetype_node_id": "at0000",
+        "items": [
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "order id"
+            },
+            "archetype_node_id": "at0001",
+            "value": {
+              "_type": "DV_TEXT",
+              "value": "PLC-77421"
+            }
+          }
+        ]
+      }
+    },
+    "feeder_system_audit": {
+      "_type": "FEEDER_AUDIT_DETAILS",
+      "system_id": "",
+      "time": {
+        "value": "2021-09-21T21:51:00-03:00"
+      }
+    }
+  },
+  "language": {
+    "terminology_id": {
+      "value": "ISO_639-1"
+    },
+    "code_string": "en"
+  },
+  "territory": {
+    "terminology_id": {
+      "value": "ISO_3166-1"
+    },
+    "code_string": "UY"
+  },
+  "category": {
+    "value": "event",
+    "defining_code": {
+      "terminology_id": {
+        "value": "openehr"
+      },
+      "code_string": "433"
+    }
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "external_ref": {
+      "id": {
+        "_type": "HIER_OBJECT_ID",
+        "value": "fc376c46-29c1-4090-bc01-5cc046af7f26"
+      },
+      "namespace": "DEMOGRAPHIC",
+      "type": "PERSON"
+    },
+    "name": "Dr. House"
+  },
+  "context": {
+    "start_time": {
+      "value": "2021-09-21T21:52:31.927-03:00"
+    },
+    "setting": {
+      "value": "primary medical care",
+      "defining_code": {
+        "terminology_id": {
+          "value": "openehr"
+        },
+        "code_string": "228"
+      }
+    },
+    "participations": [
+      {
+        "function": {
+          "value": "legal guardian consent author"
+        },
+        "performer": {
+          "_type": "PARTY_RELATED",
+          "name": "Alexandra Alamo",
+          "relationship": {
+            "value": "mother",
+            "defining_code": {
+              "terminology_id": {
+                "value": "openehr"
+              },
+              "code_string": "10"
+            }
+          }
+        },
+        "mode": {
+          "value": "not specified",
+          "defining_code": {
+            "terminology_id": {
+              "value": "openehr"
+            },
+            "code_string": "193"
+          }
+        }
+      }
+    ]
+  },
+  "content": [
+    {
+      "_type": "EVALUATION",
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Minimal"
+      },
+      "archetype_details": {
+        "archetype_id": {
+          "value": "openEHR-EHR-EVALUATION.minimal.v1"
+        },
+        "template_id": {
+          "value": "minimal_evaluation.en.v1"
+        },
+        "rm_version": "1.0.2"
+      },
+      "archetype_node_id": "openEHR-EHR-EVALUATION.minimal.v1",
+      "language": {
+        "terminology_id": {
+          "value": "ISO_639-1"
+        },
+        "code_string": "en"
+      },
+      "encoding": {
+        "terminology_id": {
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "data": {
+        "_type": "ITEM_TREE",
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Arbol"
+        },
+        "archetype_node_id": "at0001",
+        "items": [
+          {
+            "_type": "ELEMENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "quantity"
+            },
+            "archetype_node_id": "at0002",
+            "value": {
+              "_type": "DV_QUANTITY",
+              "magnitude": 78.5,
+              "units": "kg"
+            },
+            "feeder_audit": {
+              "_type": "FEEDER_AUDIT",
+              "originating_system_item_ids": [
+                {
+                  "_type": "DV_IDENTIFIER",
+                  "issuer": "Lab Uruguay",
+                  "assigner": "Lab Uruguay",
+                  "id": "OBX-1",
+                  "type": "observation"
+                }
+              ],
+              "originating_system_audit": {
+                "_type": "FEEDER_AUDIT_DETAILS",
+                "system_id": "",
+                "time": {
+                  "value": "2021-09-21T21:50:00-03:00"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-feeder_empty_system_id.yaml
+++ b/tools/cnf-runner/artifacts/schedule/contribution/I_EHR_CONTRIBUTION.commit_contribution-feeder_empty_system_id.yaml
@@ -1,0 +1,37 @@
+# The FEEDER_AUDIT_DETAILS System_id_valid refusal twin (RM Integration
+# ch.2, issue #2493): `not system_id.is_empty`
+# (feeder_audit_details.adoc §Invariants). One defect — the accepted
+# feeder-audit fixture with its system ids emptied; the accepting twin is
+# cnf.composition.minimal_event.feeder_audit.v1 (committed green by the
+# feeder_audit_carried flow).
+id: I_EHR_CONTRIBUTION.commit_contribution-feeder_empty_system_id
+kind: functional
+component: EHR_CONTRIBUTION
+sm_operation: I_EHR_CONTRIBUTION.commit_contribution
+capabilities: [ChangeSets]
+profiles: [CORE]
+test_purpose: "A committed FEEDER_AUDIT_DETAILS whose mandatory system_id is the empty string is refused as invalid content, and no version is created."
+description: "commit a composition whose feeder audit carries an empty system_id"
+spec_refs:
+  - "SM openehr_platform §I_EHR_CONTRIBUTION.commit_contribution"
+  - "RM UML/classes/org.openehr.rm.common.feeder_audit_details.adoc §Invariants (System_id_valid: not system_id.is_empty)"
+  - "ITS-REST overview Requests_and_responses.md §HTTP status codes (the semantic 422 branch)"
+applies: { rm: ">=1.0.2" }
+requires:
+  server: any
+  templates: [cnf.opt.minimal_event]
+  ehr: { commits: none }
+parameters:
+  iteration: reset_per_row
+  fixture_set:
+    - { data_set: cnf.composition.minimal_event.feeder_empty_system_id, expected: validation_failed, defect: "empty FEEDER_AUDIT_DETAILS.system_id (System_id_valid)" }
+flow:
+  - step: 1
+    call: commit_contribution
+    with:
+      versions: "${ds:fixture}"
+      audit: { change_type: creation, committer: { name: "conformance tester" } }
+    expect: "${fixture.expected}"
+postconditions:
+  - assert: version
+    count: 0

--- a/tools/cnf-runner/artifacts/vocab/capability_matrix.yaml
+++ b/tools/cnf-runner/artifacts/vocab/capability_matrix.yaml
@@ -18,7 +18,7 @@ EhrOperations: { family: Platform, tier: CORE, required: true, min_cases: 24, so
 EhrStatus: { family: Platform, tier: CORE, required: true, min_cases: 49, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: EHR Status)" }
 CompositionOps: { family: Platform, tier: CORE, required: true, min_cases: 59, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Composition Operations)" }
 DirectoryOps: { family: Platform, tier: STANDARD, required: true, min_cases: 85, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Directory Operations)" }
-ChangeSets: { family: Platform, tier: CORE, required: true, min_cases: 104, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Change sets)" }
+ChangeSets: { family: Platform, tier: CORE, required: true, min_cases: 105, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Change sets)" }
 Versioning: { family: Platform, tier: CORE, required: true, min_cases: 73, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Versioning)" }
 ArchetypeValidation: { family: Platform, tier: CORE, required: true, min_cases: 125, source: "CNF profiles master03-profiles.adoc §Functional (EHR Persistence: Archetype Validation)" }
 PartyOperations: { family: Platform, tier: OPTIONS, required: false, min_cases: 90, source: "CNF profiles master03-profiles.adoc §Functional (Demographic Persistence: Party Operations)" }


### PR DESCRIPTION
Closes #2493

The wire-coverage finding of the Integration ch.2 (#938) audit: `FEEDER_AUDIT_DETAILS.System_id_valid` (`not system_id.is_empty`) is enforced and register-pinned, but had no refusal case while the acceptance side commits green (the `minimal_event.feeder_audit` fixtures with fully-populated feeder audits at two depths).

One single-defect fixture — the accepted feeder v1 with every `FEEDER_AUDIT_DETAILS.system_id` emptied — expected `validation_failed`, version count 0. ChangeSets floor 104→105.

Fresh pipeline: **1046 passed / 0 failed / 0 errored — CORE+STANDARD PASS, 1046/1046**; `cnf-runner validate` 1085 cases 0 findings; the 348-test battery green.