### PR TITLE
ci(tooling): the SonarQube Cloud MCP server as a project MCP entry

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "sonarqube": {
+      "type": "http",
+      "url": "https://api.sonarcloud.io/mcp",
+      "headers": {
+        "Authorization": "Bearer ${SONARQUBE_TOKEN}",
+        "SONARQUBE_ORG": "rubentalstra"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Part of #2639 (the issue closes on the demonstrated smoke query).

`.mcp.json` at the repo root registers SonarSource's own cloud-hosted MCP server — `https://api.sonarcloud.io/mcp` over HTTP transport — so Sonar findings are workable from any MCP-enabled agent session in this repo, with no local MCP infrastructure to run or update (the official docs recommend the hosted endpoint for exactly that reason). Authentication is a SonarQube user token referenced as `${SONARQUBE_TOKEN}` (environment-variable expansion; no secret in the tree), plus the `SONARQUBE_ORG` header. The hosted server is read-only by default, which matches the advisory posture; the write-enabling header is deliberately not set.