### PR TITLE
fix(ci): the chart read-back and the book pin the build-chart.yml signer identity

### DIFF
--- a/.github/workflows/build-chart.yml
+++ b/.github/workflows/build-chart.yml
@@ -449,10 +449,10 @@ jobs:
         run: |
           set -euo pipefail
           cosign verify "${CHART_REF}@${DIGEST}" \
-            --certificate-identity-regexp "^https://github\.com/${REPO}/\.github/workflows/publish-chart\.yml@" \
+            --certificate-identity-regexp "^https://github\.com/${REPO}/\.github/workflows/build-chart\.yml@" \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             > /dev/null
-          echo "the signature verifies against ${REPO}/.github/workflows/publish-chart.yml"
+          echo "the signature verifies against ${REPO}/.github/workflows/build-chart.yml"
 
           # The OCI fallback tag for a subject digest: `sha256:<hex>` → `sha256-<hex>`.
           fallback="${CHART_REF}:${DIGEST/:/-}"

--- a/website/book/src/installation/kubernetes.md
+++ b/website/book/src/installation/kubernetes.md
@@ -98,7 +98,7 @@ signature over the chart's digest:
 
 ```shell
 cosign verify ghcr.io/rubentalstra/charts/ferroehr:<chart-version> \
-  --certificate-identity-regexp '^https://github\.com/rubentalstra/FerroEHR/\.github/workflows/publish-chart\.yml@' \
+  --certificate-identity-regexp '^https://github\.com/rubentalstra/FerroEHR/\.github/workflows/build-chart\.yml@' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
 

--- a/website/book/src/verifying-releases.md
+++ b/website/book/src/verifying-releases.md
@@ -228,7 +228,7 @@ signature is what Helm-ecosystem tooling looks for.
 
 ```bash
 cosign verify ghcr.io/rubentalstra/charts/ferroehr:<chart-version> \
-  --certificate-identity-regexp '^https://github\.com/rubentalstra/FerroEHR/\.github/workflows/publish-chart\.yml@' \
+  --certificate-identity-regexp '^https://github\.com/rubentalstra/FerroEHR/\.github/workflows/build-chart\.yml@' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
 


### PR DESCRIPTION
Third and last rename fallout from the chart lane's SLSA L3 refactor: signing moved into the reusable `build-chart.yml`, so the Fulcio certificate names that workflow as the signer — and the lane's own read-back step still matched `publish-chart.yml`, failing the 6.0.15 run after push, sign and attest had all succeeded. The two book pages carrying the cosign command pinned the same stale identity.

Chart 6.0.15 itself is complete: verified out-of-band with the correct identity, `cosign verify` and `gh attestation verify --signer-workflow …/build-chart.yml` both pass. This fixes the verifier, not the artifact.