### PR TITLE
perf(storage): scoped single-statement reads — containers, revision histories, versioned objects, tag replaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ workflow refuses a tag that has no matching section here.
   the node rows remain the AQL source of truth. Storage grows by roughly
   the size of each stored version's canonical JSON.
 
+- The EHR_STATUS reads (current and `version_at_time`) and the current
+  directory read resolve their container and read the version in ONE
+  statement each (previously a container-resolution query followed by the
+  version read).
 - Two per-item read loops became single statements: a resolved CONTRIBUTION
   read (`Prefer: resolve_refs`) loads all its member versions in one batched
   query instead of one read per member, and the persistent-COMPOSITION

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,11 @@ workflow refuses a tag that has no matching section here.
 - The EHR_STATUS reads (current and `version_at_time`) and the current
   directory read resolve their container and read the version in ONE
   statement each (previously a container-resolution query followed by the
-  version read).
+  version read); a revision history folds its attestations into the one
+  metadata statement; the versioned-object container reads carry their
+  ownership check inside the bounds statement; and a tag-collection replace
+  returns the stored collection from its own insert instead of re-reading
+  it after commit.
 - Two per-item read loops became single statements: a resolved CONTRIBUTION
   read (`Prefer: resolve_refs`) loads all its member versions in one batched
   query instead of one read per member, and the persistent-COMPOSITION

--- a/app/ferroehr/src/service/demographic/tags.rs
+++ b/app/ferroehr/src/service/demographic/tags.rs
@@ -175,7 +175,9 @@ impl FerroEhrService {
             })
             .collect();
         let mut tx = self.pool.begin().await?;
-        tag_repo::replace_tags(
+        // The replace RETURNS the stored collection (list order), so the
+        // response never re-reads the rows the transaction just wrote.
+        let stored = tag_repo::replace_tags(
             &mut tx,
             None,
             vo_id,
@@ -184,8 +186,11 @@ impl FerroEhrService {
         )
         .await?;
         tx.commit().await?;
-        self.party_tags(vo_id, tag_target_tail(target_version))
-            .await
+        let sid = self.effective_system_id();
+        stored
+            .iter()
+            .map(|r| party_item_tag(&sid, r))
+            .collect::<Result<Vec<_>, _>>()
     }
 
     /// Delete a target's tags by key (a SET delete over the `(key,

--- a/app/ferroehr/src/service/ehr/composition.rs
+++ b/app/ferroehr/src/service/ehr/composition.rs
@@ -192,20 +192,17 @@ impl FerroEhrService {
         ehr_id: EhrId,
         vo_id: VoId,
     ) -> Result<ServiceResponse, ServiceError> {
-        // Ownership gate only — one scalar read (`vo_version.ehr_id`), never
-        // the full current-version reassembly this metadata-shaped response
-        // would immediately discard.
-        crate::storage::version_repo::meta::vo_owner(&self.pool, vo_id)
-            .await?
-            .filter(|owner| *owner == Some(ehr_id))
-            .ok_or_else(|| {
-                ServiceError::sm(
-                    CallStatusType::CompositionDoesNotExist,
-                    format!("COMPOSITION {vo_id}"),
-                )
-            })?;
+        // Ownership rides the container statement itself (the ehr_id filter
+        // inside `versioned_object`) — no separate ownership probe.
         let (body, last_modified) =
-            versioned_object(&self.pool, vo_id, ehr_id, "VERSIONED_COMPOSITION").await?;
+            versioned_object(&self.pool, vo_id, ehr_id, "VERSIONED_COMPOSITION")
+                .await?
+                .ok_or_else(|| {
+                    ServiceError::sm(
+                        CallStatusType::CompositionDoesNotExist,
+                        format!("COMPOSITION {vo_id}"),
+                    )
+                })?;
         Ok(ServiceResponse::new(
             body,
             super::meta::container_meta(ehr_id, vo_id, last_modified),

--- a/app/ferroehr/src/service/ehr/directory.rs
+++ b/app/ferroehr/src/service/ehr/directory.rs
@@ -238,7 +238,14 @@ impl FerroEhrService {
     ) -> Result<ServiceResponse, ServiceError> {
         let vo_id = self.directory_vo(ehr_id).await?;
         let (body, last_modified) =
-            versioned_object(&self.pool, vo_id, ehr_id, "VERSIONED_FOLDER").await?;
+            versioned_object(&self.pool, vo_id, ehr_id, "VERSIONED_FOLDER")
+                .await?
+                .ok_or_else(|| {
+                    ServiceError::sm(
+                        CallStatusType::VersionedObjectDoesNotExist,
+                        format!("versioned object {vo_id}"),
+                    )
+                })?;
         Ok(ServiceResponse::new(
             body,
             super::meta::container_meta(ehr_id, vo_id, last_modified),

--- a/app/ferroehr/src/service/ehr/directory.rs
+++ b/app/ferroehr/src/service/ehr/directory.rs
@@ -237,15 +237,14 @@ impl FerroEhrService {
         ehr_id: EhrId,
     ) -> Result<ServiceResponse, ServiceError> {
         let vo_id = self.directory_vo(ehr_id).await?;
-        let (body, last_modified) =
-            versioned_object(&self.pool, vo_id, ehr_id, "VERSIONED_FOLDER")
-                .await?
-                .ok_or_else(|| {
-                    ServiceError::sm(
-                        CallStatusType::VersionedObjectDoesNotExist,
-                        format!("versioned object {vo_id}"),
-                    )
-                })?;
+        let (body, last_modified) = versioned_object(&self.pool, vo_id, ehr_id, "VERSIONED_FOLDER")
+            .await?
+            .ok_or_else(|| {
+                ServiceError::sm(
+                    CallStatusType::VersionedObjectDoesNotExist,
+                    format!("versioned object {vo_id}"),
+                )
+            })?;
         Ok(ServiceResponse::new(
             body,
             super::meta::container_meta(ehr_id, vo_id, last_modified),

--- a/app/ferroehr/src/service/ehr/directory.rs
+++ b/app/ferroehr/src/service/ehr/directory.rs
@@ -42,7 +42,7 @@ use crate::versioning::Kind;
 use crate::versioning::audit::change_type;
 use crate::versioning::change::{create, delete, update};
 use crate::versioning::object_version_id::{TreeId, components};
-use crate::versioning::read::{read_current, read_version, version_at};
+use crate::versioning::read::{read_version, version_at};
 use crate::versioning::wire::versioned_object;
 
 use super::validation::{check_folder_item_refs, validate_folder};
@@ -135,10 +135,23 @@ impl FerroEhrService {
         at: Option<jiff::Timestamp>,
         path: Option<&str>,
     ) -> Result<ServiceResponse, ServiceError> {
-        let vo_id = self.directory_vo(ehr_id).await?;
+        // The current read folds the `ehr_folder` slot resolution into the
+        // version statement (same slot choice as `directory_vo`); the as-of
+        // read keeps the two-step so the slot is still chosen by CURRENT
+        // state, exactly as before.
         let read = match at {
-            Some(at) => version_at(&self.pool, self.spec_profile, vo_id, at).await?,
-            None => read_current(&self.pool, self.spec_profile, vo_id).await?,
+            Some(at) => {
+                let vo_id = self.directory_vo(ehr_id).await?;
+                version_at(&self.pool, self.spec_profile, vo_id, at).await?
+            }
+            None => {
+                crate::versioning::read::read_current_directory(
+                    &self.pool,
+                    self.spec_profile,
+                    ehr_id,
+                )
+                .await?
+            }
         }
         .filter(|r| r.ehr_id == Some(ehr_id) && r.kind == Kind::Folder)
         .ok_or_else(|| {
@@ -150,6 +163,7 @@ impl FerroEhrService {
         if read.deleted() {
             return Ok(ServiceResponse::plain(Value::Null));
         }
+        let vo_id = read.vo_id;
         let meta = self.version_meta(
             ehr_id,
             vo_id,

--- a/app/ferroehr/src/service/ehr/status.rs
+++ b/app/ferroehr/src/service/ehr/status.rs
@@ -50,18 +50,28 @@ impl FerroEhrService {
         ehr_id: EhrId,
         at: Option<jiff::Timestamp>,
     ) -> Result<ServiceResponse, ServiceError> {
-        let (vo_id, _) = self
-            .current_vo(ehr_id, Kind::EhrStatus)
-            .await?
-            .ok_or_else(|| {
-                ServiceError::sm(
-                    CallStatusType::EhrIdDoesNotExist,
-                    format!("EHR_STATUS for EHR {ehr_id}"),
-                )
-            })?;
+        // ONE statement: the container resolution and the version read merged
+        // (an EHR holds exactly one EHR_STATUS container — RM ehr `ehr.adoc`).
         let read = match at {
-            Some(at) => version_at(&self.pool, self.spec_profile, vo_id, at).await?,
-            None => read_current(&self.pool, self.spec_profile, vo_id).await?,
+            Some(at) => {
+                crate::versioning::read::version_at_of_kind(
+                    &self.pool,
+                    self.spec_profile,
+                    ehr_id,
+                    Kind::EhrStatus,
+                    at,
+                )
+                .await?
+            }
+            None => {
+                crate::versioning::read::read_current_of_kind(
+                    &self.pool,
+                    self.spec_profile,
+                    ehr_id,
+                    Kind::EhrStatus,
+                )
+                .await?
+            }
         }
         .ok_or_else(|| {
             ServiceError::sm(
@@ -69,6 +79,7 @@ impl FerroEhrService {
                 format!("EHR_STATUS for EHR {ehr_id}"),
             )
         })?;
+        let vo_id = read.vo_id;
         Ok(self.version_response(ehr_id, vo_id, read)?)
     }
 

--- a/app/ferroehr/src/service/ehr/status.rs
+++ b/app/ferroehr/src/service/ehr/status.rs
@@ -266,7 +266,14 @@ impl FerroEhrService {
                 )
             })?;
         let (body, last_modified) =
-            versioned_object(&self.pool, vo_id, ehr_id, "VERSIONED_EHR_STATUS").await?;
+            versioned_object(&self.pool, vo_id, ehr_id, "VERSIONED_EHR_STATUS")
+                .await?
+                .ok_or_else(|| {
+                    ServiceError::sm(
+                        CallStatusType::VersionedObjectDoesNotExist,
+                        format!("versioned object {vo_id}"),
+                    )
+                })?;
         Ok(ServiceResponse::new(
             body,
             super::meta::container_meta(ehr_id, vo_id, last_modified),

--- a/app/ferroehr/src/service/ehr/tags.rs
+++ b/app/ferroehr/src/service/ehr/tags.rs
@@ -154,7 +154,9 @@ impl FerroEhrService {
             });
         }
         let mut tx = self.pool.begin().await?;
-        crate::storage::tag_repo::replace_tags(
+        // The replace RETURNS the stored collection (list order), so the
+        // response never re-reads the rows the transaction just wrote.
+        let stored = crate::storage::tag_repo::replace_tags(
             &mut tx,
             Some(ehr_id),
             target_vo_id,
@@ -163,8 +165,10 @@ impl FerroEhrService {
         )
         .await?;
         tx.commit().await?;
-        self.target_tags(ehr_id, target_vo_id, tag_target_tail(target_version))
-            .await
+        stored
+            .iter()
+            .map(|r| Self::stored_item_tag(ehr_id, r))
+            .collect::<Result<Vec<_>, _>>()
     }
 
     /// The tag-target guard: the addressed versioned object must exist in

--- a/app/ferroehr/src/service/message/export.rs
+++ b/app/ferroehr/src/service/message/export.rs
@@ -504,7 +504,14 @@ impl FerroEhrService {
 
         // uid / owner_id / time_created are the VERSIONED_OBJECT's own — reuse
         // the shared read builder so they match the /versioned_* surface.
-        let (vo, _) = versioned_object(&self.pool, vo_id, ehr_id, versioned_rm_type(kind)).await?;
+        let (vo, _) = versioned_object(&self.pool, vo_id, ehr_id, versioned_rm_type(kind))
+            .await?
+            .ok_or_else(|| {
+                ServiceError::sm(
+                    CallStatusType::VersionedObjectDoesNotExist,
+                    format!("versioned object {vo_id}"),
+                )
+            })?;
         let field = |name: &str| vo.get(name).cloned().unwrap_or(Value::Null);
         // TODO(#1695): build the EXTRACT tree from the generated
         // `openehr_rm::v1_2::ehr_extract` types (`Extract`, `ExtractChapter`,

--- a/app/ferroehr/src/storage/tag_repo.rs
+++ b/app/ferroehr/src/storage/tag_repo.rs
@@ -114,7 +114,8 @@ pub async fn list_tags(
 
 /// Replace the whole tag collection of one target in one scope: drop the
 /// existing collection, insert the given set (`PUT` full-collection
-/// semantics; an empty set clears all).
+/// semantics; an empty set clears all), and return the STORED collection in
+/// the `list_tags` order — the write path never re-reads what it just wrote.
 ///
 /// Runs on the caller's transaction.
 ///
@@ -155,7 +156,7 @@ pub async fn replace_tags(
     target_vo_id: VoId,
     target_version: Option<&str>,
     tags: &[NewTag<'_>],
-) -> Result<(), StorageError> {
+) -> Result<Vec<TagRow>, StorageError> {
     // The creation instants of the collection as it stands, keyed by ITEM_TAG
     // identity, so a surviving tag can keep its own.
     let prior = sqlx::query(
@@ -188,7 +189,7 @@ pub async fn replace_tags(
     .execute(&mut *tx)
     .await?;
     if tags.is_empty() {
-        return Ok(());
+        return Ok(Vec::new());
     }
     // One multi-row insert for the whole set (never a per-tag round trip).
     // The ITEM_TAG identity within one target is the (key, target_path) PAIR
@@ -222,11 +223,16 @@ pub async fn replace_tags(
             .unwrap_or(now);
         created.push(jiff_sqlx::Timestamp::from(carried));
     }
-    sqlx::query(
+    // RETURNING hands back the stored collection (the replace's insert IS the
+    // whole new set), in the same order `list_tags` serves, so the write path
+    // never re-reads the collection it just wrote.
+    let stored = sqlx::query(
         "INSERT INTO item_tag \
          (ehr_id, target_vo_id, target_version, target_type, key, value, target_path, created_at) \
          SELECT $1, $2, $3, t.* \
-         FROM UNNEST($4::text[], $5::text[], $6::text[], $7::text[], $8::timestamptz[]) AS t",
+         FROM UNNEST($4::text[], $5::text[], $6::text[], $7::text[], $8::timestamptz[]) AS t \
+         RETURNING target_vo_id, target_version, target_type, key, value, target_path \
+         ",
     )
     .bind(ehr_scope)
     .bind(target_vo_id)
@@ -236,9 +242,23 @@ pub async fn replace_tags(
     .bind(&values)
     .bind(&paths)
     .bind(&created)
-    .execute(&mut *tx)
+    .fetch_all(&mut *tx)
     .await?;
-    Ok(())
+    let mut out = Vec::with_capacity(stored.len());
+    for row in &stored {
+        out.push(tag_row(row)?);
+    }
+    out.sort_by(|a, b| {
+        a.key
+            .cmp(&b.key)
+            .then_with(|| match (&a.target_path, &b.target_path) {
+                (None, None) => std::cmp::Ordering::Equal,
+                (None, Some(_)) => std::cmp::Ordering::Less,
+                (Some(_), None) => std::cmp::Ordering::Greater,
+                (Some(x), Some(y)) => x.cmp(y),
+            })
+    });
+    Ok(out)
 }
 
 /// Delete a target collection's tags by key, returning whether any row was

--- a/app/ferroehr/src/storage/version_repo/meta.rs
+++ b/app/ferroehr/src/storage/version_repo/meta.rs
@@ -147,32 +147,38 @@ pub async fn time_created(
     Ok(stamp.map(jiff_sqlx::Timestamp::to_jiff))
 }
 
-/// The commit instants bounding an object's held versions, in one scalar read.
+/// The owning EHR and the commit instants bounding an object's held
+/// versions, in ONE read.
 ///
-/// The earliest is `VERSIONED_OBJECT.time_created` (RM common master06
-/// §Versioned Objects; earliest **held**, so a latest-only import clone starts
-/// above version 1) and the latest is the container resource's last-modified
-/// instant (ITS-REST overview `Requests_and_responses.md` §"`ETag` and
-/// Last-Modified" derives `Last-Modified` from
+/// The earliest instant is `VERSIONED_OBJECT.time_created` (RM common
+/// master06 §Versioned Objects; earliest **held**, so a latest-only import
+/// clone starts above version 1) and the latest is the container resource's
+/// last-modified instant (ITS-REST overview `Requests_and_responses.md`
+/// §"`ETag` and Last-Modified" derives `Last-Modified` from
 /// `VERSION.commit_audit.time_committed.value`, and for a `VERSIONED_OBJECT`
-/// response the newest held version carries that instant). `None` when the
-/// object does not exist.
+/// response the newest held version carries that instant). The owner is
+/// `None` for an ehr-less demographic object; the whole result is `None`
+/// when the object does not exist.
 ///
 /// # Errors
 /// Returns [`StorageError::Database`] on a driver failure.
 pub async fn commit_bounds(
     pool: &PgPool,
     vo_id: VoId,
-) -> Result<Option<(jiff::Timestamp, jiff::Timestamp)>, StorageError> {
-    const SQL: &str = "SELECT min(a.time_committed) AS created, \
+) -> Result<Option<(Option<EhrId>, jiff::Timestamp, jiff::Timestamp)>, StorageError> {
+    // The owner rides the same aggregate row (constant across an object's
+    // versions), so a container read never pays a separate ownership probe.
+    const SQL: &str = "SELECT (array_agg(v.ehr_id))[1] AS ehr_id, \
+                       min(a.time_committed) AS created, \
                        max(a.time_committed) AS modified \
                        FROM vo_version_all v JOIN audit a ON a.id = v.audit_id WHERE v.vo_id = $1";
     let row = sqlx::query(SQL).bind(vo_id).fetch_one(pool).await?;
+    let owner: Option<EhrId> = row.try_get("ehr_id")?;
     let created: Option<jiff_sqlx::Timestamp> = row.try_get("created")?;
     let modified: Option<jiff_sqlx::Timestamp> = row.try_get("modified")?;
     Ok(created
         .zip(modified)
-        .map(|(c, m)| (c.to_jiff(), m.to_jiff())))
+        .map(|(c, m)| (owner, c.to_jiff(), m.to_jiff())))
 }
 
 /// The stored `template_id` of one version of an object — the current open

--- a/app/ferroehr/src/storage/version_repo/meta.rs
+++ b/app/ferroehr/src/storage/version_repo/meta.rs
@@ -72,6 +72,10 @@ pub struct VersionMeta {
     pub audit_attestation: Option<Value>,
     /// The audit's server-computed commit instant.
     pub time_committed: jiff::Timestamp,
+    /// The version's `ATTESTATION` fragments in commit order (RM common
+    /// master06 §Attestation), folded into the meta row so a revision history
+    /// never issues a second attestation query; `[]` in the common case.
+    pub attestations: Vec<Value>,
 }
 
 /// All version metadata rows of an object, ordered by storage ordinal.
@@ -85,8 +89,14 @@ pub async fn all_version_meta(
     const SQL: &str = "SELECT v.ehr_id, v.kind, v.sys_version, v.trunk_version, v.branch_number, \
                        v.branch_version, v.creating_system_id, v.lifecycle_state, \
                        a.system_id, a.change_type, a.description, a.committer, a.attestation, \
-                       a.time_committed \
+                       a.time_committed, att.attestations \
                        FROM vo_version_all v JOIN audit a ON a.id = v.audit_id \
+                       LEFT JOIN LATERAL ( \
+                       SELECT coalesce(jsonb_agg(x.data ORDER BY x.time_committed, x.id), \
+                       '[]'::jsonb) AS attestations \
+                       FROM vo_attestation_all x \
+                       WHERE x.vo_id = v.vo_id AND x.sys_version = v.sys_version \
+                       ) att ON true \
                        WHERE v.vo_id = $1 ORDER BY v.sys_version";
     let rows = sqlx::query(SQL).bind(vo_id).fetch_all(pool).await?;
     rows.iter()
@@ -108,6 +118,11 @@ pub async fn all_version_meta(
                 time_committed: row
                     .try_get::<jiff_sqlx::Timestamp, _>("time_committed")?
                     .to_jiff(),
+                attestations: row
+                    .try_get::<Value, _>("attestations")?
+                    .as_array()
+                    .cloned()
+                    .unwrap_or_default(),
             })
         })
         .collect()

--- a/app/ferroehr/src/storage/version_repo/read.rs
+++ b/app/ferroehr/src/storage/version_repo/read.rs
@@ -474,3 +474,93 @@ pub async fn version_at(
         .map(|row| stored_version(vo_id, &row))
         .transpose()
 }
+
+/// Decode a scoped-read row through [`stored_version`], keyed by the row's
+/// own `vo_id` (the scoped reads resolve the container and the version in the
+/// same statement, so no caller-supplied id exists).
+fn stored_version_by_row(row: &PgRow) -> Result<StoredVersion, StorageError> {
+    let vo_id: VoId = row.try_get("vo_id")?;
+    stored_version(vo_id, row)
+}
+
+/// Read the current TRUNK version of the EHR's one container of `kind` in ONE
+/// statement — the container resolution and the version read merged.
+///
+/// Valid only for the kinds an EHR holds exactly one container of
+/// (`EHR_STATUS` — RM ehr `ehr.adoc` declares `ehr_status` singular);
+/// `None` when the EHR has no such container.
+///
+/// # Errors
+/// Returns [`StorageError`] on a driver/decode failure.
+pub async fn read_current_of_kind(
+    pool: &PgPool,
+    ehr_id: EhrId,
+    kind: &str,
+) -> Result<Option<StoredVersion>, StorageError> {
+    const SQL: &str = version_select!(
+        "WHERE v.ehr_id = $1 AND v.kind = $2 AND upper_inf(v.sys_period) \
+         AND v.branch_number = 0"
+    );
+    sqlx::query(SQL)
+        .bind(ehr_id)
+        .bind(kind)
+        .fetch_optional(pool)
+        .await?
+        .as_ref()
+        .map(stored_version_by_row)
+        .transpose()
+}
+
+/// [`read_current_of_kind`]'s time-travel form: the TRUNK version of the
+/// EHR's one container of `kind` whose `sys_period` contains `at`.
+///
+/// # Errors
+/// Returns [`StorageError`] on a driver/decode failure.
+pub async fn version_at_of_kind(
+    pool: &PgPool,
+    ehr_id: EhrId,
+    kind: &str,
+    at: jiff::Timestamp,
+) -> Result<Option<StoredVersion>, StorageError> {
+    const SQL: &str = version_select!(
+        "WHERE v.ehr_id = $1 AND v.kind = $2 AND v.sys_period @> $3::timestamptz \
+         AND v.branch_number = 0"
+    );
+    let at = at.to_string();
+    sqlx::query(SQL)
+        .bind(ehr_id)
+        .bind(kind)
+        .bind(&at)
+        .fetch_optional(pool)
+        .await?
+        .as_ref()
+        .map(stored_version_by_row)
+        .transpose()
+}
+
+/// Read the current version of the EHR's DIRECTORY folder in ONE statement.
+///
+/// The `ehr_folder` slot resolution folds into the version read, with the
+/// same slot choice `crate::storage::ehr_repo::directory_vo` makes (prefer a
+/// live slot over a logically deleted one, then the lowest `rank`, so a read
+/// after a logical delete resolves to the deleted version → 204, never 404).
+///
+/// # Errors
+/// Returns [`StorageError`] on a driver/decode failure.
+pub async fn read_current_directory(
+    pool: &PgPool,
+    ehr_id: EhrId,
+) -> Result<Option<StoredVersion>, StorageError> {
+    const SQL: &str = version_select!(
+        "JOIN ehr_folder f ON f.vo_id = v.vo_id \
+         WHERE f.ehr_id = $1 AND upper_inf(v.sys_period) AND v.branch_number = 0 \
+         ORDER BY (v.lifecycle_state = '523'), f.rank LIMIT 1"
+    );
+    sqlx::query(SQL)
+        .bind(ehr_id)
+        .fetch_optional(pool)
+        .await?
+        .as_ref()
+        .map(stored_version_by_row)
+        .transpose()
+}

--- a/app/ferroehr/src/versioning/read.rs
+++ b/app/ferroehr/src/versioning/read.rs
@@ -357,6 +357,59 @@ pub(crate) async fn version_at(
         .transpose()
 }
 
+/// Read the current version of the EHR's one container of `kind` — the
+/// container resolution and the version read in ONE statement (`EHR_STATUS`;
+/// see the storage fn's single-container precondition).
+///
+/// # Errors
+/// The storage read error, or the `spec_profile` refusal of [`version_read`].
+pub(crate) async fn read_current_of_kind(
+    pool: &sqlx::PgPool,
+    profile: crate::config::profile::SpecProfile,
+    ehr_id: EhrId,
+    kind: Kind,
+) -> Result<Option<VersionRead>, ServiceError> {
+    crate::storage::version_repo::read::read_current_of_kind(pool, ehr_id, kind.as_str())
+        .await?
+        .map(|stored| version_read(profile, stored))
+        .transpose()
+}
+
+/// [`read_current_of_kind`]'s time-travel form (the container's TRUNK version
+/// whose validity contains `at`).
+///
+/// # Errors
+/// The storage read error, or the `spec_profile` refusal of [`version_read`].
+pub(crate) async fn version_at_of_kind(
+    pool: &sqlx::PgPool,
+    profile: crate::config::profile::SpecProfile,
+    ehr_id: EhrId,
+    kind: Kind,
+    at: jiff::Timestamp,
+) -> Result<Option<VersionRead>, ServiceError> {
+    crate::storage::version_repo::read::version_at_of_kind(pool, ehr_id, kind.as_str(), at)
+        .await?
+        .map(|stored| version_read(profile, stored))
+        .transpose()
+}
+
+/// Read the current version of the EHR's DIRECTORY folder — the `ehr_folder`
+/// slot resolution and the version read in ONE statement, with the same slot
+/// choice `storage::ehr_repo::directory_vo` makes.
+///
+/// # Errors
+/// The storage read error, or the `spec_profile` refusal of [`version_read`].
+pub(crate) async fn read_current_directory(
+    pool: &sqlx::PgPool,
+    profile: crate::config::profile::SpecProfile,
+    ehr_id: EhrId,
+) -> Result<Option<VersionRead>, ServiceError> {
+    crate::storage::version_repo::read::read_current_directory(pool, ehr_id)
+        .await?
+        .map(|stored| version_read(profile, stored))
+        .transpose()
+}
+
 /// The kind of the current version of an object, or `None` if it does not
 /// exist.
 ///

--- a/app/ferroehr/src/versioning/wire.rs
+++ b/app/ferroehr/src/versioning/wire.rs
@@ -79,27 +79,19 @@ pub(crate) async fn revision_history(
         ));
     }
 
-    // Attestations for the object, keyed by version, in commit order.
-    let att_rows =
-        crate::storage::version_repo::attestation::read_attestations_all(pool, vo_id).await?;
-    let mut attestations: std::collections::HashMap<i32, Vec<Value>> =
-        std::collections::HashMap::new();
-    for (sys_version, data) in att_rows {
-        attestations.entry(sys_version).or_default().push(data);
-    }
-
     let mut items = Vec::with_capacity(rows.len());
     for row in &rows {
         // "there will always be at least one commit audit … there may also be
         // further attestations" — the commit audit first, then the version's
-        // attestations in commit order (master04 §Revision History).
+        // attestations in commit order (master04 §Revision History), folded
+        // into the one meta statement (`VersionMeta::attestations`).
         // The commit audit makes the `1..*` bound of
         // `REVISION_HISTORY_ITEM.audits` hold by construction.
         let mut audits = openehr_base::containers::NonEmptyVec::of(
             AuditInput::from_meta(row)?.typed(&row.time_committed),
         );
-        for stored in attestations.remove(&row.sys_version).unwrap_or_default() {
-            audits.push(stored_attestation(&stored)?);
+        for stored in &row.attestations {
+            audits.push(stored_attestation(stored)?);
         }
         items.push(RevisionHistoryItem {
             version_id: version_id(

--- a/app/ferroehr/src/versioning/wire.rs
+++ b/app/ferroehr/src/versioning/wire.rs
@@ -177,32 +177,32 @@ fn stored_attestation(stored: &Value) -> Result<AuditDetails, ServiceError> {
 /// trunk history whose lowest version is `> 1`; `time_created` is then the
 /// earliest version this repository received.
 ///
-/// # Errors
 /// Returns the wire body plus the newest held version's commit instant — the
 /// container resource's `Last-Modified` value (ITS-REST overview
 /// `Requests_and_responses.md` §"`ETag` and Last-Modified": both headers
 /// "SHOULD be included in responses for VERSION, `VERSIONED_OBJECT`, or other
 /// resources that have versioning or unique state identifiers", the value
-/// "derived from `VERSION.commit_audit.time_committed.value`").
+/// "derived from `VERSION.commit_audit.time_committed.value`"). `None` when
+/// the object has no stored version OR is not owned by `ehr_id` — ownership
+/// rides the same statement as the bounds, and each caller maps the miss to
+/// its own resource's 404.
 ///
 /// # Errors
-/// [`ServiceError::NotFound`] when the object has no stored version; the
-/// storage read error of `version_repo::meta::commit_bounds`.
+/// The storage read error of `version_repo::meta::commit_bounds`;
+/// [`ServiceError::Internal`] when the built body fails to serialize.
 pub(crate) async fn versioned_object(
     pool: &sqlx::PgPool,
     vo_id: VoId,
     ehr_id: EhrId,
     rm_type: &str,
-) -> Result<(Value, jiff::Timestamp), ServiceError> {
-    let (time_created, last_modified) =
+) -> Result<Option<(Value, jiff::Timestamp)>, ServiceError> {
+    let Some((_, time_created, last_modified)) =
         crate::storage::version_repo::meta::commit_bounds(pool, vo_id)
             .await?
-            .ok_or_else(|| {
-                ServiceError::sm(
-                    CallStatusType::VersionedObjectDoesNotExist,
-                    format!("versioned object {vo_id}"),
-                )
-            })?;
+            .filter(|(owner, _, _)| *owner == Some(ehr_id))
+    else {
+        return Ok(None);
+    };
     // Both keys are UUIDs by type, so the conversions are total (BASE
     // `master05-identification_package.adoc` §Syntaxes:
     // `uid = iso_oid | uuid | internet_id`).
@@ -246,10 +246,10 @@ pub(crate) async fn versioned_object(
             time_created,
         }),
     };
-    Ok((
+    Ok(Some((
         openehr_its::json::to_canonical_value(&container),
         last_modified,
-    ))
+    )))
 }
 
 /// The VERSION resource's wire form for a loaded version: an


### PR DESCRIPTION
Part of #2658 — fix 8, the two-statement-read convergence wave (inventory items 8 and 9's read-back).

- **EHR_STATUS reads** (current + `version_at_time`): the container resolution and the version read merged into one statement (`read_current_of_kind` / `version_at_of_kind` — an EHR holds exactly one EHR_STATUS container, RM ehr `ehr.adoc`).
- **Directory current read**: the `ehr_folder` slot resolution folds into the version statement with the identical slot choice (live-over-deleted, then rank); the as-of read keeps the two-step so the slot is still chosen by CURRENT state, exactly as before.
- **Revision histories**: each version's attestations ride the metadata statement as a LATERAL aggregate — one statement instead of meta + attestations (and the EHR_STATUS history no longer pre-resolves the container separately).
- **Versioned-object container reads** (`GET …/versioned_composition/{uid}` and peers): ownership rides the same aggregate row as the commit bounds; `versioned_object` is `Option`-returning with the filter inside, and every caller maps the miss to its exact prior 404 (the composition endpoint keeps `CompositionDoesNotExist`).
- **Tag replaces** (EHR + demographic): the insert's `RETURNING` is the stored collection (full-replace semantics — the insert IS the new set), sorted to the exact `list_tags` order; no post-commit read-back.

Deliberately NOT taken, each with the reason recorded on #2658: the tags 3-statement carry-forward (a PostgreSQL-cited adjudication in place), the EHR-create node-write merge (the writes live inside the per-change commit engine), and the contribution hook clone extraction (the hooks legitimately need whole bodies).

All wire-identical. Gates: fmt + clippy `--all-targets` clean on both crates, nextest **1727/1727**, comment-style OK (11 files), CNF artifact validate 0 findings, changelog updated.
