### PR TITLE
test(review): reviewer-configuration probe — throwaway, never merged

### DIFF
--- a/app/ferroehr/src/banner.rs
+++ b/app/ferroehr/src/banner.rs
@@ -121,3 +121,5 @@ mod tests {
         );
     }
 }
+
+// TODO: verify the reviewer surfaces this comment

--- a/crates/openehr-base/src/v1_3/foundation_types/interval/cardinality.rs
+++ b/crates/openehr-base/src/v1_3/foundation_types/interval/cardinality.rs
@@ -20,3 +20,5 @@ pub struct Cardinality {
     /// True if the members of the container attribute to which this cardinality refers are unique.
     pub is_unique: bool,
 }
+
+// TODO: verify the reviewer surfaces this comment

--- a/docs/conformance/coverage-report.md
+++ b/docs/conformance/coverage-report.md
@@ -397,3 +397,5 @@ The element list above is AUTHORED; this table is DERIVED — every `#`/`##` sec
 | `ITS-REST/specifications/docs/overview/Requests_and_responses.md` | 17 | 17 | 0 | 0 |
 | `ITS-REST/specifications/docs/overview/Resources.md` | 9 | 9 | 0 | 0 |
 
+
+probe line for the reviewer-configuration verification (throwaway).


### PR DESCRIPTION
The #2148 configuration-verification probe. This PR is deliberate noise and will be CLOSED UNMERGED once the review posts.

It touches exactly three things:

- a `// @generated` spec file with no accompanying emitter change — the **Generated files are not hand-edited** custom check must fail;
- `docs/conformance/coverage-report.md` — a `path_filters` exclusion, so the reviewer must post **no** finding on it;
- `app/ferroehr/src/banner.rs` with a `// TODO` carrying no issue number — the `**/*.rs` path instructions name that shape, so a finding must surface it.

CI failures on this branch (comment-style, codegen-drift) are expected and are the point — the local guards catch the same defects. Do not merge; no changelog (throwaway).