### PR TITLE
fix(query): the node predicate parses its shared objectPath prefix once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5503,7 +5503,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.40"
+version = "0.0.41"
 dependencies = [
  "indexmap 2.14.0",
  "openehr-am",
@@ -5519,7 +5519,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.40"
+version = "0.0.41"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.40"
+version = "0.0.41"
 dependencies = [
  "serde",
  "serde_json",
@@ -5548,7 +5548,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.40"
+version = "0.0.41"
 dependencies = [
  "async-trait",
  "axum",
@@ -5577,7 +5577,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.40"
+version = "0.0.41"
 dependencies = [
  "assert_fs",
  "chumsky",
@@ -5591,7 +5591,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.40"
+version = "0.0.41"
 dependencies = [
  "chumsky",
  "logos",
@@ -5600,7 +5600,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.40"
+version = "0.0.41"
 dependencies = [
  "insta",
  "jsonschema",
@@ -5618,7 +5618,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.40"
+version = "0.0.41"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-adl"
-version = "0.0.40"
+version = "0.0.41"
 description = "openEHR ADL 2.4.0: hand-written ADL2/cADL/ODIN parser, AOM2 validation catalogue, specialisation flattener, OPT2 generator, and ADL 1.4→2 conversion over the generated openehr_am::v2_4::aom2 model"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,11 +16,11 @@ include = ["src/**", "README.md", "LICENSE-MIT"]
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)
-openehr-base = { path = "../openehr-base", version = "0.0.40" }   # VersionStatus for the parsed HRID
-openehr-am = { path = "../openehr-am", version = "0.0.40" }       # v2_4 ArchetypeHrid (the identification target type)
-openehr-rm = { path = "../openehr-rm", version = "0.0.40" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
-openehr-lang = { path = "../openehr-lang", version = "0.0.40" }   # openehr_lang::odin — the ODIN section parser
-openehr-term = { path = "../openehr-term", version = "0.0.40" }   # the languages code set for the RM resource-meta rows
+openehr-base = { path = "../openehr-base", version = "0.0.41" }   # VersionStatus for the parsed HRID
+openehr-am = { path = "../openehr-am", version = "0.0.41" }       # v2_4 ArchetypeHrid (the identification target type)
+openehr-rm = { path = "../openehr-rm", version = "0.0.41" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
+openehr-lang = { path = "../openehr-lang", version = "0.0.41" }   # openehr_lang::odin — the ODIN section parser
+openehr-term = { path = "../openehr-term", version = "0.0.41" }   # the languages code set for the RM resource-meta rows
 uuid.workspace = true        # meta uid/build_uid (AUTHORED_ARCHETYPE.uid: Uuid)
 indexmap.workspace = true    # OdinValue::Object body (insertion-ordered map)
 

--- a/crates/openehr-am/Cargo.toml
+++ b/crates/openehr-am/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-am"
-version = "0.0.40"
+version = "0.0.41"
 description = "openEHR AM Archetype Model, generated from BMM: generations v1_4 (AM 1.4.0, ADL 1.4) and v2_4 (AM 2.4.0, ADL 2; current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,8 +13,8 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.40" }
-openehr-lang = { path = "../openehr-lang", version = "0.0.40" }
+openehr-base = { path = "../openehr-base", version = "0.0.41" }
+openehr-lang = { path = "../openehr-lang", version = "0.0.41" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also carries the untyped `Value` fields the generator

--- a/crates/openehr-base/Cargo.toml
+++ b/crates/openehr-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-base"
-version = "0.0.40"
+version = "0.0.41"
 description = "openEHR BASE foundation + base types, generated from BMM: generations v1_2 (BASE 1.2.0) and v1_3 (BASE 1.3.0, current)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-its"
-version = "0.0.40"
+version = "0.0.41"
 description = "openEHR ITS (Implementation Technology Specifications): canonical JSON + canonical XML serialization of the RM, the generated ITS-REST 1.1.0 API contract, OPT 1.4 and AOM2 archetype XML codecs, and the Simplified Formats (FLAT / STRUCTURED / Web Template)"
 edition.workspace = true
 rust-version.workspace = true
@@ -41,14 +41,14 @@ regex = { workspace = true, optional = true }
 fancy-regex = { workspace = true, optional = true }
 # The generated XML (de)serializers impl the crate's ToXml/FromXml traits for the
 # RM/BASE spec types, so these are real (non-dev) deps.
-openehr-base = { path = "../openehr-base", version = "0.0.40", optional = true }
-openehr-rm = { path = "../openehr-rm", version = "0.0.40", optional = true }
+openehr-base = { path = "../openehr-base", version = "0.0.41", optional = true }
+openehr-rm = { path = "../openehr-rm", version = "0.0.41", optional = true }
 # The native canonical-JSON codec (`json_codec/generated`, emit-json) implements
 # `ToJson` for EVERY generated spec type the `OpenEhrType` derive covers, so it
 # spans all five spec crates (not just the RM/BASE the XML codec needs).
-openehr-lang = { path = "../openehr-lang", version = "0.0.40", optional = true }
-openehr-am = { path = "../openehr-am", version = "0.0.40", optional = true }
-openehr-term = { path = "../openehr-term", version = "0.0.40", optional = true }
+openehr-lang = { path = "../openehr-lang", version = "0.0.41", optional = true }
+openehr-am = { path = "../openehr-am", version = "0.0.41", optional = true }
+openehr-term = { path = "../openehr-term", version = "0.0.41", optional = true }
 
 # `full` — every ITS surface (canonical JSON/XML, the generated ITS-REST
 # contract, `opt14`, Simplified Formats). ON BY DEFAULT, so every consumer sees

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-lang"
-version = "0.0.40"
+version = "0.0.41"
 description = "openEHR LANG BMM/P_BMM object model, generated from BMM: generations v1_0 (LANG 1.0.0) and v1_1 (LANG 1.1.0, current; the stable BMM v2.x unit beside the paused BMM3 unit), plus hand-written ODIN/BEL/EL readers"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["parser-implementations", "data-structures"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.40" }
+openehr-base = { path = "../openehr-base", version = "0.0.41" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the
 # generated types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) —
 # never a derive. `serde_json` also carries the untyped `Value` fields the

--- a/crates/openehr-query/Cargo.toml
+++ b/crates/openehr-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-query"
-version = "0.0.40"
+version = "0.0.41"
 description = "openEHR QUERY (AQL 1.1.0): hand-written lexer, parser, typed AST and canonical printer from the official grammar (no ANTLR runtime)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-query/src/parser.rs
+++ b/crates/openehr-query/src/parser.rs
@@ -24,7 +24,7 @@ use crate::ast::{
     SortOrder, StandardPredicate, StatFunc, Terminal, TerminologyFunction, Top, TopDirection,
     ValueListItem, VersionPredicate, WhereExpr,
 };
-use crate::lexer::{SpannedTokens, Token};
+use crate::lexer::{CompOp, SpannedTokens, Token};
 use chumsky::prelude::*;
 
 // The chumsky extra-parameter alias. `chumsky::extra::Err` stays fully
@@ -365,6 +365,15 @@ fn path_parsers<'a>() -> (
     (identified, predicate, standard)
 }
 
+/// What followed the shared `objectPath` prefix of the two `objectPath`-leading
+/// `nodePredicate` alternatives, so the prefix is parsed once.
+enum NodePathTail {
+    /// `MATCHES CONTAINED_REGEX` — the raw `{/regex/}` token text.
+    Regex(String),
+    /// `COMPARISON_OPERATOR pathPredicateOperand`.
+    Compare(CompOp, PathPredicateOperand),
+}
+
 /// The `pathPredicate` and `standardPredicate` parsers over a given
 /// `objectPath` parser — the non-recursive half of the path grammar
 /// ([`path_parsers`] wires the recursion).
@@ -387,7 +396,7 @@ fn predicate_parsers<'a>(
     let standard = object
         .clone()
         .then(comparison)
-        .then(predicate_operand)
+        .then(predicate_operand.clone())
         .map(|((path, op), operand)| StandardPredicate { path, op, operand });
 
     // archetypePredicate : ARCHETYPE_HRID | PARAMETER
@@ -415,18 +424,32 @@ fn predicate_parsers<'a>(
     let node_archetype = select! { Token::ArchetypeHrid(s) => s }
         .then(just(Token::Comma).ignore_then(name_constraint).or_not())
         .map(|(hrid, name)| NodePredicate::Archetype { hrid, name });
-    let node_matches_regex = object
+    // `AqlParser.g4` `nodePredicate`: its two `objectPath`-leading alternatives
+    // (`… COMPARISON_OPERATOR pathPredicateOperand`, `… MATCHES
+    // CONTAINED_REGEX`) are told apart by the token AFTER that shared prefix,
+    // so the prefix is parsed ONCE and the tail dispatches on it. Retrying each
+    // alternative from the top re-parses the prefix — and a `pathPart` inside
+    // it may carry another `pathPredicate`, so the doubling compounds per
+    // bracket nesting level.
+    let node_path_tail = just(Token::Matches)
+        .ignore_then(select! { Token::ContainedRegex(s) => s })
+        .map(NodePathTail::Regex)
+        .or(comparison
+            .then(predicate_operand)
+            .map(|(op, operand)| NodePathTail::Compare(op, operand)));
+    let node_path = object
         .clone()
-        .then_ignore(just(Token::Matches))
-        .then(select! { Token::ContainedRegex(s) => s })
-        .map(|(path, regex)| NodePredicate::MatchesRegex { path, regex });
+        .then(node_path_tail)
+        .map(|(path, tail)| match tail {
+            NodePathTail::Regex(regex) => NodePredicate::MatchesRegex { path, regex },
+            NodePathTail::Compare(op, operand) => {
+                NodePredicate::Standard(Box::new(StandardPredicate { path, op, operand }))
+            }
+        });
     let node_atom = node_code
         .or(node_archetype)
         .or(parameter().map(NodePredicate::Parameter))
-        .or(node_matches_regex)
-        .or(standard
-            .clone()
-            .map(|s| NodePredicate::Standard(Box::new(s))));
+        .or(node_path);
     let node_and = node_atom.clone().foldl(
         just(Token::And).ignore_then(node_atom.clone()).repeated(),
         |l, r| NodePredicate::And(Box::new(l), Box::new(r)),
@@ -980,7 +1003,7 @@ mod tests {
                 ..
             } => {
                 assert_eq!(variable.as_deref(), Some("v"));
-                assert_eq!(s.op, crate::lexer::CompOp::Gt);
+                assert_eq!(s.op, CompOp::Gt);
             }
             other => panic!("expected VERSION standard predicate, got {other:?}"),
         }
@@ -1101,7 +1124,7 @@ mod tests {
                         ..
                     },
                 ..
-            } => assert_eq!(s.op, crate::lexer::CompOp::Eq),
+            } => assert_eq!(s.op, CompOp::Eq),
             other => panic!("expected PathPredicate::Standard, got {other:?}"),
         }
     }

--- a/crates/openehr-query/tests/it/backtracking.rs
+++ b/crates/openehr-query/tests/it/backtracking.rs
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: FerroEHR contributors
+// SPDX-License-Identifier: MIT
+
+#![allow(
+    clippy::panic,
+    reason = "integration-test assertions outside #[test] fns, which the clippy.toml allow-*-in-tests scoping does not reach"
+)]
+//! Parse time stays near-linear on invalid input.
+//!
+//! The parser reads attacker-typed query text, so a refusal must cost about
+//! what the input length costs. The two `objectPath`-leading `nodePredicate`
+//! alternatives (`AqlParser.g4` `nodePredicate`) share that prefix, and an
+//! `objectPath`'s `pathPart` may carry another `pathPredicate` — so retrying
+//! the alternatives instead of factoring the prefix doubles the work at every
+//! bracket nesting level.
+
+use openehr_query::parser::parse_str;
+
+/// The 222-byte fuzz artifact: ~24 unclosed `[` predicate openers inside a
+/// SELECT path expression. It is not valid AQL and must be refused; the point
+/// of the test is how long the refusal takes.
+const NESTED_PREDICATE_TIMEOUT: &str = "SELECT uuuucu0uat0ucu0u[uuuat0u[aT0u[uuuat0u[aT0v0valu[uuuat0u[aT0v0[uuuat0ucu0u[uuuat0u[aT0u[uuuat0u[aT0v0vacu0uat0ucu0u[uuuat0u[aT0u[uuuat0u[aT0v0valu[uuuat0u[aT0v0[uuuat0ucu0u[uuuat0u[aT0u[uuuat0u[alu[uuuat0u[aT0v0valu=";
+
+/// A generous bound: measured on the pinned toolchain, the doubling refused
+/// this input in 39.08 s in a debug build (and tripped the fuzz lane's
+/// `-timeout` outright), while the factored grammar refuses in under a
+/// millisecond — so the bound is nowhere near flaky in either direction.
+const BUDGET: std::time::Duration = std::time::Duration::from_secs(2);
+
+#[test]
+fn the_nested_predicate_artifact_is_refused_in_near_linear_time() {
+    let started = std::time::Instant::now();
+    let outcome = parse_str(NESTED_PREDICATE_TIMEOUT);
+    let elapsed = started.elapsed();
+
+    assert!(
+        outcome.is_err(),
+        "unclosed predicate brackets are not valid AQL, got {outcome:?}"
+    );
+    assert!(
+        elapsed < BUDGET,
+        "refusing the artifact took {elapsed:?}, budget {BUDGET:?} — the alternation is re-parsing its shared prefix per nesting level"
+    );
+}
+
+/// The same property stated as a depth sweep, so a regression is caught even
+/// if a future grammar change makes the recorded artifact fail earlier: 40
+/// nesting levels are 2^40 alternative attempts under the doubling, which no
+/// timeout could ever absorb.
+#[test]
+fn predicate_nesting_depth_does_not_multiply_parse_time() {
+    let mut src = String::from("SELECT a");
+    for _ in 0..40 {
+        src.push_str("[b");
+    }
+
+    let started = std::time::Instant::now();
+    let outcome = parse_str(&src);
+    let elapsed = started.elapsed();
+
+    assert!(
+        outcome.is_err(),
+        "forty unclosed predicate brackets are not valid AQL, got {outcome:?}"
+    );
+    assert!(
+        elapsed < BUDGET,
+        "refusing 40 nesting levels took {elapsed:?}, budget {BUDGET:?} — parse time is multiplying with depth"
+    );
+}

--- a/crates/openehr-query/tests/it/main.rs
+++ b/crates/openehr-query/tests/it/main.rs
@@ -7,6 +7,7 @@
 //! One binary per crate, split into topic modules
 //! (`.claude/rules/testing.md` §One integration-test binary per crate).
 
+mod backtracking;
 mod corpus;
 mod parse_errors;
 mod printer_round_trip;

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-rm"
-version = "0.0.40"
+version = "0.0.41"
 description = "openEHR RM Reference Model, generated from BMM: generations v1_1 (RM 1.1.0) and v1_2 (RM 1.2.0, current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,11 +13,11 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.40" }
+openehr-base = { path = "../openehr-base", version = "0.0.41" }
 # The terminology-backed RM class invariants (`validate::terminology`) resolve
 # openEHR terminology groups + code sets against the vendored TERM 3.1.0 bundle.
 # `openehr-term` itself depends only on `openehr-base`, so this is acyclic.
-openehr-term = { path = "../openehr-term", version = "0.0.40" }
+openehr-term = { path = "../openehr-term", version = "0.0.41" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also backs the untyped `Value` RM representation used by

--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-term"
-version = "0.0.40"
+version = "0.0.41"
 description = "openEHR TERM terminology data model, generated from BMM (generation v3_1 = TERM 3.1.0), plus the embedded official terminology XML bundle"
 edition.workspace = true
 rust-version.workspace = true
@@ -34,7 +34,7 @@ include = [
 ]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.40" }
+openehr-base = { path = "../openehr-base", version = "0.0.41" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1281,7 +1281,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.39"
+version = "0.0.41"
 dependencies = [
  "indexmap",
  "openehr-am",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.39"
+version = "0.0.41"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.39"
+version = "0.0.41"
 dependencies = [
  "serde",
  "serde_json",
@@ -1317,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.39"
+version = "0.0.41"
 dependencies = [
  "async-trait",
  "axum",
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.39"
+version = "0.0.41"
 dependencies = [
  "chumsky",
  "indexmap",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.39"
+version = "0.0.41"
 dependencies = [
  "chumsky",
  "logos",
@@ -1364,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.39"
+version = "0.0.41"
 dependencies = [
  "openehr-base",
  "openehr-term",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.39"
+version = "0.0.41"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/fuzz/seeds/aql_query/timeout_2758_nested_predicates.aql
+++ b/fuzz/seeds/aql_query/timeout_2758_nested_predicates.aql
@@ -1,0 +1,1 @@
+SELECT uuuucu0uat0ucu0u[uuuat0u[aT0u[uuuat0u[aT0v0valu[uuuat0u[aT0v0[uuuat0ucu0u[uuuat0u[aT0u[uuuat0u[aT0v0vacu0uat0ucu0u[uuuat0u[aT0u[uuuat0u[aT0v0valu[uuuat0u[aT0v0[uuuat0ucu0u[uuuat0u[aT0u[uuuat0u[alu[uuuat0u[aT0v0valu=


### PR DESCRIPTION
Closes #2758.

The Fuzz lane's third `aql_query` finding, a libFuzzer TIMEOUT: a 222-byte invalid input with 24 unclosed `[` predicate openers refused in 4.97 s release / 39.08 s debug. `AqlParser.g4` `nodePredicate` has two alternatives that both begin with an `objectPath`; each was tried from the top of the `or` chain, re-parsing the shared prefix, and since a `pathPart` inside that prefix may carry another `pathPredicate`, the retries compounded per bracket nesting level — measured cleanly at 2^depth (19 µs at depth 4, 15.9 ms at 16, 1.03 s at 22).

The prefix now parses once and a tail parser dispatches on the next token (`MATCHES` vs a comparison operator, disjoint — a factoring, not a reordering). The artifact refuses in under a millisecond and every `pathPredicate`-reaching site (SELECT, WHERE, FROM class + VERSION operands, ORDER BY, comparison operands, slashed paths) probed flat at depths 4/12/24/40.

The accept/refuse envelope is unchanged by construction and verified empirically: every `.aql` in the tree, the vendored QUERY worked-example listings, and twenty hand-built shapes parsed before/after with byte-identical Debug output, fault token indices and byte ranges included. Pinned by two integration tests (the artifact inside a 2 s budget + a 40-level depth sweep), both failing at 39 s on the unfixed parser; the artifact is also a fuzz seed. Gates: 67/67 nextest, clippy -D warnings clean, fmt, fuzz smoke over all three seeds exit 0. Lockstep 0.0.41 (also repairing fuzz/Cargo.lock, which the 0.0.40 bump missed — follow-up issue coming for the guard gap).