### PR TITLE
fix(subject-proxy): release-agnostic posture adjudicated; the systems table moves to its own page (#2587)

### DIFF
--- a/app/ferroehr/src/service/subject_proxy/config.rs
+++ b/app/ferroehr/src/service/subject_proxy/config.rs
@@ -53,9 +53,13 @@ pub struct SubjectProxyConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct SpFhirSystem {
-    /// FHIR R4B base URL, e.g. `https://fhir.example.org/r4` — the frame's
-    /// `query_text` is resolved relative to this after `$subject_id`
-    /// substitution. Empty is a boot error ([`SubjectProxyConfig::build`]).
+    /// The remote FHIR server's base URL, e.g. `https://fhir.example.org/r4`
+    /// — the frame's `query_text` is resolved relative to this after
+    /// `$subject_id` substitution; empty is a boot error
+    /// ([`SubjectProxyConfig::build`]). The FHIR release is the REMOTE's
+    /// property: the proxy relays `application/fhir+json` bodies untyped and
+    /// decodes nothing release-specific, so no release is claimed here (the
+    /// terminology integration's posture).
     pub base_url: String,
     /// TCP connect timeout (ms).
     pub connect_timeout_ms: u64,

--- a/website/book/src/beyond-core/subject-proxy.md
+++ b/website/book/src/beyond-core/subject-proxy.md
@@ -101,17 +101,27 @@ stricter value — registration can only make data fresher, never staler.
 
 ## Connecting FHIR systems
 
-Frames of kind `API_CALL` / `fhir_get` read from remote FHIR R4B servers. Which
+Frames of kind `API_CALL` / `fhir_get` read from remote FHIR servers (the
+FHIR release is the remote's property — the proxy relays `fhir+json` bodies
+and decodes nothing release-specific). Which
 servers are reachable is **opt-in and fail-closed**: only systems named in
 configuration can ever be called, and a frame naming an unconfigured `system_id`
 is a typed rejection, never an arbitrary outbound request. By default no system
 is configured and every FHIR frame is rejected.
 
 Systems are a map keyed by the name frames use as their `system_id`, under
-`[subject_proxy]` — the key table is on
-[Audit & subject proxy](../installation/config-audit.md#subject_proxy). Each
-system needs a `base_url` and may override the connect and request timeouts. A
-blank or missing `base_url` is a boot error that names the offending system.
+`[subject_proxy.systems.<name>]`:
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `base_url` | string | required per system | The remote FHIR server's base URL. The frame's query text is resolved relative to this. Blank or absent is a boot error naming the system. |
+| `connect_timeout_ms` | int | `2000` | TCP connect timeout. |
+| `request_timeout_ms` | int | `10000` | Overall request timeout. |
+
+```toml
+[subject_proxy.systems.pas]
+base_url = "https://pas.example.com/fhir"
+```
 
 To let the `fhir::demographics` frame above reach a patient administration
 system:
@@ -150,7 +160,7 @@ config:
         request_timeout_ms: 10000
 ```
 
-**Before you enable it:** a reachable FHIR R4B server per system, and — if the
+**Before you enable it:** a reachable FHIR server per system, and — if the
 chart's default-deny egress policy is on — an egress rule that admits it, or the
 calls fail as timeouts. **To turn it off**, remove the systems: with none
 configured every FHIR frame is rejected, which is the fail-closed default.

--- a/website/book/src/installation/config-audit.md
+++ b/website/book/src/installation/config-audit.md
@@ -92,22 +92,5 @@ The named FHIR systems a subject-proxy `API_CALL`/`fhir_get` data frame may
 retrieve from. **Empty by default and fail-closed**: no external FHIR system is
 reachable until one is named here, and a frame whose `system_id` matches no
 configured system is a typed rejection rather than an arbitrary outbound
-request. See [Subject Proxy](../beyond-core/subject-proxy.md).
-
-Systems are keyed by the name subject-proxy frames use as their `system_id`.
-
-`[subject_proxy.systems.<name>]`:
-
-| Key | Type | Default | Description |
-|---|---|---|---|
-| `base_url` | string | required per system | FHIR R4B base URL. The frame's query text is resolved relative to this. Blank or absent is a boot error naming the system. |
-| `connect_timeout_ms` | int | `2000` | TCP connect timeout. |
-| `request_timeout_ms` | int | `10000` | Overall request timeout. |
-
-```toml
-[subject_proxy.systems.pas]
-base_url = "https://pas.example.com/fhir"
-```
-
-The environment form for a named system spells the map key as just another
-segment: `FERROEHR__SUBJECT_PROXY__SYSTEMS__PAS__BASE_URL`.
+request. The per-system key table and examples live on
+[Subject Proxy — Connecting FHIR systems](../beyond-core/subject-proxy.md#connecting-fhir-systems).


### PR DESCRIPTION
Closes #2587

The subject proxy sat outside #2580's adjudicated frame, and its one release claim contradicted itself in a single sentence ("FHIR R4B base URL, e.g. `…/r4`"). Adjudicated: the proxy is **release-agnostic** — it relays `application/fhir+json` bodies untyped and decodes nothing release-specific, so the FHIR release is the REMOTE's property, the same posture the terminology integration records. The config doc now states that instead of claiming a release, and both book mirrors follow.

The `[subject_proxy.systems.<name>]` key table was misfiled on the AUDIT configuration page; it now lives in the subject-proxy page's own Connecting-FHIR-systems section (table + example together), and the audit page keeps its section stub with a cross-link — a reader configuring the proxy finds the keys where the feature is documented.

`docs-claims --all` green (the moved table's config paths still resolve against the TOML schema); mdbook-lint 0 errors; clippy clean. No behaviour changes — `no-changelog`.