### PR TITLE
ci(deploy): the sandbox deploys on release tags only — automatic Vercel deployments are off

### DIFF
--- a/.github/workflows/deploy-sandbox.yml
+++ b/.github/workflows/deploy-sandbox.yml
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+#
+# Deploy the hosted sandbox (sandbox.ferroehr.eu, #2710) to Vercel — on
+# release tags ONLY. Automatic Vercel deployments are off entirely
+# (vercel.json `git.deploymentEnabled: false`), so no PR or branch push ever
+# deploys; this lane is the one deploy path, per Vercel's own tag-based
+# recipe (vercel.com/kb/guide/can-you-deploy-based-on-tags-releases-on-vercel):
+# `vercel pull` + `vercel build` + `vercel deploy --prebuilt --prod`.
+#
+# The tag also publishes the ghcr.io image Dockerfile.vercel references, so
+# the deploy first waits for containers.yml to finish for this tag — the
+# same wait the chart lane uses (build-chart.yml).
+#
+# Secrets (Vercel account settings → the linked project):
+#   VERCEL_TOKEN, VERCEL_ORG_ID, VERCEL_PROJECT_ID
+#
+# Publish-lane rules (reliability.md §build pipeline): no build cache is
+# restored, every action is SHA-pinned, contexts reach `run:` through `env:`.
+
+name: Deploy sandbox
+
+on:
+  push:
+    tags: ["v*"]
+  # Manual redeploys (a config-only sandbox change between releases).
+  workflow_dispatch: {}
+
+permissions: {}
+
+concurrency:
+  group: deploy-sandbox
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: vercel deploy
+    runs-on: ubuntu-latest
+    environment: vercel-sandbox
+    permissions:
+      contents: read
+      actions: read # read containers.yml's run status for this tag
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # The image Dockerfile.vercel references is published by containers.yml
+      # on the same tag; deploying before it lands would fail the Vercel
+      # build on a missing FROM. Same selection-by-tag wait as the chart
+      # lane (build-chart.yml).
+      - name: Wait for the image lane to publish this tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          deadline=$(( $(date +%s) + 3600 ))
+          run_id=""
+          until [ -n "$run_id" ]; do
+            run_id=$(gh api \
+              "/repos/${REPO}/actions/workflows/containers.yml/runs?head_sha=${HEAD_SHA}&per_page=100" \
+              --jq '[.workflow_runs[] | select(.head_branch == env.REF_NAME)] | sort_by(.run_number) | last | .id // empty')
+            [ -n "$run_id" ] && break
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "::error::no containers.yml run exists for tag ${REF_NAME} — the image the sandbox deploys is never going to be published." >&2
+              exit 1
+            fi
+            echo "waiting for the containers.yml run for ${REF_NAME} to appear"
+            sleep 15
+          done
+          while :; do
+            status=$(gh api "/repos/${REPO}/actions/runs/${run_id}" --jq .status)
+            if [ "$status" = "completed" ]; then
+              conclusion=$(gh api "/repos/${REPO}/actions/runs/${run_id}" --jq .conclusion)
+              if [ "$conclusion" != "success" ]; then
+                echo "::error::containers.yml run ${run_id} for ${REF_NAME} concluded ${conclusion} — not deploying the sandbox on an unpublished image." >&2
+                exit 1
+              fi
+              break
+            fi
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "::error::containers.yml run ${run_id} for ${REF_NAME} did not complete within an hour." >&2
+              exit 1
+            fi
+            echo "containers.yml run ${run_id} is ${status}; waiting"
+            sleep 30
+          done
+
+      - name: Install the Vercel CLI
+        # zizmor: ignore[adhoc-packages] -- exact-version-pinned CLI install;
+        # Vercel ships no official pinned action and a global CLI has no
+        # lockfile to install from.
+        run: npm install -g vercel@59.5.0
+
+      - name: Deploy
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
+          vercel build --prod --token="$VERCEL_TOKEN"
+          vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ workflow refuses a tag that has no matching section here.
   seconds instead of a half-hour Rust compile, and the sandbox runs the
   exact bytes CI built, signed and tested. The release-cut guard now holds
   its `FROM` tag to the workspace version alongside the compose defaults.
+  Automatic Vercel deployments are off entirely (no per-PR previews); the
+  sandbox deploys through a release-tag workflow that waits for the image
+  publish, so it always runs the latest release.
 
 - A one-click tester sandbox: opening the repository in a GitHub Codespace
   boots the published quickstart stack (server, PostgreSQL 18, admin console)

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,8 @@
 {
     "$schema": "https://openapi.vercel.sh/vercel.json",
+    "git": {
+        "deploymentEnabled": false
+    },
     "services": {
         "api": {
             "root": ".",

--- a/website/book/src/installation/codespaces.md
+++ b/website/book/src/installation/codespaces.md
@@ -63,6 +63,9 @@ double cold start and can take a few seconds; after that it responds at
 normal speed. The free compute budget means the sandbox may be unavailable
 near the end of a heavy month. It is a demo, never a place for real data.
 
+The sandbox deploys on release tags only, so it always runs the latest
+FerroEHR release rather than a development snapshot.
+
 ## If the stack is not up
 
 The boot log is in the terminal that ran `start-stack.sh`. To restart the


### PR DESCRIPTION
Part of #2710. No Vercel deployment should run per PR; the sandbox tracks releases.

## What changed

- **`vercel.json` sets `git.deploymentEnabled: false`** — the documented switch that turns off every automatic deployment, previews included (verified against the Git-configuration reference).
- **`deploy-sandbox.yml`**: the one deploy path, Vercel's own tag-based recipe. On a `v*` tag it first waits for `containers.yml` to publish that tag's image — the same selection-by-tag wait the chart lane uses, because `Dockerfile.vercel`'s `FROM` references the just-released tag and deploying earlier fails on a missing image — then `vercel pull` / `vercel build --prod` / `vercel deploy --prebuilt --prod` with the exact-pinned CLI (59.5.0, current on npm). `workflow_dispatch` covers config-only redeploys between releases.
- The book's sandbox section states the release-only cadence.

## Security posture

Publish-lane rules: `permissions: {}` top-level with minimal per-job grants, SHA-pinned checkout, `persist-credentials: false`, every context through `env:`, no cache restored. zizmor clean with one adjudicated inline ignore (`adhoc-packages`: a version-pinned global CLI has no lockfile; Vercel ships no official pinned action). actionlint clean.

## Owner action

Add three secrets to the `vercel-sandbox` GitHub environment: `VERCEL_TOKEN` (account token), `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` (both from the Vercel project settings).