### PR TITLE
feat(admin-ui): the ADL2 template detail gains the path catalog (console-side build)

### DIFF
--- a/.claude/rules/ai-code-review.md
+++ b/.claude/rules/ai-code-review.md
@@ -41,6 +41,17 @@ job and the badges-branch machinery are gone — the README's coverage badge
 is Sonar's own, measured over the hand-written scan scope. SQL is excluded from scope entirely: the
 PLSQL analyzer assumes Oracle and this tree's SQL is PostgreSQL (#2643).
 
+## Sonar Architecture — adjudicated unavailable (2026-08-24, #2655)
+
+The Architecture feature (current/intended architecture maps, deviations as
+issues) is not in play here, for two independent reasons verified first-hand:
+the organization is on the FREE plan and the feature requires Team/Enterprise
+(`api/navigation/organization` → `"subscription":"FREE"`), and its language
+support is C#/Java/JavaScript/Python/TypeScript — no Rust — so even a plan
+upgrade would only ever cover the website's JS/TS. Re-evaluate if Sonar ships
+Rust support for it AND the plan changes; the architecture record remains
+`docs/architecture.md`, which no analyzer output outranks.
+
 ## It does not gate a merge, and it never writes
 
 No quality gate blocks a merge. Findings worth acting on are written by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
+- Admin console: the ADL 2 template detail shows the path catalog — the same
+  expandable tree and node inspector the ADL 1.4 detail has — built by the
+  console from the served AOM2 JSON. The CDR's REST surface is unchanged (the
+  released API defines no Web Template representation on the ADL 2 resource).
 - Helm chart 6.0.16: `metrics.grafanaDashboard.enabled` ships the default
   "FerroEHR — service overview" Grafana dashboard as a ConfigMap the Grafana
   dashboard sidecar (kube-prometheus-stack) auto-imports; the compose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2777,6 +2777,7 @@ dependencies = [
  "leptos_icons",
  "leptos_meta",
  "leptos_router",
+ "openehr-am",
  "openehr-its",
  "openehr-query",
  "openidconnect",

--- a/app/ferroehr-admin-ui/Cargo.toml
+++ b/app/ferroehr-admin-ui/Cargo.toml
@@ -37,6 +37,12 @@ openehr-query = { path = "../../crates/openehr-query" }
 # below adds back BFF-side — they stay out of the WASM bundle.
 openehr-its = { path = "../../crates/openehr-its", default-features = false }
 
+# The AOM2 operational-template type the ADL2 detail screen's path catalog is
+# built from (`OperationalTemplateV2` canonical JSON in, Web Template out).
+# Server-only: the build runs BFF-side, so the WASM bundle never carries the
+# AOM2 model.
+openehr-am = { path = "../../crates/openehr-am", optional = true }
+
 leptos.workspace = true
 leptos_meta.workspace = true
 leptos_router.workspace = true
@@ -150,6 +156,9 @@ ssr = [
     # The full ITS surface BFF-side (OPT parsing + WebTemplate building); the
     # scope grammar itself is unconditional (see the dependency comment above).
     "openehr-its/full",
+    # The AOM2 OperationalTemplate reader is needed BFF-side only (the ADL2
+    # path catalog).
+    "dep:openehr-am",
 ]
 
 [dev-dependencies]

--- a/app/ferroehr-admin-ui/src/adl2.rs
+++ b/app/ferroehr-admin-ui/src/adl2.rs
@@ -90,6 +90,8 @@ pub enum Adl2Tab {
     Source,
     /// The `OperationalTemplateV2` canonical JSON, read as `application/json`.
     Json,
+    /// The Web-Template path catalog, built console-side from that JSON.
+    Catalog,
     /// The CDR-generated example composition.
     Example,
 }
@@ -102,6 +104,7 @@ impl Adl2Tab {
         match self {
             Self::Source => "source",
             Self::Json => "json",
+            Self::Catalog => "catalog",
             Self::Example => "example",
         }
     }
@@ -112,6 +115,7 @@ impl Adl2Tab {
         match self {
             Self::Source => "Source",
             Self::Json => "AOM2 JSON",
+            Self::Catalog => "Path catalog",
             Self::Example => "Example",
         }
     }
@@ -122,6 +126,7 @@ impl Adl2Tab {
     pub fn from_query(value: &str) -> Self {
         match value {
             "json" => Self::Json,
+            "catalog" => Self::Catalog,
             "example" => Self::Example,
             _ => Self::Source,
         }
@@ -297,7 +302,12 @@ mod tests {
 
     #[test]
     fn the_detail_tabs_round_trip_their_query_value() {
-        for tab in [Adl2Tab::Source, Adl2Tab::Json, Adl2Tab::Example] {
+        for tab in [
+            Adl2Tab::Source,
+            Adl2Tab::Json,
+            Adl2Tab::Catalog,
+            Adl2Tab::Example,
+        ] {
             assert_eq!(Adl2Tab::from_query(tab.as_query()), tab);
         }
         assert_eq!(Adl2Tab::from_query("nonsense"), Adl2Tab::Source);

--- a/app/ferroehr-admin-ui/src/pages/template_adl2.rs
+++ b/app/ferroehr-admin-ui/src/pages/template_adl2.rs
@@ -3,8 +3,8 @@
 
 //! The `/templates/adl2/{template_id}` screen — ADL2 template detail.
 //!
-//! Three panes over one stored ADL2 operational template, matching what the
-//! ITS-REST Definition API actually serves for the resource: **Source** (the
+//! Four panes over one stored ADL2 operational template. Three of them are
+//! what the ITS-REST Definition API serves for the resource: **Source** (the
 //! stored artefact verbatim, `Accept: text/plain`), **AOM2 JSON** (the
 //! `OperationalTemplateV2` canonical-JSON projection,
 //! `Accept: application/json`), and **Example** (the CDR-generated example
@@ -13,10 +13,12 @@
 //! (`definition/template/adl2/{template_id}/{version}`) as `?version=` URL
 //! state, so a pinned view is shareable.
 //!
-//! There is deliberately no path-catalog pane: the console's catalog is built
-//! from an ADL 1.4 OPT's Web Template, and the ADL2 resource serves no Web
-//! Template representation (an `Accept` asking for one is refused `406`), so
-//! the screen says so rather than inventing one.
+//! The fourth, **Path catalog**, is built console-side: the ADL2 resource
+//! serves no Web Template representation, so the BFF reads the same
+//! `application/json` body, parses the AOM2 operational template, builds its
+//! Web Template and projects the [`crate::builder::catalog::CatalogNode`] tree
+//! the ADL 1.4 detail screen renders — same tree component, same node
+//! inspector, one code path for both families.
 //!
 //! No openEHR spec governs an admin UI — our own design / product extension;
 //! the wire it reads is the ITS-REST Definition API.
@@ -34,11 +36,15 @@ use leptos_meta::Title;
 use leptos_router::hooks::{use_params_map, use_query_map};
 
 use crate::adl2::{Adl2Tab, TemplateFamily};
+use crate::builder::catalog::CatalogNode;
 use crate::components::field::{BTN_SECONDARY, INPUT};
 use crate::components::page_header::{Crumb, PageHeader};
 use crate::components::surface::{CARD_PAD, CARD_TITLE};
 use crate::error::AdminUiError;
 use crate::format::ReprFormat;
+use crate::pages::template_detail::{
+    CatalogTreeNode, catalog_error_view, node_inspector, tree_skeleton,
+};
 use crate::pages::templates::TemplateRow;
 
 /// Fetch the stored ADL2 operational-template SOURCE.
@@ -113,6 +119,73 @@ pub async fn fetch_adl2_json(
     Ok(Some(crate::cdr::CdrClient::expect_success(response)?.body))
 }
 
+/// Build the Web-Template path catalog of one `OperationalTemplateV2`
+/// canonical-JSON body.
+///
+/// The body is read with
+/// [`openehr_its::json::from_canonical_json`] into the AOM2
+/// [`OperationalTemplate`](openehr_am::v2_4::aom2::archetype::operational_template::OperationalTemplate)
+/// — the exact type the CDR serialized — then
+/// [`openehr_its::flat::webtemplate::builder_v2_4::build_web_template_v2_4`]
+/// produces the Web Template and [`crate::builder::catalog::from_web_template`]
+/// the slim tree the views render. Both stages are named in the error, so a
+/// reader can tell a body the console could not read from a template whose Web
+/// Template does not build.
+///
+/// # Errors
+/// [`AdminUiError::Internal`] when the AOM2 JSON fails to parse or the Web
+/// Template fails to build (the diagnostic named, never a panic).
+#[cfg(feature = "ssr")]
+pub fn adl2_catalog_from_json(json: &str) -> Result<CatalogNode, AdminUiError> {
+    let opt = openehr_its::json::from_canonical_json::<
+        openehr_am::v2_4::aom2::archetype::operational_template::OperationalTemplate,
+    >(json)
+    .map_err(|e| AdminUiError::Internal(format!("OperationalTemplateV2 parse: {e}")))?;
+    let web_template = openehr_its::flat::webtemplate::builder_v2_4::build_web_template_v2_4(&opt)
+        .map_err(|e| AdminUiError::Internal(format!("WebTemplate build: {e}")))?;
+    Ok(crate::builder::catalog::from_web_template(&web_template))
+}
+
+/// Fetch the Web-Template path catalog of a stored ADL2 template.
+///
+/// The same resource and `Accept` as [`fetch_adl2_json`]: the ADL2 template
+/// GET's `application/json` 200 body IS the `OperationalTemplateV2` canonical
+/// form (`docs/specs/openehr/ITS-REST/specifications/responses/
+/// 200_Template_adl2_retrieved.yaml`). The catalog is then built console-side
+/// by [`adl2_catalog_from_json`] — by design, because the resource serves no
+/// `wt+json` representation to read one from. `404` → `Ok(None)`, the same
+/// absence the other panes render.
+///
+/// # Errors
+/// [`AdminUiError::Unauthenticated`] without a console session;
+/// [`AdminUiError::CdrUnauthorized`] / [`AdminUiError::Forbidden`] / [`AdminUiError::Cdr`] /
+/// [`AdminUiError::CdrUnreachable`] from the CDR;
+/// [`AdminUiError::Internal`] when the served JSON fails to parse or its Web
+/// Template fails to build.
+#[server]
+pub async fn fetch_adl2_catalog(
+    /// The ADL2 template to build the path catalog from.
+    template_id: String,
+    /// The release version to pin the read to, or `None`.
+    version: Option<String>,
+) -> Result<Option<CatalogNode>, AdminUiError> {
+    let session = crate::session::require_session().await?;
+    let state: crate::state::AppState = expect_context();
+    let url = state.cdr.rest_v1(&crate::adl2::template_path(
+        &template_id,
+        version.as_deref(),
+    ));
+    let response = state
+        .cdr
+        .get(&session.credential, &url, "application/json")
+        .await?;
+    if response.is(http::StatusCode::NOT_FOUND) {
+        return Ok(None);
+    }
+    let body = crate::cdr::CdrClient::expect_success(response)?.body;
+    adl2_catalog_from_json(&body).map(Some)
+}
+
 /// Fetch the CDR-generated example composition for a stored ADL2 template, in
 /// `format`.
 ///
@@ -174,13 +247,40 @@ impl PaneBody {
     }
 }
 
+/// What the path-catalog pane holds — [`PaneBody`]'s three states over the
+/// catalog tree instead of a served representation, for the same reason: an
+/// unopened tab has fetched nothing, while a `404` is a real answer to report.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+enum CatalogBody {
+    /// This pane's tab is not selected; nothing has been requested.
+    Idle,
+    /// The CDR answered `404` — no such template at the selected version.
+    Absent,
+    /// The catalog built from the served `OperationalTemplateV2`.
+    Loaded(CatalogNode),
+}
+
+impl CatalogBody {
+    /// Read one built catalog: `Some` is the tree, `None` the CDR's `404`.
+    fn of(built: Option<CatalogNode>) -> Self {
+        match built {
+            Some(node) => Self::Loaded(node),
+            None => Self::Absent,
+        }
+    }
+}
+
 /// The ADL2 template detail screen: the version bar, the tab bar, and the
-/// source / AOM2-JSON / example panes.
+/// source / AOM2-JSON / path-catalog / example panes.
 #[expect(
     clippy::must_use_candidate,
     reason = "#[component] rewrites the fn; view!/mount always consumes the value"
 )]
 #[component]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one setup pass: the URL state, one resource per pane, the tab bar"
+)]
 pub fn Adl2TemplateDetailPage() -> impl IntoView {
     // NOTE: the route param arrives ALREADY percent-decoded on both targets
     // (`leptos_router`'s `ParamsMap::insert` runs every value through
@@ -201,6 +301,7 @@ pub fn Adl2TemplateDetailPage() -> impl IntoView {
             .filter(|value| !value.is_empty())
     });
     let example_format = RwSignal::new(ReprFormat::CanonicalJson);
+    let selected_node = RwSignal::new(None::<CatalogNode>);
 
     // Each pane's resource is gated on its tab being active so only the
     // visible one fetches — the example fetch in particular runs the CDR's
@@ -223,6 +324,15 @@ pub fn Adl2TemplateDetailPage() -> impl IntoView {
             }
         },
     );
+    let catalog: Resource<Result<CatalogBody, AdminUiError>> = Resource::new(
+        move || (tab.get() == Adl2Tab::Catalog).then(|| (template_id.get(), version.get())),
+        |active| async move {
+            match active {
+                Some((id, version)) => Ok(CatalogBody::of(fetch_adl2_catalog(id, version).await?)),
+                None => Ok(CatalogBody::Idle),
+            }
+        },
+    );
     let example: Resource<Result<PaneBody, AdminUiError>> = Resource::new(
         move || (tab.get() == Adl2Tab::Example).then(|| (template_id.get(), example_format.get())),
         |active| async move {
@@ -242,9 +352,9 @@ pub fn Adl2TemplateDetailPage() -> impl IntoView {
     );
 
     let versions = version_section(template_id, tab, version, listing);
-    let catalog_note = no_catalog_note();
     let source_pane = source_tab(source);
     let json_pane = json_tab(json);
+    let catalog_pane = catalog_tab(catalog, selected_node);
     let example_pane = example_tab(example, example_format);
 
     let tab_link = move |value: Adl2Tab| {
@@ -279,10 +389,10 @@ pub fn Adl2TemplateDetailPage() -> impl IntoView {
                 mono=true
             />
             {versions}
-            {catalog_note}
             <nav aria-label="ADL2 template views" class="flex gap-1 mb-4">
                 {tab_link(Adl2Tab::Source)}
                 {tab_link(Adl2Tab::Json)}
+                {tab_link(Adl2Tab::Catalog)}
                 {tab_link(Adl2Tab::Example)}
             </nav>
             <div>
@@ -291,6 +401,9 @@ pub fn Adl2TemplateDetailPage() -> impl IntoView {
                 </div>
                 <div id="adl2-json-pane" class:hidden=move || tab.get() != Adl2Tab::Json>
                     {json_pane}
+                </div>
+                <div id="adl2-catalog-pane" class:hidden=move || tab.get() != Adl2Tab::Catalog>
+                    {catalog_pane}
                 </div>
                 <div id="adl2-example-pane" class:hidden=move || tab.get() != Adl2Tab::Example>
                     {example_pane}
@@ -443,34 +556,49 @@ fn version_form(
     .into_any()
 }
 
-/// The standing statement that this screen has no path catalog, and why.
-///
-/// Verified against the CDR's own answer: the ADL2 template resource serves
-/// `text/plain` source and `application/json` `OperationalTemplateV2` only,
-/// and an `Accept` asking for a Web Template is refused `406`. The ADL 1.4
-/// detail screen's catalog is built from an OPT 1.4 Web Template, so there is
-/// nothing equivalent to show here — and a fabricated one would be worse than
-/// none.
-fn no_catalog_note() -> AnyView {
+/// The Path catalog pane: the recursive path-catalog tree (left) and the node
+/// inspector (right), the SAME components the ADL 1.4 detail screen uses
+/// ([`CatalogTreeNode`], [`node_inspector`]) over a tree the BFF built from the
+/// served `OperationalTemplateV2`.
+fn catalog_tab(
+    catalog: Resource<Result<CatalogBody, AdminUiError>>,
+    selected: RwSignal<Option<CatalogNode>>,
+) -> AnyView {
     view! {
-        <p id="adl2-no-catalog" class="mb-4 text-sm text-ink-muted">
-            "No path catalog: the Web Template tree on the ADL 1.4 detail screen is built from an
-             OPT 1.4, and the CDR serves no Web Template representation of an ADL2 artefact. Use
-             the AOM2 JSON pane to read the template's constraint structure."
-        </p>
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 items-start">
+            <section class=CARD_PAD>
+                <h2 class=CARD_TITLE>"Path catalog (WT tree)"</h2>
+                <p class="mb-2 text-xs text-ink-muted">
+                    "Built by the console from the served OperationalTemplateV2: the ADL2 resource
+                     serves no Web Template representation of its own."
+                </p>
+                <div class="overflow-auto max-h-[70vh]">
+                    <Transition fallback=tree_skeleton>
+                        {move || Suspend::new(async move {
+                            match catalog.await {
+                                Ok(CatalogBody::Idle) => ().into_any(),
+                                Ok(CatalogBody::Loaded(node)) => {
+                                    view! {
+                                        <ul class="text-sm">
+                                            <CatalogTreeNode node=node selected=selected depth=0 />
+                                        </ul>
+                                    }
+                                        .into_any()
+                                }
+                                Ok(CatalogBody::Absent) => absent_view("path catalog"),
+                                Err(e) => catalog_error_view(&e, "/templates?family=adl2"),
+                            }
+                        })}
+                    </Transition>
+                </div>
+            </section>
+            <section class=CARD_PAD>
+                <h2 class=CARD_TITLE>"Node inspector"</h2>
+                <div>{node_inspector(selected)}</div>
+            </section>
+        </div>
     }
     .into_any()
-}
-
-/// The `<Transition>` fallback every pane shares.
-fn pane_skeleton() -> impl IntoView {
-    view! {
-        <thaw::Skeleton>
-            <thaw::SkeletonItem class="h-4 mb-2" />
-            <thaw::SkeletonItem class="h-4 mb-2 ml-4" />
-            <thaw::SkeletonItem class="h-4 ml-4" />
-        </thaw::Skeleton>
-    }
 }
 
 /// The absence state: the CDR answered `404` for the template (or the pinned
@@ -500,7 +628,7 @@ fn absent_view(what: &str) -> AnyView {
 /// pane (monospace, scrollable, copyable).
 fn source_tab(source: Resource<Result<PaneBody, AdminUiError>>) -> AnyView {
     view! {
-        <Transition fallback=pane_skeleton>
+        <Transition fallback=tree_skeleton>
             {move || Suspend::new(async move {
                 match source.await {
                     Ok(PaneBody::Idle) => ().into_any(),
@@ -521,7 +649,7 @@ fn source_tab(source: Resource<Result<PaneBody, AdminUiError>>) -> AnyView {
 /// pretty-printed into the shared document pane.
 fn json_tab(json: Resource<Result<PaneBody, AdminUiError>>) -> AnyView {
     view! {
-        <Transition fallback=pane_skeleton>
+        <Transition fallback=tree_skeleton>
             {move || Suspend::new(async move {
                 match json.await {
                     Ok(PaneBody::Idle) => ().into_any(),
@@ -562,7 +690,7 @@ fn example_tab(
                  it."
             </p>
             <crate::components::format_view::FormatSelector offered=offered selected=format />
-            <Transition fallback=pane_skeleton>
+            <Transition fallback=tree_skeleton>
                 {move || Suspend::new(async move {
                     match example.await {
                         Ok(PaneBody::Idle) => ().into_any(),

--- a/app/ferroehr-admin-ui/src/pages/template_detail.rs
+++ b/app/ferroehr-admin-ui/src/pages/template_detail.rs
@@ -492,7 +492,7 @@ fn wt_tab(
                                     }
                                         .into_any()
                                 }
-                                Err(e) => catalog_error_view(&e),
+                                Err(e) => catalog_error_view(&e, "/templates"),
                             }
                         })}
                     </Transition>
@@ -507,8 +507,9 @@ fn wt_tab(
     .into_any()
 }
 
-/// The `<Transition>` fallback while the catalog builds.
-fn tree_skeleton() -> impl IntoView {
+/// The `<Transition>` fallback the template detail panes share (both ADL
+/// families — the ADL2 screen imports it rather than re-declaring a copy).
+pub(crate) fn tree_skeleton() -> impl IntoView {
     view! {
         <thaw::Skeleton>
             <thaw::SkeletonItem class="h-4 mb-2" />
@@ -519,18 +520,19 @@ fn tree_skeleton() -> impl IntoView {
 }
 
 /// The catalog error state (e.g. a `404` unknown template, or a `WebTemplate`
-/// build failure naming the offending node) with a back link to the list. Used
+/// build failure naming the offending node) with a back link to `back_href` —
+/// the caller's own listing, so the ADL2 screens point at their family. Used
 /// by the tabs that resolve their `Result` inside the `<Transition>` — an SSR'd
 /// `ErrorBoundary` fallback mismatches at hydration in leptos 0.8 — so the error
 /// (with its back link) renders directly from the resolved `Err` branch.
-fn catalog_error_view(error: &AdminUiError) -> AnyView {
+pub(crate) fn catalog_error_view(error: &AdminUiError, back_href: &'static str) -> AnyView {
     let message = error.to_string();
     view! {
         <thaw::MessageBar intent=thaw::MessageBarIntent::Error>
             <thaw::MessageBarBody>
                 {message} " — "
                 <leptos_router::components::A
-                    href="/templates"
+                    href=back_href
                     attr:class="text-accent hover:underline"
                 >
                     "back to templates"
@@ -548,11 +550,16 @@ fn catalog_error_view(error: &AdminUiError) -> AnyView {
 /// component recurse (an un-erased recursive view would be an infinite type)
 /// and keeps rustc's layout-recursion depth bounded on plain `cargo` builds
 /// (rules §1).
-///
-/// # Errors
-/// Infallible — renders whatever the (already-fetched) catalog node contains.
+#[expect(
+    clippy::must_use_candidate,
+    reason = "#[component] rewrites the fn; view!/mount always consumes the value"
+)]
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "a component prop is owned data; the node is cloned into the row's selection and its children"
+)]
 #[component]
-fn CatalogTreeNode(
+pub(crate) fn CatalogTreeNode(
     /// The catalog node to render (static data; the component runs once).
     node: CatalogNode,
     /// The shared "inspected node" selection, set when a label is clicked.
@@ -656,7 +663,7 @@ fn CatalogTreeNode(
 
 /// The node inspector: nothing until a node is picked, then its aqlPath,
 /// rmType, node id, selectability, and any unit / code options as chips.
-fn node_inspector(selected: RwSignal<Option<CatalogNode>>) -> AnyView {
+pub(crate) fn node_inspector(selected: RwSignal<Option<CatalogNode>>) -> AnyView {
     view! {
         {move || match selected.get() {
             None => {
@@ -777,7 +784,7 @@ fn opt_tab(detail: Resource<Result<TemplateDetail, AdminUiError>>) -> AnyView {
                         }
                             .into_any()
                     }
-                    Err(e) => catalog_error_view(&e),
+                    Err(e) => catalog_error_view(&e, "/templates"),
                 }
             })}
         </Transition>
@@ -815,7 +822,7 @@ fn example_tab(
                             view! { <crate::components::format_view::DocumentPane body=pretty /> }
                                 .into_any()
                         }
-                        Err(e) => catalog_error_view(&e),
+                        Err(e) => catalog_error_view(&e, "/templates"),
                     }
                 })}
             </Transition>

--- a/app/ferroehr-admin-ui/tests/it/e2e_adl2.rs
+++ b/app/ferroehr-admin-ui/tests/it/e2e_adl2.rs
@@ -21,9 +21,10 @@
 //! What they pin is the whole ADL2 surface the console consumes: the
 //! `text/plain` source upload with the openEHR-ADL engine's diagnostics
 //! surfaced verbatim, the listing, the stored SOURCE and `OperationalTemplateV2`
-//! JSON representations, the CDR-generated example composition, and the
-//! versioned get — both an exact release version and the wire's
-//! `{major}` prefix resolution, driven through the screen's own version bar.
+//! JSON representations, the console-built path catalog over that JSON, the
+//! CDR-generated example composition, and the versioned get — both an exact
+//! release version and the wire's `{major}` prefix resolution, driven through
+//! the screen's own version bar.
 //!
 //! …and, since #2568, the per-row DELETE the ADL2 rows now carry over the
 //! artefact resource.
@@ -184,8 +185,9 @@ async fn ensure_adl2_template_present(h: &Harness, relative: &str, hrid: &str) -
 }
 
 /// Uploading an ADL2 source lists it under the ADL2 family, and its detail
-/// screen serves both stored representations: the artefact SOURCE verbatim and
-/// the `OperationalTemplateV2` canonical JSON.
+/// screen serves both stored representations — the artefact SOURCE verbatim and
+/// the `OperationalTemplateV2` canonical JSON — plus the path catalog the
+/// console builds from that JSON.
 #[tokio::test]
 async fn adl2_upload_lists_and_serves_source_and_json() {
     let Some(h) = Harness::start("adl2-detail").await else {
@@ -219,9 +221,6 @@ async fn adl2_upload_lists_and_serves_source_and_json() {
     // HRID on the artefact-identifier line.
     wait_text_contains(&h, "#adl2-source-pane", "operational_template").await;
     wait_text_contains(&h, "#adl2-source-pane", VERSIONED_V100).await;
-    // No path catalog is claimed for ADL2 — the screen says so rather than
-    // faking one.
-    h.wait_css("#adl2-no-catalog").await;
     h.shot(3, "adl2-source-pane").await;
 
     // The AOM2 JSON pane serves the OperationalTemplateV2 projection. The
@@ -236,6 +235,24 @@ async fn adl2_upload_lists_and_serves_source_and_json() {
     wait_text_contains(&h, "#adl2-json-pane", "OPERATIONAL_TEMPLATE").await;
     wait_text_contains(&h, "#adl2-json-pane", "\"release_version\": \"1.0.0\"").await;
     h.shot(4, "adl2-json-pane").await;
+
+    // The path catalog is built by the console from that same JSON, and it
+    // renders with the ADL 1.4 screen's own tree + inspector components: a tree
+    // node exists only once the AOM2 parse and the WebTemplate build both
+    // succeeded. The standing "no path catalog" note is gone with it.
+    h.wait_css("a[data-adl2-tab='catalog']")
+        .await
+        .click()
+        .await
+        .expect("open the path-catalog pane");
+    h.wait_url_contains("tab=catalog").await;
+    h.wait_css("#adl2-catalog-pane ul.text-sm li button").await;
+    wait_text_contains(&h, "#adl2-catalog-pane", "Node inspector").await;
+    assert!(
+        h.driver.find(By::Css("#adl2-no-catalog")).await.is_err(),
+        "the ADL2 screen no longer claims it has no path catalog"
+    );
+    h.shot(5, "adl2-catalog-pane").await;
 
     h.assert_console_clean(&["Failed to load resource"]).await;
     remove_adl2_artefacts(&[VERSIONED_V100]).await;

--- a/website/book/src/admin-ui/browsing.md
+++ b/website/book/src/admin-ui/browsing.md
@@ -77,7 +77,8 @@ diagnostics (the AOM 2 rule codes with their line and column) are shown in
 full above the editor as well as in the failure notification, so the source can
 be corrected in place and re-sent.
 
-Opening a row shows the artefact's three server-side representations:
+Opening a row shows the artefact's three server-side representations plus a
+derived view:
 
 - **Source:** the stored ADL 2 text, exactly as the CDR holds it.
 - **AOM2 JSON:** the same operational template as canonical JSON
@@ -85,6 +86,8 @@ Opening a row shows the artefact's three server-side representations:
   and occurrences are readable.
 - **Example:** a composition the CDR generates from the template, in
   canonical JSON, canonical XML, FLAT or STRUCTURED.
+- **Path catalog:** the same expandable tree and node inspector the ADL 1.4
+  detail shows, built by the console from the AOM2 JSON.
 
 ![ADL 2 template detail](img/templates/template-adl2-detail.png)
 
@@ -99,10 +102,10 @@ named and does not follow the version bar: the CDR publishes no versioned
 example resource.
 
 > [!NOTE]
-> ADL 2 templates have no path catalog. The catalog on the ADL 1.4 detail
-> screen is built from an OPT 1.4 Web Template, and the CDR serves no Web
-> Template representation of an ADL 2 artefact, so the screen says so instead
-> of showing an invented tree. Read the AOM2 JSON pane for the structure.
+> The ADL 2 path catalog is built by the console itself: the CDR serves no
+> Web Template representation of an ADL 2 artefact, so the console reads the
+> AOM2 JSON and derives the same tree the ADL 1.4 detail shows. The CDR wire
+> stays exactly the released REST API.
 
 #### Deleting an ADL 2 template
 


### PR DESCRIPTION
Closes #2569. Closes #2655.

The ADL2 template detail renders the Web Template path catalog with the same components the ADL 1.4 detail uses. Decided shape (recorded on #2569): the build is console-side — the released ITS-REST 1.1.0 defines only `text/plain` + `application/json` on the ADL2 template GET (`specifications/responses/200_Template_adl2_retrieved.yaml`), so the CDR wire is untouched.

- New session-guarded `#[server] fetch_adl2_catalog(template_id, version)`: GETs the ADL2 template's `application/json` (the `OperationalTemplateV2` canonical form, pinned to the page's `?version=` bar like every sibling pane), reads it with `openehr_its::json::from_canonical_json::<openehr_am::v2_4 OperationalTemplate>` — the exact reader for what the CDR serializes — then `build_web_template_v2_4` → the existing `CatalogNode` projection. `404 → Ok(None)` (the page's absence idiom).
- New `Path catalog` tab (`?tab=catalog`) rendering `CatalogTreeNode` + `node_inspector` from `template_detail` (bumped to `pub(crate)`); the "No path catalog" note and its book claim are gone.
- Worker-surfaced findings fixed in the same branch: the shared `catalog_error_view` now takes the caller's back link (the ADL2 screens point at `/templates?family=adl2`), the byte-identical per-screen skeleton folded into the shared `tree_skeleton`, and a bogus `# Errors` section on an infallible component removed.
- `openehr-am` joins the console as an ssr-only optional dependency (the AOM2 model is BFF-side only; zero wasm growth).
- Book: `admin-ui/browsing.md` documents the new pane; changelog entry added.
- Also closes #2655: Sonar Architecture adjudicated unavailable (FREE plan; feature requires Team/Enterprise and supports no Rust) — recorded in `.claude/rules/ai-code-review.md`.

Gates: clippy green on native(ssr) + wasm32(hydrate), 448/448 nextest, leptosfmt/fmt clean, comment-style OK, cargo-leptos build + rustdoc clean (worker-verified). The composed-stack e2e battery with `UI_E2E_DOCS_SHOTS=1` was deliberately aborted mid-image-build on owner instruction (P0 perf pivot) — the ADL2 journey extension and the refreshed detail screenshot ride the next e2e run; the `ui-screenshot-guard` is bypassed by owner-sanctioned admin merge, not by a false `no-ui-visual-change` claim.
