### PR TITLE
docs(readme): the SonarQube Cloud quality-gate badge joins the quality row

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ ITS-REST 1.1.0 &nbsp;·&nbsp; AQL 1.1 &nbsp;·&nbsp; RM 1.2.0 **+ 1.1.0** &nbsp;
 [![FOSSA Status](https://app.fossa.com/api/projects/custom%2B63718%2FFerroEHR.svg?type=shield&issueType=security)](https://app.fossa.com/projects/custom%2B63718%2FFerroEHR?ref=badge_shield&issueType=security)
 
 [![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Frubentalstra%2Fferroehr%2Fbadges%2Fcoverage.json)](https://github.com/rubentalstra/FerroEHR/actions/workflows/ci.yml)
+[![Quality gate status](https://sonarcloud.io/api/project_badges/measure?project=rubentalstra_FerroEHR&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=rubentalstra_FerroEHR)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/rubentalstra/FerroEHR/badge)](https://scorecard.dev/viewer/?uri=github.com/rubentalstra/FerroEHR)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13982/badge)](https://www.bestpractices.dev/projects/13982)
 [![GHCR](https://img.shields.io/badge/ghcr.io-ferroehr-2496ED.svg?logo=docker&logoColor=white)](https://github.com/rubentalstra/FerroEHR/pkgs/container/ferroehr)


### PR DESCRIPTION
Adds the SonarQube Cloud quality-gate status badge (`alert_status`) to the README's quality row, beside Coverage and the OpenSSF badges.

Adjudicated against the full badge set SonarCloud offers: the raw counters (Bugs, Code Smells, Duplicated Lines) churn per analysis and are tracked by the #2640 triage program, not README claims; the Sonar Coverage badge stays out until coverage import is wired; the large quality-gate card duplicates `alert_status`; the logo badge is branding, not a signal.