### PR TITLE
fix(helm): chart 6.0.13 — the appVersion change is packaged content

### DIFF
--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # A published OCI version is immutable by refusal rather than by the registry —
 # `helm push` over an existing tag replaces it silently — so a correction always
 # ships as a NEW version and the published one stands as it was.
-version: 6.0.12
+version: 6.0.13
 # The default container image tag (overridable via image.tag), and the released
 # application version — kept equal to the workspace version by the
 # `chart-appversion` CI guard, so a release cannot ship a chart pointing at the

--- a/deploy/helm/ferroehr/README.md
+++ b/deploy/helm/ferroehr/README.md
@@ -2,7 +2,7 @@
 
 Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.1.0 + AQL 1.1). A single static binary deployed with a hardened-by-default security posture: runs as a non-root, read-only-rootfs workload whose NetworkPolicy admits its serving port only, and that connects to an EXTERNAL PostgreSQL 18 as an unprivileged app role (migrations are run out of band by a separate migrator role).
 
-![Version: 6.0.12](https://img.shields.io/badge/Version-6.0.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.0](https://img.shields.io/badge/AppVersion-4.0.0-informational?style=flat-square)
+![Version: 6.0.13](https://img.shields.io/badge/Version-6.0.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.0](https://img.shields.io/badge/AppVersion-4.0.0-informational?style=flat-square)
 
 FerroEHR is a pure-Rust openEHR Clinical Data Repository: ITS-REST 1.1.0 at the
 API, AQL 1.1 as the query language, PostgreSQL 18-native storage, shipped as a
@@ -33,7 +33,7 @@ add — `helm repo add` does not apply to this chart and never will:
 
 ```console
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 6.0.12 \
+  --version 6.0.13 \
   --namespace ferroehr --create-namespace \
   --set database.existingSecret=ferroehr-db \
   --set image.tag=4.0.0
@@ -47,7 +47,7 @@ They are independent SemVer lines and they move independently:
 
 | What | Set with | This release |
 |---|---|---|
-| the **chart** (templates, defaults, this document) | `--version` | `6.0.12` |
+| the **chart** (templates, defaults, this document) | `--version` | `6.0.13` |
 | the **server image** | `image.tag` | `4.0.0` |
 
 `appVersion` is the image the chart defaults to; pinning `image.tag` explicitly
@@ -59,7 +59,7 @@ The chart carries two keyless Sigstore artifacts, and they answer different
 questions. A **cosign signature** — who signed this:
 
 ```console
-cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.12 \
+cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.13 \
   --certificate-identity-regexp '^https://github\.com/rubentalstra/FerroEHR/\.github/workflows/publish-chart\.yml@' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
@@ -67,7 +67,7 @@ cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.12 \
 A **SLSA build provenance attestation** — what source it was built from, and how:
 
 ```console
-gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:6.0.12 \
+gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:6.0.13 \
   -R rubentalstra/FerroEHR
 gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:4.0.0 \
   -R rubentalstra/FerroEHR

--- a/deploy/helm/golden/admin-ui.yaml
+++ b/deploy/helm/golden/admin-ui.yaml
@@ -18,7 +18,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the admin console: only its HTTP port, but from EVERY source — this policy narrows ports, NOT sources (adminUi.networkPolicy.ingressAllowAll=true). Set adminUi.networkPolicy.ingressFrom for a PHI workload. Egress admits the CDR Service and DNS only.
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"
@@ -90,7 +90,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"
@@ -118,7 +118,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"
@@ -139,7 +139,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr-admin-ui
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"
@@ -154,7 +154,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"
@@ -184,7 +184,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"
@@ -201,7 +201,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"
@@ -332,7 +332,7 @@ metadata:
     kubernetes.io/description: >-
       In-cluster address for the FerroEHR admin console. The console is a REST client of the CDR and holds no data of its own; it is the human-facing surface, so this is the Service an Ingress normally publishes.
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"
@@ -355,7 +355,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"
@@ -385,7 +385,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR admin console: a Leptos SSR web UI that consumes the CDR strictly over ITS-REST. It never reaches the database, which the console NetworkPolicy enforces rather than assumes.
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"
@@ -492,7 +492,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), and only from the networkPolicy.ingressFrom peers.
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"
@@ -97,7 +97,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"
@@ -118,7 +118,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"
@@ -150,7 +150,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"
@@ -176,7 +176,7 @@ kind: Secret
 metadata:
   name: ferroehr-config
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"
@@ -197,7 +197,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"
@@ -388,7 +388,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"
@@ -422,7 +422,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"
@@ -653,7 +653,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"
@@ -687,7 +687,7 @@ kind: Ingress
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"
@@ -725,7 +725,7 @@ kind: ServiceMonitor
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"

--- a/deploy/helm/golden/basic-auth.yaml
+++ b/deploy/helm/golden/basic-auth.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"
@@ -51,7 +51,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"
@@ -72,7 +72,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"
@@ -102,7 +102,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"
@@ -119,7 +119,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"
@@ -247,7 +247,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"
@@ -277,7 +277,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"
@@ -51,7 +51,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"
@@ -72,7 +72,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"
@@ -87,7 +87,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"
@@ -212,7 +212,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"
@@ -242,7 +242,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.12
+    helm.sh/chart: ferroehr-6.0.13
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.0"


### PR DESCRIPTION
Closes nothing — the v4.0.0 cut bumped the chart's `appVersion`, README and artifacthub image tags (all packaged content) without bumping the chart's own version, so the tag-triggered publish lane refused to overwrite the already-published 6.0.12 — exactly the immutability guard doing its job. The chart moves to 6.0.13 (goldens + README regenerated); once the 4.0.0 images finish publishing from the tag's containers run, the chart publishes through the documented chart-only-fix lane (`publish-chart.yml` workflow_dispatch with `publish: true`).