### PR TITLE
docs(admin-ui): login_guard's doc names its private helper as a code span

### DIFF
--- a/app/ferroehr-admin-ui/src/server.rs
+++ b/app/ferroehr-admin-ui/src/server.rs
@@ -88,7 +88,7 @@ pub fn router(app_state: AppState, leptos_options: LeptosOptions) -> axum::Route
 /// navigation gate.
 ///
 /// Scope: `GET`/`HEAD` on everything except the public paths
-/// ([`is_public_path`]). Server-function calls (`/api/…`) keep their own
+/// (`is_public_path`). Server-function calls (`/api/…`) keep their own
 /// typed refusals; the export POST enforces its own session.
 ///
 /// Fail-closed: a request that reaches this layer without session machinery


### PR DESCRIPTION
The develop CI red after #2729: `rustdoc::private_intra_doc_links` (deny) refuses a public item's intra-doc link to the private `is_public_path` — the console's OWN rustdoc step, which my gate run skipped (I ran the workspace lane, which excludes the console). Link → code span; `RUSTDOCFLAGS="-D warnings" cargo doc -p ferroehr-admin-ui --features ssr --no-deps` green locally.