### PR TITLE
ci(workflows): phase 4 — one watcher engine, uniform run colour

### DIFF
--- a/.claude/rules/image-security.md
+++ b/.claude/rules/image-security.md
@@ -25,8 +25,8 @@ detection lane existed but the remediation path was tribal.
 | Instrument | When | What it catches |
 |---|---|---|
 | the `scan-and-tag.yml` image-scan job (called by `containers.yml` and the release pipeline) | every image build | what was known at build time |
-| `image-scan.yml` | Mondays 07:13 UTC, on the PUBLISHED `:latest` refs | CVEs published after the release; files/updates ONE tracking issue and goes red |
-| `base-image-watcher.yml` | Mondays 07:43 UTC | a newer `postgres` patch tag on the pinned major, or the pinned tag re-pointed upstream (a same-version security respin); files/updates ONE tracking issue |
+| `image-scan.yml` | Mondays 07:13 UTC, on the PUBLISHED `:latest` refs | CVEs published after the release; files/updates ONE tracking issue — **the issue is the alert**, the run stays green (#2778) |
+| `base-image-watcher.yml` | Mondays 08:13 UTC | a newer `postgres` patch tag on the pinned major, or the pinned tag re-pointed upstream (a same-version security respin); files/updates ONE tracking issue |
 | `scripts/security/scan-images.sh` | on demand, locally | reruns the EXACT published-image scan (same `trivy.yaml`, `.trivyignore.yaml`, `security/vex/*.json`) against the published refs or a locally built candidate |
 
 All four read the same three config surfaces: `trivy.yaml` (severity floor +

--- a/.github/actions/file-watcher-issue/action.yml
+++ b/.github/actions/file-watcher-issue/action.yml
@@ -3,21 +3,21 @@
 
 # .github/actions/file-watcher-issue — file one tracking issue, or comment on it.
 #
-# ONE engine for the watcher family (#2775): six workflows file an issue when
-# their probe finds something, today with three different dedup idioms. The
-# semantics here are the ones the image scan uses, which are the ones worth
-# keeping: dedup by an EXACT-title search over open issues, comment on the
-# existing issue rather than opening a second one, and never touch a closed
-# issue (a finding that returns after a close is new work, not a reopen).
+# The workflow-facing interface of the watcher family's filing engine (#2778).
+# All the behaviour lives in the sibling `file-issue.sh`, which the two probe
+# shells `scripts/watch/spec-{update,release}.sh` call directly because they file
+# N issues per run; that script's header carries the dedup match rule, the
+# body-by-file rule and the family's run-colour law. In short:
 #
-# A dedup search matches the title EXACTLY (`in:title "<title>"`), so the title
-# is the dedup key — a title carrying a run number, a date, or a version would
-# open a new issue every run. Keep it constant and put the varying detail in the
-# body.
-#
-# The body arrives as a FILE, never as an argument: watcher bodies carry remote
-# content (upstream release notes, scanner output, server messages) that must
-# never be parsed as script or as a flag.
+#   * dedup by an exact-title search over open issues, or by `dedup-key` tokens
+#     that must appear in the title (`state: all` searches closed issues too);
+#   * comment on the existing issue rather than opening a second one, and never
+#     touch a closed one — a finding that returns after a close is new work;
+#   * reaching this action is never a failure. A finding files or updates an
+#     issue and the run stays GREEN; the run goes RED only when the PROBE itself
+#     cannot answer, which fails in the probe step and never reaches here. The
+#     issue is the alert — a red scheduled run is invisible to anyone not
+#     watching the Actions tab.
 #
 # Requires the repository to be checked out (a local action resolves against the
 # runner's workspace), and a token with `issues: write`.
@@ -26,7 +26,7 @@ description: Open one tracking issue for a watcher finding, or comment on the op
 
 inputs:
   title:
-    description: The issue title — also the dedup key, so keep it constant across runs.
+    description: The issue title — also the dedup key unless `dedup-key` overrides it, so keep it constant across runs.
     required: true
   body-file:
     description: Path to the markdown body (a file, so remote content is never an argument).
@@ -35,6 +35,22 @@ inputs:
     description: Comma-separated labels applied when the issue is CREATED (ignored on a comment).
     required: false
     default: ""
+  dedup-key:
+    description: Match issues whose title CONTAINS this token instead of matching the title exactly.
+    required: false
+    default: ""
+  state:
+    description: Which issues the dedup search covers — `open` (the default) or `all`.
+    required: false
+    default: open
+  on-existing:
+    description: What an existing match gets — `comment` (the default), `update` (replace the body) or `skip`.
+    required: false
+    default: comment
+  dry-run:
+    description: Report what would be filed and write nothing.
+    required: false
+    default: "false"
   repo:
     description: The repository to file in.
     required: false
@@ -46,10 +62,10 @@ inputs:
 
 outputs:
   issue:
-    description: The issue number that was created or commented on.
+    description: The issue number that was created, commented on, updated or matched.
     value: ${{ steps.file.outputs.issue }}
   outcome:
-    description: '"created" or "commented".'
+    description: '"created", "commented" or "none" (a dry run) — plus "updated"/"skipped" when `on-existing` selects those.'
     value: ${{ steps.file.outputs.outcome }}
 
 runs:
@@ -63,36 +79,18 @@ runs:
         TITLE: ${{ inputs.title }}
         BODY_FILE: ${{ inputs.body-file }}
         LABELS: ${{ inputs.labels }}
+        DEDUP_KEY: ${{ inputs.dedup-key }}
+        STATE: ${{ inputs.state }}
+        ON_EXISTING: ${{ inputs.on-existing }}
+        DRY_RUN: ${{ inputs.dry-run }}
       run: |
         set -euo pipefail
-        [ -s "$BODY_FILE" ] || { echo "::error::body file '$BODY_FILE' is missing or empty"; exit 1; }
-
-        existing="$(gh issue list --repo "$REPO" --state open --search "in:title \"$TITLE\"" \
-                      --json number --jq '.[0].number // empty')"
-        if [ -n "$existing" ]; then
-          gh issue comment "$existing" --repo "$REPO" --body-file "$BODY_FILE"
-          echo "commented on #${existing}"
-          {
-            echo "issue=$existing"
-            echo "outcome=commented"
-          } >> "$GITHUB_OUTPUT"
-          exit 0
+        args=(file --title "$TITLE" --body-file "$BODY_FILE" --repo "$REPO"
+              --state "$STATE" --on-existing "$ON_EXISTING" --labels "$LABELS")
+        if [ -n "$DEDUP_KEY" ]; then
+          args+=(--dedup-key "$DEDUP_KEY")
         fi
-
-        # One --label per name; an empty list creates an unlabelled issue.
-        label_args=()
-        if [ -n "$LABELS" ]; then
-          IFS=',' read -r -a names <<<"$LABELS"
-          for name in "${names[@]}"; do
-            name="${name#"${name%%[![:space:]]*}"}"
-            name="${name%"${name##*[![:space:]]}"}"
-            [ -n "$name" ] && label_args+=(--label "$name")
-          done
+        if [ "$DRY_RUN" = "true" ]; then
+          args+=(--dry-run)
         fi
-        url="$(gh issue create --repo "$REPO" --title "$TITLE" --body-file "$BODY_FILE" \
-                 "${label_args[@]+"${label_args[@]}"}")"
-        echo "filed ${url}"
-        {
-          echo "issue=${url##*/}"
-          echo "outcome=created"
-        } >> "$GITHUB_OUTPUT"
+        bash "$GITHUB_ACTION_PATH/file-issue.sh" "${args[@]}"

--- a/.github/actions/file-watcher-issue/file-issue.sh
+++ b/.github/actions/file-watcher-issue/file-issue.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+#
+# The watcher family's filing engine (#2778) — ONE dedup search and ONE
+# file-or-comment loop for all six watchers. Before this file there were three
+# dedup idioms and four label conventions across six lanes, and one lane
+# (latest-deps) silently skipped an existing issue instead of commenting on it,
+# so a recurring finding vanished after its first report.
+#
+# Callers: the sibling `action.yml` (the workflow-facing interface, used by
+# image-scan, base-image-watcher, latest-deps and link-check-external) and the
+# two probe shells `scripts/watch/spec-{update,release}.sh`, which file N issues
+# per run and therefore call this script directly. The engine lives in the
+# action directory because the action must be self-contained — a composite
+# resolves its own files through `$GITHUB_ACTION_PATH`
+# (https://docs.github.com/en/actions/reference/workflows-and-actions/metadata-syntax#runsstepsrun)
+# — and the scripts reach into it rather than the reverse.
+#
+# RUN COLOUR. This engine only runs after a probe has produced an answer, so
+# reaching it is never a failure: it exits 0 for every outcome (created,
+# commented, updated, skipped, none) and non-zero only when its own `gh` call
+# fails, which is a broken filing path rather than a finding. A probe that
+# cannot answer — transport error, tool crash, unparseable output — fails in the
+# probe step and never gets here. That is the family's uniform rule: the run is
+# RED only when the PROBE fails; a finding files or updates an issue and the run
+# stays GREEN, because the issue is the alert.
+#
+# DEDUP MATCH RULE. GitHub's `in:title "phrase"` is a phrase search, not an
+# exact-title match, so the search alone can return a title that merely CONTAINS
+# the phrase. Both modes therefore post-filter the search result:
+#
+#   * default (no `--dedup-key`) — the title IS the key: a match is an issue
+#     whose title is byte-equal. Keep the title constant across runs (a run
+#     number, date or version in it would open a new issue every run) and put
+#     the varying detail in the body.
+#   * `--dedup-key K` (repeatable) — the key is a token that must appear in the
+#     title: a match is an issue whose title contains EVERY key,
+#     case-insensitively. This is what the spec watchers need, where the Jira
+#     key or the component-plus-version pair identifies the work and the rest of
+#     the title is free text.
+#
+# BODY BY FILE ONLY. Watcher bodies carry remote content — upstream release
+# notes, scanner output, third-party server messages — which must never be
+# parsed as script or as a flag.
+#
+# Usage:
+#   file-issue.sh file --title T --body-file F [--labels a,b] [--dedup-key K]...
+#                      [--state open|all] [--on-existing comment|update|skip]
+#                      [--repo R] [--dry-run]
+#   file-issue.sh find [--title T] [--dedup-key K]... [--state open|all] [--repo R]
+#
+# `file` prints one `file-issue: <outcome> …` line and, when `$GITHUB_OUTPUT` is
+# set, writes `issue=` and `outcome=` to it. `find` prints the matching issue
+# number, or nothing.
+#
+# Env: GH_TOKEN (or GITHUB_TOKEN) for gh · GITHUB_REPOSITORY as the `--repo`
+# default · GITHUB_OUTPUT to receive the outputs.
+set -euo pipefail
+
+verb="${1:-}"
+case "$verb" in
+  file | find) shift ;;
+  *)
+    echo "file-issue: expected verb 'file' or 'find', got '${verb:-<none>}'" >&2
+    exit 2
+    ;;
+esac
+
+title=""
+body_file=""
+labels=""
+state="open"
+on_existing="comment"
+repo="${GITHUB_REPOSITORY:-}"
+dry_run=0
+dedup_keys=()
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --title) title="${2:?--title needs a value}"; shift 2 ;;
+    --body-file) body_file="${2:?--body-file needs a value}"; shift 2 ;;
+    --labels) labels="${2-}"; shift 2 ;;
+    --dedup-key) dedup_keys+=("${2:?--dedup-key needs a value}"); shift 2 ;;
+    --state) state="${2:?--state needs a value}"; shift 2 ;;
+    --on-existing) on_existing="${2:?--on-existing needs a value}"; shift 2 ;;
+    --repo) repo="${2:?--repo needs a value}"; shift 2 ;;
+    --dry-run) dry_run=1; shift ;;
+    *) echo "file-issue: unknown argument '$1'" >&2; exit 2 ;;
+  esac
+done
+
+case "$state" in
+  open | all) ;;
+  *) echo "file-issue: --state must be open or all (got '$state')" >&2; exit 2 ;;
+esac
+case "$on_existing" in
+  comment | update | skip) ;;
+  *) echo "file-issue: --on-existing must be comment, update or skip (got '$on_existing')" >&2; exit 2 ;;
+esac
+
+# The dedup key defaults to the title, which is then matched exactly.
+exact=0
+if [ "${#dedup_keys[@]}" -eq 0 ]; then
+  [ -n "$title" ] || { echo "file-issue: --title is required when no --dedup-key is given" >&2; exit 2; }
+  dedup_keys=("$title")
+  exact=1
+fi
+
+gh_args=()
+if [ -n "$repo" ]; then
+  gh_args=(--repo "$repo")
+fi
+
+# THE dedup search — the single implementation for the whole family.
+find_existing() {
+  local query="" key json
+  for key in "${dedup_keys[@]}"; do
+    query+="in:title \"${key}\" "
+  done
+  json="$(gh issue list "${gh_args[@]+"${gh_args[@]}"}" --state "$state" --search "$query" \
+            --limit 100 --json number,title)"
+  if [ "$exact" = 1 ]; then
+    printf '%s' "$json" | jq -r --arg t "$title" \
+      'map(select(.title == $t)) | .[0].number // empty'
+  else
+    printf '%s' "$json" | jq -r --args \
+      'map(select((.title | ascii_downcase) as $t
+                  | all($ARGS.positional[]; . as $k | $t | contains($k | ascii_downcase))))
+       | .[0].number // empty' -- "${dedup_keys[@]}"
+  fi
+}
+
+# Checked before the search, so a broken caller costs no API call.
+if [ "$verb" = file ]; then
+  [ -n "$title" ] || { echo "file-issue: --title is required" >&2; exit 2; }
+  [ -n "$body_file" ] || { echo "file-issue: --body-file is required" >&2; exit 2; }
+  [ -s "$body_file" ] || { echo "::error::body file '$body_file' is missing or empty"; exit 1; }
+fi
+
+existing="$(find_existing)"
+
+if [ "$verb" = find ]; then
+  printf '%s\n' "$existing"
+  exit 0
+fi
+
+emit() { # $1 = issue number (may be empty), $2 = outcome
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+      echo "issue=$1"
+      echo "outcome=$2"
+    } >> "$GITHUB_OUTPUT"
+  fi
+  echo "file-issue: $2${1:+ #$1} — $title"
+}
+
+if [ "$dry_run" = 1 ]; then
+  if [ -n "$existing" ]; then
+    echo "file-issue: DRY-RUN would $on_existing on #$existing — $title"
+  else
+    echo "file-issue: DRY-RUN would create — $title [${labels:-no labels}]"
+  fi
+  emit "$existing" none
+  exit 0
+fi
+
+if [ -n "$existing" ]; then
+  case "$on_existing" in
+    comment)
+      gh issue comment "$existing" "${gh_args[@]+"${gh_args[@]}"}" --body-file "$body_file" >/dev/null
+      emit "$existing" commented
+      ;;
+    update)
+      gh issue edit "$existing" "${gh_args[@]+"${gh_args[@]}"}" --body-file "$body_file" >/dev/null
+      emit "$existing" updated
+      ;;
+    skip)
+      emit "$existing" skipped
+      ;;
+  esac
+  exit 0
+fi
+
+# One --label per name; an empty list creates an unlabelled issue.
+label_args=()
+if [ -n "$labels" ]; then
+  IFS=',' read -r -a names <<<"$labels"
+  for name in "${names[@]}"; do
+    name="${name#"${name%%[![:space:]]*}"}"
+    name="${name%"${name##*[![:space:]]}"}"
+    [ -n "$name" ] && label_args+=(--label "$name")
+  done
+fi
+url="$(gh issue create "${gh_args[@]+"${gh_args[@]}"}" --title "$title" --body-file "$body_file" \
+         "${label_args[@]+"${label_args[@]}"}")"
+emit "${url##*/}" created

--- a/.github/workflows/base-image-watcher.yml
+++ b/.github/workflows/base-image-watcher.yml
@@ -19,17 +19,21 @@
 # CVE exposure surfaces through the image scans, and the rust image follows
 # the toolchain watcher's bumps.
 #
-# A finding files/updates ONE tracking issue (the image-scan.yml dedup
-# pattern); the run itself stays green — a newer base is actionable, not
-# broken. Remediation: the base-bump checklist in
+# RUN COLOUR (the watcher family's uniform rule, #2778). A finding files or
+# updates ONE tracking issue through .github/actions/file-watcher-issue and the
+# run stays GREEN — a newer base is actionable, not broken. The run goes RED only
+# when the PROBE fails: the Docker Hub tag API unreachable, the pinned tag
+# unresolvable, an answer jq cannot read. Remediation: the base-bump checklist in
 # .claude/rules/image-security.md.
 name: Base image watcher
 
 on:
   schedule:
-    # Mondays 07:43 UTC — off the hour, after the 07:13 published-image scan,
-    # clear of the other scheduled lanes (05:17/05:23/05:37/06:17/06:47).
-    - cron: "43 7 * * 1"
+    # Mondays 08:13 UTC — off the hour (GitHub delays on-the-hour runs under
+    # load) and in a slot of its own: it shared 07:43 with the toolchain watcher
+    # until #2778. Read the estate's slots with
+    # `grep -rE '^ +- cron:' .github/workflows/`.
+    - cron: "13 8 * * 1"
   workflow_dispatch: {}
 
 concurrency:
@@ -89,30 +93,21 @@ jobs:
           echo "stale=${stale:-0}" >> "$GITHUB_OUTPUT"
           cat details.md >> "$GITHUB_STEP_SUMMARY"
 
-      - name: File or update the tracking issue
+      - name: Write the tracking-issue body
         if: steps.check.outputs.stale == '1'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          title="chore(images): the pinned postgres base is stale — newer upstream bytes exist"
-          existing=$(gh issue list --repo "$REPO" --state open --search "in:title \"$title\"" \
-                       --json number --jq '.[0].number // empty')
-          cat > body.md <<'PREAMBLE'
-          The weekly base-image watcher found the digest-pinned postgres base behind upstream.
+          {
+            printf 'The weekly base-image watcher found the digest-pinned postgres base behind upstream.\n\n'
+            cat details.md
+            printf '\nRemedy: the base-bump pin-site checklist in `.claude/rules/image-security.md`,\n'
+            printf 'verified with `scripts/security/scan-images.sh --candidate` before merge.\n'
+          } > body.md
 
-          PREAMBLE
-          cat details.md >> body.md
-          cat >> body.md <<'REMEDY'
-
-          Remedy: the base-bump pin-site checklist in `.claude/rules/image-security.md`,
-          verified with `scripts/security/scan-images.sh --candidate` before merge.
-          REMEDY
-          if [ -n "$existing" ]; then
-            gh issue comment "$existing" --repo "$REPO" --body-file body.md
-            echo "commented on #$existing"
-          else
-            gh issue create --repo "$REPO" --title "$title" \
-              --label chore --label P2 --body-file body.md
-          fi
+      - name: File or update the tracking issue
+        if: steps.check.outputs.stale == '1'
+        uses: ./.github/actions/file-watcher-issue
+        with:
+          title: "chore(images): the pinned postgres base is stale — newer upstream bytes exist"
+          body-file: body.md
+          labels: chore,P2

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -27,12 +27,21 @@
 # they do not bind in the build-time lane — measured 2026-08-06: the `pkg:oci/…`
 # products match a PUBLISHED reference (by tag and by digest), and the build lane
 # scans `ferroehr-postgres` under a local tag, which is what fails to match.
+#
+# RUN COLOUR (the watcher family's uniform rule, #2778). The run is RED only when
+# the PROBE fails — an image that cannot be resolved or pulled, a trivy crash,
+# output jq cannot read. A FINDING files or updates the tracking issue and the
+# run stays GREEN: THE ISSUE IS THE ALERT. Until #2778 this lane also exited
+# non-zero on a finding, which made the red Monday run the signal; a red
+# scheduled run is invisible to anyone not watching the Actions tab, and the
+# issue (created or commented, `bug`/`P1`) reaches the tracker instead.
 name: Published image scan
 
 on:
   schedule:
-    # Mondays 07:13 UTC — off the hour, and clear of the other scheduled lanes
-    # (codeql 05:23, latest-deps 05:17, scorecard 05:37, spec watchers 06:17/06:47).
+    # Mondays 07:13 UTC — off the hour (GitHub delays on-the-hour runs under
+    # load) and in a slot of its own; read the estate's slots with
+    # `grep -rE '^ +- cron:' .github/workflows/`.
     - cron: "13 7 * * 1"
   workflow_dispatch:
     inputs:
@@ -137,24 +146,16 @@ jobs:
           if-no-files-found: warn
           retention-days: 30
 
-      # A finding does TWO things, because either alone fails quietly. A red
-      # scheduled run is invisible to anyone not looking at the Actions tab, and
-      # an issue with no failing check can be closed without the finding being
-      # addressed. So: one tracking issue (updated by comment on later runs, never
-      # duplicated — the same dedup-by-searching-the-board approach as the spec
-      # watchers) AND a non-zero exit.
-      - name: File or update the tracking issue
+      # An issue with no failing check can be closed without the finding being
+      # addressed, so the issue says what the remedy is and the remediation law
+      # (.claude/rules/image-security.md) says who may VEX instead of fixing.
+      - name: Write the tracking-issue body
         if: steps.scan.outputs.total != '0' && !inputs.report_only
         env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
           TOTAL: ${{ steps.scan.outputs.total }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-          title="security(images): published images carry fixable HIGH/CRITICAL findings"
-          existing=$(gh issue list --repo "$REPO" --state open --search "in:title \"$title\"" \
-                       --json number --jq '.[0].number // empty')
           {
             printf 'A scheduled scan of the PUBLISHED images found **%s** fixable HIGH/CRITICAL findings.\n\n' "$TOTAL"
             printf '| image | platform | digest | findings |\n|---|---|---|---|\n'
@@ -165,18 +166,11 @@ jobs:
             printf ' genuinely unreachable in our usage belongs in `security/vex/` with its'
             printf ' argument, per `security/vex/README.md`.\n'
           } > body.md
-          if [ -n "$existing" ]; then
-            gh issue comment "$existing" --repo "$REPO" --body-file body.md
-            echo "commented on #$existing"
-          else
-            gh issue create --repo "$REPO" --title "$title" \
-              --label bug --label P1 --body-file body.md
-          fi
 
-      - name: Fail when the published images carry fixable findings
-        if: steps.scan.outputs.total != '0'
-        env:
-          TOTAL: ${{ steps.scan.outputs.total }}
-        run: |
-          echo "::error::${TOTAL} fixable HIGH/CRITICAL findings in the published images — see the run summary and the tracking issue."
-          exit 1
+      - name: File or update the tracking issue
+        if: steps.scan.outputs.total != '0' && !inputs.report_only
+        uses: ./.github/actions/file-watcher-issue
+        with:
+          title: "security(images): published images carry fixable HIGH/CRITICAL findings"
+          body-file: body.md
+          labels: bug,P1

--- a/.github/workflows/latest-deps.yml
+++ b/.github/workflows/latest-deps.yml
@@ -11,11 +11,23 @@
 # (https://doc.rust-lang.org/cargo/guide/continuous-integration.html#verifying-latest-dependencies).
 # Check-only by design: DB-backed tests need the composed stack; a resolution
 # or compile break is the signal this job exists to catch.
+#
+# RUN COLOUR (the watcher family's uniform rule, #2778). A compile or resolution
+# break IS this lane's finding: it files or updates the tracking issue through
+# .github/actions/file-watcher-issue and the run stays GREEN. The run goes RED
+# only when the PROBE fails: the toolchain not installing, or `cargo update`
+# unable to resolve the registry at all, which says nothing about our code. Until
+# #2778 the finding reddened the run, and a repeat finding was dropped entirely —
+# the old filing step skipped an existing issue instead of commenting on it, so a
+# break that persisted for weeks was reported once and then never again.
 name: latest-deps
 
 on:
   schedule:
-    - cron: "17 5 * * 1" # Mondays 05:17 UTC
+    # Mondays 05:17 UTC — off the hour (GitHub delays on-the-hour runs under
+    # load) and in a slot of its own; read the estate's slots with
+    # `grep -rE '^ +- cron:' .github/workflows/`.
+    - cron: "17 5 * * 1"
   workflow_dispatch:
 
 # A scheduled probe: only the newest run is interesting, so cancel freely.
@@ -33,45 +45,57 @@ jobs:
     permissions:
       contents: read
       # A scheduled red is invisible unless someone happens to open the
-      # Actions tab — the failure step below files it on the tracker instead
-      # (the same visibility mechanism as the two spec watchers).
+      # Actions tab — the finding is filed on the tracker instead, which is
+      # what makes the green-on-finding rule safe here.
       issues: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+      # Probe half: a registry it cannot resolve at all is a probe failure and
+      # reddens the run, because it says nothing about the workspace.
       - name: Update to the latest in-range dependency set
         run: cargo update
       - name: Check the workspace against it
+        id: check
         # The console is excluded from --all-features lanes (mutually
         # exclusive hydrate/ssr, compile_error!-guarded) and checked
         # per-feature instead — the same split as ci.yml.
+        #
+        # The exit status is CAPTURED, not propagated: a break here is the
+        # finding this lane exists to report, and the log is carried into the
+        # issue body so the first-line triage needs no run archaeology.
         run: |
-          cargo check --workspace --exclude ferroehr-admin-ui --all-targets --all-features
-          cargo check -p ferroehr-admin-ui --all-targets --features ssr
-      - name: Open a tracker issue on failure (deduplicated)
-        if: failure()
+          set -uo pipefail
+          status=0
+          {
+            cargo check --workspace --exclude ferroehr-admin-ui --all-targets --all-features &&
+              cargo check -p ferroehr-admin-ui --all-targets --features ssr
+          } 2>&1 | tee check.log || status=$?
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "cargo check exited ${status}"
+      - name: Write the tracking-issue body
+        if: steps.check.outputs.status != '0'
         env:
-          GH_TOKEN: ${{ github.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-          title="latest-deps: workspace no longer builds against the newest in-range dependencies"
-          existing=$(gh issue list --state open --search "in:title \"$title\"" --json number --jq 'length')
-          if [ "$existing" -gt 0 ]; then
-            echo "Open issue already tracks this — not filing a duplicate."
-            exit 0
-          fi
-          body_file=$(mktemp)
-          cat > "$body_file" <<EOF
-          The scheduled latest-deps run failed: a newest-in-range dependency set no longer compiles (Cargo book: verifying latest dependencies).
-
-          Run: $RUN_URL
-
-          Triage: reproduce with \`cargo update && cargo check --workspace --exclude ferroehr-admin-ui --all-targets --all-features\`, then either fix the incompatibility or pin the offending range with a dated comment.
-          EOF
-          gh issue create \
-            --title "$title" \
-            --label "bug" --label "P2" --label "ci" \
-            --body-file "$body_file"
+          {
+            printf 'The scheduled latest-deps run found that the newest in-range dependency set no'
+            printf ' longer compiles (Cargo book: verifying latest dependencies).\n\n'
+            printf 'Run: %s\n\n' "$RUN_URL"
+            printf 'Triage: reproduce with `cargo update && cargo check --workspace --exclude'
+            printf ' ferroehr-admin-ui --all-targets --all-features`, then either fix the'
+            printf ' incompatibility or pin the offending range with a dated comment.\n\n'
+            printf '<details><summary>Last 200 lines of the check log</summary>\n\n```\n'
+            tail -n 200 check.log
+            printf '```\n\n</details>\n'
+          } > body.md
+      - name: File or update the tracking issue
+        if: steps.check.outputs.status != '0'
+        uses: ./.github/actions/file-watcher-issue
+        with:
+          title: "latest-deps: workspace no longer builds against the newest in-range dependencies"
+          body-file: body.md
+          labels: bug,P2,ci

--- a/.github/workflows/link-check-external.yml
+++ b/.github/workflows/link-check-external.yml
@@ -17,6 +17,12 @@
 #
 # A check nobody reads is not a check, so a genuine failure here opens an
 # issue rather than writing to a log that closes with the run.
+#
+# RUN COLOUR (the watcher family's uniform rule, #2778). An unreachable link is a
+# FINDING: it files or updates the report issue through
+# .github/actions/file-watcher-issue and the run stays GREEN. The run goes RED
+# only when the PROBE fails — lychee exiting non-zero without producing a summary
+# at all, which is a broken invocation rather than an answer about any host.
 name: External links
 
 on:
@@ -69,26 +75,39 @@ jobs:
       # on this run, so a slow host gets the benefit of the doubt rather than
       # producing a false report. 429 is accepted outright — being rate-limited
       # is evidence the host is UP, which is the only thing being measured.
+      # A non-zero lychee exit is a FINDING when it came with a summary, and a
+      # PROBE FAILURE when it did not: the summary is the answer, and without one
+      # there is nothing to report about any host. The exit codes themselves are
+      # deliberately not read — the artifact is the evidence.
       - name: Check external links
         id: lychee
-        continue-on-error: true
         run: |
+          set -uo pipefail
+          status=0
           lychee --no-progress --max-retries 5 --retry-wait-time 10 --timeout 45 \
             --accept '200..=299,429' --exclude-loopback \
             --root-dir "$PWD/_site" \
             --exclude '^https://ferroehr\.eu' \
             --output summary.md --format markdown \
-            './_site/**/*.html'
+            './_site/**/*.html' || status=$?
+          finding=0
+          if [ "$status" -ne 0 ]; then
+            if [ -s summary.md ]; then
+              finding=1
+            else
+              echo "::error::lychee exited ${status} without writing a summary — the probe itself failed"
+              exit 1
+            fi
+          fi
+          echo "finding=${finding}" >> "$GITHUB_OUTPUT"
 
-      # Report through the environment, never interpolated into the shell:
-      # every line of that summary is remote content (URLs and server messages
-      # from third-party hosts) and must not be parsed as script.
-      - name: Open or update the report issue
-        if: steps.lychee.outcome == 'failure'
+      # Report through a file, never interpolated into the shell: every line of
+      # that summary is remote content (URLs and server messages from
+      # third-party hosts) and must not be parsed as script.
+      - name: Write the report-issue body
+        if: steps.lychee.outputs.finding == '1'
         env:
-          GH_TOKEN: ${{ github.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          TITLE: "docs: external links are failing the scheduled reachability check"
         run: |
           set -euo pipefail
           {
@@ -100,13 +119,13 @@ jobs:
             cat summary.md
           } > body.md
 
-          existing=$(gh issue list --state open --search "$TITLE in:title" \
-                       --json number --jq '.[0].number // empty')
-          if [ -n "$existing" ]; then
-            gh issue comment "$existing" --body-file body.md
-          else
-            gh issue create --title "$TITLE" --label documentation --label P3 --body-file body.md
-          fi
+      - name: Open or update the report issue
+        if: steps.lychee.outputs.finding == '1'
+        uses: ./.github/actions/file-watcher-issue
+        with:
+          title: "docs: external links are failing the scheduled reachability check"
+          body-file: body.md
+          labels: documentation,P3
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()

--- a/.github/workflows/spec-release-watcher.yml
+++ b/.github/workflows/spec-release-watcher.yml
@@ -5,7 +5,12 @@
 # spec-update-watcher.yml: that workflow tracks individual completed spec
 # changes; this one guarantees a component RELEASE is never missed (the
 # ITS-REST 1.1.0 release was discovered by hand — never again). Mechanism
-# notes live in scripts/watch/spec-release.sh.
+# notes live in scripts/watch/spec-release.sh, which files through the watcher
+# family's one engine (.github/actions/file-watcher-issue/file-issue.sh, #2778).
+#
+# RUN COLOUR (the family's uniform rule, #2778): a tags-API transport failure or
+# an unexpected shape is a RED run — the probe could not answer. A release FOUND
+# files work and the run stays GREEN.
 name: Spec-release watcher
 
 on:

--- a/.github/workflows/spec-update-watcher.yml
+++ b/.github/workflows/spec-update-watcher.yml
@@ -8,9 +8,14 @@
 # Twice weekly it polls the public openEHR Jira for newly COMPLETED SPEC*
 # changes and diffs the upstream amendment records against the vendored spec
 # mirror, opening ONE `spec-update` issue per change for conformance-impact
-# triage. Dedup/watermark is the issue board itself (search --state all by
-# the Jira key in the title) — no state file. A transport/shape failure is a
-# RED run; only a successful poll matching nothing is green-with-zero.
+# triage. Filing goes through the watcher family's one engine
+# (.github/actions/file-watcher-issue/file-issue.sh, #2778), called from the
+# script because this lane files N issues per run; dedup/watermark is the issue
+# board itself (--state all, by the Jira key in the title) — no state file.
+#
+# RUN COLOUR (the family's uniform rule, #2778): a transport or shape failure is
+# a RED run — the probe could not answer. A change FOUND files work and the run
+# stays GREEN, as does a successful poll matching nothing.
 #
 # NOTE: GitHub disables scheduled workflows after 60 days without repo
 # activity — a non-issue for an active repo, re-enable from the Actions tab

--- a/.github/workflows/toolchain-watcher.yml
+++ b/.github/workflows/toolchain-watcher.yml
@@ -45,9 +45,12 @@ name: Toolchain watcher
 
 on:
   schedule:
-    # Mondays 07:43 UTC — off the hour, and clear of every other scheduled
-    # lane (fuzz 02:41, latest-deps 05:17, codeql 05:23, scorecard 05:37,
-    # spec watchers 06:17/06:47, image-scan 07:13).
+    # Mondays 07:43 UTC — off the hour (GitHub delays on-the-hour runs under
+    # load) and in a slot of its own. The enumeration that used to sit here
+    # claimed clearance while omitting the base-image watcher, which shared this
+    # exact slot until #2778 moved it to 08:13; a list of other lanes rots the
+    # moment one moves, so read the estate's slots with
+    # `grep -rE '^ +- cron:' .github/workflows/`.
     - cron: "43 7 * * 1"
   workflow_dispatch:
     inputs:

--- a/scripts/watch/spec-release.sh
+++ b/scripts/watch/spec-release.sh
@@ -17,19 +17,30 @@
 # always-latest adoption umbrella.
 #
 # Backfill guard + watermark: a release is filed only when NEWER than the
-# pin (comparable pins), and the issue board is the dedup — the search
-# `"<COMP>" "<X.Y.Z>" in:title --state all` also matches hand-made adoption
-# umbrellas (e.g. #178 "Adopt ITS-REST 1.1.0 …"), so covered releases are
-# never re-filed. No state file.
+# pin (comparable pins), and the issue board is the dedup — the component and
+# the version must both appear in the title, over open AND closed issues, which
+# also matches hand-made adoption umbrellas (e.g. #178 "Adopt ITS-REST 1.1.0 …"),
+# so covered releases are never re-filed. No state file.
+#
+# Filing goes through the watcher family's one engine (#2778),
+# .github/actions/file-watcher-issue/file-issue.sh, which owns the single dedup
+# search idiom; this script keeps the probe — the tag poll, the version
+# comparison and the routing.
 #
 # Failure honesty: a tags-API transport failure or unexpected shape is a RED
-# run; an empty tag list on a never-tagged repo is a logged skip.
+# run; an empty tag list on a never-tagged repo is a logged skip. A release
+# FOUND is a green run that files work, per the family's run-colour rule.
 #
 # Env: DRY_RUN=1 (report, create nothing) · GH_TOKEN/GITHUB_TOKEN for gh.
 set -euo pipefail
 cd "$(dirname "$0")/../.."
 
 DRY_RUN="${DRY_RUN:-0}"
+FILE_ISSUE=".github/actions/file-watcher-issue/file-issue.sh"
+engine_dry=()
+if [[ "$DRY_RUN" = "1" ]]; then
+  engine_dry=(--dry-run)
+fi
 for bin in jq gh; do
   command -v "$bin" >/dev/null 2>&1 || { echo "spec-release-watcher: $bin is required" >&2; exit 1; }
 done
@@ -74,9 +85,9 @@ while IFS='|' read -r comp repo ref sha; do
   fi
   # Board dedup — matches [spec-release] issues AND hand-made adoption
   # umbrellas that already carry the component + version in the title.
-  covered=$(gh issue list --state all --search "\"$comp\" \"$latest\" in:title" --json number --jq 'length')
-  if [[ "$covered" -gt 0 ]]; then
-    echo "  $comp Release-$latest: already on the board — skipped"
+  covered=$("$FILE_ISSUE" find --state all --dedup-key "$comp" --dedup-key "$latest")
+  if [[ -n "$covered" ]]; then
+    echo "  $comp Release-$latest: already on the board (#$covered) — skipped"
     skipped=$((skipped + 1))
     continue
   fi
@@ -110,19 +121,26 @@ Upstream published a new **$comp** release: **Release-$latest**
 _Opened automatically by \`.github/workflows/spec-release-watcher.yml\`._
 EOF
   lbl=$(label_for_component "$comp")
-  label_args=(--label spec-update --label P1)
-  [[ -n "$lbl" ]] && label_args+=(--label "$lbl")
   up_label="upstream:${comp}-${latest}"
+  labels="spec-update,P1,$up_label"
+  [[ -n "$lbl" ]] && labels="$labels,$lbl"
   if [[ "$DRY_RUN" = "1" ]]; then
-    echo "DRY-RUN would create: $title  [${label_args[*]} --label $up_label]"
     sed 's/^/    │ /' "$tmp/body.md"
   else
     # Ensure the per-release collection label exists (idempotent).
     gh label create "$up_label" --description "Changes arriving with the upstream $comp Release-$latest" --color BFD4F2 2>/dev/null || true
-    gh issue create --title "$title" "${label_args[@]}" --label "$up_label" --body-file "$tmp/body.md" >/dev/null
-    echo "created: $title"
   fi
-  filed=$((filed + 1))
+  # `--on-existing skip` re-runs the dedup at filing time: a race that lands a
+  # covering issue between the check above and here must not double-file, and
+  # the counters below follow the engine's reported outcome rather than assuming.
+  engine_out=$("$FILE_ISSUE" file --title "$title" --body-file "$tmp/body.md" --labels "$labels" \
+    --dedup-key "$comp" --dedup-key "$latest" --state all --on-existing skip \
+    "${engine_dry[@]+"${engine_dry[@]}"}")
+  printf '%s\n' "$engine_out"
+  case "${engine_out##*$'\n'}" in
+    *"file-issue: skipped"*) skipped=$((skipped + 1)) ;;
+    *) filed=$((filed + 1)) ;;
+  esac
 done < <(grep -E '^  "[A-Z-]+\|' scripts/vendor/spec-docs.sh | tr -d '"' | sed 's/^  //')
 
 echo "spec-release-watcher: done — $filed new release(s) filed, $skipped already covered/current."

--- a/scripts/watch/spec-update.sh
+++ b/scripts/watch/spec-update.sh
@@ -31,9 +31,15 @@
 # file, no repo variables. (C dedups by its stable per-component title, open
 # issues only — closed means caught-up, and a new delta reopens a fresh one.)
 #
+# Filing goes through the watcher family's one engine (#2778),
+# .github/actions/file-watcher-issue/file-issue.sh, which owns the single dedup
+# search idiom (an exact title for the rolling per-component issues of C, a key
+# that must appear in the title for A/B/D); this script keeps the probes.
+#
 # Failure honesty: any non-2xx (one bounded retry on 429), unexpected JSON
 # shape, or missing amendment path exits non-zero — the run goes RED. Only a
-# successful poll that genuinely matches nothing is green-with-zero.
+# successful poll that genuinely matches nothing is green-with-zero. A change
+# FOUND is a green run that files work, per the family's run-colour rule.
 #
 # Env: DRY_RUN=1 (report, create nothing) · WINDOW_DAYS (default 14 — the scheduled cadence; run manually with a wide window, e.g. 365, to catch any backlog: dedup + the vendored baseline make that safe) ·
 #      GH_TOKEN/GITHUB_TOKEN for gh. Requires curl, jq, gh.
@@ -43,6 +49,11 @@ cd "$(dirname "$0")/../.."
 JIRA="https://openehr.atlassian.net"
 WINDOW_DAYS="${WINDOW_DAYS:-14}"
 DRY_RUN="${DRY_RUN:-0}"
+FILE_ISSUE=".github/actions/file-watcher-issue/file-issue.sh"
+engine_dry=()
+if [[ "$DRY_RUN" = "1" ]]; then
+  engine_dry=(--dry-run)
+fi
 [[ "$WINDOW_DAYS" =~ ^[0-9]{1,4}$ ]] ||
   { echo "spec-update-watcher: WINDOW_DAYS must be a number of days, got '$WINDOW_DAYS'" >&2; exit 1; }
 # Field separator for the candidate rows: ASCII unit separator — non-whitespace,
@@ -295,8 +306,7 @@ while IFS='|' read -r comp repo ref sha; do
   head_sha=$(gh api "repos/openEHR/$repo/branches/$default" --jq '.commit.sha') ||
     { echo "spec-update-watcher: failed to read openEHR/$repo $default head" >&2; exit 1; }
   title="[spec-update] $comp spec repo is ahead of the vendored pin"
-  num=$(gh issue list --state open --search "\"$title\" in:title" --json number,title \
-        --jq "[.[] | select(.title == \"$title\")][0].number // empty")
+  num=$("$FILE_ISSUE" find --title "$title")
   if [[ "$ahead" -gt 0 ]]; then
     count_line="**Commits ahead of the pin:** $ahead (pin \`${sha:0:9}\`, upstream $default @ \`${head_sha:0:9}\`)"
     cat > "$tmp/ahead-body.md" <<EOF
@@ -316,28 +326,24 @@ $count_line
 
 _Maintained automatically by the spec-update watcher: the count above updates in place as the delta grows, and the issue closes when a re-vendor catches the pin up._
 EOF
+    if [[ -n "$num" ]] && gh issue view "$num" --json body --jq '.body' | grep -qF "$count_line"; then
+      continue # unchanged since the last run
+    fi
+    labels="spec-update"
+    lbl=$(label_for_component "$comp" || true)
+    [[ -n "${lbl:-}" ]] && labels="$labels,$lbl"
+    if [[ "$DRY_RUN" = "1" ]] && [[ -z "$num" ]]; then
+      sed 's/^/    │ /' "$tmp/ahead-body.md"
+    fi
+    # One engine call covers both branches: create the rolling issue when it
+    # does not exist, replace its body in place when it does (the count updates
+    # as the delta grows).
+    "$FILE_ISSUE" file --title "$title" --body-file "$tmp/ahead-body.md" \
+      --labels "$labels" --on-existing update "${engine_dry[@]+"${engine_dry[@]}"}"
+    echo "  $comp is $ahead commit(s) ahead"
     if [[ -n "$num" ]]; then
-      if gh issue view "$num" --json body --jq '.body' | grep -qF "$count_line"; then
-        continue # unchanged since the last run
-      fi
-      if [[ "$DRY_RUN" = "1" ]]; then
-        echo "DRY-RUN would update #$num: $title ($ahead ahead)"
-      else
-        gh issue edit "$num" --body-file "$tmp/ahead-body.md" >/dev/null
-        echo "updated #$num: $comp now $ahead commit(s) ahead"
-      fi
       ahead_updated=$((ahead_updated + 1))
     else
-      label_args=(--label spec-update)
-      lbl=$(label_for_component "$comp" || true)
-      [[ -n "${lbl:-}" ]] && label_args+=(--label "$lbl")
-      if [[ "$DRY_RUN" = "1" ]]; then
-        echo "DRY-RUN would create: $title ($ahead ahead)  [${label_args[*]}]"
-        sed 's/^/    │ /' "$tmp/ahead-body.md"
-      else
-        gh issue create --title "$title" "${label_args[@]}" --body-file "$tmp/ahead-body.md" >/dev/null
-        echo "created: $title ($ahead ahead)"
-      fi
       ahead_created=$((ahead_created + 1))
     fi
   elif [[ -n "$num" ]]; then
@@ -365,17 +371,21 @@ amendment_keys=$(awk -F"$US" '$4 == "amendment" { print $1 }' "$CANDIDATES" | so
 created=0 skipped=0 unblocked=0
 while IFS="$US" read -r key component summary source resolved fixv comps status resolution itype jcreated fixv_plain descr; do
   [[ -n "$key" ]] || continue
-  match=$(gh issue list --state all --search "\"$key\" in:title" --json number,state,labels --jq '.[0] // empty')
-  if [[ -n "$match" ]]; then
+  num=$("$FILE_ISSUE" find --state all --dedup-key "$key")
+  if [[ -n "$num" ]]; then
     # AUTO-UNBLOCK: an amendment-diff hit means the key's normative text has
     # now LANDED upstream. If the board carries this key as an OPEN issue
     # labelled blocked-upstream (resolved in Jira before the text was
     # published), announce the landing and drop the label; every other
-    # existing-issue hit keeps the silent dedup skip.
-    if echo "$amendment_keys" | grep -qxF "$key" &&
+    # existing-issue hit keeps the silent dedup skip. The state and labels are
+    # read only on that path — the dedup itself needs the number alone.
+    match=""
+    if echo "$amendment_keys" | grep -qxF "$key"; then
+      match=$(gh issue view "$num" --json state,labels)
+    fi
+    if [[ -n "$match" ]] &&
       [[ "$(echo "$match" | jq -r '.state')" = "OPEN" ]] &&
       [[ "$(echo "$match" | jq -r '[.labels[].name] | any(. == "blocked-upstream")')" = "true" ]]; then
-      num=$(echo "$match" | jq -r '.number')
       if [[ "$DRY_RUN" = "1" ]]; then
         echo "DRY-RUN would unblock #$num ($key): $summary"
       else
@@ -392,10 +402,6 @@ while IFS="$US" read -r key component summary source resolved fixv comps status 
   # version live in the BODY and the spec:* label, never as title clutter).
   # Long Jira summaries (some embed whole URLs) are capped for readability;
   # dedup only needs the key, which always leads.
-  case "$fixv_plain" in
-    ""|"—") target="version unassigned" ;;
-    *) target="$fixv_plain" ;;
-  esac
   if [[ -n "$component" ]]; then
     pin=$(pin_for_component "$component")
   else
@@ -406,9 +412,9 @@ while IFS="$US" read -r key component summary source resolved fixv comps status 
     short_summary="${short_summary:0:87}..."
   fi
   title="[spec-update] $key — $short_summary"
-  label_args=(--label spec-update)
+  labels="spec-update"
   lbl=$([[ -n "$component" ]] && label_for_component "$component" || true)
-  [[ -n "${lbl:-}" ]] && label_args+=(--label "$lbl")
+  [[ -n "${lbl:-}" ]] && labels="$labels,$lbl"
 
   cat > "$tmp/body.md" <<EOF
 Upstream openEHR spec change completed — conformance-impact triage needed.
@@ -438,13 +444,18 @@ _Opened automatically by \`.github/workflows/spec-update-watcher.yml\`._
 EOF
 
   if [[ "$DRY_RUN" = "1" ]]; then
-    echo "DRY-RUN would create: $title  [${label_args[*]}]"
     sed 's/^/    │ /' "$tmp/body.md"
-  else
-    gh issue create --title "$title" "${label_args[@]}" --body-file "$tmp/body.md" >/dev/null
-    echo "created: $title"
   fi
-  created=$((created + 1))
+  # `--on-existing skip` re-runs the dedup at filing time: a race that lands a
+  # covering issue between the check above and here must not double-file, and
+  # the counters below follow the engine's reported outcome rather than assuming.
+  engine_out=$("$FILE_ISSUE" file --title "$title" --body-file "$tmp/body.md" --labels "$labels" \
+    --dedup-key "$key" --state all --on-existing skip "${engine_dry[@]+"${engine_dry[@]}"}")
+  printf '%s\n' "$engine_out"
+  case "${engine_out##*$'\n'}" in
+    *"file-issue: skipped"*) skipped=$((skipped + 1)) ;;
+    *) created=$((created + 1)) ;;
+  esac
 done < "$tmp/unique.tsv"
 
 echo "spec-update-watcher: done — $created new, $unblocked unblocked, $skipped already on the board (dedup by key)."


### PR DESCRIPTION
Closes #2778 (phase 4 of #2772; design §2.5).

The six file-an-issue watchers now share ONE dedup/file/comment implementation — `.github/actions/file-watcher-issue/file-issue.sh`, fronted by the phase-1 composite for workflow steps and called directly by the two `scripts/watch` shells (whose N-issues-per-run filing a composite cannot express; probe logic untouched). The engine POST-FILTERS the search the old idioms trusted raw: `in:title "phrase"` is containment, not equality, so a `… — WONTFIX` sibling title could silently swallow a real finding — now byte-equal titles (or explicit `--dedup-key` containment for the spec watchers), proven by a fake-`gh` shim transcript covering create/comment/update/skip/dry-run/probe-failure plus both real scripts end-to-end.

Uniform semantics, stated in every header: a run is RED only when the PROBE fails; a FINDING files/updates the issue (which IS the alert) and stays green. Deliberate changes: image-scan and latest-deps stop reddening on findings; latest-deps stops silently skipping an existing issue (it comments now); link-check-external gains a real probe-failure red (lychee crashing without a summary was invisible); image-scan's `report_only` dispatch is honoured fully (it half-was). Schedule: base-image-watcher moves Mon 07:43 → 08:13, ending the collision with toolchain-watcher — all 11 cron slots now distinct (grep-proven), and the stale clearance comments are replaced by the command that checks.

Gates: shellcheck/actionlint clean, zizmor byte-identical to develop, exactly one `gh issue list` dedup site left in the tree (the engine). En-route findings filed separately.