### PR TITLE
ci(scorecard): the two official-template deltas worth taking

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -33,6 +33,9 @@
 name: Scorecard
 
 on:
+  # Re-score immediately when branch protection changes (the official template's
+  # trigger; the Branch-Protection check reads exactly that configuration).
+  branch_protection_rule:
   # Weekly, because most checks measure repository CONFIGURATION rather than a
   # commit: branch protection, code scanning, the update bot. A per-push run
   # would re-measure unchanged settings.
@@ -49,6 +52,9 @@ jobs:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # publish_results works only from the default branch (the action refuses
+    # elsewhere); this keeps a stray off-branch dispatch from failing confusingly.
+    if: github.ref_name == github.event.repository.default_branch
     permissions:
       # Upload the SARIF into code scanning.
       security-events: write


### PR DESCRIPTION
Owner asked how our Scorecard lane compares to the official ossf template. Ours is ahead on every hardening axis (SHA pins — the template ships `codeql-action@v3` as a bare tag; `permissions: {}` + per-job minimums vs their `read-all`; the deliberate no-standing-PAT stance for the Branch-Protection check; no redundant SARIF artifact). Two template features were genuinely missing and land here: the `branch_protection_rule` trigger (immediate re-score on protection changes instead of up to a week late) and the default-branch guard on `publish_results` (the action refuses off-branch publishes — the guard turns a confusing failure into a clean skip). actionlint + zizmor clean.