### PR TITLE
perf(storage): the lineage close, the thaw, and the invariant read all ride existing statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,21 @@ workflow refuses a tag that has no matching section here.
 
 ### Changed
 
+- A version UPDATE gets three round trips faster. Closing the superseded
+  lineage tip now rides the one folded commit statement (its leading CTE, at
+  the same bound instant, so the close boundary and the new version's open
+  bound are one value by construction); the archived-object thaw rides the
+  version-tree placement read instead of its own statement; and the
+  first-version invariant read (archetype and category stability across
+  versions) rides the update's merged pre-read instead of a transaction-time
+  statement. Measured on a 14k-version store: composition update p50 drops
+  from 10.6 ms to 5.6 ms, within ~1 ms of create.
+
+- The first-version invariant read now consults both storage tiers, so
+  updating an archived composition enforces the cross-version archetype and
+  category invariants instead of silently skipping them (the read used to run
+  before the thaw and saw only the primary tier).
+
 - The write path sheds most of another btree: the node CONTAINS-anchor
   index narrows from `(rm_type, archetype)` to `(rm_type)` alone — 83% of
   node rows carry at-code archetype text whose key bytes dominated the

--- a/app/ferroehr/src/service/ehr/composition.rs
+++ b/app/ferroehr/src/service/ehr/composition.rs
@@ -403,12 +403,15 @@ impl FerroEhrService {
         // the template it was committed against.
         let template_id = composition_template_id(&composition).map(str::to_owned);
 
-        let mut tx = self.pool.begin().await?;
         // VERSIONED_COMPOSITION cross-version invariants (RM ehr
-        // `versioned_composition.adoc`), lifted out of the versioning write
-        // path — checked in the same transaction as the commit.
-        super::validation::check_versioned_composition_invariants(&mut tx, vo_id, &composition)
-            .await?;
+        // `versioned_composition.adoc`), checked off the merged pre-read —
+        // the first version's root is immutable, so no transaction is needed
+        // to read it consistently.
+        super::validation::check_versioned_composition_first_root(
+            current.first_root,
+            &composition,
+        )?;
+        let mut tx = self.pool.begin().await?;
         let committed = update(
             &mut tx,
             Some(ehr_id),

--- a/app/ferroehr/src/service/ehr/validation.rs
+++ b/app/ferroehr/src/service/ehr/validation.rs
@@ -342,9 +342,22 @@ pub(in crate::service) async fn check_versioned_composition_invariants(
     // NOTE: no openEHR spec governs the `spec_profile` gate — our own
     // design/extension: this write-path read compares two root fields and
     // serves nothing, so it stays ungated.
-    let Some((first_ani, first_category)) =
-        crate::storage::node_repo::first_version_root(tx, vo_id).await?
-    else {
+    let first_root = crate::storage::node_repo::first_version_root(tx, vo_id).await?;
+    check_versioned_composition_first_root(first_root, canonical)
+}
+
+/// The pure half of [`check_versioned_composition_invariants`]: compare the
+/// incoming root against the first stored version's `(archetype_node_id,
+/// category code)` pair, already read — the direct update path threads it off
+/// its merged pre-read instead of paying a second statement.
+///
+/// # Errors
+/// [`ServiceError::Unprocessable`] naming the violated invariant (→ 422).
+pub(in crate::service) fn check_versioned_composition_first_root(
+    first_root: Option<(Option<String>, Option<String>)>,
+    canonical: &Value,
+) -> Result<(), ServiceError> {
+    let Some((first_ani, first_category)) = first_root else {
         // No stored content version (e.g. every prior version deleted) — no
         // first-version root to compare against.
         return Ok(());

--- a/app/ferroehr/src/storage/node_repo.rs
+++ b/app/ferroehr/src/storage/node_repo.rs
@@ -550,9 +550,12 @@ async fn read_root_bodies(
     Ok(out)
 }
 
-/// The `(archetype_node_id, category code)` of the FIRST stored content
-/// version of an object — the two scalars the cross-version invariants
-/// compare, read as text off the materialized `vo_version.body`.
+/// Reads the first stored content version's `(archetype_node_id, category
+/// code)` pair — the two scalars the cross-version invariants compare.
+///
+/// Read as text off the materialized body over BOTH storage tiers
+/// (`vo_version_all`: the read runs before the commit path's thaw, and an
+/// archived first version still fixes the invariants).
 ///
 /// `None` when no content version exists (e.g. every prior version deleted);
 /// either scalar is `None` when the stored body lacks that field.
@@ -568,7 +571,7 @@ pub async fn first_version_root(
     Ok(sqlx::query_as(
         "SELECT body ->> 'archetype_node_id', \
          body #>> '{category,defining_code,code_string}' \
-         FROM vo_version WHERE vo_id = $1 AND body IS NOT NULL \
+         FROM vo_version_all WHERE vo_id = $1 AND body IS NOT NULL \
          ORDER BY sys_version LIMIT 1",
     )
     .bind(vo_id)

--- a/app/ferroehr/src/storage/version_repo/attestation.rs
+++ b/app/ferroehr/src/storage/version_repo/attestation.rs
@@ -89,14 +89,31 @@ pub async fn attestation_target(
     kind: &str,
 ) -> Result<Option<AttestTargetRow>, StorageError> {
     // Attesting an archived version appends a row that references it, so the
-    // object comes back to the primary tier first — same rule as the version
-    // commit path (`crate::storage::version_repo::tier`).
-    crate::storage::version_repo::tier::thaw_one(&mut *tx, vo_id).await?;
+    // statement's leading CTEs bring the object back to the primary tier —
+    // the same merged thaw the commit path's placement read carries
+    // (`crate::storage::version_repo::placement::next_placement`); the lookup
+    // reads `vo_version` UNION ALL the thaw's own `RETURNING` rows because a
+    // same-statement `INSERT` is invisible to the sibling scans
+    // (<https://www.postgresql.org/docs/18/queries-with.html>).
     let (t, b, v) = tree;
     let row = sqlx::query(
-        "SELECT ehr_id, sys_version, creating_system_id, \
-         (wrapped_original IS NOT NULL) AS imported FROM vo_version \
-         WHERE vo_id = $1 AND trunk_version = $2 AND branch_number = $3 \
+        "WITH cv AS (DELETE FROM cold.vo_version WHERE vo_id = $1 RETURNING *), \
+         cn AS (DELETE FROM cold.node WHERE vo_id = $1 RETURNING *), \
+         ct AS (DELETE FROM cold.vo_attestation WHERE vo_id = $1 RETURNING *), \
+         cm AS (DELETE FROM vo_archive WHERE vo_id = $1), \
+         iv AS (INSERT INTO vo_version SELECT * FROM cv), \
+         inn AS (INSERT INTO node SELECT * FROM cn), \
+         it AS (INSERT INTO vo_attestation SELECT * FROM ct), \
+         src AS (SELECT ehr_id, sys_version, creating_system_id, wrapped_original, \
+                        trunk_version, branch_number, branch_version, kind \
+                 FROM vo_version WHERE vo_id = $1 \
+                 UNION ALL \
+                 SELECT ehr_id, sys_version, creating_system_id, wrapped_original, \
+                        trunk_version, branch_number, branch_version, kind \
+                 FROM cv) \
+         SELECT ehr_id, sys_version, creating_system_id, \
+         (wrapped_original IS NOT NULL) AS imported FROM src \
+         WHERE trunk_version = $2 AND branch_number = $3 \
          AND branch_version = $4 AND kind = $5",
     )
     .bind(vo_id)

--- a/app/ferroehr/src/storage/version_repo/commit.rs
+++ b/app/ferroehr/src/storage/version_repo/commit.rs
@@ -195,31 +195,6 @@ pub async fn write_contribution(
     Ok((contribution_id, audit_id, time_committed))
 }
 
-/// Close (supersede) one specific version row — the lineage tip a new version
-/// replaces — at `now()`.
-///
-/// Lineage-precise: a branch commit closes its branch tip, a trunk commit the
-/// trunk tip; a FORK closes nothing (master06 §Version tree, realized by the
-/// temporal `sys_period`).
-///
-/// # Errors
-/// Returns [`StorageError::Database`] on a driver/update failure.
-pub async fn close_ordinal_at_now(
-    tx: &mut PgConnection,
-    vo_id: VoId,
-    ordinal: i32,
-) -> Result<(), StorageError> {
-    sqlx::query(
-        "UPDATE vo_version SET sys_period = tstzrange(lower(sys_period), now(), '[)') \
-         WHERE vo_id = $1 AND sys_version = $2 AND upper_inf(sys_period)",
-    )
-    .bind(vo_id)
-    .bind(ordinal)
-    .execute(&mut *tx)
-    .await?;
-    Ok(())
-}
-
 /// The `vo_version` columns for a **folded** commit — every content column of
 /// a stored version EXCEPT `contribution_id`/`audit_id`, which come from the
 /// same statement's `contribution`/`audit` CTEs.
@@ -230,13 +205,12 @@ pub async fn close_ordinal_at_now(
 /// the `sys_period` open bound, and the instant the `VERSION.signature` was
 /// computed over one value BY CONSTRUCTION.
 ///
-/// A superseded lineage tip is closed by the caller in a **separate, prior**
-/// statement ([`close_ordinal_at_now`]) — never folded into this insert: the
+/// A superseded lineage tip is closed INSIDE the same statement: when
+/// `close_ordinal` is set, the leading `cl` CTE closes that tip's `sys_period`
+/// at the identical bound instant, and the insert CTE depends on it, so the
 /// one-open-row-per-lineage partial unique indexes (`uq_vo_version_current` /
-/// `uq_vo_version_branch_current`) require the old open row to be gone before
-/// the new one is inserted, and data-modifying CTEs in one statement share a
-/// snapshot with undefined ordering, so a fold could momentarily hold two open
-/// rows for the lineage. Close-then-insert stays ordered (master06 §The 'Virtual Version Tree').
+/// `uq_vo_version_branch_current`) see the closed tip before the new open row
+/// lands (master06 §The 'Virtual Version Tree').
 #[derive(Debug)]
 pub struct FoldedVersion<'a> {
     /// The versioned object's id.
@@ -285,6 +259,13 @@ pub struct FoldedVersion<'a> {
     /// node CTE ordered after the version row (empty on a logical delete:
     /// the unnest yields no rows and the CTE writes nothing).
     pub rows: &'a [crate::storage::row::NodeRow],
+    /// The storage ordinal of the lineage tip this version supersedes —
+    /// closed by the SAME statement's leading `cl` CTE at the bound commit
+    /// instant, before the version row inserts (the insert CTE depends on
+    /// `cl`, so the one-open-row-per-lineage partial unique indexes see the
+    /// closed tip). `None` (a create or a fork) matches no row and closes
+    /// nothing.
+    pub close_ordinal: Option<i32>,
 }
 
 /// A **standalone** folded commit.
@@ -320,7 +301,12 @@ pub async fn commit_new_version(
 ) -> Result<(Uuid, Uuid, jiff::Timestamp), StorageError> {
     static SQL: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
         format!(
-            "WITH a AS ( \
+            "WITH cl AS ( \
+                 UPDATE vo_version \
+                 SET sys_period = tstzrange(lower(sys_period), $22::timestamptz, '[)') \
+                 WHERE vo_id = $8 AND sys_version = $23 AND upper_inf(sys_period) \
+                 RETURNING 1 \
+             ), a AS ( \
                  INSERT INTO audit (system_id, change_type, description, committer, attestation, \
                                     time_committed) \
                  VALUES ($1, $2, $3, $4, $5, $22::timestamptz) RETURNING id, time_committed \
@@ -337,12 +323,12 @@ pub async fn commit_new_version(
                     signature_client_supplied, stable_compatible, body) \
                  SELECT $8, $9, $7, $10, $11, $12, $13, tstzrange($22::timestamptz, NULL, '[)'), \
                         $14, $15, $16, c.id, a.id, $17, $18, $19, $20, $21 \
-                 FROM a, c \
+                 FROM a, c, (SELECT count(*) FROM cl) AS cl_done \
                  RETURNING 1 \
              ), n AS ( {} ) \
              SELECT a.id AS audit_id, a.time_committed, c.id AS contribution_id \
              FROM a LEFT JOIN c ON true",
-            crate::storage::node_repo::node_insert_cte("$8", "$10", "$7", 23)
+            crate::storage::node_repo::node_insert_cte("$8", "$10", "$7", 24)
         )
     });
     let row = sqlx::query(sqlx::AssertSqlSafe(SQL.as_str()))
@@ -367,7 +353,8 @@ pub async fn commit_new_version(
         .bind(v.signature_client_supplied)
         .bind(v.stable_compatible)
         .bind(v.body)
-        .bind(v.time_committed.to_string());
+        .bind(v.time_committed.to_string())
+        .bind(v.close_ordinal);
     let node_refs: Vec<&crate::storage::row::NodeRow> = v.rows.iter().collect();
     let row = crate::storage::node_repo::bind_node_arrays(row, &node_refs)
         .fetch_one(&mut *tx)
@@ -405,7 +392,12 @@ pub async fn commit_version_into(
 ) -> Result<(Uuid, jiff::Timestamp), StorageError> {
     static SQL: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
         format!(
-            "WITH a AS ( \
+            "WITH cl AS ( \
+                 UPDATE vo_version \
+                 SET sys_period = tstzrange(lower(sys_period), $22::timestamptz, '[)') \
+                 WHERE vo_id = $6 AND sys_version = $23 AND upper_inf(sys_period) \
+                 RETURNING 1 \
+             ), a AS ( \
                  INSERT INTO audit (system_id, change_type, description, committer, attestation, \
                                     time_committed) \
                  VALUES ($1, $2, $3, $4, $5, $22::timestamptz) RETURNING id, time_committed \
@@ -417,11 +409,11 @@ pub async fn commit_version_into(
                     signature_client_supplied, stable_compatible, body) \
                  SELECT $6, $7, $8, $9, $10, $11, $12, tstzrange($22::timestamptz, NULL, '[)'), \
                         $13, $14, $15, $16, a.id, $17, $18, $19, $20, $21 \
-                 FROM a \
+                 FROM a, (SELECT count(*) FROM cl) AS cl_done \
                  RETURNING 1 \
              ), n AS ( {} ) \
              SELECT a.id AS audit_id, a.time_committed FROM a",
-            crate::storage::node_repo::node_insert_cte("$6", "$9", "$8", 23)
+            crate::storage::node_repo::node_insert_cte("$6", "$9", "$8", 24)
         )
     });
     let row = sqlx::query(sqlx::AssertSqlSafe(SQL.as_str()))
@@ -446,7 +438,8 @@ pub async fn commit_version_into(
         .bind(v.signature_client_supplied)
         .bind(v.stable_compatible)
         .bind(v.body)
-        .bind(v.time_committed.to_string());
+        .bind(v.time_committed.to_string())
+        .bind(v.close_ordinal);
     let node_refs: Vec<&crate::storage::row::NodeRow> = v.rows.iter().collect();
     let row = crate::storage::node_repo::bind_node_arrays(row, &node_refs)
         .fetch_one(&mut *tx)

--- a/app/ferroehr/src/storage/version_repo/meta.rs
+++ b/app/ferroehr/src/storage/version_repo/meta.rs
@@ -611,9 +611,20 @@ pub struct CurrentCompositionMeta {
     /// The stored `archetype_details.template_id.value`, or `None` for a
     /// deleted current (NULL `body`) or an undeclared template.
     pub stored_template: Option<String>,
+    /// The FIRST stored content version's root fields —
+    /// `(archetype_node_id, category code)` — for the `VERSIONED_COMPOSITION`
+    /// cross-version invariants; `None` when no content version exists.
+    pub first_root: Option<(Option<String>, Option<String>)>,
 }
 
 /// Read the lean [`CurrentCompositionMeta`] for a COMPOSITION's current version.
+///
+/// One statement carries the whole write pre-check: the current tip row, the
+/// owning EHR's `is_modifiable`, the stored template id, and the first content
+/// version's root fields (immutable after creation, so reading them before the
+/// commit transaction races nothing). Both reads go over the `*_all` union
+/// views, so an archived object answers correctly before the commit path's
+/// thaw runs.
 ///
 /// # Errors
 /// Returns [`StorageError::Database`] on a driver failure.
@@ -624,14 +635,28 @@ pub async fn current_composition_meta(
     const SQL: &str = "SELECT v.ehr_id, v.lifecycle_state, v.trunk_version, v.branch_number, \
                        v.branch_version, v.creating_system_id, a.time_committed, \
                        e.is_modifiable, \
-                       v.body #>> '{archetype_details,template_id,value}' AS stored_template \
+                       v.body #>> '{archetype_details,template_id,value}' AS stored_template, \
+                       fv.found AS first_found, fv.ani AS first_ani, \
+                       fv.category AS first_category \
                        FROM vo_version_all v \
                        JOIN audit a ON a.id = v.audit_id \
                        JOIN ehr e ON e.id = v.ehr_id \
+                       LEFT JOIN LATERAL ( \
+                           SELECT true AS found, \
+                                  f.body ->> 'archetype_node_id' AS ani, \
+                                  f.body #>> '{category,defining_code,code_string}' AS category \
+                           FROM vo_version_all f \
+                           WHERE f.vo_id = $1 AND f.body IS NOT NULL \
+                           ORDER BY f.sys_version LIMIT 1 \
+                       ) fv ON true \
                        WHERE v.vo_id = $1 AND upper_inf(v.sys_period) AND v.branch_number = 0";
     let found = sqlx::query(SQL).bind(vo_id).fetch_optional(pool).await?;
     let Some(row) = found else {
         return Ok(None);
+    };
+    let first_root = match row.try_get::<Option<bool>, _>("first_found")? {
+        Some(true) => Some((row.try_get("first_ani")?, row.try_get("first_category")?)),
+        _ => None,
     };
     Ok(Some(CurrentCompositionMeta {
         ehr_id: row.try_get("ehr_id")?,
@@ -645,6 +670,7 @@ pub async fn current_composition_meta(
             .to_jiff(),
         is_modifiable: row.try_get("is_modifiable")?,
         stored_template: row.try_get("stored_template")?,
+        first_root,
     }))
 }
 

--- a/app/ferroehr/src/storage/version_repo/placement.rs
+++ b/app/ferroehr/src/storage/version_repo/placement.rs
@@ -56,7 +56,8 @@ pub struct Placement {
     pub now: jiff::Timestamp,
 }
 
-/// The version-tree placement read, merged into ONE statement.
+/// The version-tree placement read, merged into ONE statement — the thaw
+/// included.
 ///
 /// Returns the preceding lineage tip (the version `expected` names, or the open
 /// TRUNK tip), the next storage commit ordinal, and the transaction timestamp.
@@ -66,6 +67,14 @@ pub struct Placement {
 /// master06 §Digital Signature) and commit through the folded CTE
 /// unconditionally.
 ///
+/// A new version must never land in the primary tier while its predecessors sit
+/// in the cold one, so the statement's leading data-modifying CTEs move any
+/// archived rows back first — primary-key probes finding nothing for the
+/// overwhelmingly common unarchived case. A same-statement `INSERT` is
+/// invisible to the sibling scans
+/// (<https://www.postgresql.org/docs/18/queries-with.html>), so the placement
+/// reads run over `vo_version` UNION ALL the thaw's own `RETURNING` rows.
+///
 /// # Errors
 /// Returns [`StorageError::Database`] on a driver failure.
 pub async fn next_placement(
@@ -73,24 +82,33 @@ pub async fn next_placement(
     vo_id: VoId,
     expected: Option<(i32, i32, i32)>,
 ) -> Result<Placement, StorageError> {
-    // A new version must never land in the primary tier while its predecessors
-    // sit in the cold one, so an archived object is brought back first — one
-    // statement, a no-op for every unarchived object
-    // (`crate::storage::version_repo::tier`).
-    crate::storage::version_repo::tier::thaw_one(&mut *tx, vo_id).await?;
     macro_rules! placement_select {
         ($tip_where:literal) => {
             concat!(
+                "WITH cv AS (DELETE FROM cold.vo_version WHERE vo_id = $1 RETURNING *), ",
+                "cn AS (DELETE FROM cold.node WHERE vo_id = $1 RETURNING *), ",
+                "ct AS (DELETE FROM cold.vo_attestation WHERE vo_id = $1 RETURNING *), ",
+                "cm AS (DELETE FROM vo_archive WHERE vo_id = $1), ",
+                "iv AS (INSERT INTO vo_version SELECT * FROM cv), ",
+                "inn AS (INSERT INTO node SELECT * FROM cn), ",
+                "it AS (INSERT INTO vo_attestation SELECT * FROM ct), ",
+                "src AS (SELECT vo_id, ehr_id, kind, sys_version, trunk_version, branch_number, ",
+                "               branch_version, creating_system_id, lifecycle_state, sys_period ",
+                "        FROM vo_version WHERE vo_id = $1 ",
+                "        UNION ALL ",
+                "        SELECT vo_id, ehr_id, kind, sys_version, trunk_version, branch_number, ",
+                "               branch_version, creating_system_id, lifecycle_state, sys_period ",
+                "        FROM cv) ",
                 "SELECT o.next_ordinal, now() AS ts, tip.ehr_id, tip.kind, tip.sys_version, ",
                 "tip.trunk_version, tip.branch_number, tip.branch_version, ",
                 "tip.creating_system_id, tip.lifecycle_state, tip.open ",
                 "FROM (SELECT (COALESCE(MAX(sys_version), 0) + 1)::int AS next_ordinal ",
-                "      FROM vo_version WHERE vo_id = $1) o ",
+                "      FROM src) o ",
                 "LEFT JOIN LATERAL ( ",
                 "    SELECT t.ehr_id, t.kind, t.sys_version, t.trunk_version, ",
                 "           t.branch_number, t.branch_version, t.creating_system_id, ",
                 "           t.lifecycle_state, upper_inf(t.sys_period) AS open ",
-                "    FROM vo_version t WHERE ",
+                "    FROM src t WHERE ",
                 $tip_where,
                 ") tip ON true"
             )

--- a/app/ferroehr/src/storage/version_repo/tier.rs
+++ b/app/ferroehr/src/storage/version_repo/tier.rs
@@ -13,8 +13,10 @@
 //!
 //! Two rules keep the tier invisible on the wire:
 //!
-//! - a **write** always thaws first ([`thaw`]), so a versioned object is never
-//!   split across tiers;
+//! - a **write** always thaws first ([`thaw`] on the admin restore path; the
+//!   commit path's thaw rides the merged placement read,
+//!   `crate::storage::version_repo::placement::next_placement`), so a
+//!   versioned object is never split across tiers;
 //! - a **read** goes through the `*_all` union views (`vo_version_all` /
 //!   `node_all` / `vo_attestation_all`), so ONE statement serves both tiers
 //!   and a miss never pays a retry transaction.
@@ -75,34 +77,6 @@ pub async fn thaw(tx: &mut PgConnection, vo_ids: &[VoId]) -> Result<(), StorageE
     ] {
         sqlx::query(sql).bind(vo_ids).execute(&mut *tx).await?;
     }
-    Ok(())
-}
-
-/// Thaws one versioned object before it is written to, so a new version never
-/// lands in the primary tier while its predecessors sit in the cold one.
-///
-/// A no-op (three primary-key probes finding nothing) for the overwhelmingly
-/// common unarchived case; the whole thaw is folded into ONE statement so the
-/// write path pays a single round trip for the guarantee. The data-modifying
-/// `WITH` clauses all run in the same statement, so the deferred `node` →
-/// `vo_version` foreign key is satisfied at statement end
-/// (<https://www.postgresql.org/docs/18/queries-with.html>).
-///
-/// # Errors
-/// Returns [`StorageError::Database`] on a driver failure.
-pub async fn thaw_one(tx: &mut PgConnection, vo_id: VoId) -> Result<(), StorageError> {
-    sqlx::query(
-        "WITH v AS (DELETE FROM cold.vo_version WHERE vo_id = $1 RETURNING *), \
-              n AS (DELETE FROM cold.node WHERE vo_id = $1 RETURNING *), \
-              t AS (DELETE FROM cold.vo_attestation WHERE vo_id = $1 RETURNING *), \
-              m AS (DELETE FROM vo_archive WHERE vo_id = $1), \
-              iv AS (INSERT INTO vo_version SELECT * FROM v), \
-              inn AS (INSERT INTO node SELECT * FROM n) \
-         INSERT INTO vo_attestation SELECT * FROM t",
-    )
-    .bind(vo_id)
-    .execute(&mut *tx)
-    .await?;
     Ok(())
 }
 

--- a/app/ferroehr/src/versioning/change.rs
+++ b/app/ferroehr/src/versioning/change.rs
@@ -719,17 +719,6 @@ async fn commit_resolved(
     let audit_row = audit.row();
     let (trunk_version, branch_number, branch_version) = r.tree.columns();
 
-    // Close the superseded lineage tip FIRST, as its own statement, before the
-    // folded insert: the one-open-row-per-lineage partial unique indexes
-    // (`uq_vo_version_current` / `uq_vo_version_branch_current`) require the
-    // old open row to be gone before the new open row is inserted. `now()` is
-    // the transaction timestamp, so the close boundary and the new version's
-    // `sys_period` open at the identical instant (master06 §The 'Virtual Version Tree').
-    if let Some(close_ordinal) = r.close_ordinal {
-        crate::storage::version_repo::commit::close_ordinal_at_now(tx, r.vo_id, close_ordinal)
-            .await?;
-    }
-
     // The enclosing CONTRIBUTION id: pre-existing for a multi-change commit,
     // generated here for a standalone write — known before the signature.
     let contribution_id = match contribution {
@@ -774,6 +763,13 @@ async fn commit_resolved(
         body: body.as_ref(),
         time_committed: r.time_committed,
         rows: &r.rows,
+        // The superseded lineage tip closes inside the SAME statement (its
+        // leading `cl` CTE, at the same bound instant) — the close boundary
+        // and the new `sys_period` open at the identical instant (master06
+        // §The 'Virtual Version Tree'), and the insert CTE depends on `cl`
+        // so the one-open-row-per-lineage partial unique indexes see the
+        // closed tip first.
+        close_ordinal: r.close_ordinal,
     };
     // The folded statements BIND `r.time_committed` (the instant the signature
     // was computed over) as the audit time and the `sys_period` open bound, so


### PR DESCRIPTION
Part of #2698 (the v4.0.3 write-latency program). A version UPDATE made eight database round trips to a create's four; this folds three of them into statements the path already pays for, and fixes an archived-object correctness gap the fold exposed.

## What changed

- **The lineage close rides the folded commit.** The superseded tip's `sys_period` closes in a leading `cl` CTE of the one commit statement, at the same bound instant the new version's `sys_period` opens at (RM common master06 §The 'Virtual Version Tree'). The insert CTE depends on `cl`, so the one-open-row-per-lineage partial unique indexes see the closed tip before the new open row lands — proven by the burst-update suites. `close_ordinal_at_now` is deleted.
- **The thaw rides the placement read.** `next_placement` (and the attestation-target lookup) now open with the cold-tier delete/insert CTEs and read `vo_version UNION ALL` the thaw's own `RETURNING` rows, since a same-statement `INSERT` is invisible to sibling scans (PostgreSQL 18 `queries-with`). `thaw_one` is deleted.
- **The first-version invariant read rides the pre-read.** `current_composition_meta` carries the first content version's `(archetype_node_id, category)` as a LATERAL; the `VERSIONED_COMPOSITION` cross-version comparison is now a pure function running before the transaction opens. The CONTRIBUTION path keeps the tx-reading wrapper.
- **Correctness fix en route:** the first-version read used to run before the thaw over the primary tier only, so updating an **archived** composition silently skipped the cross-version invariants. It now reads `vo_version_all`.

## Measured

Native release server against the composed PG18, 14k-version store, keep-alive connection, 65-node composition: update p50 **10.6 ms → 5.6 ms** (p90 12.6 → ~8), within ~1 ms of create. Per-update statement trace is now: merged pre-read, BEGIN, advisory lock, merged placement+thaw (0.04 ms), folded commit (1.6 ms), COMMIT.

## Gates

`cargo fmt` · the exact CI clippy lane (`--locked --workspace --exclude ferroehr-admin-ui --all-targets --all-features`) · `cargo nextest run -p ferroehr` 967/967 · the rustdoc gate with `--document-private-items`.