### PR TITLE
ci: SonarQube Cloud analysis as the third advisory machine opinion

### DIFF
--- a/.claude/rules/ai-code-review.md
+++ b/.claude/rules/ai-code-review.md
@@ -91,6 +91,19 @@ that *describes* a rule as if it violated one. Record such a finding on the
 measurement issue rather than silencing it; an instruction is only edited
 when the instruction is actually wrong, never to make a comment go away.
 
+## SonarQube Cloud — the third machine opinion, same standing (#2630)
+
+SonarQube Cloud analyzes every PR and every develop push
+(`.github/workflows/sonar.yml`, scope in `sonar-project.properties`). Rust
+is first-party there: the analyzer runs Clippy itself — at workspace
+default features, a deliberately independent second Clippy configuration
+beside our deny-tier lanes. Everything above applies unchanged: findings
+are advisory, the precedence order is identical, no quality gate blocks a
+merge, and nothing it says relaxes `testing.md`. A finding worth acting on
+is written by hand in a normal change; a false positive is data, not a
+reason to tune the scanner. Promotion to a gating check would follow a
+precision measurement, exactly like the CodeRabbit decision recorded above.
+
 Official documentation (durable citations):
 <https://docs.coderabbit.ai/configure-coderabbit/> ·
 <https://docs.coderabbit.ai/reference/yaml-template>

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
+# SonarQube Cloud analysis — the THIRD machine opinion beside CodeQL and
+# CodeRabbit (#2630), under the same standing law as the AI reviewer
+# (.claude/rules/ai-code-review.md): findings are advisory, never outrank
+# the vendored specs, the rules, or the local gates, and gate no merge.
+#
+# Rust is analyzed first-party (announced 2025-04-17,
+# https://www.sonarsource.com/blog/introducing-rust-in-sonarqube/): the
+# analyzer runs Clippy itself from the root Cargo.toml — 85 Clippy rules
+# managed as quality-profile rules, plus complexity metrics. That run uses
+# the workspace DEFAULT features (the console compiles as an empty shell
+# with neither ssr nor hydrate), so it sees less than our own deny-tier
+# clippy lanes; it is a second, independent configuration on purpose.
+# Scope (what is scanned vs excluded) lives in sonar-project.properties.
+#
+# Rust is not in SonarQube Cloud's Automatic Analysis — CI-based analysis
+# is the documented path. SONAR_HOST_URL is not needed for Cloud
+# (SonarSource/sonarqube-scan-action README, v8.2.1).
+name: SonarQube Cloud
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+jobs:
+  scan:
+    name: analyze
+    # PR analysis authenticates with SONAR_TOKEN, which fork PRs cannot read.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-26.04
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      pull-requests: read # PR decoration reads the PR metadata
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history: Sonar assigns issues and new-code status by blame.
+          fetch-depth: 0
+          persist-credentials: false
+
+      # Build cache for the analyzer's own Clippy run. This lane publishes
+      # nothing, so restoring a cache is inside the reliability.md rule
+      # (only publishing lanes must run cache-free).
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          shared-key: sonar
+
+      - uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,42 @@
+# SonarQube Cloud project scope (#2630). Advisory instrument — see
+# .claude/rules/ai-code-review.md for the standing law.
+sonar.projectKey=rubentalstra_FerroEHR
+sonar.organization=rubentalstra
+sonar.projectName=FerroEHR
+sonar.sourceEncoding=UTF-8
+
+# Hand-written trees only. The generated spec crates, the generated parts of
+# openehr-its, the vendored spec text/corpora/assets, and machine-produced
+# records are excluded: findings on bytes a generator or a vendor script owns
+# are noise the attribution law forbids acting on in place.
+sonar.sources=app,crates,tools,scripts,deploy,website
+
+sonar.exclusions=\
+  crates/openehr-base/**,\
+  crates/openehr-rm/**,\
+  crates/openehr-am/**,\
+  crates/openehr-lang/src/v1_0/**,\
+  crates/openehr-lang/src/v1_1/**,\
+  crates/openehr-term/src/v3_1/**,\
+  crates/openehr-its/src/aom2/**,\
+  crates/openehr-its/src/aom2_model/**,\
+  crates/openehr-its/src/json_codec/generated/**,\
+  crates/openehr-its/src/opt14/**,\
+  crates/openehr-its/src/rest/generated/**,\
+  crates/openehr-its/src/xml/generated/**,\
+  crates/openehr-adl/tests/corpus/**,\
+  crates/openehr-adl/vendor/**,\
+  crates/openehr-its/schemas/**,\
+  crates/openehr-its/tests/vendor/**,\
+  crates/openehr-its/vendor/**,\
+  crates/openehr-lang/tests/vendor/**,\
+  crates/openehr-lang/vendor/**,\
+  crates/openehr-query/vendor/**,\
+  crates/openehr-term/assets/**,\
+  tools/openehr-codegen/vendor/**,\
+  tools/cnf-runner/artifacts/**,\
+  deploy/helm/golden/**,\
+  website/api/vendor/**,\
+  website/api/spec/**,\
+  website/book/theme/**,\
+  website/book/src/katex/**


### PR DESCRIPTION
Part of #2630 (the issue closes once the first develop analysis completes and the assessment is posted).

- `.github/workflows/sonar.yml`: push-to-develop + PR triggers, fork PRs skipped (no `SONAR_TOKEN` there), full-history checkout for blame-based new-code status, `Swatinem/rust-cache` for the analyzer's own Clippy run (this lane publishes nothing, so a cache is inside the reliability rule), and the scan action at the live-verified v8.2.1 SHA. `SONAR_HOST_URL` is not set: the action's README states it is not needed for SonarQube Cloud.
- `sonar-project.properties`: hand-written trees only — the generated spec crates, the generated parts of `openehr-its`, vendored corpora/schemas/assets, goldens, and the conformance artifacts are excluded, since findings on generator- or vendor-owned bytes cannot be acted on in place.
- `.claude/rules/ai-code-review.md`: the advisory posture recorded — same precedence law as CodeRabbit, no gate, promotion only after a precision measurement.

Adjudication recorded on the issue: the analyzer runs its own Clippy at workspace default features (the console compiles as an empty shell with neither `ssr` nor `hydrate`, verified against the `compile_error!` guard) rather than importing our lanes' JSON — an independent second opinion is the point of the instrument, and importing would demote every finding to external-issue status outside quality profiles. Coverage import is deliberately not wired: it would add an instrumented full build plus a PG-backed test run to an advisory lane.