### PR TITLE
docs(changelog): the 6.0.13 chart entry the bump PR owed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Fixed
+
+- The Helm chart publishes again as 6.0.13, carrying the v4.0.0 server as
+  its `appVersion`: the v4.0.0 cut changed packaged chart content
+  (`appVersion`, the generated README, the image annotations) without
+  bumping the chart's own version, so the tag-triggered publish was
+  correctly refused by the immutability guard and no chart for v4.0.0
+  existed until this one.
+
 ## [4.0.0] - 2026-08-24
 
 ### Added


### PR DESCRIPTION
Closes nothing — #2622 carried `no-changelog`, which was wrong: a chart version bump is a Helm-artifact change and those are user-visible by the changelog rule's own list. The missing entry also broke the chart-only publish lane, whose Artifact Hub annotation injector reads the `[Unreleased]` section on a between-releases dispatch and refuses an empty one. Entry added; the 6.0.13 dispatch re-runs after this merges.