### PR TITLE
chore(conformance): the v4.0.2 release-gate baseline — 1,064/1,064, the mixed-change-set cases green

### DIFF
--- a/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
@@ -7,12 +7,12 @@ Runner: cnf-runner 4.0.1 · verification pack: passed
 
 | Status | Count |
 | --- | --- |
-| passed | 1062 |
+| passed | 1064 |
 | failed | 0 |
 | errored | 0 |
 | skipped | 0 |
 | not_applicable | 38 |
-| total | 1100 |
+| total | 1102 |
 
 ## By chapter
 
@@ -20,12 +20,12 @@ Grouping is the published per-chapter chart's taxonomy: chapters with their band
 
 | Chapter / band | passed | failed | errored | cited n/a |
 | --- | --- | --- | --- | --- |
-| **EHR** | 472 | 0 | 0 | 18 |
+| **EHR** | 474 | 0 | 0 | 18 |
 | — EHR resource | 25 | 0 | 0 | 2 |
 | — EHR_STATUS | 47 | 0 | 0 | 5 |
 | — COMPOSITION | 142 | 0 | 0 | 0 |
 | — DIRECTORY | 80 | 0 | 0 | 6 |
-| — CONTRIBUTION | 110 | 0 | 0 | 5 |
+| — CONTRIBUTION | 112 | 0 | 0 | 5 |
 | — Item tags | 62 | 0 | 0 | 0 |
 | — Revision history | 6 | 0 | 0 | 0 |
 | **Definitions** | 103 | 0 | 0 | 10 |
@@ -86,7 +86,7 @@ Selected gating cases per claimed capability. `inconclusive` counts cases whose 
 | EhrStatus | pass | 45 | 0 | 0 | 5 |
 | CompositionOps | pass | 60 | 0 | 0 | 0 |
 | DirectoryOps | pass | 78 | 0 | 0 | 8 |
-| ChangeSets | pass | 102 | 0 | 0 | 5 |
+| ChangeSets | pass | 104 | 0 | 0 | 5 |
 | Versioning | pass | 75 | 0 | 0 | 0 |
 | ArchetypeValidation | pass | 125 | 0 | 0 | 0 |
 | PartyOperations | pass | 88 | 0 | 0 | 4 |
@@ -175,7 +175,7 @@ Percentiles re-derive from the embedded HDR V2 histograms; the class verdict is 
 
 ## Honesty
 
-Coverage: 1062 of 1100 selected cases driven.
+Coverage: 1064 of 1102 selected cases driven.
 
 Not-executed verdicts (each cited):
 

--- a/docs/conformance/ferroehr/badge.json
+++ b/docs/conformance/ferroehr/badge.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "openEHR conformance",
-  "message": "CORE+STANDARD PASS · 1062/1062 cases",
+  "message": "CORE+STANDARD PASS · 1064/1064 cases",
   "color": "brightgreen"
 }

--- a/docs/conformance/ferroehr/results.json
+++ b/docs/conformance/ferroehr/results.json
@@ -2149,6 +2149,12 @@
       "rows_total": 1
     },
     {
+      "case": "I_EHR_CONTRIBUTION.commit_contribution-deactivating_mixed_change_set",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
       "case": "I_EHR_CONTRIBUTION.commit_contribution-delete",
       "status": "passed",
       "rows_driven": 1,
@@ -2483,6 +2489,12 @@
     },
     {
       "case": "I_EHR_CONTRIBUTION.commit_contribution-quantity_rich",
+      "status": "passed",
+      "rows_driven": 1,
+      "rows_total": 1
+    },
+    {
+      "case": "I_EHR_CONTRIBUTION.commit_contribution-reactivating_mixed_change_set",
       "status": "passed",
       "rows_driven": 1,
       "rows_total": 1

--- a/docs/conformance/ferroehr/verdicts.json
+++ b/docs/conformance/ferroehr/verdicts.json
@@ -268,7 +268,7 @@
     [
       "ChangeSets",
       {
-        "passed": 102,
+        "passed": 104,
         "failed": 0,
         "inconclusive": 0,
         "unevidenced": 5
@@ -588,9 +588,9 @@
     }
   ],
   "coverage": {
-    "selected": 1100,
-    "driven": 1062,
-    "passed": 1062,
+    "selected": 1102,
+    "driven": 1064,
+    "passed": 1064,
     "failed": 0,
     "inconclusive": 0
   }


### PR DESCRIPTION
Closes #2658.

The final release-gate conformance run over the fully merged v4.0.2 tree: **1,102 case-records, 1,064 passed / 0 failed / 0 errored / 38 n-a** — the baseline ratchets up by the two new mixed-change-set cases (#2676), both green on the wire, full clinical posture on.

This closes the #2658 performance program. Its record, all on the issue thread with measurements:
- Community-harness verification (his code, his methodology, everything in Docker): reads 24.42 ms → **1.69 ms** per query over 700,000 queries (14.4×); commits 7.02 ms → **5.56 ms** per composition over 100,000 (−21%), with ATNA audit + version signing on.
- Eight optimization merges (#2660–#2667), two defect fixes (#2668/#2669 via #2670), the nine-item residual queue (#2672), and the community-reported gate adjudication (#2673 via #2676) — conformance zero-drift or ratchet-up at every merge.
- The attributed write-path residual (3 ms node btree maintenance) continues as #2677 in v4.0.3.