### PR TITLE
perf(versioning): one body assembly per commit; scalar pre-reads off the materialized body

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -30,3 +30,4 @@
 - [This is a rewrite, not inherited code](rewrite-not-inherited-code.md) — existing code is never assumed correct; read the ancestor spec + existing code before implementing; breaking changes preferred over preserving bad code; distrust instruments too
 - [One Closes keyword per issue; current milestone always](pr-closes-one-keyword-per-issue.md) — "Closes #1, #2, #3" closes only #1, verify after merge; every en-route issue goes in the CURRENT milestone, never the next
 - [Greenfield migrations editable](greenfield-migrations-editable.md) — migration files are edited in place while greenfield (deployments recreate); never add checksum/immutability machinery or re-file it as a defect
+- [Rewrite fn docs on update](rewrite-fn-docs-on-update.md) — always fully rewrite a touched function's doc comment; include the /// block in old_string so docs never orphan

--- a/.claude/memory/rewrite-fn-docs-on-update.md
+++ b/.claude/memory/rewrite-fn-docs-on-update.md
@@ -1,0 +1,26 @@
+---
+name: rewrite-fn-docs-on-update
+description: "Owner hard rule 2026-08-24 — when updating a function, fully rewrite its doc comment; never orphan or stale it"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 61772e07-7f45-4d64-a77c-e5be26729532
+  modified: 2026-08-24T15:53:29.402Z
+---
+
+Owner rule (2026-08-24, after two incidents in one day): whenever a function
+is updated — signature, behaviour, or a helper inserted above it — its `///`
+doc comment is REWRITTEN in full to describe the new reality. Never leave the
+old doc standing, never let an insertion orphan a doc comment onto the wrong
+item, and never keep "stupid long" stale prose.
+
+**Why:** an Edit whose `old_string` starts at `fn name(` leaves the doc
+comment above the match — an inserted item then absorbs the previous
+function's doc (compiles fine, docs land on the wrong fn). Happened with
+`version_signature`/`body_and_signature` and `first_version_root`.
+
+**How to apply:** every Edit that touches a fn includes the fn's doc comment
+in `old_string` (start the match at the `///` block, not at `fn`); after any
+signature/behaviour change, rewrite the whole doc block from scratch to the
+current contract (comments.md budgets apply). Verify no doc block sits
+directly above another `///` block after inserting items.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ workflow refuses a tag that has no matching section here.
   the node rows remain the AQL source of truth. Storage grows by roughly
   the size of each stored version's canonical JSON.
 
+- Commit and update paths do less per-request work: the version body is
+  assembled once per commit (it previously reassembled twice — once for the
+  signature, once for storage), the composition-update pre-read and the
+  cross-version invariant checks read two text scalars off the materialized
+  body instead of fetching and parsing JSON fragments, and the per-request
+  EHR_ACCESS gate shares the cached settings instead of cloning the access
+  list.
+
 ### Added
 
 - Admin console: the ADL 2 template detail shows the path catalog — the same

--- a/app/ferroehr-rest/src/extensions/access/ehr_access.rs
+++ b/app/ferroehr-rest/src/extensions/access/ehr_access.rs
@@ -259,7 +259,7 @@ pub(crate) async fn enforce(
             ));
         }
     };
-    let settings = settings.as_ref();
+    let settings = (*settings).as_ref();
 
     // 1. The per-EHR gate (every EHR-scoped route). A setting-less EHR falls
     // back to the server-wide disposition; with authz absent entirely there is

--- a/app/ferroehr/src/service/ehr/access.rs
+++ b/app/ferroehr/src/service/ehr/access.rs
@@ -139,13 +139,15 @@ impl FerroEhrService {
         Ok(EhrAccessSettings::from_ehr_access(&read.canonical))
     }
 
-    /// The EHR's current `EHR_ACCESS` scheme settings, cached per EHR — the
-    /// `EhrAccessAdapter` native-API extension: the protocol adapter
-    /// (`ferroehr-rest`) — the out-of-band access-decision point (SM
-    /// `openehr_platform/master02-overview.adoc`) — reads the settings through
-    /// this seam. The SM defines no `I_EHR_ACCESS` interface — no openEHR spec
-    /// governs this adapter, our own extension. `None` = default-open (no
-    /// settings, or a scheme this server does not understand).
+    /// The EHR's current `EHR_ACCESS` scheme settings, cached per EHR and
+    /// returned as the cache's own [`std::sync::Arc`] (the per-request gate
+    /// never clones an access list) — the `EhrAccessAdapter` native-API
+    /// extension: the protocol adapter (`ferroehr-rest`) — the out-of-band
+    /// access-decision point (SM `openehr_platform/master02-overview.adoc`)
+    /// — reads the settings through this seam. The SM defines no
+    /// `I_EHR_ACCESS` interface — no openEHR spec governs this adapter, our
+    /// own extension. `None` = default-open (no settings, or a scheme this
+    /// server does not understand).
     ///
     /// # Errors
     /// [`SmError`] when the cache-miss load (the `current_vo` + `read_current`
@@ -154,19 +156,17 @@ impl FerroEhrService {
     pub async fn current_ehr_access_settings(
         &self,
         ehr_id: EhrId,
-    ) -> Result<Option<EhrAccessSettings>, SmError> {
+    ) -> Result<std::sync::Arc<Option<EhrAccessSettings>>, SmError> {
         // Clone the (cheap, Arc-backed) service into an owned, `'static` load
         // future so `moka`'s single-flight `try_get_with` can drive it.
         let svc = self.clone();
-        let cached = self
-            .ehr_access
+        self.ehr_access
             .get_or_load(
                 ehr_id,
                 async move { svc.load_ehr_access_settings(ehr_id).await },
             )
             .await
-            .map_err(|e| (*e).clone())?;
-        Ok((*cached).clone())
+            .map_err(|e| (*e).clone())
     }
 }
 

--- a/app/ferroehr/src/service/ehr/composition.rs
+++ b/app/ferroehr/src/service/ehr/composition.rs
@@ -385,10 +385,7 @@ impl FerroEhrService {
         // is_persistent across versions but not
         // archetype_details.template_id) — our own design convention,
         // consistent with those container invariants.
-        let stored_template = current
-            .root_data
-            .as_ref()
-            .and_then(|d| composition_template_id(d));
+        let stored_template = current.stored_template.as_deref();
         if let (Some(stored), Some(incoming)) =
             (stored_template, composition_template_id(&composition))
             && stored != incoming

--- a/app/ferroehr/src/service/ehr/validation.rs
+++ b/app/ferroehr/src/service/ehr/validation.rs
@@ -348,19 +348,13 @@ pub(in crate::service) async fn check_versioned_composition_invariants(
     // NOTE: no openEHR spec governs the `spec_profile` gate — our own
     // design/extension: this write-path read compares two root fields and
     // serves nothing, so it stays ungated.
-    let Some(first) = crate::storage::node_repo::first_version_root(tx, vo_id).await? else {
+    let Some((first_ani, first_category)) =
+        crate::storage::node_repo::first_version_root(tx, vo_id).await?
+    else {
         // No stored content version (e.g. every prior version deleted) — no
         // first-version root to compare against.
         return Ok(());
     };
-    let first_ani = first
-        .get("archetype_node_id")
-        .and_then(Value::as_str)
-        .map(str::to_owned);
-    let first_category = first
-        .pointer("/category/defining_code/code_string")
-        .and_then(Value::as_str)
-        .map(str::to_owned);
     let incoming_ani = canonical.get("archetype_node_id").and_then(Value::as_str);
     if let (Some(stored), Some(incoming)) = (first_ani.as_deref(), incoming_ani)
         && stored != incoming

--- a/app/ferroehr/src/storage/node_repo.rs
+++ b/app/ferroehr/src/storage/node_repo.rs
@@ -337,20 +337,26 @@ pub async fn read_subtrees_canonical(
     Ok(out)
 }
 
-/// The root node fragment (`num = 0`) of the FIRST stored content version of
-/// an object — the anchor for cross-version invariants (a root fragment is
-/// small: children are pruned by the decomposition).
+/// The `(archetype_node_id, category code)` of the FIRST stored content
+/// version of an object — the two scalars the cross-version invariants
+/// compare, read as text off the materialized `vo_version.body`.
 ///
-/// `None` when no content version exists (e.g. every prior version deleted).
+/// `None` when no content version exists (e.g. every prior version deleted);
+/// either scalar is `None` when the stored body lacks that field.
 ///
 /// # Errors
 /// Returns [`StorageError::Database`] on a driver failure.
 pub async fn first_version_root(
     tx: &mut PgConnection,
     vo_id: VoId,
-) -> Result<Option<Value>, StorageError> {
-    Ok(sqlx::query_scalar(
-        "SELECT data FROM node WHERE vo_id = $1 AND num = 0 ORDER BY sys_version LIMIT 1",
+) -> Result<Option<(Option<String>, Option<String>)>, StorageError> {
+    // Two text scalars off the materialized body — never a fragment fetch and
+    // a Value parse for a two-field comparison.
+    Ok(sqlx::query_as(
+        "SELECT body ->> 'archetype_node_id', \
+         body #>> '{category,defining_code,code_string}' \
+         FROM vo_version WHERE vo_id = $1 AND body IS NOT NULL \
+         ORDER BY sys_version LIMIT 1",
     )
     .bind(vo_id)
     .fetch_optional(&mut *tx)

--- a/app/ferroehr/src/storage/version_repo/meta.rs
+++ b/app/ferroehr/src/storage/version_repo/meta.rs
@@ -648,13 +648,12 @@ pub async fn current_demographic_meta(
 ///   (RM common master06 §Version Identification / §Committal);
 /// - the EHR's promoted `is_modifiable` flag (the content-write guard, RM ehr
 ///   master04 §EHR Active Status) via the `ehr` join;
-/// - the **root node fragment** (`num = 0`, children pruned) from which the
-///   modify path reads the declared `archetype_details.template_id.value` —
-///   **without** reassembling every node the full
-///   [`crate::storage::version_repo::read::read_current`] pays.
+/// - the stored `archetype_details.template_id.value` as ONE text scalar off
+///   the materialized `vo_version.body` — the modify path's template-stability
+///   check needs nothing else from the content.
 ///
-/// `root_data` is `None` for a deleted current (a logical delete stores no node
-/// rows). `None` when the object has no current trunk version (a COMPOSITION
+/// `stored_template` is `None` for a deleted current (`body` is NULL) or an
+/// undeclared template. `None` when the object has no current trunk version (a COMPOSITION
 /// always owns an `ehr`, so the inner join never drops a live row). No openEHR
 /// spec governs the SQL — our own design.
 #[derive(Debug, Clone)]
@@ -675,9 +674,9 @@ pub struct CurrentCompositionMeta {
     pub time_committed: jiff::Timestamp,
     /// The EHR's promoted `is_modifiable` flag — the content-write guard.
     pub is_modifiable: bool,
-    /// The root node's canonical JSON fragment (children pruned), or `None`
-    /// for a deleted current, which stores no node rows.
-    pub root_data: Option<Value>,
+    /// The stored `archetype_details.template_id.value`, or `None` for a
+    /// deleted current (NULL `body`) or an undeclared template.
+    pub stored_template: Option<String>,
 }
 
 /// Read the lean [`CurrentCompositionMeta`] for a COMPOSITION's current version.
@@ -688,16 +687,16 @@ pub async fn current_composition_meta(
     pool: &PgPool,
     vo_id: VoId,
 ) -> Result<Option<CurrentCompositionMeta>, StorageError> {
-    // On the cold-tier retry `node` resolves to the archival mirror while `ehr`
-    // and `audit`, which are never moved, keep resolving to the primary schema.
+    // On the cold-tier retry `vo_version` resolves to the archival mirror while
+    // `ehr` and `audit`, which are never moved, keep resolving to the primary
+    // schema.
     const SQL: &str = "SELECT v.ehr_id, v.lifecycle_state, v.trunk_version, v.branch_number, \
                        v.branch_version, v.creating_system_id, a.time_committed, \
-                       e.is_modifiable, n.data AS root_data \
+                       e.is_modifiable, \
+                       v.body #>> '{archetype_details,template_id,value}' AS stored_template \
                        FROM vo_version v \
                        JOIN audit a ON a.id = v.audit_id \
                        JOIN ehr e ON e.id = v.ehr_id \
-                       LEFT JOIN node n ON n.vo_id = v.vo_id \
-                       AND n.sys_version = v.sys_version AND n.num = 0 \
                        WHERE v.vo_id = $1 AND upper_inf(v.sys_period) AND v.branch_number = 0";
     let mut found = sqlx::query(SQL).bind(vo_id).fetch_optional(pool).await?;
     if found.is_none() {
@@ -720,7 +719,7 @@ pub async fn current_composition_meta(
             .try_get::<jiff_sqlx::Timestamp, _>("time_committed")?
             .to_jiff(),
         is_modifiable: row.try_get("is_modifiable")?,
-        root_data: row.try_get("root_data")?,
+        stored_template: row.try_get("stored_template")?,
     }))
 }
 

--- a/app/ferroehr/src/versioning/change.rs
+++ b/app/ferroehr/src/versioning/change.rs
@@ -753,17 +753,8 @@ async fn commit_resolved(
     .map(openehr_its::json::to_canonical_value)
     .collect();
 
-    let (signature, signature_client_supplied) =
-        version_signature(ctx, audit, contribution_id, &r, &at_committal_attestations)?;
-
-    // NOTE: `vo_version.body` reassembles from the SAME rows `write_nodes`
-    // stores below, so the materialized body is byte-identical to the node
-    // reassembly point reads formerly performed; empty rows = logical delete.
-    let body = if r.rows.is_empty() {
-        None
-    } else {
-        Some(reassemble(&r.rows)?)
-    };
+    let (body, signature, signature_client_supplied) =
+        body_and_signature(ctx, audit, contribution_id, &r, &at_committal_attestations)?;
 
     let folded = crate::storage::version_repo::commit::FoldedVersion {
         vo_id: r.vo_id,
@@ -839,16 +830,46 @@ async fn commit_resolved(
     ))
 }
 
+/// Reassemble the version body ONCE and derive the signature over it.
+///
+/// The value the signature covers, the stored `vo_version.body`, and the value
+/// point reads serve are the same bytes by construction — the rows are the
+/// ones `write_nodes` stores; empty rows = logical delete (`None` body).
+///
+/// # Errors
+/// The reassembly [`ServiceError`] or the signer's failure.
+fn body_and_signature(
+    ctx: &SigningCtx<'_>,
+    audit: &AuditInput,
+    contribution_id: Uuid,
+    r: &ResolvedWrite,
+    at_committal_attestations: &[Value],
+) -> Result<(Option<Value>, Option<String>, bool), ServiceError> {
+    let body = if r.rows.is_empty() {
+        None
+    } else {
+        Some(reassemble(&r.rows)?)
+    };
+    let (signature, client_supplied) = version_signature(
+        ctx,
+        audit,
+        contribution_id,
+        r,
+        body.as_ref(),
+        at_committal_attestations,
+    )?;
+    Ok((body, signature, client_supplied))
+}
+
 /// The signature stored with the version, and whether it is **client-supplied**
 /// (foreign — stored verbatim, never re-verified at read; master06 §Digital
 /// Signature) vs server-generated. A client-supplied signature is kept verbatim;
-/// otherwise, with server signing enabled, the version's canonical form is
-/// signed — a logically deleted version has no nodes → Void (master06 §Logical
-/// Deletion); a content version signs the reassembled served bytes so the digest
-/// recomputes at read time. Reassembly runs only when a signature will actually
-/// be computed. `at_committal_attestations` are the completed `ATTESTATION`s
-/// committed with the version, which the signed form includes (master06
-/// §Digital Signature: "the entire Version object").
+/// otherwise, with server signing enabled, the pre-reassembled `body` is signed
+/// — a logically deleted version signs Void (master06 §Logical Deletion), and a
+/// content version signs the same served bytes reads return, so the digest
+/// recomputes at read time. `at_committal_attestations` are the completed
+/// `ATTESTATION`s committed with the version, which the signed form includes
+/// (master06 §Digital Signature: "the entire Version object").
 ///
 /// # Errors
 /// [`ServiceError::Signing`] when the canonical form cannot be produced or the
@@ -858,6 +879,7 @@ fn version_signature(
     audit: &AuditInput,
     contribution_id: Uuid,
     r: &ResolvedWrite,
+    body: Option<&Value>,
     at_committal_attestations: &[Value],
 ) -> Result<(Option<String>, bool), ServiceError> {
     if let Some(client) = &r.client_signature {
@@ -866,11 +888,8 @@ fn version_signature(
     if !ctx.signer.enabled() {
         return Ok((None, false));
     }
-    let served = if r.rows.is_empty() {
-        Value::Null
-    } else {
-        reassemble(&r.rows)?
-    };
+    // The signed content is the SAME reassembled value the caller stores as
+    // `vo_version.body` — computed once, never re-reassembled here.
     let signature = integrity::sign_version(
         ctx,
         audit,
@@ -880,7 +899,7 @@ fn version_signature(
         r.preceding_uid.as_deref(),
         contribution_id,
         &r.lifecycle,
-        &served,
+        body.unwrap_or(&Value::Null),
         at_committal_attestations,
     )?;
     Ok((signature, false))

--- a/app/ferroehr/tests/it/service_ehr_access.rs
+++ b/app/ferroehr/tests/it/service_ehr_access.rs
@@ -112,7 +112,9 @@ async fn ehr_access_settings_round_trip_through_contribution() {
     let settings = svc
         .current_ehr_access_settings(ehr_id)
         .await
-        .expect("read settings")
+        .expect("read settings");
+    let settings = (*settings)
+        .as_ref()
         .expect("scheme settings present after commit");
     assert_eq!(settings.gate_keeper.as_deref(), Some("user:alice"));
     assert_eq!(settings.default_access, DefaultAccess::Restricted);


### PR DESCRIPTION
Part of #2658 — fix 3, the write-path CPU wave from the hot-path inventory.

- `versioning::change`: the commit path assembled the identical document twice per commit — once inside `version_signature` (the signed `served` value) and once for `vo_version.body`. A new `body_and_signature` helper reassembles ONCE and signs that same value; byte-identical signatures by construction (the same rows feed both), one document-sized deep copy removed from every commit.
- `current_composition_meta` (the composition-update pre-read) dropped its `node num=0` join: the template-stability check now reads `v.body #>> '{archetype_details,template_id,value}'` as one text scalar — no fragment detoast, no `Value` parse.
- `first_version_root` (the VERSIONED_COMPOSITION cross-version invariants — also the per-member pre-check of CONTRIBUTION commits) now selects the two compared scalars (`archetype_node_id`, category code) as text off the materialized body instead of fetching and parsing the root fragment per call.
- `current_ehr_access_settings` returns the cache's own `Arc` — the per-request EHR_ACCESS gate no longer clones the access list.

All wire-identical. Gates: clippy `--all-targets` clean on `ferroehr` + `ferroehr-rest`, nextest **1727/1727** across both, fmt + comment-style clean, changelog entry added.
