### PR TITLE
fix(fuzz): the AQL parser's Rc cycles and the stricter-than-spec identifier assertion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5503,7 +5503,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "indexmap 2.14.0",
  "openehr-am",
@@ -5519,7 +5519,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "serde",
  "serde_json",
@@ -5548,7 +5548,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "async-trait",
  "axum",
@@ -5577,7 +5577,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "assert_fs",
  "chumsky",
@@ -5591,7 +5591,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "chumsky",
  "logos",
@@ -5600,7 +5600,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "insta",
  "jsonschema",
@@ -5618,7 +5618,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-adl"
-version = "0.0.38"
+version = "0.0.39"
 description = "openEHR ADL 2.4.0: hand-written ADL2/cADL/ODIN parser, AOM2 validation catalogue, specialisation flattener, OPT2 generator, and ADL 1.4→2 conversion over the generated openehr_am::v2_4::aom2 model"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,11 +16,11 @@ include = ["src/**", "README.md", "LICENSE-MIT"]
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)
-openehr-base = { path = "../openehr-base", version = "0.0.38" }   # VersionStatus for the parsed HRID
-openehr-am = { path = "../openehr-am", version = "0.0.38" }       # v2_4 ArchetypeHrid (the identification target type)
-openehr-rm = { path = "../openehr-rm", version = "0.0.38" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
-openehr-lang = { path = "../openehr-lang", version = "0.0.38" }   # openehr_lang::odin — the ODIN section parser
-openehr-term = { path = "../openehr-term", version = "0.0.38" }   # the languages code set for the RM resource-meta rows
+openehr-base = { path = "../openehr-base", version = "0.0.39" }   # VersionStatus for the parsed HRID
+openehr-am = { path = "../openehr-am", version = "0.0.39" }       # v2_4 ArchetypeHrid (the identification target type)
+openehr-rm = { path = "../openehr-rm", version = "0.0.39" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
+openehr-lang = { path = "../openehr-lang", version = "0.0.39" }   # openehr_lang::odin — the ODIN section parser
+openehr-term = { path = "../openehr-term", version = "0.0.39" }   # the languages code set for the RM resource-meta rows
 uuid.workspace = true        # meta uid/build_uid (AUTHORED_ARCHETYPE.uid: Uuid)
 indexmap.workspace = true    # OdinValue::Object body (insertion-ordered map)
 

--- a/crates/openehr-am/Cargo.toml
+++ b/crates/openehr-am/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-am"
-version = "0.0.38"
+version = "0.0.39"
 description = "openEHR AM Archetype Model, generated from BMM: generations v1_4 (AM 1.4.0, ADL 1.4) and v2_4 (AM 2.4.0, ADL 2; current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,8 +13,8 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.38" }
-openehr-lang = { path = "../openehr-lang", version = "0.0.38" }
+openehr-base = { path = "../openehr-base", version = "0.0.39" }
+openehr-lang = { path = "../openehr-lang", version = "0.0.39" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also carries the untyped `Value` fields the generator

--- a/crates/openehr-base/Cargo.toml
+++ b/crates/openehr-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-base"
-version = "0.0.38"
+version = "0.0.39"
 description = "openEHR BASE foundation + base types, generated from BMM: generations v1_2 (BASE 1.2.0) and v1_3 (BASE 1.3.0, current)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-base/src/v1_2/base_types/identification/object_version_id_impl.rs
+++ b/crates/openehr-base/src/v1_2/base_types/identification/object_version_id_impl.rs
@@ -247,6 +247,27 @@ mod tests {
     /// The verbatim accessor preserves case where the typed one normalises it
     /// (BASE master05 §"Composite Identifiers and Case", case-preserving half).
     #[test]
+    fn uppercase_uuid_recomposes_to_the_same_identifier() {
+        let original = "8849182c-82ad-40A8-a07f-48ead4180515::ferroehr.example.org::1.2.3";
+        let o = ObjectVersionId::new(original).expect("a legal OBJECT_VERSION_ID");
+        assert_eq!(o.value(), original, "storage is case-preserving");
+        let recomposed = ObjectVersionId::compose(
+            &o.object_id(),
+            &o.creating_system_id(),
+            &o.version_tree_id(),
+        );
+        assert_eq!(
+            recomposed.value(),
+            "8849182c-82ad-40a8-a07f-48ead4180515::ferroehr.example.org::1.2.3",
+            "the typed Uid door renders the UUID part in RFC 4122 lowercase"
+        );
+        assert!(
+            super::super::lexical::composite_ids_equal(recomposed.value(), o.value()),
+            "the two spellings identify the same thing (master05 case-insensitive)"
+        );
+    }
+
+    #[test]
     fn creating_system_id_str_is_verbatim() {
         let o = ovid("1.2.840::openEHR.org::1");
         assert_eq!(o.creating_system_id_str(), "openEHR.org");

--- a/crates/openehr-base/src/v1_3/base_types/identification/object_version_id_impl.rs
+++ b/crates/openehr-base/src/v1_3/base_types/identification/object_version_id_impl.rs
@@ -247,6 +247,27 @@ mod tests {
     /// The verbatim accessor preserves case where the typed one normalises it
     /// (BASE master05 §"Composite Identifiers and Case", case-preserving half).
     #[test]
+    fn uppercase_uuid_recomposes_to_the_same_identifier() {
+        let original = "8849182c-82ad-40A8-a07f-48ead4180515::ferroehr.example.org::1.2.3";
+        let o = ObjectVersionId::new(original).expect("a legal OBJECT_VERSION_ID");
+        assert_eq!(o.value(), original, "storage is case-preserving");
+        let recomposed = ObjectVersionId::compose(
+            &o.object_id(),
+            &o.creating_system_id(),
+            &o.version_tree_id(),
+        );
+        assert_eq!(
+            recomposed.value(),
+            "8849182c-82ad-40a8-a07f-48ead4180515::ferroehr.example.org::1.2.3",
+            "the typed Uid door renders the UUID part in RFC 4122 lowercase"
+        );
+        assert!(
+            super::super::lexical::composite_ids_equal(recomposed.value(), o.value()),
+            "the two spellings identify the same thing (master05 case-insensitive)"
+        );
+    }
+
+    #[test]
     fn creating_system_id_str_is_verbatim() {
         let o = ovid("1.2.840::openEHR.org::1");
         assert_eq!(o.creating_system_id_str(), "openEHR.org");

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-its"
-version = "0.0.38"
+version = "0.0.39"
 description = "openEHR ITS (Implementation Technology Specifications): canonical JSON + canonical XML serialization of the RM, the generated ITS-REST 1.1.0 API contract, OPT 1.4 and AOM2 archetype XML codecs, and the Simplified Formats (FLAT / STRUCTURED / Web Template)"
 edition.workspace = true
 rust-version.workspace = true
@@ -41,14 +41,14 @@ regex = { workspace = true, optional = true }
 fancy-regex = { workspace = true, optional = true }
 # The generated XML (de)serializers impl the crate's ToXml/FromXml traits for the
 # RM/BASE spec types, so these are real (non-dev) deps.
-openehr-base = { path = "../openehr-base", version = "0.0.38", optional = true }
-openehr-rm = { path = "../openehr-rm", version = "0.0.38", optional = true }
+openehr-base = { path = "../openehr-base", version = "0.0.39", optional = true }
+openehr-rm = { path = "../openehr-rm", version = "0.0.39", optional = true }
 # The native canonical-JSON codec (`json_codec/generated`, emit-json) implements
 # `ToJson` for EVERY generated spec type the `OpenEhrType` derive covers, so it
 # spans all five spec crates (not just the RM/BASE the XML codec needs).
-openehr-lang = { path = "../openehr-lang", version = "0.0.38", optional = true }
-openehr-am = { path = "../openehr-am", version = "0.0.38", optional = true }
-openehr-term = { path = "../openehr-term", version = "0.0.38", optional = true }
+openehr-lang = { path = "../openehr-lang", version = "0.0.39", optional = true }
+openehr-am = { path = "../openehr-am", version = "0.0.39", optional = true }
+openehr-term = { path = "../openehr-term", version = "0.0.39", optional = true }
 
 # `full` — every ITS surface (canonical JSON/XML, the generated ITS-REST
 # contract, `opt14`, Simplified Formats). ON BY DEFAULT, so every consumer sees

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-lang"
-version = "0.0.38"
+version = "0.0.39"
 description = "openEHR LANG BMM/P_BMM object model, generated from BMM: generations v1_0 (LANG 1.0.0) and v1_1 (LANG 1.1.0, current; the stable BMM v2.x unit beside the paused BMM3 unit), plus hand-written ODIN/BEL/EL readers"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["parser-implementations", "data-structures"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.38" }
+openehr-base = { path = "../openehr-base", version = "0.0.39" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the
 # generated types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) —
 # never a derive. `serde_json` also carries the untyped `Value` fields the

--- a/crates/openehr-query/Cargo.toml
+++ b/crates/openehr-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-query"
-version = "0.0.38"
+version = "0.0.39"
 description = "openEHR QUERY (AQL 1.1.0): hand-written lexer, parser, typed AST and canonical printer from the official grammar (no ANTLR runtime)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-query/src/parser.rs
+++ b/crates/openehr-query/src/parser.rs
@@ -329,10 +329,51 @@ fn path_parsers<'a>() -> (
     impl Parser<'a, &'a [Token], PathPredicate, Err<'a>> + Clone,
     impl Parser<'a, &'a [Token], StandardPredicate, Err<'a>> + Clone,
 ) {
-    let mut identified = Recursive::declare();
-    let mut object = Recursive::declare();
-    let mut predicate = Recursive::declare();
+    // The only genuine recursion is objectPath → pathPart → pathPredicate →
+    // objectPath, expressed through `recursive`'s WEAK self-handle. The
+    // former three `Recursive::declare` handles owned each other through
+    // their definitions (object ⇄ predicate) — an Rc cycle chumsky never
+    // breaks, one leaked parser graph per `parse_str` call (#2746). The
+    // predicate family the caller receives is a second instance over the
+    // finished `object`, held OUTSIDE its definition, so it drops with the
+    // query parser.
+    let object = recursive(|object| {
+        let (predicate, _standard) = predicate_parsers(object);
+        // pathPart : IDENTIFIER pathPredicate?
+        let path_part = ident()
+            .then(predicate.or_not())
+            .map(|(name, predicate)| PathPart { name, predicate });
+        // objectPath : pathPart ('/' pathPart)*
+        path_part
+            .separated_by(just(Token::Slash))
+            .at_least(1)
+            .collect::<Vec<_>>()
+            .map(|parts| ObjectPath { parts })
+    });
+    let (predicate, standard) = predicate_parsers(object.clone());
 
+    // identifiedPath : IDENTIFIER pathPredicate? ('/' objectPath)?
+    let identified = ident()
+        .then(predicate.clone().or_not())
+        .then(just(Token::Slash).ignore_then(object).or_not())
+        .map(|((root, predicate), path)| IdentifiedPath {
+            root,
+            predicate,
+            path,
+        });
+
+    (identified, predicate, standard)
+}
+
+/// The `pathPredicate` and `standardPredicate` parsers over a given
+/// `objectPath` parser — the non-recursive half of the path grammar
+/// ([`path_parsers`] wires the recursion).
+fn predicate_parsers<'a>(
+    object: impl Parser<'a, &'a [Token], ObjectPath, Err<'a>> + Clone + 'a,
+) -> (
+    impl Parser<'a, &'a [Token], PathPredicate, Err<'a>> + Clone,
+    impl Parser<'a, &'a [Token], StandardPredicate, Err<'a>> + Clone,
+) {
     // pathPredicateOperand : primitive | objectPath | PARAMETER | ID_CODE | AT_CODE
     let code = select! { Token::IdCode(s) => s, Token::AtCode(s) => s };
     let predicate_operand = primitive()
@@ -404,44 +445,16 @@ fn path_parsers<'a>() -> (
     // comparison classifies as `PathPredicate::Standard`. We realise that split
     // by parsing the node boolean tree and lifting a *top-level* bare
     // `NodePredicate::Standard` back out; `archetype` wins for a plain HRID.
-    predicate.define(
-        archetype
-            .clone()
-            .map(PathPredicate::Archetype)
-            .or(node.map(|n| match n {
-                NodePredicate::Standard(s) => PathPredicate::Standard(s),
-                other => PathPredicate::Node(Box::new(other)),
-            }))
-            .delimited_by(just(Token::LeftBracket), just(Token::RightBracket)),
-    );
+    let predicate = archetype
+        .clone()
+        .map(PathPredicate::Archetype)
+        .or(node.map(|n| match n {
+            NodePredicate::Standard(s) => PathPredicate::Standard(s),
+            other => PathPredicate::Node(Box::new(other)),
+        }))
+        .delimited_by(just(Token::LeftBracket), just(Token::RightBracket));
 
-    // pathPart : IDENTIFIER pathPredicate?
-    let path_part = ident()
-        .then(predicate.clone().or_not())
-        .map(|(name, predicate)| PathPart { name, predicate });
-
-    // objectPath : pathPart ('/' pathPart)*
-    object.define(
-        path_part
-            .separated_by(just(Token::Slash))
-            .at_least(1)
-            .collect::<Vec<_>>()
-            .map(|parts| ObjectPath { parts }),
-    );
-
-    // identifiedPath : IDENTIFIER pathPredicate? ('/' objectPath)?
-    identified.define(
-        ident()
-            .then(predicate.clone().or_not())
-            .then(just(Token::Slash).ignore_then(object.clone()).or_not())
-            .map(|((root, predicate), path)| IdentifiedPath {
-                root,
-                predicate,
-                path,
-            }),
-    );
-
-    (identified, predicate, standard)
+    (predicate, standard)
 }
 
 // ── functions & terminals ───────────────────────────────────────────────────
@@ -464,15 +477,10 @@ fn terminology_fn<'a>() -> impl Parser<'a, &'a [Token], TerminologyFunction, Err
         })
 }
 
-/// `functionCall` and `aggregateFunctionCall`, given the `identified_path` and
-/// `terminal` parsers.
-fn function_parsers<'a>(
-    identified: impl Parser<'a, &'a [Token], IdentifiedPath, Err<'a>> + Clone + 'a,
+/// `functionCall`, given the `terminal` parser (its argument grammar).
+fn function_parser<'a>(
     terminal: impl Parser<'a, &'a [Token], Terminal, Err<'a>> + Clone + 'a,
-) -> (
-    impl Parser<'a, &'a [Token], FunctionCall, Err<'a>> + Clone,
-    impl Parser<'a, &'a [Token], AggregateCall, Err<'a>> + Clone,
-) {
+) -> impl Parser<'a, &'a [Token], FunctionCall, Err<'a>> + Clone {
     // functionCall : terminologyFunction | name '(' (terminal (',' terminal)*)? ')'
     // The STRING function `CONTAINS(expr, substring)` shares its name with the
     // containment keyword (QUERY master03 §Functions/String functions) — in
@@ -487,8 +495,15 @@ fn function_parsers<'a>(
                 .delimited_by(just(Token::LeftParen), just(Token::RightParen)),
         )
         .map(|(name, args)| FunctionCall::Named { name, args });
-    let function = terminology_fn().map(FunctionCall::Terminology).or(named);
+    terminology_fn().map(FunctionCall::Terminology).or(named)
+}
 
+/// `aggregateFunctionCall`, given the `identified_path` parser (aggregates
+/// take a path or `*`, never a `terminal` — which is what lets this builder
+/// live outside the `terminal` recursion, #2746).
+fn aggregate_parser<'a>(
+    identified: impl Parser<'a, &'a [Token], IdentifiedPath, Err<'a>> + Clone + 'a,
+) -> impl Parser<'a, &'a [Token], AggregateCall, Err<'a>> + Clone {
     // aggregateFunctionCall
     let count = just(Token::Count).ignore_then(
         just(Token::Distinct)
@@ -517,7 +532,7 @@ fn function_parsers<'a>(
                 .delimited_by(just(Token::LeftParen), just(Token::RightParen)),
         )
         .map(|(func, path)| AggregateCall::Stat { func, path });
-    (function, count.or(stat))
+    count.or(stat)
 }
 
 // ── top-level query ──────────────────────────────────────────────────────────
@@ -534,16 +549,24 @@ fn query<'a>() -> impl Parser<'a, &'a [Token], SelectQuery, Err<'a>> {
     let (identified, predicate, standard) = path_parsers();
 
     // terminal : primitive | PARAMETER | identifiedPath | functionCall
-    // (functionCall needs terminal → declare terminal recursively.)
-    let mut terminal = Recursive::declare();
-    let (function, aggregate) = function_parsers(identified.clone(), terminal.clone());
-    terminal.define(
+    // (functionCall needs terminal → the self-reference goes through
+    // `recursive`'s WEAK handle. `Recursive::declare` hands out an OWNED
+    // handle, and embedding its clone in its own `define` is an Rc cycle
+    // chumsky never breaks — one leaked parser graph per `parse_str` call,
+    // found by the nightly LeakSanitizer lane, #2746.)
+    let terminal = recursive(|terminal| {
+        let function = function_parser(terminal);
         primitive()
             .map(Terminal::Primitive)
             .or(parameter().map(Terminal::Parameter))
-            .or(function.clone().map(Terminal::Function))
-            .or(identified.clone().map(Terminal::Path)),
-    );
+            .or(function.map(Terminal::Function))
+            .or(identified.clone().map(Terminal::Path))
+    });
+    // The column-level functionCall is its own instance: it holds an OWNED
+    // handle to `terminal`, which is cycle-free because it lives outside
+    // terminal's definition and drops with the query parser.
+    let function = function_parser(terminal.clone());
+    let aggregate = aggregate_parser(identified.clone());
 
     // ── SELECT ──
     // columnExpr : identifiedPath | primitive | aggregateFunctionCall | functionCall

--- a/crates/openehr-query/tests/it/printer_round_trip.rs
+++ b/crates/openehr-query/tests/it/printer_round_trip.rs
@@ -107,3 +107,15 @@ fn a_parenthesised_contains_is_not_its_unparenthesised_twin() {
         "the CONTAINS operand is greedy, so these two sources must not parse alike"
     );
 }
+
+/// The nightly fuzz artifact (#2746): this exact input exposed the
+/// `Recursive::declare` Rc cycle that leaked one parser graph per
+/// `parse_str` call. The leak property itself is guarded by the nightly
+/// LeakSanitizer lane over the committed seed
+/// (`fuzz/seeds/aql_query/leak_2746_simple_select.aql`); this pins the
+/// behavioural half — the restructured recursion parses and round-trips the
+/// same query.
+#[test]
+fn the_leak_artifact_query_still_parses_and_round_trips() {
+    assert_round_trips("SELECT e/ehr_id/value FROM EHR e\n");
+}

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-rm"
-version = "0.0.38"
+version = "0.0.39"
 description = "openEHR RM Reference Model, generated from BMM: generations v1_1 (RM 1.1.0) and v1_2 (RM 1.2.0, current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,11 +13,11 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.38" }
+openehr-base = { path = "../openehr-base", version = "0.0.39" }
 # The terminology-backed RM class invariants (`validate::terminology`) resolve
 # openEHR terminology groups + code sets against the vendored TERM 3.1.0 bundle.
 # `openehr-term` itself depends only on `openehr-base`, so this is acyclic.
-openehr-term = { path = "../openehr-term", version = "0.0.38" }
+openehr-term = { path = "../openehr-term", version = "0.0.39" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also backs the untyped `Value` RM representation used by

--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-term"
-version = "0.0.38"
+version = "0.0.39"
 description = "openEHR TERM terminology data model, generated from BMM (generation v3_1 = TERM 3.1.0), plus the embedded official terminology XML bundle"
 edition.workspace = true
 rust-version.workspace = true
@@ -34,7 +34,7 @@ include = [
 ]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.38" }
+openehr-base = { path = "../openehr-base", version = "0.0.39" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1281,7 +1281,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.34"
+version = "0.0.39"
 dependencies = [
  "indexmap",
  "openehr-am",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.34"
+version = "0.0.39"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.34"
+version = "0.0.39"
 dependencies = [
  "serde",
  "serde_json",
@@ -1317,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.34"
+version = "0.0.39"
 dependencies = [
  "async-trait",
  "axum",
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.34"
+version = "0.0.39"
 dependencies = [
  "chumsky",
  "indexmap",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.34"
+version = "0.0.39"
 dependencies = [
  "chumsky",
  "logos",
@@ -1364,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.34"
+version = "0.0.39"
 dependencies = [
  "openehr-base",
  "openehr-term",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.34"
+version = "0.0.39"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/fuzz/fuzz_targets/identifiers.rs
+++ b/fuzz/fuzz_targets/identifiers.rs
@@ -22,6 +22,7 @@ use libfuzzer_sys::fuzz_target;
 use std::str::FromStr;
 
 use openehr_base::prelude::{ArchetypeId, HierObjectId, ObjectVersionId, VersionTreeId};
+use openehr_base::v1_3::base_types::identification::lexical::composite_ids_equal;
 
 fuzz_target!(|data: &[u8]| {
     // Identifiers arrive as text; non-UTF-8 is rejected by the HTTP layer long
@@ -40,14 +41,19 @@ fuzz_target!(|data: &[u8]| {
         let _ = ovid.creating_system_id_str();
         let _ = ovid.is_branch();
 
-        // The composite's own contract, checked rather than assumed: a value
-        // reassembled from the three parts this reader just produced must equal
-        // it. A reader that mis-slices one of the two separator kinds can still
-        // return Ok, and only a recomposition catches that.
-        assert_eq!(
-            ObjectVersionId::compose(&object_id, &system, &tree),
-            ovid,
-            "an OBJECT_VERSION_ID recomposed from its own parts must equal itself"
+        // A value reassembled from the parts this reader produced must
+        // IDENTIFY the same thing — a mis-slice moves a `::` boundary, which
+        // no case fold hides. BASE master05 §Composite Identifiers and Case
+        // makes the comparison case-insensitive; the typed `Uid` door renders
+        // a UUID part lowercase, so byte equality refused a legal spelling of
+        // the same identifier (#2746).
+        let recomposed = ObjectVersionId::compose(&object_id, &system, &tree);
+        assert!(
+            composite_ids_equal(recomposed.value(), ovid.value()),
+            "an OBJECT_VERSION_ID recomposed from its own parts must identify \
+             itself (master05 case-insensitive comparison): {} vs {}",
+            recomposed.value(),
+            ovid.value()
         );
     }
 

--- a/tools/openehr-codegen/templates/openehr-base/base_types/identification/object_version_id_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-base/base_types/identification/object_version_id_impl.rs
@@ -247,6 +247,27 @@ mod tests {
     /// The verbatim accessor preserves case where the typed one normalises it
     /// (BASE master05 §"Composite Identifiers and Case", case-preserving half).
     #[test]
+    fn uppercase_uuid_recomposes_to_the_same_identifier() {
+        let original = "8849182c-82ad-40A8-a07f-48ead4180515::ferroehr.example.org::1.2.3";
+        let o = ObjectVersionId::new(original).expect("a legal OBJECT_VERSION_ID");
+        assert_eq!(o.value(), original, "storage is case-preserving");
+        let recomposed = ObjectVersionId::compose(
+            &o.object_id(),
+            &o.creating_system_id(),
+            &o.version_tree_id(),
+        );
+        assert_eq!(
+            recomposed.value(),
+            "8849182c-82ad-40a8-a07f-48ead4180515::ferroehr.example.org::1.2.3",
+            "the typed Uid door renders the UUID part in RFC 4122 lowercase"
+        );
+        assert!(
+            super::super::lexical::composite_ids_equal(recomposed.value(), o.value()),
+            "the two spellings identify the same thing (master05 case-insensitive)"
+        );
+    }
+
+    #[test]
     fn creating_system_id_str_is_verbatim() {
         let o = ovid("1.2.840::openEHR.org::1");
         assert_eq!(o.creating_system_id_str(), "openEHR.org");


### PR DESCRIPTION
Closes #2746. Both nightly-red findings, attributed per the triage law and fixed at the source — full investigation on the issue.

**The leak (real server defect, not fuzzer-only):** every `openehr_query::parser::parse_str` call leaked ~5.7 KB — `Recursive::declare`'s OWNED Rc handles were embedded in their own definitions (the `terminal` grammar, and the `object ⇄ predicate` pair), cycles chumsky never breaks (verified against the chumsky 0.13.0 source: only `recursive()`'s closure handle is Weak, via `Rc::new_cyclic`; `declare()` wraps an owned Rc). Since the parser is built per call, the PUBLIC query endpoint leaked per request. All recursion now goes through `recursive()`'s Weak self-handle; the predicate/functionCall instances the rest of the grammar consumes are second instances over the finished parsers, held outside the definitions. Zero `declare` sites remain; the 64-case corpus (including the new leak-input round-trip pin) passes untouched.

**The identifier assertion:** the harness demanded byte-equality of a recomposed `OBJECT_VERSION_ID` with its original; the typed `Uid` door renders UUID parts in RFC 4122 lowercase, so `…40A8…` was a legal spelling the assert refused. Re-derived from BASE `master05-identification_package.adoc` §Composite Identifiers and Case ("two identifiers identical apart from case are considered to be identical"): the assert now uses `composite_ids_equal` — which still catches the mis-slicing class it exists for — with the citation inline. The uppercase-UUID recompose semantics are pinned as a template test (case-preserving `value`, lowercase typed rendering, case-insensitive identity), regenerated into both generations.

Both artifacts are committed seeds (`fuzz/seeds/aql_query/leak_2746_simple_select.aql`, `fuzz/seeds/identifiers/crash_2746_uppercase_uuid_ovid`). Verified: 515 tests across openehr-query/openehr-base, fuzz workspace compiles on nightly, the identifiers artifact runs clean under `cargo fuzz run -s none` (LeakSanitizer needs Linux — the dispatched Fuzz run after merge is the leak verification). Lockstep 0.0.39.