### PR TITLE
docs: point repo-checkout readers to the override behavior early

### DIFF
--- a/website/book/src/installation/compose.md
+++ b/website/book/src/installation/compose.md
@@ -10,6 +10,13 @@ authentication posture the quickstart ships with, the optional profiles and
 overlays, and the variables that tune them. For a step-by-step first run, see
 [Getting started](../getting-started.md).
 
+> [!NOTE]
+> This chapter describes the **standalone** `docker-compose.yml` downloaded
+> into an empty directory. If you're running `docker compose up` from a
+> checkout of the repository instead, `docker-compose.override.yml` is
+> merged in automatically and the behavior is different — see
+> [Repository development](#repository-development) below.
+
 <!-- toc -->
 
 > [!NOTE]


### PR DESCRIPTION
The quickstart intro promises "docker compose up pulls published images", which only holds for the standalone downloaded file. A reader running the same command from a repository checkout hits docker-compose.override.yml instead and gets a from-source build with a confusing "failed to resolve reference ...:local" warning, with the actual explanation buried in the Repository development section far below. Add an early pointer so that reader isn't misled by the intro.

## Checks

- [ ] `cargo fmt --all --check` · `cargo clippy --workspace --all-targets` · `cargo nextest run --workspace`
- [ ] No test weakened, skipped, or edited to route around a bug
- [ ] User-visible change → `CHANGELOG.md [Unreleased]` entry (else the `no-changelog` label)
- [ ] REST/config/CLI/deployment change → matching `website/book/src` page updated
- [ ] Implemented `docs/plans/*.md` plan file deleted (unless another open issue still consumes it)
- [ ] New issues opened from this work are linked as GitHub relationships (sub-issue / blocked-by via `scripts/gh/rel.sh`), not prose (`.claude/rules/issue-relationships.md`)
