### PR TITLE
chore(admin-ui): one refusal reader for both error vocabularies (#2581)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,11 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- Admin console: a FHIR-shaped refusal (an `OperationOutcome`) now renders
+  its human diagnostics wherever an error surfaces — the shared diagnostic
+  reader speaks both error vocabularies, so no screen can hand raw JSON to
+  a toast.
+
 - The FHIR read facade serves one Bundle entry per stored composition —
   with several enabled mappings over one template it previously served the
   same composition once per mapping, duplicating `fullUrl`s within a Bundle

--- a/app/ferroehr-admin-ui/src/cdr.rs
+++ b/app/ferroehr-admin-ui/src/cdr.rs
@@ -343,11 +343,40 @@ impl CdrClient {
     }
 }
 
-/// Pull the human diagnostic out of an openEHR error body
-/// (`{"error": …, "message": …}` per ITS-REST), falling back to the raw
-/// body or the bare status.
+/// Pull the human diagnostic out of a refused body, whatever its vocabulary:
+/// the openEHR error shape (`{"error": …, "message": …}` per ITS-REST) or a
+/// FHIR `OperationOutcome` (the connector authors its refusals as outcomes —
+/// their `issue[].diagnostics` join into one line), falling back to the raw
+/// body or the bare status. ONE reader for both vocabularies, so no screen
+/// ever hands raw JSON to a toast (#2581).
 fn diagnostic_of(response: &CdrResponse) -> String {
     if let Ok(value) = serde_json::from_str::<serde_json::Value>(&response.body) {
+        if value
+            .get("resourceType")
+            .and_then(serde_json::Value::as_str)
+            == Some("OperationOutcome")
+        {
+            let joined = value
+                .get("issue")
+                .and_then(serde_json::Value::as_array)
+                .map(|issues| {
+                    issues
+                        .iter()
+                        .filter_map(|issue| {
+                            issue
+                                .get("diagnostics")
+                                .or_else(|| issue.get("code"))
+                                .and_then(serde_json::Value::as_str)
+                                .filter(|text| !text.is_empty())
+                        })
+                        .collect::<Vec<_>>()
+                        .join("; ")
+                })
+                .unwrap_or_default();
+            if !joined.is_empty() {
+                return joined;
+            }
+        }
         for key in ["message", "error"] {
             if let Some(text) = value.get(key).and_then(serde_json::Value::as_str) {
                 return text.to_owned();
@@ -374,6 +403,22 @@ mod tests {
             content_type: Some("application/json".to_owned()),
             body: body.to_owned(),
         }
+    }
+
+    #[test]
+    fn an_operation_outcome_refusal_yields_its_diagnostics_never_raw_json() {
+        // #2581: the shared reader speaks the FHIR refusal vocabulary too.
+        let response = CdrResponse {
+            status: 400,
+            content_type: Some("application/fhir+json".to_owned()),
+            body: r#"{"resourceType":"OperationOutcome","issue":[
+                {"severity":"error","code":"invalid","diagnostics":"missing field `template_id`"},
+                {"severity":"error","code":"structure"}]}"#
+                .to_owned(),
+        };
+        let text = diagnostic_of(&response);
+        assert_eq!(text, "missing field `template_id`; structure");
+        assert!(!text.contains("resourceType"), "never raw JSON: {text}");
     }
 
     #[test]

--- a/app/ferroehr-admin-ui/src/fhir.rs
+++ b/app/ferroehr-admin-ui/src/fhir.rs
@@ -27,14 +27,15 @@
 //! group (`401`/`403`) still counts as present, and the refusal surfaces as
 //! copy on the screen that asked.
 //!
-//! **Two error vocabularies meet on this surface, and the split is load
-//! bearing.** Every refusal the connector itself authors is a FHIR
+//! **Two error vocabularies meet on this surface, and ONE reader speaks
+//! both (#2581).** Every refusal the connector itself authors is a FHIR
 //! `OperationOutcome` (`{resourceType, issue: [{severity, code,
-//! diagnostics}]}`), which the shared openEHR diagnostic reader
-//! ([`crate::cdr`]) cannot see into — so this module extracts the diagnostics
-//! itself ([`outcome_summary`]). Authentication and authorization refusals come
-//! from the layer ABOVE the handler and keep the openEHR `{error, message}`
-//! body, so they travel the shared path unchanged.
+//! diagnostics}]}`); authentication and authorization refusals come from the
+//! layer ABOVE the handler and carry the openEHR `{error, message}` body.
+//! The shared reader ([`crate::cdr`]'s `expect_success`) extracts the human
+//! diagnostic from either shape, so this module keeps no refusal shim;
+//! [`outcome_summary`] remains for the VERDICT panel, which classifies
+//! outcomes rather than reading refusals.
 //!
 //! Every `#[server]` fn guards with
 //! [`require_session`](crate::session::require_session) first (a server fn is a
@@ -460,7 +461,7 @@ pub async fn list_fhir_mappings() -> Result<Option<Vec<FhirMappingRow>>, AdminUi
     if response.is(http::StatusCode::NOT_FOUND) {
         return Ok(None);
     }
-    let body = expect_fhir_success(response)?.body;
+    let body = crate::cdr::CdrClient::expect_success(response)?.body;
     let value = serde_json::from_str::<serde_json::Value>(&body)
         .map_err(|e| AdminUiError::Internal(format!("FHIR mapping list JSON: {e}")))?;
     let rows = value
@@ -507,7 +508,7 @@ pub async fn create_fhir_mapping(
             mapping_body(Some(name.trim()), &definition, enabled)?,
         )
         .await?;
-    stored_record(&expect_fhir_success(response)?.body)
+    stored_record(&crate::cdr::CdrClient::expect_success(response)?.body)
 }
 
 /// Replace a stored mapping's definition and enabled flag
@@ -552,7 +553,7 @@ pub async fn update_fhir_mapping(
             mapping_body(None, &definition, enabled)?,
         )
         .await?;
-    stored_record(&expect_fhir_success(response)?.body)
+    stored_record(&crate::cdr::CdrClient::expect_success(response)?.body)
 }
 
 /// Delete one stored mapping (`DELETE admin/fhir_mapping/{mapping_id}`).
@@ -577,7 +578,7 @@ pub async fn delete_fhir_mapping(
         urlencoding::encode(&mapping_id)
     ));
     let response = state.cdr.delete(&session.credential, &url, &[]).await?;
-    expect_fhir_success(response)?;
+    crate::cdr::CdrClient::expect_success(response)?;
     Ok(())
 }
 
@@ -682,7 +683,14 @@ pub async fn dry_run_fhir_resource(
 #[cfg(feature = "ssr")]
 fn fhir_answer(response: &crate::cdr::CdrResponse) -> Result<FhirAnswer, AdminUiError> {
     if response.is(http::StatusCode::UNAUTHORIZED) || response.is(http::StatusCode::FORBIDDEN) {
-        return Err(refusal(response));
+        // NOTE: the shared reader speaks both refusal vocabularies (#2581),
+        // so the auth layer's openEHR body needs no FHIR-side shim.
+        return Err(
+            match crate::cdr::CdrClient::expect_success(response.clone()) {
+                Err(e) => e,
+                Ok(_) => AdminUiError::Forbidden(String::new()),
+            },
+        );
     }
     let parsed = serde_json::from_str::<serde_json::Value>(&response.body).ok();
     let issues = parsed.as_ref().map(outcome_issues).unwrap_or_default();
@@ -695,47 +703,6 @@ fn fhir_answer(response: &crate::cdr::CdrResponse) -> Result<FhirAnswer, AdminUi
         body,
         issues,
     })
-}
-
-/// The mapping-store equivalent of
-/// [`CdrClient::expect_success`](crate::cdr::CdrClient::expect_success), reading
-/// the FHIR error vocabulary.
-///
-/// The store answers every refusal it authors as an `OperationOutcome`, whose
-/// diagnostics the shared openEHR reader cannot see — it would hand the raw
-/// JSON to a toast. Authentication and authorization refusals keep the openEHR
-/// body, and both vocabularies are covered by [`refusal`].
-#[cfg(feature = "ssr")]
-fn expect_fhir_success(
-    response: crate::cdr::CdrResponse,
-) -> Result<crate::cdr::CdrResponse, AdminUiError> {
-    if (200..300).contains(&response.status) {
-        return Ok(response);
-    }
-    Err(refusal(&response))
-}
-
-/// Normalize one refused response: the FHIR outcome's diagnostics when it is an
-/// outcome, the shared openEHR reader's diagnostic otherwise.
-#[cfg(feature = "ssr")]
-fn refusal(response: &crate::cdr::CdrResponse) -> AdminUiError {
-    let message = outcome_summary(&response.body).unwrap_or_else(|| {
-        // The openEHR-shaped bodies (401/403 from the layer above the handler)
-        // and any non-JSON body go through the shared reader, which is the one
-        // place that knows the `{error, message}` shape.
-        match crate::cdr::CdrClient::expect_success(response.clone()) {
-            Err(AdminUiError::Forbidden(message) | AdminUiError::Cdr { message, .. }) => message,
-            _ => response.body.clone(),
-        }
-    });
-    if response.is(http::StatusCode::UNAUTHORIZED) || response.is(http::StatusCode::FORBIDDEN) {
-        AdminUiError::Forbidden(message)
-    } else {
-        AdminUiError::Cdr {
-            status: response.status,
-            message,
-        }
-    }
 }
 
 /// The `{name?, definition, enabled}` request body a create or update sends.
@@ -1122,27 +1089,28 @@ mod tests {
     #[cfg(feature = "ssr")]
     #[test]
     fn a_refusal_reads_the_fhir_vocabulary_and_falls_back_to_the_openehr_one() {
+        // #2581: ONE reader for both vocabularies — the store's own
+        // OperationOutcome refusals and the auth layer's openEHR bodies both
+        // go through the shared `expect_success`.
         let outcome = crate::cdr::CdrResponse {
             status: 409,
             content_type: Some("application/fhir+json".to_owned()),
             body: r#"{"resourceType":"OperationOutcome","issue":[{"severity":"error","code":"conflict","diagnostics":"a FHIR mapping with that name exists"}]}"#.to_owned(),
         };
         assert_eq!(
-            super::refusal(&outcome),
+            crate::cdr::CdrClient::expect_success(outcome).unwrap_err(),
             AdminUiError::Cdr {
                 status: 409,
                 message: "a FHIR mapping with that name exists".to_owned(),
             }
         );
-        // The auth layer sits ABOVE the handler and answers the openEHR body,
-        // which the shared reader is the one place that understands.
         let refused = crate::cdr::CdrResponse {
             status: 403,
             content_type: Some("application/json".to_owned()),
             body: r#"{"error":"Forbidden","message":"forbidden: operation requires the 'ADMIN' role"}"#.to_owned(),
         };
         assert_eq!(
-            super::refusal(&refused),
+            crate::cdr::CdrClient::expect_success(refused).unwrap_err(),
             AdminUiError::Forbidden("forbidden: operation requires the 'ADMIN' role".to_owned())
         );
     }


### PR DESCRIPTION
Closes #2581

The shared `diagnostic_of` was blind to `OperationOutcome`, so a FHIR-shaped refusal consumed through `expect_success` handed raw JSON to a toast — the FHIR screen worked around it with a local shim, and the next console surface would have rediscovered the problem.

The shared reader now speaks both vocabularies (the openEHR `{error, message}` shape, and `OperationOutcome` with `issue[].diagnostics` joined and the code as fallback), and the FHIR-side shim (`expect_fhir_success` + `refusal`) dissolves into it — one documented home, as the issue's option A. `outcome_summary` deliberately remains on the FHIR module for the VERDICT panel, which classifies outcomes rather than reading refusals; the module doc states that split.

No assertion weakened: the shim's both-vocabulary test survives verbatim through the shared path, and a new `cdr.rs` unit pins that an OperationOutcome yields its joined diagnostics and never raw JSON. Console suites 389/389; both clippy lanes; `cargo doc` clean.