### PR TITLE
fix(compose): Podman-verified quickstart — the s3 wait gate and the LGTM /data mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,28 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- Compose: `docker compose --profile s3 up -d --wait` no longer fails after
+  everything succeeded. Current Compose (v5.4, Docker and Podman alike)
+  treats any exited container as a `--wait` failure, including the bucket
+  initializer's successful exit; the server now declares a
+  `service_completed_successfully` dependency on the initializer (inert
+  without the `s3` profile), which both orders startup after bucket creation
+  and marks the initializer as a one-shot. The documented invocation drops
+  the initializer from the service list.
+- Compose: the observability overlay boots under Podman. Every component of
+  the LGTM container creates its state under `/data`, which the image cannot
+  create under Podman (its root directory ships mode 555 and the overlay
+  drops all capabilities); a `tmpfs` mount at `/data` fixes it on both
+  engines.
+
+### Added
+
+- Docs: the compose installation page states the supported container
+  engines — the quickstart, both profiles and both overlays are verified on
+  Docker and Podman.
+
+### Fixed
+
 - Helm chart 6.0.15: the chart-signing step retries transient Sigstore
   failures instead of stranding a published version unsigned. Chart 6.0.14
   was pushed but lost its signature and provenance attestation to a single

--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -75,6 +75,14 @@ services:
     environment:
       # Keep collected data in the container's lifetime (dev).
       - ENABLE_LOGS_ALL=true
+    # Every LGTM component mkdirs its state under /data at startup. The image
+    # ships `/` as mode 555, and with cap_drop ALL (no DAC_OVERRIDE) even root
+    # cannot create it: Docker normalizes the root inode to 755 so this never
+    # surfaced there; Podman preserves the image's 555 and every component died
+    # at mkdir (issue #2636). A tmpfs matches the dev-lifetime intent above and
+    # behaves identically on both engines.
+    tmpfs:
+      - /data
     configs:
       # Inline provisioning so the downloaded overlay is self-sufficient
       # (docs.docker.com/reference/compose-file/configs — the `content`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,6 +158,14 @@ services:
     depends_on:
       ferroehr-postgres:
         condition: service_healthy
+      # Inert without the s3 profile (required: false). With it, this edge does
+      # two jobs: the server starts only after the bucket initializer exits 0,
+      # and `up -d --wait` learns the initializer is a one-shot — Compose v5.4
+      # otherwise fails --wait on ANY exited container, even a successful one
+      # (measured on Docker and Podman alike, 2026-08-24, issue #2636).
+      seaweedfs-init:
+        condition: service_completed_successfully
+        required: false
     environment:
       # FERROEHR_ env overrides use the mechanical `__` mapping (TOML path,
       # upper-cased, `__` between segments); they layer on top of the mounted
@@ -292,7 +300,7 @@ services:
   #        export FERROEHR__MULTIMEDIA__ENDPOINT=http://seaweedfs:8333
   #        export FERROEHR__MULTIMEDIA__BUCKET=openehr-multimedia
   #        export FERROEHR__MULTIMEDIA__ALLOW_HTTP=true   # dev only; prod S3 is HTTPS
-  #   2. docker compose --profile s3 up -d --wait ferroehr seaweedfs seaweedfs-init
+  #   2. docker compose --profile s3 up -d --wait ferroehr seaweedfs
   #      `seaweedfs-init` creates the bucket; the gateway ships with none, and an
   #      S3 PUT into a missing bucket answers 403 AccessDenied, which reads as a
   #      credentials problem and is not one.

--- a/website/book/src/installation/compose.md
+++ b/website/book/src/installation/compose.md
@@ -111,6 +111,37 @@ Swagger UI at `http://localhost:8080/ferroehr/rest/swagger-ui`.
 > pre-18 `/var/lib/postgresql/data`. The bundled Compose file already does this
 > correctly; keep the convention if you adapt it.
 
+## Container engines: Docker and Podman
+
+The quickstart runs on Docker and on Podman. Both were verified first-hand on
+2026-08-24: the core stack, the `admin-ui` and `s3` profiles, and both
+overlays boot to healthy under `podman compose` exactly as under
+`docker compose`, with the same commands:
+
+```shell
+podman compose up -d --wait
+```
+
+Podman-specific notes:
+
+- `podman compose` delegates to an external Compose provider. With Docker's
+  own Compose CLI installed (the common case on a machine that has ever run
+  Docker Desktop) you get identical Compose behaviour; with the Python
+  `podman-compose` package, flag coverage differs — prefer the Docker Compose
+  provider.
+- The default `podman machine` on macOS ships with 2 GiB of memory. That is
+  enough for the quickstart and both overlays, but not for building the
+  server image from source inside the VM (a single spec-crate compile at
+  release optimization holds more than that). If you want the
+  build-from-source developer path under Podman, resize the machine first:
+  `podman machine set --memory 8192`.
+- Building from source under Podman (Buildah) is not part of the verified
+  quickstart surface; the supported quickstart path is the published images.
+
+The repository's own CI and measurement lanes run Docker; the compose-driven
+scripts (`scripts/conformance.sh`, the deployment probe, the UI journey
+battery) are exercised against Docker only.
+
 ## The isolation posture
 
 Every service in every committed compose file drops **all** Linux capabilities
@@ -234,7 +265,7 @@ you ask for them:
   export FERROEHR__MULTIMEDIA__BUCKET=openehr-multimedia
   export FERROEHR__MULTIMEDIA__ALLOW_HTTP=true    # dev only; production S3 is HTTPS
 
-  docker compose --profile s3 up -d --wait ferroehr seaweedfs seaweedfs-init
+  docker compose --profile s3 up -d --wait ferroehr seaweedfs
   ```
 
   The compose file passes the whole `FERROEHR__MULTIMEDIA__*` set through from


### PR DESCRIPTION
Closes #2636.

The full compose surface was validated first-hand under Podman 5.8.3 (`podman compose` with the Docker Compose v5.4 provider): the quickstart core, the `admin-ui` and `s3` profiles, and both overlays boot to healthy, the API answers (EHR create 201, OIDC discovery 200, bucket listable). Two real defects surfaced, both fixed and re-proven on BOTH engines:

- **`up -d --wait` false-failed with the `s3` profile — on Docker too.** Compose v5.4 fails `--wait` on any exited container, even the bucket initializer's successful exit-0 (the A/B against Docker Desktop reproduced it identically, so this was never Podman-specific). The server now declares `depends_on: seaweedfs-init: {condition: service_completed_successfully, required: false}` — inert without the profile; with it, startup orders after bucket creation and Compose treats the initializer as a one-shot. Every invocation form now exits 0 on both engines, and the documented command drops the initializer from the service list.
- **The observability overlay never came up under Podman.** Every LGTM component does `mkdir /data` at startup; the image ships `/` as mode 555, and with `cap_drop: [ALL]` even root lacks the `DAC_OVERRIDE` to write it. Docker masks this by normalizing the root inode to 755. A `tmpfs` mount at `/data` matches the overlay's dev-lifetime intent and brings Grafana healthy in 5 s on both engines.

Docs: `installation/compose.md` gains a container-engines section (what is verified on Podman, the provider note, the 2 GiB `podman machine` sizing caveat for from-source builds, and that the compose-driven scripts are exercised on Docker only). Changelog carries both fixes.

Not exercised, stated honestly: building the server image from source under Buildah (needs a resized machine; the quickstart path is the published images), and the compose-driven dev scripts under a Podman socket.