### PR TITLE
docs(conformance): comparison re-derived from the fresh ehrbase verdicts

### DIFF
--- a/docs/conformance/COMPARISON.md
+++ b/docs/conformance/COMPARISON.md
@@ -69,7 +69,7 @@ them.
 | | verdict scope (selected) | driven | in-scope passed | in-scope failed | in-scope inconclusive |
 |---|---|---|---|---|---|
 | **ferroehr** | 1100 | 1062 | 1062 | 0 | 0 |
-| **EHRbase** | 645 | 571 | 148 | 148 | 275 |
+| **EHRbase** | 648 | 571 | 148 | 148 | 275 |
 
 An **inconclusive** row's wire answered outside the operation's bound outcome
 map, or its required ground could not be established (e.g. a refused


### PR DESCRIPTION
Closes nothing — the #2618 regeneration ran `comparison.sh` BEFORE `conformance-docs.sh` refreshed the EHRbase verdicts, so the committed comparison derived its EHRbase selected-count (645) from the stale verdicts while CI, whose checkout already carries the fresh ones, derives 648 (the three new cases — the volunteered-If-Match twins and the uncoercible-binding case — are selected under EHRbase's claims too). Re-derived in the render scripts' converged state; one number changes and nothing is hand-edited.