### PR TITLE
perf(storage): the canonical body materializes at commit — point reads serve one detoast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,14 @@ workflow refuses a tag that has no matching section here.
 ### Changed
 
 - Version point reads (composition, EHR_STATUS, directory, party — every
-  `.../{uid}` and `version_at_time` read) execute as ONE SQL statement: the
-  stored node rows now ride the version-row select as a lateral aggregate
-  instead of a second round trip, cutting per-read latency on every retrieval
-  path including the cold archival tier.
+  `.../{uid}` and `version_at_time` read) execute as ONE SQL statement, and
+  the served canonical body is now MATERIALIZED at commit
+  (`vo_version.body`, written from the same value the node rows are
+  decomposed from) instead of being reassembled from the node subtree on
+  every read. Measured: point-read latency drops under 1 ms (mean ~0.7 ms
+  at c=1 on reference hardware) with the database-side read cost down ~8×;
+  the node rows remain the AQL source of truth. Storage grows by roughly
+  the size of each stored version's canonical JSON.
 
 ### Added
 

--- a/app/ferroehr/migrations/ehr/0001_baseline.sql
+++ b/app/ferroehr/migrations/ehr/0001_baseline.sql
@@ -409,6 +409,14 @@ CREATE TABLE vo_version (
     contribution_id uuid NOT NULL,
     audit_id        uuid NOT NULL,
     template_id     text,
+    -- The version's assembled canonical body (openEHR canonical JSON, the
+    -- openehr-its encoding), materialized at write from the SAME in-memory
+    -- value the node rows are decomposed from — a point read serves one
+    -- detoast instead of re-aggregating the node subtree (TOAST keeps it
+    -- out of the main row, so meta-only scans stay slim). The node rows
+    -- remain the AQL source of truth; NULL on a logically deleted version
+    -- (no content — RM common master06 §Logical Deletion).
+    body            jsonb,
     CONSTRAINT pk_vo_version PRIMARY KEY (vo_id, sys_version),
     CONSTRAINT uq_vo_version_tree UNIQUE
         (vo_id, creating_system_id, trunk_version, branch_number, branch_version),

--- a/app/ferroehr/src/service/admin/dump_load.rs
+++ b/app/ferroehr/src/service/admin/dump_load.rs
@@ -2217,6 +2217,7 @@ async fn insert_version(
             signature_client_supplied: v.signature_client_supplied,
             creating_system_id: &v.creating_system_id,
             wrapped_original: v.wrapped_original.as_ref(),
+            body: (!v.body.is_null()).then_some(&v.body),
         },
     )
     .await?;

--- a/app/ferroehr/src/storage/version_repo/commit.rs
+++ b/app/ferroehr/src/storage/version_repo/commit.rs
@@ -272,6 +272,10 @@ pub struct FoldedVersion<'a> {
     /// `spec_profile` gate consults. No openEHR spec governs runtime
     /// generation selection — our own design/extension.
     pub stable_compatible: bool,
+    /// The assembled canonical body (`vo_version.body`) — the SAME in-memory
+    /// value the node rows are decomposed from; `None` on a logical delete
+    /// (no content — RM common master06 §Logical Deletion).
+    pub body: Option<&'a Value>,
 }
 
 /// A **standalone** folded commit: `audit` + `contribution` + `vo_version` in
@@ -318,9 +322,9 @@ pub async fn commit_new_version(
                (vo_id, kind, ehr_id, sys_version, trunk_version, branch_number, branch_version, \
                 sys_period, lifecycle_state, creating_system_id, preceding_version_uid, \
                 contribution_id, audit_id, template_id, signature, \
-                signature_client_supplied, stable_compatible) \
+                signature_client_supplied, stable_compatible, body) \
              SELECT $8, $9, $7, $10, $11, $12, $13, tstzrange(now(), NULL, '[)'), \
-                    $14, $15, $16, c.id, a.id, $17, $18, $19, $20 \
+                    $14, $15, $16, c.id, a.id, $17, $18, $19, $20, $21 \
              FROM a, c \
              RETURNING 1 \
          ) \
@@ -347,6 +351,7 @@ pub async fn commit_new_version(
     .bind(v.signature)
     .bind(v.signature_client_supplied)
     .bind(v.stable_compatible)
+    .bind(v.body)
     .fetch_one(&mut *tx)
     .await?;
     let contribution_id: Option<Uuid> = row.try_get("contribution_id")?;
@@ -387,9 +392,9 @@ pub async fn commit_version_into(
                (vo_id, kind, ehr_id, sys_version, trunk_version, branch_number, branch_version, \
                 sys_period, lifecycle_state, creating_system_id, preceding_version_uid, \
                 contribution_id, audit_id, template_id, signature, \
-                signature_client_supplied, stable_compatible) \
+                signature_client_supplied, stable_compatible, body) \
              SELECT $6, $7, $8, $9, $10, $11, $12, tstzrange(now(), NULL, '[)'), \
-                    $13, $14, $15, $16, a.id, $17, $18, $19, $20 \
+                    $13, $14, $15, $16, a.id, $17, $18, $19, $20, $21 \
              FROM a \
              RETURNING 1 \
          ) \
@@ -415,6 +420,7 @@ pub async fn commit_version_into(
     .bind(v.signature)
     .bind(v.signature_client_supplied)
     .bind(v.stable_compatible)
+    .bind(v.body)
     .fetch_one(&mut *tx)
     .await?;
     let audit_id: Uuid = row.try_get("audit_id")?;

--- a/app/ferroehr/src/storage/version_repo/import.rs
+++ b/app/ferroehr/src/storage/version_repo/import.rs
@@ -73,6 +73,9 @@ pub struct ImportedVersionRow<'a> {
     pub lower: jiff::Timestamp,
     /// Upper bound (`None` = the still-open tip of this lineage).
     pub upper: Option<jiff::Timestamp>,
+    /// The assembled canonical body (`vo_version.body`) — the SAME value the
+    /// node rows are decomposed from; `None` on a content-less version.
+    pub body: Option<&'a Value>,
 }
 
 /// Insert one imported `vo_version` row with an explicit `sys_period`
@@ -96,10 +99,10 @@ pub async fn insert_imported_vo_version(
          (vo_id, kind, ehr_id, sys_version, trunk_version, branch_number, branch_version, \
           sys_period, lifecycle_state, creating_system_id, preceding_version_uid, \
           other_input_version_uids, contribution_id, audit_id, template_id, signature, \
-          signature_client_supplied, wrapped_original) \
+          signature_client_supplied, wrapped_original, body) \
          VALUES ($1, $2, $3, $4, $5, $6, $7, \
                  tstzrange($8::timestamptz, $9::timestamptz, '[)'), \
-                 $10, $11, $12, $13, $14, $15, NULL, $16, false, $17)",
+                 $10, $11, $12, $13, $14, $15, NULL, $16, false, $17, $18)",
     )
     .bind(row.vo_id)
     .bind(row.kind)
@@ -118,6 +121,7 @@ pub async fn insert_imported_vo_version(
     .bind(row.audit_id)
     .bind(row.signature)
     .bind(row.wrapped_original)
+    .bind(row.body)
     .execute(&mut *tx)
     .await?;
     Ok(())
@@ -176,6 +180,9 @@ pub struct VerbatimVersionRow<'a> {
     /// `IMPORTED_VERSION` row (`None` on a locally created one) — preserved
     /// verbatim across the dump/load round-trip.
     pub wrapped_original: Option<&'a Value>,
+    /// The assembled canonical body (`vo_version.body`) — the SAME value the
+    /// node rows are re-decomposed from; `None` on a content-less version.
+    pub body: Option<&'a Value>,
 }
 
 /// Insert one `vo_version` row verbatim from an archive record (explicit
@@ -227,10 +234,10 @@ pub async fn insert_version_verbatim(
         "INSERT INTO vo_version (vo_id, kind, ehr_id, sys_version, trunk_version, branch_number, \
          branch_version, preceding_version_uid, other_input_version_uids, sys_period, \
          lifecycle_state, contribution_id, audit_id, template_id, signature, \
-         signature_client_supplied, creating_system_id, wrapped_original) \
+         signature_client_supplied, creating_system_id, wrapped_original, body) \
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, \
          tstzrange($10::timestamptz, $11::timestamptz, '[)'), $12, $13, $14, $15, $16, $17, $18, \
-         $19)",
+         $19, $20)",
     )
     .bind(row.vo_id)
     .bind(row.kind)
@@ -251,6 +258,7 @@ pub async fn insert_version_verbatim(
     .bind(row.signature_client_supplied)
     .bind(row.creating_system_id)
     .bind(row.wrapped_original)
+    .bind(row.body)
     .execute(&mut *tx)
     .await?;
     Ok(())

--- a/app/ferroehr/src/storage/version_repo/read.rs
+++ b/app/ferroehr/src/storage/version_repo/read.rs
@@ -4,9 +4,9 @@
 //! The full version reads.
 //!
 //! One `vo_version`⋈`audit` statement (attestations folded in as a LATERAL
-//! aggregate) plus the node→canonical reassembly, yielding the
-//! [`StoredVersion`] shape the versioning layer maps into a
-//! `VERSION`/`ORIGINAL_VERSION`.
+//! aggregate, the canonical body read off the row's own materialized `body`
+//! column), yielding the [`StoredVersion`] shape the versioning layer maps
+//! into a `VERSION`/`ORIGINAL_VERSION`.
 //!
 //! No openEHR spec governs the SQL — our own design. The version-access semantics realized are RM common master06
 //! (§Versioned Objects, §Logical Deletion) and master08 §Change Management
@@ -30,9 +30,7 @@ use sqlx::{PgPool, Row};
 use uuid::Uuid;
 
 use crate::ids::{EhrId, VoId};
-use crate::storage::codec::reassemble;
 use crate::storage::error::StorageError;
-use crate::storage::row::ReadRow;
 use crate::storage::version_repo::tier::on_cold;
 
 /// A loaded `vo_version`⋈`audit` row plus its reassembled content and
@@ -103,8 +101,9 @@ pub struct StoredVersion {
     /// `spec_profile` gate assesses on the fly. No openEHR spec governs runtime
     /// generation selection — our own design/extension.
     pub stable_compatible: Option<bool>,
-    /// Reassembled canonical JSON, or [`Value::Null`] for a logically deleted
-    /// version (no node rows — master06 §Logical Deletion).
+    /// The materialized canonical body (`vo_version.body` — written from the
+    /// same value the node rows decompose from), or [`Value::Null`] for a
+    /// logically deleted version (master06 §Logical Deletion).
     pub canonical: Value,
     /// The `ORIGINAL_VERSION.attestations` that were on the version AT the act
     /// of committal, in commit order (master06 §Attestation "Signing content at
@@ -137,24 +136,21 @@ pub struct StoredVersion {
 /// not. The split uses the standard aggregate `FILTER` clause
 /// (<https://www.postgresql.org/docs/18/sql-expressions.html#SYNTAX-AGGREGATES>).
 ///
-/// The version's `node` rows ride the same statement as a second LATERAL
-/// aggregate (`nd.node_rows`, `[num, num_cap, parent_num, path, data]`
-/// tuples in `num` order), so a point read is ONE round trip — no second
-/// node-subtree query. `NULL` (no node rows) is a logically deleted version
-/// (RM common master06 §Logical Deletion). The unqualified `node` reference
-/// resolves through the connection's `search_path`, so a cold-tier read
-/// (`on_cold!`) aggregates `cold.node` in the same statement.
+/// The version's canonical body is the row's own `v.body` column — the form
+/// MATERIALIZED at write time from the same value the node rows decompose
+/// from — so a point read is ONE statement and one TOAST detoast, never a
+/// node-subtree re-aggregation. `NULL` is a logically deleted version (RM
+/// common master06 §Logical Deletion).
 macro_rules! version_select {
     ($tail:literal) => {
         concat!(
             "SELECT v.kind, v.ehr_id, v.sys_version, v.trunk_version, v.branch_number, ",
             "v.branch_version, v.lifecycle_state, v.creating_system_id, v.preceding_version_uid, ",
             "v.other_input_version_uids, v.contribution_id, v.template_id, v.signature, ",
-            "v.signature_client_supplied, v.wrapped_original, v.stable_compatible, ",
+            "v.signature_client_supplied, v.wrapped_original, v.stable_compatible, v.body, ",
             "a.system_id, a.change_type, a.description, a.committer, a.attestation, ",
             "a.time_committed, ",
-            "att.attestations_at_committal, att.attestations_after_committal, ",
-            "nd.node_rows ",
+            "att.attestations_at_committal, att.attestations_after_committal ",
             "FROM vo_version v JOIN audit a ON a.id = v.audit_id ",
             "LEFT JOIN LATERAL (",
             "SELECT coalesce(jsonb_agg(x.data ORDER BY x.time_committed, x.id) ",
@@ -164,69 +160,15 @@ macro_rules! version_select {
             "FROM vo_attestation x ",
             "WHERE x.vo_id = v.vo_id AND x.sys_version = v.sys_version",
             ") att ON true ",
-            "LEFT JOIN LATERAL (",
-            "SELECT jsonb_agg(jsonb_build_array(n.num, n.num_cap, n.parent_num, n.path, n.data) ",
-            "ORDER BY n.num) AS node_rows ",
-            "FROM node n ",
-            "WHERE n.vo_id = v.vo_id AND n.sys_version = v.sys_version",
-            ") nd ON true ",
             $tail
         )
     };
 }
 
-/// Decode the `nd.node_rows` LATERAL aggregate into the lean [`ReadRow`]s and
-/// reassemble the canonical body; `None`/`NULL` (no node rows) is a logically
-/// deleted version and reassembles to [`Value::Null`] (RM common master06
-/// §Logical Deletion).
-fn canonical_from_node_rows(vo_id: VoId, node_rows: Option<Value>) -> Result<Value, StorageError> {
-    let Some(Value::Array(tuples)) = node_rows else {
-        return Ok(Value::Null);
-    };
-    let rows: Vec<ReadRow> = tuples
-        .into_iter()
-        .map(|tuple| {
-            let Value::Array(mut f) = tuple else {
-                return Err(StorageError::InvalidRows(format!(
-                    "node_rows aggregate of {vo_id} holds a non-array element"
-                )));
-            };
-            let bad = |what: &str| {
-                StorageError::InvalidRows(format!(
-                    "node_rows aggregate of {vo_id} has a malformed {what}"
-                ))
-            };
-            if f.len() != 5 {
-                return Err(bad("tuple arity"));
-            }
-            let data = f.pop().unwrap_or(Value::Null);
-            let Some(Value::String(path)) = f.pop() else {
-                return Err(bad("path"));
-            };
-            let int = |v: Option<Value>, what: &str| -> Result<i32, StorageError> {
-                v.and_then(|v| v.as_i64())
-                    .and_then(|n| i32::try_from(n).ok())
-                    .ok_or_else(|| bad(what))
-            };
-            let parent_num = int(f.pop(), "parent_num")?;
-            let num_cap = int(f.pop(), "num_cap")?;
-            let num = int(f.pop(), "num")?;
-            Ok(ReadRow {
-                num,
-                num_cap,
-                parent_num,
-                path,
-                data,
-            })
-        })
-        .collect::<Result<_, _>>()?;
-    reassemble(&rows)
-}
-
-/// Build a [`StoredVersion`] from a `vo_version`⋈`audit` row, the canonical
-/// body reassembled from the row's own `nd.node_rows` LATERAL aggregate —
-/// the whole version read is the ONE statement that produced `row`, on
-/// whichever tier's connection ran it.
+/// Build a [`StoredVersion`] from a `vo_version`⋈`audit` row; the canonical
+/// body is the row's own materialized `body` column (`NULL` → [`Value::Null`],
+/// a logical delete), so the whole version read is the ONE statement that
+/// produced `row`, on whichever tier's connection ran it.
 fn stored_version(vo_id: VoId, row: &PgRow) -> Result<StoredVersion, StorageError> {
     let sys_version: i32 = row.try_get("sys_version")?;
     // A stored `other_input_version_uids` that does not decode is OUR data
@@ -245,7 +187,9 @@ fn stored_version(vo_id: VoId, row: &PgRow) -> Result<StoredVersion, StorageErro
             ))
         })?
         .unwrap_or_default();
-    let canonical = canonical_from_node_rows(vo_id, row.try_get("node_rows")?)?;
+    let canonical = row
+        .try_get::<Option<Value>, _>("body")?
+        .unwrap_or(Value::Null);
     // The attestations arrive folded into the version-select row (the LATERAL
     // aggregates in `version_select!`), in commit order and already split on
     // `at_committal` — no separate round trip.

--- a/app/ferroehr/src/versioning/change.rs
+++ b/app/ferroehr/src/versioning/change.rs
@@ -756,6 +756,15 @@ async fn commit_resolved(
     let (signature, signature_client_supplied) =
         version_signature(ctx, audit, contribution_id, &r, &at_committal_attestations)?;
 
+    // NOTE: `vo_version.body` reassembles from the SAME rows `write_nodes`
+    // stores below, so the materialized body is byte-identical to the node
+    // reassembly point reads formerly performed; empty rows = logical delete.
+    let body = if r.rows.is_empty() {
+        None
+    } else {
+        Some(reassemble(&r.rows)?)
+    };
+
     let folded = crate::storage::version_repo::commit::FoldedVersion {
         vo_id: r.vo_id,
         kind: r.kind.as_str(),
@@ -771,6 +780,7 @@ async fn commit_resolved(
         signature: signature.as_deref(),
         signature_client_supplied,
         stable_compatible: r.stable_compatible,
+        body: body.as_ref(),
     };
     let time_committed = match contribution {
         ContributionCtx::New => {

--- a/app/ferroehr/src/versioning/import.rs
+++ b/app/ferroehr/src/versioning/import.rs
@@ -577,6 +577,7 @@ async fn commit_import_scoped(
                     wrapped_original: &wrapped_original,
                     lower,
                     upper,
+                    body: (!served.is_null()).then_some(&served),
                 },
             )
             .await?;

--- a/app/ferroehr/tests/it/persistence.rs
+++ b/app/ferroehr/tests/it/persistence.rs
@@ -342,6 +342,7 @@ async fn a_trunk_position_is_unique_across_creating_systems_but_a_branch_id_is_n
             signature_client_supplied: false,
             creating_system_id: system,
             wrapped_original: None,
+            body: None,
         }
     };
 
@@ -458,6 +459,7 @@ async fn an_as_of_read_resolves_along_the_trunk() {
         signature_client_supplied: false,
         creating_system_id: "sysB.example.org",
         wrapped_original: None,
+        body: None,
     };
     let mut conn = pool.acquire().await.expect("connection");
 
@@ -832,4 +834,41 @@ fn corpus_sample() -> Value {
     );
     serde_json::from_str(&std::fs::read_to_string(path).expect("read ips_canonical.json"))
         .expect("parse composition")
+}
+
+/// The materialized `vo_version.body` is byte-identical to the node-row
+/// reassembly on a REAL service commit — the parity the body column's whole
+/// design rests on (reads serve `body`; AQL reads the nodes; both must be the
+/// same canonical value, RM common master06 §Copying: a stored version is
+/// served verbatim).
+#[tokio::test]
+async fn materialized_body_matches_node_reassembly_on_a_real_commit() {
+    use ferroehr::service::FerroEhrService;
+    use ferroehr::storage::node_repo::read_version_canonical;
+
+    let db = testkit::db().await.expect("testkit database");
+    let pool = db.pool();
+    let service = FerroEhrService::new(pool.clone());
+    let ehr_id = service.create_ehr(None).await.expect("ehr create");
+
+    // The EHR create commits an EHR_STATUS through the full commit path.
+    let (vo, body): (Uuid, Option<Value>) = sqlx::query_as(
+        "SELECT vo_id, body FROM vo_version WHERE ehr_id = $1 AND kind = 'EHR_STATUS'",
+    )
+    .bind(ehr_id.0)
+    .fetch_one(&pool)
+    .await
+    .expect("status version row");
+    let body = body.expect("a content-bearing version materializes its body");
+    let reassembled = read_version_canonical(&pool, ferroehr::ids::VoId(vo), 1)
+        .await
+        .expect("node reassembly");
+    assert_eq!(
+        body, reassembled,
+        "vo_version.body must equal the node-row reassembly"
+    );
+    assert_eq!(
+        body.get("_type").and_then(Value::as_str),
+        Some("EHR_STATUS")
+    );
 }


### PR DESCRIPTION
Part of #2658 — fix 2, building on #2660 (the single-statement read).

The EXPLAIN of the merged read named its remaining cost: the node-subtree `jsonb_agg` LATERAL burned ~0.45 ms of PG CPU re-serializing ~60 fragments per body read. The body is now materialized once, at write time: `vo_version.body jsonb` (TOASTed out of the main row, so metadata scans stay slim), written by every vo_version writer from the SAME canonical the node rows decompose from — the local commit reassembles it from the very rows `write_nodes` stores (`versioning::change::commit_resolved`), the EHR-Extract import stores the `served = reassemble(rows)` it already computes, and the archive load stores the dumped body it already re-decomposes. `version_select!` reads `v.body` instead of aggregating; `NULL` = logical delete, exactly the prior semantics; the cold tier inherits the column through `LIKE` and `INSERT SELECT *`.

The node rows remain the AQL source of truth; a new parity test (`materialized_body_matches_node_reassembly_on_a_real_commit`) machine-pins `body == reassemble(nodes)` on a real service commit (RM common master06 §Copying — a stored version is served verbatim).

Measured (idle host, native release, fresh schema, ab keep-alive, 22 KB Vital signs composition):

| | before (#2660) | now |
|---|---|---|
| point read c=1 mean | 1.04–1.06 ms | **0.65–0.75 ms** |
| c=1 throughput | ~950 rps | **1,336–1,528 rps** |
| read statement PG exec | 0.62–0.72 ms | **0.085 ms** |

Storage cost: += the canonical JSON per stored version (deliberate — the read projection is materialized, the decomposed rows stay for querying). Greenfield baseline edited in place per the standing migration policy (#2452).

Gates: clippy `-p ferroehr --all-targets` clean, nextest 955/955 (incl. the new parity test; cold-tier/archive/dump-load/import suites green), fmt + comment-style clean, CNF artifact validate 0 findings, changelog updated.
