### PR TITLE
perf(versioning): batched resolved-CONTRIBUTION reads; one-statement persistent-duplicate check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ workflow refuses a tag that has no matching section here.
   the node rows remain the AQL source of truth. Storage grows by roughly
   the size of each stored version's canonical JSON.
 
+- Two per-item read loops became single statements: a resolved CONTRIBUTION
+  read (`Prefer: resolve_refs`) loads all its member versions in one batched
+  query instead of one read per member, and the persistent-COMPOSITION
+  uniqueness pre-check is one `EXISTS` probe instead of reading every live
+  composition body in the EHR.
 - Response compression now runs at the fastest level for every negotiated
   encoding (it previously used the libraries' default levels — real clients
   negotiating brotli paid visible per-response compression CPU for a

--- a/app/ferroehr/src/service/ehr/validation.rs
+++ b/app/ferroehr/src/service/ehr/validation.rs
@@ -38,7 +38,6 @@ use crate::ids::{EhrId, VoId};
 use crate::service::FerroEhrService;
 use crate::service::ehr::category::code;
 use crate::service::error::{ServiceError, Violation};
-use crate::versioning::read::read_current;
 use crate::versioning::{Kind, lifecycle};
 
 impl FerroEhrService {
@@ -67,39 +66,34 @@ impl FerroEhrService {
         let Some(template_id) = composition_template_id(composition) else {
             return Ok(());
         };
-        // The pre-check reads the EHR's live COMPOSITION ids in one SELECT and
-        // reassembles each to read its category + declared template, so cost is
-        // linear in the EHR's live COMPOSITION count. It is paid ONLY on a
+        // ONE statement over the promoted `template_id` column and a body
+        // scalar — never one body read per live COMPOSITION. Paid ONLY on a
         // create whose body is persistent (`431|persistent|`) AND declares a
         // template — every event-composition create returns at the two guards
         // above without touching storage.
         // NOTE: openEHR defines no such cardinality — the criterion is the CNF
         // schedule's, still "under debate in the openEHR SEC"
         // (`CNF/docs/platform_test_schedule/master07-func_tc_ehr_composition.adoc`).
-        let vo_ids = crate::storage::version_repo::meta::current_vo_ids(
+        let exists = crate::storage::version_repo::meta::persistent_template_exists(
             &self.pool,
             ehr_id,
-            "COMPOSITION",
-            Some(lifecycle::state::DELETED),
+            template_id,
+            code::PERSISTENT,
+            lifecycle::state::DELETED,
         )
         .await?;
-        for vo_id in vo_ids {
-            if let Some(read) = read_current(&self.pool, self.spec_profile, vo_id).await?
-                && is_persistent(&read.canonical)
-                && composition_template_id(&read.canonical) == Some(template_id)
-            {
-                // NOTE: SM ehr_call_status_type.adoc declares
-                // composition_already_exists; this refusal is precisely a
-                // COMPOSITION-exists conflict.
-                return Err(ServiceError::sm(
-                    CallStatusType::CompositionAlreadyExists,
-                    format!(
-                        "EHR {ehr_id} already has a persistent COMPOSITION for template \
-                         {template_id}; only one create is allowed (subsequent commits \
-                         must be modifications)"
-                    ),
-                ));
-            }
+        if exists {
+            // NOTE: SM ehr_call_status_type.adoc declares
+            // composition_already_exists; this refusal is precisely a
+            // COMPOSITION-exists conflict.
+            return Err(ServiceError::sm(
+                CallStatusType::CompositionAlreadyExists,
+                format!(
+                    "EHR {ehr_id} already has a persistent COMPOSITION for template \
+                     {template_id}; only one create is allowed (subsequent commits \
+                     must be modifications)"
+                ),
+            ));
         }
         Ok(())
     }

--- a/app/ferroehr/src/storage/version_repo/meta.rs
+++ b/app/ferroehr/src/storage/version_repo/meta.rs
@@ -305,6 +305,38 @@ const EXISTS_SQL: &str = "SELECT EXISTS(SELECT 1 FROM vo_version_all WHERE vo_id
                           AND trunk_version = $2 AND branch_number = $3 \
                           AND branch_version = $4)";
 
+/// Whether the EHR holds a LIVE persistent COMPOSITION for `template_id`.
+///
+/// One `EXISTS` over the promoted `template_id` column plus the body's
+/// category code, primary tier (the live operational store, like every
+/// EHR-wide read here).
+///
+/// `persistent_code`/`deleted_state` are the domain's openEHR codes, passed
+/// in so this stays a dumb row probe.
+///
+/// # Errors
+/// Returns [`StorageError::Database`] on a driver failure.
+pub async fn persistent_template_exists(
+    pool: &PgPool,
+    ehr_id: EhrId,
+    template_id: &str,
+    persistent_code: &str,
+    deleted_state: &str,
+) -> Result<bool, StorageError> {
+    Ok(sqlx::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM vo_version WHERE ehr_id = $1 AND kind = 'COMPOSITION' \
+         AND upper_inf(sys_period) AND branch_number = 0 AND lifecycle_state <> $2 \
+         AND template_id = $3 \
+         AND body #>> '{category,defining_code,code_string}' = $4)",
+    )
+    .bind(ehr_id)
+    .bind(deleted_state)
+    .bind(template_id)
+    .bind(persistent_code)
+    .fetch_one(pool)
+    .await?)
+}
+
 // ── current-version identity reads ────────────────────────────────────────────
 
 /// The current version of an EHR-owned object of one kind: its `vo_id` and

--- a/app/ferroehr/src/storage/version_repo/read.rs
+++ b/app/ferroehr/src/storage/version_repo/read.rs
@@ -142,7 +142,7 @@ pub struct StoredVersion {
 macro_rules! version_select {
     ($tail:literal) => {
         concat!(
-            "SELECT v.kind, v.ehr_id, v.sys_version, v.trunk_version, v.branch_number, ",
+            "SELECT v.vo_id, v.kind, v.ehr_id, v.sys_version, v.trunk_version, v.branch_number, ",
             "v.branch_version, v.lifecycle_state, v.creating_system_id, v.preceding_version_uid, ",
             "v.other_input_version_uids, v.contribution_id, v.template_id, v.signature, ",
             "v.signature_client_supplied, v.wrapped_original, v.stable_compatible, v.body, ",
@@ -386,6 +386,47 @@ pub async fn read_version(
         .await?
         .map(|row| stored_version(vo_id, &row))
         .transpose()
+}
+
+/// Read a SET of specific versions in ONE statement.
+///
+/// Each is addressed by `(vo_id, VERSION_TREE_ID columns)` — the
+/// resolved-CONTRIBUTION reader's batch (a K-member CONTRIBUTION resolves
+/// its members without K point reads). Absent versions are simply missing
+/// from the result; the caller maps absence to its own refusal.
+///
+/// # Errors
+/// Returns [`StorageError`] on a driver/decode failure.
+pub async fn read_versions_by_tree(
+    pool: &PgPool,
+    refs: &[(VoId, (i32, i32, i32))],
+) -> Result<Vec<StoredVersion>, StorageError> {
+    const SQL: &str = version_select!(
+        "JOIN unnest($1::uuid[], $2::int[], $3::int[], $4::int[]) \
+         AS q(vo_id, trunk_version, branch_number, branch_version) \
+         ON q.vo_id = v.vo_id AND q.trunk_version = v.trunk_version \
+         AND q.branch_number = v.branch_number AND q.branch_version = v.branch_version"
+    );
+    if refs.is_empty() {
+        return Ok(Vec::new());
+    }
+    let vo_ids: Vec<Uuid> = refs.iter().map(|(id, _)| id.0).collect();
+    let trunks: Vec<i32> = refs.iter().map(|(_, (t, _, _))| *t).collect();
+    let branches: Vec<i32> = refs.iter().map(|(_, (_, b, _))| *b).collect();
+    let branch_versions: Vec<i32> = refs.iter().map(|(_, (_, _, bv))| *bv).collect();
+    let rows = sqlx::query(SQL)
+        .bind(&vo_ids)
+        .bind(&trunks)
+        .bind(&branches)
+        .bind(&branch_versions)
+        .fetch_all(pool)
+        .await?;
+    rows.into_iter()
+        .map(|row| {
+            let vo_id: VoId = row.try_get("vo_id")?;
+            stored_version(vo_id, &row)
+        })
+        .collect()
 }
 
 /// Read the version of an object current at a given instant (time-travel):

--- a/app/ferroehr/src/versioning/contribution.rs
+++ b/app/ferroehr/src/versioning/contribution.rs
@@ -1333,18 +1333,29 @@ pub(crate) async fn get_contribution(
     )
     .await?;
 
+    // Resolved members load in ONE batched statement (never one point read
+    // per member — a K-member CONTRIBUTION resolves with K+2 statements
+    // otherwise).
+    let mut resolved = if resolve_refs {
+        let refs: Vec<(VoId, TreeId)> = referenced
+            .iter()
+            .map(|(vo_id, (t, b, v), _, _)| (*vo_id, TreeId::from_columns(*t, *b, *v)))
+            .collect();
+        read::read_versions(pool, profile, &refs).await?
+    } else {
+        std::collections::HashMap::new()
+    };
+
     let mut versions = Vec::with_capacity(referenced.len());
     for (vo_id, (t, b, v), creating_system_id, kind) in referenced {
         let tree = TreeId::from_columns(t, b, v);
         if resolve_refs {
-            let loaded = read::read_version(pool, profile, vo_id, tree)
-                .await?
-                .ok_or_else(|| {
-                    ServiceError::sm(
-                        CallStatusType::ObjectVersionDoesNotExist,
-                        format!("VERSION {vo_id}::{tree}"),
-                    )
-                })?;
+            let loaded = resolved.remove(&(vo_id, tree)).ok_or_else(|| {
+                ServiceError::sm(
+                    CallStatusType::ObjectVersionDoesNotExist,
+                    format!("VERSION {vo_id}::{tree}"),
+                )
+            })?;
             // The resolved object is the VERSION the CONTRIBUTION lists
             // (`CONTRIBUTION.versions`, master06 §Contributions: "a
             // CONTRIBUTION object will be created, listing the affected

--- a/app/ferroehr/src/versioning/object_version_id.rs
+++ b/app/ferroehr/src/versioning/object_version_id.rs
@@ -39,7 +39,7 @@ use crate::service::error::ServiceError;
 /// `(branch_number, branch_version)` pair (both `>= 1` per BASE
 /// `VERSION_TREE_ID`; RM common master06 §Local Versioning: "a further pair of
 /// numbers is added … Both of these numbers also start at '1'").
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TreeId {
     /// The trunk version this id sits on (first lexical part).
     pub(crate) trunk: i32,

--- a/app/ferroehr/src/versioning/read.rs
+++ b/app/ferroehr/src/versioning/read.rs
@@ -309,6 +309,35 @@ pub(crate) async fn read_version(
         .transpose()
 }
 
+/// Read a SET of specific versions in ONE statement (the
+/// resolved-CONTRIBUTION batch), each passing the same `spec_profile` gate a
+/// point read passes; keyed by `(vo_id, tree)`, with absent versions simply
+/// missing from the map.
+///
+/// # Errors
+/// The storage read error of `version_repo::read::read_versions_by_tree`, or
+/// the `spec_profile` refusal of [`version_read`] on any member.
+pub(crate) async fn read_versions(
+    pool: &sqlx::PgPool,
+    profile: crate::config::profile::SpecProfile,
+    refs: &[(VoId, TreeId)],
+) -> Result<std::collections::HashMap<(VoId, TreeId), VersionRead>, ServiceError> {
+    let columns: Vec<(VoId, (i32, i32, i32))> = refs
+        .iter()
+        .map(|(id, tree)| (*id, tree.columns()))
+        .collect();
+    let stored = crate::storage::version_repo::read::read_versions_by_tree(pool, &columns).await?;
+    let mut out = std::collections::HashMap::with_capacity(stored.len());
+    for s in stored {
+        let key = (
+            s.vo_id,
+            TreeId::from_columns(s.trunk_version, s.branch_number, s.branch_version),
+        );
+        out.insert(key, version_read(profile, s)?);
+    }
+    Ok(out)
+}
+
 /// Read the version of an object that was current at a given instant
 /// (time-travel; RM common master08 §Change Management — any previous state is
 /// reconstructable): the row whose `sys_period` contains `at`.


### PR DESCRIPTION
Part of #2658 — fix 7, the N+1 wave (inventory items 5 and 10).

- **Resolved CONTRIBUTION reads** (`GET /ehr/{id}/contribution/{uid}` with `Prefer: resolve_refs`): previously one full version read per member — a 50-version CONTRIBUTION cost 52 statements and 50 body fetches. Now `read_versions_by_tree` loads every member through ONE `unnest` join over the same `version_select!` statement (K+2 → 3 statements); the versioning wrapper applies the identical `spec_profile` gate per member and the missing-member refusal is unchanged (`ObjectVersionDoesNotExist`, same message). `version_select!` now also selects `v.vo_id` (needed to key the batch; other callers ignore it) and `TreeId` derives `Hash`.
- **Persistent-COMPOSITION uniqueness pre-check**: previously enumerated the EHR's live composition ids and read every body back to inspect two fields — linear in EHR size, one body fetch per composition. Now ONE `EXISTS` over the promoted `template_id` column plus the materialized body's category scalar (`body #>> '{category,defining_code,code_string}'`), primary tier like every EHR-wide read. Same refusal, same status, same CNF-schedule-cited criterion.

All wire-identical. Gates: clippy `--all-targets` clean on both crates, nextest **1727/1727**, fmt + comment-style clean, changelog entry added.
