### PR TITLE
fix(release): plan refuses a cut whose chart version is already published

### DIFF
--- a/.claude/rules/changelog.md
+++ b/.claude/rules/changelog.md
@@ -48,8 +48,12 @@ optional:
   version match is missing**. Releases publish as OFFICIAL
   releases — `prerelease` is true only for an explicitly suffixed tag
   (`vX.Y.Z-rc1`, ...) — owner sign-off 2026-07-31.
-- **The Helm chart, in the SAME release PR:** bump the chart's own `version` if
-  any packaged chart content changed in the cycle (`chart-version-guard`), and
+- **The Helm chart, in the SAME release PR:** bump the chart's own `version` —
+  EVERY release, not only on chart diffs: since #2779 the packaged chart's
+  release facts (appVersion, image tags, changes) are injected at package
+  time, so every release ships a DISTINCT packaged chart, and an unbumped
+  version collides with refuse-overwrite at the tag (#2818 — the pipeline's
+  `plan` refuses that tag before anything builds). Then
   regenerate whatever that change moved — the golden renders
   (`deploy/helm/validate.sh --update`) and the generated chart README
   (`helm-docs --chart-search-root deploy/helm/ferroehr --template-files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,6 +186,23 @@ jobs:
       - name: The committed chart release facts are coherent
         run: bash scripts/checks/chart-appversion.sh
 
+      # Every release publishes a DIFFERENT packaged chart (appVersion, image
+      # tags and changes are injected at package time, #2779), so every release
+      # needs its own chart version — and since the injection, no diff-guard
+      # forces the bump. Refusing here costs seconds; the chart leg refusing
+      # after the images published costs a red release (v4.0.6-rc3, #2818).
+      - uses: ./.github/actions/helm-pinned
+      - name: The chart version is not already published
+        env:
+          CHART_REF: ghcr.io/${{ github.repository_owner }}/charts/ferroehr
+        run: |
+          ver=$(awk '$1 == "version:" {print $2; exit}' deploy/helm/ferroehr/Chart.yaml)
+          if helm show chart "oci://${CHART_REF}" --version "$ver" >/dev/null 2>&1; then
+            echo "::error::chart version ${ver} is already published at ${CHART_REF} — every release ships a distinct packaged chart (injected release facts), so bump deploy/helm/ferroehr/Chart.yaml version in the release PR." >&2
+            exit 1
+          fi
+          echo "chart ${ver} is unpublished — the chart leg can ship it"
+
       - name: The ferroehr party statement's product version matches the workspace
         run: bash scripts/checks/statement-version.sh
 


### PR DESCRIPTION
Closes #2818. The rc3 finding: the #2779 injection removed the thing that forced a per-release chart bump (appVersion edits), but every release still ships a DISTINCT packaged chart — so rc3 (chart still 6.0.21, published by rc2) hit refuse-overwrite at the chart leg, after the images had published. `plan` now probes `helm show chart oci://…` for the committed version and refuses the tag in seconds with the remedy named — mutation-proven live in both directions (6.0.21 → would refuse; 6.0.99 → passes). The cut procedure documents the every-cycle bump with its real reason. actionlint + zizmor clean.