### PR TITLE
release: v4.0.0

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -4,8 +4,8 @@
   "language": "eng",
   "title": "FerroEHR",
   "description": "<p>A pure-Rust, openEHR-specification-conformant clinical data repository (CDR): ITS-REST 1.1.0 REST API, AQL 1.1 query language, and the openEHR RM 1.2.0 reference model on PostgreSQL-18-native storage. The openEHR specification layer is generated from the official machine-readable specifications, and conformance is machine-verified per release by a built-in CNF conformance runner.</p>",
-  "publication_date": "2026-08-21",
-  "version": "3.20.0",
+  "publication_date": "2026-08-24",
+  "version": "4.0.0",
   "creators": [
     {
       "name": "Talstra, Ruben",
@@ -39,7 +39,7 @@
       "resource_type": "publication-softwaredocumentation"
     },
     {
-      "identifier": "https://github.com/rubentalstra/FerroEHR/tree/v3.20.0",
+      "identifier": "https://github.com/rubentalstra/FerroEHR/tree/v4.0.0",
       "relation": "isSupplementTo",
       "resource_type": "software"
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+## [4.0.0] - 2026-08-24
+
 ### Added
 
 - Admin console: a **Subscriptions** screen (shown only when the CDR's

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -37,5 +37,5 @@ keywords:
   - ITS-REST
   - Rust
   - PostgreSQL
-version: 3.20.0
-date-released: 2026-08-21
+version: 4.0.0
+date-released: 2026-08-24

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "cnf-runner"
-version = "3.20.0"
+version = "4.0.0"
 dependencies = [
  "assert_fs",
  "base64 0.23.1",
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "docs-meta"
-version = "3.20.0"
+version = "4.0.0"
 
 [[package]]
 name = "dotenvy"
@@ -2683,7 +2683,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ferroehr"
-version = "3.20.0"
+version = "4.0.0"
 dependencies = [
  "argon2",
  "assert_fs",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-admin-ui"
-version = "3.20.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2799,7 +2799,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-ext"
-version = "3.20.0"
+version = "4.0.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2823,7 +2823,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-rest"
-version = "3.20.0"
+version = "4.0.0"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -2883,7 +2883,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-server"
-version = "3.20.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-codegen"
-version = "3.20.0"
+version = "4.0.0"
 dependencies = [
  "roxmltree",
  "serde_json",
@@ -8753,7 +8753,7 @@ dependencies = [
 
 [[package]]
 name = "testkit"
-version = "3.20.0"
+version = "4.0.0"
 dependencies = [
  "ferroehr",
  "jiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "3"
 members = ["crates/*", "app/*", "tools/*"]
 
 [workspace.package]
-version = "3.20.0"
+version = "4.0.0"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT"

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -26,7 +26,7 @@ version: 6.0.12
 # previous image. It is NOT a promise that this tag accepts the chart's current
 # `config` defaults: values track development between releases, so the publish
 # lane re-checks the pairing against the image itself.
-appVersion: "3.20.0"
+appVersion: "4.0.0"
 
 # A COMPATIBILITY floor, and a real one: 1.36 is the release where the newest
 # field this chart renders became stable.
@@ -136,7 +136,7 @@ annotations:
   # scan while leaving the false claim in place, so it is deliberately not used.
   artifacthub.io/images: |
     - name: ferroehr
-      image: ghcr.io/rubentalstra/ferroehr:3.20.0
+      image: ghcr.io/rubentalstra/ferroehr:4.0.0
       platforms:
         - linux/amd64
         - linux/arm64
@@ -145,7 +145,7 @@ annotations:
     # visible to anyone considering it. See #2193: this chart cannot deploy it
     # yet, so today the entry advertises intent rather than chart behaviour.
     - name: ferroehr-admin-ui
-      image: ghcr.io/rubentalstra/ferroehr-admin-ui:3.20.0
+      image: ghcr.io/rubentalstra/ferroehr-admin-ui:4.0.0
       platforms:
         - linux/amd64
         - linux/arm64

--- a/deploy/helm/ferroehr/README.md
+++ b/deploy/helm/ferroehr/README.md
@@ -2,7 +2,7 @@
 
 Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.1.0 + AQL 1.1). A single static binary deployed with a hardened-by-default security posture: runs as a non-root, read-only-rootfs workload whose NetworkPolicy admits its serving port only, and that connects to an EXTERNAL PostgreSQL 18 as an unprivileged app role (migrations are run out of band by a separate migrator role).
 
-![Version: 6.0.12](https://img.shields.io/badge/Version-6.0.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.20.0](https://img.shields.io/badge/AppVersion-3.20.0-informational?style=flat-square)
+![Version: 6.0.12](https://img.shields.io/badge/Version-6.0.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.0](https://img.shields.io/badge/AppVersion-4.0.0-informational?style=flat-square)
 
 FerroEHR is a pure-Rust openEHR Clinical Data Repository: ITS-REST 1.1.0 at the
 API, AQL 1.1 as the query language, PostgreSQL 18-native storage, shipped as a
@@ -36,7 +36,7 @@ helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
   --version 6.0.12 \
   --namespace ferroehr --create-namespace \
   --set database.existingSecret=ferroehr-db \
-  --set image.tag=3.20.0
+  --set image.tag=4.0.0
 ```
 
 OCI registries require Helm 3.8 or newer.
@@ -48,7 +48,7 @@ They are independent SemVer lines and they move independently:
 | What | Set with | This release |
 |---|---|---|
 | the **chart** (templates, defaults, this document) | `--version` | `6.0.12` |
-| the **server image** | `image.tag` | `3.20.0` |
+| the **server image** | `image.tag` | `4.0.0` |
 
 `appVersion` is the image the chart defaults to; pinning `image.tag` explicitly
 is what keeps an upgrade of one from silently moving the other.
@@ -69,7 +69,7 @@ A **SLSA build provenance attestation** — what source it was built from, and h
 ```console
 gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:6.0.12 \
   -R rubentalstra/FerroEHR
-gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:3.20.0 \
+gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:4.0.0 \
   -R rubentalstra/FerroEHR
 ```
 

--- a/deploy/helm/golden/admin-ui.yaml
+++ b/deploy/helm/golden/admin-ui.yaml
@@ -21,7 +21,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -93,7 +93,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -121,7 +121,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -142,7 +142,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -157,7 +157,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 automountServiceAccountToken: false
@@ -187,7 +187,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -204,7 +204,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -335,7 +335,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -358,7 +358,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -388,7 +388,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -424,7 +424,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: admin-ui
-          image: "ghcr.io/rubentalstra/ferroehr-admin-ui:3.20.0"
+          image: "ghcr.io/rubentalstra/ferroehr-admin-ui:4.0.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -495,7 +495,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -543,7 +543,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:3.20.0"
+          image: "ghcr.io/rubentalstra/ferroehr:4.0.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -26,7 +26,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -100,7 +100,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -121,7 +121,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -153,7 +153,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -179,7 +179,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -200,7 +200,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -391,7 +391,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -425,7 +425,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -475,7 +475,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:3.20.0"
+          image: "ghcr.io/rubentalstra/ferroehr:4.0.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -656,7 +656,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -690,7 +690,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -728,7 +728,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     release: kube-prometheus-stack

--- a/deploy/helm/golden/basic-auth.yaml
+++ b/deploy/helm/golden/basic-auth.yaml
@@ -26,7 +26,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -54,7 +54,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -75,7 +75,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 automountServiceAccountToken: false
@@ -105,7 +105,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -122,7 +122,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -250,7 +250,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -280,7 +280,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -328,7 +328,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:3.20.0"
+          image: "ghcr.io/rubentalstra/ferroehr:4.0.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -26,7 +26,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -54,7 +54,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -75,7 +75,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 automountServiceAccountToken: false
@@ -90,7 +90,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -215,7 +215,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -245,7 +245,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.12
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "3.20.0"
+    app.kubernetes.io/version: "4.0.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -293,7 +293,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:3.20.0"
+          image: "ghcr.io/rubentalstra/ferroehr:4.0.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,7 @@
 
 services:
   ferroehr-postgres:
-    image: ${FERROEHR_POSTGRES_IMAGE:-ghcr.io/rubentalstra/ferroehr-postgres:3.20.0}
+    image: ${FERROEHR_POSTGRES_IMAGE:-ghcr.io/rubentalstra/ferroehr-postgres:4.0.0}
     # Docker's default 64MB /dev/shm starves PostgreSQL's dynamic shared
     # memory under load (parallel workers error `could not resize shared
     # memory segment … No space left on device`); measured runs share this
@@ -154,7 +154,7 @@ services:
       start_period: 10s
 
   ferroehr:
-    image: ${FERROEHR_IMAGE:-ghcr.io/rubentalstra/ferroehr:3.20.0}
+    image: ${FERROEHR_IMAGE:-ghcr.io/rubentalstra/ferroehr:4.0.0}
     depends_on:
       ferroehr-postgres:
         condition: service_healthy
@@ -252,7 +252,7 @@ services:
   # FERROEHR_ADMIN__AUTH__OIDC__* variables at your identity provider.
   ferroehr-admin-ui:
     profiles: [admin-ui]
-    image: ${FERROEHR_ADMIN_UI_IMAGE:-ghcr.io/rubentalstra/ferroehr-admin-ui:3.20.0}
+    image: ${FERROEHR_ADMIN_UI_IMAGE:-ghcr.io/rubentalstra/ferroehr-admin-ui:4.0.0}
     depends_on:
       ferroehr:
         condition: service_healthy

--- a/docs/conformance/ferroehr/CONFORMANCE_STATEMENT.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_STATEMENT.md
@@ -1,6 +1,6 @@
 # Conformance Statement (SDoC)
 
-Product: FerroEHR 3.20.0 — Ruben Talstra (urn:rubentalstra:ferroehr)
+Product: FerroEHR 4.0.0 — Ruben Talstra (urn:rubentalstra:ferroehr)
 Schedule release: cnf-2.0-w2
 
 ## Declared spec versions

--- a/tools/cnf-runner/party/ferroehr/statement.json
+++ b/tools/cnf-runner/party/ferroehr/statement.json
@@ -1,7 +1,7 @@
 {
   "product": {
     "name": "FerroEHR",
-    "version": "3.20.0",
+    "version": "4.0.0",
     "vendor": "Ruben Talstra",
     "identifier": "urn:rubentalstra:ferroehr"
   },


### PR DESCRIPTION
The v4.0.0 cut. The milestone closed at 60 issues, headlined by the admin-console program's completion (#152/#2052 — nineteen children from design polish through the close-out spec audit), the console wire audit with its twelve dispositioned findings, the uniform error body (AMB-217), the volunteered-If-Match evaluation with its CNF twins, and the coverage growth to 1,100 catalogue executions with the committed baseline at 1,062 driven green.

The mechanical cut, per the release procedure: `[Unreleased]` → `[4.0.0] - 2026-08-24` with the link references extended; the workspace version and lock to 4.0.0; the chart's `appVersion` (+ its artifacthub image tags and regenerated README/goldens — the chart's own version stays 6.0.12, no packaged chart content changed this cycle); `CITATION.cff` + the re-rendered `.zenodo.json`; the ferroehr party statement's product version with the derived conformance documents re-rendered in the converged order (statement → party docs → comparison); and the compose quickstart's default image tags to 4.0.0.

Guards run locally: statement-version OK (4.0.0), compose-image-tags OK, the full helm validation suite green (goldens + README regenerated), fmt clean, the lock refreshed by cargo check.
