### PR TITLE
chore(ui-gates): the skill lanes match CI

### DIFF
--- a/.claude/rules/leptos-ui.md
+++ b/.claude/rules/leptos-ui.md
@@ -280,7 +280,8 @@ in the root `[workspace.dependencies]`: Leptos 0.8 SSR/full-stack,
 - **E2E is a merge gate**: Rust-native only —
   `thirtyfour` (WebDriver, built on `fantoccini`) driving headless Chromium
   against the composed stack (`scripts/ui-e2e.sh`); journeys are plain
-  `#[tokio::test]`s in `app/ferroehr-admin-ui/tests/e2e_*.rs`, skip-with-
+  `#[tokio::test]`s in the `e2e_*` modules of the one integration binary
+  (`app/ferroehr-admin-ui/tests/it/`), skip-with-
   reason when `UI_E2E_BASE_URL` is unset (CI always sets it). Every journey
   fails on any browser-console hydration error or panic. Explicit waits on
   elements/conditions, never `sleep`; a flaky journey is fixed, never

--- a/.claude/skills/ui-gates/SKILL.md
+++ b/.claude/skills/ui-gates/SKILL.md
@@ -30,17 +30,19 @@ failure; run the cheap gates first.
 ## The battery (in order)
 
 ```bash
-# 1. Format (fast, catches drift)
+# 1. Format (fast, catches drift) — tests/ carries view! macros too
 cargo fmt -p ferroehr-admin-ui --check
-leptosfmt --check app/ferroehr-admin-ui/src
+leptosfmt --check app/ferroehr-admin-ui/src app/ferroehr-admin-ui/tests
 
-# 2. Clippy — BOTH compilation targets (the wasm pass catches
-#    server-only deps leaking past the ssr feature gate)
-cargo clippy -p ferroehr-admin-ui --all-targets
+# 2. Clippy — BOTH compilation targets, in the EXACT CI feature shapes
+#    (the featureless crate ships nowhere: neither ssr nor hydrate; the
+#    wasm pass catches server-only deps leaking past the ssr feature gate)
+cargo clippy -p ferroehr-admin-ui --all-targets --features ssr
 cargo clippy -p ferroehr-admin-ui --lib --target wasm32-unknown-unknown --no-default-features --features hydrate
 
-# 3. Tests
-cargo nextest run -p ferroehr-admin-ui
+# 3. Tests — the ssr shape the crate ships and CI instruments; a
+#    featureless run silently skips every #[cfg(feature = "ssr")] module
+cargo nextest run -p ferroehr-admin-ui --features ssr
 
 # 4. Full build (server bin + WASM + assets) — only when the change
 #    touches the build surface (Cargo.toml, styles, assets, features);

--- a/app/ferroehr-admin-ui/CLAUDE.md
+++ b/app/ferroehr-admin-ui/CLAUDE.md
@@ -206,8 +206,10 @@ extension); the wire it consumes IS spec-bound (`docs/specs/openehr/ITS-REST/`
 
 ## Gates
 
-`/ui-gates`: clippy on **native and wasm32** targets, `cargo nextest run -p
-ferroehr-admin-ui`, leptosfmt + cargo fmt, cargo-leptos build; E2E journeys
-(`tests/e2e_*.rs`, skip-with-reason via `UI_E2E_BASE_URL`) merge-gate in CI;
-a UI-visual change re-captures the `website/book` screenshots
-(`ui-screenshot-guard`).
+`/ui-gates`: clippy on **native (`--features ssr`) and wasm32 (hydrate)**
+targets, `cargo nextest run -p ferroehr-admin-ui --features ssr` (the
+featureless crate ships nowhere and skips every ssr-gated test), leptosfmt
+(src + tests) + cargo fmt, cargo-leptos build; E2E journeys (the `e2e_*`
+modules under `tests/it/`, skip-with-reason via `UI_E2E_BASE_URL`)
+merge-gate in CI; a UI-visual change re-captures the `website/book`
+screenshots (`ui-screenshot-guard`).


### PR DESCRIPTION
Closes #2689 (found by the #2688 worker, fixed in the same cadence).

- The `/ui-gates` battery ran clippy + nextest on the FEATURELESS console — a configuration that ships nowhere (`ssr`/`hydrate` are the two real shapes) and silently skipped 124 of 474 tests. The skill now runs the exact CI lanes: `--features ssr` for native clippy and nextest, the wasm hydrate lane unchanged.
- `leptosfmt --check` now covers `app/ferroehr-admin-ui/tests` too (it carries `view!` macros since #2688); verified clean.
- The two stale `tests/e2e_*.rs` references (pre-#1311 layout) in `.claude/rules/leptos-ui.md` and the crate `CLAUDE.md` now point at the `e2e_*` modules of the one integration binary.

Docs/skill-only (`no-ui-visual-change`: no rendered output is touched).