### PR TITLE
perf(storage): the node rows ride the folded commit statement — a commit is one SQL statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ workflow refuses a tag that has no matching section here.
 
 ### Changed
 
+- A versioned-object commit is ONE SQL statement: the decomposed node rows
+  ride the folded commit CTE (ordered after the version row, which also
+  satisfies their foreign key in-statement), removing the separate node
+  insert round trip from every local write — composition, EHR_STATUS,
+  directory, demographic, and the CONTRIBUTION route alike. A logical
+  delete folds through with empty arrays.
+
 - Every versioned-object write sheds one btree: EHR-scoped AQL routes its
   scoping through the version spine (where the engine already mirrored the
   predicate), so the per-node-row `ehr_id` index — maintained for every row

--- a/app/ferroehr/src/storage/node_repo.rs
+++ b/app/ferroehr/src/storage/node_repo.rs
@@ -79,6 +79,56 @@ fn write_nodes_sql(per_row_context: bool) -> String {
 static WRITE_NODES_SQL: std::sync::LazyLock<String> =
     std::sync::LazyLock::new(|| write_nodes_sql(false));
 
+/// The node-insert body as a CTE fragment for the FOLDED commit statements:
+/// the same fixed-text `unnest` shape as [`write_nodes_sql`], with the
+/// storage context spelled as the CALLER's parameter placeholders
+/// (`vo`/`sys`/`ehr`, e.g. `"$8"`) and the array binds starting at
+/// `first_array_param`. `CROSS JOIN v` orders this CTE after the caller's
+/// version-row CTE `v`, which is also what makes the node rows' FK to the
+/// version row satisfiable inside the one statement. Empty arrays insert
+/// nothing — a logical delete folds through unchanged.
+pub(crate) fn node_insert_cte(vo: &str, sys: &str, ehr: &str, first_array_param: usize) -> String {
+    use std::fmt::Write;
+    let mut columns = String::new();
+    let mut selects = String::new();
+    let mut arrays = String::new();
+    let mut names = String::new();
+    for (i, leaf) in crate::storage::promoted::PROMOTED_LEAVES.iter().enumerate() {
+        columns.push_str(", ");
+        columns.push_str(leaf.column);
+        match leaf.kind {
+            crate::storage::promoted::PromotedKind::Timestamp => {
+                let _ = write!(selects, ", ext.openehr_timestamp(t.p{i})");
+            }
+        }
+        let _ = write!(arrays, ", ${}::text[]", first_array_param + 12 + i);
+        let _ = write!(names, ", p{i}");
+    }
+    let p = |offset: usize| first_array_param + offset;
+    format!(
+        "INSERT INTO node (vo_id, sys_version, ehr_id, num, num_cap, parent_num, citem_num, \
+         rm_type, archetype, arch_entity, arch_concept, arch_major, name, path, data{columns}) \
+         SELECT {vo}, {sys}, {ehr}, t.num, t.num_cap, t.parent_num, t.citem_num, t.rm_type, \
+         t.archetype, t.arch_entity, t.arch_concept, t.arch_major, t.name, t.path, t.data{selects} \
+         FROM unnest(${}::int[], ${}::int[], ${}::int[], ${}::int[], ${}::text[], ${}::text[], \
+         ${}::text[], ${}::text[], ${}::int[], ${}::text[], ${}::text[], ${}::jsonb[]{arrays}) \
+         AS t(num, num_cap, parent_num, citem_num, rm_type, archetype, arch_entity, \
+         arch_concept, arch_major, name, path, data{names}) CROSS JOIN v",
+        p(0),
+        p(1),
+        p(2),
+        p(3),
+        p(4),
+        p(5),
+        p(6),
+        p(7),
+        p(8),
+        p(9),
+        p(10),
+        p(11),
+    )
+}
+
 /// The cross-version batch node insert (per-row storage context).
 static WRITE_NODES_BATCH_SQL: std::sync::LazyLock<String> =
     std::sync::LazyLock::new(|| write_nodes_sql(true));
@@ -162,7 +212,7 @@ pub async fn write_nodes_batch(
 /// Bind the twelve per-node column arrays plus the promoted-leaf arrays onto a
 /// node-insert statement whose storage-context parameters (`$1..$3`) are
 /// already bound.
-fn bind_node_arrays<'q>(
+pub(crate) fn bind_node_arrays<'q>(
     mut query: sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments>,
     rows: &[&'q NodeRow],
 ) -> sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments> {

--- a/app/ferroehr/src/storage/version_repo/commit.rs
+++ b/app/ferroehr/src/storage/version_repo/commit.rs
@@ -281,10 +281,14 @@ pub struct FoldedVersion<'a> {
     /// CONTRIBUTION's committal), stored as the audit `time_committed` and
     /// the `sys_period` open bound.
     pub time_committed: jiff::Timestamp,
+    /// The decomposed node rows — inserted by the SAME statement through a
+    /// node CTE ordered after the version row (empty on a logical delete:
+    /// the unnest yields no rows and the CTE writes nothing).
+    pub rows: &'a [crate::storage::row::NodeRow],
 }
 
-/// A **standalone** folded commit: `audit` + `contribution` + `vo_version` in
-/// ONE data-modifying CTE, returning `(contribution_id, audit_id,
+/// A **standalone** folded commit: `audit` + `contribution` + `vo_version` +
+/// the decomposed `node` rows in ONE data-modifying CTE chain, returning `(contribution_id, audit_id,
 /// time_committed)`.
 ///
 /// The single audit row serves both the CONTRIBUTION and the version's
@@ -312,54 +316,60 @@ pub async fn commit_new_version(
     supplied: Option<Uuid>,
     v: &FoldedVersion<'_>,
 ) -> Result<(Uuid, Uuid, jiff::Timestamp), StorageError> {
-    let row = sqlx::query(
-        "WITH a AS ( \
-             INSERT INTO audit (system_id, change_type, description, committer, attestation, \
-                                time_committed) \
-             VALUES ($1, $2, $3, $4, $5, $22::timestamptz) RETURNING id, time_committed \
-         ), c AS ( \
-             INSERT INTO contribution (id, ehr_id, audit_id) \
-             SELECT COALESCE($6, uuidv7()), $7, a.id FROM a \
-             ON CONFLICT (id) DO NOTHING \
-             RETURNING id \
-         ), v AS ( \
-             INSERT INTO vo_version \
-               (vo_id, kind, ehr_id, sys_version, trunk_version, branch_number, branch_version, \
-                sys_period, lifecycle_state, creating_system_id, preceding_version_uid, \
-                contribution_id, audit_id, template_id, signature, \
-                signature_client_supplied, stable_compatible, body) \
-             SELECT $8, $9, $7, $10, $11, $12, $13, tstzrange($22::timestamptz, NULL, '[)'), \
-                    $14, $15, $16, c.id, a.id, $17, $18, $19, $20, $21 \
-             FROM a, c \
-             RETURNING 1 \
-         ) \
-         SELECT a.id AS audit_id, a.time_committed, c.id AS contribution_id \
-         FROM a LEFT JOIN c ON true",
-    )
-    .bind(audit.system_id)
-    .bind(audit.change_type)
-    .bind(&audit.description)
-    .bind(&audit.committer)
-    .bind(&audit.attestation)
-    .bind(supplied)
-    .bind(v.ehr_id)
-    .bind(v.vo_id)
-    .bind(v.kind)
-    .bind(v.sys_version)
-    .bind(v.trunk_version)
-    .bind(v.branch_number)
-    .bind(v.branch_version)
-    .bind(v.lifecycle_state)
-    .bind(v.creating_system_id)
-    .bind(v.preceding_version_uid)
-    .bind(v.template_id)
-    .bind(v.signature)
-    .bind(v.signature_client_supplied)
-    .bind(v.stable_compatible)
-    .bind(v.body)
-    .bind(v.time_committed.to_string())
-    .fetch_one(&mut *tx)
-    .await?;
+    static SQL: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "WITH a AS ( \
+                 INSERT INTO audit (system_id, change_type, description, committer, attestation, \
+                                    time_committed) \
+                 VALUES ($1, $2, $3, $4, $5, $22::timestamptz) RETURNING id, time_committed \
+             ), c AS ( \
+                 INSERT INTO contribution (id, ehr_id, audit_id) \
+                 SELECT COALESCE($6, uuidv7()), $7, a.id FROM a \
+                 ON CONFLICT (id) DO NOTHING \
+                 RETURNING id \
+             ), v AS ( \
+                 INSERT INTO vo_version \
+                   (vo_id, kind, ehr_id, sys_version, trunk_version, branch_number, branch_version, \
+                    sys_period, lifecycle_state, creating_system_id, preceding_version_uid, \
+                    contribution_id, audit_id, template_id, signature, \
+                    signature_client_supplied, stable_compatible, body) \
+                 SELECT $8, $9, $7, $10, $11, $12, $13, tstzrange($22::timestamptz, NULL, '[)'), \
+                        $14, $15, $16, c.id, a.id, $17, $18, $19, $20, $21 \
+                 FROM a, c \
+                 RETURNING 1 \
+             ), n AS ( {} ) \
+             SELECT a.id AS audit_id, a.time_committed, c.id AS contribution_id \
+             FROM a LEFT JOIN c ON true",
+            crate::storage::node_repo::node_insert_cte("$8", "$10", "$7", 23)
+        )
+    });
+    let row = sqlx::query(sqlx::AssertSqlSafe(SQL.as_str()))
+        .bind(audit.system_id)
+        .bind(audit.change_type)
+        .bind(&audit.description)
+        .bind(&audit.committer)
+        .bind(&audit.attestation)
+        .bind(supplied)
+        .bind(v.ehr_id)
+        .bind(v.vo_id)
+        .bind(v.kind)
+        .bind(v.sys_version)
+        .bind(v.trunk_version)
+        .bind(v.branch_number)
+        .bind(v.branch_version)
+        .bind(v.lifecycle_state)
+        .bind(v.creating_system_id)
+        .bind(v.preceding_version_uid)
+        .bind(v.template_id)
+        .bind(v.signature)
+        .bind(v.signature_client_supplied)
+        .bind(v.stable_compatible)
+        .bind(v.body)
+        .bind(v.time_committed.to_string());
+    let node_refs: Vec<&crate::storage::row::NodeRow> = v.rows.iter().collect();
+    let row = crate::storage::node_repo::bind_node_arrays(row, &node_refs)
+        .fetch_one(&mut *tx)
+        .await?;
     let contribution_id: Option<Uuid> = row.try_get("contribution_id")?;
     let contribution_id = contribution_id.ok_or(StorageError::ContributionUidInUse(supplied))?;
     let audit_id: Uuid = row.try_get("audit_id")?;
@@ -370,8 +380,8 @@ pub async fn commit_new_version(
 }
 
 /// A folded commit WITHIN an already-opened CONTRIBUTION: the version's own
-/// `commit_audit` + `vo_version` in ONE data-modifying CTE, referencing the
-/// pre-existing `contribution_id`.
+/// `commit_audit` + `vo_version` + the decomposed `node` rows in ONE
+/// data-modifying CTE chain, referencing the pre-existing `contribution_id`.
 ///
 /// Returns `(audit_id, time_committed)`. The CONTRIBUTION and its own audit
 /// were written earlier in the same transaction ([`write_contribution`]);
@@ -389,48 +399,54 @@ pub async fn commit_version_into(
     contribution_id: Uuid,
     v: &FoldedVersion<'_>,
 ) -> Result<(Uuid, jiff::Timestamp), StorageError> {
-    let row = sqlx::query(
-        "WITH a AS ( \
-             INSERT INTO audit (system_id, change_type, description, committer, attestation, \
-                                time_committed) \
-             VALUES ($1, $2, $3, $4, $5, $22::timestamptz) RETURNING id, time_committed \
-         ), v AS ( \
-             INSERT INTO vo_version \
-               (vo_id, kind, ehr_id, sys_version, trunk_version, branch_number, branch_version, \
-                sys_period, lifecycle_state, creating_system_id, preceding_version_uid, \
-                contribution_id, audit_id, template_id, signature, \
-                signature_client_supplied, stable_compatible, body) \
-             SELECT $6, $7, $8, $9, $10, $11, $12, tstzrange($22::timestamptz, NULL, '[)'), \
-                    $13, $14, $15, $16, a.id, $17, $18, $19, $20, $21 \
-             FROM a \
-             RETURNING 1 \
-         ) \
-         SELECT a.id AS audit_id, a.time_committed FROM a",
-    )
-    .bind(audit.system_id)
-    .bind(audit.change_type)
-    .bind(&audit.description)
-    .bind(&audit.committer)
-    .bind(&audit.attestation)
-    .bind(v.vo_id)
-    .bind(v.kind)
-    .bind(v.ehr_id)
-    .bind(v.sys_version)
-    .bind(v.trunk_version)
-    .bind(v.branch_number)
-    .bind(v.branch_version)
-    .bind(v.lifecycle_state)
-    .bind(v.creating_system_id)
-    .bind(v.preceding_version_uid)
-    .bind(contribution_id)
-    .bind(v.template_id)
-    .bind(v.signature)
-    .bind(v.signature_client_supplied)
-    .bind(v.stable_compatible)
-    .bind(v.body)
-    .bind(v.time_committed.to_string())
-    .fetch_one(&mut *tx)
-    .await?;
+    static SQL: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "WITH a AS ( \
+                 INSERT INTO audit (system_id, change_type, description, committer, attestation, \
+                                    time_committed) \
+                 VALUES ($1, $2, $3, $4, $5, $22::timestamptz) RETURNING id, time_committed \
+             ), v AS ( \
+                 INSERT INTO vo_version \
+                   (vo_id, kind, ehr_id, sys_version, trunk_version, branch_number, branch_version, \
+                    sys_period, lifecycle_state, creating_system_id, preceding_version_uid, \
+                    contribution_id, audit_id, template_id, signature, \
+                    signature_client_supplied, stable_compatible, body) \
+                 SELECT $6, $7, $8, $9, $10, $11, $12, tstzrange($22::timestamptz, NULL, '[)'), \
+                        $13, $14, $15, $16, a.id, $17, $18, $19, $20, $21 \
+                 FROM a \
+                 RETURNING 1 \
+             ), n AS ( {} ) \
+             SELECT a.id AS audit_id, a.time_committed FROM a",
+            crate::storage::node_repo::node_insert_cte("$6", "$9", "$8", 23)
+        )
+    });
+    let row = sqlx::query(sqlx::AssertSqlSafe(SQL.as_str()))
+        .bind(audit.system_id)
+        .bind(audit.change_type)
+        .bind(&audit.description)
+        .bind(&audit.committer)
+        .bind(&audit.attestation)
+        .bind(v.vo_id)
+        .bind(v.kind)
+        .bind(v.ehr_id)
+        .bind(v.sys_version)
+        .bind(v.trunk_version)
+        .bind(v.branch_number)
+        .bind(v.branch_version)
+        .bind(v.lifecycle_state)
+        .bind(v.creating_system_id)
+        .bind(v.preceding_version_uid)
+        .bind(contribution_id)
+        .bind(v.template_id)
+        .bind(v.signature)
+        .bind(v.signature_client_supplied)
+        .bind(v.stable_compatible)
+        .bind(v.body)
+        .bind(v.time_committed.to_string());
+    let node_refs: Vec<&crate::storage::row::NodeRow> = v.rows.iter().collect();
+    let row = crate::storage::node_repo::bind_node_arrays(row, &node_refs)
+        .fetch_one(&mut *tx)
+        .await?;
     let audit_id: Uuid = row.try_get("audit_id")?;
     let time_committed = row
         .try_get::<jiff_sqlx::Timestamp, _>("time_committed")?

--- a/app/ferroehr/src/versioning/change.rs
+++ b/app/ferroehr/src/versioning/change.rs
@@ -773,6 +773,7 @@ async fn commit_resolved(
         stable_compatible: r.stable_compatible,
         body: body.as_ref(),
         time_committed: r.time_committed,
+        rows: &r.rows,
     };
     // The folded statements BIND `r.time_committed` (the instant the signature
     // was computed over) as the audit time and the `sys_period` open bound, so
@@ -797,8 +798,8 @@ async fn commit_resolved(
         }
     };
 
-    // The shared commit tail: node rows, folder membership, attestations.
-    crate::storage::node_repo::write_nodes(tx, r.vo_id, r.ordinal, r.ehr_id, &r.rows).await?;
+    // The shared commit tail: folder membership + attestations (the node rows
+    // rode the folded statement itself, through its node CTE).
     // A newly created FOLDER hierarchy joins `EHR.folders` as a new member (RM
     // ehr master04 §Folders). Recorded only on CREATION.
     if r.is_first_folder


### PR DESCRIPTION
Works #2698 (lever 2).

Both folded commit statements gain a node CTE: the same fixed-text `unnest` shape as the standalone writer, its storage context spelled as the statement's own version parameters, `CROSS JOIN v` ordering it after the version row — which is also what satisfies the node rows' FK inside one statement (the proven sibling-CTE pattern the contribution→audit FK already uses). Empty arrays insert nothing, so logical deletes fold through unchanged; `write_nodes` stays for the import/archive batch writers.

**Measured** (400-commit dive, 12k seed, the release binary on loopback against the compose PG, lever 1 included): the whole commit's DML is now **one 2.16 ms statement** where the same work was two statements totalling 2.29 ms plus a round trip; with the ATNA event (0.35 ms) total DB work per commit is ~2.5 ms, wall p50 6.0 ms. Every local write path benefits — composition, EHR_STATUS, directory, demographic, the CONTRIBUTION route — since all commit through these two statements.

The remaining DB mass is btree maintenance on the surviving node indexes (65 rows × 4), which is lever 3's measured question (`idx_node_type_archetype` narrowing) on #2698.

Gates: 141 write-path tests green (persistence incl. the body/nodes parity suite, contribution, signing, composition, status, directory); crate clippy clean; changelog entry added.