### PR TITLE
chore(quality): the generated emit-json outputs leave the Sonar scope

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -29,6 +29,13 @@ sonar.coverage.exclusions=\
 # rules (S3641 and friends) warn on every analysis and can never apply.
 # Correctness for our SQL is owned by sqlx, PostgreSQL itself, and the CNF
 # suite.
+#
+# The lang/term crate-root entries below are the emit-json/module-declaration
+# outputs the generator writes OUTSIDE those crates' generation modules
+# (`// @generated` headers; openehr-lang's json_serde.rs alone is ~40k lines)
+# — they escaped the original generated-tree list (#2656), against this
+# file's own stated intent. Their correctness is owned by the emitter
+# invariants and the fidelity gates, like every other generated tree here.
 sonar.exclusions=\
   **/*.sql,\
   crates/openehr-base/**,\
@@ -37,6 +44,12 @@ sonar.exclusions=\
   crates/openehr-lang/src/v1_0/**,\
   crates/openehr-lang/src/v1_1/**,\
   crates/openehr-term/src/v3_1/**,\
+  crates/openehr-lang/src/json_serde.rs,\
+  crates/openehr-lang/src/lib.rs,\
+  crates/openehr-lang/src/prelude.rs,\
+  crates/openehr-term/src/json_serde.rs,\
+  crates/openehr-term/src/lib.rs,\
+  crates/openehr-term/src/prelude.rs,\
   crates/openehr-its/src/aom2/**,\
   crates/openehr-its/src/aom2_model/**,\
   crates/openehr-its/src/json_codec/generated/**,\


### PR DESCRIPTION
Works #2656 (the coverage program's scope-honesty half — the test-writing half follows).

`sonar-project.properties` states that every generated tree is excluded from analysis, but the `emit-json` outputs the generator writes at crate ROOTS — `crates/openehr-lang/src/json_serde.rs` (~40k lines, 0% covered: **53% of the project's entire uncovered-line count**), `crates/openehr-term/src/json_serde.rs`, and the emitted `lib.rs`/`prelude.rs` module declarations — sat outside the generation-module globs the list actually names. All carry `// @generated` headers; their correctness is owned by the emitter invariants and the fidelity gates, exactly like the base/rm/am trees already excluded.

This is a scope correction against the file's own written intent, not a bar movement: the quality gate stays at 80%, and what the measured number then describes is hand-written code. Expected effect on the badge: roughly 59% → mid-70s; the remaining distance to 80% is genuine test work (the cnf-runner binary, the codegen render stage, telemetry, the console's ssr-rendered pages), tracked on #2656.