### PR TITLE
perf(docker): the build context drops 807 MB of material the compile never reads

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -31,6 +31,37 @@ docs-dist/
 corpus/
 crates/openehr-adl/tests/corpus/
 
+# The fuzz harnesses (#2813): their own NIGHTLY workspace, deliberately not a
+# root-workspace member, so `-p ferroehr-server` never parses or compiles them
+# — and fuzz/corpus alone is ~46 MB of seed inputs.
+fuzz/
+
+# The website sources + the locally generated site build output (#2813): pure
+# prose/HTML, no crate reads them (verified: no include_str!/build.rs path
+# reaches website/ or _site/).
+website/
+_site/
+
+# Codegen INPUTS and reference grammars (#2813): the generated code is
+# committed, the generator does not run in the image build, and every
+# include_str! under crates/ that reaches a vendor/ path sits in tests/ (the
+# openehr_sdk corpus in openehr-its/tests/it). openehr-lang's vendored .g4
+# grammar set is reference text for the hand-written lexer, not a compile
+# input (no build.rs, no include_str! names it).
+crates/*/vendor/
+tools/openehr-codegen/vendor/
+
+# The vendored XSD bundles (#2813): read by the xml_xsd_validity test at
+# RUNTIME, never by the lib compile. schemas/json/ STAYS — src/json.rs
+# include_str!s openehr_rm_1.1.0_all.json into the lib (it is even in the
+# crate's packaged `include` list).
+crates/openehr-its/schemas/xml/
+
+# Local terminology releases (#2813): the 681 MB SNOMED NL zip parked in the
+# repo root for #2236 dominated the context; no tracked zip exists and no
+# build input is an archive.
+*.zip
+
 # Agent worktrees (full duplicate build trees) and Node artifacts.
 .claude/worktrees/
 **/node_modules/


### PR DESCRIPTION
Closes #2813.

Every image build transfers the whole context to the daemon, and 944 MB of it was material the `-p ferroehr-server` compile never reads. Measured honestly — a fresh buildx builder each time, so the transfer is full, not the context-cache increment:

| | context transfer |
|---|---|
| before | **944.63 MB** (18.0s) |
| after | **137.55 MB** (4.4s) |

Adjudication per entry, each verified against what the compile actually reads:

- **`fuzz/`** — its own nightly workspace, deliberately not a root-workspace member (`members = ["crates/*", "app/*", "tools/*"]`), so the build never parses it; `fuzz/corpus` alone is ~46 MB.
- **`website/` + `_site/`** — prose/HTML sources and the locally generated site output (22 + 36 MB); no `include_str!` or build.rs path reaches either.
- **`crates/*/vendor/` + `tools/openehr-codegen/vendor/`** — codegen inputs; the generated code is committed and the generator does not run in the image build. Every `include_str!` under `crates/` that names a `vendor/` path sits in `tests/` (the openehr_sdk corpus in `openehr-its/tests/it`). openehr-lang's vendored `.g4` grammars are reference text for the hand-written lexer, not a compile input.
- **`crates/openehr-its/schemas/xml/`** — read by the `xml_xsd_validity` test at runtime, never by the lib compile. **`schemas/json/` stays**: `src/json.rs` `include_str!`s `openehr_rm_1.1.0_all.json` into the lib, and the crate's packaged `include` list names it.
- **`*.zip`** — the single largest contributor: the untracked 681 MB SNOMED NL release parked in the repo root for #2236. No tracked zip exists and no build input is an archive.

Acceptance evidence (from-source image build + compose smoke) follows as a comment before merge — the cold in-image compile is running now.

`no-changelog`: build-context hygiene; no shipped byte changes.