### PR TITLE
fix(sandbox): stale :latest under Vercel's build cache; the wait verifies the served version

### DIFF
--- a/.github/workflows/sandbox-deploy.yml
+++ b/.github/workflows/sandbox-deploy.yml
@@ -86,6 +86,8 @@ jobs:
       - name: Wait for the sandbox to serve again
         env:
           HOOK_URL: ${{ secrets.SANDBOX_DEPLOY_HOOK_URL }}
+          # Only compared against the served version string, never executed.
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           set -euo pipefail
           if [ -z "$HOOK_URL" ]; then
@@ -96,18 +98,31 @@ jobs:
           # image, minutes at most) and swaps the deployment; poll until the
           # API answers. Serverless cold boots re-run the migrations, so the
           # first 200 proves the new deployment is live AND migrated.
+          # A bare 200 is NOT proof of the new deployment — the OLD one
+          # answers 200 too (measured: the 4.0.4 dispatch went green while
+          # the sandbox still served 4.0.3). A release-triggered run knows
+          # the version the tag names and waits for exactly it; other runs
+          # log what is served.
+          expected=""
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_run" ] && [ -n "${HEAD_BRANCH}" ]; then
+            expected="${HEAD_BRANCH#v}"
+          fi
           deadline=$(( $(date +%s) + 1200 ))
           sleep 60
-          until code=$(curl -sS -m 30 -o /dev/null -w '%{http_code}' \
-              https://sandbox.ferroehr.eu/ferroehr/rest/status); [ "$code" = "200" ]; do
+          while :; do
+            body=$(curl -sS -m 30 https://sandbox.ferroehr.eu/ferroehr/rest/status || true)
+            served=$(printf '%s' "$body" | sed -nE 's/.*"server_version":"([^"]+)".*/\1/p')
+            if [ -n "$served" ] && { [ -z "$expected" ] || [ "$served" = "$expected" ]; }; then
+              echo "sandbox is serving version ${served}"
+              break
+            fi
             if [ "$(date +%s)" -ge "$deadline" ]; then
-              echo "::error::the sandbox did not serve within 20 minutes of the deploy ping." >&2
+              echo "::error::the sandbox serves '${served:-nothing}' (expected '${expected:-any}') 20 minutes after the deploy ping." >&2
               exit 1
             fi
-            echo "status answered ${code:-nothing}; waiting"
+            echo "sandbox serves '${served:-nothing}'; waiting for '${expected:-any}'"
             sleep 20
           done
-          echo "sandbox is serving"
 
   reseed:
     name: reseed after deploy

--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,11 @@
             "**": false
         }
     },
+    "build": {
+        "env": {
+            "VERCEL_FORCE_NO_BUILD_CACHE": "1"
+        }
+    },
     "services": {
         "api": {
             "root": ".",


### PR DESCRIPTION
Found live minutes after dispatching the sandbox to 4.0.4: the run went GREEN while the sandbox kept serving 4.0.3. Two defects, both in #2724's redesign, both fixed:

1. **Vercel's build cache defeats a moving `FROM :latest`** — the builder reused the cached base instead of re-pulling the moved tag. `vercel.json` sets `VERCEL_FORCE_NO_BUILD_CACHE=1`; sandbox builds are rare (releases + posture pushes) and are a pull-and-retag, so no-cache costs seconds.
2. **The wait step proved nothing** — it accepted any `/rest/status` 200, and the OLD deployment answers 200. It now parses `server_version`: a `workflow_run` (release-tag) run waits for exactly the tag's version and FAILS loudly on a mismatch after 20 minutes; dispatch/posture runs log the served version so a green run always says what is live.

Merging this PR is its own test: it touches the posture paths, so the Sandbox deploy fires, Vercel rebuilds cache-free from the current `:latest` (= the adjudicated 4.0.4 image), and the run's wait step must print `sandbox is serving version 4.0.4`.

Part of #2747's verification trail.