### PR TITLE
feat(onboarding): a GitHub Codespace boots the published stack with one click

### DIFF
--- a/.claude/memory/caching-replica-safe-only.md
+++ b/.claude/memory/caching-replica-safe-only.md
@@ -1,0 +1,15 @@
+---
+name: caching-replica-safe-only
+description: Owner rule — only replica-safe in-process caches; nothing that breaks horizontal scaling; no shared cache service
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 61772e07-7f45-4d64-a77c-e5be26729532
+  modified: 2026-08-25T11:46:48.351Z
+---
+
+Owner directive (2026-08-25, during the #2698 perf program): never introduce caching that prevents running multiple server replicas ("do never use system caching because then you can't parallelize run and vertical scale it"), and no shared cache service (Valkey/Redis) — a shared-cache GET is its own network round trip, defeating the latency win.
+
+**Why:** FerroEHR must scale horizontally; any per-process state whose correctness depends on cross-replica invalidation makes replicas serve diverging answers.
+
+**How to apply:** An in-process cache is allowed only when it holds a pure derivation of IMMUTABLE data (e.g. the verified-signature cache: a committed version's body+signature never change, so every replica independently converges — no invalidation event exists). A cache over mutable facts (latest version, template store after re-upload) is only acceptable if invalidated through PostgreSQL itself (LISTEN/NOTIFY to evict local entries), never via a second stateful service and never TTL-only for correctness-bearing reads.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: FerroEHR contributors
+// SPDX-License-Identifier: MIT
+//
+// The tester sandbox (#2709): "Open in GitHub Codespaces" boots the published
+// FerroEHR images and forwards the API + admin console, so trying FerroEHR
+// needs nothing installed locally. This is deliberately NOT a Rust
+// development environment — repo development uses a local checkout and the
+// compose override (see website/book/src/installation/compose.md).
+//
+// COMPOSE_FILE pins every compose invocation in this container to the
+// standalone docker-compose.yml: a bare `docker compose up` inside a checkout
+// would otherwise merge docker-compose.override.yml and try a from-source
+// build (the trap documented at the top of the compose book page).
+//
+// Schema: https://containers.dev/implementors/json_reference
+{
+    "name": "FerroEHR tester sandbox",
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+    "features": {
+        "ghcr.io/devcontainers/features/docker-in-docker:4": {}
+    },
+    "containerEnv": {
+        "COMPOSE_FILE": "docker-compose.yml"
+    },
+    "hostRequirements": {
+        "cpus": 2,
+        "memory": "8gb",
+        "storage": "32gb"
+    },
+    // Pull the published images at create time (and during a prebuild, where
+    // configured), so the first start only has to boot them.
+    "onCreateCommand": "bash .devcontainer/pull-stack.sh",
+    // Start the stack on every container start, resume included.
+    "postStartCommand": "bash .devcontainer/start-stack.sh",
+    "forwardPorts": [8080, 3000],
+    "portsAttributes": {
+        "8080": {
+            "label": "FerroEHR API + Swagger UI",
+            "onAutoForward": "notify"
+        },
+        "3000": {
+            "label": "FerroEHR admin console",
+            "onAutoForward": "notify"
+        }
+    },
+    "otherPortsAttributes": {
+        "onAutoForward": "silent"
+    }
+}

--- a/.devcontainer/pull-stack.sh
+++ b/.devcontainer/pull-stack.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+#
+# Codespace create-time image pull (#2709): fetch the published quickstart
+# images once, so the first `postStartCommand` boot is fast. Explicit `-f`
+# keeps this on the standalone file even if COMPOSE_FILE is ever unset —
+# the repo's docker-compose.override.yml (from-source builds) must never
+# apply in the tester sandbox.
+set -Eeuo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+docker compose -f docker-compose.yml --profile admin-ui pull

--- a/.devcontainer/start-stack.sh
+++ b/.devcontainer/start-stack.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+#
+# Codespace start-time boot (#2709): bring the published quickstart stack up
+# and wait until the server reports healthy, then print where everything is.
+# Runs on every container start (postStartCommand), so a resumed Codespace
+# comes back serving without any manual step.
+set -Eeuo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+docker compose -f docker-compose.yml --profile admin-ui up -d --wait
+
+cat <<'EOF'
+
+FerroEHR is up.
+
+  API + Swagger UI   http://localhost:8080/ferroehr/rest/swagger-ui
+  Health             http://localhost:8080/health
+  Admin console      http://localhost:3000
+  Credentials        ferroehr / ferroehr
+
+In a Codespace, open the forwarded ports 8080 and 3000 from the PORTS panel.
+A two-minute walkthrough (create an EHR, upload a template, commit a
+composition, query it back) is in the docs: https://ferroehr.eu/docs/latest/getting-started.html
+EOF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
+- A one-click tester sandbox: opening the repository in a GitHub Codespace
+  boots the published quickstart stack (server, PostgreSQL 18, admin console)
+  automatically and forwards the API and console ports. The committed
+  `.devcontainer/` pins every compose command to the standalone
+  `docker-compose.yml`, so the sandbox runs release images rather than
+  building the checkout. Documented at *Installation → Try it in Codespaces*
+  and linked from the README quick start.
+
 - `POST {base}/admin/integrity/verify` sweeps the stored data for
   content-copy disagreement. Every version's content is stored twice — as
   the materialized document a point read serves and as the decomposed rows

--- a/README.md
+++ b/README.md
@@ -205,9 +205,13 @@ on the documentation site.
 
 ## Quick start
 
-Run the full stack (server + PostgreSQL 18) with Docker Compose: one
-downloaded file, no checkout (needs Compose 2.23.1+). Grab
-`docker-compose.yml` from the [latest release](https://github.com/rubentalstra/FerroEHR/releases/latest)
+No local setup at all: [open a GitHub Codespace](https://codespaces.new/rubentalstra/FerroEHR)
+and the published stack (server, PostgreSQL 18, admin console) boots in your
+browser. Details in [Try it in Codespaces](https://ferroehr.eu/docs/latest/installation/codespaces.html).
+
+Or run it locally with Docker Compose: one downloaded file, no checkout
+(needs Compose 2.23.1+). Grab `docker-compose.yml` from the
+[latest release](https://github.com/rubentalstra/FerroEHR/releases/latest)
 and start it:
 
 ```shell

--- a/website/book/src/SUMMARY.md
+++ b/website/book/src/SUMMARY.md
@@ -5,6 +5,7 @@
 - [Why FerroEHR exists](why-ferroehr.md)
 - [Getting started](getting-started.md)
 - [Installation](installation/index.md)
+  - [Try it in Codespaces](installation/codespaces.md)
   - [Docker Compose](installation/compose.md)
   - [Kubernetes & Helm](installation/kubernetes.md)
   - [Cluster hardening](installation/kubernetes-hardening.md)

--- a/website/book/src/installation/codespaces.md
+++ b/website/book/src/installation/codespaces.md
@@ -1,0 +1,58 @@
+# Try it in Codespaces
+
+The fastest way to try FerroEHR is a GitHub Codespace: one click boots the
+published images in your browser, with nothing installed on your machine.
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/rubentalstra/FerroEHR)
+
+<!-- toc -->
+
+## What you get
+
+Creating a Codespace on the FerroEHR repository starts a container that pulls
+the published quickstart images and runs `docker compose up` for you:
+
+- the FerroEHR server with a preconfigured PostgreSQL 18,
+- the admin console,
+- the Swagger UI for the full REST API.
+
+The stack boots automatically. When the terminal prints `FerroEHR is up.`,
+open the **PORTS** panel and follow the forwarded ports:
+
+| Port | What it serves |
+|---|---|
+| `8080` | the REST API, with the Swagger UI at `/ferroehr/rest/swagger-ui` |
+| `3000` | the admin console |
+
+Sign in with the quickstart credentials, `ferroehr` / `ferroehr`. From there
+the [Getting started](../getting-started.md) walkthrough applies unchanged:
+create an EHR, upload a template, commit a composition, and query it back
+with AQL, either from the Swagger UI or with `curl` in the Codespace
+terminal.
+
+## What it is, and what it is not
+
+The Codespace is a **tester sandbox** and always runs the published release
+images pinned in the standalone `docker-compose.yml`. It does not build the
+checkout you opened it on: the `COMPOSE_FILE` environment variable inside the
+container pins every `docker compose` command to that file, so the
+repository's development override (which switches to from-source builds) does
+not apply. To develop FerroEHR itself, use a local checkout as described
+under [Repository development](compose.md#repository-development).
+
+The Codespace runs on your own GitHub account. The smallest machine type
+(2 cores, 8 GB) is enough, and GitHub's free monthly Codespaces allowance
+covers a long evaluation. Stop or delete the Codespace when you are done;
+a stopped Codespace restarts the stack automatically on resume.
+
+## If the stack is not up
+
+The boot log is in the terminal that ran `start-stack.sh`. To restart the
+stack by hand:
+
+```bash
+bash .devcontainer/start-stack.sh
+```
+
+`docker compose ps` shows the three services; the server is healthy when
+`curl http://localhost:8080/health` answers `200`.

--- a/website/book/src/installation/index.md
+++ b/website/book/src/installation/index.md
@@ -6,6 +6,10 @@ provision: the binary links a pure-Rust TLS stack and needs no OpenSSL and no
 JVM, so all you choose is how to run it and where the database lives. This part
 covers the three paths and the full configuration surface.
 
+- **[Try it in Codespaces](codespaces.md):** one click boots the published
+  images in a GitHub Codespace in your browser, with the Swagger UI and admin
+  console forwarded. Nothing to install. Made for evaluating FerroEHR; a real
+  deployment uses one of the paths below.
 - **[Docker Compose](compose.md):** the fastest way to run the server plus a
   preconfigured PostgreSQL 18, for development and evaluation. One downloadable
   file that pulls the published images and needs no configuration. Optional


### PR DESCRIPTION
Closes #2709. Community ask from the tester thread: trying FerroEHR should need nothing installed locally.

## What ships

- **`.devcontainer/`**: base ubuntu image + the `docker-in-docker:4` feature (verified against the current containers.dev json_reference and the feature's own manifest). `onCreateCommand` pulls the published quickstart images; `postStartCommand` runs `docker compose -f docker-compose.yml --profile admin-ui up -d --wait` and prints the URLs and quickstart credentials. Ports 8080 (API + Swagger UI) and 3000 (admin console) forward with labels and `notify`; other ports forward silently. `hostRequirements` declares the smallest machine type (2 cores / 8 GB).
- **The Joost trap is fenced twice**: `COMPOSE_FILE=docker-compose.yml` in `containerEnv` pins even commands the tester types, and both scripts pass `-f` explicitly, so the repository's from-source override can not apply inside the sandbox.
- **Docs**: a new book page (*Installation → Try it in Codespaces*) with the Codespaces badge, ports table, credentials, the sandbox-vs-development boundary and a recovery section; the installation index and the README quick start link it.
- The hosted public sandbox half of the issue is split to #2710 with its own acceptance criteria (infra + budget are an owner decision).

## Verified

The exact scripts ran locally against a fresh volume: images pulled, `up --wait` reached all three services healthy, then `GET /health` = 200, the Swagger UI answered with its documented mount redirect, and the console answered on 3000. The Codespaces-side wiring (DinD, port forwarding, lifecycle order) follows the current official spec; a one-click test on github.com after merge is the last acceptance box to tick.

## Gates

`docs-claims` OK over the whole book; the site builds with the new page; changelog entry included.