### PR TITLE
chore(codegen): the constant emitter drops the redundant 'static

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5503,7 +5503,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.37"
+version = "0.0.38"
 dependencies = [
  "indexmap 2.14.0",
  "openehr-am",
@@ -5519,7 +5519,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.37"
+version = "0.0.38"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.37"
+version = "0.0.38"
 dependencies = [
  "serde",
  "serde_json",
@@ -5548,7 +5548,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.37"
+version = "0.0.38"
 dependencies = [
  "async-trait",
  "axum",
@@ -5577,7 +5577,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.37"
+version = "0.0.38"
 dependencies = [
  "assert_fs",
  "chumsky",
@@ -5591,7 +5591,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.37"
+version = "0.0.38"
 dependencies = [
  "chumsky",
  "logos",
@@ -5600,7 +5600,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.37"
+version = "0.0.38"
 dependencies = [
  "insta",
  "jsonschema",
@@ -5618,7 +5618,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.37"
+version = "0.0.38"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-adl"
-version = "0.0.37"
+version = "0.0.38"
 description = "openEHR ADL 2.4.0: hand-written ADL2/cADL/ODIN parser, AOM2 validation catalogue, specialisation flattener, OPT2 generator, and ADL 1.4→2 conversion over the generated openehr_am::v2_4::aom2 model"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,11 +16,11 @@ include = ["src/**", "README.md", "LICENSE-MIT"]
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)
-openehr-base = { path = "../openehr-base", version = "0.0.37" }   # VersionStatus for the parsed HRID
-openehr-am = { path = "../openehr-am", version = "0.0.37" }       # v2_4 ArchetypeHrid (the identification target type)
-openehr-rm = { path = "../openehr-rm", version = "0.0.37" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
-openehr-lang = { path = "../openehr-lang", version = "0.0.37" }   # openehr_lang::odin — the ODIN section parser
-openehr-term = { path = "../openehr-term", version = "0.0.37" }   # the languages code set for the RM resource-meta rows
+openehr-base = { path = "../openehr-base", version = "0.0.38" }   # VersionStatus for the parsed HRID
+openehr-am = { path = "../openehr-am", version = "0.0.38" }       # v2_4 ArchetypeHrid (the identification target type)
+openehr-rm = { path = "../openehr-rm", version = "0.0.38" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
+openehr-lang = { path = "../openehr-lang", version = "0.0.38" }   # openehr_lang::odin — the ODIN section parser
+openehr-term = { path = "../openehr-term", version = "0.0.38" }   # the languages code set for the RM resource-meta rows
 uuid.workspace = true        # meta uid/build_uid (AUTHORED_ARCHETYPE.uid: Uuid)
 indexmap.workspace = true    # OdinValue::Object body (insertion-ordered map)
 

--- a/crates/openehr-am/Cargo.toml
+++ b/crates/openehr-am/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-am"
-version = "0.0.37"
+version = "0.0.38"
 description = "openEHR AM Archetype Model, generated from BMM: generations v1_4 (AM 1.4.0, ADL 1.4) and v2_4 (AM 2.4.0, ADL 2; current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,8 +13,8 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.37" }
-openehr-lang = { path = "../openehr-lang", version = "0.0.37" }
+openehr-base = { path = "../openehr-base", version = "0.0.38" }
+openehr-lang = { path = "../openehr-lang", version = "0.0.38" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also carries the untyped `Value` fields the generator

--- a/crates/openehr-am/src/v2_4/aom2/definitions/adl_code_definitions.rs
+++ b/crates/openehr-am/src/v2_4/aom2/definitions/adl_code_definitions.rs
@@ -33,19 +33,19 @@ pub struct AdlCodeDefinitionsData {}
 impl AdlCodeDefinitionsData {
     /// String leader of ‘identifier’ codes, i.e. codes used to identify at-coded archetype nodes.
     /// BMM constant `At_code_leader`.
-    pub const AT_CODE_LEADER: &'static str = "at";
+    pub const AT_CODE_LEADER: &str = "at";
 
     /// String leader of ‘identifier’ codes, i.e. codes used to identify id-coded archetype nodes.
     /// BMM constant `Id_code_leader`.
-    pub const ID_CODE_LEADER: &'static str = "id";
+    pub const ID_CODE_LEADER: &str = "id";
 
     /// String leader of ‘value’ codes, i.e. codes used to identify codes values, including value set members.
     /// BMM constant `Value_code_leader`.
-    pub const VALUE_CODE_LEADER: &'static str = "at";
+    pub const VALUE_CODE_LEADER: &str = "at";
 
     /// String leader of ‘value set’ codes, i.e. codes used to identify value sets.
     /// BMM constant `Value_set_code_leader`.
-    pub const VALUE_SET_CODE_LEADER: &'static str = "ac";
+    pub const VALUE_SET_CODE_LEADER: &str = "ac";
 
     /// Character used to separate numeric parts of codes belonging to different specialisation levels.
     /// BMM constant `Specialisation_separator`.
@@ -53,19 +53,19 @@ impl AdlCodeDefinitionsData {
 
     /// Regex used to define the legal numeric part of any archetype code. Corresponds to the simple pattern of dotted numbers, as used in typical multi-level numbering schemes.
     /// BMM constant `Code_regex_pattern`.
-    pub const CODE_REGEX_PATTERN: &'static str = "(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*))*";
+    pub const CODE_REGEX_PATTERN: &str = "(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*))*";
 
     /// Regex pattern of the root code of any archetype.
     ///
     /// Corresponds to at-codes of the form `at0000`, `at0000.1`, `at0000.1.1` etc, and id-codes of the form `id1`, `id1.1`, `id1.1.1` etc. For at-coded ADL2 numbering starts with zero (i.e. `at0000`) while the id-coded ADL2 numbering starts with one (i.e. `id1`).
     /// BMM constant `Root_code_regex_pattern`.
-    pub const ROOT_CODE_REGEX_PATTERN: &'static str = "^(id1|at0000)(\\.1)*$";
+    pub const ROOT_CODE_REGEX_PATTERN: &str = "^(id1|at0000)(\\.1)*$";
 
     /// Code id used for `C_PRIMITIVE_OBJECT` nodes on creation.
     ///
     /// NOTE: For id-coded archetypes this is `"id9999"`.
     /// BMM constant `Primitive_node_id`.
-    pub const PRIMITIVE_NODE_ID: &'static str = "at9999";
+    pub const PRIMITIVE_NODE_ID: &str = "at9999";
 }
 
 /// Polymorphic slot of `ADL_CODE_DEFINITIONS`, dispatched on each payload's `_type`.

--- a/crates/openehr-am/src/v2_4/bmm/core/bmm_definitions.rs
+++ b/crates/openehr-am/src/v2_4/bmm/core/bmm_definitions.rs
@@ -17,19 +17,19 @@ pub struct BmmDefinitionsData {}
 impl BmmDefinitionsData {
     /// Current internal version of BMM meta-model, used to determine if a given schema can be processed by a given implementation of the model.
     /// BMM constant `Bmm_internal_version`.
-    pub const BMM_INTERNAL_VERSION: &'static str = "";
+    pub const BMM_INTERNAL_VERSION: &str = "";
 
     /// Delimiter used to separate schema id from package path in a fully qualified path.
     /// BMM constant `Schema_name_delimiter`.
-    pub const SCHEMA_NAME_DELIMITER: &'static str = "::";
+    pub const SCHEMA_NAME_DELIMITER: &str = "::";
 
     /// Delimiter used to separate package names in a package path.
     /// BMM constant `Package_name_delimiter`.
-    pub const PACKAGE_NAME_DELIMITER: &'static str = ".";
+    pub const PACKAGE_NAME_DELIMITER: &str = ".";
 
     /// Extension used for BMM files.
     /// BMM constant `Bmm_schema_file_extension`.
-    pub const BMM_SCHEMA_FILE_EXTENSION: &'static str = ".bmm";
+    pub const BMM_SCHEMA_FILE_EXTENSION: &str = ".bmm";
 
     /// Appears between a name and a type in a declaration or type signature.
     /// BMM constant `Type_delimiter`.
@@ -76,35 +76,35 @@ impl BmmDefinitionsData {
 
     /// Attribute name of logical attribute 'bmm_version' in .bmm schema file.
     /// BMM constant `Metadata_bmm_version`.
-    pub const METADATA_BMM_VERSION: &'static str = "bmm_version";
+    pub const METADATA_BMM_VERSION: &str = "bmm_version";
 
     /// Attribute name of logical attribute 'schema_name' in .bmm schema file.
     /// BMM constant `Metadata_schema_name`.
-    pub const METADATA_SCHEMA_NAME: &'static str = "schema_name";
+    pub const METADATA_SCHEMA_NAME: &str = "schema_name";
 
     /// Attribute name of logical attribute 'rm_publisher' in .bmm schema file.
     /// BMM constant `Metadata_rm_publisher`.
-    pub const METADATA_RM_PUBLISHER: &'static str = "rm_publisher";
+    pub const METADATA_RM_PUBLISHER: &str = "rm_publisher";
 
     /// Attribute name of logical attribute 'rm_release' in .bmm schema file.
     /// BMM constant `Metadata_rm_release`.
-    pub const METADATA_RM_RELEASE: &'static str = "rm_release";
+    pub const METADATA_RM_RELEASE: &str = "rm_release";
 
     /// Attribute name of logical attribute 'schema_revision' in .bmm schema file.
     /// BMM constant `Metadata_schema_revision`.
-    pub const METADATA_SCHEMA_REVISION: &'static str = "schema_revision";
+    pub const METADATA_SCHEMA_REVISION: &str = "schema_revision";
 
     /// Attribute name of logical attribute 'schema_lifecycle_state' in .bmm schema file.
     /// BMM constant `Metadata_schema_lifecycle_state`.
-    pub const METADATA_SCHEMA_LIFECYCLE_STATE: &'static str = "schema_lifecycle_state";
+    pub const METADATA_SCHEMA_LIFECYCLE_STATE: &str = "schema_lifecycle_state";
 
     /// Attribute name of logical attribute 'schema_description' in .bmm schema file.
     /// BMM constant `Metadata_schema_description`.
-    pub const METADATA_SCHEMA_DESCRIPTION: &'static str = "schema_description";
+    pub const METADATA_SCHEMA_DESCRIPTION: &str = "schema_description";
 
     /// Path of schema file.
     /// BMM constant `Metadata_schema_path`.
-    pub const METADATA_SCHEMA_PATH: &'static str = "schema_path";
+    pub const METADATA_SCHEMA_PATH: &str = "schema_path";
 }
 
 /// Polymorphic slot of `BMM_DEFINITIONS`, dispatched on each payload's `_type`.

--- a/crates/openehr-am/src/v2_4/bmm3/core/entity/bmm_function_type.rs
+++ b/crates/openehr-am/src/v2_4/bmm3/core/entity/bmm_function_type.rs
@@ -25,5 +25,5 @@ pub struct BmmFunctionType {
 impl BmmFunctionType {
     /// Base name (built-in).
     /// BMM constant `base_name`.
-    pub const BASE_NAME: &'static str = "Function";
+    pub const BASE_NAME: &str = "Function";
 }

--- a/crates/openehr-am/src/v2_4/bmm3/core/entity/bmm_procedure_type.rs
+++ b/crates/openehr-am/src/v2_4/bmm3/core/entity/bmm_procedure_type.rs
@@ -24,5 +24,5 @@ pub struct BmmProcedureType {
 impl BmmProcedureType {
     /// Base name (built-in).
     /// BMM constant `base_name`.
-    pub const BASE_NAME: &'static str = "Procedure";
+    pub const BASE_NAME: &str = "Procedure";
 }

--- a/crates/openehr-am/src/v2_4/bmm3/core/entity/bmm_routine_type.rs
+++ b/crates/openehr-am/src/v2_4/bmm3/core/entity/bmm_routine_type.rs
@@ -25,7 +25,7 @@ pub struct BmmRoutineTypeData {
 impl BmmRoutineTypeData {
     /// Base name (built-in).
     /// BMM constant `base_name`.
-    pub const BASE_NAME: &'static str = "Routine";
+    pub const BASE_NAME: &str = "Routine";
 }
 
 /// Polymorphic slot of `BMM_ROUTINE_TYPE`, dispatched on each payload's `_type`.

--- a/crates/openehr-am/src/v2_4/bmm3/core/entity/bmm_signature.rs
+++ b/crates/openehr-am/src/v2_4/bmm3/core/entity/bmm_signature.rs
@@ -23,7 +23,7 @@ pub struct BmmSignatureData {
 impl BmmSignatureData {
     /// Base name (built-in).
     /// BMM constant `base_name`.
-    pub const BASE_NAME: &'static str = "Signature";
+    pub const BASE_NAME: &str = "Signature";
 }
 
 /// Polymorphic slot of `BMM_SIGNATURE`, dispatched on each payload's `_type`.

--- a/crates/openehr-am/src/v2_4/bmm3/core/entity/bmm_tuple_type.rs
+++ b/crates/openehr-am/src/v2_4/bmm3/core/entity/bmm_tuple_type.rs
@@ -21,5 +21,5 @@ pub struct BmmTupleType {
 impl BmmTupleType {
     /// Base name (built-in).
     /// BMM constant `base_name`.
-    pub const BASE_NAME: &'static str = "Tuple";
+    pub const BASE_NAME: &str = "Tuple";
 }

--- a/crates/openehr-base/Cargo.toml
+++ b/crates/openehr-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-base"
-version = "0.0.37"
+version = "0.0.38"
 description = "openEHR BASE foundation + base types, generated from BMM: generations v1_2 (BASE 1.2.0) and v1_3 (BASE 1.3.0, current)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-base/src/v1_2/foundation_types/interval/multiplicity_interval.rs
+++ b/crates/openehr-base/src/v1_2/foundation_types/interval/multiplicity_interval.rs
@@ -28,7 +28,7 @@ pub struct MultiplicityInterval {
 impl MultiplicityInterval {
     /// Marker to use in string form of interval between limits.
     /// BMM constant `Multiplicity_range_marker`.
-    pub const MULTIPLICITY_RANGE_MARKER: &'static str = "..";
+    pub const MULTIPLICITY_RANGE_MARKER: &str = "..";
 
     /// Symbol to use to indicate upper limit unbounded.
     /// BMM constant `Multiplicity_unbounded_marker`.

--- a/crates/openehr-base/src/v1_3/foundation_types/interval/multiplicity_interval.rs
+++ b/crates/openehr-base/src/v1_3/foundation_types/interval/multiplicity_interval.rs
@@ -28,7 +28,7 @@ pub struct MultiplicityInterval {
 impl MultiplicityInterval {
     /// Marker to use in string form of interval between limits.
     /// BMM constant `Multiplicity_range_marker`.
-    pub const MULTIPLICITY_RANGE_MARKER: &'static str = "..";
+    pub const MULTIPLICITY_RANGE_MARKER: &str = "..";
 
     /// Symbol to use to indicate upper limit unbounded.
     /// BMM constant `Multiplicity_unbounded_marker`.

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-its"
-version = "0.0.37"
+version = "0.0.38"
 description = "openEHR ITS (Implementation Technology Specifications): canonical JSON + canonical XML serialization of the RM, the generated ITS-REST 1.1.0 API contract, OPT 1.4 and AOM2 archetype XML codecs, and the Simplified Formats (FLAT / STRUCTURED / Web Template)"
 edition.workspace = true
 rust-version.workspace = true
@@ -41,14 +41,14 @@ regex = { workspace = true, optional = true }
 fancy-regex = { workspace = true, optional = true }
 # The generated XML (de)serializers impl the crate's ToXml/FromXml traits for the
 # RM/BASE spec types, so these are real (non-dev) deps.
-openehr-base = { path = "../openehr-base", version = "0.0.37", optional = true }
-openehr-rm = { path = "../openehr-rm", version = "0.0.37", optional = true }
+openehr-base = { path = "../openehr-base", version = "0.0.38", optional = true }
+openehr-rm = { path = "../openehr-rm", version = "0.0.38", optional = true }
 # The native canonical-JSON codec (`json_codec/generated`, emit-json) implements
 # `ToJson` for EVERY generated spec type the `OpenEhrType` derive covers, so it
 # spans all five spec crates (not just the RM/BASE the XML codec needs).
-openehr-lang = { path = "../openehr-lang", version = "0.0.37", optional = true }
-openehr-am = { path = "../openehr-am", version = "0.0.37", optional = true }
-openehr-term = { path = "../openehr-term", version = "0.0.37", optional = true }
+openehr-lang = { path = "../openehr-lang", version = "0.0.38", optional = true }
+openehr-am = { path = "../openehr-am", version = "0.0.38", optional = true }
+openehr-term = { path = "../openehr-term", version = "0.0.38", optional = true }
 
 # `full` — every ITS surface (canonical JSON/XML, the generated ITS-REST
 # contract, `opt14`, Simplified Formats). ON BY DEFAULT, so every consumer sees

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-lang"
-version = "0.0.37"
+version = "0.0.38"
 description = "openEHR LANG BMM/P_BMM object model, generated from BMM: generations v1_0 (LANG 1.0.0) and v1_1 (LANG 1.1.0, current; the stable BMM v2.x unit beside the paused BMM3 unit), plus hand-written ODIN/BEL/EL readers"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["parser-implementations", "data-structures"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.37" }
+openehr-base = { path = "../openehr-base", version = "0.0.38" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the
 # generated types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) —
 # never a derive. `serde_json` also carries the untyped `Value` fields the

--- a/crates/openehr-lang/src/v1_0/bmm/bmm_definitions.rs
+++ b/crates/openehr-lang/src/v1_0/bmm/bmm_definitions.rs
@@ -14,19 +14,19 @@ pub struct BmmDefinitions {}
 impl BmmDefinitions {
     /// Current internal version of BMM meta-model, used to determine if a given schema can be processed by a given implementation of the model.
     /// BMM constant `Bmm_internal_version`.
-    pub const BMM_INTERNAL_VERSION: &'static str = "";
+    pub const BMM_INTERNAL_VERSION: &str = "";
 
     /// Delimiter used to separate schema id from package path in a fully qualified path.
     /// BMM constant `Schema_name_delimiter`.
-    pub const SCHEMA_NAME_DELIMITER: &'static str = "::";
+    pub const SCHEMA_NAME_DELIMITER: &str = "::";
 
     /// Delimiter used to separate package names in a package path.
     /// BMM constant `Package_name_delimiter`.
-    pub const PACKAGE_NAME_DELIMITER: &'static str = ".";
+    pub const PACKAGE_NAME_DELIMITER: &str = ".";
 
     /// Extension used for BMM files.
     /// BMM constant `Bmm_schema_file_extension`.
-    pub const BMM_SCHEMA_FILE_EXTENSION: &'static str = ".bmm";
+    pub const BMM_SCHEMA_FILE_EXTENSION: &str = ".bmm";
 
     /// Appears between a name and a type in a declaration or type signature.
     /// BMM constant `Type_delimiter`.
@@ -73,33 +73,33 @@ impl BmmDefinitions {
 
     /// Attribute name of logical attribute 'bmm_version' in .bmm schema file.
     /// BMM constant `Metadata_bmm_version`.
-    pub const METADATA_BMM_VERSION: &'static str = "bmm_version";
+    pub const METADATA_BMM_VERSION: &str = "bmm_version";
 
     /// Attribute name of logical attribute 'schema_name' in .bmm schema file.
     /// BMM constant `Metadata_schema_name`.
-    pub const METADATA_SCHEMA_NAME: &'static str = "schema_name";
+    pub const METADATA_SCHEMA_NAME: &str = "schema_name";
 
     /// Attribute name of logical attribute 'rm_publisher' in .bmm schema file.
     /// BMM constant `Metadata_rm_publisher`.
-    pub const METADATA_RM_PUBLISHER: &'static str = "rm_publisher";
+    pub const METADATA_RM_PUBLISHER: &str = "rm_publisher";
 
     /// Attribute name of logical attribute 'rm_release' in .bmm schema file.
     /// BMM constant `Metadata_rm_release`.
-    pub const METADATA_RM_RELEASE: &'static str = "rm_release";
+    pub const METADATA_RM_RELEASE: &str = "rm_release";
 
     /// Attribute name of logical attribute 'schema_revision' in .bmm schema file.
     /// BMM constant `Metadata_schema_revision`.
-    pub const METADATA_SCHEMA_REVISION: &'static str = "schema_revision";
+    pub const METADATA_SCHEMA_REVISION: &str = "schema_revision";
 
     /// Attribute name of logical attribute 'schema_lifecycle_state' in .bmm schema file.
     /// BMM constant `Metadata_schema_lifecycle_state`.
-    pub const METADATA_SCHEMA_LIFECYCLE_STATE: &'static str = "schema_lifecycle_state";
+    pub const METADATA_SCHEMA_LIFECYCLE_STATE: &str = "schema_lifecycle_state";
 
     /// Attribute name of logical attribute 'schema_description' in .bmm schema file.
     /// BMM constant `Metadata_schema_description`.
-    pub const METADATA_SCHEMA_DESCRIPTION: &'static str = "schema_description";
+    pub const METADATA_SCHEMA_DESCRIPTION: &str = "schema_description";
 
     /// Path of schema file.
     /// BMM constant `Metadata_schema_path`.
-    pub const METADATA_SCHEMA_PATH: &'static str = "schema_path";
+    pub const METADATA_SCHEMA_PATH: &str = "schema_path";
 }

--- a/crates/openehr-lang/src/v1_0/bmm/core/entity/bmm_signature.rs
+++ b/crates/openehr-lang/src/v1_0/bmm/core/entity/bmm_signature.rs
@@ -24,5 +24,5 @@ pub struct BmmSignature {
 impl BmmSignature {
     /// Base name (built-in).
     /// BMM constant `base_name`.
-    pub const BASE_NAME: &'static str = "Signature";
+    pub const BASE_NAME: &str = "Signature";
 }

--- a/crates/openehr-lang/src/v1_0/bmm/core/entity/bmm_tuple_type.rs
+++ b/crates/openehr-lang/src/v1_0/bmm/core/entity/bmm_tuple_type.rs
@@ -21,5 +21,5 @@ pub struct BmmTupleType {
 impl BmmTupleType {
     /// Base name (built-in).
     /// BMM constant `base_name`.
-    pub const BASE_NAME: &'static str = "Tuple";
+    pub const BASE_NAME: &str = "Tuple";
 }

--- a/crates/openehr-lang/src/v1_1/bmm/core/bmm_definitions.rs
+++ b/crates/openehr-lang/src/v1_1/bmm/core/bmm_definitions.rs
@@ -26,19 +26,19 @@ pub struct BmmDefinitionsData {}
 impl BmmDefinitionsData {
     /// Current internal version of BMM meta-model, used to determine if a given schema can be processed by a given implementation of the model.
     /// BMM constant `Bmm_internal_version`.
-    pub const BMM_INTERNAL_VERSION: &'static str = "";
+    pub const BMM_INTERNAL_VERSION: &str = "";
 
     /// Delimiter used to separate schema id from package path in a fully qualified path.
     /// BMM constant `Schema_name_delimiter`.
-    pub const SCHEMA_NAME_DELIMITER: &'static str = "::";
+    pub const SCHEMA_NAME_DELIMITER: &str = "::";
 
     /// Delimiter used to separate package names in a package path.
     /// BMM constant `Package_name_delimiter`.
-    pub const PACKAGE_NAME_DELIMITER: &'static str = ".";
+    pub const PACKAGE_NAME_DELIMITER: &str = ".";
 
     /// Extension used for BMM files.
     /// BMM constant `Bmm_schema_file_extension`.
-    pub const BMM_SCHEMA_FILE_EXTENSION: &'static str = ".bmm";
+    pub const BMM_SCHEMA_FILE_EXTENSION: &str = ".bmm";
 }
 
 /// Polymorphic slot of `BMM_DEFINITIONS`, dispatched on each payload's `_type`.

--- a/crates/openehr-lang/src/v1_1/bmm3/bmm_definitions.rs
+++ b/crates/openehr-lang/src/v1_1/bmm3/bmm_definitions.rs
@@ -14,19 +14,19 @@ pub struct BmmDefinitions {}
 impl BmmDefinitions {
     /// Current internal version of BMM meta-model, used to determine if a given schema can be processed by a given implementation of the model.
     /// BMM constant `Bmm_internal_version`.
-    pub const BMM_INTERNAL_VERSION: &'static str = "";
+    pub const BMM_INTERNAL_VERSION: &str = "";
 
     /// Delimiter used to separate schema id from package path in a fully qualified path.
     /// BMM constant `Schema_name_delimiter`.
-    pub const SCHEMA_NAME_DELIMITER: &'static str = "::";
+    pub const SCHEMA_NAME_DELIMITER: &str = "::";
 
     /// Delimiter used to separate package names in a package path.
     /// BMM constant `Package_name_delimiter`.
-    pub const PACKAGE_NAME_DELIMITER: &'static str = ".";
+    pub const PACKAGE_NAME_DELIMITER: &str = ".";
 
     /// Extension used for BMM files.
     /// BMM constant `Bmm_schema_file_extension`.
-    pub const BMM_SCHEMA_FILE_EXTENSION: &'static str = ".bmm";
+    pub const BMM_SCHEMA_FILE_EXTENSION: &str = ".bmm";
 
     /// Appears between a name and a type in a declaration or type signature.
     /// BMM constant `Type_delimiter`.
@@ -73,33 +73,33 @@ impl BmmDefinitions {
 
     /// Attribute name of logical attribute 'bmm_version' in .bmm schema file.
     /// BMM constant `Metadata_bmm_version`.
-    pub const METADATA_BMM_VERSION: &'static str = "bmm_version";
+    pub const METADATA_BMM_VERSION: &str = "bmm_version";
 
     /// Attribute name of logical attribute 'schema_name' in .bmm schema file.
     /// BMM constant `Metadata_schema_name`.
-    pub const METADATA_SCHEMA_NAME: &'static str = "schema_name";
+    pub const METADATA_SCHEMA_NAME: &str = "schema_name";
 
     /// Attribute name of logical attribute 'rm_publisher' in .bmm schema file.
     /// BMM constant `Metadata_rm_publisher`.
-    pub const METADATA_RM_PUBLISHER: &'static str = "rm_publisher";
+    pub const METADATA_RM_PUBLISHER: &str = "rm_publisher";
 
     /// Attribute name of logical attribute 'rm_release' in .bmm schema file.
     /// BMM constant `Metadata_rm_release`.
-    pub const METADATA_RM_RELEASE: &'static str = "rm_release";
+    pub const METADATA_RM_RELEASE: &str = "rm_release";
 
     /// Attribute name of logical attribute 'schema_revision' in .bmm schema file.
     /// BMM constant `Metadata_schema_revision`.
-    pub const METADATA_SCHEMA_REVISION: &'static str = "schema_revision";
+    pub const METADATA_SCHEMA_REVISION: &str = "schema_revision";
 
     /// Attribute name of logical attribute 'schema_lifecycle_state' in .bmm schema file.
     /// BMM constant `Metadata_schema_lifecycle_state`.
-    pub const METADATA_SCHEMA_LIFECYCLE_STATE: &'static str = "schema_lifecycle_state";
+    pub const METADATA_SCHEMA_LIFECYCLE_STATE: &str = "schema_lifecycle_state";
 
     /// Attribute name of logical attribute 'schema_description' in .bmm schema file.
     /// BMM constant `Metadata_schema_description`.
-    pub const METADATA_SCHEMA_DESCRIPTION: &'static str = "schema_description";
+    pub const METADATA_SCHEMA_DESCRIPTION: &str = "schema_description";
 
     /// Path of schema file.
     /// BMM constant `Metadata_schema_path`.
-    pub const METADATA_SCHEMA_PATH: &'static str = "schema_path";
+    pub const METADATA_SCHEMA_PATH: &str = "schema_path";
 }

--- a/crates/openehr-lang/src/v1_1/bmm3/core/entity/bmm_function_type.rs
+++ b/crates/openehr-lang/src/v1_1/bmm3/core/entity/bmm_function_type.rs
@@ -25,5 +25,5 @@ pub struct BmmFunctionType {
 impl BmmFunctionType {
     /// Base name (built-in).
     /// BMM constant `base_name`.
-    pub const BASE_NAME: &'static str = "Function";
+    pub const BASE_NAME: &str = "Function";
 }

--- a/crates/openehr-lang/src/v1_1/bmm3/core/entity/bmm_procedure_type.rs
+++ b/crates/openehr-lang/src/v1_1/bmm3/core/entity/bmm_procedure_type.rs
@@ -24,5 +24,5 @@ pub struct BmmProcedureType {
 impl BmmProcedureType {
     /// Base name (built-in).
     /// BMM constant `base_name`.
-    pub const BASE_NAME: &'static str = "Procedure";
+    pub const BASE_NAME: &str = "Procedure";
 }

--- a/crates/openehr-lang/src/v1_1/bmm3/core/entity/bmm_routine_type.rs
+++ b/crates/openehr-lang/src/v1_1/bmm3/core/entity/bmm_routine_type.rs
@@ -25,7 +25,7 @@ pub struct BmmRoutineTypeData {
 impl BmmRoutineTypeData {
     /// Base name (built-in).
     /// BMM constant `base_name`.
-    pub const BASE_NAME: &'static str = "Routine";
+    pub const BASE_NAME: &str = "Routine";
 }
 
 /// Polymorphic slot of `BMM_ROUTINE_TYPE`, dispatched on each payload's `_type`.

--- a/crates/openehr-lang/src/v1_1/bmm3/core/entity/bmm_signature.rs
+++ b/crates/openehr-lang/src/v1_1/bmm3/core/entity/bmm_signature.rs
@@ -23,7 +23,7 @@ pub struct BmmSignatureData {
 impl BmmSignatureData {
     /// Base name (built-in).
     /// BMM constant `base_name`.
-    pub const BASE_NAME: &'static str = "Signature";
+    pub const BASE_NAME: &str = "Signature";
 }
 
 /// Polymorphic slot of `BMM_SIGNATURE`, dispatched on each payload's `_type`.

--- a/crates/openehr-lang/src/v1_1/bmm3/core/entity/bmm_status_type.rs
+++ b/crates/openehr-lang/src/v1_1/bmm3/core/entity/bmm_status_type.rs
@@ -14,5 +14,5 @@ pub struct BmmStatusType {}
 impl BmmStatusType {
     /// Base name (built-in).
     /// BMM constant `base_name`.
-    pub const BASE_NAME: &'static str = "Status";
+    pub const BASE_NAME: &str = "Status";
 }

--- a/crates/openehr-lang/src/v1_1/bmm3/core/entity/bmm_tuple_type.rs
+++ b/crates/openehr-lang/src/v1_1/bmm3/core/entity/bmm_tuple_type.rs
@@ -21,5 +21,5 @@ pub struct BmmTupleType {
 impl BmmTupleType {
     /// Base name (built-in).
     /// BMM constant `base_name`.
-    pub const BASE_NAME: &'static str = "Tuple";
+    pub const BASE_NAME: &str = "Tuple";
 }

--- a/crates/openehr-query/Cargo.toml
+++ b/crates/openehr-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-query"
-version = "0.0.37"
+version = "0.0.38"
 description = "openEHR QUERY (AQL 1.1.0): hand-written lexer, parser, typed AST and canonical printer from the official grammar (no ANTLR runtime)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-rm"
-version = "0.0.37"
+version = "0.0.38"
 description = "openEHR RM Reference Model, generated from BMM: generations v1_1 (RM 1.1.0) and v1_2 (RM 1.2.0, current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,11 +13,11 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.37" }
+openehr-base = { path = "../openehr-base", version = "0.0.38" }
 # The terminology-backed RM class invariants (`validate::terminology`) resolve
 # openEHR terminology groups + code sets against the vendored TERM 3.1.0 bundle.
 # `openehr-term` itself depends only on `openehr-base`, so this is acyclic.
-openehr-term = { path = "../openehr-term", version = "0.0.37" }
+openehr-term = { path = "../openehr-term", version = "0.0.38" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also backs the untyped `Value` RM representation used by

--- a/crates/openehr-rm/src/v1_1/support/terminology/openehr_code_set_identifiers.rs
+++ b/crates/openehr-rm/src/v1_1/support/terminology/openehr_code_set_identifiers.rs
@@ -15,25 +15,25 @@ pub struct OpenehrCodeSetIdentifiersData {}
 
 impl OpenehrCodeSetIdentifiersData {
     /// BMM constant `Code_set_id_character_sets`.
-    pub const CODE_SET_ID_CHARACTER_SETS: &'static str = "character sets";
+    pub const CODE_SET_ID_CHARACTER_SETS: &str = "character sets";
 
     /// BMM constant `Code_set_id_compression_algorithms`.
-    pub const CODE_SET_ID_COMPRESSION_ALGORITHMS: &'static str = "compression algorithms";
+    pub const CODE_SET_ID_COMPRESSION_ALGORITHMS: &str = "compression algorithms";
 
     /// BMM constant `Code_set_id_countries`.
-    pub const CODE_SET_ID_COUNTRIES: &'static str = "countries";
+    pub const CODE_SET_ID_COUNTRIES: &str = "countries";
 
     /// BMM constant `Code_set_integrity_check_algorithms`.
-    pub const CODE_SET_INTEGRITY_CHECK_ALGORITHMS: &'static str = "integrity check algorithms";
+    pub const CODE_SET_INTEGRITY_CHECK_ALGORITHMS: &str = "integrity check algorithms";
 
     /// BMM constant `Code_set_id_languages`.
-    pub const CODE_SET_ID_LANGUAGES: &'static str = "languages";
+    pub const CODE_SET_ID_LANGUAGES: &str = "languages";
 
     /// BMM constant `Code_set_id_media_types`.
-    pub const CODE_SET_ID_MEDIA_TYPES: &'static str = "media types";
+    pub const CODE_SET_ID_MEDIA_TYPES: &str = "media types";
 
     /// BMM constant `Code_set_id_normal_statuses`.
-    pub const CODE_SET_ID_NORMAL_STATUSES: &'static str = "normal statuses";
+    pub const CODE_SET_ID_NORMAL_STATUSES: &str = "normal statuses";
 }
 
 /// Polymorphic slot of `OPENEHR_CODE_SET_IDENTIFIERS`, dispatched on each payload's `_type`.

--- a/crates/openehr-rm/src/v1_1/support/terminology/openehr_terminology_group_identifiers.rs
+++ b/crates/openehr-rm/src/v1_1/support/terminology/openehr_terminology_group_identifiers.rs
@@ -16,49 +16,49 @@ pub struct OpenehrTerminologyGroupIdentifiersData {}
 impl OpenehrTerminologyGroupIdentifiersData {
     /// Name of openEHR's own terminology.
     /// BMM constant `Terminology_id_openehr`.
-    pub const TERMINOLOGY_ID_OPENEHR: &'static str = "openehr";
+    pub const TERMINOLOGY_ID_OPENEHR: &str = "openehr";
 
     /// BMM constant `Group_id_audit_change_type`.
-    pub const GROUP_ID_AUDIT_CHANGE_TYPE: &'static str = "audit change type";
+    pub const GROUP_ID_AUDIT_CHANGE_TYPE: &str = "audit change type";
 
     /// BMM constant `Group_id_attestation_reason`.
-    pub const GROUP_ID_ATTESTATION_REASON: &'static str = "attestation reason";
+    pub const GROUP_ID_ATTESTATION_REASON: &str = "attestation reason";
 
     /// BMM constant `Group_id_composition_category`.
-    pub const GROUP_ID_COMPOSITION_CATEGORY: &'static str = "composition category";
+    pub const GROUP_ID_COMPOSITION_CATEGORY: &str = "composition category";
 
     /// BMM constant `Group_id_event_math_function`.
-    pub const GROUP_ID_EVENT_MATH_FUNCTION: &'static str = "event math function";
+    pub const GROUP_ID_EVENT_MATH_FUNCTION: &str = "event math function";
 
     /// BMM constant `Group_id_instruction_states`.
-    pub const GROUP_ID_INSTRUCTION_STATES: &'static str = "instruction states";
+    pub const GROUP_ID_INSTRUCTION_STATES: &str = "instruction states";
 
     /// BMM constant `Group_id_instruction_transitions`.
-    pub const GROUP_ID_INSTRUCTION_TRANSITIONS: &'static str = "instruction transitions";
+    pub const GROUP_ID_INSTRUCTION_TRANSITIONS: &str = "instruction transitions";
 
     /// BMM constant `Group_id_null_flavours`.
-    pub const GROUP_ID_NULL_FLAVOURS: &'static str = "null flavours";
+    pub const GROUP_ID_NULL_FLAVOURS: &str = "null flavours";
 
     /// BMM constant `Group_id_property`.
-    pub const GROUP_ID_PROPERTY: &'static str = "property";
+    pub const GROUP_ID_PROPERTY: &str = "property";
 
     /// BMM constant `Group_id_participation_function`.
-    pub const GROUP_ID_PARTICIPATION_FUNCTION: &'static str = "participation function";
+    pub const GROUP_ID_PARTICIPATION_FUNCTION: &str = "participation function";
 
     /// BMM constant `Group_id_participation_mode`.
-    pub const GROUP_ID_PARTICIPATION_MODE: &'static str = "participation mode";
+    pub const GROUP_ID_PARTICIPATION_MODE: &str = "participation mode";
 
     /// BMM constant `Group_id_setting`.
-    pub const GROUP_ID_SETTING: &'static str = "setting";
+    pub const GROUP_ID_SETTING: &str = "setting";
 
     /// BMM constant `Group_id_term_mapping_purpose`.
-    pub const GROUP_ID_TERM_MAPPING_PURPOSE: &'static str = "term mapping purpose";
+    pub const GROUP_ID_TERM_MAPPING_PURPOSE: &str = "term mapping purpose";
 
     /// BMM constant `Group_id_subject_relationship`.
-    pub const GROUP_ID_SUBJECT_RELATIONSHIP: &'static str = "subject relationship";
+    pub const GROUP_ID_SUBJECT_RELATIONSHIP: &str = "subject relationship";
 
     /// BMM constant `Group_id_version_life_cycle_state`.
-    pub const GROUP_ID_VERSION_LIFE_CYCLE_STATE: &'static str = "version lifecycle state";
+    pub const GROUP_ID_VERSION_LIFE_CYCLE_STATE: &str = "version lifecycle state";
 }
 
 /// Polymorphic slot of `OPENEHR_TERMINOLOGY_GROUP_IDENTIFIERS`, dispatched on each payload's `_type`.

--- a/crates/openehr-rm/src/v1_2/support/terminology/openehr_code_set_identifiers.rs
+++ b/crates/openehr-rm/src/v1_2/support/terminology/openehr_code_set_identifiers.rs
@@ -15,25 +15,25 @@ pub struct OpenehrCodeSetIdentifiersData {}
 
 impl OpenehrCodeSetIdentifiersData {
     /// BMM constant `Code_set_id_character_sets`.
-    pub const CODE_SET_ID_CHARACTER_SETS: &'static str = "character sets";
+    pub const CODE_SET_ID_CHARACTER_SETS: &str = "character sets";
 
     /// BMM constant `Code_set_id_compression_algorithms`.
-    pub const CODE_SET_ID_COMPRESSION_ALGORITHMS: &'static str = "compression algorithms";
+    pub const CODE_SET_ID_COMPRESSION_ALGORITHMS: &str = "compression algorithms";
 
     /// BMM constant `Code_set_id_countries`.
-    pub const CODE_SET_ID_COUNTRIES: &'static str = "countries";
+    pub const CODE_SET_ID_COUNTRIES: &str = "countries";
 
     /// BMM constant `Code_set_integrity_check_algorithms`.
-    pub const CODE_SET_INTEGRITY_CHECK_ALGORITHMS: &'static str = "integrity check algorithms";
+    pub const CODE_SET_INTEGRITY_CHECK_ALGORITHMS: &str = "integrity check algorithms";
 
     /// BMM constant `Code_set_id_languages`.
-    pub const CODE_SET_ID_LANGUAGES: &'static str = "languages";
+    pub const CODE_SET_ID_LANGUAGES: &str = "languages";
 
     /// BMM constant `Code_set_id_media_types`.
-    pub const CODE_SET_ID_MEDIA_TYPES: &'static str = "media types";
+    pub const CODE_SET_ID_MEDIA_TYPES: &str = "media types";
 
     /// BMM constant `Code_set_id_normal_statuses`.
-    pub const CODE_SET_ID_NORMAL_STATUSES: &'static str = "normal statuses";
+    pub const CODE_SET_ID_NORMAL_STATUSES: &str = "normal statuses";
 }
 
 /// Polymorphic slot of `OPENEHR_CODE_SET_IDENTIFIERS`, dispatched on each payload's `_type`.

--- a/crates/openehr-rm/src/v1_2/support/terminology/openehr_terminology_group_identifiers.rs
+++ b/crates/openehr-rm/src/v1_2/support/terminology/openehr_terminology_group_identifiers.rs
@@ -16,49 +16,49 @@ pub struct OpenehrTerminologyGroupIdentifiersData {}
 impl OpenehrTerminologyGroupIdentifiersData {
     /// Name of openEHR's own terminology.
     /// BMM constant `Terminology_id_openehr`.
-    pub const TERMINOLOGY_ID_OPENEHR: &'static str = "openehr";
+    pub const TERMINOLOGY_ID_OPENEHR: &str = "openehr";
 
     /// BMM constant `Group_id_audit_change_type`.
-    pub const GROUP_ID_AUDIT_CHANGE_TYPE: &'static str = "audit change type";
+    pub const GROUP_ID_AUDIT_CHANGE_TYPE: &str = "audit change type";
 
     /// BMM constant `Group_id_attestation_reason`.
-    pub const GROUP_ID_ATTESTATION_REASON: &'static str = "attestation reason";
+    pub const GROUP_ID_ATTESTATION_REASON: &str = "attestation reason";
 
     /// BMM constant `Group_id_composition_category`.
-    pub const GROUP_ID_COMPOSITION_CATEGORY: &'static str = "composition category";
+    pub const GROUP_ID_COMPOSITION_CATEGORY: &str = "composition category";
 
     /// BMM constant `Group_id_event_math_function`.
-    pub const GROUP_ID_EVENT_MATH_FUNCTION: &'static str = "event math function";
+    pub const GROUP_ID_EVENT_MATH_FUNCTION: &str = "event math function";
 
     /// BMM constant `Group_id_instruction_states`.
-    pub const GROUP_ID_INSTRUCTION_STATES: &'static str = "instruction states";
+    pub const GROUP_ID_INSTRUCTION_STATES: &str = "instruction states";
 
     /// BMM constant `Group_id_instruction_transitions`.
-    pub const GROUP_ID_INSTRUCTION_TRANSITIONS: &'static str = "instruction transitions";
+    pub const GROUP_ID_INSTRUCTION_TRANSITIONS: &str = "instruction transitions";
 
     /// BMM constant `Group_id_null_flavours`.
-    pub const GROUP_ID_NULL_FLAVOURS: &'static str = "null flavours";
+    pub const GROUP_ID_NULL_FLAVOURS: &str = "null flavours";
 
     /// BMM constant `Group_id_property`.
-    pub const GROUP_ID_PROPERTY: &'static str = "property";
+    pub const GROUP_ID_PROPERTY: &str = "property";
 
     /// BMM constant `Group_id_participation_function`.
-    pub const GROUP_ID_PARTICIPATION_FUNCTION: &'static str = "participation function";
+    pub const GROUP_ID_PARTICIPATION_FUNCTION: &str = "participation function";
 
     /// BMM constant `Group_id_participation_mode`.
-    pub const GROUP_ID_PARTICIPATION_MODE: &'static str = "participation mode";
+    pub const GROUP_ID_PARTICIPATION_MODE: &str = "participation mode";
 
     /// BMM constant `Group_id_setting`.
-    pub const GROUP_ID_SETTING: &'static str = "setting";
+    pub const GROUP_ID_SETTING: &str = "setting";
 
     /// BMM constant `Group_id_term_mapping_purpose`.
-    pub const GROUP_ID_TERM_MAPPING_PURPOSE: &'static str = "term mapping purpose";
+    pub const GROUP_ID_TERM_MAPPING_PURPOSE: &str = "term mapping purpose";
 
     /// BMM constant `Group_id_subject_relationship`.
-    pub const GROUP_ID_SUBJECT_RELATIONSHIP: &'static str = "subject relationship";
+    pub const GROUP_ID_SUBJECT_RELATIONSHIP: &str = "subject relationship";
 
     /// BMM constant `Group_id_version_life_cycle_state`.
-    pub const GROUP_ID_VERSION_LIFE_CYCLE_STATE: &'static str = "version lifecycle state";
+    pub const GROUP_ID_VERSION_LIFE_CYCLE_STATE: &str = "version lifecycle state";
 }
 
 /// Polymorphic slot of `OPENEHR_TERMINOLOGY_GROUP_IDENTIFIERS`, dispatched on each payload's `_type`.

--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-term"
-version = "0.0.37"
+version = "0.0.38"
 description = "openEHR TERM terminology data model, generated from BMM (generation v3_1 = TERM 3.1.0), plus the embedded official terminology XML bundle"
 edition.workspace = true
 rust-version.workspace = true
@@ -34,7 +34,7 @@ include = [
 ]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.37" }
+openehr-base = { path = "../openehr-base", version = "0.0.38" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive.

--- a/tools/openehr-codegen/src/render/emit.rs
+++ b/tools/openehr-codegen/src/render/emit.rs
@@ -912,7 +912,7 @@ fn render_constants(class: &BmmClass, ty: &str) -> String {
 
 /// Decode a BMM constant's raw `value` to a Rust `(type, literal)` pair. A JSON
 /// number keys off the BMM `type` (`Real`/`Double` → `f64`, else `i64`); a JSON
-/// string carries a quoted `"…"` (→ `&'static str`) or `'…'` (→ `char`) literal,
+/// string carries a quoted `"…"` (→ `&str`) or `'…'` (→ `char`) literal,
 /// a bareword cross-reference to a sibling constant (→ `Self::OTHER`), or a
 /// boolean keyword. Numeric character references (`&#42;`) and Eiffel octal
 /// escapes (`\015`) inside literals are decoded.
@@ -928,10 +928,7 @@ fn const_literal(c: &BmmConstant, siblings: &BTreeSet<&str>) -> (String, String)
         serde_json::Value::String(s) => {
             let t = s.trim();
             if let Some(inner) = strip_delims(t, '"') {
-                (
-                    "&'static str".to_string(),
-                    format!("{:?}", decode_entities(inner)),
-                )
+                ("&str".to_string(), format!("{:?}", decode_entities(inner)))
             } else if let Some(inner) = strip_delims(t, '\'') {
                 ("char".to_string(), format!("{:?}", decode_char(inner)))
             } else if siblings.contains(t) {
@@ -948,11 +945,11 @@ fn const_literal(c: &BmmConstant, siblings: &BTreeSet<&str>) -> (String, String)
             } else {
                 // A bareword that is neither a sibling nor a boolean: emit as a
                 // string literal (verbatim), the safest total decoding.
-                ("&'static str".to_string(), format!("{t:?}"))
+                ("&str".to_string(), format!("{t:?}"))
             }
         }
         serde_json::Value::Null | serde_json::Value::Array(_) | serde_json::Value::Object(_) => {
-            ("&'static str".to_string(), "\"\"".to_string())
+            ("&str".to_string(), "\"\"".to_string())
         }
     }
 }


### PR DESCRIPTION
Closes #2733. `const_literal` in `render/emit.rs` is the one decision point for BMM-constant associated-const types; its three string arms rendered `&'static str`, which const/static item elision makes redundant. They now render `&str` — 106 emitted lines change across `openehr-am`/`base`/`lang`/`rm`, and zero const/static ITEMS carrying `'static` remain in the generated crates. Deliberately kept: generic type arguments (`LazyLock<HashMap<&'static str, …>>`), struct fields, and fn return types — elision does not reach any of them, and the elision boundary was verified first-hand on the pinned toolchain (a lifetime-parameterized impl refuses an elided associated const loudly via `elided_lifetimes_in_associated_constant`; no emitted spec type carries a lifetime parameter). The issue's `&'static [...]` half had no live sites — the slice constants already emit elided.

Regenerated via the full emit set; `codegen-drift.sh` green over the staged tree; `-- check` green for all 10 generations; clippy `-D warnings` over the seven touched crates; nextest 1558/1558; fmt clean. Lockstep `0.0.38` across the eight `openehr-*` crates (packaged bytes change; a consumer's compile is unaffected — `&str` in a const item IS `&'static str`).

Part of the #2640 program.