### PR TITLE
feat(admin): the storage-parity sweep — the node copy gains a supported integrity channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Added
+
+- `POST {base}/admin/integrity/verify` sweeps the stored data for
+  content-copy disagreement. Every version's content is stored twice — as
+  the materialized document a point read serves and as the decomposed rows
+  the AQL engine queries — and read-time signature verification only ever
+  recomputed the first, so a row edited behind the server's back could reach
+  a client through an AQL scalar result with no integrity signal. The sweep
+  re-derives every stored version from its decomposed rows, compares, and
+  reports every mismatch by identifier with a defect of `content_differs`,
+  `nodes_missing`, `nodes_unreadable`, or `unexpected_nodes`. It reads the
+  archived tier too, takes no lock, runs off the request path, and never logs
+  or returns content. A finding is reported in the **200** body, not as a
+  failed request. Behind the existing admin switch and admin role.
+
 ### Changed
 
 - Commit latency's tail shrinks: the large stored JSON columns

--- a/app/ferroehr-rest/src/api/admin/integrity.rs
+++ b/app/ferroehr-rest/src/api/admin/integrity.rs
@@ -1,0 +1,188 @@
+// SPDX-FileCopyrightText: FerroEHR contributors
+// SPDX-License-Identifier: MIT
+
+//! The ADMIN **storage-integrity** wire — **our own extension**.
+//!
+//! No openEHR ITS-REST operation governs this route, and no SM interface
+//! declares it either. The released Admin API is exactly two EHR deletes
+//! (`specifications/admin.openapi.yaml`), and
+//! `docs/specs/openehr/SM/docs/UML/classes/i_admin_service.adoc` declares
+//! deletes, archival and reporting — nothing that inspects stored data for
+//! damage. No openEHR spec governs storage mechanics at all, so both the
+//! two-copy storage design and this route over it are ours.
+//!
+//! What it exposes: the storage keeps every version's content twice — the
+//! materialized `vo_version.body` a point read serves, and the decomposed
+//! `node` rows the AQL engine queries. Read-time signature verification (RM
+//! common `master06-change_control_package.adoc` §Digital Signature) covers
+//! the first copy. This route re-derives the second one and compares, so
+//! tampering or corruption of either becomes visible.
+//!
+//! It is a `POST` because it is an action, not a resource: RFC 9110 §9.3.3
+//! defines `POST` as "providing a block of data … to a data-handling process",
+//! while a `GET` would present an expensive whole-repository scan as a
+//! cacheable representation.
+//!
+//! Gating: mounted under `/admin/`, so it inherits the group's two gates
+//! unchanged — the coarse RBAC `OperationClass::Admin` classifier (`401`
+//! unauthenticated / `403` non-admin, our own authorization design; the
+//! released admin operations carry `security: []`) and the
+//! `AppConfig::admin.enabled` config gate, which answers `405` with an empty
+//! `Allow` while the group is off (`crate::api::admin::dispatch`, whose ground
+//! is the overview rule "If a method is recognized but not allowed for the
+//! target resource, the response SHOULD be `405 Method Not Allowed` status
+//! code" — `docs/overview/Requests_and_responses.md` §"HTTP Methods").
+
+#![expect(
+    clippy::disallowed_types,
+    reason = "owner-approved 2026-08-03 (#1694 family 8): genuinely open operational JSON (the \
+              storage-parity report is an operational document, not an RM resource)"
+)]
+
+use axum::extract::State;
+use axum::response::{IntoResponse, Response};
+use http::StatusCode;
+use serde_json::{Value, json};
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
+use openehr_its::rest::runtime::ApiError;
+
+use ferroehr::service::admin::integrity::StorageParityReport;
+
+use crate::api::{BoxResponse, RequestParts, guarded_dispatch};
+use crate::negotiate;
+use crate::overview::error::RestError;
+use crate::state::AppState;
+
+/// The storage-integrity extension route as a native `utoipa-axum` router —
+/// **no ITS-REST contract** (see the module docs). Group-relative path (nested
+/// under `base_path`); the operation runs through [`guarded_dispatch`] with
+/// [`dispatch`].
+pub(crate) fn integrity_routes() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new().routes(routes!(admin_verify_storage_parity))
+}
+
+/// Sweep the stored versions for content-copy disagreement
+/// (`POST /admin/integrity/verify`).
+///
+/// **Our own extension — no ITS-REST operation governs this, and it realizes
+/// no SM operation either** (module docs). Every stored version in both
+/// storage tiers is reassembled from its `node` rows and compared with its
+/// materialized body; the response is the resulting report.
+#[utoipa::path(
+    post, path = "/admin/integrity/verify", tag = "admin-integrity",
+    responses(
+        (status = 200, description = "The sweep ran. The body is the report: \
+                                      how many stored versions were read, how \
+                                      many carried a body, how many mismatches \
+                                      were found, and the mismatching versions \
+                                      by identifier. `mismatch_count` is the \
+                                      full count; `mismatches` is capped and \
+                                      `truncated` says whether the cap was \
+                                      reached (every mismatch is logged at \
+                                      `warn` whatever the cap does). A finding \
+                                      is NOT a request failure — the sweep \
+                                      succeeded and is reporting what it saw, \
+                                      so the status stays `200`.",
+         body = serde_json::Value,
+         example = json!({
+             "versions_checked": 128,
+             "versions_with_body": 126,
+             "versions_without_body": 2,
+             "mismatch_count": 1,
+             "mismatches": [{
+                 "vo_id": "8849182c-82ad-4088-a07f-48ead4180515",
+                 "sys_version": 2,
+                 "kind": "COMPOSITION",
+                 "defect": "content_differs"
+             }],
+             "truncated": false,
+             "elapsed_ms": 431
+         })),
+        (status = 401, description = "Unauthenticated (auth enabled, no valid \
+                                      principal). Our own authorization design \
+                                      — the released admin operations carry \
+                                      `security: []` and declare no such \
+                                      branch.",
+         body = serde_json::Value),
+        (status = 403, description = "Authenticated but not in the Admin class \
+                                      (`OperationClass::Admin`, keyed off the \
+                                      `/admin/` path). Our own authorization \
+                                      design.",
+         body = serde_json::Value),
+        (status = 405, description = "The admin API is disabled on this server \
+                                      (`AppConfig::admin.enabled`, default \
+                                      false), answered with an empty `Allow` \
+                                      per RFC 9110 §10.2.1.",
+         body = serde_json::Value)
+    )
+)]
+pub(crate) async fn admin_verify_storage_parity(
+    State(state): State<AppState>,
+    request: axum::extract::Request,
+) -> Response {
+    let parts = crate::api::into_parts(request).await;
+    guarded_dispatch(state, "admin_verify_storage_parity", parts, dispatch).await
+}
+
+// ── dispatch ─────────────────────────────────────────────────────────────────
+
+pub(crate) fn dispatch(state: AppState, op: &'static str, parts: RequestParts) -> BoxResponse {
+    Box::pin(async move {
+        run(state, op, parts)
+            .await
+            .unwrap_or_else(IntoResponse::into_response)
+    })
+}
+
+async fn run(
+    state: AppState,
+    op: &'static str,
+    parts: RequestParts,
+) -> Result<Response, RestError> {
+    // The whole ADMIN group is opt-in; the gate and its two grounds are stated
+    // once, in the group dispatcher.
+    if let Some(refusal) = super::dispatch::admin_group_gate(&state) {
+        return Ok(refusal);
+    }
+    match op {
+        "admin_verify_storage_parity" => {
+            let report = state.backend().verify_storage_parity().await?;
+            Ok(negotiate::respond(
+                &parts.headers,
+                StatusCode::OK,
+                &parity_report(&report),
+            ))
+        }
+        other => Err(RestError(ApiError::Internal(format!(
+            "unrouted admin integrity operation: {other}"
+        )))),
+    }
+}
+
+/// Render the storage-parity report as the response body.
+///
+/// The shape is ours end to end (no openEHR spec governs storage mechanics),
+/// so it is written out explicitly here rather than derived: the wire contract
+/// is this function, not a serde attribute on a service type.
+fn parity_report(report: &StorageParityReport) -> Value {
+    json!({
+        "versions_checked": report.versions_checked,
+        "versions_with_body": report.versions_with_body,
+        "versions_without_body": report.versions_without_body,
+        "mismatch_count": report.mismatch_count,
+        "mismatches": report
+            .mismatches
+            .iter()
+            .map(|m| json!({
+                "vo_id": m.vo_id.to_string(),
+                "sys_version": m.sys_version,
+                "kind": m.kind,
+                "defect": m.defect.as_str(),
+            }))
+            .collect::<Vec<Value>>(),
+        "truncated": report.truncated,
+        "elapsed_ms": report.elapsed_ms,
+    })
+}

--- a/app/ferroehr-rest/src/api/admin/mod.rs
+++ b/app/ferroehr-rest/src/api/admin/mod.rs
@@ -8,15 +8,18 @@
 //! [`dispatch`] implements the generated operation contract over the
 //! `ferroehr-sm` native API.
 //!
-//! Three further groups sit beside it under the same `/admin/` prefix and the
-//! same gates, realizing SM admin interfaces the release never surfaced —
-//! **our own extensions, governed by no ITS-REST operation**: [`archive`]
+//! Four further groups sit beside it under the same `/admin/` prefix and the
+//! same gates — **our own extensions, governed by no ITS-REST operation**.
+//! Three realize SM admin interfaces the release never surfaced: [`archive`]
 //! (`I_ADMIN_ARCHIVE`), [`report`] (the four `I_ADMIN_SERVICE` statistics
-//! calls) and [`dump_load`] (`I_ADMIN_DUMP_LOAD`). Each carries its own
-//! spec-silence flag and register citation.
+//! calls) and [`dump_load`] (`I_ADMIN_DUMP_LOAD`). The fourth, [`integrity`],
+//! realizes no SM interface at all: it sweeps the storage's two content copies
+//! for disagreement, and no openEHR spec governs storage mechanics. Each
+//! carries its own spec-silence flag and register citation.
 
 pub mod archive;
 pub mod dispatch;
 pub mod dump_load;
+pub mod integrity;
 pub(crate) mod openapi_routes;
 pub mod report;

--- a/app/ferroehr-rest/src/api/mod.rs
+++ b/app/ferroehr-rest/src/api/mod.rs
@@ -162,6 +162,7 @@ pub(crate) fn api_openapi_router() -> OpenApiRouter<AppState> {
         .merge(admin::archive::archive_routes())
         .merge(admin::report::report_routes())
         .merge(admin::dump_load::dump_load_routes())
+        .merge(admin::integrity::integrity_routes())
         .merge(message::extract::extract_routes())
         .merge(message::tdd::tdd_routes())
         .merge(terminology::routes())

--- a/app/ferroehr-rest/src/extensions/openapi.rs
+++ b/app/ferroehr-rest/src/extensions/openapi.rs
@@ -178,6 +178,7 @@ const SECURITY_SCHEME: &str = "openehr_auth";
         (name = "definition-archetype", description = "ADL 1.4 / ADL 2 archetype + artefact provisioning — SM I_DEFINITION_ADL14 / I_DEFINITION_ADL2 operations the released Definition API never surfaced (it provisions operational templates only). OUR OWN EXTENSION: no ITS-REST operation governs these routes."),
         (name = "admin-report", description = "The SM I_ADMIN_SERVICE activity-report calls (contribution/version statistics per PLATFORM_SERVICE). OUR OWN EXTENSION: the released Admin API is the two EHR deletes alone, so no ITS-REST operation governs these routes (same admin gate + RBAC Admin class)."),
         (name = "admin-archive", description = "The SM I_ADMIN_ARCHIVE calls (move selected EHRs / parties to archival storage) plus the reverse movement the SM declares no operation for (restore selected EHRs / parties from archival storage). OUR OWN EXTENSION: no ITS-REST operation governs these routes (same admin gate + RBAC Admin class)."),
+        (name = "admin-integrity", description = "The storage-parity sweep: every stored version is re-derived from its decomposed node rows and compared with its materialized body, so tampering or corruption of either copy is reported. OUR OWN EXTENSION: no ITS-REST operation and no SM interface governs this route, and no openEHR spec governs storage mechanics (same admin gate + RBAC Admin class)."),
         (name = "admin-dump-load", description = "The SM I_ADMIN_DUMP_LOAD calls (export every EHR to a file-system archive; populate the repository from one). OUR OWN EXTENSION: no ITS-REST operation governs these routes (same admin gate + RBAC Admin class)."),
         (name = "message", description = "The SM MESSAGE component — I_EHR_EXTRACT_SERVICE (EHR-Extract export/import) and I_TDD_SERVICE (Template Data Document import). OUR OWN EXTENSION: ITS-REST 1.1.0 publishes no message/extract/TDD API at all, so no released operation governs any route here; they carry the ordinary clinical authentication class, not the admin gate."),
         (name = "event-subscription", description = "Event-subscription CRUD extension (config-gated: FERROEHR_REST_EVENT_SUBSCRIPTION__ENABLED)."),
@@ -562,10 +563,16 @@ const FAMILIES: &[(&str, &str, Members)] = &[
             exclude: &[],
             // The ADMIN group's own-design routes (template delete, stored-query
             // version delete, the redacted config read, the activity report, the
-            // archive pair and the dump/load pair) live under sibling `/admin/*`
-            // paths, not under `/admin/ehr`; they are part of this group and
-            // belong in its document.
-            also_tagged: &["ADMIN", "admin-report", "admin-archive", "admin-dump-load"],
+            // archive pair, the dump/load pair and the storage-parity sweep)
+            // live under sibling `/admin/*` paths, not under `/admin/ehr`; they
+            // are part of this group and belong in its document.
+            also_tagged: &[
+                "ADMIN",
+                "admin-report",
+                "admin-archive",
+                "admin-dump-load",
+                "admin-integrity",
+            ],
         },
     ),
     // The server's own extension families, by tag.

--- a/app/ferroehr-rest/tests/it/authz_route_matrix.rs
+++ b/app/ferroehr-rest/tests/it/authz_route_matrix.rs
@@ -358,6 +358,11 @@ const ADMIN_WRITE: &[(&str, &str)] = &[
     ("POST", "/admin/archive/parties/restore"),
     ("POST", "/admin/dump"),
     ("POST", "/admin/load"),
+    // The storage-parity sweep mutates nothing, but it is an extension route
+    // outside the generated tables, where `extension_is_write` reads the HTTP
+    // verb and every mutating verb is a write (fail-safe). So a read-only admin
+    // is refused it, and this row states what the gate actually does.
+    ("POST", "/admin/integrity/verify"),
     ("POST", "/admin/tenant"),
     ("PUT", "/admin/tenant/{tenant_id}"),
     ("DELETE", "/admin/tenant/{tenant_id}"),

--- a/app/ferroehr/src/service/admin/integrity.rs
+++ b/app/ferroehr/src/service/admin/integrity.rs
@@ -1,0 +1,337 @@
+// SPDX-FileCopyrightText: FerroEHR contributors
+// SPDX-License-Identifier: MIT
+
+//! The storage-parity sweep: the two stored copies of every version's content
+//! are re-derived and compared.
+//!
+//! NOTE: no openEHR spec governs storage mechanics — our own design/extension;
+//! the storage keeps a version's content twice, as `vo_version.body` (the
+//! materialized projection point reads serve) and as the decomposed `node`
+//! rows (the AQL index), and their equality is an invariant of the commit path.
+//!
+//! This is the storage-parity sibling of the read-time signature verification
+//! in `crate::versioning::integrity`. That check covers the `body` copy: a
+//! signature is computed over the version's canonical serialized form (RM
+//! common `master06-change_control_package.adoc` §Digital Signature), and a
+//! point read recomputes it. It says nothing about the `node` rows, which no
+//! read-path check recomputes. This sweep closes that gap from the other side:
+//! it reassembles each version from its node rows and compares the result to
+//! the stored body, so a tampered or corrupt row in EITHER copy becomes
+//! visible through a supported channel.
+//!
+//! It runs off the request path, on an administrator's call, and reads every
+//! stored version in both storage tiers. It never logs content — a mismatch is
+//! reported by identifier alone.
+
+#![expect(
+    clippy::disallowed_types,
+    reason = "owner-approved 2026-08-03 (#1694 family 1): stored canonical fragments — a typed \
+              round-trip drops forward-compatible keys (the openEHR release strategy: minors are compatible supersets)"
+)]
+
+use std::time::Instant;
+
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::ids::VoId;
+use crate::service::FerroEhrService;
+use crate::service::error::ServiceError;
+use crate::service::status::SmError;
+use crate::storage::node_repo::read_version_canonical_all;
+
+/// How many version rows one page of the sweep's cursor query returns.
+///
+/// The page carries identifiers only (no content), so it stays small whatever
+/// the documents weigh; each version's body and node rows are then read one
+/// version at a time, which bounds the sweep's memory to a single document.
+const PAGE_SIZE: i64 = 500;
+
+/// How many mismatches the returned report carries in full.
+///
+/// Every mismatch is also logged at `warn`, so nothing is lost when a sweep
+/// over a badly damaged store passes this cap; the report still counts them
+/// all and says it was truncated.
+const MAX_REPORTED_MISMATCHES: usize = 1000;
+
+/// The way one stored version's two content copies disagree.
+///
+/// NOTE: no openEHR spec governs storage mechanics — our own design/extension.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StorageParityDefect {
+    /// The version has both copies and they are not the same value.
+    ContentDiffers,
+    /// The version has a stored body but no node rows at all.
+    NodesMissing,
+    /// The version has node rows that do not reassemble into one tree, so the
+    /// node copy cannot be compared to anything.
+    NodesUnreadable,
+    /// The version is a logical delete (data Void, RM common
+    /// `master06-change_control_package.adoc` §Logical Deletion) and therefore
+    /// stores no body, yet node rows exist for it.
+    UnexpectedNodes,
+}
+
+impl StorageParityDefect {
+    /// Returns the stable wire token for this defect.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ContentDiffers => "content_differs",
+            Self::NodesMissing => "nodes_missing",
+            Self::NodesUnreadable => "nodes_unreadable",
+            Self::UnexpectedNodes => "unexpected_nodes",
+        }
+    }
+}
+
+/// One stored version whose two content copies disagree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StorageParityMismatch {
+    /// The versioned object the version belongs to.
+    pub vo_id: Uuid,
+    /// The per-object storage commit ordinal of the version.
+    pub sys_version: i32,
+    /// The `vo_version.kind` discriminator (`COMPOSITION` / `EHR_STATUS` /
+    /// `FOLDER` / a demographic PARTY class / …).
+    pub kind: String,
+    /// How the two copies disagree.
+    pub defect: StorageParityDefect,
+}
+
+/// The outcome of one storage-parity sweep.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StorageParityReport {
+    /// How many stored versions were read, across both storage tiers.
+    pub versions_checked: u64,
+    /// How many of them carry a materialized body (a content version).
+    pub versions_with_body: u64,
+    /// How many of them carry no body (a logical delete).
+    pub versions_without_body: u64,
+    /// How many mismatches were found in total, whatever `mismatches` holds.
+    pub mismatch_count: u64,
+    /// The mismatches, up to the reporting cap.
+    pub mismatches: Vec<StorageParityMismatch>,
+    /// Whether `mismatches` was cut short by the cap.
+    pub truncated: bool,
+    /// Wall-clock duration of the sweep, in milliseconds.
+    pub elapsed_ms: u64,
+}
+
+impl StorageParityReport {
+    /// Returns `true` when every stored version's two content copies agree.
+    #[must_use]
+    pub fn is_clean(&self) -> bool {
+        self.mismatch_count == 0
+    }
+}
+
+/// One page row of the sweep cursor: the identifiers of a stored version plus
+/// whether it carries a body. No content is fetched here.
+struct VersionKey {
+    vo_id: Uuid,
+    sys_version: i32,
+    kind: String,
+    has_body: bool,
+}
+
+impl FerroEhrService {
+    /// Re-derives every stored version's content from its `node` rows and
+    /// compares it to the materialized `vo_version.body`, reporting every
+    /// disagreement.
+    ///
+    /// The sweep reads BOTH storage tiers (the `vo_version_all` / `node_all`
+    /// union views), so archived content is checked like everything else. It
+    /// takes no lock and holds no transaction: a version committed while the
+    /// sweep runs is simply checked or not, and a version read mid-commit
+    /// cannot be seen half-written because a commit writes both copies in one
+    /// transaction.
+    ///
+    /// NOTE: no openEHR spec governs storage mechanics — our own
+    /// design/extension (the module docs carry the full derivation).
+    ///
+    /// # Errors
+    /// - `exception` — a database fault while enumerating or reading versions.
+    ///   A version whose node rows are unreadable is a REPORTED mismatch, not
+    ///   an error: one damaged record must not abort the sweep that found it.
+    pub async fn verify_storage_parity(&self) -> Result<StorageParityReport, SmError> {
+        Ok(self.sweep_storage_parity().await?)
+    }
+
+    /// The sweep itself, over the storage error domain.
+    async fn sweep_storage_parity(&self) -> Result<StorageParityReport, ServiceError> {
+        let started = Instant::now();
+        let mut report = StorageParityReport {
+            versions_checked: 0,
+            versions_with_body: 0,
+            versions_without_body: 0,
+            mismatch_count: 0,
+            mismatches: Vec::new(),
+            truncated: false,
+            elapsed_ms: 0,
+        };
+        let mut cursor: Option<(Uuid, i32)> = None;
+
+        loop {
+            let page = self.parity_page(cursor).await?;
+            let Some(last) = page.last() else { break };
+            cursor = Some((last.vo_id, last.sys_version));
+
+            for key in &page {
+                report.versions_checked += 1;
+                if key.has_body {
+                    report.versions_with_body += 1;
+                } else {
+                    report.versions_without_body += 1;
+                }
+                if let Some(defect) = self.version_parity_defect(key).await? {
+                    record(&mut report, key, defect);
+                }
+            }
+        }
+
+        report.elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+        Ok(report)
+    }
+
+    /// One page of stored-version identifiers after `cursor`, in
+    /// `(vo_id, sys_version)` order — a keyset walk, so a long sweep never
+    /// pays a growing `OFFSET`.
+    async fn parity_page(
+        &self,
+        cursor: Option<(Uuid, i32)>,
+    ) -> Result<Vec<VersionKey>, ServiceError> {
+        let (after_vo, after_version) = match cursor {
+            Some((vo_id, sys_version)) => (Some(vo_id), Some(sys_version)),
+            None => (None, None),
+        };
+        let rows: Vec<(Uuid, i32, String, bool)> = sqlx::query_as(
+            "SELECT vo_id, sys_version, kind, body IS NOT NULL \
+             FROM vo_version_all \
+             WHERE ($1::uuid IS NULL OR (vo_id, sys_version) > ($1::uuid, $2::int)) \
+             ORDER BY vo_id, sys_version \
+             LIMIT $3",
+        )
+        .bind(after_vo)
+        .bind(after_version)
+        .bind(PAGE_SIZE)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .map(|(vo_id, sys_version, kind, has_body)| VersionKey {
+                vo_id,
+                sys_version,
+                kind,
+                has_body,
+            })
+            .collect())
+    }
+
+    /// How one stored version's two copies disagree, or `None` when they
+    /// agree.
+    ///
+    /// A reassembly failure is a verdict, never a propagated error: the sweep
+    /// exists to find damaged records, so it reports them and keeps going.
+    async fn version_parity_defect(
+        &self,
+        key: &VersionKey,
+    ) -> Result<Option<StorageParityDefect>, ServiceError> {
+        let reassembled =
+            read_version_canonical_all(&self.pool, VoId(key.vo_id), key.sys_version).await;
+        if !key.has_body {
+            return Ok(match reassembled {
+                Ok(Value::Null) => None,
+                Ok(_) | Err(_) => Some(StorageParityDefect::UnexpectedNodes),
+            });
+        }
+        let Some(body) = self.stored_body(key).await? else {
+            // The version left the primary tier (an archive move) or the
+            // repository (a physical delete) between the page read and this
+            // one; there is nothing left to compare, and no defect to claim.
+            return Ok(None);
+        };
+        Ok(match reassembled {
+            Ok(Value::Null) => Some(StorageParityDefect::NodesMissing),
+            Ok(value) if value == body => None,
+            Ok(_) => Some(StorageParityDefect::ContentDiffers),
+            Err(_) => Some(StorageParityDefect::NodesUnreadable),
+        })
+    }
+
+    /// The materialized body of one stored version, read one version at a time
+    /// so the sweep holds a single document in memory.
+    async fn stored_body(&self, key: &VersionKey) -> Result<Option<Value>, ServiceError> {
+        let row: Option<(Option<Value>,)> =
+            sqlx::query_as("SELECT body FROM vo_version_all WHERE vo_id = $1 AND sys_version = $2")
+                .bind(key.vo_id)
+                .bind(key.sys_version)
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(row.and_then(|(body,)| body))
+    }
+}
+
+/// Count a mismatch, log it by identifier, and record it while the report has
+/// room.
+///
+/// The log line carries identifiers and the defect token only: a body fragment
+/// would put clinical content into an operational log.
+fn record(report: &mut StorageParityReport, key: &VersionKey, defect: StorageParityDefect) {
+    report.mismatch_count += 1;
+    tracing::warn!(
+        vo_id = %key.vo_id,
+        sys_version = key.sys_version,
+        kind = %key.kind,
+        defect = defect.as_str(),
+        "storage parity sweep: the node rows and the materialized body of a stored version disagree"
+    );
+    if report.mismatches.len() < MAX_REPORTED_MISMATCHES {
+        report.mismatches.push(StorageParityMismatch {
+            vo_id: key.vo_id,
+            sys_version: key.sys_version,
+            kind: key.kind.clone(),
+            defect,
+        });
+    } else {
+        report.truncated = true;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defect_tokens_are_the_documented_wire_values() {
+        assert_eq!(
+            StorageParityDefect::ContentDiffers.as_str(),
+            "content_differs"
+        );
+        assert_eq!(StorageParityDefect::NodesMissing.as_str(), "nodes_missing");
+        assert_eq!(
+            StorageParityDefect::NodesUnreadable.as_str(),
+            "nodes_unreadable"
+        );
+        assert_eq!(
+            StorageParityDefect::UnexpectedNodes.as_str(),
+            "unexpected_nodes"
+        );
+    }
+
+    #[test]
+    fn a_report_with_no_mismatch_count_is_clean() {
+        let mut report = StorageParityReport {
+            versions_checked: 3,
+            versions_with_body: 2,
+            versions_without_body: 1,
+            mismatch_count: 0,
+            mismatches: Vec::new(),
+            truncated: false,
+            elapsed_ms: 1,
+        };
+        assert!(report.is_clean());
+        report.mismatch_count = 1;
+        assert!(!report.is_clean());
+    }
+}

--- a/app/ferroehr/src/service/admin/mod.rs
+++ b/app/ferroehr/src/service/admin/mod.rs
@@ -19,6 +19,8 @@
 //!   / `versioned_composition_count` / `composition_version_count`.
 //! - `archive` — `I_ADMIN_ARCHIVE.archive_ehrs` / `archive_parties`.
 //! - `dump_load` — `I_ADMIN_DUMP_LOAD.export_ehrs` / `load_ehrs`.
+//! - [`integrity`] — the storage-parity sweep, our own extension: no SM
+//!   interface declares it and no openEHR spec governs storage mechanics.
 //! - [`types`] — the SM information classes of the ADMIN group
 //!   (`EXPORT_SPEC`, `DUMP_LOAD_FAIL_REPORT`, the format enumerations).
 //!
@@ -26,7 +28,9 @@
 //!
 //! - **`crate::storage`** — `dump_load` reassembles/decomposes version bodies
 //!   through the storage codec (`node_repo::read_version_canonical` /
-//!   `decompose` + `write_nodes`).
+//!   `decompose` + `write_nodes`); `integrity` reassembles every stored
+//!   version through `node_repo::read_version_canonical_all` to compare it
+//!   with the materialized `vo_version.body`.
 //! - **`archive`** marks EHR/party versioned objects archived and physically
 //!   moves their rows into the spec-silent cold tier
 //!   ([`crate::storage::version_repo::tier`]), reversibly; `delete` and
@@ -38,6 +42,7 @@ mod delete;
 mod dump_load;
 mod statistics;
 
+pub mod integrity;
 pub mod types;
 
 use uuid::Uuid;

--- a/app/ferroehr/tests/it/main.rs
+++ b/app/ferroehr/tests/it/main.rs
@@ -63,6 +63,7 @@ mod service_template;
 mod service_validation;
 mod signing_pgp;
 mod sql_injection;
+mod storage_parity;
 mod storage_spike;
 mod system_log_tls_roundtrip;
 mod telemetry;

--- a/app/ferroehr/tests/it/storage_parity.rs
+++ b/app/ferroehr/tests/it/storage_parity.rs
@@ -1,0 +1,329 @@
+// SPDX-FileCopyrightText: FerroEHR contributors
+// SPDX-License-Identifier: MIT
+
+//! The admin storage-parity sweep against a real `PostgreSQL` 18 (shared
+//! testkit harness).
+//!
+//! NOTE: no openEHR spec governs storage mechanics — our own design/extension;
+//! the sweep re-derives every stored version from its `node` rows and compares
+//! the result with the materialized `vo_version.body`.
+//!
+//! Every tamper case reaches PAST the service into the stored rows with raw
+//! SQL, which is the point: an attacker or a corrupt page does not go through
+//! the write path, so neither does the fixture. A case that tampers must prove
+//! the `UPDATE`/`DELETE` matched something, or it would pass while testing
+//! nothing.
+
+#![expect(
+    clippy::expect_used,
+    reason = "clippy's in-test lint scoping (clippy.toml `allow-*-in-tests`) only \
+              reaches `#[test]`-annotated functions, so it misses this module's \
+              fixture helpers; a failing fixture must panic at the fixture (the \
+              Rust Book ch11)"
+)]
+
+use serde_json::{Value, json};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use openehr_its::rest::generated::common::{UpdateAudit, UpdateAuditData, UpdateVersion};
+use openehr_rm::prelude::PartyProxy;
+
+use ferroehr::ids::EhrId;
+use ferroehr::service::FerroEhrService;
+use ferroehr::service::admin::integrity::StorageParityDefect;
+use ferroehr::service::version_update::{change_type_coded, lifecycle_state_coded};
+
+/// The SM `UPDATE_VERSION` commit envelope for a bare-RM write.
+fn uv<T: serde::de::DeserializeOwned>(
+    data: &Value,
+    change_code: &str,
+    preceding: Option<&str>,
+) -> UpdateVersion<T> {
+    UpdateVersion {
+        preceding_version_uid: preceding.map(|p| p.parse().expect("OBJECT_VERSION_ID")),
+        lifecycle_state: lifecycle_state_coded("532"),
+        attestations: None,
+        data: openehr_its::json::from_canonical_value(data)
+            .expect("the fixture commit body decodes as its RM type"),
+        commit_audit: UpdateAudit::UpdateAudit(UpdateAuditData {
+            _type: None,
+            system_id: None,
+            change_type: change_type_coded(change_code),
+            description: None,
+            committer: openehr_its::json::from_canonical_value::<PartyProxy>(
+                &json!({ "_type": "PARTY_IDENTIFIED", "name": "conformance tester" }),
+            )
+            .expect("committer"),
+        }),
+        signature: None,
+    }
+}
+
+/// A minimal *valid* RM COMPOSITION: `language`, `territory`, `category` and
+/// `composer` are all `1..1` (RM ehr, COMPOSITION class), so the typed RM
+/// validation rejects a fixture without them.
+fn composition(name: &str) -> Value {
+    json!({
+        "_type": "COMPOSITION",
+        "archetype_node_id": "openEHR-EHR-COMPOSITION.encounter.v1",
+        "archetype_details": {
+            "_type": "ARCHETYPED",
+            "archetype_id": {
+                "_type": "ARCHETYPE_ID",
+                "value": "openEHR-EHR-COMPOSITION.encounter.v1"
+            },
+            "rm_version": "1.2.0"
+        },
+        "name": { "_type": "DV_TEXT", "value": name },
+        "language": {
+            "_type": "CODE_PHRASE",
+            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_639-1" },
+            "code_string": "en"
+        },
+        "territory": {
+            "_type": "CODE_PHRASE",
+            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_3166-1" },
+            "code_string": "NL"
+        },
+        "category": {
+            "_type": "DV_CODED_TEXT",
+            "value": "event",
+            "defining_code": {
+                "_type": "CODE_PHRASE",
+                "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" },
+                "code_string": "433"
+            }
+        },
+        "composer": { "_type": "PARTY_IDENTIFIED", "name": "conformance tester" }
+    })
+}
+
+/// A minimal *valid* root FOLDER (a folder-hierarchy root).
+fn folder(name: &str) -> Value {
+    json!({
+        "_type": "FOLDER",
+        "archetype_node_id": "openEHR-EHR-FOLDER.generic.v1",
+        "name": { "_type": "DV_TEXT", "value": name }
+    })
+}
+
+/// An EHR carrying one committed COMPOSITION — three content versions in all
+/// (`EHR_STATUS`, `EHR_ACCESS`, the COMPOSITION), every one of which the sweep
+/// reads.
+async fn seed_ehr_with_composition(svc: &FerroEhrService) -> EhrId {
+    let ehr_id = svc.create_ehr(None).await.expect("ehr create");
+    svc.create_composition(ehr_id, uv(&composition("Encounter"), "249", None))
+        .await
+        .expect("composition commit");
+    ehr_id
+}
+
+/// The `(vo_id, sys_version)` of the one stored version of `kind` in `ehr_id`.
+async fn one_version(pool: &PgPool, ehr_id: EhrId, kind: &str) -> (Uuid, i32) {
+    sqlx::query_as(
+        "SELECT vo_id, sys_version FROM vo_version WHERE ehr_id = $1 AND kind = $2 \
+         ORDER BY sys_version DESC LIMIT 1",
+    )
+    .bind(ehr_id.0)
+    .bind(kind)
+    .fetch_one(pool)
+    .await
+    .expect("a stored version of the requested kind")
+}
+
+/// Run a statement that must touch at least one row — a tamper fixture that
+/// matched nothing would let its test pass while proving nothing.
+async fn tamper(pool: &PgPool, sql: &'static str, vo_id: Uuid, sys_version: i32) {
+    let affected = sqlx::query(sql)
+        .bind(vo_id)
+        .bind(sys_version)
+        .execute(pool)
+        .await
+        .expect("the tamper statement runs")
+        .rows_affected();
+    assert!(
+        affected > 0,
+        "the tamper statement matched no rows, so nothing was actually tampered"
+    );
+}
+
+#[tokio::test]
+async fn a_committed_composition_sweeps_clean() {
+    let db = testkit::db().await.expect("testkit database");
+    let svc = FerroEhrService::new(db.pool());
+    seed_ehr_with_composition(&svc).await;
+
+    let report = svc.verify_storage_parity().await.expect("sweep");
+
+    assert!(
+        report.is_clean(),
+        "a repository written through the commit path must be parity-clean: {report:?}"
+    );
+    assert!(report.mismatches.is_empty());
+    assert!(
+        report.versions_checked >= 3,
+        "the EHR create plus one composition commit stores at least three versions, saw {}",
+        report.versions_checked
+    );
+    assert_eq!(
+        report.versions_checked,
+        report.versions_with_body + report.versions_without_body
+    );
+}
+
+#[tokio::test]
+async fn a_tampered_node_row_is_reported_as_content_differs() {
+    let db = testkit::db().await.expect("testkit database");
+    let pool = db.pool();
+    let svc = FerroEhrService::new(pool.clone());
+    let ehr_id = seed_ehr_with_composition(&svc).await;
+    let (vo_id, sys_version) = one_version(&pool, ehr_id, "COMPOSITION").await;
+
+    // The AQL index copy, which read-time signature verification never sees.
+    tamper(
+        &pool,
+        "UPDATE node SET data = jsonb_set(data, '{archetype_node_id}', '\"tampered\"') \
+         WHERE vo_id = $1 AND sys_version = $2 AND num = 0",
+        vo_id,
+        sys_version,
+    )
+    .await;
+
+    let report = svc.verify_storage_parity().await.expect("sweep");
+
+    assert_eq!(
+        report.mismatch_count, 1,
+        "exactly the tampered version must be reported: {report:?}"
+    );
+    let found = &report.mismatches[0];
+    assert_eq!(found.vo_id, vo_id);
+    assert_eq!(found.sys_version, sys_version);
+    assert_eq!(found.kind, "COMPOSITION");
+    assert_eq!(found.defect, StorageParityDefect::ContentDiffers);
+    assert!(!report.truncated);
+}
+
+#[tokio::test]
+async fn a_tampered_version_body_is_reported_as_content_differs() {
+    let db = testkit::db().await.expect("testkit database");
+    let pool = db.pool();
+    let svc = FerroEhrService::new(pool.clone());
+    let ehr_id = seed_ehr_with_composition(&svc).await;
+    let (vo_id, sys_version) = one_version(&pool, ehr_id, "COMPOSITION").await;
+
+    // The other copy: the materialized projection every point read serves.
+    tamper(
+        &pool,
+        "UPDATE vo_version SET body = jsonb_set(body, '{archetype_node_id}', '\"tampered\"') \
+         WHERE vo_id = $1 AND sys_version = $2",
+        vo_id,
+        sys_version,
+    )
+    .await;
+
+    let report = svc.verify_storage_parity().await.expect("sweep");
+
+    assert_eq!(report.mismatch_count, 1, "{report:?}");
+    let found = &report.mismatches[0];
+    assert_eq!(found.vo_id, vo_id);
+    assert_eq!(found.sys_version, sys_version);
+    assert_eq!(found.defect, StorageParityDefect::ContentDiffers);
+}
+
+#[tokio::test]
+async fn a_version_whose_node_rows_are_gone_is_reported_as_nodes_missing() {
+    let db = testkit::db().await.expect("testkit database");
+    let pool = db.pool();
+    let svc = FerroEhrService::new(pool.clone());
+    let ehr_id = seed_ehr_with_composition(&svc).await;
+    let (vo_id, sys_version) = one_version(&pool, ehr_id, "COMPOSITION").await;
+
+    tamper(
+        &pool,
+        "DELETE FROM node WHERE vo_id = $1 AND sys_version = $2",
+        vo_id,
+        sys_version,
+    )
+    .await;
+
+    let report = svc.verify_storage_parity().await.expect("sweep");
+
+    assert_eq!(report.mismatch_count, 1, "{report:?}");
+    let found = &report.mismatches[0];
+    assert_eq!(found.vo_id, vo_id);
+    assert_eq!(found.sys_version, sys_version);
+    assert_eq!(found.defect, StorageParityDefect::NodesMissing);
+}
+
+#[tokio::test]
+async fn a_logically_deleted_version_sweeps_clean() {
+    let db = testkit::db().await.expect("testkit database");
+    let pool = db.pool();
+    let svc = FerroEhrService::new(pool.clone());
+    let ehr_id = svc.create_ehr(None).await.expect("ehr create");
+    let dir = svc
+        .create_directory(ehr_id, uv(&folder("root"), "249", None))
+        .await
+        .expect("directory create");
+    svc.delete_directory(ehr_id, Some(dir.uid.parse().expect("ovid")), None)
+        .await
+        .expect("directory delete");
+
+    // The delete committed a version with data Void (RM common master06
+    // §Logical Deletion): no body, and no node rows to disagree with it.
+    let bodiless: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM vo_version WHERE ehr_id = $1 AND kind = 'FOLDER' AND body IS NULL",
+    )
+    .bind(ehr_id.0)
+    .fetch_one(&pool)
+    .await
+    .expect("count");
+    assert_eq!(bodiless, 1, "the delete must store one bodiless version");
+
+    let report = svc.verify_storage_parity().await.expect("sweep");
+
+    assert!(report.is_clean(), "{report:?}");
+    assert_eq!(report.versions_without_body, 1);
+}
+
+#[tokio::test]
+async fn node_rows_under_a_bodiless_version_are_reported_as_unexpected_nodes() {
+    let db = testkit::db().await.expect("testkit database");
+    let pool = db.pool();
+    let svc = FerroEhrService::new(pool.clone());
+    let ehr_id = svc.create_ehr(None).await.expect("ehr create");
+    let dir = svc
+        .create_directory(ehr_id, uv(&folder("root"), "249", None))
+        .await
+        .expect("directory create");
+    svc.delete_directory(ehr_id, Some(dir.uid.parse().expect("ovid")), None)
+        .await
+        .expect("directory delete");
+    let (vo_id, sys_version) = one_version(&pool, ehr_id, "FOLDER").await;
+
+    // Give the bodiless version the previous version's rows: content in the
+    // AQL index that no served version accounts for.
+    let inserted = sqlx::query(
+        "INSERT INTO node (vo_id, sys_version, ehr_id, num, num_cap, parent_num, citem_num, \
+         rm_type, archetype, arch_entity, arch_concept, arch_major, name, path, data) \
+         SELECT vo_id, $2, ehr_id, num, num_cap, parent_num, citem_num, rm_type, archetype, \
+         arch_entity, arch_concept, arch_major, name, path, data \
+         FROM node WHERE vo_id = $1 AND sys_version = $2 - 1",
+    )
+    .bind(vo_id)
+    .bind(sys_version)
+    .execute(&pool)
+    .await
+    .expect("insert the stray rows")
+    .rows_affected();
+    assert!(inserted > 0, "the fixture must actually insert stray rows");
+
+    let report = svc.verify_storage_parity().await.expect("sweep");
+
+    assert_eq!(report.mismatch_count, 1, "{report:?}");
+    let found = &report.mismatches[0];
+    assert_eq!(found.vo_id, vo_id);
+    assert_eq!(found.sys_version, sys_version);
+    assert_eq!(found.defect, StorageParityDefect::UnexpectedNodes);
+}

--- a/scripts/deploy-probes/signing.sh
+++ b/scripts/deploy-probes/signing.sh
@@ -8,11 +8,13 @@
 # signed on every read and refuses to serve a provably corrupt record. That is a
 # strong claim, and it had never been watched work.
 #
-# The probe that matters is the TAMPER one: a signing feature with no
-# demonstrated detection is decoration. So this reaches past the API into the
-# stored rows, changes a byte of clinical content, and asserts the next read
-# FAILS — the only way to show the verification is real rather than a field
-# nobody checks.
+# The probes that matter are the TAMPER ones: a signing feature with no
+# demonstrated detection is decoration. So they reach past the API into the
+# stored rows, change a byte of clinical content, and assert it is caught — the
+# only way to show the verification is real rather than a field nobody checks.
+# There are two stored copies of a version's content and one probe per copy:
+# vo_version.body, caught by the read path, and the node rows, caught by the
+# admin storage-parity sweep.
 #
 # Sourced by scripts/deploy-probe.sh; never run directly.
 
@@ -48,9 +50,9 @@ probes_signing() {
   # The one that makes the feature more than decoration. Reaching past the API
   # into the stored rows is the point: an attacker or a corrupt disk does not
   # go through the write path, so neither does this. The tamper target is
-  # vo_version.body — the materialized projection every point read serves
-  # (the node rows are the AQL index; the parity between the two copies is
-  # pinned by the persistence suite, not by this probe).
+  # vo_version.body — the materialized projection every point read serves. The
+  # node rows are the storage's OTHER copy, and P-NODE-TAMPER below covers
+  # them through the channel that does see them.
   probe "P-SIGN-TAMPER" "broken" "server" "-" \
     "a tampered stored version is REFUSED on read, not served"
   local before after rows
@@ -71,6 +73,46 @@ probes_signing() {
       *)  probe_fail "a 5xx integrity refusal" "$after" \
             "verify_on_read is strict by default, so a corrupt record must not be served (was $before before tampering)" ;;
     esac
+  fi
+  probe_done
+
+  # The storage keeps every version's content twice: vo_version.body, which the
+  # probe above covers, and the decomposed node rows the AQL engine queries. A
+  # read-time signature check recomputes only the first, so a tampered node row
+  # is invisible to it; the admin storage-parity sweep is the channel that sees
+  # it. Same reach-past-the-API shape, aimed at the other copy.
+  probe "P-NODE-TAMPER" "broken" "server" "-" \
+    "a tampered node row is reported by the admin storage-parity sweep"
+  local node_ehr node_vo node_rows sweep sweep_code
+  node_ehr="$(curl -s -u "$BASIC" -X POST -D - -o /dev/null "$API/ehr" \
+    | grep -i '^location' | tr -d '\r' | awk -F/ '{print $NF}')"
+  node_vo="$(probe_psql "SELECT vo_id FROM ehr.vo_version
+                          WHERE ehr_id = '$node_ehr'::uuid AND kind = 'EHR_STATUS';" \
+             | tr -d '[:space:]')"
+  if [ -z "$node_ehr" ] || [ -z "$node_vo" ]; then
+    probe_fail "a committed EHR_STATUS version" "ehr='$node_ehr' vo='$node_vo'" \
+      "the probe could not locate the stored version, so detection was never tested"
+    probe_done
+    return 0
+  fi
+  node_rows="$(probe_psql "UPDATE ehr.node
+                              SET data = jsonb_set(data, '{archetype_node_id}', '\"tampered\"')
+                            WHERE vo_id = '$node_vo'::uuid AND num = 0;" \
+               && probe_psql "SELECT count(*) FROM ehr.node
+                               WHERE vo_id = '$node_vo'::uuid
+                                 AND data #>> '{archetype_node_id}' = 'tampered';")"
+  if [ "${node_rows:-0}" = "0" ]; then
+    probe_fail "a tampered node row" "the UPDATE matched nothing" \
+      "the probe could not reach the AQL index copy, so detection was never tested"
+  else
+    sweep_code="$(http_code -u "$BASIC" -X POST "$API/admin/integrity/verify")"
+    assert_eq "200" "$sweep_code" \
+      "the sweep itself must succeed — a finding is reported in the body, not as a failed request"
+    sweep="$(curl -s -u "$BASIC" -X POST "$API/admin/integrity/verify")"
+    assert_contains "$sweep" "$node_vo" \
+      "the sweep must name the tampered versioned object"
+    assert_contains "$sweep" '"defect":"content_differs"' \
+      "a node row that no longer matches the materialized body is a content_differs mismatch"
   fi
   probe_done
 }

--- a/website/book/src/operations-admin-apis.md
+++ b/website/book/src/operations-admin-apis.md
@@ -174,6 +174,69 @@ Two consequences to plan for:
   visibility is the effect to plan around, and the restore routes are how you
   get it back.
 
+## Storage integrity
+
+One route that checks the stored data against itself, behind the same switch
+and role. FerroEHR stores every version's content twice: once as the
+materialized document a point read serves, and once as the decomposed rows the
+AQL engine queries. A commit writes both in the same transaction, so they
+always agree; anything that changes one of them behind the server's back
+breaks that agreement.
+
+| Route | **200** body |
+|---|---|
+| `POST {base}/admin/integrity/verify` | the sweep report |
+
+The sweep re-derives every stored version from its decomposed rows and compares
+the result with the stored document. It reads the archived tier as well, takes
+no lock, and runs outside the request path of any clinical call, so it is safe
+to run on a live server. It is also a full scan of the repository: expect it to
+take minutes on a large one, and schedule it rather than calling it per
+request.
+
+```json
+{
+  "versions_checked": 128,
+  "versions_with_body": 126,
+  "versions_without_body": 2,
+  "mismatch_count": 1,
+  "mismatches": [
+    {
+      "vo_id": "8849182c-82ad-4088-a07f-48ead4180515",
+      "sys_version": 2,
+      "kind": "COMPOSITION",
+      "defect": "content_differs"
+    }
+  ],
+  "truncated": false,
+  "elapsed_ms": 431
+}
+```
+
+`defect` is one of four values:
+
+- `content_differs`: both copies exist and hold different content.
+- `nodes_missing`: the version has a stored document but no decomposed rows.
+- `nodes_unreadable`: the decomposed rows exist but no longer form one tree.
+- `unexpected_nodes`: the version is a logical delete, which stores no
+  document, yet decomposed rows exist for it.
+
+`mismatch_count` is the full count. `mismatches` is capped at 1000 entries and
+`truncated` says whether the cap was reached; every mismatch is logged at
+`warn` level with its identifiers whatever the cap does, so a truncated report
+never loses a finding. The log line and the response carry identifiers only,
+never content.
+
+A finding is **not** a request failure: the sweep ran and is telling you what
+it saw, so the status stays **200** and the report is the body. Check
+`mismatch_count`, not the status code.
+
+> [!NOTE]
+> This is the companion check to [digest signing](signing/digest.md). A stored
+> digest covers the document a point read serves; it says nothing about the
+> decomposed rows, which no read-path check recomputes. Together the two cover
+> both copies.
+
 ## Dump and load
 
 Two routes that move the whole repository to and from an archive on the

--- a/website/book/src/signing/digest.md
+++ b/website/book/src/signing/digest.md
@@ -107,6 +107,22 @@ tamper-detection control against accidental corruption and against an actor
 who reaches the data but not the write path. Authorship and non-repudiation
 need a key, which is [PGP mode](pgp.md).
 
+It also covers one of the two copies FerroEHR stores. Every version's
+content is written twice in the same transaction: as the materialized
+document a point read serves, and as the decomposed rows the AQL engine
+queries. The digest is computed over the first one, and read-time
+verification recomputes it from the same place. The decomposed rows are
+never recomputed on a read, so a row edited behind the server's back is
+invisible to this check and can still reach a client through an AQL scalar
+result.
+
+That copy has its own channel: `POST {base}/admin/integrity/verify`
+re-derives every stored version from its decomposed rows and reports any
+that no longer match the stored document. It is an admin route, it runs
+outside the request path, and it reports by identifier rather than by
+content. The [admin API reference](../operations-admin-apis.md#storage-integrity)
+documents the report and its four defect values.
+
 ## Verification at read
 
 `signing.verify_on_read` resolves to `strict` whenever signing is enabled,
@@ -126,7 +142,9 @@ Verification runs where the server serves a VERSION object: the
 CONTRIBUTION read resolves under `Prefer: resolve_refs`. A plain content read
 (`GET /ehr/{ehr_id}/composition/{uid_based_id}`) returns the COMPOSITION
 rather than the VERSION that carries the signature, and runs no check. AQL
-reads storage rows directly and runs no check either.
+reads the decomposed storage rows directly and runs no check either; the
+[storage-parity sweep](../operations-admin-apis.md#storage-integrity) is what
+covers those.
 
 > [!WARNING]
 > A `strict` mismatch is a `500` on purpose. The alternative is serving a


### PR DESCRIPTION
Closes #2680.

Storage holds two copies of every version's content: `vo_version.body` (served by point reads, covered by read-time signature verification) and the `node` rows (the AQL index) — uncovered since the materialized body (#2661) moved reads off them. The adjudicated mechanism is the off-request-path parity sweep:

- **`POST /admin/integrity/verify`** (admin gate, `ADMIN_WRITE` in the authz matrix): streams every version from the two-tier union views, re-derives `reassemble(node rows)` and compares to `body`. Report: totals, elapsed, and mismatches `{vo_id, sys_version, kind, defect}` with defect ∈ `content_differs` / `nodes_missing` / `nodes_unreadable` (damaged rows are reported, never abort the sweep) / `unexpected_nodes` (rows under a logically deleted version); the list caps at 1,000 with the full count + `truncated` beside it. Mismatches log identifiers only — no clinical content anywhere.
- **Six DB-backed tests** pin every defect class from real tampering (each fixture asserts its UPDATE/DELETE matched rows, so no case can pass vacuously) plus the clean paths.
- **`P-NODE-TAMPER` deploy probe**: tampers `ehr.node` via psql — the exact move the old signing probes made — and asserts the sweep reports it, restoring the coverage #2681's probe retarget honestly gave up.
- **Book**: the digest page now states the two-copy proof boundary and names the sweep as the node-copy channel; the admin-APIs page documents the route. Changelog entry added.

En-route findings recorded for follow-up (not drive-by-fixed): a READONLY admin is refused the sweep by `extension_is_write` though it mutates nothing (widening `EXTENSION_READ_ROUTES` to bodyless routes needs an owner call); `classify.rs`'s "all admin ops physically delete" comment is stale against the read-only admin ops; one stale change-narration NOTE in `service_admin.rs`.

Gates: clippy both crates clean; the six parity tests + the full ferroehr-rest suite (772) green; docs-claims/comment-style/typed-status/default-style OK; rustdoc clean; `bash -n` on the probe.