### PR TITLE
ci(sonar): exclude SQL from analysis — PLSQL analyzer vs PostgreSQL tree

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,7 +11,13 @@ sonar.sourceEncoding=UTF-8
 # are noise the attribution law forbids acting on in place.
 sonar.sources=app,crates,tools,scripts,deploy,website
 
+# SQL is excluded as a language: every .sql here is PostgreSQL (migrations,
+# fixtures), and Sonar's PLSQL analyzer assumes Oracle — its Data Dictionary
+# rules (S3641 and friends) warn on every analysis and can never apply.
+# Correctness for our SQL is owned by sqlx, PostgreSQL itself, and the CNF
+# suite.
 sonar.exclusions=\
+  **/*.sql,\
   crates/openehr-base/**,\
   crates/openehr-rm/**,\
   crates/openehr-am/**,\


### PR DESCRIPTION
Part of #2630. The first analysis warned that the Data Dictionary is not configured for the PLSQL analyzer (rules S3641, S3921, S3618, S3651). Those rules require a live Oracle connection and target the PL/SQL dialect; every `.sql` file in this tree is PostgreSQL, so the analyzer can only ever produce dialect noise. SQL leaves the Sonar scope; its correctness instruments remain sqlx, PostgreSQL, and the CNF suite.