### PR TITLE
chore(quality): the mechanical Sonar Rust classes are fixed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5503,7 +5503,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "indexmap 2.14.0",
  "openehr-am",
@@ -5519,7 +5519,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "serde",
  "serde_json",
@@ -5548,7 +5548,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "async-trait",
  "axum",
@@ -5577,7 +5577,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "assert_fs",
  "chumsky",
@@ -5591,7 +5591,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "chumsky",
  "logos",
@@ -5600,7 +5600,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "insta",
  "jsonschema",
@@ -5618,7 +5618,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/app/ferroehr-rest/src/extensions/access/authz/cedar.rs
+++ b/app/ferroehr-rest/src/extensions/access/authz/cedar.rs
@@ -314,7 +314,7 @@ fn load_and_validate(dir: &Path, schema: &Schema) -> Result<PolicySet, AuthzErro
         let path = entry
             .map_err(|e| AuthzError::PolicyLoad(format!("policy dir entry: {e}")))?
             .path();
-        if path.extension().and_then(|e| e.to_str()) == Some("cedar") {
+        if path.extension().and_then(std::ffi::OsStr::to_str) == Some("cedar") {
             let text = std::fs::read_to_string(&path).map_err(|e| {
                 AuthzError::PolicyLoad(format!("reading policy {}: {e}", path.display()))
             })?;

--- a/app/ferroehr/src/service/admin/types.rs
+++ b/app/ferroehr/src/service/admin/types.rs
@@ -41,8 +41,7 @@ impl ExportFormat {
     }
 
     /// Both vendored members, in `export_format.adoc` order.
-    pub const ALL: &'static [ExportFormat] =
-        &[Self::OpenehrCanonicalXml, Self::OpenehrCanonicalJson];
+    pub const ALL: &[ExportFormat] = &[Self::OpenehrCanonicalXml, Self::OpenehrCanonicalJson];
 }
 
 impl std::str::FromStr for ExportFormat {
@@ -89,7 +88,7 @@ impl CompressionFormat {
     }
 
     /// Both vendored members, in `compression_format.adoc` order.
-    pub const ALL: &'static [CompressionFormat] = &[Self::Zip, Self::SevenZip];
+    pub const ALL: &[CompressionFormat] = &[Self::Zip, Self::SevenZip];
 }
 
 impl std::str::FromStr for CompressionFormat {

--- a/app/ferroehr/src/service/definition/opt14_convert.rs
+++ b/app/ferroehr/src/service/definition/opt14_convert.rs
@@ -2002,7 +2002,7 @@ mod tests {
         let mut count = 0usize;
         for entry in std::fs::read_dir(&dir).expect("opt corpus dir") {
             let path = entry.expect("dir entry").path();
-            if path.extension().and_then(|e| e.to_str()) != Some("opt") {
+            if path.extension().and_then(std::ffi::OsStr::to_str) != Some("opt") {
                 continue;
             }
             count += 1;

--- a/app/ferroehr/src/service/ehr/validation.rs
+++ b/app/ferroehr/src/service/ehr/validation.rs
@@ -915,7 +915,7 @@ mod tests {
         let mut checked = 0u32;
         for entry in std::fs::read_dir(dir).expect("read ehr/invalid") {
             let path = entry.expect("dir entry").path();
-            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            if path.extension().and_then(std::ffi::OsStr::to_str) != Some("json") {
                 continue;
             }
             let text = std::fs::read_to_string(&path).expect("read fixture");

--- a/app/ferroehr/src/service/platform_service.rs
+++ b/app/ferroehr/src/service/platform_service.rs
@@ -58,7 +58,7 @@ impl PlatformService {
     }
 
     /// All eight vendored members, in `platform_service.adoc` order.
-    pub const ALL: &'static [PlatformService] = &[
+    pub const ALL: &[PlatformService] = &[
         Self::Admin,
         Self::Definitions,
         Self::Ehr,

--- a/app/ferroehr/src/validation/opt/rm_conformance.rs
+++ b/app/ferroehr/src/validation/opt/rm_conformance.rs
@@ -40,7 +40,7 @@ use super::{NodeView, RuleViolation};
 /// a spec-pin bump follows automatically. PATHABLE's inherited members
 /// (`parent`, which the flattened model also reports) are excluded, since the
 /// tolerance exists precisely for classes the RM derives from PATHABLE alone.
-static LOCATABLE_META_ATTRS: LazyLock<BTreeSet<&'static str>> = LazyLock::new(|| {
+static LOCATABLE_META_ATTRS: LazyLock<BTreeSet<&str>> = LazyLock::new(|| {
     let pathable: BTreeSet<&'static str> = model::attributes("PATHABLE").map(|a| a.name).collect();
     model::attributes("LOCATABLE")
         .map(|a| a.name)

--- a/app/ferroehr/tests/it/opt_resource_meta.rs
+++ b/app/ferroehr/tests/it/opt_resource_meta.rs
@@ -46,7 +46,7 @@ fn vendored_opt_corpora_pass_the_resource_meta_checks() {
     for dir in corpora {
         for entry in std::fs::read_dir(dir).expect("corpus directory is readable") {
             let path = entry.expect("corpus directory entry is readable").path();
-            if path.extension().and_then(|e| e.to_str()) != Some("opt") {
+            if path.extension().and_then(std::ffi::OsStr::to_str) != Some("opt") {
                 continue;
             }
             let xml = std::fs::read_to_string(&path).expect("corpus OPT is readable");

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-adl"
-version = "0.0.36"
+version = "0.0.37"
 description = "openEHR ADL 2.4.0: hand-written ADL2/cADL/ODIN parser, AOM2 validation catalogue, specialisation flattener, OPT2 generator, and ADL 1.4→2 conversion over the generated openehr_am::v2_4::aom2 model"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,11 +16,11 @@ include = ["src/**", "README.md", "LICENSE-MIT"]
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)
-openehr-base = { path = "../openehr-base", version = "0.0.36" }   # VersionStatus for the parsed HRID
-openehr-am = { path = "../openehr-am", version = "0.0.36" }       # v2_4 ArchetypeHrid (the identification target type)
-openehr-rm = { path = "../openehr-rm", version = "0.0.36" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
-openehr-lang = { path = "../openehr-lang", version = "0.0.36" }   # openehr_lang::odin — the ODIN section parser
-openehr-term = { path = "../openehr-term", version = "0.0.36" }   # the languages code set for the RM resource-meta rows
+openehr-base = { path = "../openehr-base", version = "0.0.37" }   # VersionStatus for the parsed HRID
+openehr-am = { path = "../openehr-am", version = "0.0.37" }       # v2_4 ArchetypeHrid (the identification target type)
+openehr-rm = { path = "../openehr-rm", version = "0.0.37" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
+openehr-lang = { path = "../openehr-lang", version = "0.0.37" }   # openehr_lang::odin — the ODIN section parser
+openehr-term = { path = "../openehr-term", version = "0.0.37" }   # the languages code set for the RM resource-meta rows
 uuid.workspace = true        # meta uid/build_uid (AUTHORED_ARCHETYPE.uid: Uuid)
 indexmap.workspace = true    # OdinValue::Object body (insertion-ordered map)
 

--- a/crates/openehr-adl/tests/it/ckm_archetype_packs.rs
+++ b/crates/openehr-adl/tests/it/ckm_archetype_packs.rs
@@ -120,7 +120,7 @@ fn files_with_extension(dir: &Path, ext: &str) -> Vec<PathBuf> {
 
 fn file_name(path: &Path) -> String {
     path.file_name()
-        .and_then(|n| n.to_str())
+        .and_then(std::ffi::OsStr::to_str)
         .unwrap_or("?")
         .to_owned()
 }

--- a/crates/openehr-adl/tests/it/ckm_conversion_breadth.rs
+++ b/crates/openehr-adl/tests/it/ckm_conversion_breadth.rs
@@ -84,7 +84,7 @@ fn adl_sources(dir: &Path) -> Vec<PathBuf> {
 
 fn file_name(path: &Path) -> String {
     path.file_name()
-        .and_then(|n| n.to_str())
+        .and_then(std::ffi::OsStr::to_str)
         .unwrap_or("?")
         .to_owned()
 }

--- a/crates/openehr-adl/tests/it/corpus_definition_parse.rs
+++ b/crates/openehr-adl/tests/it/corpus_definition_parse.rs
@@ -68,7 +68,7 @@ fn collect_adls(dir: &Path, out: &mut Vec<PathBuf>) {
 fn is_excluded(path: &Path) -> bool {
     let name = path
         .file_name()
-        .and_then(|n| n.to_str())
+        .and_then(std::ffi::OsStr::to_str)
         .unwrap_or_default();
     EXCLUSIONS.iter().any(|(f, _)| *f == name)
 }

--- a/crates/openehr-adl/tests/it/corpus_lex.rs
+++ b/crates/openehr-adl/tests/it/corpus_lex.rs
@@ -43,7 +43,7 @@ fn collect_adls(dir: &Path, out: &mut Vec<PathBuf>) {
 fn is_excluded(path: &Path) -> bool {
     let name = path
         .file_name()
-        .and_then(|n| n.to_str())
+        .and_then(std::ffi::OsStr::to_str)
         .unwrap_or_default();
     EXCLUSIONS.iter().any(|(f, _)| *f == name)
 }

--- a/crates/openehr-adl/tests/it/corpus_outer_parse.rs
+++ b/crates/openehr-adl/tests/it/corpus_outer_parse.rs
@@ -92,7 +92,7 @@ fn collect_adls(dir: &Path, out: &mut Vec<PathBuf>) {
 fn is_excluded(path: &Path) -> bool {
     let name = path
         .file_name()
-        .and_then(|n| n.to_str())
+        .and_then(std::ffi::OsStr::to_str)
         .unwrap_or_default();
     EXCLUSIONS.iter().any(|(f, _)| *f == name)
 }
@@ -148,7 +148,7 @@ fn every_excluded_file_is_actually_rejected() {
     for (name, reason) in EXCLUSIONS {
         let path = files
             .iter()
-            .find(|p| p.file_name().and_then(|n| n.to_str()) == Some(name))
+            .find(|p| p.file_name().and_then(std::ffi::OsStr::to_str) == Some(name))
             .unwrap_or_else(|| panic!("excluded fixture {name} missing from the corpus"));
         let src = std::fs::read_to_string(path).expect("read corpus file");
         assert!(

--- a/crates/openehr-adl/tests/it/corpus_roundtrip.rs
+++ b/crates/openehr-adl/tests/it/corpus_roundtrip.rs
@@ -65,7 +65,7 @@ fn collect_adls(dir: &Path, out: &mut Vec<PathBuf>) {
 fn is_excluded(path: &Path) -> bool {
     let name = path
         .file_name()
-        .and_then(|n| n.to_str())
+        .and_then(std::ffi::OsStr::to_str)
         .unwrap_or_default();
     EXCLUSIONS.iter().any(|(f, _)| *f == name)
 }

--- a/crates/openehr-adl/tests/it/corpus_rules_parse.rs
+++ b/crates/openehr-adl/tests/it/corpus_rules_parse.rs
@@ -27,7 +27,7 @@ fn adls_files(dir: &Path, out: &mut Vec<PathBuf>) {
         let path = entry.path();
         if path.is_dir() {
             adls_files(&path, out);
-        } else if path.extension().and_then(|e| e.to_str()) == Some("adls") {
+        } else if path.extension().and_then(std::ffi::OsStr::to_str) == Some("adls") {
             out.push(path);
         }
     }

--- a/crates/openehr-am/Cargo.toml
+++ b/crates/openehr-am/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-am"
-version = "0.0.36"
+version = "0.0.37"
 description = "openEHR AM Archetype Model, generated from BMM: generations v1_4 (AM 1.4.0, ADL 1.4) and v2_4 (AM 2.4.0, ADL 2; current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,8 +13,8 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.36" }
-openehr-lang = { path = "../openehr-lang", version = "0.0.36" }
+openehr-base = { path = "../openehr-base", version = "0.0.37" }
+openehr-lang = { path = "../openehr-lang", version = "0.0.37" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also carries the untyped `Value` fields the generator

--- a/crates/openehr-base/Cargo.toml
+++ b/crates/openehr-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-base"
-version = "0.0.36"
+version = "0.0.37"
 description = "openEHR BASE foundation + base types, generated from BMM: generations v1_2 (BASE 1.2.0) and v1_3 (BASE 1.3.0, current)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-its"
-version = "0.0.36"
+version = "0.0.37"
 description = "openEHR ITS (Implementation Technology Specifications): canonical JSON + canonical XML serialization of the RM, the generated ITS-REST 1.1.0 API contract, OPT 1.4 and AOM2 archetype XML codecs, and the Simplified Formats (FLAT / STRUCTURED / Web Template)"
 edition.workspace = true
 rust-version.workspace = true
@@ -41,14 +41,14 @@ regex = { workspace = true, optional = true }
 fancy-regex = { workspace = true, optional = true }
 # The generated XML (de)serializers impl the crate's ToXml/FromXml traits for the
 # RM/BASE spec types, so these are real (non-dev) deps.
-openehr-base = { path = "../openehr-base", version = "0.0.36", optional = true }
-openehr-rm = { path = "../openehr-rm", version = "0.0.36", optional = true }
+openehr-base = { path = "../openehr-base", version = "0.0.37", optional = true }
+openehr-rm = { path = "../openehr-rm", version = "0.0.37", optional = true }
 # The native canonical-JSON codec (`json_codec/generated`, emit-json) implements
 # `ToJson` for EVERY generated spec type the `OpenEhrType` derive covers, so it
 # spans all five spec crates (not just the RM/BASE the XML codec needs).
-openehr-lang = { path = "../openehr-lang", version = "0.0.36", optional = true }
-openehr-am = { path = "../openehr-am", version = "0.0.36", optional = true }
-openehr-term = { path = "../openehr-term", version = "0.0.36", optional = true }
+openehr-lang = { path = "../openehr-lang", version = "0.0.37", optional = true }
+openehr-am = { path = "../openehr-am", version = "0.0.37", optional = true }
+openehr-term = { path = "../openehr-term", version = "0.0.37", optional = true }
 
 # `full` — every ITS surface (canonical JSON/XML, the generated ITS-REST
 # contract, `opt14`, Simplified Formats). ON BY DEFAULT, so every consumer sees

--- a/crates/openehr-its/src/flat/example.rs
+++ b/crates/openehr-its/src/flat/example.rs
@@ -347,7 +347,7 @@ fn is_repeating(node: &WebTemplateNode) -> bool {
 /// Template child may sit several RM levels below its Web Template parent, so
 /// the parent's class is not the right scope to resolve against.
 fn rm_declares(aql_path: &str) -> bool {
-    static DECLARED: std::sync::LazyLock<std::collections::BTreeSet<&'static str>> =
+    static DECLARED: std::sync::LazyLock<std::collections::BTreeSet<&str>> =
         std::sync::LazyLock::new(|| {
             openehr_rm::v1_2::model::classes()
                 .flat_map(|c| c.attributes.iter().map(|a| a.name))

--- a/crates/openehr-its/src/flat/tdd.rs
+++ b/crates/openehr-its/src/flat/tdd.rs
@@ -670,7 +670,7 @@ fn is_multiple(attr: &str) -> bool {
 /// attribute through the RM abstract→concrete descendant sets. Correctness
 /// reference: the attribute cardinalities in openEHR RM `common`, `composition`,
 /// `ehr`, and `data_structures`.
-static MULTIVALUED_ATTRS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+static MULTIVALUED_ATTRS: LazyLock<HashSet<&str>> = LazyLock::new(|| {
     let mut set: HashSet<&'static str> = HashSet::new();
     let mut seen: HashSet<&'static str> = HashSet::new();
     let mut queue: Vec<&'static str> = vec!["COMPOSITION", "EHR_STATUS", "FOLDER"];

--- a/crates/openehr-its/src/flat/validation/mod.rs
+++ b/crates/openehr-its/src/flat/validation/mod.rs
@@ -604,7 +604,7 @@ struct Validator {
 /// answers — a constraint on an attribute NO RM class declares — is fully
 /// decided by the name.
 fn rm_declares_attribute(attr: &str) -> bool {
-    static DECLARED: std::sync::LazyLock<std::collections::BTreeSet<&'static str>> =
+    static DECLARED: std::sync::LazyLock<std::collections::BTreeSet<&str>> =
         std::sync::LazyLock::new(|| {
             openehr_rm::v1_2::model::classes()
                 .flat_map(|c| c.attributes.iter().map(|a| a.name))

--- a/crates/openehr-its/src/xml/runtime.rs
+++ b/crates/openehr-its/src/xml/runtime.rs
@@ -347,63 +347,6 @@ impl ToXml for f64 {
     }
 }
 
-#[cfg(test)]
-mod real_lexical_tests {
-    use super::xsd_double_lexical;
-
-    /// Every `Real` shape against the `xs:double` lexical space (XML Schema
-    /// Part 2 §3.2.5), including the three special values a bare
-    /// `f64::to_string` spells wrongly.
-    #[test]
-    fn real_values_take_the_xsd_double_lexical_form() {
-        // Whole reals keep the decimal point openEHR writes.
-        assert_eq!(xsd_double_lexical(120.0), "120.0");
-        assert_eq!(xsd_double_lexical(0.0), "0.0");
-        assert_eq!(xsd_double_lexical(-0.0), "-0.0");
-        assert_eq!(xsd_double_lexical(-7.0), "-7.0");
-        // Fractional reals round-trip through the shortest form.
-        assert_eq!(xsd_double_lexical(5.66), "5.66");
-        assert_eq!(
-            xsd_double_lexical(32.299_869_242_485_19),
-            "32.29986924248519"
-        );
-        // The special values: `INF` / `-INF` / `NaN`, never Rust's spellings.
-        assert_eq!(xsd_double_lexical(f64::INFINITY), "INF");
-        assert_eq!(xsd_double_lexical(f64::NEG_INFINITY), "-INF");
-        assert_eq!(xsd_double_lexical(f64::NAN), "NaN");
-        assert_ne!(xsd_double_lexical(f64::INFINITY), f64::INFINITY.to_string());
-    }
-
-    /// The emitted lexeme must parse back to the same value — the fidelity
-    /// property the round-trip gates rest on.
-    #[test]
-    fn every_emitted_lexeme_parses_back() {
-        for v in [
-            120.0_f64,
-            -0.0,
-            5.66,
-            32.299_869_242_485_19,
-            1e21,
-            1e-7,
-            f64::MAX,
-            f64::MIN_POSITIVE,
-            f64::INFINITY,
-            f64::NEG_INFINITY,
-        ] {
-            let text = xsd_double_lexical(v);
-            let back: f64 = text
-                .parse()
-                .unwrap_or_else(|e| panic!("{text:?} does not parse back: {e}"));
-            assert_eq!(back.to_bits(), v.to_bits(), "{text:?}");
-        }
-        assert!(
-            xsd_double_lexical(f64::NAN)
-                .parse::<f64>()
-                .is_ok_and(f64::is_nan)
-        );
-    }
-}
-
 impl<T: ToXml> ToXml for Box<T> {
     fn xml_type_name(&self) -> &'static str {
         (**self).xml_type_name()
@@ -928,5 +871,62 @@ impl FromXml for XmlAny {
             }
         }
         Ok(any)
+    }
+}
+
+#[cfg(test)]
+mod real_lexical_tests {
+    use super::xsd_double_lexical;
+
+    /// Every `Real` shape against the `xs:double` lexical space (XML Schema
+    /// Part 2 §3.2.5), including the three special values a bare
+    /// `f64::to_string` spells wrongly.
+    #[test]
+    fn real_values_take_the_xsd_double_lexical_form() {
+        // Whole reals keep the decimal point openEHR writes.
+        assert_eq!(xsd_double_lexical(120.0), "120.0");
+        assert_eq!(xsd_double_lexical(0.0), "0.0");
+        assert_eq!(xsd_double_lexical(-0.0), "-0.0");
+        assert_eq!(xsd_double_lexical(-7.0), "-7.0");
+        // Fractional reals round-trip through the shortest form.
+        assert_eq!(xsd_double_lexical(5.66), "5.66");
+        assert_eq!(
+            xsd_double_lexical(32.299_869_242_485_19),
+            "32.29986924248519"
+        );
+        // The special values: `INF` / `-INF` / `NaN`, never Rust's spellings.
+        assert_eq!(xsd_double_lexical(f64::INFINITY), "INF");
+        assert_eq!(xsd_double_lexical(f64::NEG_INFINITY), "-INF");
+        assert_eq!(xsd_double_lexical(f64::NAN), "NaN");
+        assert_ne!(xsd_double_lexical(f64::INFINITY), f64::INFINITY.to_string());
+    }
+
+    /// The emitted lexeme must parse back to the same value — the fidelity
+    /// property the round-trip gates rest on.
+    #[test]
+    fn every_emitted_lexeme_parses_back() {
+        for v in [
+            120.0_f64,
+            -0.0,
+            5.66,
+            32.299_869_242_485_19,
+            1e21,
+            1e-7,
+            f64::MAX,
+            f64::MIN_POSITIVE,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+        ] {
+            let text = xsd_double_lexical(v);
+            let back: f64 = text
+                .parse()
+                .unwrap_or_else(|e| panic!("{text:?} does not parse back: {e}"));
+            assert_eq!(back.to_bits(), v.to_bits(), "{text:?}");
+        }
+        assert!(
+            xsd_double_lexical(f64::NAN)
+                .parse::<f64>()
+                .is_ok_and(f64::is_nan)
+        );
     }
 }

--- a/crates/openehr-its/tests/it/aom2_xml.rs
+++ b/crates/openehr-its/tests/it/aom2_xml.rs
@@ -76,7 +76,7 @@ fn aom2_example_documents_read() {
     for path in &files {
         let name = path
             .file_name()
-            .and_then(|n| n.to_str())
+            .and_then(std::ffi::OsStr::to_str)
             .unwrap_or("?")
             .to_owned();
         let expected = ADJUDICATED.iter().find(|(file, _)| *file == name);
@@ -128,7 +128,7 @@ fn aom2_examples_round_trip() {
     for path in &files {
         let name = path
             .file_name()
-            .and_then(|n| n.to_str())
+            .and_then(std::ffi::OsStr::to_str)
             .unwrap_or("?")
             .to_owned();
         if ADJUDICATED.iter().any(|(file, _)| *file == name) {
@@ -179,7 +179,7 @@ fn aom2_examples_carry_the_group_body() {
     for path in &files {
         let name = path
             .file_name()
-            .and_then(|n| n.to_str())
+            .and_then(std::ffi::OsStr::to_str)
             .unwrap_or("?")
             .to_owned();
         if ADJUDICATED.iter().any(|(file, _)| *file == name) {

--- a/crates/openehr-its/tests/it/ckm_archetype_xml.rs
+++ b/crates/openehr-its/tests/it/ckm_archetype_xml.rs
@@ -110,7 +110,7 @@ fn ckm_archetype_xml_pack_reads() {
     for path in &files {
         let name = path
             .file_name()
-            .and_then(|n| n.to_str())
+            .and_then(std::ffi::OsStr::to_str)
             .unwrap_or("?")
             .to_owned();
         let expected = ADJUDICATED.iter().find(|(file, _)| *file == name);

--- a/crates/openehr-its/tests/it/ckm_full_pack.rs
+++ b/crates/openehr-its/tests/it/ckm_full_pack.rs
@@ -73,7 +73,7 @@ fn opt_files(dir: &Path) -> Vec<PathBuf> {
 
 fn file_name(path: &Path) -> String {
     path.file_name()
-        .and_then(|n| n.to_str())
+        .and_then(std::ffi::OsStr::to_str)
         .unwrap_or("?")
         .to_owned()
 }

--- a/crates/openehr-its/tests/it/coded_names.rs
+++ b/crates/openehr-its/tests/it/coded_names.rs
@@ -57,7 +57,7 @@ fn collect_opts(dir: &Path, out: &mut Vec<PathBuf>) {
         let p = e.path();
         if p.is_dir() {
             collect_opts(&p, out);
-        } else if p.extension().and_then(|s| s.to_str()) == Some("opt") {
+        } else if p.extension().and_then(std::ffi::OsStr::to_str) == Some("opt") {
             out.push(p);
         }
     }

--- a/crates/openehr-its/tests/it/common.rs
+++ b/crates/openehr-its/tests/it/common.rs
@@ -66,7 +66,7 @@ pub(crate) fn corpus_rel(path: &Path) -> String {
 /// or it re-reads a document the corpus gates already refused. Routing through
 /// here keeps one substitution rule for every gate.
 pub(crate) fn twinned(path: &Path) -> PathBuf {
-    let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+    let Some(stem) = path.file_stem().and_then(std::ffi::OsStr::to_str) else {
         return path.to_path_buf();
     };
     let twin = Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -109,7 +109,7 @@ pub(crate) fn declared_root_type(path: &Path) -> Option<&'static str> {
         .into_iter()
         .find(|p| {
             corpus_rel(p).starts_with("openehr_sdk/")
-                && p.file_stem().and_then(|s| s.to_str()) == Some(stem)
+                && p.file_stem().and_then(std::ffi::OsStr::to_str) == Some(stem)
         })
         .and_then(|p| declared_root_type(&p))
 }

--- a/crates/openehr-its/tests/it/example_rm_validity.rs
+++ b/crates/openehr-its/tests/it/example_rm_validity.rs
@@ -75,7 +75,9 @@ fn ckm_pack_examples_are_rm_shape_valid() {
                 &example,
                 &format!(
                     "{}@{level:?}",
-                    path.file_name().and_then(|n| n.to_str()).unwrap_or("?")
+                    path.file_name()
+                        .and_then(std::ffi::OsStr::to_str)
+                        .unwrap_or("?")
                 ),
                 &mut findings,
             );

--- a/crates/openehr-its/tests/it/example_stub.rs
+++ b/crates/openehr-its/tests/it/example_stub.rs
@@ -240,7 +240,7 @@ fn committable_example_of_every_fixture_fully_validates() {
         };
         let name = path
             .file_name()
-            .and_then(|n| n.to_str())
+            .and_then(std::ffi::OsStr::to_str)
             .unwrap_or_default();
         for level in [DetailLevel::Required, DetailLevel::Medium] {
             let contradictory = CONTRADICTORY_FIXTURES
@@ -326,7 +326,7 @@ fn collect_opts(dir: &Path, out: &mut Vec<PathBuf>) {
         let p = e.path();
         if p.is_dir() {
             collect_opts(&p, out);
-        } else if p.extension().and_then(|s| s.to_str()) == Some("opt") {
+        } else if p.extension().and_then(std::ffi::OsStr::to_str) == Some("opt") {
             out.push(p);
         }
     }

--- a/crates/openehr-its/tests/it/format_parity.rs
+++ b/crates/openehr-its/tests/it/format_parity.rs
@@ -148,12 +148,15 @@ fn invalid_fixture_verdicts_agree_across_canonical_formats() {
     let mut structural = 0usize;
     for entry in std::fs::read_dir(&dir).expect("catalogue fixture dir") {
         let path = entry.expect("dir entry").path();
-        if path.extension().and_then(|e| e.to_str()) != Some("json")
-            || !path.file_name().and_then(|n| n.to_str()).is_some_and(|n| {
-                n.contains("invalid")
-                    || n.contains("location_empty")
-                    || n.contains("cluster_no_items")
-            })
+        if path.extension().and_then(std::ffi::OsStr::to_str) != Some("json")
+            || !path
+                .file_name()
+                .and_then(std::ffi::OsStr::to_str)
+                .is_some_and(|n| {
+                    n.contains("invalid")
+                        || n.contains("location_empty")
+                        || n.contains("cluster_no_items")
+                })
         {
             continue;
         }

--- a/crates/openehr-its/tests/it/opt14_corpus.rs
+++ b/crates/openehr-its/tests/it/opt14_corpus.rs
@@ -121,7 +121,7 @@ fn every_official_cnf_robot_template_parses() {
     for path in &files {
         let name = path
             .file_name()
-            .and_then(|n| n.to_str())
+            .and_then(std::ffi::OsStr::to_str)
             .unwrap_or_default();
         let xml = std::fs::read_to_string(path).expect("read opt file");
         let outcome = openehr_its::opt14::from_xml(&xml);

--- a/crates/openehr-its/tests/it/rm_validation.rs
+++ b/crates/openehr-its/tests/it/rm_validation.rs
@@ -431,7 +431,7 @@ fn corpus_files() -> Vec<std::path::PathBuf> {
             let path = entry.expect("dir entry").path();
             if path.is_dir() {
                 roots.push(path);
-            } else if path.extension().and_then(|e| e.to_str()) == Some("json") {
+            } else if path.extension().and_then(std::ffi::OsStr::to_str) == Some("json") {
                 if crate::common::excluded(&crate::common::corpus_rel(&path)).is_some() {
                     let twin = crate::common::twinned(&path);
                     if twin != path {
@@ -673,7 +673,9 @@ fn corpus_terminology_audit_is_clean() {
             for iv in v {
                 findings.push(format!(
                     "{}: {ty} {} — {}",
-                    path.file_name().and_then(|s| s.to_str()).unwrap_or("?"),
+                    path.file_name()
+                        .and_then(std::ffi::OsStr::to_str)
+                        .unwrap_or("?"),
                     iv.path,
                     iv.message,
                 ));

--- a/crates/openehr-its/tests/it/xml_c14n.rs
+++ b/crates/openehr-its/tests/it/xml_c14n.rs
@@ -171,7 +171,7 @@ fn composition_c14n_matches_cnf_canonical_fixtures() {
     let mut failures = Vec::new();
     for entry in std::fs::read_dir(&dir).expect("read fixtures dir") {
         let path = entry.unwrap().path();
-        if path.extension().and_then(|e| e.to_str()) != Some("xml") {
+        if path.extension().and_then(std::ffi::OsStr::to_str) != Some("xml") {
             continue;
         }
         let stem = path.file_stem().unwrap().to_str().unwrap().to_string();

--- a/crates/openehr-its/tests/it/xml_roundtrip.rs
+++ b/crates/openehr-its/tests/it/xml_roundtrip.rs
@@ -32,7 +32,7 @@ fn composition_xml_round_trips() {
     let mut failures = Vec::new();
     for entry in std::fs::read_dir(corpus_dir()).expect("corpus dir") {
         let path = entry.unwrap().path();
-        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+        if path.extension().and_then(std::ffi::OsStr::to_str) != Some("json") {
             continue;
         }
         let stem = path.file_stem().unwrap().to_str().unwrap().to_string();

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-lang"
-version = "0.0.36"
+version = "0.0.37"
 description = "openEHR LANG BMM/P_BMM object model, generated from BMM: generations v1_0 (LANG 1.0.0) and v1_1 (LANG 1.1.0, current; the stable BMM v2.x unit beside the paused BMM3 unit), plus hand-written ODIN/BEL/EL readers"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["parser-implementations", "data-structures"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.36" }
+openehr-base = { path = "../openehr-base", version = "0.0.37" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the
 # generated types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) —
 # never a derive. `serde_json` also carries the untyped `Value` fields the

--- a/crates/openehr-lang/src/v1_1/bmm/rm_access/reference_model_access_impl.rs
+++ b/crates/openehr-lang/src/v1_1/bmm/rm_access/reference_model_access_impl.rs
@@ -227,7 +227,7 @@ fn scan(directories: &[String]) -> Result<BTreeMap<String, SchemaDescriptor>, Rm
             let path = entry.path();
             let is_schema_file = path
                 .file_name()
-                .and_then(|name| name.to_str())
+                .and_then(std::ffi::OsStr::to_str)
                 .is_some_and(|name| name.ends_with(BmmDefinitionsData::BMM_SCHEMA_FILE_EXTENSION));
             if is_schema_file && path.is_file() {
                 files.push(path);

--- a/crates/openehr-lang/tests/it/vendor_bmm_schema.rs
+++ b/crates/openehr-lang/tests/it/vendor_bmm_schema.rs
@@ -984,7 +984,7 @@ fn collect_bmm(dir: &Path, root: &Path, out: &mut Vec<String>) {
         let path = entry.unwrap_or_else(|e| panic!("dir entry: {e}")).path();
         if path.is_dir() {
             collect_bmm(&path, root, out);
-        } else if path.extension().and_then(|e| e.to_str()) == Some("bmm") {
+        } else if path.extension().and_then(std::ffi::OsStr::to_str) == Some("bmm") {
             let rel = path
                 .strip_prefix(root)
                 .unwrap_or_else(|e| panic!("strip_prefix: {e}"));

--- a/crates/openehr-query/Cargo.toml
+++ b/crates/openehr-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-query"
-version = "0.0.36"
+version = "0.0.37"
 description = "openEHR QUERY (AQL 1.1.0): hand-written lexer, parser, typed AST and canonical printer from the official grammar (no ANTLR runtime)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-rm"
-version = "0.0.36"
+version = "0.0.37"
 description = "openEHR RM Reference Model, generated from BMM: generations v1_1 (RM 1.1.0) and v1_2 (RM 1.2.0, current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,11 +13,11 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.36" }
+openehr-base = { path = "../openehr-base", version = "0.0.37" }
 # The terminology-backed RM class invariants (`validate::terminology`) resolve
 # openEHR terminology groups + code sets against the vendored TERM 3.1.0 bundle.
 # `openehr-term` itself depends only on `openehr-base`, so this is acyclic.
-openehr-term = { path = "../openehr-term", version = "0.0.36" }
+openehr-term = { path = "../openehr-term", version = "0.0.37" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also backs the untyped `Value` RM representation used by

--- a/crates/openehr-rm/src/v1_1/composition/composition_impl.rs
+++ b/crates/openehr-rm/src/v1_1/composition/composition_impl.rs
@@ -39,7 +39,7 @@ impl Composition {
     /// "True if category is `431|persistent|`" — so `431` is normative here,
     /// not a local convention. The rubric is a rendering of it and is resolved
     /// from the terminology bundle, never compared against.
-    const PERSISTENT_CATEGORY: &'static str = "431";
+    const PERSISTENT_CATEGORY: &str = "431";
 
     /// Returns `true` when this composition's category is `431|persistent|`.
     ///

--- a/crates/openehr-rm/src/v1_1/data_types/text/term_mapping_impl.rs
+++ b/crates/openehr-rm/src/v1_1/data_types/text/term_mapping_impl.rs
@@ -25,7 +25,7 @@ impl TermMapping {
     /// RM `TERM_MAPPING.is_valid_match_code(c)`: `c` is one of `> = < ?`.
     #[must_use]
     pub fn is_valid_match_code(c: char) -> bool {
-        matches!(c, '>' | '=' | '<' | '?')
+        matches!(c, '<'..='?')
     }
 
     /// RM `TERM_MAPPING.narrower()`: the mapping is to a narrower term

--- a/crates/openehr-rm/src/v1_1/support/terminology/openehr_code_set_identifiers_impl.rs
+++ b/crates/openehr-rm/src/v1_1/support/terminology/openehr_code_set_identifiers_impl.rs
@@ -17,7 +17,7 @@ impl OpenehrCodeSetIdentifiersData {
     /// Spec: `org.openehr.rm.support.openehr_code_set_identifiers.adoc`
     /// §Constants — the seven identifiers, read from the emitted constants so
     /// there is no second copy of the list to drift.
-    const ALL: [&'static str; 7] = [
+    const ALL: [&str; 7] = [
         Self::CODE_SET_ID_CHARACTER_SETS,
         Self::CODE_SET_ID_COMPRESSION_ALGORITHMS,
         Self::CODE_SET_ID_COUNTRIES,

--- a/crates/openehr-rm/src/v1_1/support/terminology/openehr_terminology_group_identifiers_impl.rs
+++ b/crates/openehr-rm/src/v1_1/support/terminology/openehr_terminology_group_identifiers_impl.rs
@@ -25,7 +25,7 @@ impl OpenehrTerminologyGroupIdentifiersData {
     /// §Constants. `Terminology_id_openehr` is deliberately absent: it names
     /// openEHR's own TERMINOLOGY, not a group within it, which is why
     /// `TERMINOLOGY_SERVICE.terminology` takes it and this predicate does not.
-    const ALL: [&'static str; 14] = [
+    const ALL: [&str; 14] = [
         Self::GROUP_ID_AUDIT_CHANGE_TYPE,
         Self::GROUP_ID_ATTESTATION_REASON,
         Self::GROUP_ID_COMPOSITION_CATEGORY,

--- a/crates/openehr-rm/src/v1_2/composition/composition_impl.rs
+++ b/crates/openehr-rm/src/v1_2/composition/composition_impl.rs
@@ -39,7 +39,7 @@ impl Composition {
     /// "True if category is `431|persistent|`" — so `431` is normative here,
     /// not a local convention. The rubric is a rendering of it and is resolved
     /// from the terminology bundle, never compared against.
-    const PERSISTENT_CATEGORY: &'static str = "431";
+    const PERSISTENT_CATEGORY: &str = "431";
 
     /// Returns `true` when this composition's category is `431|persistent|`.
     ///

--- a/crates/openehr-rm/src/v1_2/data_types/text/term_mapping_impl.rs
+++ b/crates/openehr-rm/src/v1_2/data_types/text/term_mapping_impl.rs
@@ -25,7 +25,7 @@ impl TermMapping {
     /// RM `TERM_MAPPING.is_valid_match_code(c)`: `c` is one of `> = < ?`.
     #[must_use]
     pub fn is_valid_match_code(c: char) -> bool {
-        matches!(c, '>' | '=' | '<' | '?')
+        matches!(c, '<'..='?')
     }
 
     /// RM `TERM_MAPPING.narrower()`: the mapping is to a narrower term

--- a/crates/openehr-rm/src/v1_2/support/terminology/openehr_code_set_identifiers_impl.rs
+++ b/crates/openehr-rm/src/v1_2/support/terminology/openehr_code_set_identifiers_impl.rs
@@ -17,7 +17,7 @@ impl OpenehrCodeSetIdentifiersData {
     /// Spec: `org.openehr.rm.support.openehr_code_set_identifiers.adoc`
     /// §Constants — the seven identifiers, read from the emitted constants so
     /// there is no second copy of the list to drift.
-    const ALL: [&'static str; 7] = [
+    const ALL: [&str; 7] = [
         Self::CODE_SET_ID_CHARACTER_SETS,
         Self::CODE_SET_ID_COMPRESSION_ALGORITHMS,
         Self::CODE_SET_ID_COUNTRIES,

--- a/crates/openehr-rm/src/v1_2/support/terminology/openehr_terminology_group_identifiers_impl.rs
+++ b/crates/openehr-rm/src/v1_2/support/terminology/openehr_terminology_group_identifiers_impl.rs
@@ -25,7 +25,7 @@ impl OpenehrTerminologyGroupIdentifiersData {
     /// §Constants. `Terminology_id_openehr` is deliberately absent: it names
     /// openEHR's own TERMINOLOGY, not a group within it, which is why
     /// `TERMINOLOGY_SERVICE.terminology` takes it and this predicate does not.
-    const ALL: [&'static str; 14] = [
+    const ALL: [&str; 14] = [
         Self::GROUP_ID_AUDIT_CHANGE_TYPE,
         Self::GROUP_ID_ATTESTATION_REASON,
         Self::GROUP_ID_COMPOSITION_CATEGORY,

--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-term"
-version = "0.0.36"
+version = "0.0.37"
 description = "openEHR TERM terminology data model, generated from BMM (generation v3_1 = TERM 3.1.0), plus the embedded official terminology XML bundle"
 edition.workspace = true
 rust-version.workspace = true
@@ -34,7 +34,7 @@ include = [
 ]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.36" }
+openehr-base = { path = "../openehr-base", version = "0.0.37" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive.

--- a/tools/cnf-runner/src/ixit.rs
+++ b/tools/cnf-runner/src/ixit.rs
@@ -152,7 +152,7 @@ pub enum TerminologyPosture {
 
 impl TerminologyPosture {
     /// All variants, in vocabulary order (schema emission derives from this).
-    pub const ALL: &'static [TerminologyPosture] =
+    pub const ALL: &[TerminologyPosture] =
         &[TerminologyPosture::FailOpen, TerminologyPosture::FailClosed];
 
     /// The declaration token.
@@ -189,7 +189,7 @@ pub enum SpecProfile {
 
 impl SpecProfile {
     /// All variants, in vocabulary order (schema emission derives from this).
-    pub const ALL: &'static [SpecProfile] = &[SpecProfile::Stable, SpecProfile::Development];
+    pub const ALL: &[SpecProfile] = &[SpecProfile::Stable, SpecProfile::Development];
 
     /// The declaration token.
     #[must_use]

--- a/tools/cnf-runner/src/model/binding.rs
+++ b/tools/cnf-runner/src/model/binding.rs
@@ -154,7 +154,7 @@ impl TransformRule {
     }
 
     /// All members, in grammar order (schema emission derives from this).
-    pub const ALL: &'static [TransformRule] = &[
+    pub const ALL: &[TransformRule] = &[
         TransformRule::RootUid,
         TransformRule::CreatingSystemId,
         TransformRule::Uppercase,

--- a/tools/cnf-runner/src/model/capability.rs
+++ b/tools/cnf-runner/src/model/capability.rs
@@ -38,7 +38,7 @@ pub enum Realization {
 
 impl Realization {
     /// All variants, in vocabulary order (schema emission derives from this).
-    pub const ALL: &'static [Realization] = &[Realization::ReleasedWire, Realization::Extension];
+    pub const ALL: &[Realization] = &[Realization::ReleasedWire, Realization::Extension];
 
     /// The vocabulary token (matrix rows, certificate column).
     #[must_use]

--- a/tools/cnf-runner/src/model/wire_surface.rs
+++ b/tools/cnf-runner/src/model/wire_surface.rs
@@ -70,7 +70,7 @@ pub enum SurfaceReason {
 
 impl SurfaceReason {
     /// All variants, in vocabulary order (schema emission derives from this).
-    pub const ALL: &'static [SurfaceReason] = &[
+    pub const ALL: &[SurfaceReason] = &[
         SurfaceReason::OffWire,
         SurfaceReason::VariantOf,
         SurfaceReason::Accessor,

--- a/tools/cnf-runner/src/party.rs
+++ b/tools/cnf-runner/src/party.rs
@@ -229,7 +229,7 @@ pub enum VerificationPackStatus {
 
 impl VerificationPackStatus {
     /// All variants, in vocabulary order (schema emission derives from this).
-    pub const ALL: &'static [VerificationPackStatus] = &[
+    pub const ALL: &[VerificationPackStatus] = &[
         VerificationPackStatus::Passed,
         VerificationPackStatus::NotRun,
         VerificationPackStatus::Failed,
@@ -269,7 +269,7 @@ pub enum OutcomeStatus {
 
 impl OutcomeStatus {
     /// All variants, in vocabulary order (schema emission derives from this).
-    pub const ALL: &'static [OutcomeStatus] = &[
+    pub const ALL: &[OutcomeStatus] = &[
         OutcomeStatus::Passed,
         OutcomeStatus::Failed,
         OutcomeStatus::Errored,

--- a/tools/cnf-runner/src/perf.rs
+++ b/tools/cnf-runner/src/perf.rs
@@ -54,8 +54,7 @@ pub enum PerfClass {
 
 impl PerfClass {
     /// All classes, ladder order (schema emission derives from this).
-    pub const ALL: &'static [PerfClass] =
-        &[PerfClass::Poc, PerfClass::S, PerfClass::L, PerfClass::R];
+    pub const ALL: &[PerfClass] = &[PerfClass::Poc, PerfClass::S, PerfClass::L, PerfClass::R];
 
     /// The class's offered-load floor (peak API arrivals/s, sustained) —
     /// the published \[legislated\] defaults.
@@ -394,7 +393,7 @@ pub enum Principal {
 impl PerfOp {
     /// All operations, vocabulary order (schema emission + the coverage
     /// report derive from this).
-    pub const ALL: &'static [PerfOp] = &[
+    pub const ALL: &[PerfOp] = &[
         PerfOp::EhrCreate,
         PerfOp::EhrRead,
         PerfOp::EhrStatusRead,
@@ -1258,7 +1257,7 @@ pub enum ContainerRole {
 
 impl ContainerRole {
     /// All roles, fixed order (schema emission derives from this).
-    pub const ALL: &'static [ContainerRole] = &[ContainerRole::Sut, ContainerRole::Db];
+    pub const ALL: &[ContainerRole] = &[ContainerRole::Sut, ContainerRole::Db];
 
     /// The display label (progress lines, summary tables) — the same token
     /// the wire serialization carries.
@@ -1287,7 +1286,7 @@ pub enum ResourcePhase {
 
 impl ResourcePhase {
     /// All phases, run order (schema emission derives from this).
-    pub const ALL: &'static [ResourcePhase] = &[
+    pub const ALL: &[ResourcePhase] = &[
         ResourcePhase::Warmup,
         ResourcePhase::Measured,
         ResourcePhase::Drain,

--- a/tools/cnf-runner/src/validate.rs
+++ b/tools/cnf-runner/src/validate.rs
@@ -1894,7 +1894,7 @@ impl<'a> SpecIndex<'a> {
                     .collect::<Vec<_>>()
                     .join("/")
                     .to_lowercase();
-                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                if let Some(name) = path.file_name().and_then(std::ffi::OsStr::to_str) {
                     listing
                         .by_name
                         .entry(name.to_lowercase())
@@ -1977,10 +1977,13 @@ impl<'a> SpecIndex<'a> {
         let mut names = BTreeSet::new();
         if let Ok(text) = self.read(&path) {
             let yaml = matches!(
-                path.extension().and_then(|e| e.to_str()),
+                path.extension().and_then(std::ffi::OsStr::to_str),
                 Some("yaml" | "yml" | "json")
             );
-            let xsd = matches!(path.extension().and_then(|e| e.to_str()), Some("xsd"));
+            let xsd = matches!(
+                path.extension().and_then(std::ffi::OsStr::to_str),
+                Some("xsd")
+            );
             if xsd {
                 names.extend(xsd_declared_names(&text));
             } else if yaml {

--- a/tools/cnf-runner/src/vocab.rs
+++ b/tools/cnf-runner/src/vocab.rs
@@ -32,7 +32,7 @@ macro_rules! outcome_kinds {
 
         impl OutcomeKind {
             /// All kinds, in schedule order (the `vocab/outcomes.yaml` order).
-            pub const ALL: &'static [OutcomeKind] = &[ $(OutcomeKind::$variant,)+ ];
+            pub const ALL: &[OutcomeKind] = &[ $(OutcomeKind::$variant,)+ ];
 
             /// The kind's wire-independent token (`created`, `not_found`, …).
             #[must_use]
@@ -476,9 +476,9 @@ impl XmlNamespace {
     }
 
     /// The Release-1.0.2 bundle's target namespace.
-    pub const V1_URI: &'static str = "http://schemas.openehr.org/v1";
+    pub const V1_URI: &str = "http://schemas.openehr.org/v1";
     /// The Release-2.0.0 bundle's target namespace.
-    pub const V2_URI: &'static str = "http://schemas.openehr.org/v2";
+    pub const V2_URI: &str = "http://schemas.openehr.org/v2";
 }
 
 /// A named ignore-set the `equivalent` assertion may resolve
@@ -587,7 +587,7 @@ pub enum MemberVersionType {
 
 impl MemberVersionType {
     /// Every member `_type` a case may author, in RM order.
-    pub const ALL: &'static [MemberVersionType] = &[
+    pub const ALL: &[MemberVersionType] = &[
         MemberVersionType::Update,
         MemberVersionType::Original,
         MemberVersionType::Imported,
@@ -654,7 +654,7 @@ pub enum MemberChangeType {
 
 impl MemberChangeType {
     /// The whole `audit_change_type` group, in the terminology's own order.
-    pub const ALL: &'static [MemberChangeType] = &[
+    pub const ALL: &[MemberChangeType] = &[
         MemberChangeType::Creation,
         MemberChangeType::Amendment,
         MemberChangeType::Modification,
@@ -736,7 +736,7 @@ pub enum VersionLifecycleState {
 
 impl VersionLifecycleState {
     /// Every state of the `version_lifecycle_state` group, in master06 order.
-    pub const ALL: &'static [VersionLifecycleState] = &[
+    pub const ALL: &[VersionLifecycleState] = &[
         VersionLifecycleState::Complete,
         VersionLifecycleState::Incomplete,
         VersionLifecycleState::Deleted,
@@ -806,7 +806,7 @@ pub enum XVersionedClass {
 
 impl XVersionedClass {
     /// Every wrapper class, in the order the RM tables them.
-    pub const ALL: &'static [XVersionedClass] = &[
+    pub const ALL: &[XVersionedClass] = &[
         XVersionedClass::Composition,
         XVersionedClass::EhrStatus,
         XVersionedClass::EhrAccess,
@@ -881,18 +881,17 @@ mod tests {
 
 impl CaseKind {
     /// All variants, in vocabulary order (schema emission derives from this).
-    pub const ALL: &'static [CaseKind] = &[CaseKind::Functional, CaseKind::Content];
+    pub const ALL: &[CaseKind] = &[CaseKind::Functional, CaseKind::Content];
 }
 
 impl CaseStatus {
     /// All variants, in vocabulary order (schema emission derives from this).
-    pub const ALL: &'static [CaseStatus] =
-        &[CaseStatus::Active, CaseStatus::Retired, CaseStatus::Draft];
+    pub const ALL: &[CaseStatus] = &[CaseStatus::Active, CaseStatus::Retired, CaseStatus::Draft];
 }
 
 impl Component {
     /// All variants, in vocabulary order (schema emission derives from this).
-    pub const ALL: &'static [Component] = &[
+    pub const ALL: &[Component] = &[
         Component::Ehr,
         Component::EhrComposition,
         Component::EhrContribution,
@@ -913,12 +912,12 @@ impl Component {
 
 impl Family {
     /// All variants, in vocabulary order (schema emission derives from this).
-    pub const ALL: &'static [Family] = &[Family::Platform, Family::Enterprise, Family::Security];
+    pub const ALL: &[Family] = &[Family::Platform, Family::Enterprise, Family::Security];
 }
 
 impl Tier {
     /// All variants, in vocabulary order (schema emission derives from this).
-    pub const ALL: &'static [Tier] = &[
+    pub const ALL: &[Tier] = &[
         Tier::Core,
         Tier::Standard,
         Tier::Options,
@@ -931,7 +930,7 @@ impl Tier {
 
 impl Disposition {
     /// All variants, in vocabulary order (schema emission derives from this).
-    pub const ALL: &'static [Disposition] = &[
+    pub const ALL: &[Disposition] = &[
         Disposition::LooseAssert,
         Disposition::FixedHandling,
         Disposition::OptionSelect,
@@ -943,7 +942,7 @@ impl Disposition {
 
 impl FormatName {
     /// All variants, in vocabulary order (schema emission derives from this).
-    pub const ALL: &'static [FormatName] = &[
+    pub const ALL: &[FormatName] = &[
         FormatName::CanonicalJson,
         FormatName::CanonicalXml,
         FormatName::WtFlat,
@@ -954,7 +953,7 @@ impl FormatName {
 
 impl CorpusFormat {
     /// All variants, in vocabulary order (schema emission derives from this).
-    pub const ALL: &'static [CorpusFormat] = &[
+    pub const ALL: &[CorpusFormat] = &[
         CorpusFormat::CanonicalJson,
         CorpusFormat::CanonicalXml,
         CorpusFormat::WtFlat,
@@ -969,7 +968,7 @@ impl CorpusFormat {
 
 impl HttpMethod {
     /// All variants, in vocabulary order (schema emission derives from this).
-    pub const ALL: &'static [HttpMethod] = &[
+    pub const ALL: &[HttpMethod] = &[
         HttpMethod::Get,
         HttpMethod::Post,
         HttpMethod::Put,
@@ -981,28 +980,27 @@ impl HttpMethod {
 
 impl Iteration {
     /// All variants, in vocabulary order (schema emission derives from this).
-    pub const ALL: &'static [Iteration] = &[Iteration::ResetPerRow, Iteration::SinglePass];
+    pub const ALL: &[Iteration] = &[Iteration::ResetPerRow, Iteration::SinglePass];
 }
 
 impl ServerState {
     /// All variants, in vocabulary order (schema emission derives from this).
-    pub const ALL: &'static [ServerState] =
-        &[ServerState::Empty, ServerState::Exclusive, ServerState::Any];
+    pub const ALL: &[ServerState] = &[ServerState::Empty, ServerState::Exclusive, ServerState::Any];
 }
 
 impl FixtureVerdict {
     /// All variants, in vocabulary order (schema emission derives from this).
-    pub const ALL: &'static [FixtureVerdict] = &[FixtureVerdict::Valid, FixtureVerdict::Invalid];
+    pub const ALL: &[FixtureVerdict] = &[FixtureVerdict::Valid, FixtureVerdict::Invalid];
 }
 
 impl PlaceholderPolicy {
     /// All variants, in vocabulary order (schema emission derives from this).
-    pub const ALL: &'static [PlaceholderPolicy] = &[PlaceholderPolicy::RuntimeRandom];
+    pub const ALL: &[PlaceholderPolicy] = &[PlaceholderPolicy::RuntimeRandom];
 }
 
 impl SpecComponent {
     /// All variants, in vocabulary order (schema emission derives from this).
-    pub const ALL: &'static [SpecComponent] = &[
+    pub const ALL: &[SpecComponent] = &[
         SpecComponent::Rm,
         SpecComponent::Base,
         SpecComponent::Am,
@@ -1028,13 +1026,12 @@ impl SpecComponent {
 
 impl ChangeType {
     /// All variants, in vocabulary order (schema emission derives from this).
-    pub const ALL: &'static [ChangeType] =
-        &[ChangeType::Create, ChangeType::Modify, ChangeType::Deleted];
+    pub const ALL: &[ChangeType] = &[ChangeType::Create, ChangeType::Modify, ChangeType::Deleted];
 }
 
 impl ResultSetMatch {
     /// All variants, in vocabulary order (schema emission derives from this).
-    pub const ALL: &'static [ResultSetMatch] = &[
+    pub const ALL: &[ResultSetMatch] = &[
         ResultSetMatch::Ordered,
         ResultSetMatch::Set,
         ResultSetMatch::Count,
@@ -1044,7 +1041,7 @@ impl ResultSetMatch {
 
 impl ItsName {
     /// All variants, in vocabulary order (schema emission derives from this).
-    pub const ALL: &'static [ItsName] = &[ItsName::ItsRest];
+    pub const ALL: &[ItsName] = &[ItsName::ItsRest];
 }
 
 #[cfg(test)]

--- a/tools/docs-meta/src/main.rs
+++ b/tools/docs-meta/src/main.rs
@@ -94,7 +94,7 @@ fn run(site: &Path, origin: &str, base: &str) -> std::io::Result<usize> {
 
     let mut written = 0usize;
     for version_dir in versions {
-        let Some(version) = version_dir.file_name().and_then(|n| n.to_str()) else {
+        let Some(version) = version_dir.file_name().and_then(std::ffi::OsStr::to_str) else {
             continue;
         };
         let mut pages = Vec::new();

--- a/tools/openehr-codegen/src/cli.rs
+++ b/tools/openehr-codegen/src/cli.rs
@@ -1308,7 +1308,7 @@ fn declare_hand_written_modules(
         let mut hand_written: Vec<String> = Vec::new();
         for entry in std::fs::read_dir(&dir)? {
             let p = entry?.path();
-            let Some(stem) = p.file_stem().and_then(|s| s.to_str()) else {
+            let Some(stem) = p.file_stem().and_then(std::ffi::OsStr::to_str) else {
                 continue;
             };
             if p.is_dir() {
@@ -1319,7 +1319,7 @@ fn declare_hand_written_modules(
                 if child_mod.exists() && !is_generated_file(&child_mod) {
                     hand_written.push(stem.to_owned());
                 }
-            } else if p.extension().and_then(|e| e.to_str()) == Some("rs")
+            } else if p.extension().and_then(std::ffi::OsStr::to_str) == Some("rs")
                 && !matches!(stem, "mod" | "lib" | "prelude")
                 && (!is_generated_file(&p) || emit_templates::is_template_stamped(&p))
             {

--- a/tools/openehr-codegen/src/load/impls.rs
+++ b/tools/openehr-codegen/src/load/impls.rs
@@ -52,7 +52,7 @@ fn collect(dir: &Path, prefix: &str, out: &mut BTreeSet<String>) {
     };
     for entry in entries.flatten() {
         let path = entry.path();
-        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        let Some(name) = path.file_name().and_then(std::ffi::OsStr::to_str) else {
             continue;
         };
         let relative = if prefix.is_empty() {

--- a/tools/openehr-codegen/src/render/emit_templates.rs
+++ b/tools/openehr-codegen/src/render/emit_templates.rs
@@ -159,7 +159,7 @@ fn collect_templates(
         }
         if path.is_dir() {
             collect_templates(&path, overrides, out)?;
-        } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+        } else if path.extension().and_then(std::ffi::OsStr::to_str) == Some("rs") {
             out.push(path);
         }
     }

--- a/tools/openehr-codegen/src/render/model_query.rs
+++ b/tools/openehr-codegen/src/render/model_query.rs
@@ -84,7 +84,7 @@ pub(crate) enum Format {
 
 impl Format {
     /// The accepted `--format` values, for the usage/error text.
-    pub(crate) const VALID: &'static str = "table, tsv, json";
+    pub(crate) const VALID: &str = "table, tsv, json";
 
     /// Parse a `--format` value.
     ///

--- a/tools/openehr-codegen/src/testsupport.rs
+++ b/tools/openehr-codegen/src/testsupport.rs
@@ -1624,9 +1624,9 @@ fn hand_written_files(dir: &std::path::Path) -> Result<BTreeMap<String, String>,
             }
             let name = path
                 .file_name()
-                .and_then(|n| n.to_str())
+                .and_then(std::ffi::OsStr::to_str)
                 .unwrap_or_default();
-            if path.extension().and_then(|e| e.to_str()) != Some("rs")
+            if path.extension().and_then(std::ffi::OsStr::to_str) != Some("rs")
                 || matches!(name, "mod.rs" | "prelude.rs")
             {
                 continue;
@@ -1888,10 +1888,10 @@ fn rust_bodies_by_stem(dir: &std::path::Path) -> Result<BTreeMap<String, String>
                 stack.push(path);
                 continue;
             }
-            if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            if path.extension().and_then(std::ffi::OsStr::to_str) != Some("rs") {
                 continue;
             }
-            let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            let Some(stem) = path.file_stem().and_then(std::ffi::OsStr::to_str) else {
                 continue;
             };
             let body = std::fs::read_to_string(&path).map_err(|e| Error::from(e.to_string()))?;

--- a/tools/openehr-codegen/templates/openehr-rm/composition/composition_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/composition/composition_impl.rs
@@ -39,7 +39,7 @@ impl Composition {
     /// "True if category is `431|persistent|`" — so `431` is normative here,
     /// not a local convention. The rubric is a rendering of it and is resolved
     /// from the terminology bundle, never compared against.
-    const PERSISTENT_CATEGORY: &'static str = "431";
+    const PERSISTENT_CATEGORY: &str = "431";
 
     /// Returns `true` when this composition's category is `431|persistent|`.
     ///

--- a/tools/openehr-codegen/templates/openehr-rm/data_types/text/term_mapping_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/data_types/text/term_mapping_impl.rs
@@ -25,7 +25,7 @@ impl TermMapping {
     /// RM `TERM_MAPPING.is_valid_match_code(c)`: `c` is one of `> = < ?`.
     #[must_use]
     pub fn is_valid_match_code(c: char) -> bool {
-        matches!(c, '>' | '=' | '<' | '?')
+        matches!(c, '<'..='?')
     }
 
     /// RM `TERM_MAPPING.narrower()`: the mapping is to a narrower term

--- a/tools/openehr-codegen/templates/openehr-rm/support/terminology/openehr_code_set_identifiers_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/support/terminology/openehr_code_set_identifiers_impl.rs
@@ -17,7 +17,7 @@ impl OpenehrCodeSetIdentifiersData {
     /// Spec: `org.openehr.rm.support.openehr_code_set_identifiers.adoc`
     /// §Constants — the seven identifiers, read from the emitted constants so
     /// there is no second copy of the list to drift.
-    const ALL: [&'static str; 7] = [
+    const ALL: [&str; 7] = [
         Self::CODE_SET_ID_CHARACTER_SETS,
         Self::CODE_SET_ID_COMPRESSION_ALGORITHMS,
         Self::CODE_SET_ID_COUNTRIES,

--- a/tools/openehr-codegen/templates/openehr-rm/support/terminology/openehr_terminology_group_identifiers_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/support/terminology/openehr_terminology_group_identifiers_impl.rs
@@ -25,7 +25,7 @@ impl OpenehrTerminologyGroupIdentifiersData {
     /// §Constants. `Terminology_id_openehr` is deliberately absent: it names
     /// openEHR's own TERMINOLOGY, not a group within it, which is why
     /// `TERMINOLOGY_SERVICE.terminology` takes it and this predicate does not.
-    const ALL: [&'static str; 14] = [
+    const ALL: [&str; 14] = [
         Self::GROUP_ID_AUDIT_CHANGE_TYPE,
         Self::GROUP_ID_ATTESTATION_REASON,
         Self::GROUP_ID_COMPOSITION_CATEGORY,


### PR DESCRIPTION
The four mechanical Rust classes from the #2640 baseline adjudication (the class-by-class record is on the issue): **rust:S8863** — 52 redundant `'static` tokens removed from `const`/`static` item declarations across cnf-runner, the codegen templates, openehr-its' hand-written modules and the app (one site deliberately kept: `REGISTERED_VIEWS` is an associated const inside `impl<'a> Resolver<'a>`, where const lifetime elision does not apply and stripping it is three hard errors — a per-site false positive, noted on #2640). **rust:S1612** — all 44 `.and_then(|e| e.to_str())` sites become `std::ffi::OsStr::to_str` (fully qualified; no imports, no renames). **rust:S9045** — `xml/runtime.rs`'s test module moves after all other items, byte-identical. **rust:S9047** — the term-mapping template's OR pattern becomes the range `'<'..='?'` (the four RM match codes are ASCII-contiguous); template + regeneration, never a hand edit of a stamped file.

Template changes regenerated (`emit` + the sibling emit targets), drift check green after staging; the eight `openehr-*` crates take the lockstep `0.0.37` bump for the packaged-content change (crates-publishing rule).

Gates: clippy `-D warnings` over every touched crate, nextest 1371+1972 passed, `cargo fmt` clean, comment-style/typed-status/default-style `--all` green.

Worker finding worth its own issue (filed next): the EMITTER itself renders `pub const X: &'static str` into the generated crates (~60+ S8863 sites Sonar never sees because generated trees are excluded, plus two raw-string sites in `emit_rm_model.rs`) — the legitimate fix is in `openehr-codegen`'s constant rendering + regeneration.

Part of #2640.