### PR TITLE
fix(admin-ui): the routed-response test helper carries the harness expect scope

### DIFF
--- a/app/ferroehr-admin-ui/tests/it/ssr_shell.rs
+++ b/app/ferroehr-admin-ui/tests/it/ssr_shell.rs
@@ -353,6 +353,12 @@ async fn the_matched_screen_renders_inside_the_shell_s_main_region() {
 /// One request through the REAL service — `ferroehr_admin_ui::server::router`
 /// is the assembly the binary serves (session layer, the pre-render login
 /// guard, the Leptos routes, the security headers) — with no session cookie.
+#[expect(
+    clippy::expect_used,
+    reason = "every step here is fixture construction over constants — a static URI, an empty \
+              body, an in-memory response, the UTF-8 the server just wrote; a fixture that \
+              cannot be built is a broken harness, not a test outcome"
+)]
 async fn routed_response(url: &str) -> ServerPass {
     use tower::util::ServiceExt;
 


### PR DESCRIPTION
The develop CI clippy red: `clippy::expect_used` (deny) fires on test-file HELPER functions — `allow-expect-in-tests` scopes only `#[test]` fns — and #2729's new `routed_response` helper lacked the scoped `#[expect(clippy::expect_used, reason)]` its sibling `render_route` carries. Same attribute, same reason shape. Honest cause: I re-ran the wasm lane, nextest, leptosfmt and fmt after writing the tests, but not the NATIVE clippy lane. Green now: native clippy `-D warnings`, the ssr_shell suite, fmt.