### PR TITLE
perf(aql): root-anchored projections serve the materialized body; result assembly stops copying the page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ workflow refuses a tag that has no matching section here.
   the node rows remain the AQL source of truth. Storage grows by roughly
   the size of each stored version's canonical JSON.
 
+- AQL whole-object projections got cheaper end to end: a root-anchored
+  projection (`SELECT c FROM … CONTAINS COMPOSITION c`) serves the
+  materialized version body directly instead of re-aggregating and
+  reassembling the node subtree, and the `RESULT_SET` assembly moves each
+  document into its cell and into the response envelope instead of
+  deep-copying the page three times on the way out.
 - Commit and update paths do less per-request work: the version body is
   assembled once per commit (it previously reassembled twice — once for the
   signature, once for storage), the composition-update pre-read and the

--- a/app/ferroehr/src/aql/exec.rs
+++ b/app/ferroehr/src/aql/exec.rs
@@ -133,18 +133,34 @@ pub async fn execute(
         crate::versioning::profile::gate_result_bodies(pool, profile, &anchors)
             .await
             .map_err(ExecError::Profile)?;
-        let subtrees = crate::storage::node_repo::read_subtrees_canonical(pool, &anchors)
+        let mut subtrees = crate::storage::node_repo::read_subtrees_canonical(pool, &anchors)
             .await
             .map_err(ExecError::from)?;
+        // Each reassembled document MOVES into its last pending cell; only a
+        // repeated anchor (the same version projected more than once on the
+        // page) pays a clone for the earlier cells.
+        let mut remaining: std::collections::HashMap<SubtreeAnchor, usize> =
+            std::collections::HashMap::new();
+        for (_, _, anchor) in &pending {
+            *remaining.entry(*anchor).or_insert(0) += 1;
+        }
         for (ri, ci, anchor) in pending {
+            let last_use = remaining.get_mut(&anchor).is_none_or(|n| {
+                *n -= 1;
+                *n == 0
+            });
+            let value = if last_use {
+                subtrees.remove(&anchor)
+            } else {
+                subtrees.get(&anchor).cloned()
+            };
             // `(ri, ci)` was recorded while building `out_rows`, so the cell
             // exists; fetched rather than indexed so a future refactor cannot
             // turn a bookkeeping slip into a panic on a request path.
-            if let (Some(value), Some(cell)) = (
-                subtrees.get(&anchor),
-                out_rows.get_mut(ri).and_then(|row| row.get_mut(ci)),
-            ) {
-                *cell = value.clone();
+            if let (Some(value), Some(cell)) =
+                (value, out_rows.get_mut(ri).and_then(|row| row.get_mut(ci)))
+            {
+                *cell = value;
             }
         }
     }

--- a/app/ferroehr/src/aql/ir.rs
+++ b/app/ferroehr/src/aql/ir.rs
@@ -751,6 +751,12 @@ impl Params {
     pub fn get(&self, name: &str) -> Option<&ParamValue> {
         self.values.get(name)
     }
+
+    /// Whether no parameter is bound.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
 }
 
 /// A typed query-parameter value.

--- a/app/ferroehr/src/service/ehr/access.rs
+++ b/app/ferroehr/src/service/ehr/access.rs
@@ -156,7 +156,7 @@ impl FerroEhrService {
     pub async fn current_ehr_access_settings(
         &self,
         ehr_id: EhrId,
-    ) -> Result<std::sync::Arc<Option<EhrAccessSettings>>, SmError> {
+    ) -> Result<Arc<Option<EhrAccessSettings>>, SmError> {
         // Clone the (cheap, Arc-backed) service into an owned, `'static` load
         // future so `moka`'s single-flight `try_get_with` can drive it.
         let svc = self.clone();

--- a/app/ferroehr/src/service/query/execute.rs
+++ b/app/ferroehr/src/service/query/execute.rs
@@ -196,7 +196,7 @@ impl FerroEhrService {
         // `_executed_aql` carries the parameter-SUBSTITUTED text; `q` keeps
         // the original query as submitted.
         let executed = substitute_params(aql, &params);
-        let mut outcome = QueryOutcome::plain(result_set_json(aql, &executed, name, &result));
+        let mut outcome = QueryOutcome::plain(result_set_json(aql, &executed, name, result));
         // ABAC query post-check attributes (no openEHR spec governs this —
         // our own access-control extension): collect the touched EHR/template
         // sets independently of the projection, when the PEP asked for them.

--- a/app/ferroehr/src/service/query/result_set.rs
+++ b/app/ferroehr/src/service/query/result_set.rs
@@ -83,6 +83,10 @@ static PARAM_REF: LazyLock<Regex> = LazyLock::new(|| {
 /// literal form, `Null` as `NULL`; a `$name` with no binding is left verbatim
 /// (the engine already rejects an unbound parameter at planning time).
 pub(super) fn substitute_params(aql: &str, params: &Params) -> String {
+    if params.is_empty() {
+        // Nothing to substitute — skip the regex scan of the query text.
+        return aql.to_owned();
+    }
     PARAM_REF
         .replace_all(aql, |caps: &regex::Captures<'_>| {
             match params.get(&caps[1]) {
@@ -127,7 +131,7 @@ pub(super) fn result_set_json(
     aql: &str,
     executed: &str,
     name: Option<&str>,
-    result: &QueryResult,
+    result: QueryResult,
 ) -> Value {
     let columns: Vec<ResultSetColumn> = result
         .columns
@@ -166,7 +170,10 @@ pub(super) fn result_set_json(
         name: name.map(ToOwned::to_owned),
         q: Some(aql.to_owned()),
         columns: Some(columns),
-        rows: result.rows.clone(),
+        // The envelope serializes with EMPTY rows; the real rows are MOVED
+        // into the serialized map below, so a page of documents is never
+        // deep-copied by `to_value`.
+        rows: Vec::new(),
     };
 
     // Every optional property the DTOs leave `None` is OMITTED, not rendered as
@@ -176,5 +183,12 @@ pub(super) fn result_set_json(
     // an OpenAPI 3.0 `type: string` property does not admit `null`
     // (<https://spec.openapis.org/oas/v3.0.3#schema-object>). `rows` cells are
     // untouched — an unset AQL leaf is a genuine `null` there.
-    serde_json::to_value(&set).unwrap_or(Value::Null)
+    let mut envelope = serde_json::to_value(&set).unwrap_or(Value::Null);
+    if let Value::Object(map) = &mut envelope {
+        map.insert(
+            "rows".to_owned(),
+            Value::Array(result.rows.into_iter().map(Value::Array).collect()),
+        );
+    }
+    envelope
 }

--- a/app/ferroehr/src/storage/node_repo.rs
+++ b/app/ferroehr/src/storage/node_repo.rs
@@ -238,6 +238,13 @@ pub struct SubtreeAnchor {
 /// data Void, RM common master06 §Logical Deletion) is **absent** from the map;
 /// the caller treats a miss as [`Value::Null`], its empty-subtree result.
 ///
+/// A ROOT anchor (`num == 0` — the whole version, the dominant projection
+/// shape `SELECT c FROM … CONTAINS COMPOSITION c`) is served straight from the
+/// materialized `vo_version.body` with zero node rows and zero reassembly;
+/// only genuine sub-tree anchors take the interval join. The two forms are
+/// byte-identical by the commit-time parity invariant (`body` is written from
+/// the same rows the node store holds).
+///
 /// # Errors
 /// Returns [`StorageError`] on a driver failure, or if any anchor's fetched rows
 /// do not reassemble into one tree.
@@ -258,6 +265,16 @@ pub async fn read_subtrees_canonical(
             distinct.push(*anchor);
             distinct.len() - 1
         });
+    }
+
+    // Root anchors (`num == 0`) are whole versions — served from the
+    // materialized body with no node rows; only genuine sub-tree anchors
+    // proceed to the interval join.
+    let roots: Vec<SubtreeAnchor> = distinct.iter().filter(|a| a.num == 0).copied().collect();
+    let mut out = read_root_bodies(pool, &roots).await?;
+    let distinct: Vec<SubtreeAnchor> = distinct.into_iter().filter(|a| a.num != 0).collect();
+    if distinct.is_empty() {
+        return Ok(out);
     }
 
     let idx: Vec<i32> = (0..distinct.len())
@@ -298,7 +315,6 @@ pub async fn read_subtrees_canonical(
         ));
     }
 
-    let mut out: HashMap<SubtreeAnchor, Value> = HashMap::with_capacity(distinct.len());
     for (group_idx, mut nodes) in grouped {
         // The anchor is the lowest-`num` row (the queried `num`); its path is the
         // prefix to strip so descendants re-root at it (the anchor-relative
@@ -333,6 +349,52 @@ pub async fn read_subtrees_canonical(
             })
             .collect();
         out.insert(anchor, reassemble(&read_rows)?);
+    }
+    Ok(out)
+}
+
+/// The materialized bodies of whole-version (root) anchors, keyed by anchor —
+/// one `unnest` join against `vo_version.body`, no node rows, no reassembly.
+///
+/// An anchor whose version has a `NULL` body (a logical delete) is absent
+/// from the map — the same miss contract the interval join produces.
+///
+/// # Errors
+/// Returns [`StorageError::Database`] on a driver failure.
+async fn read_root_bodies(
+    pool: &PgPool,
+    roots: &[SubtreeAnchor],
+) -> Result<HashMap<SubtreeAnchor, Value>, StorageError> {
+    let mut out: HashMap<SubtreeAnchor, Value> = HashMap::with_capacity(roots.len());
+    if roots.is_empty() {
+        return Ok(out);
+    }
+    let vo_ids: Vec<Uuid> = roots.iter().map(|a| a.vo_id.0).collect();
+    let sys_versions: Vec<i32> = roots.iter().map(|a| a.sys_version).collect();
+    let rows = sqlx::query(
+        "SELECT v.vo_id, v.sys_version, v.body \
+         FROM unnest($1::uuid[], $2::int[]) AS a(vo_id, sys_version) \
+         JOIN vo_version v \
+           ON v.vo_id = a.vo_id AND v.sys_version = a.sys_version \
+         WHERE v.body IS NOT NULL",
+    )
+    .bind(&vo_ids)
+    .bind(&sys_versions)
+    .fetch_all(pool)
+    .await?;
+    let mut by_key: HashMap<(Uuid, i32), Value> = rows
+        .into_iter()
+        .map(|row| {
+            Ok((
+                (row.try_get("vo_id")?, row.try_get("sys_version")?),
+                row.try_get("body")?,
+            ))
+        })
+        .collect::<Result<_, StorageError>>()?;
+    for anchor in roots {
+        if let Some(body) = by_key.remove(&(anchor.vo_id.0, anchor.sys_version)) {
+            out.insert(*anchor, body);
+        }
     }
     Ok(out)
 }


### PR DESCRIPTION
Part of #2658 — fix 4, the AQL wave from the hot-path inventory.

- `read_subtrees_canonical` partitions its anchors: a **root anchor** (`num == 0` — the whole stored version, the dominant whole-object projection `SELECT c FROM … CONTAINS COMPOSITION c`) is served straight from the materialized `vo_version.body` through one `unnest` join — zero node rows fetched, zero reassembly CPU, byte-identical by the commit-time parity invariant. Genuine subtree anchors keep the interval join unchanged; a NULL body (logical delete) keeps the absent-from-map miss contract.
- The `RESULT_SET` pipeline had four document-sized copies per page (reassemble → cell clone → rows clone → `to_value` re-walk). Now: each document MOVES into its last pending cell (a clone only for a repeated anchor on the same page), and the rows array MOVES into the serialized envelope (the DTO serializes with empty rows; the real rows are inserted as `Value::Array` — the DTO-driven envelope shape is unchanged, `rows` stays present).
- `substitute_params` short-circuits when no parameter is bound — no regex scan of the query text per execution.

All wire-identical. Gates: clippy `--all-targets` clean, nextest **955/955**, fmt + comment-style clean, changelog entry added.
