### PR TITLE
perf(storage): one statement serves both tiers — the cold-tier retry machinery is gone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ workflow refuses a tag that has no matching section here.
   the node rows remain the AQL source of truth. Storage grows by roughly
   the size of each stored version's canonical JSON.
 
+- Every object-addressed read (full version reads and the metadata/existence
+  lookups behind `ETag`s, revision histories, and 404 checks) queries the
+  two-tier union view in ONE statement instead of retrying the cold archival
+  tier in its own transaction on a primary miss — a miss (an unknown id, a
+  not-yet-created resource, a probing client) no longer costs four extra
+  database round trips, and archived objects stay retrievable exactly as
+  before.
 - AQL whole-object projections got cheaper end to end: a root-anchored
   projection (`SELECT c FROM … CONTAINS COMPOSITION c`) serves the
   materialized version body directly instead of re-aggregating and

--- a/app/ferroehr/migrations/ehr/0007_cold_archive_tier.sql
+++ b/app/ferroehr/migrations/ehr/0007_cold_archive_tier.sql
@@ -132,9 +132,9 @@ CREATE VIEW vo_attestation_all WITH (security_invoker = true) AS
     UNION ALL
     SELECT * FROM cold.vo_attestation;
 
-COMMENT ON VIEW vo_version_all IS 'Both storage tiers of vo_version (primary UNION ALL cold). For whole-repository readers only (admin export, physical delete); serving reads consult the cold tier on a primary miss instead, so the hot path never scans it.';
-COMMENT ON VIEW node_all IS 'Both storage tiers of node (primary UNION ALL cold) — whole-repository readers only.';
-COMMENT ON VIEW vo_attestation_all IS 'Both storage tiers of vo_attestation (primary UNION ALL cold) — whole-repository readers only.';
+COMMENT ON VIEW vo_version_all IS 'Both storage tiers of vo_version (primary UNION ALL cold). Every object-addressed serving read goes through this view — one statement serves both tiers (the empty cold side costs one index probe); AQL and the EHR-wide enumerations stay primary-only.';
+COMMENT ON VIEW node_all IS 'Both storage tiers of node (primary UNION ALL cold) — the whole-repository readers (admin export, physical delete).';
+COMMENT ON VIEW vo_attestation_all IS 'Both storage tiers of vo_attestation (primary UNION ALL cold) — joined by every full version read.';
 
 -- ── vo_archive: the marker now drives a physical move ────────────────────────
 COMMENT ON TABLE vo_archive IS 'Archive markers realizing SM I_ADMIN_ARCHIVE (SM openehr_platform master15-admin_service.adoc); the SM defines no storage form — our own design. A marker records that the object''s rows have been MOVED to the cold archival tier (schema `cold`): serving reads find them there on a primary-tier miss, so archival stays read-neutral on the wire. Intentionally FK-less (vo_id is not a per-version key).';

--- a/app/ferroehr/src/service/admin/dump_load.rs
+++ b/app/ferroehr/src/service/admin/dump_load.rs
@@ -125,7 +125,6 @@ use crate::service::admin::types::{
 use crate::service::error::ServiceError;
 use crate::service::status::{CallStatusType, SmError};
 use crate::storage::codec::decompose;
-use crate::storage::version_repo::tier::Tier;
 use crate::storage::{node_repo, version_repo};
 use crate::versioning::audit::AuditInput;
 use crate::versioning::object_version_id::{TreeId, object_version_id};
@@ -1741,7 +1740,7 @@ impl FerroEhrService {
         let body = if lifecycle_state == DELETED_LIFECYCLE {
             Value::Null
         } else {
-            node_repo::read_version_canonical_in(&self.pool, vo_id, sys_version, Tier::Both).await?
+            node_repo::read_version_canonical_all(&self.pool, vo_id, sys_version).await?
         };
         Ok(VersionRecord {
             vo_id,
@@ -1856,8 +1855,7 @@ impl FerroEhrService {
             let body = if lifecycle_state == DELETED_LIFECYCLE {
                 Value::Null
             } else {
-                node_repo::read_version_canonical_in(&self.pool, vo_id, sys_version, Tier::Both)
-                    .await?
+                node_repo::read_version_canonical_all(&self.pool, vo_id, sys_version).await?
             };
             versions.push(VersionRecord {
                 vo_id,

--- a/app/ferroehr/src/storage/node_repo.rs
+++ b/app/ferroehr/src/storage/node_repo.rs
@@ -25,7 +25,6 @@ use crate::ids::{EhrId, VoId};
 use crate::storage::codec::reassemble;
 use crate::storage::error::StorageError;
 use crate::storage::row::{NodeRow, ReadRow};
-use crate::storage::version_repo::tier::{Tier, on_cold};
 
 /// Bulk-insert the decomposed node rows of one stored version.
 ///
@@ -113,37 +112,25 @@ const READ_ROWS_SQL: &str = "SELECT num, num_cap, parent_num, path, data \
 const READ_ROWS_ALL_SQL: &str = "SELECT num, num_cap, parent_num, path, data \
                                  FROM node_all WHERE vo_id = $1 AND sys_version = $2 ORDER BY num";
 
-/// Fetch the lean read rows of one stored version, ordered by `num`, from the
-/// requested storage tier (no openEHR spec governs storage tiering — our own
-/// design; see [`crate::storage::version_repo::tier`]).
+/// Fetch the lean read rows of one stored version, ordered by `num` —
+/// primary tier only, or both tiers through the `node_all` union view (no
+/// openEHR spec governs storage tiering — our own design).
 async fn read_rows(
     pool: &PgPool,
     vo_id: VoId,
     sys_version: i32,
-    tier: Tier,
+    both_tiers: bool,
 ) -> Result<Vec<ReadRow>, StorageError> {
-    let rows = match tier {
-        Tier::Primary => {
-            sqlx::query(READ_ROWS_SQL)
-                .bind(vo_id)
-                .bind(sys_version)
-                .fetch_all(pool)
-                .await?
-        }
-        Tier::Cold => on_cold!(pool, |conn| sqlx::query(READ_ROWS_SQL)
-            .bind(vo_id)
-            .bind(sys_version)
-            .fetch_all(&mut *conn)
-            .await),
-        Tier::Both => {
-            sqlx::query(READ_ROWS_ALL_SQL)
-                .bind(vo_id)
-                .bind(sys_version)
-                .fetch_all(pool)
-                .await?
-        }
+    let sql = if both_tiers {
+        READ_ROWS_ALL_SQL
+    } else {
+        READ_ROWS_SQL
     };
-
+    let rows = sqlx::query(sql)
+        .bind(vo_id)
+        .bind(sys_version)
+        .fetch_all(pool)
+        .await?;
     let mut read = Vec::with_capacity(rows.len());
     for row in rows {
         read.push(ReadRow {
@@ -157,9 +144,8 @@ async fn read_rows(
     Ok(read)
 }
 
-/// Reassemble one stored version's canonical JSON from its `node` rows — the
-/// single consolidated node→canonical reload (the version read path and the
-/// message/admin exports all call this by name).
+/// Reassemble one stored version's canonical JSON from its primary-tier
+/// `node` rows — the consolidated node→canonical reload.
 ///
 /// A version with no stored nodes (a logical delete — data Void, RM common
 /// master06 §Logical Deletion) reassembles to [`Value::Null`], so callers need
@@ -174,26 +160,27 @@ pub async fn read_version_canonical(
     vo_id: VoId,
     sys_version: i32,
 ) -> Result<Value, StorageError> {
-    read_version_canonical_in(pool, vo_id, sys_version, Tier::Primary).await
+    let rows = read_rows(pool, vo_id, sys_version, false).await?;
+    if rows.is_empty() {
+        return Ok(Value::Null);
+    }
+    reassemble(&rows)
 }
 
-/// Reassemble one stored version's canonical JSON from the requested storage
-/// tier ([`crate::storage::version_repo::tier`]).
-///
-/// [`read_version_canonical`] is the primary-tier form every ordinary caller
-/// uses.
+/// [`read_version_canonical`] over BOTH storage tiers (the `node_all` union
+/// view) — for the whole-repository readers (admin export, physical delete)
+/// that must see archived content by definition.
 ///
 /// # Errors
 ///
 /// Returns [`StorageError`] on a DB error or if a non-empty row set does not
 /// form one tree rooted at `num = 0`.
-pub async fn read_version_canonical_in(
+pub async fn read_version_canonical_all(
     pool: &PgPool,
     vo_id: VoId,
     sys_version: i32,
-    tier: Tier,
 ) -> Result<Value, StorageError> {
-    let rows = read_rows(pool, vo_id, sys_version, tier).await?;
+    let rows = read_rows(pool, vo_id, sys_version, true).await?;
     if rows.is_empty() {
         return Ok(Value::Null);
     }

--- a/app/ferroehr/src/storage/version_repo/meta.rs
+++ b/app/ferroehr/src/storage/version_repo/meta.rs
@@ -13,12 +13,12 @@
 //! §Version Identification; the commit instant is §Committal.
 //!
 //! NOTE (no openEHR spec governs storage tiering — our own design): every
-//! object-addressed lookup here falls back to the cold archival tier
-//! ([`crate::storage::version_repo::tier`]) ONLY when the primary tier misses,
-//! so an unarchived read costs exactly what it always did. The EHR-wide
-//! aggregate and enumeration reads at the bottom of this file stay
-//! primary-only: they answer for the operational store, which is precisely what
-//! an archived object has been moved out of.
+//! object-addressed lookup here reads the `vo_version_all` union view — ONE
+//! statement serving both tiers, so an archived object stays retrievable and
+//! a miss never pays a cold-tier retry transaction. The EHR-wide aggregate
+//! and enumeration reads at the bottom of this file stay primary-only: they
+//! answer for the operational store, which is precisely what an archived
+//! object has been moved out of.
 
 #![expect(
     clippy::disallowed_types,
@@ -32,7 +32,6 @@ use sqlx::{PgPool, Row};
 
 use crate::ids::{EhrId, VoId};
 use crate::storage::error::StorageError;
-use crate::storage::version_repo::tier::on_cold;
 
 // ── revision-history enumeration ──────────────────────────────────────────────
 
@@ -87,15 +86,9 @@ pub async fn all_version_meta(
                        v.branch_version, v.creating_system_id, v.lifecycle_state, \
                        a.system_id, a.change_type, a.description, a.committer, a.attestation, \
                        a.time_committed \
-                       FROM vo_version v JOIN audit a ON a.id = v.audit_id \
+                       FROM vo_version_all v JOIN audit a ON a.id = v.audit_id \
                        WHERE v.vo_id = $1 ORDER BY v.sys_version";
-    let mut rows = sqlx::query(SQL).bind(vo_id).fetch_all(pool).await?;
-    if rows.is_empty() {
-        rows = on_cold!(pool, |conn| sqlx::query(SQL)
-            .bind(vo_id)
-            .fetch_all(&mut *conn)
-            .await);
-    }
+    let rows = sqlx::query(SQL).bind(vo_id).fetch_all(pool).await?;
     rows.iter()
         .map(|row| {
             Ok(VersionMeta {
@@ -130,20 +123,12 @@ pub async fn time_created(
     pool: &PgPool,
     vo_id: VoId,
 ) -> Result<Option<jiff::Timestamp>, StorageError> {
-    const SQL: &str = "SELECT a.time_committed FROM vo_version v JOIN audit a ON a.id = v.audit_id \
-                       WHERE v.vo_id = $1 ORDER BY v.sys_version LIMIT 1";
-    let mut stamp = sqlx::query_scalar::<_, jiff_sqlx::Timestamp>(SQL)
+    const SQL: &str = "SELECT a.time_committed FROM vo_version_all v JOIN audit a ON a.id = v.audit_id \
+         WHERE v.vo_id = $1 ORDER BY v.sys_version LIMIT 1";
+    let stamp = sqlx::query_scalar::<_, jiff_sqlx::Timestamp>(SQL)
         .bind(vo_id)
         .fetch_optional(pool)
         .await?;
-    if stamp.is_none() {
-        stamp = on_cold!(pool, |conn| sqlx::query_scalar::<_, jiff_sqlx::Timestamp>(
-            SQL
-        )
-        .bind(vo_id)
-        .fetch_optional(&mut *conn)
-        .await);
-    }
     Ok(stamp.map(jiff_sqlx::Timestamp::to_jiff))
 }
 
@@ -166,23 +151,13 @@ pub async fn commit_bounds(
 ) -> Result<Option<(jiff::Timestamp, jiff::Timestamp)>, StorageError> {
     const SQL: &str = "SELECT min(a.time_committed) AS created, \
                        max(a.time_committed) AS modified \
-                       FROM vo_version v JOIN audit a ON a.id = v.audit_id WHERE v.vo_id = $1";
-    let bounds = |row: &PgRow| -> Result<Option<(jiff::Timestamp, jiff::Timestamp)>, StorageError> {
-        let created: Option<jiff_sqlx::Timestamp> = row.try_get("created")?;
-        let modified: Option<jiff_sqlx::Timestamp> = row.try_get("modified")?;
-        Ok(created
-            .zip(modified)
-            .map(|(c, m)| (c.to_jiff(), m.to_jiff())))
-    };
+                       FROM vo_version_all v JOIN audit a ON a.id = v.audit_id WHERE v.vo_id = $1";
     let row = sqlx::query(SQL).bind(vo_id).fetch_one(pool).await?;
-    if let Some(found) = bounds(&row)? {
-        return Ok(Some(found));
-    }
-    let cold_row = on_cold!(pool, |conn| sqlx::query(SQL)
-        .bind(vo_id)
-        .fetch_one(&mut *conn)
-        .await);
-    bounds(&cold_row)
+    let created: Option<jiff_sqlx::Timestamp> = row.try_get("created")?;
+    let modified: Option<jiff_sqlx::Timestamp> = row.try_get("modified")?;
+    Ok(created
+        .zip(modified)
+        .map(|(c, m)| (c.to_jiff(), m.to_jiff())))
 }
 
 /// The stored `template_id` of one version of an object — the current open
@@ -199,41 +174,24 @@ pub async fn template_id_of(
     vo_id: VoId,
     tree: Option<(i32, i32, i32)>,
 ) -> Result<Option<Option<String>>, StorageError> {
-    const BY_TREE_SQL: &str = "SELECT template_id FROM vo_version WHERE vo_id = $1 \
+    const BY_TREE_SQL: &str = "SELECT template_id FROM vo_version_all WHERE vo_id = $1 \
                                AND trunk_version = $2 AND branch_number = $3 \
                                AND branch_version = $4";
-    const CURRENT_SQL: &str = "SELECT template_id FROM vo_version WHERE vo_id = $1 \
+    const CURRENT_SQL: &str = "SELECT template_id FROM vo_version_all WHERE vo_id = $1 \
                                AND upper_inf(sys_period) AND branch_number = 0";
     if let Some((trunk, branch, branch_version)) = tree {
-        let primary: Option<Option<String>> = sqlx::query_scalar(BY_TREE_SQL)
+        return Ok(sqlx::query_scalar(BY_TREE_SQL)
             .bind(vo_id)
             .bind(trunk)
             .bind(branch)
             .bind(branch_version)
             .fetch_optional(pool)
-            .await?;
-        if primary.is_some() {
-            return Ok(primary);
-        }
-        return Ok(on_cold!(pool, |conn| sqlx::query_scalar(BY_TREE_SQL)
-            .bind(vo_id)
-            .bind(trunk)
-            .bind(branch)
-            .bind(branch_version)
-            .fetch_optional(&mut *conn)
-            .await));
+            .await?);
     }
-    let primary: Option<Option<String>> = sqlx::query_scalar(CURRENT_SQL)
+    Ok(sqlx::query_scalar(CURRENT_SQL)
         .bind(vo_id)
         .fetch_optional(pool)
-        .await?;
-    if primary.is_some() {
-        return Ok(primary);
-    }
-    Ok(on_cold!(pool, |conn| sqlx::query_scalar(CURRENT_SQL)
-        .bind(vo_id)
-        .fetch_optional(&mut *conn)
-        .await))
+        .await?)
 }
 
 // ── existence / kind / ownership ──────────────────────────────────────────────
@@ -258,19 +216,12 @@ pub async fn ehr_exists(pool: &PgPool, ehr_id: EhrId) -> Result<bool, StorageErr
 /// # Errors
 /// Returns [`StorageError::Database`] on a driver failure.
 pub async fn object_kind(pool: &PgPool, vo_id: VoId) -> Result<Option<String>, StorageError> {
-    const SQL: &str = "SELECT kind FROM vo_version WHERE vo_id = $1 AND upper_inf(sys_period) \
+    const SQL: &str = "SELECT kind FROM vo_version_all WHERE vo_id = $1 AND upper_inf(sys_period) \
                        AND branch_number = 0";
-    let primary: Option<String> = sqlx::query_scalar(SQL)
+    Ok(sqlx::query_scalar(SQL)
         .bind(vo_id)
         .fetch_optional(pool)
-        .await?;
-    if primary.is_some() {
-        return Ok(primary);
-    }
-    Ok(on_cold!(pool, |conn| sqlx::query_scalar(SQL)
-        .bind(vo_id)
-        .fetch_optional(&mut *conn)
-        .await))
+        .await?)
 }
 
 /// The kind text of the current version of EVERY object in `vo_ids`.
@@ -287,33 +238,15 @@ pub async fn object_kinds(
     pool: &PgPool,
     vo_ids: &[VoId],
 ) -> Result<Vec<(VoId, String)>, StorageError> {
-    const SQL: &str = "SELECT vo_id, kind FROM vo_version WHERE vo_id = ANY($1) \
+    const SQL: &str = "SELECT vo_id, kind FROM vo_version_all WHERE vo_id = ANY($1) \
                        AND upper_inf(sys_period) AND branch_number = 0";
     if vo_ids.is_empty() {
         return Ok(Vec::new());
     }
     let rows = sqlx::query(SQL).bind(vo_ids).fetch_all(pool).await?;
-    let mut found: Vec<(VoId, String)> = rows
-        .iter()
+    rows.iter()
         .map(|r| Ok((r.try_get("vo_id")?, r.try_get("kind")?)))
-        .collect::<Result<_, StorageError>>()?;
-    // Only the ids the primary tier did not answer for reach the cold tier.
-    let missing: Vec<VoId> = vo_ids
-        .iter()
-        .filter(|id| !found.iter().any(|(seen, _)| seen == *id))
-        .copied()
-        .collect();
-    if missing.is_empty() {
-        return Ok(found);
-    }
-    let cold_rows = on_cold!(pool, |conn| sqlx::query(SQL)
-        .bind(&missing)
-        .fetch_all(&mut *conn)
-        .await);
-    for row in &cold_rows {
-        found.push((row.try_get("vo_id")?, row.try_get("kind")?));
-    }
-    Ok(found)
+        .collect::<Result<_, StorageError>>()
 }
 
 /// The owning EHR of a versioned object (`None` when the object does not
@@ -322,18 +255,11 @@ pub async fn object_kinds(
 /// # Errors
 /// Returns [`StorageError::Database`] on a driver failure.
 pub async fn vo_owner(pool: &PgPool, vo_id: VoId) -> Result<Option<Option<EhrId>>, StorageError> {
-    const SQL: &str = "SELECT ehr_id FROM vo_version WHERE vo_id = $1 LIMIT 1";
-    let primary: Option<Option<EhrId>> = sqlx::query_scalar(SQL)
+    const SQL: &str = "SELECT ehr_id FROM vo_version_all WHERE vo_id = $1 LIMIT 1";
+    Ok(sqlx::query_scalar(SQL)
         .bind(vo_id)
         .fetch_optional(pool)
-        .await?;
-    if primary.is_some() {
-        return Ok(primary);
-    }
-    Ok(on_cold!(pool, |conn| sqlx::query_scalar(SQL)
-        .bind(vo_id)
-        .fetch_optional(&mut *conn)
-        .await))
+        .await?)
 }
 
 /// A versioned object's owning EHR **and its RM kind**.
@@ -349,16 +275,8 @@ pub async fn vo_owner_kind(
     pool: &PgPool,
     vo_id: VoId,
 ) -> Result<Option<(Option<EhrId>, String)>, StorageError> {
-    const SQL: &str = "SELECT ehr_id, kind FROM vo_version WHERE vo_id = $1 LIMIT 1";
-    let primary: Option<(Option<EhrId>, String)> =
-        sqlx::query_as(SQL).bind(vo_id).fetch_optional(pool).await?;
-    if primary.is_some() {
-        return Ok(primary);
-    }
-    Ok(on_cold!(pool, |conn| sqlx::query_as(SQL)
-        .bind(vo_id)
-        .fetch_optional(&mut *conn)
-        .await))
+    const SQL: &str = "SELECT ehr_id, kind FROM vo_version_all WHERE vo_id = $1 LIMIT 1";
+    Ok(sqlx::query_as(SQL).bind(vo_id).fetch_optional(pool).await?)
 }
 
 /// Whether a specific VERSION of a versioned object exists, addressed by its
@@ -373,27 +291,17 @@ pub async fn version_exists(
     branch_number: i32,
     branch_version: i32,
 ) -> Result<bool, StorageError> {
-    let primary: bool = sqlx::query_scalar(EXISTS_SQL)
+    Ok(sqlx::query_scalar(EXISTS_SQL)
         .bind(vo_id)
         .bind(trunk)
         .bind(branch_number)
         .bind(branch_version)
         .fetch_one(pool)
-        .await?;
-    if primary {
-        return Ok(true);
-    }
-    Ok(on_cold!(pool, |conn| sqlx::query_scalar(EXISTS_SQL)
-        .bind(vo_id)
-        .bind(trunk)
-        .bind(branch_number)
-        .bind(branch_version)
-        .fetch_one(&mut *conn)
-        .await))
+        .await?)
 }
 
-/// The version-addressed existence probe, shared by both tiers.
-const EXISTS_SQL: &str = "SELECT EXISTS(SELECT 1 FROM vo_version WHERE vo_id = $1 \
+/// The version-addressed existence probe (both tiers via the union view).
+const EXISTS_SQL: &str = "SELECT EXISTS(SELECT 1 FROM vo_version_all WHERE vo_id = $1 \
                           AND trunk_version = $2 AND branch_number = $3 \
                           AND branch_version = $4)";
 
@@ -426,21 +334,14 @@ pub async fn current_vo(
     ehr_id: EhrId,
     kind: &str,
 ) -> Result<Option<CurrentVoRow>, StorageError> {
-    const SQL: &str = "SELECT vo_id, trunk_version, branch_number, branch_version FROM vo_version \
+    const SQL: &str = "SELECT vo_id, trunk_version, branch_number, branch_version FROM vo_version_all \
                        WHERE ehr_id = $1 AND kind = $2 AND upper_inf(sys_period) \
                        AND branch_number = 0";
-    let mut found = sqlx::query(SQL)
+    let found = sqlx::query(SQL)
         .bind(ehr_id)
         .bind(kind)
         .fetch_optional(pool)
         .await?;
-    if found.is_none() {
-        found = on_cold!(pool, |conn| sqlx::query(SQL)
-            .bind(ehr_id)
-            .bind(kind)
-            .fetch_optional(&mut *conn)
-            .await);
-    }
     let Some(row) = found else {
         return Ok(None);
     };
@@ -506,21 +407,14 @@ pub async fn current_version_meta_by_kind(
 ) -> Result<Option<CurrentMeta>, StorageError> {
     const SQL: &str = "SELECT v.vo_id, v.trunk_version, v.branch_number, v.branch_version, \
                        v.creating_system_id, a.time_committed \
-                       FROM vo_version v JOIN audit a ON a.id = v.audit_id \
+                       FROM vo_version_all v JOIN audit a ON a.id = v.audit_id \
                        WHERE v.ehr_id = $1 AND v.kind = $2 AND upper_inf(v.sys_period) \
                        AND v.branch_number = 0";
-    let mut found = sqlx::query(SQL)
+    let found = sqlx::query(SQL)
         .bind(ehr_id)
         .bind(kind)
         .fetch_optional(pool)
         .await?;
-    if found.is_none() {
-        found = on_cold!(pool, |conn| sqlx::query(SQL)
-            .bind(ehr_id)
-            .bind(kind)
-            .fetch_optional(&mut *conn)
-            .await);
-    }
     let Some(row) = found else {
         return Ok(None);
     };
@@ -544,21 +438,14 @@ pub async fn current_version_meta_scoped(
 ) -> Result<Option<CurrentMeta>, StorageError> {
     const SQL: &str = "SELECT v.vo_id, v.trunk_version, v.branch_number, v.branch_version, \
                        v.creating_system_id, a.time_committed \
-                       FROM vo_version v JOIN audit a ON a.id = v.audit_id \
+                       FROM vo_version_all v JOIN audit a ON a.id = v.audit_id \
                        WHERE v.vo_id = $1 AND v.ehr_id = $2 AND upper_inf(v.sys_period) \
                        AND v.branch_number = 0";
-    let mut found = sqlx::query(SQL)
+    let found = sqlx::query(SQL)
         .bind(vo_id)
         .bind(ehr_id)
         .fetch_optional(pool)
         .await?;
-    if found.is_none() {
-        found = on_cold!(pool, |conn| sqlx::query(SQL)
-            .bind(vo_id)
-            .bind(ehr_id)
-            .fetch_optional(&mut *conn)
-            .await);
-    }
     let Some(row) = found else {
         return Ok(None);
     };
@@ -607,16 +494,10 @@ pub async fn current_demographic_meta(
 ) -> Result<Option<CurrentDemographicMeta>, StorageError> {
     const SQL: &str = "SELECT v.kind, v.lifecycle_state, v.trunk_version, v.branch_number, \
                        v.branch_version, v.creating_system_id, a.time_committed \
-                       FROM vo_version v JOIN audit a ON a.id = v.audit_id \
+                       FROM vo_version_all v JOIN audit a ON a.id = v.audit_id \
                        WHERE v.vo_id = $1 AND v.ehr_id IS NULL AND upper_inf(v.sys_period) \
                        AND v.branch_number = 0";
-    let mut found = sqlx::query(SQL).bind(vo_id).fetch_optional(pool).await?;
-    if found.is_none() {
-        found = on_cold!(pool, |conn| sqlx::query(SQL)
-            .bind(vo_id)
-            .fetch_optional(&mut *conn)
-            .await);
-    }
+    let found = sqlx::query(SQL).bind(vo_id).fetch_optional(pool).await?;
     let Some(row) = found else {
         return Ok(None);
     };
@@ -687,24 +568,15 @@ pub async fn current_composition_meta(
     pool: &PgPool,
     vo_id: VoId,
 ) -> Result<Option<CurrentCompositionMeta>, StorageError> {
-    // On the cold-tier retry `vo_version` resolves to the archival mirror while
-    // `ehr` and `audit`, which are never moved, keep resolving to the primary
-    // schema.
     const SQL: &str = "SELECT v.ehr_id, v.lifecycle_state, v.trunk_version, v.branch_number, \
                        v.branch_version, v.creating_system_id, a.time_committed, \
                        e.is_modifiable, \
                        v.body #>> '{archetype_details,template_id,value}' AS stored_template \
-                       FROM vo_version v \
+                       FROM vo_version_all v \
                        JOIN audit a ON a.id = v.audit_id \
                        JOIN ehr e ON e.id = v.ehr_id \
                        WHERE v.vo_id = $1 AND upper_inf(v.sys_period) AND v.branch_number = 0";
-    let mut found = sqlx::query(SQL).bind(vo_id).fetch_optional(pool).await?;
-    if found.is_none() {
-        found = on_cold!(pool, |conn| sqlx::query(SQL)
-            .bind(vo_id)
-            .fetch_optional(&mut *conn)
-            .await);
-    }
+    let found = sqlx::query(SQL).bind(vo_id).fetch_optional(pool).await?;
     let Some(row) = found else {
         return Ok(None);
     };

--- a/app/ferroehr/src/storage/version_repo/read.rs
+++ b/app/ferroehr/src/storage/version_repo/read.rs
@@ -12,11 +12,10 @@
 //! (§Versioned Objects, §Logical Deletion) and master08 §Change Management
 //! (time-travel).
 //!
-//! NOTE (no openEHR spec governs storage tiering — our own design): each read
-//! retries against the cold archival tier
-//! ([`crate::storage::version_repo::tier`]) ONLY when the primary tier has no
-//! such version, so an archived object stays retrievable while an unarchived
-//! read is untouched.
+//! NOTE (no openEHR spec governs storage tiering — our own design): every
+//! full version read queries the `vo_version_all`/`vo_attestation_all` union
+//! views, so ONE statement serves both tiers — an archived object stays
+//! retrievable and a miss never pays a cold-tier retry transaction.
 
 #![expect(
     clippy::disallowed_types,
@@ -31,7 +30,6 @@ use uuid::Uuid;
 
 use crate::ids::{EhrId, VoId};
 use crate::storage::error::StorageError;
-use crate::storage::version_repo::tier::on_cold;
 
 /// A loaded `vo_version`⋈`audit` row plus its reassembled content and
 /// attestations — the storage read shape the versioning layer maps into a
@@ -151,13 +149,13 @@ macro_rules! version_select {
             "a.system_id, a.change_type, a.description, a.committer, a.attestation, ",
             "a.time_committed, ",
             "att.attestations_at_committal, att.attestations_after_committal ",
-            "FROM vo_version v JOIN audit a ON a.id = v.audit_id ",
+            "FROM vo_version_all v JOIN audit a ON a.id = v.audit_id ",
             "LEFT JOIN LATERAL (",
             "SELECT coalesce(jsonb_agg(x.data ORDER BY x.time_committed, x.id) ",
             "FILTER (WHERE x.at_committal), '[]'::jsonb) AS attestations_at_committal, ",
             "coalesce(jsonb_agg(x.data ORDER BY x.time_committed, x.id) ",
             "FILTER (WHERE NOT x.at_committal), '[]'::jsonb) AS attestations_after_committal ",
-            "FROM vo_attestation x ",
+            "FROM vo_attestation_all x ",
             "WHERE x.vo_id = v.vo_id AND x.sys_version = v.sys_version",
             ") att ON true ",
             $tail
@@ -334,18 +332,12 @@ pub async fn read_current(
 ) -> Result<Option<StoredVersion>, StorageError> {
     const SQL: &str =
         version_select!("WHERE v.vo_id = $1 AND upper_inf(v.sys_period) AND v.branch_number = 0");
-    let primary = sqlx::query(SQL).bind(vo_id).fetch_optional(pool).await?;
-    if let Some(row) = primary {
-        return Ok(Some(stored_version(vo_id, &row)?));
-    }
-    let Some(row) = on_cold!(pool, |conn| sqlx::query(SQL)
+    sqlx::query(SQL)
         .bind(vo_id)
-        .fetch_optional(&mut *conn)
-        .await)
-    else {
-        return Ok(None);
-    };
-    Ok(Some(stored_version(vo_id, &row)?))
+        .fetch_optional(pool)
+        .await?
+        .map(|row| stored_version(vo_id, &row))
+        .transpose()
 }
 
 /// Read a specific version by its STORAGE ORDINAL (`sys_version`) — for internal
@@ -360,23 +352,13 @@ pub async fn read_version_by_ordinal(
     ordinal: i32,
 ) -> Result<Option<StoredVersion>, StorageError> {
     const SQL: &str = version_select!("WHERE v.vo_id = $1 AND v.sys_version = $2");
-    let primary = sqlx::query(SQL)
+    sqlx::query(SQL)
         .bind(vo_id)
         .bind(ordinal)
         .fetch_optional(pool)
-        .await?;
-    if let Some(row) = primary {
-        return Ok(Some(stored_version(vo_id, &row)?));
-    }
-    let Some(row) = on_cold!(pool, |conn| sqlx::query(SQL)
-        .bind(vo_id)
-        .bind(ordinal)
-        .fetch_optional(&mut *conn)
-        .await)
-    else {
-        return Ok(None);
-    };
-    Ok(Some(stored_version(vo_id, &row)?))
+        .await?
+        .map(|row| stored_version(vo_id, &row))
+        .transpose()
 }
 
 /// Read a specific version by its `VERSION_TREE_ID` column ints (for
@@ -395,27 +377,15 @@ pub async fn read_version(
         "WHERE v.vo_id = $1 AND v.trunk_version = $2 \
          AND v.branch_number = $3 AND v.branch_version = $4"
     );
-    let primary = sqlx::query(SQL)
+    sqlx::query(SQL)
         .bind(vo_id)
         .bind(trunk_version)
         .bind(branch_number)
         .bind(branch_version)
         .fetch_optional(pool)
-        .await?;
-    if let Some(row) = primary {
-        return Ok(Some(stored_version(vo_id, &row)?));
-    }
-    let Some(row) = on_cold!(pool, |conn| sqlx::query(SQL)
-        .bind(vo_id)
-        .bind(trunk_version)
-        .bind(branch_number)
-        .bind(branch_version)
-        .fetch_optional(&mut *conn)
-        .await)
-    else {
-        return Ok(None);
-    };
-    Ok(Some(stored_version(vo_id, &row)?))
+        .await?
+        .map(|row| stored_version(vo_id, &row))
+        .transpose()
 }
 
 /// Read the version of an object current at a given instant (time-travel):
@@ -455,21 +425,11 @@ pub async fn version_at(
          AND v.branch_number = 0"
     );
     let at = at.to_string();
-    let primary = sqlx::query(SQL)
+    sqlx::query(SQL)
         .bind(vo_id)
         .bind(&at)
         .fetch_optional(pool)
-        .await?;
-    if let Some(row) = primary {
-        return Ok(Some(stored_version(vo_id, &row)?));
-    }
-    let Some(row) = on_cold!(pool, |conn| sqlx::query(SQL)
-        .bind(vo_id)
-        .bind(&at)
-        .fetch_optional(&mut *conn)
-        .await)
-    else {
-        return Ok(None);
-    };
-    Ok(Some(stored_version(vo_id, &row)?))
+        .await?
+        .map(|row| stored_version(vo_id, &row))
+        .transpose()
 }

--- a/app/ferroehr/src/storage/version_repo/tier.rs
+++ b/app/ferroehr/src/storage/version_repo/tier.rs
@@ -15,85 +15,14 @@
 //!
 //! - a **write** always thaws first ([`thaw`]), so a versioned object is never
 //!   split across tiers;
-//! - a **read** consults the cold tier only after the primary tier misses
-//!   (`on_cold`), so an unarchived read pays nothing at all.
-//!
-//! `on_cold` runs the caller's own statement — verbatim, no cold twin of the
-//! SQL — inside a transaction whose `SET LOCAL search_path` resolves the
-//! versioned-object spine to `cold`
-//! (<https://www.postgresql.org/docs/18/sql-set.html>: `SET LOCAL` reverts at
-//! transaction end, so the pooled connection is never left altered).
+//! - a **read** goes through the `*_all` union views (`vo_version_all` /
+//!   `node_all` / `vo_attestation_all`), so ONE statement serves both tiers
+//!   and a miss never pays a retry transaction.
 
-use sqlx::{PgConnection, PgPool, Postgres, Transaction};
+use sqlx::PgConnection;
 
 use crate::ids::{EhrId, VoId};
 use crate::storage::error::StorageError;
-
-/// Search path resolving the versioned-object spine to the cold archival tier
-/// while `audit` / `ehr` / the `ext` helpers keep resolving normally.
-const COLD_SEARCH_PATH_SQL: &str = "SET LOCAL search_path TO cold, ehr, ext, public";
-
-/// Which storage tier a read addresses.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Tier {
-    /// The primary tier — every unarchived object, and the only tier a hot read
-    /// touches.
-    Primary,
-    /// The cold archival tier alone — used on a primary-tier miss, once the
-    /// version row itself has been found there.
-    Cold,
-    /// Both tiers at once, through the `*_all` union views — for the
-    /// whole-repository readers (admin export, physical delete) that must see
-    /// archived content by definition.
-    Both,
-}
-
-/// Begins a transaction whose statements read the cold archival tier.
-///
-/// The caller runs its ordinary primary-tier SQL on the returned transaction
-/// and commits it; every unqualified `vo_version` / `node` / `vo_attestation`
-/// reference resolves to the `cold` mirror instead.
-///
-/// # Errors
-/// Returns [`StorageError::Database`] when the transaction or the `SET LOCAL`
-/// fails.
-pub async fn begin_cold(pool: &PgPool) -> Result<Transaction<'_, Postgres>, StorageError> {
-    let mut tx = pool.begin().await?;
-    sqlx::query(COLD_SEARCH_PATH_SQL).execute(&mut *tx).await?;
-    Ok(tx)
-}
-
-/// Runs one read statement against the cold archival tier.
-///
-/// The body is the SAME statement the primary-tier read uses — there is no
-/// second copy of the SQL to drift — evaluated on a [`begin_cold`] transaction
-/// that is committed before the value is returned.
-///
-/// # Examples
-///
-/// ```text
-/// let kind: Option<String> = on_cold!(pool, |c| sqlx::query_scalar(SQL)
-///     .bind(vo_id)
-///     .fetch_optional(&mut *c)
-///     .await);
-/// ```
-macro_rules! on_cold {
-    ($pool:expr, |$conn:ident| $body:expr) => {{
-        // Boxed so the archival retry's transaction state lives on the heap
-        // instead of widening every calling future — the read seams sit deep
-        // inside the request futures `clippy::large_futures` measures.
-        let cold = ::std::boxed::Box::pin(async {
-            let mut tx = $crate::storage::version_repo::tier::begin_cold($pool).await?;
-            let $conn = &mut *tx;
-            let outcome = $body;
-            tx.commit().await?;
-            ::std::result::Result::<_, $crate::storage::error::StorageError>::Ok(outcome?)
-        });
-        cold.await?
-    }};
-}
-
-pub(crate) use on_cold;
 
 /// Moves every row of `vo_ids` from the primary tier to the cold archival tier.
 ///


### PR DESCRIPTION
Part of #2658 — fix 5, the miss-path wave from the hot-path inventory (item 11, taken further than the proposed flag).

Every object-addressed read previously retried the cold archival tier on a primary miss inside its own transaction (`BEGIN` + `SET LOCAL search_path` + query + `COMMIT`) — four extra round trips on **every 404**: unknown ids, not-yet-created resources, probing clients, existence pre-checks. With the body materialized, no read needs tier-dependent `search_path` resolution anymore, so all of them now query the `*_all` union views (`vo_version_all` / `vo_attestation_all` / `node_all`) — **one statement serves both tiers**; the hot path pays one empty-side index probe (the cold PK), the miss path pays nothing extra at all, and archived objects stay retrievable exactly as before (the tier stays wire-invisible).

Deleted outright: the `on_cold!` macro, `begin_cold`, `COLD_SEARCH_PATH_SQL`, and the `Tier` enum (owner: "do we really need this macro at all?" — no). The dump/load export's both-tier read is the explicit `read_version_canonical_all`; freeze/thaw are untouched. The 0007 migration's view comments now state the design (greenfield in-place edit per #2452).

Wire-identical (the archive suites prove archived-object retrieval end to end). Gates: clippy `--all-targets` clean on both crates, nextest **1727/1727**, fmt + comment-style clean, changelog entry added.
