### PR TITLE
chore(cnf-runner): the FixedHandling/Editorial boundary made decidable (#2546)

### DIFF
--- a/tools/cnf-runner/artifacts/registers/ambiguities.yaml
+++ b/tools/cnf-runner/artifacts/registers/ambiguities.yaml
@@ -1031,7 +1031,7 @@ AMB-44:
     designators only). The affected DV_TIME/interval-of-time cases tag
     this entry. Flips back if a future BASE release admits the T-prefixed
     time form.
-  disposition: fixed_handling
+  disposition: editorial
   upstream_issue: 1503
 AMB-45:
   ambiguity: >-
@@ -7986,7 +7986,7 @@ AMB-180:
     containment predicate neither source defines. The refusals that ARE pinned
     (empty list, non-`DV_EHR_URI` member) trace to the invariant and the
     attribute type, not to the disputed sentence.
-  disposition: editorial
+  disposition: fixed_handling
   upstream_issue: 1634
 
 AMB-181:

--- a/tools/cnf-runner/schemas/ambiguity-register.schema.json
+++ b/tools/cnf-runner/schemas/ambiguity-register.schema.json
@@ -39,7 +39,8 @@
           "report_only",
           "statement_declared",
           "editorial"
-        ]
+        ],
+        "description": "The machine-readable handling class. The fixed_handling/editorial boundary (issue #2546) is one question — did the entry CHOOSE anything? editorial = a wording/typography defect with zero behavioural latitude (the corrected reading is forced by the surrounding released text); fixed_handling = real latitude existed and the entry pins this catalogue's choice. Neither changes gating; report_only and editorial additionally require an upstream_issue."
       },
       "options": {
         "type": "array",

--- a/tools/cnf-runner/src/schema.rs
+++ b/tools/cnf-runner/src/schema.rs
@@ -711,7 +711,7 @@ pub fn ambiguity_register_schema() -> Value {
                 "ambiguity": { "type": "string", "minLength": 1 },
                 "source": { "type": "string", "minLength": 1, "description": "Where the silence/divergence was verified. Convention (machine-gated by the validate spec-ref check, issue #2545): the field splits into `;`/` + ` fragments; every fragment opening with a spec component token (RM, BASE, AM, QUERY, TERM, LANG, SM, CNF, ITS-REST, ITS-XML, ITS-JSON) is a citation clause and must machine-resolve against the vendored trees (document + § sections; {a,b} brace shorthands expand and every variant must resolve); any other fragment is adjudication prose and passes. A source with no citation clause at all fails — a silence claim must ground on at least one resolvable citation." },
                 "handling": { "type": "string", "minLength": 1 },
-                "disposition": { "enum": tokens(Disposition::ALL) },
+                "disposition": { "enum": tokens(Disposition::ALL), "description": "The machine-readable handling class. The fixed_handling/editorial boundary (issue #2546) is one question — did the entry CHOOSE anything? editorial = a wording/typography defect with zero behavioural latitude (the corrected reading is forced by the surrounding released text); fixed_handling = real latitude existed and the entry pins this catalogue's choice. Neither changes gating; report_only and editorial additionally require an upstream_issue." },
                 "options": { "type": "array", "items": { "type": "string", "pattern": OPTION_TAG_PATTERN } },
                 "upstream_issue": { "type": "integer", "minimum": 1 }
             },

--- a/tools/cnf-runner/src/vocab.rs
+++ b/tools/cnf-runner/src/vocab.rs
@@ -263,12 +263,24 @@ impl Tier {
 
 /// The machine-readable handling class of an ambiguity-register entry — the
 /// pipeline branches on this (closed enum).
+///
+/// The `FixedHandling`/`Editorial` boundary (issue #2546) is decidable by one
+/// question: **did the entry CHOOSE anything?** `Editorial` records a
+/// wording/typography defect with zero behavioural latitude — the corrected
+/// reading is forced by the surrounding released text, and the catalogue
+/// encodes that one reading. `FixedHandling` records real latitude — several
+/// readings were defensible and the entry pins this catalogue's choice.
+/// Neither changes gating (`verdict.rs` branches identically); the split
+/// exists so a reader knows whether re-adjudication could ever move the
+/// behaviour (`fixed_handling`: yes, on a better ground; `editorial`: only if
+/// the text itself changes).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Disposition {
     /// Assert loosely (e.g. AMB-1: at most a `message` string).
     LooseAssert,
-    /// Handling encoded directly in bindings/cases.
+    /// Real latitude existed; the entry pins this catalogue's choice,
+    /// encoded directly in bindings/cases.
     FixedHandling,
     /// Sibling cases carry `option:` tags; the ICS `options` declaration selects.
     OptionSelect,
@@ -276,7 +288,8 @@ pub enum Disposition {
     ReportOnly,
     /// No normative cases; statement-declared behaviour only.
     StatementDeclared,
-    /// Editorial defect in the schedule text itself.
+    /// A wording/typography defect with zero behavioural latitude: the
+    /// corrected reading is forced, nothing was chosen.
     Editorial,
 }
 


### PR DESCRIPTION
Closes #2546

**The boundary** (now stated on the `Disposition` enum docs and the register schema's `disposition` description): one question — did the entry CHOOSE anything? `editorial` = a wording/typography defect with zero behavioural latitude (the corrected reading is forced by the surrounding released text; it moves only if the text changes). `fixed_handling` = real latitude existed and the entry pins this catalogue's choice (a better ground could move it). Neither changes gating — `verdict.rs` branches identically — so the split is purely a reader's signal about re-adjudicability.

**The sweep** (all 21 editorial entries read against the test, plus a keyword hunt over the 124 fixed_handling handlings): exactly two reclassifications —
- **AMB-44 → editorial**: the schedule's T-prefixed time literals are corrected against the BASE `Iso8601_time` grammar, which forces the reading (DV_TIME.value's type oracle) — the same class as AMB-45/51, which were already editorial; it was the filing inconsistency that motivated this issue. Its `upstream_issue` (1503) already satisfies the editorial shape rule.
- **AMB-180 → fixed_handling**: the entry pins the class-model reading over the prose — a defensible-choice resolution, and its own handling text opens "Fixed handling".

Everything else survives: the "only reading" rhetoric in several fixed_handling entries (AMB-66/96/140/143/145/187/203, each checked) argues for a pinned choice among readings, which is exactly what that disposition means. Distribution stays 124/21 by the symmetric swap.

**Verification**: `validate --specs` 0 findings; cnf-runner suite 352/352; clippy clean; schemas regenerated. Dispositions gate nothing at run time, so no pipeline re-run is required.