### PR TITLE
test(admin-ui): the AppShell harness is in service; the __eh_frame warning is adjudicated

### DIFF
--- a/app/ferroehr-admin-ui/CLAUDE.md
+++ b/app/ferroehr-admin-ui/CLAUDE.md
@@ -204,6 +204,17 @@ extension); the wire it consumes IS spec-bound (`docs/specs/openehr/ITS-REST/`
   every other answer counts as present — capability is not authorization, so a
   `401`/`403` refusal surfaces as actionable copy on the screen that asked.
 
+## Accepted build warning (adjudicated, #2697)
+
+macOS/aarch64 bin links print Apple ld's `__eh_frame section too large (max
+16MB) to encode dwarf unwind offsets in compact unwind table, performance of
+exception handling might be affected`. Accepted with record: the shipped
+console is a Linux ELF image (Apple's compact-unwind machinery never applies
+to production), and on local macOS builds the cost is slower DWARF unwinding
+on the already-exceptional panic path — the `panic = "unwind"` contract needs
+unwinding to WORK, not to be fast. Do not re-file it, and do not silence
+`linker_messages` (it would hide genuinely new linker findings).
+
 ## Gates
 
 `/ui-gates`: clippy on **native (`--features ssr`) and wasm32 (hydrate)**


### PR DESCRIPTION
Closes out the AppShell harness issue. The route-tree-renderer harness itself landed with #2701 and is in service: `tests/it/ssr_shell.rs` renders `app::App` through `leptos_axum::render_app_async_with_context` (the same handler the binary mounts) and asserts the chrome's load-bearing HTML in process — the full static sidebar around a matched screen, the probe-gated nav entries left out when a probe cannot answer, the topbar (wordmark, health pill, user menu, dark toggle), the footer (version + scope count), the screen-inside-`<main>` proof, and the session-guard redirect. #2729 extended the same suite to drive the REAL assembled service (`server::router`) with `oneshot`, adding the empty-302-body pin and the public `/login` pass, so the chrome now has both a bare-render and a routed-service harness. That satisfies the first acceptance box; this PR carries the second:

**The `__eh_frame` linker warning, adjudicated — accepted with record.** Reproduced on a fresh bin link (macOS/aarch64, Apple ld: `__eh_frame section too large (max 16MB) to encode dwarf unwind offsets in compact unwind table, performance of exception handling might be affected`). The shipped console is a Linux ELF image built in CI, so Apple's compact-unwind machinery never applies to a production binary; on local macOS developer builds the cost is slower DWARF-based unwinding on the already-exceptional panic path — the `panic = "unwind"` reliability contract requires unwinding to WORK (CatchPanic's clean 500), not to be fast, and correctness is unaffected. Recorded in the crate `CLAUDE.md` so it is not re-filed; `linker_messages` stays armed so a genuinely new linker finding still surfaces.

Closes #2697
