### PR TITLE
chore(memory): a conformance-artifact commit runs the full docs render set

### DIFF
--- a/.claude/memory/session-workflow-gotchas.md
+++ b/.claude/memory/session-workflow-gotchas.md
@@ -138,3 +138,12 @@ commit-message wording; close/reopen for late labels.
   `gh pr merge --merge` behind the green-gate `if` (gotcha 6). `gh run
   rerun` refuses while the run is `in_progress` — wait for `completed`
   first.
+
+8. **A conformance-artifact commit must run the FULL docs render set** (hit
+   three times on 2026-08-25: the #2726 artifact refresh turned the docs lane
+   red in three successive drift gates). Committing a regenerated
+   `docs/conformance/<sut>/results.json` obligates, in the SAME commit, every
+   derived surface docs.yml regenerates and diffs: `conformance-stats.sh
+   includes`, `comparison.sh` (COMPARISON.md), `perf-assets.sh`,
+   `conformance-assets.sh` (+ `CONF_SUT=ehrbase`), `conformance-docs.sh`
+   (report/certificate/badges). Run all six, commit whatever changed.


### PR DESCRIPTION
Learned three times in one day (#2726 → #2735's literal fix, #2737's COMPARISON.md, #2739's SVGs): committing a refreshed `results.json` obligates every derived surface the docs lane's drift gates regenerate, in the same commit. Recorded as gotcha 8.