### PR TITLE
release: v4.0.6-rc1 — the pipeline verification cut

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -5,7 +5,7 @@
   "title": "FerroEHR",
   "description": "<p>A pure-Rust, openEHR-specification-conformant clinical data repository (CDR): ITS-REST 1.1.0 REST API, AQL 1.1 query language, and the openEHR RM 1.2.0 reference model on PostgreSQL-18-native storage. The openEHR specification layer is generated from the official machine-readable specifications, and conformance is machine-verified per release by a built-in CNF conformance runner.</p>",
   "publication_date": "2026-08-26",
-  "version": "4.0.5",
+  "version": "4.0.6-rc1",
   "creators": [
     {
       "name": "Talstra, Ruben",
@@ -39,7 +39,7 @@
       "resource_type": "publication-softwaredocumentation"
     },
     {
-      "identifier": "https://github.com/rubentalstra/FerroEHR/tree/v4.0.5",
+      "identifier": "https://github.com/rubentalstra/FerroEHR/tree/v4.0.6-rc1",
       "relation": "isSupplementTo",
       "resource_type": "software"
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+## [4.0.6-rc1] - 2026-08-26
+
 ### Added
 
 - A weekly report of container manifests in the registry that nothing can reach
@@ -7592,7 +7594,8 @@ but has not yet run in production.
   seccomp, default-deny NetworkPolicy) and golden-render validation.
 
 
-[unreleased]: https://github.com/rubentalstra/FerroEHR/compare/v4.0.5...HEAD
+[unreleased]: https://github.com/rubentalstra/FerroEHR/compare/v4.0.6-rc1...HEAD
+[4.0.6-rc1]: https://github.com/rubentalstra/FerroEHR/compare/v4.0.5...v4.0.6-rc1
 [4.0.5]: https://github.com/rubentalstra/FerroEHR/compare/v4.0.4...v4.0.5
 [4.0.4]: https://github.com/rubentalstra/FerroEHR/compare/v4.0.3...v4.0.4
 [4.0.3]: https://github.com/rubentalstra/FerroEHR/compare/v4.0.2...v4.0.3

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -37,5 +37,5 @@ keywords:
   - ITS-REST
   - Rust
   - PostgreSQL
-version: 4.0.5
+version: 4.0.6-rc1
 date-released: 2026-08-26

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "cnf-runner"
-version = "4.0.5"
+version = "4.0.6-rc1"
 dependencies = [
  "assert_fs",
  "base64 0.23.1",
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "docs-meta"
-version = "4.0.5"
+version = "4.0.6-rc1"
 
 [[package]]
 name = "dotenvy"
@@ -2683,7 +2683,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ferroehr"
-version = "4.0.5"
+version = "4.0.6-rc1"
 dependencies = [
  "argon2",
  "assert_fs",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-admin-ui"
-version = "4.0.5"
+version = "4.0.6-rc1"
 dependencies = [
  "anyhow",
  "axum",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-ext"
-version = "4.0.5"
+version = "4.0.6-rc1"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2824,7 +2824,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-rest"
-version = "4.0.5"
+version = "4.0.6-rc1"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -2884,7 +2884,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-server"
-version = "4.0.5"
+version = "4.0.6-rc1"
 dependencies = [
  "anyhow",
  "clap",
@@ -5539,7 +5539,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-codegen"
-version = "4.0.5"
+version = "4.0.6-rc1"
 dependencies = [
  "roxmltree",
  "serde_json",
@@ -8754,7 +8754,7 @@ dependencies = [
 
 [[package]]
 name = "testkit"
-version = "4.0.5"
+version = "4.0.6-rc1"
 dependencies = [
  "ferroehr",
  "jiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "3"
 members = ["crates/*", "app/*", "tools/*"]
 
 [workspace.package]
-version = "4.0.5"
+version = "4.0.6-rc1"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,7 @@
 
 services:
   ferroehr-postgres:
-    image: ${FERROEHR_POSTGRES_IMAGE:-ghcr.io/rubentalstra/ferroehr-postgres:4.0.5}
+    image: ${FERROEHR_POSTGRES_IMAGE:-ghcr.io/rubentalstra/ferroehr-postgres:4.0.6-rc1}
     # Docker's default 64MB /dev/shm starves PostgreSQL's dynamic shared
     # memory under load (parallel workers error `could not resize shared
     # memory segment … No space left on device`); measured runs share this
@@ -160,7 +160,7 @@ services:
       start_period: 10s
 
   ferroehr:
-    image: ${FERROEHR_IMAGE:-ghcr.io/rubentalstra/ferroehr:4.0.5}
+    image: ${FERROEHR_IMAGE:-ghcr.io/rubentalstra/ferroehr:4.0.6-rc1}
     depends_on:
       ferroehr-postgres:
         condition: service_healthy
@@ -266,7 +266,7 @@ services:
   # FERROEHR_ADMIN__AUTH__OIDC__* variables at your identity provider.
   ferroehr-admin-ui:
     profiles: [admin-ui]
-    image: ${FERROEHR_ADMIN_UI_IMAGE:-ghcr.io/rubentalstra/ferroehr-admin-ui:4.0.5}
+    image: ${FERROEHR_ADMIN_UI_IMAGE:-ghcr.io/rubentalstra/ferroehr-admin-ui:4.0.6-rc1}
     depends_on:
       ferroehr:
         condition: service_healthy

--- a/docs/conformance/ferroehr/CONFORMANCE_STATEMENT.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_STATEMENT.md
@@ -1,6 +1,6 @@
 # Conformance Statement (SDoC)
 
-Product: FerroEHR 4.0.5 — Ruben Talstra (urn:rubentalstra:ferroehr)
+Product: FerroEHR 4.0.6-rc1 — Ruben Talstra (urn:rubentalstra:ferroehr)
 Schedule release: cnf-2.0-w2
 
 ## Declared spec versions

--- a/scripts/checks/docs-claims.sh
+++ b/scripts/checks/docs-claims.sh
@@ -310,7 +310,7 @@ for f in $files; do
     [[ -n "$v" ]] || continue
     [[ "$v" = "$app_version" ]] \
       || report "$f" "pins image tag \`$v\`; the workspace version is $app_version"
-  done < <(grep -ohE '(ferroehr(-admin-ui)?:|image\.tag=)[0-9]+\.[0-9]+\.[0-9]+' "$f" \
+  done < <(grep -ohE '(ferroehr(-admin-ui)?:|image\.tag=)[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?' "$f" \
     | sed -E 's/^.*[:=]//' | sort -u)
 done
 # Every page (and the landing): a fully-spelled ghcr image reference must carry
@@ -326,7 +326,7 @@ for f in $files website/landing/index.html; do
     [[ -n "$v" ]] || continue
     [[ "$v" = "$app_version" ]] \
       || report "$f" "pins ghcr image tag \`$v\`; the workspace version is $app_version"
-  done < <(grep -ohE 'ghcr\.io/rubentalstra/(ferroehr|ferroehr-admin-ui|ferroehr-postgres):[0-9]+\.[0-9]+\.[0-9]+' "$f" | sed 's/.*://' | sort -u)
+  done < <(grep -ohE 'ghcr\.io/rubentalstra/(ferroehr|ferroehr-admin-ui|ferroehr-postgres):[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?' "$f" | sed 's/.*://' | sort -u)
 done
 # The from-source page: a Rust version literal must be the toolchain channel or
 # the MSRV ("Rust 1.96.1" shipped against a 1.97.1 toolchain — #2348).
@@ -396,15 +396,15 @@ if in_files "$VERIFY_PAGE"; then
     [[ -n "$v" ]] || continue
     [[ "$v" = "$app_version" ]] \
       || report "$VERIFY_PAGE" "names the release asset \`ferroehr-v${v}…\`; the workspace version is $app_version"
-  done < <(grep -ohE 'ferroehr-v[0-9]+\.[0-9]+\.[0-9]+' "$VERIFY_PAGE" | sed 's/^ferroehr-v//' | sort -u)
+  done < <(grep -ohE 'ferroehr-v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?' "$VERIFY_PAGE" | sed 's/^ferroehr-v//' | sort -u)
   # The substitution note. Its sentence wraps, so the page is line-joined first.
   while read -r v; do
     [[ -n "$v" ]] || continue
     [[ "$v" = "$app_version" ]] \
       || report "$VERIFY_PAGE" "tells the reader to substitute the tag \`v$v\`; the workspace version is $app_version"
   done < <(tr '\n' ' ' < "$VERIFY_PAGE" \
-    | grep -ohE 'for example[[:space:]]+`v[0-9]+\.[0-9]+\.[0-9]+`' \
-    | sed -E 's/.*`v([0-9.]+)`.*/\1/' | sort -u)
+    | grep -ohE 'for example[[:space:]]+`v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?`' \
+    | sed -E 's/.*`v([0-9A-Za-z.-]+)`.*/\1/' | sort -u)
   # The wording-independent net, because the rule above is anchored on a phrase
   # and a reword would silently disarm it: the released tag has to appear on the
   # page SOMEWHERE. A cut that bumps Cargo.toml and forgets this page fails here

--- a/tools/cnf-runner/party/ferroehr/statement.json
+++ b/tools/cnf-runner/party/ferroehr/statement.json
@@ -1,7 +1,7 @@
 {
   "product": {
     "name": "FerroEHR",
-    "version": "4.0.5",
+    "version": "4.0.6-rc1",
     "vendor": "Ruben Talstra",
     "identifier": "urn:rubentalstra:ferroehr"
   },

--- a/website/book/src/installation/kubernetes.md
+++ b/website/book/src/installation/kubernetes.md
@@ -40,7 +40,7 @@ kubectl -n ferroehr create secret generic ferroehr-db \
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
   --version 6.0.21 -n ferroehr \
   --set database.existingSecret=ferroehr-db \
-  --set image.tag=4.0.5
+  --set image.tag=4.0.6-rc1
 ```
 
 > [!IMPORTANT]
@@ -69,7 +69,7 @@ against.
 | | Selects | Pin with | Line |
 |---|---|---|---|
 | Chart version | templates, values schema, defaults | `--version 6.0.21` | SemVer over the chart's own contract |
-| Image tag | the server binary | `--set image.tag=4.0.5` (or `image.digest`) | the application's SemVer line |
+| Image tag | the server binary | `--set image.tag=4.0.6-rc1` (or `image.digest`) | the application's SemVer line |
 
 Always pin the image to an immutable version or, better, a `@sha256` digest,
 never `latest`. Pin the two deliberately: the `config` tree is passed through to
@@ -734,7 +734,7 @@ The check that closes that gap runs the image against your rendered
 configuration:
 
 ```shell
-FERROEHR_IMAGE=ghcr.io/rubentalstra/ferroehr:4.0.5 \
+FERROEHR_IMAGE=ghcr.io/rubentalstra/ferroehr:4.0.6-rc1 \
   deploy/helm/ci/boot-check.sh my-values.yaml
 ```
 

--- a/website/book/src/verifying-releases.md
+++ b/website/book/src/verifying-releases.md
@@ -17,7 +17,7 @@ signer identity is one you can pin to a single hardened workflow.
 ## What a release publishes
 
 Substitute the release tag you downloaded for `<tag>` (for example
-`v4.0.5`) and the architecture for `<arch>` (`x86_64` or `aarch64`) throughout
+`v4.0.6-rc1`) and the architecture for `<arch>` (`x86_64` or `aarch64`) throughout
 this page. Linux is the only published target.
 
 | Asset | What it is |
@@ -175,7 +175,7 @@ carry a Sigstore-signed SLSA provenance attestation, plus the SPDX SBOM and
 provenance the builder writes onto the image index itself.
 
 ```bash
-gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:4.0.5 \
+gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:4.0.6-rc1 \
   -R rubentalstra/FerroEHR
 ```
 
@@ -199,7 +199,7 @@ tag once and verify the digest it resolved — otherwise the bytes verified and
 the bytes pulled can differ:
 
 ```bash
-digest=$(docker buildx imagetools inspect ghcr.io/rubentalstra/ferroehr:4.0.5 \
+digest=$(docker buildx imagetools inspect ghcr.io/rubentalstra/ferroehr:4.0.6-rc1 \
   | awk '/^Digest:/{print $2}')
 gh attestation verify "oci://ghcr.io/rubentalstra/ferroehr@${digest}" \
   -R rubentalstra/FerroEHR


### PR DESCRIPTION
Part of #2780 (phase 6 of #2772) — the rc that live-proves the rebuilt pipeline before the real 4.0.6. Full cut mechanics (workspace/CITATION/zenodo/statement/compose/book pins to 4.0.6-rc1; the chart's committed appVersion correctly STAYS 4.0.5 per the phase-5 injection design — the published rc chart gets 4.0.6-rc1 injected at package time). First rc catch already banked: docs-claims' version regexes stopped at X.Y.Z, so they read `4.0.6` out of `4.0.6-rc1` and failed self-consistently — the guard now admits prerelease suffixes (four extraction sites + the substitution-note char class). All local guards green: changelog-structure, statement-version, compose-image-tags, chart-appversion, docs-claims --all.

After the merge: tag `v4.0.6-rc1` on the merge commit; the pipeline run is the verification record — watch-items: job-level concurrency on the chart call, `gh workflow run` from docs-freeze (must SKIP — prerelease), :latest digest unmoved, sandbox skipped, release published prerelease. NO admin-merge past any red check on this PR — the discipline is part of what phase 6 proves.