### PR TITLE
fix(query): the printer re-escapes string literals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5503,7 +5503,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "indexmap 2.14.0",
  "openehr-am",
@@ -5519,7 +5519,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "serde",
  "serde_json",
@@ -5548,7 +5548,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "async-trait",
  "axum",
@@ -5577,7 +5577,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "assert_fs",
  "chumsky",
@@ -5591,7 +5591,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "chumsky",
  "logos",
@@ -5600,7 +5600,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "insta",
  "jsonschema",
@@ -5618,7 +5618,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-adl"
-version = "0.0.39"
+version = "0.0.40"
 description = "openEHR ADL 2.4.0: hand-written ADL2/cADL/ODIN parser, AOM2 validation catalogue, specialisation flattener, OPT2 generator, and ADL 1.4→2 conversion over the generated openehr_am::v2_4::aom2 model"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,11 +16,11 @@ include = ["src/**", "README.md", "LICENSE-MIT"]
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)
-openehr-base = { path = "../openehr-base", version = "0.0.39" }   # VersionStatus for the parsed HRID
-openehr-am = { path = "../openehr-am", version = "0.0.39" }       # v2_4 ArchetypeHrid (the identification target type)
-openehr-rm = { path = "../openehr-rm", version = "0.0.39" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
-openehr-lang = { path = "../openehr-lang", version = "0.0.39" }   # openehr_lang::odin — the ODIN section parser
-openehr-term = { path = "../openehr-term", version = "0.0.39" }   # the languages code set for the RM resource-meta rows
+openehr-base = { path = "../openehr-base", version = "0.0.40" }   # VersionStatus for the parsed HRID
+openehr-am = { path = "../openehr-am", version = "0.0.40" }       # v2_4 ArchetypeHrid (the identification target type)
+openehr-rm = { path = "../openehr-rm", version = "0.0.40" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
+openehr-lang = { path = "../openehr-lang", version = "0.0.40" }   # openehr_lang::odin — the ODIN section parser
+openehr-term = { path = "../openehr-term", version = "0.0.40" }   # the languages code set for the RM resource-meta rows
 uuid.workspace = true        # meta uid/build_uid (AUTHORED_ARCHETYPE.uid: Uuid)
 indexmap.workspace = true    # OdinValue::Object body (insertion-ordered map)
 

--- a/crates/openehr-am/Cargo.toml
+++ b/crates/openehr-am/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-am"
-version = "0.0.39"
+version = "0.0.40"
 description = "openEHR AM Archetype Model, generated from BMM: generations v1_4 (AM 1.4.0, ADL 1.4) and v2_4 (AM 2.4.0, ADL 2; current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,8 +13,8 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.39" }
-openehr-lang = { path = "../openehr-lang", version = "0.0.39" }
+openehr-base = { path = "../openehr-base", version = "0.0.40" }
+openehr-lang = { path = "../openehr-lang", version = "0.0.40" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also carries the untyped `Value` fields the generator

--- a/crates/openehr-base/Cargo.toml
+++ b/crates/openehr-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-base"
-version = "0.0.39"
+version = "0.0.40"
 description = "openEHR BASE foundation + base types, generated from BMM: generations v1_2 (BASE 1.2.0) and v1_3 (BASE 1.3.0, current)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-its"
-version = "0.0.39"
+version = "0.0.40"
 description = "openEHR ITS (Implementation Technology Specifications): canonical JSON + canonical XML serialization of the RM, the generated ITS-REST 1.1.0 API contract, OPT 1.4 and AOM2 archetype XML codecs, and the Simplified Formats (FLAT / STRUCTURED / Web Template)"
 edition.workspace = true
 rust-version.workspace = true
@@ -41,14 +41,14 @@ regex = { workspace = true, optional = true }
 fancy-regex = { workspace = true, optional = true }
 # The generated XML (de)serializers impl the crate's ToXml/FromXml traits for the
 # RM/BASE spec types, so these are real (non-dev) deps.
-openehr-base = { path = "../openehr-base", version = "0.0.39", optional = true }
-openehr-rm = { path = "../openehr-rm", version = "0.0.39", optional = true }
+openehr-base = { path = "../openehr-base", version = "0.0.40", optional = true }
+openehr-rm = { path = "../openehr-rm", version = "0.0.40", optional = true }
 # The native canonical-JSON codec (`json_codec/generated`, emit-json) implements
 # `ToJson` for EVERY generated spec type the `OpenEhrType` derive covers, so it
 # spans all five spec crates (not just the RM/BASE the XML codec needs).
-openehr-lang = { path = "../openehr-lang", version = "0.0.39", optional = true }
-openehr-am = { path = "../openehr-am", version = "0.0.39", optional = true }
-openehr-term = { path = "../openehr-term", version = "0.0.39", optional = true }
+openehr-lang = { path = "../openehr-lang", version = "0.0.40", optional = true }
+openehr-am = { path = "../openehr-am", version = "0.0.40", optional = true }
+openehr-term = { path = "../openehr-term", version = "0.0.40", optional = true }
 
 # `full` — every ITS surface (canonical JSON/XML, the generated ITS-REST
 # contract, `opt14`, Simplified Formats). ON BY DEFAULT, so every consumer sees

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-lang"
-version = "0.0.39"
+version = "0.0.40"
 description = "openEHR LANG BMM/P_BMM object model, generated from BMM: generations v1_0 (LANG 1.0.0) and v1_1 (LANG 1.1.0, current; the stable BMM v2.x unit beside the paused BMM3 unit), plus hand-written ODIN/BEL/EL readers"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["parser-implementations", "data-structures"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.39" }
+openehr-base = { path = "../openehr-base", version = "0.0.40" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the
 # generated types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) —
 # never a derive. `serde_json` also carries the untyped `Value` fields the

--- a/crates/openehr-query/Cargo.toml
+++ b/crates/openehr-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-query"
-version = "0.0.39"
+version = "0.0.40"
 description = "openEHR QUERY (AQL 1.1.0): hand-written lexer, parser, typed AST and canonical printer from the official grammar (no ANTLR runtime)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-query/src/ast.rs
+++ b/crates/openehr-query/src/ast.rs
@@ -557,7 +557,9 @@ impl fmt::Display for NodePredicate {
 impl fmt::Display for NodeNameConstraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            NodeNameConstraint::String(s) => write!(f, "'{s}'"),
+            NodeNameConstraint::String(s) => {
+                write!(f, "'{}'", crate::printer::escape_string(s))
+            }
             NodeNameConstraint::Parameter(p) | NodeNameConstraint::Code(p) => f.write_str(p),
             NodeNameConstraint::TermCode(t) => f.write_str(t),
         }
@@ -577,7 +579,7 @@ impl fmt::Display for PathPredicateOperand {
 impl fmt::Display for Primitive {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Primitive::String(s) => write!(f, "'{s}'"),
+            Primitive::String(s) => write!(f, "'{}'", crate::printer::escape_string(s)),
             Primitive::Integer(i) => write!(f, "{i}"),
             Primitive::Real(r) => write!(f, "{r}"),
             Primitive::Boolean(b) => write!(f, "{b}"),

--- a/crates/openehr-query/src/printer.rs
+++ b/crates/openehr-query/src/printer.rs
@@ -56,10 +56,13 @@ pub fn to_aql(query: &SelectQuery) -> String {
 
 /// Escapes a raw string for embedding in an AQL single-quoted literal.
 ///
-/// The escapes are backslash escapes per the AQL lexer: use this when
-/// CONSTRUCTING
-/// [`Primitive::String`](crate::ast::Primitive::String) from user input — the printer emits stored string
-/// content verbatim (parser round-trip keeps source escapes intact).
+/// The escapes are backslash escapes per the AQL lexer (`AqlLexer.g4`
+/// `ESCAPE_SEQ`). The parser DECODES escape sequences into the AST
+/// ([`Primitive::String`](crate::ast::Primitive::String) carries the decoded
+/// value), so every printer site that emits stored string content must pass
+/// it back through here — emitting the decoded bytes verbatim re-decodes
+/// them on reparse and drifts the AST (found by the fuzzer on a
+/// backslash-heavy `TERMINOLOGY` argument, #2746).
 #[must_use]
 pub fn escape_string(raw: &str) -> String {
     let mut out = String::with_capacity(raw.len());
@@ -67,6 +70,11 @@ pub fn escape_string(raw: &str) -> String {
         match c {
             '\\' => out.push_str("\\\\"),
             '\'' => out.push_str("\\'"),
+            '\t' => out.push_str("\\t"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\u{0008}' => out.push_str("\\b"),
+            '\u{000C}' => out.push_str("\\f"),
             other => out.push(other),
         }
     }
@@ -168,7 +176,9 @@ fn terminology(out: &mut String, t: &TerminologyFunction) {
     let _ = write!(
         out,
         "TERMINOLOGY('{}', '{}', '{}')",
-        t.operation, t.arg2, t.arg3
+        escape_string(&t.operation),
+        escape_string(&t.arg2),
+        escape_string(&t.arg3)
     );
 }
 
@@ -381,7 +391,7 @@ fn identified_expr(out: &mut String, expr: &IdentifiedExpr) {
             out.push_str(" LIKE ");
             match operand {
                 LikeOperand::String(s) => {
-                    let _ = write!(out, "'{s}'");
+                    let _ = write!(out, "'{}'", escape_string(s));
                 }
                 LikeOperand::Parameter(p) => out.push_str(p),
             }

--- a/crates/openehr-query/tests/it/printer_round_trip.rs
+++ b/crates/openehr-query/tests/it/printer_round_trip.rs
@@ -111,11 +111,33 @@ fn a_parenthesised_contains_is_not_its_unparenthesised_twin() {
 /// The nightly fuzz artifact (#2746): this exact input exposed the
 /// `Recursive::declare` Rc cycle that leaked one parser graph per
 /// `parse_str` call. The leak property itself is guarded by the nightly
-/// LeakSanitizer lane over the committed seed
+/// `LeakSanitizer` lane over the committed seed
 /// (`fuzz/seeds/aql_query/leak_2746_simple_select.aql`); this pins the
 /// behavioural half — the restructured recursion parses and round-trips the
 /// same query.
 #[test]
 fn the_leak_artifact_query_still_parses_and_round_trips() {
     assert_round_trips("SELECT e/ehr_id/value FROM EHR e\n");
+}
+
+/// The second #2746 fuzz artifact: the parser DECODES string escapes into the
+/// AST, so a printer site emitting the decoded value verbatim re-decodes on
+/// reparse and drifts the AST. Every string-literal emission site now
+/// re-escapes; these cover the four sites (TERMINOLOGY arguments, LIKE,
+/// node-name constraints, primitive strings) with the characters that drift:
+/// backslashes, quotes, and the decoded control escapes.
+#[test]
+fn string_literals_with_escapes_round_trip_at_every_emission_site() {
+    for src in [
+        // TERMINOLOGY arguments (the artifact's shape).
+        r"SELECT TERMINOLOGY('e\\pand', 'open\'ehr', 'a\tb') FROM EHR e",
+        // LIKE operand.
+        r"SELECT c/uid/value FROM COMPOSITION c WHERE c/name/value LIKE 'O\'Neil\\%'",
+        // A primitive string comparison.
+        r"SELECT c/uid/value FROM COMPOSITION c WHERE c/name/value = 'a\\b\'c'",
+        // A node-name constraint inside a path predicate.
+        r"SELECT c/uid/value FROM COMPOSITION c CONTAINS OBSERVATION o[at0001, 'we\'ird\\name']",
+    ] {
+        assert_round_trips(src);
+    }
 }

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-rm"
-version = "0.0.39"
+version = "0.0.40"
 description = "openEHR RM Reference Model, generated from BMM: generations v1_1 (RM 1.1.0) and v1_2 (RM 1.2.0, current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,11 +13,11 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.39" }
+openehr-base = { path = "../openehr-base", version = "0.0.40" }
 # The terminology-backed RM class invariants (`validate::terminology`) resolve
 # openEHR terminology groups + code sets against the vendored TERM 3.1.0 bundle.
 # `openehr-term` itself depends only on `openehr-base`, so this is acyclic.
-openehr-term = { path = "../openehr-term", version = "0.0.39" }
+openehr-term = { path = "../openehr-term", version = "0.0.40" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also backs the untyped `Value` RM representation used by

--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-term"
-version = "0.0.39"
+version = "0.0.40"
 description = "openEHR TERM terminology data model, generated from BMM (generation v3_1 = TERM 3.1.0), plus the embedded official terminology XML bundle"
 edition.workspace = true
 rust-version.workspace = true
@@ -34,7 +34,7 @@ include = [
 ]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.39" }
+openehr-base = { path = "../openehr-base", version = "0.0.40" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive.


### PR DESCRIPTION
The second `aql_query` fuzz finding under #2746/#2747's verification runs — reachable only once the Rc-cycle leak (#2748) stopped killing the campaign at the first input. The parser DECODES AQL escape sequences into the AST (`unquote`/`unescape` per `AqlLexer.g4` `ESCAPE_SEQ`), but four printer sites emitted the stored value VERBATIM — `TERMINOLOGY` arguments, `LIKE` operands, node-name constraints, and `Primitive::String` — so printing and reparsing decoded the escapes a second time and drifted the AST (the harness's round-trip invariant caught it on a backslash-heavy TERMINOLOGY argument). `escape_string`'s doc even codified the wrong model ("the printer emits stored string content verbatim"); it now states the real contract and covers the decoded control escapes, inverting `unquote` exactly; characters outside the escape set pass raw in both directions, which the lexer accepts (the artifact's NUL/tab bytes prove it live).

All four sites route through the escaper; the artifact is a committed seed (`fuzz/seeds/aql_query/crash_2746_backslash_terminology.aql`); new round-trip pins cover each site with backslashes, quotes and tabs. Verified: 65/65 crate tests, both seeds clean under `cargo fuzz run -s none`, clippy `-D warnings`, fmt. Lockstep 0.0.40. The re-dispatched Fuzz lane after merge is the campaign-level proof.

Part of #2746's closure trail.