### PR TITLE
fix(rest): every member-scoped CONTRIBUTION refusal names versions[i] (#2590)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,11 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- Every member-scoped refusal on the contribution commit now names the
+  offending member (`versions[i]`) — the data-parse, template-resolution,
+  change-type and audit refusals previously carried no index, so a client
+  staging several changes could not tell which one was rejected.
+
 - Admin console: a FHIR-shaped refusal (an `OperationOutcome`) now renders
   its human diagnostics wherever an error surfaces — the shared diagnostic
   reader speaks both error vocabularies, so no screen can hand raw JSON to

--- a/app/ferroehr/src/service/error.rs
+++ b/app/ferroehr/src/service/error.rs
@@ -525,6 +525,48 @@ impl ServiceError {
         }
     }
 
+    /// Attribute a per-member refusal to its CONTRIBUTION version member.
+    ///
+    /// The commit route's whole purpose is a multi-member change set, so a
+    /// member-scoped refusal names `versions[index]` the way the declared-key
+    /// check always has (#2590): SM-status rows prefix the message, violation
+    /// rows prefix the path, validation rows prefix each violation's path.
+    /// Rows that are never member-scoped pass through unchanged.
+    #[must_use]
+    pub(crate) fn for_version_member(self, index: usize) -> Self {
+        let prefix_message = |mut sm: SmError| {
+            sm.message = format!("versions[{index}]: {}", sm.message);
+            sm
+        };
+        match self {
+            ServiceError::NotFound(sm) => ServiceError::NotFound(prefix_message(sm)),
+            ServiceError::BadRequest(sm) => ServiceError::BadRequest(prefix_message(sm)),
+            ServiceError::Conflict(sm) => ServiceError::Conflict(prefix_message(sm)),
+            ServiceError::VersionConflict(sm) => ServiceError::VersionConflict(prefix_message(sm)),
+            ServiceError::Unprocessable {
+                status,
+                mut violation,
+            } => {
+                violation.path = Some(match violation.path.take() {
+                    Some(path) => format!("versions[{index}]/{path}"),
+                    None => format!("versions[{index}]"),
+                });
+                ServiceError::Unprocessable { status, violation }
+            }
+            ServiceError::ValidationFailed(mut violations) => {
+                for violation in &mut violations {
+                    violation.path = if violation.path.is_empty() {
+                        format!("versions[{index}]")
+                    } else {
+                        format!("versions[{index}]/{}", violation.path)
+                    };
+                }
+                ServiceError::ValidationFailed(violations)
+            }
+            other => other,
+        }
+    }
+
     /// A server-side fault (`500`) whose diagnosis is a log detail.
     ///
     /// `detail` diagnoses the fault (a codec error, an unexpected stored shape,

--- a/app/ferroehr/src/versioning/contribution.rs
+++ b/app/ferroehr/src/versioning/contribution.rs
@@ -214,6 +214,9 @@ fn classify(
 /// One parsed `UPDATE_VERSION` of a CONTRIBUTION commit — the single-pass plan
 /// entry (see the parse pass in [`commit_version_set`]).
 struct PlannedVersion {
+    /// The member's position in the submitted `versions` array — every
+    /// member-scoped refusal names it (#2590).
+    index: usize,
     action: Action,
     /// The parsed `preceding_version_uid` target (modify/delete/attest).
     target: Option<(VoId, TreeId)>,
@@ -470,12 +473,13 @@ pub(crate) async fn commit_version_set(
         let has_preceding = version
             .get("preceding_version_uid")
             .is_some_and(|v| !v.is_null());
-        let (action, code) = classify(token.as_deref(), has_preceding, data.is_some())?;
+        let (action, code) = classify(token.as_deref(), has_preceding, data.is_some())
+            .map_err(|e| e.for_version_member(index))?;
 
         let target = if action == Action::Create {
             None
         } else {
-            Some(parse_preceding(version)?)
+            Some(parse_preceding(version).map_err(|e| e.for_version_member(index))?)
         };
         // m4: default committer/system_id from the CONTRIBUTION audit when the
         // version item omits them (a "should be copied", so an explicit
@@ -489,7 +493,8 @@ pub(crate) async fn commit_version_set(
             &contrib_committer,
             &contrib_system_id,
             action != Action::Attest,
-        )?;
+        )
+        .map_err(|e| e.for_version_member(index))?;
         let lifecycle_state = lifecycle_of(version);
         // `UPDATE_VERSION.lifecycle_state` is REQUIRED on this wire (SM
         // `master03-common_package.adoc` §Version Update Semantics: "must be
@@ -503,25 +508,24 @@ pub(crate) async fn commit_version_set(
         // and only it — it commits no new version (master06 §Contributions), so
         // it has no version lifecycle state to supply; the RM governs the gap.
         if version.get("other_input_version_uids").is_some() {
-            return Err(ServiceError::precondition(
-                "other_input_version_uids is not a member of UPDATE_VERSION — the \
-                 released commit wire declares no merge shape (ITS-REST \
-                 UpdateVersion.yaml); merge provenance is served on reads only \
-                 (OriginalVersion.yaml)"
-                    .to_owned(),
-            ));
+            return Err(ServiceError::precondition(format!(
+                "versions[{index}]: other_input_version_uids is not a member of \
+                 UPDATE_VERSION — the released commit wire declares no merge shape \
+                 (ITS-REST UpdateVersion.yaml); merge provenance is served on reads \
+                 only (OriginalVersion.yaml)"
+            )));
         }
         if action != Action::Attest && lifecycle_state.is_none() {
-            return Err(ServiceError::precondition(
-                "lifecycle_state is required on every CONTRIBUTION version \
-                 (SM master03 §Version Update Semantics: \"The lifecycle_state must \
-                 be supplied in all cases\"; ITS-REST UpdateVersion.yaml lists it \
+            return Err(ServiceError::precondition(format!(
+                "versions[{index}]: lifecycle_state is required on every CONTRIBUTION \
+                 version (SM master03 §Version Update Semantics: \"The lifecycle_state \
+                 must be supplied in all cases\"; ITS-REST UpdateVersion.yaml lists it \
                  under required)"
-                    .to_owned(),
-            ));
+            )));
         }
         if action == Action::Delete {
-            reject_contradictory_delete_lifecycle(lifecycle_state.as_deref())?;
+            reject_contradictory_delete_lifecycle(lifecycle_state.as_deref())
+                .map_err(|e| e.for_version_member(index))?;
         }
         // A `553|incomplete|` version gets relaxed content validation
         // (master06 §Incomplete Content).
@@ -530,6 +534,7 @@ pub(crate) async fn commit_version_set(
             .and_then(lifecycle_state_code)
             .is_some_and(|c| c == state::INCOMPLETE);
         plan.push(PlannedVersion {
+            index,
             action,
             target,
             data,
@@ -587,8 +592,8 @@ pub(crate) async fn commit_version_set(
                     "attest plan entry lost its parsed preceding target".to_owned(),
                 ));
             };
-            let kind = require_kind(vo_id)?;
-            check_kind_scope(kind, party_only)?;
+            let kind = require_kind(vo_id).map_err(|e| e.for_version_member(v.index))?;
+            check_kind_scope(kind, party_only).map_err(|e| e.for_version_member(v.index))?;
             let partial = v.commit_audit.ok_or_else(|| {
                 ServiceError::content_invalid(
                     Violation::new(
@@ -607,21 +612,25 @@ pub(crate) async fn commit_version_set(
         }
         // AUDIT_DETAILS.System_id_valid + committer PARTY invariants — a
         // client-supplied version commit_audit must be a valid RM instance.
-        validate_commit_audit(&v.audit)?;
+        validate_commit_audit(&v.audit).map_err(|e| e.for_version_member(v.index))?;
         let change = match v.action {
             Action::Create => {
                 let data = v.data.ok_or_else(|| {
                     ServiceError::content_invalid(
                         Violation::new("is required on a creation version").with_path("data"),
                     )
+                    .for_version_member(v.index)
                 })?;
-                let kind = data_kind(&data)?;
-                check_kind_scope(kind, party_only)?;
-                typed_decode_gate(kind, &data, v.incomplete)?;
+                let kind = data_kind(&data).map_err(|e| e.for_version_member(v.index))?;
+                check_kind_scope(kind, party_only).map_err(|e| e.for_version_member(v.index))?;
+                typed_decode_gate(kind, &data, v.incomplete)
+                    .map_err(|e| e.for_version_member(v.index))?;
                 // A CONTRIBUTION commit is a full commit route: its versions
                 // are validated exactly as a direct create/update, relaxed for
                 // a `553|incomplete|` lifecycle (master06 §Incomplete Content).
-                cx.validate_for_commit(kind, &data, v.incomplete).await?;
+                cx.validate_for_commit(kind, &data, v.incomplete)
+                    .await
+                    .map_err(|e| e.for_version_member(v.index))?;
                 // An EHR holds exactly one EHR_STATUS / EHR_ACCESS (RM ehr,
                 // EHR class); FOLDER hierarchies follow the CNF
                 // master08-func_tc_ehr_contribution E.2 criterion.
@@ -645,7 +654,8 @@ pub(crate) async fn commit_version_set(
                     template_id,
                     signature: v.signature,
                     lifecycle_state: v.lifecycle_state,
-                    attestations: accompanying(&v.accompanying)?,
+                    attestations: accompanying(&v.accompanying)
+                        .map_err(|e| e.for_version_member(v.index))?,
                 }
             }
             Action::Modify => {
@@ -653,16 +663,20 @@ pub(crate) async fn commit_version_set(
                     ServiceError::content_invalid(
                         Violation::new("is required on a modification version").with_path("data"),
                     )
+                    .for_version_member(v.index)
                 })?;
                 let Some((vo_id, expected)) = v.target else {
                     return Err(ServiceError::exception(
                         "modify plan entry lost its parsed preceding target".to_owned(),
                     ));
                 };
-                let kind = require_kind(vo_id)?;
-                check_kind_scope(kind, party_only)?;
-                typed_decode_gate(kind, &data, v.incomplete)?;
-                cx.validate_for_commit(kind, &data, v.incomplete).await?;
+                let kind = require_kind(vo_id).map_err(|e| e.for_version_member(v.index))?;
+                check_kind_scope(kind, party_only).map_err(|e| e.for_version_member(v.index))?;
+                typed_decode_gate(kind, &data, v.incomplete)
+                    .map_err(|e| e.for_version_member(v.index))?;
+                cx.validate_for_commit(kind, &data, v.incomplete)
+                    .await
+                    .map_err(|e| e.for_version_member(v.index))?;
                 // Same template stamping as the Create arm (the delete guard
                 // counts every version row, modifications included).
                 let template_id = (kind == Kind::Composition)
@@ -679,7 +693,8 @@ pub(crate) async fn commit_version_set(
                     template_id,
                     signature: v.signature,
                     lifecycle_state: v.lifecycle_state,
-                    attestations: accompanying(&v.accompanying)?,
+                    attestations: accompanying(&v.accompanying)
+                        .map_err(|e| e.for_version_member(v.index))?,
                 }
             }
             Action::Delete => {
@@ -688,8 +703,8 @@ pub(crate) async fn commit_version_set(
                         "delete plan entry lost its parsed preceding target".to_owned(),
                     ));
                 };
-                let kind = require_kind(vo_id)?;
-                check_kind_scope(kind, party_only)?;
+                let kind = require_kind(vo_id).map_err(|e| e.for_version_member(v.index))?;
+                check_kind_scope(kind, party_only).map_err(|e| e.for_version_member(v.index))?;
                 // EHR.ehr_status is mandatory (RM ehr, EHR class:
                 // ehr_status 1..1) — deleting the only EHR_STATUS would
                 // leave the EHR violating its own invariant, so a delete

--- a/app/ferroehr/tests/it/service_contribution.rs
+++ b/app/ferroehr/tests/it/service_contribution.rs
@@ -2016,3 +2016,99 @@ async fn contribution_audit_change_type_is_required_not_derived() {
         "the client's own change type is stored verbatim"
     );
 }
+
+/// Every member-scoped CONTRIBUTION refusal names `versions[i]` (#2590):
+/// measured live, the declared-key check named the member while the data
+/// parse and validation refusals did not — on the one route whose purpose is
+/// a multi-member change set, a client could not tell which member failed.
+#[tokio::test]
+async fn member_scoped_refusals_name_the_offending_version_index() {
+    let db = testkit::db().await.expect("testkit database");
+    let svc = FerroEhrService::new(db.pool());
+    let ehr_id = create_ehr(&svc).await;
+    let ehr = ehr_id.parse().expect("ehr uuid");
+
+    let good = json!({
+        "data": composition("attributed-good"),
+        "lifecycle_state": { "_type": "DV_CODED_TEXT", "value": "complete", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "532" } },
+        "commit_audit": { "change_type": change_type("249", "creation"), "committer": committer("conformance tester") }
+    });
+    let audit = json!({
+        "change_type": change_type("249", "creation"),
+        "committer": committer("conformance tester")
+    });
+
+    // (a) the second member's data fails the strict canonical parse
+    // (`language` removed) — the 400 names versions[1].
+    let mut broken = composition("attributed-parse");
+    broken.as_object_mut().expect("object").remove("language");
+    let bad_parse = json!({
+        "data": broken,
+        "lifecycle_state": good["lifecycle_state"],
+        "commit_audit": good["commit_audit"]
+    });
+    let err = svc
+        .create_ehr_contribution(
+            ehr,
+            json!({ "audit": audit, "versions": [good.clone(), bad_parse] }),
+        )
+        .await
+        .expect_err("a non-decoding member is refused");
+    let sm = err;
+    assert!(
+        sm.message.contains("versions[1]"),
+        "the parse refusal names the member: {}",
+        sm.message
+    );
+
+    // (b) the second member's change_type contradicts its shape — 422 naming
+    // versions[1].
+    let bad_change = json!({
+        "data": composition("attributed-change"),
+        "lifecycle_state": good["lifecycle_state"],
+        "preceding_version_uid": format!("{}::ferroehr.local::1", uuid::Uuid::nil()),
+        "commit_audit": { "change_type": change_type("249", "creation"), "committer": committer("conformance tester") }
+    });
+    let err = svc
+        .create_ehr_contribution(
+            ehr,
+            json!({ "audit": audit, "versions": [good, bad_change] }),
+        )
+        .await
+        .expect_err("creation with a preceding version is refused");
+    let sm = err;
+    assert!(
+        sm.message.contains("versions[1]"),
+        "the change-type refusal names the member: {}",
+        sm.message
+    );
+
+    // (c) the second member names a template the store does not hold — the
+    // validation 422 names versions[1].
+    let mut templated = composition("attributed-template");
+    templated["archetype_details"]["template_id"] =
+        json!({ "_type": "TEMPLATE_ID", "value": "no_such_template.v1" });
+    let good = json!({
+        "data": composition("attributed-good-2"),
+        "lifecycle_state": { "_type": "DV_CODED_TEXT", "value": "complete", "defining_code": { "_type": "CODE_PHRASE", "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" }, "code_string": "532" } },
+        "commit_audit": { "change_type": change_type("249", "creation"), "committer": committer("conformance tester") }
+    });
+    let bad_template = json!({
+        "data": templated,
+        "lifecycle_state": good["lifecycle_state"],
+        "commit_audit": good["commit_audit"]
+    });
+    let err = svc
+        .create_ehr_contribution(
+            ehr,
+            json!({ "audit": audit, "versions": [good, bad_template] }),
+        )
+        .await
+        .expect_err("an unknown template is refused");
+    let sm = err;
+    assert!(
+        sm.message.contains("versions[1]") && sm.message.contains("no_such_template.v1"),
+        "the template refusal names the member and the template: {}",
+        sm.message
+    );
+}


### PR DESCRIPTION
Closes #2590

Measured during #314's wire probing: on `POST /ehr/{ehr_id}/contribution` — the one route whose whole purpose is a multi-member change set — only the declared-key check named the offending member; the data-parse `400`, the template and change-type `422`s, and the audit refusals carried no index, so a client staging several changes could not tell which one was rejected (the console compensated with its own row-naming pre-check, a workaround).

`ServiceError::for_version_member(index)` attributes a refusal generically per class: SM-status rows prefix the message (`versions[1]: …`), violation rows prefix the path (the established `versions[1]/…` format the key check already used), validation rows prefix each violation's path, and never-member-scoped rows pass through untouched. `PlannedVersion` carries the member's submitted position, and both loops thread it through classify, the preceding/audit parses, the lifecycle and merge-shape preconditions, the typed decode gate, commit validation, kind scoping and attestation assembly.

A three-class regression pins the index on the strict-parse 400, the contradictory-change-type 422 and the unknown-template 422 (each with a healthy first member, proving the index is the DEFECTIVE member's). No conformance exposure: the contribution catalogue pins statuses and outcomes, never these message texts (zero `matches:` in its cases). `ferroehr` 954/954; `ferroehr-rest` 770/770; clippy + fmt + the guards clean.