### PR TITLE
perf(storage): lz4 for the write path — stored-body compression and compressed WAL full-page images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Changed
+
+- Commit latency's tail shrinks: the large stored JSON columns
+  (`vo_version.body`, `vo_version.wrapped_original`; the node fragments and
+  audit columns already had it) compress with lz4 instead of PostgreSQL's
+  default pglz, and the bundled compose database enables
+  `wal_compression=lz4` — measured together, per-commit WAL volume roughly
+  halves (~52 KB → ~24 KB) and the post-checkpoint p99 drops from ~180 ms to
+  ~19 ms on the reference workload, with the median commit ~0.5–1 ms faster.
+  Greenfield deployments pick the column compression up by recreating the
+  database; the WAL setting is the compose default and an operator knob
+  (`BENCH_PG_WAL_COMPRESSION`) elsewhere.
+
 ## [4.0.2] - 2026-08-24
 
 ### Added

--- a/app/ferroehr/migrations/ehr/0001_baseline.sql
+++ b/app/ferroehr/migrations/ehr/0001_baseline.sql
@@ -397,7 +397,7 @@ CREATE TABLE vo_version (
     -- act of committal" true for time_created / Last-Modified / time travel.
     -- The wrapped contribution CANNOT be a foreign key: it names a CONTRIBUTION
     -- in the SOURCE system, which this repository does not hold.
-    wrapped_original jsonb,
+    wrapped_original jsonb COMPRESSION lz4,
     -- ORIGINAL_VERSION.other_input_version_uids: merge provenance (RM common
     -- master06 §Version Merging). PRODUCE-only on the released wire: the commit
     -- wire declares no merge shape, so a CONTRIBUTION member carrying it is
@@ -416,7 +416,7 @@ CREATE TABLE vo_version (
     -- out of the main row, so meta-only scans stay slim). The node rows
     -- remain the AQL source of truth; NULL on a logically deleted version
     -- (no content — RM common master06 §Logical Deletion).
-    body            jsonb,
+    body            jsonb COMPRESSION lz4,
     CONSTRAINT pk_vo_version PRIMARY KEY (vo_id, sys_version),
     CONSTRAINT uq_vo_version_tree UNIQUE
         (vo_id, creating_system_id, trunk_version, branch_number, branch_version),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,6 +112,12 @@ services:
       - max_wal_size=${BENCH_PG_MAX_WAL_SIZE:-4GB}
       - -c
       - work_mem=${BENCH_PG_WORK_MEM:-16MB}
+      # Compressed full-page images halve the WAL a commit fsyncs (measured
+      # ~52 KB -> ~24 KB per composition commit) and collapse the post-
+      # checkpoint latency tail; lz4's compression CPU is far below the fsync
+      # it saves (PostgreSQL docs: Write Ahead Log / wal_compression).
+      - -c
+      - wal_compression=${BENCH_PG_WAL_COMPRESSION:-lz4}
     volumes:
       - ferroehr-pgdata:/var/lib/postgresql
     ports:

--- a/website/book/src/installation/compose.md
+++ b/website/book/src/installation/compose.md
@@ -78,8 +78,9 @@ This pulls and starts the two core services (no profile needed):
 
 - **`ferroehr-postgres`:** the database image, with a named data volume, a
   `pg_isready` healthcheck, `pg_stat_statements` preloaded, and a modest tuning
-  floor (shared buffers, WAL size, work memory, and a larger `/dev/shm` than
-  Docker's default, which otherwise starves parallel workers).
+  floor (shared buffers, WAL size, work memory, lz4-compressed WAL full-page
+  images — which cut per-commit WAL volume roughly in half — and a larger
+  `/dev/shm` than Docker's default, which otherwise starves parallel workers).
 - **`ferroehr`:** the server, which waits for the database to report healthy
   (`depends_on: condition: service_healthy`), then boots, migrates, and serves
   on port 8080. Its healthcheck is the binary's own `healthcheck` subcommand,


### PR DESCRIPTION
Works #2677 — the first adopted levers from the measured write-path program.

**Adopted (A/B-measured on the composed stack, 12k-composition seed, 400-commit dives with `pg_stat_statements` attribution — the full record is on #2677):**
- `vo_version.body` and `vo_version.wrapped_original` columns compress with **lz4** (the node fragments and audit columns already did; PostgreSQL's default is the slower pglz).
- The compose database floor gains **`wal_compression=lz4`** (`BENCH_PG_WAL_COMPRESSION` overrides), and the compose book page documents it.

| 400-commit dive | before (pglz, wal off) | after |
|---|---|---|
| WAL per commit | ~52 KB | ~24 KB |
| wall p99 | 33–182 ms | 18.6 ms |
| node-insert mean (DB) | 2.02–2.31 ms | 1.73 ms |
| wall p50 | 7.5–8.7 ms | 6.9 ms |

**Closed with evidence (no code change): index slimming.** On the homogeneous seed all four node secondaries sat idle across representative AQL shapes — but re-probed over a heterogeneous four-template corpus with selective archetype anchors, `pg_stat_user_indexes` shows `idx_node_type_archetype` (20 scans), `idx_node_ehr` (20) and `idx_node_arch_subsume` (2) all serving real plans. The remaining node-insert maintenance is load-bearing; dropping indexes would trade read plans for write latency. Recorded on #2677.

Greenfield migration policy: the baseline edit applies on database recreation. Gates: persistence/codec suites green over the rebuilt template DB; changelog-structure, docs-claims, stale-numbers, compose-hardening, compose-image-tags all green.