### PR TITLE
perf(signing): verify_on_read gains 'once' — the default verifies a version per process, not per read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,17 @@ workflow refuses a tag that has no matching section here.
 
 ### Changed
 
+- Read-time signature verification gains a fourth policy, `once`, and it is
+  the new effective default while signing is enabled: a version's server
+  signature is verified on its first read each process and the verdict is
+  remembered (a committed version is immutable), so later reads skip
+  recomputing the canonical form (~0.5 ms per VERSION read). A mismatch is
+  still a `500`. `strict` keeps its exact per-read meaning as an explicit
+  opt-in; the new `signing.verify_cache_capacity` key (default 65536, a few
+  megabytes when full, `0` = behave like `strict`) bounds the memory. Each
+  replica keeps its own verdicts, so horizontal scaling needs no
+  coordination.
+
 - A composition CREATE skips the explicit transaction when the commit is the
   one folded statement (no accompanying attestations, event outbox off — the
   common case): a single SQL statement is atomic on its own, so the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -385,7 +385,7 @@ pprof = { version = "0.15.0" }
 inferno = { version = "0.12", features = ["nameattr"] }
 
 # ── Caching, rate limiting, resilience ───────────────────────────────────────
-moka = { version = "0.12", features = ["future"] }   # Caffeine equivalent (template/WebTemplate cache)
+moka = { version = "0.12", features = ["future", "sync"] }   # Caffeine equivalent (template/WebTemplate cache + the sync verified-signature cache)
 quick_cache = "0.7.0"
 # Rate limiting for axum (GCRA via `governor`). `tonic` is in its default
 # feature set and we serve no gRPC, so only `axum` is enabled; `tracing` stays

--- a/app/ferroehr/assets/ferroehr.default.toml
+++ b/app/ferroehr/assets/ferroehr.default.toml
@@ -347,7 +347,11 @@ retired_key_paths = []       # e.g. ["/etc/ferroehr/signing-2025.pub.asc"]
 # longer recomputes is a 5xx integrity fault. Set explicitly to opt out:
 # `warn` (log + meter, still serve) or `off` (never check). Client-supplied
 # signatures are always stored verbatim and never re-verified.
-#? verify_on_read = "strict" # off | warn | strict (unset ⇒ strict when enabled)
+#? verify_on_read = "once" # off | warn | once | strict (unset ⇒ once when enabled)
+# How many verified signatures the `once` policy remembers (a committed version
+# is immutable, so a verdict is recomputed once per process, not on every
+# read). 0 disables the cache, making `once` behave like `strict`.
+verify_cache_capacity = 65536
 
 # ── [query] — AQL execution knobs ─────────────────────────────────────────────
 [query]

--- a/app/ferroehr/src/versioning/integrity.rs
+++ b/app/ferroehr/src/versioning/integrity.rs
@@ -191,13 +191,16 @@ fn sign_canonical(ctx: &SigningCtx<'_>, value: &Value) -> Result<Option<String>,
 /// author may have signed another agreed serialization we cannot recompute —
 /// master06 §Digital Signature / §Copying). Otherwise a no-op when
 /// `verify_on_read = off` or the version carries no signature. A `warn`
-/// mismatch logs + meters (`version_signature_invalid_total`); a `strict`
-/// mismatch is a 5xx integrity failure.
+/// mismatch logs + meters (`version_signature_invalid_total`); an `once` or
+/// `strict` mismatch is a 5xx integrity failure. Under `once` (the effective
+/// default with signing enabled) a verified signature is remembered for the
+/// process lifetime and the recompute is skipped on subsequent reads;
+/// `strict` recomputes on every read.
 ///
 /// # Errors
-/// [`ServiceError::Signing`] when `verify_on_read = strict` and the stored
-/// server signature fails verification, or (in any non-`off` mode) when the
-/// served version's canonical form cannot be recomputed.
+/// [`ServiceError::Signing`] when `verify_on_read` is `once` or `strict` and
+/// the stored server signature fails verification, or (in any non-`off` mode)
+/// when the served version's canonical form cannot be recomputed.
 pub(crate) fn verify_on_read(
     signer: &Signer,
     ov: &Value,
@@ -212,10 +215,19 @@ pub(crate) fn verify_on_read(
     let Some(signature) = signature else {
         return Ok(());
     };
+    // Under `once`, a committed version is immutable (master06 §The 'Virtual
+    // Version Tree'), so a signature that verified once this process needs no
+    // recompute; `warn`/`strict` recompute on every read.
+    if signer.verify_on_read() == VerifyOnRead::Once && signer.already_verified(signature) {
+        return Ok(());
+    }
     let canonical =
         openehr_rm::v1_2::common::change_control::version_impl::canonical_form_of_json(ov)
             .map_err(|e| ServiceError::SigningCanonical(e.to_string(), e))?;
     let verdict = signer.verify(&canonical, signature);
+    if !verdict.is_failure() && signer.verify_on_read() == VerifyOnRead::Once {
+        signer.remember_verified(signature);
+    }
     if verdict.is_failure() {
         crate::telemetry::metrics::metrics()
             .version_signature_invalid
@@ -227,7 +239,10 @@ pub(crate) fn verify_on_read(
             verdict = verdict.label(),
             "version signature failed verification (verify_on_read)"
         );
-        if signer.verify_on_read() == VerifyOnRead::Strict {
+        if matches!(
+            signer.verify_on_read(),
+            VerifyOnRead::Strict | VerifyOnRead::Once
+        ) {
             return Err(ServiceError::Signing(format!(
                 "stored version signature does not verify ({})",
                 verdict.label()

--- a/app/ferroehr/src/versioning/signature/config.rs
+++ b/app/ferroehr/src/versioning/signature/config.rs
@@ -51,7 +51,17 @@ pub enum VerifyOnRead {
     Off,
     /// Log + meter a mismatch (`version_signature_invalid_total`); still serve.
     Warn,
-    /// A mismatch is a 5xx integrity failure (the record is provably corrupt).
+    /// Verify each version ONCE per process and remember the verdict — a
+    /// committed version is immutable, so the recompute is skipped on
+    /// subsequent reads (capacity: [`SigningConfig::verify_cache_capacity`]).
+    /// A mismatch, when a verification does run, is the same 5xx integrity
+    /// failure as [`Self::Strict`]; a row tampered after its version already
+    /// verified is caught on the next uncached verification (process restart
+    /// or cache eviction), with the storage-parity sweep as the continuous
+    /// deep channel.
+    Once,
+    /// Recompute-and-compare on EVERY read; a mismatch is a 5xx integrity
+    /// failure (the record is provably corrupt).
     Strict,
 }
 
@@ -91,6 +101,15 @@ pub struct SigningConfig {
     /// when signing is enabled — the explicit "sign but never check" state is
     /// reachable only by deliberately setting `off`.
     pub verify_on_read: Option<VerifyOnRead>,
+    /// How many verified signatures the read path remembers, so an unchanged
+    /// stored version is re-verified once per process instead of on every
+    /// read. `0` disables the cache and every read recomputes the canonical
+    /// form. A version body is immutable once committed (RM common master06
+    /// §The 'Virtual Version Tree'), so a remembered verdict only ever skips
+    /// recomputing bytes that cannot have legitimately changed; the
+    /// storage-parity sweep remains the deep integrity channel for detecting
+    /// out-of-band tampering.
+    pub verify_cache_capacity: u64,
 }
 
 impl Default for SigningConfig {
@@ -103,6 +122,7 @@ impl Default for SigningConfig {
             key_passphrase_file: None,
             retired_key_paths: Vec::new(),
             verify_on_read: None,
+            verify_cache_capacity: 65_536,
         }
     }
 }
@@ -111,13 +131,14 @@ impl SigningConfig {
     /// The effective read-time verification policy, resolving the enabled-
     /// dependent default of an unset [`Self::verify_on_read`].
     ///
-    /// - unset + signing enabled → [`VerifyOnRead::Strict`] (our-own-design
+    /// - unset + signing enabled → [`VerifyOnRead::Once`] (our-own-design
     ///   integrity hardening: a served version whose stored server signature no
-    ///   longer recomputes is provably corrupt, so it fails loud rather than
-    ///   being silently served);
+    ///   longer recomputes fails loud, verified once per process because a
+    ///   committed version is immutable; `strict` opts into per-read
+    ///   recomputation);
     /// - unset + signing disabled → [`VerifyOnRead::Off`] (there are no server
     ///   signatures to verify);
-    /// - explicit `off` / `warn` / `strict` → honoured as configured.
+    /// - explicit `off` / `warn` / `once` / `strict` → honoured as configured.
     ///
     /// No openEHR spec governs read-time verification timing (RM common master06
     /// §Digital Signature) — our own design.
@@ -125,7 +146,7 @@ impl SigningConfig {
     pub fn effective_verify_on_read(&self) -> VerifyOnRead {
         match self.verify_on_read {
             Some(policy) => policy,
-            None if self.enabled => VerifyOnRead::Strict,
+            None if self.enabled => VerifyOnRead::Once,
             None => VerifyOnRead::Off,
         }
     }
@@ -136,14 +157,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn defaults_sign_on_digest_verify_strict_when_enabled() {
+    fn defaults_sign_on_digest_verify_once_when_enabled() {
         let c = SigningConfig::default();
         assert!(c.enabled);
         assert_eq!(c.mode, Mode::Digest);
         // The raw field is unset (None), but the effective policy resolves to
-        // strict for a signing-enabled server (#273 — our-own-design hardening).
+        // once for a signing-enabled server (#273 hardening; the once mode is
+        // the #2698 verified-signature cache).
         assert_eq!(c.verify_on_read, None);
-        assert_eq!(c.effective_verify_on_read(), VerifyOnRead::Strict);
+        assert_eq!(c.effective_verify_on_read(), VerifyOnRead::Once);
         assert!(c.key_path.is_none());
     }
 
@@ -155,8 +177,13 @@ mod tests {
             ..SigningConfig::default()
         };
         assert_eq!(disabled.effective_verify_on_read(), VerifyOnRead::Off);
-        // explicit off / warn are honoured even with signing enabled.
-        for policy in [VerifyOnRead::Off, VerifyOnRead::Warn, VerifyOnRead::Strict] {
+        // every explicit policy is honoured even with signing enabled.
+        for policy in [
+            VerifyOnRead::Off,
+            VerifyOnRead::Warn,
+            VerifyOnRead::Once,
+            VerifyOnRead::Strict,
+        ] {
             let c = SigningConfig {
                 verify_on_read: Some(policy),
                 ..SigningConfig::default()

--- a/app/ferroehr/src/versioning/signature/signer.rs
+++ b/app/ferroehr/src/versioning/signature/signer.rs
@@ -71,6 +71,13 @@ pub struct Signer {
     enabled: bool,
     verify_on_read: VerifyOnRead,
     pub(crate) mode: SignerMode,
+    /// Signatures that already verified once this process — a committed
+    /// version is immutable, so a remembered verdict skips recomputing the
+    /// canonical form on every subsequent read (`verify_on_read = once`).
+    /// Keyed by a 128-bit hash of the signature, so a full cache stays a few
+    /// megabytes at the default capacity. `None` when
+    /// `verify_cache_capacity = 0`.
+    verified: Option<moka::sync::Cache<u128, ()>>,
 }
 
 impl std::fmt::Debug for Signer {
@@ -79,6 +86,10 @@ impl std::fmt::Debug for Signer {
             .field("enabled", &self.enabled)
             .field("verify_on_read", &self.verify_on_read)
             .field("mode", &self.mode)
+            .field(
+                "verified_cache",
+                &self.verified.as_ref().map(moka::sync::Cache::entry_count),
+            )
             .finish()
     }
 }
@@ -121,6 +132,7 @@ impl Signer {
             enabled: config.enabled,
             verify_on_read: config.effective_verify_on_read(),
             mode,
+            verified: verified_cache(config.verify_cache_capacity),
         })
     }
 
@@ -135,6 +147,7 @@ impl Signer {
             enabled: config.enabled,
             verify_on_read: config.effective_verify_on_read(),
             mode: SignerMode::Digest,
+            verified: verified_cache(config.verify_cache_capacity),
         }
     }
 
@@ -169,6 +182,42 @@ impl Signer {
     pub fn verify(&self, canonical: &str, signature: &str) -> Verdict {
         verify::verify(&self.mode, canonical, signature)
     }
+
+    /// Whether `signature` already verified once this process (a cached
+    /// verdict; a committed version is immutable, so the recompute is skipped).
+    /// Always `false` when the cache is disabled.
+    #[must_use]
+    pub(crate) fn already_verified(&self, signature: &str) -> bool {
+        self.verified
+            .as_ref()
+            .is_some_and(|cache| cache.contains_key(&verified_key(signature)))
+    }
+
+    /// Remember a successful verification of `signature` for the process
+    /// lifetime (capacity-bounded LRU); a no-op when the cache is disabled.
+    pub(crate) fn remember_verified(&self, signature: &str) {
+        if let Some(cache) = &self.verified {
+            cache.insert(verified_key(signature), ());
+        }
+    }
+}
+
+/// The verified-signature cache for `capacity` entries, or `None` for `0`
+/// (every read recomputes the canonical form).
+fn verified_cache(capacity: u64) -> Option<moka::sync::Cache<u128, ()>> {
+    (capacity > 0).then(|| moka::sync::Cache::new(capacity))
+}
+
+/// The cache key for a verified signature: the first 16 bytes of its SHA-256,
+/// so the cache stores 16 bytes per entry instead of the signature text (an
+/// armored `OpenPGP` signature runs to hundreds of bytes). A 128-bit collision
+/// is cryptographically negligible.
+fn verified_key(signature: &str) -> u128 {
+    let hash = Sha256::digest(signature.as_bytes());
+    let (head, _) = hash.split_at(16);
+    let mut key = [0_u8; 16];
+    key.copy_from_slice(head);
+    u128::from_le_bytes(key)
 }
 
 /// The digest signature for `canonical`: `sha256:` + radix-64(SHA-256(bytes)).

--- a/app/ferroehr/tests/it/service_dump_load.rs
+++ b/app/ferroehr/tests/it/service_dump_load.rs
@@ -1283,6 +1283,7 @@ async fn attestations_round_trip_and_the_restored_signature_verifies() {
         key_passphrase_file: None,
         retired_key_paths: Vec::new(),
         verify_on_read: Some(VerifyOnRead::Strict),
+        verify_cache_capacity: 65_536,
     };
     let src_db = testkit::db().await.expect("testkit database");
     let source = FerroEhrService::new(src_db.pool())

--- a/app/ferroehr/tests/it/service_import.rs
+++ b/app/ferroehr/tests/it/service_import.rs
@@ -856,6 +856,7 @@ async fn a_signed_import_signs_the_wrapper_and_the_read_verifies_it() {
         key_passphrase_file: None,
         retired_key_paths: Vec::new(),
         verify_on_read: Some(VerifyOnRead::Strict),
+        verify_cache_capacity: 65_536,
     };
     let signer = Signer::from_config(&config).expect("digest signer");
     let target = FerroEhrService::new(target_db.pool()).with_signer(Arc::new(signer));

--- a/app/ferroehr/tests/it/service_signing.rs
+++ b/app/ferroehr/tests/it/service_signing.rs
@@ -375,6 +375,7 @@ async fn strict_verify_on_read_rejects_a_tampered_row() {
         key_passphrase_file: None,
         retired_key_paths: Vec::new(),
         verify_on_read: Some(VerifyOnRead::Strict),
+        verify_cache_capacity: 65_536,
     };
     let signer = Signer::from_config(&config).expect("strict signer");
     let svc = FerroEhrService::new(pool.clone()).with_signer(Arc::new(signer));
@@ -474,6 +475,7 @@ fn service_with_verify(pool: PgPool, policy: VerifyOnRead) -> FerroEhrService {
         key_passphrase_file: None,
         retired_key_paths: Vec::new(),
         verify_on_read: Some(policy),
+        verify_cache_capacity: 65_536,
     };
     let signer = Signer::from_config(&config).expect("signer");
     FerroEhrService::new(pool).with_signer(Arc::new(signer))
@@ -582,6 +584,7 @@ fn signing_disabled(pool: PgPool) -> FerroEhrService {
         key_passphrase_file: None,
         retired_key_paths: Vec::new(),
         verify_on_read: Some(VerifyOnRead::Off),
+        verify_cache_capacity: 65_536,
     };
     let signer = Signer::from_config(&config).expect("disabled signer");
     FerroEhrService::new(pool).with_signer(Arc::new(signer))
@@ -827,6 +830,65 @@ async fn at_committal_attestation_is_signed_and_a_tamper_is_caught() {
             })
         ),
         "an altered at-committal attestation must fail strict verify_on_read, got {tampered:?}"
+    );
+}
+
+/// The `once` policy's contract (the #2698 verified-signature cache; our own
+/// design — no openEHR spec governs read-time verification timing, RM common
+/// master06 §Digital Signature): a version verifies on its FIRST read this
+/// process and the verdict is remembered, so a row tampered AFTER that first
+/// read is served from the cached verdict — and a fresh process (a fresh
+/// `Signer`) detects the tamper on its own first, uncached verification.
+#[tokio::test]
+async fn once_verifies_first_read_and_a_fresh_process_catches_a_later_tamper() {
+    let db = testkit::db().await.expect("testkit database");
+    let pool = db.pool();
+    let svc = service_with_verify(pool.clone(), VerifyOnRead::Once);
+    let ehr_id = create_ehr(&svc).await;
+    let ehr_uuid = ferroehr::ids::EhrId(ehr_id.parse::<uuid::Uuid>().expect("ehr uuid"));
+
+    let mut version = uv(&composition("attested"), "249", None);
+    version.attestations = Some(vec![update_attestation("witnessed")]);
+    let ovid = svc
+        .create_composition(ehr_uuid, version)
+        .await
+        .expect("create_composition with an accompanying attestation")
+        .version_uid();
+
+    // First read verifies and caches the verdict.
+    svc.composition_version_envelope(ehr_uuid, ovid.parse().expect("ovid"))
+        .await
+        .expect("clean first read verifies");
+
+    // Tamper the stored attestation after the verdict was cached.
+    sqlx::query(
+        "UPDATE vo_attestation SET data = jsonb_set(data, '{reason,value}', '\"forged\"') \
+         WHERE at_committal",
+    )
+    .execute(&pool)
+    .await
+    .expect("tamper the at-committal attestation");
+
+    // The SAME process serves from the cached verdict — the documented `once`
+    // detection boundary.
+    svc.composition_version_envelope(ehr_uuid, ovid.parse().expect("ovid"))
+        .await
+        .expect("a cached verdict serves within the same process");
+
+    // A fresh Signer (a fresh process) has no cached verdict and catches it.
+    let fresh = service_with_verify(pool.clone(), VerifyOnRead::Once);
+    let caught = fresh
+        .composition_version_envelope(ehr_uuid, ovid.parse().expect("ovid"))
+        .await;
+    assert!(
+        matches!(
+            caught,
+            Err(SmError {
+                status: CallStatusType::Exception,
+                ..
+            })
+        ),
+        "a fresh process's first uncached read must catch the tamper, got {caught:?}"
     );
 }
 

--- a/app/ferroehr/tests/it/signing_pgp.rs
+++ b/app/ferroehr/tests/it/signing_pgp.rs
@@ -72,6 +72,7 @@ fn pgp_signer(armored_key: &str, passphrase: Option<&str>) -> Result<Signer, Sig
         key_passphrase_file: None,
         retired_key_paths: Vec::new(),
         verify_on_read: Some(VerifyOnRead::Strict),
+        verify_cache_capacity: 65_536,
     };
     Signer::from_config(&config)
 }
@@ -132,6 +133,7 @@ fn boot_fails_when_key_path_missing() {
         key_passphrase_file: None,
         retired_key_paths: Vec::new(),
         verify_on_read: Some(VerifyOnRead::Off),
+        verify_cache_capacity: 65_536,
     };
     assert!(matches!(
         Signer::from_config(&config),
@@ -171,6 +173,7 @@ fn boot_fails_on_missing_key_file() {
         key_passphrase_file: None,
         retired_key_paths: Vec::new(),
         verify_on_read: Some(VerifyOnRead::Off),
+        verify_cache_capacity: 65_536,
     };
     assert!(matches!(
         Signer::from_config(&config),
@@ -189,6 +192,7 @@ fn digest_mode_verify_matches_and_mismatches() {
         key_passphrase_file: None,
         retired_key_paths: Vec::new(),
         verify_on_read: Some(VerifyOnRead::Strict),
+        verify_cache_capacity: 65_536,
     };
     let signer = Signer::from_config(&config).expect("digest signer");
     let sig = signer.sign(CANONICAL).expect("sign");
@@ -236,6 +240,7 @@ fn signer_with_retired(active: &str, retired: &[&str]) -> Signer {
         key_passphrase_file: None,
         retired_key_paths: retired.iter().map(|cert| temp_file(cert)).collect(),
         verify_on_read: Some(VerifyOnRead::Strict),
+        verify_cache_capacity: 65_536,
     };
     Signer::from_config(&config).expect("build signer")
 }

--- a/website/book/src/installation/config-auth.md
+++ b/website/book/src/installation/config-auth.md
@@ -338,7 +338,8 @@ the server's own signatures **strict** by default.
 | `key_path` | path | unset | Armored secret key; **required for `pgp`** (a boot error otherwise). |
 | `key_passphrase` / `key_passphrase_file` | secret / path | unset | Key passphrase. At most one of the pair. |
 | `retired_key_paths` | list of path | `[]` | Armored **public** keys retired from signing and kept for verification, so versions signed before a key rotation keep verifying. |
-| `verify_on_read` | enum{off,warn,strict} | unset ⇒ `strict` when signing is enabled | Read-time recompute-and-compare policy for the server's own signatures. |
+| `verify_on_read` | enum{off,warn,once,strict} | unset ⇒ `once` when signing is enabled | Read-time recompute-and-compare policy for the server's own signatures. `once` remembers a verified version for the process (a committed version is immutable); `strict` recomputes on every read. |
+| `verify_cache_capacity` | u64 | `65536` | How many verified signatures the `once` policy remembers (a few megabytes when full). `0` disables the cache, making `once` behave like `strict`. |
 
 `retired_key_paths` exists because a stored `VERSION.signature` records no key
 identifier and is an immutable committed fact that cannot be re-issued;
@@ -348,12 +349,14 @@ takes a comma-separated list
 (`FERROEHR__SIGNING__RETIRED_KEY_PATHS=/keys/a.pub.asc,/keys/b.pub.asc`).
 
 > [!NOTE]
-> **`verify_on_read` resolves to `strict` when signing is enabled.** On every
-> read the server recomputes the signature of a version it signed and, on a
-> mismatch, returns a `500` integrity fault rather than silently serving a
-> provably corrupt record. Set it explicitly to `warn` (log + meter
-> `version_signature_invalid_total`, still serve) or `off` (never check) to opt
-> out. **Client-supplied signatures** (an author's own, or one carried by an
+> **`verify_on_read` resolves to `once` when signing is enabled.** The server
+> recomputes the signature of a version it signed on that version's first read
+> each process and, on a mismatch, returns a `500` integrity fault rather than
+> silently serving a provably corrupt record; because a committed version is
+> immutable, the verified verdict is then remembered and later reads skip the
+> recompute. Set it explicitly to `strict` (recompute on every read), `warn`
+> (log + meter `version_signature_invalid_total`, still serve) or `off` (never
+> check). **Client-supplied signatures** (an author's own, or one carried by an
 > imported version) are always stored verbatim and **never** re-verified,
 > whatever this setting says, because the author may have signed a different
 > agreed serialization.

--- a/website/book/src/signing/digest.md
+++ b/website/book/src/signing/digest.md
@@ -125,16 +125,22 @@ documents the report and its four defect values.
 
 ## Verification at read
 
-`signing.verify_on_read` resolves to `strict` whenever signing is enabled,
+`signing.verify_on_read` resolves to `once` whenever signing is enabled,
 so the default deployment checks its own digests. On a VERSION read the
 server rebuilds the envelope from the stored row, recomputes the canonical
 form, recomputes the digest, and compares.
 
-| `verify_on_read`                                | On a mismatch                                                                                                |
-|-------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
-| `strict` (the default while signing is enabled) | `500`; the record is provably corrupt and is not served                                                      |
-| `warn`                                          | logs at `error` level, increments `version_signature_invalid_total{verdict="digest_mismatch"}`, still serves |
-| `off`                                           | no check at all                                                                                              |
+| `verify_on_read`                              | On a mismatch                                                                                                |
+|-----------------------------------------------|--------------------------------------------------------------------------------------------------------------|
+| `once` (the default while signing is enabled) | `500` when a verification runs; a committed version is immutable, so a verified verdict is remembered for the process and the recompute is skipped on later reads (`verify_cache_capacity` entries, `0` = behave like `strict`) |
+| `strict`                                      | `500`; recomputed on every read; the record is provably corrupt and is not served                            |
+| `warn`                                        | logs at `error` level, increments `version_signature_invalid_total{verdict="digest_mismatch"}`, still serves |
+| `off`                                         | no check at all                                                                                              |
+
+Under `once`, a row tampered after its version already verified is caught by
+the next uncached verification (a process restart or cache eviction) and by
+the storage-parity sweep; each replica keeps its own in-process verdicts, so
+running several servers needs no coordination.
 
 Verification runs where the server serves a VERSION object: the
 `versioned_composition` and `versioned_ehr_status` version routes, their

--- a/website/book/src/signing/pgp.md
+++ b/website/book/src/signing/pgp.md
@@ -158,9 +158,11 @@ flowchart TD
     B -->|yes| S["serve"]
     B -->|no| C{"verify_on_read"}
     C -->|off| S
-    C -->|"warn / strict"| D{"a stored signature?"}
+    C -->|"warn / once / strict"| D{"a stored signature?"}
     D -->|no| S
-    D -->|yes| E["recompute the canonical form<br/>drop signature, RFC 8785 (JCS)"]
+    D -->|yes| D2{"once: verdict already cached?"}
+    D2 -->|yes| S
+    D2 -->|no| E["recompute the canonical form<br/>drop signature, RFC 8785 (JCS)"]
     E --> F{"stored value's format"}
     F -->|"sha256: prefix"| G["recompute the digest and compare"]
     F -->|"PGP armor"| H{"a PGP key configured?"}
@@ -171,10 +173,11 @@ flowchart TD
     I3 -->|"no: pgp_invalid"| L
     G --> K{"verdict"}
     J --> K
-    K -->|"match"| S
+    K -->|"match"| K2["once: remember the verdict"]
+    K2 --> S
     K -->|"failure"| L{"verify_on_read"}
     L -->|warn| M["log + version_signature_invalid_total,<br/>then serve"]
-    L -->|strict| N["500 integrity failure"]
+    L -->|"once / strict"| N["500 integrity failure"]
     S --> T["append attestations added after committal"]
     M --> T
     I --> T


### PR DESCRIPTION
Part of #2698. Strict read-time verification recomputed the JCS canonical form + digest on every read of the same immutable version, ~0.5 ms per VERSION read.

## What changed

- `verify_on_read` gains a fourth policy, **`once`**, now the effective default while signing is enabled: a version's server signature verifies on its first read each process, the verdict is remembered, and later reads skip the recompute. A mismatch when a verification runs is the same `500` as `strict`.
- `strict` keeps its exact per-read meaning as an explicit opt-in and never consults the cache; `warn`/`off` are unchanged. Client-supplied signatures stay never-verified.
- New key `signing.verify_cache_capacity` (default 65536, `0` = behave like `strict`). The cache stores a 128-bit hash of each verified signature, so it is a few megabytes even full — the server's ~51 MiB footprint stays put.
- Replica-safe by construction (owner rule): the cache holds a pure derivation of immutable data, so replicas converge with zero coordination and no shared cache service is introduced.
- Docs: the digest/pgp signing pages, the mermaid verification flow, the config reference, the default TOML template.

## Semantics, pinned by tests

The existing tamper test keeps pinning `strict` (tamper caught on the very next read). A new twin pins `once`: first read verifies, a later tamper is served from the cached verdict within the process, and a fresh process catches it on its first uncached verification. The storage-parity sweep remains the continuous deep channel.

## Measured

VERSION envelope read (65-node composition, keep-alive, native release): p50 **1547 → 867 µs**.

## Gates

`cargo fmt` · exact CI clippy lane · `cargo nextest run -p ferroehr` 968/968 · rustdoc with `--document-private-items` · config template-sync tests.