### PR TITLE
chore(fhir): the connector's release identity is R4, recorded and normalized (#2580)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,15 @@ workflow refuses a tag that has no matching section here.
   worked blood-pressure example are now documented in the book's FHIR
   chapter.
 
+### Changed
+
+- The FHIR connector's release identity is recorded as **FHIR R4**: every
+  resource and element it touches is unchanged in R4B (HL7's own R4B scope
+  statement), so the wire's `/fhir/r4` is truthful and connector-side text
+  and citations now say R4 consistently. The terminology integration keeps
+  its deliberate R4B identity — the two vocabularies are intentionally
+  different, and the documentation says which is which.
+
 ### Fixed
 
 - Admin console: a FHIR-shaped refusal (an `OperationOutcome`) now renders

--- a/app/ferroehr-admin-ui/src/pages/audit.rs
+++ b/app/ferroehr-admin-ui/src/pages/audit.rs
@@ -6,7 +6,7 @@
 //! Browses the CDR's local Audit Record Repository through the RESTful-ATNA
 //! **ITI-81** retrieval (`GET fhir/r4/AuditEvent`): a filter form (event-time
 //! window, patient, principal, outcome, action), a paged table of the stored
-//! FHIR R4B `AuditEvent` documents (IHE BALP shape), and a per-row raw-record
+//! FHIR R4 `AuditEvent` documents (IHE BALP shape), and a per-row raw-record
 //! view. No openEHR spec governs an admin UI — our own design / product
 //! extension; the wire it reads is IHE's (the `RESTful` ATNA supplement's
 //! ITI-81 FHIR search), served by the CDR.

--- a/app/ferroehr-ext/CLAUDE.md
+++ b/app/ferroehr-ext/CLAUDE.md
@@ -2,7 +2,7 @@
 
 The carve-out target for the platform's OPTIONAL integrations (#1890):
 `fhir` (mapping engine, outbound publisher, feeder-audit probe, the typed
-FHIR R4B surface — the ATNA `AuditEvent` renderer and the
+FHIR surface — the ATNA `AuditEvent` renderer and the
 terminology-response decoder), `events` (subscriptions + publisher
 transports), `multimedia` (blob store/offload). One ADDITIVE cargo feature
 per integration; the shipped binary builds all-on, slim deployments compile
@@ -17,11 +17,19 @@ integrations out.
 - **No openEHR spec governs these surfaces** — flag every behaviour decision
   as our own design; vendor implementations are prior art only. FHIR wire
   facts still cite official HL7/docs.rs sources.
+- **Two FHIR release identities, deliberately** (`src/fhir/mod.rs` §Release
+  identity): the CONNECTOR speaks **R4** (its wire is `/fhir/r4`; every
+  resource it builds is outside R4B's changed set, so the documents are valid
+  under either release) and cites `hl7.org/fhir/R4/…`; the TERMINOLOGY
+  decoder (`fhir::terminology`) speaks **R4B** because the release belongs to
+  the external server it reads, and cites `hl7.org/fhir/R4B/…`. Keep a new
+  citation on the side its subsystem is on.
 - Heavy external model dependencies (a generated FHIR model, brokers,
-  codecs) land HERE, never in `ferroehr`. **`fhir-model` (fhir-sdk's R4B
-  model) is named ONLY in this crate's `fhir` module** — no other crate may
-  name a `fhir_model` type; the platform seams take the neutral descriptor
-  structs (`fhir::audit::AuditRecord`) and get plain JSON / plain views back.
+  codecs) land HERE, never in `ferroehr`. **`fhir-model` (fhir-sdk's `r4b`
+  model generation) is named ONLY in this crate's `fhir` module** — no other
+  crate may name a `fhir_model` type; the platform seams take the neutral
+  descriptor structs (`fhir::audit::AuditRecord`) and get plain JSON / plain
+  views back.
 - Zero re-exports. The serde CONFIG sections stay in the `ferroehr` config
   tree (they carry `Secret`/`SecretUrl` and the tree's redaction semantics);
   this crate takes plain runtime parameter structs at construction

--- a/app/ferroehr-ext/src/fhir/audit.rs
+++ b/app/ferroehr-ext/src/fhir/audit.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: FerroEHR contributors
 // SPDX-License-Identifier: MIT
 
-//! The FHIR R4B `AuditEvent` renderer of the ATNA audit trail.
+//! The FHIR R4 `AuditEvent` renderer of the ATNA audit trail.
 //!
 //! The platform's system log decides WHAT an audit record says — the IHE
 //! BALP codings, role direction, entities, and profile claims. This module
@@ -10,9 +10,12 @@
 //! [`AuditRecord`] description and serializes it.
 //!
 //! **No openEHR spec governs FHIR resource representation — our own
-//! design/extension.** The resource model is the `fhir-model` crate's R4B
-//! (4.3.0) generation
-//! (<https://docs.rs/fhir-model/0.13.0/fhir_model/r4b/resources/struct.AuditEvent.html>).
+//! design/extension.** The rendered document is R4 (the connector's release —
+//! see [`super`]); `AuditEvent` is unchanged between the releases, so the
+//! crate's `r4b` generation
+//! (<https://docs.rs/fhir-model/0.13.0/fhir_model/r4b/resources/struct.AuditEvent.html>)
+//! builds it faithfully — R4B's own page records "No Changes" for this
+//! resource (<https://hl7.org/fhir/R4B/auditevent.html>).
 
 use fhir_model::r4b::codes::{AuditEventAction, AuditEventAgentNetworkType, AuditEventOutcome};
 use fhir_model::r4b::resources::{
@@ -117,7 +120,7 @@ pub struct AuditEntityRef {
 }
 
 /// A resolved audit record, in the neutral shape [`render`] turns into a FHIR
-/// R4B `AuditEvent`.
+/// R4 `AuditEvent`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AuditRecord {
     /// The profiles the record claims (`meta.profile`); empty claims none.
@@ -142,7 +145,7 @@ pub struct AuditRecord {
     pub entities: Vec<AuditEntityRef>,
 }
 
-/// Renders a resolved audit record as a FHIR R4B `AuditEvent` JSON document.
+/// Renders a resolved audit record as a FHIR R4 `AuditEvent` JSON document.
 ///
 /// # Errors
 ///

--- a/app/ferroehr-ext/src/fhir/mapping.rs
+++ b/app/ferroehr-ext/src/fhir/mapping.rs
@@ -13,7 +13,7 @@
 //! lives in [`super::feeder_audit`]. Gate: the connector's inbound routes are
 //! config-gated in `ferroehr-rest`.
 //!
-//! A mapping definition binds one FHIR R4B resource profile to one openEHR
+//! A mapping definition binds one FHIR R4 resource profile to one openEHR
 //! template. Its `entries` each read a value out of the incoming FHIR resource
 //! (a **`FHIRPath`-lite** dot-path — see [`resolve`]) and write it to a
 //! template-relative **openEHR FLAT path** (the `id[:i]/…|suffix` key

--- a/app/ferroehr-ext/src/fhir/mod.rs
+++ b/app/ferroehr-ext/src/fhir/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: FerroEHR contributors
 // SPDX-License-Identifier: MIT
 
-//! The FHIR R4B integration core.
+//! The FHIR integration core.
 //!
 //! The mapping model + FLAT builder, the outbound reverse-map, the
 //! feeder-audit probe, the ATNA `AuditEvent` renderer, and the
@@ -12,8 +12,28 @@
 //! store, the outbound emitter loop, the audit sinks, the terminology HTTP
 //! client) lives in the platform crate behind its `fhir` cargo feature; this
 //! module owns only the pure conversion logic and the typed
-//! `fhir-model` R4B resource surface — no other crate names a `fhir_model`
+//! `fhir-model` resource surface — no other crate names a `fhir_model`
 //! type.
+//!
+//! # Release identity
+//!
+//! The **connector speaks FHIR R4** — the release its wire advertises
+//! (`/fhir/r4`). Every resource it builds (`AuditEvent`, `Bundle`,
+//! `OperationOutcome`) and every data type they carry (`CodeableConcept`,
+//! `Coding`, `Identifier`, `Meta`, `Reference`) is outside R4B's changed set,
+//! so the documents are equally valid under either release: R4B changed only
+//! the medication-definition, clinical-reasoning and subscription families and
+//! added `CodeableReference`/`RatioRange`, and "implementers that do not use
+//! the specific portions where changes have been made can continue to use
+//! either R4 or R4B without any functional difference"
+//! (<https://hl7.org/fhir/R4B/r4b-explanation.html>). [`mapping`] and
+//! [`reverse`] fix no resource at all — the resource type is mapping data. The
+//! typed model is the `fhir-model` crate's `r4b` generation, which is an
+//! implementation detail of the dependency, not the wire's release.
+//!
+//! [`terminology`] is the exception and stays **R4B** by its own design: it
+//! decodes responses from external terminology servers, whose release is the
+//! remote's property, not ours.
 
 pub mod audit;
 pub mod feeder_audit;

--- a/app/ferroehr-rest/src/config.rs
+++ b/app/ferroehr-rest/src/config.rs
@@ -29,7 +29,7 @@ pub struct AppConfig {
     pub tenancy: TenancyConfig,
     /// `[smart]` — SMART App Launch resource-server posture.
     pub smart: SmartConfig,
-    /// `[fhir].api_enabled` — mount the FHIR R4B inbound façade + admin mapping.
+    /// `[fhir].api_enabled` — mount the FHIR R4 inbound façade + admin mapping.
     pub fhir_api_enabled: bool,
     /// `[terminology].api_enabled` — mount the terminology extension API.
     pub terminology_api_enabled: bool,

--- a/app/ferroehr-rest/src/extensions/fhir.rs
+++ b/app/ferroehr-rest/src/extensions/fhir.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: FerroEHR contributors
 // SPDX-License-Identifier: MIT
 
-//! HTTP dispatch for the **FHIR R4B inbound connector** + mapping-store CRUD
+//! HTTP dispatch for the **FHIR R4 inbound connector** + mapping-store CRUD
 //! over the `ferroehr::service::FhirConnectorAdapter` seam.
 //!
 //! **No openEHR spec governs this — our own enterprise feature (E3, FHIR
@@ -16,7 +16,7 @@
 //! `false`): when disabled every route answers `404` (an `OperationOutcome`)
 //! without touching the backend.
 //!
-//! * `POST /fhir/r4/{resource_type}` — the inbound connector. A FHIR R4B
+//! * `POST /fhir/r4/{resource_type}` — the inbound connector. A FHIR R4
 //!   resource is accepted, its mapping resolved by type + `meta.profile`, a
 //!   COMPOSITION built and committed through the NORMAL validated path with
 //!   `FEEDER_AUDIT` provenance. Only the starter resource
@@ -68,7 +68,7 @@ use crate::negotiate;
 use crate::overview::error::RestError;
 use crate::state::AppState;
 
-/// FHIR R4B media type for the `OperationOutcome` / connector responses.
+/// FHIR R4 media type for the `OperationOutcome` / connector responses.
 const FHIR_JSON: &str = "application/fhir+json";
 
 /// The starter resource set the inbound connector maps;
@@ -98,7 +98,7 @@ pub(crate) fn routes() -> OpenApiRouter<AppState> {
         ))
 }
 
-/// Inbound connector: commit a FHIR R4B resource as an openEHR COMPOSITION
+/// Inbound connector: commit a FHIR R4 resource as an openEHR COMPOSITION
 /// (`POST /fhir/r4/{resource_type}`).
 ///
 /// Only the starter set (Patient, Observation, Condition, `DocumentReference`)
@@ -111,8 +111,8 @@ pub(crate) fn routes() -> OpenApiRouter<AppState> {
 /// so the whole group (paths, payloads, status codes) is our own design.
 #[utoipa::path(
     post, path = "/fhir/r4/{resource_type}", tag = "fhir",
-    params(("resource_type" = String, Path, description = "The FHIR R4B resource type (starter set only).")),
-    request_body(content = serde_json::Value, description = "A FHIR R4B resource (JSON)."),
+    params(("resource_type" = String, Path, description = "The FHIR R4 resource type (starter set only).")),
+    request_body(content = serde_json::Value, description = "A FHIR R4 resource (JSON)."),
     responses(
         (status = 201, description = "Committed as a COMPOSITION (informational OperationOutcome + ETag/Location pointing at the openEHR COMPOSITION).", content_type = "application/fhir+json"),
         (status = 400, description = "The request body is not valid JSON, or a mapping precondition failed (OperationOutcome).", content_type = "application/fhir+json"),
@@ -129,7 +129,7 @@ pub(crate) async fn fhir_ingest(
     guarded_dispatch(state, "fhir_ingest", parts, dispatch).await
 }
 
-/// The ingest door's dry twin: validate a FHIR R4B resource against its
+/// The ingest door's dry twin: validate a FHIR R4 resource against its
 /// mapping WITHOUT committing (`POST /fhir/r4/{resource_type}/$validate`).
 ///
 /// The wire convention is HL7 FHIR R4's own validation operation
@@ -149,8 +149,8 @@ pub(crate) async fn fhir_ingest(
 /// HL7 FHIR R4 (official external documentation).
 #[utoipa::path(
     post, path = "/fhir/r4/{resource_type}/$validate", tag = "fhir",
-    params(("resource_type" = String, Path, description = "The FHIR R4B resource type (starter set only).")),
-    request_body(content = serde_json::Value, description = "A FHIR R4B resource (JSON)."),
+    params(("resource_type" = String, Path, description = "The FHIR R4 resource type (starter set only).")),
+    request_body(content = serde_json::Value, description = "A FHIR R4 resource (JSON)."),
     responses(
         (status = 200, description = "Validation completed — the OperationOutcome carries the verdict: `information` issues (valid + the EHR disposition) or `error` issues with the commit path's rejections verbatim. Nothing is committed either way.", content_type = "application/fhir+json"),
         (status = 400, description = "The request body is not valid JSON, or a mapping precondition failed (OperationOutcome) — the same class the ingest door refuses `400`.", content_type = "application/fhir+json"),
@@ -180,7 +180,7 @@ pub(crate) async fn fhir_validate(
 #[utoipa::path(
     get, path = "/fhir/r4/{resource_type}", tag = "fhir",
     params(
-        ("resource_type" = String, Path, description = "The FHIR R4B resource type (starter set only)."),
+        ("resource_type" = String, Path, description = "The FHIR R4 resource type (starter set only)."),
         ("patient" = String, Query, description = "The patient scope (EHR subject or id) — required, non-empty."),
         ("_count" = Option<i64>, Query, description = "Optional page size.")
     ),
@@ -202,7 +202,7 @@ pub(crate) async fn fhir_search(
 /// The RESTful-ATNA **ITI-81 Retrieve ATNA Audit Event** transaction
 /// (`GET /fhir/r4/AuditEvent`): a FHIR search over the local Audit Record
 /// Repository, returning a `searchset`
-/// Bundle of stored FHIR R4B `AuditEvent` documents (IHE BALP shape). Gated by
+/// Bundle of stored FHIR R4 `AuditEvent` documents (IHE BALP shape). Gated by
 /// the local store (`[audit.store]`; 404 when off — independent of the FHIR
 /// connector gate) and admin-only under RBAC (the node's security log is an
 /// operator surface). Supported parameter subset: `date` (`ge`/`le`

--- a/app/ferroehr-rest/src/extensions/mod.rs
+++ b/app/ferroehr-rest/src/extensions/mod.rs
@@ -27,7 +27,7 @@
 //! - [`terminology`] — the `/terminology` wire: `I_TERMINOLOGY_SERVICE` is SM
 //!   `master12`; the development-edition OAS set defines no terminology API, so
 //!   the operation semantics are cited from SM and the wire shape is our own.
-//! - [`event_subscription`] + [`fhir`] — eventing and the FHIR R4B connector
+//! - [`event_subscription`] + [`fhir`] — eventing and the FHIR R4 connector
 //!   (enterprise features E1/E3); nothing in SM/ITS-REST governs them.
 //! - [`tenant_routes`] — multi-tenancy (enterprise feature E2); zero spec
 //!   mentions.

--- a/app/ferroehr-rest/src/extensions/openapi.rs
+++ b/app/ferroehr-rest/src/extensions/openapi.rs
@@ -182,7 +182,7 @@ const SECURITY_SCHEME: &str = "openehr_auth";
         (name = "message", description = "The SM MESSAGE component — I_EHR_EXTRACT_SERVICE (EHR-Extract export/import) and I_TDD_SERVICE (Template Data Document import). OUR OWN EXTENSION: ITS-REST 1.1.0 publishes no message/extract/TDD API at all, so no released operation governs any route here; they carry the ordinary clinical authentication class, not the admin gate."),
         (name = "event-subscription", description = "Event-subscription CRUD extension (config-gated: FERROEHR_REST_EVENT_SUBSCRIPTION__ENABLED)."),
         (name = "tenancy", description = "Multi-tenancy admin extension (config-gated: FERROEHR_REST_TENANCY__ENABLED)."),
-        (name = "fhir", description = "FHIR R4B inbound connector + mapping store (config-gated: FERROEHR_REST_FHIR__ENABLED)."),
+        (name = "fhir", description = "FHIR R4 inbound connector + mapping store (config-gated: FERROEHR_REST_FHIR__ENABLED)."),
     )
 )]
 #[derive(Debug)]
@@ -608,7 +608,7 @@ const FAMILIES: &[(&str, &str, Members)] = &[
     (
         "FerroEHR — FHIR Connector",
         "fhir",
-        // `audit` = the ITI-81 AuditEvent retrieval: a FHIR R4B surface served
+        // `audit` = the ITI-81 AuditEvent retrieval: a FHIR R4 surface served
         // under the same `/fhir/r4` root, gated by the local audit repository
         // rather than by the connector.
         Members::Tags(&["fhir", "audit"]),

--- a/app/ferroehr-rest/tests/it/fhir_http.rs
+++ b/app/ferroehr-rest/tests/it/fhir_http.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: FerroEHR contributors
 // SPDX-License-Identifier: MIT
 
-//! End-to-end HTTP tests for the FHIR R4B connector API group (our own extension
+//! End-to-end HTTP tests for the FHIR R4 connector API group (our own extension
 //! — no openEHR spec governs this; E3): the config gate
 //! (`AppConfig::fhir_api_enabled`), the starter-scope `501`, the inbound
 //! `POST /fhir/r4/{resourceType}` outcomes, the `/admin/fhir_mapping` CRUD, and

--- a/app/ferroehr-rest/tests/it/served_openapi.rs
+++ b/app/ferroehr-rest/tests/it/served_openapi.rs
@@ -1405,7 +1405,7 @@ const NON_SPEC_FAMILIES: &[NonSpecFamily] = &[
         operations: 6,
     },
     NonSpecFamily {
-        label: "the FHIR R4B connector + read facade",
+        label: "the FHIR R4 connector + read facade",
         prefixes: &["/ferroehr/rest/openehr/v1/fhir/r4/{resource_type}"],
         flag: "no openehr spec governs this",
         // Ingest, the read facade, and the ingest door's `$validate` dry

--- a/app/ferroehr/assets/ferroehr.default.toml
+++ b/app/ferroehr/assets/ferroehr.default.toml
@@ -486,7 +486,7 @@ transport = "udp"            # udp | tls ; PROD: tls
 #? tls_identity_cert_file = "/etc/ferroehr/client.pem"
 #? tls_identity_key_file = "/etc/ferroehr/client.key"
 
-# RESTful ATNA feed: FHIR R4B AuditEvent POSTs (IHE ITI-20 ATX:FHIR Feed).
+# RESTful ATNA feed: FHIR R4 AuditEvent POSTs (IHE ITI-20 ATX:FHIR Feed).
 [audit.fhir_feed]
 enabled = false
 url = "http://localhost:8080/fhir"   # POSTs {url}/AuditEvent; URL creds redacted

--- a/app/ferroehr/src/system_log/config.rs
+++ b/app/ferroehr/src/system_log/config.rs
@@ -105,7 +105,7 @@ impl Default for SyslogConfig {
 }
 
 /// The RESTful-ATNA feed (`[audit.fhir_feed]`): ITI-20 **ATX: FHIR Feed** —
-/// HTTP `POST {url}/AuditEvent` of the FHIR R4B `AuditEvent` (IHE BALP shape)
+/// HTTP `POST {url}/AuditEvent` of the FHIR R4 `AuditEvent` (IHE BALP shape)
 /// to an external Audit Record Repository.
 ///
 /// When the local store is on, the feed drains the store's outbox

--- a/app/ferroehr/src/system_log/fhir.rs
+++ b/app/ferroehr/src/system_log/fhir.rs
@@ -1,15 +1,15 @@
 // SPDX-FileCopyrightText: FerroEHR contributors
 // SPDX-License-Identifier: MIT
 
-//! FHIR R4B `AuditEvent` rendering of the audit event model, following the
+//! FHIR R4 `AuditEvent` rendering of the audit event model, following the
 //! IHE **BALP** (Basic Audit Log Patterns) content profiles.
 //!
 //! This is the modern half of the dual ATNA rendering (the classic half is
 //! the DICOM PS3.15 §A.5 XML in [`super::message`]): the same resolved
-//! [`super::event::AuditEvent`] renders to one FHIR R4B (4.3.0)
+//! [`super::event::AuditEvent`] renders to one FHIR R4
 //! `AuditEvent` JSON document. This module decides the BALP content; the
 //! resource itself is built and serialized by
-//! [`ferroehr_ext::fhir::audit`], over the typed `fhir-model` R4B model.
+//! [`ferroehr_ext::fhir::audit`], over the typed `fhir-model` model.
 //! The BALP profiles pin the codings this module emits (IHE BALP v1.1.4,
 //! `IHE.BasicAudit.*` StructureDefinitions):
 //!
@@ -44,7 +44,7 @@ use crate::system_log::AuditError;
 use crate::system_log::event::{AuditEvent, EventActionCode, EventOutcome, EventType, ObjectClass};
 use crate::system_log::message::AuditContext;
 
-// ── Code systems (FHIR R4B / IHE BALP fixed bindings) ─────────────────────────
+// ── Code systems (FHIR R4 / IHE BALP fixed bindings) ──────────────────────────
 
 /// FHIR `audit-event-type` code system (`rest`).
 pub const SYS_AUDIT_EVENT_TYPE: &str = "http://terminology.hl7.org/CodeSystem/audit-event-type";
@@ -81,7 +81,7 @@ fn coding(system: &str, code: &str, display: &str) -> AuditCoding {
     }
 }
 
-/// Renders a resolved [`AuditEvent`] as a FHIR R4B `AuditEvent` document.
+/// Renders a resolved [`AuditEvent`] as a FHIR R4 `AuditEvent` document.
 ///
 /// The content follows the IHE BALP patterns, with the server identity from
 /// the [`AuditContext`] and the optionally-resolved patient subject id.

--- a/app/ferroehr/src/system_log/mod.rs
+++ b/app/ferroehr/src/system_log/mod.rs
@@ -19,7 +19,7 @@
 //! default, served back via the RESTful-ATNA ITI-81 retrieval), the classic
 //! **DICOM Audit Message** feed (DICOM PS3.15 §A.5 XML — *not* openEHR
 //! ITS-XML — over RFC 5424 syslog; RFC 5426 UDP or RFC 5425 TLS; IHE ITI
-//! TF-2 ITI-20), and the **FHIR R4B `AuditEvent`** feed (IHE BALP shape;
+//! TF-2 ITI-20), and the **FHIR R4 `AuditEvent`** feed (IHE BALP shape;
 //! ITI-20 ATX:FHIR Feed). This is authorized defensive security-audit
 //! logging for a healthcare system.
 //!
@@ -46,7 +46,7 @@
 //! - [`codes`] — DCM / RFC-3881 code constants + the ATNA rendering of the
 //!   event enums.
 //! - [`message`] — the DICOM `AuditMessage` model + `quick-xml` serializer.
-//! - `fhir` — the FHIR R4B `AuditEvent` rendering per the IHE BALP content
+//! - `fhir` — the FHIR R4 `AuditEvent` rendering per the IHE BALP content
 //!   profiles (the modern half of the dual format; the `fhir` cargo
 //!   feature, over `ferroehr_ext::fhir::audit`).
 //! - [`syslog`] — RFC 5424 assembly + RFC 5426 UDP / RFC 5425 TLS transports.
@@ -120,7 +120,7 @@ impl From<std::io::Error> for AuditError {
 /// The loud slim-build refusal for the FHIR-rendering audit sinks.
 ///
 /// Both the local Audit Record Repository and the ITI-20 ATX:FHIR Feed carry
-/// a FHIR R4B `AuditEvent` document, which a binary built without the `fhir`
+/// a FHIR R4 `AuditEvent` document, which a binary built without the `fhir`
 /// cargo feature cannot render. A configuration that enables either is a
 /// boot error, never a silently document-less audit trail (the syslog sink
 /// needs no FHIR and stays available).

--- a/app/ferroehr/src/system_log/sender.rs
+++ b/app/ferroehr/src/system_log/sender.rs
@@ -8,7 +8,7 @@
 //! The request path only [`AuditSender::emit`]s (a `try_send`, never blocking
 //! or awaiting). The drain task optionally enriches the patient subject
 //! (background only — never on the request path), renders the record — the
-//! FHIR R4B `AuditEvent` (IHE BALP, [`super::fhir`]) and/or the DICOM PS3.15
+//! FHIR R4 `AuditEvent` (IHE BALP, [`super::fhir`]) and/or the DICOM PS3.15
 //! §A.5 XML ([`super::message`]) — and delivers it:
 //!
 //! - **store** (`[audit.store]`, the durability anchor): the record is
@@ -616,7 +616,7 @@ async fn drain(
     tracing::debug!("ATNA audit drain: channel closed, task exiting");
 }
 
-/// The FHIR R4B `AuditEvent` document for one resolved record, or `None` when
+/// The FHIR R4 `AuditEvent` document for one resolved record, or `None` when
 /// the rendering failed (metered + logged, never silent).
 #[cfg(feature = "fhir")]
 fn render_audit_event(

--- a/app/ferroehr/src/system_log/store.rs
+++ b/app/ferroehr/src/system_log/store.rs
@@ -12,7 +12,7 @@
 //! §Access logging), so the store lives in its own `audit` schema, strictly
 //! outside the EHR data (`migrations/audit/0001_baseline.sql`).
 //!
-//! The canonical stored form is the **FHIR R4B `AuditEvent`** (IHE BALP
+//! The canonical stored form is the **FHIR R4 `AuditEvent`** (IHE BALP
 //! shape, rendered by the `fhir` cargo feature) in the `fhir` jsonb column —
 //! the exact document
 //! the RESTful-ATNA ITI-81 search serves; the promoted columns are derived

--- a/app/ferroehr/tests/it/audit_feed.rs
+++ b/app/ferroehr/tests/it/audit_feed.rs
@@ -3,7 +3,7 @@
 
 //! End-to-end test of the RESTful-ATNA feed (IHE ITI-20 **ATX: FHIR Feed**):
 //! events emitted through the sender land in the local store, and the outbox
-//! worker POSTs each stored FHIR R4B `AuditEvent` to the ARR
+//! worker POSTs each stored FHIR R4 `AuditEvent` to the ARR
 //! (`{url}/AuditEvent`, `application/fhir+json`) and stamps
 //! `delivered_fhir_feed_at` — a real `PostgreSQL` 18 (shared testkit harness) plus a
 //! `wiremock` ARR.

--- a/app/ferroehr/tests/it/audit_store.rs
+++ b/app/ferroehr/tests/it/audit_store.rs
@@ -5,7 +5,7 @@
 //! (`ferroehr::system_log::store`) against a real `PostgreSQL` 18
 //! (shared testkit harness): the `audit` schema migrates cleanly alongside
 //! `ext`/`ehr`, inserted records land with the promoted search columns and
-//! the FHIR R4B `AuditEvent` payload (IHE BALP shape), and the retention
+//! the FHIR R4 `AuditEvent` payload (IHE BALP shape), and the retention
 //! reaper deletes only rows older than the horizon (0 = keep forever).
 //! No openEHR spec governs audit storage — our own design/extension (the
 //! schema-separation rationale is BASE

--- a/website/book/src/admin-ui/index.md
+++ b/website/book/src/admin-ui/index.md
@@ -195,7 +195,7 @@ accessed what, with what outcome — through the standard IHE ITI-81
 retrieval (`GET /fhir/r4/AuditEvent`; see the
 [Audit trail chapter](../audit.md)). Filter by event-time window, patient,
 principal, outcome, or action; every filter lives in the URL, so a filtered
-view is shareable and refresh-safe. Each row opens the full stored FHIR R4B
+view is shareable and refresh-safe. Each row opens the full stored FHIR R4
 `AuditEvent` record.
 
 The audit trail is an operator surface: under role-based access control the

--- a/website/book/src/audit.md
+++ b/website/book/src/audit.md
@@ -20,7 +20,7 @@ reads and rejected attempts.
 Every audited operation produces one record, rendered in the two formats the
 IHE standards define:
 
-- **FHIR R4B `AuditEvent`** following the IHE **BALP** (Basic Audit Log
+- **FHIR R4 `AuditEvent`** following the IHE **BALP** (Basic Audit Log
   Patterns) content profiles — the modern RESTful-ATNA form and the canonical
   stored form. Patient-centric operations carry the resolved EHR subject as
   the patient entity (`PatientRead`/`PatientCreate`/… profile claims); query

--- a/website/book/src/beyond-core/fhir.md
+++ b/website/book/src/beyond-core/fhir.md
@@ -1,7 +1,8 @@
 # FHIR connectors
 
-Many systems around a CDR speak FHIR. FerroEHR ships a set of FHIR R4B
-connectors so it can take FHIR resources in, hand openEHR data back out as FHIR,
+Many systems around a CDR speak FHIR. FerroEHR ships a set of
+[FHIR R4](https://hl7.org/fhir/R4/) connectors so it can take FHIR resources in,
+hand openEHR data back out as FHIR,
 and emit FHIR resources to downstream systems — all driven by mappings you
 control. It is not a full FHIR server; it is a focused, mapping-driven bridge
 between the FHIR and openEHR worlds.
@@ -12,6 +13,19 @@ characteristics. All FHIR routes are relative to the API base path
 (`/ferroehr/rest/openehr/v1`) and speak `application/fhir+json`; every response
 on this surface — success or failure — is a FHIR resource, so an error arrives as
 an `OperationOutcome` rather than the openEHR error body.
+
+> [!NOTE]
+> **R4, and what that means if you run R4B.** The connector's routes are
+> `/fhir/r4/…`, and the resources it exchanges — `Bundle`, `OperationOutcome`,
+> `AuditEvent` — are identical in R4 and R4B, so an R4B client can use this
+> surface unchanged: HL7 states that "implementers that do not use the specific
+> portions where changes have been made can continue to use either R4 or R4B
+> without any functional difference"
+> ([what R4B changed](https://hl7.org/fhir/R4B/r4b-explanation.html)). Which
+> resource types you may actually exchange is set by your mappings, not by the
+> release. One neighbouring subsystem is deliberately different: the
+> [external terminology servers](terminology.md) FerroEHR *calls out to* are
+> R4B, because there the release belongs to the server you point it at.
 
 <!-- toc -->
 

--- a/website/book/src/beyond-core/index.md
+++ b/website/book/src/beyond-core/index.md
@@ -87,7 +87,7 @@ for the exact list of settings a slim binary rejects.
 - **[Change events (AMQP)](amqp.md)** — a transactional outbox that publishes a
   PHI-free, at-least-once event for every commit to an AMQP broker, so
   downstream systems can respond to changes instead of polling.
-- **[FHIR connectors](fhir.md)** — mapping-driven ingestion of FHIR R4B
+- **[FHIR connectors](fhir.md)** — mapping-driven ingestion of FHIR R4
   resources, a patient-scoped read façade that returns openEHR data as FHIR, and
   event-driven outbound emission of mapped FHIR resources.
 - **[S3 multimedia](s3-multimedia.md)** — threshold-based, content-addressed

--- a/website/book/src/concepts/architecture.md
+++ b/website/book/src/concepts/architecture.md
@@ -50,7 +50,7 @@ regeneration, not a rewrite. That layer is also published for reuse, as
 **The application layer is the server** — everything the generated layer does
 not give you: storage, the query execution engine, validation, and security.
 This is where design choices specific to FerroEHR live. The optional
-integrations (FHIR R4B, change events, S3 multimedia) sit beside it in their own
+integrations (FHIR R4, change events, S3 multimedia) sit beside it in their own
 crate behind additive cargo features, so a build without them contains none of
 their code — see [Beyond the core](../beyond-core/index.md).
 

--- a/website/book/src/installation/config-audit.md
+++ b/website/book/src/installation/config-audit.md
@@ -39,7 +39,7 @@ queue_capacity = 8192
 | `server_host` | string | unset ⇒ the `value_if_missing` fill | This node's advertised network address, reported as the destination `NetworkAccessPointID`. |
 
 > [!NOTE]
-> The local store and the ATX:FHIR Feed both carry a FHIR R4B `AuditEvent`
+> The local store and the ATX:FHIR Feed both carry a FHIR R4 `AuditEvent`
 > document, so both need the `fhir` build feature — on in the published binary
 > and container images. A binary built with `--no-default-features` refuses at
 > startup if `audit.store.enabled` or `audit.fhir_feed.enabled` is set; the

--- a/website/book/src/security.md
+++ b/website/book/src/security.md
@@ -595,7 +595,7 @@ byte-for-byte as a single-tenant system.
 Separately from openEHR's own provenance, FerroEHR keeps an IHE ATNA
 security audit trail of API access — **on by default**, persisted in the
 local Audit Record Repository (the dedicated `audit` PostgreSQL schema),
-rendered in both official formats (FHIR R4B `AuditEvent` per IHE BALP, and
+rendered in both official formats (FHIR R4 `AuditEvent` per IHE BALP, and
 the DICOM PS3.15 audit message for the classic syslog feed), retrievable via
 the RESTful-ATNA **ITI-81** FHIR search, and optionally forwarded to an
 external ARR over syslog and/or the ITI-20 FHIR feed. Node authentication

--- a/website/book/src/threat-model.md
+++ b/website/book/src/threat-model.md
@@ -302,7 +302,7 @@ contribution and an audit record in the same transaction.
 ### B7 — The audit trail
 
 **Control.** Every access is recorded in both official renderings (DICOM PS3.15
-and FHIR R4B `AuditEvent`/BALP) into a local Audit Record Repository, on by
+and FHIR R4 `AuditEvent`/BALP) into a local Audit Record Repository, on by
 default, with optional syslog and ATX:FHIR-Feed forwarding. Refusals — `401`,
 `403`, and the `400` a malformed credential header earns — are always recorded,
 and an unattributable denial is recorded as unattributed rather than under a

--- a/website/book/src/why-ferroehr.md
+++ b/website/book/src/why-ferroehr.md
@@ -39,7 +39,7 @@ and published* rather than asserted in a datasheet.
 
 - **MIT for all of our own code, with no open-core tier.** Multi-tenancy,
   role- and attribute-based access control, IHE ATNA audit, per-version
-  digital signatures, the FHIR R4B connectors, change events, the admin
+  digital signatures, the FHIR R4 connectors, change events, the admin
   console — one repository, one licence. Nothing is held back to be sold back
   to you. (Vendored openEHR material keeps its own upstream terms, and the
   spec crates that embed it say so in their own metadata — see


### PR DESCRIPTION
Closes #2580

**The adjudication, grounded first-hand:** the connector's identity is **FHIR R4**. The touched-resource inventory (AuditEvent — the only fully typed resource — plus Bundle searchset, OperationOutcome, and the datatype set; the mapping/reverse cores fix no resource at all, navigating untyped JSON) has **zero intersection** with R4B's changed set. HL7's own scope statement (hl7.org/fhir/R4B/r4b-explanation.html): "implementers that do not use the specific portions where changes have been made can continue to use either R4 or R4B **without any functional difference**" — and R4B's AuditEvent page records "No Changes". The wire's `/fhir/r4` (and the SMART FHIR base) is therefore truthful; no path or operation changes.

**The normalization:** 31 connector-side R4B mentions → R4, including the ATNA `AuditEvent` renderer (one renderer, one document — the release is the renderer's property, so the ITI-20 feed follows ITI-81); 41 terminology-side mentions deliberately KEPT R4B (its own recorded cross-version design); the `fhir-model` dependency respelled as its `r4b` module generation — a crate path, not a release claim. The identity is recorded in three homes (the ferroehr-ext module docs' Release identity section, the crate CLAUDE.md, and the book's FHIR page as an end-user callout), each with the cite, and the deliberate R4-vs-R4B split between the two subsystems is stated rather than left as a trap. The console's last r4-route/R4B-payload contradiction (`pages/audit.rs`) is fixed here; the subject proxy sits outside the adjudicated frame and its self-contradictory sentence + misfiled config table are filed as #2587.

No crossed citations existed — connector-side cites were already R4, terminology-side already R4B; the two R4B links added on the connector side are the evidence for the claim, not crossings.

Gates: clippy across ferroehr/ferroehr-rest/ferroehr-ext (all features) + the console ssr lane; ferroehr-ext 42/42; the fhir + served-OpenAPI suites 43/43; the system-log/audit suites 62/62 (insta snapshots clean); `cargo doc` clean; comment-style, docs-claims, mdbook-lint green. The served-OpenAPI description text changed, so the changelog carries a Changed entry.