### PR TITLE
chore(memory): the label gotcha reflects the labeled-event types

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -33,3 +33,4 @@
 - [Rewrite fn docs on update](rewrite-fn-docs-on-update.md) — always fully rewrite a touched function's doc comment; include the /// block in old_string so docs never orphan
 - [UNLOGGED node rejected](unlogged-node-rejected.md) — owner ruling 2026-08-25: node stays LOGGED; never re-propose reduced-durability storage tiers (measured record on #2698)
 - [Public comments: one and short](public-comments-one-and-short.md) — external-facing threads get exactly ONE short plain comment; edit it rather than adding another
+- [No AI tells in prose](no-ai-tells-in-prose.md) — em dashes, not-X-but-Y, triads, buzzwords banned in all drafted prose

--- a/.claude/memory/session-workflow-gotchas.md
+++ b/.claude/memory/session-workflow-gotchas.md
@@ -5,7 +5,7 @@ metadata:
   node_type: memory
   type: project
   originSessionId: 1be6641a-9768-4fd5-8149-acb2551a1d97
-  modified: 2026-08-26T12:01:18.434Z
+  modified: 2026-08-26T12:03:26.100Z
 ---
 
 Recurring session-workflow traps (all hit 2026-07-13/14):
@@ -71,7 +71,12 @@ Recurring session-workflow traps (all hit 2026-07-13/14):
    trigger time), so adding the label then rerunning the failed job still
    fails. Since #2777 ci.yml listens for `labeled`/`unlabeled`, so applying
    the label raises a fresh run by itself — wait for that run, never re-run
-   the stale one (close+reopen is obsolete). Also (hit 2026-07-20):
+   the stale one (close+reopen is obsolete). Corollary (hit 2026-08-26):
+   `gh pr create --label X` fires opened+labeled in the same second — the
+   opened run gets CANCELLED and `gh pr checks` then shows its rows as
+   `fail` beside the live run's rows. Monitor the RUN ID
+   (`gh run list --branch <br>`), never the mixed pr-checks rows. Also
+   (hit 2026-07-20):
    a label a workflow references must actually EXIST in the repo —
    `no-ui-visual-change` didn't until it was first needed; `gh label
    create` fails loudly at apply time, the workflow never warns.


### PR DESCRIPTION
The in-repo memory's guard-label gotcha now records the #2777 mechanism (applying a label raises a fresh run; a re-run replays the stale payload; close+reopen is obsolete) plus the corollary hit while landing it: `gh pr create --label X` fires opened+labeled in the same second, the opened run is cancelled by design, and `gh pr checks` shows the corpse's rows as failures beside the live run — monitor the run id, never the mixed rows.