### PR TITLE
fix(admin-ui): the builder stores decoded string values — the printer escapes at emission

### DIFF
--- a/app/ferroehr-admin-ui/src/builder/lift.rs
+++ b/app/ferroehr-admin-ui/src/builder/lift.rs
@@ -15,10 +15,10 @@
 //! in step. The refusal is then made total by a **round trip**: the lifted state
 //! is lowered again, re-parsed, and compared with the original parse. Anything
 //! that would come back different is refused, so an accepted lift is provably
-//! equivalent to the stored definition. Comparing re-PARSED trees (rather than
-//! text) is what makes string escaping symmetric: the parser decodes a literal's
-//! escapes, [`crate::builder::lower`] re-encodes them, and both sides of the
-//! comparison have been through the parser.
+//! equivalent to the stored definition. String escaping is symmetric by the
+//! query crate's own contract: the parser decodes a literal's escapes into the
+//! AST, and `openehr_query::printer` re-encodes them at emission — the AST
+//! (and therefore the builder state) always holds the decoded value.
 
 use openehr_query::ast::{
     AggregateCall, ClassExprOperand, ColumnExpr, CompareOperand, ContainsExpr, IdentifiedExpr,

--- a/app/ferroehr-admin-ui/src/builder/lower.rs
+++ b/app/ferroehr-admin-ui/src/builder/lower.rs
@@ -15,7 +15,6 @@ use openehr_query::ast::{
     SelectQuery, SortOrder, Terminal, ValueListItem, WhereExpr,
 };
 use openehr_query::lexer::CompOp;
-use openehr_query::printer::escape_string;
 
 use crate::builder::model::{
     BoolOp, BuilderQuery, Criterion, CriterionKind, CriterionNode, QueryShape,
@@ -257,7 +256,7 @@ fn leaf(criterion: &Criterion) -> Result<WhereExpr, BuilderError> {
         CriterionKind::TextEquals { text } => compare_str(&at("value"), CompOp::Eq, text),
         CriterionKind::TextLike { pattern } => Ok(WhereExpr::Identified(IdentifiedExpr::Like {
             path: parse_path(COMP_VAR, &at("value"))?,
-            operand: openehr_query::ast::LikeOperand::String(escape_string(pattern)),
+            operand: openehr_query::ast::LikeOperand::String(pattern.clone()),
         })),
         CriterionKind::DateTimeRange { from, to } => {
             let mut parts = Vec::new();
@@ -330,7 +329,7 @@ fn coded_in(
         operand: MatchesOperand::ValueList(
             codes
                 .iter()
-                .map(|code| ValueListItem::Primitive(Primitive::String(escape_string(code))))
+                .map(|code| ValueListItem::Primitive(Primitive::String(code.clone())))
                 .collect(),
         ),
     });
@@ -352,7 +351,7 @@ fn compare_str(relative: &str, op: CompOp, value: &str) -> Result<WhereExpr, Bui
     Ok(WhereExpr::Identified(IdentifiedExpr::Compare {
         lhs: CompareOperand::Path(parse_path(COMP_VAR, relative)?),
         op,
-        rhs: Terminal::Primitive(Primitive::String(escape_string(value))),
+        rhs: Terminal::Primitive(Primitive::String(value.to_owned())),
     }))
 }
 


### PR DESCRIPTION
Fixes the red `every_criterion_kind_round_trips` on develop — downstream fallout of #2754 in the console's query builder. `lower.rs` pre-escaped string values into the AST (three sites: LIKE patterns, coded-value lists, string comparisons), which was the correct compensation while the printer emitted stored content verbatim; under the fixed printer the emission escapes again, so a printed literal double-escaped and the lift round-trip refused its own lowered output. The builder now stores decoded values — the query crate's actual contract (parser decodes in, printer encodes out) — and the lift module doc states that contract instead of the old compensation. Verified: the full console suite 511/511 (the previously failing round-trip test included), clippy clean on both targets (ssr + wasm32 hydrate), fmt.