### PR TITLE
feat(ehr): the archetype-root refusal names its remedy, and the book documents both create-EHR branches

### DIFF
--- a/app/ferroehr/src/service/ehr/validation.rs
+++ b/app/ferroehr/src/service/ehr/validation.rs
@@ -438,7 +438,9 @@ pub(in crate::service) fn validate_root_locatable(
             ServiceError::content_invalid(
                 Violation::new(format!(
                     "is mandatory: {kind} is an archetype root (Is_archetype_root), \
-                     and a root without ARCHETYPED is invalid"
+                     and a root without ARCHETYPED is invalid; supply \
+                     archetype_details with its archetype_id (for a plain \
+                     status, openEHR-EHR-EHR_STATUS.generic.v1)"
                 ))
                 .with_path(format!("{kind}.archetype_details"))
                 .with_invariant("LOCATABLE.Archetyped_valid"),

--- a/website/book/src/using-the-api/resources.md
+++ b/website/book/src/using-the-api/resources.md
@@ -40,6 +40,17 @@ subject and flags at creation. Returns **201 Created** with the new EHR id in
 the full `EHR`; otherwise it is empty. Supplying an `EHR_STATUS` whose subject
 already has an EHR returns **409 Conflict**.
 
+With no body the server mints the spec's default `EHR_STATUS`
+(`is_queryable: true`, `is_modifiable: true`, a `PARTY_SELF` subject, and an
+`archetype_details` block naming `openEHR-EHR-EHR_STATUS.generic.v1`). A
+supplied `EHR_STATUS` must be a complete, RM-valid instance: `EHR_STATUS` is
+always an archetype root, so `archetype_details` (with its `archetype_id`) is
+mandatory, and a body without it is refused with **422** naming the violated
+invariant. Some servers accept such a partial status and fill the gap
+silently; FerroEHR validates the supplied resource exactly as the Reference
+Model defines it, so either send the complete status or omit the body and let
+the server mint the default.
+
 To create with a specific id, use `PUT /ehr/{ehr_id}` (also 201; 409 if that id
 is already used).
 


### PR DESCRIPTION
Closes #2759.

Adjudicated on the live wire and the vendored RM text (full derivation on the issue): omitting the EHR_STATUS on `POST /ehr` already mints the ITS-REST default (201, catalogue-pinned by `create_ehr-main`'s absent rows), and the reported 422 fires only on a SUPPLIED EHR_STATUS missing `archetype_details` — a refusal the RM requires (`EHR_STATUS` `Is_archetype_root`; `LOCATABLE` `Archetyped_valid`) and the catalogue pins as its own invalid twin (`create_ehr-invalid_status`, `missing-archetype-details`). Acceptance would be the leniency defect class; what ships instead is guidance: the 422 message now names the remedy (supply `archetype_details` with its `archetype_id`), and the API book's create-EHR section documents both branches — what the minted default contains, and that a supplied status must be a complete RM-valid instance, with the difference to more lenient servers stated plainly.

Gates: clippy `-p ferroehr` clean, the scoped ehr-status/validation nextest slice green (36/36), `docs-claims` unaffected (no config/values claims added). The changelog entry rides the open v4.0.5 release PR (#2757), where this lands.