### PR TITLE
chore(memory): the SM program's audit-pattern refinements

### DIFF
--- a/.claude/memory/spec-chapter-audit-programs.md
+++ b/.claude/memory/spec-chapter-audit-programs.md
@@ -62,3 +62,14 @@ issues under the cadence above, zero-drift pipeline at program close. Which
 component programs are open vs released is read from the milestones
 (`gh api … /milestones`), never copied forward. Milestone routing for a fix
 whose program has closed: [[component-fixes-ride-current-patch]].
+
+**SM-program refinements (v3.19.0, 2026-08-21):** DEVELOPMENT-state model
+documents (SDF, Simplified IM-B) get adjudication-verification chapters —
+the audit question is "does the never-implement adjudication hold and is it
+flagged", walkable in-session with no researcher fan-out. Upstream defects
+consolidate into per-defect-class reports (14 for the whole SM), never
+per-cell issues. SM UML diagrams are text-free path art carrying normative
+structure absent from the class tables (inheritance, generic bindings,
+multiplicities) — researchers must rasterize them (`rsvg-convert`), and the
+spec-tree README now records this. Extraction researchers run max 2 ahead of
+the in-session walk; the walk + records + closes stay with the orchestrator.


### PR DESCRIPTION
Extends the spec-chapter-audit-programs memory with what the v3.19.0 SM program proved: adjudication-verification chapters for DEVELOPMENT-state documents close in-session; upstream defects consolidate per defect class (fourteen reports for the whole component); the SM's text-free UML diagrams carry normative structure and must be rasterized. no-changelog.