### PR TITLE
release: v4.0.6-rc2 — the recovery rule, exercised live

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -5,7 +5,7 @@
   "title": "FerroEHR",
   "description": "<p>A pure-Rust, openEHR-specification-conformant clinical data repository (CDR): ITS-REST 1.1.0 REST API, AQL 1.1 query language, and the openEHR RM 1.2.0 reference model on PostgreSQL-18-native storage. The openEHR specification layer is generated from the official machine-readable specifications, and conformance is machine-verified per release by a built-in CNF conformance runner.</p>",
   "publication_date": "2026-08-26",
-  "version": "4.0.6-rc1",
+  "version": "4.0.6-rc2",
   "creators": [
     {
       "name": "Talstra, Ruben",
@@ -39,7 +39,7 @@
       "resource_type": "publication-softwaredocumentation"
     },
     {
-      "identifier": "https://github.com/rubentalstra/FerroEHR/tree/v4.0.6-rc1",
+      "identifier": "https://github.com/rubentalstra/FerroEHR/tree/v4.0.6-rc2",
       "relation": "isSupplementTo",
       "resource_type": "software"
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
-## [4.0.6-rc1] - 2026-08-26
+## [4.0.6-rc2] - 2026-08-26
 
 ### Added
 
@@ -7594,8 +7594,8 @@ but has not yet run in production.
   seccomp, default-deny NetworkPolicy) and golden-render validation.
 
 
-[unreleased]: https://github.com/rubentalstra/FerroEHR/compare/v4.0.6-rc1...HEAD
-[4.0.6-rc1]: https://github.com/rubentalstra/FerroEHR/compare/v4.0.5...v4.0.6-rc1
+[unreleased]: https://github.com/rubentalstra/FerroEHR/compare/v4.0.6-rc2...HEAD
+[4.0.6-rc2]: https://github.com/rubentalstra/FerroEHR/compare/v4.0.5...v4.0.6-rc2
 [4.0.5]: https://github.com/rubentalstra/FerroEHR/compare/v4.0.4...v4.0.5
 [4.0.4]: https://github.com/rubentalstra/FerroEHR/compare/v4.0.3...v4.0.4
 [4.0.3]: https://github.com/rubentalstra/FerroEHR/compare/v4.0.2...v4.0.3

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -37,5 +37,5 @@ keywords:
   - ITS-REST
   - Rust
   - PostgreSQL
-version: 4.0.6-rc1
+version: 4.0.6-rc2
 date-released: 2026-08-26

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "cnf-runner"
-version = "4.0.6-rc1"
+version = "4.0.6-rc2"
 dependencies = [
  "assert_fs",
  "base64 0.23.1",
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "docs-meta"
-version = "4.0.6-rc1"
+version = "4.0.6-rc2"
 
 [[package]]
 name = "dotenvy"
@@ -2683,7 +2683,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ferroehr"
-version = "4.0.6-rc1"
+version = "4.0.6-rc2"
 dependencies = [
  "argon2",
  "assert_fs",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-admin-ui"
-version = "4.0.6-rc1"
+version = "4.0.6-rc2"
 dependencies = [
  "anyhow",
  "axum",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-ext"
-version = "4.0.6-rc1"
+version = "4.0.6-rc2"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2824,7 +2824,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-rest"
-version = "4.0.6-rc1"
+version = "4.0.6-rc2"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -2884,7 +2884,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-server"
-version = "4.0.6-rc1"
+version = "4.0.6-rc2"
 dependencies = [
  "anyhow",
  "clap",
@@ -5539,7 +5539,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-codegen"
-version = "4.0.6-rc1"
+version = "4.0.6-rc2"
 dependencies = [
  "roxmltree",
  "serde_json",
@@ -8754,7 +8754,7 @@ dependencies = [
 
 [[package]]
 name = "testkit"
-version = "4.0.6-rc1"
+version = "4.0.6-rc2"
 dependencies = [
  "ferroehr",
  "jiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "3"
 members = ["crates/*", "app/*", "tools/*"]
 
 [workspace.package]
-version = "4.0.6-rc1"
+version = "4.0.6-rc2"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,7 @@
 
 services:
   ferroehr-postgres:
-    image: ${FERROEHR_POSTGRES_IMAGE:-ghcr.io/rubentalstra/ferroehr-postgres:4.0.6-rc1}
+    image: ${FERROEHR_POSTGRES_IMAGE:-ghcr.io/rubentalstra/ferroehr-postgres:4.0.6-rc2}
     # Docker's default 64MB /dev/shm starves PostgreSQL's dynamic shared
     # memory under load (parallel workers error `could not resize shared
     # memory segment … No space left on device`); measured runs share this
@@ -160,7 +160,7 @@ services:
       start_period: 10s
 
   ferroehr:
-    image: ${FERROEHR_IMAGE:-ghcr.io/rubentalstra/ferroehr:4.0.6-rc1}
+    image: ${FERROEHR_IMAGE:-ghcr.io/rubentalstra/ferroehr:4.0.6-rc2}
     depends_on:
       ferroehr-postgres:
         condition: service_healthy
@@ -266,7 +266,7 @@ services:
   # FERROEHR_ADMIN__AUTH__OIDC__* variables at your identity provider.
   ferroehr-admin-ui:
     profiles: [admin-ui]
-    image: ${FERROEHR_ADMIN_UI_IMAGE:-ghcr.io/rubentalstra/ferroehr-admin-ui:4.0.6-rc1}
+    image: ${FERROEHR_ADMIN_UI_IMAGE:-ghcr.io/rubentalstra/ferroehr-admin-ui:4.0.6-rc2}
     depends_on:
       ferroehr:
         condition: service_healthy

--- a/docs/conformance/ferroehr/CONFORMANCE_STATEMENT.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_STATEMENT.md
@@ -1,6 +1,6 @@
 # Conformance Statement (SDoC)
 
-Product: FerroEHR 4.0.6-rc1 — Ruben Talstra (urn:rubentalstra:ferroehr)
+Product: FerroEHR 4.0.6-rc2 — Ruben Talstra (urn:rubentalstra:ferroehr)
 Schedule release: cnf-2.0-w2
 
 ## Declared spec versions

--- a/tools/cnf-runner/party/ferroehr/statement.json
+++ b/tools/cnf-runner/party/ferroehr/statement.json
@@ -1,7 +1,7 @@
 {
   "product": {
     "name": "FerroEHR",
-    "version": "4.0.6-rc1",
+    "version": "4.0.6-rc2",
     "vendor": "Ruben Talstra",
     "identifier": "urn:rubentalstra:ferroehr"
   },

--- a/website/book/src/installation/kubernetes.md
+++ b/website/book/src/installation/kubernetes.md
@@ -40,7 +40,7 @@ kubectl -n ferroehr create secret generic ferroehr-db \
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
   --version 6.0.21 -n ferroehr \
   --set database.existingSecret=ferroehr-db \
-  --set image.tag=4.0.6-rc1
+  --set image.tag=4.0.6-rc2
 ```
 
 > [!IMPORTANT]
@@ -69,7 +69,7 @@ against.
 | | Selects | Pin with | Line |
 |---|---|---|---|
 | Chart version | templates, values schema, defaults | `--version 6.0.21` | SemVer over the chart's own contract |
-| Image tag | the server binary | `--set image.tag=4.0.6-rc1` (or `image.digest`) | the application's SemVer line |
+| Image tag | the server binary | `--set image.tag=4.0.6-rc2` (or `image.digest`) | the application's SemVer line |
 
 Always pin the image to an immutable version or, better, a `@sha256` digest,
 never `latest`. Pin the two deliberately: the `config` tree is passed through to
@@ -734,7 +734,7 @@ The check that closes that gap runs the image against your rendered
 configuration:
 
 ```shell
-FERROEHR_IMAGE=ghcr.io/rubentalstra/ferroehr:4.0.6-rc1 \
+FERROEHR_IMAGE=ghcr.io/rubentalstra/ferroehr:4.0.6-rc2 \
   deploy/helm/ci/boot-check.sh my-values.yaml
 ```
 

--- a/website/book/src/verifying-releases.md
+++ b/website/book/src/verifying-releases.md
@@ -17,7 +17,7 @@ signer identity is one you can pin to a single hardened workflow.
 ## What a release publishes
 
 Substitute the release tag you downloaded for `<tag>` (for example
-`v4.0.6-rc1`) and the architecture for `<arch>` (`x86_64` or `aarch64`) throughout
+`v4.0.6-rc2`) and the architecture for `<arch>` (`x86_64` or `aarch64`) throughout
 this page. Linux is the only published target.
 
 | Asset | What it is |
@@ -175,7 +175,7 @@ carry a Sigstore-signed SLSA provenance attestation, plus the SPDX SBOM and
 provenance the builder writes onto the image index itself.
 
 ```bash
-gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:4.0.6-rc1 \
+gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:4.0.6-rc2 \
   -R rubentalstra/FerroEHR
 ```
 
@@ -199,7 +199,7 @@ tag once and verify the digest it resolved — otherwise the bytes verified and
 the bytes pulled can differ:
 
 ```bash
-digest=$(docker buildx imagetools inspect ghcr.io/rubentalstra/ferroehr:4.0.6-rc1 \
+digest=$(docker buildx imagetools inspect ghcr.io/rubentalstra/ferroehr:4.0.6-rc2 \
   | awk '/^Digest:/{print $2}')
 gh attestation verify "oci://ghcr.io/rubentalstra/ferroehr@${digest}" \
   -R rubentalstra/FerroEHR


### PR DESCRIPTION
Part of #2780. The rc1 tag landed on the wrong commit through a silently-refused merge (`gh pr merge` without `--admin` prints advice and exits zero-ish — en-route finding for the memory), the tag ruleset refused deletion (422, working as designed), and the recorded recovery rule answered: NEW VERSION, never a retag. This PR renames the cut rc1 → rc2 across every pin site (all local guards green: changelog-structure, statement-version, compose-image-tags, chart-appversion, docs-claims --all). Two phase-6 proofs already banked before any tag succeeded: `plan` refused the wrong-commit tag in seconds with nothing published, and the immutability + recovery discipline held under a real mistake.