### PR TITLE
fix(ci): the sandbox reseed call inherits secrets

### DIFF
--- a/.github/workflows/sandbox-deploy.yml
+++ b/.github/workflows/sandbox-deploy.yml
@@ -115,7 +115,11 @@ jobs:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.reseed }}
     permissions:
       contents: read
-    # SANDBOX_DATABASE_URL is an ENVIRONMENT secret; the called workflow's
-    # job declares `environment: sandbox-reseed`, so it resolves there — no
-    # secret passing is needed.
+    # A called workflow's `secrets` context holds ONLY what the caller passes
+    # (verified first-hand: without this, SANDBOX_DATABASE_URL arrived empty
+    # and the Neon fence refused the wipe — run 32887862798). `inherit` is
+    # the one way to reach an ENVIRONMENT secret from a caller, since a
+    # `uses:` job cannot declare the environment itself; the called job's
+    # `environment: sandbox-reseed` still applies its protection rules.
     uses: ./.github/workflows/sandbox-reseed.yml
+    secrets: inherit

--- a/.github/workflows/sandbox-deploy.yml
+++ b/.github/workflows/sandbox-deploy.yml
@@ -121,5 +121,7 @@ jobs:
     # the one way to reach an ENVIRONMENT secret from a caller, since a
     # `uses:` job cannot declare the environment itself; the called job's
     # `environment: sandbox-reseed` still applies its protection rules.
+    # zizmor's preferred explicit passing is impossible here: the caller's
+    # job cannot read an environment-scoped secret to pass it on.
     uses: ./.github/workflows/sandbox-reseed.yml
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]


### PR DESCRIPTION
The dry run of #2724's pipeline proved the deploy half and the Neon fail-closed fence, and exposed the reusable-workflow secrets contract: a called workflow's secrets context holds only what the caller passes, and a `uses:` job cannot declare the environment that scopes `SANDBOX_DATABASE_URL` — so the reseed saw an empty DSN and refused (run 32887862798, exactly the fail-closed behaviour the fence exists for). `secrets: inherit` is the sanctioned way to reach an environment secret from a caller; the called job's `environment: sandbox-reseed` protection still applies. zizmor stays clean.