### PR TITLE
ci(images): tags apply only after the vulnerability scan passes

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -46,6 +46,15 @@ on:
         required: false
         type: string
         default: ""
+      defer-tags:
+        description: >-
+          Push by DIGEST only, applying no tags. The caller tags the digest
+          itself (docker buildx imagetools create) after its own gates pass,
+          using the computed list in the `tags` output — so a failed gate
+          leaves nothing referencable (#2747).
+        required: false
+        type: boolean
+        default: false
       qemu:
         description: Set up QEMU (needed when a RUN layer executes foreign-arch code).
         required: false
@@ -76,6 +85,11 @@ on:
       digest:
         description: The pushed image index digest.
         value: ${{ jobs.build.outputs.digest }}
+      tags:
+        description: >-
+          The newline-separated tag list the metadata step computed — what a
+          defer-tags caller applies once its gates pass.
+        value: ${{ jobs.build.outputs.tags }}
 
 permissions: {}
 
@@ -93,6 +107,7 @@ jobs:
       attestations: write # store them against this repository
     outputs:
       digest: ${{ steps.build.outputs.digest }}
+      tags: ${{ steps.meta.outputs.tags }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -175,6 +190,10 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           fi
 
+      # With defer-tags the push is BY DIGEST (type=image,push-by-digest): the
+      # index lands in the registry untagged, and the caller applies the
+      # computed tags only after its gates pass. Attestations bind the digest,
+      # so they are identical either way.
       - name: Package and push
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -183,8 +202,11 @@ jobs:
           file: ${{ inputs.dockerfile }}
           target: ${{ inputs.target }}
           platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          push: ${{ !inputs.defer-tags }}
+          outputs: ${{ inputs.defer-tags && format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', inputs.image) || '' }}
+          # Inverted ternary on purpose: the truthy arm must be the non-empty
+          # value (a falsy '' true-arm would fall through to the tags).
+          tags: ${{ !inputs.defer-tags && steps.meta.outputs.tags || '' }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
           build-args: ${{ steps.args.outputs.list }}

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -260,6 +260,7 @@ jobs:
     uses: ./.github/workflows/build-image.yml
     with:
       image: ghcr.io/rubentalstra/ferroehr
+      defer-tags: true
       dockerfile: docker/Dockerfile
       target: runtime-prebuilt
       binary-artifact-prefix: ferroehr
@@ -395,6 +396,7 @@ jobs:
     uses: ./.github/workflows/build-image.yml
     with:
       image: ghcr.io/rubentalstra/ferroehr-admin-ui
+      defer-tags: true
       dockerfile: docker/admin-ui/Dockerfile
       target: runtime-prebuilt
       binary-artifact-prefix: ferroehr-admin-ui
@@ -431,6 +433,7 @@ jobs:
     uses: ./.github/workflows/build-image.yml
     with:
       image: ghcr.io/rubentalstra/ferroehr-postgres
+      defer-tags: true
       dockerfile: docker/postgres/Dockerfile
       context: docker/postgres
       qemu: true
@@ -529,6 +532,67 @@ jobs:
           severity: HIGH,CRITICAL
           ignore-unfixed: true
           trivy-config: trivy.yaml
+
+  # Tags exist only AFTER the vulnerability scan passes (#2747): the builds
+  # push by digest (defer-tags), and this job makes them referencable. The
+  # v4.0.4 cut is why the order is load-bearing — tagged images went live
+  # first and the scan failed second, so a HIGH finding was already `latest`
+  # by the time the lane turned red. `imagetools create` over a single source
+  # re-tags the SAME digest, so the attestations bound to it stay valid.
+  apply-tags:
+    name: apply image tags (after the scan gate)
+    runs-on: ubuntu-26.04
+    timeout-minutes: 10
+    permissions:
+      packages: write # tag the digests this run pushed
+    needs: [app-image, admin-ui-image, postgres-image, image-scan]
+    # postgres-image legitimately skips on most pushes (it builds on
+    # docker/postgres changes and tags), so this runs whenever the SCAN
+    # passed and tags each image whose build actually ran.
+    if: >-
+      !cancelled() && needs.image-scan.result == 'success' &&
+      needs.app-image.result == 'success'
+    steps:
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag the app image
+        env:
+          IMAGE: ${{ env.APP_IMAGE }}
+          DIGEST: ${{ needs.app-image.outputs.digest }}
+          TAGS: ${{ needs.app-image.outputs.tags }}
+        run: |
+          set -euo pipefail
+          args=()
+          while IFS= read -r t; do [ -n "$t" ] && args+=(-t "$t"); done <<< "$TAGS"
+          docker buildx imagetools create "${args[@]}" "${IMAGE}@${DIGEST}"
+
+      - name: Tag the admin-ui image
+        if: needs.admin-ui-image.result == 'success'
+        env:
+          IMAGE: ${{ env.ADMIN_UI_IMAGE }}
+          DIGEST: ${{ needs.admin-ui-image.outputs.digest }}
+          TAGS: ${{ needs.admin-ui-image.outputs.tags }}
+        run: |
+          set -euo pipefail
+          args=()
+          while IFS= read -r t; do [ -n "$t" ] && args+=(-t "$t"); done <<< "$TAGS"
+          docker buildx imagetools create "${args[@]}" "${IMAGE}@${DIGEST}"
+
+      - name: Tag the postgres image
+        if: needs.postgres-image.result == 'success'
+        env:
+          IMAGE: ${{ env.POSTGRES_IMAGE }}
+          DIGEST: ${{ needs.postgres-image.outputs.digest }}
+          TAGS: ${{ needs.postgres-image.outputs.tags }}
+        run: |
+          set -euo pipefail
+          args=()
+          while IFS= read -r t; do [ -n "$t" ] && args+=(-t "$t"); done <<< "$TAGS"
+          docker buildx imagetools create "${args[@]}" "${IMAGE}@${DIGEST}"
 
   # The pushed CONSOLE artifact is assembled from two jobs (the per-arch ssr
   # binary + the once-built site bundle), so its one novel failure class is


### PR DESCRIPTION
Criterion 2 of #2747. `build-image.yml` gains `defer-tags`: the multi-arch build pushes BY DIGEST (`type=image,push-by-digest`), the metadata step's computed tag list becomes a workflow output, and the attestation step is untouched (it binds the digest, which tagging never changes). `containers.yml` turns it on for all three images and adds an `apply-tags` job gated on the scan: `needs: [app-image, admin-ui-image, postgres-image, image-scan]`, running whenever the SCAN passed and the app build succeeded, tagging each image whose build actually ran (`imagetools create` over the single source digest — same bytes, same digest, attestations valid). The postgres lane's legitimate skip on ordinary pushes is handled per-step.

What this changes on a red scan: the v4.0.4 failure mode — a HIGH-finding image live as `4.0.4` and `:latest` with the lane red after the fact — becomes an untagged digest nothing references. The digest consumers inside the run (admin-ui asset-chain smoke, the compose smoke) always pulled by digest and are unaffected; the sandbox lane already gates on the whole run's conclusion.

zizmor over both files: no findings — including its (correct) unsound-ternary catch on the first version of the conditional `tags:`, fixed by inverting so the truthy arm is the non-empty value. Verification is the merge itself: this develop push runs the full Containers pipeline, and green means digest-push → scan → tags applied for the `develop`/`sha-` tags.

Part of #2747.