### PR TITLE
chore(quality): the Sonar shell classes — [[ ]] everywhere bash, case defaults, HTTPS-pinned vendor fetches

### DIFF
--- a/deploy/helm/ci/boot-check.sh
+++ b/deploy/helm/ci/boot-check.sh
@@ -222,6 +222,10 @@ boot_one() {
           docker_env+=(-e "${name}=ci-boot-check-external-secret-value")
         fi
         ;;
+      *)
+        red "  ${name}: unknown env source '${kind}'; teach boot-check.sh about it"
+        return 1
+        ;;
     esac
   done < "$envlist"
 

--- a/deploy/helm/validate.sh
+++ b/deploy/helm/validate.sh
@@ -156,7 +156,7 @@ yaml_ok() {
 gate_jq() {
   local file="$1" program="$2" out
   out="$(yq -o=json -I0 '.' "$file" | jq -s -r -f "$(dirname "$0")/gates/$program")" || return 1
-  [ -z "$out" ] || { printf '%s\n' "$out" | sed 's/^/  /'; return 1; }
+  [[ -z "$out" ]] || { printf '%s\n' "$out" | sed 's/^/  /'; return 1; }
   return 0
 }
 
@@ -458,7 +458,7 @@ refusal_registry_gate() {
     for record in "${registry[@]}"; do
       [[ "$(cut -d'|' -f1 <<<"$record")" == "$file" ]] || continue
       anchor="$(cut -d'|' -f2 <<<"$record")"
-      case "$content" in *"$anchor"*) covered=1 ;; esac
+      case "$content" in *"$anchor"*) covered=1 ;; *) ;; esac
     done
     if [[ "$covered" -eq 0 ]]; then
       red "  UNPROBED \`fail\`: ${site%%:*}:$(cut -d: -f2 <<<"$site")"
@@ -477,7 +477,7 @@ refusal_registry_gate() {
       [[ "${site%%:*}" == *"/${file}" ]] || continue
       content="${site#*:}"
       content="${content#*:}"
-      case "$content" in *"$anchor"*) covered=1 ;; esac
+      case "$content" in *"$anchor"*) covered=1 ;; *) ;; esac
     done <<<"$sites"
     if [[ "$covered" -eq 0 ]]; then
       red "  STALE probe: no \`fail\` in ${file} says '${anchor}' any more — drop or re-anchor the record"
@@ -697,14 +697,14 @@ artifacthub.io/links
 artifacthub.io/maintainers
 artifacthub.io/screenshots"
 actual_annotations="$(yq -r '.annotations | keys | .[]' "$CHART_DIR/Chart.yaml" | sort)"
-if [ "$actual_annotations" != "$expected_annotations" ]; then
+if [[ "$actual_annotations" != "$expected_annotations" ]]; then
   red "  Artifact Hub annotation set changed — decide it on the record (#2206), then update this list"
   diff <(printf '%s\n' "$expected_annotations") <(printf '%s\n' "$actual_annotations") || true
   exit 1
 fi
 # The listing logo is a Chart.yaml field, not an annotation, and its absence is
 # invisible except on the published page.
-[ -n "$(yq -r '.icon // ""' "$CHART_DIR/Chart.yaml")" ] || {
+[[ -n "$(yq -r '.icon // ""' "$CHART_DIR/Chart.yaml")" ]] || {
   red "  Chart.yaml has no icon — Artifact Hub renders a placeholder without one"
   exit 1
 }

--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -48,7 +48,7 @@ wait_healthy() {
   local cid
   for _ in $(seq 1 60); do
     cid=$("${COMPOSE[@]}" ps -q ferroehr)
-    if [ -n "$cid" ] && [ "$(docker inspect -f '{{.State.Health.Status}}' "$cid")" = "healthy" ]; then
+    if [[ -n "$cid" ]] && [[ "$(docker inspect -f '{{.State.Health.Status}}' "$cid")" = "healthy" ]]; then
       return 0
     fi
     sleep 5
@@ -75,25 +75,25 @@ wait_healthy
 
 echo "==> GET /rest/status must be 200"
 code=$(curl -fsS -o /dev/null -w '%{http_code}' "$BASE/status")
-[ "$code" = "200" ] || { echo "::error::/rest/status returned $code"; exit 1; }
+[[ "$code" = "200" ]] || { echo "::error::/rest/status returned $code"; exit 1; }
 
 echo "==> POST /ehr with dev Basic creds must be 201"
 code=$(curl -sS -o /dev/null -w '%{http_code}' -u ferroehr:ferroehr \
   -X POST "$BASE/openehr/v1/ehr" \
   -H 'Prefer: return=minimal')
-[ "$code" = "201" ] || { echo "::error::POST /ehr returned $code (expected 201)"; exit 1; }
+[[ "$code" = "201" ]] || { echo "::error::POST /ehr returned $code (expected 201)"; exit 1; }
 
 echo "==> Recording migration ledger before restart"
 before=$(migration_count)
 echo "    ehr._sqlx_migrations count = $before"
-[ "$before" -ge 1 ] || { echo "::error::migrations did not apply on first boot"; exit 1; }
+[[ "$before" -ge 1 ]] || { echo "::error::migrations did not apply on first boot"; exit 1; }
 
 echo "==> Restarting app (second boot must be a migration no-op)"
 "${COMPOSE[@]}" restart ferroehr
 wait_healthy
 after=$(migration_count)
 echo "    ehr._sqlx_migrations count = $after"
-[ "$before" = "$after" ] || {
+[[ "$before" = "$after" ]] || {
   echo "::error::migration count changed across restart ($before -> $after); not idempotent"
   exit 1
 }

--- a/docker/terminology/seed.sh
+++ b/docker/terminology/seed.sh
@@ -3,6 +3,10 @@
 # SPDX-License-Identifier: MIT
 # Seed the composed FHIR R4 terminology server with the CNF test terminologies.
 #
+# POSIX sh ON PURPOSE (the one non-bash script in the tree): the terminology
+# container runs this via /bin/sh and ships no bash, so bash-only constructs
+# ([[ ]] included) must stay out of this file.
+#
 # Runs as a one-shot init container of the `terminology` compose profile, after
 # the server answers its own capability statement. Everything it writes is
 # SYNTHETIC test content under the reserved example.test domain (IETF RFC 6761

--- a/scripts/checks/access-provenance.sh
+++ b/scripts/checks/access-provenance.sh
@@ -36,14 +36,14 @@ PATHS=(
 failures=0
 for pattern in 'EHRbase' 'v1 parity' 'v1-compatible' 'Stage-1' 'Stage-2' 'CLAUDE\.md'; do
   hits=$(grep -rnE "$pattern" "${PATHS[@]}" 2>/dev/null || true)
-  if [ -n "$hits" ]; then
+  if [[ -n "$hits" ]]; then
     printf 'access-provenance: %s must not appear under the access layer:\n' "$pattern" >&2
     printf '%s\n' "$hits" | sed 's/^/    /' >&2
     failures=$((failures + 1))
   fi
 done
 
-if [ "$failures" -gt 0 ]; then
+if [[ "$failures" -gt 0 ]]; then
   printf 'access-provenance: %d stale-attribution class(es) — cite an RFC, a \n' "$failures" >&2
   printf '    standards publication, or docs/specs/openehr/ instead.\n' >&2
   exit 1

--- a/scripts/checks/advisory-exceptions.sh
+++ b/scripts/checks/advisory-exceptions.sh
@@ -55,7 +55,7 @@ resolved="$(printf '%s\n' "$json" | jq -r '
   | select(.message == "no crate matched advisory criteria")
   | .span')"
 
-if [ -n "$resolved" ]; then
+if [[ -n "$resolved" ]]; then
   echo "error: deny.toml keeps an exception for an advisory the gate no longer raises:" >&2
   sed 's/^/  /' <<<"$resolved" >&2
   echo >&2

--- a/scripts/checks/comment-style.sh
+++ b/scripts/checks/comment-style.sh
@@ -37,21 +37,22 @@ case "$mode" in
   # `git ls-files` reads the index, so a file deleted from the worktree but
   # not yet staged would still be listed — skip it rather than letting awk
   # fail on a missing path.
-  while IFS= read -r f; do [ -f "$f" ] && files+=("$f"); done \
+  while IFS= read -r f; do [[ -f "$f" ]] && files+=("$f"); done \
     < <(git ls-files 'crates/*.rs' 'app/*.rs' 'tools/*.rs')
   ;;
 --diff)
   base="${2:?usage: --diff <base> [head]}"
   head="${3:-HEAD}"
   while IFS= read -r f; do
-    [ -f "$f" ] && files+=("$f")
+    [[ -f "$f" ]] && files+=("$f")
   done < <(git diff --name-only "$base" "$head" -- 'crates/*.rs' 'app/*.rs' 'tools/*.rs')
   ;;
 --files)
   shift
   for f in "$@"; do
     case "$f" in
-    *.rs) [ -f "$f" ] && files+=("$f") ;;
+    *.rs) [[ -f "$f" ]] && files+=("$f") ;;
+    *) ;;
     esac
   done
   ;;
@@ -61,7 +62,7 @@ case "$mode" in
   ;;
 esac
 
-[ "${#files[@]}" -eq 0 ] && {
+[[ "${#files[@]}" -eq 0 ]] && {
   echo "comment-style: no files to check — OK."
   exit 0
 }
@@ -157,13 +158,13 @@ for f in "${files[@]}"; do
     }
     END { flush_note(); flush_run(); flush_doc_note() }
   ' "$f")"
-  if [ -n "$out" ]; then
+  if [[ -n "$out" ]]; then
     printf '%s\n' "$out" | sed "s|^|$f|"
     fail=1
   fi
 done
 
-if [ "$fail" -ne 0 ]; then
+if [[ "$fail" -ne 0 ]]; then
   echo "comment-style: violations found (rules: .claude/rules/comments.md)." >&2
   exit 1
 fi

--- a/scripts/checks/compose-hardening.sh
+++ b/scripts/checks/compose-hardening.sh
@@ -47,7 +47,7 @@ report() {
 }
 
 for f in $(mapfile_compat); do
-  [ -f "$f" ] || continue
+  [[ -f "$f" ]] || continue
   grep -q '^services:' "$f" || continue
 
   # Comments are excluded from every content rule below: this guard's own rules
@@ -69,7 +69,7 @@ for f in $(mapfile_compat); do
   fi
   # (6) a published port names its host interface
   while IFS=: read -r line _; do
-    [ -n "${line:-}" ] || continue
+    [[ -n "${line:-}" ]] || continue
     report "$f:$line publishes a port without a host address — it binds every \
 interface and bypasses the host firewall"
   done < <(grep -nE '^\s+- "?[0-9$][^:]*:[0-9]+"?\s*$' "$f" | grep -v 'BIND_HOST' || true)
@@ -90,7 +90,7 @@ interface and bypasses the host firewall"
   # redundant — it makes `docker compose config` fail with "items at 0 and 1 are
   # equal", because list-valued keys concatenate.
   base_services=""
-  if [ "$f" != "./docker-compose.yml" ] && [ -f docker-compose.yml ]; then
+  if [[ "$f" != "./docker-compose.yml" ]] && [[ -f docker-compose.yml ]]; then
     base_services=$(awk '
       /^services:/ { in_services = 1; next }
       /^[a-z]/     { in_services = 0 }
@@ -119,13 +119,13 @@ interface and bypasses the host firewall"
       svc = ""
     }
   ' "$f")
-  if [ -n "$missing" ]; then
+  if [[ -n "$missing" ]]; then
     report "$f defines service(s) without the isolation floor (cap_drop + \
 no-new-privileges): $missing"
   fi
 done
 
-if [ "$failures" -gt 0 ]; then
+if [[ "$failures" -gt 0 ]]; then
   echo "compose-hardening: $failures violation(s) — see above." >&2
   exit 1
 fi

--- a/scripts/checks/compose-image-tags.sh
+++ b/scripts/checks/compose-image-tags.sh
@@ -19,7 +19,7 @@ VERCEL_FILE="$ROOT_DIR/Dockerfile.vercel"
 MANIFEST="$ROOT_DIR/Cargo.toml"
 
 version="$(sed -nE 's/^version = "(.*)"$/\1/p' "$MANIFEST" | head -1)"
-if [ -z "$version" ]; then
+if [[ -z "$version" ]]; then
   echo "::error::could not read the workspace version from $MANIFEST" >&2
   exit 1
 fi
@@ -29,13 +29,13 @@ for var in FERROEHR_IMAGE FERROEHR_POSTGRES_IMAGE FERROEHR_ADMIN_UI_IMAGE; do
   # The default is the `:-` fallback inside `${VAR:-ghcr.io/owner/name:tag}`.
   ref="$(grep -oE "\\\$\{$var:-[^}]+\}" "$COMPOSE_FILE" | head -1 \
     | sed -E "s/^\\\$\{$var:-//; s/\}$//")"
-  if [ -z "$ref" ]; then
+  if [[ -z "$ref" ]]; then
     echo "::error::$COMPOSE_FILE declares no \${$var:-…} default image reference" >&2
     rc=1
     continue
   fi
   tag="${ref##*:}"
-  if [ "$tag" != "$version" ]; then
+  if [[ "$tag" != "$version" ]]; then
     echo "::error::$var default is '$ref' (tag $tag) but the workspace version is $version — the release cut bumps the docker-compose.yml image tags (.claude/rules/changelog.md)." >&2
     rc=1
   else
@@ -48,7 +48,7 @@ done
 # so this guard only pins it to that pointer — a versioned FROM reappearing
 # would resurrect the release-cut bump this guard used to police.
 vercel_ref="$(grep -oE '^FROM ghcr\.io/[^ ]+' "$VERCEL_FILE" | head -1 | sed 's/^FROM //')"
-if [ "$vercel_ref" != "ghcr.io/rubentalstra/ferroehr:latest" ]; then
+if [[ "$vercel_ref" != "ghcr.io/rubentalstra/ferroehr:latest" ]]; then
   echo "::error::Dockerfile.vercel must be FROM ghcr.io/rubentalstra/ferroehr:latest (the release pointer, #2724); found '$vercel_ref'." >&2
   rc=1
 else

--- a/scripts/checks/conformance-numbers.sh
+++ b/scripts/checks/conformance-numbers.sh
@@ -43,7 +43,7 @@ if hits=$(grep -rInE --exclude='*.svg' "$pattern_perf" website/landing website/b
   fail=1
 fi
 
-if [ "$fail" -ne 0 ]; then
+if [[ "$fail" -ne 0 ]]; then
   echo "::error::Hand-typed conformance/performance numbers or verdicts found in site sources (above). The website derives conformance claims from docs/conformance/ferroehr/ and performance claims from the committed measurement records — use the data-cnf markers (landing), the generated includes (book), or the generated SVG assets, never literals. See scripts/render/conformance-stats.sh and scripts/render/perf-assets.sh." >&2
   exit 1
 fi

--- a/scripts/checks/copyright-holder.sh
+++ b/scripts/checks/copyright-holder.sh
@@ -23,7 +23,7 @@ readonly HOLDER='FerroEHR contributors'
 fail=0
 check() {
   local what="$1" found="$2"
-  if [ "$found" != "$HOLDER" ]; then
+  if [[ "$found" != "$HOLDER" ]]; then
     echo "error: $what states the copyright holder as:" >&2
     echo "         ${found:-<not found>}" >&2
     echo "       every source must state: $HOLDER" >&2
@@ -45,7 +45,7 @@ check "tools/openehr-codegen/src/render/spdx.rs" \
   "$(sed -n 's/^pub(crate) const PROJECT_COPYRIGHT: &str = "\(.*\)";$/\1/p' \
        tools/openehr-codegen/src/render/spdx.rs | head -1)"
 
-if [ "$fail" -ne 0 ]; then
+if [[ "$fail" -ne 0 ]]; then
   echo >&2
   echo "Changing the holder means changing ALL of them together, plus the file" >&2
   echo "headers (re-run the codegen emit set for the generated half)." >&2

--- a/scripts/checks/default-style.sh
+++ b/scripts/checks/default-style.sh
@@ -44,11 +44,11 @@ cd "$(dirname "$0")/../.."
 STD_PATHS='Option::default|Vec::default|String::default|bool::default'
 
 collect() {
-  if [ "${1:-}" = "--all" ]; then
+  if [[ "${1:-}" = "--all" ]]; then
     # -co --exclude-standard: tracked AND untracked (unignored) files — a new
     # file is checkable before it is ever staged.
     git ls-files -co --exclude-standard '*.rs'
-  elif [ "$#" -gt 0 ]; then
+  elif [[ "$#" -gt 0 ]]; then
     printf '%s\n' "$@"
   else
     git diff --name-only origin/develop...HEAD -- '*.rs' 2>/dev/null || git ls-files '*.rs'
@@ -62,14 +62,14 @@ report() {
 }
 
 files=$(collect "$@")
-[ -n "$files" ] || { echo "default-style: no Rust files to check."; exit 0; }
+[[ -n "$files" ]] || { echo "default-style: no Rust files to check."; exit 0; }
 
 for f in $files; do
-  [ -f "$f" ] || continue
+  [[ -f "$f" ]] || continue
 
   # (1) the per-field serde path form
   while IFS=: read -r line body; do
-    [ -n "${line:-}" ] || continue
+    [[ -n "${line:-}" ]] || continue
     printf '%s' "$body" | grep -qE "$STD_PATHS" && continue
     report "$f:$line: \`#[serde(default = \"…\")]\` — put the value in the struct's \
 \`impl Default\` and use container-level \`#[serde(default)]\` instead \
@@ -84,7 +84,7 @@ for f in $files; do
   # are ordinary functions that happen to start with the word, and
   # `#[test] fn default_is_development()`, which returns nothing.
   while IFS=: read -r line _; do
-    [ -n "${line:-}" ] || continue
+    [[ -n "${line:-}" ]] || continue
     report "$f:$line: a zero-argument \`default_*\` constructor — inline the value \
 in the struct's \`impl Default\` (scripts/checks/default-style.sh)"
   done < <(grep -nE '^[[:space:]]*(pub(\([^)]*\))?[[:space:]]+)?(const[[:space:]]+)?fn[[:space:]]+default_[a-z0-9_]*[[:space:]]*\(\)[[:space:]]*->' "$f" || true)
@@ -105,11 +105,11 @@ done
 # `--untracked` for the same reason (`git grep` alone sees only tracked
 # content).
 for f in $files; do
-  [ -f "$f" ] || continue
+  [[ -f "$f" ]] || continue
   while IFS=: read -r line decl; do
-    [ -n "${line:-}" ] || continue
+    [[ -n "${line:-}" ]] || continue
     name=$(printf '%s' "$decl" | sed -nE 's/.*const[[:space:]]+(DEFAULT_[A-Z0-9_]+).*/\1/p')
-    [ -n "$name" ] || continue
+    [[ -n "$name" ]] || continue
     if printf '%s' "$decl" | grep -q 'pub[[:space:]]\|pub(' ; then
       # Visible beyond the file: count tree-wide, discounting every declaration.
       hits=$(git grep --untracked -how "$name" -- '*.rs' | wc -l | tr -d ' ')
@@ -118,7 +118,7 @@ for f in $files; do
     else
       readers=$(($(grep -cow "$name" "$f" | tr -d ' ') - 1))
     fi
-    if [ "$readers" -le 1 ]; then
+    if [[ "$readers" -le 1 ]]; then
       report "$f:$line: \`const $name\` has $readers reader(s) — a constant \
 earns its name by being shared; inline the value in the \`impl Default\` that \
 reads it (scripts/checks/default-style.sh)"
@@ -126,7 +126,7 @@ reads it (scripts/checks/default-style.sh)"
   done < <(grep -nE 'const[[:space:]]+DEFAULT_[A-Z0-9_]+' "$f" || true)
 done
 
-if [ "$failures" -gt 0 ]; then
+if [[ "$failures" -gt 0 ]]; then
   echo "default-style: $failures violation(s) — see above." >&2
   exit 1
 fi

--- a/scripts/checks/docs-claims.sh
+++ b/scripts/checks/docs-claims.sh
@@ -64,13 +64,13 @@ CHART_PAGES=$(printf '%s ' "$BOOK"/installation/kubernetes*.md "$BOOK"/installat
   "$BOOK"/operations.md "$BOOK"/operations-admin-apis.md)
 
 for required in "$TOML" "$VALUES"; do
-  [ -f "$required" ] || { echo "docs-claims: missing authority file $required" >&2; exit 1; }
+  [[ -f "$required" ]] || { echo "docs-claims: missing authority file $required" >&2; exit 1; }
 done
 
 collect() {
-  if [ "${1:-}" = "--all" ]; then
+  if [[ "${1:-}" = "--all" ]]; then
     git ls-files "$BOOK/**/*.md" "$BOOK/*.md"
-  elif [ "$#" -gt 0 ]; then
+  elif [[ "$#" -gt 0 ]]; then
     printf '%s\n' "$@"
   else
     git diff --name-only origin/develop...HEAD -- "$BOOK/*.md" "$BOOK/**/*.md" 2>/dev/null \
@@ -142,12 +142,12 @@ files=$(collect "$@")
 
 # ── 1. configuration keys ────────────────────────────────────────────────────
 for f in $files; do
-  [ -f "$f" ] || continue
+  [[ -f "$f" ]] || continue
   # A form ending in `__` is prose naming a prefix ("FERROEHR__AUDIT__…"), not a
   # key. Anything else must resolve.
   while read -r form; do
-    [ -n "$form" ] || continue
-    case "$form" in *__) continue ;; esac
+    [[ -n "$form" ]] || continue
+    case "$form" in *__) continue ;; *) ;; esac
     grep -qxF "$form" "$work/env" \
       || report "$f" "documents \`$form\`, which is not a key in $TOML"
   done < <(grep -ohE 'FERROEHR__[A-Z0-9_]+' "$f" | sort -u)
@@ -176,7 +176,7 @@ for f in $files; do
     "$BOOK"/installation/configuration.md|"$BOOK"/installation/config-*.md) ;;
     *) continue ;;
   esac
-  [ -f "$f" ] || continue
+  [[ -f "$f" ]] || continue
   awk '
     /^#/ { intab=0
            if (match($0, /\[[a-z0-9_.]+\]/)) sect = substr($0, RSTART+1, RLENGTH-2)
@@ -193,15 +193,15 @@ for f in $files; do
     !/^\|/ { intab=0 }
   ' "$f" > "$work/page_defaults"
   while IFS=$(printf '\t') read -r path documented; do
-    [ -n "$path" ] || continue
+    [[ -n "$path" ]] || continue
     actual=$(awk -F'\t' -v p="$path" '$1==p{print $2; exit}' "$work/toml_defaults")
-    [ -n "$actual" ] || continue
+    [[ -n "$actual" ]] || continue
     doc_n=$documented; act_n=$actual
     # A page may spell a string default with its TOML quotes (`"1.3"`); the
     # TOML side is stored unquoted, so strip a quote wrapper before comparing.
     doc_n=${doc_n#\"}; doc_n=${doc_n%\"}
-    case "$doc_n" in \[*) doc_n=$(printf '%s' "$doc_n" | tr -d ' '); act_n=$(printf '%s' "$act_n" | tr -d ' ') ;; esac
-    [ "$doc_n" = "$act_n" ] \
+    case "$doc_n" in \[*) doc_n=$(printf '%s' "$doc_n" | tr -d ' '); act_n=$(printf '%s' "$act_n" | tr -d ' ') ;; *) ;; esac
+    [[ "$doc_n" = "$act_n" ]] \
       || report "$f" "documents \`$path\` default as \`$documented\`; $TOML says \`$actual\`"
   done < "$work/page_defaults"
 done
@@ -209,9 +209,9 @@ done
 # ── 2. Helm values paths (chart pages only) ──────────────────────────────────
 for f in $files; do
   case " $CHART_PAGES " in *" $f "*) ;; *) continue ;; esac
-  [ -f "$f" ] || continue
+  [[ -f "$f" ]] || continue
   while read -r path; do
-    [ -n "$path" ] || continue
+    [[ -n "$path" ]] || continue
     first=${path%%.*}
     # Only a token rooted at a real top-level values key is read as a values
     # path; anything else is ordinary prose that happens to contain a dot.
@@ -221,6 +221,7 @@ for f in $files; do
     # its authority.
     case "$path" in
       config.*) grep -qxF "${path#config.}" "$work/toml" && continue ;;
+      *) ;;
     esac
     # The other verbatim-passthrough subtrees. `config.*` is not the only one:
     # values.schema.json declares these "rendered verbatim", so the whole
@@ -231,16 +232,18 @@ for f in $files; do
     case "$path" in
       securityContext.*|podSecurityContext.*|autoscaling.behavior.*|\
       adminUi.securityContext.*|adminUi.podSecurityContext.*) continue ;;
+      *) ;;
     esac
     report "$f" "documents Helm value \`$path\`, which the chart does not define"
   done < <(grep -ohE '`[a-z][A-Za-z0-9]*(\.[A-Za-z0-9_]+)+(=[^`]*)?`' "$f" | tr -d '`' | sed -E 's/=.*$//' | sort -u)
   # `--set` is unambiguous wherever it appears, so it is checked without the
   # top-level-key filter above.
   while read -r path; do
-    [ -n "$path" ] || continue
+    [[ -n "$path" ]] || continue
     grep -qxF "$path" "$work/values" && continue
     case "$path" in
       config.*) grep -qxF "${path#config.}" "$work/toml" && continue ;;
+      *) ;;
     esac
     # The other verbatim-passthrough subtrees. `config.*` is not the only one:
     # values.schema.json declares these "rendered verbatim", so the whole
@@ -251,6 +254,7 @@ for f in $files; do
     case "$path" in
       securityContext.*|podSecurityContext.*|autoscaling.behavior.*|\
       adminUi.securityContext.*|adminUi.podSecurityContext.*) continue ;;
+      *) ;;
     esac
     report "$f" "\`--set $path=\` names a value the chart does not define"
   done < <(grep -ohE '\-\-set +[a-z][A-Za-z0-9_.]*=' "$f" | sed -E 's/--set +//; s/=$//' | sort -u)
@@ -265,15 +269,15 @@ chart_version=$(awk '$1=="version:"{print $2; exit}' "$CHART_YAML")
 app_version=$(awk '$1=="appVersion:"{gsub(/"/,""); print $2; exit}' "$CHART_YAML")
 for f in $files; do
   case " $CHART_PAGES " in *" $f "*) ;; *) continue ;; esac
-  [ -f "$f" ] || continue
+  [[ -f "$f" ]] || continue
   while read -r v; do
-    [ -n "$v" ] || continue
-    [ "$v" = "$chart_version" ] \
+    [[ -n "$v" ]] || continue
+    [[ "$v" = "$chart_version" ]] \
       || report "$f" "pins chart \`--version $v\`; Chart.yaml says $chart_version"
   done < <(grep -ohE '\-\-version +[0-9]+\.[0-9]+\.[0-9]+' "$f" | awk '{print $2}' | sort -u)
   while read -r v; do
-    [ -n "$v" ] || continue
-    [ "$v" = "$app_version" ] \
+    [[ -n "$v" ]] || continue
+    [[ "$v" = "$app_version" ]] \
       || report "$f" "pins image tag \`$v\`; Chart.yaml appVersion is $app_version"
   done < <(grep -ohE 'ferroehr(-admin-ui)?:[0-9]+\.[0-9]+\.[0-9]+' "$f" | sed 's/.*://' | sort -u)
 done
@@ -281,14 +285,14 @@ done
 # the current appVersion, and never a `v` prefix — the publish lane tags
 # `{{version}}` without one, so `ghcr.io/…:v3.17.5` does not resolve at all.
 for f in $files website/landing/index.html; do
-  [ -f "$f" ] || continue
+  [[ -f "$f" ]] || continue
   if grep -qE 'ghcr\.io/rubentalstra/[A-Za-z0-9._-]+:v[0-9]' "$f"; then
     report "$f" "references a v-prefixed ghcr image tag; published tags carry no v prefix"
   fi
-  case " $CHART_PAGES " in *" $f "*) continue ;; esac
+  case " $CHART_PAGES " in *" $f "*) continue ;; *) ;; esac
   while read -r v; do
-    [ -n "$v" ] || continue
-    [ "$v" = "$app_version" ] \
+    [[ -n "$v" ]] || continue
+    [[ "$v" = "$app_version" ]] \
       || report "$f" "pins ghcr image tag \`$v\`; Chart.yaml appVersion is $app_version"
   done < <(grep -ohE 'ghcr\.io/rubentalstra/(ferroehr|ferroehr-admin-ui|ferroehr-postgres):[0-9]+\.[0-9]+\.[0-9]+' "$f" | sed 's/.*://' | sort -u)
 done
@@ -299,10 +303,10 @@ case " $files " in *" $RUST_PAGE "*)
   channel=$(awk -F'"' '/^channel/{print $2; exit}' rust-toolchain.toml)
   msrv=$(awk -F'"' '/^rust-version/{print $2; exit}' Cargo.toml)
   while read -r v; do
-    case "$v" in "$channel"|"${channel%.*}"|"$msrv"|"$msrv".*) continue ;; esac
+    case "$v" in "$channel"|"${channel%.*}"|"$msrv"|"$msrv".*) continue ;; *) ;; esac
     report "$RUST_PAGE" "names Rust \`$v\`, which is neither the toolchain channel ($channel) nor the MSRV ($msrv)"
   done < <(grep -ohE '1\.[0-9]{2}(\.[0-9]+)?' "$RUST_PAGE" | sort -u)
-;; esac
+;; *) ;; esac
 
 # ── 3b. quoted wire evidence on the comparison page ─────────────────────────
 # Five fabricated response-body quotes shipped on the published comparison page
@@ -312,12 +316,12 @@ case " $files " in *" $RUST_PAGE "*)
 COMPARISON_PAGE="$BOOK/comparison.md"
 case " $files " in *" $COMPARISON_PAGE "*)
   while read -r quote; do
-    [ -n "$quote" ] || continue
+    [[ -n "$quote" ]] || continue
     inner=${quote#\`\"}; inner=${inner%\"\`}
     grep -qF "$inner" docs/conformance/ehrbase/results.json docs/conformance/ferroehr/results.json 2>/dev/null \
       || report "$COMPARISON_PAGE" "quotes \`\"$inner\"\` as wire evidence, but no committed results record contains it"
   done < <(grep -ohE '`"[^"`]{4,}"`' "$COMPARISON_PAGE" | sort -u)
-;; esac
+;; *) ;; esac
 
 # ── 3c. banned phrases with a recorded refutation ────────────────────────────
 # "static binary" shipped on four pages, the landing and the README while the
@@ -327,7 +331,7 @@ case " $files " in *" $COMPARISON_PAGE "*)
 # stays legal; the match runs over line-joined text so a negation split across
 # a line wrap is still recognised.
 while read -r f; do
-  [ -f "$f" ] || continue
+  [[ -f "$f" ]] || continue
   tr '\n' ' ' < "$f" \
     | sed -E 's/(not|never) a static(ally linked)? binary//Ig' \
     | grep -qiE 'static(ally linked)? binary' \
@@ -352,14 +356,14 @@ done < <(grep -rilE 'static(ally linked)? binary' --include='*.md' "$BOOK" websi
 # generated markdown is therefore the GENERATOR, so the render scripts are the
 # third haystack.
 while read -r svg; do
-  [ -n "$svg" ] || continue
+  [[ -n "$svg" ]] || continue
   base=${svg##*/}
   grep -rqF "$base" --include='*.md' "$BOOK" website/book/generated \
     || grep -rqF "$base" scripts/render \
     || report "$svg" "is committed but neither a page, a generated include, nor a render script embeds it"
 done < <(git ls-files "$BOOK/*-assets/*.svg")
 
-if [ "$failures" -gt 0 ]; then
+if [[ "$failures" -gt 0 ]]; then
   echo "docs-claims: $failures unresolvable claim(s) — see above." >&2
   echo "  A documented key must exist in its source. Fix the page, or fix the" >&2
   echo "  source if the page is describing what the software should do." >&2

--- a/scripts/checks/error-hygiene.sh
+++ b/scripts/checks/error-hygiene.sh
@@ -74,12 +74,12 @@ failures=0
 hits=$(grep -rn -A 2 -E "${CONSTRUCTORS}" app/ferroehr-rest/src app/ferroehr/src crates/openehr-its/src 2>/dev/null \
   | grep -vE '^[^:]+[:-][0-9]*[:-]?[[:space:]]*//' \
   | grep -E "$ERROR_VALUE" || true)
-if [ -n "$hits" ]; then
+if [[ -n "$hits" ]]; then
   printf 'error-hygiene: %s\n' "$hits" >&2
   failures=$(printf '%s\n' "$hits" | wc -l | tr -d ' ')
 fi
 
-if [ "$failures" -gt 0 ]; then
+if [[ "$failures" -gt 0 ]]; then
   cat >&2 <<'MSG'
 error-hygiene: a 5xx error body or a health `detail` interpolates an error value —
 that can carry SQL, a DSN, a filesystem path, an internal URL or a whole

--- a/scripts/checks/error-source-chain.sh
+++ b/scripts/checks/error-source-chain.sh
@@ -75,11 +75,11 @@ for entry in "${BUDGETS[@]}"; do
            | grep -v '/tests/' | grep -vc 'with_source' || true)"
   count="${count:-0}"
   printf '%-26s %3s flattened (budget %s)\n' "$tree" "$count" "$budget"
-  if [ "$count" -gt "$budget" ]; then
+  if [[ "$count" -gt "$budget" ]]; then
     echo "::error::$tree grew from $budget to $count flattened error sites — an error carries its cause (RFC 0201, #2034)"
     fail=1
   fi
 done
 
-[ "$fail" -eq 0 ] || exit 1
+[[ "$fail" -eq 0 ]] || exit 1
 echo "error-source-chain: no tree grew"

--- a/scripts/checks/image-labels.sh
+++ b/scripts/checks/image-labels.sh
@@ -85,22 +85,22 @@ workflow_label() {
 for entry in $IMAGES; do
   image=${entry%%:*}
   dockerfile=${entry#*:}
-  [ -f "$dockerfile" ] || { report "image-labels: missing $dockerfile"; continue; }
+  [[ -f "$dockerfile" ]] || { report "image-labels: missing $dockerfile"; continue; }
 
   for key in $SHARED; do
     d=$(dockerfile_label "$dockerfile" "$key" || true)
     w=$(workflow_label "$image" "$key" || true)
-    if [ -z "$d" ]; then
+    if [[ -z "$d" ]]; then
       report "image-labels: $dockerfile declares no org.opencontainers.image.$key"
       continue
     fi
-    if [ -z "$w" ]; then
+    if [[ -z "$w" ]]; then
       report "image-labels: $WORKFLOW declares no org.opencontainers.image.$key for $image"
       continue
     fi
     # The Dockerfile substitutes ${VERSION}/${REVISION} from build args; the
     # shared keys are all literals, so a plain comparison is right.
-    if [ "$d" != "$w" ]; then
+    if [[ "$d" != "$w" ]]; then
       report "image-labels: $image .$key disagrees —
     $dockerfile: $d
     $WORKFLOW: $w"
@@ -110,7 +110,7 @@ for entry in $IMAGES; do
   # base.name/base.digest must match the runtime stage's actual FROM pin, or the
   # image claims a parent it was not built on — worse than claiming none.
   from=$(grep -E '^FROM [^ ]+@sha256:' "$dockerfile" | tail -1 || true)
-  if [ -z "$from" ]; then
+  if [[ -z "$from" ]]; then
     report "image-labels: $dockerfile has no digest-pinned FROM to check base.* against"
   else
     ref=$(printf '%s' "$from" | awk '{print $2}')
@@ -118,9 +118,9 @@ for entry in $IMAGES; do
     want_digest=${ref#*@}
     got_name=$(dockerfile_label "$dockerfile" base.name || true)
     got_digest=$(dockerfile_label "$dockerfile" base.digest || true)
-    [ "$got_name" = "$want_name" ] \
+    [[ "$got_name" = "$want_name" ]] \
       || report "image-labels: $dockerfile base.name is '$got_name', but its FROM is '$want_name'"
-    [ "$got_digest" = "$want_digest" ] \
+    [[ "$got_digest" = "$want_digest" ]] \
       || report "image-labels: $dockerfile base.digest is '$got_digest', but its FROM pins '$want_digest'"
   fi
 done
@@ -130,15 +130,15 @@ done
 # image ships (found as a checklist item in #2408/#2410, enforced here since).
 CI_WORKFLOW=.github/workflows/ci.yml
 pg_from=$(grep -E '^FROM postgres:' docker/postgres/Dockerfile | awk '{print $2}' || true)
-if [ -z "$pg_from" ]; then
+if [[ -z "$pg_from" ]]; then
   report "image-labels: docker/postgres/Dockerfile has no 'FROM postgres:' pin"
 else
   ci_pins=$(grep -Eo 'image: postgres:[^[:space:]]+' "$CI_WORKFLOW" | sed 's/^image: //' | sort -u || true)
-  if [ -z "$ci_pins" ]; then
+  if [[ -z "$ci_pins" ]]; then
     report "image-labels: $CI_WORKFLOW declares no postgres service pins to check"
   else
     for pin in $ci_pins; do
-      [ "$pin" = "$pg_from" ] \
+      [[ "$pin" = "$pg_from" ]] \
         || report "image-labels: $CI_WORKFLOW pins service '$pin', but docker/postgres/Dockerfile FROM is '$pg_from'"
     done
   fi
@@ -148,13 +148,13 @@ fi
 # description from. The publishing mechanics live ONCE in the reusable
 # build-image.yml lane; containers.yml calls it once per image.
 levels=$(grep -c 'DOCKER_METADATA_ANNOTATIONS_LEVELS: index,manifest' "$BUILD_WORKFLOW" || true)
-[ "$levels" -eq 1 ] \
+[[ "$levels" -eq 1 ]] \
   || report "image-labels: expected the one reusable metadata step with DOCKER_METADATA_ANNOTATIONS_LEVELS: index,manifest in $BUILD_WORKFLOW, found $levels"
 annots=$(grep -c 'annotations: ${{ steps.meta.outputs.annotations }}' "$BUILD_WORKFLOW" || true)
-[ "$annots" -eq 1 ] \
+[[ "$annots" -eq 1 ]] \
   || report "image-labels: expected the one reusable build step passing the annotations output in $BUILD_WORKFLOW, found $annots"
 lanes=$(grep -c 'uses: ./.github/workflows/build-image.yml' "$WORKFLOW" || true)
-[ "$lanes" -eq 3 ] \
+[[ "$lanes" -eq 3 ]] \
   || report "image-labels: expected 3 publishing lanes calling build-image.yml in $WORKFLOW, found $lanes"
 
 # The one predefined key we deliberately leave unset, recorded rather than
@@ -163,7 +163,7 @@ lanes=$(grep -c 'uses: ./.github/workflows/build-image.yml' "$WORKFLOW" || true)
 # carries several tags, so a single ref.name would have to pick one arbitrarily.
 # `created` is set by the action from the build time and needs no declaration.
 
-if [ "$failures" -gt 0 ]; then
+if [[ "$failures" -gt 0 ]]; then
   echo "image-labels: $failures problem(s) — see above." >&2
   exit 1
 fi

--- a/scripts/checks/licensing-declarations.sh
+++ b/scripts/checks/licensing-declarations.sh
@@ -29,9 +29,9 @@ readonly LICENSES_DIR='LICENSES'
 readonly CHAPTER='website/book/src/licensing.md'
 
 for required in "$REUSE_TOML" "$CHAPTER"; do
-  [ -f "$required" ] || { echo "error: missing $required" >&2; exit 1; }
+  [[ -f "$required" ]] || { echo "error: missing $required" >&2; exit 1; }
 done
-[ -d "$LICENSES_DIR" ] || { echo "error: missing $LICENSES_DIR/" >&2; exit 1; }
+[[ -d "$LICENSES_DIR" ]] || { echo "error: missing $LICENSES_DIR/" >&2; exit 1; }
 command -v yq >/dev/null || { echo "error: yq is required" >&2; exit 1; }
 
 # Every identifier named in an SPDX expression. Expressions here are `AND`/`OR`
@@ -51,19 +51,19 @@ fail=0
 note() { echo "licensing-declarations: $*" >&2; fail=1; }
 
 while read -r id; do
-  [ -n "$id" ] || continue
+  [[ -n "$id" ]] || continue
   note "REUSE.toml declares '$id' but $LICENSES_DIR/$id.txt does not exist — REUSE requires the full text of every licence the tree is offered under"
 done < <(comm -23 <(echo "$declared") <(echo "$texts"))
 
 while read -r id; do
-  [ -n "$id" ] || continue
+  [[ -n "$id" ]] || continue
   note "$LICENSES_DIR/$id.txt is present but nothing in REUSE.toml is offered under '$id' — delete the text, or declare the files that need it"
 done < <(comm -13 <(echo "$declared") <(echo "$texts"))
 
 # The chapter names licences the way a reader does ("CC-BY-SA 3.0"), so both the
 # SPDX spelling and the spaced human spelling count as a mention.
 while read -r id; do
-  [ -n "$id" ] || continue
+  [[ -n "$id" ]] || continue
   human=${id%-only}
   human=$(printf '%s' "$human" | sed -E 's/^(CC-BY-SA)-([0-9])/\1 \2/; s/^(MPL|AGPL|Apache|GPL|LGPL)-([0-9])/\1 \2/')
   if ! grep -qF -- "$id" "$CHAPTER" && ! grep -qF -- "$human" "$CHAPTER"; then
@@ -71,7 +71,7 @@ while read -r id; do
   fi
 done < <(echo "$declared")
 
-[ "$fail" -eq 0 ] || {
+[[ "$fail" -eq 0 ]] || {
   echo >&2
   echo "The machine-readable declarations (REUSE.toml + LICENSES/) and the" >&2
   echo "licensing chapter are the same statement in two registers; they may" >&2

--- a/scripts/checks/no-python.sh
+++ b/scripts/checks/no-python.sh
@@ -29,16 +29,17 @@ ROOTS=(scripts .github/workflows .claude/hooks deploy docker)
 
 hits=0
 while IFS= read -r file; do
-  [ -f "$file" ] || continue
+  [[ -f "$file" ]] || continue
   case "$file" in
     */node_modules/*|*/vendor/*|*/target/*) continue ;;
+    *) ;;
   esac
   printf '%s' "$file" | grep -qE "$EXEMPT" && continue
   # An invocation, not the word: prose about not using Python is fine and this
   # repository contains several such comments.
   if matches="$(grep -nE '(^|[^[:alnum:]_./-])python3?([[:space:]]|$)' "$file" \
                 | grep -vE '#.*python' || true)"; then
-    if [ -n "$matches" ]; then
+    if [[ -n "$matches" ]]; then
       printf '%s:\n%s\n' "$file" "$matches"
       hits=$((hits + 1))
     fi
@@ -51,7 +52,7 @@ while IFS= read -r py; do
   hits=$((hits + 1))
 done < <(find "${ROOTS[@]}" -type f -name '*.py' 2>/dev/null | sort)
 
-if [ "$hits" -gt 0 ]; then
+if [[ "$hits" -gt 0 ]]; then
   echo
   echo "::error::Python is banned in this repository (see .claude/rules/rust-style.md)."
   echo "  Use bash + jq/awk/sed, or Rust. The two Helm gates are the only"

--- a/scripts/checks/packaged-attribution.sh
+++ b/scripts/checks/packaged-attribution.sh
@@ -34,11 +34,11 @@ for row in "${ROWS[@]}"; do
   IFS='|' read -r crate provenance attribution <<<"$row"
   manifest="$crate/Cargo.toml"
   for required in "$crate/$provenance" "$crate/$attribution" "$manifest"; do
-    [ -f "$required" ] || { note "missing $required"; continue 2; }
+    [[ -f "$required" ]] || { note "missing $required"; continue 2; }
   done
 
   revision=$(grep -oE '[0-9a-f]{40}' "$crate/$provenance" | head -1 || true)
-  if [ -z "$revision" ]; then
+  if [[ -z "$revision" ]]; then
     note "$crate/$provenance records no 40-hex upstream commit — the packaged attribution has nothing to pin to"
     continue
   fi
@@ -54,7 +54,7 @@ for row in "${ROWS[@]}"; do
   fi
 done
 
-[ "$fail" -eq 0 ] || {
+[[ "$fail" -eq 0 ]] || {
   echo >&2
   echo "Attribution for redistributed third-party material must be inside the" >&2
   echo "published artifact, not only in the repository it was built from." >&2

--- a/scripts/checks/packaged-includes.sh
+++ b/scripts/checks/packaged-includes.sh
@@ -37,7 +37,7 @@ embeds=0
 for manifest in crates/*/Cargo.toml; do
   crate_dir="$(dirname "$manifest")"
   crate_name="$(sed -nE 's/^name *= *"([^"]+)".*/\1/p' "$manifest" | head -1)"
-  [ -n "$crate_name" ] || { note "$manifest declares no package name"; continue; }
+  [[ -n "$crate_name" ]] || { note "$manifest declares no package name"; continue; }
   crates=$((crates + 1))
 
   packaged="$(cargo package --list -p "$crate_name" --allow-dirty 2>/dev/null)" || {
@@ -48,16 +48,16 @@ for manifest in crates/*/Cargo.toml; do
   while IFS= read -r packaged_file; do
     case "$packaged_file" in *.rs) ;; *) continue ;; esac
     source_file="$crate_dir/$packaged_file"
-    [ -f "$source_file" ] || continue
+    [[ -f "$source_file" ]] || continue
 
     # Newlines become spaces so a macro call split across lines is still one
     # match; a path literal never contains a newline.
     while IFS= read -r match; do
-      [ -n "$match" ] || continue
+      [[ -n "$match" ]] || continue
       literal="$(printf '%s' "$match" | sed -E 's/.*"([^"]*)".*/\1/')"
       embeds=$((embeds + 1))
       target="$(resolve "$(dirname "$source_file")" "$literal")"
-      if [ -z "$target" ]; then
+      if [[ -z "$target" ]]; then
         note "$source_file embeds \"$literal\", which resolves to no existing directory"
         continue
       fi
@@ -89,7 +89,7 @@ for manifest in crates/*/Cargo.toml; do
   done <<<"$packaged"
 done
 
-[ "$fail" -eq 0 ] || {
+[[ "$fail" -eq 0 ]] || {
   echo >&2
   echo "A published crate is a self-contained artifact: everything its packaged" >&2
   echo "sources embed must travel with it." >&2

--- a/scripts/checks/spdx-headers-text.sh
+++ b/scripts/checks/spdx-headers-text.sh
@@ -66,7 +66,7 @@ fixed=0
 checked=0
 
 while IFS= read -r f; do
-  [ -f "$f" ] || continue
+  [[ -f "$f" ]] || continue
   checked=$((checked + 1))
   prefix=$(comment_prefix "$f")
 
@@ -75,7 +75,7 @@ while IFS= read -r f; do
     continue
   fi
 
-  if [ "$mode" != --fix ]; then
+  if [[ "$mode" != --fix ]]; then
     echo "$f: no $LICENSE in the first 8 lines" >&2
     fail=1
     continue
@@ -102,12 +102,12 @@ while IFS= read -r f; do
   fixed=$((fixed + 1))
 done < <(git ls-files '*.sh' '*.sql' '*.yml' | grep -vE "$EXCLUDED")
 
-if [ "$mode" = --fix ]; then
+if [[ "$mode" = --fix ]]; then
   echo "spdx-headers-text: $fixed header(s) inserted across $checked file(s)."
   exit 0
 fi
 
-if [ "$fail" -ne 0 ]; then
+if [[ "$fail" -ne 0 ]]; then
   echo "spdx-headers-text: files without a licence header (run --fix)." >&2
   exit 1
 fi

--- a/scripts/checks/spdx-headers.sh
+++ b/scripts/checks/spdx-headers.sh
@@ -91,7 +91,7 @@ expected_header() {
   local krate
   krate=$(licensing_crate "$1")
   for dual in "${DUAL_CRATES[@]}"; do
-    if [ "$krate" = "$dual" ]; then
+    if [[ "$krate" = "$dual" ]]; then
       printf '%s' "$DUAL_HEADER"
       return
     fi
@@ -107,16 +107,16 @@ fail=0
 fixed=0
 checked=0
 while IFS= read -r f; do
-  [ -f "$f" ] || continue
+  [[ -f "$f" ]] || continue
   checked=$((checked + 1))
   expected=$(expected_header "$f")
   found=$(head -n "$HEAD_LINES" "$f" | grep -E '^// SPDX-(FileCopyrightText|License-Identifier): ' || true)
 
-  if [ "$found" = "$expected" ]; then
+  if [[ "$found" = "$expected" ]]; then
     continue
   fi
 
-  if [ -z "$found" ] && [ "$mode" = --fix ] && ! is_generated "$f"; then
+  if [[ -z "$found" ]] && [[ "$mode" = --fix ]] && ! is_generated "$f"; then
     printf '%s\n\n' "$expected" | cat - "$f" >"$f.spdx.tmp"
     mv "$f.spdx.tmp" "$f"
     fixed=$((fixed + 1))
@@ -124,7 +124,7 @@ while IFS= read -r f; do
   fi
 
   fail=1
-  if [ -z "$found" ]; then
+  if [[ -z "$found" ]]; then
     echo "$f: no SPDX header in the first $HEAD_LINES lines" >&2
   else
     echo "$f: SPDX header does not match the licensing REUSE.toml declares" >&2
@@ -136,10 +136,10 @@ while IFS= read -r f; do
   fi
 done < <(git ls-files '*.rs')
 
-if [ "$fixed" -ne 0 ]; then
+if [[ "$fixed" -ne 0 ]]; then
   echo "spdx-headers: inserted $fixed header(s)."
 fi
-if [ "$fail" -ne 0 ]; then
+if [[ "$fail" -ne 0 ]]; then
   echo >&2
   echo "Licensing must travel with a file that is copied out of this tree" >&2
   echo "(REUSE 3.3). Hand-written files take the header directly; generated" >&2

--- a/scripts/checks/sql-string-building.sh
+++ b/scripts/checks/sql-string-building.sh
@@ -57,10 +57,10 @@ KEYWORDS='SELECT|FROM|WHERE|ORDER[[:space:]]+BY|GROUP[[:space:]]+BY|HAVING|JOIN|
 EXEMPT='app/ferroehr/src/storage/node_repo.rs:push_str(leaf.column)'
 
 collect() {
-  if [ "${1:-}" = "--all" ]; then
+  if [[ "${1:-}" = "--all" ]]; then
     # shellcheck disable=SC2086 # SCOPE is a deliberate list of pathspecs
     git ls-files -- $SCOPE
-  elif [ "$#" -gt 0 ]; then
+  elif [[ "$#" -gt 0 ]]; then
     printf '%s\n' "$@"
   else
     # shellcheck disable=SC2086
@@ -79,10 +79,11 @@ report() {
 exempted() {
   local file=$1 body=$2 entry needle
   for entry in $EXEMPT; do
-    [ "${entry%%:*}" = "$file" ] || continue
+    [[ "${entry%%:*}" = "$file" ]] || continue
     needle=${entry#*:}
     case $body in
     *"$needle"*) return 0 ;;
+    *) ;;
     esac
   done
   return 1
@@ -94,26 +95,26 @@ exempted() {
 quoted() { printf '%s\n' "$1" | grep -o '"[^"]*"' || true; }
 
 files=$(collect "$@")
-[ -n "$files" ] || {
+[[ -n "$files" ]] || {
   echo "sql-string-building: no files in scope to check."
   exit 0
 }
 
 for f in $files; do
-  [ -f "$f" ] || continue
+  [[ -f "$f" ]] || continue
   case $f in
   *.rs) ;;
   *) continue ;;
   esac
 
   while IFS=: read -r line body; do
-    [ -n "${line:-}" ] || continue
+    [[ -n "${line:-}" ]] || continue
     exempted "$f" "$body" && continue
 
     # (1) an interpolated literal that carries a clause keyword
     if printf '%s' "$body" | grep -qE '(format!|write!|writeln!)[[:space:]]*\('; then
       while IFS= read -r lit; do
-        [ -n "$lit" ] || continue
+        [[ -n "$lit" ]] || continue
         printf '%s' "$lit" | grep -qE "$KEYWORDS" || continue
         printf '%s' "$lit" | grep -q '{' || continue
         report "$f:$line: interpolated SQL literal $lit — build the clause with \
@@ -124,7 +125,7 @@ for f in $files; do
     # (2) a clause keyword pushed onto a String
     if printf '%s' "$body" | grep -qE 'push_str[[:space:]]*\([[:space:]]*"'; then
       while IFS= read -r lit; do
-        [ -n "$lit" ] || continue
+        [[ -n "$lit" ]] || continue
         printf '%s' "$lit" | grep -qE "$KEYWORDS" || continue
         report "$f:$line: SQL fragment $lit pushed onto a String — assemble the \
 statement with \`sea-query\` instead (scripts/checks/sql-string-building.sh)"
@@ -135,7 +136,7 @@ statement with \`sea-query\` instead (scripts/checks/sql-string-building.sh)"
     # `push_str(` on the line is judged separately, so a line that also pushes a
     # literal cannot shield a value push.
     while IFS= read -r push; do
-      [ -n "$push" ] || continue
+      [[ -n "$push" ]] || continue
       printf '%s' "$push" | grep -qE 'push_str[[:space:]]*\([[:space:]]*r?#*"' && continue
       report "$f:$line: a runtime value is appended to a string ($push) — if that \
 string is SQL, bind the value; if it is not, add a named exemption with its \
@@ -150,7 +151,7 @@ false for an interpolated statement (scripts/checks/sql-string-building.sh)"
   done < <(grep -nE 'format!|write!|writeln!|push_str|AssertSqlSafe' "$f" || true)
 done
 
-if [ "$failures" -gt 0 ]; then
+if [[ "$failures" -gt 0 ]]; then
   echo "sql-string-building: $failures violation(s) — see above." >&2
   exit 1
 fi

--- a/scripts/checks/statement-version.sh
+++ b/scripts/checks/statement-version.sh
@@ -17,11 +17,11 @@ cd "$(dirname "$0")/../.."
 workspace=$(grep -m1 '^version = "' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
 statement=$(jq -r '.product.version' tools/cnf-runner/party/ferroehr/statement.json)
 
-if [ -z "$workspace" ]; then
+if [[ -z "$workspace" ]]; then
   echo "statement-version: cannot read the workspace version from Cargo.toml" >&2
   exit 1
 fi
-if [ "$workspace" != "$statement" ]; then
+if [[ "$workspace" != "$statement" ]]; then
   echo "statement-version: the ferroehr party statement declares product \
 version $statement but the workspace is $workspace — bump \
 tools/cnf-runner/party/ferroehr/statement.json (and regenerate the derived \

--- a/scripts/checks/typed-status.sh
+++ b/scripts/checks/typed-status.sh
@@ -52,9 +52,9 @@ cd "$(dirname "$0")/../.."
 # wire JSON. `--all-really` is kept as an alias so callers written against
 # the parked-era flag keep working.
 collect() {
-  if [ "${1:-}" = "--all-really" ] || [ "${1:-}" = "--all" ]; then
+  if [[ "${1:-}" = "--all-really" ]] || [[ "${1:-}" = "--all" ]]; then
     git ls-files '*.rs'
-  elif [ "$#" -gt 0 ]; then
+  elif [[ "$#" -gt 0 ]]; then
     printf '%s\n' "$@"
   else
     git diff --name-only origin/develop...HEAD -- '*.rs' 2>/dev/null || git ls-files '*.rs'
@@ -63,13 +63,13 @@ collect() {
 
 failures=0
 files=$(collect "$@")
-[ -n "$files" ] || { echo "typed-status: no Rust files to check."; exit 0; }
+[[ -n "$files" ]] || { echo "typed-status: no Rust files to check."; exit 0; }
 
 for f in $files; do
-  [ -f "$f" ] || continue
+  [[ -f "$f" ]] || continue
   # `.as_u16()` immediately compared, or a `.status()` compared to a literal.
   while IFS=: read -r line body; do
-    [ -n "${line:-}" ] || continue
+    [[ -n "${line:-}" ]] || continue
     printf '%s:%s: numeric status comparison (%s) — compare the typed \n' \
       "$f" "$line" "$(printf '%s' "$body" | sed 's/^[[:space:]]*//' | cut -c1-60)" >&2
     printf '    `http::StatusCode` constant instead (scripts/checks/typed-status.sh)\n' >&2
@@ -89,7 +89,7 @@ for f in $files; do
   # scrutinee-anchored so openEHR's own 3-digit codes (249/523/…) matched under
   # non-status scrutinees stay out of scope.
   while IFS=: read -r line body; do
-    [ -n "${line:-}" ] || continue
+    [[ -n "${line:-}" ]] || continue
     printf '%s:%s: numeric status comparison (%s) — compare the typed \n' \
       "$f" "$line" "$(printf '%s' "$body" | sed 's/^[[:space:]]*//' | cut -c1-60)" >&2
     printf '    `http::StatusCode` constant instead (scripts/checks/typed-status.sh)\n' >&2
@@ -104,7 +104,7 @@ for f in $files; do
   ' "$f" || true)
 done
 
-if [ "$failures" -gt 0 ]; then
+if [[ "$failures" -gt 0 ]]; then
   echo "typed-status: $failures violation(s) — see above." >&2
   exit 1
 fi

--- a/scripts/checks/vex-advisories.sh
+++ b/scripts/checks/vex-advisories.sh
@@ -28,7 +28,7 @@ cd "$(dirname "$0")/../.."
 
 readonly OUT='security/vex/rust-advisories.openvex.json'
 
-[ -f "$OUT" ] || {
+[[ -f "$OUT" ]] || {
   echo "error: $OUT does not exist — run scripts/security/vex-generate.sh" >&2
   exit 1
 }

--- a/scripts/checks/vex-reachability.sh
+++ b/scripts/checks/vex-reachability.sh
@@ -56,7 +56,7 @@ readonly DOC='security/vex/rust-advisories.openvex.json'
 for tool in cargo jq comm; do
   command -v "$tool" >/dev/null || { echo "vex-reachability: $tool is required" >&2; exit 1; }
 done
-[ -f "$DOC" ] || {
+[[ -f "$DOC" ]] || {
   echo "error: $DOC does not exist — run scripts/security/vex-generate.sh" >&2
   exit 1
 }
@@ -87,7 +87,7 @@ note() { echo "vex-reachability: $*" >&2; fail=1; }
 # inside the process substitution feeding the loop, would run zero iterations
 # and report every statement verified.
 expected="$(jq -r '.statements | length' "$DOC")"
-[ "$expected" -gt 0 ] 2>/dev/null || {
+[[ "$expected" -gt 0 ]] 2>/dev/null || {
   echo "error: $DOC declares no statements, so nothing would be verified" >&2
   exit 1
 }
@@ -98,7 +98,7 @@ setfile() { sort -u | sed '/^$/d' > "$1"; }
 
 statements=0
 while read -r statement; do
-  [ -n "$statement" ] || continue
+  [[ -n "$statement" ]] || continue
   id="$(jq -r '.vulnerability.name // "<no id>"' <<<"$statement")"
 
   if ! jq -e 'has("ferroehr:reachability")' <<<"$statement" > /dev/null; then
@@ -131,22 +131,23 @@ while read -r statement; do
     case "$level" in
       direct) what='direct dependent' ;;
       roots) what='workspace root' ;;
+      *) echo "error: unknown dependency level '$level' — no label to report it under" >&2; exit 1 ;;
     esac
     while read -r crate; do
-      [ -n "$crate" ] || continue
+      [[ -n "$crate" ]] || continue
       note "$id: claims $spec has the $what '$crate', which is in no edge of the resolved graph"
     done < <(comm -23 "$work/said-$level" "$work/has-$level")
     while read -r crate; do
-      [ -n "$crate" ] || continue
+      [[ -n "$crate" ]] || continue
       note "$id: '$crate' is a $what of $spec in the resolved graph and the statement does not name it — the impact statement argues about a path set that is not the real one"
     done < <(comm -13 "$work/said-$level" "$work/has-$level")
   done
 done < <(jq -c '.statements[]' "$DOC")
 
-[ "$statements" -eq "$expected" ] \
+[[ "$statements" -eq "$expected" ]] \
   || note "only $statements of the document's $expected statements carried a dependency-path claim"
 
-if [ "$fail" -ne 0 ]; then
+if [[ "$fail" -ne 0 ]]; then
   echo >&2
   echo "A VEX statement's argument rests on where the affected crate enters the" >&2
   echo "build, so a wrong path makes the published justification a false claim." >&2

--- a/scripts/conformance.sh
+++ b/scripts/conformance.sh
@@ -112,7 +112,7 @@ FERROEHR_RS_COMPOSE=(docker compose -p ferroehr-cnf \
 # server's knee on purpose and a 429 would measure the limiter instead of the
 # server. Declared as a file rather than an exported variable so the posture of
 # a recorded run is readable after the fact.
-if [ -n "${CONF_PERF_CLASS:-}" ] || [ -n "${CONF_STRESS:-}" ]; then
+if [[ -n "${CONF_PERF_CLASS:-}" ]] || [[ -n "${CONF_STRESS:-}" ]]; then
   FERROEHR_RS_COMPOSE+=(-f "$REPO_ROOT/docker/sut-measurement.yml")
   echo "==> Measurement lane: composing docker/sut-measurement.yml (rate limiting off)"
 fi
@@ -154,11 +154,11 @@ export SUT_ADMIN_PASS="${SUT_ADMIN_PASS:-ferroehr}"
 export SUT_RO_USER="${SUT_RO_USER:-ferroehr-readonly}"
 export SUT_RO_PASS="${SUT_RO_PASS:-ferroehr}"
 
-[ -f "$IXIT" ] || { echo "conformance: ixit not found: $IXIT" >&2; exit 2; }
-[ -f "$STATEMENT" ] || { echo "conformance: statement not found: $STATEMENT" >&2; exit 2; }
+[[ -f "$IXIT" ]] || { echo "conformance: ixit not found: $IXIT" >&2; exit 2; }
+[[ -f "$STATEMENT" ]] || { echo "conformance: statement not found: $STATEMENT" >&2; exit 2; }
 
 # byo: rewrite the ixit's base URLs into a temp copy.
-if [ "$SUT" = "byo" ] && [ -n "${CONF_BASE_URL:-}" ]; then
+if [[ "$SUT" = "byo" ]] && [[ -n "${CONF_BASE_URL:-}" ]]; then
   TMP_IXIT="$(mktemp -t cnf-ixit.XXXXXX)"
   # jq, not python: this is a two-key JSON edit, and jq is the tool for it.
   jq --arg url "${CONF_BASE_URL%/}" \
@@ -167,7 +167,7 @@ if [ "$SUT" = "byo" ] && [ -n "${CONF_BASE_URL:-}" ]; then
   IXIT="$TMP_IXIT"
 fi
 
-if [ "$SUT" = "ehrbase" ]; then
+if [[ "$SUT" = "ehrbase" ]]; then
   # The upstream image tag is the SUT version (default pinned in the compose).
   EHRBASE_IMAGE="${FERROEHR_EHRBASE_IMAGE:-ehrbase/ehrbase:2.34.0}"
   SUT_VERSION="${EHRBASE_IMAGE#*:}"
@@ -180,7 +180,7 @@ fi
 EHRBASE_COMPOSE=(docker compose -p cnf-ehrbase -f "$REPO_ROOT/docker/sut-ehrbase.yml")
 
 compose_down() {
-  if [ "$SUT" = "ehrbase" ]; then
+  if [[ "$SUT" = "ehrbase" ]]; then
     "${EHRBASE_COMPOSE[@]}" down -v || true
   else
     (cd "$REPO_ROOT" && "${FERROEHR_RS_COMPOSE[@]}" down -v) || true
@@ -188,10 +188,10 @@ compose_down() {
   fi
 }
 
-if [ -z "${CONF_NO_COMPOSE:-}" ] && [ "$SUT" != "byo" ]; then
+if [[ -z "${CONF_NO_COMPOSE:-}" ]] && [[ "$SUT" != "byo" ]]; then
   trap compose_down EXIT
   echo "==> Composing $SUT on fresh volumes (the exclusive-server ground)"
-  if [ "$SUT" = "ehrbase" ]; then
+  if [[ "$SUT" = "ehrbase" ]]; then
     "${EHRBASE_COMPOSE[@]}" down -v || true
     "${EHRBASE_COMPOSE[@]}" up -d
     # The official EHRbase image has no in-container health tooling (no
@@ -204,14 +204,15 @@ if [ -z "${CONF_NO_COMPOSE:-}" ] && [ "$SUT" != "byo" ]; then
         "http://localhost:${FERROEHR_EHRBASE_PORT:-8091}/ehrbase/rest/status" || true)
       case "$code" in
         200|401|403) ready=1; break ;;
+        *) ;;
       esac
       sleep 5
     done
-    [ -n "$ready" ] || { echo "conformance: upstream EHRbase never became ready" >&2; exit 2; }
+    [[ -n "$ready" ]] || { echo "conformance: upstream EHRbase never became ready" >&2; exit 2; }
   else
     (cd "$REPO_ROOT" && "${FERROEHR_RS_COMPOSE[@]}" down -v) || true
     (cd "$REPO_ROOT" && "${FERROEHR_RS_PGP_COMPOSE[@]}" down -v) || true
-    if [ -n "${SKIP_BUILD:-}" ]; then
+    if [[ -n "${SKIP_BUILD:-}" ]]; then
       (cd "$REPO_ROOT" && "${FERROEHR_RS_COMPOSE[@]}" up -d --wait ferroehr)
     else
       # A conformance verdict on OUR server is only meaningful against the
@@ -243,12 +244,12 @@ echo "==> Executing the catalogue (sut=$SUT_NAME filter='${FILTER}')"
 run_args=(run --root "$ROOT" --ixit "$IXIT" --out "$OUT"
           --sut-name "$SUT_NAME" --sut-version "$SUT_VERSION"
           --statement "$STATEMENT")
-[ -n "$FILTER" ] && run_args+=(--filter "$FILTER")
+[[ -n "$FILTER" ]] && run_args+=(--filter "$FILTER")
 # Exit 1 = failing cases (data for the verdict pipeline, not a pipeline
 # abort); only 2 (runner defect) stops the run.
 run_rc=0
 "$REPO_ROOT/target/debug/cnf-runner" "${run_args[@]}" || run_rc=$?
-if [ "$run_rc" -ge 2 ]; then
+if [[ "$run_rc" -ge 2 ]]; then
   echo "conformance: runner defect (exit $run_rc)" >&2
   exit "$run_rc"
 fi
@@ -262,13 +263,13 @@ fi
 # and needs the exclusive composed SUT — never on by default.
 # CONF_PERF_HOURS=1|2|4|6|8|12 extends the sustained window (default 1 —
 # the case's normative hour; longer holds are stricter demonstrations).
-if [ -n "${CONF_PERF_CLASS:-}" ]; then
+if [[ -n "${CONF_PERF_CLASS:-}" ]]; then
   # A measured record is environment-bound, and the parallel pgp deployment is
   # part of the environment while it is resident (a second server + database
   # holding their own CPU/memory limits). The functional catalogue is done with
   # it by now, and perf drives the primary alone, so tear it down BEFORE the
   # window opens — the measured envelope must be the one the ixit declares.
-  if [ -z "${CONF_NO_COMPOSE:-}" ] && [ "$SUT" = "ferroehr" ]; then
+  if [[ -z "${CONF_NO_COMPOSE:-}" ]] && [[ "$SUT" = "ferroehr" ]]; then
     echo "==> Tearing down the parallel pgp deployment before the measured window"
     (cd "$REPO_ROOT" && "${FERROEHR_RS_PGP_COMPOSE[@]}" down -v) || true
     # The stable-profile server shares the primary's project AND database; a
@@ -282,7 +283,7 @@ if [ -n "${CONF_PERF_CLASS:-}" ]; then
              --class "$CONF_PERF_CLASS" --hours "${CONF_PERF_HOURS:-1}")
   perf_rc=0
   "$REPO_ROOT/target/debug/cnf-runner" "${perf_args[@]}" || perf_rc=$?
-  if [ "$perf_rc" -ge 2 ]; then
+  if [[ "$perf_rc" -ge 2 ]]; then
     echo "conformance: perf run defect (exit $perf_rc)" >&2
     exit "$perf_rc"
   fi
@@ -296,7 +297,7 @@ verdict_rc=0
 "$REPO_ROOT/target/debug/cnf-runner" verdicts \
   --statement "$STATEMENT" --results "$OUT/results.json" \
   --root "$ROOT" --out "$OUT" || verdict_rc=$?
-if [ "$verdict_rc" -ge 2 ]; then
+if [[ "$verdict_rc" -ge 2 ]]; then
   echo "conformance: verdict pipeline defect (exit $verdict_rc)" >&2
   exit "$verdict_rc"
 fi

--- a/scripts/deploy-probe-k8s.sh
+++ b/scripts/deploy-probe-k8s.sh
@@ -38,7 +38,7 @@ set -uo pipefail
 cd "$(dirname "$0")/.." || exit 1
 
 KEEP_UP=0
-[ "${1:-}" = "--keep-up" ] && KEEP_UP=1
+[[ "${1:-}" = "--keep-up" ]] && KEEP_UP=1
 
 PROBE_TMP="$(mktemp -d)"
 export PROBE_TMP
@@ -52,7 +52,7 @@ COMPOSE_PROJECT="ferroehr-probe-k8s"
 . scripts/deploy-probes/kubernetes.sh
 
 cleanup() {
-  if [ "$KEEP_UP" -eq 0 ]; then
+  if [[ "$KEEP_UP" -eq 0 ]]; then
     k8s_teardown
   else
     k8s_pf_stop
@@ -73,7 +73,7 @@ kubectl cluster-info >/dev/null 2>&1 || {
 # Which image to probe. A locally built one is a legitimate SUT for behaviour
 # and hardening; it is NOT legitimate for a provenance claim, since it carries
 # no attestation — nothing here makes one.
-if [ -n "${PROBE_K8S_IMAGE:-}" ]; then
+if [[ -n "${PROBE_K8S_IMAGE:-}" ]]; then
   PROBE_K8S_IMAGE_REPO="${PROBE_K8S_IMAGE%:*}"
   PROBE_K8S_IMAGE_TAG="${PROBE_K8S_IMAGE##*:}"
 else
@@ -82,8 +82,8 @@ else
   # Desktop hides its node from the container list while `docker exec` into it
   # works, so a ps-based check reports "no node" on the commonest dev cluster.
   node="$(k8s_node_container || true)"
-  if [ -n "$node" ] && [ "$(docker exec "$node" crictl images 2>/dev/null \
-       | grep -cE 'rubentalstra/ferroehr +dev-local')" != "0" ]; then
+  if [[ -n "$node" ]] && [[ "$(docker exec "$node" crictl images 2>/dev/null \
+       | grep -cE 'rubentalstra/ferroehr +dev-local')" != "0" ]]; then
     PROBE_K8S_IMAGE_TAG="dev-local"
   else
     PROBE_K8S_IMAGE_TAG="$(grep '^appVersion:' deploy/helm/ferroehr/Chart.yaml | awk '{print $2}' | tr -d '"')"
@@ -100,7 +100,7 @@ echo
 bold "bringing up the host database the chart will be pointed at"
 k8s_db_up || { red "FATAL: the compose PostgreSQL never became ready"; exit 1; }
 K8S_DB_HOST="$(k8s_resolve_db_host)"
-if [ -z "$K8S_DB_HOST" ]; then
+if [[ -z "$K8S_DB_HOST" ]]; then
   red "FATAL: no address reached the host database from inside a pod"
   echo "  tried host.docker.internal, gateway.docker.internal and the node's default gateway"
   exit 1

--- a/scripts/deploy-probe.sh
+++ b/scripts/deploy-probe.sh
@@ -39,7 +39,7 @@ set -uo pipefail
 cd "$(dirname "$0")/.." || exit 1
 
 KEEP_UP=0
-[ "${1:-}" = "--keep-up" ] && KEEP_UP=1
+[[ "${1:-}" = "--keep-up" ]] && KEEP_UP=1
 
 PROBE_TMP="$(mktemp -d)"
 export PROBE_TMP
@@ -67,7 +67,7 @@ PROBE_OUT="${PROBE_OUT:-docs/conformance/deployment/compose.json}"
 . scripts/deploy-probes/signing_pgp.sh
 
 cleanup() {
-  if [ "$KEEP_UP" -eq 0 ]; then
+  if [[ "$KEEP_UP" -eq 0 ]]; then
     compose_down
   else
     dim "── stack left running (--keep-up): $CDR"
@@ -99,7 +99,7 @@ compose_up ferroehr seaweedfs seaweedfs-init
 # and ~8 GB, so its CI lane runs it alone rather than paying for every other
 # family to prove something already proven on every pull request.
 run_family() {
-  [ -z "${PROBE_ONLY:-}" ] || [ "${PROBE_ONLY}" = "$1" ]
+  [[ -z "${PROBE_ONLY:-}" ]] || [[ "${PROBE_ONLY}" = "$1" ]]
 }
 
 run_family shipped_config && probes_shipped_config_boots

--- a/scripts/deploy-probes/compose.sh
+++ b/scripts/deploy-probes/compose.sh
@@ -146,7 +146,7 @@ probes_multimedia() {
   local uri
   PROBE_MEDIA_EHR="$(probe_commit_media_status)"
   local ehr="$PROBE_MEDIA_EHR" key=""
-  if [ -z "$ehr" ]; then
+  if [[ -z "$ehr" ]]; then
     probe_fail "an EHR carrying a 400 KiB DV_MULTIMEDIA" "the commit did not return an id"
   else
     uri="$(curl -s -u "$BASIC" "$API/ehr/$ehr/ehr_status" \
@@ -154,7 +154,7 @@ probes_multimedia() {
     assert_contains "$uri" "s3://openehr-multimedia/" "the stored record must reference the blob"
     key="${uri##*/}"
     PROBE_MEDIA_KEY="$key"
-    if [ -n "$key" ]; then
+    if [[ -n "$key" ]]; then
       assert_eq "200" "$(http_code "$S3/openehr-multimedia/$key")" \
         "the blob must be retrievable from the bucket by its content hash"
     fi
@@ -165,12 +165,12 @@ probes_multimedia() {
   # COMPOSITION read alone, so EHR_STATUS content had no way back.
   probe "P-MM-EXPAND" "working" "server" "#2197" \
     "?expand_multimedia=true returns the bytes on an EHR_STATUS read"
-  if [ -n "${ehr:-}" ]; then
+  if [[ -n "${ehr:-}" ]]; then
     local expanded data digest
     expanded="$(curl -s -u "$BASIC" "$API/ehr/$ehr/ehr_status?expand_multimedia=true")"
     data="$(printf '%s' "$expanded" \
       | jq -r '.other_details.items[0].value.data // empty' 2>/dev/null)"
-    if [ -z "$data" ]; then
+    if [[ -z "$data" ]]; then
       probe_fail "a re-inlined DV_MULTIMEDIA.data" "no data member in the served value" \
         "the read must re-inline the blob, not answer with the compact reference"
     else
@@ -206,7 +206,7 @@ probes_multimedia_restart() {
   # works, which is a different and weaker claim.
   probe "P-MM-RESTART" "working" "server" "-" \
     "externalized content survives a server restart, byte-for-byte"
-  if [ -z "${PROBE_MEDIA_EHR:-}" ] || [ -z "${PROBE_MEDIA_KEY:-}" ]; then
+  if [[ -z "${PROBE_MEDIA_EHR:-}" ]] || [[ -z "${PROBE_MEDIA_KEY:-}" ]]; then
     probe_fail "a record committed earlier in this run" "none was recorded" \
       "P-MM-OFFLOAD must run first — this probe deliberately re-reads its record"
     probe_done
@@ -228,7 +228,7 @@ probes_multimedia_restart() {
   local data digest
   data="$(curl -s -u "$BASIC" "$API/ehr/$PROBE_MEDIA_EHR/ehr_status?expand_multimedia=true" \
     | jq -r '.other_details.items[0].value.data // empty' 2>/dev/null)"
-  if [ -z "$data" ]; then
+  if [[ -z "$data" ]]; then
     probe_fail "the re-inlined bytes after a restart" "no data member in the served value" \
       "content committed before the restart must still be retrievable"
   else
@@ -263,7 +263,7 @@ probes_multimedia_off() {
   assert_contains "$off_env" '"enabled":false' "the switch must actually be off for this probe to mean anything"
 
   local ehr; ehr="$(probe_commit_media_status)"
-  if [ -z "$ehr" ]; then
+  if [[ -z "$ehr" ]]; then
     probe_fail "a committed EHR" "the commit returned no id" \
       "an inline commit needs no object store and must succeed"
   else

--- a/scripts/deploy-probes/events.sh
+++ b/scripts/deploy-probes/events.sh
@@ -69,13 +69,13 @@ YAML
 # rather than measure nothing and call it a finding.
 events_bind_queue() {
   local tries=40
-  while [ "$tries" -gt 0 ]; do
+  while [[ "$tries" -gt 0 ]]; do
     curl -s -u "$EVT_AUTH" "$EVT_MGMT/api/exchanges/%2f/$EVT_EXCHANGE" \
       | grep -q '"name"' && break
     tries=$((tries - 1))
     sleep 3
   done
-  [ "$tries" -gt 0 ] || return 1
+  [[ "$tries" -gt 0 ]] || return 1
   curl -s -o /dev/null -u "$EVT_AUTH" -X PUT -H 'Content-Type: application/json' \
     -d '{"durable":true}' "$EVT_MGMT/api/queues/%2f/$EVT_QUEUE"
   local code
@@ -92,7 +92,7 @@ events_bind_queue() {
 events_wait_mgmt() {
   local tries="${1:-40}"
   for _ in $(seq 1 "$tries"); do
-    [ "$(curl -s -o /dev/null -w '%{http_code}' -u "$EVT_AUTH" "$EVT_MGMT/api/overview")" = "200" ] && return 0
+    [[ "$(curl -s -o /dev/null -w '%{http_code}' -u "$EVT_AUTH" "$EVT_MGMT/api/overview")" = "200" ]] && return 0
     sleep 3
   done
   return 1
@@ -113,7 +113,7 @@ events_wait_message() {
   local tries="${1:-30}" body
   for _ in $(seq 1 "$tries"); do
     body="$(events_get 10)"
-    if [ -n "$body" ] && [ "$body" != "[]" ]; then printf '%s' "$body"; return 0; fi
+    if [[ -n "$body" ]] && [[ "$body" != "[]" ]]; then printf '%s' "$body"; return 0; fi
     sleep 3
   done
   printf '%s' "${body:-[]}"
@@ -159,7 +159,7 @@ probes_events() {
   local ehr body
   ehr="$(curl -s -u "$BASIC" -X POST -D - -o /dev/null "$API/ehr" \
          | grep -i '^location' | tr -d '\r' | awk -F/ '{print $NF}')"
-  if [ -z "$ehr" ]; then
+  if [[ -z "$ehr" ]]; then
     probe_fail "a committed EHR" "no id returned"
     probe_done
   else
@@ -175,7 +175,7 @@ probes_events() {
     # The privacy claim, checked against the bytes actually on the wire.
     probe "P-EVT-NO-PHI" "working" "server" "#2178" \
       "the published envelope carries identity and provenance only — no clinical content"
-    if [ -z "${body:-}" ] || [ "${body:-[]}" = "[]" ]; then
+    if [[ -z "${body:-}" ]] || [[ "${body:-[]}" = "[]" ]]; then
       probe_fail "a message to inspect" "none captured" \
         "without the payload the PHI-free claim cannot be checked at all"
     else
@@ -201,7 +201,7 @@ probes_events() {
   local queued
   queued="$(curl -s -u "$BASIC" -X POST -D - -o /dev/null "$API/ehr" \
             | grep -i '^location' | tr -d '\r' | awk -F/ '{print $NF}')"
-  if [ -z "$queued" ]; then
+  if [[ -z "$queued" ]]; then
     probe_fail "a commit that succeeds with the broker down" "no EHR id returned" \
       "commits must never block on the broker; that is what the outbox is for"
   fi
@@ -214,7 +214,7 @@ probes_events() {
   dc start ferroehr-rabbitmq >/dev/null 2>&1
   events_wait_mgmt || true
   events_bind_queue || true
-  if [ -n "$queued" ]; then
+  if [[ -n "$queued" ]]; then
     local after
     if ! after="$(events_wait_message 40)"; then
       probe_fail "the queued event delivered after recovery" "queue still empty after 120s" \

--- a/scripts/deploy-probes/fhir.sh
+++ b/scripts/deploy-probes/fhir.sh
@@ -89,6 +89,7 @@ probes_fhir() {
            "still 404 with the API enabled means the flag does not mount anything" ;;
     5*)  probe_fail "a mounted FHIR route" "$on_code" \
            "a 5xx is the route existing and failing, which is a different defect than not existing" ;;
+    *)   ;;
   esac
   probe_done
 
@@ -106,7 +107,7 @@ probes_fhir() {
       -d '{"routing_key":"#"}' \
       "$EVT_MGMT/api/bindings/%2f/e/$FHIR_EXCHANGE/q/$FHIR_QUEUE" && bound=1
   fi
-  if [ "$bound" -eq 0 ]; then
+  if [[ "$bound" -eq 0 ]]; then
     # An honest boundary rather than a false pass: the exchange is declared on
     # first publish, and a deployment whose mapping set is empty publishes
     # nothing, so there may legitimately be nothing to bind to.
@@ -118,7 +119,7 @@ probes_fhir() {
     msg="$(curl -s -u "$EVT_AUTH" -X POST -H 'Content-Type: application/json' \
            -d '{"count":5,"ackmode":"ack_requeue_false","encoding":"auto"}' \
            "$EVT_MGMT/api/queues/%2f/$FHIR_QUEUE/get" 2>/dev/null)"
-    if [ -z "$msg" ] || [ "$msg" = "[]" ]; then
+    if [[ -z "$msg" ]] || [[ "$msg" = "[]" ]]; then
       uncovered "the FHIR outbound stream's payload" \
         "the exchange exists but nothing was published — a deployment with no mapping set emits nothing"
     else

--- a/scripts/deploy-probes/kubernetes.sh
+++ b/scripts/deploy-probes/kubernetes.sh
@@ -101,7 +101,7 @@ k8s_resolve_db_host() {
   local _try host
   for _try in 1 2 3 4 5; do
     host="$(k8s_try_db_hosts)"
-    [ -n "$host" ] && { printf '%s' "$host"; return 0; }
+    [[ -n "$host" ]] && { printf '%s' "$host"; return 0; }
     sleep 4
   done
   return 1
@@ -119,7 +119,7 @@ k8s_try_db_hosts() {
       done' >/dev/null 2>&1
   for _i in $(seq 1 15); do
     phase="$(kubectl get pod "$name" -o jsonpath='{.status.phase}' 2>/dev/null)"
-    case "$phase" in Succeeded | Failed) break ;; esac
+    case "$phase" in Succeeded | Failed) break ;; *) ;; esac
     sleep 2
   done
   out="$(kubectl logs "$name" 2>/dev/null)"
@@ -172,7 +172,7 @@ k8s_rollout() { kc rollout status "deploy/$K8S_RELEASE" --timeout="${1:-180s}" >
 # operator.
 k8s_ui_install() {
   local args=(--set adminUi.enabled=true)
-  if [ -n "$K8S_UI_IMAGE" ]; then
+  if [[ -n "$K8S_UI_IMAGE" ]]; then
     args+=(--set adminUi.image.repository="${K8S_UI_IMAGE%:*}"
            --set adminUi.image.tag="${K8S_UI_IMAGE##*:}")
   fi
@@ -203,7 +203,7 @@ k8s_ui_get() {
     --command -- wget -q -O - "http://$K8S_UI:3000${1:-/login}" >/dev/null 2>&1
   for _i in $(seq 1 30); do
     phase="$(kc get pod "$name" -o jsonpath='{.status.phase}' 2>/dev/null)"
-    case "$phase" in Succeeded | Failed) break ;; esac
+    case "$phase" in Succeeded | Failed) break ;; *) ;; esac
     sleep 2
   done
   out="$(kc logs "$name" 2>/dev/null)"
@@ -223,7 +223,7 @@ k8s_pod() {
   ready="$(kc get pod -l app.kubernetes.io/name=ferroehr \
     -o jsonpath='{range .items[?(@.status.containerStatuses[0].ready==true)]}{.metadata.name}{"\n"}{end}' \
     2>/dev/null | head -1)"
-  [ -n "$ready" ] && { printf '%s' "$ready"; return 0; }
+  [[ -n "$ready" ]] && { printf '%s' "$ready"; return 0; }
   kc get pod -l app.kubernetes.io/name=ferroehr -o jsonpath='{.items[0].metadata.name}' 2>/dev/null
 }
 
@@ -252,7 +252,7 @@ k8s_pf_stop() {
   # `disown` first: killing a backgrounded job otherwise makes the shell print
   # a "Terminated" notice into the report, which reads like a failure in an
   # instrument whose whole value is that its output means something.
-  if [ -n "$K8S_PF_PID" ]; then
+  if [[ -n "$K8S_PF_PID" ]]; then
     disown "$K8S_PF_PID" 2>/dev/null || true
     kill "$K8S_PF_PID" >/dev/null 2>&1 || true
     wait "$K8S_PF_PID" 2>/dev/null || true
@@ -324,7 +324,7 @@ probes_k8s_boot() {
   local headers ehr
   headers="$(curl -s -u "$K8S_BASIC" -X POST -D - -o /dev/null "$K8S_API/ehr")"
   ehr="$(printf '%s' "$headers" | grep -i '^location' | tr -d '\r' | awk -F/ '{print $NF}')"
-  if [ -z "$ehr" ]; then
+  if [[ -z "$ehr" ]]; then
     probe_fail "a Location header naming the new EHR" "$(printf '%s' "$headers" | head -3)"
   else
     assert_contains "$(curl -s -u "$K8S_BASIC" "$K8S_API/ehr/$ehr")" "\"$ehr\"" \
@@ -363,7 +363,7 @@ probes_k8s_runtime_posture() {
 
   local node
   node="$(k8s_node_container)"
-  if [ -z "$node" ]; then
+  if [[ -z "$node" ]]; then
     uncovered "the applied runtime posture (uid, capabilities, seccomp, read-only root)" \
       "this cluster's node is not a local container, so its runtime spec is not readable from here"
     return 0
@@ -373,7 +373,7 @@ probes_k8s_runtime_posture() {
     "the runtime applied non-root, no-new-privileges, no capabilities, read-only root, seccomp"
   local cid spec
   cid="$(docker exec "$node" crictl ps --name ferroehr -q 2>/dev/null | head -1)"
-  if [ -z "$cid" ]; then
+  if [[ -z "$cid" ]]; then
     probe_fail "a running ferroehr container on the node" "crictl listed none"
     probe_done
     return 0
@@ -393,7 +393,7 @@ probes_k8s_runtime_posture() {
   writable="$(printf '%s' "$spec" | jq -r '
     .mounts[] | select(.destination | test("^/etc/ferroehr"))
     | select((.options // []) | index("ro") | not) | .destination' | tr '\n' ' ')"
-  if [ -n "${writable// /}" ]; then
+  if [[ -n "${writable// /}" ]]; then
     probe_fail "every /etc/ferroehr* mount carrying 'ro'" "writable: $writable" \
       "configuration and key material must not be rewritable from inside the container"
   fi
@@ -543,7 +543,7 @@ probes_k8s_readiness() {
   local _i ready="unknown" kubelet="unknown"
   for _i in $(seq 1 20); do
     kubelet="$(kc get pod "$pod" -o jsonpath='{.status.containerStatuses[0].ready}' 2>/dev/null)"
-    [ "$kubelet" = "false" ] && break
+    [[ "$kubelet" = "false" ]] && break
     sleep 3
   done
   assert_eq "false" "$kubelet" \
@@ -551,7 +551,7 @@ probes_k8s_readiness() {
   for _i in $(seq 1 20); do
     ready="$(kc get endpointslice -l "kubernetes.io/service-name=$K8S_RELEASE" \
              -o jsonpath='{.items[0].endpoints[0].conditions.ready}' 2>/dev/null)"
-    [ "$ready" = "false" ] && break
+    [[ "$ready" = "false" ]] && break
     sleep 3
   done
   assert_eq "false" "$ready" \
@@ -641,7 +641,7 @@ probes_k8s_admin_ui() {
 probes_k8s_ui_runtime() {
   local node cid spec
   node="$(k8s_node_container)"
-  if [ -z "$node" ]; then
+  if [[ -z "$node" ]]; then
     uncovered "the console's applied runtime posture (uid, capabilities, seccomp, read-only root)" \
       "this cluster node is not a local container, so its runtime spec is not readable from here"
     return 0
@@ -649,7 +649,7 @@ probes_k8s_ui_runtime() {
   probe "P-K8S-UI-RUNTIME" "working" "chart" "-" \
     "the console container runs under the same hardened posture as the server"
   cid="$(docker exec "$node" crictl ps --name admin-ui -q 2>/dev/null | head -1)"
-  if [ -z "$cid" ]; then
+  if [[ -z "$cid" ]]; then
     probe_fail "a running admin-ui container on the node" "crictl listed none"
   else
     spec="$(docker exec "$node" crictl inspect "$cid" 2>/dev/null | jq -c '.info.runtimeSpec')"

--- a/scripts/deploy-probes/lib.sh
+++ b/scripts/deploy-probes/lib.sh
@@ -52,7 +52,7 @@ probe() {
 # Record the outcome of the probe that just ran.
 probe_done() {
   local outcome="pass"
-  if [ "$PROBE_FAILED" -eq 1 ]; then
+  if [[ "$PROBE_FAILED" -eq 1 ]]; then
     outcome="fail"
     PROBE_FAIL=$((PROBE_FAIL + 1))
   else
@@ -60,7 +60,7 @@ probe_done() {
   fi
   PROBE_ROWS+=("$(printf '{"id":"%s","state":"%s","outcome":"%s","layer":"%s","issue":"%s","title":"%s"}' \
     "$PROBE_ID" "$PROBE_STATE" "$outcome" \
-    "$([ "$outcome" = fail ] && printf '%s' "$PROBE_LAYER" || printf '')" \
+    "$([[ "$outcome" = fail ]] && printf '%s' "$PROBE_LAYER" || printf '')" \
     "$PROBE_ISSUE" "$PROBE_TITLE")")
 }
 
@@ -74,13 +74,13 @@ probe_fail() {
   red   "    FAIL  layer=$PROBE_LAYER${PROBE_ISSUE:+  regression-of=$PROBE_ISSUE}"
   echo  "      expected: $expected"
   echo  "      actual:   $actual"
-  [ -n "$note" ] && echo "      note:     $note"
+  [[ -n "$note" ]] && echo "      note:     $note"
   return 0
 }
 
 # assert_eq <expected> <actual> [note]
 assert_eq() {
-  [ "$1" = "$2" ] && return 0
+  [[ "$1" = "$2" ]] && return 0
   probe_fail "$1" "$2" "${3:-}"
 }
 
@@ -88,6 +88,7 @@ assert_eq() {
 assert_contains() {
   case "$1" in
     *"$2"*) return 0 ;;
+    *) ;;
   esac
   probe_fail "output containing '$2'" "${1:0:300}" "${3:-}"
 }
@@ -123,7 +124,7 @@ wait_http() {
 wait_status() {
   local url="$1" want="$2" tries="${3:-30}"
   for _ in $(seq 1 "$tries"); do
-    [ "$(curl -s -o /dev/null -w '%{http_code}' "$url")" = "$want" ] && return 0
+    [[ "$(curl -s -o /dev/null -w '%{http_code}' "$url")" = "$want" ]] && return 0
     sleep 2
   done
   return 1
@@ -136,7 +137,7 @@ probe_report() {
   local out="$1" platform="$2"
   echo
   bold "── not exercised by this run ───────────────────────────────"
-  if [ "${#PROBE_UNCOVERED[@]}" -eq 0 ]; then
+  if [[ "${#PROBE_UNCOVERED[@]}" -eq 0 ]]; then
     echo "  (nothing declared — which is itself suspicious; see lib.sh 'uncovered')"
   else
     local row
@@ -151,12 +152,12 @@ probe_report() {
       "$platform" "$PROBE_PASS" "$PROBE_FAIL" "$PROBE_SKIP"
     local i
     for i in "${!PROBE_ROWS[@]}"; do
-      [ "$i" -gt 0 ] && printf ','
+      [[ "$i" -gt 0 ]] && printf ','
       printf '%s' "${PROBE_ROWS[$i]}"
     done
     printf '],"not_exercised":['
     for i in "${!PROBE_UNCOVERED[@]}"; do
-      [ "$i" -gt 0 ] && printf ','
+      [[ "$i" -gt 0 ]] && printf ','
       printf '%s' "${PROBE_UNCOVERED[$i]}"
     done
     printf ']}\n'
@@ -166,6 +167,6 @@ probe_report() {
   bold "── result ──────────────────────────────────────────────────"
   echo "  passed $PROBE_PASS   failed $PROBE_FAIL   not exercised $PROBE_SKIP"
   echo "  record: $out"
-  [ "$PROBE_FAIL" -eq 0 ] || { red "DEPLOYMENT PROBES FAILED"; return 1; }
+  [[ "$PROBE_FAIL" -eq 0 ]] || { red "DEPLOYMENT PROBES FAILED"; return 1; }
   green "ALL DEPLOYMENT PROBES PASSED (read the 'not exercised' list above)"
 }

--- a/scripts/deploy-probes/observability.sh
+++ b/scripts/deploy-probes/observability.sh
@@ -57,7 +57,7 @@ obs_wait_series() {
   local uid="$1" query="$2" tries="${3:-30}" n
   for _ in $(seq 1 "$tries"); do
     n="$(obs_promql_series "$uid" "$query")"
-    if [ "${n:-0}" -ge 1 ] 2>/dev/null; then printf '%s' "$n"; return 0; fi
+    if [[ "${n:-0}" -ge 1 ]] 2>/dev/null; then printf '%s' "$n"; return 0; fi
     sleep 4
   done
   printf '%s' "${n:-0}"
@@ -72,7 +72,7 @@ obs_wait_traces() {
       --data-urlencode 'q={ resource.service.name="ferroehr" }' \
       "$GRAFANA/api/datasources/proxy/uid/$uid/api/search" \
       | jq -r '.traces | length' 2>/dev/null)"
-    if [ "${n:-0}" -ge 1 ] 2>/dev/null; then printf '%s' "$n"; return 0; fi
+    if [[ "${n:-0}" -ge 1 ]] 2>/dev/null; then printf '%s' "$n"; return 0; fi
     sleep 4
   done
   printf '%s' "${n:-0}"
@@ -107,7 +107,7 @@ probes_observability() {
   # own scrape endpoint proved nothing — that was true throughout the defect.
   probe "P-OBS-METRICS" "working" "server" "#2173" \
     "FerroEHR metrics arrive in the collector's Prometheus"
-  if [ -z "$prom_uid" ]; then
+  if [[ -z "$prom_uid" ]]; then
     probe_fail "a Prometheus datasource in Grafana" "none found" \
       "the bundled stack provisions it; without it nothing here can be observed"
   else
@@ -124,7 +124,7 @@ probes_observability() {
   # so this one names the family.
   probe "P-OBS-BUILDINFO" "working" "server" "#2175" \
     "ferroehr_build_info reaches the collector, not just the local scrape"
-  if [ -z "$prom_uid" ]; then
+  if [[ -z "$prom_uid" ]]; then
     probe_fail "a Prometheus datasource" "none found"
   else
     local bi
@@ -141,7 +141,7 @@ probes_observability() {
     "a span for this service arrives in the collector's trace store"
   local tempo_uid found
   tempo_uid="$(obs_datasource_uid tempo)"
-  if [ -z "$tempo_uid" ]; then
+  if [[ -z "$tempo_uid" ]]; then
     # Not a failure of the SUT: without a queryable trace store this run cannot
     # observe the far end, and saying so is the honest outcome. It is declared
     # as a gap rather than passed silently.

--- a/scripts/deploy-probes/oidc.sh
+++ b/scripts/deploy-probes/oidc.sh
@@ -30,6 +30,7 @@ jwt_claims() {
   case $(( ${#payload} % 4 )) in
     2) payload="${payload}==" ;;
     3) payload="${payload}=" ;;
+    *) ;;
   esac
   printf '%s' "$payload" | base64 -d 2>/dev/null
 }
@@ -59,7 +60,7 @@ probes_oidc() {
   # quickstart impossible rather than merely misconfigured.
   probe "P-OIDC-AUD" "working" "compose" "#2176" \
     "the demo realm mints a token carrying aud=ferroehr"
-  if [ -z "$token" ]; then
+  if [[ -z "$token" ]]; then
     probe_fail "an access token from the password grant" "the token endpoint returned none" \
       "the realm's client must have the password grant enabled"
   else
@@ -79,7 +80,7 @@ probes_oidc() {
   # And the whole point: the documented flow SUCCEEDS.
   probe "P-OIDC-ACCEPT" "working" "server" "#2176" \
     "the API accepts that token — the documented quickstart works end to end"
-  if [ -z "$token" ]; then
+  if [[ -z "$token" ]]; then
     probe_fail "201 from POST /ehr" "no token to present"
   else
     local code
@@ -143,11 +144,11 @@ probes_oidc_roles() {
   probe "P-OIDC-IDENTITIES" "working" "compose" "#2160" \
     "the demo realm mints a token for each of the four identities"
   local missing=""
-  [ -n "$admin" ]     || missing="$missing ferroehr"
-  [ -n "$clinician" ] || missing="$missing clinician"
-  [ -n "$auditor" ]   || missing="$missing auditor"
-  [ -n "$nobody" ]    || missing="$missing nobody"
-  if [ -n "$missing" ]; then
+  [[ -n "$admin" ]]     || missing="$missing ferroehr"
+  [[ -n "$clinician" ]] || missing="$missing clinician"
+  [[ -n "$auditor" ]]   || missing="$missing auditor"
+  [[ -n "$nobody" ]]    || missing="$missing nobody"
+  if [[ -n "$missing" ]]; then
     probe_fail "a token for every demo user" "no token for:$missing" \
       "the realm import must create all four, or the separation below is untestable"
     probe_done

--- a/scripts/deploy-probes/signing.sh
+++ b/scripts/deploy-probes/signing.sh
@@ -35,7 +35,7 @@ probes_signing() {
   local ehr version
   ehr="$(curl -s -u "$BASIC" -X POST -D - -o /dev/null "$API/ehr" \
     | grep -i '^location' | tr -d '\r' | awk -F/ '{print $NF}')"
-  if [ -z "$ehr" ]; then
+  if [[ -z "$ehr" ]]; then
     probe_fail "a committed EHR" "no id returned"
     probe_done
     return 0
@@ -63,7 +63,7 @@ probes_signing() {
           && probe_psql "SELECT count(*) FROM ehr.vo_version
                           WHERE ehr_id = '$ehr'::uuid
                             AND body #>> '{name,value}' = 'tampered';")"
-  if [ "${rows:-0}" = "0" ]; then
+  if [[ "${rows:-0}" = "0" ]]; then
     probe_fail "a tampered stored row" "the UPDATE matched nothing" \
       "the probe could not reach the stored content, so detection was never tested"
   else
@@ -89,7 +89,7 @@ probes_signing() {
   node_vo="$(probe_psql "SELECT vo_id FROM ehr.vo_version
                           WHERE ehr_id = '$node_ehr'::uuid AND kind = 'EHR_STATUS';" \
              | tr -d '[:space:]')"
-  if [ -z "$node_ehr" ] || [ -z "$node_vo" ]; then
+  if [[ -z "$node_ehr" ]] || [[ -z "$node_vo" ]]; then
     probe_fail "a committed EHR_STATUS version" "ehr='$node_ehr' vo='$node_vo'" \
       "the probe could not locate the stored version, so detection was never tested"
     probe_done
@@ -101,7 +101,7 @@ probes_signing() {
                && probe_psql "SELECT count(*) FROM ehr.node
                                WHERE vo_id = '$node_vo'::uuid
                                  AND data #>> '{archetype_node_id}' = 'tampered';")"
-  if [ "${node_rows:-0}" = "0" ]; then
+  if [[ "${node_rows:-0}" = "0" ]]; then
     probe_fail "a tampered node row" "the UPDATE matched nothing" \
       "the probe could not reach the AQL index copy, so detection was never tested"
   else

--- a/scripts/deploy-probes/signing_pgp.sh
+++ b/scripts/deploy-probes/signing_pgp.sh
@@ -35,11 +35,11 @@ pgp_material() {
     "FerroEHR Probe $name <probe-$name@example.test>" default default never >/dev/null 2>&1 || return 1
   fpr="$(GNUPGHOME="$dir/gnupg" gpg --batch --list-secret-keys --with-colons 2>/dev/null \
     | awk -F: '/^fpr:/ {print $10; exit}')"
-  [ -n "$fpr" ] || return 1
+  [[ -n "$fpr" ]] || return 1
   GNUPGHOME="$dir/gnupg" gpg --batch --pinentry-mode loopback \
     --passphrase "$PGP_PASS" --armor --export-secret-keys "$fpr" > "$dir/signing.asc" 2>/dev/null || return 1
   GNUPGHOME="$dir/gnupg" gpg --batch --armor --export "$fpr" > "$dir/public.asc" 2>/dev/null || return 1
-  [ -s "$dir/signing.asc" ] && [ -s "$dir/public.asc" ] || return 1
+  [[ -s "$dir/signing.asc" ]] && [[ -s "$dir/public.asc" ]] || return 1
   printf '%s' "$PGP_PASS" > "$dir/passphrase"
   # The container runs as the distroless nonroot uid; these are throwaway probe
   # credentials, so world-readable is the simplest way to guarantee the mount is
@@ -76,7 +76,7 @@ probes_signing_pgp() {
     return 0
   fi
   local dir overlay
-  if ! dir="$(pgp_material)" || [ -z "$dir" ]; then
+  if ! dir="$(pgp_material)" || [[ -z "$dir" ]]; then
     uncovered "signing in PGP mode (#2163)" "this host's gpg would not generate a probe key"
     return 0
   fi
@@ -102,7 +102,7 @@ probes_signing_pgp() {
   local ehr version
   ehr="$(curl -s -u "$BASIC" -X POST -D - -o /dev/null "$API/ehr" \
     | grep -i '^location' | tr -d '\r' | awk -F/ '{print $NF}')"
-  if [ -z "$ehr" ]; then
+  if [[ -z "$ehr" ]]; then
     probe_fail "a committed EHR" "no id returned"
     probe_done
     return 0
@@ -127,7 +127,7 @@ probes_signing_pgp() {
   matched="$(probe_psql "SELECT count(*) FROM ehr.vo_version
                           WHERE ehr_id = '$ehr'::uuid
                             AND body #>> '{name,value}' = 'tampered';")"
-  if [ "${matched:-0}" = "0" ]; then
+  if [[ "${matched:-0}" = "0" ]]; then
     probe_fail "a tampered stored row" "the UPDATE matched nothing" \
       "detection was never tested — the probe could not reach the stored content"
   else
@@ -182,8 +182,8 @@ probes_signing_rotation() {
     return 0
   fi
   local key_a key_b overlay ehr_a
-  if ! key_a="$(pgp_material rotate-a)" || [ -z "$key_a" ] \
-     || ! key_b="$(pgp_material rotate-b)" || [ -z "$key_b" ]; then
+  if ! key_a="$(pgp_material rotate-a)" || [[ -z "$key_a" ]] \
+     || ! key_b="$(pgp_material rotate-b)" || [[ -z "$key_b" ]]; then
     uncovered "PGP key rotation (#2122)" "this host's gpg would not generate the two probe keys"
     return 0
   fi
@@ -217,7 +217,7 @@ probes_signing_rotation() {
   # key-A version back under strict verification without an integrity failure.
   probe "P-ROT-HISTORY" "working" "server" "#2122" \
     "a version signed by the RETIRED key still verifies after rotation"
-  if [ -z "$ehr_a" ]; then
+  if [[ -z "$ehr_a" ]]; then
     probe_fail "a version signed under key A" "no EHR was committed before the rotation"
   else
     assert_eq "200" "$(http_code -u "$BASIC" "$API/ehr/$ehr_a/versioned_ehr_status/version")" \
@@ -237,7 +237,7 @@ probes_signing_rotation() {
   matched="$(probe_psql "SELECT count(*) FROM ehr.vo_version
                           WHERE ehr_id = '$ehr_a'::uuid
                             AND body #>> '{name,value}' = 'tampered';")"
-  if [ "${matched:-0}" = "0" ]; then
+  if [[ "${matched:-0}" = "0" ]]; then
     probe_fail "a tampered stored row" "the UPDATE matched nothing" \
       "permissiveness was never tested — the probe could not reach the stored content"
   else

--- a/scripts/deploy-probes/tenancy.sh
+++ b/scripts/deploy-probes/tenancy.sh
@@ -79,7 +79,7 @@ probes_tenancy() {
   tenancy_register beta
   a="$(tenancy_new_ehr alpha)"
   b="$(tenancy_new_ehr beta)"
-  if [ -z "$a" ] || [ -z "$b" ]; then
+  if [[ -z "$a" ]] || [[ -z "$b" ]]; then
     probe_fail "an EHR id for each tenant" "alpha='$a' beta='$b'" \
       "without both ids the isolation probes below would pass vacuously"
     probe_done

--- a/scripts/deploy-probes/terminology.sh
+++ b/scripts/deploy-probes/terminology.sh
@@ -94,7 +94,7 @@ terminology_import() {
     -H 'Content-Type: application/json' \
     -d '{"branchPath":"MAIN","createCodeSystemVersion":true,"type":"SNAPSHOT"}' \
     | grep -i '^location' | tr -d '\r' | awk '{print $2}')"
-  [ -n "$location" ] || return 1
+  [[ -n "$location" ]] || return 1
   job="${location##*/}"
   curl -s -o /dev/null -X POST "$TERM_URL/imports/$job/archive" -F "file=@${zip}" || return 1
   # The import is long. Poll its own status rather than guessing a duration.
@@ -104,6 +104,7 @@ terminology_import() {
     case "$status" in
       COMPLETED) return 0 ;;
       FAILED)    return 1 ;;
+      *)         ;;
     esac
     sleep 15
   done
@@ -129,16 +130,16 @@ terminology_release() {
   # beside the checkout is the whole setup. The NEWEST match wins, and the one
   # actually used is echoed by the caller — with two editions present, silently
   # picking one would make a run unattributable.
-  if [ -z "$zip" ]; then
+  if [[ -z "$zip" ]]; then
     zip="$(find . -maxdepth 1 -name 'SnomedCT_*.zip' -print 2>/dev/null \
            | grep -v ManagedService | sort | tail -1)"
     # Prefer a national edition over the International one when both are there:
     # the national package is the deployment reality being probed.
     local national
     national="$(find . -maxdepth 1 -name 'SnomedCT_ManagedService*.zip' -print 2>/dev/null | sort | tail -1)"
-    [ -n "$national" ] && zip="$national"
+    [[ -n "$national" ]] && zip="$national"
   fi
-  if [ -n "$zip" ] && [ -f "$zip" ]; then
+  if [[ -n "$zip" ]] && [[ -f "$zip" ]]; then
     terminology_verify "$zip" || return 1
     printf '%s' "$zip"
     return 0
@@ -150,19 +151,19 @@ terminology_release() {
 # resolve against it. Discovered the same way and never the national package.
 terminology_international() {
   local intl="${FERROEHR_SNOMED_RF2_INTL:-}"
-  if [ -z "$intl" ]; then
+  if [[ -z "$intl" ]]; then
     intl="$(find . -maxdepth 1 -name 'SnomedCT_InternationalRF2_*.zip' -print 2>/dev/null | sort | tail -1)"
   fi
-  [ -n "$intl" ] && [ -f "$intl" ] && printf '%s' "$intl"
+  [[ -n "$intl" ]] && [[ -f "$intl" ]] && printf '%s' "$intl"
 }
 
 terminology_verify() {
   local want="${FERROEHR_SNOMED_RF2_MD5:-}"
-  [ -n "$want" ] || return 0
+  [[ -n "$want" ]] || return 0
   local got
   got="$(md5sum "$1" 2>/dev/null | awk '{print $1}')"
-  [ -n "$got" ] || got="$(md5 -q "$1" 2>/dev/null)"
-  if [ "$got" != "$want" ]; then
+  [[ -n "$got" ]] || got="$(md5 -q "$1" 2>/dev/null)"
+  if [[ "$got" != "$want" ]]; then
     red "  SNOMED RF2 checksum mismatch: expected $want, got ${got:-none}"
     return 1
   fi
@@ -181,7 +182,7 @@ probes_terminology() {
   #   PROBE_ONLY=terminology bash scripts/deploy-probe.sh
   #
   # or when FERROEHR_SNOMED_RF2 is set explicitly, which is itself an ask.
-  if [ "${PROBE_ONLY:-}" != "terminology" ] && [ -z "${FERROEHR_SNOMED_RF2:-}" ]; then
+  if [[ "${PROBE_ONLY:-}" != "terminology" ]] && [[ -z "${FERROEHR_SNOMED_RF2:-}" ]]; then
     uncovered "terminology against a real server (#2178)" \
       "opt-in: run PROBE_ONLY=terminology, because a real SNOMED import takes longer than every other family combined"
     return 0
@@ -217,7 +218,7 @@ probes_terminology() {
   # assumed, and the run reports what was actually served either way.
   local intl
   intl="$(terminology_international)"
-  if [ -n "$intl" ]; then
+  if [[ -n "$intl" ]]; then
     probe "P-TERM-IMPORT-INTL" "working" "compose" "#2178" \
       "the International Edition imports to MAIN, so a national extension can resolve against it"
     terminology_import "$intl" || probe_fail "a COMPLETED International import" \

--- a/scripts/generate-ckm-examples.sh
+++ b/scripts/generate-ckm-examples.sh
@@ -28,7 +28,7 @@ for opt in "$PACK"/*.opt; do
   tid=$(tr '\n' ' ' < "$opt" \
     | sed -n 's|.*<template_id>[[:space:]]*<value>\([^<]*\)</value>.*|\1|p' \
     | head -1)
-  [ -n "$tid" ] || { echo "::error::no <template_id><value> in $opt" >&2; exit 1; }
+  [[ -n "$tid" ]] || { echo "::error::no <template_id><value> in $opt" >&2; exit 1; }
   echo "==> $slug ($tid)"
   status=$(curl -sS -o /dev/null -w '%{http_code}' -u "$AUTH" \
     -X POST "$BASE/definition/template/adl1.4" \

--- a/scripts/gh/project.sh
+++ b/scripts/gh/project.sh
@@ -51,6 +51,7 @@ die() {
 need_int() {
   case "${1:-}" in
     '' | *[!0-9]*) die "expected an issue number, got '${1:-}'" ;;
+    *) ;;
   esac
 }
 
@@ -63,12 +64,12 @@ OWNER="${REPO%%/*}"
 # Resolve the project's number + node id by title. One call, cached per run.
 PROJ_NUMBER="" PROJ_ID=""
 resolve_project() {
-  [ -n "$PROJ_ID" ] && return 0
+  [[ -n "$PROJ_ID" ]] && return 0
   local row
   row="$(gh project list --owner "$OWNER" --format json \
     --jq ".projects[] | select(.title == \"$TITLE\") | \"\(.number) \(.id)\"" 2>/dev/null)" ||
     die "could not list projects for $OWNER (missing 'project' token scope? run: gh auth refresh -s project)"
-  [ -n "$row" ] || die "no project titled '$TITLE' under $OWNER"
+  [[ -n "$row" ]] || die "no project titled '$TITLE' under $OWNER"
   PROJ_NUMBER="${row%% *}"
   PROJ_ID="${row##* }"
 }
@@ -85,7 +86,7 @@ status_option_id() {
   local want="$1" id
   id="$(gh project field-list "$PROJ_NUMBER" --owner "$OWNER" --format json \
     --jq ".fields[] | select(.name == \"Status\") | .options[] | select(.name == \"$want\") | .id")"
-  [ -n "$id" ] || die "the board has no Status option named '$want'"
+  [[ -n "$id" ]] || die "the board has no Status option named '$want'"
   printf '%s' "$id"
 }
 
@@ -131,11 +132,11 @@ cmd_status() {
   resolve_project
   local item
   item="$(item_id_for_issue "$n")"
-  if [ -z "$item" ]; then
+  if [[ -z "$item" ]]; then
     # Auto-add normally races ahead of a manual move; add explicitly and retry.
     cmd_add "$n" >/dev/null
     item="$(item_id_for_issue "$n")"
-    [ -n "$item" ] || die "could not place #$n on the board"
+    [[ -n "$item" ]] || die "could not place #$n on the board"
   fi
   gh project item-edit --id "$item" --project-id "$PROJ_ID" \
     --field-id "$(status_field_id)" \
@@ -180,7 +181,7 @@ cmd_update() {
   local body="${2:?message body (markdown)}"
   shift 2
   local start="" target="" enum
-  while [ $# -gt 0 ]; do
+  while [[ $# -gt 0 ]]; do
     case "$1" in
       --start) start="${2:?--start needs YYYY-MM-DD}"; shift 2 ;;
       --target) target="${2:?--target needs YYYY-MM-DD}"; shift 2 ;;
@@ -197,8 +198,8 @@ cmd_update() {
   esac
   resolve_project
   local -a dateargs=()
-  [ -n "$start" ] && dateargs+=(-f startDate="$start")
-  [ -n "$target" ] && dateargs+=(-f targetDate="$target")
+  [[ -n "$start" ]] && dateargs+=(-f startDate="$start")
+  [[ -n "$target" ]] && dateargs+=(-f targetDate="$target")
   # shellcheck disable=SC2016  # GraphQL $variables are literal, never shell expansion
   gh api graphql \
     -f query='mutation($projectId: ID!, $body: String!, $status: ProjectV2StatusUpdateStatus!, $startDate: Date, $targetDate: Date) {
@@ -234,7 +235,7 @@ cmd_sync_dates() {
   local field_id
   field_id="$(gh project field-list "$PROJ_NUMBER" --owner "$OWNER" --format json \
     --jq '.fields[] | select(.name == "Target date") | .id')"
-  [ -n "$field_id" ] || die 'the board has no "Target date" field'
+  [[ -n "$field_id" ]] || die 'the board has no "Target date" field'
   local cursor="" page rows=0 set=0 cleared=0
   while :; do
     # shellcheck disable=SC2016  # GraphQL $variables are literal, never shell expansion
@@ -253,8 +254,8 @@ cmd_sync_dates() {
       --jq '.data.node.items')"
     while IFS=$'\t' read -r item want have; do
       rows=$((rows + 1))
-      [ "$want" = "$have" ] && continue
-      if [ -n "$want" ]; then
+      [[ "$want" = "$have" ]] && continue
+      if [[ -n "$want" ]]; then
         gh project item-edit --id "$item" --project-id "$PROJ_ID" \
           --field-id "$field_id" --date "$want" >/dev/null
         set=$((set + 1))
@@ -264,7 +265,7 @@ cmd_sync_dates() {
         cleared=$((cleared + 1))
       fi
     done < <(printf '%s' "$page" | jq -r '.nodes[] | [.id, (.content.milestone.dueOn // "" | .[0:10]), (.fieldValueByName.date // "")] | @tsv')
-    if [ "$(printf '%s' "$page" | jq -r '.pageInfo.hasNextPage')" = "true" ]; then
+    if [[ "$(printf '%s' "$page" | jq -r '.pageInfo.hasNextPage')" = "true" ]]; then
       cursor="$(printf '%s' "$page" | jq -r '.pageInfo.endCursor')"
     else
       break
@@ -274,12 +275,15 @@ cmd_sync_dates() {
 }
 
 usage() {
-  sed -n '2,38p' "$0" | sed 's/^# \{0,1\}//'
+  # The banner is the header comment block itself, printed structurally
+  # (skip the shebang + SPDX lines, stop at the first non-comment line) so
+  # editing the header can never misalign a hardcoded line window.
+  awk 'NR <= 3 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "$0"
 }
 
 main() {
   local sub="${1:-}"
-  [ -n "$sub" ] || {
+  [[ -n "$sub" ]] || {
     usage
     exit 1
   }

--- a/scripts/gh/rel.sh
+++ b/scripts/gh/rel.sh
@@ -47,6 +47,7 @@ die() {
 need_int() {
   case "${1:-}" in
     '' | *[!0-9]*) die "expected an issue number, got '${1:-}'" ;;
+    *) ;;
   esac
 }
 
@@ -64,6 +65,7 @@ dbid() {
     die "issue #$1 not found in $REPO"
   case "$id" in
     '' | *[!0-9]*) die "could not resolve the database id for #$1" ;;
+    *) ;;
   esac
   printf '%s' "$id"
 }
@@ -72,19 +74,19 @@ dbid() {
 list_or_dash() {
   local out
   out="$(gh api "$1" --jq "$2" 2>/dev/null || true)"
-  if [ -n "$out" ]; then echo "$out"; else echo "    —"; fi
+  if [[ -n "$out" ]]; then echo "$out"; else echo "    —"; fi
 }
 
 cmd_parent() {
   local child="${1:?child issue number}" parent="${2:?parent issue number}" flag="${3:-}"
   need_int "$child"
   need_int "$parent"
-  [ "$child" != "$parent" ] || die "an issue cannot be its own parent"
+  [[ "$child" != "$parent" ]] || die "an issue cannot be its own parent"
   local cid body
   cid="$(dbid "$child")"
-  if [ "$flag" = "--replace" ]; then
+  if [[ "$flag" = "--replace" ]]; then
     body="$(printf '{"sub_issue_id":%d,"replace_parent":true}' "$cid")"
-  elif [ -n "$flag" ]; then
+  elif [[ -n "$flag" ]]; then
     die "unknown flag '$flag' (only --replace is supported)"
   else
     body="$(printf '{"sub_issue_id":%d}' "$cid")"
@@ -98,7 +100,7 @@ cmd_unparent() {
   need_int "$child"
   local parent cid
   parent="$(gh api "repos/$REPO/issues/$child/parent" --jq '.number' 2>/dev/null || true)"
-  [ -n "$parent" ] || die "#$child has no parent"
+  [[ -n "$parent" ]] || die "#$child has no parent"
   cid="$(dbid "$child")"
   printf '{"sub_issue_id":%d}' "$cid" | gh api --method DELETE "repos/$REPO/issues/$parent/sub_issue" --input - >/dev/null
   echo "ok: detached #$child from parent #$parent"
@@ -108,7 +110,7 @@ cmd_blocked_by() {
   local n="${1:?issue number}" blocker="${2:?blocker issue number}"
   need_int "$n"
   need_int "$blocker"
-  [ "$n" != "$blocker" ] || die "an issue cannot block itself"
+  [[ "$n" != "$blocker" ]] || die "an issue cannot block itself"
   local bid
   bid="$(dbid "$blocker")"
   printf '{"issue_id":%d}' "$bid" | gh api --method POST "repos/$REPO/issues/$n/dependencies/blocked_by" --input - >/dev/null
@@ -131,7 +133,7 @@ cmd_blocking() {
   local n="${1:?issue number}" blocked="${2:?blocked issue number}"
   need_int "$n"
   need_int "$blocked"
-  [ "$n" != "$blocked" ] || die "an issue cannot block itself"
+  [[ "$n" != "$blocked" ]] || die "an issue cannot block itself"
   local nid
   nid="$(dbid "$n")"
   printf '{"issue_id":%d}' "$nid" | gh api --method POST "repos/$REPO/issues/$blocked/dependencies/blocked_by" --input - >/dev/null
@@ -173,12 +175,15 @@ cmd_id() {
 }
 
 usage() {
-  sed -n '2,42p' "$0" | sed 's/^# \{0,1\}//'
+  # The banner is the header comment block itself, printed structurally
+  # (skip the shebang + SPDX lines, stop at the first non-comment line) so
+  # editing the header can never misalign a hardcoded line window.
+  awk 'NR <= 3 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "$0"
 }
 
 main() {
   local sub="${1:-}"
-  [ -n "$sub" ] || {
+  [[ -n "$sub" ]] || {
     usage
     exit 1
   }

--- a/scripts/profile.sh
+++ b/scripts/profile.sh
@@ -26,14 +26,14 @@ PSQLF() { docker exec ferroehr-ferroehr-postgres-1 psql -U postgres -d ferroehr 
 
 echo "==> composing stack"
 docker compose down -v >/dev/null 2>&1 || true
-if [ "${SKIP_BUILD:-0}" != "1" ]; then
+if [[ "${SKIP_BUILD:-0}" != "1" ]]; then
   docker compose up -d --build ferroehr-postgres ferroehr
 else
   docker compose up -d ferroehr-postgres ferroehr
 fi
 for _ in $(seq 1 60); do
   code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/ferroehr/rest/status || true)
-  [ "$code" = "200" ] && break; sleep 3
+  [[ "$code" = "200" ]] && break; sleep 3
 done
 
 echo "==> seeding ${SCALE}"

--- a/scripts/render/comparison.sh
+++ b/scripts/render/comparison.sh
@@ -23,7 +23,7 @@ OUT="website/book/generated"
 
 command -v jq >/dev/null 2>&1 || { echo "render-comparison: jq is required" >&2; exit 1; }
 for f in "$RS/results.json" "$EB/results.json"; do
-  [ -f "$f" ] || { echo "render-comparison: missing artifact $f" >&2; exit 1; }
+  [[ -f "$f" ]] || { echo "render-comparison: missing artifact $f" >&2; exit 1; }
 done
 mkdir -p "$OUT" website/book/src/comparison-assets
 
@@ -45,13 +45,13 @@ run_date() {
   local d
   d=$(TZ=UTC git log --follow --diff-filter=AM -1 --date=format-local:%Y-%m-%d \
     --format=%cd -- "$1/results.json" 2>/dev/null || true)
-  if [ -z "$d" ]; then
+  if [[ -z "$d" ]]; then
     # The mtime fallback exists ONLY for a local, not-yet-committed
     # regeneration. Under CI an empty git log means a SHALLOW checkout, and
     # the fallback would stamp the checkout day — which the drift gate then
     # reads as a one-line date change (#2402, red on both tag runs). Fail
     # naming the cause instead.
-    if [ -n "${GITHUB_ACTIONS:-}" ]; then
+    if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
       echo "::error::run_date: git log found no commit for $1/results.json — a shallow checkout; give the job fetch-depth: 0" >&2
       exit 1
     fi
@@ -194,7 +194,7 @@ $(jq -rn --slurpfile a "$RS/results.json" --slurpfile b "$EB/results.json" '
   (INDEX($b[0].outcomes[]; "\(.case)|\(.format // "-")")) as $eb
   | [$a[0].outcomes[] | select(.status=="failed")]
   | sort_by(.case)[]
-  | "| \(.case) | \(.format // "—") | \((.reason // "") | .[0:90] | gsub("\\|"; "\\\\|")) | \($eb["\(.case)|\(.format // "-")"].status // "—") |"' ; [ "$(count "$RS" failed)" = "0" ] && echo '| — | — | *none — zero failing cases* | — |' )
+  | "| \(.case) | \(.format // "—") | \((.reason // "") | .[0:90] | gsub("\\|"; "\\\\|")) | \($eb["\(.case)|\(.format // "-")"].status // "—") |"' ; [[ "$(count "$RS" failed)" = "0" ]] && echo '| — | — | *none — zero failing cases* | — |' )
 
 ### EHRbase failures by schedule chapter
 
@@ -301,7 +301,7 @@ knee_res() { # $1 file, $2 role, $3 field-expression over samples
 corpus_of() { jq -r '.corpus' "$1"; }
 
 {
-  if [ -f "$RS_STRESS" ] && [ -f "$EB_STRESS" ]; then
+  if [[ -f "$RS_STRESS" ]] && [[ -f "$EB_STRESS" ]]; then
     cargo run -q -p cnf-runner -- stress-compare \
       --left "$RS_STRESS" --left-label "ferroehr" \
       --right "$EB_STRESS" --right-label "EHRbase" \
@@ -326,7 +326,7 @@ A stress report is exploration evidence: it earns no conformance class
 (classes are earned exclusively by the hour-long measured class runs) and
 carries no class vocabulary — the chart shows where each system breaks.
 EOF
-  elif [ -f "$RS_STRESS" ]; then
+  elif [[ -f "$RS_STRESS" ]]; then
     cat <<EOF
 The step-load stress instrument (\`cnf-runner stress\`) has a committed
 report for **ferroehr** — the maximum sustainable throughput of

--- a/scripts/render/conformance-assets.sh
+++ b/scripts/render/conformance-assets.sh
@@ -17,7 +17,7 @@ cd "$(dirname "$0")/../.."
 SUT="${CONF_SUT:-ferroehr}"
 ART="docs/conformance/$SUT"
 for f in "$ART/results.json" "$ART/verdicts.json"; do
-  [ -f "$f" ] || {
+  [[ -f "$f" ]] || {
     echo "render-conformance-assets: $f missing — run the conformance suite first" >&2
     exit 1
   }

--- a/scripts/render/conformance-docs.sh
+++ b/scripts/render/conformance-docs.sh
@@ -21,13 +21,13 @@
 set -euo pipefail
 cd "$(dirname "$0")/../.."
 
-if [ -n "${CONF_SUT:-}" ]; then
+if [[ -n "${CONF_SUT:-}" ]]; then
   parties=("$CONF_SUT")
 else
   parties=()
   for statement in tools/cnf-runner/party/*/statement.json; do
     party="$(basename "$(dirname "$statement")")"
-    [ -f "docs/conformance/$party/results.json" ] && parties+=("$party")
+    [[ -f "docs/conformance/$party/results.json" ]] && parties+=("$party")
   done
 fi
 
@@ -35,7 +35,7 @@ for party in "${parties[@]}"; do
   statement="tools/cnf-runner/party/$party/statement.json"
   results="docs/conformance/$party/results.json"
   for f in "$statement" "$results"; do
-    [ -f "$f" ] || {
+    [[ -f "$f" ]] || {
       echo "render-conformance-docs: $f missing — run the conformance suite first" >&2
       exit 1
     }

--- a/scripts/render/conformance-stats.sh
+++ b/scripts/render/conformance-stats.sh
@@ -20,7 +20,7 @@ command -v jq >/dev/null 2>&1 || {
   exit 1
 }
 for f in "$ART/results.json" "$ART/verdicts.json"; do
-  [ -f "$f" ] || {
+  [[ -f "$f" ]] || {
     echo "render-conformance-stats: $f missing — run the conformance suite first" >&2
     exit 1
   }
@@ -40,7 +40,7 @@ driven=$((passed + failed + errored))
 # The results artifact is deliberately clock-free (deterministic re-runs);
 # the run date is the artifact's last commit date (fallback: file mtime).
 run_date=$(git log -1 --format=%cs -- "$ART/results.json" 2>/dev/null || true)
-[ -n "$run_date" ] || run_date=$(date -r "$ART/results.json" +%Y-%m-%d)
+[[ -n "$run_date" ]] || run_date=$(date -r "$ART/results.json" +%Y-%m-%d)
 
 # ── profile verdicts, straight from the computed verdict report ──────────────
 pverdict() {
@@ -61,7 +61,7 @@ for v in "$total" "$passed" "$failed" "$errored" "$na" "$driven" "$caps_ok" "$ca
   [[ "$v" =~ ^[0-9]+$ ]] || { echo "render-conformance-stats: non-numeric stat '$v'" >&2; exit 1; }
 done
 for v in "$core" "$standard" "$options" "$sec"; do
-  [ -n "$v" ] && [ "$v" != "—" ] || { echo "render-conformance-stats: empty profile verdict in verdicts.json" >&2; exit 1; }
+  [[ -n "$v" ]] && [[ "$v" != "—" ]] || { echo "render-conformance-stats: empty profile verdict in verdicts.json" >&2; exit 1; }
 done
 
 upper() { printf '%s' "$1" | tr '[:lower:]' '[:upper:]'; }

--- a/scripts/render/perf-assets.sh
+++ b/scripts/render/perf-assets.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd "$(dirname "$0")/../.."
 
 SUT="${CONF_SUT:-ferroehr}"
-if [ "$SUT" = "ferroehr" ]; then
+if [[ "$SUT" = "ferroehr" ]]; then
   OUT="${1:-website/book/src/perf-assets}"
   SUMMARY="${2:-website/book/generated/perf-summary.md}"
 else
@@ -36,6 +36,6 @@ args=(perf-assets
   --summary "$SUMMARY")
 # The latency-throughput stress curve renders only once a committed stress
 # report exists (cnf-runner stress — exploration, never a conformance record).
-[ -f "$STRESS" ] && args+=(--stress "$STRESS")
+[[ -f "$STRESS" ]] && args+=(--stress "$STRESS")
 
 cargo run -q -p cnf-runner -- "${args[@]}"

--- a/scripts/render/zenodo-json.sh
+++ b/scripts/render/zenodo-json.sh
@@ -46,7 +46,7 @@ cff_scalar() {
   local v
   v="$(sed -nE "s/^$1:[[:space:]]*(.*)$/\1/p" "$CFF" | head -1)"
   v="${v%\"}"; v="${v#\"}"
-  [ -n "$v" ] || { echo "$CFF has no \`$1\`" >&2; exit 1; }
+  [[ -n "$v" ]] || { echo "$CFF has no \`$1\`" >&2; exit 1; }
   printf '%s' "$v"
 }
 
@@ -163,8 +163,8 @@ rendered="$(
 }'
 )"
 
-if [ "$MODE" = "--check" ]; then
-  [ -f "$OUT" ] || { echo "::error::$OUT is missing — run scripts/render/zenodo-json.sh" >&2; exit 1; }
+if [[ "$MODE" = "--check" ]]; then
+  [[ -f "$OUT" ]] || { echo "::error::$OUT is missing — run scripts/render/zenodo-json.sh" >&2; exit 1; }
   if ! printf '%s\n' "$rendered" | diff -u "$OUT" - >/dev/null; then
     echo "::error::$OUT is stale versus $CFF — run scripts/render/zenodo-json.sh" >&2
     printf '%s\n' "$rendered" | diff -u "$OUT" - || true

--- a/scripts/sandbox/reseed.sh
+++ b/scripts/sandbox/reseed.sh
@@ -69,11 +69,11 @@ for e in $(seq 1 "$EHRS"); do
   for attempt in $(seq 1 "$ATTEMPTS"); do
     ehr=$(curl -sS -m 60 -u "$AUTH" -X POST "$BASE/ehr" -H 'Prefer: return=minimal' \
       -D- -o /dev/null 2>/dev/null | tr -d '\r' | awk -F'/ehr/' 'tolower($0) ~ /^location/{print $2}' | tr -d ' ') || true
-    [ -n "$ehr" ] && break
+    [[ -n "$ehr" ]] && break
     echo "  EHR creation returned no Location (attempt $attempt/$ATTEMPTS); retrying" >&2
     sleep "$RETRY_DELAY"
   done
-  if [ -z "$ehr" ]; then
+  if [[ -z "$ehr" ]]; then
     echo "::error::EHR creation kept failing after $ATTEMPTS attempts — the sandbox is not serving writes." >&2
     exit 1
   fi
@@ -84,7 +84,7 @@ seeded=0
 for slug in "${TEMPLATES[@]}"; do
   opt="$TPL_DIR/$slug.opt"
   example="$TPL_DIR/$slug.example.json"
-  [ -f "$opt" ] && [ -f "$example" ] || {
+  [[ -f "$opt" ]] && [[ -f "$example" ]] || {
     echo "::error::missing template pair for $slug in $TPL_DIR" >&2
     exit 1
   }
@@ -103,7 +103,7 @@ for slug in "${TEMPLATES[@]}"; do
       code=$(post_retry "composition $slug" "$BASE/ehr/$ehr/composition" \
         -H 'Content-Type: application/json' -H 'Prefer: return=minimal' \
         --data-binary @"$example")
-      if [ "$code" != "201" ]; then
+      if [[ "$code" != "201" ]]; then
         echo "::error::composition commit answered $code ($slug into $ehr)" >&2
         exit 1
       fi

--- a/scripts/security/scan-images.sh
+++ b/scripts/security/scan-images.sh
@@ -36,13 +36,13 @@ OWNER=${OWNER:-rubentalstra}
 
 # Each entry is "ref|platform"; an empty platform scans the ref as built.
 targets=()
-if [ "${1:-}" = "--candidate" ]; then
+if [[ "${1:-}" = "--candidate" ]]; then
   shift
-  [ $# -ge 1 ] || { echo "--candidate needs at least one image ref" >&2; exit 2; }
+  [[ $# -ge 1 ]] || { echo "--candidate needs at least one image ref" >&2; exit 2; }
   for ref in "$@"; do
     targets+=("${ref}|")
   done
-elif [ $# -gt 0 ]; then
+elif [[ $# -gt 0 ]]; then
   echo "unknown argument: $1 (only --candidate IMAGE... is accepted)" >&2
   exit 2
 else
@@ -56,7 +56,7 @@ fi
 # Every VEX document, exactly as the scheduled lane passes them.
 vex_args=()
 for doc in security/vex/*.json; do
-  [ -e "$doc" ] || continue
+  [[ -e "$doc" ]] || continue
   vex_args+=(--vex "$doc")
 done
 
@@ -68,14 +68,14 @@ for target in "${targets[@]}"; do
   ref=${target%|*}
   platform=${target##*|}
   platform_args=()
-  [ -n "$platform" ] && platform_args=(--platform "$platform")
+  [[ -n "$platform" ]] && platform_args=(--platform "$platform")
   safe=$(printf '%s' "${ref}_${platform}" | tr '/:@' '___')
   report="$out_dir/${safe}.json"
   echo "── scanning ${ref} ${platform:-'(as built)'}"
   trivy image --skip-version-check --config trivy.yaml --scanners vuln \
     "${platform_args[@]}" "${vex_args[@]}" -f json -o "$report" "$ref"
   count=$(jq '[.Results[]?.Vulnerabilities // [] | .[]] | length' "$report")
-  if [ "$count" -gt 0 ]; then
+  if [[ "$count" -gt 0 ]]; then
     jq -r '.Results[]? | .Target as $t | (.Vulnerabilities // [])[]
            | "  \($t) | \(.PkgName) \(.InstalledVersion) \(.VulnerabilityID) \(.Severity) -> \(.FixedVersion)"' \
       "$report"
@@ -85,4 +85,4 @@ for target in "${targets[@]}"; do
 done
 
 echo "total fixable HIGH/CRITICAL findings: ${total}"
-[ "$total" -eq 0 ]
+[[ "$total" -eq 0 ]]

--- a/scripts/security/vex-generate.sh
+++ b/scripts/security/vex-generate.sh
@@ -50,7 +50,7 @@ for tool in yq jq; do
   command -v "$tool" >/dev/null || { echo "vex-generate: $tool is required" >&2; exit 1; }
 done
 for required in "$PROSE" "$GATE"; do
-  [ -f "$required" ] || { echo "vex-generate: missing $required" >&2; exit 1; }
+  [[ -f "$required" ]] || { echo "vex-generate: missing $required" >&2; exit 1; }
 done
 
 # The controlled vocabularies, so a typo in the prose file fails here instead of
@@ -70,7 +70,7 @@ prose_json="$(yq -p toml -o json '.' "$PROSE")"
 # cannot. Bare non-advisory entries (`yanked@0.1.1`) stay legal.
 ignore_json="$(yq -p toml -o json '[.advisories.ignore[]]' "$GATE")"
 if bare="$(jq -r '.[] | select(type == "string" and startswith("RUSTSEC-"))' <<<"$ignore_json")" \
-   && [ -n "$bare" ]; then
+   && [[ -n "$bare" ]]; then
   echo "vex-generate: deny.toml ignores an advisory in the bare-string form:" >&2
   sed 's/^/  /' <<<"$bare" >&2
   echo "Use { id = \"…\", reason = \"…\" } so the exception carries its reason" >&2
@@ -86,7 +86,7 @@ if unreasoned="$(jq -r '
       .[]
       | select(type == "object" and has("id"))
       | select((.reason // "" | gsub("^\\s+|\\s+$"; "")) == "")
-      | .id' <<<"$ignore_json")" && [ -n "$unreasoned" ]; then
+      | .id' <<<"$ignore_json")" && [[ -n "$unreasoned" ]]; then
   echo "vex-generate: deny.toml accepts an advisory with no reason:" >&2
   sed 's/^/  /' <<<"$unreasoned" >&2
   echo "Every accepted advisory states why it does not apply and when to" >&2
@@ -104,12 +104,12 @@ note() { echo "vex-generate: $*" >&2; fail=1; }
 
 # ── the two-way agreement that makes one list impossible to forget ──────────
 while read -r id; do
-  [ -n "$id" ] || continue
+  [[ -n "$id" ]] || continue
   note "deny.toml accepts $id but $PROSE has no [[accepted]] entry for it — every accepted advisory needs a published justification"
 done < <(comm -23 <(echo "$gate_ids") <(echo "$accepted_ids"))
 
 while read -r id; do
-  [ -n "$id" ] || continue
+  [[ -n "$id" ]] || continue
   note "$PROSE claims $id is accepted but deny.toml does not ignore it — a VEX statement for an advisory the gate still fails on is a false claim"
 done < <(comm -13 <(echo "$gate_ids") <(echo "$accepted_ids"))
 
@@ -117,17 +117,17 @@ done < <(comm -13 <(echo "$gate_ids") <(echo "$accepted_ids"))
 # acceptance (move it to [[accepted]]) or the ignore that deny.toml's header
 # explicitly refuses to carry.
 while read -r id; do
-  [ -n "$id" ] || continue
+  [[ -n "$id" ]] || continue
   note "$id is listed as [[lockfile_only]] but deny.toml now ignores it — move it to [[accepted]], or drop the ignore"
 done < <(comm -12 <(echo "$gate_ids") <(echo "$lockfile_ids"))
 
 # ── vocabulary + completeness of every statement ────────────────────────────
 while read -r entry; do
-  [ -n "$entry" ] || continue
+  [[ -n "$entry" ]] || continue
   id="$(jq -r '.id // ""' <<<"$entry")"
   for field in crate status justification impact; do
     value="$(jq -r --arg f "$field" '.[$f] // ""' <<<"$entry")"
-    [ -n "$value" ] || note "${id:-<no id>}: missing '$field'"
+    [[ -n "$value" ]] || note "${id:-<no id>}: missing '$field'"
   done
   # The dependency-path claim is required, and its EMPTY form has meaning ("the
   # crate is absent from the resolved graph"), so presence is checked with
@@ -142,13 +142,13 @@ while read -r entry; do
   justification="$(jq -r '.justification // ""' <<<"$entry")"
   grep -qw -- "$status" <<<"$VALID_STATUS" \
     || note "$id: status '$status' is not an OpenVEX status ($VALID_STATUS)"
-  if [ "$status" = "not_affected" ]; then
+  if [[ "$status" = "not_affected" ]]; then
     grep -qw -- "$justification" <<<"$VALID_JUSTIFICATION" \
       || note "$id: justification '$justification' is not in the OpenVEX vocabulary ($VALID_JUSTIFICATION)"
   fi
 done < <(jq -c '((.accepted // []) + (.lockfile_only // []))[]' <<<"$prose_json")
 
-[ "$fail" -eq 0 ] || exit 1
+[[ "$fail" -eq 0 ]] || exit 1
 
 document="$(jq -S '
   .document as $d
@@ -183,7 +183,7 @@ document="$(jq -S '
 
 # jq -S sorts object keys alphabetically, which is what makes the output
 # byte-stable across jq versions; the statement ORDER is fixed above by id.
-if [ "$mode" = "--stdout" ]; then
+if [[ "$mode" = "--stdout" ]]; then
   printf '%s\n' "$document"
 else
   printf '%s\n' "$document" > "$OUT"

--- a/scripts/ui-e2e.sh
+++ b/scripts/ui-e2e.sh
@@ -70,7 +70,7 @@ export COMPOSE_PROFILES=keycloak,admin-ui
 # server Dockerfile). Degrades to `unknown` off-checkout.
 export REVISION="${REVISION:-$(git -C "$ROOT" rev-parse --short=12 HEAD 2>/dev/null || echo unknown)}"
 
-if [ -n "${UI_E2E_IMAGE:-}" ]; then
+if [[ -n "${UI_E2E_IMAGE:-}" ]]; then
   # Image mode: the composed console publishes the quickstart port.
   CONSOLE_ADDR="127.0.0.1:3000"
 else
@@ -97,7 +97,7 @@ TREE_STATE_BEFORE="$(git_tree_state)"
 assert_no_tree_residue() {
   local after
   after="$(git_tree_state)"
-  if [ "$after" != "$TREE_STATE_BEFORE" ]; then
+  if [[ "$after" != "$TREE_STATE_BEFORE" ]]; then
     echo "FATAL: the e2e run left residue in the working tree:" >&2
     diff <(printf '%s\n' "$TREE_STATE_BEFORE") <(printf '%s\n' "$after") >&2 || true
     return 1
@@ -108,12 +108,12 @@ assert_no_tree_residue() {
 CONSOLE_PID=""
 DRIVER_PID=""
 cleanup() {
-  [ -n "$CONSOLE_PID" ] && kill "$CONSOLE_PID" 2>/dev/null || true
-  if [ -n "${UI_E2E_IMAGE:-}" ] && [ -z "${UI_E2E_KEEP_UP:-}" ]; then
+  [[ -n "$CONSOLE_PID" ]] && kill "$CONSOLE_PID" 2>/dev/null || true
+  if [[ -n "${UI_E2E_IMAGE:-}" ]] && [[ -z "${UI_E2E_KEEP_UP:-}" ]]; then
     docker compose stop ferroehr-admin-ui >/dev/null 2>&1 || true
   fi
-  [ -n "$DRIVER_PID" ] && kill "$DRIVER_PID" 2>/dev/null || true
-  if [ -z "${UI_E2E_NO_COMPOSE:-}" ] && [ -z "${UI_E2E_KEEP_UP:-}" ]; then
+  [[ -n "$DRIVER_PID" ]] && kill "$DRIVER_PID" 2>/dev/null || true
+  if [[ -z "${UI_E2E_NO_COMPOSE:-}" ]] && [[ -z "${UI_E2E_KEEP_UP:-}" ]]; then
     # --remove-orphans: belt-and-braces against a future profiled/renamed
     # service surviving the teardown the way keycloak used to.
     docker compose down -v --remove-orphans >/dev/null 2>&1 || true
@@ -133,13 +133,13 @@ wait_http() { # url, tries
 }
 
 # ── 1. The composed stack: postgres + CDR + Keycloak ────────────────────────
-if [ -z "${UI_E2E_NO_COMPOSE:-}" ]; then
+if [[ -z "${UI_E2E_NO_COMPOSE:-}" ]]; then
   echo "── compose up (postgres + ferroehr + keycloak)"
   # keycloak is behind the `keycloak` profile, enabled for every call in this
   # lane by the COMPOSE_PROFILES export above, so the OIDC journeys have an
   # issuer AND the teardown can see the container.
   BUILD_ARGS=(--build)
-  [ -n "${UI_E2E_NO_BUILD:-}" ] && BUILD_ARGS=(--no-build)
+  [[ -n "${UI_E2E_NO_BUILD:-}" ]] && BUILD_ARGS=(--no-build)
   # The e2e overlay rides BOTH lanes: without it here, its `ferroehr:` env
   # block (tenancy on, terminology on) never reached the host-mode CDR — the
   # lane CI actually runs.
@@ -240,7 +240,7 @@ done
 echo "   seeded 3 extra FLAT compositions with quantity magnitudes"
 
 # ── 3. The console under test ────────────────────────────────────────────────
-if [ -n "${UI_E2E_IMAGE:-}" ]; then
+if [[ -n "${UI_E2E_IMAGE:-}" ]]; then
   # Image mode — the TRUE shipped artifact: compose-build the console image
   # (docker/admin-ui/Dockerfile) with the e2e-env override supplying the OIDC
   # test wiring; the issuer (http://keycloak:8081) resolves in-network via
@@ -250,7 +250,7 @@ if [ -n "${UI_E2E_IMAGE:-}" ]; then
   # if this call's model gave `ferroehr` a different config than the running
   # container, `up ferroehr-admin-ui` would RECREATE the server mid-run —
   # breaking the lane. The bare calls (stop/down/logs) recreate nothing.
-  if [ -n "${UI_E2E_IMAGE_REF:-}" ]; then
+  if [[ -n "${UI_E2E_IMAGE_REF:-}" ]]; then
     echo "── compose up the PUBLISHED console image ($UI_E2E_IMAGE_REF)"
     FERROEHR_ADMIN_UI_IMAGE="$UI_E2E_IMAGE_REF" \
       docker compose -f docker-compose.yml -f docker-compose.override.yml \
@@ -263,10 +263,10 @@ if [ -n "${UI_E2E_IMAGE:-}" ]; then
       up -d --build ferroehr-admin-ui
   fi
 else
-  if [ -n "${UI_E2E_PREBUILT_CONSOLE:-}" ]; then
+  if [[ -n "${UI_E2E_PREBUILT_CONSOLE:-}" ]]; then
     echo "── using the prebuilt console (UI_E2E_PREBUILT_CONSOLE)"
     for p in "$ROOT/target/debug/ferroehr-admin-ui" "$ROOT/target/site/pkg"; do
-      [ -e "$p" ] || { echo "FATAL: UI_E2E_PREBUILT_CONSOLE set but $p is missing" >&2; exit 1; }
+      [[ -e "$p" ]] || { echo "FATAL: UI_E2E_PREBUILT_CONSOLE set but $p is missing" >&2; exit 1; }
     done
   else
     echo "── building the console (cargo-leptos)"
@@ -318,10 +318,10 @@ wait_http "http://127.0.0.1:$DRIVER_PORT/status"
 # unaffected — CI builds the archive on the same runner image + workspace
 # path, which the workflow documents).
 NEXTEST_TARGET=(-p ferroehr-admin-ui --features ssr)
-if [ -n "${UI_E2E_NEXTEST_ARCHIVE:-}" ]; then
+if [[ -n "${UI_E2E_NEXTEST_ARCHIVE:-}" ]]; then
   NEXTEST_TARGET=(--archive-file "$UI_E2E_NEXTEST_ARCHIVE" --workspace-remap "$ROOT")
 fi
-if [ -n "${UI_E2E_SHOTS_ONLY:-}" ]; then
+if [[ -n "${UI_E2E_SHOTS_ONLY:-}" ]]; then
   echo "── journeys skipped (UI_E2E_SHOTS_ONLY)"
 else
 echo "── running e2e journeys"
@@ -333,7 +333,7 @@ echo "── running e2e journeys"
 # of its own (table paging) seeds and removes its fixtures over ITS-REST rather
 # than through the UI, whose own paths have their own journeys.
 NEXTEST_FILTER=(-E 'binary(it) - test(/^e2e_docs_shots::/)')
-[ -n "$FILTER" ] && NEXTEST_FILTER=(-E "test($FILTER)")
+[[ -n "$FILTER" ]] && NEXTEST_FILTER=(-E "test($FILTER)")
 UI_E2E_BASE_URL="$CONSOLE_URL" \
 UI_E2E_WEBDRIVER_URL="http://127.0.0.1:$DRIVER_PORT" \
 UI_E2E_SHOTS_DIR="$SHOTS_DIR" \
@@ -353,7 +353,7 @@ fi
 # When UI_E2E_DOCS_SHOTS is set, capture the canonical per-screen screenshots
 # for website/book (writes into website/book/src/admin-ui/img). Runs after the
 # journeys so the browse journeys have seeded the fixture template.
-if [ -n "${UI_E2E_DOCS_SHOTS:-}" ]; then
+if [[ -n "${UI_E2E_DOCS_SHOTS:-}" ]]; then
   echo "── capturing documentation screenshots"
   UI_E2E_BASE_URL="$CONSOLE_URL" \
   UI_E2E_WEBDRIVER_URL="http://127.0.0.1:$DRIVER_PORT" \

--- a/scripts/vendor/adl-grammars.sh
+++ b/scripts/vendor/adl-grammars.sh
@@ -31,7 +31,7 @@ ADL_ANTLR_COMMIT="8db091ec3d810371cc41cd072fee81ce893fea47" # 2024-04-06
 
 fetch() {
   local path="$1" out="$2"
-  curl -fsSL "https://raw.githubusercontent.com/${ADL_ANTLR_REPO}/${ADL_ANTLR_COMMIT}/${path}" -o "${out}"
+  curl -fsSL --proto '=https' --proto-redir '=https' "https://raw.githubusercontent.com/${ADL_ANTLR_REPO}/${ADL_ANTLR_COMMIT}/${path}" -o "${out}"
   echo "vendored ${out} @ ${ADL_ANTLR_COMMIT}"
 }
 

--- a/scripts/vendor/adl2-archetypes.sh
+++ b/scripts/vendor/adl2-archetypes.sh
@@ -63,7 +63,7 @@ trap 'rm -rf "$WORK"' EXIT
 STAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 echo "==> fetching $REPO @ ${PIN:0:12}"
-curl -fsSL "https://codeload.github.com/$REPO/tar.gz/$PIN" -o "$WORK/repo.tar.gz"
+curl -fsSL --proto '=https' --proto-redir '=https' "https://codeload.github.com/$REPO/tar.gz/$PIN" -o "$WORK/repo.tar.gz"
 mkdir -p "$WORK/src"
 tar -xzf "$WORK/repo.tar.gz" -C "$WORK/src" --strip-components=1
 

--- a/scripts/vendor/ckm-archetypes.sh
+++ b/scripts/vendor/ckm-archetypes.sh
@@ -82,7 +82,7 @@ curl -fsS "$CKM/archetypes?page=0&size=10000" -H "Accept: application/json" \
 # silently vendor only the last. `group_by` + the within-group index reproduces
 # the previous counter exactly, on the same `resourceMainId` sort order.
 published=$(jq 'length' "$WORK/archetypes.json")
-if [ "$published" -le 20 ]; then
+if [[ "$published" -le 20 ]]; then
   echo "::error::the list endpoint returned only $published rows — CKM ignored the" \
        "pagination parameters (use ?page=N&size=M)" >&2
   exit 1

--- a/scripts/vendor/lang-grammars.sh
+++ b/scripts/vendor/lang-grammars.sh
@@ -33,7 +33,7 @@ ANTLR4_COMMIT="3494da942f3ed35963279837447b3039dd098e20" # master 2025-12-15
 
 fetch() {
   local repo="$1" commit="$2" path="$3" out="$4"
-  curl -fsSL "https://raw.githubusercontent.com/${repo}/${commit}/${path}" -o "${out}"
+  curl -fsSL --proto '=https' --proto-redir '=https' "https://raw.githubusercontent.com/${repo}/${commit}/${path}" -o "${out}"
   echo "vendored ${out} @ ${commit}"
 }
 

--- a/scripts/vendor/openehr-sdk-json.sh
+++ b/scripts/vendor/openehr-sdk-json.sh
@@ -41,7 +41,7 @@ WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
 
 echo "==> fetching $REPO @ ${PIN:0:12}"
-curl -fsSL "https://codeload.github.com/$REPO/tar.gz/$PIN" -o "$WORK/repo.tar.gz"
+curl -fsSL --proto '=https' --proto-redir '=https' "https://codeload.github.com/$REPO/tar.gz/$PIN" -o "$WORK/repo.tar.gz"
 mkdir -p "$WORK/src"
 tar -xzf "$WORK/repo.tar.gz" -C "$WORK/src" --strip-components=1
 

--- a/scripts/vendor/spec-docs.sh
+++ b/scripts/vendor/spec-docs.sh
@@ -117,7 +117,7 @@ for entry in "${COMPONENTS[@]}"; do
   # The upstream LICENSE rides along verbatim (redistribution keeps the
   # source's own terms): the spec-docs repos carry CC-BY-SA 3.0, the ITS
   # artifact repos Apache-2.0. Anything else is unadjudicated — fail loud.
-  if [ ! -f "$src/LICENSE" ]; then
+  if [[ ! -f "$src/LICENSE" ]]; then
     echo "ERROR: $name has no LICENSE at $sha — adjudicate before vendoring" >&2
     exit 1
   fi
@@ -136,11 +136,11 @@ for entry in "${COMPONENTS[@]}"; do
   # exactly those out of the same pinned checkout.
   refs="$(grep -rhoE '\{uml_diagrams_uri\}/[A-Za-z0-9._-]+' "$out" | sed 's|.*/||' | sort -u || true)"
   diagrams=0
-  if [ -n "$refs" ]; then
+  if [[ -n "$refs" ]]; then
     mkdir -p "$out/docs/UML/diagrams"
     while IFS= read -r svg; do
-      [ -n "$svg" ] || continue
-      if [ ! -f "$src/docs/UML/diagrams/$svg" ]; then
+      [[ -n "$svg" ]] || continue
+      if [[ ! -f "$src/docs/UML/diagrams/$svg" ]]; then
         echo "ERROR: $name references UML/diagrams/$svg, which does not exist at $sha" >&2
         exit 1
       fi
@@ -155,15 +155,15 @@ for entry in "${COMPONENTS[@]}"; do
   # chapter text, then taken out of the same pinned checkout.
   figures=0
   for docdir in "$out"/docs/*/; do
-    [ -d "$docdir" ] || continue
+    [[ -d "$docdir" ]] || continue
     doc="$(basename "$docdir")"
     for kind in diagrams images; do
       frefs="$(grep -rhoE --include='*.adoc' "\{${kind}_uri\}/[A-Za-z0-9._-]+" "$docdir" | sed 's|.*/||' | sort -u || true)"
-      [ -n "$frefs" ] || continue
+      [[ -n "$frefs" ]] || continue
       mkdir -p "$out/docs/$doc/$kind"
       while IFS= read -r fig; do
-        [ -n "$fig" ] || continue
-        if [ ! -f "$src/docs/$doc/$kind/$fig" ]; then
+        [[ -n "$fig" ]] || continue
+        if [[ ! -f "$src/docs/$doc/$kind/$fig" ]]; then
           echo "ERROR: $name references $doc/$kind/$fig, which does not exist at $sha" >&2
           exit 1
         fi
@@ -173,7 +173,7 @@ for entry in "${COMPONENTS[@]}"; do
     done
   done
 
-  if [ "$diagrams" -gt 0 ]; then
+  if [[ "$diagrams" -gt 0 ]]; then
     diagram_note="- Plus the $diagrams UML class-diagram SVG(s) under \`docs/UML/diagrams/\` that
   the vendored chapters reference as \`image::{uml_diagrams_uri}/<name>.svg\`,
   taken from the same pinned commit. Referenced files only — the upstream
@@ -183,7 +183,7 @@ for entry in "${COMPONENTS[@]}"; do
   reference none."
   fi
 
-  if [ "$figures" -gt 0 ]; then
+  if [[ "$figures" -gt 0 ]]; then
     figure_note="- Plus the $figures per-document figure(s) under
   \`docs/<doc_name>/diagrams/\` and \`docs/<doc_name>/images/\` that the vendored
   chapters reference as \`image::{diagrams_uri}/<name>\` /
@@ -220,7 +220,7 @@ done
 REQ_OUT="$DEST/REQUIREMENTS"
 mkdir -p "$REQ_OUT"
 echo "==> REQUIREMENTS (release artifacts)"
-curl -fsSL -o "$REQ_OUT/iso18308_conformance.pdf" \
+curl -fsSL --proto '=https' --proto-redir '=https' -o "$REQ_OUT/iso18308_conformance.pdf" \
   "https://specifications.openehr.org/releases/1.0.2/requirements/iso18308_conformance.pdf"
 cat >"$REQ_OUT/PROVENANCE.md" <<'EOF'
 # Vendored openEHR requirements-conformance documents

--- a/scripts/watch/spec-release.sh
+++ b/scripts/watch/spec-release.sh
@@ -48,7 +48,7 @@ label_for_component() {
 filed=0 skipped=0
 # component|repo|ref|sha rows from the vendor script (the single pin source).
 while IFS='|' read -r comp repo ref sha; do
-  [ -n "$comp" ] || continue
+  [[ -n "$comp" ]] || continue
   # Highest Release-X.Y.Z tag (vN re-cut suffixes collapse to their base).
   if ! gh api "repos/openEHR/$repo/tags?per_page=100" --jq '[.[].name]' > "$tmp/tags.json" 2>"$tmp/gh-err"; then
     echo "spec-release-watcher: tags fetch FAILED for openEHR/$repo:" >&2
@@ -58,16 +58,16 @@ while IFS='|' read -r comp repo ref sha; do
   latest=$(jq -r '.[] | select(test("^Release-[0-9]+\\.[0-9]+\\.[0-9]+(v[0-9]+)?$"))
                   | sub("^Release-"; "") | sub("v[0-9]+$"; "")' "$tmp/tags.json" |
            sort -uV | tail -1)
-  if [ -z "$latest" ]; then
+  if [[ -z "$latest" ]]; then
     echo "  $comp (openEHR/$repo): no Release-* tags — skipped"
     continue
   fi
   pin_ver=$(echo "$ref" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
 
-  if [ -n "$pin_ver" ]; then
+  if [[ -n "$pin_ver" ]]; then
     # Comparable pin: only a strictly NEWER release is a missed event.
-    if [ "$latest" = "$pin_ver" ] ||
-      [ "$(printf '%s\n%s\n' "$latest" "$pin_ver" | sort -V | tail -1)" = "$pin_ver" ]; then
+    if [[ "$latest" = "$pin_ver" ]] ||
+      [[ "$(printf '%s\n%s\n' "$latest" "$pin_ver" | sort -V | tail -1)" = "$pin_ver" ]]; then
       skipped=$((skipped + 1))
       continue
     fi
@@ -75,7 +75,7 @@ while IFS='|' read -r comp repo ref sha; do
   # Board dedup — matches [spec-release] issues AND hand-made adoption
   # umbrellas that already carry the component + version in the title.
   covered=$(gh issue list --state all --search "\"$comp\" \"$latest\" in:title" --json number --jq 'length')
-  if [ "$covered" -gt 0 ]; then
+  if [[ "$covered" -gt 0 ]]; then
     echo "  $comp Release-$latest: already on the board — skipped"
     skipped=$((skipped + 1))
     continue
@@ -84,9 +84,9 @@ while IFS='|' read -r comp repo ref sha; do
   # Routing per the version policy.
   pin_major="${pin_ver%%.*}"
   rel_major="${latest%%.*}"
-  if [ "$comp" = "ITS-REST" ]; then
+  if [[ "$comp" = "ITS-REST" ]]; then
     routing="ITS-REST is single-version (always the latest RELEASED API): open an adoption umbrella like #178 — re-vendor the released tag, regenerate, implement the delta, sweep the served identity."
-  elif [ -n "$pin_ver" ] && [ "$rel_major" != "$pin_major" ]; then
+  elif [[ -n "$pin_ver" ]] && [[ "$rel_major" != "$pin_major" ]]; then
     routing="**MAJOR release** — incompatible by openEHR's release strategy: a per-component generation decision is required (dual generation via the am14/am24 codegen pattern only if the ecosystem runs both; otherwise cutover). See docs/VERSIONS.md §Spec version policy."
   else
     routing="Minor/patch of the pinned line (compatible superset): re-vendor at the release tag, regenerate, implement any behaviour delta, update docs/VERSIONS.md."
@@ -111,9 +111,9 @@ _Opened automatically by \`.github/workflows/spec-release-watcher.yml\`._
 EOF
   lbl=$(label_for_component "$comp")
   label_args=(--label spec-update --label P1)
-  [ -n "$lbl" ] && label_args+=(--label "$lbl")
+  [[ -n "$lbl" ]] && label_args+=(--label "$lbl")
   up_label="upstream:${comp}-${latest}"
-  if [ "$DRY_RUN" = "1" ]; then
+  if [[ "$DRY_RUN" = "1" ]]; then
     echo "DRY-RUN would create: $title  [${label_args[*]} --label $up_label]"
     sed 's/^/    │ /' "$tmp/body.md"
   else

--- a/scripts/watch/spec-update.sh
+++ b/scripts/watch/spec-update.sh
@@ -92,18 +92,18 @@ label_for_component() { # vendored component dir -> label
 pin_for_component() {
   local comp="$1" line ref sha ver
   line=$(grep -E "^  \"${comp}\|" scripts/vendor/spec-docs.sh | head -1 | tr -d '"') || true
-  [ -n "$line" ] || { echo "unpinned"; return 0; }
+  [[ -n "$line" ]] || { echo "unpinned"; return 0; }
   ref=$(echo "$line" | awk -F'|' '{print $3}')
   sha=$(echo "$line" | awk -F'|' '{printf "%.9s", $4}')
   # "master (BASE 1.3.0)" -> 1.3.0 · "Release-1.1.0" -> 1.1.0 · else the ref word
   ver=$(echo "$ref" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-  [ -n "$ver" ] || ver=$(echo "$ref" | awk '{print $1}')
+  [[ -n "$ver" ]] || ver=$(echo "$ref" | awk '{print $1}')
   echo "$ver @ $sha"
 }
 repo_for_component() {
   local comp="$1" line
   line=$(grep -E "^  \"${comp}\|" scripts/vendor/spec-docs.sh | head -1 | tr -d '"') || true
-  [ -n "$line" ] || return 1
+  [[ -n "$line" ]] || return 1
   echo "$line" | awk -F'|' '{print $2}'
 }
 # The numeric version of our pin for a component, empty when the pin has no
@@ -132,19 +132,19 @@ component_for_fixversion() {
 # (an equal-version target may postdate our vendored commit; triage decides).
 all_fixversions_inside_pin() {
   local fixv_names="$1" fallback_comp="$2" name comp fv_ver pin_ver any=1
-  [ -n "$fixv_names" ] || return 1
+  [[ -n "$fixv_names" ]] || return 1
   while IFS= read -r name; do
-    [ -n "$name" ] || continue
+    [[ -n "$name" ]] || continue
     any=0
     comp=$(component_for_fixversion "$name" "$fallback_comp")
-    [ -n "$comp" ] || return 1
+    [[ -n "$comp" ]] || return 1
     fv_ver=$(echo "$name" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-    [ -n "$fv_ver" ] || return 1
+    [[ -n "$fv_ver" ]] || return 1
     pin_ver=$(pin_version_for_component "$comp")
-    [ -n "$pin_ver" ] || return 1
-    [ "$fv_ver" = "$pin_ver" ] && return 1
+    [[ -n "$pin_ver" ]] || return 1
+    [[ "$fv_ver" = "$pin_ver" ]] && return 1
     # fv_ver < pin_ver ⟺ the version-sorted max is the pin
-    [ "$(printf '%s\n%s\n' "$fv_ver" "$pin_ver" | sort -V | tail -1)" = "$pin_ver" ] || return 1
+    [[ "$(printf '%s\n%s\n' "$fv_ver" "$pin_ver" | sort -V | tail -1)" = "$pin_ver" ]] || return 1
   done <<< "$fixv_names"
   return $any
 }
@@ -161,7 +161,8 @@ jira_fetch() { # $1 = full URL; body on stdout; one bounded retry on 429
       { echo "spec-update-watcher: curl transport failure for $url" >&2; return 1; }
     case "$code" in
       200) cat "$tmp/resp.json"; return 0 ;;
-      429) [ "$attempt" = 1 ] && { echo "Jira 429 — one bounded retry in 30s" >&2; sleep 30; continue; } ;;
+      429) [[ "$attempt" = 1 ]] && { echo "Jira 429 — one bounded retry in 30s" >&2; sleep 30; continue; } ;;
+      *) ;;
     esac
     echo "spec-update-watcher: Jira returned HTTP $code for $url" >&2
     head -c 500 "$tmp/resp.json" >&2 || true
@@ -178,14 +179,14 @@ echo "spec-update-watcher: Jira poll — window ${WINDOW_DAYS}d, projects ${PROJ
 token=""
 while :; do
   url="$JIRA/rest/api/3/search/jql?maxResults=50&fields=$fields&jql=$jql_enc"
-  [ -n "$token" ] && url="$url&nextPageToken=$(jq -rn --arg s "$token" '$s|@uri')"
+  [[ -n "$token" ]] && url="$url&nextPageToken=$(jq -rn --arg s "$token" '$s|@uri')"
   body=$(jira_fetch "$url")
   echo "$body" | jq -e 'has("issues") and has("isLast")' >/dev/null ||
     { echo "spec-update-watcher: unexpected Jira payload shape (no issues/isLast) — API changed?" >&2; exit 1; }
   echo "$body" | jq -c '.issues[]' >> "$tmp/jira.jsonl"
-  [ "$(echo "$body" | jq -r '.isLast')" = "true" ] && break
+  [[ "$(echo "$body" | jq -r '.isLast')" = "true" ]] && break
   token=$(echo "$body" | jq -r '.nextPageToken // empty')
-  [ -n "$token" ] || { echo "spec-update-watcher: isLast=false but no nextPageToken" >&2; exit 1; }
+  [[ -n "$token" ]] || { echo "spec-update-watcher: isLast=false but no nextPageToken" >&2; exit 1; }
 done
 
 jira_count=$(wc -l < "$tmp/jira.jsonl" | tr -d ' ')
@@ -217,6 +218,7 @@ while IFS= read -r issue; do
     "Rejected"|"Superseded"|"Won't Do"|"Won't Fix"|"Duplicate"|"Cannot Reproduce"|"Declined"|"Abandoned"|"Not a Bug")
       echo "  $key: resolution '$resolution' — no spec change, skipped"
       continue ;;
+    *) ;;
   esac
   component=$(component_for_project "$project")
   # A change whose fix versions are ALL strictly older than our pins is
@@ -251,7 +253,7 @@ amendment_files="$amendment_files
 docs/specs/openehr/ITS-REST/specifications/docs/overview/Amendment_record.md"
 
 while IFS= read -r local_path; do
-  [ -f "$local_path" ] || { echo "spec-update-watcher: vendored amendment file missing: $local_path" >&2; exit 1; }
+  [[ -f "$local_path" ]] || { echo "spec-update-watcher: vendored amendment file missing: $local_path" >&2; exit 1; }
   comp=${local_path#docs/specs/openehr/}; comp=${comp%%/*}
   rel=${local_path#docs/specs/openehr/"$comp"/}
   repo=$(repo_for_component "$comp") ||
@@ -266,7 +268,7 @@ while IFS= read -r local_path; do
   new_keys=$(comm -23 \
     <(grep -oE 'SPEC[A-Z]*-[0-9]+' "$tmp/upstream" | sort -u) \
     <(grep -oE 'SPEC[A-Z]*-[0-9]+' "$local_path" | sort -u) || true)
-  if [ -n "$new_keys" ]; then
+  if [[ -n "$new_keys" ]]; then
     while IFS= read -r key; do
       printf "%s${US}%s${US}%s${US}amendment${US}%s${US}%s${US}%s${US}%s${US}%s${US}%s${US}%s${US}%s${US}%s\n" \
         "$key" "$comp" "new amendment-record row in openEHR/$repo/$rel" \
@@ -284,7 +286,7 @@ done <<< "$amendment_files"
 echo "spec-update-watcher: commits-ahead cross-check against the vendored pins"
 ahead_created=0 ahead_updated=0 ahead_closed=0
 while IFS='|' read -r comp repo ref sha; do
-  [ -n "$comp" ] || continue
+  [[ -n "$comp" ]] || continue
   case "$ref" in master*) ;; *) continue ;; esac
   default=$(gh api "repos/openEHR/$repo" --jq '.default_branch') ||
     { echo "spec-update-watcher: failed to read openEHR/$repo default branch" >&2; exit 1; }
@@ -295,7 +297,7 @@ while IFS='|' read -r comp repo ref sha; do
   title="[spec-update] $comp spec repo is ahead of the vendored pin"
   num=$(gh issue list --state open --search "\"$title\" in:title" --json number,title \
         --jq "[.[] | select(.title == \"$title\")][0].number // empty")
-  if [ "$ahead" -gt 0 ]; then
+  if [[ "$ahead" -gt 0 ]]; then
     count_line="**Commits ahead of the pin:** $ahead (pin \`${sha:0:9}\`, upstream $default @ \`${head_sha:0:9}\`)"
     cat > "$tmp/ahead-body.md" <<EOF
 Upstream \`openEHR/$repo\` ($comp) has moved past our vendored pin — commit-delta triage needed (the per-commit triage pattern that closed #341).
@@ -314,11 +316,11 @@ $count_line
 
 _Maintained automatically by the spec-update watcher: the count above updates in place as the delta grows, and the issue closes when a re-vendor catches the pin up._
 EOF
-    if [ -n "$num" ]; then
+    if [[ -n "$num" ]]; then
       if gh issue view "$num" --json body --jq '.body' | grep -qF "$count_line"; then
         continue # unchanged since the last run
       fi
-      if [ "$DRY_RUN" = "1" ]; then
+      if [[ "$DRY_RUN" = "1" ]]; then
         echo "DRY-RUN would update #$num: $title ($ahead ahead)"
       else
         gh issue edit "$num" --body-file "$tmp/ahead-body.md" >/dev/null
@@ -328,8 +330,8 @@ EOF
     else
       label_args=(--label spec-update)
       lbl=$(label_for_component "$comp" || true)
-      [ -n "${lbl:-}" ] && label_args+=(--label "$lbl")
-      if [ "$DRY_RUN" = "1" ]; then
+      [[ -n "${lbl:-}" ]] && label_args+=(--label "$lbl")
+      if [[ "$DRY_RUN" = "1" ]]; then
         echo "DRY-RUN would create: $title ($ahead ahead)  [${label_args[*]}]"
         sed 's/^/    │ /' "$tmp/ahead-body.md"
       else
@@ -338,8 +340,8 @@ EOF
       fi
       ahead_created=$((ahead_created + 1))
     fi
-  elif [ -n "$num" ]; then
-    if [ "$DRY_RUN" = "1" ]; then
+  elif [[ -n "$num" ]]; then
+    if [[ "$DRY_RUN" = "1" ]]; then
       echo "DRY-RUN would close #$num: $title (pin caught up)"
     else
       gh issue comment "$num" --body "Auto-close (spec-update watcher): the vendored pin has caught up with upstream \`openEHR/$repo\` $default — 0 commits ahead." >/dev/null
@@ -362,19 +364,19 @@ amendment_keys=$(awk -F"$US" '$4 == "amendment" { print $1 }' "$CANDIDATES" | so
 
 created=0 skipped=0 unblocked=0
 while IFS="$US" read -r key component summary source resolved fixv comps status resolution itype jcreated fixv_plain descr; do
-  [ -n "$key" ] || continue
+  [[ -n "$key" ]] || continue
   match=$(gh issue list --state all --search "\"$key\" in:title" --json number,state,labels --jq '.[0] // empty')
-  if [ -n "$match" ]; then
+  if [[ -n "$match" ]]; then
     # AUTO-UNBLOCK: an amendment-diff hit means the key's normative text has
     # now LANDED upstream. If the board carries this key as an OPEN issue
     # labelled blocked-upstream (resolved in Jira before the text was
     # published), announce the landing and drop the label; every other
     # existing-issue hit keeps the silent dedup skip.
     if echo "$amendment_keys" | grep -qxF "$key" &&
-      [ "$(echo "$match" | jq -r '.state')" = "OPEN" ] &&
-      [ "$(echo "$match" | jq -r '[.labels[].name] | any(. == "blocked-upstream")')" = "true" ]; then
+      [[ "$(echo "$match" | jq -r '.state')" = "OPEN" ]] &&
+      [[ "$(echo "$match" | jq -r '[.labels[].name] | any(. == "blocked-upstream")')" = "true" ]]; then
       num=$(echo "$match" | jq -r '.number')
-      if [ "$DRY_RUN" = "1" ]; then
+      if [[ "$DRY_RUN" = "1" ]]; then
         echo "DRY-RUN would unblock #$num ($key): $summary"
       else
         gh issue comment "$num" --body "Auto-unblock (spec-update watcher): the normative text for $key has landed upstream — $summary. Re-vendor the component at pickup; this issue is implementable now — assign it to the current milestone when picked up (blocked issues carry no milestone)." >/dev/null
@@ -394,19 +396,19 @@ while IFS="$US" read -r key component summary source resolved fixv comps status 
     ""|"—") target="version unassigned" ;;
     *) target="$fixv_plain" ;;
   esac
-  if [ -n "$component" ]; then
+  if [[ -n "$component" ]]; then
     pin=$(pin_for_component "$component")
   else
     pin="n/a"
   fi
   short_summary="$summary"
-  if [ "${#short_summary}" -gt 90 ]; then
+  if [[ "${#short_summary}" -gt 90 ]]; then
     short_summary="${short_summary:0:87}..."
   fi
   title="[spec-update] $key — $short_summary"
   label_args=(--label spec-update)
-  lbl=$([ -n "$component" ] && label_for_component "$component" || true)
-  [ -n "${lbl:-}" ] && label_args+=(--label "$lbl")
+  lbl=$([[ -n "$component" ]] && label_for_component "$component" || true)
+  [[ -n "${lbl:-}" ]] && label_args+=(--label "$lbl")
 
   cat > "$tmp/body.md" <<EOF
 Upstream openEHR spec change completed — conformance-impact triage needed.
@@ -423,7 +425,7 @@ Upstream openEHR spec change completed — conformance-impact triage needed.
 
 $summary
 
-$([ -n "$descr" ] && printf '<details><summary>Upstream description (excerpt)</summary>\n\n%s\n\n</details>' "$descr")
+$([[ -n "$descr" ]] && printf '<details><summary>Upstream description (excerpt)</summary>\n\n%s\n\n</details>' "$descr")
 
 ### Triage checklist
 
@@ -435,7 +437,7 @@ $([ -n "$descr" ] && printf '<details><summary>Upstream description (excerpt)</s
 _Opened automatically by \`.github/workflows/spec-update-watcher.yml\`._
 EOF
 
-  if [ "$DRY_RUN" = "1" ]; then
+  if [[ "$DRY_RUN" = "1" ]]; then
     echo "DRY-RUN would create: $title  [${label_args[*]}]"
     sed 's/^/    │ /' "$tmp/body.md"
   else

--- a/website/book/src/performance.md
+++ b/website/book/src/performance.md
@@ -83,8 +83,8 @@ to disk before the server answers, so an acknowledged commit survives a crash.
 That flush (one `fsync` on the WAL device per commit) is a physical lower
 bound on single-client write latency, and no storage design takes a lone
 sequential client below it. On a laptop-class Docker setup the flush alone
-measures around 1.5–2 ms; on server NVMe it is typically an order of magnitude
-smaller. FerroEHR's optimization target is therefore everything *around* the
+dominates a single write's budget; on server NVMe it is typically an order of
+magnitude smaller. FerroEHR's optimization target is therefore everything *around* the
 flush: the database's own per-commit work (one folded commit statement, one
 merged placement read) stays far below the flush itself. That is also what
 makes concurrent throughput scale: PostgreSQL group-commits, amortizing one


### PR DESCRIPTION
The shell half of the #2640 program (the class adjudication is on the issue).

**shelldre:S7688 (398 sites, 57 files):** every command-position `[ ]` test in a bash script becomes `[[ ]]`. The transform was structural, not a blind sed — jq/awk program strings, heredoc markdown checklists and array literals were excluded by position; every unquoted right-hand side of a comparison was quoted so nothing silently became a glob pattern; the three arithmetic-comparison sites were adjudicated individually (`jq length` outputs make `[[ ]]`'s arithmetic evaluation behaviourally identical). `docker/terminology/seed.sh` is the tree's ONE deliberate POSIX script (the container runs it via `/bin/sh`, no bash) — skipped, and its header now says so, so nobody refiles it.

**shelldre:S131 (29 sites, 16 files):** every `case` gains a default arm. Two are loud refusals where an unexpected value is a defect — `deploy/helm/ci/boot-check.sh` (an env source the replay cannot handle — the #2159 hole class) and `scripts/checks/vex-reachability.sh` (a dependency level with no report label); the other 27 are `*) ;;` where fall-through is the design (poll loops, membership filters, integer guards, base64 padding).

**shell:S6506 (5 sites):** every `curl -L` in `scripts/vendor/*.sh` now refuses an HTTPS→HTTP redirect (`--proto '=https' --proto-redir '=https'`) — a silent downgrade would alter bytes that get committed verbatim, the class the provenance discipline exists for. The CKM fetchers carry no `-L` and are untouched.

**Riding along, found under the same sweep:** the docs lane has been red on develop since #2726 — `conformance-numbers.sh` rightly refused the durability paragraph's hand-typed "1.5–2 ms"; the sentence now states the boundary without a literal and the guard is green. And the `rel.sh`/`project.sh` `usage()` banners printed a hardcoded line window of their own source that had drifted (SPDX noise at the top, `set -euo pipefail` and `die() {` leaking in at the bottom); both now print the header comment block structurally, so header edits can never misalign them.

Verification: `bash -n` on all changed files (0 failures); per-file shellcheck before/after — zero new findings, full-tree totals identical; the repo's own check suite green (comment-style/typed-status/default-style/compose-image-tags/no-python/docs-claims/conformance-numbers); behavioural spot-runs green (`rel.sh` banner, `project.sh url`, `deploy/helm/validate.sh` ALL RENDER CHECKS PASSED, `zenodo-json.sh --check`).

Part of #2640.