### PR TITLE
security(images): CVE-2026-14456 adjudicated — unreachable libssl in the distroless base

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -154,3 +154,31 @@ vulnerabilities:
   - id: CVE-2026-56862
     paths:
       - usr/local/bin/gosu
+
+  # CVE-2026-14456 (openssl: DoS via unbounded memory) in `libssl3t64
+  # 3.5.6-1~deb13u2`, shipped by the gcr.io/distroless/cc-debian13 base of the
+  # app and admin-console images. Debian's fix (3.5.7-1~deb13u2) is released,
+  # but distroless has NOT rebuilt with it yet (current upstream digest
+  # a77defd6…, checked 2026-08-26) — so no rebuild of ours can heal it today,
+  # which is what makes this an adjudication rather than a fix (#2747).
+  #
+  # Reachability: nothing in the shipped binaries links libssl. The whole TLS
+  # stack is rustls/aws-lc; Cargo.lock carries no openssl-sys — only
+  # openssl-probe, a pure-Rust certificate-path prober with no libssl linkage.
+  # The library is dead bytes from the base filesystem. The ARGUMENT lives in
+  # security/vex/distroless-libssl.openvex.json (not_affected,
+  # vulnerable_code_not_in_execute_path).
+  #
+  # Package findings carry no file path, so this entry is id-scoped — bounded
+  # by `expired_at` instead, so it cannot rot silently. It GOES the moment
+  # distroless rebuilds with 3.5.7 (the base-image watcher and the Monday
+  # published-image scan both resurface the state). The postgres image is not
+  # implicated: its security-upgrade RUN layer pulls the fixed package at
+  # build time.
+  - id: CVE-2026-14456
+    expired_at: 2026-09-16
+    statement: >-
+      libssl3t64 ships in the distroless base but nothing in the images links
+      it (rustls/aws-lc everywhere; no openssl-sys in Cargo.lock); no fixed
+      distroless base exists yet. Remove when distroless rebuilds with
+      openssl 3.5.7-1~deb13u2.

--- a/security/vex/distroless-libssl.openvex.json
+++ b/security/vex/distroless-libssl.openvex.json
@@ -1,0 +1,27 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://ferroehr.eu/vex/distroless-libssl",
+  "author": "FerroEHR project",
+  "role": "vendor",
+  "timestamp": "2026-08-26T00:00:00Z",
+  "version": 1,
+  "tooling": "hand-authored; see security/vex/README.md",
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-14456"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/ferroehr"
+        },
+        {
+          "@id": "pkg:oci/ferroehr-admin-ui"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The finding is in libssl3t64, shipped by the gcr.io/distroless/cc-debian13 base filesystem of both images. Nothing in the shipped binaries links or loads it: the entire TLS stack is rustls over aws-lc (reqwest, sqlx, axum-server, jsonwebtoken), Cargo.lock contains no openssl-sys, and the only openssl-named crate is openssl-probe, a pure-Rust certificate-path prober with no libssl linkage. The library is unreferenced bytes from the base image. Debian's fixed package (3.5.7-1~deb13u2) is released but distroless has not rebuilt with it yet, so no rebuild of these images can pick it up; this statement is removed the moment a distroless rebuild carries the fix (the base-image watcher and the weekly published-image scan both resurface the state). Tracked in #2747."
+    }
+  ]
+}


### PR DESCRIPTION
Part of #2747 (criterion 1). The v4.0.4 tag scan finding, adjudicated per the image-security law's reachability pattern because NO fixable rebuild exists: Debian released `3.5.7-1~deb13u2` but the current distroless `cc-debian13:nonroot` digest (`a77defd6…`, verified by pulling and scanning it) still carries 3.5.6 — a rebuild of our images today ships the same bytes.

Reachability, evidenced: the shipped binaries never link or load libssl — rustls/aws-lc across the stack, zero `openssl-sys` in `Cargo.lock` (the only openssl-named crate is `openssl-probe`, a pure-Rust cert-path prober). `.trivyignore.yaml` gains the id-scoped entry — package findings carry no file path to scope by, so it is TIME-bounded instead (`expired_at: 2026-09-16`) and cannot rot silently — and `security/vex/distroless-libssl.openvex.json` carries the not_affected/vulnerable_code_not_in_execute_path statement with the removal condition (the entry GOES when distroless rebuilds; the base watcher and Monday scan both resurface it). The postgres image is not implicated: its security-upgrade layer pulls the fixed package at build time.

Verified: `scripts/security/scan-images.sh` over every published image — **0 fixable HIGH/CRITICAL findings** with the adjudication applied (previously 1 HIGH on the app and admin-ui images).