### PR TITLE
chore(access): the parity sweep is a pinned extension read

### DIFF
--- a/app/ferroehr-rest/src/extensions/access/authz/classify.rs
+++ b/app/ferroehr-rest/src/extensions/access/authz/classify.rs
@@ -226,8 +226,11 @@ fn write_verb(op: &str) -> Option<bool> {
     if op.starts_with("query_execute_") {
         return Some(false);
     }
-    // Write markers: the mutating verbs across every family, plus the whole
-    // admin API (all admin ops physically delete).
+    // Write markers: the mutating verbs across every family, plus the
+    // GENERATED-table admin ops, which all physically delete. The read-only
+    // admin surfaces (config, reports, the parity sweep) are extension routes
+    // outside the generated tables, so this prefix never sees them —
+    // `extension_is_write` + EXTENSION_READ_ROUTES classify those.
     if op.starts_with("admin_")
         || op.contains("_create")
         || op.contains("_update")

--- a/app/ferroehr-rest/src/extensions/access/authz/mod.rs
+++ b/app/ferroehr-rest/src/extensions/access/authz/mod.rs
@@ -285,17 +285,27 @@ pub(crate) struct RbacGate {
 /// outside the generated ITS-REST tables.
 ///
 /// Matched by method + path SUFFIX so the deployment's configured base path is
-/// irrelevant. Each entry is a read whose selector is a whole structure and so
-/// travels as a request body, exactly as the released ad-hoc AQL read does:
+/// irrelevant. Each entry is a POST whose handler provably performs no write —
+/// either a read whose selector is a whole structure and so travels as a
+/// request body (the released ad-hoc AQL read's shape), or a bodyless
+/// computation over held data:
 ///
 /// - `POST /message/export` — SM `I_EHR_EXTRACT_SERVICE.export_ehr_extracts`
 ///   (`SM/docs/UML/classes/i_ehr_extract_service.adoc`), a query over held
 ///   versions whose selector is an `EXTRACT_SPEC` (RM `ehr_extract`
 ///   `extract_spec.adoc`). It commits nothing: the import operations are the
 ///   mutating half of that interface.
+/// - `POST /admin/integrity/verify` — the storage-parity sweep (#2680): a
+///   whole-store comparison of the two stored content copies that writes
+///   nothing and answers identifiers + defect classes only, strictly less
+///   than the admin read routes already expose. A read-only integrity
+///   auditor is exactly who runs it (adjudicated on #2692).
 ///
 /// No openEHR spec governs role semantics — our own design/extension.
-const EXTENSION_READ_ROUTES: &[(&str, &str)] = &[("POST", "/message/export")];
+const EXTENSION_READ_ROUTES: &[(&str, &str)] = &[
+    ("POST", "/message/export"),
+    ("POST", "/admin/integrity/verify"),
+];
 
 /// Extension routes that are [`OperationClass::Admin`] despite not sitting under
 /// `/admin/` — the destructive half of the shared-definition surface.

--- a/app/ferroehr-rest/tests/it/authz_route_matrix.rs
+++ b/app/ferroehr-rest/tests/it/authz_route_matrix.rs
@@ -337,6 +337,10 @@ const ADMIN_READ: &[(&str, &str)] = &[
     ("GET", "/admin/event_subscription/{subscription_id}"),
     ("GET", "/admin/fhir_mapping"),
     ("GET", "/admin/fhir_mapping/{mapping_id}"),
+    // The storage-parity sweep mutates nothing and answers identifiers +
+    // defect classes only — a pinned EXTENSION_READ_ROUTES read despite the
+    // POST verb, so a read-only integrity auditor can run it (#2692).
+    ("POST", "/admin/integrity/verify"),
 ];
 
 /// Admin-class writes (base-relative).
@@ -358,11 +362,6 @@ const ADMIN_WRITE: &[(&str, &str)] = &[
     ("POST", "/admin/archive/parties/restore"),
     ("POST", "/admin/dump"),
     ("POST", "/admin/load"),
-    // The storage-parity sweep mutates nothing, but it is an extension route
-    // outside the generated tables, where `extension_is_write` reads the HTTP
-    // verb and every mutating verb is a write (fail-safe). So a read-only admin
-    // is refused it, and this row states what the gate actually does.
-    ("POST", "/admin/integrity/verify"),
     ("POST", "/admin/tenant"),
     ("PUT", "/admin/tenant/{tenant_id}"),
     ("DELETE", "/admin/tenant/{tenant_id}"),

--- a/app/ferroehr/tests/it/service_admin.rs
+++ b/app/ferroehr/tests/it/service_admin.rs
@@ -145,13 +145,9 @@ async fn ehr_rows(pool: &PgPool, ehr_id: Uuid) -> EhrRows {
 /// Seed an EHR with enough content to exercise every FK the physical delete
 /// must cascade through: `EHR_STATUS` (two versions) + `EHR_ACCESS` from
 /// creation, a directory FOLDER, and an item tag on the `EHR_STATUS`.
-///
-/// NOTE: this deliberately avoids COMPOSITION. On this base commit,
-/// COMPOSITION validation is stricter than the shared test fixtures supply, so
-/// the pre-existing `service_ehr::ehr_composition_lifecycle_end_to_end` fails
-/// identically (a base issue, not the admin change). `EHR_STATUS`/FOLDER writes
-/// populate the same `vo_version`/`node`/`contribution`/`audit`/`item_tag`
-/// tables, so the cascade contract is fully covered without COMPOSITION.
+/// COMPOSITION is deliberately absent: `EHR_STATUS`/FOLDER writes populate
+/// the same `vo_version`/`node`/`contribution`/`audit`/`item_tag` tables, so
+/// the cascade contract is fully covered without one.
 async fn seed_full_ehr(svc: &FerroEhrService) -> ferroehr::ids::EhrId {
     let ehr_uuid = svc.create_ehr(None).await.expect("ehr");
 

--- a/tools/openehr-codegen/src/cli.rs
+++ b/tools/openehr-codegen/src/cli.rs
@@ -77,13 +77,14 @@ pub(crate) struct EmittedFile {
     pub(crate) body: String,
 }
 
-/// What `emit-xml` produces: the rendered files, plus the XSD-declared elements
-/// that matched no BMM field and are therefore reported rather than emitted.
+/// What an XSD-driven emit target produces: the rendered files, plus the
+/// XSD-declared elements that matched no field in the model behind them and are
+/// therefore reported rather than emitted.
 #[derive(Debug)]
-pub(crate) struct XmlEmission {
+pub(crate) struct XsdEmission {
     /// The rendered files.
     pub(crate) files: Vec<EmittedFile>,
-    /// The XSD-only `(type, element)` pairs skipped for want of a BMM field.
+    /// The XSD-only `(type, element)` pairs skipped for want of a model field.
     pub(crate) unmatched: Vec<(String, String)>,
 }
 
@@ -377,7 +378,7 @@ fn cmd_emit_xml() -> Result<(), Box<dyn std::error::Error>> {
 /// # Errors
 /// Returns an error if the RM/BASE compositions or the vendored XSD bundles
 /// cannot be loaded, or if the XML emission itself fails.
-pub(crate) fn render_xml_files() -> Result<XmlEmission, Box<dyn std::error::Error>> {
+pub(crate) fn render_xml_files() -> Result<XsdEmission, Box<dyn std::error::Error>> {
     // The XML codec covers the CURRENT RM/BASE generations (the wire the
     // server serves).
     let base = compose("base")?;
@@ -424,7 +425,7 @@ pub(crate) fn render_xml_files() -> Result<XmlEmission, Box<dyn std::error::Erro
         //! Canonical-XML `ToXml`/`FromXml` impls for the RM/BASE spec types.\n\n\
         mod impls;\n";
 
-    Ok(XmlEmission {
+    Ok(XsdEmission {
         files: vec![
             EmittedFile {
                 path: format!("{XML_GEN_DIR}/impls.rs"),


### PR DESCRIPTION
Closes #2692.

1. **A read-only admin can run the integrity sweep.** `EXTENSION_READ_ROUTES`' rationale widens from "a read whose selector travels as a request body" to "a POST whose handler provably performs no write", and `POST /admin/integrity/verify` joins `POST /message/export` under it. Safety: the sweep writes nothing and answers identifiers + defect classes only — strictly less than the ADMIN_READ report routes already expose to the same principal — and a read-only integrity auditor is exactly its intended caller. The route stays behind the admin gate; only the read-only restriction stops refusing it. The authz route matrix row moves to `ADMIN_READ`, and the matrix probe (which drives every row with real principals) is the behavioural test.
2. **`classify.rs`'s `write_verb` comment** stated "the whole admin API (all admin ops physically delete)" — false since the read-only admin ops exist; they never reach that classifier only because extension routes bypass the generated tables. The comment now states the actual rule.
3. The stale base-commit change-narration NOTE in `service_admin.rs` is deleted (the test it referenced passes and has for many releases).

`no-changelog`: the sweep route shipped unreleased minutes ago in #2691, so its visible behaviour has never been in a release; this completes its access classification before it ever ships.