### PR TITLE
docs(book): the verifying-releases attestation examples pin 4.0.5

### DIFF
--- a/website/book/src/verifying-releases.md
+++ b/website/book/src/verifying-releases.md
@@ -175,7 +175,7 @@ carry a Sigstore-signed SLSA provenance attestation, plus the SPDX SBOM and
 provenance the builder writes onto the image index itself.
 
 ```bash
-gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:4.0.4 \
+gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:4.0.5 \
   -R rubentalstra/FerroEHR
 ```
 
@@ -199,7 +199,7 @@ tag once and verify the digest it resolved — otherwise the bytes verified and
 the bytes pulled can differ:
 
 ```bash
-digest=$(docker buildx imagetools inspect ghcr.io/rubentalstra/ferroehr:4.0.4 \
+digest=$(docker buildx imagetools inspect ghcr.io/rubentalstra/ferroehr:4.0.5 \
   | awk '/^Digest:/{print $2}')
 gh attestation verify "oci://ghcr.io/rubentalstra/ferroehr@${digest}" \
   -R rubentalstra/FerroEHR


### PR DESCRIPTION
The release-cut sweep updated the `v4.0.5` tag mention but missed the two bare `ghcr.io/rubentalstra/ferroehr:4.0.4` pins in the attestation-verify and digest-inspect examples — `docs-claims` (`--all`, the CI shape) caught them against the bumped appVersion on the release PR's post-merge run. Verified locally with `--all`: OK. Also the durable lesson, recorded in memory: the cut's local verification runs `docs-claims.sh --all`, never the bare changed-files form, which is vacuous on a clean tree.