### PR TITLE
perf(rest): fastest-level response compression; bare reads skip the no-op uid re-stamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ workflow refuses a tag that has no matching section here.
   the node rows remain the AQL source of truth. Storage grows by roughly
   the size of each stored version's canonical JSON.
 
+- Response compression now runs at the fastest level for every negotiated
+  encoding (it previously used the libraries' default levels — real clients
+  negotiating brotli paid visible per-response compression CPU for a
+  marginal ratio gain), and a bare object read no longer re-stamps a `uid`
+  the stored body already carries.
 - Every object-addressed read (full version reads and the metadata/existence
   lookups behind `ETag`s, revision histories, and 404 checks) queries the
   two-tier union view in ONE statement instead of retrying the cold archival

--- a/app/ferroehr-rest/src/router.rs
+++ b/app/ferroehr-rest/src/router.rs
@@ -59,6 +59,7 @@ use http::header::{AUTHORIZATION, CONTENT_TYPE};
 use http::{HeaderName, HeaderValue, header};
 use openehr_its::rest::runtime::ApiError;
 use tower::ServiceBuilder;
+use tower_http::CompressionLevel;
 use tower_http::catch_panic::CatchPanicLayer;
 use tower_http::compression::CompressionLayer;
 use tower_http::cors::CorsLayer;
@@ -265,7 +266,10 @@ fn with_shared_stack(
                     StatusCode::REQUEST_TIMEOUT,
                     REQUEST_TIMEOUT,
                 ))
-                .layer(CompressionLayer::new()),
+                // NOTE (docs.rs tower-http `CompressionLayer::quality`):
+                // Fastest — the default brotli/gzip levels spend visible
+                // per-response CPU for a marginal ratio gain on ~KB bodies.
+                .layer(CompressionLayer::new().quality(CompressionLevel::Fastest)),
         )
         .layer(axum::middleware::map_response(align_transport_error_body))
         .layer(

--- a/app/ferroehr/src/service/ehr/meta.rs
+++ b/app/ferroehr/src/service/ehr/meta.rs
@@ -127,9 +127,16 @@ impl FerroEhrService {
         .with_last_modified(at)
     }
 
-    /// Inject the `uid` (`OBJECT_VERSION_ID`, RM common master06 §Version
-    /// Identification) into a versioned object's canonical JSON so a bare read
-    /// carries its wire identity.
+    /// Ensure the versioned object's canonical JSON carries its `uid`
+    /// (`OBJECT_VERSION_ID`, RM common master06 §Version Identification) so a
+    /// bare read serves its wire identity.
+    ///
+    /// The write path already stamps the uid into the stored body
+    /// (`crate::versioning::change` — `stamp_version_uid` runs before
+    /// decomposition), so on a locally committed version this is a no-op:
+    /// when the stored `uid` is an `OBJECT_VERSION_ID` whose value matches,
+    /// the body passes through untouched. Only a body that lacks or mismatches
+    /// it (e.g. a verbatim-imported foreign version) pays the re-stamp.
     #[expect(
         clippy::unused_self,
         reason = "call-site ergonomics: every caller already holds the service, \
@@ -143,14 +150,14 @@ impl FerroEhrService {
         version: TreeId,
     ) -> Result<Value, VersionIdError> {
         if let Value::Object(map) = &mut canonical {
-            map.insert(
-                "uid".to_owned(),
-                openehr_its::json::to_canonical_value(&version_id(
-                    vo_id,
-                    creating_system_id,
-                    version,
-                )?),
-            );
+            let id = version_id(vo_id, creating_system_id, version)?;
+            let already_stamped = map.get("uid").is_some_and(|uid| {
+                uid.get("_type").and_then(Value::as_str) == Some("OBJECT_VERSION_ID")
+                    && uid.get("value").and_then(Value::as_str) == Some(id.value())
+            });
+            if !already_stamped {
+                map.insert("uid".to_owned(), openehr_its::json::to_canonical_value(&id));
+            }
         }
         Ok(canonical)
     }


### PR DESCRIPTION
Part of #2658 — fix 6, the response-pipeline wave (inventory items 14-safe-subset and 16, both owner-ruled free to change under the greenfield posture).

- `CompressionLayer::new().quality(CompressionLevel::Fastest)`: the layer previously compressed at the libraries' default levels, and real clients (Node fetch among them — the community benchmark's client) negotiate **brotli**, paying its default-level CPU on every body. Fastest keeps excellent ratios on canonical JSON (22 KB → 1.8 KB br, 2.0 KB gzip) at a fraction of the CPU.
- `with_uid` compare-and-skip: the write path already stamps the `uid` into the stored body (`stamp_version_uid` before decomposition), so the read-side injection re-parsed and re-serialized an `OBJECT_VERSION_ID` for nothing on every bare read. It now inserts only when the stored uid is absent or mismatched (e.g. a verbatim-imported foreign body — RM common master06 §Copying).

Measured idle (native release, ab keep-alive for plain, curl loops for negotiated encodings — curl's ~1.2 ms process overhead rides both columns):

| | before | after |
|---|---|---|
| plain c=1 | 1.08 ms / 923 rps | **0.81 ms / 1,232 rps** |
| brotli-negotiated | 1.90 ms | **1.69 ms** |
| gzip-negotiated | 1.70 ms | 1.68 ms |

Gates: clippy `--all-targets` clean on both crates, nextest **1727/1727**, fmt + comment-style clean, changelog entry added.
