### PR TITLE
feat(fhir): where()/first() mapping paths and cross-terminology code translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
+- **FHIR mapping definitions gained `where()`/`first()` paths and
+  cross-terminology code translation.** The connector's FHIRPath subset now
+  supports single-condition `where(path = literal)` filters and `first()`
+  (picking, say, a component by its code instead of its position), and a
+  `coded` entry can declare `translate` to convert codes between
+  terminologies at ingest time via a configured FHIR terminology server's
+  `ConceptMap/$translate`. Only strictly equivalent matches are taken; an
+  untranslatable required entry refuses the ingest, an optional one writes
+  nothing, and a translate mapping without a configured terminology server
+  is a configuration error — the untranslated code is never passed through
+  under the target terminology.
+
 - **The whole-repository dump archives standalone demographic containers.**
   `POST {base}/admin/dump` now writes a demographic wave beside the EHR wave:
   parties and party relationships that live outside any EHR land in

--- a/app/ferroehr-ext/src/fhir/mapping.rs
+++ b/app/ferroehr-ext/src/fhir/mapping.rs
@@ -26,16 +26,25 @@
 //! here; the orchestration (mapping-store lookup, EHR resolution, commit)
 //! lives in the parent [`super`] module on `FerroEhrService`.
 //!
-//! The FHIR side is a deliberate **subset** of `FHIRPath`: object-field
-//! navigation and array indexing only (`code.coding[0].code`,
-//! `component[1].valueQuantity.value`), never the full language (no functions,
-//! filters, `where()`, `resolve()`, unions, `$this`, arithmetic) — which is
-//! what the flat, single-value leaf extraction openEHR FLAT paths need.
-// TODO(#2458): richer FHIRPath support and cross-terminology code translation
-// (through the TerminologyService seam).
-//! `code_map` binds a FHIR system URL to an openEHR `terminology_id` and passes
-//! the code through unchanged; the built COMPOSITION's own terminology
-//! validation is the authority on the result.
+//! The FHIR side is a deliberate **subset** of `FHIRPath`
+//! (<https://hl7.org/fhirpath/>): object-field navigation, array indexing,
+//! `first()`, and single-condition `where(path = literal)` filters
+//! (`code.coding.where(system = 'http://loinc.org').code`,
+//! `component.where(code.coding[0].code = '8480-6').valueQuantity.value`) —
+//! never the full language (no other functions, unions, `$this`, arithmetic).
+//! `FHIRPath` defines `where()` over collections; this single-value subset
+//! takes the FIRST matching element, which is what the flat, single-value
+//! leaf extraction openEHR FLAT paths need.
+//!
+//! `code_map` binds a FHIR system URL to an openEHR `terminology_id` and
+//! passes the code through unchanged. A `coded` entry may additionally
+//! declare `translate`, requesting cross-terminology code translation: the
+//! orchestrator resolves each [`TranslationRequest`] (from
+//! [`collect_translations`]) through the platform's terminology seam (FHIR
+//! `ConceptMap/$translate`) and hands the answers back as
+//! [`CodeTranslations`] — this module stays pure and never talks to a
+//! server. The built COMPOSITION's own terminology validation remains the
+//! authority on the result.
 
 #![expect(
     clippy::disallowed_types,
@@ -145,7 +154,70 @@ pub enum Transform {
         /// `FHIRPath`-lite path to the human-readable display text.
         #[serde(default)]
         display_path: Option<String>,
+        /// Cross-terminology translation of the code before it is written
+        /// (resolved by the orchestrator through the terminology seam).
+        #[serde(default)]
+        translate: Option<CodeTranslate>,
     },
+}
+
+/// A `coded` entry's translation request: translate the source code into
+/// `target_system` before writing it, via FHIR `ConceptMap/$translate`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CodeTranslate {
+    /// The FHIR code-system URL to translate INTO (the `targetsystem`
+    /// parameter; also the `code_map` key that names the leaf's
+    /// `terminology_id`).
+    pub target_system: String,
+    /// An explicit `ConceptMap` canonical URL (the `url` parameter); absent =
+    /// the terminology server picks from its registered maps.
+    #[serde(default)]
+    pub concept_map: Option<String>,
+}
+
+/// One code the orchestrator must translate before [`build_flat`] can apply a
+/// `translate`-declaring entry: the source coding, the target system, and the
+/// openEHR terminology token the entry's `code_map` binds the target to (the
+/// routing key for the terminology seam).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct TranslationRequest {
+    /// The source code's system URL (from the entry's `system_path`).
+    pub system: String,
+    /// The source code.
+    pub code: String,
+    /// The FHIR system URL to translate into.
+    pub target_system: String,
+    /// The explicit `ConceptMap` URL, when the entry pins one.
+    pub concept_map: Option<String>,
+    /// The openEHR `terminology_id` the entry's `code_map` resolves
+    /// `target_system` to (`None` when the map has no binding — the
+    /// orchestrator then routes to its default provider).
+    pub route_terminology: Option<String>,
+}
+
+/// A resolved translation: the target code (and display, when the server
+/// returned one).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TranslatedCode {
+    /// The translated code in the target system.
+    pub code: String,
+    /// The target concept's display text.
+    pub display: Option<String>,
+}
+
+/// The resolved answers [`build_flat`] reads, keyed by
+/// `(system, code, target_system)`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CodeTranslations(pub BTreeMap<(String, String, String), TranslatedCode>);
+
+impl CodeTranslations {
+    /// Looks up the translation for one source coding into one target system.
+    #[must_use]
+    pub fn get(&self, system: &str, code: &str, target_system: &str) -> Option<&TranslatedCode> {
+        self.0
+            .get(&(system.to_owned(), code.to_owned(), target_system.to_owned()))
+    }
 }
 
 /// A FHIR→openEHR mapping transform failure.
@@ -176,6 +248,26 @@ pub enum FhirMapError {
     /// A `coded` entry was declared without a `fhir_path`.
     #[error("coded mapping entry for '{0}' has no fhir_path")]
     CodedWithoutSource(String),
+    /// A `translate`-declaring entry's source coding had no system to
+    /// translate from (no `system_path`, or nothing at it).
+    #[error("coded mapping entry for '{0}' declares translate but resolves no source system")]
+    TranslateWithoutSystem(String),
+    /// A required entry's code could not be translated into the target
+    /// system (the terminology seam returned no equivalent concept).
+    #[error(
+        "required code '{code}' ({system}) has no translation into '{target_system}' \
+         (→ '{openehr_path}')"
+    )]
+    Untranslatable {
+        /// The source code's system URL.
+        system: String,
+        /// The source code.
+        code: String,
+        /// The FHIR system URL the entry translates into.
+        target_system: String,
+        /// The FLAT target path.
+        openehr_path: String,
+    },
     /// The reverse transform could not flatten the COMPOSITION (its
     /// `WebTemplate` walk failed) — a server-side error (the stored
     /// COMPOSITION should always flatten).
@@ -190,32 +282,110 @@ pub enum FhirMapError {
 
 /// Resolve a **`FHIRPath`-lite** dot-path against a JSON value.
 ///
-/// Grammar (a deliberate subset of `FHIRPath` — see the module NOTE):
+/// Grammar (a deliberate subset of `FHIRPath`,
+/// <https://hl7.org/fhirpath/> §5.1 `first()` / §5.2 `where()`):
 ///
 /// ```text
 /// path    := segment ('.' segment)*
-/// segment := name index? | index
+/// segment := name index? | index | 'first()' | 'where(' path '=' literal ')'
 /// name    := [A-Za-z_][A-Za-z0-9_]*
 /// index   := '[' digits ']'
+/// literal := '\'' chars '\'' | digits ('.' digits)? | 'true' | 'false'
 /// ```
 ///
-/// A `name` selects an object field; an `index` selects an array element. So
-/// `component[0].valueQuantity.value`, `code.coding[0].code`,
-/// `subject.reference`, and `meta.profile[0]` all resolve. Anything richer
-/// (functions, filters, unions) is out of scope and yields `None`.
+/// A `name` selects an object field; an `index` selects an array element;
+/// `first()` selects an array's first element; `where(path = literal)` on an
+/// array selects the FIRST element whose `path` equals the literal (on an
+/// object, the object itself when it matches). `FHIRPath` proper evaluates
+/// `where()` over collections — this single-value subset takes the first
+/// match, because a FLAT leaf is one value. So
+/// `component.where(code.coding[0].code = '8480-6').valueQuantity.value`,
+/// `code.coding.where(system = 'http://loinc.org').code`, and
+/// `meta.profile[0]` all resolve. Anything richer (other functions, unions,
+/// arithmetic) is out of scope and yields `None`.
 #[must_use]
 pub fn resolve<'a>(root: &'a Value, path: &str) -> Option<&'a Value> {
     let mut cur = root;
-    for seg in path.split('.') {
-        let (name, index) = parse_segment(seg)?;
-        if !name.is_empty() {
-            cur = cur.get(name)?;
-        }
-        if let Some(i) = index {
-            cur = cur.get(i)?;
+    for seg in split_steps(path)? {
+        if seg == "first()" {
+            cur = cur.as_array()?.first()?;
+        } else if let Some(inner) = seg.strip_prefix("where(").and_then(|r| r.strip_suffix(')')) {
+            let (lhs, rhs) = parse_condition(inner)?;
+            cur = match cur {
+                Value::Array(items) => items
+                    .iter()
+                    .find(|item| resolve(item, lhs).is_some_and(|v| *v == rhs))?,
+                other if resolve(other, lhs).is_some_and(|v| *v == rhs) => other,
+                _ => return None,
+            };
+        } else {
+            let (name, index) = parse_segment(seg)?;
+            if !name.is_empty() {
+                cur = cur.get(name)?;
+            }
+            if let Some(i) = index {
+                cur = cur.get(i)?;
+            }
         }
     }
     Some(cur)
+}
+
+/// Splits a path on `.` at depth zero — dots inside `where(…)` parentheses or
+/// single-quoted literals do not split. `None` on unbalanced parens/quotes.
+fn split_steps(path: &str) -> Option<Vec<&str>> {
+    let mut steps = Vec::new();
+    let mut depth = 0_u32;
+    let mut in_quote = false;
+    let mut start = 0;
+    for (i, c) in path.char_indices() {
+        match c {
+            '\'' => in_quote = !in_quote,
+            '(' if !in_quote => depth += 1,
+            ')' if !in_quote => depth = depth.checked_sub(1)?,
+            '.' if !in_quote && depth == 0 => {
+                steps.push(path.get(start..i)?);
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    if depth != 0 || in_quote {
+        return None;
+    }
+    steps.push(path.get(start..)?);
+    Some(steps)
+}
+
+/// Parses a `where()` condition body — `path = literal` — into the comparison
+/// path and the literal's JSON value.
+fn parse_condition(inner: &str) -> Option<(&str, Value)> {
+    // The `=` split must ignore any `=` inside the quoted literal, so scan at
+    // quote depth zero.
+    let mut in_quote = false;
+    let eq = inner.char_indices().find_map(|(i, c)| match c {
+        '\'' => {
+            in_quote = !in_quote;
+            None
+        }
+        '=' if !in_quote => Some(i),
+        _ => None,
+    })?;
+    let lhs = inner.get(..eq)?.trim();
+    let raw = inner.get(eq + 1..)?.trim();
+    if lhs.is_empty() || raw.is_empty() {
+        return None;
+    }
+    let rhs = if let Some(s) = raw.strip_prefix('\'').and_then(|r| r.strip_suffix('\'')) {
+        Value::String(s.to_owned())
+    } else if raw == "true" || raw == "false" {
+        Value::Bool(raw == "true")
+    } else {
+        serde_json::from_str::<serde_json::Number>(raw)
+            .ok()
+            .map(Value::Number)?
+    };
+    Some((lhs, rhs))
 }
 
 /// Splits one path segment into its `(name, index)` parts.
@@ -236,28 +406,89 @@ pub fn parse_segment(seg: &str) -> Option<(&str, Option<usize>)> {
 }
 
 /// Build the FLAT map for a resource under a mapping definition: the seed
-/// `context` keys, then each entry's produced leaf(s).
+/// `context` keys, then each entry's produced leaf(s). `translations` carries
+/// the orchestrator's resolved [`TranslationRequest`] answers (empty when no
+/// entry declares `translate`).
 /// # Errors
 /// Returns [`FhirMapError`] when a mapping entry cannot be applied to the
-/// resource (missing/mistyped member, unresolvable path).
+/// resource (missing/mistyped member, unresolvable path, an untranslatable
+/// required code).
 pub fn build_flat(
     resource: &Value,
     def: &FhirMappingDefinition,
+    translations: &CodeTranslations,
 ) -> Result<Map<String, Value>, FhirMapError> {
     let mut flat = Map::new();
     for (key, value) in &def.context {
         flat.insert(key.clone(), value.clone());
     }
     for entry in &def.entries {
-        apply_entry(resource, entry, &mut flat)?;
+        apply_entry(resource, entry, translations, &mut flat)?;
     }
     Ok(flat)
+}
+
+/// Enumerate the translations `def` needs for `resource`: one request per
+/// `translate`-declaring coded entry whose source code + system resolve.
+/// Deduplicated and ordered; the orchestrator resolves each through the
+/// terminology seam and hands the answers to [`build_flat`].
+/// # Errors
+/// Returns [`FhirMapError::TranslateWithoutSystem`] when a `translate` entry
+/// resolves a code but no source system, and
+/// [`FhirMapError::MissingField`] when a required entry's code is absent —
+/// the same refusals [`build_flat`] would reach, surfaced before any
+/// terminology call.
+pub fn collect_translations(
+    resource: &Value,
+    def: &FhirMappingDefinition,
+) -> Result<Vec<TranslationRequest>, FhirMapError> {
+    let mut requests = std::collections::BTreeSet::new();
+    for entry in &def.entries {
+        let Transform::Coded {
+            system_path,
+            translate: Some(translate),
+            ..
+        } = &entry.transform
+        else {
+            continue;
+        };
+        if entry.constant.is_some() {
+            continue;
+        }
+        let fhir_path = entry
+            .fhir_path
+            .as_deref()
+            .ok_or_else(|| FhirMapError::CodedWithoutSource(entry.openehr_path.clone()))?;
+        let Some(code) = resolve(resource, fhir_path).and_then(Value::as_str) else {
+            if entry.required {
+                return Err(FhirMapError::MissingField {
+                    fhir_path: fhir_path.to_owned(),
+                    openehr_path: entry.openehr_path.clone(),
+                });
+            }
+            continue;
+        };
+        let system = system_path
+            .as_deref()
+            .and_then(|p| resolve(resource, p))
+            .and_then(Value::as_str)
+            .ok_or_else(|| FhirMapError::TranslateWithoutSystem(entry.openehr_path.clone()))?;
+        requests.insert(TranslationRequest {
+            system: system.to_owned(),
+            code: code.to_owned(),
+            target_system: translate.target_system.clone(),
+            concept_map: translate.concept_map.clone(),
+            route_terminology: entry.code_map.get(&translate.target_system).cloned(),
+        });
+    }
+    Ok(requests.into_iter().collect())
 }
 
 /// Apply one entry, writing zero or more FLAT leaves into `flat`.
 fn apply_entry(
     resource: &Value,
     entry: &MappingEntry,
+    translations: &CodeTranslations,
     flat: &mut Map<String, Value>,
 ) -> Result<(), FhirMapError> {
     // A constant short-circuits any source read (any transform).
@@ -290,6 +521,7 @@ fn apply_entry(
         Transform::Coded {
             system_path,
             display_path,
+            translate,
         } => {
             let fhir_path = entry
                 .fhir_path
@@ -304,11 +536,51 @@ fn apply_entry(
                 }
                 return Ok(());
             };
-            flat.insert(format!("{}|code", entry.openehr_path), json!(code));
             let system = system_path
                 .as_deref()
                 .and_then(|p| resolve(resource, p))
                 .and_then(Value::as_str);
+            if let Some(translate) = translate {
+                let system = system.ok_or_else(|| {
+                    FhirMapError::TranslateWithoutSystem(entry.openehr_path.clone())
+                })?;
+                let Some(translated) = translations.get(system, code, &translate.target_system)
+                else {
+                    // No equivalent concept: writing the SOURCE code under the
+                    // TARGET terminology would be a silently wrong clinical
+                    // value, so a required entry refuses and an optional one
+                    // writes nothing.
+                    if entry.required {
+                        return Err(FhirMapError::Untranslatable {
+                            system: system.to_owned(),
+                            code: code.to_owned(),
+                            target_system: translate.target_system.clone(),
+                            openehr_path: entry.openehr_path.clone(),
+                        });
+                    }
+                    return Ok(());
+                };
+                flat.insert(
+                    format!("{}|code", entry.openehr_path),
+                    json!(translated.code),
+                );
+                let terminology = entry
+                    .code_map
+                    .get(&translate.target_system)
+                    .or_else(|| entry.code_map.get("*"))
+                    .map_or("local", String::as_str);
+                flat.insert(
+                    format!("{}|terminology", entry.openehr_path),
+                    json!(terminology),
+                );
+                // The translated concept's own display wins; the source
+                // resource's display_path text names the SOURCE concept.
+                if let Some(display) = &translated.display {
+                    flat.insert(format!("{}|value", entry.openehr_path), json!(display));
+                }
+                return Ok(());
+            }
+            flat.insert(format!("{}|code", entry.openehr_path), json!(code));
             let terminology = system
                 .and_then(|s| entry.code_map.get(s))
                 .or_else(|| entry.code_map.get("*"))
@@ -476,7 +748,7 @@ mod tests {
                 { "valueQuantity": { "value": 80 } }
             ]
         });
-        let flat = build_flat(&resource, &d).expect("build_flat");
+        let flat = build_flat(&resource, &d, &CodeTranslations::default()).expect("build_flat");
         assert_eq!(
             flat["encounter_training_sample/blood_pressure_training_sample:0/systolic|magnitude"],
             json!(120)
@@ -515,7 +787,7 @@ mod tests {
             "resourceType": "Condition",
             "code": { "coding": [{ "system": "http://snomed.info/sct", "code": "73211009", "display": "Diabetes mellitus" }] }
         });
-        let flat = build_flat(&resource, &d).expect("build_flat");
+        let flat = build_flat(&resource, &d, &CodeTranslations::default()).expect("build_flat");
         assert_eq!(flat["x/problem|code"], json!("73211009"));
         assert_eq!(flat["x/problem|terminology"], json!("SNOMED-CT"));
         assert_eq!(flat["x/problem|value"], json!("Diabetes mellitus"));
@@ -533,7 +805,7 @@ mod tests {
         }));
         let resource =
             json!({ "code": { "coding": [{ "system": "http://unknown", "code": "z" }] } });
-        let flat = build_flat(&resource, &d).expect("build_flat");
+        let flat = build_flat(&resource, &d, &CodeTranslations::default()).expect("build_flat");
         assert_eq!(flat["x/problem|terminology"], json!("local"));
     }
 
@@ -544,7 +816,7 @@ mod tests {
             "subject": { "reference_path": "id", "namespace": "fhir" },
             "entries": [ { "openehr_path": "x/y", "fhir_path": "absent.here", "required": true } ]
         }));
-        let err = build_flat(&json!({}), &d).unwrap_err();
+        let err = build_flat(&json!({}), &d, &CodeTranslations::default()).unwrap_err();
         assert!(matches!(err, FhirMapError::MissingField { .. }));
     }
 
@@ -621,7 +893,7 @@ mod tests {
             ]
         });
 
-        let flat = build_flat(&resource, &d).expect("build_flat");
+        let flat = build_flat(&resource, &d, &CodeTranslations::default()).expect("build_flat");
         // Fixed ctx/time (ITS-REST simplified_formats master04 §Context) so the
         // built composition is deterministic under test.
         let mut comp = composition_from_flat(&flat, &wt, "2024-01-01T00:00:00Z")
@@ -652,5 +924,167 @@ mod tests {
         let s = comp.to_string();
         assert!(s.contains("118"), "systolic magnitude present");
         assert!(s.contains("76"), "diastolic magnitude present");
+    }
+
+    // ── `FHIRPath`-lite: where() + first() ───────────────────────────────────
+    #[test]
+    fn resolve_where_filters_and_first_selects() {
+        let r = json!({
+            "code": { "coding": [
+                { "system": "http://loinc.org", "code": "8480-6" },
+                { "system": "http://snomed.info/sct", "code": "271649006" }
+            ]},
+            "component": [
+                { "code": { "coding": [{ "code": "8480-6" }] },
+                  "valueQuantity": { "value": 120 } },
+                { "code": { "coding": [{ "code": "8462-4" }] },
+                  "valueQuantity": { "value": 80 } }
+            ]
+        });
+        assert_eq!(
+            resolve(
+                &r,
+                "code.coding.where(system = 'http://snomed.info/sct').code"
+            )
+            .and_then(Value::as_str),
+            Some("271649006")
+        );
+        assert_eq!(
+            resolve(
+                &r,
+                "component.where(code.coding[0].code = '8462-4').valueQuantity.value"
+            )
+            .and_then(Value::as_i64),
+            Some(80),
+            "the filter picks by content, not position"
+        );
+        assert_eq!(
+            resolve(&r, "code.coding.first().code").and_then(Value::as_str),
+            Some("8480-6")
+        );
+        assert!(
+            resolve(
+                &r,
+                "component.where(code.coding[0].code = 'absent').valueQuantity"
+            )
+            .is_none()
+        );
+        // A numeric literal compares as a number, not a string.
+        assert!(
+            resolve(
+                &r,
+                "component.where(valueQuantity.value = 120).code.coding[0].code"
+            )
+            .is_some()
+        );
+        // Malformed paths yield None, never a panic.
+        assert!(resolve(&r, "code.where(system = 'unterminated").is_none());
+        assert!(resolve(&r, "code.where(system 'no-eq')").is_none());
+        assert!(resolve(&r, "code.coding.where()").is_none());
+    }
+
+    // ── translate: collect + apply through CodeTranslations ─────────────────
+    fn translate_def(required: bool) -> FhirMappingDefinition {
+        def(json!({
+            "resource_type": "Condition", "template_id": "t",
+            "subject": { "reference_path": "id", "namespace": "fhir" },
+            "entries": [
+                { "openehr_path": "x/problem",
+                  "fhir_path": "code.coding[0].code",
+                  "required": required,
+                  "transform": { "kind": "coded",
+                    "system_path": "code.coding[0].system",
+                    "display_path": "code.coding[0].display",
+                    "translate": { "target_system": "http://snomed.info/sct" } },
+                  "code_map": { "http://snomed.info/sct": "SNOMED-CT" } }
+            ]
+        }))
+    }
+
+    fn loinc_condition() -> Value {
+        json!({ "code": { "coding": [{
+            "system": "http://loinc.org", "code": "8480-6", "display": "Systolic BP"
+        }] } })
+    }
+
+    #[test]
+    fn collect_translations_enumerates_the_route() {
+        let requests =
+            collect_translations(&loinc_condition(), &translate_def(false)).expect("collect");
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].system, "http://loinc.org");
+        assert_eq!(requests[0].code, "8480-6");
+        assert_eq!(requests[0].target_system, "http://snomed.info/sct");
+        assert_eq!(requests[0].route_terminology.as_deref(), Some("SNOMED-CT"));
+    }
+
+    #[test]
+    fn build_flat_translated_code_wins_over_source() {
+        let mut translations = CodeTranslations::default();
+        translations.0.insert(
+            (
+                "http://loinc.org".to_owned(),
+                "8480-6".to_owned(),
+                "http://snomed.info/sct".to_owned(),
+            ),
+            TranslatedCode {
+                code: "271649006".to_owned(),
+                display: Some("Systolic blood pressure".to_owned()),
+            },
+        );
+        let flat =
+            build_flat(&loinc_condition(), &translate_def(false), &translations).expect("build");
+        assert_eq!(flat["x/problem|code"], json!("271649006"));
+        assert_eq!(flat["x/problem|terminology"], json!("SNOMED-CT"));
+        assert_eq!(
+            flat["x/problem|value"],
+            json!("Systolic blood pressure"),
+            "the translated concept's display wins over display_path"
+        );
+    }
+
+    #[test]
+    fn build_flat_untranslated_required_refuses_and_optional_writes_nothing() {
+        let err = build_flat(
+            &loinc_condition(),
+            &translate_def(true),
+            &CodeTranslations::default(),
+        )
+        .unwrap_err();
+        assert!(matches!(err, FhirMapError::Untranslatable { .. }));
+
+        let flat = build_flat(
+            &loinc_condition(),
+            &translate_def(false),
+            &CodeTranslations::default(),
+        )
+        .expect("build");
+        assert!(
+            !flat.contains_key("x/problem|code"),
+            "an untranslatable optional entry writes NO leaf — never the source code \
+             under the target terminology"
+        );
+    }
+
+    #[test]
+    fn translate_without_source_system_refuses() {
+        let d = def(json!({
+            "resource_type": "Condition", "template_id": "t",
+            "subject": { "reference_path": "id", "namespace": "fhir" },
+            "entries": [
+                { "openehr_path": "x/problem", "fhir_path": "code.coding[0].code",
+                  "transform": { "kind": "coded",
+                    "translate": { "target_system": "http://snomed.info/sct" } } }
+            ]
+        }));
+        let resource = json!({ "code": { "coding": [{ "code": "8480-6" }] } });
+        assert!(matches!(
+            collect_translations(&resource, &d).unwrap_err(),
+            FhirMapError::TranslateWithoutSystem(_)
+        ));
+        assert!(matches!(
+            build_flat(&resource, &d, &CodeTranslations::default()).unwrap_err(),
+            FhirMapError::TranslateWithoutSystem(_)
+        ));
     }
 }

--- a/app/ferroehr-ext/src/fhir/reverse.rs
+++ b/app/ferroehr-ext/src/fhir/reverse.rs
@@ -105,9 +105,13 @@ fn reverse_entry(flat: &impl FlatLookup, entry: &MappingEntry, resource: &mut Va
                 set_at(resource, up, u.clone());
             }
         }
+        // NOTE: no openEHR spec governs FHIR conversion — our own design: a
+        // `translate` entry reverses to the stored (translated) coding, whose
+        // `|code`/`|terminology` pair is internally consistent.
         Transform::Coded {
             system_path,
             display_path,
+            translate: _,
         } => {
             if let Some(code) = flat.lookup(&format!("{}|code", entry.openehr_path)) {
                 set_at(resource, fhir_path, code.clone());
@@ -226,7 +230,7 @@ mod tests {
     use openehr_its::opt14;
     use serde_json::json;
 
-    use super::super::mapping::build_flat;
+    use super::super::mapping::{CodeTranslations, build_flat};
     use super::*;
 
     fn def(v: Value) -> FhirMappingDefinition {
@@ -330,7 +334,7 @@ mod tests {
 
         // FHIR → inbound build → COMPOSITION. Fixed ctx/time (ITS-REST
         // simplified_formats master04 §Context) keeps the build deterministic.
-        let flat = build_flat(&original, &d).expect("build_flat");
+        let flat = build_flat(&original, &d, &CodeTranslations::default()).expect("build_flat");
         let comp = composition_from_flat(&flat, &wt, "2024-01-01T00:00:00Z").expect("from_flat");
 
         // COMPOSITION → reverse → FHIR (subject id is the post-strip subject).

--- a/app/ferroehr-ext/src/fhir/terminology.rs
+++ b/app/ferroehr-ext/src/fhir/terminology.rs
@@ -38,6 +38,23 @@ pub struct ParametersView {
     pub codes: BTreeMap<String, String>,
     /// `valueString` parameters (e.g. `$lookup` `display`).
     pub strings: BTreeMap<String, String>,
+    /// `ConceptMap/$translate` `match` parameters, in response order.
+    pub matches: Vec<TranslateMatch>,
+}
+
+/// One `match` of a `ConceptMap/$translate` response: the `equivalence` code
+/// plus the target `concept` Coding's members
+/// (<https://hl7.org/fhir/R4B/conceptmap-operation-translate.html>).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TranslateMatch {
+    /// The match's `equivalence` (`equivalent`, `equal`, `wider`, …).
+    pub equivalence: Option<String>,
+    /// The target concept's code system URL.
+    pub system: Option<String>,
+    /// The target concept's code.
+    pub code: Option<String>,
+    /// The target concept's display text.
+    pub display: Option<String>,
 }
 
 /// One member of a `ValueSet.expansion`, with its nested members.
@@ -61,6 +78,10 @@ pub fn decode_parameters(body: &[u8]) -> Result<ParametersView, TerminologyDecod
     let parameters: Parameters = serde_json::from_slice(body)?;
     let mut view = ParametersView::default();
     for parameter in parameters.parameter.iter().flatten() {
+        if parameter.name == "match" {
+            view.matches.push(translate_match(parameter));
+            continue;
+        }
         match &parameter.value {
             Some(ParametersParameterValue::Boolean(value)) => {
                 view.booleans.insert(parameter.name.clone(), *value);
@@ -75,6 +96,26 @@ pub fn decode_parameters(body: &[u8]) -> Result<ParametersView, TerminologyDecod
         }
     }
     Ok(view)
+}
+
+/// Reads one `$translate` `match` parameter's parts (`equivalence` +
+/// `concept`).
+fn translate_match(parameter: &fhir_model::r4b::resources::ParametersParameter) -> TranslateMatch {
+    let mut m = TranslateMatch::default();
+    for part in parameter.part.iter().flatten() {
+        match (part.name.as_str(), &part.value) {
+            ("equivalence", Some(ParametersParameterValue::Code(value))) => {
+                m.equivalence = Some(value.clone());
+            }
+            ("concept", Some(ParametersParameterValue::Coding(coding))) => {
+                m.system.clone_from(&coding.0.system);
+                m.code.clone_from(&coding.0.code);
+                m.display.clone_from(&coding.0.display);
+            }
+            _ => {}
+        }
+    }
+    m
 }
 
 /// Decodes a FHIR `ValueSet` `$expand` response into its expansion members.

--- a/app/ferroehr/src/extensions/fhir/ingest.rs
+++ b/app/ferroehr/src/extensions/fhir/ingest.rs
@@ -559,6 +559,70 @@ impl FerroEhrService {
         Ok(self.delete_mapping(a_mapping_id).await?)
     }
 
+    /// Resolve every cross-terminology translation `def` requests for
+    /// `a_resource` through the terminology seam (`ConceptMap/$translate`),
+    /// keyed for [`ferroehr_ext::fhir::mapping::build_flat`].
+    ///
+    /// Fail-closed: a mapping that declares `translate` on a deployment with
+    /// no terminology provider for the route is a configuration fault (500),
+    /// never a silent pass-through of the untranslated code. A provider that
+    /// ANSWERS "no translation" is not a fault — the entry's own
+    /// `required` flag decides between refusal and skip in `build_flat`.
+    ///
+    /// # Errors
+    /// `precondition` when the mapping's translate entries are malformed
+    /// against the resource; `Exception` when no provider serves a request's
+    /// route or the provider call fails.
+    async fn resolve_code_translations(
+        &self,
+        a_resource: &Value,
+        def: &FhirMappingDefinition,
+    ) -> Result<ferroehr_ext::fhir::mapping::CodeTranslations, SmError> {
+        let requests = ferroehr_ext::fhir::mapping::collect_translations(a_resource, def)
+            .map_err(|e| SmError::precondition(e.to_string()).with_source(e))?;
+        let mut translations = ferroehr_ext::fhir::mapping::CodeTranslations::default();
+        if requests.is_empty() {
+            return Ok(translations);
+        }
+        let Some(router) = &self.terminology else {
+            return Err(internal_fault(
+                "translate a FHIR mapping's codes",
+                &"the mapping declares translate but no terminology provider is configured",
+            ));
+        };
+        for request in requests {
+            let provider = request
+                .route_terminology
+                .as_deref()
+                .and_then(|t| router.provider_for(t))
+                .or_else(|| router.default_provider())
+                .ok_or_else(|| {
+                    internal_fault(
+                        "translate a FHIR mapping's codes",
+                        &format_args!(
+                            "no terminology provider serves route '{}'",
+                            request.route_terminology.as_deref().unwrap_or("default")
+                        ),
+                    )
+                })?;
+            if let Some(translated) = provider
+                .translate(
+                    &request.system,
+                    &request.code,
+                    &request.target_system,
+                    request.concept_map.as_deref(),
+                )
+                .await?
+            {
+                translations.0.insert(
+                    (request.system, request.code, request.target_system),
+                    translated,
+                );
+            }
+        }
+        Ok(translations)
+    }
+
     /// Ingest a FHIR resource: resolve the enabled mapping for
     /// `resource_type` + `profile`, resolve-or-create the target EHR from the
     /// resource's subject, build the COMPOSITION (FLAT → canonical), stamp
@@ -600,11 +664,14 @@ impl FerroEhrService {
             .ensure_ehr_for_subject(SubjectRef::person(subject.id, subject.namespace))
             .await?;
 
-        // 3. Build the FLAT map + the canonical COMPOSITION. `now` supplies the
-        //    ctx/time default (ITS-REST simplified_formats master04 §Context) and
-        //    the FEEDER_AUDIT provenance instant — one ingestion instant for both.
+        // 3. Resolve the mapping's cross-terminology translations through the
+        //    terminology seam (FHIR ConceptMap/$translate), then build the
+        //    FLAT map + the canonical COMPOSITION. `now` supplies the ctx/time
+        //    default (ITS-REST simplified_formats master04 §Context) and the
+        //    FEEDER_AUDIT provenance instant — one ingestion instant for both.
+        let translations = self.resolve_code_translations(&a_resource, &def).await?;
         let wt = self.web_template_for(&def.template_id).await?;
-        let flat = ferroehr_ext::fhir::mapping::build_flat(&a_resource, &def)
+        let flat = ferroehr_ext::fhir::mapping::build_flat(&a_resource, &def, &translations)
             .map_err(|e| SmError::precondition(e.to_string()).with_source(e))?;
         let now = ferroehr_ext::fhir::feeder_audit::now_iso();
         let mut composition = openehr_its::flat::convert::composition_from_flat(&flat, &wt, &now)

--- a/app/ferroehr/src/service/terminology/fhir.rs
+++ b/app/ferroehr/src/service/terminology/fhir.rs
@@ -396,6 +396,63 @@ impl FhirTerminologyProvider {
         Ok(expansion.into_extract(value_set_code))
     }
 
+    /// Cross-terminology code translation → FHIR `ConceptMap/$translate`
+    /// (<https://hl7.org/fhir/R4B/conceptmap-operation-translate.html>):
+    /// `system`/`code` name the source coding, `target_system` the FHIR
+    /// `targetsystem`, and `concept_map` (when pinned) the `url`.
+    ///
+    /// `Ok(None)` when no translation exists — the server answered `404`, the
+    /// response's `result` is `false`, or no match is STRICTLY equivalent
+    /// (`equivalence` ∈ {`equivalent`, `equal`}; the looser relations —
+    /// `wider`, `narrower`, `relatedto`, `inexact` — are deliberately not
+    /// taken: no openEHR spec governs FHIR conversion, and writing a
+    /// non-equivalent code would be a silently wrong clinical value).
+    ///
+    /// # Errors
+    ///
+    /// Precondition on an empty `code`; exception on a transport fault or a
+    /// malformed response.
+    #[cfg(feature = "fhir")]
+    pub async fn translate(
+        &self,
+        system: &str,
+        code: &str,
+        target_system: &str,
+        concept_map: Option<&str>,
+    ) -> Result<Option<ferroehr_ext::fhir::mapping::TranslatedCode>, SmError> {
+        if code.is_empty() {
+            return Err(SmError::precondition("code must not be empty"));
+        }
+        let mut query = vec![
+            ("system", system),
+            ("code", code),
+            ("targetsystem", target_system),
+        ];
+        if let Some(url) = concept_map {
+            query.push(("url", url));
+        }
+        let Some(values) = self.parameters("/ConceptMap/$translate", &query).await? else {
+            return Ok(None);
+        };
+        if values.booleans.get("result") != Some(&true) {
+            return Ok(None);
+        }
+        Ok(values
+            .matches
+            .iter()
+            .find(|m| {
+                matches!(m.equivalence.as_deref(), Some("equivalent" | "equal")) && m.code.is_some()
+            })
+            .and_then(|m| {
+                m.code
+                    .clone()
+                    .map(|code| ferroehr_ext::fhir::mapping::TranslatedCode {
+                        code,
+                        display: m.display.clone(),
+                    })
+            }))
+    }
+
     /// `subsumes` → FHIR `CodeSystem/$subsumes` (`codeA` = `ref_code`,
     /// `codeB` = `candidate_child_code`). True iff the outcome is `subsumes`
     /// — the SM's *strict* subsumption (`equivalent` is excluded).
@@ -586,6 +643,21 @@ struct ParameterValues {
     codes: BTreeMap<String, String>,
     /// `valueString` parameters (`$lookup` `display`).
     strings: BTreeMap<String, String>,
+    /// `$translate` `match` parameters, in response order.
+    #[cfg(feature = "fhir")]
+    matches: Vec<TranslateMatchValues>,
+}
+
+/// One `$translate` match: the equivalence code + the target concept.
+#[cfg(feature = "fhir")]
+#[derive(Debug, Clone, Default)]
+struct TranslateMatchValues {
+    /// The match's `equivalence` (`equivalent`, `equal`, `wider`, …).
+    equivalence: Option<String>,
+    /// The target concept's code.
+    code: Option<String>,
+    /// The target concept's display text.
+    display: Option<String>,
 }
 
 /// A `$expand` expansion reduced to the extract's membership + hierarchy.
@@ -662,6 +734,15 @@ fn decode(kind: ResponseKind, body: &[u8]) -> Result<DecodedResponse, DecodeErro
                 booleans: view.booleans,
                 codes: view.codes,
                 strings: view.strings,
+                matches: view
+                    .matches
+                    .into_iter()
+                    .map(|m| TranslateMatchValues {
+                        equivalence: m.equivalence,
+                        code: m.code,
+                        display: m.display,
+                    })
+                    .collect(),
             }))
         }
         ResponseKind::ValueSet => {

--- a/app/ferroehr/tests/it/fhir_ingest_translate.rs
+++ b/app/ferroehr/tests/it/fhir_ingest_translate.rs
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: FerroEHR contributors
+// SPDX-License-Identifier: MIT
+
+//! The FHIR-ingest cross-terminology translation seam (no openEHR spec
+//! governs FHIR conversion — our own design/extension): a `translate`
+//! mapping entry drives `ConceptMap/$translate` through the terminology
+//! router before the FLAT build, and a deployment with no provider for the
+//! route fails CLOSED — never a silent pass-through of the untranslated
+//! code.
+
+#![expect(
+    clippy::expect_used,
+    reason = "clippy's in-test lint scoping (clippy.toml `allow-*-in-tests`) only \
+              reaches `#[test]`-annotated functions, so it misses this integration \
+              module's helpers and async bodies; panicking assertions are the \
+              intended shape here (the Rust Book ch11)"
+)]
+
+use std::sync::Arc;
+
+use ferroehr::service::FerroEhrService;
+use ferroehr::service::status::CallStatusType;
+use ferroehr::service::terminology::config::{FhirOperation, FhirProviderConfig, ProviderKind};
+use ferroehr::service::terminology::fhir::FhirTerminologyProvider;
+use ferroehr::service::terminology::router::TerminologyRouter;
+use serde_json::{Value, json};
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const OPT_REL: &str = "tests/resources/service/knowledge/opt/minimal_evaluation.opt";
+const TEMPLATE_ID: &str = "minimal_evaluation.en.v1";
+
+fn opt_xml() -> String {
+    let path = format!("{}/{OPT_REL}", env!("CARGO_MANIFEST_DIR"));
+    std::fs::read_to_string(&path).expect("read the OPT fixture")
+}
+
+/// A mapping whose one coded entry requests LOINC → SNOMED CT translation.
+fn translate_mapping() -> Value {
+    json!({
+        "name": "translate-probe",
+        "definition": {
+            "resource_type": "Observation",
+            "template_id": TEMPLATE_ID,
+            "subject": { "reference_path": "subject.reference", "namespace": "fhir",
+                         "strip_prefix": "Patient/" },
+            "context": { "ctx/language": "en", "ctx/territory": "US",
+                         "ctx/composer_name": "fhir-connector",
+                         "ctx/time": "2026-02-03T04:05:06Z" },
+            "entries": [
+                { "openehr_path": "minimal/minimal:0/coded_probe",
+                  "fhir_path": "code.coding[0].code",
+                  "transform": { "kind": "coded",
+                    "system_path": "code.coding[0].system",
+                    "translate": { "target_system": "http://snomed.info/sct" } },
+                  "code_map": { "http://snomed.info/sct": "SNOMED-CT" } }
+            ]
+        }
+    })
+}
+
+fn loinc_observation() -> Value {
+    json!({
+        "resourceType": "Observation",
+        "id": "obs-translate-1",
+        "status": "final",
+        "subject": { "reference": "Patient/p-77" },
+        "code": { "coding": [{ "system": "http://loinc.org", "code": "8480-6" }] }
+    })
+}
+
+fn provider(base: &str) -> FhirTerminologyProvider {
+    let cfg = FhirProviderConfig {
+        kind: ProviderKind::Fhir,
+        url: base.to_owned(),
+        operation: FhirOperation::ValidateCode,
+        connect_timeout_ms: 500,
+        request_timeout_ms: 800,
+        oauth2_client: None,
+        client_cert_path: None,
+        client_key_path: None,
+        ca_bundle_path: None,
+        cache_ttl_secs: 0,
+        cache_capacity: 0,
+    };
+    FhirTerminologyProvider::new("test", &cfg).expect("build provider")
+}
+
+#[tokio::test]
+async fn translate_mapping_without_a_provider_fails_closed() {
+    let db = testkit::db().await.expect("testkit database");
+    let svc = FerroEhrService::new(db.pool());
+    svc.template_adl14_upload(opt_xml())
+        .await
+        .expect("ingest OPT");
+    svc.fhir_mapping_create(translate_mapping())
+        .await
+        .expect("store mapping");
+
+    let err = svc
+        .fhir_ingest("Observation".to_owned(), None, loinc_observation())
+        .await
+        .expect_err("no terminology provider is configured");
+    assert_eq!(
+        err.status,
+        CallStatusType::Exception,
+        "a translate mapping on a deployment without a terminology provider is a \
+         configuration fault, never a silent pass-through: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn translate_mapping_drives_the_terminology_seam_before_the_build() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/ConceptMap/$translate"))
+        .and(query_param("system", "http://loinc.org"))
+        .and(query_param("code", "8480-6"))
+        .and(query_param("targetsystem", "http://snomed.info/sct"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "result", "valueBoolean": true},
+                {"name": "match", "part": [
+                    {"name": "equivalence", "valueCode": "equivalent"},
+                    {"name": "concept", "valueCoding": {
+                        "system": "http://snomed.info/sct", "code": "271649006"}}
+                ]}
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let db = testkit::db().await.expect("testkit database");
+    let svc = FerroEhrService::new(db.pool()).with_terminology_router(Arc::new(
+        TerminologyRouter::single(Arc::new(provider(&server.uri()))),
+    ));
+    svc.template_adl14_upload(opt_xml())
+        .await
+        .expect("ingest OPT");
+    svc.fhir_mapping_create(translate_mapping())
+        .await
+        .expect("store mapping");
+
+    // The template has no coded_probe node, so the FLAT build refuses AFTER
+    // the seam ran — wiremock's expect(1) pins that the $translate call
+    // happened, with the request's own coding and the entry's target system.
+    let err = svc
+        .fhir_ingest("Observation".to_owned(), None, loinc_observation())
+        .await
+        .expect_err("the coded_probe FLAT path is not in the template");
+    assert_eq!(err.status, CallStatusType::ContentInvalid, "{err:?}");
+    server.verify().await;
+}

--- a/app/ferroehr/tests/it/main.rs
+++ b/app/ferroehr/tests/it/main.rs
@@ -33,6 +33,7 @@ mod canonical_json_literals;
 mod codec_corpus;
 mod directory_item_refs;
 mod events_amqp;
+mod fhir_ingest_translate;
 mod fhir_outbound_amqp;
 mod item_tag_fixture;
 mod multimedia_s3;

--- a/app/ferroehr/tests/it/terminology_fhir.rs
+++ b/app/ferroehr/tests/it/terminology_fhir.rs
@@ -411,3 +411,144 @@ async fn repeated_operations_are_served_from_the_cache() {
         );
     }
 }
+
+// ── ConceptMap/$translate (the FHIR-mapping code-translation seam) ───────────
+
+#[tokio::test]
+async fn translate_takes_the_first_strictly_equivalent_match() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/ConceptMap/$translate"))
+        .and(query_param("system", "http://loinc.org"))
+        .and(query_param("code", "8480-6"))
+        .and(query_param("targetsystem", "http://snomed.info/sct"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "result", "valueBoolean": true},
+                {"name": "match", "part": [
+                    {"name": "equivalence", "valueCode": "wider"},
+                    {"name": "concept", "valueCoding": {
+                        "system": "http://snomed.info/sct", "code": "75367002"}}
+                ]},
+                {"name": "match", "part": [
+                    {"name": "equivalence", "valueCode": "equivalent"},
+                    {"name": "concept", "valueCoding": {
+                        "system": "http://snomed.info/sct", "code": "271649006",
+                        "display": "Systolic blood pressure"}}
+                ]}
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let p = provider(&server.uri(), FhirOperation::ValidateCode);
+    let hit = p
+        .translate("http://loinc.org", "8480-6", "http://snomed.info/sct", None)
+        .await
+        .expect("call")
+        .expect("a strictly equivalent match translates");
+    assert_eq!(hit.code, "271649006", "the wider match is skipped");
+    assert_eq!(hit.display.as_deref(), Some("Systolic blood pressure"));
+}
+
+#[tokio::test]
+async fn translate_without_a_strict_match_is_none() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/ConceptMap/$translate"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "result", "valueBoolean": true},
+                {"name": "match", "part": [
+                    {"name": "equivalence", "valueCode": "narrower"},
+                    {"name": "concept", "valueCoding": {"code": "x"}}
+                ]}
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let p = provider(&server.uri(), FhirOperation::ValidateCode);
+    let hit = p
+        .translate("http://loinc.org", "8480-6", "http://snomed.info/sct", None)
+        .await
+        .expect("call");
+    assert!(hit.is_none(), "narrower is never taken");
+}
+
+#[tokio::test]
+async fn translate_result_false_and_404_are_none() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/ConceptMap/$translate"))
+        .and(query_param("code", "unmapped"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "resourceType": "Parameters",
+            "parameter": [{"name": "result", "valueBoolean": false}]
+        })))
+        .mount(&server)
+        .await;
+
+    let p = provider(&server.uri(), FhirOperation::ValidateCode);
+    assert!(
+        p.translate(
+            "http://loinc.org",
+            "unmapped",
+            "http://snomed.info/sct",
+            None
+        )
+        .await
+        .expect("call")
+        .is_none(),
+        "result=false is no translation"
+    );
+    assert!(
+        p.translate(
+            "http://loinc.org",
+            "no-map-at-all",
+            "http://snomed.info/sct",
+            None
+        )
+        .await
+        .expect("call")
+        .is_none(),
+        "an unmatched route (404) is no translation, not a fault"
+    );
+}
+
+#[tokio::test]
+async fn translate_pins_the_concept_map_url() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/ConceptMap/$translate"))
+        .and(query_param("url", "http://example.org/ConceptMap/bp"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "result", "valueBoolean": true},
+                {"name": "match", "part": [
+                    {"name": "equivalence", "valueCode": "equal"},
+                    {"name": "concept", "valueCoding": {"code": "target-1"}}
+                ]}
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let p = provider(&server.uri(), FhirOperation::ValidateCode);
+    let hit = p
+        .translate(
+            "http://loinc.org",
+            "8480-6",
+            "http://snomed.info/sct",
+            Some("http://example.org/ConceptMap/bp"),
+        )
+        .await
+        .expect("call")
+        .expect("equal is strict too");
+    assert_eq!(hit.code, "target-1");
+}

--- a/website/book/src/beyond-core/fhir.md
+++ b/website/book/src/beyond-core/fhir.md
@@ -113,11 +113,43 @@ with `*` as the fallback for any unmatched system. An entry can be marked
 required, which turns an absent source value into an error instead of a skipped
 field.
 
-The FHIR-path support is a deliberate subset: object-field navigation and
-zero-based array indexing (for example `code.coding[0].code`,
-`component[0].valueQuantity.value`), not the full FHIRPath language. The mapping
+A coded transform can also declare `translate`, asking for **cross-terminology
+code translation** at ingest time:
+
+```json
+{ "openehr_path": "…/problem",
+  "fhir_path": "code.coding[0].code",
+  "transform": { "kind": "coded",
+    "system_path": "code.coding[0].system",
+    "translate": { "target_system": "http://snomed.info/sct",
+                   "concept_map": "http://example.org/ConceptMap/my-map" } },
+  "code_map": { "http://snomed.info/sct": "SNOMED-CT" } }
+```
+
+The server resolves each such code through a configured FHIR terminology
+server's `ConceptMap/$translate` (routed by the openEHR terminology the
+`code_map` binds the target system to; `concept_map` optionally pins one map).
+Only a **strictly equivalent** match is taken — a `wider`, `narrower`, or
+`relatedto` mapping is treated as no translation, because writing a
+non-equivalent code would silently change clinical meaning. When no
+translation exists, a required entry refuses the ingest and an optional one
+writes nothing — the untranslated source code is never passed through under
+the target terminology. A mapping that declares `translate` on a deployment
+with no terminology server configured is refused as a server configuration
+error rather than silently skipped.
+
+The FHIR-path support is a deliberate subset of
+[FHIRPath](https://hl7.org/fhirpath/): object-field navigation, zero-based
+array indexing, `first()`, and single-condition `where(path = literal)`
+filters — for example `code.coding[0].code`,
+`code.coding.where(system = 'http://loinc.org').code`, and
+`component.where(code.coding[0].code = '8480-6').valueQuantity.value` — not
+the full FHIRPath language (no other functions, unions, or arithmetic).
+FHIRPath's `where()` filters a collection; because a FLAT leaf holds a single
+value, this subset takes the first matching element. The mapping
 is symmetric — the same definition drives inbound ingest, the read façade, and
-outbound emission — so a field you can ingest is a field you can serve back.
+outbound emission — so a field you can ingest is a field you can serve back
+(a translated entry serves back the stored, translated coding).
 
 Each mapping also carries an `enabled` flag (default on). Only enabled mappings
 resolve, for ingest, for the façade, and for outbound emission, which makes


### PR DESCRIPTION
The #2441 sweep left two prose deferrals in the FHIR mapping core as tracker work; this lands both capabilities. No openEHR spec governs FHIR conversion — our own design/extension.

## Richer FHIRPath subset

`resolve()` grows two genuine FHIRPath constructs (<https://hl7.org/fhirpath/> §5.1/§5.2): `first()` and single-condition `where(path = literal)` filters — so a mapping can pick an Observation component by its code (`component.where(code.coding[0].code = '8480-6').valueQuantity.value`) instead of by position. The splitter respects parens/quotes; FHIRPath's collection semantics are deliberately narrowed to first-match (a FLAT leaf is one value), documented in the module and the book. Everything else (other functions, unions, arithmetic) stays out and resolves to `None`. `parse_segment` (the reverse writer's grammar) is unchanged.

## Cross-terminology code translation through the terminology seam

A `coded` entry can declare `translate: { target_system, concept_map? }`. The design keeps `mapping.rs` pure:

- `collect_translations(resource, def)` enumerates deduplicated `TranslationRequest`s (source system+code, target system, and the routing token the entry's `code_map` binds the target to).
- The ingest orchestrator resolves each through the `TerminologyRouter` (`provider_for(route)` → `default_provider()`) via the new `FhirTerminologyProvider::translate()` — FHIR `ConceptMap/$translate`, decoded by the extended `ParametersView` (`match` parameter parts: `equivalence` + `concept` Coding).
- `build_flat(resource, def, &CodeTranslations)` writes the translated code + the target's `code_map` terminology, preferring the translated concept's own display.

Strictness, fail-closed at every branch: only `equivalent`/`equal` matches are taken (`wider`/`narrower`/`relatedto` are no-translation — a non-equivalent code is a silently wrong clinical value); an untranslatable required entry refuses (`Untranslatable`), an optional one writes NO leaf (never the source code under the target terminology); a translate-declaring mapping on a deployment with no terminology provider is a 500-class configuration fault. Reverse mapping serves the stored (translated) coding — the pair stays internally consistent (NOTE in `reverse.rs`).

## Tests

- `mapping.rs` units: `where()`/`first()` navigation incl. malformed-path refusals and numeric literals; `collect_translations` routing; translated-code-wins; required-refuses/optional-skips; translate-without-system refusal.
- `terminology_fhir.rs` wire tests (wiremock): strict-equivalence selection order, non-strict → `None`, `result=false`/404 → `None`, `concept_map` URL pinning.
- `fhir_ingest_translate.rs` (new, testkit): the fail-closed no-provider path, and the full seam drive — `expect(1)` pins the `$translate` call (with the right query) fired ahead of the FLAT build.
- Slim lanes: `translate()` and the match view are `fhir`-feature-gated; `--no-default-features` checks green.

## Gates

- `cargo clippy --workspace --exclude ferroehr-admin-ui --all-targets --all-features` — clean
- `cargo nextest run` — ferroehr-ext 42/42; the FHIR/terminology/ingest suites 66/66
- `docs-claims`, `comment-style` — OK; book page (`beyond-core/fhir.md`) + changelog updated in-PR

Closes #2458