### PR TITLE
ci(release): phase 5 — release facts injected at package time, the guards that were thin, and the GHCR orphan watcher

### DIFF
--- a/.claude/rules/changelog.md
+++ b/.claude/rules/changelog.md
@@ -21,8 +21,7 @@ optional:
   `[Unreleased]` → `## [X.Y.Z] - YYYY-MM-DD`, re-add an empty
   `[Unreleased]`, update the link references at the bottom, bump the
   workspace `version` in the root `Cargo.toml` (+ `Cargo.lock` via a
-  `cargo check`, + Helm `appVersion`, golden renders via
-  `deploy/helm/validate.sh --update`, + `CITATION.cff` `version` and
+  `cargo check`, + `CITATION.cff` `version` and
   `date-released` (the `citation-guard` CI job enforces the version match),
   then re-render `.zenodo.json` (`bash scripts/render/zenodo-json.sh`, checked
   by the same job), + the ferroehr party statement's product version
@@ -39,21 +38,35 @@ optional:
   `sandbox-deploy.yml` redeploys + reseeds it automatically after the tag's
   Containers run — `deploy/vercel/README.md`), + the book's pinned versions — `website/book/src/installation/
   kubernetes.md` pins the chart `--version` and `image.tag`, and
-  `website/book/src/verifying-releases.md` pins the release tag in its
-  examples; `docs-claims` catches the chart/image pins, learned at the
-  v4.0.0 cut which shipped them stale), merge the release PR, then tag
+  `website/book/src/verifying-releases.md` pins the release tag and the image
+  tags in its examples; `docs-claims` catches all of them, the chart/image pins
+  since the v4.0.0 cut shipped them stale and the verifying-releases asset names
+  and substitution note since v4.0.5 froze two stale attestation examples into
+  `/docs/v4.0.5/` (#2779)), merge the release PR, then tag
   `vX.Y.Z` on the merge commit. The release workflow publishes the GitHub
   Release from the matching changelog section and **fails if the section or
   version match is missing**. Releases publish as OFFICIAL
   releases — `prerelease` is true only for an explicitly suffixed tag
   (`vX.Y.Z-rc1`, ...) — owner sign-off 2026-07-31.
-- **The Helm chart, in the SAME release PR:** bump
-  `deploy/helm/ferroehr/Chart.yaml` `appVersion` to the release version (the
-  `chart-appversion-guard` CI job enforces it, and so do the
-  `artifacthub.io/images` tags in the same file), and bump the chart's own
-  `version` if any packaged chart content changed in the cycle
-  (`chart-version-guard`). The two are INDEPENDENT SemVer lines and stay so.
-  Regenerate the golden renders (`deploy/helm/validate.sh --update`).
+- **The Helm chart, in the SAME release PR:** bump the chart's own `version` if
+  any packaged chart content changed in the cycle (`chart-version-guard`), and
+  regenerate whatever that change moved — the golden renders
+  (`deploy/helm/validate.sh --update`) and the generated chart README
+  (`helm-docs --chart-search-root deploy/helm/ferroehr --template-files
+  README.md.gotmpl`). The chart version and `appVersion` are INDEPENDENT SemVer
+  lines and stay so.
+
+  **`appVersion` is NOT a cut step any more (#2779), and neither are the
+  `artifacthub.io/images` tags.** The publish lane injects both from the tag
+  (`helm package --app-version ${TAG#v}` plus
+  `deploy/helm/release-facts.sh`), the same way it has injected
+  `artifacthub.io/changes` since #2107 and for the same reason: they are facts
+  about a release, and a committed copy is stale from the next merge onwards.
+  What stays committed is a between-releases DEFAULT, held only to being a real
+  released version whose image annotations and generated README agree with it —
+  `scripts/checks/chart-appversion.sh`, run by the `chart-appversion` CI job and
+  again by the release pipeline's `plan` at the tagged commit. Refreshing that
+  default is ordinary maintenance, not a release step.
 - **The chart publishes as the release pipeline's `chart` leg** (`build-chart.yml`,
   called by `release.yml` after the scanned tags apply; `publish-chart.yml` is
   the dispatch-only dry-run/recovery lane between releases): it refuses to

--- a/.claude/rules/docs-website.md
+++ b/.claude/rules/docs-website.md
@@ -69,6 +69,12 @@ job, `--all` over the whole book:
   verbatim into `ferroehr.toml`.
 - Every committed chart under a `*-assets/` directory is embedded by a page or
   by an mdBook `{{#include}}` source.
+- Every version literal that is a claim about the current release: a chart
+  `--version` against `Chart.yaml`'s own version, an `image.tag=`/`ghcr.io/…:`
+  tag against the WORKSPACE version (not the chart's `appVersion`, which is
+  injected at publish time and may lag in the tree — #2779), and on
+  `verifying-releases.md` the release-asset filenames and the
+  substitute-this-tag note.
 
 **Review-only, deliberately:**
 

--- a/.claude/rules/kubernetes-helm.md
+++ b/.claude/rules/kubernetes-helm.md
@@ -193,7 +193,8 @@ evidence if it ran in an enforcing namespace — say which.
 | Secrets never env-borne as values | `validate.sh` `secret_leak_gate` |
 | `values.schema.json` accepts/rejects | `validate.sh` `schema_gate`, `fixture_gate` |
 | Golden render drift | CI compare against `deploy/helm/golden/` |
-| Chart/app version bumps | `chart-version-guard`, `chart-appversion-guard` |
+| Chart version bump on packaged-content change | `chart-version-guard` |
+| The committed `appVersion` names a released version, and the image annotations + generated README agree with it | `chart-appversion-guard` → `scripts/checks/chart-appversion.sh` (mutation-proven). The PUBLISHED appVersion and image tags are INJECTED at package time, not guarded in the tree — #2779 |
 | Field-vs-`kubeVersion` availability | **review-enforced** — no tool knows which fields a manifest uses; §1 is the procedure |
 | Applied posture, admission, readiness gating, secret reads | `scripts/deploy-probe-k8s.sh` — observed on a live cluster, machine-readable record |
 | Live behaviour beyond those probes | **review-enforced** — the `/k8s-test` skill is the procedure; the PR quotes observations |

--- a/.github/workflows/build-chart.yml
+++ b/.github/workflows/build-chart.yml
@@ -36,9 +36,10 @@ on:
       release-tag:
         description: >-
           The `vX.Y.Z` tag being released, when this call is the release
-          pipeline's chart leg. Non-empty means: appVersion MUST equal it, the
-          chart is judged against the appVersion image, and the push happens.
-          Empty means a between-releases dispatch.
+          pipeline's chart leg. Non-empty means: the package is given THIS
+          version as its appVersion and image annotations, it is judged against
+          that version's image, and the push happens. Empty means a
+          between-releases dispatch, which packages the committed default.
         required: false
         type: string
         default: ""
@@ -95,33 +96,50 @@ jobs:
       # No build cache is restored anywhere in this lane (#2011): everything it
       # publishes is built from this checkout and nothing else.
 
+      # TWO app versions, and the difference is the whole of #2779.
+      #
+      # `app` is what Chart.yaml COMMITS: the default image tag for a chart
+      # packaged outside a release, which may legitimately lag the newest
+      # release now that a cut no longer hand-edits it (scripts/checks/
+      # chart-appversion.sh is what still holds it to a released version).
+      #
+      # `effective` is what this package will CARRY. On a release it is the tag
+      # being released, injected below — `helm package --app-version` for the
+      # field and deploy/helm/release-facts.sh for the annotation's tags,
+      # the same treatment `artifacthub.io/changes` already gets and for the same
+      # reason: they are facts about a release, and a committed copy is stale
+      # from the next merge onwards. On a dispatch it is the committed value,
+      # because a chart-only republish between releases must not invent a version
+      # nobody released.
       - name: Read the chart's own versions
         id: chart
+        env:
+          RELEASE_TAG: ${{ inputs.release-tag }}
         run: |
           set -euo pipefail
           version=$(helm show chart "$CHART_DIR" | sed -nE 's/^version: *"?([^"]+)"?/\1/p')
           app=$(helm show chart "$CHART_DIR" | sed -nE 's/^appVersion: *"?([^"]+)"?/\1/p')
           [ -n "$version" ] && [ -n "$app" ] || { echo "::error::could not read version/appVersion from $CHART_DIR/Chart.yaml"; exit 1; }
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "app=$app" >> "$GITHUB_OUTPUT"
-          echo "chart version $version, appVersion $app"
-
-      # A release must publish the chart version the tree carries, and the
-      # release cut moves `appVersion` to the released application version, so
-      # they have to agree. A mismatch means the release PR forgot one of them.
-      # (`plan` checks the same fact against Cargo.toml before anything is
-      # built; this is the check at the point of use.)
-      - name: On a release, appVersion must be the tag being released
-        if: inputs.release-tag != ''
-        env:
-          TAG: ${{ inputs.release-tag }}
-          APP: ${{ steps.chart.outputs.app }}
-        run: |
-          set -euo pipefail
-          if [ "${TAG#v}" != "$APP" ]; then
-            echo "::error::tag $TAG does not match Chart.yaml appVersion $APP — the release cut bumps appVersion with the workspace version."
-            exit 1
+          if [ -n "$RELEASE_TAG" ]; then
+            effective="${RELEASE_TAG#v}"
+            why="the released version, injected at package time"
+          else
+            effective="$app"
+            why="the committed default (a between-releases dispatch invents no version)"
           fi
+          {
+            echo "version=$version"
+            echo "app=$app"
+            echo "effective=$effective"
+          } >> "$GITHUB_OUTPUT"
+          echo "chart version $version; committed appVersion $app; packaging appVersion $effective — $why"
+
+      # The committed release facts still have to be internally coherent, and
+      # `plan` runs this same script at the tagged commit before anything is
+      # built. It no longer asserts equality with the workspace version: that
+      # assertion is what forced the hand edit this lane now performs.
+      - name: The committed chart release facts are coherent
+        run: bash scripts/checks/chart-appversion.sh
 
       # The chart gates read the rendered YAML structurally (yq -o=json | jq),
       # because a grep over a manifest passes as soon as ONE container carries a
@@ -180,17 +198,18 @@ jobs:
           exit 1
 
       # WHICH image the chart is judged against is a per-trigger decision,
-      # because `appVersion` and the chart's `config` defaults move on
-      # different clocks (#2144).
+      # because the packaged appVersion and the chart's `config` defaults move on
+      # different clocks (#2144). It is the PACKAGING appVersion that decides —
+      # `steps.chart.outputs.effective`, not the committed one (#2779).
       #
-      # On a release, `appVersion` IS the version being released (the guard
-      # above refuses the run otherwise), so the image a `helm install` of this
-      # chart will actually pull is the one this cut publishes — judging against
-      # it is exactly right, and it is the only judgement that gates a push.
-      # That image exists BY CONSTRUCTION: this lane is a `needs: scan-and-tag`
-      # job of the release pipeline, so the tags were applied before it started.
+      # On a release that is the version being released, so the image a `helm
+      # install` of the published chart will actually pull is the one this cut
+      # publishes — judging against it is exactly right, and it is the only
+      # judgement that gates a push. That image exists BY CONSTRUCTION: this lane
+      # is a `needs: scan-and-tag` job of the release pipeline, so the tags were
+      # applied before it started.
       #
-      # Between releases `appVersion` is still the LAST release, while
+      # Between releases the packaged appVersion is a past release, while
       # values.yaml and the server's configuration vocabulary advance together
       # in-tree. Judging a mid-cycle dry run against it therefore fails from
       # the first commit that adds a configuration key until the release PR —
@@ -204,7 +223,7 @@ jobs:
       - name: Select the image the chart is judged against
         id: judge
         env:
-          APP: ${{ steps.chart.outputs.app }}
+          APP: ${{ steps.chart.outputs.effective }}
           IS_RELEASE: ${{ inputs.release-tag != '' }}
           SHA: ${{ github.sha }}
         run: |
@@ -262,10 +281,6 @@ jobs:
             exit 1
           fi
 
-      # The per-release Artifact Hub annotations, derived from CHANGELOG.md so
-      # there is one changelog rather than two (#2107). Injected at package time
-      # rather than committed: they are facts about a release, and a committed
-      # copy would be stale from the next merge onwards.
       # THE prerelease rule, one definition (#2775/#2776): any `-` suffix. This
       # lane used to spell it as `*-rc*|*-alpha*|*-beta*`, which is NARROWER —
       # a `v4.1.0-pre.1` tag published a pre-release GitHub Release and moved no
@@ -278,13 +293,25 @@ jobs:
         with:
           tag: ${{ inputs.release-tag }}
 
-      # The per-release Artifact Hub annotations, derived from CHANGELOG.md so
-      # there is one changelog rather than two (#2107). Injected at package time
-      # rather than committed: they are facts about a release, and a committed
-      # copy would be stale from the next merge onwards.
+      # Everything about this package that is a fact about A RELEASE rather than
+      # about the chart, injected here rather than committed — the argument
+      # `artifacthub.io/changes` has carried since #2107, now applied to the two
+      # sites that were still hand-edited at every cut (#2779):
+      #
+      #   * `artifacthub.io/changes` (+ containsSecurityUpdates) from CHANGELOG.md,
+      #     so there is one changelog rather than two;
+      #   * `artifacthub.io/prerelease` for an `-rc`-style tag;
+      #   * the `artifacthub.io/images` TAGS, which `helm package --app-version`
+      #     does not touch — it sets the appVersion field and nothing else, so
+      #     without this the listing would advertise the previous release's
+      #     images beside a correct appVersion.
+      #
+      # It runs AFTER `deploy/helm/validate.sh` on purpose: the golden renders
+      # are byte-compared against the COMMITTED chart, and a rewritten Chart.yaml
+      # would read as chart drift.
       - name: Inject the release's Artifact Hub annotations
         env:
-          APP: ${{ steps.chart.outputs.app }}
+          APP: ${{ steps.chart.outputs.effective }}
           IS_RELEASE_CUT: ${{ inputs.release-tag != '' }}
           IS_PRERELEASE: ${{ steps.kind.outputs.is-prerelease }}
         run: |
@@ -292,8 +319,8 @@ jobs:
           # A release publishes that release's section. A dispatch between
           # releases publishes what is currently unreleased — and when
           # Unreleased is EMPTY (the recover-a-failed-tag-publish case, twice
-          # live: 6.0.13 and 6.0.14), it falls back to the appVersion's own
-          # released section, which is what the chart being recovered ships.
+          # live: 6.0.13 and 6.0.14), it falls back to the packaged appVersion's
+          # own released section, which is what the chart being recovered ships.
           if [ "$IS_RELEASE_CUT" = "true" ]; then
             section="$APP"
           elif awk '/^## \[Unreleased\]/{f=1;next} /^## \[/{exit} f && (/^- /||/^### /){found=1} END{exit !found}' CHANGELOG.md; then
@@ -303,21 +330,60 @@ jobs:
             section="$APP"
           fi
           bash deploy/helm/artifacthub-changes.sh "$section" --inject
+          bash deploy/helm/release-facts.sh "$APP"
           if [ "$IS_PRERELEASE" = "true" ]; then
             printf '  artifacthub.io/prerelease: "true"\n' >> "$CHART_DIR/Chart.yaml"
           fi
           echo "--- annotations as packaged ---"
           sed -n '/^annotations:/,$p' "$CHART_DIR/Chart.yaml"
 
+      # `--app-version` is passed unconditionally, because `effective` already IS
+      # the committed value on a dispatch — one code path, and the flag is helm's
+      # own documented way to set a package's appVersion without editing the
+      # source chart.
       - name: Package
         id: package
         env:
           VERSION: ${{ steps.chart.outputs.version }}
+          APP: ${{ steps.chart.outputs.effective }}
         run: |
           set -euo pipefail
-          helm package "$CHART_DIR" --destination dist
+          helm package "$CHART_DIR" --app-version "$APP" --destination dist
           ls -l dist
           echo "path=dist/ferroehr-${VERSION}.tgz" >> "$GITHUB_OUTPUT"
+
+      # The injection is READ BACK from the packaged tarball, not assumed. Every
+      # other publishing assertion in this lane is a read-back for the same
+      # reason: a silent miss here publishes a listing that advertises the
+      # previous release's images, and Artifact Hub would show it for a whole
+      # cycle before anyone noticed.
+      - name: The package carries the appVersion and image tags it should
+        env:
+          PACKAGE: ${{ steps.package.outputs.path }}
+          APP: ${{ steps.chart.outputs.effective }}
+        run: |
+          set -euo pipefail
+          packaged=$(helm show chart "$PACKAGE" | sed -nE 's/^appVersion: *"?([^"]+)"?/\1/p')
+          if [ "$packaged" != "$APP" ]; then
+            echo "::error::${PACKAGE} carries appVersion ${packaged}, expected ${APP} — 'helm package --app-version' did not take."
+            exit 1
+          fi
+          wrong=$(helm show chart "$PACKAGE" | grep -oE 'image: ghcr\.io/[^:]+:[^ ]+' | grep -v ":${APP}\$" || true)
+          if [ -n "$wrong" ]; then
+            echo "::error::${PACKAGE} advertises artifacthub.io/images tags that are not ${APP}:"
+            echo "$wrong"
+            exit 1
+          fi
+          # The README travels inside the package and is what Artifact Hub
+          # renders as the front page, so its install example has to name the
+          # same version the chart carries.
+          readme=$(tar -xzOf "$PACKAGE" ferroehr/README.md)
+          if ! printf '%s' "$readme" | grep -qF -- "--set image.tag=${APP}"; then
+            echo "::error::the README inside ${PACKAGE} does not teach 'image.tag=${APP}' — the packaged front page would advertise a different version from the chart."
+            printf '%s' "$readme" | grep -nE 'AppVersion|image\.tag=' || true
+            exit 1
+          fi
+          echo "packaged appVersion ${packaged}; every artifacthub.io/images tag and the packaged README at ${APP}"
 
       - name: Dry run — everything but the push
         if: inputs.release-tag == '' && !inputs.publish
@@ -545,7 +611,8 @@ jobs:
         if: always()
         env:
           VERSION: ${{ steps.chart.outputs.version }}
-          APP: ${{ steps.chart.outputs.app }}
+          APP: ${{ steps.chart.outputs.effective }}
+          COMMITTED_APP: ${{ steps.chart.outputs.app }}
           DIGEST: ${{ steps.push.outputs.digest }}
           SIGNATURE: ${{ steps.verify.outputs.sig }}
           JUDGED: ${{ steps.judge.outputs.image }}
@@ -555,7 +622,8 @@ jobs:
             printf '## Chart publish\n\n'
             printf '| | |\n|---|---|\n'
             printf '| chart version | `%s` |\n' "$VERSION"
-            printf '| appVersion | `%s` |\n' "$APP"
+            printf '| appVersion (packaged) | `%s` |\n' "$APP"
+            printf '| appVersion (committed default) | `%s` |\n' "$COMMITTED_APP"
             printf '| judged against | `%s` (%s) |\n' "${JUDGED:-not selected}" "${WHY:-—}"
             printf '| repository | `%s` |\n' "$CHART_REF"
             printf '| digest | `%s` |\n' "${DIGEST:-not pushed}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1810,26 +1810,29 @@ jobs:
           fi
           echo "Chart version bumped $old -> $new — OK."
 
-  # appVersion guard (issue #2108): `appVersion` is the image tag a user gets from
-  # a plain `helm install`, so it must never lag the released application version.
-  # It is kept equal to the workspace version — the same shape as
-  # compose-image-tags.sh, and the same reason: both are "an artifact references
-  # the released version" checks that would otherwise depend on someone
-  # remembering a release-procedure step.
+  # appVersion guard (issue #2108, narrowed by #2779). It used to hold
+  # `appVersion` and the `artifacthub.io/images` tags equal to the WORKSPACE
+  # version, which made both of them per-release facts a human had to hand-edit
+  # at every cut. They are injected now: `build-chart.yml` packages with
+  # `helm package --app-version <released version>` and rewrites the annotation's
+  # tags in the same step, so the published chart is right by construction and a
+  # cut edits neither.
   #
-  # The `artifacthub.io/images` tags are checked with it, because those are what
-  # the Artifact Hub security report scans — a stale tag there means the listing
-  # reports vulnerabilities for an image nobody is running.
+  # What is left in the tree is a DEFAULT — for a chart-only dispatch between
+  # releases, and for anyone running `helm template`/`helm install` against this
+  # directory — and the properties that default still has to have are in
+  # scripts/checks/chart-appversion.sh, which `plan` runs against the tagged
+  # commit too. One script rather than two copies of one check.
   #
-  # What this guard does NOT catch, stated because it was measured rather than
-  # imagined: `appVersion` naming the right release does not mean that release's
+  # What no version guard catches, stated because it was measured rather than
+  # imagined: an appVersion naming a real release does not mean that release's
   # image ACCEPTS the chart's current `config` defaults. Values track development
   # between releases, so the rendered default configuration carries
   # `server.limits` and `db.statement_timeout_ms`, which 3.17.3 does not know — its
   # own `config check` refuses the file, and a plain `helm install` crash-loops.
-  # Only the published image can answer that, so the check lives in
-  # publish-chart.yml, which refuses to publish a chart that cannot deploy its own
-  # default image.
+  # Only an image can answer that: the `chart-boot` job below replays it against
+  # the tree-built image, and build-chart.yml refuses to publish a chart that
+  # cannot deploy the image it selects.
   chart-appversion:
     name: chart-appversion-guard
     runs-on: ubuntu-latest
@@ -1840,26 +1843,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: appVersion and the artifacthub.io image tags match the workspace version
-        run: |
-          set -euo pipefail
-          ws=$(sed -nE 's/^version = "(.*)"$/\1/p' Cargo.toml | head -1)
-          app=$(sed -nE 's/^appVersion: *"?([^"]+)"?$/\1/p' deploy/helm/ferroehr/Chart.yaml)
-          if [ -z "$ws" ] || [ -z "$app" ]; then
-            echo "::error::could not extract versions (workspace: '$ws', appVersion: '$app')." >&2
-            exit 1
-          fi
-          if [ "$app" != "$ws" ]; then
-            echo "::error::Chart.yaml appVersion ($app) != workspace version ($ws) — the release cut bumps appVersion with the workspace version (.claude/rules/changelog.md), or a plain 'helm install' deploys the previous release." >&2
-            exit 1
-          fi
-          bad=$(grep -oE 'image: ghcr\.io/[^:]+:[^ ]+' deploy/helm/ferroehr/Chart.yaml | grep -v ":${ws}\$" || true)
-          if [ -n "$bad" ]; then
-            echo "::error::artifacthub.io/images tags do not match the workspace version ($ws):" >&2
-            echo "$bad" >&2
-            exit 1
-          fi
-          echo "appVersion and every artifacthub.io/images tag are at $ws — OK."
+      - name: The committed chart release facts are coherent
+        run: bash scripts/checks/chart-appversion.sh
 
   # Changelog guard (Keep a Changelog discipline): a PR that changes
   # user-visible surfaces must update CHANGELOG.md's [Unreleased] section in

--- a/.github/workflows/ghcr-orphan-watcher.yml
+++ b/.github/workflows/ghcr-orphan-watcher.yml
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
+# .github/workflows/ghcr-orphan-watcher.yml
+#
+# Weekly inventory of GHCR manifests NOTHING can reach any more (#2779).
+#
+# Every image in this estate is pushed by digest and tagged in a separate later
+# job (scan-and-tag.yml, so a scanner's verdict comes before a tag moves). A run
+# that dies between the two leaves a manifest in the registry that no tag and no
+# index points at, and nothing prunes it: GHCR keeps it forever, it counts
+# against the package's storage, and it fills the version list that makes the
+# real ones hard to see.
+#
+# THIS WATCHER ONLY REPORTS. Deletion is manual, by design, and the issue it
+# files carries the exact `gh api -X DELETE` command per digest. The reason is
+# that reachability here is computed, not read: a multi-arch image is a tagged
+# index whose per-architecture manifests are untagged, buildkit adds untagged
+# attestation manifests to that same index, and — because GHCR serves no
+# referrers API — every cosign signature and SLSA provenance reaches the
+# registry through the OCI fallback TAG `sha256-<hex>`, whose children are
+# untagged again. Measured over the three packages: 1801 untagged manifests, of
+# which 1706 are reachable. An automated prune that got one media type wrong
+# would destroy the published attestations of releases this project publishes as
+# IMMUTABLE, and the damage would stay invisible until a consumer's
+# `gh attestation verify` returned a 404. A human reviewing 95 digests is the
+# cheaper side of that trade.
+#
+# RUN COLOUR (the watcher family's uniform rule, #2778): finding orphans files
+# or updates ONE tracking issue and the run stays GREEN. The run goes RED only
+# when the PROBE cannot answer — the packages API refusing, a tagged manifest
+# the registry will not serve, an answer jq cannot read — because an unmeasured
+# absence must never present as "nothing to clean".
+name: GHCR orphan watcher
+
+on:
+  schedule:
+    # Mondays 08:43 UTC — off the hour (GitHub delays on-the-hour runs under
+    # load) and in a slot of its own, 30 minutes after the base-image watcher's
+    # 08:13. Read the estate's slots with
+    # `grep -rE '^ +- cron:' .github/workflows/`.
+    - cron: "43 8 * * 1"
+  workflow_dispatch: {}
+
+concurrency:
+  group: ghcr-orphan-watcher
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  watch:
+    name: unreachable GHCR manifests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: read # list the three container packages' versions
+      issues: write # file/update the one tracking issue below
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # The probe. `GH_TOKEN` needs `read:packages` over the OWNER's packages,
+      # which the repository's own installation token may not carry — the
+      # packages here are user-scoped, not repository-scoped. So an optional
+      # `GHCR_PACKAGES_TOKEN` secret takes precedence when it exists, and a
+      # refusal is reported as a probe failure naming that remedy rather than as
+      # "no orphans found".
+      - name: Enumerate unreachable manifests
+        id: probe
+        env:
+          GH_TOKEN: ${{ secrets.GHCR_PACKAGES_TOKEN || github.token }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          if ! bash scripts/watch/ghcr-orphans.sh --owner "$OWNER" --out body.md > summary.txt 2> probe.log; then
+            cat probe.log >&2
+            {
+              printf '## The GHCR orphan probe could not answer\n\n'
+              printf 'Nothing was reported, deliberately: an unmeasured absence must not\n'
+              printf 'present as a clean registry.\n\n```\n'
+              tail -40 probe.log
+              printf '```\n\nIf the failure is the packages API refusing to list, the token lacks\n'
+              printf '`read:packages` over the packages of the owner account — add a\n'
+              printf '`GHCR_PACKAGES_TOKEN` repository secret holding a PAT with that scope.\n'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          orphans=$(sed -nE 's/^orphans=([0-9]+)$/\1/p' probe.log | tail -1)
+          [ -n "$orphans" ] || { echo "::error::the probe printed no orphan count"; exit 1; }
+          echo "orphans=$orphans" >> "$GITHUB_OUTPUT"
+          cat body.md >> "$GITHUB_STEP_SUMMARY"
+
+      # An issue body is capped at 65536 characters and this list grows with
+      # every failed run, so the tail is dropped rather than the whole filing
+      # being refused by the API.
+      - name: Trim the body to what an issue accepts
+        if: steps.probe.outputs.orphans != '0'
+        run: |
+          set -euo pipefail
+          if [ "$(wc -c < body.md)" -gt 60000 ]; then
+            head -c 59000 body.md > trimmed.md
+            printf '\n\n_Truncated: the full list is in the run summary of this workflow._\n' >> trimmed.md
+            mv trimmed.md body.md
+          fi
+
+      # `on-existing: update` rather than the family's default comment: the body
+      # IS the current inventory, so a weekly comment would stack near-identical
+      # lists and the newest one would be the hardest to find.
+      - name: File or update the tracking issue
+        if: steps.probe.outputs.orphans != '0'
+        uses: ./.github/actions/file-watcher-issue
+        with:
+          title: "chore(images): unreachable GHCR manifests are accumulating"
+          body-file: body.md
+          labels: chore,P3
+          on-existing: update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,27 +175,16 @@ jobs:
       # released. Each of these guards exists because its site shipped stale
       # once; they ran on pull requests only, so a cut whose develop CI run was
       # cancelled re-verified nothing.
-      - name: appVersion and the artifacthub.io image tags match the workspace version
-        env:
-          VERSION: ${{ steps.tag.outputs.version }}
-        run: |
-          set -euo pipefail
-          app=$(sed -nE 's/^appVersion: *"?([^"]+)"?$/\1/p' deploy/helm/ferroehr/Chart.yaml)
-          if [ -z "$app" ]; then
-            echo "::error::could not read appVersion from deploy/helm/ferroehr/Chart.yaml." >&2
-            exit 1
-          fi
-          if [ "$app" != "$VERSION" ]; then
-            echo "::error::Chart.yaml appVersion ($app) != released version ($VERSION) — the release cut bumps appVersion with the workspace version, or a plain 'helm install' deploys the previous release." >&2
-            exit 1
-          fi
-          bad=$(grep -oE 'image: ghcr\.io/[^:]+:[^ ]+' deploy/helm/ferroehr/Chart.yaml | grep -v ":${VERSION}\$" || true)
-          if [ -n "$bad" ]; then
-            echo "::error::artifacthub.io/images tags do not match the released version ($VERSION):" >&2
-            echo "$bad" >&2
-            exit 1
-          fi
-          echo "appVersion and every artifacthub.io/images tag are at $VERSION — OK."
+      # NOT equality with the released version any more (#2779): the chart leg
+      # packages with `helm package --app-version ${TAG#v}` and rewrites the
+      # `artifacthub.io/images` tags at the same moment, so the PUBLISHED chart
+      # carries the released version whatever the tree says. What is still
+      # checked is what still has content — that the committed default names a
+      # version this project released, that the image annotation agrees with it,
+      # and that no injected annotation is committed. One script, so this and the
+      # `chart-appversion` CI job cannot drift apart (they were two copies).
+      - name: The committed chart release facts are coherent
+        run: bash scripts/checks/chart-appversion.sh
 
       - name: The ferroehr party statement's product version matches the workspace
         run: bash scripts/checks/statement-version.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,14 +15,47 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Added
+
+- A weekly report of container manifests in the registry that nothing can reach
+  any more, the residue of a publish that pushed an image by digest and then
+  failed before its tags were applied. It files one tracking issue listing the
+  digests and the command that removes each. Deletion stays manual: a
+  miscomputed reachability would destroy published signatures and attestations.
+
 ### Changed
 
+- A published Helm chart now takes its `appVersion` and its
+  `artifacthub.io/images` tags from the release being cut, injected when the
+  chart is packaged, instead of from values edited into `Chart.yaml` beforehand.
+  What the published chart says does not change; it can no longer say the
+  previous release. The committed values are the default for a chart packaged
+  between releases and for `helm template` against a checkout, and they may lag.
 - The conformance instrument (`tools/cnf-runner` — the CNF 2.0 runner, its
   machine-readable catalogue, schemas, and party artifacts) is now licensed
   under Apache-2.0 instead of MIT: attribution travels with every copy and
   derivative (license + NOTICE retention), and the license carries an
   explicit patent grant. The rest of the project stays MIT; the vendored
   test corpora keep their upstream terms unchanged.
+
+### Fixed
+
+- The chart's generated `README.md`, the page Artifact Hub renders, was a
+  release behind: it advertised chart 6.0.19 and image tag 4.0.4 while the chart
+  was 6.0.20 with an appVersion of 4.0.5. It is regenerated, and a guard now
+  refuses a README that disagrees with the chart it ships in.
+- Two `gh attestation verify` examples in *Verifying releases* still pinned
+  image tag 4.0.4 at the v4.0.5 cut, and that page was then frozen into the
+  4.0.5 documentation. The docs guard now checks release-asset filenames and the
+  substitute-this-tag note on that page, and it reads the workspace version
+  rather than the chart's `appVersion`.
+- Three checks in the documentation-claims guard could never fire: they tested
+  membership of a newline-separated file list against a space-delimited pattern,
+  so the quoted-wire-evidence check and the Rust-version check on the
+  from-source page had never run once.
+- The documentation-claims guard now recognises an `image.tag=X.Y.Z` pin on a
+  chart page. That spelling is the defect the check was written for, and it was
+  the one spelling the pattern did not match.
 
 ## [4.0.5] - 2026-08-26
 

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -20,12 +20,28 @@ type: application
 # `helm push` over an existing tag replaces it silently — so a correction always
 # ships as a NEW version and the published one stands as it was.
 version: 6.0.20
-# The default container image tag (overridable via image.tag), and the released
-# application version — kept equal to the workspace version by the
-# `chart-appversion` CI guard, so a release cannot ship a chart pointing at the
-# previous image. It is NOT a promise that this tag accepts the chart's current
-# `config` defaults: values track development between releases, so the publish
-# lane re-checks the pairing against the image itself.
+# The DEFAULT container image tag (overridable via image.tag) — no longer a
+# per-release fact (#2779).
+#
+# A published chart's appVersion is injected at package time, from the tag being
+# released: `helm package --app-version ${TAG#v}`, beside the rewrite of the
+# `artifacthub.io/images` tags below and the `artifacthub.io/changes` injection
+# that has worked this way since #2107. The argument is the same for all three —
+# they are facts about a release, and a committed copy is stale from the next
+# merge onwards. So a release cut edits none of them, and the published chart is
+# correct whatever this line says.
+#
+# What this line therefore IS: the default for a chart packaged OUTSIDE a release
+# (the between-releases `publish-chart.yml` dispatch) and for anyone running
+# `helm template` or `helm install` against this directory. It names the most
+# recent release it was refreshed at and may lag; what it may NOT do is name a
+# version this project never released, which is what
+# scripts/checks/chart-appversion.sh holds it to (CHANGELOG.md is the authority).
+#
+# It is NOT a promise that this tag accepts the chart's current `config`
+# defaults: values track development between releases, so the publish lane
+# re-checks the pairing against an image, and the `chart-boot` CI job replays it
+# against the image built from the tree.
 appVersion: "4.0.5"
 
 # A COMPATIBILITY floor, and a real one: 1.36 is the release where the newest
@@ -86,11 +102,13 @@ icon: https://ferroehr.eu/assets/logo-mark-dark.svg
 # ─────────────────────────────────────────────────────────────────────────────
 # Artifact Hub display metadata (https://artifacthub.io/docs/topics/annotations/helm/).
 #
-# Two annotations are NOT here because they are per-release facts that would go
+# Three annotations are NOT here because they are per-release facts that would go
 # stale the moment they were committed; the publish lane injects them at package
 # time from CHANGELOG.md and the tag (deploy/helm/artifacthub-changes.sh):
 # `artifacthub.io/changes` and `artifacthub.io/containsSecurityUpdates`, plus
-# `artifacthub.io/prerelease` for an `-rc` tag.
+# `artifacthub.io/prerelease` for an `-rc` tag. Committing any of the three is
+# refused by scripts/checks/chart-appversion.sh: two declarations of one key make
+# the packaged metadata depend on YAML key-collision behaviour.
 #
 # Deliberately absent, so a later reader does not wonder:
 #   operator, operatorCapabilities — this is not an operator.
@@ -122,11 +140,13 @@ annotations:
   artifacthub.io/maintainers: |
     - name: Ruben Talstra
       email: me@rubentalstra.nl
-  # All three published images, so the hub's security report covers what the
-  # PROJECT ships. Only `ferroehr` is deployed by this chart — there is no
-  # in-chart PostgreSQL, and the admin console is its own deployment — so the
-  # other two are listed as product images rather than chart contents. Every tag
-  # here must equal `appVersion`; the `chart-appversion` CI guard checks it.
+  # Every tag here must equal `appVersion` (scripts/checks/chart-appversion.sh
+  # checks it), and the publish lane REWRITES them to the released version at
+  # package time — deploy/helm/release-facts.sh, because
+  # `helm package --app-version` sets the appVersion field and does not touch
+  # annotations (#2779). So these committed tags are the between-releases
+  # default, like appVersion itself, and never what a published listing shows.
+  #
   # ONLY images this chart actually deploys. Artifact Hub scans every entry here
   # and attributes the findings to this package, so listing an image the chart
   # never installs reports us for software no user runs. `ferroehr-postgres` was

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # A published OCI version is immutable by refusal rather than by the registry —
 # `helm push` over an existing tag replaces it silently — so a correction always
 # ships as a NEW version and the published one stands as it was.
-version: 6.0.20
+version: 6.0.21
 # The DEFAULT container image tag (overridable via image.tag) — no longer a
 # per-release fact (#2779).
 #

--- a/deploy/helm/ferroehr/README.md
+++ b/deploy/helm/ferroehr/README.md
@@ -2,7 +2,7 @@
 
 Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.1.0 + AQL 1.1). A single static binary deployed with a hardened-by-default security posture: runs as a non-root, read-only-rootfs workload whose NetworkPolicy admits its serving port only, and that connects to an EXTERNAL PostgreSQL 18 as an unprivileged app role (migrations are run out of band by a separate migrator role).
 
-![Version: 6.0.19](https://img.shields.io/badge/Version-6.0.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.4](https://img.shields.io/badge/AppVersion-4.0.4-informational?style=flat-square)
+![Version: 6.0.20](https://img.shields.io/badge/Version-6.0.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.5](https://img.shields.io/badge/AppVersion-4.0.5-informational?style=flat-square)
 
 FerroEHR is a pure-Rust openEHR Clinical Data Repository: ITS-REST 1.1.0 at the
 API, AQL 1.1 as the query language, PostgreSQL 18-native storage, shipped as a
@@ -33,10 +33,10 @@ to add; `helm repo add` does not apply to this chart:
 
 ```console
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 6.0.19 \
+  --version 6.0.20 \
   --namespace ferroehr --create-namespace \
   --set database.existingSecret=ferroehr-db \
-  --set image.tag=4.0.4
+  --set image.tag=4.0.5
 ```
 
 OCI registries require Helm 3.8 or newer.
@@ -47,8 +47,8 @@ They are independent SemVer lines and they move independently:
 
 | What | Set with | This release |
 |---|---|---|
-| the **chart** (templates, defaults, this document) | `--version` | `6.0.19` |
-| the **server image** | `image.tag` | `4.0.4` |
+| the **chart** (templates, defaults, this document) | `--version` | `6.0.20` |
+| the **server image** | `image.tag` | `4.0.5` |
 
 `appVersion` is the image the chart defaults to; pinning `image.tag` explicitly
 is what keeps an upgrade of one from silently moving the other.
@@ -59,7 +59,7 @@ The chart carries two keyless Sigstore artifacts, and they answer different
 questions. A **cosign signature:** who signed this:
 
 ```console
-cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.19 \
+cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.20 \
   --certificate-identity-regexp '^https://github\.com/rubentalstra/FerroEHR/\.github/workflows/publish-chart\.yml@' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
@@ -67,9 +67,9 @@ cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.19 \
 A **SLSA build provenance attestation:** what source it was built from, and how:
 
 ```console
-gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:6.0.19 \
+gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:6.0.20 \
   -R rubentalstra/FerroEHR
-gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:4.0.4 \
+gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:4.0.5 \
   -R rubentalstra/FerroEHR
 ```
 

--- a/deploy/helm/golden/admin-ui.yaml
+++ b/deploy/helm/golden/admin-ui.yaml
@@ -18,7 +18,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the admin console: only its HTTP port, but from EVERY source — this policy narrows ports, NOT sources (adminUi.networkPolicy.ingressAllowAll=true). Set adminUi.networkPolicy.ingressFrom for a PHI workload. Egress admits the CDR Service and DNS only.
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -90,7 +90,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -118,7 +118,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -139,7 +139,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr-admin-ui
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -154,7 +154,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -184,7 +184,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -201,7 +201,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -332,7 +332,7 @@ metadata:
     kubernetes.io/description: >-
       In-cluster address for the FerroEHR admin console. The console is a REST client of the CDR and holds no data of its own; it is the human-facing surface, so this is the Service an Ingress normally publishes.
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -355,7 +355,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -385,7 +385,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR admin console: a Leptos SSR web UI that consumes the CDR strictly over ITS-REST. It never reaches the database, which the console NetworkPolicy enforces rather than assumes.
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -492,7 +492,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), and only from the networkPolicy.ingressFrom peers.
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -97,7 +97,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -118,7 +118,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -150,7 +150,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -176,7 +176,7 @@ kind: Secret
 metadata:
   name: ferroehr-config
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -197,7 +197,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -401,7 +401,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr-grafana-dashboard
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -652,7 +652,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -686,7 +686,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -919,7 +919,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -953,7 +953,7 @@ kind: Ingress
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -991,7 +991,7 @@ kind: ServiceMonitor
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"

--- a/deploy/helm/golden/basic-auth.yaml
+++ b/deploy/helm/golden/basic-auth.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -51,7 +51,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -72,7 +72,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -102,7 +102,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -119,7 +119,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -247,7 +247,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -277,7 +277,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -51,7 +51,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -72,7 +72,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -87,7 +87,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -212,7 +212,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"
@@ -242,7 +242,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.20
+    helm.sh/chart: ferroehr-6.0.21
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.5"

--- a/deploy/helm/release-facts.sh
+++ b/deploy/helm/release-facts.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+#
+# Rewrite the chart's PER-RELEASE facts to a given application version, at
+# PACKAGE time (#2779).
+#
+# `helm package --app-version <v>` sets the packaged chart's appVersion field and
+# nothing else. Two other places in the packaged chart restate that same version,
+# and both would otherwise advertise the previous release:
+#
+#   * `artifacthub.io/images` in Chart.yaml — the image list Artifact Hub scans,
+#     so a stale tag reports vulnerabilities for software nobody is running;
+#   * README.md — a GENERATED file (helm-docs, from Chart.yaml + the `# --`
+#     comments in values.yaml) whose install example, "This release" table,
+#     attestation example and version badge all name the appVersion. Artifact Hub
+#     renders it as the package's front page.
+#
+# The sibling artifacthub-changes.sh already injects `artifacthub.io/changes`
+# rather than committing it, on the argument that a fact about a release is stale
+# in the tree from the next merge onwards. This is the same argument applied to
+# the two sites that were still hand-edited at every cut.
+#
+# It is a set of ANCHORED substitutions rather than a `yq` round-trip or a
+# helm-docs re-run: Chart.yaml is ~120 lines of load-bearing commentary (the
+# kubeVersion floor's KEP table, the deliberately-absent annotations) that a
+# structural rewrite would re-emit, and helm-docs is a Go binary this publishing
+# lane would have to install and pin to run once. Every substitution is
+# counted, and the script refuses when a count does not add up, so a file that
+# changed shape fails loudly instead of publishing stale facts.
+#
+# Usage: deploy/helm/release-facts.sh <version>
+#   e.g. deploy/helm/release-facts.sh 4.0.6
+# A version equal to the committed appVersion is a no-op for the README (the
+# between-releases dispatch path).
+
+set -euo pipefail
+
+VERSION="${1:-}"
+if [[ -z "$VERSION" ]]; then
+  echo "usage: $(basename "$0") <version>" >&2
+  exit 2
+fi
+# A tag, never a ref: `v`-prefixed input is the mistake that would publish
+# annotations pointing at tags this project does not push (the book's own
+# warning: published image tags carry no `v` prefix).
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+  echo "::error::'$VERSION' is not a bare X.Y.Z[-suffix] image tag (published tags carry no 'v' prefix)" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="${SCRIPT_DIR}/ferroehr/Chart.yaml"
+README="${SCRIPT_DIR}/ferroehr/README.md"
+for required in "$CHART" "$README"; do
+  [[ -f "$required" ]] || { echo "::error::no ${required}" >&2; exit 1; }
+done
+
+OLD=$(sed -nE 's/^appVersion: *"?([^"]+)"?$/\1/p' "$CHART")
+[[ -n "$OLD" ]] || { echo "::error::could not read appVersion from ${CHART}" >&2; exit 1; }
+
+# ── Chart.yaml: the artifacthub.io/images tags ───────────────────────────────
+# `image: ghcr.io/…:<tag>` occurs only inside that annotation — the same anchor
+# scripts/checks/chart-appversion.sh reads.
+img_before=$(grep -cE '^[[:space:]]+image: ghcr\.io/[^:]+:[^[:space:]]+$' "$CHART" || true)
+if [[ "$img_before" -eq 0 ]]; then
+  echo "::error::${CHART} declares no 'image: ghcr.io/…:<tag>' line, so there is nothing to rewrite — the artifacthub.io/images annotation changed shape." >&2
+  exit 1
+fi
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+sed -E "s|^([[:space:]]+image: ghcr\\.io/[^:]+):[^[:space:]]+\$|\\1:${VERSION}|" "$CHART" > "$tmp"
+cat "$tmp" > "$CHART"
+img_after=$(grep -cE "^[[:space:]]+image: ghcr\\.io/[^:]+:${VERSION}\$" "$CHART" || true)
+if [[ "$img_after" -ne "$img_before" ]]; then
+  echo "::error::rewrote ${img_after} of ${img_before} artifacthub.io/images tags in ${CHART}." >&2
+  exit 1
+fi
+
+# ── README.md: every restatement of the appVersion ───────────────────────────
+# Four anchored contexts, not a global replace: a global one would also rewrite
+# the CHART version if the two ever happened to be the same string, and the
+# chart version is not a per-release fact.
+readme_patterns=(
+  "AppVersion-${OLD}-informational"
+  "AppVersion: ${OLD}"
+  "image.tag=${OLD}"
+  "ferroehr:${OLD}"
+  "| \`${OLD}\` |"
+)
+if [[ "$OLD" != "$VERSION" ]]; then
+  matched=0
+  for pattern in "${readme_patterns[@]}"; do
+    replacement="${pattern//${OLD}/${VERSION}}"
+    before=$(grep -cF "$pattern" "$README" || true)
+    [[ "$before" -eq 0 ]] && continue
+    matched=$((matched + 1))
+    sed -i.bak "s|$(printf '%s' "$pattern" | sed 's/[|&\\]/\\&/g')|$(printf '%s' "$replacement" | sed 's/[|&\\]/\\&/g')|g" "$README"
+    rm -f "${README}.bak"
+    after=$(grep -cF "$replacement" "$README" || true)
+    remaining=$(grep -cF "$pattern" "$README" || true)
+    if [[ "$after" -lt "$before" || "$remaining" -ne 0 ]]; then
+      echo "::error::rewriting '${pattern}' in ${README} left ${remaining} occurrence(s) behind." >&2
+      exit 1
+    fi
+  done
+  # Zero matches means the committed README does not restate the committed
+  # appVersion — it is generated FROM Chart.yaml, so the two can only disagree
+  # if the README was never regenerated. That is not a shape this may publish
+  # around: the v4.0.5 cut left it a release behind (6.0.19/4.0.4 against a
+  # 6.0.20/4.0.5 chart) and only a local `deploy/helm/validate.sh` run noticed,
+  # because the CI lane skips the drift check when helm-docs is absent.
+  if [[ "$matched" -eq 0 ]]; then
+    echo "::error::${README} restates no appVersion ${OLD}, so it cannot be moved to ${VERSION}. It is generated from Chart.yaml — regenerate it: helm-docs --chart-search-root ${SCRIPT_DIR}/ferroehr --template-files README.md.gotmpl" >&2
+    exit 1
+  fi
+fi
+
+echo "release facts set to ${VERSION} (from a committed default of ${OLD}):" >&2
+grep -E '^[[:space:]]+image: ghcr\.io/' "$CHART" >&2
+grep -nE "AppVersion|image\.tag=|ferroehr:[0-9]" "$README" >&2 || true

--- a/scripts/checks/chart-appversion.sh
+++ b/scripts/checks/chart-appversion.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+#
+# scripts/checks/chart-appversion.sh — what the chart's COMMITTED release facts
+# still have to be true about, now that the published ones are injected (#2779).
+#
+# Until #2779, `appVersion` and the `artifacthub.io/images` tags were per-release
+# facts kept equal to the workspace version by hand at every cut, and guarded in
+# three places. They are not per-release facts any more: `build-chart.yml`
+# packages with `helm package --app-version <released version>` and rewrites the
+# image annotation's tags at the same moment, exactly as it already injects
+# `artifacthub.io/changes` — "facts about a release, and a committed copy would
+# be stale from the next merge onwards". So the PUBLISHED chart is correct by
+# construction and no longer depends on the tree at all.
+#
+# What the committed values still ARE: the defaults for a chart packaged OUTSIDE
+# a release — the between-releases `publish-chart.yml` dispatch — and for anyone
+# who runs `helm template`/`helm install` against this directory. That leaves
+# three properties with real content, and this script is the one home for them:
+#
+#   1. `appVersion` names a version this project has actually RELEASED. A default
+#      image tag that was never published produces an ImagePullBackOff, and a
+#      future version is a promise the registry cannot keep. CHANGELOG.md is the
+#      machine authority: a released version has a `## [X.Y.Z]` section.
+#   2. Every `artifacthub.io/images` tag equals `appVersion`. The two describe
+#      one thing — the product version this chart defaults to — and the injection
+#      rewrites both from one input, so a tree where they already disagree would
+#      publish an annotation the package's own appVersion contradicts.
+#   3. Chart.yaml carries NONE of the injected annotations. A committed
+#      `artifacthub.io/changes`, `containsSecurityUpdates` or `prerelease` key
+#      would collide with the injected one and leave the packaged metadata
+#      depending on YAML key-collision behaviour.
+#   4. The chart README — a GENERATED file, and the one Artifact Hub renders as
+#      the package front page — restates the same appVersion. It is generated
+#      FROM Chart.yaml, so a disagreement means it was never regenerated, and
+#      the injection has nothing to move: the v4.0.5 cut left it a release
+#      behind (6.0.19/4.0.4 against a 6.0.20/4.0.5 chart) and only a local
+#      `deploy/helm/validate.sh` noticed, because the CI drift check skips
+#      itself when helm-docs is not installed on the runner.
+#
+# What is deliberately NOT checked here any more: equality with the workspace
+# version. Asserting it would re-impose the hand edit this change removes.
+#
+# Usage: scripts/checks/chart-appversion.sh
+# Callers: the `chart-appversion` job in ci.yml, and the `plan` job of
+# release.yml (which re-runs the whole guard tier at the tagged commit).
+
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+CHART=deploy/helm/ferroehr/Chart.yaml
+CHANGELOG=CHANGELOG.md
+
+for required in "$CHART" "$CHANGELOG"; do
+  [[ -f "$required" ]] || { echo "::error::missing $required" >&2; exit 1; }
+done
+
+failures=0
+report() {
+  echo "::error::$1" >&2
+  failures=$((failures + 1))
+}
+
+app=$(sed -nE 's/^appVersion: *"?([^"]+)"?$/\1/p' "$CHART")
+if [[ -z "$app" ]]; then
+  report "could not read appVersion from $CHART."
+  exit 1
+fi
+
+# 1. A released version, per the changelog.
+if ! grep -qE "^## \[${app//./\\.}\]" "$CHANGELOG"; then
+  report "$CHART appVersion is $app, which has no '## [$app]' section in $CHANGELOG — the committed appVersion is the default image tag for a chart packaged outside a release, so it must name a version that was actually published. (A release no longer needs to bump it: build-chart.yml injects the released version with 'helm package --app-version'.)"
+fi
+
+# 2. The image annotation agrees with it.
+bad=$(grep -oE 'image: ghcr\.io/[^:]+:[^ ]+' "$CHART" | grep -v ":${app}\$" || true)
+if [[ -n "$bad" ]]; then
+  report "$CHART artifacthub.io/images tags disagree with appVersion ($app):
+$bad"
+fi
+if ! grep -q 'image: ghcr\.io/' "$CHART"; then
+  report "$CHART declares no artifacthub.io/images entry — the publish lane rewrites those tags at package time and would rewrite nothing."
+fi
+
+# 3. None of the injected annotations is committed.
+for injected in artifacthub.io/changes artifacthub.io/containsSecurityUpdates artifacthub.io/prerelease; do
+  if grep -q "^  ${injected}:" "$CHART"; then
+    report "$CHART commits ${injected}, which build-chart.yml injects at package time — two declarations of one key make the packaged metadata depend on YAML key-collision behaviour."
+  fi
+done
+
+# 4. The generated README agrees with it.
+README=deploy/helm/ferroehr/README.md
+if [[ -f "$README" ]]; then
+  if ! grep -qF -- "--set image.tag=${app}" "$README"; then
+    report "$README teaches an image.tag other than the committed appVersion ($app) — it is generated from Chart.yaml, so regenerate it: helm-docs --chart-search-root deploy/helm/ferroehr --template-files README.md.gotmpl"
+  fi
+else
+  report "no $README — the chart publishes a generated README and this check has nothing to read."
+fi
+
+if [[ "$failures" -gt 0 ]]; then
+  exit 1
+fi
+echo "chart-appversion: appVersion $app is a released version, the artifacthub.io/images tags and the generated README agree with it, and no injected annotation is committed — OK."

--- a/scripts/checks/docs-claims.sh
+++ b/scripts/checks/docs-claims.sh
@@ -140,6 +140,21 @@ report() {
 
 files=$(collect "$@")
 
+# Membership of the file list, for the sections that check ONE named page.
+#
+# It needs a helper because the obvious spelling does not work: `$files` is
+# NEWLINE-separated, so `case " $files " in *" $page "*)` asks for a match
+# delimited by spaces and can never find one. Three sections were written that
+# way and were silently inert — the quoted-wire-evidence check on comparison.md
+# and the Rust-version check on from-source.md never ran once, proven by
+# mutating both pages and watching the guard report OK (#2779). Space-normalise
+# the list once and test against that.
+# shellcheck disable=SC2086 # deliberate re-splitting: the newlines become spaces
+files_spaced=" $(echo $files) "
+in_files() {
+  case "$files_spaced" in *" $1 "*) return 0 ;; *) return 1 ;; esac
+}
+
 # ── 1. configuration keys ────────────────────────────────────────────────────
 for f in $files; do
   [[ -f "$f" ]] || continue
@@ -262,11 +277,22 @@ done
 
 # ── 3. chart/app version literals (chart pages only) ────────────────────────
 # Both went stale on the published site (`--version 5.0.1` against a 6.x chart,
-# `image.tag=3.17.3` against a 3.17.5 appVersion — #2348). Chart.yaml is the
-# machine authority for both, so a literal that disagrees with it fails here.
+# `image.tag=3.17.3` against a 3.17.5 appVersion — #2348), so a literal that
+# disagrees with its authority fails here.
+#
+# TWO authorities, not one (#2779). The CHART version is Chart.yaml's own
+# `version` — the chart's independent SemVer line, still committed and still
+# hand-bumped. The APPLICATION version is the WORKSPACE version in Cargo.toml,
+# no longer Chart.yaml's `appVersion`: the publish lane now injects the released
+# version into the packaged chart (`helm package --app-version`), so the
+# committed appVersion is a between-releases default that may legitimately lag,
+# while a book page teaches the tag an operator can actually pull from the
+# newest release — which is the workspace version.
 CHART_YAML=deploy/helm/ferroehr/Chart.yaml
 chart_version=$(awk '$1=="version:"{print $2; exit}' "$CHART_YAML")
-app_version=$(awk '$1=="appVersion:"{gsub(/"/,""); print $2; exit}' "$CHART_YAML")
+app_version=$(sed -nE 's/^version = "(.*)"$/\1/p' Cargo.toml | head -1)
+[[ -n "$chart_version" && -n "$app_version" ]] \
+  || { echo "docs-claims: could not read the chart version ($CHART_YAML) or the workspace version (Cargo.toml)" >&2; exit 1; }
 for f in $files; do
   case " $CHART_PAGES " in *" $f "*) ;; *) continue ;; esac
   [[ -f "$f" ]] || continue
@@ -275,11 +301,17 @@ for f in $files; do
     [[ "$v" = "$chart_version" ]] \
       || report "$f" "pins chart \`--version $v\`; Chart.yaml says $chart_version"
   done < <(grep -ohE '\-\-version +[0-9]+\.[0-9]+\.[0-9]+' "$f" | awk '{print $2}' | sort -u)
+  # `image.tag=<ver>` is in the pattern deliberately (#2779). The motivating
+  # defect this section records is "`image.tag=3.17.3` against a 3.17.5
+  # appVersion", and the pattern did not match that spelling at all — only a
+  # fully-spelled `…/ferroehr:<ver>` reference. Mutating the kubernetes page's
+  # `--set image.tag=` pin was reported as OK.
   while read -r v; do
     [[ -n "$v" ]] || continue
     [[ "$v" = "$app_version" ]] \
-      || report "$f" "pins image tag \`$v\`; Chart.yaml appVersion is $app_version"
-  done < <(grep -ohE 'ferroehr(-admin-ui)?:[0-9]+\.[0-9]+\.[0-9]+' "$f" | sed 's/.*://' | sort -u)
+      || report "$f" "pins image tag \`$v\`; the workspace version is $app_version"
+  done < <(grep -ohE '(ferroehr(-admin-ui)?:|image\.tag=)[0-9]+\.[0-9]+\.[0-9]+' "$f" \
+    | sed -E 's/^.*[:=]//' | sort -u)
 done
 # Every page (and the landing): a fully-spelled ghcr image reference must carry
 # the current appVersion, and never a `v` prefix — the publish lane tags
@@ -293,20 +325,20 @@ for f in $files website/landing/index.html; do
   while read -r v; do
     [[ -n "$v" ]] || continue
     [[ "$v" = "$app_version" ]] \
-      || report "$f" "pins ghcr image tag \`$v\`; Chart.yaml appVersion is $app_version"
+      || report "$f" "pins ghcr image tag \`$v\`; the workspace version is $app_version"
   done < <(grep -ohE 'ghcr\.io/rubentalstra/(ferroehr|ferroehr-admin-ui|ferroehr-postgres):[0-9]+\.[0-9]+\.[0-9]+' "$f" | sed 's/.*://' | sort -u)
 done
 # The from-source page: a Rust version literal must be the toolchain channel or
 # the MSRV ("Rust 1.96.1" shipped against a 1.97.1 toolchain — #2348).
 RUST_PAGE="$BOOK/installation/from-source.md"
-case " $files " in *" $RUST_PAGE "*)
+if in_files "$RUST_PAGE"; then
   channel=$(awk -F'"' '/^channel/{print $2; exit}' rust-toolchain.toml)
   msrv=$(awk -F'"' '/^rust-version/{print $2; exit}' Cargo.toml)
   while read -r v; do
     case "$v" in "$channel"|"${channel%.*}"|"$msrv"|"$msrv".*) continue ;; *) ;; esac
     report "$RUST_PAGE" "names Rust \`$v\`, which is neither the toolchain channel ($channel) nor the MSRV ($msrv)"
   done < <(grep -ohE '1\.[0-9]{2}(\.[0-9]+)?' "$RUST_PAGE" | sort -u)
-;; *) ;; esac
+fi
 
 # ── 3b. quoted wire evidence on the comparison page ─────────────────────────
 # Five fabricated response-body quotes shipped on the published comparison page
@@ -314,14 +346,14 @@ case " $files " in *" $RUST_PAGE "*)
 # double-quoted string on that page presents itself as captured wire evidence,
 # so it must occur verbatim in one of the committed results records.
 COMPARISON_PAGE="$BOOK/comparison.md"
-case " $files " in *" $COMPARISON_PAGE "*)
+if in_files "$COMPARISON_PAGE"; then
   while read -r quote; do
     [[ -n "$quote" ]] || continue
     inner=${quote#\`\"}; inner=${inner%\"\`}
     grep -qF "$inner" docs/conformance/ehrbase/results.json docs/conformance/ferroehr/results.json 2>/dev/null \
       || report "$COMPARISON_PAGE" "quotes \`\"$inner\"\` as wire evidence, but no committed results record contains it"
   done < <(grep -ohE '`"[^"`]{4,}"`' "$COMPARISON_PAGE" | sort -u)
-;; *) ;; esac
+fi
 
 # ── 3c. banned phrases with a recorded refutation ────────────────────────────
 # "static binary" shipped on four pages, the landing and the README while the
@@ -338,6 +370,48 @@ while read -r f; do
     && report "$f" "claims a static binary — the binary is dynamically linked (distroless/cc); say 'self-contained'"
 done < <(grep -rilE 'static(ally linked)? binary' --include='*.md' "$BOOK" website/landing README.md 2>/dev/null; \
          grep -lFi 'static binary' website/landing/index.html 2>/dev/null)
+
+# ── 3d. the release-verification page's copy-paste literals ─────────────────
+# `verifying-releases.md` is a procedure an operator pastes, so a version
+# literal in it is a claim about the CURRENT release rather than prose. The
+# v4.0.5 cut updated the substitution note and left both
+# `gh attestation verify …/ferroehr:4.0.4` examples behind; the docs freeze then
+# published them, and the fix could only ever land in a later version's site
+# (#2779). The bare image-tag half was already covered by the every-page ghcr
+# rule in section 3 — and it DID report on the release PR, which was merged
+# anyway — so what is added here is the half with no authority at all: the
+# release-ASSET filename shape, plus two independent nets under the
+# substitute-this-tag note.
+#
+# Historical prose on this page is deliberately NOT checked. "From v4.0.1 on,
+# the shipped binary embeds…" and "Images and the chart reach L3 from the first
+# publish after v4.0.1" are correct BECAUSE they name an older release, so a
+# blanket rule over every `vX.Y.Z` literal would report three true sentences.
+# The currency claim lives in the asset names, the substitution note and the
+# commands — and nowhere else on the page.
+VERIFY_PAGE="$BOOK/verifying-releases.md"
+if in_files "$VERIFY_PAGE"; then
+  # A release asset is named after the git TAG, so its version carries the `v`.
+  while read -r v; do
+    [[ -n "$v" ]] || continue
+    [[ "$v" = "$app_version" ]] \
+      || report "$VERIFY_PAGE" "names the release asset \`ferroehr-v${v}…\`; the workspace version is $app_version"
+  done < <(grep -ohE 'ferroehr-v[0-9]+\.[0-9]+\.[0-9]+' "$VERIFY_PAGE" | sed 's/^ferroehr-v//' | sort -u)
+  # The substitution note. Its sentence wraps, so the page is line-joined first.
+  while read -r v; do
+    [[ -n "$v" ]] || continue
+    [[ "$v" = "$app_version" ]] \
+      || report "$VERIFY_PAGE" "tells the reader to substitute the tag \`v$v\`; the workspace version is $app_version"
+  done < <(tr '\n' ' ' < "$VERIFY_PAGE" \
+    | grep -ohE 'for example[[:space:]]+`v[0-9]+\.[0-9]+\.[0-9]+`' \
+    | sed -E 's/.*`v([0-9.]+)`.*/\1/' | sort -u)
+  # The wording-independent net, because the rule above is anchored on a phrase
+  # and a reword would silently disarm it: the released tag has to appear on the
+  # page SOMEWHERE. A cut that bumps Cargo.toml and forgets this page fails here
+  # whatever the sentence around the literal says.
+  grep -qF "v${app_version}" "$VERIFY_PAGE" \
+    || report "$VERIFY_PAGE" "never names the released tag \`v$app_version\` — its substitution examples still teach an older release"
+fi
 
 # ── 4. generated charts nothing embeds ───────────────────────────────────────
 # Whole-corpus by nature: a page deleting its figure is exactly the case to

--- a/scripts/watch/ghcr-orphans.sh
+++ b/scripts/watch/ghcr-orphans.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+#
+# scripts/watch/ghcr-orphans.sh — enumerate GENUINELY unreachable GHCR manifests.
+#
+# WHY (#2779): every image push in this estate is push-by-digest followed by a
+# separate tag application (scan-and-tag.yml). A run that dies between those two
+# steps leaves a manifest in the registry that no tag and no index points at, and
+# nothing in the estate prunes it — GHCR keeps it, and it keeps counting against
+# the package's storage and its version list, forever.
+#
+# WHY A NAIVE UNTAGGED LIST IS USELESS HERE: on this repository ~80% of every
+# package's versions are untagged and almost all of them are REACHABLE. A
+# multi-arch image is a tagged INDEX whose per-architecture manifests carry no
+# tags of their own; buildkit adds one attestation manifest per platform to that
+# same index; and because GHCR serves no referrers API, cosign signatures and
+# SLSA attestations reach the registry through the OCI fallback TAG
+# `sha256-<hex>` — a tagged index whose children are, again, untagged. So this
+# script computes reachability rather than reporting absence of a tag:
+#
+#   orphan = untagged AND not a child of any tagged index (at any depth)
+#
+# The tagged half comes from the GitHub packages API (which knows the tags), the
+# child half from the OCI distribution API (which knows the indexes). Both are
+# read-only.
+#
+# THIS SCRIPT NEVER DELETES, and the watcher that calls it never deletes either.
+# Deletion is a manual, reviewed act: an automated prune that miscomputed
+# reachability by one media type would destroy published attestations and
+# signatures for releases that are immutable by policy, and the failure would be
+# silent until a consumer's `gh attestation verify` returned a 404. The report
+# lists the exact `gh api -X DELETE` command for each orphan instead.
+#
+# Usage:
+#   scripts/watch/ghcr-orphans.sh                 # report to stdout
+#   scripts/watch/ghcr-orphans.sh --out report.md # also write the markdown body
+#   scripts/watch/ghcr-orphans.sh --owner X --package Y   # narrow the sweep
+#
+# Requires: gh (authenticated, `read:packages`), jq, curl.
+# Exits non-zero only when the PROBE cannot answer — an unreachable API, a
+# manifest the registry refuses, an answer jq cannot read. Finding orphans is a
+# successful run (the watcher family's run-colour law, #2778).
+
+# Every backtick below is markdown in a report body, never command substitution.
+# shellcheck disable=SC2016
+set -euo pipefail
+
+OWNER="rubentalstra"
+PACKAGES=(ferroehr ferroehr-admin-ui ferroehr-postgres)
+OUT=""
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --owner) OWNER="$2"; shift 2 ;;
+    --package) PACKAGES=("$2"); shift 2 ;;
+    --out) OUT="$2"; shift 2 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+for tool in gh jq curl; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "$tool is required" >&2; exit 1; }
+done
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Every manifest media type a child of ours can be. Listing them explicitly
+# matters: a registry served a v2 schema when the Accept header omitted the OCI
+# index type, and the index would then read as a leaf with no children — every
+# per-arch manifest under it would be reported as an orphan.
+ACCEPT='application/vnd.oci.image.index.v1+json'
+ACCEPT="${ACCEPT},application/vnd.docker.distribution.manifest.list.v2+json"
+ACCEPT="${ACCEPT},application/vnd.oci.image.manifest.v1+json"
+ACCEPT="${ACCEPT},application/vnd.docker.distribution.manifest.v2+json"
+
+# A pull token for one repository. The packages are public, so an anonymous
+# token is enough and is what a third party auditing this would use; a token in
+# GH_TOKEN/GITHUB_TOKEN is offered to the token endpoint when present so the
+# script also works before a package is made public.
+ghcr_token() {
+  local repo="$1" auth=() body
+  if [[ -n "${GITHUB_TOKEN:-${GH_TOKEN:-}}" ]]; then
+    auth=(-u "x:${GITHUB_TOKEN:-${GH_TOKEN}}")
+  fi
+  body="$(curl --proto '=https' --tlsv1.2 -sSL --fail \
+    --retry 5 --retry-connrefused --retry-delay 2 --max-time 60 \
+    "${auth[@]+"${auth[@]}"}" \
+    "https://ghcr.io/token?service=ghcr.io&scope=repository:${repo}:pull")" || return 1
+  printf '%s' "$body" | jq -er '.token'
+}
+
+# One manifest by digest. Guarded by the caller: a refusal is a probe failure,
+# never "it has no children".
+fetch_manifest() {
+  local repo="$1" digest="$2" token="$3"
+  curl --proto '=https' --tlsv1.2 -sSL --fail \
+    --retry 5 --retry-connrefused --retry-delay 2 --max-time 60 \
+    -H "Authorization: Bearer ${token}" -H "Accept: ${ACCEPT}" \
+    "https://ghcr.io/v2/${repo}/manifests/${digest}"
+}
+
+failures=0
+total_untagged=0
+total_by_index=0
+total_referrer=0
+total_orphans=0
+: > "$WORK/report.md"
+: > "$WORK/orphans.tsv"
+
+for pkg in "${PACKAGES[@]}"; do
+  repo="${OWNER}/${pkg}"
+  echo "== ${repo}" >&2
+
+  # `name` is the manifest digest, `id` is what the delete endpoint takes.
+  if ! gh api "/users/${OWNER}/packages/container/${pkg}/versions?per_page=100" --paginate \
+      --jq '.[] | [.name, (.id|tostring), ((.metadata.container.tags // []) | join(","))] | @tsv' \
+      > "$WORK/${pkg}.versions"; then
+    echo "::error::could not list versions of ${repo} — the probe could not answer" >&2
+    failures=$((failures + 1))
+    continue
+  fi
+
+  awk -F'\t' '$3 != ""' "$WORK/${pkg}.versions" > "$WORK/${pkg}.tagged"
+  awk -F'\t' '$3 == ""' "$WORK/${pkg}.versions" > "$WORK/${pkg}.untagged"
+
+  if ! token="$(ghcr_token "$repo")"; then
+    echo "::error::could not obtain a pull token for ${repo} — the probe could not answer" >&2
+    failures=$((failures + 1))
+    continue
+  fi
+
+  # Walk every tagged manifest and record the digests it points at. The `sha256-`
+  # fallback tags are walked like any other index: their children are the
+  # signature and provenance blobs' manifests, which is exactly the set a naive
+  # untagged list would offer up for deletion.
+  : > "$WORK/${pkg}.by-index"
+  : > "$WORK/${pkg}.by-referrer"
+  : > "$WORK/${pkg}.nested"
+  probe_ok=1
+  while IFS=$'\t' read -r digest _id tags; do
+    [[ -n "$digest" ]] || continue
+    case "$tags" in sha256-*) sink="$WORK/${pkg}.by-referrer" ;; *) sink="$WORK/${pkg}.by-index" ;; esac
+    if ! manifest="$(fetch_manifest "$repo" "$digest" "$token")"; then
+      echo "::error::${repo}@${digest} is tagged (${tags}) but its manifest could not be fetched — reachability is unknown, so nothing is reported" >&2
+      probe_ok=0
+      break
+    fi
+    printf '%s' "$manifest" | jq -r '.manifests // [] | .[].digest' >> "$sink" || {
+      echo "::error::${repo}@${digest} returned a manifest jq could not read" >&2
+      probe_ok=0
+      break
+    }
+    # A child that is ITSELF an index has grandchildren to reach; the media type
+    # in the parent's descriptor says so, so no extra request is spent asking.
+    printf '%s' "$manifest" \
+      | jq -r '.manifests // [] | .[] | select(.mediaType | test("index|manifest.list")) | .digest' \
+      >> "$WORK/${pkg}.nested"
+  done < "$WORK/${pkg}.tagged"
+
+  if [[ "$probe_ok" -eq 0 ]]; then
+    failures=$((failures + 1))
+    continue
+  fi
+
+  # The nested level. Nothing in this estate writes such a shape today, so this
+  # pass normally reads nothing — it is here because "normally" is not a
+  # reachability proof, and a missed level presents as a deletable orphan.
+  while IFS= read -r child; do
+    [[ -n "$child" ]] || continue
+    if ! manifest="$(fetch_manifest "$repo" "$child" "$token")"; then
+      echo "::error::${repo}@${child} is referenced by a tagged index but could not be fetched" >&2
+      probe_ok=0
+      break
+    fi
+    printf '%s' "$manifest" | jq -r '.manifests // [] | .[].digest' >> "$WORK/${pkg}.by-index"
+  done < <(sort -u "$WORK/${pkg}.nested")
+
+  if [[ "$probe_ok" -eq 0 ]]; then
+    failures=$((failures + 1))
+    continue
+  fi
+
+  sort -u "$WORK/${pkg}.by-index" > "$WORK/${pkg}.by-index.u"
+  sort -u "$WORK/${pkg}.by-referrer" > "$WORK/${pkg}.by-referrer.u"
+  cat "$WORK/${pkg}.by-index.u" "$WORK/${pkg}.by-referrer.u" | sort -u > "$WORK/${pkg}.referenced"
+
+  untagged=$(wc -l < "$WORK/${pkg}.untagged" | tr -d ' ')
+  cut -f1 "$WORK/${pkg}.untagged" | sort -u > "$WORK/${pkg}.untagged.d"
+  by_index=$(comm -12 "$WORK/${pkg}.untagged.d" "$WORK/${pkg}.by-index.u" | wc -l | tr -d ' ')
+  by_referrer=$(comm -12 "$WORK/${pkg}.untagged.d" "$WORK/${pkg}.by-referrer.u" | wc -l | tr -d ' ')
+  comm -23 "$WORK/${pkg}.untagged.d" "$WORK/${pkg}.referenced" > "$WORK/${pkg}.orphans.d"
+  orphans=$(wc -l < "$WORK/${pkg}.orphans.d" | tr -d ' ')
+
+  total_untagged=$((total_untagged + untagged))
+  total_by_index=$((total_by_index + by_index))
+  total_referrer=$((total_referrer + by_referrer))
+  total_orphans=$((total_orphans + orphans))
+
+  {
+    printf '### `%s`\n\n' "$repo"
+    printf '| | count |\n|---|---|\n'
+    printf '| versions | %s |\n' "$(wc -l < "$WORK/${pkg}.versions" | tr -d ' ')"
+    printf '| tagged | %s |\n' "$(wc -l < "$WORK/${pkg}.tagged" | tr -d ' ')"
+    printf '| untagged | %s |\n' "$untagged"
+    printf '| untagged, but a per-arch or attestation child of a tagged index | %s |\n' "$by_index"
+    printf '| untagged, but a child of a `sha256-…` referrer index (signature / provenance) | %s |\n' "$by_referrer"
+    printf '| **genuine orphans** | **%s** |\n\n' "$orphans"
+  } >> "$WORK/report.md"
+
+  if [[ "$orphans" -gt 0 ]]; then
+    {
+      printf 'Unreachable manifests in `%s`, with the command that removes each one:\n\n' "$repo"
+      printf '```shell\n'
+      while IFS= read -r d; do
+        [[ -n "$d" ]] || continue
+        id=$(awk -F'\t' -v d="$d" '$1==d{print $2; exit}' "$WORK/${pkg}.untagged")
+        printf '# %s\n' "$d"
+        printf 'gh api -X DELETE /user/packages/container/%s/versions/%s\n' "$pkg" "$id"
+        printf '%s\t%s\t%s\n' "$pkg" "$d" "$id" >> "$WORK/orphans.tsv"
+      done < "$WORK/${pkg}.orphans.d"
+      printf '```\n\n'
+    } >> "$WORK/report.md"
+  fi
+done
+
+if [[ "$failures" -gt 0 ]]; then
+  echo "ghcr-orphans: $failures package(s) could not be assessed — reporting nothing." >&2
+  exit 1
+fi
+
+{
+  printf 'Untagged manifests in GHCR, split by whether anything still reaches them.\n'
+  printf 'A tagged index reaches its per-architecture manifests, its buildkit\n'
+  printf 'attestation manifests, and — through the `sha256-…` OCI fallback tag,\n'
+  printf 'because GHCR serves no referrers API — the cosign signature and SLSA\n'
+  printf 'provenance of every published digest. Only what NOTHING reaches is an\n'
+  printf 'orphan, and only orphans are listed below.\n\n'
+  printf '| | count |\n|---|---|\n'
+  printf '| untagged versions | %s |\n' "$total_untagged"
+  printf '| reachable as an index child | %s |\n' "$total_by_index"
+  printf '| reachable as a referrer artifact | %s |\n' "$total_referrer"
+  printf '| **genuine orphans** | **%s** |\n\n' "$total_orphans"
+  cat "$WORK/report.md"
+  if [[ "$total_orphans" -gt 0 ]]; then
+    printf 'These are the residue of a run that pushed by digest and then died before\n'
+    printf '`scan-and-tag` applied its tags. Deletion is deliberately MANUAL: an\n'
+    printf 'automated prune that miscomputes reachability by one media type destroys\n'
+    printf 'published signatures and attestations for releases this project publishes\n'
+    printf 'as immutable, and the damage is invisible until a consumer verifies. Check\n'
+    printf 'a couple of digests by hand (`docker buildx imagetools inspect\n'
+    printf '%s/<pkg>@<digest>`) before running anything above.\n' "ghcr.io/${OWNER}"
+  fi
+} > "$WORK/body.md"
+
+cat "$WORK/body.md"
+if [[ -n "$OUT" ]]; then
+  cp "$WORK/body.md" "$OUT"
+fi
+printf 'orphans=%s\n' "$total_orphans" >&2

--- a/website/book/src/installation/kubernetes.md
+++ b/website/book/src/installation/kubernetes.md
@@ -38,7 +38,7 @@ kubectl -n ferroehr create secret generic ferroehr-db \
   --from-literal=FERROEHR__DB__URL='postgres://ferroehr_app:***@pg-host:5432/ferroehr?sslmode=verify-full'
 
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 6.0.20 -n ferroehr \
+  --version 6.0.21 -n ferroehr \
   --set database.existingSecret=ferroehr-db \
   --set image.tag=4.0.5
 ```
@@ -55,7 +55,7 @@ helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
 reference. To read the chart's metadata without installing it:
 
 ```shell
-helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.20
+helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.21
 ```
 
 ### Pin two versions, not one
@@ -68,7 +68,7 @@ against.
 
 | | Selects | Pin with | Line |
 |---|---|---|---|
-| Chart version | templates, values schema, defaults | `--version 6.0.20` | SemVer over the chart's own contract |
+| Chart version | templates, values schema, defaults | `--version 6.0.21` | SemVer over the chart's own contract |
 | Image tag | the server binary | `--set image.tag=4.0.5` (or `image.digest`) | the application's SemVer line |
 
 Always pin the image to an immutable version or, better, a `@sha256` digest,
@@ -167,7 +167,7 @@ metadata lists: the server, and the optional admin console.
 > the image itself as the authority:
 >
 > ```shell
-> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.20 \
+> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.21 \
 >   -s templates/configmap.yaml --set database.existingSecret=ferroehr-db \
 >   | sed -n '/ferroehr.toml/,$p' | sed '1d;s/^    //' > /tmp/ferroehr.toml
 > docker run --rm -v /tmp/ferroehr.toml:/etc/ferroehr/ferroehr.toml:ro \
@@ -556,7 +556,7 @@ config:
 
 ```shell
 helm upgrade ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 6.0.20 -n ferroehr --reuse-values \
+  --version 6.0.21 -n ferroehr --reuse-values \
   --set config.query.plan_cache_capacity=512
 ```
 
@@ -709,7 +709,7 @@ Preview an upgrade against what you have installed with
 `helm diff`, or render the new chart version and read it:
 
 ```shell
-helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.20 \
+helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.21 \
   -n ferroehr -f my-values.yaml | less
 ```
 


### PR DESCRIPTION
Closes #2779 (phase 5 of #2772).

**Injection**: the chart's published `appVersion`, `artifacthub.io/images` tags, and the packaged README's version restatements are injected at package time from the release tag (`deploy/helm/release-facts.sh`), exactly like the existing `artifacthub.io/changes` injection and for the recorded same reason — a committed copy is stale from the next merge onwards. Proven: a 9.9.9 dry package shows every fact at 9.9.9 inside the .tgz while the tree is untouched; goldens unaffected (they render the source directory, and the injection is ordered after validate.sh). The committed values become dispatch-path defaults; the whole guard web is re-derived so nothing asserts a fact that stopped existing (the full agreement audit is in the implementation record): `chart-appversion` becomes one script asserting the committed appVersion names a RELEASED version and everything committed agrees with it, shared by ci.yml and the pipeline's `plan`; `build-chart.yml`'s tag-equality refusal is replaced by a post-package read-back; docs-claims re-keys its image-tag rules to the workspace version and gains the verifying-releases asset-filename + substitution-note + released-tag-present rules (six-direction mutation transcript in the record), reviving two dormant checks en route.

**Record correction for #2772**: the plan said the verifying-releases pins "had no guard" — false. docs-claims covered them and REPORTED red on the v4.0.5 release PR, which was admin-merged past it. The defect class is merging past a reported guard; the new rules make the report richer, and the process fix is the merge discipline itself.

**GHCR orphan watcher** (`ghcr-orphan-watcher.yml` + `scripts/watch/ghcr-orphans.sh`, on the phase-4 engine, report-only by design — deletion stays manual because a miscomputed reachability delete destroys published attestations): computes real reachability (index children + referrer artifacts) before calling anything an orphan. Live read-only proof: 1801 untagged versions, 1706 reachable, 95 genuine orphans; the `:4.0.5` index's four children appear in no orphan list.

Gates: every check green (full tails in the record), zizmor suppression counts identical, shellcheck clean on all six scripts, changelog entry included.