### PR TITLE
fix(ci): changelog structure + the openehr-its test SPDX header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,19 @@ workflow refuses a tag that has no matching section here.
   (`PERSON`, `ORGANISATION`, `GROUP`, `AGENT`, `ROLE`, `PARTY_RELATIONSHIP`)
   instead of failing, and still reads archives written before the wave
   existed.
+- **Template and archetype uploads now validate the artefact's own meta-data
+  against the RM resource-package rules.** An OPT 1.4 whose header violates
+  the RM class invariants — a language outside the openEHR `languages` code
+  set, `is_controlled` without a revision history, a description without an
+  author or details, duplicate detail languages, an empty `lifecycle_state`
+  or `purpose` — is refused with a `422` naming the violated invariant, and
+  `validate` answers with the same catalogue as upload, so the two can no
+  longer disagree. ADL 1.4 source uploads refuse the structural and
+  language-code rows the same way; the empty-prose rows
+  (`purpose`/`use`/`misuse` as `<"">`) are reported as named warnings there,
+  because the empty string is how real-world 1.4 authoring spells absence
+  (adjudicated against the full vendored CKM library, which uploads
+  unchanged).
 
 ### Fixed
 
@@ -134,22 +147,6 @@ workflow refuses a tag that has no matching section here.
   serializer previously emitted the v1 namespace, whose published schema
   bundle cannot describe every RM 1.2.0 class this model emits; the v1
   lineage stays available by explicit selection.
-
-### Added
-
-- **Template and archetype uploads now validate the artefact's own meta-data
-  against the RM resource-package rules.** An OPT 1.4 whose header violates
-  the RM class invariants — a language outside the openEHR `languages` code
-  set, `is_controlled` without a revision history, a description without an
-  author or details, duplicate detail languages, an empty `lifecycle_state`
-  or `purpose` — is refused with a `422` naming the violated invariant, and
-  `validate` answers with the same catalogue as upload, so the two can no
-  longer disagree. ADL 1.4 source uploads refuse the structural and
-  language-code rows the same way; the empty-prose rows
-  (`purpose`/`use`/`misuse` as `<"">`) are reported as named warnings there,
-  because the empty string is how real-world 1.4 authoring spells absence
-  (adjudicated against the full vendored CKM library, which uploads
-  unchanged).
 
 ## [3.17.8] - 2026-08-19
 

--- a/crates/openehr-its/tests/it/canonical_json_literals.rs
+++ b/crates/openehr-its/tests/it/canonical_json_literals.rs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: FerroEHR contributors
-// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: openEHR Foundation
+// SPDX-License-Identifier: MIT AND Apache-2.0
 
 //! Regression gate: canonical RM shapes are BUILT from the generated
 //! `openehr-*` types, never hand-written as `json!` literals.


### PR DESCRIPTION
Two pre-existing guard defects surfaced by #2534's CI run (path-filtered guards, so the offending merges never triggered them):

- `changelog-guard`'s structure check: the `[3.18.0]` section carried a duplicate `### Added` subsection — its entry is merged into the section's existing Added block. A structural repair of a shipped section, not a user-visible change (`no-changelog`).
- `licensing`: `crates/openehr-its/tests/it/canonical_json_literals.rs` carried the plain MIT header while REUSE.toml declares the crate `MIT AND Apache-2.0` — the header now matches. Tests are unpackaged, so no crate bump.

Both guards green locally (`spdx-headers: OK (2481 files)`, `changelog structure OK`).
