### PR TITLE
perf(storage): the node anchor index narrows to rm_type alone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@ workflow refuses a tag that has no matching section here.
 
 ### Changed
 
+- The write path sheds most of another btree: the node CONTAINS-anchor
+  index narrows from `(rm_type, archetype)` to `(rm_type)` alone — 83% of
+  node rows carry at-code archetype text whose key bytes dominated the
+  index's maintenance, while every measured anchor plan either used the
+  subsumption index (full-HRID anchors) or filtered archetype after the
+  rm_type probe at identical latency. Measured: the one-statement commit
+  drops a further ~0.3 ms; the read probes (EHR-scoped, archetype-anchored,
+  rm_type-only, and the no-match worst case) are unchanged.
+
 - A versioned-object commit is ONE SQL statement: the decomposed node rows
   ride the folded commit CTE (ordered after the version row, which also
   satisfies their foreign key in-statement), removing the separate node

--- a/app/ferroehr/migrations/ehr/0001_baseline.sql
+++ b/app/ferroehr/migrations/ehr/0001_baseline.sql
@@ -628,13 +628,16 @@ CREATE TABLE node (
         REFERENCES vo_version (vo_id, sys_version) ON DELETE CASCADE
         DEFERRABLE INITIALLY IMMEDIATE
 );
--- The archetype column is case-folded AT WRITE (storage::codec): composite
--- identifiers compare case-insensitively (BASE base_types master05
--- §"Composite Identifiers and Case"), so AQL archetype equality is plain
--- indexed equality on this composite index — no functional lower() index,
--- honest planner statistics (the canonical `data` fragment keeps original
--- casing).
-CREATE INDEX idx_node_type_archetype ON node (rm_type, archetype);
+-- The rm_type-only CONTAINS anchor path (a class filter with no archetype).
+-- Deliberately WITHOUT the archetype column (measured 2026-08-25, #2698):
+-- 83% of node rows carry at-code archetype text, so the composite's key
+-- bytes dominated the write path's index maintenance while every measured
+-- anchor plan either used the subsumption index below (full-HRID anchors)
+-- or filtered archetype after this rm_type probe at identical latency. The
+-- archetype column stays case-folded at write (storage::codec; BASE
+-- base_types master05 §"Composite Identifiers and Case") so the residual
+-- filter is plain equality with honest statistics.
+CREATE INDEX idx_node_rm_type ON node (rm_type);
 -- Archetype-subsumption scan (BASE architecture_overview master10 §Design-time
 -- Relationships; AM master07 §Querying): a parent-archetype predicate resolves
 -- to arch_entity = $entity AND arch_major = $major AND (arch_concept = $concept


### PR DESCRIPTION
Works #2698 (lever 3).

The measured ladder (400/300-commit dives, 12k seed, the release binary on loopback):

| index shape | one-statement commit mean |
|---|---|
| `(rm_type, archetype)` — shipped | 1.86 ms |
| **`(rm_type)` — adopted** | **1.55 ms** |
| dropped entirely | 1.69 ms (within noise of the narrow shape) |

The at-code archetype text (83% of node rows) was the key mass; the anchor path itself is nearly free. Read verification: EHR-scoped uid + leaf projections, a whole-corpus archetype anchor, an rm_type-only anchor, and the no-match worst case (`CONTAINS CLUSTER` over a corpus with zero clusters — a full walk by nature) all measure identically under both shapes (the worst case: 570 vs 581 ms). Full-HRID anchors ride `idx_node_arch_subsume` as the captured plans already showed; at-code anchors filter after the rm_type probe.

Cumulative #2698 state at the 12k reference: the commit's whole DML is one statement at ~1.55 ms + the ATNA event ~0.35 ms ≈ **1.9 ms DB work**, from ~4.5 ms when the program started. 148 AQL/persistence/parity tests green; the exact CI clippy lane verified locally (0 errors); changelog entry added.