### PR TITLE
fix(conformance): regenerate the ehrbase derived documents after the register cleanup

### DIFF
--- a/docs/conformance/ehrbase/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ehrbase/CONFORMANCE_REPORT.md
@@ -83,7 +83,7 @@ Selected gating cases per claimed capability. `inconclusive` counts cases whose 
 | EhrStatus | FAIL | 14 | 26 | 3 | 5 |
 | CompositionOps | INCONCLUSIVE (errored rows — never green by absorption) | 5 | 0 | 51 | 2 |
 | DirectoryOps | FAIL | 61 | 13 | 1 | 10 |
-| ChangeSets | FAIL | 7 | 12 | 58 | 23 |
+| ChangeSets | FAIL | 7 | 13 | 58 | 23 |
 | Versioning | FAIL | 8 | 3 | 50 | 6 |
 | ArchetypeValidation | FAIL | 0 | 67 | 54 | 4 |
 | AqlBasic | FAIL | 5 | 3 | 26 | 0 |

--- a/docs/conformance/ehrbase/CONFORMANCE_STATEMENT.md
+++ b/docs/conformance/ehrbase/CONFORMANCE_STATEMENT.md
@@ -39,7 +39,7 @@ Capabilities claimed:
 - AuthenticatedAccess
 - AuthorizationSeparation
 
-Options declared: contribution-xml-unsupported, directory-empty-error, directory-xml-supported, ehr-status-xml-supported, ehr-xml-supported, adl14-partial-id-exact, xml-namespace-fixed
+Options declared: contribution-xml-unsupported, directory-xml-supported, ehr-status-xml-supported, ehr-xml-supported, adl14-partial-id-exact, xml-namespace-fixed
 
 ## Additional non-openEHR surface
 

--- a/docs/conformance/ehrbase/verdicts.json
+++ b/docs/conformance/ehrbase/verdicts.json
@@ -269,7 +269,7 @@
       "ChangeSets",
       {
         "passed": 7,
-        "failed": 12,
+        "failed": 13,
         "inconclusive": 58,
         "unevidenced": 23
       }


### PR DESCRIPTION
The Docs lane's party-documents drift gate failed on the v3.20.0 pushes: #2532 edited the ehrbase party statement (dropping the `directory-empty-error` option selection with AMB-8) and re-dispositioned the AMB-9 case, without regenerating the derived ehrbase documents. This regenerates them from the committed statement + results + catalogue (`scripts/render/conformance-docs.sh`); the ferroehr set was already current from the pipeline run.
