### PR TITLE
perf(storage): the composition-update mega-read and the raw-body read passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,25 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Changed
+
+- Composition updates got faster: the whole write pre-check (ownership,
+  `If-Match`, lifecycle, `is_modifiable`, template stability, the
+  cross-version invariants) now rides the write transaction's own placement
+  statement under the per-object lock, instead of a separate pre-read round
+  trip. The refusal outcomes and their order are unchanged.
+- `GET …/composition/{uid}` with a JSON `Accept` now serves the stored
+  canonical body verbatim instead of parsing and re-serializing it. The JSON
+  is semantically identical; insignificant whitespace now follows
+  PostgreSQL's jsonb rendering (a space after `:` and `,`), so byte-exact
+  comparisons against previous responses will differ while every JSON parser
+  sees the same document. XML, FLAT and STRUCTURED representations, and
+  `expand_multimedia=true` reads, are parsed exactly as before.
+- The performance page documents the durability floor: why a single durable
+  commit cannot beat the WAL flush, how group commit scales concurrent
+  writers past it, and the `synchronous_commit` trade-off as an explicit
+  operator choice (never a FerroEHR default).
+
 ## [4.0.3] - 2026-08-25
 
 ### Added

--- a/app/ferroehr-rest/src/api/ehr/composition.rs
+++ b/app/ferroehr-rest/src/api/ehr/composition.rs
@@ -33,7 +33,7 @@ use openehr_its::rest::runtime::ApiError;
 use openehr_rm::prelude::Composition;
 
 use ferroehr::ids::{EhrId, VoId};
-use ferroehr::service::response::{ResourceMeta, ServiceResponse};
+use ferroehr::service::response::{RawServiceResponse, ReadBody, ResourceMeta, ServiceResponse};
 use ferroehr::versioning::change::Committed;
 
 use ferroehr::versioning::object_version_id::parse_uid_based_id;
@@ -195,7 +195,29 @@ pub(super) async fn run(
                     .composition_latest_response(ehr_id, uid.vo_id)
                     .await?
             };
-            let ServiceResponse { mut body, meta } = read;
+            let RawServiceResponse { body, meta } = read;
+            // The negotiated representation decides whether the stored
+            // canonical text can pass through verbatim: a plain JSON accept
+            // with no multimedia expansion serves the stored bytes (the body
+            // is uid-stamped at commit); every other representation parses.
+            let expand = params::query_param(q, "expand_multimedia").as_deref() == Some("true");
+            let accept =
+                negotiate::resolve_accept(h, COMPOSITION_FORMATS, WireFormat::CanonicalJson);
+            let mut body = match body {
+                ReadBody::RawJson(text) if !expand && accept == Some(WireFormat::CanonicalJson) => {
+                    let mut out = negotiate::raw_json_body(ok, text);
+                    if let Some(meta) = &meta {
+                        negotiate::set_versioning_headers(&mut out, meta);
+                    }
+                    return Ok(out);
+                }
+                other => other.into_value().map_err(|e| {
+                    RestError::from(crate::overview::error::internal_fault(
+                        "re-parse the stored composition body",
+                        &e,
+                    ))
+                })?,
+            };
             // A deleted version resolves to a null body → 204 No Content
             // (composition_get.yaml `204_because_deleted*`).
             if body.is_null() {
@@ -209,7 +231,7 @@ pub(super) async fn run(
             // "the `ETag` value is independent of its resource serialization
             // format (JSON/XML)" (§"ETag and Last-Modified") — so the
             // simplified representations carry them too.
-            match negotiate::resolve_accept(h, COMPOSITION_FORMATS, WireFormat::CanonicalJson) {
+            match accept {
                 Some(WireFormat::Flat) => {
                     let mut out =
                         crate::formats::dispatch::composition_flat_response(&state, ok, &body)

--- a/app/ferroehr-rest/src/overview/negotiate.rs
+++ b/app/ferroehr-rest/src/overview/negotiate.rs
@@ -1204,6 +1204,19 @@ pub(crate) fn error_with_meta(
     out
 }
 
+/// Serve pre-formed canonical JSON verbatim as `application/json` — the
+/// stored-body passthrough (the text is the database's own jsonb rendering of
+/// the canonical body, uid-stamped at commit; no parse → serialize round
+/// trip).
+pub(crate) fn raw_json_body(status: StatusCode, json: String) -> Response {
+    let mut resp = (status, json).into_response();
+    resp.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static(APPLICATION_JSON),
+    );
+    resp
+}
+
 /// Serve a pre-formed XML document verbatim as `application/xml`.
 ///
 /// The lineage-agnostic builder: the OPT 1.4 template representation (always

--- a/app/ferroehr-rest/tests/it/protocol_tail.rs
+++ b/app/ferroehr-rest/tests/it/protocol_tail.rs
@@ -847,6 +847,80 @@ async fn composition_version_serves_xml_with_signature() {
     assert!(body.contains("sha256:"), "digest signature value: {body}");
 }
 
+/// The JSON-accept composition GET serves the stored body text VERBATIM (the
+/// raw passthrough): the response opens with the commit-time `uid` stamp —
+/// jsonb renders object keys length-first, so the stamped body's text starts
+/// with its own `uid` — still parses as the same canonical value, and the
+/// version-addressed variant passes through identically. An XML accept on the
+/// same resource still parses and re-serializes (the passthrough is
+/// representation-local).
+#[tokio::test]
+async fn composition_get_serves_stored_json_verbatim() {
+    let (_pg, app) = app().await;
+    let (ehr_id, v1) = commit_ips_composition(&app).await;
+    let vo = vo_of(&v1);
+
+    let get = |uri: String, accept: &'static str| {
+        Request::builder()
+            .method("GET")
+            .uri(uri)
+            .header(header::ACCEPT, accept)
+            .body(Body::empty())
+            .unwrap()
+    };
+    let prefix = format!("{{\"uid\": {{\"_type\": \"OBJECT_VERSION_ID\", \"value\": \"{v1}\"}}");
+
+    // The latest read.
+    let (status, h, body) = send(
+        &app,
+        get(
+            format!("{BASE}/ehr/{ehr_id}/composition/{vo}"),
+            "application/json",
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(
+        h.get(header::CONTENT_TYPE).and_then(|v| v.to_str().ok()),
+        Some("application/json")
+    );
+    assert!(
+        body.starts_with(&prefix),
+        "the stored text passes through, opening with the commit-time uid stamp: {body}"
+    );
+    let parsed: Value = serde_json::from_str(&body).expect("the passthrough text is JSON");
+    assert_eq!(parsed["uid"]["value"], Value::String(v1.clone()));
+    assert_eq!(parsed["_type"], Value::String("COMPOSITION".to_owned()));
+
+    // The version-addressed read takes the same passthrough.
+    let (status, _h, at_version) = send(
+        &app,
+        get(
+            format!("{BASE}/ehr/{ehr_id}/composition/{v1}"),
+            "application/json",
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {at_version}");
+    assert!(at_version.starts_with(&prefix), "body: {at_version}");
+
+    // XML negotiation still parses and re-serializes the same resource.
+    let (status, h, xml) = send(
+        &app,
+        get(
+            format!("{BASE}/ehr/{ehr_id}/composition/{vo}"),
+            "application/xml",
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {xml}");
+    assert_eq!(
+        h.get(header::CONTENT_TYPE).and_then(|v| v.to_str().ok()),
+        Some("application/xml")
+    );
+    assert!(xml.contains(&v1), "the XML body carries the uid: {xml}");
+}
+
 /// The versioned-composition by-id read is container-scoped: a well-formed,
 /// EXISTING `version_uid` whose `object_id` names a DIFFERENT container than
 /// the path's `{versioned_object_uid}` names no version of that resource -> `404` (ITS-REST overview `Resources.md` §Identifier types: "the `object_id`

--- a/app/ferroehr/src/service/ehr/composition.rs
+++ b/app/ferroehr/src/service/ehr/composition.rs
@@ -28,11 +28,11 @@ use crate::service::datetime::parse_at_time;
 #[cfg(feature = "multimedia")]
 use crate::service::error::internal_fault;
 use crate::service::error::{ServiceError, Violation};
-use crate::service::response::{ResourceMeta, ServiceResponse};
+use crate::service::response::{RawServiceResponse, ReadBody, ResourceMeta, ServiceResponse};
 use crate::service::status::{CallStatusType, SmError};
 use crate::versioning::Kind;
 use crate::versioning::audit::change_type;
-use crate::versioning::change::{create, delete, update};
+use crate::versioning::change::{create, delete, update_with_placement};
 use crate::versioning::object_version_id::{TreeId, components, parse_tree_id};
 use crate::versioning::read::{read_current, read_version, version_at};
 use crate::versioning::wire::{revision_history, version_envelope, versioned_object};
@@ -176,6 +176,90 @@ impl FerroEhrService {
         Ok(self.version_response(ehr_id, vo_id, read)?)
     }
 
+    /// [`Self::read_composition`] with the body kept as the stored canonical
+    /// text wherever nothing needs it parsed — the JSON-accept passthrough.
+    ///
+    /// The stored body is uid-stamped at commit
+    /// (`crate::versioning::change` — `stamp_version_uid` runs before
+    /// decomposition), and jsonb renders object keys length-first, so a
+    /// stamped COMPOSITION's text opens with its own `uid`: the prefix
+    /// compare below PROVES the stamp byte-exactly, and any other shape (a
+    /// verbatim-loaded foreign body) falls back to the parsed re-stamp path.
+    ///
+    /// # Errors
+    /// [`ServiceError::NotFound`] when the version does not exist or belongs
+    /// to another EHR; [`ServiceError::Database`] on a storage failure;
+    /// [`ServiceError::Internal`] on undecodable stored text.
+    pub(in crate::service) async fn read_composition_raw(
+        &self,
+        ehr_id: EhrId,
+        vo_id: VoId,
+        version: Option<TreeId>,
+    ) -> Result<RawServiceResponse, ServiceError> {
+        let raw = match version {
+            Some(v) => {
+                crate::versioning::read::read_version_raw(&self.pool, self.spec_profile, vo_id, v)
+                    .await?
+            }
+            None => {
+                crate::versioning::read::read_current_raw(&self.pool, self.spec_profile, vo_id)
+                    .await?
+            }
+        }
+        .filter(|r| r.read.ehr_id == Some(ehr_id) && r.read.kind == Kind::Composition)
+        .ok_or_else(|| {
+            ServiceError::sm(
+                CallStatusType::CompositionDoesNotExist,
+                format!("COMPOSITION {vo_id}"),
+            )
+        })?;
+        if raw.read.deleted() {
+            return Ok(RawServiceResponse {
+                body: ReadBody::Value(Value::Null),
+                meta: None,
+            });
+        }
+        let read = raw.read;
+        let meta = self.version_meta(
+            ehr_id,
+            vo_id,
+            &read.creating_system_id,
+            read.tree,
+            read.time_committed,
+        );
+        let Some(text) = raw.raw_json else {
+            let stamped =
+                self.with_uid(read.canonical, vo_id, &read.creating_system_id, read.tree)?;
+            return Ok(RawServiceResponse {
+                body: ReadBody::Value(stamped),
+                meta: Some(meta),
+            });
+        };
+        let uid = crate::versioning::object_version_id::object_version_id(
+            vo_id,
+            &read.creating_system_id,
+            read.tree,
+        );
+        let prefix =
+            format!("{{\"uid\": {{\"_type\": \"OBJECT_VERSION_ID\", \"value\": \"{uid}\"}}");
+        if text.starts_with(&prefix) {
+            return Ok(RawServiceResponse {
+                body: ReadBody::RawJson(text),
+                meta: Some(meta),
+            });
+        }
+        let value: Value = serde_json::from_str(&text).map_err(|e| {
+            ServiceError::exception(format!(
+                "the stored body of COMPOSITION {vo_id} is not decodable JSON: {e}"
+            ))
+        })?;
+        let stamped = self.with_uid(value, vo_id, &read.creating_system_id, read.tree)?;
+        Ok(RawServiceResponse {
+            body: ReadBody::Value(stamped),
+            meta: Some(meta),
+        })
+    }
+
     /// A COMPOSITION as it was at an instant (time-travel), with its `uid`
     /// set. A deleted version resolves to an empty body (→ `204`).
     ///
@@ -312,13 +396,18 @@ impl FerroEhrService {
 
     /// `update_composition` (SM `i_ehr_composition.adoc`): commit a new
     /// version of `vo_id` from the caller's full `UPDATE_VERSION` envelope,
-    /// returning the committed version identity. ONE merged pre-read
-    /// (`current_composition_meta`) carries the whole write pre-check: the
-    /// owning EHR (ownership → 404), the full-`OBJECT_VERSION_ID` `If-Match`
-    /// identity (412 — ITS-REST overview §Concurrency control), the
-    /// lifecycle (deleted → 404), the stored template root fragment (422) and
-    /// the EHR's `is_modifiable` flag (409) — the former `If-Match` meta read,
-    /// modify pre-read, and `is_modifiable` side-SELECT are one statement.
+    /// returning the committed version identity. The whole write pre-check —
+    /// the owning EHR (ownership → 404), the full-`OBJECT_VERSION_ID`
+    /// `If-Match` identity (412 — ITS-REST overview §Concurrency control),
+    /// the lifecycle (deleted → 404), the EHR's `is_modifiable` flag (409),
+    /// the stored template root fragment (422), and the version-tree
+    /// placement itself — rides ONE in-transaction statement
+    /// ([`crate::storage::version_repo::placement::update_placement`]) under
+    /// the per-vo advisory lock, so no pool pre-read round trip remains. The
+    /// CPU-side envelope resolution and content validation run BEFORE the
+    /// transaction (never under the lock — validation may consult the
+    /// template store and routed terminology); their failures surface in the
+    /// same order as before, after the in-transaction gates ahead of them.
     ///
     /// # Errors
     /// [`ServiceError::NotFound`] when the COMPOSITION does not exist in this
@@ -340,61 +429,67 @@ impl FerroEhrService {
         // await so the typed RM value does not ride the whole write
         // transaction (`super::canonicalize`).
         let version = super::canonicalize(version);
-        let Some(current) =
-            crate::storage::version_repo::meta::current_composition_meta(&self.pool, vo_id)
-                .await?
-                .filter(|m| m.ehr_id == Some(ehr_id))
+        let preceding_version_uid = version.preceding_version_uid.clone();
+        // The CPU-side envelope resolution and the content validation run
+        // BEFORE the write transaction: validation may consult the template
+        // store and the routed terminology servers, so neither the pool
+        // connection nor the per-vo advisory lock is ever held across it.
+        // Both RESULTS are held and surfaced below in the pre-check order the
+        // in-transaction gates define.
+        let resolved = resolve_envelope(
+            version,
+            change_type::MODIFICATION,
+            "COMPOSITION update",
+            &self.effective_system_id(),
+        );
+        let validated = match &resolved {
+            Ok(parts) => Some(
+                self.validate_composition_for_commit(&parts.canonical, parts.incomplete)
+                    .await,
+            ),
+            Err(_) => None,
+        };
+        let mut tx = self.pool.begin().await?;
+        // Serialize concurrent writers of the same object, then read the
+        // placement + every pre-check column in ONE statement (thaw riding).
+        crate::storage::version_repo::commit::advisory_lock(&mut tx, vo_id).await?;
+        let pre = crate::storage::version_repo::placement::update_placement(&mut tx, vo_id).await?;
+        let Some(tip) = pre
+            .placement
+            .tip
+            .as_ref()
+            .filter(|t| t.ehr_id == Some(ehr_id))
         else {
             return Err(ServiceError::sm(
                 CallStatusType::CompositionDoesNotExist,
                 format!("COMPOSITION {vo_id}"),
             ));
         };
-        // The full-`OBJECT_VERSION_ID` `If-Match` compare, built from
-        // the same merged read (ITS-REST overview §Concurrency control).
-        let tree = TreeId::from_columns(
-            current.trunk_version,
-            current.branch_number,
-            current.branch_version,
-        );
-        let latest = self.version_meta(
+        let expected = self.update_if_match_gate(
             ehr_id,
             vo_id,
-            &current.creating_system_id,
-            tree,
-            current.time_committed,
-        );
-        super::ensure_if_match(version.preceding_version_uid.as_ref(), Some(&latest))?;
-        let expected = version
-            .preceding_version_uid
-            .as_ref()
-            .map(|o| components(o).map(|(_, v)| v))
-            .transpose()?;
+            tip,
+            pre.tip_time_committed,
+            preceding_version_uid.as_ref(),
+        )?;
         let super::CommitParts {
             audit,
             envelope,
-            incomplete,
+            incomplete: _,
             canonical: composition,
-        } = resolve_envelope(
-            version,
-            change_type::MODIFICATION,
-            "COMPOSITION update",
-            &self.effective_system_id(),
-        )?;
+        } = resolved?;
         // The lifecycle (deleted → 404, RM common master06 §Logical Deletion)
-        // and the content-write guard are checked from the threaded pre-read.
-        if current.lifecycle_state == crate::versioning::lifecycle::state::DELETED {
+        // and the content-write guard are checked from the same merged read.
+        if tip.lifecycle_state == crate::versioning::lifecycle::state::DELETED {
             return Err(ServiceError::sm(
                 CallStatusType::CompositionDoesNotExist,
                 format!("COMPOSITION {vo_id} is deleted"),
             ));
         }
         // is_modifiable = False forbids content writes (RM ehr master04 §EHR
-        // Active Status) — folded from the standalone `ensure_content_writable`
-        // side-SELECT into the merged pre-read; the 409 outcome and its
-        // ordering (after the deleted 404, before the template 422) are
-        // unchanged.
-        if !current.is_modifiable {
+        // Active Status); the 409 outcome and its ordering (after the deleted
+        // 404, before the template 422) are unchanged.
+        if pre.is_modifiable == Some(false) {
             return Err(Self::not_modifiable_error(ehr_id));
         }
         // Reject an update whose body declares a *different* template than the
@@ -404,7 +499,7 @@ impl FerroEhrService {
         // is_persistent across versions but not
         // archetype_details.template_id) — our own design convention,
         // consistent with those container invariants.
-        let stored_template = current.stored_template.as_deref();
+        let stored_template = pre.stored_template.as_deref();
         if let (Some(stored), Some(incoming)) =
             (stored_template, composition_template_id(&composition))
             && stored != incoming
@@ -417,23 +512,18 @@ impl FerroEhrService {
                 .with_path("COMPOSITION.archetype_details.template_id"),
             ));
         }
-        self.validate_composition_for_commit(&composition, incomplete)
-            .await?;
+        if let Some(validation) = validated {
+            validation?;
+        }
 
         // Same template stamping as the create arm — every version row carries
         // the template it was committed against.
         let template_id = composition_template_id(&composition).map(str::to_owned);
 
         // VERSIONED_COMPOSITION cross-version invariants (RM ehr
-        // `versioned_composition.adoc`), checked off the merged pre-read —
-        // the first version's root is immutable, so no transaction is needed
-        // to read it consistently.
-        super::validation::check_versioned_composition_first_root(
-            current.first_root,
-            &composition,
-        )?;
-        let mut tx = self.pool.begin().await?;
-        let committed = update(
+        // `versioned_composition.adoc`), checked off the same merged read.
+        super::validation::check_versioned_composition_first_root(pre.first_root, &composition)?;
+        let committed = update_with_placement(
             &mut tx,
             Some(ehr_id),
             vo_id,
@@ -444,6 +534,7 @@ impl FerroEhrService {
             &audit,
             envelope,
             &self.signing_ctx(),
+            pre.placement,
         )
         .await?;
         tx.commit().await?;
@@ -453,6 +544,43 @@ impl FerroEhrService {
         crate::versioning::change::meter_committed(&committed);
 
         Ok(committed)
+    }
+
+    /// The composition-update `If-Match` gate off the merged in-transaction
+    /// read: the full-`OBJECT_VERSION_ID` compare against the current tip
+    /// (412 on mismatch — ITS-REST overview §Concurrency control), returning
+    /// the expected `VERSION_TREE_ID` the placement decision pins.
+    ///
+    /// # Errors
+    /// [`ServiceError::VersionConflict`] on an `If-Match` mismatch (→ 412);
+    /// the `components` rejection of a malformed `preceding_version_uid`;
+    /// [`ServiceError::Internal`] when the tip carries no commit audit.
+    fn update_if_match_gate(
+        &self,
+        ehr_id: EhrId,
+        vo_id: VoId,
+        tip: &crate::storage::version_repo::placement::TipRow,
+        tip_time_committed: Option<jiff::Timestamp>,
+        preceding_version_uid: Option<&ObjectVersionId>,
+    ) -> Result<Option<TreeId>, ServiceError> {
+        let tree = TreeId::from_columns(tip.trunk_version, tip.branch_number, tip.branch_version);
+        let tip_time_committed = tip_time_committed.ok_or_else(|| {
+            ServiceError::exception(format!(
+                "the current version of COMPOSITION {vo_id} has no commit audit"
+            ))
+        })?;
+        let latest = self.version_meta(
+            ehr_id,
+            vo_id,
+            &tip.creating_system_id,
+            tree,
+            tip_time_committed,
+        );
+        super::ensure_if_match(preceding_version_uid, Some(&latest))?;
+        preceding_version_uid
+            .map(|o| components(o).map(|(_, v)| v))
+            .transpose()
+            .map_err(ServiceError::from)
     }
 
     /// The current COMPOSITION version metadata (the latest `version_uid` a
@@ -748,10 +876,20 @@ impl FerroEhrService {
         an_ehr_id: EhrId,
         a_versioned_object_uid: VoId,
     ) -> Result<Value, SmError> {
-        Ok(self
+        let resp = self
             .composition_latest_response(an_ehr_id, a_versioned_object_uid)
-            .await?
-            .body)
+            .await?;
+        Ok(Self::read_body_value(a_versioned_object_uid, resp.body)?)
+    }
+
+    /// The typed value of a [`ReadBody`], mapping an undecodable stored text
+    /// to an internal fault (the stored body is our own jsonb rendering).
+    fn read_body_value(vo_id: VoId, body: ReadBody) -> Result<Value, ServiceError> {
+        body.into_value().map_err(|e| {
+            ServiceError::exception(format!(
+                "the stored body of COMPOSITION {vo_id} is not decodable JSON: {e}"
+            ))
+        })
     }
 
     /// SM `I_EHR_COMPOSITION.get_composition_at_time` — the COMPOSITION
@@ -766,10 +904,10 @@ impl FerroEhrService {
         a_versioned_object_uid: VoId,
         a_time: Option<String>,
     ) -> Result<Value, SmError> {
-        Ok(self
+        let resp = self
             .composition_at_time_response(an_ehr_id, a_versioned_object_uid, a_time)
-            .await?
-            .body)
+            .await?;
+        Ok(Self::read_body_value(a_versioned_object_uid, resp.body)?)
     }
 
     /// SM `I_EHR_COMPOSITION.get_composition_at_version` — the bare
@@ -783,10 +921,11 @@ impl FerroEhrService {
         an_ehr_id: EhrId,
         a_version_uid: ObjectVersionId,
     ) -> Result<Value, SmError> {
-        Ok(self
+        let (vo_id, _) = components(&a_version_uid)?;
+        let resp = self
             .composition_at_version_response(an_ehr_id, a_version_uid)
-            .await?
-            .body)
+            .await?;
+        Ok(Self::read_body_value(vo_id, resp.body)?)
     }
 
     /// SM `I_EHR_COMPOSITION.get_versioned_composition` — the
@@ -929,9 +1068,9 @@ impl FerroEhrService {
         &self,
         an_ehr_id: EhrId,
         a_versioned_object_uid: VoId,
-    ) -> Result<ServiceResponse, SmError> {
+    ) -> Result<RawServiceResponse, SmError> {
         Ok(self
-            .read_composition(an_ehr_id, a_versioned_object_uid, None)
+            .read_composition_raw(an_ehr_id, a_versioned_object_uid, None)
             .await?)
     }
 
@@ -946,14 +1085,20 @@ impl FerroEhrService {
         an_ehr_id: EhrId,
         a_versioned_object_uid: VoId,
         a_time: Option<String>,
-    ) -> Result<ServiceResponse, SmError> {
+    ) -> Result<RawServiceResponse, SmError> {
         match a_time.as_deref() {
             None => Ok(self
-                .read_composition(an_ehr_id, a_versioned_object_uid, None)
+                .read_composition_raw(an_ehr_id, a_versioned_object_uid, None)
                 .await?),
-            Some(raw) => Ok(self
-                .composition_at_time(an_ehr_id, a_versioned_object_uid, parse_at_time(raw)?)
-                .await?),
+            Some(raw) => {
+                let resp = self
+                    .composition_at_time(an_ehr_id, a_versioned_object_uid, parse_at_time(raw)?)
+                    .await?;
+                Ok(RawServiceResponse {
+                    body: ReadBody::Value(resp.body),
+                    meta: resp.meta,
+                })
+            }
         }
     }
 
@@ -967,10 +1112,10 @@ impl FerroEhrService {
         &self,
         an_ehr_id: EhrId,
         a_version_uid: ObjectVersionId,
-    ) -> Result<ServiceResponse, SmError> {
+    ) -> Result<RawServiceResponse, SmError> {
         let (vo_id, version) = components(&a_version_uid)?;
         let read = self
-            .read_composition(an_ehr_id, vo_id, Some(version))
+            .read_composition_raw(an_ehr_id, vo_id, Some(version))
             .await?;
         if let Some(meta) = read.meta.as_ref() {
             super::ensure_addressed_version(&a_version_uid, &meta.uid)?;

--- a/app/ferroehr/src/service/response.rs
+++ b/app/ferroehr/src/service/response.rs
@@ -99,6 +99,46 @@ pub struct ServiceResponse {
     pub meta: Option<ResourceMeta>,
 }
 
+/// A read body: the parsed canonical value, or the stored text verbatim.
+///
+/// The raw form carries the stored canonical text (already uid-stamped at
+/// commit) — the JSON-accept passthrough the protocol adapter writes to the
+/// wire without a parse → serialize round trip.
+#[derive(Debug, Clone)]
+pub enum ReadBody {
+    /// The parsed canonical value.
+    Value(Value),
+    /// The stored body's own jsonb text rendering, served verbatim for a
+    /// JSON accept; a consumer needing the typed value parses it.
+    RawJson(String),
+}
+
+impl ReadBody {
+    /// The typed value: the parsed representation as-is, or the raw text
+    /// parsed on demand.
+    ///
+    /// # Errors
+    /// The `serde_json` rejection of undecodable text (the stored body is our
+    /// own jsonb rendering — a failure is corrupt data, never a client
+    /// condition; callers map it to an internal fault).
+    pub fn into_value(self) -> Result<Value, serde_json::Error> {
+        match self {
+            ReadBody::Value(v) => Ok(v),
+            ReadBody::RawJson(text) => serde_json::from_str(&text),
+        }
+    }
+}
+
+/// A [`ServiceResponse`] whose body may still be the stored canonical text
+/// (see [`ReadBody`]).
+#[derive(Debug, Clone)]
+pub struct RawServiceResponse {
+    /// The read body, parsed or verbatim.
+    pub body: ReadBody,
+    /// Resource metadata for header derivation, if any.
+    pub meta: Option<ResourceMeta>,
+}
+
 impl ServiceResponse {
     /// A response carrying both an RM body and resource metadata.
     #[must_use]

--- a/app/ferroehr/src/storage/version_repo/placement.rs
+++ b/app/ferroehr/src/storage/version_repo/placement.rs
@@ -200,6 +200,11 @@ pub async fn update_placement(
     tx: &mut PgConnection,
     vo_id: VoId,
 ) -> Result<UpdatePlacement, StorageError> {
+    // `src` stays NARROW (no body): it is referenced more than once, so the
+    // planner materializes it, and a body column would copy every version's
+    // document into the tuplestore. The two body-derived facts are read by
+    // targeted laterals instead — each touches exactly one row's body (the
+    // tip's, and the earliest content version's).
     const SQL: &str = concat!(
         "WITH cv AS (DELETE FROM cold.vo_version WHERE vo_id = $1 RETURNING *), ",
         "cn AS (DELETE FROM cold.node WHERE vo_id = $1 RETURNING *), ",
@@ -210,35 +215,49 @@ pub async fn update_placement(
         "it AS (INSERT INTO vo_attestation SELECT * FROM ct), ",
         "src AS (SELECT vo_id, ehr_id, kind, sys_version, trunk_version, branch_number, ",
         "               branch_version, creating_system_id, lifecycle_state, sys_period, ",
-        "               audit_id, body ",
+        "               audit_id ",
         "        FROM vo_version WHERE vo_id = $1 ",
         "        UNION ALL ",
         "        SELECT vo_id, ehr_id, kind, sys_version, trunk_version, branch_number, ",
         "               branch_version, creating_system_id, lifecycle_state, sys_period, ",
-        "               audit_id, body ",
+        "               audit_id ",
         "        FROM cv) ",
         "SELECT o.next_ordinal, now() AS ts, tip.ehr_id, tip.kind, tip.sys_version, ",
         "tip.trunk_version, tip.branch_number, tip.branch_version, ",
         "tip.creating_system_id, tip.lifecycle_state, tip.open, ",
-        "a.time_committed, e.is_modifiable, tip.stored_template, ",
+        "a.time_committed, e.is_modifiable, tb.stored_template, ",
         "fv.found AS first_found, fv.ani AS first_ani, fv.category AS first_category ",
         "FROM (SELECT (COALESCE(MAX(sys_version), 0) + 1)::int AS next_ordinal ",
         "      FROM src) o ",
         "LEFT JOIN LATERAL ( ",
         "    SELECT t.ehr_id, t.kind, t.sys_version, t.trunk_version, ",
         "           t.branch_number, t.branch_version, t.creating_system_id, ",
-        "           t.lifecycle_state, upper_inf(t.sys_period) AS open, t.audit_id, ",
-        "           t.body #>> '{archetype_details,template_id,value}' AS stored_template ",
+        "           t.lifecycle_state, upper_inf(t.sys_period) AS open, t.audit_id ",
         "    FROM src t WHERE upper_inf(t.sys_period) AND t.branch_number = 0 ",
         ") tip ON true ",
         "LEFT JOIN audit a ON a.id = tip.audit_id ",
         "LEFT JOIN ehr e ON e.id = tip.ehr_id ",
         "LEFT JOIN LATERAL ( ",
+        "    SELECT b.body #>> '{archetype_details,template_id,value}' AS stored_template ",
+        "    FROM (SELECT body FROM vo_version ",
+        "          WHERE vo_id = $1 AND sys_version = tip.sys_version ",
+        "          UNION ALL ",
+        "          SELECT body FROM cv WHERE cv.sys_version = tip.sys_version) b ",
+        "    LIMIT 1 ",
+        ") tb ON true ",
+        "LEFT JOIN LATERAL ( ",
+        // The ORDER BY + LIMIT sit INSIDE the subquery and the jsonb
+        // extractions OUTSIDE it: evaluated inline, the planner computes the
+        // extractions for every version row below the sort.
         "    SELECT true AS found, ",
-        "           f.body ->> 'archetype_node_id' AS ani, ",
-        "           f.body #>> '{category,defining_code,code_string}' AS category ",
-        "    FROM src f WHERE f.body IS NOT NULL ",
-        "    ORDER BY f.sys_version LIMIT 1 ",
+        "           b.body ->> 'archetype_node_id' AS ani, ",
+        "           b.body #>> '{category,defining_code,code_string}' AS category ",
+        "    FROM (SELECT f.sys_version, f.body ",
+        "          FROM (SELECT sys_version, body FROM vo_version ",
+        "                WHERE vo_id = $1 AND body IS NOT NULL ",
+        "                UNION ALL ",
+        "                SELECT sys_version, body FROM cv WHERE body IS NOT NULL) f ",
+        "          ORDER BY f.sys_version LIMIT 1) b ",
         ") fv ON true"
     );
     let row = sqlx::query(SQL).bind(vo_id).fetch_one(&mut *tx).await?;

--- a/app/ferroehr/src/storage/version_repo/placement.rs
+++ b/app/ferroehr/src/storage/version_repo/placement.rs
@@ -158,6 +158,124 @@ pub async fn next_placement(
     })
 }
 
+/// The composition-update mega-read: [`next_placement`]'s current-trunk-tip
+/// form plus every column the update pre-checks need
+/// ([`UpdatePlacement`]).
+#[derive(Debug)]
+pub struct UpdatePlacement {
+    /// The version-tree placement (tip + next ordinal + the transaction
+    /// timestamp). `tip = None` when the object has no current open trunk
+    /// version.
+    pub placement: Placement,
+    /// The tip's commit instant (`audit.time_committed`) — the `ETag` /
+    /// `If-Match` metadata instant. `None` iff there is no tip.
+    pub tip_time_committed: Option<jiff::Timestamp>,
+    /// The owning EHR's promoted `is_modifiable` flag. `None` iff there is no
+    /// tip or the tip has no owning EHR.
+    pub is_modifiable: Option<bool>,
+    /// The tip body's `archetype_details.template_id.value`, or `None` for a
+    /// deleted tip (NULL body) or an undeclared template.
+    pub stored_template: Option<String>,
+    /// The FIRST stored content version's root fields —
+    /// `(archetype_node_id, category code)` — for the `VERSIONED_COMPOSITION`
+    /// cross-version invariants; `None` when no content version exists.
+    pub first_root: Option<(Option<String>, Option<String>)>,
+}
+
+/// The composition-update placement + pre-check read, merged into ONE
+/// in-transaction statement — the thaw included.
+///
+/// [`next_placement`]'s current-trunk-tip form (the update route's `If-Match`
+/// gate has already pinned the addressed version to the current trunk tip, so
+/// no expectation-addressed variant exists here) extended with the columns the
+/// former pool pre-read (`super::meta::current_composition_meta`) carried: the
+/// tip audit's commit instant, the owning EHR's `is_modifiable`, the stored
+/// template id, and the first content version's root fields. Run under the
+/// per-vo advisory lock inside the write transaction, it replaces that pool
+/// round trip entirely. No openEHR spec governs the SQL — our own design.
+///
+/// # Errors
+/// Returns [`StorageError::Database`] on a driver failure.
+pub async fn update_placement(
+    tx: &mut PgConnection,
+    vo_id: VoId,
+) -> Result<UpdatePlacement, StorageError> {
+    const SQL: &str = concat!(
+        "WITH cv AS (DELETE FROM cold.vo_version WHERE vo_id = $1 RETURNING *), ",
+        "cn AS (DELETE FROM cold.node WHERE vo_id = $1 RETURNING *), ",
+        "ct AS (DELETE FROM cold.vo_attestation WHERE vo_id = $1 RETURNING *), ",
+        "cm AS (DELETE FROM vo_archive WHERE vo_id = $1), ",
+        "iv AS (INSERT INTO vo_version SELECT * FROM cv), ",
+        "inn AS (INSERT INTO node SELECT * FROM cn), ",
+        "it AS (INSERT INTO vo_attestation SELECT * FROM ct), ",
+        "src AS (SELECT vo_id, ehr_id, kind, sys_version, trunk_version, branch_number, ",
+        "               branch_version, creating_system_id, lifecycle_state, sys_period, ",
+        "               audit_id, body ",
+        "        FROM vo_version WHERE vo_id = $1 ",
+        "        UNION ALL ",
+        "        SELECT vo_id, ehr_id, kind, sys_version, trunk_version, branch_number, ",
+        "               branch_version, creating_system_id, lifecycle_state, sys_period, ",
+        "               audit_id, body ",
+        "        FROM cv) ",
+        "SELECT o.next_ordinal, now() AS ts, tip.ehr_id, tip.kind, tip.sys_version, ",
+        "tip.trunk_version, tip.branch_number, tip.branch_version, ",
+        "tip.creating_system_id, tip.lifecycle_state, tip.open, ",
+        "a.time_committed, e.is_modifiable, tip.stored_template, ",
+        "fv.found AS first_found, fv.ani AS first_ani, fv.category AS first_category ",
+        "FROM (SELECT (COALESCE(MAX(sys_version), 0) + 1)::int AS next_ordinal ",
+        "      FROM src) o ",
+        "LEFT JOIN LATERAL ( ",
+        "    SELECT t.ehr_id, t.kind, t.sys_version, t.trunk_version, ",
+        "           t.branch_number, t.branch_version, t.creating_system_id, ",
+        "           t.lifecycle_state, upper_inf(t.sys_period) AS open, t.audit_id, ",
+        "           t.body #>> '{archetype_details,template_id,value}' AS stored_template ",
+        "    FROM src t WHERE upper_inf(t.sys_period) AND t.branch_number = 0 ",
+        ") tip ON true ",
+        "LEFT JOIN audit a ON a.id = tip.audit_id ",
+        "LEFT JOIN ehr e ON e.id = tip.ehr_id ",
+        "LEFT JOIN LATERAL ( ",
+        "    SELECT true AS found, ",
+        "           f.body ->> 'archetype_node_id' AS ani, ",
+        "           f.body #>> '{category,defining_code,code_string}' AS category ",
+        "    FROM src f WHERE f.body IS NOT NULL ",
+        "    ORDER BY f.sys_version LIMIT 1 ",
+        ") fv ON true"
+    );
+    let row = sqlx::query(SQL).bind(vo_id).fetch_one(&mut *tx).await?;
+    let kind: Option<String> = row.try_get("kind")?;
+    let tip = match kind {
+        None => None,
+        Some(kind) => Some(TipRow {
+            ehr_id: row.try_get("ehr_id")?,
+            kind,
+            sys_version: row.try_get("sys_version")?,
+            trunk_version: row.try_get("trunk_version")?,
+            branch_number: row.try_get("branch_number")?,
+            branch_version: row.try_get("branch_version")?,
+            creating_system_id: row.try_get("creating_system_id")?,
+            lifecycle_state: row.try_get("lifecycle_state")?,
+            open: row.try_get("open")?,
+        }),
+    };
+    let first_root = match row.try_get::<Option<bool>, _>("first_found")? {
+        Some(true) => Some((row.try_get("first_ani")?, row.try_get("first_category")?)),
+        _ => None,
+    };
+    Ok(UpdatePlacement {
+        placement: Placement {
+            tip,
+            next_ordinal: row.try_get("next_ordinal")?,
+            now: row.try_get::<jiff_sqlx::Timestamp, _>("ts")?.to_jiff(),
+        },
+        tip_time_committed: row
+            .try_get::<Option<jiff_sqlx::Timestamp>, _>("time_committed")?
+            .map(jiff_sqlx::Timestamp::to_jiff),
+        is_modifiable: row.try_get("is_modifiable")?,
+        stored_template: row.try_get("stored_template")?,
+        first_root,
+    })
+}
+
 /// The transaction timestamp (`now()`), stable for the whole transaction —
 /// the commit instant for a create (no placement read exists to carry it).
 ///

--- a/app/ferroehr/src/storage/version_repo/read.rs
+++ b/app/ferroehr/src/storage/version_repo/read.rs
@@ -101,8 +101,14 @@ pub struct StoredVersion {
     pub stable_compatible: Option<bool>,
     /// The materialized canonical body (`vo_version.body` — written from the
     /// same value the node rows decompose from), or [`Value::Null`] for a
-    /// logically deleted version (master06 §Logical Deletion).
+    /// logically deleted version (master06 §Logical Deletion). [`Value::Null`]
+    /// on a raw read that populated [`Self::canonical_text`] instead.
     pub canonical: Value,
+    /// The body as the database's own jsonb text rendering, populated ONLY by
+    /// the raw read variants ([`read_current_raw`] / [`read_version_raw`]) —
+    /// the JSON-accept passthrough source. `None` on every parsed read and on
+    /// a logically deleted version.
+    pub canonical_text: Option<String>,
     /// The `ORIGINAL_VERSION.attestations` that were on the version AT the act
     /// of committal, in commit order (master06 §Attestation "Signing content at
     /// committal") — the ones inside the version's signed canonical form.
@@ -163,11 +169,65 @@ macro_rules! version_select {
     };
 }
 
+/// [`version_select!`] with the body as the database's own jsonb text
+/// rendering (`v.body::text`) — the raw-read column list for the JSON-accept
+/// passthrough ([`read_current_raw`] / [`read_version_raw`]). Every other
+/// column is identical.
+macro_rules! version_select_raw {
+    ($tail:literal) => {
+        concat!(
+            "SELECT v.vo_id, v.kind, v.ehr_id, v.sys_version, v.trunk_version, v.branch_number, ",
+            "v.branch_version, v.lifecycle_state, v.creating_system_id, v.preceding_version_uid, ",
+            "v.other_input_version_uids, v.contribution_id, v.template_id, v.signature, ",
+            "v.signature_client_supplied, v.wrapped_original, v.stable_compatible, ",
+            "v.body::text AS body, ",
+            "a.system_id, a.change_type, a.description, a.committer, a.attestation, ",
+            "a.time_committed, ",
+            "att.attestations_at_committal, att.attestations_after_committal ",
+            "FROM vo_version_all v JOIN audit a ON a.id = v.audit_id ",
+            "LEFT JOIN LATERAL (",
+            "SELECT coalesce(jsonb_agg(x.data ORDER BY x.time_committed, x.id) ",
+            "FILTER (WHERE x.at_committal), '[]'::jsonb) AS attestations_at_committal, ",
+            "coalesce(jsonb_agg(x.data ORDER BY x.time_committed, x.id) ",
+            "FILTER (WHERE NOT x.at_committal), '[]'::jsonb) AS attestations_after_committal ",
+            "FROM vo_attestation_all x ",
+            "WHERE x.vo_id = v.vo_id AND x.sys_version = v.sys_version",
+            ") att ON true ",
+            $tail
+        )
+    };
+}
+
 /// Build a [`StoredVersion`] from a `vo_version`⋈`audit` row; the canonical
 /// body is the row's own materialized `body` column (`NULL` → [`Value::Null`],
 /// a logical delete), so the whole version read is the ONE statement that
 /// produced `row`, on whichever tier's connection ran it.
 fn stored_version(vo_id: VoId, row: &PgRow) -> Result<StoredVersion, StorageError> {
+    let canonical = row
+        .try_get::<Option<Value>, _>("body")?
+        .unwrap_or(Value::Null);
+    stored_version_fields(vo_id, row, canonical, None)
+}
+
+/// [`stored_version`] for a raw-read row (`v.body::text AS body`): the body
+/// arrives as the database's own jsonb text rendering, kept verbatim in
+/// [`StoredVersion::canonical_text`] with `canonical = Value::Null` — the
+/// JSON-accept passthrough source (the caller parses the text wherever a
+/// typed value is still needed).
+fn stored_version_raw(vo_id: VoId, row: &PgRow) -> Result<StoredVersion, StorageError> {
+    let canonical_text: Option<String> = row.try_get("body")?;
+    stored_version_fields(vo_id, row, Value::Null, canonical_text)
+}
+
+/// The shared `vo_version`⋈`audit` field mapping of [`stored_version`] /
+/// [`stored_version_raw`] — everything except the body representation, which
+/// the two builders extract each their own way.
+fn stored_version_fields(
+    vo_id: VoId,
+    row: &PgRow,
+    canonical: Value,
+    canonical_text: Option<String>,
+) -> Result<StoredVersion, StorageError> {
     let sys_version: i32 = row.try_get("sys_version")?;
     // A stored `other_input_version_uids` that does not decode is OUR data
     // gone wrong (the merge inputs of an IMPORTED_VERSION, RM common master06
@@ -185,9 +245,6 @@ fn stored_version(vo_id: VoId, row: &PgRow) -> Result<StoredVersion, StorageErro
             ))
         })?
         .unwrap_or_default();
-    let canonical = row
-        .try_get::<Option<Value>, _>("body")?
-        .unwrap_or(Value::Null);
     // The attestations arrive folded into the version-select row (the LATERAL
     // aggregates in `version_select!`), in commit order and already split on
     // `at_committal` — no separate round trip.
@@ -227,6 +284,7 @@ fn stored_version(vo_id: VoId, row: &PgRow) -> Result<StoredVersion, StorageErro
         wrapped_original: row.try_get("wrapped_original")?,
         stable_compatible: row.try_get("stable_compatible")?,
         canonical,
+        canonical_text,
         attestations_at_committal,
         attestations_after_committal,
     })
@@ -337,6 +395,54 @@ pub async fn read_current(
         .fetch_optional(pool)
         .await?
         .map(|row| stored_version(vo_id, &row))
+        .transpose()
+}
+
+/// [`read_current`] with the body as its stored jsonb text — the
+/// JSON-accept passthrough read ([`StoredVersion::canonical_text`] carries
+/// the text; `canonical` is [`Value::Null`]).
+///
+/// # Errors
+/// Returns [`StorageError`] on a driver failure.
+pub async fn read_current_raw(
+    pool: &PgPool,
+    vo_id: VoId,
+) -> Result<Option<StoredVersion>, StorageError> {
+    const SQL: &str = version_select_raw!(
+        "WHERE v.vo_id = $1 AND upper_inf(v.sys_period) AND v.branch_number = 0"
+    );
+    sqlx::query(SQL)
+        .bind(vo_id)
+        .fetch_optional(pool)
+        .await?
+        .map(|row| stored_version_raw(vo_id, &row))
+        .transpose()
+}
+
+/// [`read_version`] with the body as its stored jsonb text — the
+/// JSON-accept passthrough read.
+///
+/// # Errors
+/// Returns [`StorageError`] on a driver failure.
+pub async fn read_version_raw(
+    pool: &PgPool,
+    vo_id: VoId,
+    trunk_version: i32,
+    branch_number: i32,
+    branch_version: i32,
+) -> Result<Option<StoredVersion>, StorageError> {
+    const SQL: &str = version_select_raw!(
+        "WHERE v.vo_id = $1 AND v.trunk_version = $2 \
+         AND v.branch_number = $3 AND v.branch_version = $4"
+    );
+    sqlx::query(SQL)
+        .bind(vo_id)
+        .bind(trunk_version)
+        .bind(branch_number)
+        .bind(branch_version)
+        .fetch_optional(pool)
+        .await?
+        .map(|row| stored_version_raw(vo_id, &row))
         .transpose()
 }
 

--- a/app/ferroehr/src/versioning/change.rs
+++ b/app/ferroehr/src/versioning/change.rs
@@ -300,18 +300,26 @@ async fn next_version(
     kind: Kind,
     expected: Option<TreeId>,
     local_system_id: &str,
+    preplaced: Option<crate::storage::version_repo::placement::Placement>,
 ) -> Result<NextVersion, ServiceError> {
-    // Serialize concurrent writers of the same object.
-    crate::storage::version_repo::commit::advisory_lock(tx, vo_id).await?;
+    // The caller may already hold the advisory lock and the placement read
+    // (the composition-update mega-read); otherwise both run here.
+    let preplaced_read = preplaced.is_some();
+    let placement = if let Some(placement) = preplaced {
+        placement
+    } else {
+        // Serialize concurrent writers of the same object.
+        crate::storage::version_repo::commit::advisory_lock(tx, vo_id).await?;
 
-    // ONE statement: preceding tip + next ordinal + the transaction timestamp
-    // (the commit instant every row of this transaction stamps).
-    let placement = crate::storage::version_repo::placement::next_placement(
-        tx,
-        vo_id,
-        expected.map(TreeId::columns),
-    )
-    .await?;
+        // ONE statement: preceding tip + next ordinal + the transaction
+        // timestamp (the commit instant every row of this transaction stamps).
+        crate::storage::version_repo::placement::next_placement(
+            tx,
+            vo_id,
+            expected.map(TreeId::columns),
+        )
+        .await?
+    };
     let ordinal = placement.next_ordinal;
     let now = placement.now;
     let tip = placement.tip.map(preceding_tip).transpose()?;
@@ -346,6 +354,18 @@ async fn next_version(
     if !tip.open {
         return Err(ServiceError::version_conflict(format!(
             "expected version {} has been superseded",
+            tip.tree
+        )));
+    }
+    // A preplaced read is the CURRENT-trunk-tip form; the caller's `If-Match`
+    // gate pinned `expected` to it, and this guard keeps that coupling honest
+    // instead of silently continuing from a different tip.
+    if preplaced_read
+        && let Some(expected) = expected
+        && tip.tree != expected
+    {
+        return Err(ServiceError::version_conflict(format!(
+            "expected version {expected}, current is {}",
             tip.tree
         )));
     }
@@ -520,6 +540,10 @@ struct CommitScope<'a> {
     /// path reads `now()` once for the whole set); `None` makes this change
     /// read its own.
     known_now: Option<jiff::Timestamp>,
+    /// A placement the caller already read under the advisory lock it already
+    /// holds (the composition-update mega-read); `None` makes the Modify /
+    /// Delete arm take the lock and read its own.
+    preplaced: Option<crate::storage::version_repo::placement::Placement>,
 }
 
 #[expect(
@@ -539,6 +563,7 @@ async fn apply_change(
         ctx,
         committer_fallback,
         known_now,
+        preplaced,
     } = scope;
     let resolved = match change {
         Change::Create {
@@ -620,7 +645,8 @@ async fn apply_change(
             // Deletion). Refused before the placement read, so a data-carrying
             // `523` never reaches storage.
             reject_deleted_with_data(&lifecycle)?;
-            let next = next_version(tx, ehr_id, vo_id, kind, expected, &ctx.system_id).await?;
+            let next =
+                next_version(tx, ehr_id, vo_id, kind, expected, &ctx.system_id, preplaced).await?;
             // the transition from the preceding version's state must be
             // legal (master06 §Version Lifecycle state machine).
             validate_transition(Some(&next.preceding_lifecycle), &lifecycle)?;
@@ -654,7 +680,8 @@ async fn apply_change(
             expected,
             signature,
         } => {
-            let next = next_version(tx, ehr_id, vo_id, kind, expected, &ctx.system_id).await?;
+            let next =
+                next_version(tx, ehr_id, vo_id, kind, expected, &ctx.system_id, preplaced).await?;
             // A deleted version carries no data — its `ORIGINAL_VERSION.data` is
             // Void (master06 §Logical Deletion); the signature is over the
             // data-less version wrapper. Logical deletion is permitted from any
@@ -962,6 +989,7 @@ pub(crate) async fn create(
             ctx,
             committer_fallback: &audit.committer,
             known_now,
+            preplaced: None,
         },
         Change::Create {
             kind,
@@ -1010,6 +1038,64 @@ pub(crate) async fn update(
             ctx,
             committer_fallback: &audit.committer,
             known_now: None,
+            preplaced: None,
+        },
+        Change::Modify {
+            vo_id,
+            kind,
+            canonical,
+            expected,
+            template_id: template_id.map(str::to_owned),
+            signature: envelope.signature,
+            lifecycle_state: envelope.lifecycle_state,
+            attestations: envelope.attestations,
+        },
+    )
+    .await?;
+    write_single_outbox(tx, ctx, contribution_id, ehr_id, &committed).await?;
+    Ok(committed)
+}
+
+/// [`update`] with the advisory lock and placement read already taken by the
+/// caller — the composition-update mega-read path.
+///
+/// The caller has opened the write transaction, taken the per-vo advisory
+/// lock, and run the merged placement + pre-check statement
+/// ([`crate::storage::version_repo::placement::update_placement`]); this
+/// commits the new version off that placement without re-reading. `expected`
+/// must equal the placement tip's tree id (the caller's `If-Match` gate pins
+/// it; [`next_version`] re-checks).
+///
+/// # Errors
+/// The [`update`] errors, minus the placement read's own.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the write parameters, named individually; a parameter struct \
+              would not read clearer at the service call sites"
+)]
+pub(crate) async fn update_with_placement(
+    tx: &mut PgConnection,
+    ehr_id: Option<EhrId>,
+    vo_id: VoId,
+    kind: Kind,
+    canonical: Value,
+    expected: Option<TreeId>,
+    template_id: Option<&str>,
+    audit: &AuditInput,
+    envelope: WriteEnvelope,
+    ctx: &SigningCtx<'_>,
+    placement: crate::storage::version_repo::placement::Placement,
+) -> Result<Committed, ServiceError> {
+    let (committed, contribution_id) = apply_change(
+        tx,
+        CommitScope {
+            ehr_id,
+            contribution: ContributionCtx::New,
+            audit,
+            ctx,
+            committer_fallback: &audit.committer,
+            known_now: None,
+            preplaced: Some(placement),
         },
         Change::Modify {
             vo_id,
@@ -1062,6 +1148,7 @@ pub(crate) async fn delete(
             ctx,
             committer_fallback: &audit.committer,
             known_now: None,
+            preplaced: None,
         },
         Change::Delete {
             vo_id,
@@ -1126,6 +1213,7 @@ pub(crate) async fn commit_contribution(
                 ctx,
                 committer_fallback,
                 known_now: Some(contribution_time),
+                preplaced: None,
             },
             change,
         )

--- a/app/ferroehr/src/versioning/read.rs
+++ b/app/ferroehr/src/versioning/read.rs
@@ -271,6 +271,91 @@ pub(crate) async fn read_current(
         .transpose()
 }
 
+/// A version read whose body may still be the stored jsonb text — the
+/// JSON-accept passthrough shape.
+///
+/// `raw_json = Some(text)` iff the body never needed parsing: a locally
+/// created version (no `IMPORTED_VERSION` wrapper) whose `spec_profile` gate
+/// decided on the commit-time stamp alone; `read.canonical` is `Value::Null`
+/// then. Otherwise the body was parsed into `read.canonical` and `raw_json`
+/// is `None` — the ordinary [`VersionRead`] contract.
+#[derive(Debug)]
+pub(crate) struct RawVersionRead {
+    /// The loaded version (see [`RawVersionRead::raw_json`] for its body
+    /// representation).
+    pub(crate) read: VersionRead,
+    /// The stored body's own jsonb text, when it never needed parsing.
+    pub(crate) raw_json: Option<String>,
+}
+
+/// Compose a [`RawVersionRead`]: parse the raw text back into a typed value
+/// wherever one is still needed — an imported version (the uid re-stamp path)
+/// or a `stable`-profile read the commit-time stamp cannot decide — else keep
+/// the text verbatim for the passthrough.
+///
+/// # Errors
+/// The [`version_read`] rejections; [`ServiceError::Internal`] when the
+/// stored body text does not parse (our own jsonb rendering — corrupt data,
+/// never a client condition).
+fn raw_version_read(
+    profile: crate::config::profile::SpecProfile,
+    mut stored: crate::storage::version_repo::read::StoredVersion,
+) -> Result<RawVersionRead, ServiceError> {
+    let needs_value = stored.wrapped_original.is_some()
+        || (profile == crate::config::profile::SpecProfile::Stable
+            && stored.stable_compatible != Some(true));
+    let mut raw_json = stored.canonical_text.take();
+    if needs_value && let Some(text) = raw_json.as_deref() {
+        stored.canonical = serde_json::from_str(text).map_err(|e| {
+            ServiceError::exception(format!(
+                "the stored body of versioned object {} is not decodable JSON: {e}",
+                stored.vo_id
+            ))
+        })?;
+        raw_json = None;
+    }
+    Ok(RawVersionRead {
+        read: version_read(profile, stored)?,
+        raw_json,
+    })
+}
+
+/// [`read_current`] with the body kept as the stored jsonb text when nothing
+/// needs it parsed — the JSON-accept passthrough read.
+///
+/// # Errors
+/// The storage read error of `version_repo::read::read_current_raw`, or the
+/// [`raw_version_read`] rejections.
+pub(crate) async fn read_current_raw(
+    pool: &sqlx::PgPool,
+    profile: crate::config::profile::SpecProfile,
+    vo_id: VoId,
+) -> Result<Option<RawVersionRead>, ServiceError> {
+    crate::storage::version_repo::read::read_current_raw(pool, vo_id)
+        .await?
+        .map(|stored| raw_version_read(profile, stored))
+        .transpose()
+}
+
+/// [`read_version`] with the body kept as the stored jsonb text when nothing
+/// needs it parsed — the JSON-accept passthrough read.
+///
+/// # Errors
+/// The storage read error of `version_repo::read::read_version_raw`, or the
+/// [`raw_version_read`] rejections.
+pub(crate) async fn read_version_raw(
+    pool: &sqlx::PgPool,
+    profile: crate::config::profile::SpecProfile,
+    vo_id: VoId,
+    tree: TreeId,
+) -> Result<Option<RawVersionRead>, ServiceError> {
+    let (t, b, v) = tree.columns();
+    crate::storage::version_repo::read::read_version_raw(pool, vo_id, t, b, v)
+        .await?
+        .map(|stored| raw_version_read(profile, stored))
+        .transpose()
+}
+
 /// Read the current versions of a SET of objects in ONE statement (the
 /// extract export's demographics batch), each passing the same `spec_profile`
 /// gate a point read passes; keyed by `vo_id`, with absent objects simply

--- a/app/ferroehr/tests/it/service_dump_load.rs
+++ b/app/ferroehr/tests/it/service_dump_load.rs
@@ -761,20 +761,24 @@ async fn assert_xml_round_trip(compression: Option<CompressionFormat>, container
 /// kind an EHR owns.
 #[tokio::test]
 async fn canonical_xml_export_round_trips_byte_equal_over_a_mixed_kind_ehr() {
-    assert_xml_round_trip(None, "loose").await;
+    Box::pin(assert_xml_round_trip(None, "loose")).await;
 }
 
 /// The logical format and the container are independent axes: the identical
 /// entry set travels in `archive.zip`.
 #[tokio::test]
 async fn canonical_xml_export_round_trips_through_the_zip_container() {
-    assert_xml_round_trip(Some(CompressionFormat::Zip), "zip").await;
+    Box::pin(assert_xml_round_trip(Some(CompressionFormat::Zip), "zip")).await;
 }
 
 /// …and in `archive.7z`.
 #[tokio::test]
 async fn canonical_xml_export_round_trips_through_the_sevenz_container() {
-    assert_xml_round_trip(Some(CompressionFormat::SevenZip), "7z").await;
+    Box::pin(assert_xml_round_trip(
+        Some(CompressionFormat::SevenZip),
+        "7z",
+    ))
+    .await;
 }
 
 /// The archive's SHAPE, not just its round trip: the manifest records the

--- a/docs/conformance/ferroehr/CONFORMANCE_CERTIFICATE.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_CERTIFICATE.md
@@ -4,9 +4,9 @@
 
 | Field | Value |
 | --- | --- |
-| Solution | ferroehr 4.0.2 |
+| Solution | ferroehr 4.0.3 |
 | Vendor | Ruben Talstra |
-| Runner | cnf-runner 4.0.2 |
+| Runner | cnf-runner 4.0.3 |
 | Infrastructure | ixit.json#/environment |
 
 ## Scope of Test

--- a/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
@@ -1,7 +1,7 @@
 # Conformance Report
 
-SUT: FerroEHR 4.0.2 (sut `ferroehr`) · schedule cnf-2.0-w2 · ITS its-rest
-Runner: cnf-runner 4.0.2 · verification pack: passed
+SUT: FerroEHR 4.0.3 (sut `ferroehr`) · schedule cnf-2.0-w2 · ITS its-rest
+Runner: cnf-runner 4.0.3 · verification pack: passed
 
 ## Summary
 

--- a/docs/conformance/ferroehr/results.json
+++ b/docs/conformance/ferroehr/results.json
@@ -1,11 +1,11 @@
 {
   "sut": {
     "name": "ferroehr",
-    "version": "4.0.2"
+    "version": "4.0.3"
   },
   "runner": {
     "name": "cnf-runner",
-    "version": "4.0.2",
+    "version": "4.0.3",
     "verification_pack_status": "passed"
   },
   "schedule_release": "cnf-2.0-w2",

--- a/website/book/src/performance.md
+++ b/website/book/src/performance.md
@@ -76,6 +76,33 @@ The floors that fall out of this chain are the published defaults the runner
 enforces; the concrete rates per class are carried in the class ladder above and
 the summary table below, never re-typed into this prose.
 
+## The durability floor — what a single write can never beat
+
+Every committed version is durable: the transaction's WAL records are flushed
+to disk before the server answers, so an acknowledged commit survives a crash.
+That flush is a physical lower bound on single-client write latency — one
+`fsync` on the WAL device per commit — and no storage design takes a lone
+sequential client below it. On a laptop-class Docker setup the flush alone
+measures around 1.5–2 ms; on server NVMe it is typically an order of magnitude
+smaller. FerroEHR's optimization target is therefore everything *around* the
+flush: the database's own per-commit work (one folded commit statement, one
+merged placement read) is kept far below the flush itself, which also means
+concurrent throughput scales — PostgreSQL group-commits, amortizing one flush
+across every transaction that reaches it in the same window.
+
+The knob behind this boundary is PostgreSQL's
+[`synchronous_commit`](https://www.postgresql.org/docs/18/runtime-config-wal.html#GUC-SYNCHRONOUS-COMMIT).
+Setting it `off` makes commits return before the WAL flush: single-client
+write latency drops to the statement work alone, and a server crash can lose
+the most recent acknowledged commits (up to three times `wal_writer_delay`,
+per the PostgreSQL documentation — the database stays consistent; the tail of
+acknowledged writes is what is at risk). **FerroEHR never defaults this off
+and does not recommend it for clinical data.** It is an operator decision,
+made per deployment on the database side, defensible only where the record of
+loss is acceptable (a load-test rig, a reseedable sandbox, an analytics
+replica). All published FerroEHR numbers are measured with full durability
+on.
+
 ## The hospital simulation
 
 The measured workload is not a flat operation mix: it **simulates a hospital, end

--- a/website/book/src/performance.md
+++ b/website/book/src/performance.md
@@ -80,23 +80,23 @@ the summary table below, never re-typed into this prose.
 
 Every committed version is durable: the transaction's WAL records are flushed
 to disk before the server answers, so an acknowledged commit survives a crash.
-That flush is a physical lower bound on single-client write latency — one
-`fsync` on the WAL device per commit — and no storage design takes a lone
+That flush (one `fsync` on the WAL device per commit) is a physical lower
+bound on single-client write latency, and no storage design takes a lone
 sequential client below it. On a laptop-class Docker setup the flush alone
 measures around 1.5–2 ms; on server NVMe it is typically an order of magnitude
 smaller. FerroEHR's optimization target is therefore everything *around* the
 flush: the database's own per-commit work (one folded commit statement, one
-merged placement read) is kept far below the flush itself, which also means
-concurrent throughput scales — PostgreSQL group-commits, amortizing one flush
-across every transaction that reaches it in the same window.
+merged placement read) stays far below the flush itself. That is also what
+makes concurrent throughput scale: PostgreSQL group-commits, amortizing one
+flush across every transaction that reaches it in the same window.
 
 The knob behind this boundary is PostgreSQL's
 [`synchronous_commit`](https://www.postgresql.org/docs/18/runtime-config-wal.html#GUC-SYNCHRONOUS-COMMIT).
 Setting it `off` makes commits return before the WAL flush: single-client
 write latency drops to the statement work alone, and a server crash can lose
 the most recent acknowledged commits (up to three times `wal_writer_delay`,
-per the PostgreSQL documentation — the database stays consistent; the tail of
-acknowledged writes is what is at risk). **FerroEHR never defaults this off
+per the PostgreSQL documentation). The database stays consistent; the tail of
+acknowledged writes is what is at risk. **FerroEHR never defaults this off
 and does not recommend it for clinical data.** It is an operator decision,
 made per deployment on the database side, defensible only where the record of
 loss is acceptable (a load-test rig, a reseedable sandbox, an analytics


### PR DESCRIPTION
The v4.0.4 round of the write-latency program (#2698): the composition-update mega-read and the raw-body read passthrough, plus the durability-floor page the program's last acceptance box asks for. The UNLOGGED `node` lever was measured on a 10k store and REJECTED by owner ruling (recorded on the issue): no single-client latency change, −16%/−11% DB statement work, −84% WAL volume — not worth crash-truncation, a blocking boot rebuild, and the empty-standby caveat now that the folded commit already captured the original motivation.

**The update mega-read.** The composition-update pool pre-read (`current_composition_meta`) is gone: ownership (404), the full-`OBJECT_VERSION_ID` `If-Match` compare (412), the deleted-lifecycle gate (404), `is_modifiable` (409), the stored-template stability check (422), the `VERSIONED_COMPOSITION` first-version invariants, and the version-tree placement (tip + next ordinal + `now()`) all ride ONE in-transaction statement under the per-vo advisory lock, thaw CTEs included (`update_placement`). The envelope resolution and content validation run BEFORE the transaction — validation may consult the template store and routed terminology, so neither the pool connection nor the advisory lock is ever held across it — and their held results surface in the exact pre-check order the route always had. The update is now five round trips (BEGIN, lock, mega-read, folded commit, COMMIT) against six-plus-a-pool-read. `next_version` takes an optional preplaced placement (`CommitScope.preplaced`) and re-checks that a preplaced `expected` equals the tip, so the coupling to the caller's If-Match gate is verified, never assumed. Two SQL-shape lessons are pinned in comments: the multi-referenced `src` CTE stays NARROW (a body column would be materialized per version), and the first-root lateral sorts the raw row before extracting (inline jsonb extractions under an ORDER BY evaluate on every row below the sort — measured 0.76 ms, restructured 0.15 ms, versus the 0.168 ms the old pre-read + placement pair cost).

**The raw-body read passthrough.** `GET …/composition/{uid}` (latest and at-version) with a JSON accept serves the stored `body::text` verbatim instead of parse → stamp → re-serialize. Safety is proved, not assumed: the body is uid-stamped at commit (`stamp_version_uid` runs before decomposition) and jsonb renders object keys length-first, so a stamped COMPOSITION's text opens with its own `uid` — the service compares that exact prefix (`{"uid": {"_type": "OBJECT_VERSION_ID", "value": "<uid>"}`) and anything else (verbatim-loaded foreign bodies) falls back to the parsed re-stamp path. Imported versions, `stable`-profile rows the commit stamp cannot decide, XML/FLAT/STRUCTURED accepts, and `expand_multimedia=true` all parse exactly as before; bare reads never verified signatures (verification lives on the VERSION-envelope reads), so `verify_on_read = strict` semantics are untouched. Wire note (changelogged): insignificant JSON whitespace now follows PostgreSQL's jsonb rendering.

**Measured** (native release binary, composed PG18, keep-alive battery, 43-node vital-signs composition, defaults on incl. signing; before = develop v4.0.3+, after = this branch):

| endpoint | before p50 | after p50 |
|---|---|---|
| GET composition (latest, JSON) | 0.829 ms | 0.634 ms |
| GET composition (at-version, JSON) | 0.765 ms | 0.637 ms |
| composition update | 4.833 ms | 4.875 ms (noise; −1 round trip, DB side 0.168 → 0.150 ms) |
| composition create (unchanged path, noise floor) | 2.943 ms | 2.826 ms |

**The durability floor** is now a book section (`performance.md`): why a durable commit cannot beat the WAL fsync, how group commit scales past it, and `synchronous_commit` as an explicit operator choice, never a FerroEHR default.

**Conformance:** `scripts/conformance.sh` — 1064 passed / 0 failed / 0 errored / 38 n-a, verdicts byte-identical to the committed baseline; the only artifact diff is the version stamp refresh (4.0.2 → 4.0.3, the baseline predating the release cut), committed here.

Gates: workspace clippy (all-features), rustdoc, `cargo fmt`, full nextest 5205/5205, plus a new REST test pinning the passthrough bytes (`composition_get_serves_stored_json_verbatim`).
