### PR TITLE
chore(conformance): COMPARISON.md follows the 4.0.3 artifact stamp

### DIFF
--- a/docs/conformance/COMPARISON.md
+++ b/docs/conformance/COMPARISON.md
@@ -19,7 +19,7 @@
 
 | | ferroehr | EHRbase |
 |---|---|---|
-| Product | ferroehr 4.0.2 | ehrbase 2.34.0 |
+| Product | ferroehr 4.0.3 | ehrbase 2.34.0 |
 | Run date | 2026-08-25 | 2026-08-14 |
 | Party statement | committed with the runner (declares ITS-REST pin, signing, terminology posture) | committed with the runner |
 | Stack | the project's own compose stack, built from the current sources | a dedicated compose stack of the official EHRbase images |


### PR DESCRIPTION
The docs lane's party-documents drift gate is red on develop: #2726 committed the conformance run's refreshed `results.json` (version stamp 4.0.2 → 4.0.3) but not the DERIVED `docs/conformance/COMPARISON.md`, which `scripts/render/comparison.sh` regenerates from it. Regenerated; the diff is exactly the one product-version cell the gate showed. (The lane's other red — the hand-typed latency literal — was already fixed in #2735.)