### PR TITLE
test(review): the AI-reviewer measurement — keep it, keep it advisory

### DIFF
--- a/.claude/rules/ai-code-review.md
+++ b/.claude/rules/ai-code-review.md
@@ -36,13 +36,25 @@ The installed app does hold `code: write` — a GitHub App's permission set is
 declared by the app and cannot be narrowed by the installer — so this
 property is a configuration choice, not a capability boundary.
 
-## It does not gate a merge
+## It does not gate a merge — a measured decision, not a default
 
 No pre-merge check is at `error`, and `request_changes_workflow` is off. The
-app publishes a check run named `CodeRabbit`; it is **not required**, and
-making it required is a deliberate future step, not something to inherit by
-accident. Merge authority stays where it was: the local gates green, and the
-owner's call.
+app publishes a check run named `CodeRabbit`; it is **not required**. Merge
+authority stays where it was: the local gates green, and the owner's call.
+
+That standing was **measured, then kept** (issue #2148, 2026-08-20): over the
+25 merged PRs the reviewer actually reviewed under the committed
+configuration, its 137 actionable findings graded 82 true positives, 29
+false positives, 26 noise — ≈60% precision. The true positives included
+genuinely severe catches (an `f64` pre-rounding in `DvCount::multiply`, a
+fail-open Helm gate, an unchecked RSA signing key), which is why it is kept;
+the 40% FP+noise band is why it does not gate — a blocking check at that
+precision trains override-slapping, which also mutes the 60%. Two structural
+facts from the measurement shape how to read its comments: it fabricates
+citations for files excluded from its checkout (the vendored specs are
+path-filtered out), and it reviews only PRs open long enough to finish — a
+fast-merge cadence means most PRs get no review at all. Re-promotion is a
+future re-measurement, not a config toggle.
 
 A pre-merge check reported as a warning is information. It does not block,
 and it is not a reason to reword a PR description that is already correct.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -8,9 +8,12 @@
 
 language: en-US
 
+# The 250-char cap forces brevity; the full never-assert-unseen-content rule
+# rides the "**" path instruction below.
 tone_instructions: >-
   Terse and technical. Cite the governing .claude/rules file or vendored spec
-  section for each finding. No praise, no filler, no restating the diff.
+  section, quoting only text visible in this checkout — never assert what an
+  excluded file contains. No praise, no filler, no restating the diff.
 
 reviews:
   profile: chill
@@ -149,6 +152,15 @@ reviews:
   # The full standards live in the knowledge base (CLAUDE.md + .claude/rules).
   # These are the per-path reminders of what to actually look for.
   path_instructions:
+    - path: "**"
+      instructions: >-
+        The vendored spec trees (docs/specs/openehr/ and every other
+        path_filters exclusion, including Cargo.lock) are NOT in this
+        checkout. You may name the spec section or file a change should be
+        verified against, but never assert, quote, or paraphrase what an
+        excluded file contains — a claim that depends on unseen content is
+        unverifiable and must say so. The same applies to rule-file sections
+        you have not read: cite only text you can see.
     - path: "**/*.rs"
       instructions: >-
         Judgement, not lint: clippy at deny plus the comment-style, typed-status
@@ -161,9 +173,20 @@ reviews:
         derived `Error` (the smart pointer becomes the source hop and downcast
         breaks); HashMap/HashSet iteration feeding canonical output or SQL; an
         import renamed with `use X as Y`; a re-export; a `// TODO` without an
-        issue number; a `// NOTE:` longer than three lines or describing work
-        not yet done. Clinical payload must never reach a `Debug` impl or a
-        tracing field.
+        issue number; a LINE-comment `// NOTE:` longer than three lines or
+        describing work not yet done (a `NOTE:` inside a `///` doc comment has
+        an eight-line budget — do not flag doc-comment NOTEs of four to eight
+        lines). Clinical payload must never reach a `Debug` impl or a tracing
+        field.
+    - path: "crates/*/Cargo.toml"
+      instructions: >-
+        These crates publish to crates.io, so sibling openehr-* dependencies
+        are declared per-manifest as `path` plus an explicit `version`
+        requirement, bumped in lockstep (.claude/rules/crates-publishing.md).
+        There is deliberately NO openehr-* entry in the root
+        [workspace.dependencies] table — that table is for third-party pins.
+        Never propose converting an openehr-* sibling dependency to
+        `dep.workspace = true` or adding one to the workspace table.
     - path: "crates/openehr-{base,rm,am,term,lang,its}/**/*.rs"
       instructions: >-
         Most files here start with `// @generated ... DO NOT EDIT` or


### PR DESCRIPTION
The #2148 measurement and the decision it earns. The full record — the per-PR grading table over the 25 reviewed PRs (137 findings: 82 TP / 29 FP / 26 noise, ≈60% precision), the false-positive attribution, and the configuration-verification probe (#2497, closed unmerged: custom check fired, exclusion held, path instructions surfaced both planted defects, zero extras) — lives on the issue.

**Decision, recorded in `.claude/rules/ai-code-review.md`:** the reviewer stays, and stays advisory. No `custom_checks` promotion to `error`, the `CodeRabbit` check run does not become required on `develop` (the #2138 prerequisite is closed, so this is a choice). At 60% precision a blocking gate trains override-slapping, which also mutes the 60% worth keeping — and the true positives include an `f64` pre-rounding in `DvCount::multiply`, a fail-open Helm gate, and an unchecked RSA signing key, which is why "remove it" loses too. Because it gates nothing, no override path is needed.

**The three `.coderabbit.yaml` edits, each naming its motivating findings:**

1. **New `crates/*/Cargo.toml` path instruction** — the single dominant FP pattern (5 occurrences across #2327/#2372/#2455) demanded `dep.workspace = true` for `openehr-*` sibling deps, the opposite of the crates-publishing publish shape. The instruction now states it: per-manifest `path` + `version`, no `openehr-*` entry in the workspace table.
2. **Never assert excluded-file content** (tone line + a global `"**"` path instruction) — all 3 missing-context FPs and 2 fabricated rule-file citations trace to trees `path_filters` hides while the old tone line told the reviewer to cite vendored specs. The tone line stays under the schema's 250-char cap; the full rule rides the path instruction.
3. **NOTE-budget split in `**/*.rs`** — the instruction's bare "a `// NOTE:` longer than three lines" produced two noise findings on 4–8-line doc-comment NOTEs the comment-style guard's doc budget permits; both budgets are now stated.

Config validated against <https://coderabbit.ai/integrations/schema.v2.json> (ajv, draft 2020-12). Note the base-branch rule: these edits take effect only once merged — a follow-up review on this very PR still runs the old config.

Closes #2148