### PR TITLE
test(codegen): in-memory seams + drift-proving tests for emit-json/xml/rest

### DIFF
--- a/tools/openehr-codegen/src/cli.rs
+++ b/tools/openehr-codegen/src/cli.rs
@@ -48,9 +48,64 @@ const XSD_V2_DIR: &str = concat!(
     "/../../crates/openehr-its/schemas/xml/its-xml-2.0.0-nsv2"
 );
 
+/// The `emit-xml` output directory, relative to the workspace `crates/` dir.
+const XML_GEN_DIR: &str = "openehr-its/src/xml/generated";
+/// The `emit-rest` output directory, relative to the workspace `crates/` dir.
+const REST_GEN_DIR: &str = "openehr-its/src/rest/generated";
+/// The `emit-json` `_type`-dispatch output directory, relative to the workspace
+/// `crates/` dir.
+const JSON_GEN_DIR: &str = "openehr-its/src/json_codec/generated";
+
 /// Exit code for an unrecognized subcommand (distinct from a pipeline failure,
 /// which exits 1, so a wrapper script can tell a typo from a codegen error).
 const EXIT_USAGE: u8 = 2;
+
+/// One file an emit target produces, before it reaches the filesystem.
+///
+/// Separating the rendered text from the write lets a target's whole
+/// orchestration run in memory (`testsupport`) and on disk (the `cmd_*`
+/// handlers) through ONE code path, so the tested text and the emitted text
+/// cannot drift.
+#[derive(Debug)]
+pub(crate) struct EmittedFile {
+    /// Where the file lands, relative to the workspace `crates/` directory.
+    pub(crate) path: String,
+    /// The crate that owns the file, whose SPDX header it carries.
+    pub(crate) crate_name: &'static str,
+    /// The rendered body, before the value-carrier guard, the SPDX header and
+    /// `rustfmt`.
+    pub(crate) body: String,
+}
+
+/// What `emit-xml` produces: the rendered files, plus the XSD-declared elements
+/// that matched no BMM field and are therefore reported rather than emitted.
+#[derive(Debug)]
+pub(crate) struct XmlEmission {
+    /// The rendered files.
+    pub(crate) files: Vec<EmittedFile>,
+    /// The XSD-only `(type, element)` pairs skipped for want of a BMM field.
+    pub(crate) unmatched: Vec<(String, String)>,
+}
+
+/// Write an emit target's rendered files into the workspace `crates/` tree,
+/// creating each file's parent directories, and return the written paths for
+/// the caller's `rustfmt` pass.
+///
+/// # Errors
+/// Returns the underlying filesystem error.
+fn write_emitted(files: &[EmittedFile]) -> std::io::Result<Vec<PathBuf>> {
+    let root = crates_root();
+    let mut written = Vec::with_capacity(files.len());
+    for f in files {
+        let full = root.join(&f.path);
+        if let Some(parent) = full.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        write_generated(&full, f.crate_name, &f.body)?;
+        written.push(full);
+    }
+    Ok(written)
+}
 
 pub(crate) fn run() -> std::process::ExitCode {
     let args: Vec<String> = std::env::args().skip(1).collect();
@@ -190,6 +245,28 @@ fn parse_model_query_args(
 /// Emit the ITS-REST contract (DTOs, param structs, server trait, route table)
 /// for each API group into `openehr-its/src/rest/generated/`.
 fn cmd_emit_rest() -> Result<(), Box<dyn std::error::Error>> {
+    let files = render_rest_files()?;
+    let written = write_emitted(&files)?;
+    rustfmt(&written)?;
+    println!(
+        "emitted {} files into {}",
+        written.len(),
+        crates_root().join(REST_GEN_DIR).display()
+    );
+    Ok(())
+}
+
+/// Render the ITS-REST contract for every API group, plus the shared `common`
+/// module and the module declaration file, without touching the filesystem.
+///
+/// The text half of [`cmd_emit_rest`], shared with the emitter-invariant tests
+/// (`testsupport::emit_rest_to_memory`), so the CLI and the tests drive one
+/// orchestration.
+///
+/// # Errors
+/// Returns an error if the RM/BASE compositions or a vendored OAS bundle cannot
+/// be loaded.
+pub(crate) fn render_rest_files() -> Result<Vec<EmittedFile>, Box<dyn std::error::Error>> {
     // Every API group whose OAS declares operations. `overview` is excluded
     // because it is the release's index document: it declares no `paths`.
     // `system` DOES declare one — `system-codegen.openapi.yaml` `paths` `/`
@@ -223,8 +300,6 @@ fn cmd_emit_rest() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let oas_dir = Path::new(ITS_ROOT).join("vendor/rest-oas");
-    let gen_dir = Path::new(ITS_ROOT).join("src/rest/generated");
-    std::fs::create_dir_all(&gen_dir)?;
 
     // Load every bundle up front: the cross-group hoist analysis needs the
     // whole set (schemas identical in every declaring group hoist into the
@@ -236,22 +311,24 @@ fn cmd_emit_rest() -> Result<(), Box<dyn std::error::Error>> {
     }
     let hoisted = emit_rest::hoist_set(&bundles, &names);
 
-    let mut written = Vec::new();
+    let mut files = Vec::new();
     // `common` always emits from the merged per-name view (first declarer
     // wins; the copies are identical by the hoist analysis) — ONE emission
     // path, so no representative-vs-merged equivalence needs testing (#1854).
     {
         let merged = oas::Oas::merged_schemas(&bundles, &hoisted);
-        let body = emit_rest::emit_common(&merged, &names, &hoisted);
-        let path = gen_dir.join("common.rs");
-        write_generated(&path, ITS_CRATE, &body)?;
-        written.push(path);
+        files.push(EmittedFile {
+            path: format!("{REST_GEN_DIR}/common.rs"),
+            crate_name: ITS_CRATE,
+            body: emit_rest::emit_common(&merged, &names, &hoisted),
+        });
     }
     for (group, oas) in &bundles {
-        let body = emit_rest::emit_group(oas, group, &names, &hoisted);
-        let path = gen_dir.join(format!("{group}.rs"));
-        write_generated(&path, ITS_CRATE, &body)?;
-        written.push(path);
+        files.push(EmittedFile {
+            path: format!("{REST_GEN_DIR}/{group}.rs"),
+            crate_name: ITS_CRATE,
+            body: emit_rest::emit_group(oas, group, &names, &hoisted),
+        });
     }
     let mod_rs = {
         let mut s = String::from(
@@ -265,19 +342,42 @@ fn cmd_emit_rest() -> Result<(), Box<dyn std::error::Error>> {
         }
         s
     };
-    let mod_path = gen_dir.join("mod.rs");
-    write_generated(&mod_path, ITS_CRATE, &mod_rs)?;
-    written.push(mod_path);
-
-    rustfmt(&written)?;
-    println!("emitted {} files into {}", written.len(), gen_dir.display());
-    Ok(())
+    files.push(EmittedFile {
+        path: format!("{REST_GEN_DIR}/mod.rs"),
+        crate_name: ITS_CRATE,
+        body: mod_rs,
+    });
+    Ok(files)
 }
 
 /// Emit canonical-XML `ToXml`/`FromXml` impls for the RM/BASE spec types into
 /// `openehr-its/src/xml/generated/`. Generates both wire lineages: v1
 /// (`.../v1`, parity target) and v2 (`.../v2`, latest).
 fn cmd_emit_xml() -> Result<(), Box<dyn std::error::Error>> {
+    let emission = render_xml_files()?;
+    let written = write_emitted(&emission.files)?;
+    rustfmt(&written)?;
+    println!(
+        "emitted {} files into {} ({} XSD-only elements without a BMM field skipped)",
+        written.len(),
+        crates_root().join(XML_GEN_DIR).display(),
+        emission.unmatched.len()
+    );
+    Ok(())
+}
+
+/// Render the canonical-XML `ToXml`/`FromXml` impls and their module
+/// declaration file without touching the filesystem, reporting the XSD-only
+/// elements that matched no BMM field.
+///
+/// The text half of [`cmd_emit_xml`], shared with the emitter-invariant tests
+/// (`testsupport::emit_xml_to_memory`), so the CLI and the tests drive one
+/// orchestration.
+///
+/// # Errors
+/// Returns an error if the RM/BASE compositions or the vendored XSD bundles
+/// cannot be loaded, or if the XML emission itself fails.
+pub(crate) fn render_xml_files() -> Result<XmlEmission, Box<dyn std::error::Error>> {
     // The XML codec covers the CURRENT RM/BASE generations (the wire the
     // server serves).
     let base = compose("base")?;
@@ -299,9 +399,6 @@ fn cmd_emit_xml() -> Result<(), Box<dyn std::error::Error>> {
         Path::new(XSD_V2_DIR),
     ))?;
 
-    let gen_dir = Path::new(ITS_ROOT).join("src/xml/generated");
-    std::fs::create_dir_all(&gen_dir)?;
-
     let schemas = [
         emit_xml::XmlSchema {
             model: &base_unit.model,
@@ -322,24 +419,26 @@ fn cmd_emit_xml() -> Result<(), Box<dyn std::error::Error>> {
     ];
     let mut unmatched = Vec::new();
     let body = emit_xml::emit_file(&schemas, &v1, &mut unmatched)?;
-    let impls_path = gen_dir.join("impls.rs");
-    write_generated(&impls_path, ITS_CRATE, &body)?;
 
     let mod_rs = "// @generated by openehr-codegen (emit-xml) — DO NOT EDIT.\n\
         //! Canonical-XML `ToXml`/`FromXml` impls for the RM/BASE spec types.\n\n\
         mod impls;\n";
-    let mod_path = gen_dir.join("mod.rs");
-    write_generated(&mod_path, ITS_CRATE, mod_rs)?;
 
-    let written = vec![impls_path, mod_path];
-    rustfmt(&written)?;
-    println!(
-        "emitted {} files into {} ({} XSD-only elements without a BMM field skipped)",
-        written.len(),
-        gen_dir.display(),
-        unmatched.len()
-    );
-    Ok(())
+    Ok(XmlEmission {
+        files: vec![
+            EmittedFile {
+                path: format!("{XML_GEN_DIR}/impls.rs"),
+                crate_name: ITS_CRATE,
+                body,
+            },
+            EmittedFile {
+                path: format!("{XML_GEN_DIR}/mod.rs"),
+                crate_name: ITS_CRATE,
+                body: mod_rs.to_owned(),
+            },
+        ],
+        unmatched,
+    })
 }
 
 /// Emit the canonical-JSON `serde::Serialize`/`serde::Deserialize` impls for
@@ -352,6 +451,36 @@ fn cmd_emit_xml() -> Result<(), Box<dyn std::error::Error>> {
 /// Covers the same crate composition `emit` consumes, including AM 2.4's
 /// cross-schema re-emission closure.
 fn cmd_emit_json() -> Result<(), Box<dyn std::error::Error>> {
+    let files = render_json_files()?;
+    let mut written = write_emitted(&files)?;
+    for f in &files {
+        if f.path.ends_with(JSON_SERDE_FILE) {
+            let lib = crates_root().join(&f.path).with_file_name("lib.rs");
+            declare_json_serde_module(&lib, &mut written)?;
+        }
+    }
+    rustfmt(&written)?;
+    println!("emitted {} files", written.len());
+    Ok(())
+}
+
+/// Where a spec crate's emitted canonical-JSON impls live, relative to that
+/// crate's directory.
+const JSON_SERDE_FILE: &str = "src/json_serde.rs";
+
+/// Render the canonical-JSON `serde` impls and the `_type` dispatch without
+/// touching the filesystem.
+///
+/// The text half of [`cmd_emit_json`], shared with the emitter-invariant tests
+/// (`testsupport::emit_json_to_memory`), so the CLI and the tests drive one
+/// orchestration. The module declaration [`cmd_emit_json`] appends to each spec
+/// crate's `lib.rs` is a read-modify-write of a file this target does not
+/// render, so it stays on the CLI path.
+///
+/// # Errors
+/// Returns an error if a composition's BMM files cannot be loaded, or if the
+/// structural-dispatch priority list names an unknown composition key.
+pub(crate) fn render_json_files() -> Result<Vec<EmittedFile>, Box<dyn std::error::Error>> {
     // One JsonSchema per (crate, generation), each named from its generation
     // root — every generation is codec-complete, colliding twins included
     // (see `JsonSchema::root` for the adjudication).
@@ -404,19 +533,14 @@ fn cmd_emit_json() -> Result<(), Box<dyn std::error::Error>> {
     // defined (orphan rule), and being in-crate is also what lets them read the
     // `pub(crate)` fields of a validated class and construct through its
     // hand-written door (`plan::construction`).
-    let mut written = Vec::new();
+    let mut files = Vec::new();
     for (c, schemas) in composed.iter().zip(&schemas_by_crate) {
         let krate = c.comp.crate_name.replace('-', "_");
-        let src = crates_root().join(c.comp.crate_name).join("src");
-        std::fs::create_dir_all(&src)?;
-        let path = src.join("json_serde.rs");
-        write_generated(
-            &path,
-            c.comp.crate_name,
-            &emit_json::emit_file(schemas, &krate),
-        )?;
-        declare_json_serde_module(&src.join("lib.rs"), &mut written)?;
-        written.push(path);
+        files.push(EmittedFile {
+            path: format!("{}/{JSON_SERDE_FILE}", c.comp.crate_name),
+            crate_name: c.comp.crate_name,
+            body: emit_json::emit_file(schemas, &krate),
+        });
     }
 
     // The structural dispatch is keyed by the bare `_type`, so a name several
@@ -457,25 +581,23 @@ fn cmd_emit_json() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    let gen_dir = Path::new(ITS_ROOT).join("src/json_codec/generated");
-    std::fs::create_dir_all(&gen_dir)?;
-
-    let structural = emit_json::emit_structural_file(&structural_schemas);
-    let structural_path = gen_dir.join("structural.rs");
-    write_generated(&structural_path, ITS_CRATE, &structural)?;
-    written.push(structural_path);
+    files.push(EmittedFile {
+        path: format!("{JSON_GEN_DIR}/structural.rs"),
+        crate_name: ITS_CRATE,
+        body: emit_json::emit_structural_file(&structural_schemas),
+    });
 
     let mod_rs = "// @generated by openehr-codegen (emit-json) — DO NOT EDIT.\n\
         //! The canonical-JSON `_type` dispatch (the per-type `serde` impls live in\n\
         //! each spec crate's own `json_serde` module).\n\n\
         pub mod structural;\n";
-    let mod_path = gen_dir.join("mod.rs");
-    write_generated(&mod_path, ITS_CRATE, mod_rs)?;
-    written.push(mod_path);
+    files.push(EmittedFile {
+        path: format!("{JSON_GEN_DIR}/mod.rs"),
+        crate_name: ITS_CRATE,
+        body: mod_rs.to_owned(),
+    });
 
-    rustfmt(&written)?;
-    println!("emitted {} files", written.len());
-    Ok(())
+    Ok(files)
 }
 
 /// Declare the emitted `json_serde` module in a spec crate's generated
@@ -905,15 +1027,15 @@ fn cmd_emit(_outdir: Option<PathBuf>) -> Result<(), Box<dyn std::error::Error>> 
     Ok(())
 }
 
-/// Write one emitted file: the value-carrier guard where it applies, then the
-/// SPDX header its destination crate's licensing requires, then the bytes.
+/// Returns the exact bytes an emitted file carries before `rustfmt`: the
+/// value-carrier guard where it applies, then the SPDX header its destination
+/// crate's licensing requires, then the rendered body.
 ///
-/// Every emitted file goes through here, so a new emission site cannot ship a
-/// file whose licensing does not travel with it.
-///
-/// # Errors
-/// Returns the underlying filesystem error.
-fn write_generated(path: &Path, crate_name: &str, body: &str) -> std::io::Result<()> {
+/// Every emitted file goes through here — [`write_generated`] on the CLI path,
+/// `testsupport` on the in-memory one — so a new emission site cannot ship a
+/// file whose licensing does not travel with it, and the tested bytes are the
+/// written bytes.
+pub(crate) fn generated_bytes(crate_name: &str, body: &str) -> String {
     // A template-stamped body is hand-written text that already carries its own
     // scoped suppressions — the generated-file guard would duplicate them.
     let guarded = if body.starts_with(emit_templates::TEMPLATE_MARKER) {
@@ -921,7 +1043,16 @@ fn write_generated(path: &Path, crate_name: &str, body: &str) -> std::io::Result
     } else {
         emit::guard_value_carriers(body)
     };
-    std::fs::write(path, spdx::stamp(crate_name, &guarded))
+    spdx::stamp(crate_name, &guarded)
+}
+
+/// Write one emitted file, with the guard + SPDX header [`generated_bytes`]
+/// applies.
+///
+/// # Errors
+/// Returns the underlying filesystem error.
+fn write_generated(path: &Path, crate_name: &str, body: &str) -> std::io::Result<()> {
+    std::fs::write(path, generated_bytes(crate_name, body))
 }
 
 /// Write a generated crate's `src/` in place. Wipes the crate's `src/` first

--- a/tools/openehr-codegen/src/testsupport.rs
+++ b/tools/openehr-codegen/src/testsupport.rs
@@ -18,6 +18,7 @@
 )]
 use crate::analyze::invariants::{self, Bucket};
 use crate::analyze::{Model, augment_with_reemit, class_paths, cross_schema_reemit};
+use crate::cli;
 use crate::load::bmm::BmmSchema;
 use crate::load::impls::SiblingImpls;
 use crate::load::oas;
@@ -530,6 +531,61 @@ pub fn render_all_to_memory() -> Result<BTreeMap<String, String>, Error> {
         }
     }
     Ok(out)
+}
+
+/// Render the canonical-JSON `serde` impls and `_type` dispatch (`emit-json`)
+/// to an in-memory map, keyed by each file's path relative to the workspace
+/// `crates/` directory.
+///
+/// Drives `cli::render_json_files` — the same text production the `emit-json`
+/// subcommand drives — and applies the value-carrier guard and SPDX header the
+/// subcommand writes, so a value equals the on-disk file before `rustfmt`.
+///
+/// # Errors
+/// Returns an error if a composition's BMM files cannot be loaded.
+pub fn emit_json_to_memory() -> Result<BTreeMap<String, String>, Error> {
+    Ok(to_memory(cli::render_json_files()?))
+}
+
+/// Render the canonical-XML `ToXml`/`FromXml` impls (`emit-xml`) to an
+/// in-memory map, keyed by each file's path relative to the workspace `crates/`
+/// directory.
+///
+/// Drives `cli::render_xml_files` — the same text production the `emit-xml`
+/// subcommand drives — and applies the value-carrier guard and SPDX header the
+/// subcommand writes, so a value equals the on-disk file before `rustfmt`.
+///
+/// # Errors
+/// Returns an error if the RM/BASE compositions or the vendored XSD bundles
+/// cannot be loaded, or if the XML emission itself fails.
+pub fn emit_xml_to_memory() -> Result<BTreeMap<String, String>, Error> {
+    Ok(to_memory(cli::render_xml_files()?.files))
+}
+
+/// Render the ITS-REST contract (`emit-rest`) to an in-memory map, keyed by
+/// each file's path relative to the workspace `crates/` directory.
+///
+/// Drives `cli::render_rest_files` — the same text production the `emit-rest`
+/// subcommand drives — and applies the value-carrier guard and SPDX header the
+/// subcommand writes, so a value equals the on-disk file before `rustfmt`.
+///
+/// # Errors
+/// Returns an error if the RM/BASE compositions or a vendored OAS bundle cannot
+/// be loaded.
+pub fn emit_rest_to_memory() -> Result<BTreeMap<String, String>, Error> {
+    Ok(to_memory(cli::render_rest_files()?))
+}
+
+/// Turn an emit target's rendered files into the path → bytes map the tests
+/// compare, applying the same [`cli::generated_bytes`] the CLI writes through.
+fn to_memory(files: Vec<cli::EmittedFile>) -> BTreeMap<String, String> {
+    files
+        .into_iter()
+        .map(|f| {
+            let bytes = cli::generated_bytes(f.crate_name, &f.body);
+            (f.path, bytes)
+        })
+        .collect()
 }
 
 /// The hand-written `*_impl.rs` siblings of a generated crate — the same

--- a/tools/openehr-codegen/tests/it/emit_targets.rs
+++ b/tools/openehr-codegen/tests/it/emit_targets.rs
@@ -158,10 +158,14 @@ fn assert_file_set(target: &str, files: &BTreeMap<String, String>, expected: &[&
             banner.contains("@generated") && banner.contains(target),
             "{target}: {path} does not open with its generated banner: {banner:?}",
         );
+        // The needle names the SPDX tag WITHOUT an expression, which the
+        // REUSE scanner would otherwise parse and refuse as invalid.
+        // REUSE-IgnoreStart
         assert!(
             body.contains("SPDX-License-Identifier: "),
             "{target}: {path} carries no SPDX licence header",
         );
+        // REUSE-IgnoreEnd
     }
 }
 

--- a/tools/openehr-codegen/tests/it/emit_targets.rs
+++ b/tools/openehr-codegen/tests/it/emit_targets.rs
@@ -1,0 +1,265 @@
+// SPDX-FileCopyrightText: FerroEHR contributors
+// SPDX-License-Identifier: MIT
+
+//! The three text-producing emit targets — `emit-json`, `emit-xml`,
+//! `emit-rest` — as properties over the **real** pipeline on the **real**
+//! vendored inputs.
+//!
+//! Each test drives `openehr_codegen::testsupport::emit_*_to_memory`, which
+//! calls the very render function the matching `cmd_*` handler calls: the
+//! handler is a write-files shell over it, so tested text and emitted text
+//! cannot drift. Every target is asserted three ways — the render is
+//! byte-deterministic, it produces exactly its file set (each non-empty,
+//! banner-headed and SPDX-stamped), and its bytes equal the committed
+//! generated tree, which is the in-process half of the `codegen-drift` check.
+
+use openehr_codegen::testsupport;
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+/// The complete file set `emit-json` produces, in emitted-map (sorted) order.
+const JSON_FILES: &[&str] = &[
+    "openehr-am/src/json_serde.rs",
+    "openehr-base/src/json_serde.rs",
+    "openehr-its/src/json_codec/generated/mod.rs",
+    "openehr-its/src/json_codec/generated/structural.rs",
+    "openehr-lang/src/json_serde.rs",
+    "openehr-rm/src/json_serde.rs",
+    "openehr-term/src/json_serde.rs",
+];
+
+/// The complete file set `emit-xml` produces, in emitted-map (sorted) order.
+const XML_FILES: &[&str] = &[
+    "openehr-its/src/xml/generated/impls.rs",
+    "openehr-its/src/xml/generated/mod.rs",
+];
+
+/// The complete file set `emit-rest` produces, in emitted-map (sorted) order:
+/// the shared `common` module, one module per API group whose OAS declares
+/// operations, and the module declaration file.
+const REST_FILES: &[&str] = &[
+    "openehr-its/src/rest/generated/admin.rs",
+    "openehr-its/src/rest/generated/common.rs",
+    "openehr-its/src/rest/generated/definition.rs",
+    "openehr-its/src/rest/generated/demographic.rs",
+    "openehr-its/src/rest/generated/ehr.rs",
+    "openehr-its/src/rest/generated/mod.rs",
+    "openehr-its/src/rest/generated/query.rs",
+    "openehr-its/src/rest/generated/system.rs",
+];
+
+// ── emit-json ───────────────────────────────────────────────────────────────
+
+/// Rendering the canonical-JSON impls twice yields byte-identical output.
+#[test]
+fn emit_json_is_byte_deterministic() {
+    let a = testsupport::emit_json_to_memory().unwrap();
+    let b = testsupport::emit_json_to_memory().unwrap();
+    assert_deterministic("emit-json", &a, &b);
+}
+
+/// `emit-json` produces exactly its file set, each file non-empty and carrying
+/// the generated banner plus its crate's SPDX header.
+#[test]
+fn emit_json_emits_its_whole_file_set() {
+    let files = testsupport::emit_json_to_memory().unwrap();
+    assert_file_set("emit-json", &files, JSON_FILES);
+}
+
+/// The rendered canonical-JSON impls equal the committed generated tree.
+#[test]
+fn emit_json_matches_the_committed_tree() {
+    let files = testsupport::emit_json_to_memory().unwrap();
+    assert_matches_committed_tree("emit-json", &files);
+}
+
+// ── emit-xml ────────────────────────────────────────────────────────────────
+
+/// Rendering the canonical-XML impls twice yields byte-identical output.
+#[test]
+fn emit_xml_is_byte_deterministic() {
+    let a = testsupport::emit_xml_to_memory().unwrap();
+    let b = testsupport::emit_xml_to_memory().unwrap();
+    assert_deterministic("emit-xml", &a, &b);
+}
+
+/// `emit-xml` produces exactly its file set, each file non-empty and carrying
+/// the generated banner plus its crate's SPDX header.
+#[test]
+fn emit_xml_emits_its_whole_file_set() {
+    let files = testsupport::emit_xml_to_memory().unwrap();
+    assert_file_set("emit-xml", &files, XML_FILES);
+}
+
+/// The rendered canonical-XML impls equal the committed generated tree.
+#[test]
+fn emit_xml_matches_the_committed_tree() {
+    let files = testsupport::emit_xml_to_memory().unwrap();
+    assert_matches_committed_tree("emit-xml", &files);
+}
+
+// ── emit-rest ───────────────────────────────────────────────────────────────
+
+/// Rendering the ITS-REST contract twice yields byte-identical output.
+#[test]
+fn emit_rest_is_byte_deterministic() {
+    let a = testsupport::emit_rest_to_memory().unwrap();
+    let b = testsupport::emit_rest_to_memory().unwrap();
+    assert_deterministic("emit-rest", &a, &b);
+}
+
+/// `emit-rest` produces exactly its file set, each file non-empty and carrying
+/// the generated banner plus its crate's SPDX header.
+#[test]
+fn emit_rest_emits_its_whole_file_set() {
+    let files = testsupport::emit_rest_to_memory().unwrap();
+    assert_file_set("emit-rest", &files, REST_FILES);
+}
+
+/// The rendered ITS-REST contract equals the committed generated tree.
+#[test]
+fn emit_rest_matches_the_committed_tree() {
+    let files = testsupport::emit_rest_to_memory().unwrap();
+    assert_matches_committed_tree("emit-rest", &files);
+}
+
+// ── shared assertions ───────────────────────────────────────────────────────
+
+/// Assert two renders of the same target agree on every path and every byte.
+fn assert_deterministic(target: &str, a: &BTreeMap<String, String>, b: &BTreeMap<String, String>) {
+    assert!(!a.is_empty(), "{target}: rendered nothing");
+    let paths_a: Vec<&String> = a.keys().collect();
+    let paths_b: Vec<&String> = b.keys().collect();
+    assert_eq!(
+        paths_a, paths_b,
+        "{target}: the two renders emitted different files",
+    );
+    for ((path, body_a), body_b) in a.iter().zip(b.values()) {
+        assert!(
+            body_a == body_b,
+            "{target}: {path} differs between two renders{}",
+            difference_hint(body_a, body_b),
+        );
+    }
+}
+
+/// Assert a target emitted exactly `expected`, with every file non-empty, its
+/// `@generated` banner naming the target on line one, and its SPDX licence
+/// header present.
+fn assert_file_set(target: &str, files: &BTreeMap<String, String>, expected: &[&str]) {
+    let actual: Vec<&str> = files.keys().map(String::as_str).collect();
+    assert_eq!(actual, expected, "{target}: emitted a different file set");
+    for (path, body) in files {
+        assert!(!body.trim().is_empty(), "{target}: {path} rendered empty");
+        let banner = body.lines().next().unwrap_or_default();
+        assert!(
+            banner.contains("@generated") && banner.contains(target),
+            "{target}: {path} does not open with its generated banner: {banner:?}",
+        );
+        assert!(
+            body.contains("SPDX-License-Identifier: "),
+            "{target}: {path} carries no SPDX licence header",
+        );
+    }
+}
+
+/// Assert a target's rendered bytes equal the committed generated tree.
+///
+/// The rendered body is put through `rustfmt` first, exactly as the `cmd_*`
+/// handler puts the file it just wrote through it — `rustfmt` reading stdin
+/// formats byte-identically to `rustfmt` reading that same text from a file, so
+/// nothing has to be written to compare.
+#[expect(
+    clippy::panic,
+    reason = "test diagnostics: a missing committed file names itself instead of \
+              failing as a bare unwrap"
+)]
+fn assert_matches_committed_tree(target: &str, files: &BTreeMap<String, String>) {
+    let root = crates_root();
+    for (path, body) in files {
+        let full = root.join(path);
+        let committed = std::fs::read_to_string(&full)
+            .unwrap_or_else(|e| panic!("{target}: cannot read committed {path}: {e}"));
+        let rendered = rustfmt(&committed_relative_name(path), body);
+        assert!(
+            rendered == committed,
+            "{target}: {path} does not match the committed generated tree{}",
+            difference_hint(&rendered, &committed),
+        );
+    }
+}
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+/// The workspace `crates/` directory every emitted path is relative to.
+fn crates_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../crates")
+}
+
+/// A short label for a path, used only in `rustfmt` failure messages.
+fn committed_relative_name(path: &str) -> String {
+    format!("crates/{path}")
+}
+
+/// Format `text` with the same `rustfmt` invocation the emitter shells out to.
+///
+/// The body is written from a separate thread because a large file (the biggest
+/// emitted impl set is megabytes) fills the pipe buffer long before `rustfmt`
+/// finishes, and writing it all before reading stdout would deadlock.
+#[expect(
+    clippy::panic,
+    reason = "test diagnostics: each subprocess failure mode names itself, so a red \
+              run points at the toolchain rather than at the emitter"
+)]
+fn rustfmt(label: &str, text: &str) -> String {
+    let mut child = Command::new("rustfmt")
+        .args(["--edition", "2024", "--quiet", "--emit", "stdout"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap_or_else(|e| panic!("{label}: rustfmt is not runnable: {e}"));
+    let mut stdin = child
+        .stdin
+        .take()
+        .unwrap_or_else(|| panic!("{label}: rustfmt stdin was not piped"));
+    let body = text.to_owned();
+    let writer = std::thread::spawn(move || stdin.write_all(body.as_bytes()));
+    let out = child
+        .wait_with_output()
+        .unwrap_or_else(|e| panic!("{label}: rustfmt did not complete: {e}"));
+    writer
+        .join()
+        .unwrap_or_else(|_| panic!("{label}: the rustfmt writer thread panicked"))
+        .unwrap_or_else(|e| panic!("{label}: writing to rustfmt failed: {e}"));
+    assert!(
+        out.status.success(),
+        "{label}: rustfmt failed ({}): {}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr),
+    );
+    String::from_utf8(out.stdout)
+        .unwrap_or_else(|e| panic!("{label}: rustfmt emitted non-UTF-8: {e}"))
+}
+
+/// A one-line locator for the first place two texts diverge.
+///
+/// The emitted files run to megabytes, so a whole-body `assert_eq!` would print
+/// an unreadable pair; the first differing line is what actually identifies the
+/// defect.
+fn difference_hint(a: &str, b: &str) -> String {
+    for (i, (la, lb)) in a.lines().zip(b.lines()).enumerate() {
+        if la != lb {
+            return format!(
+                "\n  first difference at line {}:\n  - {la}\n  + {lb}",
+                i + 1
+            );
+        }
+    }
+    format!(
+        "\n  line counts differ: {} vs {}",
+        a.lines().count(),
+        b.lines().count(),
+    )
+}

--- a/tools/openehr-codegen/tests/it/main.rs
+++ b/tools/openehr-codegen/tests/it/main.rs
@@ -6,5 +6,6 @@
 //! <https://doc.rust-lang.org/cargo/reference/cargo-targets.html>). Each topic
 //! is a module; nextest still runs every test in its own process.
 
+mod emit_targets;
 mod emitter_invariants;
 mod model_query;


### PR DESCRIPTION
Works #2656 — the codegen render stage was 0% covered because only the CLI script path ever ran it.

- `cmd_emit_json`/`cmd_emit_xml`/`cmd_emit_rest` each split into a `render_*_files()` producing every output in memory and a thin file-writing shell; `testsupport` exposes `emit_*_to_memory()` over the same fns, so the CLI and the tests can never diverge by code path. Printed messages and file counts unchanged (7 / 2 / 8).
- Nine new tests: per target — byte-determinism (two runs identical), the exact file set with `@generated` + SPDX headers, and **byte-identity against the committed `crates/**` tree** (through the same rustfmt pass), which is the codegen-drift check running in-process on every `cargo nextest`. Non-vacuity mutation-proven: a changed emitted line fails exactly the matching target's tree test.
- Regeneration after the refactor: `git status crates/` empty — output-neutral by construction and by proof.

Gates: crate clippy/fmt/doc clean; `cargo nextest run -p openehr-codegen` 91/91.

En-route findings (filed as the follow-up issue): `render_all_to_memory` is a hand-copied mirror of `cmd_emit` that has already drifted (it never calls `stamp_templates`, so the determinism suite runs over a different file set than `emit` writes), and `emit-opt`/`emit-aom2`/`emit-rm-model`/`emit-validate` still have no seam.