### PR TITLE
feat(deploy): the sandbox image is the published release plus a baked posture, and the loader speaks libpq

### DIFF
--- a/.claude/rules/changelog.md
+++ b/.claude/rules/changelog.md
@@ -32,7 +32,8 @@ optional:
   `CITATION.cff` completely whenever a `.zenodo.json` exists
   (<https://help.zenodo.org/docs/github/describe-software/zenodo-json/>),
   + the default image tags in `docker-compose.yml` — the `ghcr.io/…:X.Y.Z`
-  fallbacks the standalone quickstart pulls, guarded by
+  fallbacks the standalone quickstart pulls — and the `FROM ghcr.io/…:X.Y.Z`
+  pin in `Dockerfile.vercel` (the hosted sandbox), both guarded by
   `scripts/checks/compose-image-tags.sh` / the `compose-version-guard` CI
   job, + the book's pinned versions — `website/book/src/installation/
   kubernetes.md` pins the chart `--version` and `image.tag`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,18 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
-- The server understands the container-platform `PORT` convention: when
-  `PORT` is set (Vercel, Cloud Run, Heroku inject it), the server binds
-  `0.0.0.0:<PORT>`. It sits below `FERROEHR__SERVER__BIND`, which still wins
-  when both are set. A `Dockerfile.vercel` plus `vercel.json` ship for
-  Vercel's Container preset (the hosted sandbox), building the same
-  from-source path as the standard image onto the same distroless runtime.
+- The server understands two more deployment-platform conventions. `PORT`
+  (Vercel, Cloud Run, Heroku inject it) binds `0.0.0.0:<PORT>`, below
+  `FERROEHR__SERVER__BIND`. The libpq environment set (`PGHOST`, `PGUSER`,
+  `PGPASSWORD`, `PGDATABASE`, `PGPORT`, `PGSSLMODE` — what managed-Postgres
+  integrations such as Neon inject) assembles the database DSN when no URL
+  form is set; `DATABASE_URL` beats the assembled form and
+  `FERROEHR__DB__URL` beats both. A `Dockerfile.vercel` plus `vercel.json` ship for
+  Vercel's Container preset (the hosted sandbox); the Dockerfile references
+  the published release image, so Vercel's build step is a pull measured in
+  seconds instead of a half-hour Rust compile, and the sandbox runs the
+  exact bytes CI built, signed and tested. The release-cut guard now holds
+  its `FROM` tag to the workspace version alongside the compose defaults.
 
 - A one-click tester sandbox: opening the repository in a GitHub Codespace
   boots the published quickstart stack (server, PostgreSQL 18, admin console)

--- a/Dockerfile.vercel
+++ b/Dockerfile.vercel
@@ -3,34 +3,23 @@
 #
 # The Vercel container build for the hosted demo sandbox (#2710) — the name
 # Dockerfile.vercel is Vercel's convention for its Container preset
-# (https://vercel.com/kb/guide/deploy-rust-on-vercel-with-docker). It mirrors
-# docker/Dockerfile's from-source path in the two ways the guide requires:
-# multi-stage with the toolchain excluded from the runtime image, and both
-# stages on the same OS family (Debian). The server reads Vercel's injected
-# `PORT` through the config loader's port convention and binds 0.0.0.0.
-# Vercel builds without BuildKit cache mounts on its own cache, so this file
-# uses plain RUN steps instead of docker/Dockerfile's mount-cached ones.
+# (https://vercel.com/kb/guide/deploy-rust-on-vercel-with-docker). Vercel
+# always builds a Dockerfile and pushes the result to its own registry
+# (https://vercel.com/docs/functions/container-images), so this file
+# references the PUBLISHED image GitHub CI already compiled, signed and
+# tested: Vercel's build step is a pull and retag measured in seconds, and
+# the sandbox runs the exact release bytes. The tag is the current release
+# and bumps at every release cut alongside the docker-compose.yml defaults
+# (the compose-version-guard covers both files).
 #
 # The image serves a DEMO: no persistent filesystem exists on Vercel and the
-# database is an external PostgreSQL 18 DSN supplied as DATABASE_URL.
+# database is an external PostgreSQL 18 DSN supplied as FERROEHR__DB__URL.
 
-FROM rust:1.97.1-slim-trixie@sha256:3b2879047d42784ca9403ad20c51ed3df361a50f1df96f5777d39b4e33aa65cd AS builder
-WORKDIR /app
-COPY . .
-# Parallelism capped like docker/Dockerfile: a single generated spec crate at
-# opt-level 3 holds gigabytes, and the build VM is small.
-ARG CARGO_BUILD_JOBS=2
-RUN cargo build --release --locked --jobs "${CARGO_BUILD_JOBS}" -p ferroehr-server \
-    && cp target/release/ferroehr /usr/local/bin/ferroehr \
-    && strip /usr/local/bin/ferroehr
+FROM ghcr.io/rubentalstra/ferroehr:4.0.2
 
-# Same digest-pinned distroless runtime as docker/Dockerfile: glibc + libgcc_s
-# (the binary links libgcc_s.so.1 for unwinding), non-root uid 65532.
-FROM gcr.io/distroless/cc-debian13:nonroot@sha256:d97bc0a941b8d4be647dc0ee75b264ddbb772f1ac5ba690a4309c00723b23775
-USER 65532:65532
-COPY --from=builder /usr/local/bin/ferroehr /usr/local/bin/ferroehr
-# Vercel injects PORT and routes traffic to it; 80 is its default container
-# port, so the fallback matches the platform (the config loader turns PORT
-# into a 0.0.0.0:<PORT> bind).
+# The sandbox posture (demo user, no admin/management surface, port 80 —
+# Vercel's default container port). The DSN arrives as FERROEHR__DB__URL
+# from the Vercel project settings.
+COPY deploy/vercel/ferroehr.sandbox.toml /etc/ferroehr/ferroehr.toml
+ENV FERROEHR_CONFIG=/etc/ferroehr/ferroehr.toml
 ENV PORT=80
-ENTRYPOINT ["/usr/local/bin/ferroehr"]

--- a/app/ferroehr/src/config/loader.rs
+++ b/app/ferroehr/src/config/loader.rs
@@ -166,6 +166,39 @@ pub fn assemble<S: std::hash::BuildHasher>(
             .entry("FERROEHR__SERVER__BIND".to_owned())
             .or_insert_with(|| format!("0.0.0.0:{port}"));
     }
+    // The libpq environment convention (PostgreSQL's own variable set,
+    // https://www.postgresql.org/docs/current/libpq-envars.html): managed
+    // Postgres integrations (Neon on Vercel among them) inject PGHOST/PGUSER/
+    // PGPASSWORD/PGDATABASE instead of a URL. Assembled into a DSN BELOW both
+    // URL forms — `DATABASE_URL` overwrites this entry, `FERROEHR__DB__URL`
+    // overrides the whole layer — so an explicit URL always wins.
+    if let Some(host) = env.get("PGHOST") {
+        let mut dsn = String::from("postgres://");
+        if let Some(user) = env.get("PGUSER") {
+            dsn.push_str(&urlencoding::encode(user));
+            if let Some(password) = env.get("PGPASSWORD") {
+                dsn.push(':');
+                dsn.push_str(&urlencoding::encode(password));
+            }
+            dsn.push('@');
+        }
+        dsn.push_str(host);
+        if let Some(port) = env.get("PGPORT") {
+            dsn.push(':');
+            dsn.push_str(port);
+        }
+        dsn.push('/');
+        dsn.push_str(env.get("PGDATABASE").map_or("postgres", String::as_str));
+        if let Some(sslmode) = env.get("PGSSLMODE") {
+            dsn.push_str("?sslmode=");
+            dsn.push_str(sslmode);
+        }
+        // `or_insert_with`: a `DATABASE_URL` already claimed this entry in the
+        // CONVENTIONAL loop above, and it outranks the assembled form.
+        alias_map
+            .entry("FERROEHR__DB__URL".to_owned())
+            .or_insert(dsn);
+    }
 
     // The canonical (uniform-grammar) `FERROEHR__…` variables. Allowlisted
     // infra names never carry the double prefix, so the prefix check alone

--- a/app/ferroehr/src/config/mod.rs
+++ b/app/ferroehr/src/config/mod.rs
@@ -587,6 +587,50 @@ mod tests {
     }
 
     #[test]
+    fn libpq_convention_assembles_a_dsn_below_the_url_forms() {
+        // PGHOST + friends alone assemble the DSN (the libpq environment
+        // convention managed-Postgres integrations inject), password
+        // percent-encoded.
+        let c = assemble_ok(
+            None,
+            &env(&[
+                ("PGHOST", "db.example.neon.tech"),
+                ("PGUSER", "demo"),
+                ("PGPASSWORD", "p@ss/w"),
+                ("PGDATABASE", "ferroehr"),
+                ("PGSSLMODE", "require"),
+            ]),
+            &[],
+        );
+        assert_eq!(
+            c.db.url.expose(),
+            "postgres://demo:p%40ss%2Fw@db.example.neon.tech/ferroehr?sslmode=require"
+        );
+        // DATABASE_URL wins over the assembled form.
+        let c = assemble_ok(
+            None,
+            &env(&[
+                ("PGHOST", "db.example.neon.tech"),
+                ("PGUSER", "demo"),
+                ("DATABASE_URL", "postgres://a@h/x"),
+            ]),
+            &[],
+        );
+        assert_eq!(c.db.url.expose(), "postgres://a@h/x");
+        // FERROEHR__DB__URL wins over everything.
+        let c = assemble_ok(
+            None,
+            &env(&[
+                ("PGHOST", "db.example.neon.tech"),
+                ("DATABASE_URL", "postgres://a@h/x"),
+                ("FERROEHR__DB__URL", "postgres://b@h/y"),
+            ]),
+            &[],
+        );
+        assert_eq!(c.db.url.expose(), "postgres://b@h/y");
+    }
+
+    #[test]
     fn port_convention_expands_to_an_all_interfaces_bind() {
         // PORT alone binds server.bind on all interfaces (the container-
         // platform convention: Vercel/Cloud Run/Heroku inject only the port).

--- a/deploy/vercel/ferroehr.sandbox.toml
+++ b/deploy/vercel/ferroehr.sandbox.toml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+#
+# The hosted-sandbox posture (#2710, sandbox.ferroehr.eu), baked into the
+# Vercel image by Dockerfile.vercel. It differs from the compose quickstart
+# where a PUBLIC endpoint demands it: the admin API and the management
+# introspection stay OFF (defaults), so the public demo credentials can read
+# and write clinical data and nothing else. The database DSN comes from the
+# environment (FERROEHR__DB__URL), never from this file.
+
+[server]
+# Vercel's default container port; the PORT environment convention lands on
+# the same value at runtime.
+bind = "0.0.0.0:80"
+# Browser tinkering against the demo is the point.
+cors_permissive = true
+
+[auth]
+enabled = true
+
+# The demo user: ferroehr / ferroehr (the hash is Argon2id of "ferroehr").
+# Public by design; the sandbox holds demo data only and is wiped on a
+# schedule.
+[[auth.basic.users]]
+username = "ferroehr"
+password_hash = "$argon2id$v=19$m=19456,t=2,p=1$ZmVycm9laHJEZXZTYWx0$be5nPwWjfUl1qvSrvkvqvdMOuCgM0VFcN/VN4MFLjT8"
+roles = ["USER"]
+
+# Authentication only, no role gate — one demo user, no admin surface exists
+# to separate (admin + management stay disabled above by default).
+[authz.rbac]
+enabled = false

--- a/scripts/checks/compose-image-tags.sh
+++ b/scripts/checks/compose-image-tags.sh
@@ -8,11 +8,14 @@
 # quickstart pinned to the previous release. This guard fails when any default
 # tag in the `${FERROEHR_*_IMAGE:-ghcr.io/...:X.Y.Z}` fallbacks disagrees with
 # the workspace version in Cargo.toml (.claude/rules/changelog.md §Cutting a
-# release). Dependency-free: grep + sed only.
+# release). Dockerfile.vercel pins the same published image for the hosted
+# sandbox, so its FROM tag is held to the same version. Dependency-free:
+# grep + sed only.
 set -Eeuo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
+VERCEL_FILE="$ROOT_DIR/Dockerfile.vercel"
 MANIFEST="$ROOT_DIR/Cargo.toml"
 
 version="$(sed -nE 's/^version = "(.*)"$/\1/p' "$MANIFEST" | head -1)"
@@ -39,5 +42,19 @@ for var in FERROEHR_IMAGE FERROEHR_POSTGRES_IMAGE FERROEHR_ADMIN_UI_IMAGE; do
     echo "$var default $ref matches the workspace version."
   fi
 done
+
+vercel_ref="$(grep -oE '^FROM ghcr\.io/[^ ]+' "$VERCEL_FILE" | head -1 | sed 's/^FROM //')"
+if [ -z "$vercel_ref" ]; then
+  echo "::error::$VERCEL_FILE declares no ghcr.io FROM reference" >&2
+  rc=1
+else
+  vercel_tag="${vercel_ref##*:}"
+  if [ "$vercel_tag" != "$version" ]; then
+    echo "::error::Dockerfile.vercel pins '$vercel_ref' (tag $vercel_tag) but the workspace version is $version — the release cut bumps it with the compose tags (.claude/rules/changelog.md)." >&2
+    rc=1
+  else
+    echo "Dockerfile.vercel FROM $vercel_ref matches the workspace version."
+  fi
+fi
 
 exit "$rc"

--- a/website/book/src/installation/configuration.md
+++ b/website/book/src/installation/configuration.md
@@ -40,11 +40,20 @@ highest:
 3. **`FERROEHR_*` environment variables:** override individual keys.
 4. **`--set key=value` CLI flags** (repeatable), which win over everything.
 
-Three conventional names sit *below* their `FERROEHR_` forms within layer 3:
-`DATABASE_URL` → `db.url`, `RUST_LOG` → `log.filter`, and `PORT` → a
-`0.0.0.0:<PORT>` value for `server.bind` (the port container platforms such
-as Vercel, Cloud Run and Heroku inject and route traffic to). Nothing else
-has a non-`FERROEHR_` name.
+Some conventional names sit *below* their `FERROEHR_` forms within layer 3:
+
+- `DATABASE_URL` → `db.url`, and `RUST_LOG` → `log.filter`.
+- `PORT` → a `0.0.0.0:<PORT>` value for `server.bind` (the port container
+  platforms such as Vercel, Cloud Run and Heroku inject and route traffic
+  to).
+- The [libpq environment set](https://www.postgresql.org/docs/current/libpq-envars.html)
+  (`PGHOST`, `PGUSER`, `PGPASSWORD`, `PGDATABASE`, `PGPORT`, `PGSSLMODE`),
+  which managed-Postgres integrations such as Neon inject: when `PGHOST` is
+  set and no URL form is, the server assembles the DSN from them. An
+  explicit `DATABASE_URL` beats the assembled form, and `FERROEHR__DB__URL`
+  beats both.
+
+Nothing else has a non-`FERROEHR_` name.
 
 ### The environment-variable mapping
 


### PR DESCRIPTION
Part of #2710. Three corrections to the first Vercel cut (#2712), each verified against official documentation or a live container.

## Vercel never deploys a prebuilt image, so the Dockerfile references one

The container-images documentation is explicit: Vercel builds the Dockerfile and pushes to its own registry; no image field exists. `Dockerfile.vercel` therefore now reads `FROM ghcr.io/rubentalstra/ferroehr:4.0.2` — the build becomes a pull measured in seconds instead of a half-hour workspace compile on Vercel's builders, and the sandbox runs the exact bytes CI compiled, signed and tested. `compose-image-tags.sh` (the `compose-version-guard` lane) now holds that `FROM` tag to the workspace version, and the release procedure names it beside the compose bumps.

## The sandbox posture is baked into the image

A zero-config boot refuses loudly (auth on, no mechanism configured): the compose quickstart's demo user lives in compose's inline config, which Vercel has no equivalent of, and Basic users are file-only by the env grammar. `deploy/vercel/ferroehr.sandbox.toml` bakes the public-demo posture: the demo user, `bind 0.0.0.0:80` (Vercel's default container port, working on the current release before the `PORT` convention ships), permissive CORS, and deliberately NO admin API and NO management surface — a public credential must not reach either. Smoke-tested on the built image: `/health` 200, authenticated EHR create 201, the admin route 405, `/management` 404.

## The loader speaks libpq

The Neon Vercel integration injects PostgreSQL's own libpq variable set (`PGHOST`, `PGUSER`, `PGPASSWORD`, `PGDATABASE`, …) rather than a URL our loader read. The loader now assembles the DSN from them when no URL form is set (password percent-encoded via the sanctioned codec), layered below both URL forms: `DATABASE_URL` beats the assembled DSN, `FERROEHR__DB__URL` beats both. Env-mapping tests pin all three layers, and the configuration page documents the convention. Result: the Neon integration works with zero hand-copied variables.

## Gates

`cargo fmt` · the exact CI clippy lane · config suite 127/127 · `docs-claims` OK · `compose-image-tags` green over the new pin.