### PR TITLE
ci(workflows): phase 1 — composite actions and one home for shared facts

### DIFF
--- a/.claude/rules/image-security.md
+++ b/.claude/rules/image-security.md
@@ -78,7 +78,9 @@ patch milestone — the remedy is only real once a tag republishes the image.
 
 Machine-enforced agreement (`scripts/checks/image-labels.sh`, per-PR in CI):
 the Dockerfile `FROM` digest ↔ its `base.name`/`base.digest` LABELs ↔ the
-`containers.yml` labels ↔ the `ci.yml` postgres service pins. Everything else
+`containers.yml` labels ↔ every workflow's postgres service pins (the guard
+scans `.github/workflows/*.yml`, so a new lane's pin is covered the day it
+lands; it read `ci.yml` alone until #2775 and missed `sonar.yml`). Everything else
 is a sweep — run `grep -rn '18\.<old-patch>'` over the tree and expect to
 touch:
 
@@ -86,7 +88,8 @@ touch:
   `base.*` LABELs (the digest is the MANIFEST-LIST digest:
   `docker buildx imagetools inspect postgres:<tag>` → `Digest:`)
 - `.github/workflows/containers.yml` — postgres lane comment + both label lines
-- `.github/workflows/ci.yml` — the two service-container pins + the job heading
+- `.github/workflows/ci.yml` — its service-container pin + the job heading
+- `.github/workflows/sonar.yml` — its own service-container pin
 - `docs/VERSIONS.md` §Database, `docs/postgres-features.md` §Versioning note
   (latest-patch version + date, from postgresql.org — never copied forward),
   root `CLAUDE.md` §Tech stack, `docs/architecture.md` §PostgreSQL 18,

--- a/.github/actions/docs-toolchain/action.yml
+++ b/.github/actions/docs-toolchain/action.yml
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
+# .github/actions/docs-toolchain — install the pinned documentation toolchain.
+#
+# THE pinned toolchain for the docs site: the versions below are the single
+# source of truth, replacing the two verbatim `env:` blocks that declared them
+# in docs.yml and link-check-external.yml (#2775). Those two files kept
+# SITE_ORIGIN/SITE_BASE — that is site configuration, not a tool pin.
+#
+# The two link-check tools are optional because the jobs that only RENDER the
+# book (the frozen version cut, the full-site assembly) install neither: they
+# lint and link-check nothing, so pulling mdbook-lint and lychee there would be
+# download time for nothing. The tool list is assembled in the pinned order the
+# workflows used.
+#
+# Requires the repository to be checked out (a local action resolves against the
+# runner's workspace).
+name: Install the docs toolchain
+description: Install the pinned mdBook toolchain (plus the lint and link-check tools when asked for).
+
+inputs:
+  mdbook-version:
+    description: mdBook version.
+    required: false
+    default: "0.5.4"
+  mdbook-mermaid-version:
+    description: mdbook-mermaid version.
+    required: false
+    default: "0.17.0"
+  mdbook-toc-version:
+    description: mdbook-toc version.
+    required: false
+    default: "0.15.4"
+  mdbook-katex-version:
+    description: mdbook-katex version.
+    required: false
+    default: "0.10.0"
+  mdbook-lint-version:
+    description: mdbook-lint version.
+    required: false
+    default: "0.14.4"
+  lychee-version:
+    description: lychee version.
+    required: false
+    default: "0.24.2"
+  lint:
+    description: Also install mdbook-lint (the markdown lint gate).
+    required: false
+    default: "true"
+  link-check:
+    description: Also install lychee (the link-check gate).
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - uses: taiki-e/install-action@288e746965032cfcc232e09af2daf5f23c14d780 # v2.86.1
+      with:
+        tool: mdbook@${{ inputs.mdbook-version }},mdbook-mermaid@${{ inputs.mdbook-mermaid-version }},mdbook-toc@${{ inputs.mdbook-toc-version }},mdbook-katex@${{ inputs.mdbook-katex-version }}${{ inputs.lint == 'true' && format(',mdbook-lint@{0}', inputs.mdbook-lint-version) || '' }}${{ inputs.link-check == 'true' && format(',lychee@{0}', inputs.lychee-version) || '' }}

--- a/.github/actions/file-watcher-issue/action.yml
+++ b/.github/actions/file-watcher-issue/action.yml
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
+# .github/actions/file-watcher-issue — file one tracking issue, or comment on it.
+#
+# ONE engine for the watcher family (#2775): six workflows file an issue when
+# their probe finds something, today with three different dedup idioms. The
+# semantics here are the ones the image scan uses, which are the ones worth
+# keeping: dedup by an EXACT-title search over open issues, comment on the
+# existing issue rather than opening a second one, and never touch a closed
+# issue (a finding that returns after a close is new work, not a reopen).
+#
+# A dedup search matches the title EXACTLY (`in:title "<title>"`), so the title
+# is the dedup key — a title carrying a run number, a date, or a version would
+# open a new issue every run. Keep it constant and put the varying detail in the
+# body.
+#
+# The body arrives as a FILE, never as an argument: watcher bodies carry remote
+# content (upstream release notes, scanner output, server messages) that must
+# never be parsed as script or as a flag.
+#
+# Requires the repository to be checked out (a local action resolves against the
+# runner's workspace), and a token with `issues: write`.
+name: File or update a watcher issue
+description: Open one tracking issue for a watcher finding, or comment on the open one that already exists.
+
+inputs:
+  title:
+    description: The issue title — also the dedup key, so keep it constant across runs.
+    required: true
+  body-file:
+    description: Path to the markdown body (a file, so remote content is never an argument).
+    required: true
+  labels:
+    description: Comma-separated labels applied when the issue is CREATED (ignored on a comment).
+    required: false
+    default: ""
+  repo:
+    description: The repository to file in.
+    required: false
+    default: ${{ github.repository }}
+  token:
+    description: "A token with `issues: write`."
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  issue:
+    description: The issue number that was created or commented on.
+    value: ${{ steps.file.outputs.issue }}
+  outcome:
+    description: '"created" or "commented".'
+    value: ${{ steps.file.outputs.outcome }}
+
+runs:
+  using: composite
+  steps:
+    - id: file
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        REPO: ${{ inputs.repo }}
+        TITLE: ${{ inputs.title }}
+        BODY_FILE: ${{ inputs.body-file }}
+        LABELS: ${{ inputs.labels }}
+      run: |
+        set -euo pipefail
+        [ -s "$BODY_FILE" ] || { echo "::error::body file '$BODY_FILE' is missing or empty"; exit 1; }
+
+        existing="$(gh issue list --repo "$REPO" --state open --search "in:title \"$TITLE\"" \
+                      --json number --jq '.[0].number // empty')"
+        if [ -n "$existing" ]; then
+          gh issue comment "$existing" --repo "$REPO" --body-file "$BODY_FILE"
+          echo "commented on #${existing}"
+          {
+            echo "issue=$existing"
+            echo "outcome=commented"
+          } >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # One --label per name; an empty list creates an unlabelled issue.
+        label_args=()
+        if [ -n "$LABELS" ]; then
+          IFS=',' read -r -a names <<<"$LABELS"
+          for name in "${names[@]}"; do
+            name="${name#"${name%%[![:space:]]*}"}"
+            name="${name%"${name##*[![:space:]]}"}"
+            [ -n "$name" ] && label_args+=(--label "$name")
+          done
+        fi
+        url="$(gh issue create --repo "$REPO" --title "$TITLE" --body-file "$BODY_FILE" \
+                 "${label_args[@]+"${label_args[@]}"}")"
+        echo "filed ${url}"
+        {
+          echo "issue=${url##*/}"
+          echo "outcome=created"
+        } >> "$GITHUB_OUTPUT"

--- a/.github/actions/helm-pinned/action.yml
+++ b/.github/actions/helm-pinned/action.yml
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
+# .github/actions/helm-pinned — install the helm the golden renders are pinned to.
+#
+# ONE home for the read-the-pin-then-install pair that was copied verbatim into
+# three jobs (build-chart.yml, ci.yml `helm-golden`, ci.yml `chart-boot`) — #2775.
+#
+# `azure/setup-helm` has NO `version-file` input — its inputs are `version`,
+# `token` and `downloadBaseURL`. An unknown input is a WARNING, not an error, so
+# passing one silently installs the latest helm and the pin stops meaning
+# anything: that is how a run reported "running helm 4.2.3, goldens are pinned
+# to 4.1.3". Read the pin here and pass it as the input that exists.
+#
+# The pin is load-bearing, not hygiene: `helm template` output is not byte-stable
+# across helm releases, so an unpinned runner turns the golden compare into a
+# whitespace diff nobody can act on. deploy/helm/.tool-versions carries the
+# version and the full rationale.
+#
+# Requires the repository to be checked out (a local action resolves against the
+# runner's workspace, and the version file is read from it).
+name: Install the pinned helm
+description: Read the helm pin from a .tool-versions file and install exactly that helm.
+
+inputs:
+  version-file:
+    description: The asdf/mise .tool-versions file carrying the `helm <version>` line.
+    required: false
+    default: deploy/helm/.tool-versions
+
+outputs:
+  version:
+    description: The installed helm version, `v`-prefixed (e.g. `v4.2.3`).
+    value: ${{ steps.helm-pin.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Read the pinned helm version
+      id: helm-pin
+      shell: bash
+      env:
+        VERSION_FILE: ${{ inputs.version-file }}
+      run: |
+        set -euo pipefail
+        version="$(awk '$1 == "helm" { print $2 }' "$VERSION_FILE")"
+        [ -n "$version" ] || { echo "::error::no helm line in $VERSION_FILE"; exit 1; }
+        echo "version=v${version}" >> "$GITHUB_OUTPUT"
+        echo "pinned helm: v${version}"
+    - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+      with:
+        version: ${{ steps.helm-pin.outputs.version }}

--- a/.github/actions/release-kind/action.yml
+++ b/.github/actions/release-kind/action.yml
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
+# .github/actions/release-kind — is this a release, and is it a pre-release?
+#
+# THE definition of the pre-release rule for step-level consumers (#2775): it was
+# spelled four ways in four files, one of them missing the pre-release half
+# entirely. Releases publish as OFFICIAL releases (owner sign-off 2026-07-31,
+# superseding the 2026-07-11 always-prerelease rule); only an explicitly suffixed
+# tag (v3.16.0-rc1, ...) is a pre-release.
+#
+#   is-release     a v* tag with no `-` suffix — the cut that moves the RELEASE
+#                  pointers (`:latest`, /docs/latest/, the hosted sandbox)
+#   is-prerelease  a v* tag WITH a `-` suffix
+#
+# Neither is true when the ref is not a `v*` tag at all (a develop push, a
+# pull request), so a caller can branch on one output alone.
+#
+# A workflow that must decide in an EXPRESSION position a step output cannot
+# reach (a `jobs.<id>.if`, a `with:` on a job call) still spells the rule inline
+# and carries a comment pointing here.
+#
+# Requires the repository to be checked out (a local action resolves against the
+# runner's workspace, not against the repository of the running workflow —
+# https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax),
+# so a lane that checks out a TAG reads this action from that tag's tree.
+name: Classify the release kind
+description: Decide whether this ref is a release tag and whether it is a pre-release.
+
+inputs:
+  tag:
+    description: >-
+      The tag to classify. Defaults to the pushed tag (empty when the ref is not
+      a tag), which is what every trigger-driven caller wants; a lane that
+      resolves its tag from a dispatch input passes that resolved tag instead.
+    required: false
+    default: ""
+
+outputs:
+  is-release:
+    description: '"true" for a `v*` tag with no pre-release suffix, else "false".'
+    value: ${{ steps.kind.outputs.is-release }}
+  is-prerelease:
+    description: '"true" for a `v*` tag WITH a pre-release suffix, else "false".'
+    value: ${{ steps.kind.outputs.is-prerelease }}
+  tag:
+    description: The tag that was classified, empty when the ref is not a tag.
+    value: ${{ steps.kind.outputs.tag }}
+
+runs:
+  using: composite
+  steps:
+    - id: kind
+      shell: bash
+      env:
+        INPUT_TAG: ${{ inputs.tag }}
+        REF: ${{ github.ref }}
+        REF_NAME: ${{ github.ref_name }}
+      run: |
+        set -euo pipefail
+        tag="$INPUT_TAG"
+        if [ -z "$tag" ] && [ "${REF#refs/tags/}" != "$REF" ]; then
+          tag="$REF_NAME"
+        fi
+        is_release=false
+        is_prerelease=false
+        case "$tag" in
+          v*-*) is_prerelease=true ;;
+          v*)   is_release=true ;;
+        esac
+        {
+          echo "tag=$tag"
+          echo "is-release=$is_release"
+          echo "is-prerelease=$is_prerelease"
+        } >> "$GITHUB_OUTPUT"
+        echo "tag '${tag}': release=${is_release} prerelease=${is_prerelease}"

--- a/.github/workflows/build-chart.yml
+++ b/.github/workflows/build-chart.yml
@@ -54,21 +54,10 @@ jobs:
         with:
           persist-credentials: false
 
-      # The same helm the golden renders are pinned to, from the same file.
-      # `azure/setup-helm` takes `version`, not `version-file` — an unknown input
-      # is only a warning, so passing the wrong one silently installs the latest
-      # helm and the pin stops meaning anything.
-      - name: Read the pinned helm version
-        id: helm-pin
-        run: |
-          set -euo pipefail
-          version="$(awk '$1 == "helm" { print $2 }' deploy/helm/.tool-versions)"
-          [ -n "$version" ] || { echo "::error::no helm line in deploy/helm/.tool-versions"; exit 1; }
-          echo "version=v${version}" >> "$GITHUB_OUTPUT"
-          echo "pinned helm: v${version}"
-      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
-        with:
-          version: ${{ steps.helm-pin.outputs.version }}
+      # The same helm the golden renders are pinned to, from the same file. The
+      # read-and-install pair lives in the composite (#2775), which is also where
+      # the `version` vs `version-file` trap is recorded.
+      - uses: ./.github/actions/helm-pinned
       - uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
         with:
           version: 1.3.3
@@ -314,6 +303,10 @@ jobs:
           fi
           bash deploy/helm/artifacthub-changes.sh "$section" --inject
           # An `-rc` tag is a chart pre-release, matching release.yml's own rule.
+          # The prerelease rule — one definition: .github/actions/release-kind.
+          # This suffix list is NARROWER than that definition (it accepts three
+          # suffixes, not any `-`), so collapsing the two is a behaviour
+          # decision, not a refactor.
           case "$TAG" in
             *-rc*|*-alpha*|*-beta*)
               printf '  artifacthub.io/prerelease: "true"\n' >> "$CHART_DIR/Chart.yaml" ;;

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -149,6 +149,10 @@ jobs:
       # tags identically by construction.
       # `latest` is the RELEASE pointer (the hosted sandbox tracks it —
       # deploy/vercel/README.md); a prerelease tag must not move it.
+      # The prerelease rule — one definition: .github/actions/release-kind. Still
+      # spelled inline here: this lane's tag policy is read by every image, and
+      # moving it onto the composite's output is part of forming the release
+      # pipeline (#2775), not of deduplicating steps.
       - name: Metadata
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,16 +329,20 @@ jobs:
       - uses: taiki-e/install-action@288e746965032cfcc232e09af2daf5f23c14d780 # v2.86.1
         with:
           tool: zizmor@1.29.0
-      - name: Audit .github/workflows
+      - name: Audit .github/workflows + .github/actions
         # GH_TOKEN enables the ONLINE audits, which is the point of running this
         # beside SHA pinning: impostor-commit verifies that a pinned commit
         # really belongs to the repository named in front of it, and it cannot
         # do that offline. --min-severity=low gates on every actionable tier
         # (artipacked is Low) and leaves the informational tier advisory; zizmor
         # exits non-zero when anything at or above the floor is found.
+        #
+        # The composite actions are audited too (#2775): they carry `uses:` of
+        # their own, so a pin only they declare would otherwise be the one
+        # `uses:` in the estate nothing checks.
         env:
           GH_TOKEN: ${{ github.token }}
-        run: zizmor --min-severity=low .github/workflows/
+        run: zizmor --min-severity=low .github/workflows/ .github/actions/
 
   # actionlint (github.com/rhysd/actionlint) is the CORRECTNESS half of the pair
   # above: zizmor audits security posture, actionlint checks that the workflow
@@ -1045,23 +1049,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      # `azure/setup-helm` has NO `version-file` input — its inputs are `version`,
-      # `token` and `downloadBaseURL`. An unknown input is a WARNING, not an
-      # error, so the action silently installed the latest helm and the golden
-      # compare skipped itself ("running helm 4.2.3, goldens are pinned to
-      # 4.1.3") while the job still went red. Read the pin and pass it as the
-      # input that exists.
-      - name: Read the pinned helm version
-        id: helm-pin
-        run: |
-          set -euo pipefail
-          version="$(awk '$1 == "helm" { print $2 }' deploy/helm/.tool-versions)"
-          [ -n "$version" ] || { echo "::error::no helm line in deploy/helm/.tool-versions"; exit 1; }
-          echo "version=v${version}" >> "$GITHUB_OUTPUT"
-          echo "pinned helm: v${version}"
-      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
-        with:
-          version: ${{ steps.helm-pin.outputs.version }}
+      # The pinned helm, read from deploy/helm/.tool-versions and installed by the
+      # composite (#2775) — which is also where the `version` vs `version-file`
+      # trap that silently installed the latest helm is recorded.
+      - uses: ./.github/actions/helm-pinned
       - name: helm lint (default + all-features value sets)
         run: |
           helm lint deploy/helm/ferroehr -f deploy/helm/ci/default-values.yaml
@@ -1117,18 +1108,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      # The same pin as the goldens, from the same file: `azure/setup-helm` takes
-      # `version`, never `version-file`, and an unknown input is only a warning.
-      - name: Read the pinned helm version
-        id: helm-pin
-        run: |
-          set -euo pipefail
-          version="$(awk '$1 == "helm" { print $2 }' deploy/helm/.tool-versions)"
-          [ -n "$version" ] || { echo "::error::no helm line in deploy/helm/.tool-versions"; exit 1; }
-          echo "version=v${version}" >> "$GITHUB_OUTPUT"
-      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
-        with:
-          version: ${{ steps.helm-pin.outputs.version }}
+      # The same pin as the goldens, from the same file and the same composite.
+      - uses: ./.github/actions/helm-pinned
       # The artifact download loses the executable bit; the Dockerfile COPYs the
       # binary with `--chmod=0755`, which is why that does not matter here.
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -28,6 +28,13 @@ concurrency:
   group: containers-${{ github.ref }}
   cancel-in-progress: true
 
+# The three image names, derived from the repository owner — the same derivation
+# build-chart.yml and image-scan.yml use. Every STEP in this file reads them from
+# here; the three `uses: build-image.yml` lanes repeat the derivation inline
+# because the `env` context does not exist at job level, which is a documented
+# context restriction and not a choice
+# (https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#context-availability).
+# They used to repeat the OWNER as a literal instead (#2775).
 env:
   REGISTRY: ghcr.io
   APP_IMAGE: ghcr.io/${{ github.repository_owner }}/ferroehr
@@ -259,7 +266,7 @@ jobs:
     # scripts/checks/image-labels.sh fails if the two ever disagree.
     uses: ./.github/workflows/build-image.yml
     with:
-      image: ghcr.io/rubentalstra/ferroehr
+      image: ghcr.io/${{ github.repository_owner }}/ferroehr
       defer-tags: true
       dockerfile: docker/Dockerfile
       target: runtime-prebuilt
@@ -395,7 +402,7 @@ jobs:
     # The reusable SLSA Build L3 lane; see the app image above.
     uses: ./.github/workflows/build-image.yml
     with:
-      image: ghcr.io/rubentalstra/ferroehr-admin-ui
+      image: ghcr.io/${{ github.repository_owner }}/ferroehr-admin-ui
       defer-tags: true
       dockerfile: docker/admin-ui/Dockerfile
       target: runtime-prebuilt
@@ -432,7 +439,7 @@ jobs:
     # security upgrade, #2408) executes on the non-native platform.
     uses: ./.github/workflows/build-image.yml
     with:
-      image: ghcr.io/rubentalstra/ferroehr-postgres
+      image: ghcr.io/${{ github.repository_owner }}/ferroehr-postgres
       defer-tags: true
       dockerfile: docker/postgres/Dockerfile
       context: docker/postgres

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,14 +13,9 @@ on:
   pull_request:             # PR: build + lint + link-check ONLY (no deploy)
   workflow_dispatch:
 
-# Pinned toolchain — the single source of truth for the docs build.
+# The pinned toolchain lives in .github/actions/docs-toolchain (#2775) — it was
+# declared verbatim here and in link-check-external.yml.
 env:
-  MDBOOK_VERSION: "0.5.4"
-  MDBOOK_MERMAID_VERSION: "0.17.0"
-  MDBOOK_TOC_VERSION: "0.15.4"
-  MDBOOK_KATEX_VERSION: "0.10.0"
-  MDBOOK_LINT_VERSION: "0.14.4"
-  LYCHEE_VERSION: "0.24.2"
   # Custom domain (ferroehr.eu): the site is served at the apex root, so the
   # base path is empty. Set explicitly so CI and scripts/site/build.sh agree.
   SITE_ORIGIN: "https://ferroehr.eu"
@@ -54,9 +49,7 @@ jobs:
       # The deployed site is rebuilt in the deploy job, which restores no build
       # cache; this job publishes only a pull-request diagnostic artifact.
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0 # zizmor: ignore[cache-poisoning]
-      - uses: taiki-e/install-action@288e746965032cfcc232e09af2daf5f23c14d780 # v2.86.1
-        with:
-          tool: mdbook@${{ env.MDBOOK_VERSION }},mdbook-mermaid@${{ env.MDBOOK_MERMAID_VERSION }},mdbook-toc@${{ env.MDBOOK_TOC_VERSION }},mdbook-katex@${{ env.MDBOOK_KATEX_VERSION }},mdbook-lint@${{ env.MDBOOK_LINT_VERSION }},lychee@${{ env.LYCHEE_VERSION }}
+      - uses: ./.github/actions/docs-toolchain
       - name: Stale-numbers gate (no hand-typed conformance claims in site sources)
         run: bash scripts/checks/conformance-numbers.sh
       - name: Render conformance stats + comparison + perf assets (the generated includes must exist before lint)
@@ -131,9 +124,12 @@ jobs:
         with:
           persist-credentials: true # zizmor: ignore[artipacked]
           fetch-depth: 0
-      - uses: taiki-e/install-action@288e746965032cfcc232e09af2daf5f23c14d780 # v2.86.1
+      # This job renders the book and pushes it; it lints and link-checks
+      # nothing, so neither link-check tool is installed.
+      - uses: ./.github/actions/docs-toolchain
         with:
-          tool: mdbook@${{ env.MDBOOK_VERSION }},mdbook-mermaid@${{ env.MDBOOK_MERMAID_VERSION }},mdbook-toc@${{ env.MDBOOK_TOC_VERSION }},mdbook-katex@${{ env.MDBOOK_KATEX_VERSION }}
+          lint: "false"
+          link-check: "false"
       - name: Build frozen vX.Y.Z + push to docs-dist
         run: bash scripts/site/cut-version.sh "${GITHUB_REF_NAME}"   # site-url, rsync into docs-dist, update versions.json, commit+push
 
@@ -168,9 +164,11 @@ jobs:
           persist-credentials: true # zizmor: ignore[artipacked]
       - name: Fetch docs-dist (frozen versions)
         run: git fetch origin docs-dist && git worktree add docs-dist origin/docs-dist || true
-      - uses: taiki-e/install-action@288e746965032cfcc232e09af2daf5f23c14d780 # v2.86.1
+      # Assembly only: the lint and link-check gates ran in `build`.
+      - uses: ./.github/actions/docs-toolchain
         with:
-          tool: mdbook@${{ env.MDBOOK_VERSION }},mdbook-mermaid@${{ env.MDBOOK_MERMAID_VERSION }},mdbook-toc@${{ env.MDBOOK_TOC_VERSION }},mdbook-katex@${{ env.MDBOOK_KATEX_VERSION }}
+          lint: "false"
+          link-check: "false"
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - name: Assemble full _site (landing + dev + frozen versions + latest + sitemap)
         run: bash scripts/site/build.sh --full

--- a/.github/workflows/link-check-external.yml
+++ b/.github/workflows/link-check-external.yml
@@ -27,13 +27,9 @@ on:
     - cron: "11 6 * * 1"
   workflow_dispatch:
 
+# The toolchain pins live in .github/actions/docs-toolchain (#2775); these two
+# are site configuration, not tool pins.
 env:
-  MDBOOK_VERSION: "0.5.4"
-  MDBOOK_MERMAID_VERSION: "0.17.0"
-  MDBOOK_TOC_VERSION: "0.15.4"
-  MDBOOK_KATEX_VERSION: "0.10.0"
-  MDBOOK_LINT_VERSION: "0.14.4"
-  LYCHEE_VERSION: "0.24.2"
   SITE_ORIGIN: "https://ferroehr.eu"
   SITE_BASE: ""
 
@@ -55,9 +51,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0 # zizmor: ignore[cache-poisoning]
-      - uses: taiki-e/install-action@288e746965032cfcc232e09af2daf5f23c14d780 # v2.86.1
-        with:
-          tool: mdbook@${{ env.MDBOOK_VERSION }},mdbook-mermaid@${{ env.MDBOOK_MERMAID_VERSION }},mdbook-toc@${{ env.MDBOOK_TOC_VERSION }},mdbook-katex@${{ env.MDBOOK_KATEX_VERSION }},mdbook-lint@${{ env.MDBOOK_LINT_VERSION }},lychee@${{ env.LYCHEE_VERSION }}
+      - uses: ./.github/actions/docs-toolchain
 
       - name: Render the generated includes the book expects
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,6 +169,13 @@ jobs:
           [ "$count" -gt 0 ] || { echo "::error::the SPDX SBOM lists no packages"; exit 1; }
           echo "SPDX ${version}, ${count} packages"
 
+      # The tag comes from the step above (a dispatch names it, a push carries
+      # it), never from the ref alone.
+      - id: kind
+        uses: ./.github/actions/release-kind
+        with:
+          tag: ${{ steps.tag.outputs.tag }}
+
       # Created as a DRAFT, and finalized only after every asset is attached.
       #
       # Release immutability is enabled on this repository: once a release is
@@ -197,8 +204,8 @@ jobs:
           # Releases publish as OFFICIAL releases (owner sign-off
           # 2026-07-31, superseding the 2026-07-11 always-prerelease rule);
           # only an explicitly suffixed tag (v3.16.0-rc1, ...) is a
-          # pre-release.
-          prerelease: ${{ contains(steps.tag.outputs.tag, '-') }}
+          # pre-release. The rule itself lives in the composite above.
+          prerelease: ${{ steps.kind.outputs.is-prerelease }}
 
   # Native runner per arch (no cross toolchain, no QEMU) — same strategy as
   # .github/workflows/containers.yml, which handles the GHCR images on tags.

--- a/.github/workflows/sandbox-deploy.yml
+++ b/.github/workflows/sandbox-deploy.yml
@@ -68,6 +68,8 @@ jobs:
     # for workflow_run, only a SUCCESSFUL Containers run for a release tag
     # (head_branch carries the tag name on tag-triggered runs; a prerelease
     # suffix is skipped — `latest` does not move for those either).
+    # The prerelease rule — one definition: .github/actions/release-kind. It is
+    # spelled inline here because a job-level `if:` cannot read a step output.
     if: >-
       github.repository == 'rubentalstra/FerroEHR' &&
       (github.event_name != 'workflow_run' ||

--- a/scripts/checks/image-labels.sh
+++ b/scripts/checks/image-labels.sh
@@ -66,13 +66,15 @@ dockerfile_label() {
 # The value declared in the workflow's `labels:` block for one lane. A lane is
 # one `uses: build-image.yml` call; it opens at its `image: ghcr.io/...<name>`
 # input (matched to end-of-line, so a name that prefixes another cannot open
-# the wrong lane) and closes at the next lane's.
+# the wrong lane) and closes at the next lane's. The owner is derived from
+# `github.repository_owner` in the workflow, so the lane opener is matched by
+# its trailing `/<name>` rather than by a hard-coded owner.
 workflow_label() {
-  awk -v lane="image: ghcr.io/rubentalstra/$1" -v key="org.opencontainers.image.$2=" '
+  awk -v lane="/$1" -v key="org.opencontainers.image.$2=" '
     /image: ghcr\.io\// {
       line = $0
       sub(/^[[:space:]]*/, "", line); sub(/[[:space:]]*$/, "", line)
-      inlane = (line == lane)
+      inlane = (substr(line, length(line) - length(lane) + 1) == lane)
     }
     inlane && index($0, key) {
       i = index($0, key) + length(key)
@@ -125,23 +127,32 @@ for entry in $IMAGES; do
   fi
 done
 
-# The CI service containers must run the exact base the postgres image is
-# built on — a drifted service pin tests against different bytes than the
-# image ships (found as a checklist item in #2408/#2410, enforced here since).
-CI_WORKFLOW=.github/workflows/ci.yml
+# Every service container must run the exact base the postgres image is built
+# on — a drifted service pin tests against different bytes than the image ships
+# (found as a checklist item in #2408/#2410, enforced here since).
+#
+# EVERY workflow is scanned, not a named list: the check was written against
+# ci.yml alone and sonar.yml's identical service pin — a second full instrumented
+# suite against the same database — was never covered (#2775). A list would have
+# to be extended by whoever adds the next service container, which is exactly the
+# person who does not know this guard exists.
 pg_from=$(grep -E '^FROM postgres:' docker/postgres/Dockerfile | awk '{print $2}' || true)
 if [[ -z "$pg_from" ]]; then
   report "image-labels: docker/postgres/Dockerfile has no 'FROM postgres:' pin"
 else
-  ci_pins=$(grep -Eo 'image: postgres:[^[:space:]]+' "$CI_WORKFLOW" | sed 's/^image: //' | sort -u || true)
-  if [[ -z "$ci_pins" ]]; then
-    report "image-labels: $CI_WORKFLOW declares no postgres service pins to check"
-  else
-    for pin in $ci_pins; do
+  found_any=0
+  for wf in .github/workflows/*.yml; do
+    pins=$(grep -Eo 'image: postgres:[^[:space:]]+' "$wf" | sed 's/^image: //' | sort -u || true)
+    [[ -n "$pins" ]] || continue
+    found_any=1
+    for pin in $pins; do
       [[ "$pin" = "$pg_from" ]] \
-        || report "image-labels: $CI_WORKFLOW pins service '$pin', but docker/postgres/Dockerfile FROM is '$pg_from'"
+        || report "image-labels: $wf pins service '$pin', but docker/postgres/Dockerfile FROM is '$pg_from'"
     done
-  fi
+  done
+  # A guard that finds nothing to check is not passing, it is vacuous.
+  [[ "$found_any" -eq 1 ]] \
+    || report "image-labels: no workflow declares a postgres service pin — this check verified nothing"
 fi
 
 # Annotations must reach the INDEX, which is the only place GHCR reads a package

--- a/scripts/gh/retry-net.sh
+++ b/scripts/gh/retry-net.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+# scripts/gh/retry-net.sh — the two network idioms a publishing lane may use.
+#
+# WHY THIS EXISTS (#2775): a publishing lane runs under `set -euo pipefail`, and
+# a bare network call in a command substitution therefore ENDS the lane on any
+# transient failure. At v4.0.4 one TLS handshake timeout inside the chart lane's
+# wait loop failed a release with nothing wrong with the chart. The lesson is not
+# "retry more" — it is that the two kinds of network call have two different
+# correct shapes:
+#
+#   1. An IDEMPOTENT READ retries inside curl and fails loud when it truly
+#      cannot be served: `retry_read`.
+#   2. A POLL — "has the thing appeared yet?" — treats ANY failure as "not
+#      observed yet" and lets the deadline decide: `poll_until`. A poll that
+#      dies on a transient error reports an absence that was never measured.
+#
+# A STATE-CHANGING call (a push, a signature) is neither: it retries a bounded
+# number of times with a growing pause and fails loud, because "did it happen?"
+# is not answerable by asking again. `retry_state` is that shape (the chart
+# lane's 3-attempt cosign loop, which exists because chart 6.0.14 was lost to a
+# single Fulcio connection reset).
+#
+# This is a FUNCTION LIBRARY, not a wrapper action: a composite action cannot
+# wrap an arbitrary step of its caller. Source it inside the `run:` block:
+#
+#   source scripts/gh/retry-net.sh
+#   body="$(retry_read "https://crates.io/api/v1/crates/openehr-base/versions")"
+#
+# curl flags, per the official documentation
+# (https://everything.curl.dev/usingcurl/downloads/retry.html):
+#   --retry N              retry transient failures (timeouts, 408/429/5xx)
+#   --retry-connrefused    also retry a refused connection — a service still
+#                          starting, which is the common CI case
+#   --retry-all-errors     retry EVERYTHING, including a non-transient 4xx; only
+#                          for a request that is safe to re-send and where a
+#                          wrong answer is worse than a slow one. Not used by
+#                          the helpers here.
+#   --fail                 a 4xx/5xx body is not output as if it were data (the
+#                          defect that let an error body reach jq and end a step)
+set -uo pipefail
+
+# retry_read <url> [curl-arg...] — GET an idempotent resource, retried inside
+# curl, printing the body on stdout. Returns curl's exit status, so the caller
+# decides whether a failure is fatal.
+retry_read() {
+  local url="$1"
+  shift || true
+  curl --proto '=https' --tlsv1.2 -sSL --fail \
+    --retry 5 --retry-connrefused --retry-delay 2 --max-time 60 \
+    "$@" "$url"
+}
+
+# poll_until <deadline-epoch> <interval-seconds> <command...> — run the command
+# until it succeeds or the deadline passes. Transient failure is "not observed
+# yet", never lane death: the command runs guarded in an `if`, so nothing it
+# does can trip `set -e` in the caller.
+#
+# Returns 0 as soon as the command succeeds, 1 when the deadline passes. The
+# caller writes the ::error:: message, because only it knows what the absence
+# means and what a human should do about it.
+poll_until() {
+  local deadline="$1" interval="$2"
+  shift 2
+  while :; do
+    if "$@"; then
+      return 0
+    fi
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      return 1
+    fi
+    sleep "$interval"
+  done
+}
+
+# deadline_in <seconds> — an absolute epoch deadline for poll_until.
+deadline_in() {
+  echo $(( $(date +%s) + $1 ))
+}
+
+# retry_state <attempts> <what> <command...> — a STATE-CHANGING call, retried a
+# bounded number of times with a growing pause. Returns 0 on the first success,
+# 1 when every attempt failed; the caller writes the ::error:: message.
+retry_state() {
+  local attempts="$1" what="$2"
+  shift 2
+  local attempt
+  for (( attempt = 1; attempt <= attempts; attempt++ )); do
+    if "$@"; then
+      return 0
+    fi
+    if [ "$attempt" -lt "$attempts" ]; then
+      echo "${what} attempt ${attempt} failed; retrying in $(( attempt * 10 ))s"
+      sleep $(( attempt * 10 ))
+    fi
+  done
+  return 1
+}


### PR DESCRIPTION
Closes #2775 (phase 1 of #2772; the approved design is `docs/plans/github-workflows-greenfield.md`).

Step-level deduplication with zero behaviour change: `.github/actions/{helm-pinned,docs-toolchain,release-kind,file-watcher-issue}` + `scripts/gh/retry-net.sh`, consumed by build-chart/ci/docs/link-check-external/release; `containers.yml` now derives its three image names the same way its siblings do (the `env` context is unavailable at job level — documented restriction, noted in place); `image-labels.sh` extends to every workflow's postgres service pins (it read only ci.yml and missed sonar.yml — mutation-proven in both directions on the PR thread's report). Two planned composites are adjudicated OUT with platform evidence on the issue: checkout (a local action cannot perform a job's first checkout) and rust-toolchain (actions/runner#3514 would silently invert the cache-save posture through rust-cache's post step).

Verified: zizmor identical to the develop baseline (zero new findings, composites included), actionlint clean (and proven to validate composite inputs by name), shellcheck clean, image-labels OK + 3 mutations, ci-conclusion-complete 41/41, per-file behaviour-identity review in the implementation report. This PR's own CI run is the live proof — it executes the edited ci.yml with the composites.