### PR TITLE
docs(book): from-source states the real 1.97.1 pin, and the MSRV arm rejects phantom patches

### DIFF
--- a/scripts/checks/docs-claims.sh
+++ b/scripts/checks/docs-claims.sh
@@ -328,14 +328,16 @@ for f in $files website/landing/index.html; do
       || report "$f" "pins ghcr image tag \`$v\`; the workspace version is $app_version"
   done < <(grep -ohE 'ghcr\.io/rubentalstra/(ferroehr|ferroehr-admin-ui|ferroehr-postgres):[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?' "$f" | sed 's/.*://' | sort -u)
 done
-# The from-source page: a Rust version literal must be the toolchain channel or
-# the MSRV ("Rust 1.96.1" shipped against a 1.97.1 toolchain — #2348).
+# The from-source page: a Rust version literal must be the toolchain channel
+# (with or without its patch) or the EXACT declared MSRV ("Rust 1.96.1"
+# shipped against a 1.97.1 toolchain — #2348; the MSRV arm then accepted the
+# same phantom patch because "1.96.*" matched it — #2805).
 RUST_PAGE="$BOOK/installation/from-source.md"
 if in_files "$RUST_PAGE"; then
   channel=$(awk -F'"' '/^channel/{print $2; exit}' rust-toolchain.toml)
   msrv=$(awk -F'"' '/^rust-version/{print $2; exit}' Cargo.toml)
   while read -r v; do
-    case "$v" in "$channel"|"${channel%.*}"|"$msrv"|"$msrv".*) continue ;; *) ;; esac
+    case "$v" in "$channel"|"${channel%.*}"|"$msrv") continue ;; *) ;; esac
     report "$RUST_PAGE" "names Rust \`$v\`, which is neither the toolchain channel ($channel) nor the MSRV ($msrv)"
   done < <(grep -ohE '1\.[0-9]{2}(\.[0-9]+)?' "$RUST_PAGE" | sort -u)
 fi

--- a/website/book/src/installation/from-source.md
+++ b/website/book/src/installation/from-source.md
@@ -8,7 +8,7 @@ published container images ([Docker Compose](compose.md),
 
 ## Prerequisites
 
-- **The pinned Rust toolchain.** The repository pins Rust **1.96.1** (edition
+- **The pinned Rust toolchain.** The repository pins Rust **1.97.1** (edition
   2024) via `rust-toolchain.toml`, so `rustup` installs and selects it
   automatically the first time you build in the checkout; you do not choose a
   version by hand.


### PR DESCRIPTION
Closes #2805.

`website/book/src/installation/from-source.md` claimed "pins Rust **1.96.1**" while `rust-toolchain.toml` pins 1.97.1 — the exact defect class #2348 created the docs-claims rust-version rule for. The rule could not catch its own motivating example: its `"$msrv".*` case arm accepted any `1.96.x` literal, because the declared MSRV is `1.96` and the project declares no MSRV patch.

Two halves, one PR:

- the page states the toolchain's real pin (1.97.1);
- the guard's arm tightens to exactly `"$channel" | "${channel%.*}" | "$msrv"` — a phantom MSRV patch is now a finding.

Mutation proof, run live: with the page fixed, `docs-claims.sh --all` exits 0; reintroducing `1.96.1` fails with `names Rust \`1.96.1\`, which is neither the toolchain channel (1.97.1) nor the MSRV (1.96)`.

`no-changelog`: a docs-page correction plus a CI guard tightening — no user-visible product behaviour changes.