### PR TITLE
feat(fhir): the $validate dry run — mapping verification that commits nothing (#342)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Added
+
+- FHIR mapping dry run: `POST /fhir/r4/{resource_type}/$validate` (the HL7
+  FHIR R4 validation-operation convention) runs the whole ingest pipeline —
+  mapping resolution, the FLAT build, the provenance stamp, and the same
+  validation the real commit runs — and commits nothing. The
+  `OperationOutcome` carries the verdict: the validator's rejections
+  verbatim, or the valid verdict plus the EHR disposition (the target EHR is
+  resolved and reported, never created). Same starter-set scope, config gate
+  and access class as the ingest door; the mapping-definition contract and a
+  worked blood-pressure example are now documented in the book's FHIR
+  chapter.
+
 ### Fixed
 
 - Importing an EHR Extract that advances an already-held BRANCH lineage (a

--- a/app/ferroehr-rest/src/extensions/fhir.rs
+++ b/app/ferroehr-rest/src/extensions/fhir.rs
@@ -86,6 +86,7 @@ pub(crate) fn routes() -> OpenApiRouter<AppState> {
     // mixing paths panics at router build with "Overlapping method route").
     OpenApiRouter::new()
         .routes(routes!(fhir_ingest, fhir_search))
+        .routes(routes!(fhir_validate))
         // The static /fhir/r4/AuditEvent route wins over the dynamic
         // /fhir/r4/{resource_type} façade route (axum static-first matching).
         .routes(routes!(audit_event_search))
@@ -126,6 +127,43 @@ pub(crate) async fn fhir_ingest(
 ) -> Response {
     let parts = crate::api::into_parts(request).await;
     guarded_dispatch(state, "fhir_ingest", parts, dispatch).await
+}
+
+/// The ingest door's dry twin: validate a FHIR R4B resource against its
+/// mapping WITHOUT committing (`POST /fhir/r4/{resource_type}/$validate`).
+///
+/// The wire convention is HL7 FHIR R4's own validation operation
+/// (`resource-operation-validate`,
+/// <https://hl7.org/fhir/R4/resource-operation-validate.html>): the sibling
+/// `$validate` path on the ingest door, returning an `OperationOutcome`. A
+/// COMPLETED validation is `200` whichever way the verdict falls — the
+/// verdict rides the issues: the commit path's rejections VERBATIM as
+/// `error` issues, or the valid verdict plus the EHR disposition
+/// (`would commit into …` / `would create …` — resolved, never created) as
+/// `information` issues. Operation-level failures mirror the ingest door's
+/// statuses. Same starter-set scope, same config gate, same access class as
+/// the ingest door (its dry twin exists for mapping development).
+///
+/// OUR OWN EXTENSION — no openEHR spec governs this: neither the SM nor
+/// ITS-REST defines a FHIR connector; the operation's wire shape follows
+/// HL7 FHIR R4 (official external documentation).
+#[utoipa::path(
+    post, path = "/fhir/r4/{resource_type}/$validate", tag = "fhir",
+    params(("resource_type" = String, Path, description = "The FHIR R4B resource type (starter set only).")),
+    request_body(content = serde_json::Value, description = "A FHIR R4B resource (JSON)."),
+    responses(
+        (status = 200, description = "Validation completed — the OperationOutcome carries the verdict: `information` issues (valid + the EHR disposition) or `error` issues with the commit path's rejections verbatim. Nothing is committed either way.", content_type = "application/fhir+json"),
+        (status = 400, description = "The request body is not valid JSON, or a mapping precondition failed (OperationOutcome) — the same class the ingest door refuses `400`.", content_type = "application/fhir+json"),
+        (status = 404, description = "No enabled mapping matches the resource type (the ingest door's `404`), or the FHIR connector is disabled (`fhir_api_enabled` off) (OperationOutcome). With authentication enabled, an unauthenticated request to a disabled group is answered `401` first (the group gate sits behind authentication).", content_type = "application/fhir+json"),
+        (status = 501, description = "Resource type outside the starter set (OperationOutcome).", content_type = "application/fhir+json")
+    )
+)]
+pub(crate) async fn fhir_validate(
+    State(state): State<AppState>,
+    request: axum::extract::Request,
+) -> Response {
+    let parts = crate::api::into_parts(request).await;
+    guarded_dispatch(state, "fhir_validate", parts, dispatch).await
 }
 
 /// Read façade: a patient-scoped FHIR searchset Bundle of reverse-mapped
@@ -357,6 +395,7 @@ async fn run(state: AppState, op: &'static str, parts: RequestParts) -> Response
     let h = &parts.headers;
     match op {
         "fhir_ingest" => ingest(&state, &parts).await,
+        "fhir_validate" => validate(&state, &parts).await,
         "fhir_search" => search(&state, &parts).await,
         "fhir_mapping_list" => match state.backend().fhir_mapping_list().await {
             Ok(items) => negotiate::respond(h, StatusCode::OK, &items),
@@ -454,6 +493,30 @@ async fn ingest(state: &AppState, parts: &RequestParts) -> Response {
         .await
     {
         Ok(resp) => ingest_created(state, &resp),
+        Err(e) => sm_error_outcome(e),
+    }
+}
+
+/// `POST /fhir/r4/{resource_type}/$validate` — the ingest door's dry twin.
+async fn validate(state: &AppState, parts: &RequestParts) -> Response {
+    let resource_type = match scoped_resource_type(parts) {
+        Ok(rt) => rt,
+        Err(resp) => return resp,
+    };
+    let body = match negotiate::json_value(&parts.headers, &parts.body) {
+        Ok(b) => b,
+        Err(e) => return api_error_outcome(&e),
+    };
+    let profile = first_profile(&body);
+    match state
+        .backend()
+        .fhir_validate(resource_type, profile, body)
+        .await
+    {
+        // A completed validation is 200 whichever way the verdict fell (the
+        // OperationOutcome carries it); only operation-level failures take
+        // the ingest door's statuses.
+        Ok(outcome) => fhir_json(StatusCode::OK, &outcome),
         Err(e) => sm_error_outcome(e),
     }
 }

--- a/app/ferroehr-rest/tests/it/authz_route_matrix.rs
+++ b/app/ferroehr-rest/tests/it/authz_route_matrix.rs
@@ -315,6 +315,11 @@ const CLINICAL_WRITE: &[(&str, &str)] = &[
     ("POST", "/message/tdd/{ehr_id}"),
     ("POST", "/message/tdd/{ehr_id}/batch"),
     ("POST", "/fhir/r4/{resource_type}"),
+    // The ingest door's dry twin (#342): the same class as the door it
+    // previews — it exists for mapping development by callers allowed to
+    // ingest, and although it commits nothing it exercises the same
+    // mapping/template surface.
+    ("POST", "/fhir/r4/{resource_type}/$validate"),
 ];
 
 /// Admin-class reads (base-relative) — every one under the `/admin/` prefix

--- a/app/ferroehr-rest/tests/it/fhir_inbound.rs
+++ b/app/ferroehr-rest/tests/it/fhir_inbound.rs
@@ -453,3 +453,193 @@ async fn mapping_crud_over_http() {
     let (status, _, _) = send(&router, req("GET", &format!("{MAPPINGS}/{id}"), None)).await;
     assert_eq!(status, StatusCode::NOT_FOUND);
 }
+
+/// The `(vo_version, ehr)` row counts — the dry run's commits-nothing proof.
+async fn commit_counts(pool: &PgPool) -> (i64, i64) {
+    let versions: i64 = sqlx::query_scalar("SELECT count(*) FROM vo_version")
+        .fetch_one(pool)
+        .await
+        .expect("count vo_version");
+    let ehrs: i64 = sqlx::query_scalar("SELECT count(*) FROM ehr")
+        .fetch_one(pool)
+        .await
+        .expect("count ehr");
+    (versions, ehrs)
+}
+
+/// `$validate` on a valid resource: `200`, an informational verdict naming the
+/// template, the would-create EHR disposition — and NOTHING committed (no
+/// version row, no EHR row).
+#[tokio::test]
+async fn validate_dry_run_reports_valid_and_commits_nothing() {
+    let db = testkit::db().await.expect("testkit database");
+    let (_svc, router) = app_with_template(db.pool(), true).await;
+    let (status, _, _) = send(
+        &router,
+        req("POST", MAPPINGS, Some(mapping_body("bp", PROFILE_OK, "US"))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let before = commit_counts(&db.pool()).await;
+    let (status, _, oo) = send(
+        &router,
+        req(
+            "POST",
+            &format!("{BASE}/fhir/r4/Observation/$validate"),
+            Some(bp_observation(PROFILE_OK)),
+        ),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "a completed validation is 200: {oo}"
+    );
+    assert_eq!(oo["resourceType"], "OperationOutcome");
+    assert_eq!(oo["issue"][0]["severity"], "information");
+    let verdict = oo["issue"][0]["diagnostics"].as_str().unwrap();
+    assert!(
+        verdict.contains("valid") && verdict.contains(TEMPLATE_ID),
+        "the verdict names the template: {verdict}"
+    );
+    let disposition = oo["issue"][1]["diagnostics"].as_str().unwrap();
+    assert!(
+        disposition.contains("would create a new EHR"),
+        "the absent EHR is simulated, never created: {disposition}"
+    );
+    assert_eq!(
+        commit_counts(&db.pool()).await,
+        before,
+        "the dry run committed nothing"
+    );
+}
+
+/// `$validate` on a resource whose mapped COMPOSITION the commit path refuses:
+/// still `200` — the verdict rides the `OperationOutcome`, carrying the
+/// openEHR validator's rejection VERBATIM — and nothing is committed.
+#[tokio::test]
+async fn validate_dry_run_carries_the_validator_rejection_verbatim() {
+    let db = testkit::db().await.expect("testkit database");
+    let (_svc, router) = app_with_template(db.pool(), true).await;
+    let (status, _, _) = send(
+        &router,
+        req(
+            "POST",
+            MAPPINGS,
+            Some(mapping_body("bp-bad", PROFILE_BAD, "ZZ")),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let before = commit_counts(&db.pool()).await;
+    let (status, _, oo) = send(
+        &router,
+        req(
+            "POST",
+            &format!("{BASE}/fhir/r4/Observation/$validate"),
+            Some(bp_observation(PROFILE_BAD)),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "the verdict is the payload: {oo}");
+    assert_eq!(oo["issue"][0]["severity"], "error");
+    assert_eq!(oo["issue"][0]["code"], "invalid");
+    let diag = oo["issue"][0]["diagnostics"]
+        .as_str()
+        .unwrap()
+        .to_lowercase();
+    assert!(
+        diag.contains("territory") || diag.contains("country") || diag.contains("zz"),
+        "the ingest path's rejection, verbatim: {diag}"
+    );
+    assert_eq!(
+        commit_counts(&db.pool()).await,
+        before,
+        "an invalid dry run committed nothing either"
+    );
+}
+
+/// With the subject's EHR already existing (a prior real ingest), the dry run
+/// reports the would-commit-into disposition — and still commits nothing.
+#[tokio::test]
+async fn validate_dry_run_reports_the_existing_ehr_disposition() {
+    let db = testkit::db().await.expect("testkit database");
+    let (_svc, router) = app_with_template(db.pool(), true).await;
+    let (status, _, _) = send(
+        &router,
+        req("POST", MAPPINGS, Some(mapping_body("bp", PROFILE_OK, "US"))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let (status, _, _) = send(
+        &router,
+        req(
+            "POST",
+            &format!("{BASE}/fhir/r4/Observation"),
+            Some(bp_observation(PROFILE_OK)),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "the real ingest seeds the EHR");
+
+    let before = commit_counts(&db.pool()).await;
+    let (status, _, oo) = send(
+        &router,
+        req(
+            "POST",
+            &format!("{BASE}/fhir/r4/Observation/$validate"),
+            Some(bp_observation(PROFILE_OK)),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let disposition = oo["issue"][1]["diagnostics"].as_str().unwrap();
+    assert!(
+        disposition.contains("would commit into existing EHR"),
+        "the resolved EHR is reported, not touched: {disposition}"
+    );
+    assert_eq!(commit_counts(&db.pool()).await, before);
+}
+
+/// Operation-level statuses mirror the ingest door: no mapping → `404`, an
+/// out-of-scope type → `501`, the disabled connector → `404`.
+#[tokio::test]
+async fn validate_operation_level_statuses_mirror_ingest() {
+    let db = testkit::db().await.expect("testkit database");
+    let (_svc, router) = app_with_template(db.pool(), true).await;
+    let (status, _, oo) = send(
+        &router,
+        req(
+            "POST",
+            &format!("{BASE}/fhir/r4/Patient/$validate"),
+            Some(json!({ "resourceType": "Patient", "id": "p-1" })),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "no mapping → 404: {oo}");
+    let (status, _, oo) = send(
+        &router,
+        req(
+            "POST",
+            &format!("{BASE}/fhir/r4/MedicationRequest/$validate"),
+            Some(json!({ "resourceType": "MedicationRequest" })),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_IMPLEMENTED, "{oo}");
+
+    let db2 = testkit::db().await.expect("testkit database");
+    let (_svc, off) = app_with_template(db2.pool(), false).await;
+    let (status, _, _) = send(
+        &off,
+        req(
+            "POST",
+            &format!("{BASE}/fhir/r4/Observation/$validate"),
+            Some(bp_observation(PROFILE_OK)),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "the config gate answers 404");
+}

--- a/app/ferroehr-rest/tests/it/served_openapi.rs
+++ b/app/ferroehr-rest/tests/it/served_openapi.rs
@@ -1407,7 +1407,9 @@ const NON_SPEC_FAMILIES: &[NonSpecFamily] = &[
         label: "the FHIR R4B connector + read facade",
         prefixes: &["/ferroehr/rest/openehr/v1/fhir/r4/{resource_type}"],
         flag: "no openehr spec governs this",
-        operations: 2,
+        // Ingest, the read facade, and the ingest door's `$validate` dry
+        // twin (#342).
+        operations: 3,
     },
     NonSpecFamily {
         label: "the FHIR mapping store",

--- a/app/ferroehr/src/extensions/fhir/ingest.rs
+++ b/app/ferroehr/src/extensions/fhir/ingest.rs
@@ -718,6 +718,142 @@ impl FerroEhrService {
         Ok(self.committed_response(ehr_id, &committed))
     }
 
+    /// The ingest door's dry twin — FHIR R4 `$validate`: resolve the mapping,
+    /// map to FLAT, build and provenance-stamp the COMPOSITION exactly as
+    /// [`Self::fhir_ingest`] would, run the commit path's own validation, and
+    /// commit NOTHING. Returns the FHIR `OperationOutcome` carrying the
+    /// verdict: the validator's rejections verbatim as `error` issues, or the
+    /// valid verdict plus the EHR disposition (`would commit into …` /
+    /// `would create …` — the target EHR is resolved, never created) as
+    /// `information` issues.
+    ///
+    /// NOTE: no openEHR spec governs FHIR interop — our own extension; the
+    /// wire convention is HL7 FHIR R4 `resource-operation-validate`
+    /// (<https://hl7.org/fhir/R4/resource-operation-validate.html>).
+    ///
+    /// # Errors
+    /// Operation-level failures mirror [`Self::fhir_ingest`]:
+    /// `VersionedObjectDoesNotExist` (404) when no enabled mapping matches;
+    /// `precondition` when the resource lacks the mapped subject or a
+    /// required field; `Exception` on a broken stored definition or
+    /// terminology fault. CONTENT failures are never errors — they are the
+    /// verdict this operation exists to preview.
+    pub async fn fhir_validate(
+        &self,
+        resource_type: String,
+        profile: Option<String>,
+        a_resource: Value,
+    ) -> Result<Value, SmError> {
+        // Steps 1–4 of the ingest path, verbatim: the dry run validates the
+        // exact artifact the real commit would hand the validator.
+        let def_value = self
+            .resolve_mapping(&resource_type, profile.as_deref())
+            .await?
+            .ok_or_else(|| {
+                SmError::new(
+                    CallStatusType::VersionedObjectDoesNotExist,
+                    format!("no enabled FHIR mapping for resource type '{resource_type}'"),
+                )
+            })?;
+        let def: FhirMappingDefinition = serde_json::from_value(def_value)
+            .map_err(|e| internal_fault("read a stored FHIR mapping definition", &e))?;
+        let subject = ferroehr_ext::fhir::mapping::extract_subject(&a_resource, &def)
+            .map_err(|e| SmError::precondition(e.to_string()).with_source(e))?;
+        // Resolve — never create: the disposition is reported, not enacted.
+        let disposition = match self
+            .get_ehrs_for_subject(SubjectRef::person(
+                subject.id.clone(),
+                subject.namespace.clone(),
+            ))
+            .await?
+            .first()
+        {
+            Some(existing) => format!("would commit into existing EHR {}", existing.ehr_id),
+            None => format!(
+                "would create a new EHR for subject '{}' (namespace '{}')",
+                subject.id, subject.namespace
+            ),
+        };
+        let translations = self.resolve_code_translations(&a_resource, &def).await?;
+        let wt = self.web_template_for(&def.template_id).await?;
+        let flat = ferroehr_ext::fhir::mapping::build_flat(&a_resource, &def, &translations)
+            .map_err(|e| SmError::precondition(e.to_string()).with_source(e))?;
+        let now = ferroehr_ext::fhir::feeder_audit::now_iso();
+        let template_id = def.template_id.clone();
+
+        // From here every failure is the VERDICT: exactly the refusals the
+        // ingest path classes content-invalid (422), previewed instead of
+        // enacted.
+        let verdict = self
+            .dry_run_verdict(&resource_type, &a_resource, &flat, &wt, &now)
+            .await?;
+        Ok(match verdict {
+            None => serde_json::json!({
+                "resourceType": "OperationOutcome",
+                "issue": [
+                    { "severity": "information", "code": "informational",
+                      "diagnostics": format!(
+                          "valid: the resource maps to a COMPOSITION under template \
+                           '{template_id}' that passes commit validation; nothing was committed"
+                      ) },
+                    { "severity": "information", "code": "informational",
+                      "diagnostics": disposition }
+                ]
+            }),
+            Some(rejection) => serde_json::json!({
+                "resourceType": "OperationOutcome",
+                "issue": [
+                    { "severity": "error", "code": "invalid", "diagnostics": rejection },
+                    { "severity": "information", "code": "informational",
+                      "diagnostics": disposition }
+                ]
+            }),
+        })
+    }
+
+    /// The dry run's content verdict: `None` when the mapped COMPOSITION
+    /// builds, re-types and passes the commit path's own validation (the
+    /// validity-checking seam every commit runs); `Some(rejection)` carrying
+    /// the refusal text verbatim otherwise.
+    ///
+    /// # Errors
+    /// Only non-verdict service failures (template store or database faults)
+    /// propagate; a validation refusal is the RETURN VALUE, never an error.
+    async fn dry_run_verdict(
+        &self,
+        resource_type: &str,
+        a_resource: &Value,
+        flat: &serde_json::Map<String, Value>,
+        wt: &openehr_its::flat::webtemplate::model::WebTemplate,
+        now: &str,
+    ) -> Result<Option<String>, SmError> {
+        let mut composition = match openehr_its::flat::convert::composition_from_flat(flat, wt, now)
+        {
+            Ok(c) => c,
+            Err(e) => {
+                return Ok(Some(format!(
+                    "FHIR resource did not map to a valid COMPOSITION: {e}"
+                )));
+            }
+        };
+        let feeder = ferroehr_ext::fhir::feeder_audit::feeder_audit(
+            resource_type,
+            &ferroehr_ext::fhir::feeder_audit::resource_id(a_resource, resource_type),
+            ferroehr_ext::fhir::feeder_audit::resource_version(a_resource).as_deref(),
+            now,
+        );
+        ferroehr_ext::fhir::feeder_audit::inject_feeder_audit(&mut composition, feeder);
+        if let Err(e) = openehr_its::json::from_canonical_value::<openehr_rm::prelude::Composition>(
+            &composition,
+        ) {
+            return Ok(Some(format!(
+                "FHIR resource did not map to a valid COMPOSITION: {e}"
+            )));
+        }
+        self.commit_rejection(crate::versioning::Kind::Composition, &composition)
+            .await
+    }
+
     /// The read façade: the FHIR `searchset` Bundle for `resource_type` scoped
     /// to `patient` (an EHR uuid or a subject external id), reverse-mapped from
     /// the stored COMPOSITIONs. `count` caps rows per mapping (`_count`).

--- a/app/ferroehr/src/service/validity.rs
+++ b/app/ferroehr/src/service/validity.rs
@@ -78,11 +78,33 @@ impl FerroEhrService {
         let Some(kind) = Kind::from_type(rm_type) else {
             return Ok(false);
         };
-        match self.validate_for_commit(kind, a_content, false).await {
-            Ok(()) => Ok(true),
-            Err(ServiceError::ValidationFailed(_) | ServiceError::Unprocessable { .. }) => {
-                Ok(false)
-            }
+        Ok(self.commit_rejection(kind, a_content).await?.is_none())
+    }
+
+    /// The diagnostics-bearing sibling of [`Self::content_valid`]: the same
+    /// commit-path validation, answering `None` for valid content and
+    /// `Some(rejection)` with the refusal text VERBATIM — the seam a dry-run
+    /// caller (the FHIR `$validate` door) previews the commit's own verdict
+    /// through. Full strictness, exactly like a bare validity check.
+    ///
+    /// # Errors
+    /// A validation verdict is never an error; any other service failure from
+    /// the validation path (e.g. a template-store/database fault) propagates
+    /// as its [`SmError`] mapping.
+    pub(crate) async fn commit_rejection(
+        &self,
+        a_kind: Kind,
+        a_content: &Value,
+    ) -> Result<Option<String>, SmError> {
+        match self.validate_for_commit(a_kind, a_content, false).await {
+            Ok(()) => Ok(None),
+            // Rendered through the SM bridge — where the per-path violation
+            // list joins into one message — so the text matches what the
+            // committing routes serve, verbatim.
+            Err(
+                rejection
+                @ (ServiceError::ValidationFailed(_) | ServiceError::Unprocessable { .. }),
+            ) => Ok(Some(SmError::from(rejection).message)),
             Err(other) => Err(other.into()),
         }
     }

--- a/tools/cnf-runner/artifacts/vocab/wire_surface.yaml
+++ b/tools/cnf-runner/artifacts/vocab/wire_surface.yaml
@@ -1873,6 +1873,7 @@ served_extensions:
   - family: fhir-r4-connector
     routes:
       - "POST /ferroehr/rest/openehr/v1/fhir/r4/{resource_type}"
+      - "POST /ferroehr/rest/openehr/v1/fhir/r4/{resource_type}/$validate"
       - "GET /ferroehr/rest/openehr/v1/fhir/r4/{resource_type}"
     config_gate: "[fhir].api_enabled (default off); the gate sits in-handler behind authentication and refuses with a FHIR OperationOutcome"
     spec_silence: "FHIR interoperability is outside every released openEHR component: ITS-REST defines no FHIR resource, media type or route, and no released clause governs the URI space beyond the resource set. Our own design/extension — the inbound HL7 FHIR R4 façade, whose contract is HL7's, not openEHR's."

--- a/website/book/src/beyond-core/fhir.md
+++ b/website/book/src/beyond-core/fhir.md
@@ -40,6 +40,38 @@ Provenance is not optional: the composition the CDR stores carries a
 `FEEDER_AUDIT` naming the FHIR origin and the source resource's own id, so an
 ingested record is always distinguishable from one authored in openEHR.
 
+## Validating without committing (`$validate`)
+
+`POST /fhir/r4/{resource_type}/$validate` is the ingest door's dry twin,
+following FHIR R4's own
+[validation operation](https://hl7.org/fhir/R4/resource-operation-validate.html)
+convention. It runs the whole ingest pipeline — mapping resolution, the FLAT
+build, the `FEEDER_AUDIT` stamp, and the *same validation the real commit
+runs* — and **commits nothing**: no composition, no version, and no EHR is
+created (the target EHR is resolved and reported, never touched).
+
+The response is a FHIR `OperationOutcome`, and a completed validation is
+`200` whichever way the verdict falls:
+
+- **Valid**: `information` issues — the verdict naming the resolved template,
+  plus the EHR disposition (`would commit into existing EHR <id>`, or
+  `would create a new EHR for subject '<id>'`).
+- **Invalid**: an `error` issue carrying the openEHR validator's rejection
+  **verbatim** — the exact text the real ingest would refuse with as a `422` —
+  plus the same disposition issue.
+
+Operation-level failures mirror the ingest door: no enabled mapping is `404`,
+a type outside the starter set is `501`, a malformed body is `400`, and the
+disabled connector is `404`. This is what makes mapping development safe:
+iterate on a mapping with `$validate` against real sample resources, and only
+switch to the real `POST` once the outcome reads valid.
+
+```bash
+curl -s -X POST "$CDR/fhir/r4/Observation/\$validate" \
+  -H 'Content-Type: application/json' \
+  --data-binary @observation.json | jq '.issue[].diagnostics'
+```
+
 ## Read façade
 
 `GET /fhir/r4/{resource_type}?patient=<subject>` returns openEHR data
@@ -99,7 +131,59 @@ through an admin API (classed under admin authorization):
 A mapping definition binds **one FHIR resource type** (optionally scoped to a
 `meta.profile` URL) to **one openEHR template**, and lists field bindings — each
 mapping an openEHR FLAT path to a FHIR path, or to a constant, shaped by a
-transform:
+transform.
+
+**Resolution is two-step and deterministic.** An incoming resource resolves by
+its type plus the *first* entry of `meta.profile` (only `meta.profile[0]` is
+consulted): an enabled mapping whose `profile_url` **exactly matches** that URL
+wins; otherwise the type's enabled mapping with **no `profile_url`** — the
+type default — applies. A resource declaring no profile matches only the type
+default. When neither exists, the ingest (and `$validate`) answer `404`.
+
+The stored definition is the deployable artifact — the CDR stores it verbatim
+and interprets it at ingest time, so a mapping deploys, updates, and rolls
+back without a server release. Its shape (this is the whole contract — no
+openEHR specification governs FHIR interop; the wire vocabulary follows
+[HL7 FHIR R4](https://hl7.org/fhir/R4/)):
+
+```json
+{
+  "resource_type": "Observation",
+  "profile_url": "http://hl7.org/fhir/StructureDefinition/bp",
+  "template_id": "blood_pressure.en.v1",
+  "subject": {
+    "reference_path": "subject.reference",
+    "namespace": "fhir",
+    "strip_prefix": "Patient/"
+  },
+  "context": {
+    "ctx/language": "en",
+    "ctx/territory": "US",
+    "ctx/composer_name": "fhir-connector"
+  },
+  "entries": [
+    { "openehr_path": "blood_pressure/blood_pressure:0/systolic",
+      "fhir_path": "component.where(code.coding[0].code = '8480-6').valueQuantity.value",
+      "transform": { "kind": "quantity",
+        "unit_path": "component.where(code.coding[0].code = '8480-6').valueQuantity.unit" },
+      "required": true },
+    { "openehr_path": "blood_pressure/blood_pressure:0/diastolic",
+      "fhir_path": "component.where(code.coding[0].code = '8462-4').valueQuantity.value",
+      "transform": { "kind": "quantity",
+        "unit_path": "component.where(code.coding[0].code = '8462-4').valueQuantity.unit" },
+      "required": true }
+  ]
+}
+```
+
+The example binds the HL7 FHIR R4 core
+[blood-pressure profile](https://hl7.org/fhir/R4/bp.html) (systolic LOINC
+`8480-6`, diastolic `8462-4`, each a `component` of one `Observation`) to a
+blood-pressure template's two quantity leaves. `subject` names where the
+patient identity lives in the resource and how it becomes the EHR subject
+(`Patient/p-42` → subject id `p-42` in namespace `fhir`); `context` supplies
+the FLAT `ctx/` defaults every built composition carries (an omitted
+`ctx/time` defaults to the ingestion instant). The transforms:
 
 | Transform | What it writes |
 |---|---|


### PR DESCRIPTION
Closes #342

**The design ruling** (criterion 1): the wire shape is FHIR R4's own validation operation — `POST /fhir/r4/{resource_type}/$validate` (HL7 FHIR R4 `resource-operation-validate`) as the ingest door's sibling; the response is a FHIR `OperationOutcome`; a COMPLETED validation is `200` whichever way the verdict falls (the verdict rides the issues — the commit path's rejections verbatim, or the valid verdict naming the resolved template), while operation-level failures mirror the ingest door's statuses (404 no mapping, 501 outside the starter set, 400 malformed body, 404 connector off); an absent EHR is SIMULATED — the subject is resolved and the disposition reported (`would create…` / `would commit into existing EHR…`), never created. Same `[fhir].api_enabled` gate and the same authorization class as the door it previews.

**The implementation** reuses the shipped chain end to end: mapping resolution → terminology translations → WebTemplate → FLAT build → `FEEDER_AUDIT` stamp → the typed re-read → the validity-checking seam every commit runs. `service::validity` gains `commit_rejection` — the diagnostics-bearing sibling of the SM `content_valid` bool — rendering rejections through the SM bridge so the text matches the committing routes byte-for-byte.

**Commits nothing, asserted**: the REST-level tests count `vo_version` and `ehr` rows before/after on the valid, invalid and existing-EHR paths (criterion 2); the rejection text is asserted verbatim against the ingest door's own 422 rendering (criterion 3). The authz route matrix and the served-OpenAPI extension battery declare the new route; the CNF `wire_surface` extension family lists it (`never_gates`).

**Docs** (criterion 4): the book's FHIR chapter now defines the mapping contract as an extension contract — the verbatim-stored definition shape, the two-step resolution rule (exact `meta.profile[0]` match, then the NULL-profile type default), the enabled flag, and a worked example against the HL7 R4 core blood-pressure profile — plus the `$validate` section, all flagged as our own extension with the FHIR citations. Changelog entry added (criterion 5's endpoint-map half is superseded: `docs/endpoint-map.md` was deleted by the 2026-07-26 ruling — call chains are read from the code; the served OpenAPI documents the route natively).

**Verification**: ferroehr + ferroehr-rest suites 1711/1711; clippy clean; `docs-claims` OK; CNF `validate --specs` 0 findings. The route is extension-only (`never_gates`) so no conformance-pipeline drift is possible.