### PR TITLE
fix(fhir): one Bundle entry per composition on the read facade (#2579)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,12 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- The FHIR read facade serves one Bundle entry per stored composition —
+  with several enabled mappings over one template it previously served the
+  same composition once per mapping, duplicating `fullUrl`s within a Bundle
+  (HL7 FHIR R4 `bdl-7`) and over-counting `total`. The mapping that wins a
+  composition follows the same precedence ingest uses.
+
 - The published conformance statement's product version had sat at 3.6.0
   since that release while the record beside it moved on — it now matches
   the workspace version, and the release-cut guard fails whenever the two

--- a/app/ferroehr-rest/tests/it/fhir_inbound.rs
+++ b/app/ferroehr-rest/tests/it/fhir_inbound.rs
@@ -643,3 +643,58 @@ async fn validate_operation_level_statuses_mirror_ingest() {
     .await;
     assert_eq!(status, StatusCode::NOT_FOUND, "the config gate answers 404");
 }
+
+/// Two enabled mappings over ONE template serve one committed composition as
+/// ONE Bundle entry — never one per mapping. HL7 FHIR R4 `bdl-7` ("`FullUrl`
+/// must be unique in a bundle"); the #2579 regression, measured live as
+/// `total: 2` with two identical `fullUrl`s for one stored composition.
+#[tokio::test]
+async fn two_mappings_over_one_template_serve_one_entry_per_composition() {
+    let db = testkit::db().await.expect("testkit database");
+    let (_svc, router) = app_with_template(db.pool(), true).await;
+
+    for (name, profile) in [("bp", PROFILE_OK), ("bp-alt", "http://example.org/alt")] {
+        let (status, _, body) = send(
+            &router,
+            req("POST", MAPPINGS, Some(mapping_body(name, profile, "US"))),
+        )
+        .await;
+        assert_eq!(status, StatusCode::CREATED, "mapping {name}: {body}");
+    }
+
+    let (status, _, oo) = send(
+        &router,
+        req(
+            "POST",
+            &format!("{BASE}/fhir/r4/Observation"),
+            Some(bp_observation(PROFILE_OK)),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "ingest committed: {oo}");
+
+    let (status, _, bundle) = send(
+        &router,
+        req(
+            "GET",
+            &format!("{BASE}/fhir/r4/Observation?patient=p-42&_count=10"),
+            None,
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "façade query: {bundle}");
+    assert_eq!(
+        bundle["total"], 1,
+        "one composition is one entry, regardless of how many mappings are enabled: {bundle}"
+    );
+    let entries = bundle["entry"].as_array().expect("entry array");
+    assert_eq!(entries.len(), 1, "{bundle}");
+    let full_urls: Vec<&str> = entries
+        .iter()
+        .filter_map(|e| e["fullUrl"].as_str())
+        .collect();
+    let mut deduped = full_urls.clone();
+    deduped.sort_unstable();
+    deduped.dedup();
+    assert_eq!(full_urls.len(), deduped.len(), "unique fullUrls: {bundle}");
+}

--- a/app/ferroehr/src/extensions/fhir/ingest.rs
+++ b/app/ferroehr/src/extensions/fhir/ingest.rs
@@ -266,6 +266,14 @@ impl FerroEhrService {
     ) -> Result<Value, SmError> {
         let scope = self.resolve_patient_scope(patient).await?;
         let mut entries: Vec<Value> = Vec::new();
+        // One entry per COMPOSITION, never per mapping: two enabled mappings
+        // sharing a template would otherwise serve the same versioned object
+        // twice under one fullUrl, which HL7 FHIR R4 bundle.html `bdl-7`
+        // forbids ("FullUrl must be unique in a bundle"). Definitions iterate
+        // in the ingest disposition's own precedence (profiled first, then
+        // id — `enabled_definitions_for_type`), so the mapping that wins a
+        // composition is the one ingest would have picked.
+        let mut seen: std::collections::HashSet<VoId> = std::collections::HashSet::new();
         for raw in self.enabled_definitions_for_type(resource_type).await? {
             let def: FhirMappingDefinition = serde_json::from_value(raw)
                 .map_err(|e| internal_fault("read a stored FHIR mapping definition", &e))?;
@@ -305,6 +313,9 @@ impl FerroEhrService {
                 ) else {
                     continue;
                 };
+                if seen.contains(&vo_id) {
+                    continue;
+                }
                 let Some(read) = crate::versioning::read::read_version_by_ordinal(
                     &self.pool,
                     self.spec_profile,
@@ -320,6 +331,7 @@ impl FerroEhrService {
                 if read.canonical.is_null() || !read.canonical.is_object() {
                     continue;
                 }
+                seen.insert(vo_id);
                 let mut fhir = ferroehr_ext::fhir::reverse::to_fhir(
                     resource_type,
                     &read.canonical,


### PR DESCRIPTION
Closes #2579

Measured live during #313: two enabled `Observation` mappings over one template made `GET /fhir/r4/Observation?patient=…` answer `total: 2` with two entries carrying the IDENTICAL `fullUrl` for one stored composition — the search-bundle loop pushed one entry per (definition, composition) pair. The cited authority (our own extension; no openEHR spec governs FHIR interop): HL7 FHIR R4 `bundle.html` invariant **bdl-7** — "FullUrl must be unique in a bundle, or else entries with the same fullUrl must have different meta.versionId".

The bundle now keeps the first entry per versioned object. `enabled_definitions_for_type` already iterates in the ingest disposition's own precedence (profiled first, then id), so the mapping that wins a composition on read is the one ingest would have picked — the selection rule is stated at the loop, mirroring the ingest disposition rule as #2579's criteria asked. The outbound events fanout deliberately stays per-mapping (each mapping is a subscriber-facing projection; stated there).

Regression pinned: two enabled mappings, one ingested Observation → `total: 1`, one entry, unique `fullUrl`s. `fhir_inbound` 14/14; `ferroehr` + `ferroehr-rest` clippy clean; fmt + guards green. The facade is a served extension with no CNF battery (the adjudicated posture), so the conformance baseline is untouched.