### PR TITLE
fix(sandbox): the reseed rides out stale serverless instances

### DIFF
--- a/scripts/sandbox/reseed.sh
+++ b/scripts/sandbox/reseed.sh
@@ -8,6 +8,12 @@
 # commits each one's committed example composition into a handful of fresh
 # EHRs.
 #
+# Every request retries: right after the nightly wipe, serverless instances
+# booted BEFORE the wipe keep serving until they idle out, and the platform
+# load-balances across old and fresh instances — a request landing on a
+# stale one answers 5xx until it recycles (observed live, #2710). Retrying
+# for a few minutes rides that window out.
+#
 # Environment: SANDBOX_BASE (default https://sandbox.ferroehr.eu),
 # SANDBOX_USER / SANDBOX_PASS (default the public demo credentials).
 set -Eeuo pipefail
@@ -28,16 +34,47 @@ TEMPLATES=(
 )
 EHRS=3
 COMPOSITIONS_PER_EXAMPLE=2
+ATTEMPTS=12
+RETRY_DELAY=15
+
+# POST with retry; prints the final status code. `$1` = a label, `$2` = the
+# URL, remaining args go to curl verbatim. Retries any 5xx/connection
+# failure; any non-5xx answer is final.
+post_retry() {
+  local label="$1" url="$2"
+  shift 2
+  local attempt code
+  for attempt in $(seq 1 "$ATTEMPTS"); do
+    code=$(curl -sS -m 120 -u "$AUTH" -o /dev/null -w '%{http_code}' -X POST "$url" "$@" || echo 000)
+    case "$code" in
+      5?? | 000)
+        echo "  $label answered $code (attempt $attempt/$ATTEMPTS); a stale instance may still be serving — retrying" >&2
+        sleep "$RETRY_DELAY"
+        ;;
+      *)
+        printf '%s' "$code"
+        return 0
+        ;;
+    esac
+  done
+  printf '%s' "$code"
+}
 
 echo "==> seeding $BASE"
 
 # The demo EHRs, shared across every template so each carries a mixed record.
 ehrs=()
 for e in $(seq 1 "$EHRS"); do
-  ehr=$(curl -sS -m 60 -u "$AUTH" -X POST "$BASE/ehr" -H 'Prefer: return=minimal' \
-    -D- -o /dev/null | tr -d '\r' | awk -F'/ehr/' 'tolower($0) ~ /^location/{print $2}' | tr -d ' ')
+  ehr=""
+  for attempt in $(seq 1 "$ATTEMPTS"); do
+    ehr=$(curl -sS -m 60 -u "$AUTH" -X POST "$BASE/ehr" -H 'Prefer: return=minimal' \
+      -D- -o /dev/null 2>/dev/null | tr -d '\r' | awk -F'/ehr/' 'tolower($0) ~ /^location/{print $2}' | tr -d ' ') || true
+    [ -n "$ehr" ] && break
+    echo "  EHR creation returned no Location (attempt $attempt/$ATTEMPTS); retrying" >&2
+    sleep "$RETRY_DELAY"
+  done
   if [ -z "$ehr" ]; then
-    echo "::error::EHR creation returned no Location (is the server up and migrated?)" >&2
+    echo "::error::EHR creation kept failing after $ATTEMPTS attempts — the sandbox is not serving writes." >&2
     exit 1
   fi
   ehrs+=("$ehr")
@@ -51,8 +88,7 @@ for slug in "${TEMPLATES[@]}"; do
     echo "::error::missing template pair for $slug in $TPL_DIR" >&2
     exit 1
   }
-  code=$(curl -sS -m 120 -u "$AUTH" -o /dev/null -w '%{http_code}' \
-    -X POST "$BASE/definition/template/adl1.4" \
+  code=$(post_retry "template $slug" "$BASE/definition/template/adl1.4" \
     -H 'Content-Type: application/xml' --data-binary @"$opt")
   case "$code" in
     201 | 204 | 409) echo "template $slug -> $code" ;;
@@ -64,8 +100,7 @@ for slug in "${TEMPLATES[@]}"; do
 
   for ehr in "${ehrs[@]}"; do
     for c in $(seq 1 "$COMPOSITIONS_PER_EXAMPLE"); do
-      code=$(curl -sS -m 120 -u "$AUTH" -o /dev/null -w '%{http_code}' \
-        -X POST "$BASE/ehr/$ehr/composition" \
+      code=$(post_retry "composition $slug" "$BASE/ehr/$ehr/composition" \
         -H 'Content-Type: application/json' -H 'Prefer: return=minimal' \
         --data-binary @"$example")
       if [ "$code" != "201" ]; then


### PR DESCRIPTION
Part of #2710. The first live reseed run (32862157609) failed on its opening request: the readiness gate correctly went 503 → 200 (a fresh instance had re-run the migrations), but the next request was load-balanced onto a pre-wipe instance still holding connections to the dropped schemas. Stale instances keep serving until they idle out, and probes keep waking them.

Every seed request now retries 5xx/connection-failure outcomes (12 attempts, 15 s apart — three minutes, longer than the stale window), while any non-5xx answer stays final so a genuine refusal still fails loudly. Error messages now carry the status code they saw. No changelog entry (`no-changelog`: an internal ops script fix, no user-visible behaviour).