### PR TITLE
test(codegen): every emit target gets the shared render seam

### DIFF
--- a/app/ferroehr-rest/src/extensions/access/authz/classify.rs
+++ b/app/ferroehr-rest/src/extensions/access/authz/classify.rs
@@ -226,8 +226,11 @@ fn write_verb(op: &str) -> Option<bool> {
     if op.starts_with("query_execute_") {
         return Some(false);
     }
-    // Write markers: the mutating verbs across every family, plus the whole
-    // admin API (all admin ops physically delete).
+    // Write markers: the mutating verbs across every family, plus the
+    // GENERATED-table admin ops, which all physically delete. The read-only
+    // admin surfaces (config, reports, the parity sweep) are extension routes
+    // outside the generated tables, so this prefix never sees them —
+    // `extension_is_write` + EXTENSION_READ_ROUTES classify those.
     if op.starts_with("admin_")
         || op.contains("_create")
         || op.contains("_update")

--- a/app/ferroehr-rest/src/extensions/access/authz/mod.rs
+++ b/app/ferroehr-rest/src/extensions/access/authz/mod.rs
@@ -285,17 +285,27 @@ pub(crate) struct RbacGate {
 /// outside the generated ITS-REST tables.
 ///
 /// Matched by method + path SUFFIX so the deployment's configured base path is
-/// irrelevant. Each entry is a read whose selector is a whole structure and so
-/// travels as a request body, exactly as the released ad-hoc AQL read does:
+/// irrelevant. Each entry is a POST whose handler provably performs no write —
+/// either a read whose selector is a whole structure and so travels as a
+/// request body (the released ad-hoc AQL read's shape), or a bodyless
+/// computation over held data:
 ///
 /// - `POST /message/export` — SM `I_EHR_EXTRACT_SERVICE.export_ehr_extracts`
 ///   (`SM/docs/UML/classes/i_ehr_extract_service.adoc`), a query over held
 ///   versions whose selector is an `EXTRACT_SPEC` (RM `ehr_extract`
 ///   `extract_spec.adoc`). It commits nothing: the import operations are the
 ///   mutating half of that interface.
+/// - `POST /admin/integrity/verify` — the storage-parity sweep (#2680): a
+///   whole-store comparison of the two stored content copies that writes
+///   nothing and answers identifiers + defect classes only, strictly less
+///   than the admin read routes already expose. A read-only integrity
+///   auditor is exactly who runs it (adjudicated on #2692).
 ///
 /// No openEHR spec governs role semantics — our own design/extension.
-const EXTENSION_READ_ROUTES: &[(&str, &str)] = &[("POST", "/message/export")];
+const EXTENSION_READ_ROUTES: &[(&str, &str)] = &[
+    ("POST", "/message/export"),
+    ("POST", "/admin/integrity/verify"),
+];
 
 /// Extension routes that are [`OperationClass::Admin`] despite not sitting under
 /// `/admin/` — the destructive half of the shared-definition surface.

--- a/app/ferroehr-rest/tests/it/authz_route_matrix.rs
+++ b/app/ferroehr-rest/tests/it/authz_route_matrix.rs
@@ -337,6 +337,10 @@ const ADMIN_READ: &[(&str, &str)] = &[
     ("GET", "/admin/event_subscription/{subscription_id}"),
     ("GET", "/admin/fhir_mapping"),
     ("GET", "/admin/fhir_mapping/{mapping_id}"),
+    // The storage-parity sweep mutates nothing and answers identifiers +
+    // defect classes only — a pinned EXTENSION_READ_ROUTES read despite the
+    // POST verb, so a read-only integrity auditor can run it (#2692).
+    ("POST", "/admin/integrity/verify"),
 ];
 
 /// Admin-class writes (base-relative).
@@ -358,11 +362,6 @@ const ADMIN_WRITE: &[(&str, &str)] = &[
     ("POST", "/admin/archive/parties/restore"),
     ("POST", "/admin/dump"),
     ("POST", "/admin/load"),
-    // The storage-parity sweep mutates nothing, but it is an extension route
-    // outside the generated tables, where `extension_is_write` reads the HTTP
-    // verb and every mutating verb is a write (fail-safe). So a read-only admin
-    // is refused it, and this row states what the gate actually does.
-    ("POST", "/admin/integrity/verify"),
     ("POST", "/admin/tenant"),
     ("PUT", "/admin/tenant/{tenant_id}"),
     ("DELETE", "/admin/tenant/{tenant_id}"),

--- a/app/ferroehr/tests/it/service_admin.rs
+++ b/app/ferroehr/tests/it/service_admin.rs
@@ -145,13 +145,9 @@ async fn ehr_rows(pool: &PgPool, ehr_id: Uuid) -> EhrRows {
 /// Seed an EHR with enough content to exercise every FK the physical delete
 /// must cascade through: `EHR_STATUS` (two versions) + `EHR_ACCESS` from
 /// creation, a directory FOLDER, and an item tag on the `EHR_STATUS`.
-///
-/// NOTE: this deliberately avoids COMPOSITION. On this base commit,
-/// COMPOSITION validation is stricter than the shared test fixtures supply, so
-/// the pre-existing `service_ehr::ehr_composition_lifecycle_end_to_end` fails
-/// identically (a base issue, not the admin change). `EHR_STATUS`/FOLDER writes
-/// populate the same `vo_version`/`node`/`contribution`/`audit`/`item_tag`
-/// tables, so the cascade contract is fully covered without COMPOSITION.
+/// COMPOSITION is deliberately absent: `EHR_STATUS`/FOLDER writes populate
+/// the same `vo_version`/`node`/`contribution`/`audit`/`item_tag` tables, so
+/// the cascade contract is fully covered without one.
 async fn seed_full_ehr(svc: &FerroEhrService) -> ferroehr::ids::EhrId {
     let ehr_uuid = svc.create_ehr(None).await.expect("ehr");
 

--- a/tools/openehr-codegen/CLAUDE.md
+++ b/tools/openehr-codegen/CLAUDE.md
@@ -64,8 +64,11 @@ output, never the raw files:
 - `src/render/` — the only stage that produces text: `emit`, `emit_json`,
   `emit_xml`, `emit_rest`, `emit_rm_model`, `emit_opt`, `emit_validate`, and the
   shared `naming` helper.
-- `src/cli.rs` + a thin `src/main.rs` — argument dispatch and the
-  stage-orchestrating `cmd_*` handlers that write each emit target's files.
+- `src/cli.rs` + a thin `src/main.rs` — argument dispatch. EVERY emit target's
+  text production is a `render_*_files()` seam consumed by both its `cmd_*`
+  write-shell and `testsupport::emit_*_to_memory()` (#2686/#2687), so the CLI
+  and the invariant tests can never diverge by code path; the `cmd_*` handlers
+  only write files.
 
 ## Discipline
 

--- a/tools/openehr-codegen/src/cli.rs
+++ b/tools/openehr-codegen/src/cli.rs
@@ -77,13 +77,14 @@ pub(crate) struct EmittedFile {
     pub(crate) body: String,
 }
 
-/// What `emit-xml` produces: the rendered files, plus the XSD-declared elements
-/// that matched no BMM field and are therefore reported rather than emitted.
+/// What an XSD-driven emit target produces: the rendered files, plus the
+/// XSD-declared elements that matched no field in the model behind them and are
+/// therefore reported rather than emitted.
 #[derive(Debug)]
-pub(crate) struct XmlEmission {
+pub(crate) struct XsdEmission {
     /// The rendered files.
     pub(crate) files: Vec<EmittedFile>,
-    /// The XSD-only `(type, element)` pairs skipped for want of a BMM field.
+    /// The XSD-only `(type, element)` pairs skipped for want of a model field.
     pub(crate) unmatched: Vec<(String, String)>,
 }
 
@@ -377,7 +378,7 @@ fn cmd_emit_xml() -> Result<(), Box<dyn std::error::Error>> {
 /// # Errors
 /// Returns an error if the RM/BASE compositions or the vendored XSD bundles
 /// cannot be loaded, or if the XML emission itself fails.
-pub(crate) fn render_xml_files() -> Result<XmlEmission, Box<dyn std::error::Error>> {
+pub(crate) fn render_xml_files() -> Result<XsdEmission, Box<dyn std::error::Error>> {
     // The XML codec covers the CURRENT RM/BASE generations (the wire the
     // server serves).
     let base = compose("base")?;
@@ -424,7 +425,7 @@ pub(crate) fn render_xml_files() -> Result<XmlEmission, Box<dyn std::error::Erro
         //! Canonical-XML `ToXml`/`FromXml` impls for the RM/BASE spec types.\n\n\
         mod impls;\n";
 
-    Ok(XmlEmission {
+    Ok(XsdEmission {
         files: vec![
             EmittedFile {
                 path: format!("{XML_GEN_DIR}/impls.rs"),

--- a/tools/openehr-codegen/src/cli.rs
+++ b/tools/openehr-codegen/src/cli.rs
@@ -627,8 +627,8 @@ fn declare_json_serde_module(
     Ok(())
 }
 
-/// Emit one XSD-driven constraint-model module (`types.rs` + `impls.rs` +
-/// `mod.rs`) under `crates/openehr-its/src/<dir>`.
+/// Render one XSD-driven constraint-model module (`types.rs` + `impls.rs` +
+/// `mod.rs`) destined for `crates/openehr-its/src/<dir>`.
 ///
 /// Shared by every `emit_opt` target so the three modules (`opt14`, `aom2`,
 /// `aom2_model`) stay structurally identical: only the XSD closure, the emission
@@ -637,37 +637,35 @@ fn declare_json_serde_module(
 /// `Resource.xsd`+`BaseTypes.xsd` with the RM-instance set, and those shared types
 /// resolve to the already-generated `openehr-base`/`openehr-rm` XML impls while the
 /// archetype constraint model is generated fresh.
-fn emit_xsd_model(
-    base_paths: &BTreeMap<String, String>,
-    rm_paths: &BTreeMap<String, String>,
+///
+/// # Errors
+/// Returns an error if the XSD closure cannot be parsed.
+fn render_xsd_model(
+    paths: &SpecPaths,
     files: &[PathBuf],
     dir: &str,
     target: &'static emit_opt::ModelTarget,
     module: &emit_opt::ModuleSpec,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<XsdEmission, Box<dyn std::error::Error>> {
     let xsd = xsd::XsdModel::parse_files(files)?;
-    let model = emit_opt::OptModel::new(&xsd, base_paths, rm_paths, target);
-
-    let gen_dir = Path::new(ITS_ROOT).join("src").join(dir);
-    std::fs::create_dir_all(&gen_dir)?;
-
+    let model = emit_opt::OptModel::new(&xsd, &paths.base, &paths.rm, target);
     let mut unmatched = Vec::new();
-    let types_path = gen_dir.join("types.rs");
-    let impls_path = gen_dir.join("impls.rs");
-    let mod_path = gen_dir.join("mod.rs");
-    write_generated(&types_path, ITS_CRATE, &model.emit_types())?;
-    write_generated(&impls_path, ITS_CRATE, &model.emit_impls(&mut unmatched))?;
-    write_generated(&mod_path, ITS_CRATE, &emit_opt::emit_module(module))?;
-
-    let written = vec![types_path, impls_path, mod_path];
-    rustfmt(&written)?;
-    println!(
-        "emitted {} files into {} ({} XSD-only elements without a matching field skipped)",
-        written.len(),
-        gen_dir.display(),
-        unmatched.len()
-    );
-    Ok(())
+    let bodies = [
+        ("types.rs", model.emit_types()),
+        ("impls.rs", model.emit_impls(&mut unmatched)),
+        ("mod.rs", emit_opt::emit_module(module)),
+    ];
+    Ok(XsdEmission {
+        files: bodies
+            .into_iter()
+            .map(|(name, body)| EmittedFile {
+                path: format!("{ITS_CRATE}/src/{dir}/{name}"),
+                crate_name: ITS_CRATE,
+                body,
+            })
+            .collect(),
+        unmatched,
+    })
 }
 
 /// Emit the OPT 1.4 model (`opt14`): typed Rust types + canonical-XML
@@ -675,20 +673,21 @@ fn emit_xsd_model(
 /// constraint XSD closure (`Template.xsd` + includes). RM instance types
 /// resolve to the already-generated `openehr-base`/`openehr-rm` impls.
 fn cmd_emit_opt() -> Result<(), Box<dyn std::error::Error>> {
-    let base = compose("base")?;
-    let rm = compose("rm")?;
-    let base_paths = generation_spec_paths(
-        base.current(),
-        &format!("openehr_base::{}", base.current().spec.module),
-    );
-    let rm_paths = generation_spec_paths(
-        rm.current(),
-        &format!("openehr_rm::{}", rm.current().spec.module),
-    );
+    write_xsd_emission("emit-opt", &render_opt_files()?)
+}
 
-    emit_xsd_model(
-        &base_paths,
-        &rm_paths,
+/// Render the OPT 1.4 model without touching the filesystem.
+///
+/// The text half of [`cmd_emit_opt`], shared with the emit-target tests
+/// (`testsupport::emit_opt_to_memory`), so the CLI and the tests drive one
+/// orchestration.
+///
+/// # Errors
+/// Returns an error if the RM/BASE compositions or the AM/OPT XSD closure
+/// cannot be loaded.
+pub(crate) fn render_opt_files() -> Result<XsdEmission, Box<dyn std::error::Error>> {
+    render_xsd_model(
+        &current_spec_paths()?,
         &xsd::am_files_v1(Path::new(XSD_V1_DIR)),
         "opt14",
         &emit_opt::OPT_TARGET,
@@ -710,34 +709,59 @@ fn cmd_emit_opt() -> Result<(), Box<dyn std::error::Error>> {
 /// form's entry points are typed to `AUTHORED_ARCHETYPE` and not to the
 /// `abstract` `ARCHETYPE` the schema's global element names.
 fn cmd_emit_aom2() -> Result<(), Box<dyn std::error::Error>> {
-    let base = compose("base")?;
-    let rm = compose("rm")?;
-    let base_paths = generation_spec_paths(
-        base.current(),
-        &format!("openehr_base::{}", base.current().spec.module),
-    );
-    let rm_paths = generation_spec_paths(
-        rm.current(),
-        &format!("openehr_rm::{}", rm.current().spec.module),
-    );
-    let aom2_dir = Path::new(XSD_AOM2_DIR);
+    write_xsd_emission("emit-aom2", &render_aom2_files()?)
+}
 
-    emit_xsd_model(
-        &base_paths,
-        &rm_paths,
+/// Render both AOM2 archetype serializations without touching the filesystem.
+///
+/// The text half of [`cmd_emit_aom2`], shared with the emit-target tests
+/// (`testsupport::emit_aom2_to_memory`), so the CLI and the tests drive one
+/// orchestration. Both closures' files (and both skipped-element reports) come
+/// back as one emission — the subcommand writes them in one pass.
+///
+/// # Errors
+/// Returns an error if the RM/BASE compositions or either AOM2 XSD closure
+/// cannot be loaded.
+pub(crate) fn render_aom2_files() -> Result<XsdEmission, Box<dyn std::error::Error>> {
+    let paths = current_spec_paths()?;
+    let aom2_dir = Path::new(XSD_AOM2_DIR);
+    let mut persistent = render_xsd_model(
+        &paths,
         &xsd::aom2_files(aom2_dir),
         "aom2",
         &emit_opt::AOM2_TARGET,
         &emit_opt::AOM2_MODULE,
     )?;
-    emit_xsd_model(
-        &base_paths,
-        &rm_paths,
+    let mut model = render_xsd_model(
+        &paths,
         &xsd::aom2_model_files(aom2_dir),
         "aom2_model",
         &emit_opt::AOM2_MODEL_TARGET,
         &emit_opt::AOM2_MODEL_MODULE,
-    )
+    )?;
+    persistent.files.append(&mut model.files);
+    persistent.unmatched.append(&mut model.unmatched);
+    Ok(persistent)
+}
+
+/// Write an XSD-driven target's rendered files and report what it skipped.
+///
+/// # Errors
+/// Returns the underlying filesystem error, or a `rustfmt` failure.
+fn write_xsd_emission(
+    target: &str,
+    emission: &XsdEmission,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let written = write_emitted(&emission.files)?;
+    rustfmt(&written)?;
+    println!(
+        "{target}: emitted {} files into {} ({} XSD-only elements without a matching field \
+         skipped)",
+        written.len(),
+        crates_root().display(),
+        emission.unmatched.len()
+    );
+    Ok(())
 }
 
 /// Emit the static RM attribute/type model (`openehr-rm/src/model/`) — the AQL
@@ -746,39 +770,69 @@ fn cmd_emit_aom2() -> Result<(), Box<dyn std::error::Error>> {
 /// touch the generated spec files) and declares `pub mod model;` in `lib.rs` if
 /// absent, so it is correct run standalone; `emit` produces the identical output.
 fn cmd_emit_rm_model() -> Result<(), Box<dyn std::error::Error>> {
-    let rm = compose("rm")?;
-    let src = crates_root().join("openehr-rm").join("src");
-    let mut written = Vec::new();
-    let mut n = 0_usize;
-    for g in &rm.generations {
-        let module = g.spec.module;
-        let unit = g.unit()?;
-        let files = prefix_gen_files(emit_rm_model::emit_files(&unit.model), module);
-        for f in &files {
-            let full = src.join(&f.path);
-            if let Some(parent) = full.parent() {
-                std::fs::create_dir_all(parent)?;
-            }
-            write_generated(&full, RM_CRATE, &f.body)?;
-            written.push(full);
+    let files = render_rm_model_files()?;
+    let mut written = write_emitted(&files)?;
+    let src = crates_root().join(RM_CRATE).join("src");
+    for g in &compose("rm")?.generations {
+        // `emit` is the usual authority for the generation `mod.rs`, where it
+        // declares the module in the RENDERED body (`inject_rm_model`). This
+        // target does not render that file, so the standalone run declares the
+        // module by read-modify-write — the same text, so both runs leave the
+        // tree byte-identical.
+        let gen_mod = src.join(g.spec.module).join("mod.rs");
+        if !gen_mod.exists() {
+            continue;
         }
-        n += files.len();
-        // `emit` is the usual authority for the generation `mod.rs`; ensure
-        // the module is declared so the standalone target is correct +
-        // byte-identical to `emit`'s output.
-        let gen_mod = src.join(module).join("mod.rs");
-        if gen_mod.exists() {
-            let mut body = std::fs::read_to_string(&gen_mod)?;
-            if !body.contains("pub mod model;") {
-                body.push_str("pub mod model;\n");
-                std::fs::write(&gen_mod, &body)?;
-                written.push(gen_mod);
-            }
+        let mut body = std::fs::read_to_string(&gen_mod)?;
+        if !body.contains(RM_MODEL_DECL) {
+            body.push_str(RM_MODEL_DECL);
+            body.push('\n');
+            std::fs::write(&gen_mod, &body)?;
+            written.push(gen_mod);
         }
     }
     rustfmt(&written)?;
-    println!("emitted {n} files into {}", src.display());
+    println!("emitted {} files into {}", files.len(), src.display());
     Ok(())
+}
+
+/// Render the static RM attribute/type model for every RM generation, without
+/// touching the filesystem.
+///
+/// The text half of [`cmd_emit_rm_model`], shared with `emit`
+/// ([`render_emit_files`]) and the emit-target tests
+/// (`testsupport::emit_rm_model_to_memory`), so all three drive one
+/// orchestration. The `pub mod model;` declaration [`cmd_emit_rm_model`] adds to
+/// each generation's `mod.rs` is a read-modify-write of a file this target does
+/// not render, so it stays on the CLI path — over the same [`RM_MODEL_DECL`]
+/// text [`inject_rm_model`] appends to `emit`'s rendered body.
+///
+/// # Errors
+/// Returns an error if the RM composition's BMM files cannot be loaded.
+pub(crate) fn render_rm_model_files() -> Result<Vec<EmittedFile>, Box<dyn std::error::Error>> {
+    let rm = compose("rm")?;
+    let mut out = Vec::new();
+    for g in &rm.generations {
+        let unit = g.unit()?;
+        out.extend(rm_crate_files(prefix_gen_files(
+            emit_rm_model::emit_files(&unit.model),
+            g.spec.module,
+        )));
+    }
+    Ok(out)
+}
+
+/// Turn `openehr-rm`-destined generated files (paths relative to the crate's
+/// `src/`) into [`EmittedFile`]s addressed from the workspace `crates/` dir.
+fn rm_crate_files(files: Vec<GenFile>) -> Vec<EmittedFile> {
+    files
+        .into_iter()
+        .map(|f| EmittedFile {
+            path: format!("{RM_CRATE}/src/{}", f.path),
+            crate_name: RM_CRATE,
+            body: f.body,
+        })
+        .collect()
 }
 
 /// Emit the RM class-invariant cores (`openehr-rm/src/validate/generated.rs`) —
@@ -788,28 +842,39 @@ fn cmd_emit_rm_model() -> Result<(), Box<dyn std::error::Error>> {
 /// `validate.rs`, so this target never touches a hand-written file. `emit`
 /// produces the identical output (via `inject_validate`).
 fn cmd_emit_validate() -> Result<(), Box<dyn std::error::Error>> {
-    let rm = compose("rm")?;
-    let src = crates_root().join("openehr-rm").join("src");
-    let mut written = Vec::new();
-    let mut n = 0_usize;
-    for g in &rm.generations {
-        let module = g.spec.module;
-        let unit = g.unit()?;
-        let rm_aug = augmented_schema(g, unit);
-        let files = prefix_gen_files(emit_validate::emit_files(&unit.model, &rm_aug), module);
-        for f in &files {
-            let full = src.join(&f.path);
-            if let Some(parent) = full.parent() {
-                std::fs::create_dir_all(parent)?;
-            }
-            write_generated(&full, RM_CRATE, &f.body)?;
-            written.push(full);
-        }
-        n += files.len();
-    }
+    let files = render_validate_files()?;
+    let written = write_emitted(&files)?;
     rustfmt(&written)?;
-    println!("emitted {n} file(s) into {}", src.display());
+    println!(
+        "emitted {} file(s) into {}",
+        files.len(),
+        crates_root().join(RM_CRATE).join("src").display()
+    );
     Ok(())
+}
+
+/// Render the RM class-invariant cores for every RM generation, without
+/// touching the filesystem.
+///
+/// The text half of [`cmd_emit_validate`], shared with `emit`
+/// ([`render_emit_files`]) and the emit-target tests
+/// (`testsupport::emit_validate_to_memory`), so all three drive one
+/// orchestration.
+///
+/// # Errors
+/// Returns an error if the RM composition's BMM files cannot be loaded.
+pub(crate) fn render_validate_files() -> Result<Vec<EmittedFile>, Box<dyn std::error::Error>> {
+    let rm = compose("rm")?;
+    let mut out = Vec::new();
+    for g in &rm.generations {
+        let unit = g.unit()?;
+        let aug = augmented_schema(g, unit);
+        out.extend(rm_crate_files(prefix_gen_files(
+            emit_validate::emit_files(&unit.model, &aug),
+            g.spec.module,
+        )));
+    }
+    Ok(out)
 }
 
 /// Prefix every generated file path with the generation module directory
@@ -833,6 +898,14 @@ fn inject_validate(files: &mut Vec<GenFile>, mut validate_files: Vec<GenFile>) {
     files.append(&mut validate_files);
 }
 
+/// The declaration an RM generation's `mod.rs` carries for the emitted static
+/// RM model.
+///
+/// One text, two writers — [`inject_rm_model`] appends it to `emit`'s rendered
+/// body, [`cmd_emit_rm_model`] to the file on disk — so the standalone target
+/// and `emit` cannot disagree about the declaration.
+const RM_MODEL_DECL: &str = "pub mod model;";
+
 /// Append the generated RM-model files to `openehr-rm`'s file set and declare
 /// the module in its generation `mod.rs` (the authority for the generation's
 /// layout). `model_files` are already generation-prefixed
@@ -840,8 +913,9 @@ fn inject_validate(files: &mut Vec<GenFile>, mut validate_files: Vec<GenFile>) {
 fn inject_rm_model(files: &mut Vec<GenFile>, mut model_files: Vec<GenFile>, module: &str) {
     let gen_mod = format!("{module}/mod.rs");
     for f in files.iter_mut() {
-        if f.path == gen_mod && !f.body.contains("pub mod model;") {
-            f.body.push_str("pub mod model;\n");
+        if f.path == gen_mod && !f.body.contains(RM_MODEL_DECL) {
+            f.body.push_str(RM_MODEL_DECL);
+            f.body.push('\n');
         }
     }
     files.append(&mut model_files);
@@ -903,6 +977,35 @@ fn augmented_schema(g: &ComposedGeneration, u: &ComposedUnit) -> BmmSchema {
     augment_with_reemit(&u.schema, &u.model, &reemit, &dep_refs)
 }
 
+/// The CURRENT BASE and RM generations' class → module-path maps, the pair
+/// every XSD-driven target resolves already-generated RM instance types against.
+#[derive(Debug)]
+struct SpecPaths {
+    /// The BASE generation's map.
+    base: BTreeMap<String, String>,
+    /// The RM generation's map.
+    rm: BTreeMap<String, String>,
+}
+
+/// Build the CURRENT BASE and RM generations' spec-path maps.
+///
+/// # Errors
+/// Returns an error if either composition's BMM files cannot be loaded.
+fn current_spec_paths() -> Result<SpecPaths, Box<dyn std::error::Error>> {
+    let base = compose("base")?;
+    let rm = compose("rm")?;
+    Ok(SpecPaths {
+        base: generation_spec_paths(
+            base.current(),
+            &format!("openehr_base::{}", base.current().spec.module),
+        ),
+        rm: generation_spec_paths(
+            rm.current(),
+            &format!("openehr_rm::{}", rm.current().spec.module),
+        ),
+    })
+}
+
 /// Spec class name → the full generation-module path of its defining module
 /// (`openehr_rm::v1_2::…`), over one generation's emittable specs — the map
 /// shape the XSD/OAS emitters resolve shared types against.
@@ -951,81 +1054,126 @@ fn templates_root() -> PathBuf {
 }
 
 fn cmd_emit(_outdir: Option<PathBuf>) -> Result<(), Box<dyn std::error::Error>> {
-    // ONE uniform path for every crate, driven by the declarative
-    // `plan::composition::COMPOSITIONS` table (see it for the `includes`
-    // citations). `cross_schema_reemit` grafts the COMPLETE set of upstream
-    // classes whose Rust form widens in a generation — a full, non-minimal
-    // re-emission (owner ruling 2026-07-19, #1699). `openehr-rm` additionally
-    // carries the static RM model and the invariant cores, emitted here so a
-    // plain `emit` keeps the crate self-consistent.
+    let files = render_emit_files()?;
     for comp in composition::COMPOSITIONS {
-        let c = compose(comp.key)?;
-        let impls = sibling_impls(comp.crate_name);
-        // One augmented schema per (generation, unit), flattened in table
-        // order — the same shape the render loop consumes.
-        let augmented: Vec<Vec<BmmSchema>> = c
-            .generations
+        let crate_files: Vec<&EmittedFile> = files
             .iter()
-            .map(|g| g.units.iter().map(|u| augmented_schema(g, u)).collect())
+            .filter(|f| f.crate_name == comp.crate_name)
             .collect();
-        let gens: Vec<CrateGeneration<'_>> = c
-            .generations
-            .iter()
-            .zip(&augmented)
-            .map(|(g, augs)| CrateGeneration {
-                spec: g.spec,
-                units: g
-                    .units
-                    .iter()
-                    .zip(augs)
-                    .map(|(u, aug)| RenderUnit {
-                        spec: u.spec,
-                        model: &u.model,
-                        schema: aug,
-                    })
-                    .collect(),
-                external: &g.external,
-            })
-            .collect();
-        let mut files = emit_composed(comp, &gens, &impls);
-        if comp.key == "rm" {
-            // EVERY RM generation carries its own attribute model + invariant
-            // cores (the same uniform rule as the per-generation codecs): a
-            // selectable generation is a complete peer, not a types-only
-            // shell (#1942).
-            for (g, augs) in c.generations.iter().zip(&augmented) {
-                let module = g.spec.module;
-                let unit = g.unit()?;
-                let aug = augs
-                    .first()
-                    .ok_or("an RM generation carries no specification unit")?;
-                inject_rm_model(
-                    &mut files,
-                    prefix_gen_files(emit_rm_model::emit_files(&unit.model), module),
-                    module,
-                );
-                inject_validate(
-                    &mut files,
-                    prefix_gen_files(emit_validate::emit_files(&unit.model, aug), module),
-                );
-            }
-        }
-        // Generation-twin templates: one hand-written source per family,
-        // stamped per generation (render::emit_templates). A path collision
-        // with a generated file is a defect, never a silent overwrite.
-        for stamped in emit_templates::stamp_templates(&templates_root(), comp)? {
-            if files.iter().any(|f| f.path == stamped.path) {
-                return Err(format!(
-                    "template stamp collides with a generated file: {}",
-                    stamped.path
-                )
-                .into());
-            }
-            files.push(stamped);
-        }
-        write_crate(comp.crate_name, &files)?;
+        write_crate(comp.crate_name, &crate_files)?;
     }
+    eprintln!("{INCOMPLETE_AFTER_EMIT}");
     Ok(())
+}
+
+/// Render every generated spec crate's `src/` tree without touching the
+/// filesystem.
+///
+/// The text half of [`cmd_emit`], shared with the emit-target tests
+/// (`testsupport::emit_to_memory`), so the CLI and the tests drive one
+/// orchestration — the whole file set included, generation-twin template stamps
+/// and all. The purge, the hand-written-module weave and the `rustfmt` pass are
+/// filesystem operations over files this target does not render, so they stay on
+/// the CLI path.
+///
+/// # Errors
+/// Returns an error if a composition's BMM files cannot be loaded, or if a
+/// template stamp collides with a generated file.
+pub(crate) fn render_emit_files() -> Result<Vec<EmittedFile>, Box<dyn std::error::Error>> {
+    let mut out = Vec::new();
+    for comp in composition::COMPOSITIONS {
+        for f in render_crate_files(comp)? {
+            out.push(EmittedFile {
+                path: format!("{}/src/{}", comp.crate_name, f.path),
+                crate_name: comp.crate_name,
+                body: f.body,
+            });
+        }
+    }
+    Ok(out)
+}
+
+/// Render one composition entry's whole file set: the spec types, the RM
+/// crate's model + invariant cores, and the generation-twin template stamps.
+///
+/// ONE uniform path for every crate, driven by the declarative
+/// `plan::composition::COMPOSITIONS` table (see it for the `includes`
+/// citations). `cross_schema_reemit` grafts the COMPLETE set of upstream classes
+/// whose Rust form widens in a generation — a full, non-minimal re-emission
+/// (owner ruling 2026-07-19, #1699). `openehr-rm` additionally carries the
+/// static RM model and the invariant cores, emitted here so a plain `emit` keeps
+/// the crate self-consistent.
+///
+/// # Errors
+/// Returns an error if the composition's BMM files cannot be loaded, or if a
+/// template stamp collides with a generated file.
+fn render_crate_files(
+    comp: &'static composition::CrateComposition,
+) -> Result<Vec<GenFile>, Box<dyn std::error::Error>> {
+    let c = compose(comp.key)?;
+    let impls = sibling_impls(comp.crate_name);
+    // One augmented schema per (generation, unit), flattened in table order —
+    // the same shape the render loop consumes.
+    let augmented: Vec<Vec<BmmSchema>> = c
+        .generations
+        .iter()
+        .map(|g| g.units.iter().map(|u| augmented_schema(g, u)).collect())
+        .collect();
+    let gens: Vec<CrateGeneration<'_>> = c
+        .generations
+        .iter()
+        .zip(&augmented)
+        .map(|(g, augs)| CrateGeneration {
+            spec: g.spec,
+            units: g
+                .units
+                .iter()
+                .zip(augs)
+                .map(|(u, aug)| RenderUnit {
+                    spec: u.spec,
+                    model: &u.model,
+                    schema: aug,
+                })
+                .collect(),
+            external: &g.external,
+        })
+        .collect();
+    let mut files = emit_composed(comp, &gens, &impls);
+    if comp.key == "rm" {
+        // EVERY RM generation carries its own attribute model + invariant cores
+        // (the same uniform rule as the per-generation codecs): a selectable
+        // generation is a complete peer, not a types-only shell (#1942).
+        for (g, augs) in c.generations.iter().zip(&augmented) {
+            let module = g.spec.module;
+            let unit = g.unit()?;
+            let aug = augs
+                .first()
+                .ok_or("an RM generation carries no specification unit")?;
+            inject_rm_model(
+                &mut files,
+                prefix_gen_files(emit_rm_model::emit_files(&unit.model), module),
+                module,
+            );
+            inject_validate(
+                &mut files,
+                prefix_gen_files(emit_validate::emit_files(&unit.model, aug), module),
+            );
+        }
+    }
+    // Generation-twin templates: one hand-written source per family, stamped
+    // per generation (render::emit_templates). A path collision with a
+    // generated file is a defect, never a silent overwrite.
+    for stamped in emit_templates::stamp_templates(&templates_root(), comp)? {
+        if files.iter().any(|f| f.path == stamped.path) {
+            return Err(format!(
+                "template stamp collides with a generated file: {}",
+                stamped.path
+            )
+            .into());
+        }
+        files.push(stamped);
+    }
+    Ok(files)
 }
 
 /// Returns the exact bytes an emitted file carries before `rustfmt`: the
@@ -1056,10 +1204,12 @@ fn write_generated(path: &Path, crate_name: &str, body: &str) -> std::io::Result
     std::fs::write(path, generated_bytes(crate_name, body))
 }
 
-/// Write a generated crate's `src/` in place. Wipes the crate's `src/` first
-/// (there is no hand-written `*_impl.rs` yet; when there is, this must preserve
-/// it).
-fn write_crate(crate_name: &str, files: &[GenFile]) -> Result<(), Box<dyn std::error::Error>> {
+/// Write a generated crate's `src/` in place. Wipes the crate's previously
+/// generated files first, preserving the hand-written siblings beside them.
+///
+/// Each file's `path` is relative to the workspace `crates/` directory, exactly
+/// as [`render_emit_files`] addresses it.
+fn write_crate(crate_name: &str, files: &[&EmittedFile]) -> Result<(), Box<dyn std::error::Error>> {
     let src = crates_root().join(crate_name).join("src");
     // Preserve hand-written code: delete only previously-`@generated`
     // files, never the hand-written `*_impl.rs` / spec-behaviour modules beside
@@ -1071,7 +1221,7 @@ fn write_crate(crate_name: &str, files: &[GenFile]) -> Result<(), Box<dyn std::e
     std::fs::create_dir_all(&src)?;
     let mut written = Vec::with_capacity(files.len());
     for f in files {
-        let full = src.join(&f.path);
+        let full = crates_root().join(&f.path);
         if let Some(parent) = full.parent() {
             std::fs::create_dir_all(parent)?;
         }
@@ -1085,7 +1235,6 @@ fn write_crate(crate_name: &str, files: &[GenFile]) -> Result<(), Box<dyn std::e
     declare_hand_written_modules(&src, &mut written)?;
     rustfmt(&written)?;
     println!("emitted {} files into {}", files.len(), src.display());
-    eprintln!("{INCOMPLETE_AFTER_EMIT}");
     Ok(())
 }
 

--- a/tools/openehr-codegen/src/testsupport.rs
+++ b/tools/openehr-codegen/src/testsupport.rs
@@ -25,8 +25,8 @@ use crate::load::oas;
 use crate::plan::composition::{self, compose};
 use crate::plan::overrides;
 use crate::plan::{Emission, decide};
-use crate::render::emit::{CrateGeneration, GenFile, RenderUnit, emit_composed};
-use crate::render::{emit_rest, emit_rm_model, emit_validate, model_query, naming};
+use crate::render::emit::{CrateGeneration, RenderUnit, emit_composed};
+use crate::render::{emit_rest, model_query, naming};
 use std::collections::{BTreeMap, BTreeSet};
 
 type Error = Box<dyn std::error::Error>;
@@ -457,80 +457,20 @@ fn shape_name(e: &Emission) -> &'static str {
     }
 }
 
-/// Render every emit-crate's spec files to an in-memory map keyed
-/// `"<crate>/<path>"` (pre-rustfmt bodies).
+/// Render every generated spec crate's `src/` tree (`emit`) to an in-memory
+/// map, keyed by each file's path relative to the workspace `crates/`
+/// directory.
 ///
-/// Reproduces `cli::cmd_emit`'s emission half without WRITING to the
-/// filesystem (it reads the same inputs `cmd_emit` does, the vendored BMM
-/// plus each crate's hand-written `*_impl.rs` siblings), so a double call
-/// proves the emitter is byte-deterministic.
+/// Drives `cli::render_emit_files` — the same text production the `emit`
+/// subcommand drives, generation-twin template stamps included — and applies the
+/// value-carrier guard and SPDX header the subcommand writes, so a value equals
+/// the on-disk file before `rustfmt`.
 ///
 /// # Errors
-/// Returns an error if any crate's BMM files cannot be loaded.
-pub fn render_all_to_memory() -> Result<BTreeMap<String, String>, Error> {
-    let mut out = BTreeMap::new();
-    for comp in composition::COMPOSITIONS {
-        let c = compose(comp.key)?;
-        let impls = sibling_impls(comp.crate_name);
-        let augmented: Vec<Vec<BmmSchema>> = c
-            .generations
-            .iter()
-            .map(|g| {
-                g.units
-                    .iter()
-                    .map(|u| {
-                        let reemit = cross_schema_reemit(&u.model, &u.schema);
-                        let deps: Vec<&BmmSchema> = g.dep_schemas.iter().collect();
-                        augment_with_reemit(&u.schema, &u.model, &reemit, &deps)
-                    })
-                    .collect()
-            })
-            .collect();
-        let gens: Vec<CrateGeneration<'_>> = c
-            .generations
-            .iter()
-            .zip(&augmented)
-            .map(|(g, augs)| CrateGeneration {
-                spec: g.spec,
-                units: g
-                    .units
-                    .iter()
-                    .zip(augs)
-                    .map(|(u, aug)| RenderUnit {
-                        spec: u.spec,
-                        model: &u.model,
-                        schema: aug,
-                    })
-                    .collect(),
-                external: &g.external,
-            })
-            .collect();
-        let mut files = emit_composed(comp, &gens, &impls);
-        if comp.key == "rm" {
-            // Mirror of `cli::cmd_emit`: every RM generation carries its own
-            // attribute model + invariant cores.
-            for (g, augs) in c.generations.iter().zip(&augmented) {
-                let module = g.spec.module;
-                let unit = g.unit()?;
-                let aug = augs
-                    .first()
-                    .ok_or("an RM generation carries no specification unit")?;
-                inject_rm_model(
-                    &mut files,
-                    prefix_gen_files(emit_rm_model::emit_files(&unit.model), module),
-                    module,
-                );
-                files.extend(prefix_gen_files(
-                    emit_validate::emit_files(&unit.model, aug),
-                    module,
-                ));
-            }
-        }
-        for f in files {
-            out.insert(format!("{}/{}", comp.crate_name, f.path), f.body);
-        }
-    }
-    Ok(out)
+/// Returns an error if a composition's BMM files cannot be loaded, or if a
+/// template stamp collides with a generated file.
+pub fn emit_to_memory() -> Result<BTreeMap<String, String>, Error> {
+    Ok(to_memory(cli::render_emit_files()?))
 }
 
 /// Render the canonical-JSON `serde` impls and `_type` dispatch (`emit-json`)
@@ -576,6 +516,64 @@ pub fn emit_rest_to_memory() -> Result<BTreeMap<String, String>, Error> {
     Ok(to_memory(cli::render_rest_files()?))
 }
 
+/// Render the OPT 1.4 model + canonical-XML codec (`emit-opt`) to an in-memory
+/// map, keyed by each file's path relative to the workspace `crates/`
+/// directory.
+///
+/// Drives `cli::render_opt_files` — the same text production the `emit-opt`
+/// subcommand drives — and applies the value-carrier guard and SPDX header the
+/// subcommand writes, so a value equals the on-disk file before `rustfmt`.
+///
+/// # Errors
+/// Returns an error if the RM/BASE compositions or the AM/OPT XSD closure cannot
+/// be loaded.
+pub fn emit_opt_to_memory() -> Result<BTreeMap<String, String>, Error> {
+    Ok(to_memory(cli::render_opt_files()?.files))
+}
+
+/// Render both AOM2 archetype codecs (`emit-aom2`) to an in-memory map, keyed by
+/// each file's path relative to the workspace `crates/` directory.
+///
+/// Drives `cli::render_aom2_files` — the same text production the `emit-aom2`
+/// subcommand drives — and applies the value-carrier guard and SPDX header the
+/// subcommand writes, so a value equals the on-disk file before `rustfmt`.
+///
+/// # Errors
+/// Returns an error if the RM/BASE compositions or either AOM2 XSD closure
+/// cannot be loaded.
+pub fn emit_aom2_to_memory() -> Result<BTreeMap<String, String>, Error> {
+    Ok(to_memory(cli::render_aom2_files()?.files))
+}
+
+/// Render the static RM attribute/type model (`emit-rm-model`) to an in-memory
+/// map, keyed by each file's path relative to the workspace `crates/`
+/// directory.
+///
+/// Drives `cli::render_rm_model_files` — the same text production the
+/// `emit-rm-model` subcommand and `emit` both drive — and applies the
+/// value-carrier guard and SPDX header they write, so a value equals the on-disk
+/// file before `rustfmt`.
+///
+/// # Errors
+/// Returns an error if the RM composition's BMM files cannot be loaded.
+pub fn emit_rm_model_to_memory() -> Result<BTreeMap<String, String>, Error> {
+    Ok(to_memory(cli::render_rm_model_files()?))
+}
+
+/// Render the RM class-invariant cores (`emit-validate`) to an in-memory map,
+/// keyed by each file's path relative to the workspace `crates/` directory.
+///
+/// Drives `cli::render_validate_files` — the same text production the
+/// `emit-validate` subcommand and `emit` both drive — and applies the
+/// value-carrier guard and SPDX header they write, so a value equals the on-disk
+/// file before `rustfmt`.
+///
+/// # Errors
+/// Returns an error if the RM composition's BMM files cannot be loaded.
+pub fn emit_validate_to_memory() -> Result<BTreeMap<String, String>, Error> {
+    Ok(to_memory(cli::render_validate_files()?))
+}
+
 /// Turn an emit target's rendered files into the path → bytes map the tests
 /// compare, applying the same [`cli::generated_bytes`] the CLI writes through.
 fn to_memory(files: Vec<cli::EmittedFile>) -> BTreeMap<String, String> {
@@ -586,43 +584,6 @@ fn to_memory(files: Vec<cli::EmittedFile>) -> BTreeMap<String, String> {
             (f.path, bytes)
         })
         .collect()
-}
-
-/// The hand-written `*_impl.rs` siblings of a generated crate — the same
-/// emitter input `cli::sibling_impls` reads, so the in-memory render matches
-/// the written tree byte for byte.
-fn sibling_impls(crate_name: &str) -> SiblingImpls {
-    SiblingImpls::scan(
-        &std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("../../crates")
-            .join(crate_name)
-            .join("src"),
-    )
-}
-
-/// Mirror of `cli::prefix_gen_files` (kept private there): prefix generated
-/// file paths with the generation module directory.
-fn prefix_gen_files(files: Vec<GenFile>, module: &str) -> Vec<GenFile> {
-    files
-        .into_iter()
-        .map(|f| GenFile {
-            path: format!("{module}/{}", f.path),
-            body: f.body,
-        })
-        .collect()
-}
-
-/// Mirror of `cli::inject_rm_model` (kept private there): append the RM-model
-/// files (already generation-prefixed) and declare `pub mod model;` in the
-/// generation `mod.rs`.
-fn inject_rm_model(files: &mut Vec<GenFile>, mut model_files: Vec<GenFile>, module: &str) {
-    let gen_mod = format!("{module}/mod.rs");
-    for f in files.iter_mut() {
-        if f.path == gen_mod && !f.body.contains("pub mod model;") {
-            f.body.push_str("pub mod model;\n");
-        }
-    }
-    files.append(&mut model_files);
 }
 
 // ── cross-schema re-emission (source-package mirroring + downstream closure) ──

--- a/tools/openehr-codegen/tests/it/emit_targets.rs
+++ b/tools/openehr-codegen/tests/it/emit_targets.rs
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: FerroEHR contributors
 // SPDX-License-Identifier: MIT
 
-//! The three text-producing emit targets — `emit-json`, `emit-xml`,
-//! `emit-rest` — as properties over the **real** pipeline on the **real**
-//! vendored inputs.
+//! Every text-producing emit target — `emit`, `emit-json`, `emit-xml`,
+//! `emit-rest`, `emit-opt`, `emit-aom2`, `emit-rm-model`, `emit-validate` — as
+//! properties over the **real** pipeline on the **real** vendored inputs.
 //!
 //! Each test drives `openehr_codegen::testsupport::emit_*_to_memory`, which
 //! calls the very render function the matching `cmd_*` handler calls: the
@@ -12,6 +12,12 @@
 //! byte-deterministic, it produces exactly its file set (each non-empty,
 //! banner-headed and SPDX-stamped), and its bytes equal the committed
 //! generated tree, which is the in-process half of the `codegen-drift` check.
+//!
+//! `emit` is the one target whose file set is pinned by SHAPE rather than by
+//! enumeration: it renders the whole spec layer (four figures of files), so the
+//! properties asserted are that every composed crate contributes, that the
+//! generation-twin template stamps ride along, and that the RM crate's model and
+//! invariant cores are part of the same set.
 
 use openehr_codegen::testsupport;
 use std::collections::BTreeMap;
@@ -49,6 +55,107 @@ const REST_FILES: &[&str] = &[
     "openehr-its/src/rest/generated/query.rs",
     "openehr-its/src/rest/generated/system.rs",
 ];
+
+/// The complete file set `emit-opt` produces, in emitted-map (sorted) order.
+const OPT_FILES: &[&str] = &[
+    "openehr-its/src/opt14/impls.rs",
+    "openehr-its/src/opt14/mod.rs",
+    "openehr-its/src/opt14/types.rs",
+];
+
+/// The complete file set `emit-aom2` produces, in emitted-map (sorted) order:
+/// the persistent form (`aom2`) and the AOM model form (`aom2_model`), each its
+/// own closure into its own module.
+const AOM2_FILES: &[&str] = &[
+    "openehr-its/src/aom2/impls.rs",
+    "openehr-its/src/aom2/mod.rs",
+    "openehr-its/src/aom2/types.rs",
+    "openehr-its/src/aom2_model/impls.rs",
+    "openehr-its/src/aom2_model/mod.rs",
+    "openehr-its/src/aom2_model/types.rs",
+];
+
+/// The complete file set `emit-rm-model` produces, in emitted-map (sorted)
+/// order: one `model/` subtree per RM generation, because a selectable
+/// generation is a complete peer and not a types-only shell.
+const RM_MODEL_FILES: &[&str] = &[
+    "openehr-rm/src/v1_1/model/data.rs",
+    "openehr-rm/src/v1_1/model/mod.rs",
+    "openehr-rm/src/v1_2/model/data.rs",
+    "openehr-rm/src/v1_2/model/mod.rs",
+];
+
+/// The complete file set `emit-validate` produces, in emitted-map (sorted)
+/// order: one invariant-core file per RM generation.
+const VALIDATE_FILES: &[&str] = &[
+    "openehr-rm/src/v1_1/validate/generated.rs",
+    "openehr-rm/src/v1_2/validate/generated.rs",
+];
+
+/// The generated spec crates `emit` composes, one per `COMPOSITIONS` row.
+const EMIT_CRATES: &[&str] = &[
+    "openehr-am",
+    "openehr-base",
+    "openehr-lang",
+    "openehr-rm",
+    "openehr-term",
+];
+
+/// The first-line marker a generation-twin template stamp carries.
+const TEMPLATE_MARKER: &str = "// @generated-from-template";
+
+// ── emit ────────────────────────────────────────────────────────────────────
+
+/// Rendering the whole spec layer twice yields byte-identical output.
+#[test]
+fn emit_is_byte_deterministic() {
+    let a = testsupport::emit_to_memory().unwrap();
+    let b = testsupport::emit_to_memory().unwrap();
+    assert_deterministic("emit", &a, &b);
+}
+
+/// `emit` produces one file set covering every composed crate, the RM crate's
+/// model and invariant cores, and the generation-twin template stamps — each
+/// file non-empty, banner-headed and SPDX-stamped.
+#[test]
+fn emit_emits_every_composed_crate_including_the_template_stamps() {
+    let files = testsupport::emit_to_memory().unwrap();
+    assert_well_formed("emit", "@generated", &files);
+    for krate in EMIT_CRATES {
+        let prefix = format!("{krate}/src/");
+        assert!(
+            files.keys().any(|p| p.starts_with(&prefix)),
+            "emit: {krate} contributed no files",
+        );
+    }
+    // The RM crate's model + invariant cores are part of `emit`'s own set, not
+    // a separate run: a plain `emit` keeps the crate self-consistent.
+    for path in [
+        "openehr-rm/src/v1_2/model/mod.rs",
+        "openehr-rm/src/v1_2/validate/generated.rs",
+    ] {
+        assert!(
+            files.contains_key(path),
+            "emit: {path} is not in the emitted set",
+        );
+    }
+    let stamped: Vec<&String> = files
+        .iter()
+        .filter(|(_, body)| body.starts_with(TEMPLATE_MARKER))
+        .map(|(path, _)| path)
+        .collect();
+    assert!(
+        !stamped.is_empty(),
+        "emit: no generation-twin template stamp is in the emitted set",
+    );
+}
+
+/// The rendered spec layer equals the committed generated tree.
+#[test]
+fn emit_matches_the_committed_tree() {
+    let files = testsupport::emit_to_memory().unwrap();
+    assert_tree_matches_committed("emit", &files);
+}
 
 // ── emit-json ───────────────────────────────────────────────────────────────
 
@@ -125,6 +232,128 @@ fn emit_rest_matches_the_committed_tree() {
     assert_matches_committed_tree("emit-rest", &files);
 }
 
+// ── emit-opt ────────────────────────────────────────────────────────────────
+
+/// Rendering the OPT 1.4 model twice yields byte-identical output.
+#[test]
+fn emit_opt_is_byte_deterministic() {
+    let a = testsupport::emit_opt_to_memory().unwrap();
+    let b = testsupport::emit_opt_to_memory().unwrap();
+    assert_deterministic("emit-opt", &a, &b);
+}
+
+/// `emit-opt` produces exactly its file set, each file non-empty and carrying
+/// the generated banner plus its crate's SPDX header.
+#[test]
+fn emit_opt_emits_its_whole_file_set() {
+    let files = testsupport::emit_opt_to_memory().unwrap();
+    assert_file_set("emit-opt", &files, OPT_FILES);
+}
+
+/// The rendered OPT 1.4 model equals the committed generated tree.
+#[test]
+fn emit_opt_matches_the_committed_tree() {
+    let files = testsupport::emit_opt_to_memory().unwrap();
+    assert_matches_committed_tree("emit-opt", &files);
+}
+
+// ── emit-aom2 ───────────────────────────────────────────────────────────────
+
+/// Rendering both AOM2 archetype codecs twice yields byte-identical output.
+#[test]
+fn emit_aom2_is_byte_deterministic() {
+    let a = testsupport::emit_aom2_to_memory().unwrap();
+    let b = testsupport::emit_aom2_to_memory().unwrap();
+    assert_deterministic("emit-aom2", &a, &b);
+}
+
+/// `emit-aom2` produces exactly its file set — both closures, each into its own
+/// module — with every file non-empty, banner-headed and SPDX-stamped.
+#[test]
+fn emit_aom2_emits_its_whole_file_set() {
+    let files = testsupport::emit_aom2_to_memory().unwrap();
+    assert_file_set("emit-aom2", &files, AOM2_FILES);
+}
+
+/// The rendered AOM2 codecs equal the committed generated tree.
+#[test]
+fn emit_aom2_matches_the_committed_tree() {
+    let files = testsupport::emit_aom2_to_memory().unwrap();
+    assert_matches_committed_tree("emit-aom2", &files);
+}
+
+// ── emit-rm-model ───────────────────────────────────────────────────────────
+
+/// Rendering the static RM attribute/type model twice yields byte-identical
+/// output.
+#[test]
+fn emit_rm_model_is_byte_deterministic() {
+    let a = testsupport::emit_rm_model_to_memory().unwrap();
+    let b = testsupport::emit_rm_model_to_memory().unwrap();
+    assert_deterministic("emit-rm-model", &a, &b);
+}
+
+/// `emit-rm-model` produces exactly its file set — one `model/` subtree per RM
+/// generation — with every file non-empty, banner-headed and SPDX-stamped.
+#[test]
+fn emit_rm_model_emits_its_whole_file_set() {
+    let files = testsupport::emit_rm_model_to_memory().unwrap();
+    assert_file_set("emit-rm-model", &files, RM_MODEL_FILES);
+}
+
+/// The rendered RM model equals the committed generated tree — which is also
+/// what `emit` writes there, since both drive `cli::render_rm_model_files`.
+#[test]
+fn emit_rm_model_matches_the_committed_tree() {
+    let files = testsupport::emit_rm_model_to_memory().unwrap();
+    assert_matches_committed_tree("emit-rm-model", &files);
+}
+
+/// Every RM generation's `mod.rs` declares the emitted model module.
+///
+/// The declaration is the one thing `emit-rm-model` does NOT render — it is a
+/// read-modify-write of the generation `mod.rs`, which `emit` instead writes
+/// into the rendered body. Both spell it from `cli`'s one `RM_MODEL_DECL`
+/// constant; this asserts the outcome the two paths must agree on.
+#[test]
+fn every_rm_generation_declares_its_model_module() {
+    let root = crates_root();
+    for path in ["openehr-rm/src/v1_1/mod.rs", "openehr-rm/src/v1_2/mod.rs"] {
+        let body = std::fs::read_to_string(root.join(path)).unwrap();
+        assert!(
+            body.contains("pub mod model;"),
+            "{path} does not declare the emitted RM model module",
+        );
+    }
+}
+
+// ── emit-validate ───────────────────────────────────────────────────────────
+
+/// Rendering the RM invariant cores twice yields byte-identical output.
+#[test]
+fn emit_validate_is_byte_deterministic() {
+    let a = testsupport::emit_validate_to_memory().unwrap();
+    let b = testsupport::emit_validate_to_memory().unwrap();
+    assert_deterministic("emit-validate", &a, &b);
+}
+
+/// `emit-validate` produces exactly its file set — one invariant-core file per
+/// RM generation — with every file non-empty, banner-headed and SPDX-stamped.
+#[test]
+fn emit_validate_emits_its_whole_file_set() {
+    let files = testsupport::emit_validate_to_memory().unwrap();
+    assert_file_set("emit-validate", &files, VALIDATE_FILES);
+}
+
+/// The rendered invariant cores equal the committed generated tree — which is
+/// also what `emit` writes there, since both drive
+/// `cli::render_validate_files`.
+#[test]
+fn emit_validate_matches_the_committed_tree() {
+    let files = testsupport::emit_validate_to_memory().unwrap();
+    assert_matches_committed_tree("emit-validate", &files);
+}
+
 // ── shared assertions ───────────────────────────────────────────────────────
 
 /// Assert two renders of the same target agree on every path and every byte.
@@ -145,17 +374,26 @@ fn assert_deterministic(target: &str, a: &BTreeMap<String, String>, b: &BTreeMap
     }
 }
 
-/// Assert a target emitted exactly `expected`, with every file non-empty, its
-/// `@generated` banner naming the target on line one, and its SPDX licence
-/// header present.
+/// Assert a target emitted exactly `expected`, with every file well-formed
+/// ([`assert_well_formed`]) and its banner naming the target.
 fn assert_file_set(target: &str, files: &BTreeMap<String, String>, expected: &[&str]) {
     let actual: Vec<&str> = files.keys().map(String::as_str).collect();
     assert_eq!(actual, expected, "{target}: emitted a different file set");
+    assert_well_formed(target, target, files);
+}
+
+/// Assert every rendered file is non-empty, opens on a line-one banner carrying
+/// `banner_needle`, and carries its crate's SPDX licence header.
+///
+/// `banner_needle` is the target name for every target that stamps it into the
+/// banner; `emit`'s banner names only the generator, so it passes `@generated`.
+fn assert_well_formed(target: &str, banner_needle: &str, files: &BTreeMap<String, String>) {
+    assert!(!files.is_empty(), "{target}: rendered nothing");
     for (path, body) in files {
         assert!(!body.trim().is_empty(), "{target}: {path} rendered empty");
         let banner = body.lines().next().unwrap_or_default();
         assert!(
-            banner.contains("@generated") && banner.contains(target),
+            banner.contains("@generated") && banner.contains(banner_needle),
             "{target}: {path} does not open with its generated banner: {banner:?}",
         );
         // The needle names the SPDX tag WITHOUT an expression, which the
@@ -193,6 +431,116 @@ fn assert_matches_committed_tree(target: &str, files: &BTreeMap<String, String>)
             difference_hint(&rendered, &committed),
         );
     }
+}
+
+/// Assert `emit`'s whole rendered tree equals the committed generated tree.
+///
+/// Two things differ from the single-file comparison above. The set runs to four
+/// figures, so the bodies are formatted in ONE batched `rustfmt` pass over a
+/// scratch tree — the same `rustfmt --edition 2024 --quiet <files>` invocation
+/// the `emit` handler makes over the files it has just written. And `emit`
+/// finishes each crate by WEAVING module declarations into anchors it rendered
+/// (`declare_hand_written_modules`; `emit-json` adds `mod json_serde;` the same
+/// way), so an anchor's committed bytes are the rendered bytes plus that weave.
+/// The assertion therefore pins three things: the rendered prefix byte for byte,
+/// a tail that is nothing but woven declarations, and that only a module ANCHOR
+/// (`lib.rs` / `mod.rs`) carries such a tail at all — the weave's own rule, so
+/// the tolerance cannot widen into a blanket escape. The woven set is
+/// non-empty, which is what keeps that half of the assertion honest.
+#[expect(
+    clippy::panic,
+    reason = "test diagnostics: a missing committed file names itself instead of \
+              failing as a bare unwrap"
+)]
+fn assert_tree_matches_committed(target: &str, files: &BTreeMap<String, String>) {
+    let root = crates_root();
+    let mut woven = 0_usize;
+    for (path, rendered) in rustfmt_tree(target, files) {
+        let full = root.join(&path);
+        let committed = std::fs::read_to_string(&full)
+            .unwrap_or_else(|e| panic!("{target}: cannot read committed {path}: {e}"));
+        if committed == rendered {
+            continue;
+        }
+        let Some(tail) = committed.strip_prefix(&rendered) else {
+            panic!(
+                "{target}: {path} does not match the committed generated tree{}",
+                difference_hint(&rendered, &committed),
+            );
+        };
+        assert!(
+            path.ends_with("/lib.rs") || path.ends_with("/mod.rs"),
+            "{target}: {path} is not a module anchor, so nothing may be woven into it:\n{tail}",
+        );
+        assert!(
+            is_woven_declarations(tail),
+            "{target}: {path} carries content beyond the rendered body that is not a woven \
+             module declaration:\n{tail}",
+        );
+        woven += 1;
+    }
+    assert!(
+        woven > 0,
+        "{target}: no anchor carried a woven declaration — the weave is not being exercised",
+    );
+}
+
+/// Whether a committed file's tail beyond the rendered body is only the module
+/// declarations the CLI weaves in after writing it.
+fn is_woven_declarations(tail: &str) -> bool {
+    tail.lines().all(|line| {
+        let t = line.trim();
+        t.is_empty()
+            || t.starts_with("// ") && t.ends_with("auto-declared:")
+            || (t.starts_with("mod ") || t.starts_with("pub mod ")) && t.ends_with(';')
+    })
+}
+
+/// Format a whole rendered tree in one `rustfmt` pass, via a scratch directory.
+///
+/// Per-file `rustfmt` over four figures of files would dominate the run, and
+/// `rustfmt` is invoked exactly as the emitter invokes it — over files on disk,
+/// batched per crate — so this is also the more faithful reproduction.
+#[expect(
+    clippy::panic,
+    reason = "test diagnostics: each scratch-tree failure mode names itself, so a red \
+              run points at the toolchain rather than at the emitter"
+)]
+fn rustfmt_tree(target: &str, files: &BTreeMap<String, String>) -> BTreeMap<String, String> {
+    let scratch =
+        std::env::temp_dir().join(format!("openehr-codegen-{target}-{}", std::process::id()));
+    drop(std::fs::remove_dir_all(&scratch));
+    let mut by_crate: BTreeMap<&str, Vec<PathBuf>> = BTreeMap::new();
+    for (path, body) in files {
+        let full = scratch.join(path);
+        let parent = full
+            .parent()
+            .unwrap_or_else(|| panic!("{target}: {path} has no parent directory"));
+        std::fs::create_dir_all(parent)
+            .unwrap_or_else(|e| panic!("{target}: cannot create {}: {e}", parent.display()));
+        std::fs::write(&full, body)
+            .unwrap_or_else(|e| panic!("{target}: cannot write scratch {path}: {e}"));
+        let krate = path.split('/').next().unwrap_or_default();
+        by_crate.entry(krate).or_default().push(full);
+    }
+    for (krate, paths) in &by_crate {
+        let status = Command::new("rustfmt")
+            .args(["--edition", "2024", "--quiet"])
+            .args(paths)
+            .status()
+            .unwrap_or_else(|e| panic!("{target}: rustfmt is not runnable: {e}"));
+        assert!(status.success(), "{target}: rustfmt failed on {krate}");
+    }
+    let out = files
+        .keys()
+        .map(|path| {
+            let body = std::fs::read_to_string(scratch.join(path))
+                .unwrap_or_else(|e| panic!("{target}: cannot read scratch {path}: {e}"));
+            (path.clone(), body)
+        })
+        .collect();
+    drop(std::fs::remove_dir_all(&scratch));
+    out
 }
 
 // ── helpers ─────────────────────────────────────────────────────────────────

--- a/tools/openehr-codegen/tests/it/emitter_invariants.rs
+++ b/tools/openehr-codegen/tests/it/emitter_invariants.rs
@@ -203,8 +203,8 @@ fn determinism_plan_is_stable_across_runs() {
 /// output (the emitter is a deterministic function of the vendored inputs).
 #[test]
 fn determinism_render_is_byte_identical_across_runs() {
-    let a = testsupport::render_all_to_memory().unwrap();
-    let b = testsupport::render_all_to_memory().unwrap();
+    let a = testsupport::emit_to_memory().unwrap();
+    let b = testsupport::emit_to_memory().unwrap();
     assert!(!a.is_empty(), "rendered nothing");
     assert_eq!(
         a.len(),
@@ -300,7 +300,7 @@ fn downstream_closure_leaves_upstream_output_untouched() {
     }
     // …and they ARE emitted into the AM crate, while the shared member is
     // re-emitted downstream too.
-    let rendered = testsupport::render_all_to_memory().unwrap();
+    let rendered = testsupport::emit_to_memory().unwrap();
     let am_paths: Vec<&String> = rendered
         .keys()
         .filter(|k| k.starts_with("openehr-am/"))
@@ -379,7 +379,7 @@ fn decision_map_integrity_entries_are_cited_and_reference_real_classes() {
 /// which is exactly the "silence over an untyped slot" this map exists to end.
 #[test]
 fn untyped_field_adjudications_land_on_a_real_free_form_field() {
-    let files = testsupport::render_all_to_memory().unwrap();
+    let files = testsupport::emit_to_memory().unwrap();
     for (class, field, citation) in testsupport::untyped_fields() {
         let ident = if field == "type" {
             "r#type".to_string()
@@ -620,9 +620,9 @@ fn invariant_classification_spot_checks() {
 /// into the register.
 #[test]
 fn invariant_core_file_accounts_for_emitted_and_inert_invariants() {
-    let files = testsupport::render_all_to_memory().unwrap();
+    let files = testsupport::emit_to_memory().unwrap();
     let gen_file = files
-        .get("openehr-rm/v1_2/validate/generated.rs")
+        .get("openehr-rm/src/v1_2/validate/generated.rs")
         .expect("emit-validate did not produce v1_2/validate/generated.rs");
 
     // Every emittable invariant is accounted for, and named in the register the
@@ -680,9 +680,9 @@ fn invariant_core_file_accounts_for_emitted_and_inert_invariants() {
 /// silently is not.
 #[test]
 fn realization_register_venues_are_real() {
-    let files = testsupport::render_all_to_memory().unwrap();
+    let files = testsupport::emit_to_memory().unwrap();
     let gen_file = files
-        .get("openehr-rm/v1_2/validate/generated.rs")
+        .get("openehr-rm/src/v1_2/validate/generated.rs")
         .expect("emit-validate did not produce v1_2/validate/generated.rs");
     let repo = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
 
@@ -838,12 +838,12 @@ fn dialect_predicates_match_the_classifier() {
 /// whose hand-written `*_impl.rs` was deleted in favour of emission.
 #[test]
 fn emitted_classes_render_their_bmm_constants() {
-    let files = testsupport::render_all_to_memory().unwrap();
+    let files = testsupport::emit_to_memory().unwrap();
     let group = files
-        .get("openehr-rm/v1_2/support/terminology/openehr_terminology_group_identifiers.rs")
+        .get("openehr-rm/src/v1_2/support/terminology/openehr_terminology_group_identifiers.rs")
         .unwrap();
     let code_set = files
-        .get("openehr-rm/v1_2/support/terminology/openehr_code_set_identifiers.rs")
+        .get("openehr-rm/src/v1_2/support/terminology/openehr_code_set_identifiers.rs")
         .unwrap();
 
     // The 15 terminology-group identifier constants + the openEHR terminology id.
@@ -882,14 +882,14 @@ fn emitted_classes_render_their_bmm_constants() {
 /// enforced count drifting) fails the suite.
 #[test]
 fn register_records_terminology_invariants_as_enforced() {
-    let files = testsupport::render_all_to_memory().unwrap();
+    let files = testsupport::emit_to_memory().unwrap();
     let rows = testsupport::classify_invariants("rm").unwrap();
     // Every RM generation carries its own cores file with the same adjudicated
     // register split: 30 terminology/code-set invariants wired to the binding
     // table, the 4 `VERSIONED_OBJECT` aggregate invariants pending — per
     // generation (#1942: a selectable generation is a complete peer).
     for generation in ["v1_1", "v1_2"] {
-        let gen_path = format!("openehr-rm/{generation}/validate/generated.rs");
+        let gen_path = format!("openehr-rm/src/{generation}/validate/generated.rs");
         let gen_file = files
             .get(&gen_path)
             .unwrap_or_else(|| panic!("emit-validate did not produce {gen_path}"));


### PR DESCRIPTION
Closes #2687 — the emit-seam program's tail, finishing what #2686 started.

1. **`cmd_emit` shares its seam**: `render_emit_files()` produces every composed file (template stamps included) for both the CLI and the tests; `testsupport::render_all_to_memory`'s hand-copied orchestration and its mirrored helpers are **deleted** (repo-wide grep proof in the commit), closing the known drift — the determinism and closure invariants now run over the exact file set `emit` writes, generation-twin template stamps included and asserted.
2. **Four more targets get seams + the test triple** (`emit-opt`, `emit-aom2`, `emit-rm-model`, `emit-validate`): byte-determinism, pinned file sets, committed-tree byte-identity. The `pub mod model;` injection is one shared constant read by both writers.
3. `emit`'s tree check handles the weave: rendered prefix byte-for-byte, tails restricted to woven module declarations on anchor files only, with a `woven > 0` floor so the tolerance cannot go vacuous. **Non-vacuity measured**: two deliberate mutations of committed files each failed exactly the right test (including through the weave-tail branch), then reverted to a clean tree.

Gates: crate clippy/fmt/doc clean; **107/107** crate tests (was 91); the full eight-target emit set regenerates byte-neutrally. `no-changelog`: test/tooling machinery only.

En-route (recorded here, small): two narrower hand-built `emit_composed` orchestrations remain in testsupport support fns — same class, deliberately single-composition; fold-onto-a-parameterized-seam is future work. The codegen `CLAUDE.md`'s pipeline section should mention the `render_*_files()` seams (outside this PR's fence).