### PR TITLE
perf(storage): a plain composition create commits without an explicit transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ workflow refuses a tag that has no matching section here.
 
 ### Changed
 
+- A composition CREATE skips the explicit transaction when the commit is the
+  one folded statement (no accompanying attestations, event outbox off — the
+  common case): a single SQL statement is atomic on its own, so the
+  `BEGIN`/`COMMIT` round trips are gone and a create is two database
+  statements end to end (the merged pre-check read and the folded commit).
+
 - A version UPDATE gets three round trips faster. Closing the superseded
   lineage tip now rides the one folded commit statement (its leading CTE, at
   the same bound instant, so the close boundary and the new version's open

--- a/app/ferroehr/src/service/ehr/composition.rs
+++ b/app/ferroehr/src/service/ehr/composition.rs
@@ -97,23 +97,44 @@ impl FerroEhrService {
         // stamps it exactly like the CONTRIBUTION route.
         let template_id = composition_template_id(&composition).map(str::to_owned);
 
-        let mut tx = self.pool.begin().await?;
+        // With no accompanying attestations and no event outbox, the whole
+        // commit is the ONE folded statement — atomic on its own, so the
+        // explicit transaction's BEGIN/COMMIT round trips are skipped.
         // Boxed: the versioned-write future is by far the widest state this
         // call holds, and inlining it puts the whole node-decomposition
         // machinery on every caller's stack (clippy `large_futures`).
-        let committed = Box::pin(create(
-            &mut tx,
-            Some(ehr_id),
-            Kind::Composition,
-            composition,
-            template_id.as_deref(),
-            &audit,
-            envelope,
-            &self.signing_ctx(),
-            Some(commit_now),
-        ))
-        .await?;
-        tx.commit().await?;
+        let signing_ctx = self.signing_ctx();
+        let committed = if envelope.attestations.is_empty() && !signing_ctx.outbox_enabled {
+            let mut conn = self.pool.acquire().await?;
+            Box::pin(create(
+                &mut conn,
+                Some(ehr_id),
+                Kind::Composition,
+                composition,
+                template_id.as_deref(),
+                &audit,
+                envelope,
+                &signing_ctx,
+                Some(commit_now),
+            ))
+            .await?
+        } else {
+            let mut tx = self.pool.begin().await?;
+            let committed = Box::pin(create(
+                &mut tx,
+                Some(ehr_id),
+                Kind::Composition,
+                composition,
+                template_id.as_deref(),
+                &audit,
+                envelope,
+                &signing_ctx,
+                Some(commit_now),
+            ))
+            .await?;
+            tx.commit().await?;
+            committed
+        };
         crate::telemetry::metrics::metrics()
             .db_transactions
             .add(1, &[opentelemetry::KeyValue::new("outcome", "commit")]);


### PR DESCRIPTION
Part of #2698. A composition create's transaction held exactly ONE statement — the folded commit — whenever the envelope carries no accompanying attestations and the event outbox is off (the common case). A single SQL statement is atomic on its own, so the explicit transaction bought nothing and cost two round trips.

## What changed

`create_composition` acquires a plain pooled connection and runs the folded commit in autocommit when `envelope.attestations.is_empty() && !signing_ctx.outbox_enabled`; otherwise the explicit transaction path is unchanged (attestation inserts and the outbox row must stay atomic with the version). The versioning layer is untouched — both arms call the same `create`.

## Verified

pg_stat_statements against a live native server: 300 creates → exactly 300 merged pre-reads + 300 folded commit statements, zero `BEGIN`/`COMMIT` rows. A create is now two database statements end to end.

## Gates

`cargo fmt` · the exact CI clippy lane · `cargo nextest run -p ferroehr` 967/967 · the rustdoc gate with `--document-private-items`.