### PR TITLE
perf(storage): EHR scoping rides the version spine — the per-node-row ehr_id index is gone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@ workflow refuses a tag that has no matching section here.
 
 ### Changed
 
+- Every versioned-object write sheds one btree: EHR-scoped AQL routes its
+  scoping through the version spine (where the engine already mirrored the
+  predicate), so the per-node-row `ehr_id` index — maintained for every row
+  of every commit and, measured over the generated plans, serving no read
+  the spine route does not — is gone from the baseline. Measured at a
+  100k-composition seed: the node insert drops ~0.5 ms per commit (~13%);
+  EHR-scoped reads are unchanged. Deployments recreate to pick the baseline
+  up (greenfield policy).
+
 - Commit latency's tail shrinks: the large stored JSON columns
   (`vo_version.body`, `vo_version.wrapped_original`; the node fragments and
   audit columns already had it) compress with lz4 instead of PostgreSQL's

--- a/app/ferroehr/migrations/ehr/0001_baseline.sql
+++ b/app/ferroehr/migrations/ehr/0001_baseline.sql
@@ -649,7 +649,7 @@ CREATE INDEX idx_node_type_archetype ON node (rm_type, archetype);
 -- LIMIT early termination at corpus scale.
 CREATE INDEX idx_node_arch_subsume ON node (rm_type, arch_entity, arch_major, arch_concept text_pattern_ops)
     WHERE arch_entity IS NOT NULL;
-CREATE INDEX idx_node_ehr ON node (ehr_id);
+
 -- NOTE: two speculative jsonb indexes were REMOVED here after the measured
 -- repricing: a gin(data
 -- jsonb_ops) index (the AQL engine emits no GIN-servable operator — CONTAINS

--- a/app/ferroehr/src/aql/sql/from.rs
+++ b/app/ferroehr/src/aql/sql/from.rs
@@ -559,15 +559,13 @@ impl Builder<'_> {
             self.group_vos.push(voa.clone());
             self.vo_alias.insert(sid, voa.clone());
             if let Some(e) = ehr {
-                self.q.and_where(col(&node, "ehr_id").eq(col(e, "id")));
-                // Mirror the EHR link onto the version spine: `vo_version.
-                // ehr_id` carries the same value by construction (a versioned
-                // object belongs to exactly one EHR — RM ehr master04 §EHR),
-                // and the explicit predicate lets the planner drive
-                // `idx_vo_version_ehr` instead of scanning every current
-                // version in the store (buffers then scale with the EHR's own
-                // content, not the corpus). No openEHR spec governs plan
-                // shaping — our own storage design.
+                // The EHR link binds on the version SPINE only: vo_version.
+                // ehr_id equals the node rows' by construction (one owning
+                // EHR per versioned object — RM ehr master04 §EHR), the node
+                // group already joins the spine on (vo_id, sys_version), and
+                // the spine predicate drives idx_vo_version_ehr. A node-side
+                // twin predicate bought no plan this route does not serve and
+                // cost a per-node-row index at every write (#2698).
                 self.q.and_where(col(&voa, "ehr_id").eq(col(e, "id")));
                 self.roots_linked_to_ehr.insert(node.clone());
             }


### PR DESCRIPTION
Works #2698 — lever 1 of the every-write-path latency program.

- The AQL builder emitted `node.ehr_id = e.id` beside its own spine mirror `vo_version.ehr_id = e.id`; the node group already joins the spine on `(vo_id, sys_version)`, so the node-side twin was correctness-redundant and existed only to offer the planner a per-node-row index. Captured generated SQL (both the streaming and lateral shapes) shows every `node` access is pk-prefix-driven — the index had no plan to serve.
- `idx_node_ehr` leaves the baseline. Non-AQL consumers verified first-hand: hot-tier deletes cascade through the `(vo_id, sys_version)` FK, freeze/thaw addresses `vo_id = ANY`, and only the cold mirror queries `node.ehr_id` (its own `idx_cold_node_ehr` stays — admin-frequency).
- **Measured, within-subject on the live 100k-composition stack** (same binary, index dropped live): node-insert mean **3.72 → 3.25 ms** (−13%); the four representative read shapes (EHR-scoped uid + leaf projections, whole-corpus CONTAINS, bare-kind) at 4.7–14.2 ms first-hit, no regression. This benefits EVERY versioned-object write — composition, EHR_STATUS, directory, demographic, the CONTRIBUTION route — since all decompose through the same node writer.
- 134 AQL + parity tests green over the rebuilt template schema; changelog entry added. The conformance run over the merged tree follows the merge (the AQL chapter is the envelope proof).