### PR TITLE
fix(conformance): the party statement's product version tracks the workspace, guarded (#2576)

### DIFF
--- a/.claude/rules/changelog.md
+++ b/.claude/rules/changelog.md
@@ -25,7 +25,10 @@ optional:
   `deploy/helm/validate.sh --update`, + `CITATION.cff` `version` and
   `date-released` (the `citation-guard` CI job enforces the version match),
   then re-render `.zenodo.json` (`bash scripts/render/zenodo-json.sh`, checked
-  by the same job) — it is GENERATED, never hand-edited, because Zenodo ignores
+  by the same job), + the ferroehr party statement's product version
+  (`tools/cnf-runner/party/ferroehr/statement.json`, regenerating the derived
+  documents via `bash scripts/render/conformance-docs.sh` — the
+  `statement-version.sh` step of `citation-guard` enforces the match) — it is GENERATED, never hand-edited, because Zenodo ignores
   `CITATION.cff` completely whenever a `.zenodo.json` exists
   (<https://help.zenodo.org/docs/github/describe-software/zenodo-json/>),
   + the default image tags in `docker-compose.yml` — the `ghcr.io/…:X.Y.Z`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1952,6 +1952,14 @@ jobs:
           persist-credentials: false
       - name: Validate CITATION.cff (CFF 1.2.0 schema)
         run: pipx run cffconvert --validate
+      # The ferroehr party statement is the published conformance claim for
+      # THE product this repo ships; its product version sat at 3.6.0 while
+      # the record reached 3.20.0 with nothing failing (#2576). Same
+      # version-agreement family as the CITATION check below; the ehrbase
+      # party statement deliberately stays unchecked (another vendor's
+      # product).
+      - name: The ferroehr party statement's product version matches the workspace
+        run: bash scripts/checks/statement-version.sh
       - name: CITATION.cff version matches the workspace version
         run: |
           set -euo pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,11 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- The published conformance statement's product version had sat at 3.6.0
+  since that release while the record beside it moved on — it now matches
+  the workspace version, and the release-cut guard fails whenever the two
+  diverge again.
+
 - The product is spelled **FerroEHR** everywhere a human reads it as a name:
   the admin console's sidebar wordmark and every browser-tab title (both
   previously `ferroehr-admin`), the three published container images'

--- a/docs/conformance/ferroehr/CONFORMANCE_STATEMENT.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_STATEMENT.md
@@ -1,6 +1,6 @@
 # Conformance Statement (SDoC)
 
-Product: FerroEHR 3.6.0 — Ruben Talstra (urn:rubentalstra:ferroehr)
+Product: FerroEHR 3.20.0 — Ruben Talstra (urn:rubentalstra:ferroehr)
 Schedule release: cnf-2.0-w2
 
 ## Declared spec versions

--- a/scripts/checks/statement-version.sh
+++ b/scripts/checks/statement-version.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+# The ferroehr party statement's product version must equal the workspace
+# version (#2576): the statement is the published conformance claim for THE
+# product this repo ships, and it sat at 3.6.0 while the record reached
+# 3.20.0 — the rendered CONFORMANCE_STATEMENT.md contradicted the report
+# beside it for fourteen releases with nothing failing. The release cut
+# bumps both in one PR (.claude/rules/changelog.md); this guard is the
+# failing check that keeps them together. The ehrbase party statement is
+# deliberately NOT checked — it declares another vendor's product.
+#
+# Usage: scripts/checks/statement-version.sh
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+workspace=$(grep -m1 '^version = "' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+statement=$(jq -r '.product.version' tools/cnf-runner/party/ferroehr/statement.json)
+
+if [ -z "$workspace" ]; then
+  echo "statement-version: cannot read the workspace version from Cargo.toml" >&2
+  exit 1
+fi
+if [ "$workspace" != "$statement" ]; then
+  echo "statement-version: the ferroehr party statement declares product \
+version $statement but the workspace is $workspace — bump \
+tools/cnf-runner/party/ferroehr/statement.json (and regenerate the derived \
+documents: bash scripts/render/conformance-docs.sh) in the same PR." >&2
+  exit 1
+fi
+echo "statement-version: OK ($workspace)."

--- a/tools/cnf-runner/party/ferroehr/statement.json
+++ b/tools/cnf-runner/party/ferroehr/statement.json
@@ -1,7 +1,7 @@
 {
   "product": {
     "name": "FerroEHR",
-    "version": "3.6.0",
+    "version": "3.20.0",
     "vendor": "Ruben Talstra",
     "identifier": "urn:rubentalstra:ferroehr"
   },


### PR DESCRIPTION
Closes #2576

The ferroehr party statement declared **product FerroEHR 3.6.0** while the committed record and the rendered documents carried 3.20.0 — the published `CONFORMANCE_STATEMENT.md` opened with a product version fourteen releases stale, directly beside a report saying 3.20.0, and nothing failed.

The statement moves to the workspace version and the derived party documents regenerate (on the post-#2583 renderer, so the corrected statement line and the new report heading land together). The staleness class gets its failing check — a rule without one is a wish: `scripts/checks/statement-version.sh` requires the ferroehr party statement's product version to equal the workspace version (the ehrbase party statement is deliberately unchecked — it declares another vendor's product), mutation-proven in both directions, wired as a step of the **citation-guard** job (the existing version-agreement-at-cut gate) and added to the release-cut checklist in `.claude/rules/changelog.md`, so the cut PR that bumps the workspace version cannot leave the statement behind.