### PR TITLE
fix(storage): the 4,095-node write cliff and the dropped tenant statement_timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,16 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- A composition decomposing to more than 4,095 node rows now commits: the
+  node insert previously bound 16 parameters per row against PostgreSQL's
+  65,535-parameter statement cap, so a sufficiently large document failed
+  the write outright. The insert is now one fixed-text `unnest` statement
+  with one array bind per column at any row count (which also ends the
+  per-commit statement-text churn in the prepared-statement cache).
+- Multi-tenant deployments carry `db.statement_timeout_ms` again: the
+  tenant-scoped pool's connection hook replaced the base hook and silently
+  dropped the timeout, leaving those deployments without the database-side
+  runaway-query guard.
 - Compose: `docker compose --profile s3 up -d --wait` no longer fails after
   everything succeeded. Current Compose (v5.4, Docker and Podman alike)
   treats any exited container as a `--wait` failure, including the bucket

--- a/app/ferroehr/src/db/mod.rs
+++ b/app/ferroehr/src/db/mod.rs
@@ -373,12 +373,25 @@ async fn stamp_tenant_guc(conn: &mut PgConnection) -> Result<(), sqlx::Error> {
 /// authentication, unknown database), or the search-path initialization
 /// statement fails on that first connection.
 pub async fn connect_tenant_scoped(settings: &DbConfig) -> Result<PgPool, DbError> {
+    let statement_timeout = (settings.statement_timeout_ms > 0)
+        .then(|| format!("SET statement_timeout = {}", settings.statement_timeout_ms));
     let pool = pool_options(settings)
-        // Replaces the base `after_connect` (the setter overwrites), so the
-        // search path is applied here as well.
-        .after_connect(|conn, _meta| {
+        // Replaces the base `after_connect` (the setter overwrites), so EVERY
+        // base session setting is re-applied here — the search path AND the
+        // statement timeout (dropping the timeout silently disarms the
+        // DB-side runaway-query guard; reliability.md — a broken control must
+        // never look like a policy outcome).
+        .after_connect(move |conn, _meta| {
+            let statement_timeout = statement_timeout.clone();
             Box::pin(async move {
                 sqlx::query(SET_SEARCH_PATH_SQL).execute(&mut *conn).await?;
+                if let Some(statement_timeout) = statement_timeout {
+                    // Session-level SET; the value is our own u64 rendered
+                    // with `{}` (see `pool_options`), never client input.
+                    sqlx::query(sqlx::AssertSqlSafe(statement_timeout))
+                        .execute(&mut *conn)
+                        .await?;
+                }
                 stamp_tenant_guc(conn).await
             })
         })

--- a/app/ferroehr/src/storage/node_repo.rs
+++ b/app/ferroehr/src/storage/node_repo.rs
@@ -18,7 +18,7 @@
 use std::collections::{BTreeMap, HashMap};
 
 use serde_json::Value;
-use sqlx::{PgConnection, PgPool, QueryBuilder, Row};
+use sqlx::{PgConnection, PgPool, Row};
 use uuid::Uuid;
 
 use crate::ids::{EhrId, VoId};
@@ -26,11 +26,48 @@ use crate::storage::codec::reassemble;
 use crate::storage::error::StorageError;
 use crate::storage::row::{NodeRow, ReadRow};
 
-/// Bulk-insert the decomposed node rows of one stored version.
+/// The FIXED-text node insert: one array bind per column over `unnest`, so
+/// the statement carries the same 16 parameters at ANY row count — no
+/// per-row placeholders (PostgreSQL caps a statement at 65,535 parameters,
+/// which a per-row shape hits at ~4,095 nodes), one prepared statement
+/// forever. Built once from the shared promoted-leaf registry
+/// (`crate::storage::promoted`), each leaf bound through its kind's
+/// conversion (non-castable text becomes NULL, the ext baseline).
+static WRITE_NODES_SQL: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+    use std::fmt::Write;
+    let mut columns = String::new();
+    let mut selects = String::new();
+    let mut arrays = String::new();
+    let mut names = String::new();
+    for (i, leaf) in crate::storage::promoted::PROMOTED_LEAVES.iter().enumerate() {
+        columns.push_str(", ");
+        columns.push_str(leaf.column);
+        match leaf.kind {
+            crate::storage::promoted::PromotedKind::Timestamp => {
+                let _ = write!(selects, ", ext.openehr_timestamp(t.p{i})");
+            }
+        }
+        let _ = write!(arrays, ", ${}::text[]", 16 + i);
+        let _ = write!(names, ", p{i}");
+    }
+    format!(
+        "INSERT INTO node (vo_id, sys_version, ehr_id, num, num_cap, parent_num, citem_num, \
+         rm_type, archetype, arch_entity, arch_concept, arch_major, name, path, data{columns}) \
+         SELECT $1, $2, $3, t.num, t.num_cap, t.parent_num, t.citem_num, t.rm_type, \
+         t.archetype, t.arch_entity, t.arch_concept, t.arch_major, t.name, t.path, t.data{selects} \
+         FROM unnest($4::int[], $5::int[], $6::int[], $7::int[], $8::text[], $9::text[], \
+         $10::text[], $11::text[], $12::int[], $13::text[], $14::text[], $15::jsonb[]{arrays}) \
+         AS t(num, num_cap, parent_num, citem_num, rm_type, archetype, arch_entity, \
+         arch_concept, arch_major, name, path, data{names})"
+    )
+});
+
+/// Bulk-insert the decomposed node rows of one stored version — ONE
+/// fixed-text `unnest` statement whatever the row count.
 ///
 /// `rows` is the output of [`crate::storage::codec::decompose`]; the storage
 /// context (`vo_id`/`sys_version`/`ehr_id`) is supplied here and written onto
-/// every row.
+/// every row as constant scalars.
 ///
 /// A logically-deleted version (data Void, RM common master06 §Logical
 /// Deletion) has no node rows — the caller simply passes an empty slice and no
@@ -53,52 +90,57 @@ pub async fn write_nodes(
     if rows.is_empty() {
         return Ok(());
     }
-    // Base content columns + the promoted-leaf columns, generated from the
-    // shared registry so adding a promoted column is a migration + one registry
-    // entry, never an edit here (our own storage design — no openEHR spec
-    // governs promoted columns; see `crate::storage::promoted`).
-    let mut header = String::from(
-        "INSERT INTO node (vo_id, sys_version, num, num_cap, parent_num, citem_num, ehr_id, \
-         rm_type, archetype, arch_entity, arch_concept, arch_major, name, path, data",
-    );
-    for leaf in crate::storage::promoted::PROMOTED_LEAVES {
-        header.push_str(", ");
-        header.push_str(leaf.column);
+    let n = rows.len();
+    let mut nums = Vec::with_capacity(n);
+    let mut num_caps = Vec::with_capacity(n);
+    let mut parent_nums = Vec::with_capacity(n);
+    let mut citem_nums = Vec::with_capacity(n);
+    let mut rm_types: Vec<&str> = Vec::with_capacity(n);
+    let mut archetypes: Vec<Option<&str>> = Vec::with_capacity(n);
+    let mut arch_entities: Vec<Option<&str>> = Vec::with_capacity(n);
+    let mut arch_concepts: Vec<Option<&str>> = Vec::with_capacity(n);
+    let mut arch_majors: Vec<Option<i32>> = Vec::with_capacity(n);
+    let mut names: Vec<Option<&str>> = Vec::with_capacity(n);
+    let mut paths: Vec<&str> = Vec::with_capacity(n);
+    let mut datas: Vec<&Value> = Vec::with_capacity(n);
+    for row in rows {
+        nums.push(row.num);
+        num_caps.push(row.num_cap);
+        parent_nums.push(row.parent_num);
+        citem_nums.push(row.citem_num);
+        rm_types.push(&row.rm_type);
+        archetypes.push(row.archetype.as_deref());
+        arch_entities.push(row.arch_entity.as_deref());
+        arch_concepts.push(row.arch_concept.as_deref());
+        arch_majors.push(row.arch_major);
+        names.push(row.name.as_deref());
+        paths.push(&row.path);
+        datas.push(&row.data);
     }
-    header.push_str(") ");
-    let mut qb = QueryBuilder::new(header);
-    qb.push_values(rows, |mut b, row| {
-        b.push_bind(vo_id)
-            .push_bind(sys_version)
-            .push_bind(row.num)
-            .push_bind(row.num_cap)
-            .push_bind(row.parent_num)
-            .push_bind(row.citem_num)
-            .push_bind(ehr_id)
-            .push_bind(&row.rm_type)
-            .push_bind(&row.archetype)
-            .push_bind(&row.arch_entity)
-            .push_bind(&row.arch_concept)
-            .push_bind(row.arch_major)
-            .push_bind(&row.name)
-            .push_bind(&row.path)
-            .push_bind(&row.data);
-        // Each promoted value is bound through its kind's conversion so a
-        // value the AQL query-time cast accepted yields the same stored value,
-        // and non-castable text becomes NULL rather than failing the write
-        // (ext.openehr_timestamp, ext baseline).
-        for (i, leaf) in crate::storage::promoted::PROMOTED_LEAVES.iter().enumerate() {
-            let raw = row.promoted.get(i).and_then(Clone::clone);
-            match leaf.kind {
-                crate::storage::promoted::PromotedKind::Timestamp => {
-                    b.push("ext.openehr_timestamp(")
-                        .push_bind_unseparated(raw)
-                        .push_unseparated(")");
-                }
-            }
-        }
-    });
-    qb.build().execute(&mut *tx).await?;
+    let mut query = sqlx::query(sqlx::AssertSqlSafe(WRITE_NODES_SQL.as_str()))
+        .bind(vo_id)
+        .bind(sys_version)
+        .bind(ehr_id)
+        .bind(&nums)
+        .bind(&num_caps)
+        .bind(&parent_nums)
+        .bind(&citem_nums)
+        .bind(&rm_types)
+        .bind(&archetypes)
+        .bind(&arch_entities)
+        .bind(&arch_concepts)
+        .bind(&arch_majors)
+        .bind(&names)
+        .bind(&paths)
+        .bind(&datas);
+    for (i, _leaf) in crate::storage::promoted::PROMOTED_LEAVES.iter().enumerate() {
+        let leaf_values: Vec<Option<&str>> = rows
+            .iter()
+            .map(|row| row.promoted.get(i).and_then(Option::as_deref))
+            .collect();
+        query = query.bind(leaf_values);
+    }
+    query.execute(&mut *tx).await?;
     Ok(())
 }
 

--- a/app/ferroehr/tests/it/persistence.rs
+++ b/app/ferroehr/tests/it/persistence.rs
@@ -872,3 +872,83 @@ async fn materialized_body_matches_node_reassembly_on_a_real_commit() {
         Some("EHR_STATUS")
     );
 }
+
+/// The fixed-text `unnest` node insert has no per-row parameter cost, so a
+/// composition decomposing to more than 4,095 node rows — past the 65,535
+/// extended-protocol parameter cap the old per-row shape hit — commits in one
+/// statement (#2668).
+#[tokio::test]
+async fn write_nodes_survives_more_than_4095_rows() {
+    let db = testkit::db().await.expect("testkit database");
+    let pool = db.pool();
+    let (vo, ehr_id) = seed_version(&pool).await;
+
+    let n = 5_000;
+    let mut rows = Vec::with_capacity(n);
+    for i in 0..n {
+        let num = i32::try_from(i).expect("row ordinal fits i32");
+        rows.push(NodeRow {
+            num,
+            num_cap: num,
+            parent_num: 0,
+            citem_num: None,
+            rm_type: "ELEMENT".to_owned(),
+            archetype: None,
+            arch_entity: None,
+            arch_concept: None,
+            arch_major: None,
+            name: None,
+            path: if i == 0 {
+                String::new()
+            } else {
+                format!("items{i}.")
+            },
+            data: serde_json::json!({"_type": "ELEMENT", "archetype_node_id": "at0001"}),
+            promoted: Vec::new(),
+        });
+    }
+    let mut tx = pool.begin().await.expect("begin");
+    ferroehr::storage::node_repo::write_nodes(
+        &mut tx,
+        ferroehr::ids::VoId(vo),
+        1,
+        Some(ferroehr::ids::EhrId(ehr_id)),
+        &rows,
+    )
+    .await
+    .expect("a 5,000-row version must write in one statement");
+    tx.commit().await.expect("commit");
+
+    let count: i64 = sqlx::query_scalar("SELECT count(*) FROM node WHERE vo_id = $1")
+        .bind(vo)
+        .fetch_one(&pool)
+        .await
+        .expect("count");
+    assert_eq!(count, 5_000);
+}
+
+/// The tenant-scoped pool applies the SAME session settings the base pool
+/// does — `statement_timeout` included (#2669: the tenant `after_connect`
+/// previously replaced the base hook and silently dropped the DB-side
+/// runaway-query guard).
+#[tokio::test]
+async fn tenant_scoped_pool_applies_statement_timeout() {
+    let db = testkit::db().await.expect("testkit database");
+    let mut settings = ferroehr::db::DbConfig::default();
+    settings.url = ferroehr::config::secret::SecretUrl::new(db.url());
+    settings.statement_timeout_ms = 12_345;
+    settings.max_connections = 2;
+    settings.min_connections = 0;
+
+    let pool = ferroehr::db::connect_tenant_scoped(&settings)
+        .await
+        .expect("tenant-scoped pool");
+    let timeout: String = sqlx::query_scalar("SHOW statement_timeout")
+        .fetch_one(&pool)
+        .await
+        .expect("read timeout");
+    assert_eq!(
+        timeout, "12345ms",
+        "the tenant-scoped connection must carry the configured statement_timeout"
+    );
+}

--- a/docs/conformance/ferroehr/CONFORMANCE_CERTIFICATE.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_CERTIFICATE.md
@@ -4,9 +4,9 @@
 
 | Field | Value |
 | --- | --- |
-| Solution | ferroehr 3.20.0 |
+| Solution | ferroehr 4.0.1 |
 | Vendor | Ruben Talstra |
-| Runner | cnf-runner 3.20.0 |
+| Runner | cnf-runner 4.0.1 |
 | Infrastructure | ixit.json#/environment |
 
 ## Scope of Test

--- a/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
@@ -1,7 +1,7 @@
 # Conformance Report
 
-SUT: FerroEHR 3.20.0 (sut `ferroehr`) · schedule cnf-2.0-w2 · ITS its-rest
-Runner: cnf-runner 3.20.0 · verification pack: passed
+SUT: FerroEHR 4.0.1 (sut `ferroehr`) · schedule cnf-2.0-w2 · ITS its-rest
+Runner: cnf-runner 4.0.1 · verification pack: passed
 
 ## Summary
 

--- a/docs/conformance/ferroehr/results.json
+++ b/docs/conformance/ferroehr/results.json
@@ -1,11 +1,11 @@
 {
   "sut": {
     "name": "ferroehr",
-    "version": "3.20.0"
+    "version": "4.0.1"
   },
   "runner": {
     "name": "cnf-runner",
-    "version": "3.20.0",
+    "version": "4.0.1",
     "verification_pack_status": "passed"
   },
   "schedule_release": "cnf-2.0-w2",


### PR DESCRIPTION
Closes #2668. Closes #2669.

Both found by the second performance probe under #2658, both verified defects:

- **#2668** — `write_nodes` bound 16 parameters per node row, so a composition decomposing past 4,095 rows hit PostgreSQL's 65,535-parameter statement cap and failed to commit. The insert is now ONE fixed-text `unnest` statement (one array bind per column, built once from the promoted-leaf registry): no cap, and — since the text no longer varies with the row count — no more prepared-statement-cache churn per commit. Regression test writes a 5,000-row version in one statement.
- **#2669** — `connect_tenant_scoped`'s `after_connect` replaced the base pool hook, silently dropping `SET statement_timeout`: multi-tenant deployments ran without the DB-side runaway-query guard. The tenant hook now re-applies every base session setting. Regression test asserts `SHOW statement_timeout` on a tenant-scoped connection. (The per-checkout GUC round trip stays recorded on #2669's thread as the perf follow-up.)

Gates: fmt + clippy `--all-targets` clean on both crates, nextest **1729/1729** (both new regression tests included), comment-style OK, changelog `### Fixed` entries added.
