### PR TITLE
feat(observability): the default Grafana dashboard ships through every channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -578,6 +578,8 @@ jobs:
           persist-credentials: false
       - name: Compose artifacts stay hardened
         run: bash scripts/checks/compose-hardening.sh
+      - name: The overlay's inline dashboard matches the chart's canonical copy
+        run: bash scripts/checks/dashboard-drift.sh
 
   # RFC 0201: an error carries its cause. No clippy lint covers this, so the
   # gate is a per-tree ratchet — the flattened-site counts may only fall while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Added
+
+- Helm chart 6.0.16: `metrics.grafanaDashboard.enabled` ships the default
+  "FerroEHR — service overview" Grafana dashboard as a ConfigMap the Grafana
+  dashboard sidecar (kube-prometheus-stack) auto-imports; the compose
+  observability overlay provisions the same dashboard, now extended to AQL
+  rate and phase latency, plan-cache hit ratio, database pool, Tokio runtime,
+  and audit throughput — every panel query written against the served metric
+  names.
+
 ### Fixed
 
 - Compose: `docker compose --profile s3 up -d --wait` no longer fails after

--- a/deploy/helm/ci/all-features-values.yaml
+++ b/deploy/helm/ci/all-features-values.yaml
@@ -26,6 +26,8 @@ metrics:
     enabled: true
     labels:
       release: kube-prometheus-stack
+  grafanaDashboard:
+    enabled: true
 
 config:
   server:

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # A published OCI version is immutable by refusal rather than by the registry —
 # `helm push` over an existing tag replaces it silently — so a correction always
 # ships as a NEW version and the published one stands as it was.
-version: 6.0.15
+version: 6.0.16
 # The default container image tag (overridable via image.tag), and the released
 # application version — kept equal to the workspace version by the
 # `chart-appversion` CI guard, so a release cannot ship a chart pointing at the

--- a/deploy/helm/ferroehr/README.md
+++ b/deploy/helm/ferroehr/README.md
@@ -2,7 +2,7 @@
 
 Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.1.0 + AQL 1.1). A single static binary deployed with a hardened-by-default security posture: runs as a non-root, read-only-rootfs workload whose NetworkPolicy admits its serving port only, and that connects to an EXTERNAL PostgreSQL 18 as an unprivileged app role (migrations are run out of band by a separate migrator role).
 
-![Version: 6.0.15](https://img.shields.io/badge/Version-6.0.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.1](https://img.shields.io/badge/AppVersion-4.0.1-informational?style=flat-square)
+![Version: 6.0.16](https://img.shields.io/badge/Version-6.0.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.1](https://img.shields.io/badge/AppVersion-4.0.1-informational?style=flat-square)
 
 FerroEHR is a pure-Rust openEHR Clinical Data Repository: ITS-REST 1.1.0 at the
 API, AQL 1.1 as the query language, PostgreSQL 18-native storage, shipped as a
@@ -33,7 +33,7 @@ to add; `helm repo add` does not apply to this chart:
 
 ```console
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 6.0.15 \
+  --version 6.0.16 \
   --namespace ferroehr --create-namespace \
   --set database.existingSecret=ferroehr-db \
   --set image.tag=4.0.1
@@ -47,7 +47,7 @@ They are independent SemVer lines and they move independently:
 
 | What | Set with | This release |
 |---|---|---|
-| the **chart** (templates, defaults, this document) | `--version` | `6.0.15` |
+| the **chart** (templates, defaults, this document) | `--version` | `6.0.16` |
 | the **server image** | `image.tag` | `4.0.1` |
 
 `appVersion` is the image the chart defaults to; pinning `image.tag` explicitly
@@ -59,7 +59,7 @@ The chart carries two keyless Sigstore artifacts, and they answer different
 questions. A **cosign signature:** who signed this:
 
 ```console
-cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.15 \
+cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.16 \
   --certificate-identity-regexp '^https://github\.com/rubentalstra/FerroEHR/\.github/workflows/publish-chart\.yml@' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
@@ -67,7 +67,7 @@ cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.15 \
 A **SLSA build provenance attestation:** what source it was built from, and how:
 
 ```console
-gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:6.0.15 \
+gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:6.0.16 \
   -R rubentalstra/FerroEHR
 gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:4.0.1 \
   -R rubentalstra/FerroEHR
@@ -275,6 +275,8 @@ Kubernetes: `>=1.36.0-0`
 | ingress.hosts[0].paths[0].pathType | string | `"Prefix"` |  |
 | ingress.tls | list | `[]` | TLS blocks, passed through verbatim. |
 | metrics.enabled | bool | `false` | Add prometheus.io scrape annotations to the pods. |
+| metrics.grafanaDashboard.enabled | bool | `false` | Ship the default "FerroEHR — service overview" Grafana dashboard as a ConfigMap labelled `grafana_dashboard: "1"`, the label the Grafana Helm chart's dashboard sidecar (and therefore kube-prometheus-stack) discovers and auto-imports. The sidecar searches its own release namespace unless its `sidecar.dashboards.searchNamespace` says otherwise. |
+| metrics.grafanaDashboard.folder | string | `"FerroEHR"` | Value for the `grafana_folder` annotation. Applied only when the sidecar's `folderAnnotation` feature is configured; harmless otherwise. |
 | metrics.serviceMonitor.enabled | bool | `false` | Render a Prometheus Operator ServiceMonitor. Needs the monitoring.coreos.com CRDs installed, or the install fails on an unknown kind. |
 | metrics.serviceMonitor.interval | string | `"30s"` | Scrape interval / timeout. |
 | metrics.serviceMonitor.labels | object | `{}` | Extra labels, for the `serviceMonitorSelector` your Prometheus matches on. |

--- a/deploy/helm/ferroehr/files/dashboards/ferroehr-overview.json
+++ b/deploy/helm/ferroehr/files/dashboards/ferroehr-overview.json
@@ -1,0 +1,231 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "graphTooltip": 1,
+  "title": "FerroEHR — service overview",
+  "uid": "ferroehr-overview",
+  "tags": ["ferroehr", "openehr"],
+  "schemaVersion": 39,
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": { "list": [] },
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Version",
+      "datasource": { "type": "prometheus" },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 0 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "/^version$/" }, "textMode": "name" },
+      "targets": [
+        { "expr": "ferroehr_build_info", "format": "table", "instant": true }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Uptime",
+      "datasource": { "type": "prometheus" },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "s", "decimals": 0 }, "overrides": [] },
+      "targets": [
+        { "expr": "time() - process_start_time_seconds", "legendFormat": "uptime" }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "In-flight requests",
+      "datasource": { "type": "prometheus" },
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "targets": [
+        { "expr": "sum(http_server_active_requests)", "legendFormat": "in flight" }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "5xx error ratio (1h)",
+      "datasource": { "type": "prometheus" },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "green", "value": null },
+            { "color": "yellow", "value": 0.001 },
+            { "color": "red", "value": 0.01 }
+          ] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_request_duration_seconds_count{status_class=\"5xx\"}[1h])) / sum(rate(http_server_request_duration_seconds_count[1h]))",
+          "legendFormat": "5xx ratio"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "DB pool in use",
+      "datasource": { "type": "prometheus" },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "targets": [
+        { "expr": "sum(db_pool_connections{state=\"in_use\"})", "legendFormat": "in use" }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "RED — requests, errors, duration",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 4 }
+    },
+    {
+      "type": "timeseries",
+      "title": "Request rate by route (req/s)",
+      "datasource": { "type": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 5 },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "sum by (http_route) (rate(http_server_request_duration_seconds_count[$__rate_interval]))",
+          "legendFormat": "{{http_route}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Error rate by status class (req/s)",
+      "datasource": { "type": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 5 },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "sum by (status_class) (rate(http_server_request_duration_seconds_count{status_class=~\"4xx|5xx\"}[$__rate_interval]))",
+          "legendFormat": "{{status_class}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Request latency (p50 / p95 / p99)",
+      "datasource": { "type": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 13 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(http_server_request_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p50"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_request_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_request_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p99"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "p95 latency by route",
+      "datasource": { "type": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 13 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, http_route) (rate(http_server_request_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "{{http_route}}"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "AQL",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 21 }
+    },
+    {
+      "type": "timeseries",
+      "title": "AQL query rate by outcome (q/s)",
+      "datasource": { "type": "prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 22 },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "sum by (outcome) (rate(aql_queries_total[$__rate_interval]))",
+          "legendFormat": "{{outcome}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "AQL p95 latency by phase",
+      "datasource": { "type": "prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 22 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, phase) (rate(aql_query_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "{{phase}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "AQL plan-cache hit ratio",
+      "datasource": { "type": "prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 22 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "max": 1, "min": 0 }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "sum(rate(aql_plan_cache_events_total{event=\"hit\"}[$__rate_interval])) / sum(rate(aql_plan_cache_events_total[$__rate_interval]))",
+          "legendFormat": "hit ratio"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Database and runtime",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 30 }
+    },
+    {
+      "type": "timeseries",
+      "title": "DB pool connections by state",
+      "datasource": { "type": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 31 },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "sum by (state) (db_pool_connections)",
+          "legendFormat": "{{state}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Tokio runtime (tasks, queue depth, workers)",
+      "datasource": { "type": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 31 },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "targets": [
+        { "expr": "tokio_alive_tasks", "legendFormat": "alive tasks" },
+        { "expr": "tokio_global_queue_depth", "legendFormat": "global queue depth" },
+        { "expr": "tokio_workers", "legendFormat": "workers" }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Audit (IHE ATNA)",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 39 }
+    },
+    {
+      "type": "timeseries",
+      "title": "Audit events emitted vs forwarded (events/s)",
+      "datasource": { "type": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 40 },
+      "fieldConfig": { "defaults": { "unit": "cps" }, "overrides": [] },
+      "targets": [
+        { "expr": "sum(rate(atna_audit_emitted_total[$__rate_interval]))", "legendFormat": "emitted" },
+        { "expr": "sum(rate(atna_audit_sent_total[$__rate_interval]))", "legendFormat": "forwarded" }
+      ]
+    }
+  ]
+}

--- a/deploy/helm/ferroehr/templates/grafana-dashboard.yaml
+++ b/deploy/helm/ferroehr/templates/grafana-dashboard.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.metrics.grafanaDashboard.enabled }}
+# The default Grafana dashboard, shipped for sidecar auto-import: the Grafana
+# Helm chart's dashboard sidecar (which kube-prometheus-stack embeds) watches
+# ConfigMaps carrying the `grafana_dashboard` label — any value matches its
+# default `sidecar.dashboards.labelValue: ""` — and imports every data key as
+# a dashboard (github.com/grafana-community/helm-charts, charts/grafana
+# values). The sidecar searches its own release namespace unless configured
+# otherwise, so install this release there or widen `searchNamespace`. The
+# `grafana_folder` annotation takes effect only where the sidecar's
+# `folderAnnotation` feature is turned on; it is inert otherwise.
+#
+# The JSON is the canonical copy at files/dashboards/ferroehr-overview.json;
+# the compose observability overlay inlines the same document, and
+# scripts/checks/dashboard-drift.sh holds the two identical.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "ferroehr.fullname" . }}-grafana-dashboard
+  labels:
+    {{- include "ferroehr.labels" . | nindent 4 }}
+    grafana_dashboard: "1"
+  annotations:
+    grafana_folder: {{ .Values.metrics.grafanaDashboard.folder | quote }}
+data:
+  ferroehr-overview.json: |-
+{{ .Files.Get "files/dashboards/ferroehr-overview.json" | indent 4 }}
+{{- end }}

--- a/deploy/helm/ferroehr/values.schema.json
+++ b/deploy/helm/ferroehr/values.schema.json
@@ -262,6 +262,18 @@
               "$ref": "#/definitions/duration"
             }
           }
+        },
+        "grafanaDashboard": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "folder": {
+              "type": "string"
+            }
+          }
         }
       }
     },
@@ -624,7 +636,7 @@
           }
         },
         "ingressAllowAll": {
-          "description": "Whether an empty `ingressFrom` may render an ingress rule with no `from` — which admits every source. true (the shipped default) renders it; false refuses the render while `ingressFrom` is empty. A non-empty `ingressFrom` narrows the sources regardless.",
+          "description": "Whether an empty `ingressFrom` may render an ingress rule with no `from` \u2014 which admits every source. true (the shipped default) renders it; false refuses the render while `ingressFrom` is empty. A non-empty `ingressFrom` narrows the sources regardless.",
           "type": "boolean"
         },
         "egress": {
@@ -959,7 +971,7 @@
               "type": "array"
             },
             "ingressAllowAll": {
-              "description": "Whether an empty `ingressFrom` may render an ingress rule with no `from` — which admits every source to the console. true (the shipped default) renders it; false refuses the render while `ingressFrom` is empty. A non-empty `ingressFrom` narrows the sources regardless.",
+              "description": "Whether an empty `ingressFrom` may render an ingress rule with no `from` \u2014 which admits every source to the console. true (the shipped default) renders it; false refuses the render while `ingressFrom` is empty. A non-empty `ingressFrom` narrows the sources regardless.",
               "type": "boolean"
             }
           }

--- a/deploy/helm/ferroehr/values.yaml
+++ b/deploy/helm/ferroehr/values.yaml
@@ -262,6 +262,16 @@ metrics:
     interval: 30s
     # -- Per-scrape timeout. Must be shorter than the interval.
     scrapeTimeout: 10s
+  grafanaDashboard:
+    # -- Ship the default "FerroEHR — service overview" Grafana dashboard as a
+    # ConfigMap labelled `grafana_dashboard: "1"`, the label the Grafana Helm
+    # chart's dashboard sidecar (and therefore kube-prometheus-stack) discovers
+    # and auto-imports. The sidecar searches its own release namespace unless
+    # its `sidecar.dashboards.searchNamespace` says otherwise.
+    enabled: false
+    # -- Value for the `grafana_folder` annotation. Applied only when the
+    # sidecar's `folderAnnotation` feature is configured; harmless otherwise.
+    folder: "FerroEHR"
 
 # ═════════════════════════════════════════════════════════════════════════════
 # ferroehr.toml — rendered VERBATIM into the ConfigMap as /etc/ferroehr/ferroehr.toml

--- a/deploy/helm/golden/admin-ui.yaml
+++ b/deploy/helm/golden/admin-ui.yaml
@@ -18,7 +18,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the admin console: only its HTTP port, but from EVERY source — this policy narrows ports, NOT sources (adminUi.networkPolicy.ingressAllowAll=true). Set adminUi.networkPolicy.ingressFrom for a PHI workload. Egress admits the CDR Service and DNS only.
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"
@@ -90,7 +90,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"
@@ -118,7 +118,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"
@@ -139,7 +139,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr-admin-ui
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"
@@ -154,7 +154,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"
@@ -184,7 +184,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"
@@ -201,7 +201,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"
@@ -332,7 +332,7 @@ metadata:
     kubernetes.io/description: >-
       In-cluster address for the FerroEHR admin console. The console is a REST client of the CDR and holds no data of its own; it is the human-facing surface, so this is the Service an Ingress normally publishes.
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"
@@ -355,7 +355,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"
@@ -385,7 +385,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR admin console: a Leptos SSR web UI that consumes the CDR strictly over ITS-REST. It never reaches the database, which the console NetworkPolicy enforces rather than assumes.
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"
@@ -492,7 +492,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), and only from the networkPolicy.ingressFrom peers.
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"
@@ -97,7 +97,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"
@@ -118,7 +118,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"
@@ -150,7 +150,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"
@@ -176,7 +176,7 @@ kind: Secret
 metadata:
   name: ferroehr-config
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"
@@ -197,7 +197,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"
@@ -382,13 +382,277 @@ data:
     
 
 ---
+# Source: ferroehr/templates/grafana-dashboard.yaml
+# The default Grafana dashboard, shipped for sidecar auto-import: the Grafana
+# Helm chart's dashboard sidecar (which kube-prometheus-stack embeds) watches
+# ConfigMaps carrying the `grafana_dashboard` label — any value matches its
+# default `sidecar.dashboards.labelValue: ""` — and imports every data key as
+# a dashboard (github.com/grafana-community/helm-charts, charts/grafana
+# values). The sidecar searches its own release namespace unless configured
+# otherwise, so install this release there or widen `searchNamespace`. The
+# `grafana_folder` annotation takes effect only where the sidecar's
+# `folderAnnotation` feature is turned on; it is inert otherwise.
+#
+# The JSON is the canonical copy at files/dashboards/ferroehr-overview.json;
+# the compose observability overlay inlines the same document, and
+# scripts/checks/dashboard-drift.sh holds the two identical.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ferroehr-grafana-dashboard
+  labels:
+    helm.sh/chart: ferroehr-6.0.16
+    app.kubernetes.io/name: ferroehr
+    app.kubernetes.io/instance: ferroehr
+    app.kubernetes.io/version: "4.0.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: ferroehr
+    grafana_dashboard: "1"
+  annotations:
+    grafana_folder: "FerroEHR"
+data:
+  ferroehr-overview.json: |-
+    {
+      "annotations": { "list": [] },
+      "editable": true,
+      "graphTooltip": 1,
+      "title": "FerroEHR — service overview",
+      "uid": "ferroehr-overview",
+      "tags": ["ferroehr", "openehr"],
+      "schemaVersion": 39,
+      "time": { "from": "now-1h", "to": "now" },
+      "templating": { "list": [] },
+      "panels": [
+        {
+          "type": "stat",
+          "title": "Version",
+          "datasource": { "type": "prometheus" },
+          "gridPos": { "h": 4, "w": 4, "x": 0, "y": 0 },
+          "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "/^version$/" }, "textMode": "name" },
+          "targets": [
+            { "expr": "ferroehr_build_info", "format": "table", "instant": true }
+          ]
+        },
+        {
+          "type": "stat",
+          "title": "Uptime",
+          "datasource": { "type": "prometheus" },
+          "gridPos": { "h": 4, "w": 4, "x": 4, "y": 0 },
+          "fieldConfig": { "defaults": { "unit": "s", "decimals": 0 }, "overrides": [] },
+          "targets": [
+            { "expr": "time() - process_start_time_seconds", "legendFormat": "uptime" }
+          ]
+        },
+        {
+          "type": "stat",
+          "title": "In-flight requests",
+          "datasource": { "type": "prometheus" },
+          "gridPos": { "h": 4, "w": 4, "x": 8, "y": 0 },
+          "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+          "targets": [
+            { "expr": "sum(http_server_active_requests)", "legendFormat": "in flight" }
+          ]
+        },
+        {
+          "type": "stat",
+          "title": "5xx error ratio (1h)",
+          "datasource": { "type": "prometheus" },
+          "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percentunit",
+              "thresholds": { "mode": "absolute", "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 0.001 },
+                { "color": "red", "value": 0.01 }
+              ] }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(http_server_request_duration_seconds_count{status_class=\"5xx\"}[1h])) / sum(rate(http_server_request_duration_seconds_count[1h]))",
+              "legendFormat": "5xx ratio"
+            }
+          ]
+        },
+        {
+          "type": "stat",
+          "title": "DB pool in use",
+          "datasource": { "type": "prometheus" },
+          "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+          "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+          "targets": [
+            { "expr": "sum(db_pool_connections{state=\"in_use\"})", "legendFormat": "in use" }
+          ]
+        },
+        {
+          "type": "row",
+          "title": "RED — requests, errors, duration",
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 4 }
+        },
+        {
+          "type": "timeseries",
+          "title": "Request rate by route (req/s)",
+          "datasource": { "type": "prometheus" },
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 5 },
+          "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+          "targets": [
+            {
+              "expr": "sum by (http_route) (rate(http_server_request_duration_seconds_count[$__rate_interval]))",
+              "legendFormat": "{{http_route}}"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Error rate by status class (req/s)",
+          "datasource": { "type": "prometheus" },
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 5 },
+          "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+          "targets": [
+            {
+              "expr": "sum by (status_class) (rate(http_server_request_duration_seconds_count{status_class=~\"4xx|5xx\"}[$__rate_interval]))",
+              "legendFormat": "{{status_class}}"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Request latency (p50 / p95 / p99)",
+          "datasource": { "type": "prometheus" },
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 13 },
+          "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, sum by (le) (rate(http_server_request_duration_seconds_bucket[$__rate_interval])))",
+              "legendFormat": "p50"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_request_duration_seconds_bucket[$__rate_interval])))",
+              "legendFormat": "p95"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_request_duration_seconds_bucket[$__rate_interval])))",
+              "legendFormat": "p99"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "p95 latency by route",
+          "datasource": { "type": "prometheus" },
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 13 },
+          "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum by (le, http_route) (rate(http_server_request_duration_seconds_bucket[$__rate_interval])))",
+              "legendFormat": "{{http_route}}"
+            }
+          ]
+        },
+        {
+          "type": "row",
+          "title": "AQL",
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 21 }
+        },
+        {
+          "type": "timeseries",
+          "title": "AQL query rate by outcome (q/s)",
+          "datasource": { "type": "prometheus" },
+          "gridPos": { "h": 8, "w": 8, "x": 0, "y": 22 },
+          "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+          "targets": [
+            {
+              "expr": "sum by (outcome) (rate(aql_queries_total[$__rate_interval]))",
+              "legendFormat": "{{outcome}}"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "AQL p95 latency by phase",
+          "datasource": { "type": "prometheus" },
+          "gridPos": { "h": 8, "w": 8, "x": 8, "y": 22 },
+          "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum by (le, phase) (rate(aql_query_duration_seconds_bucket[$__rate_interval])))",
+              "legendFormat": "{{phase}}"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "AQL plan-cache hit ratio",
+          "datasource": { "type": "prometheus" },
+          "gridPos": { "h": 8, "w": 8, "x": 16, "y": 22 },
+          "fieldConfig": { "defaults": { "unit": "percentunit", "max": 1, "min": 0 }, "overrides": [] },
+          "targets": [
+            {
+              "expr": "sum(rate(aql_plan_cache_events_total{event=\"hit\"}[$__rate_interval])) / sum(rate(aql_plan_cache_events_total[$__rate_interval]))",
+              "legendFormat": "hit ratio"
+            }
+          ]
+        },
+        {
+          "type": "row",
+          "title": "Database and runtime",
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 30 }
+        },
+        {
+          "type": "timeseries",
+          "title": "DB pool connections by state",
+          "datasource": { "type": "prometheus" },
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 31 },
+          "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+          "targets": [
+            {
+              "expr": "sum by (state) (db_pool_connections)",
+              "legendFormat": "{{state}}"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Tokio runtime (tasks, queue depth, workers)",
+          "datasource": { "type": "prometheus" },
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 31 },
+          "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+          "targets": [
+            { "expr": "tokio_alive_tasks", "legendFormat": "alive tasks" },
+            { "expr": "tokio_global_queue_depth", "legendFormat": "global queue depth" },
+            { "expr": "tokio_workers", "legendFormat": "workers" }
+          ]
+        },
+        {
+          "type": "row",
+          "title": "Audit (IHE ATNA)",
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 39 }
+        },
+        {
+          "type": "timeseries",
+          "title": "Audit events emitted vs forwarded (events/s)",
+          "datasource": { "type": "prometheus" },
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 40 },
+          "fieldConfig": { "defaults": { "unit": "cps" }, "overrides": [] },
+          "targets": [
+            { "expr": "sum(rate(atna_audit_emitted_total[$__rate_interval]))", "legendFormat": "emitted" },
+            { "expr": "sum(rate(atna_audit_sent_total[$__rate_interval]))", "legendFormat": "forwarded" }
+          ]
+        }
+      ]
+    }
+    
+
+---
 # Source: ferroehr/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"
@@ -422,7 +686,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"
@@ -653,7 +917,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"
@@ -687,7 +951,7 @@ kind: Ingress
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"
@@ -725,7 +989,7 @@ kind: ServiceMonitor
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"

--- a/deploy/helm/golden/basic-auth.yaml
+++ b/deploy/helm/golden/basic-auth.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"
@@ -51,7 +51,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"
@@ -72,7 +72,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"
@@ -102,7 +102,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"
@@ -119,7 +119,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"
@@ -247,7 +247,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"
@@ -277,7 +277,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"
@@ -51,7 +51,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"
@@ -72,7 +72,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"
@@ -87,7 +87,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"
@@ -212,7 +212,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"
@@ -242,7 +242,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.15
+    helm.sh/chart: ferroehr-6.0.16
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.1"

--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -102,7 +102,7 @@ configs:
         "annotations": { "list": [] },
         "editable": true,
         "graphTooltip": 1,
-        "title": "ferroehr — service overview",
+        "title": "FerroEHR — service overview",
         "uid": "ferroehr-overview",
         "tags": ["ferroehr", "openehr"],
         "schemaVersion": 39,
@@ -110,176 +110,221 @@ configs:
         "templating": { "list": [] },
         "panels": [
           {
-            "type": "row",
-            "title": "RED — requests, errors, duration",
-            "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }
-          },
-          {
-            "type": "timeseries",
-            "title": "Request rate by route (req/s)",
+            "type": "stat",
+            "title": "Version",
             "datasource": { "type": "prometheus" },
-            "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
-            "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+            "gridPos": { "h": 4, "w": 4, "x": 0, "y": 0 },
+            "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "/^version$/" }, "textMode": "name" },
             "targets": [
-              {
-                "expr": "sum by (http_route) (rate(http_server_request_duration_seconds_count[5m]))",
-                "legendFormat": "{{http_route}}"
-              }
+              { "expr": "ferroehr_build_info", "format": "table", "instant": true }
             ]
           },
           {
             "type": "stat",
-            "title": "5xx error ratio",
+            "title": "Uptime",
             "datasource": { "type": "prometheus" },
-            "gridPos": { "h": 8, "w": 6, "x": 12, "y": 1 },
-            "fieldConfig": {
-              "defaults": {
-                "unit": "percentunit",
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    { "color": "green", "value": null },
-                    { "color": "red", "value": 0.01 }
-                  ]
-                }
-              },
-              "overrides": []
-            },
+            "gridPos": { "h": 4, "w": 4, "x": 4, "y": 0 },
+            "fieldConfig": { "defaults": { "unit": "s", "decimals": 0 }, "overrides": [] },
             "targets": [
-              {
-                "expr": "sum(rate(http_server_request_duration_seconds_count{status_class=\"5xx\"}[5m])) / clamp_min(sum(rate(http_server_request_duration_seconds_count[5m])), 1)",
-                "legendFormat": "5xx ratio"
-              }
+              { "expr": "time() - process_start_time_seconds", "legendFormat": "uptime" }
             ]
           },
           {
             "type": "stat",
             "title": "In-flight requests",
             "datasource": { "type": "prometheus" },
-            "gridPos": { "h": 8, "w": 6, "x": 18, "y": 1 },
+            "gridPos": { "h": 4, "w": 4, "x": 8, "y": 0 },
+            "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
             "targets": [
-              { "expr": "sum(http_server_active_requests)", "legendFormat": "active" }
+              { "expr": "sum(http_server_active_requests)", "legendFormat": "in flight" }
+            ]
+          },
+          {
+            "type": "stat",
+            "title": "5xx error ratio (1h)",
+            "datasource": { "type": "prometheus" },
+            "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+            "fieldConfig": {
+              "defaults": {
+                "unit": "percentunit",
+                "thresholds": { "mode": "absolute", "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 0.001 },
+                  { "color": "red", "value": 0.01 }
+                ] }
+              },
+              "overrides": []
+            },
+            "targets": [
+              {
+                "expr": "sum(rate(http_server_request_duration_seconds_count{status_class=\"5xx\"}[1h])) / sum(rate(http_server_request_duration_seconds_count[1h]))",
+                "legendFormat": "5xx ratio"
+              }
+            ]
+          },
+          {
+            "type": "stat",
+            "title": "DB pool in use",
+            "datasource": { "type": "prometheus" },
+            "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+            "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+            "targets": [
+              { "expr": "sum(db_pool_connections{state=\"in_use\"})", "legendFormat": "in use" }
+            ]
+          },
+          {
+            "type": "row",
+            "title": "RED — requests, errors, duration",
+            "gridPos": { "h": 1, "w": 24, "x": 0, "y": 4 }
+          },
+          {
+            "type": "timeseries",
+            "title": "Request rate by route (req/s)",
+            "datasource": { "type": "prometheus" },
+            "gridPos": { "h": 8, "w": 12, "x": 0, "y": 5 },
+            "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+            "targets": [
+              {
+                "expr": "sum by (http_route) (rate(http_server_request_duration_seconds_count[$$__rate_interval]))",
+                "legendFormat": "{{http_route}}"
+              }
             ]
           },
           {
             "type": "timeseries",
-            "title": "Request duration p50/p95/p99 (s)",
+            "title": "Error rate by status class (req/s)",
             "datasource": { "type": "prometheus" },
-            "gridPos": { "h": 8, "w": 12, "x": 0, "y": 9 },
+            "gridPos": { "h": 8, "w": 12, "x": 12, "y": 5 },
+            "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+            "targets": [
+              {
+                "expr": "sum by (status_class) (rate(http_server_request_duration_seconds_count{status_class=~\"4xx|5xx\"}[$$__rate_interval]))",
+                "legendFormat": "{{status_class}}"
+              }
+            ]
+          },
+          {
+            "type": "timeseries",
+            "title": "Request latency (p50 / p95 / p99)",
+            "datasource": { "type": "prometheus" },
+            "gridPos": { "h": 8, "w": 12, "x": 0, "y": 13 },
             "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
             "targets": [
               {
-                "expr": "histogram_quantile(0.50, sum by (le) (rate(http_server_request_duration_seconds_bucket[5m])))",
+                "expr": "histogram_quantile(0.50, sum by (le) (rate(http_server_request_duration_seconds_bucket[$$__rate_interval])))",
                 "legendFormat": "p50"
               },
               {
-                "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_request_duration_seconds_bucket[5m])))",
+                "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_request_duration_seconds_bucket[$$__rate_interval])))",
                 "legendFormat": "p95"
               },
               {
-                "expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_request_duration_seconds_bucket[5m])))",
+                "expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_request_duration_seconds_bucket[$$__rate_interval])))",
                 "legendFormat": "p99"
               }
             ]
           },
           {
             "type": "timeseries",
-            "title": "Auth failures by mechanism/status (/s)",
+            "title": "p95 latency by route",
             "datasource": { "type": "prometheus" },
-            "gridPos": { "h": 8, "w": 12, "x": 12, "y": 9 },
-            "targets": [
-              {
-                "expr": "sum by (mechanism, status) (rate(auth_failures_total[5m]))",
-                "legendFormat": "{{mechanism}} {{status}}"
-              }
-            ]
-          },
-          {
-            "type": "row",
-            "title": "Persistence & AQL",
-            "gridPos": { "h": 1, "w": 24, "x": 0, "y": 17 }
-          },
-          {
-            "type": "timeseries",
-            "title": "DB pool connections",
-            "datasource": { "type": "prometheus" },
-            "gridPos": { "h": 8, "w": 12, "x": 0, "y": 18 },
-            "targets": [
-              {
-                "expr": "db_pool_connections",
-                "legendFormat": "{{state}}"
-              },
-              {
-                "expr": "histogram_quantile(0.95, sum by (le) (rate(db_pool_acquire_duration_seconds_bucket[5m])))",
-                "legendFormat": "acquire p95 (s)"
-              }
-            ]
-          },
-          {
-            "type": "timeseries",
-            "title": "AQL query latency by phase (p95, s)",
-            "datasource": { "type": "prometheus" },
-            "gridPos": { "h": 8, "w": 12, "x": 12, "y": 18 },
+            "gridPos": { "h": 8, "w": 12, "x": 12, "y": 13 },
             "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
             "targets": [
               {
-                "expr": "histogram_quantile(0.95, sum by (le, phase) (rate(aql_query_duration_seconds_bucket[5m])))",
-                "legendFormat": "{{phase}}"
-              },
-              {
-                "expr": "sum by (outcome) (rate(aql_queries_total[5m]))",
-                "legendFormat": "queries {{outcome}}"
+                "expr": "histogram_quantile(0.95, sum by (le, http_route) (rate(http_server_request_duration_seconds_bucket[$$__rate_interval])))",
+                "legendFormat": "{{http_route}}"
               }
             ]
           },
           {
             "type": "row",
-            "title": "Clinical writes, validation & audit",
-            "gridPos": { "h": 1, "w": 24, "x": 0, "y": 26 }
+            "title": "AQL",
+            "gridPos": { "h": 1, "w": 24, "x": 0, "y": 21 }
           },
           {
             "type": "timeseries",
-            "title": "Compositions committed & validation failures (/s)",
+            "title": "AQL query rate by outcome (q/s)",
             "datasource": { "type": "prometheus" },
-            "gridPos": { "h": 8, "w": 12, "x": 0, "y": 27 },
+            "gridPos": { "h": 8, "w": 8, "x": 0, "y": 22 },
+            "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
             "targets": [
               {
-                "expr": "sum by (change_type) (rate(compositions_committed_total[5m]))",
-                "legendFormat": "committed {{change_type}}"
-              },
-              {
-                "expr": "sum by (pass) (rate(validation_failures_total[5m]))",
-                "legendFormat": "validation fail {{pass}}"
+                "expr": "sum by (outcome) (rate(aql_queries_total[$$__rate_interval]))",
+                "legendFormat": "{{outcome}}"
               }
             ]
           },
           {
             "type": "timeseries",
-            "title": "ATNA audit pipeline (/s)",
+            "title": "AQL p95 latency by phase",
             "datasource": { "type": "prometheus" },
-            "gridPos": { "h": 8, "w": 12, "x": 12, "y": 27 },
+            "gridPos": { "h": 8, "w": 8, "x": 8, "y": 22 },
+            "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
             "targets": [
               {
-                "expr": "rate(atna_audit_sent_total[5m])",
-                "legendFormat": "sent"
-              },
-              {
-                "expr": "rate(atna_audit_dropped_total[5m])",
-                "legendFormat": "dropped"
-              },
-              {
-                "expr": "rate(atna_audit_send_failed_total[5m])",
-                "legendFormat": "send_failed"
+                "expr": "histogram_quantile(0.95, sum by (le, phase) (rate(aql_query_duration_seconds_bucket[$$__rate_interval])))",
+                "legendFormat": "{{phase}}"
               }
             ]
           },
           {
-            "type": "table",
-            "title": "Build info",
+            "type": "timeseries",
+            "title": "AQL plan-cache hit ratio",
             "datasource": { "type": "prometheus" },
-            "gridPos": { "h": 6, "w": 24, "x": 0, "y": 35 },
+            "gridPos": { "h": 8, "w": 8, "x": 16, "y": 22 },
+            "fieldConfig": { "defaults": { "unit": "percentunit", "max": 1, "min": 0 }, "overrides": [] },
             "targets": [
-              { "expr": "ferroehr_build_info", "format": "table", "instant": true }
+              {
+                "expr": "sum(rate(aql_plan_cache_events_total{event=\"hit\"}[$$__rate_interval])) / sum(rate(aql_plan_cache_events_total[$$__rate_interval]))",
+                "legendFormat": "hit ratio"
+              }
+            ]
+          },
+          {
+            "type": "row",
+            "title": "Database and runtime",
+            "gridPos": { "h": 1, "w": 24, "x": 0, "y": 30 }
+          },
+          {
+            "type": "timeseries",
+            "title": "DB pool connections by state",
+            "datasource": { "type": "prometheus" },
+            "gridPos": { "h": 8, "w": 12, "x": 0, "y": 31 },
+            "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+            "targets": [
+              {
+                "expr": "sum by (state) (db_pool_connections)",
+                "legendFormat": "{{state}}"
+              }
+            ]
+          },
+          {
+            "type": "timeseries",
+            "title": "Tokio runtime (tasks, queue depth, workers)",
+            "datasource": { "type": "prometheus" },
+            "gridPos": { "h": 8, "w": 12, "x": 12, "y": 31 },
+            "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+            "targets": [
+              { "expr": "tokio_alive_tasks", "legendFormat": "alive tasks" },
+              { "expr": "tokio_global_queue_depth", "legendFormat": "global queue depth" },
+              { "expr": "tokio_workers", "legendFormat": "workers" }
+            ]
+          },
+          {
+            "type": "row",
+            "title": "Audit (IHE ATNA)",
+            "gridPos": { "h": 1, "w": 24, "x": 0, "y": 39 }
+          },
+          {
+            "type": "timeseries",
+            "title": "Audit events emitted vs forwarded (events/s)",
+            "datasource": { "type": "prometheus" },
+            "gridPos": { "h": 8, "w": 12, "x": 0, "y": 40 },
+            "fieldConfig": { "defaults": { "unit": "cps" }, "overrides": [] },
+            "targets": [
+              { "expr": "sum(rate(atna_audit_emitted_total[$$__rate_interval]))", "legendFormat": "emitted" },
+              { "expr": "sum(rate(atna_audit_sent_total[$$__rate_interval]))", "legendFormat": "forwarded" }
             ]
           }
         ]

--- a/scripts/checks/dashboard-drift.sh
+++ b/scripts/checks/dashboard-drift.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# The default Grafana dashboard has ONE canonical home — the Helm chart file —
+# and one embedded copy: the compose observability overlay must stay standalone
+# (downloadable with no repo checkout), so it inlines the same JSON with `$`
+# escaped as `$$` against compose interpolation. This guard holds the two
+# byte-identical (modulo that escaping); issue #2641.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+CANONICAL=deploy/helm/ferroehr/files/dashboards/ferroehr-overview.json
+OVERLAY=docker-compose.observability.yml
+
+[[ -f "$CANONICAL" ]] || { echo "dashboard-drift: missing $CANONICAL" >&2; exit 1; }
+
+inline=$(awk '
+  found && !/^      / && NF { exit }
+  found { sub(/^      /, ""); print }
+  /^    content: \|$/ { found = 1 }
+' "$OVERLAY" | sed 's/\$\$/$/g')
+
+[[ -n "$inline" ]] || { echo "dashboard-drift: no inline dashboard found under 'content: |' in $OVERLAY" >&2; exit 1; }
+
+if ! diff <(printf '%s\n' "$inline") "$CANONICAL" >/dev/null; then
+  echo "dashboard-drift: the overlay's inline dashboard differs from $CANONICAL" >&2
+  echo "regenerate the inline copy from the canonical file (escape \$ as \$\$)" >&2
+  diff <(printf '%s\n' "$inline") "$CANONICAL" | head -20 >&2
+  exit 1
+fi
+echo "dashboard-drift: OK."

--- a/website/book/src/installation/kubernetes.md
+++ b/website/book/src/installation/kubernetes.md
@@ -38,7 +38,7 @@ kubectl -n ferroehr create secret generic ferroehr-db \
   --from-literal=FERROEHR__DB__URL='postgres://ferroehr_app:***@pg-host:5432/ferroehr?sslmode=verify-full'
 
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 6.0.15 -n ferroehr \
+  --version 6.0.16 -n ferroehr \
   --set database.existingSecret=ferroehr-db \
   --set image.tag=4.0.1
 ```
@@ -55,7 +55,7 @@ helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
 reference. To read the chart's metadata without installing it:
 
 ```shell
-helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.15
+helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.16
 ```
 
 ### Pin two versions, not one
@@ -68,7 +68,7 @@ against.
 
 | | Selects | Pin with | Line |
 |---|---|---|---|
-| Chart version | templates, values schema, defaults | `--version 6.0.15` | SemVer over the chart's own contract |
+| Chart version | templates, values schema, defaults | `--version 6.0.16` | SemVer over the chart's own contract |
 | Image tag | the server binary | `--set image.tag=4.0.1` (or `image.digest`) | the application's SemVer line |
 
 Always pin the image to an immutable version or, better, a `@sha256` digest,
@@ -167,7 +167,7 @@ metadata lists: the server, and the optional admin console.
 > the image itself as the authority:
 >
 > ```shell
-> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.15 \
+> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.16 \
 >   -s templates/configmap.yaml --set database.existingSecret=ferroehr-db \
 >   | sed -n '/ferroehr.toml/,$p' | sed '1d;s/^    //' > /tmp/ferroehr.toml
 > docker run --rm -v /tmp/ferroehr.toml:/etc/ferroehr/ferroehr.toml:ro \
@@ -556,7 +556,7 @@ config:
 
 ```shell
 helm upgrade ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 6.0.15 -n ferroehr --reuse-values \
+  --version 6.0.16 -n ferroehr --reuse-values \
   --set config.query.plan_cache_capacity=512
 ```
 
@@ -709,7 +709,7 @@ Preview an upgrade against what you have installed with
 `helm diff`, or render the new chart version and read it:
 
 ```shell
-helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.15 \
+helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.16 \
   -n ferroehr -f my-values.yaml | less
 ```
 

--- a/website/book/src/operations.md
+++ b/website/book/src/operations.md
@@ -383,6 +383,24 @@ annotation-discovering Prometheus, and neither is needed if you push over OTLP
 instead. **To turn telemetry off**, drop `otlp_endpoint`; the tracing layer is
 not installed at all when it is unset.
 
+**The default dashboard.** The "FerroEHR — service overview" Grafana
+dashboard (request rate/errors/latency, AQL rate and phase latency,
+plan-cache hit ratio, database pool, Tokio runtime, audit throughput — every
+query written against the served metric names) reaches Grafana three ways:
+
+- **Compose**: the observability overlay provisions it automatically;
+  nothing to do.
+- **Kubernetes**: set `metrics.grafanaDashboard.enabled: true` and the chart
+  ships it as a ConfigMap labelled `grafana_dashboard: "1"`, which the
+  Grafana Helm chart's dashboard sidecar (kube-prometheus-stack includes it)
+  discovers and imports. The sidecar watches its own release namespace by
+  default — install FerroEHR there, or widen the sidecar's
+  `searchNamespace`. `metrics.grafanaDashboard.folder` sets the
+  `grafana_folder` annotation for sidecars with folder routing configured.
+- **Anywhere else**: import
+  `deploy/helm/ferroehr/files/dashboards/ferroehr-overview.json` by hand
+  (Grafana → Dashboards → Import).
+
 > [!WARNING]
 > With the chart's default-deny egress policy on, add the collector to
 > `networkPolicy.egress.rules` (port 4317). An OTLP exporter that cannot reach


### PR DESCRIPTION
Closes #2641.

One canonical dashboard — `deploy/helm/ferroehr/files/dashboards/ferroehr-overview.json` — reaches Grafana three ways:

- **Helm** (new): `metrics.grafanaDashboard.enabled` renders a ConfigMap labelled `grafana_dashboard: "1"`, the discovery convention of the Grafana Helm chart's dashboard sidecar, verified against the live chart source at its NEW home (grafana-community/helm-charts — the grafana/helm-charts copy was migrated 2026-01-30): default `labelValue: ""` accepts any value, the sidecar watches its release namespace unless widened, and the `grafana_folder` annotation only acts where `folderAnnotation` is configured, so it ships inert-safe. All-features CI lane renders it; goldens regenerated; chart 6.0.16.
- **Compose**: the observability overlay inlines the same JSON (it must stay standalone-downloadable), with `$` escaped as `$$` because Compose interpolates inline config content — unescaped, every `$__rate_interval` silently became a blank string, verified on `compose config`. The new `scripts/checks/dashboard-drift.sh` (wired into the compose-hardening CI job) holds the two copies byte-identical modulo that escaping.
- **Manual import** for everything else, documented on the operations page.

The panel set is grounded in a live scrape of `/management/prometheus` plus the metric definitions in `telemetry/metrics.rs`: RED by route and status class, latency quantiles, AQL rate by outcome and p95 by phase, plan-cache hit ratio (`event` ∈ hit/miss verified in `plan_cache.rs`), `db_pool_connections` by state, the Tokio gauges, and ATNA emitted-vs-forwarded rates. Multimedia panels are deliberately absent: the code exposes no multimedia metrics today, and a panel over a metric that does not exist would be a lie — noted on the issue as a possible future enhancement.