### PR TITLE
ci(sandbox): the release-image race is closed — skip until the image exists, deploy-hook ping when it does

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -624,3 +624,29 @@ jobs:
           FERROEHR_IMAGE: ferroehr:smoke
           FERROEHR_POSTGRES_IMAGE: ferroehr-postgres:smoke
         run: bash docker/smoke-test.sh
+
+  # Re-trigger the sandbox deploy once the release image exists (#2710). At a
+  # release cut the version-bump merge reaches develop before this pipeline
+  # publishes the tag's image, so Vercel's push-triggered deploy is SKIPPED by
+  # the ignoreCommand (scripts/sandbox/vercel-ignore.sh); this ping re-runs it
+  # at exactly the moment the image is pullable. A Deploy Hook is a plain
+  # trigger URL (no account token, no API scope). Skipped quietly when the
+  # secret is absent, so forks and secretless runs stay green.
+  sandbox-deploy-hook:
+    name: ping the sandbox deploy hook
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: app-image
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Trigger the Vercel deploy
+        env:
+          HOOK_URL: ${{ secrets.SANDBOX_DEPLOY_HOOK_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "$HOOK_URL" ]; then
+            echo "SANDBOX_DEPLOY_HOOK_URL is not configured; skipping the ping."
+            exit 0
+          fi
+          curl -fsS -X POST "$HOOK_URL" -o /dev/null
+          echo "sandbox deploy triggered"

--- a/scripts/sandbox/vercel-ignore.sh
+++ b/scripts/sandbox/vercel-ignore.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+#
+# The Vercel "Ignored Build Step" for the sandbox (#2710): build only when
+# the image Dockerfile.vercel pins actually exists on GHCR. At a release
+# cut the version-bump merge reaches develop minutes before CI publishes
+# that tag's image, so the deploy Vercel triggers on the push would fail on
+# a missing FROM; skipping it cleanly closes that race. The containers
+# pipeline pings the project's Deploy Hook once the image is published, so
+# the skipped deploy is re-run at exactly the right moment.
+#
+# Vercel semantics: exit 0 = skip the build, exit 1 = proceed.
+set -u
+
+tag=$(sed -nE 's/^FROM ghcr\.io\/rubentalstra\/ferroehr:(.+)$/\1/p' Dockerfile.vercel | head -1)
+if [ -z "$tag" ]; then
+  echo "no ghcr FROM pin found in Dockerfile.vercel; building" >&2
+  exit 1
+fi
+
+token=$(curl -fsS "https://ghcr.io/token?scope=repository:rubentalstra/ferroehr:pull" 2>/dev/null \
+  | sed -nE 's/.*"token" *: *"([^"]+)".*/\1/p')
+if [ -z "$token" ]; then
+  echo "could not fetch a GHCR pull token; building anyway" >&2
+  exit 1
+fi
+
+if curl -fsSI -o /dev/null \
+  -H "Authorization: Bearer $token" \
+  -H "Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json" \
+  "https://ghcr.io/v2/rubentalstra/ferroehr/manifests/$tag"; then
+  echo "ghcr.io/rubentalstra/ferroehr:$tag exists; building" >&2
+  exit 1
+fi
+
+echo "ghcr.io/rubentalstra/ferroehr:$tag is not published yet; skipping this deploy (the containers pipeline re-triggers it via the Deploy Hook once the image lands)" >&2
+exit 0

--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,7 @@
             "develop": true
         }
     },
+    "ignoreCommand": "bash scripts/sandbox/vercel-ignore.sh",
     "services": {
         "api": {
             "root": ".",


### PR DESCRIPTION
The v4.0.3 cut hit the documented race live: Vercel's push-triggered deploy tried `FROM ghcr:4.0.3` minutes before the containers pipeline published it (`manifest unknown`). Owner ask: the deploy must wait for the image.

## The two halves

- **`vercel.json` `ignoreCommand`** runs `scripts/sandbox/vercel-ignore.sh`: build only when the `Dockerfile.vercel` FROM pin is pullable on GHCR (anonymous pull token + manifest HEAD). A not-yet-published pin becomes a clean skip instead of a red deploy; probe failures fail open into a build. Both branches verified live (4.0.3 absent → skip, 4.0.2 present → build).
- **`containers.yml`** gains a tag-only job after the app image publishes: POST the project's **Deploy Hook** — a plain trigger URL from the Vercel dashboard, no account token, no API scope — re-running the skipped deploy exactly when the image exists. Quietly skipped when the secret is absent, so forks stay green.

## Owner setup (one time)

Vercel dashboard → project → Settings → Git → **Deploy Hooks** → create one for `develop`, then add its URL as the repo secret `SANDBOX_DEPLOY_HOOK_URL`.

## Gates

actionlint + zizmor clean on the workflow; the ignore script verified against live GHCR in both directions. `no-changelog`: deployment plumbing, no user-visible product behaviour.