### PR TITLE
refactor(admin-ui): typed wire-status comparisons; the guard covers the whole tree (#2055)

### DIFF
--- a/app/ferroehr-admin-ui/Cargo.toml
+++ b/app/ferroehr-admin-ui/Cargo.toml
@@ -97,7 +97,10 @@ openidconnect = { workspace = true, optional = true }
 # filter-preserving pagination hrefs on every target (ssr, hydrate, and
 # plain featureless test builds); the crate is tiny and wasm-clean.
 urlencoding = { workspace = true }
-http = { workspace = true, optional = true }
+# Typed status comparisons on every target (owner directive 2026-08-06,
+# issue #2055): `http::StatusCode` names the codes the pages branch on, and
+# the crate is tiny and wasm-clean — so it is non-optional, like urlencoding.
+http = { workspace = true }
 
 # browser-only (behind `hydrate`)
 wasm-bindgen = { workspace = true, optional = true }
@@ -143,7 +146,6 @@ ssr = [
     "dep:tower-sessions",
     "dep:csv",
     "dep:openidconnect",
-    "dep:http",
     # The full ITS surface BFF-side (OPT parsing + WebTemplate building); the
     # scope grammar itself is unconditional (see the dependency comment above).
     "openehr-its/full",

--- a/app/ferroehr-admin-ui/src/auth.rs
+++ b/app/ferroehr-admin-ui/src/auth.rs
@@ -50,12 +50,12 @@ pub async fn login_basic(
     // probe trivially passes, which is the dev posture.
     let url = state.cdr.rest_v1("definition/template/adl1.4");
     let probe = state.cdr.get(&credential, &url, "application/json").await?;
-    if probe.status == 401 {
+    if probe.is(http::StatusCode::UNAUTHORIZED) {
         return Err(AdminUiError::Invalid(
             "wrong username or password".to_owned(),
         ));
     }
-    if probe.status >= 500 {
+    if probe.status >= http::StatusCode::INTERNAL_SERVER_ERROR.as_u16() {
         return Err(AdminUiError::Cdr {
             status: probe.status,
             message: "CDR error while validating credentials".to_owned(),

--- a/app/ferroehr-admin-ui/src/cdr.rs
+++ b/app/ferroehr-admin-ui/src/cdr.rs
@@ -28,6 +28,19 @@ pub struct CdrResponse {
     pub body: String,
 }
 
+impl CdrResponse {
+    /// Whether the response carries exactly this status.
+    ///
+    /// The one comparison seam (owner directive 2026-08-06): callers name an
+    /// [`http::StatusCode`] constant, so a transposed code is a compile
+    /// error, never a silent wrong branch; the numeric field itself stays
+    /// `u16` because it is deserialized from and rendered into wire JSON.
+    #[must_use]
+    pub fn is(&self, code: http::StatusCode) -> bool {
+        self.status == code.as_u16()
+    }
+}
+
 /// The one outbound HTTP client to the CDR.
 #[derive(Debug, Clone)]
 pub struct CdrClient {

--- a/app/ferroehr-admin-ui/src/management.rs
+++ b/app/ferroehr-admin-ui/src/management.rs
@@ -109,7 +109,7 @@ impl ManagementAvailability {
 /// gate asks about.
 #[must_use]
 pub fn availability_of_status(status: u16) -> ManagementAvailability {
-    if status == 404 {
+    if status == http::StatusCode::NOT_FOUND.as_u16() {
         ManagementAvailability::Disabled
     } else {
         ManagementAvailability::Available
@@ -245,7 +245,7 @@ pub async fn fetch_readiness() -> Result<ReadinessView, AdminUiError> {
     let state: crate::state::AppState = expect_context();
     let url = state.cdr.origin_url("health/readiness");
     let response = state.cdr.get_public(&url, "application/json").await?;
-    let body = if response.status == 503 {
+    let body = if response.is(http::StatusCode::SERVICE_UNAVAILABLE) {
         response.body
     } else {
         crate::cdr::CdrClient::expect_success(response)?.body
@@ -674,7 +674,7 @@ async fn management_get(path: &str) -> Result<Option<String>, AdminUiError> {
         .cdr
         .get(&session.credential, &url, "application/json")
         .await?;
-    if response.status == 404 {
+    if response.is(http::StatusCode::NOT_FOUND) {
         return Ok(None);
     }
     Ok(Some(crate::cdr::CdrClient::expect_success(response)?.body))

--- a/app/ferroehr-admin-ui/src/pages/audit.rs
+++ b/app/ferroehr-admin-ui/src/pages/audit.rs
@@ -135,7 +135,7 @@ pub async fn search_audit(
         .cdr
         .get(&session.credential, &url, "application/fhir+json")
         .await?;
-    if response.status == 404 {
+    if response.is(http::StatusCode::NOT_FOUND) {
         // The local Audit Record Repository is disabled ([audit.store]) —
         // a rendered state, never an error.
         return Ok(AuditPage {

--- a/app/ferroehr-admin-ui/src/pages/composition.rs
+++ b/app/ferroehr-admin-ui/src/pages/composition.rs
@@ -290,7 +290,7 @@ pub async fn update_composition(
     // 412 Precondition Failed = a mid-air collision (the latest version moved
     // since this page loaded); give it a friendly prefix, the CDR diagnostic
     // appended verbatim.
-    if response.status == 412 {
+    if response.is(http::StatusCode::PRECONDITION_FAILED) {
         let detail = crate::cdr::CdrClient::expect_success(response)
             .err()
             .map(|e| e.to_string())

--- a/app/ferroehr-admin-ui/src/pages/ehr_detail/directory/mod.rs
+++ b/app/ferroehr-admin-ui/src/pages/ehr_detail/directory/mod.rs
@@ -184,7 +184,7 @@ pub async fn fetch_directory(
     // Both are the first-class "no live directory" state: the create flow
     // renders, and creating opens a NEW hierarchy (the deleted one's history
     // stays readable by version_uid).
-    if response.status == 404 || response.status == 204 {
+    if response.is(http::StatusCode::NOT_FOUND) || response.is(http::StatusCode::NO_CONTENT) {
         return Ok(None);
     }
     let body = crate::cdr::CdrClient::expect_success(response)?.body;
@@ -360,7 +360,7 @@ pub async fn list_directory_versions(
         .cdr
         .get(&session.credential, &base, "application/json")
         .await?;
-    if current.status == 404 {
+    if current.is(http::StatusCode::NOT_FOUND) {
         return Ok(Vec::new());
     }
     let current_body = crate::cdr::CdrClient::expect_success(current)?.body;
@@ -381,7 +381,7 @@ pub async fn list_directory_versions(
             .cdr
             .get(&session.credential, &url, "application/json")
             .await?;
-        if response.status == 404 {
+        if response.is(http::StatusCode::NOT_FOUND) {
             break;
         }
         let body = crate::cdr::CdrClient::expect_success(response)?.body;
@@ -475,7 +475,7 @@ pub async fn fetch_directory_subtree(
         .cdr
         .get(&session.credential, &url, "application/json")
         .await?;
-    if response.status == 404 {
+    if response.is(http::StatusCode::NOT_FOUND) {
         return Ok(DirectorySubtree::Missing);
     }
     let body = crate::cdr::CdrClient::expect_success(response)?.body;

--- a/app/ferroehr-admin-ui/src/pages/ehrs.rs
+++ b/app/ferroehr-admin-ui/src/pages/ehrs.rs
@@ -350,7 +350,7 @@ pub async fn find_ehr_by_subject(
         .cdr
         .get(&session.credential, &url, "application/json")
         .await?;
-    if response.status == 404 {
+    if response.is(http::StatusCode::NOT_FOUND) {
         return Ok(None);
     }
     let response = crate::cdr::CdrClient::expect_success(response)?;

--- a/app/ferroehr-admin-ui/src/pages/system.rs
+++ b/app/ferroehr-admin-ui/src/pages/system.rs
@@ -60,7 +60,7 @@ pub async fn fetch_smart_config() -> Result<Option<String>, AdminUiError> {
     // (master04-service_discovery.adoc §"the configuration endpoint").
     let url = state.cdr.origin_url(".well-known/smart-configuration");
     let response = state.cdr.get_public(&url, "application/json").await?;
-    if response.status == 404 {
+    if response.is(http::StatusCode::NOT_FOUND) {
         return Ok(None);
     }
     Ok(Some(crate::cdr::CdrClient::expect_success(response)?.body))
@@ -140,7 +140,7 @@ pub async fn fetch_openapi(
     let response = state.cdr.get_public(&url, "application/json").await?;
     // Public surface; if a deployment happens to gate it, retry with the
     // session credential before giving up.
-    let response = if response.status == 401 {
+    let response = if response.is(http::StatusCode::UNAUTHORIZED) {
         state
             .cdr
             .get(&session.credential, &url, "application/json")

--- a/app/ferroehr-admin-ui/src/queries_api.rs
+++ b/app/ferroehr-admin-ui/src/queries_api.rs
@@ -122,7 +122,7 @@ pub async fn list_stored_queries() -> Result<Vec<StoredQueryRow>, AdminUiError> 
         .cdr
         .get(&session.credential, &url, "application/json")
         .await?;
-    if response.status == 404 {
+    if response.is(http::StatusCode::NOT_FOUND) {
         // A CDR with no stored queries may 404 the listing; treat as empty.
         return Ok(Vec::new());
     }

--- a/app/ferroehr-admin-ui/tests/it/e2e_ehr_status.rs
+++ b/app/ferroehr-admin-ui/tests/it/e2e_ehr_status.rs
@@ -133,9 +133,9 @@ async fn put_status(
         .send()
         .await
         .expect("commit an out-of-band EHR_STATUS version");
-    let status = response.status().as_u16();
+    let status = response.status();
     assert!(
-        status == 200 || status == 204,
+        status == http::StatusCode::OK || status == http::StatusCode::NO_CONTENT,
         "the out-of-band EHR_STATUS update must be accepted (got {status})"
     );
 }

--- a/scripts/checks/typed-status.sh
+++ b/scripts/checks/typed-status.sh
@@ -44,31 +44,18 @@
 set -euo pipefail
 cd "$(dirname "$0")/../.."
 
-# The `--all` scope, and why it is not the whole tree yet.
-#
-# The rule is repo-wide, but two crates carry pre-existing violations of a shape
-# that cannot be fixed as a side effect of adding this guard, so `--all` covers
-# the server and the specification crates — where a mis-compared status IS a wire
-# defect — and the two sweeps are tracked instead of quietly excluded forever:
-#
-#   * `app/ferroehr-admin-ui` — the console's own DTOs, in a crate parked pending
-#     its full pass (#2055).
-#
-# `tools/cnf-runner` was the other one and is now clean (#2054): it holds
-# `StatusCode` in memory and applies `.as_u16()` only where a number is rendered
-# or serialized, with the committed artifacts proven byte-identical.
-#
-# `--all-really` still checks anything, so the #2055 sweep can verify itself
-# as it lands. Explicit paths (the per-edit hook) honour the SAME parked-crate
-# exclusion as `--all` — the hook must never block an edit CI accepts (#2441's
-# QA pass hit exactly that on the console's u16 DTO fields).
+# `--all` covers the WHOLE tree. Both parked sweeps have landed: the runner
+# (#2054) holds `StatusCode` in memory and applies `.as_u16()` only where a
+# number is rendered or serialized, and the console (#2055) compares through
+# `CdrResponse::is(StatusCode)` and named constants, its `status: u16` DTO
+# fields staying numeric because they are deserialized from and rendered into
+# wire JSON. `--all-really` is kept as an alias so callers written against
+# the parked-era flag keep working.
 collect() {
-  if [ "${1:-}" = "--all-really" ]; then
+  if [ "${1:-}" = "--all-really" ] || [ "${1:-}" = "--all" ]; then
     git ls-files '*.rs'
-  elif [ "${1:-}" = "--all" ]; then
-    git ls-files '*.rs' | grep -v '^app/ferroehr-admin-ui/'
   elif [ "$#" -gt 0 ]; then
-    printf '%s\n' "$@" | grep -v 'app/ferroehr-admin-ui/' || true
+    printf '%s\n' "$@"
   else
     git diff --name-only origin/develop...HEAD -- '*.rs' 2>/dev/null || git ls-files '*.rs'
   fi


### PR DESCRIPTION
Closes #2055

Fifteen sites compared a status as a number — `if probe.status == 401`, `if response.status == 404` — where the console BRANCHES: 401 drives re-authentication, 404 drives the endpoint-not-mounted path, so a transposed literal silently changes behaviour (the 2026-08-06 owner directive).

- `CdrResponse::is(StatusCode)` is the one comparison seam: callers name `http::StatusCode` constants (`NOT_FOUND`, `UNAUTHORIZED`, `PRECONDITION_FAILED`, `SERVICE_UNAVAILABLE`, `NO_CONTENT`), so a typo'd code is a compile error. The `status: u16` DTO fields stay numeric — they are deserialized from and rendered into wire JSON (`.as_u16()` kept only where a number is rendered/serialized, per the criterion).
- The `http` crate moves from ssr-only to both targets (tiny, wasm-clean — the same posture as `urlencoding`); the range check (`>= 500`) and the bare-u16 helper compare against named constants.
- `typed-status.sh --all` now sweeps the whole tree: the console exclusion and the parked-crate path filter are deleted, the header rewritten, `--all-really` kept as an alias.

Verification: `typed-status.sh --all` OK; both console clippy lanes clean (ssr all-targets + wasm32 hydrate); console suite 277/277; fmt clean.