### PR TITLE
chore(quality): the Sonar New Code window anchors to releases

### DIFF
--- a/.claude/rules/ai-code-review.md
+++ b/.claude/rules/ai-code-review.md
@@ -25,6 +25,18 @@ a deliberate recorded decision (the RFC 2008 rejection, zero re-exports, …)
 is rejected as a class in the quality profile, with the reason recorded on
 the triage program (#2640).
 
+## New Code = since the last release (#2657)
+
+The project's New Code definition is **"Previous version"**, anchored by
+`sonar.projectVersion`: the sonar lane reads the workspace `version` from the
+root `Cargo.toml` at scan time and appends it to the properties file — never
+a second hand-maintained copy. The workspace version bumps at every release
+cut (milestones are releases), so the quality gate's `new_*` conditions, PR
+decoration, and the coverage program (#2656) all measure "since the last
+release" — the same window the changelog section and the conformance baseline
+describe. Do not switch the definition to days/reference-branch without
+re-adjudicating that alignment.
+
 ## How Rust is analyzed
 
 Rust is first-party in SonarQube Cloud (announced 2025-04-17): the analyzer

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -100,6 +100,17 @@ jobs:
           name: coverage-lcov
           path: lcov.info
 
+      # sonar.projectVersion anchors the "Previous version" New Code window
+      # (docs.sonarsource.com/sonarqube-cloud/standards/about-new-code): the
+      # workspace version bumps at every release cut, so "new code" means
+      # "since the last release" — the milestones-are-releases model as the
+      # analysis window. Read from the root Cargo.toml at scan time (never a
+      # second hand-maintained copy) and appended to the properties file the
+      # scanner reads, so no context value reaches a shell or the action args.
+      - name: Derive sonar.projectVersion from the workspace version
+        run: |
+          v="$(grep -m1 '^version = ' Cargo.toml | cut -d'"' -f2)"
+          echo "sonar.projectVersion=$v" >> sonar-project.properties
       - uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Closes #2657.

The sonar lane derives `sonar.projectVersion` from the root `Cargo.toml` workspace version at scan time and appends it to `sonar-project.properties` before the scan — no second hand-maintained copy, and no context value interpolated into a `run:` block or action args (the value never leaves the runner's own shell step).

With the project's New Code definition on "Previous version" (the org default, to be confirmed in the project settings after the first post-merge analysis), the quality gate's `new_*` conditions, PR decoration, and the #2656 coverage program all measure "since the last release" — the milestones-are-releases model as the analysis window. The definition and its rationale are recorded in `.claude/rules/ai-code-review.md`.

The remaining acceptance item — the first post-release analysis demonstrably resetting the window — is observable on the next release cut's develop analysis.