### PR TITLE
ci(tooling): the MCP entry pins the default Sonar project key

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -5,7 +5,8 @@
       "url": "https://api.sonarcloud.io/mcp",
       "headers": {
         "Authorization": "Bearer ${SONARQUBE_TOKEN}",
-        "SONARQUBE_ORG": "rubentalstra"
+        "SONARQUBE_ORG": "rubentalstra",
+        "SONARQUBE_PROJECT_KEY": "rubentalstra_FerroEHR"
       }
     }
   }


### PR DESCRIPTION
From the official MCP reference (mcp.sonarqube.com/llms.txt, read 2026-08-24): `SONARQUBE_PROJECT_KEY` sets the default project so finding queries need not name it each time. The same reference confirms the rest of the committed shape — HTTP mode against `api.sonarcloud.io/mcp` with `Authorization: Bearer` + `SONARQUBE_ORG`, user-token auth (no OAuth), and the hosted server exposing the read toolsets (projects, issues, security-hotspots, quality-gates, rules, duplications, measures, dependency-risks, coverage, agentic-readiness) — exactly what the triage program needs. Part of #2639.