### PR TITLE
fix(rest): one uniform error body — Error.yaml satisfied on the assigned 400 surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,17 @@ workflow refuses a tag that has no matching section here.
   worked blood-pressure example are now documented in the book's FHIR
   chapter.
 
+### Changed
+
+- Every JSON error body now has ONE uniform shape:
+  `{"error", "message", "validationErrors"}`. Semantic-validation failures
+  populate `validationErrors` with their `"<path>: <message>"` entries (as
+  before); every other error now carries the member as an empty list, and
+  validation refusals additionally gain the machine-readable `error` reason
+  phrase. This makes the `400` bodies satisfy the released `Error.yaml`
+  schema's required member list; clients matching on the previous
+  two-shape split keep working (the change is additive on both shapes).
+
 ### Fixed
 
 - A composition `DELETE` that volunteers an `If-Match` precondition now

--- a/app/ferroehr-rest/src/overview/error.rs
+++ b/app/ferroehr-rest/src/overview/error.rs
@@ -9,20 +9,19 @@
 //! REST layer wraps it in [`RestError`] so handlers can use `?` and every error
 //! leaves the server as a structured JSON body.
 //!
-//! Two body shapes, both from the ITS-REST 1.1.0 spec:
+//! ONE body shape, uniform across every non-2xx (adjudicated on #2604):
+//! `{ "error", "message", "validationErrors" }` — the openEHR `Error`
+//! object's members
+//! (`docs/specs/openehr/ITS-REST/specifications/schemas/others/Error.yaml`:
+//! `required: [message, validationErrors]`, additional members tolerated)
+//! plus our `error` reason-phrase extra. A semantic-validation failure
+//! ([`ApiError::ValidationFailed`], HTTP `422`) populates the list with its
+//! `"<path>: <message>"` violations; every other error carries it empty.
 //!
-//! * A semantic-validation failure ([`ApiError::ValidationFailed`], HTTP `422`)
-//!   renders the openEHR `Error` object —
-//!   `docs/specs/openehr/ITS-REST/specifications/schemas/others/Error.yaml`:
-//!   `{ "message", "validationErrors": ["<path>: <message>", …] }` — via the
-//!   generated [`openehr_its::rest::generated::common::Error`] DTO.
-//!
-//!   NOTE: `422.yaml` declares no `content`/`schema` (the 422
-//!   body is spec-silent); the `Error` object is formally bound only to the
-//!   `400` response. Reusing that `{ message, validationErrors[] }` shape for
-//!   the `422` validation case is a deliberate, documented choice.
-//! * Every other error renders `{ "error", "message" }` (the status reason
-//!   phrase + human-readable detail).
+//! NOTE: the released assignment is narrow — only the OAS `400.yaml` /
+//! `400_CONTRIBUTION.yaml` attach `Error.yaml`, the docs text makes the body
+//! a MAY with no shape, and `422.yaml` declares no content at all — so the
+//! uniform shape beyond the 400 surface is our own design, flagged here.
 
 #![allow(
     clippy::disallowed_types,
@@ -173,13 +172,28 @@ impl From<ServiceError> for RestError {
     }
 }
 
-/// The JSON error body the ITS-REST spec prescribes for most non-2xx responses.
+/// The ONE JSON error body this server emits, uniform across every non-2xx.
+///
+/// The released assignment is narrow (adjudicated on #2604): only the OAS
+/// `responses/400.yaml` / `400_CONTRIBUTION.yaml` attach
+/// `schemas/others/Error.yaml` (`required: [message, validationErrors]`,
+/// additional members tolerated) to a 400 JSON body, and the docs text
+/// (`Requests_and_responses.md` §HTTP status codes) makes the body itself a
+/// MAY with no shape assignment — the `{message, code, errors}` block there
+/// is an example. Every other status's body is assigned by no source — our
+/// own design, kept uniform so a client parses one shape everywhere; `error`
+/// (the reason phrase) is our extra member on all of them.
 #[derive(Debug, Serialize)]
 struct ErrorBody {
     /// Machine-readable status label (the reason phrase, e.g. `Not Found`).
     error: String,
     /// Human-readable detail.
     message: String,
+    /// Per-path violations (`"<path>: <message>"`); empty when the failure
+    /// carries none — always emitted, so the 400 surface satisfies
+    /// `Error.yaml`'s required member list.
+    #[serde(rename = "validationErrors")]
+    validation_errors: Vec<String>,
 }
 
 /// Render an arbitrary status as the `{ error, message }` openEHR error body.
@@ -191,6 +205,7 @@ pub(crate) fn status_error_response(status: StatusCode, message: &str) -> Respon
     let body = ErrorBody {
         error: status.canonical_reason().unwrap_or("Error").to_owned(),
         message: message.to_owned(),
+        validation_errors: Vec::new(),
     };
     let json = serde_json::to_vec(&body).unwrap_or_else(|_| b"{}".to_vec());
     let mut resp = (status, json).into_response();
@@ -279,25 +294,24 @@ impl IntoResponse for RestError {
         }
         let status = self.0.status();
         let message = self.0.to_string();
-        // Semantic-validation failure → the ITS-REST `Error` object with the
-        // per-path violations as `validationErrors` (`schemas/others/Error.yaml`);
-        // every other error → the `{ error, message }` shape.
-        let json = if let ApiError::ValidationFailed(errors) = self.0 {
-            let body = openehr_its::rest::generated::common::Error {
-                message,
-                validation_errors: errors
-                    .into_iter()
-                    .map(|e| format!("{}: {}", e.path, e.message))
-                    .collect(),
-            };
-            serde_json::to_vec(&body).unwrap_or_else(|_| b"{}".to_vec())
+        // One uniform body (see [`ErrorBody`]): a semantic-validation failure
+        // populates `validationErrors` with its per-path violations
+        // (`schemas/others/Error.yaml`); every other error carries the empty
+        // list.
+        let validation_errors = if let ApiError::ValidationFailed(errors) = &self.0 {
+            errors
+                .iter()
+                .map(|e| format!("{}: {}", e.path, e.message))
+                .collect()
         } else {
-            let body = ErrorBody {
-                error: status.canonical_reason().unwrap_or("Error").to_owned(),
-                message,
-            };
-            serde_json::to_vec(&body).unwrap_or_else(|_| b"{}".to_vec())
+            Vec::new()
         };
+        let body = ErrorBody {
+            error: status.canonical_reason().unwrap_or("Error").to_owned(),
+            message,
+            validation_errors,
+        };
+        let json = serde_json::to_vec(&body).unwrap_or_else(|_| b"{}".to_vec());
         let mut resp = (status, json).into_response();
         resp.headers_mut().insert(
             header::CONTENT_TYPE,
@@ -347,7 +361,8 @@ mod tests {
         .await;
 
         assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
-        // ITS-REST `Error` shape: { message, validationErrors: [ "<path>: <message>" ] }.
+        // The uniform body: Error.yaml's members plus our `error` extra.
+        assert_eq!(body["error"], "Unprocessable Entity");
         assert!(body.get("message").and_then(Value::as_str).is_some());
         let errors = body["validationErrors"]
             .as_array()
@@ -358,12 +373,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn other_errors_keep_the_error_message_shape() {
+    async fn other_errors_carry_the_uniform_body_with_an_empty_list() {
         let (status, body) = body_json(ApiError::NotFound("EHR x".to_owned())).await;
         assert_eq!(status, StatusCode::NOT_FOUND);
         assert_eq!(body["error"], "Not Found");
         assert!(body.get("message").and_then(Value::as_str).is_some());
-        assert!(body.get("validationErrors").is_none());
+        // Always present (Error.yaml `required` on the assigned 400 surface;
+        // uniform everywhere else) — empty when no per-path violations exist.
+        assert_eq!(body["validationErrors"], serde_json::json!([]));
     }
 
     async fn handler_body(resp: axum::response::Response) -> (StatusCode, Value) {

--- a/tools/cnf-runner/artifacts/registers/ambiguities.yaml
+++ b/tools/cnf-runner/artifacts/registers/ambiguities.yaml
@@ -9751,3 +9751,44 @@ AMB-216:
     #1530; this entry is only the negotiation contradiction.)
   disposition: fixed_handling
   upstream_issue: 2539
+AMB-217:
+  ambiguity: >-
+    The release's error-body story is self-inconsistent and almost entirely
+    unassigned. The overview's §HTTP status codes makes any 4xx/5xx body a
+    MAY ("services MAY return additional error details if the
+    `Prefer: return=representation` header is present") and illustrates it
+    with an example of the shape `{message, code, errors[DV_CODED_TEXT]}`,
+    while the only published error schema — `schemas/others/Error.yaml`,
+    attached by exactly two response files (`400.yaml`,
+    `400_CONTRIBUTION.yaml`) — requires `{message, validationErrors[]}` and
+    defines neither `code` nor `errors`; the two shapes share only
+    `message`, so the release's own example is invalid against its own
+    schema. Every other error response file (404/409/412/422/…) declares no
+    content at all, so no source assigns those bodies any shape.
+  source: >-
+    ITS-REST specifications/docs/overview/Requests_and_responses.md §HTTP
+    status codes (the MAY sentence + the example error response block, read
+    first-hand — an example under a MAY, not a shape assignment); ITS-REST
+    specifications/responses/400.yaml + responses/400_CONTRIBUTION.yaml
+    (content schema $ref ../schemas/others/Error.yaml — the only two
+    attachments, cited as the OAS, docs text silent on the shape); ITS-REST
+    specifications/schemas/others/Error.yaml (required [message,
+    validationErrors], no additionalProperties bound, cited as the OAS);
+    ITS-REST specifications/responses/422.yaml (description only, no
+    content — the semantic-validation response the shape would most
+    naturally serve).
+  handling: >-
+    Fixed handling: the server emits ONE uniform error body,
+    {error, message, validationErrors} — the Error.yaml members (so the
+    assigned 400 surface satisfies the schema's required list; the list is
+    populated with "<path>: <message>" violations on semantic-validation
+    failures and empty elsewhere) plus a tolerated extra `error`
+    reason-phrase member. The shape beyond the 400 surface is our own
+    design, flagged in `ferroehr-rest::overview::error`. The docs-text
+    example is not followed: an example under a MAY assigns nothing, and
+    following it would make every body invalid against the release's own
+    schema. No catalogue case pins body members: the body itself is a MAY,
+    so a bodyless 400 is conformant and a member assertion would invent a
+    prohibition; the shape is pinned by the server's own wire tests instead.
+  disposition: editorial
+  upstream_issue: 2612

--- a/website/book/src/using-the-api/content-negotiation.md
+++ b/website/book/src/using-the-api/content-negotiation.md
@@ -404,14 +404,16 @@ against the versioned object only, so both headers carry the same list there.)
 ## Error responses
 
 Errors use conventional HTTP status codes (see the summary in
-[Resource walkthroughs](resources.md#status-code-summary)) with one of two JSON
-body shapes:
+[Resource walkthroughs](resources.md#status-code-summary)) with **one uniform
+JSON body shape** — the openEHR `Error` object's members plus a
+machine-readable `error` reason phrase:
 
-- **Validation errors** (a composition that fails its template) use the openEHR
-  error shape:
+- **Validation errors** (a composition that fails its template) populate the
+  list:
 
   ```json
   {
+    "error": "Unprocessable Entity",
     "message": "Composition validation failed",
     "validationErrors": [
       "/content[0]/data/events[0]/data/items[1]/value/magnitude: value out of range",
@@ -423,10 +425,10 @@ body shapes:
   Each entry is `"<path>: <message>"`, so a client can point the user at the
   exact offending node.
 
-- **All other errors** use a simple shape — the status reason plus a message:
+- **All other errors** carry the same shape with an empty list:
 
   ```json
-  { "error": "Not Found", "message": "No EHR with id …" }
+  { "error": "Not Found", "message": "No EHR with id …", "validationErrors": [] }
   ```
 
   This shape is used consistently — including for `405 Method Not Allowed` and
@@ -451,7 +453,7 @@ HTTP/1.1 405 Method Not Allowed
 Allow: GET,HEAD,PUT
 Content-Type: application/json
 
-{ "error": "Method Not Allowed", "message": "the request method is not allowed on this resource" }
+{ "error": "Method Not Allowed", "message": "the request method is not allowed on this resource", "validationErrors": [] }
 ```
 
 When a resource is switched off by configuration — the


### PR DESCRIPTION
Closes #2604

The error-body adjudication from the #319 audit, resolved with every citation re-derived first-hand (the full record is the comment on the issue; the register carries it as AMB-217).

**The enumeration killed the assumed conflict.** Exactly two released response files attach `Error.yaml` — `400.yaml` and `400_CONTRIBUTION.yaml`; every other error response declares no content, and the docs text's `{message, code, errors}` block is an example under a MAY, not a shape assignment. So the docs text is silent, the OAS grounds the 400 JSON body, and the rest of the error surface is assigned by no source.

**The wire change: one uniform error body.** `{error, message, validationErrors}` on every non-2xx — the `Error.yaml` members (the assigned 400 surface now satisfies `required: [message, validationErrors]`; semantic-validation failures populate the list with their `"<path>: <message>"` entries, everything else carries it empty) plus the tolerated `error` reason-phrase extra. Additive on both prior shapes: the old `{error, message}` bodies gain an empty list, the old 422 body gains `error`, and no member changed meaning — the console's `diagnostic_of` already reads all three. The module doc now states the honest citation set instead of the false "the spec prescribes this for most non-2xx" claim.

**Deliberately NO catalogue case pins the body members**: the body itself is a MAY, so a bodyless 400 is a conformant answer and a member assertion would refuse spec-legal parties — the inventing-a-prohibition defect class. The shape is pinned by the server's own wire tests (the populated-422 case and the uniform empty-list case), and AMB-217's handling records the reasoning.

**Upstream:** the release's example error response cannot validate against its own `Error.yaml` (the shapes share only `message`) — filed as upstream-report #2612, carried by AMB-217 as its `upstream_issue`.

Verification: `ferroehr-rest` 772/772 with the two reshaped error-body tests; clippy/fmt/comment-style/docs-claims clean; the catalogue validator green including the spec-ref resolution of AMB-217's citations; the book's error-body section updated to the uniform shape; the full conformance pipeline re-run at close with zero drift (statuses unchanged, bodies additive — no binding pins an exact error body).
