### PR TITLE
feat(deploy): the Vercel container artifacts and the PORT convention for the hosted sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
+- The server understands the container-platform `PORT` convention: when
+  `PORT` is set (Vercel, Cloud Run, Heroku inject it), the server binds
+  `0.0.0.0:<PORT>`. It sits below `FERROEHR__SERVER__BIND`, which still wins
+  when both are set. A `Dockerfile.vercel` plus `vercel.json` ship for
+  Vercel's Container preset (the hosted sandbox), building the same
+  from-source path as the standard image onto the same distroless runtime.
+
 - A one-click tester sandbox: opening the repository in a GitHub Codespace
   boots the published quickstart stack (server, PostgreSQL 18, admin console)
   automatically and forwards the API and console ports. The committed

--- a/Dockerfile.vercel
+++ b/Dockerfile.vercel
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+#
+# The Vercel container build for the hosted demo sandbox (#2710) — the name
+# Dockerfile.vercel is Vercel's convention for its Container preset
+# (https://vercel.com/kb/guide/deploy-rust-on-vercel-with-docker). It mirrors
+# docker/Dockerfile's from-source path in the two ways the guide requires:
+# multi-stage with the toolchain excluded from the runtime image, and both
+# stages on the same OS family (Debian). The server reads Vercel's injected
+# `PORT` through the config loader's port convention and binds 0.0.0.0.
+# Vercel builds without BuildKit cache mounts on its own cache, so this file
+# uses plain RUN steps instead of docker/Dockerfile's mount-cached ones.
+#
+# The image serves a DEMO: no persistent filesystem exists on Vercel and the
+# database is an external PostgreSQL 18 DSN supplied as DATABASE_URL.
+
+FROM rust:1.97.1-slim-trixie@sha256:3b2879047d42784ca9403ad20c51ed3df361a50f1df96f5777d39b4e33aa65cd AS builder
+WORKDIR /app
+COPY . .
+# Parallelism capped like docker/Dockerfile: a single generated spec crate at
+# opt-level 3 holds gigabytes, and the build VM is small.
+ARG CARGO_BUILD_JOBS=2
+RUN cargo build --release --locked --jobs "${CARGO_BUILD_JOBS}" -p ferroehr-server \
+    && cp target/release/ferroehr /usr/local/bin/ferroehr \
+    && strip /usr/local/bin/ferroehr
+
+# Same digest-pinned distroless runtime as docker/Dockerfile: glibc + libgcc_s
+# (the binary links libgcc_s.so.1 for unwinding), non-root uid 65532.
+FROM gcr.io/distroless/cc-debian13:nonroot@sha256:d97bc0a941b8d4be647dc0ee75b264ddbb772f1ac5ba690a4309c00723b23775
+USER 65532:65532
+COPY --from=builder /usr/local/bin/ferroehr /usr/local/bin/ferroehr
+# Vercel injects PORT and routes traffic to it; 80 is its default container
+# port, so the fallback matches the platform (the config loader turns PORT
+# into a 0.0.0.0:<PORT> bind).
+ENV PORT=80
+ENTRYPOINT ["/usr/local/bin/ferroehr"]

--- a/app/ferroehr/src/config/alias.rs
+++ b/app/ferroehr/src/config/alias.rs
@@ -74,6 +74,11 @@ pub(super) const SECTIONS: &[&str] = &[
 /// deployment platform already sets; they sit BELOW their `FERROEHR__` forms
 /// within the env layer.
 /// `(external_name, canonical FERROEHR__ env form)`.
+///
+/// A third conventional name, `PORT` (the container-platform port
+/// convention), is handled in the loader directly: its value is only the
+/// port half, so it expands to a `0.0.0.0:<PORT>` bind instead of mapping
+/// 1:1 onto a canonical form.
 pub(super) const CONVENTIONAL: &[(&str, &str)] = &[
     ("DATABASE_URL", "FERROEHR__DB__URL"),
     ("RUST_LOG", "FERROEHR__LOG__FILTER"),

--- a/app/ferroehr/src/config/loader.rs
+++ b/app/ferroehr/src/config/loader.rs
@@ -157,6 +157,15 @@ pub fn assemble<S: std::hash::BuildHasher>(
                 .or_insert_with(|| value.clone());
         }
     }
+    // The PaaS port convention: container platforms (Vercel, Cloud Run,
+    // Heroku) inject `PORT` and route traffic to it. It carries only the port
+    // half, so it maps to an all-interfaces bind rather than joining the 1:1
+    // CONVENTIONAL table — still layered BELOW `FERROEHR__SERVER__BIND`.
+    if let Some(port) = env.get("PORT") {
+        alias_map
+            .entry("FERROEHR__SERVER__BIND".to_owned())
+            .or_insert_with(|| format!("0.0.0.0:{port}"));
+    }
 
     // The canonical (uniform-grammar) `FERROEHR__…` variables. Allowlisted
     // infra names never carry the double prefix, so the prefix check alone

--- a/app/ferroehr/src/config/mod.rs
+++ b/app/ferroehr/src/config/mod.rs
@@ -586,6 +586,24 @@ mod tests {
         assert_eq!(c.db.url.expose(), "postgres://b@h/y");
     }
 
+    #[test]
+    fn port_convention_expands_to_an_all_interfaces_bind() {
+        // PORT alone binds server.bind on all interfaces (the container-
+        // platform convention: Vercel/Cloud Run/Heroku inject only the port).
+        let c = assemble_ok(None, &env(&[("PORT", "3123")]), &[]);
+        assert_eq!(c.server.bind, "0.0.0.0:3123");
+        // FERROEHR__SERVER__BIND wins over PORT.
+        let c = assemble_ok(
+            None,
+            &env(&[
+                ("PORT", "3123"),
+                ("FERROEHR__SERVER__BIND", "127.0.0.1:9000"),
+            ]),
+            &[],
+        );
+        assert_eq!(c.server.bind, "127.0.0.1:9000");
+    }
+
     // ── 2. Mapping (the test class whose absence let the dead env form ship) ──
 
     #[test]

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "https://openapi.vercel.sh/vercel.json",
+    "services": {
+        "api": {
+            "root": ".",
+            "entrypoint": "Dockerfile.vercel",
+            "runtime": "container"
+        }
+    },
+    "rewrites": [
+        { "source": "/(.*)", "destination": { "service": "api" } }
+    ]
+}

--- a/website/book/src/installation/codespaces.md
+++ b/website/book/src/installation/codespaces.md
@@ -45,6 +45,24 @@ The Codespace runs on your own GitHub account. The smallest machine type
 covers a long evaluation. Stop or delete the Codespace when you are done;
 a stopped Codespace restarts the stack automatically on resume.
 
+## The hosted sandbox
+
+A public demo at `sandbox.ferroehr.eu` is being set up as the second
+zero-install path: no GitHub account needed, point any REST client at it.
+So everyone knows what it runs on and what to expect from it:
+
+| | |
+|---|---|
+| Compute | Vercel Fluid (a container function that scales to zero when idle) |
+| Database | Neon serverless PostgreSQL 18, region Frankfurt (`fra1`) |
+| Database plan | Neon free tier: 0.5 GB storage, up to 2 CU / 8 GB RAM, 100 CU-hours of compute per month |
+| Data durability | none by design; demo data only, wiped and reseeded on a schedule |
+
+Both layers scale to zero, so the first request after an idle period pays a
+double cold start and can take a few seconds; after that it responds at
+normal speed. The free compute budget means the sandbox may be unavailable
+near the end of a heavy month. It is a demo, never a place for real data.
+
 ## If the stack is not up
 
 The boot log is in the terminal that ran `start-stack.sh`. To restart the

--- a/website/book/src/installation/configuration.md
+++ b/website/book/src/installation/configuration.md
@@ -40,8 +40,10 @@ highest:
 3. **`FERROEHR_*` environment variables:** override individual keys.
 4. **`--set key=value` CLI flags** (repeatable), which win over everything.
 
-Two permanent conventional aliases sit *below* their `FERROEHR_` forms within
-layer 3: `DATABASE_URL` → `db.url` and `RUST_LOG` → `log.filter`. Nothing else
+Three conventional names sit *below* their `FERROEHR_` forms within layer 3:
+`DATABASE_URL` → `db.url`, `RUST_LOG` → `log.filter`, and `PORT` → a
+`0.0.0.0:<PORT>` value for `server.bind` (the port container platforms such
+as Vercel, Cloud Run and Heroku inject and route traffic to). Nothing else
 has a non-`FERROEHR_` name.
 
 ### The environment-variable mapping


### PR DESCRIPTION
Part of #2710 (the hosted sandbox at sandbox.ferroehr.eu, v4.0.3/P1). Everything the Vercel Container preset needs, per the official deploy-Rust-on-Vercel-with-Docker guide.

## What ships

- **`Dockerfile.vercel`**: multi-stage from-source build (same builder pattern and the same digest-pinned distroless runtime as `docker/Dockerfile`), plain RUN steps because Vercel builds without BuildKit cache mounts, `ENV PORT=80` matching the platform's default container port.
- **`vercel.json`**: the container service entry (`runtime: container`, entrypoint `Dockerfile.vercel`) plus the catch-all rewrite, both straight from the guide.
- **The `PORT` convention in the config loader**: the third conventional env name beside `DATABASE_URL` and `RUST_LOG`. It carries only a port, so it expands to a `0.0.0.0:<PORT>` bind rather than joining the 1:1 alias table, and sits below `FERROEHR__SERVER__BIND`. Env-mapping tests pin both the expansion and the precedence.
- **Docs**: the configuration page documents the convention; the Codespaces page documents the sandbox's published shape (Vercel Fluid + Neon PG18 free tier in `fra1`, the double scale-to-zero cold start, demo-only durability).

Deployment settings and the remaining rollout steps (reseed job, banner, cold-start measurement) are recorded on #2710.

## Gates

`cargo fmt` · the exact CI clippy lane · `cargo nextest run -p ferroehr` 969/969 · `docs-claims` OK · config template-sync green.