### PR TITLE
chore(chart): the committed appVersion gains a freshness bound — at most one stable release behind

### DIFF
--- a/.claude/rules/changelog.md
+++ b/.claude/rules/changelog.md
@@ -70,7 +70,11 @@ optional:
   released version whose image annotations and generated README agree with it —
   `scripts/checks/chart-appversion.sh`, run by the `chart-appversion` CI job and
   again by the release pipeline's `plan` at the tagged commit. Refreshing that
-  default is ordinary maintenance, not a release step.
+  default is ordinary maintenance, not a release step — but bounded maintenance
+  (#2804): the guard also refuses a default more than ONE stable release behind
+  the newest changelog section (rc sections never qualify), so the release PR
+  that cuts X.Y.Z needn't touch it, and the next one fails until it is
+  refreshed.
 - **The chart publishes as the release pipeline's `chart` leg** (`build-chart.yml`,
   called by `release.yml` after the scanned tags apply; `publish-chart.yml` is
   the dispatch-only dry-run/recovery lane between releases): it refuses to

--- a/.claude/rules/kubernetes-helm.md
+++ b/.claude/rules/kubernetes-helm.md
@@ -195,6 +195,7 @@ evidence if it ran in an enforcing namespace — say which.
 | Golden render drift | CI compare against `deploy/helm/golden/` |
 | Chart version bump on packaged-content change | `chart-version-guard` |
 | The committed `appVersion` names a released version, and the image annotations + generated README agree with it | `chart-appversion-guard` → `scripts/checks/chart-appversion.sh` (mutation-proven). The PUBLISHED appVersion and image tags are INJECTED at package time, not guarded in the tree — #2779 |
+| The committed `appVersion` is FRESH: one of the two newest STABLE releases (an rc never qualifies) | the same guard, property 5 (#2804, mutation-proven). One-stable-behind is the deliberate slack that keeps #2779: the cutting release PR needn't refresh, the one after it fails until someone does — a deterministic guard, not a scheduled watcher |
 | Field-vs-`kubeVersion` availability | **review-enforced** — no tool knows which fields a manifest uses; §1 is the procedure |
 | Applied posture, admission, readiness gating, secret reads | `scripts/deploy-probe-k8s.sh` — observed on a live cluster, machine-readable record |
 | Live behaviour beyond those probes | **review-enforced** — the `/k8s-test` skill is the procedure; the PR quotes observations |

--- a/scripts/checks/chart-appversion.sh
+++ b/scripts/checks/chart-appversion.sh
@@ -38,6 +38,19 @@
 #      behind (6.0.19/4.0.4 against a 6.0.20/4.0.5 chart) and only a local
 #      `deploy/helm/validate.sh` noticed, because the CI drift check skips
 #      itself when helm-docs is not installed on the runner.
+#   5. `appVersion` is FRESH: one of the two newest STABLE releases in
+#      CHANGELOG.md (#2804). With the cut no longer bumping it (#2779), nothing
+#      moved the committed default and the gap between it and the tree's
+#      advancing `config` defaults grew unboundedly, unseen by any lane
+#      (chart-boot overrides the image; the dispatch judge uses sha-/develop).
+#      "One stable behind" is the deliberate slack that keeps #2779's design:
+#      the release PR that cuts X.Y.Z does NOT have to refresh (that would
+#      re-impose the hand edit), but the one after it fails here until someone
+#      does — bounded lag, enforced by the guard tier that already runs,
+#      instead of a scheduled watcher filing issues. Stable sections only:
+#      an -rc default would hand production installs a pre-release image, so
+#      an rc never satisfies this arm even though property 1 accepts it as
+#      "released".
 #
 # What is deliberately NOT checked here any more: equality with the workspace
 # version. Asserting it would re-impose the hand edit this change removes.
@@ -73,6 +86,17 @@ if ! grep -qE "^## \[${app//./\\.}\]" "$CHANGELOG"; then
   report "$CHART appVersion is $app, which has no '## [$app]' section in $CHANGELOG — the committed appVersion is the default image tag for a chart packaged outside a release, so it must name a version that was actually published. (A release no longer needs to bump it: build-chart.yml injects the released version with 'helm package --app-version'.)"
 fi
 
+# 5. Fresh: one of the two newest stable releases (rc/pre-release sections are
+#    skipped — a suffixed default would hand production installs a pre-release).
+stable=$(grep -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' "$CHANGELOG" | head -2 | tr -d '[]# ')
+stable1=$(printf '%s\n' "$stable" | sed -n 1p)
+stable2=$(printf '%s\n' "$stable" | sed -n 2p)
+if [[ -z "$stable1" ]]; then
+  report "$CHANGELOG has no stable '## [X.Y.Z]' section to hold the appVersion against."
+elif [[ "$app" != "$stable1" && "$app" != "$stable2" ]]; then
+  report "$CHART appVersion is $app, but the two newest stable releases are ${stable1} and ${stable2:-—}. The committed default may lag the newest cut by at most one stable release (#2804) — refresh it (appVersion + the artifacthub.io/images tags + the generated README: helm-docs --chart-search-root deploy/helm/ferroehr --template-files README.md.gotmpl)."
+fi
+
 # 2. The image annotation agrees with it.
 bad=$(grep -oE 'image: ghcr\.io/[^:]+:[^ ]+' "$CHART" | grep -v ":${app}\$" || true)
 if [[ -n "$bad" ]]; then
@@ -103,4 +127,4 @@ fi
 if [[ "$failures" -gt 0 ]]; then
   exit 1
 fi
-echo "chart-appversion: appVersion $app is a released version, the artifacthub.io/images tags and the generated README agree with it, and no injected annotation is committed — OK."
+echo "chart-appversion: appVersion $app is a stable release at most one behind the newest ($stable1), the artifacthub.io/images tags and the generated README agree with it, and no injected annotation is committed — OK."


### PR DESCRIPTION
Closes #2804.

Since #2779 nothing moved the committed default (the published appVersion, image tags and README are injected at package time), so the tree's copy froze while the chart's `config` defaults advanced every cycle — and no CI lane saw the gap (chart-boot overrides the image with the tree-built one; the dispatch judge uses sha-/develop).

Of the issue's two options, the chosen mechanism is option (b)'s criterion enforced a tier stronger than the proposed watcher: **property 5 of the existing `chart-appversion.sh` guard**, which already runs as the `chart-appversion` CI job and again in the release pipeline's `plan` at the tagged commit. A deterministic PR-failing check beats a scheduled issue-filer (the reliability register's own tier order), and it needs no new lane.

The rule: the committed `appVersion` must be one of the **two newest STABLE** `## [X.Y.Z]` changelog sections.

- One-stable-behind is the deliberate slack that preserves #2779's design: the release PR that cuts X.Y.Z does not have to refresh the default (that would re-impose the hand edit #2779 removed); the PR that cuts the release after it fails here until someone refreshes — bounded lag, roughly one refresh every second release.
- rc/pre-release sections never qualify, on either side of the comparison: a suffixed default would hand production installs a pre-release image, even though property 1 accepts an rc as "released".

Mutation proof, run live against the real changelog (stables: 4.0.5, 4.0.4):

| committed appVersion | freshness arm |
|---|---|
| `4.0.5` (stable[0]) | passes — full guard exits 0 |
| `4.0.4` (stable[1]) | passes the arm (properties 2/4 flag the unmoved annotations, as they should) |
| `4.0.3` | fails: `appVersion is 4.0.3, but the two newest stable releases are 4.0.5 and 4.0.4` |
| `4.0.6-rc3` | fails the arm |

The decision is registered in `kubernetes-helm.md`'s enforcement register, and `changelog.md`'s appVersion paragraph now states the bound. Not option (a) (a `develop` default): the between-releases dispatch packages the committed value as the effective appVersion, and `release-facts.sh` would refuse `develop` outright — a recovery chart must default to a released, pullable image.

`no-changelog`: a CI guard tightening plus rule-file records — no user-visible product behaviour changes.