### PR TITLE
ci(scripts): shellcheck every shell program at severity=style

### DIFF
--- a/.claude/hooks/inject_phase_context.sh
+++ b/.claude/hooks/inject_phase_context.sh
@@ -29,6 +29,7 @@ echo
 echo "=== tracker: open GitHub issues (gh issue view <n> --comments for the contract + discussion) ==="
 echo "--- pinned (current focus) ---"
 repo_nwo="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
+# shellcheck disable=SC2016 # $owner/$name are GraphQL variables, expanded by the server
 gh api graphql \
   -f query='query($owner: String!, $name: String!) { repository(owner: $owner, name: $name) { pinnedIssues(first: 3) { nodes { issue { number title } } } } }' \
   -f owner="${repo_nwo%%/*}" -f name="${repo_nwo##*/}" \
@@ -37,6 +38,7 @@ echo "--- open (child-of = sub-issue; {k/n} = sub-issue progress; BLOCKED-by = h
 # One batched GraphQL call yields each open issue's labels, milestone, parent,
 # sub-issue progress, and open blockers/blocks — so the tracker shows work
 # structure, not just a flat list. Falls back gracefully if gh/GraphQL fails.
+# shellcheck disable=SC2016 # $owner/$name are GraphQL variables and $labels/$b/$k are jq bindings
 gh api graphql \
   -f query='query($owner: String!, $name: String!) { repository(owner: $owner, name: $name) { issues(first: 100, states: OPEN, orderBy: {field: CREATED_AT, direction: DESC}) { nodes { number title labels(first: 20) { nodes { name } } milestone { title } parent { number } subIssuesSummary { total completed } blockedBy(first: 30) { nodes { number state } } blocking(first: 30) { nodes { number state } } } } } }' \
   -f owner="${repo_nwo%%/*}" -f name="${repo_nwo##*/}" \

--- a/.claude/rules/reliability.md
+++ b/.claude/rules/reliability.md
@@ -270,6 +270,24 @@ chapters, the Clippy book, and the Cargo/rustdoc books.)
   CodeQL's `actions` language on every pull request. An accepted finding is an
   inline `# zizmor: ignore[rule]` carrying its reason, never a silent
   suppression.
+- **The shell programs are analysed like code too** (issue #2785). The two
+  tooling languages here are bash and Rust, and only the Rust half was ever
+  lint-gated. actionlint shellchecks the `run:` blocks EMBEDDED in workflows;
+  the scripts those blocks call — every CI guard, every vendor fetcher, every
+  deploy probe, the release machinery, the git hooks — were checked by nothing.
+  ShellCheck now runs at `--severity=style`, its lowest floor, so every finding
+  gates. A finding is FIXED, or it carries a per-line
+  `# shellcheck disable=SCnnnn` directive with its reason on the same line; a
+  blanket exclusion is refused, and no `.shellcheckrc` exists, because a file
+  that can turn a code off tree-wide eventually does. Discovery is derived
+  rather than listed: every tracked `*.sh`, plus every tracked extensionless
+  file whose first line is a shell shebang (which is what covers
+  `.githooks/commit-msg` and the next hook after it), minus the vendored trees
+  nobody here may edit. Enforcement (tier 4):
+  `scripts/checks/shellcheck-lane.sh`, run per-PR by the `shellcheck` CI job
+  against the pinned upstream release binary (`shellcheck@0.11.0` — never the
+  runner's distro package, whose version would drift under the adjudicated
+  directives at every runner-image refresh).
 
 ## Recorded deviations from the API Guidelines (deliberate, owner-adjudicated)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,6 +468,39 @@ jobs:
       - name: Every CI job gates the merge
         run: bash scripts/checks/ci-conclusion-complete.sh
 
+  # The other half of the pair above. actionlint shellchecks the `run:` blocks
+  # EMBEDDED in workflows; the scripts those blocks call — every CI guard, every
+  # vendor fetcher, every deploy probe, the release machinery, the git hooks —
+  # had no static check at all until #2785. `--severity=style` is ShellCheck's
+  # lowest floor, so everything gates: a finding is fixed, or carries a per-line
+  # `# shellcheck disable=SCnnnn` directive with its reason. There is no
+  # .shellcheckrc, deliberately — nothing may turn a code off tree-wide.
+  #
+  # The lane is a committed script so local and CI run the identical check.
+  shellcheck:
+    name: shellcheck
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      # The upstream RELEASE binary, pinned by version — not the runner's distro
+      # package, which is whatever Ubuntu froze for that image and moves under us
+      # at every runner-image refresh. Every disable directive in this repository
+      # was adjudicated against 0.11.0's diagnostics, so the analyzer version is
+      # part of what the gate means. Fetched by the same SHA-pinned installer the
+      # zizmor job uses, which resolves
+      # github.com/koalaman/shellcheck/releases and verifies the checksum.
+      - uses: taiki-e/install-action@288e746965032cfcc232e09af2daf5f23c14d780 # v2.86.1
+        with:
+          tool: shellcheck@0.11.0
+      - name: Every shell program is clean at severity=style
+        run: bash scripts/checks/shellcheck-lane.sh
+
   # Comment-style guard (.claude/rules/comments.md, RFC 505/1574): block
   # comments, TODO(#N) form, NOTE/essay line budgets — over the WHOLE tree
   # hand-written .rs files (the legacy essay sweep #1870 closed; the step runs
@@ -1971,6 +2004,7 @@ jobs:
       - no-attribution
       - workflow-audit
       - workflow-lint
+      - shellcheck
       - comment-style
       - default-style
       - docs-claims

--- a/docker/postgres/initdb/10-ferroehr-init.sh
+++ b/docker/postgres/initdb/10-ferroehr-init.sh
@@ -25,6 +25,7 @@ APP_DB="${PG_INIT_DB:-ferroehr}"
 
 # psql as the bootstrap superuser, ON_ERROR_STOP so a failure aborts init.
 psql_super() { psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" "$@"; }
+# shellcheck disable=SC2120 # forwards flags like its psql_super twin; today's one caller passes none
 psql_app() { psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$APP_DB" "$@"; }
 
 echo "ferroehr init: creating role '${APP_USER}' and database '${APP_DB}'"
@@ -66,6 +67,7 @@ fi
 # 3) Schemas owned by the app role + superuser-installed extensions, in the
 #    app database. `ext` holds the openEHR helper functions and, by convention,
 #    the extensions; both schemas are on the app's search_path (ehr, ext, public).
+# shellcheck disable=SC2119 # the SQL arrives on stdin; the script's own $@ is not psql's
 psql_app <<SQL
 CREATE SCHEMA IF NOT EXISTS ehr AUTHORIZATION "${APP_USER}";
 CREATE SCHEMA IF NOT EXISTS ext AUTHORIZATION "${APP_USER}";

--- a/docker/terminology/seed.sh
+++ b/docker/terminology/seed.sh
@@ -94,12 +94,16 @@ verify() {
 # two shapes, and HAPI resolves them through different internal paths — a
 # ValueSet that answers one can still 404 the other (the "loinc" quirk below),
 # so a single sample proves nothing.
+# shellcheck disable=SC2016 # $validate-code and $expand are FHIR operation names, not shell expansions
 verify '$validate-code (sct-shaped member)' \
   "${FHIR_BASE}/ValueSet/\$validate-code?url=http://cnf.example.test/fhir/ValueSet/sct-shaped-disorders&system=http://cnf.example.test/fhir/CodeSystem/sct-shaped&code=1000002"
+# shellcheck disable=SC2016 # $expand is a FHIR operation name, not a shell expansion
 verify '$expand (sct-shaped disorders)' \
   "${FHIR_BASE}/ValueSet/\$expand?url=http://cnf.example.test/fhir/ValueSet/sct-shaped-disorders"
+# shellcheck disable=SC2016 # $validate-code is a FHIR operation name, not a shell expansion
 verify '$validate-code (lab-shaped member)' \
   "${FHIR_BASE}/ValueSet/\$validate-code?url=http://cnf.example.test/fhir/ValueSet/lab-shaped-vitals&system=http://cnf.example.test/fhir/CodeSystem/lab-shaped&code=99991-1"
+# shellcheck disable=SC2016 # $expand is a FHIR operation name, not a shell expansion
 verify '$expand (lab-shaped vitals)' \
   "${FHIR_BASE}/ValueSet/\$expand?url=http://cnf.example.test/fhir/ValueSet/lab-shaped-vitals"
 

--- a/scripts/checks/advisory-exceptions.sh
+++ b/scripts/checks/advisory-exceptions.sh
@@ -45,6 +45,7 @@ json="$(printf '%s\n' "$report" | grep '^{' || true)"
 if ! printf '%s\n' "$json" | jq -e 'select(.type == "summary")' >/dev/null 2>&1; then
   echo "error: the advisories check did not complete, so nothing was verified" >&2
   echo >&2
+  # shellcheck disable=SC2001 # indents EVERY line of a multi-line report; ${//} has no ^ anchor
   sed 's/^/  /' <<<"$report" >&2
   exit 1
 fi
@@ -57,6 +58,7 @@ resolved="$(printf '%s\n' "$json" | jq -r '
 
 if [[ -n "$resolved" ]]; then
   echo "error: deny.toml keeps an exception for an advisory the gate no longer raises:" >&2
+  # shellcheck disable=SC2001 # indents EVERY line of a multi-line list; ${//} has no ^ anchor
   sed 's/^/  /' <<<"$resolved" >&2
   echo >&2
   echo "No crate in the dependency graph matches these any more — the finding is" >&2

--- a/scripts/checks/ci-conclusion-complete.sh
+++ b/scripts/checks/ci-conclusion-complete.sh
@@ -25,6 +25,7 @@ needs=$(yq -o=json '.jobs.conclusion.needs' "$WORKFLOW" | jq -r '.[]' | sort)
 if missing=$(comm -23 <(echo "$jobs") <(echo "$needs")) && [[ -n "$missing" ]]; then
   echo "error: CI jobs that do not gate the merge" >&2
   echo >&2
+  # shellcheck disable=SC2001 # bullets EVERY line of a multi-line list; ${//} has no ^ anchor
   echo "$missing" | sed 's/^/  - /' >&2
   echo >&2
   echo "Branch protection requires only the 'conclusion' check, so a job absent" >&2
@@ -37,6 +38,7 @@ fi
 # `conclusion` fail permanently on an unresolvable dependency.
 if stale=$(comm -13 <(echo "$jobs") <(echo "$needs")) && [[ -n "$stale" ]]; then
   echo "error: conclusion.needs names jobs that do not exist" >&2
+  # shellcheck disable=SC2001 # bullets EVERY line of a multi-line list; ${//} has no ^ anchor
   echo "$stale" | sed 's/^/  - /' >&2
   exit 1
 fi

--- a/scripts/checks/docs-claims.sh
+++ b/scripts/checks/docs-claims.sh
@@ -129,7 +129,7 @@ values_paths() {
 toml_paths "$TOML" > "$work/toml"
 values_paths "$VALUES" > "$work/values"
 # Env forms: the TOML path upper-cased with `__` between segments.
-sed 's/\./__/g' "$work/toml" | tr 'a-z' 'A-Z' | sed 's/^/FERROEHR__/' | sort -u > "$work/env"
+sed 's/\./__/g' "$work/toml" | tr '[:lower:]' '[:upper:]' | sed 's/^/FERROEHR__/' | sort -u > "$work/env"
 grep -vE '\.' "$work/values" > "$work/values_top"
 
 failures=0
@@ -149,8 +149,7 @@ files=$(collect "$@")
 # and the Rust-version check on from-source.md never ran once, proven by
 # mutating both pages and watching the guard report OK (#2779). Space-normalise
 # the list once and test against that.
-# shellcheck disable=SC2086 # deliberate re-splitting: the newlines become spaces
-files_spaced=" $(echo $files) "
+files_spaced=" ${files//$'\n'/ } "
 in_files() {
   case "$files_spaced" in *" $1 "*) return 0 ;; *) return 1 ;; esac
 }
@@ -225,6 +224,7 @@ done
 for f in $files; do
   case " $CHART_PAGES " in *" $f "*) ;; *) continue ;; esac
   [[ -f "$f" ]] || continue
+  # shellcheck disable=SC2016 # the ERE below matches literal markdown backticks
   while read -r path; do
     [[ -n "$path" ]] || continue
     first=${path%%.*}
@@ -349,6 +349,7 @@ fi
 # so it must occur verbatim in one of the committed results records.
 COMPARISON_PAGE="$BOOK/comparison.md"
 if in_files "$COMPARISON_PAGE"; then
+  # shellcheck disable=SC2016 # the ERE below matches literal markdown backticks
   while read -r quote; do
     [[ -n "$quote" ]] || continue
     inner=${quote#\`\"}; inner=${inner%\"\`}
@@ -400,6 +401,7 @@ if in_files "$VERIFY_PAGE"; then
       || report "$VERIFY_PAGE" "names the release asset \`ferroehr-v${v}…\`; the workspace version is $app_version"
   done < <(grep -ohE 'ferroehr-v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?' "$VERIFY_PAGE" | sed 's/^ferroehr-v//' | sort -u)
   # The substitution note. Its sentence wraps, so the page is line-joined first.
+  # shellcheck disable=SC2016 # the ERE and sed below match literal markdown backticks
   while read -r v; do
     [[ -n "$v" ]] || continue
     [[ "$v" = "$app_version" ]] \

--- a/scripts/checks/image-labels.sh
+++ b/scripts/checks/image-labels.sh
@@ -170,6 +170,7 @@ fi
 levels=$(grep -c 'DOCKER_METADATA_ANNOTATIONS_LEVELS: index,manifest' "$BUILD_WORKFLOW" || true)
 [[ "$levels" -eq 1 ]] \
   || report "image-labels: expected the one reusable metadata step with DOCKER_METADATA_ANNOTATIONS_LEVELS: index,manifest in $BUILD_WORKFLOW, found $levels"
+# shellcheck disable=SC2016 # ${{ … }} is the literal Actions expression being searched for
 annots=$(grep -c 'annotations: ${{ steps.meta.outputs.annotations }}' "$BUILD_WORKFLOW" || true)
 [[ "$annots" -eq 1 ]] \
   || report "image-labels: expected the one reusable build step passing the annotations output in $BUILD_WORKFLOW, found $annots"

--- a/scripts/checks/shellcheck-lane.sh
+++ b/scripts/checks/shellcheck-lane.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+# ShellCheck over every shell program this repository WROTE.
+#
+# The tooling languages here are bash and Rust (.claude/rules/rust-style.md
+# §No Python), and the Rust half has been lint-gated since the beginning while
+# the bash half — the CI guards, the vendor fetchers, the deploy probes, the
+# release machinery, the git hooks — had no static check at all. actionlint
+# already shellchecks the `run:` blocks EMBEDDED in workflows, which is the
+# smaller half: the scripts those blocks call were unchecked.
+#
+# Severity: `-S style`, the lowest floor ShellCheck offers, so everything
+# gates. A finding is either fixed or carries a per-line
+# `# shellcheck disable=SCnnnn` directive with its reason on the same line —
+# never a blanket exclusion, and never a global disable (this repository has no
+# .shellcheckrc for exactly that reason: a file that can turn a code off
+# everywhere is a file that eventually does).
+#
+# Discovery is derived, not listed: every tracked `*.sh` plus every tracked
+# extensionless file whose first line is a shell shebang. The second half is
+# what covers `.githooks/commit-msg` — the one such program today — and covers
+# the next hook the day it lands rather than the day someone remembers.
+#
+# Usage: scripts/checks/shellcheck-lane.sh [<file>...]
+#   no args  → every tracked shell program outside the vendored trees
+#   <file>…  → just those files, at the same severity
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+# Vendored trees are upstream material, vendored verbatim by a
+# scripts/vendor/*.sh fetcher and never hand-edited
+# (.claude/rules/vendored-corpora.md) — a finding in one of them is not ours to
+# fix, and editing it to silence this lane is forbidden by that rule. No
+# vendored tree carries a shell program today; the exclusion is here so the
+# first one that arrives cannot turn this lane red for something unfixable.
+readonly VENDORED='^(docs/specs/|corpus/|website/book/theme/|(crates|tools)/[^/]+/vendor/)'
+
+# A shell shebang, direct or through env: bash, sh, dash, ksh, zsh.
+shell_shebang() {
+  head -n 1 "$1" 2>/dev/null | grep -Eq '^#!.*[/ ](bash|sh|dash|ksh|zsh)([[:space:]]|$)'
+}
+
+collect() {
+  git ls-files '*.sh' | grep -Ev "$VENDORED"
+  # Extensionless tracked files (no dot in the last path segment), filtered
+  # down to the ones that are actually shell.
+  while read -r f; do
+    [[ -f "$f" ]] || continue
+    if shell_shebang "$f"; then printf '%s\n' "$f"; fi
+  done < <(git ls-files | grep -Ev "$VENDORED" | grep -Ev '\.[^/]+$')
+}
+
+if [[ "$#" -gt 0 ]]; then
+  files=$(printf '%s\n' "$@")
+else
+  files=$(collect | sort -u)
+fi
+
+[[ -n "$files" ]] || { echo "shellcheck-lane: no shell programs to check."; exit 0; }
+
+command -v shellcheck >/dev/null 2>&1 || {
+  echo "error: shellcheck is not installed (https://www.shellcheck.net/)" >&2
+  exit 1
+}
+
+count=$(printf '%s\n' "$files" | wc -l | tr -d ' ')
+if ! printf '%s\n' "$files" | xargs shellcheck --severity=style --format=gcc; then
+  echo >&2
+  echo "shellcheck-lane: findings above. Fix each one, or — where the flagged" >&2
+  echo "form is deliberate — add a '# shellcheck disable=SCnnnn' directive on" >&2
+  echo "the line before the command, with the reason as a trailing comment." >&2
+  exit 1
+fi
+
+echo "shellcheck-lane: OK ($count shell programs, severity=style)."

--- a/scripts/checks/typed-status.sh
+++ b/scripts/checks/typed-status.sh
@@ -68,6 +68,7 @@ files=$(collect "$@")
 for f in $files; do
   [[ -f "$f" ]] || continue
   # `.as_u16()` immediately compared, or a `.status()` compared to a literal.
+  # shellcheck disable=SC2016 # the backticks quote a Rust path in the message text
   while IFS=: read -r line body; do
     [[ -n "${line:-}" ]] || continue
     printf '%s:%s: numeric status comparison (%s) — compare the typed \n' \
@@ -88,6 +89,7 @@ for f in $files; do
   # Both are comparisons the `[=!]=` shapes above cannot see; the arm window is
   # scrutinee-anchored so openEHR's own 3-digit codes (249/523/…) matched under
   # non-status scrutinees stay out of scope.
+  # shellcheck disable=SC2016 # the backticks quote a Rust path in the message text
   while IFS=: read -r line body; do
     [[ -n "${line:-}" ]] || continue
     printf '%s:%s: numeric status comparison (%s) — compare the typed \n' \

--- a/scripts/checks/vex-advisories.sh
+++ b/scripts/checks/vex-advisories.sh
@@ -55,7 +55,8 @@ fi
 # inherited container layers, where nothing in this repository resolves the
 # finding). They still have to be well-formed OpenVEX, so a typo does not ship
 # as a document a consumer's parser rejects.
-for doc in security/vex/*.openvex.json; do
+docs=(security/vex/*.openvex.json)
+for doc in "${docs[@]}"; do
   jq -e '
     (has("@context") and has("@id") and has("author") and has("timestamp")
      and has("version") and (.statements | type == "array" and length > 0))
@@ -76,4 +77,4 @@ for doc in security/vex/*.openvex.json; do
   }
 done
 
-echo "ok: $(ls security/vex/*.openvex.json | wc -l | tr -d ' ') VEX documents well-formed; $OUT matches deny.toml"
+echo "ok: ${#docs[@]} VEX documents well-formed; $OUT matches deny.toml"

--- a/scripts/deploy-probes/kubernetes.sh
+++ b/scripts/deploy-probes/kubernetes.sh
@@ -113,6 +113,7 @@ k8s_try_db_hosts() {
   # so the output is lost and reads like a database that never answered (the
   # same race that false-flagged P-K8S-UI-SERVE).
   local name="probe-hostcheck-$$-$RANDOM" out phase _i
+  # shellcheck disable=SC2016 # $h and $(ip route) belong to the busybox shell, not this one
   kubectl run "$name" --image=busybox:1.37 --restart=Never --command -- sh -c '
       for h in host.docker.internal gateway.docker.internal $(ip route | awk "/default/ {print \$3}"); do
         nc -w3 -z "$h" '"$K8S_DB_PORT"' && { echo "HOST=$h"; break; }

--- a/scripts/deploy-probes/oidc.sh
+++ b/scripts/deploy-probes/oidc.sh
@@ -101,9 +101,9 @@ probes_oidc() {
   hdrs="$(curl -s -o /dev/null -D - -X POST "$API/ehr")"
   assert_contains "$hdrs" "401" "an unauthenticated write must be refused"
   # Header names are case-insensitive on the wire, so fold before matching.
-  assert_contains "$(printf '%s' "$hdrs" | tr 'A-Z' 'a-z')" "www-authenticate" \
+  assert_contains "$(printf '%s' "$hdrs" | tr '[:upper:]' '[:lower:]')" "www-authenticate" \
     "a 401 without a challenge tells the client nothing about how to authenticate"
-  assert_contains "$(printf '%s' "$hdrs" | tr 'A-Z' 'a-z')" "bearer" \
+  assert_contains "$(printf '%s' "$hdrs" | tr '[:upper:]' '[:lower:]')" "bearer" \
     "with an issuer configured the challenge must advertise Bearer"
   probe_done
 

--- a/scripts/generate-ckm-examples.sh
+++ b/scripts/generate-ckm-examples.sh
@@ -49,4 +49,5 @@ for opt in "$PACK"/*.opt; do
     || { echo "::error::$slug example is not a COMPOSITION" >&2; exit 1; }
 done
 
-echo "==> generated $(ls "$PACK"/*.example.json | wc -l | tr -d ' ') example skeletons"
+examples=("$PACK"/*.example.json)
+echo "==> generated ${#examples[@]} example skeletons"

--- a/scripts/gh/project.sh
+++ b/scripts/gh/project.sh
@@ -99,6 +99,7 @@ item_id_for_issue() {
   # item-list --limit 1000` costs enough GraphQL points that GitHub's
   # secondary rate limit rejects it once the board is large (measured
   # 2026-08-25 at ~2.6k items).
+  # shellcheck disable=SC2016 # $owner/$name/$number are GraphQL variables, bound by the -f flags
   gh api graphql \
     -f owner="${REPO%%/*}" -f name="${REPO##*/}" -F number="$1" \
     -f query='query($owner:String!,$name:String!,$number:Int!){
@@ -150,6 +151,7 @@ cmd_show() {
   resolve_project
   # The issue-side lookup, for the same rate-limit reason as item_id_for_issue.
   local status
+  # shellcheck disable=SC2016 # $owner/$name/$number are GraphQL variables, bound by the -f flags
   status="$(gh api graphql \
     -f owner="${REPO%%/*}" -f name="${REPO##*/}" -F number="$n" \
     -f query='query($owner:String!,$name:String!,$number:Int!){

--- a/scripts/render/comparison.sh
+++ b/scripts/render/comparison.sh
@@ -64,8 +64,6 @@ run_date() {
 rs_date=$(run_date "$RS")
 eb_date=$(run_date "$EB")
 eb_version=$(jq -r '.sut.version // .sut.name' "$EB/results.json")
-rs_total=$(jq '(.cases // .outcomes) | length' "$RS/results.json")
-eb_total=$(jq '(.cases // .outcomes) | length' "$EB/results.json")
 
 # The shared per-case join: both runs execute the SAME committed catalogue,
 # keyed by case id + format. (A case one run records N/A — an unclaimed
@@ -76,7 +74,6 @@ shared=$(jq -n --slurpfile a "$RS/results.json" --slurpfile b "$EB/results.json"
   | [$b[0].outcomes[] | . as $o | ($rs["\(.case)|\(.format // "-")"]) as $mine
      | select($mine != null)
      | {key: "\(.case)|\(.format // "-")", theirs: .status, rs: $mine.status}]')
-shared_n=$(echo "$shared" | jq 'length')
 srow() { echo "$shared" | jq "[.[] | select(.$1 == \"$2\")] | length"; }
 
 # EHRbase failures grouped by schedule chapter (the case-id prefix), and the

--- a/scripts/sandbox/reseed.sh
+++ b/scripts/sandbox/reseed.sh
@@ -64,7 +64,7 @@ echo "==> seeding $BASE"
 
 # The demo EHRs, shared across every template so each carries a mixed record.
 ehrs=()
-for e in $(seq 1 "$EHRS"); do
+for _e in $(seq 1 "$EHRS"); do
   ehr=""
   for attempt in $(seq 1 "$ATTEMPTS"); do
     ehr=$(curl -sS -m 60 -u "$AUTH" -X POST "$BASE/ehr" -H 'Prefer: return=minimal' \
@@ -99,7 +99,7 @@ for slug in "${TEMPLATES[@]}"; do
   esac
 
   for ehr in "${ehrs[@]}"; do
-    for c in $(seq 1 "$COMPOSITIONS_PER_EXAMPLE"); do
+    for _c in $(seq 1 "$COMPOSITIONS_PER_EXAMPLE"); do
       code=$(post_retry "composition $slug" "$BASE/ehr/$ehr/composition" \
         -H 'Content-Type: application/json' -H 'Prefer: return=minimal' \
         --data-binary @"$example")

--- a/scripts/security/vex-generate.sh
+++ b/scripts/security/vex-generate.sh
@@ -72,6 +72,7 @@ ignore_json="$(yq -p toml -o json '[.advisories.ignore[]]' "$GATE")"
 if bare="$(jq -r '.[] | select(type == "string" and startswith("RUSTSEC-"))' <<<"$ignore_json")" \
    && [[ -n "$bare" ]]; then
   echo "vex-generate: deny.toml ignores an advisory in the bare-string form:" >&2
+  # shellcheck disable=SC2001 # indents EVERY line of a multi-line list; ${//} has no ^ anchor
   sed 's/^/  /' <<<"$bare" >&2
   echo "Use { id = \"…\", reason = \"…\" } so the exception carries its reason" >&2
   echo "and this gate can require a published VEX justification for it." >&2
@@ -88,6 +89,7 @@ if unreasoned="$(jq -r '
       | select((.reason // "" | gsub("^\\s+|\\s+$"; "")) == "")
       | .id' <<<"$ignore_json")" && [[ -n "$unreasoned" ]]; then
   echo "vex-generate: deny.toml accepts an advisory with no reason:" >&2
+  # shellcheck disable=SC2001 # indents EVERY line of a multi-line list; ${//} has no ^ anchor
   sed 's/^/  /' <<<"$unreasoned" >&2
   echo "Every accepted advisory states why it does not apply and when to" >&2
   echo "re-check it — deny.toml's own header requires exceptions to be" >&2

--- a/scripts/vendor/adl2-archetypes.sh
+++ b/scripts/vendor/adl2-archetypes.sh
@@ -107,6 +107,9 @@ sync_tree "$WORK/src/Reference/CKM_2013_12_09" "$CKM_PAIRS_DEST/ckm-2013-12-09"
   adls_count=$(find "$root" -name '*.adls' -print | wc -l | tr -d ' ')
   paired_count=$(comm -12 <(hrids '*.adl') <(hrids '*.adls') | wc -l | tr -d ' ')
 
+  # This block writes a markdown document: every backtick inside the printf
+  # formats is markdown code quoting, so the formats stay single-quoted.
+  # shellcheck disable=SC2016
   {
     printf '# ADL 2 archetype pack (with ADL 1.4 twins) — provenance\n\n'
     printf 'Vendored verbatim from `https://github.com/%s`\n' "$REPO"

--- a/scripts/vendor/ckm-archetypes.sh
+++ b/scripts/vendor/ckm-archetypes.sh
@@ -109,12 +109,14 @@ printf '==> %s archetypes published by CKM\n' "$published"
 
 echo "==> fetching ADL 1.4 texts (jobs=$JOBS)"
 find "$ADL_DIR" -name '*.adl' -delete
+# shellcheck disable=SC2016 # $0/$1/$2 are the inner bash -c positionals, not this shell's
 xargs -P "$JOBS" -n 2 bash -c 'bash "$0" --fetch-one "$1" "$2" adl' "$0" \
   < "$WORK/jobs_adl.txt" | tee "$WORK/adl.log"
 
 if [[ $WITH_XML == 1 ]]; then
   echo "==> fetching AM 1.4 archetype XML (jobs=$JOBS)"
   find "$XML_DIR" -name '*.xml' -delete
+  # shellcheck disable=SC2016 # $0/$1/$2 are the inner bash -c positionals, not this shell's
   xargs -P "$JOBS" -n 2 bash -c 'bash "$0" --fetch-one "$1" "$2" xml' "$0" \
     < "$WORK/jobs_xml.txt" | tee "$WORK/xml.log"
 else


### PR DESCRIPTION
Closes #2785

The two tooling languages here are bash and Rust, and only the Rust half was ever lint-gated. actionlint already shellchecks the `run:` blocks EMBEDDED in workflows, which is the smaller half: the scripts those blocks call — every CI guard, every vendor fetcher, every deploy probe, the release machinery, the git hooks — were checked by nothing.

## What the lane covers

`scripts/checks/shellcheck-lane.sh` is the gate; the new `shellcheck` CI job calls it, so a local run and a CI run are the same command (the repo pattern: guards live in `scripts/checks/`, workflows call them).

Discovery is **derived, not listed**: every tracked `*.sh`, plus every tracked extensionless file whose first line is a shell shebang. The second half is what covers `.githooks/commit-msg` — the one such program today — and covers the next hook the day it lands rather than the day someone remembers. 93 programs at this commit.

Severity is `--severity=style`, ShellCheck's lowest floor, so everything gates.

The tool is pinned to the upstream release binary, `shellcheck@0.11.0`, fetched by the same SHA-pinned `taiki-e/install-action` the zizmor job uses (it resolves github.com/koalaman/shellcheck/releases and verifies the checksum). The runner's distro package was rejected: it is whatever Ubuntu froze for that image and moves at every runner-image refresh, and every disable directive below was adjudicated against 0.11.0's diagnostics, so the analyzer version is part of what the gate means.

Job discipline matches its neighbours: `permissions: contents: read` under the workflow's `permissions: {}`, `persist-credentials: false` on checkout, every `uses:` SHA-pinned with its version comment, no context interpolated into a `run:`. `actionlint` and `zizmor --min-severity=low` are both clean on the edited workflow, and `ci-conclusion-complete.sh` confirms the job gates the merge (42 jobs).

## Exclusion policy

Excluded: `docs/specs/`, `corpus/`, `crates/*/vendor/`, `tools/*/vendor/`, `website/book/theme/`. These are vendored verbatim by a `scripts/vendor/*.sh` fetcher and never hand-edited, so a finding in one is not ours to fix and editing it to go green is forbidden outright.

Honest note: **no vendored tree carries a shell program today** (`git ls-files '*.sh'` under those paths returns 0). The exclusion is preventive, so the first one that arrives cannot turn the lane red for something unfixable.

No `.shellcheckrc` exists, deliberately. Nothing may turn a code off tree-wide.

## Finding adjudication

47 findings across 18 files, adjudicated file by file: **14 fixed, 33 suppressed** with a per-line `# shellcheck disable=SCnnnn` directive carrying its reason on the same line.

### Fixed (14)

| File | Codes | Fix |
|---|---|---|
| `scripts/render/comparison.sh` | 3× SC2034 | `rs_total`, `eb_total`, `shared_n` were computed and never read. Deleted. Re-running the renderer produces byte-identical output. |
| `scripts/sandbox/reseed.sh` | 2× SC2034 | `e` and `c` are repeat-N-times counters. Renamed `_e` / `_c`, the convention ShellCheck exempts and the file's own `_i` already uses elsewhere in the tree. |
| `scripts/checks/docs-claims.sh` | SC2018, SC2019 | `tr 'a-z' 'A-Z'` → `tr '[:lower:]' '[:upper:]'`. |
| `scripts/deploy-probes/oidc.sh` | 2× SC2018, 2× SC2019 | `tr 'A-Z' 'a-z'` → `tr '[:upper:]' '[:lower:]'` on both header folds. |
| `scripts/checks/docs-claims.sh` | SC2116 | `files_spaced=" $(echo $files) "` → `" ${files//$'\n'/ } "`. The parameter expansion says what the line means, and it retired the SC2086 directive that sat above it. |
| `scripts/checks/vex-advisories.sh` | SC2012 | `ls …\|wc -l` → a glob array (`docs=(security/vex/*.openvex.json)`), which the loop below already needed. |
| `scripts/generate-ckm-examples.sh` | SC2012 | Same: glob array, `${#examples[@]}`. |

### Suppressed with a reason (33)

| File | Codes | Why the flagged form is correct |
|---|---|---|
| `.claude/hooks/inject_phase_context.sh` | 3× SC2016 | `$owner`/`$name` are GraphQL variables and `$labels`/`$b`/`$k` are jq bindings; the server and jq expand them, not the shell. |
| `docker/terminology/seed.sh` | 4× SC2016 | `$validate-code` and `$expand` are FHIR operation names in a label string. |
| `scripts/checks/docs-claims.sh` | 4× SC2016 | The EREs and the `sed` expression match literal markdown backticks. |
| `scripts/checks/typed-status.sh` | 2× SC2016 | Backticks quoting a Rust path inside the diagnostic text. |
| `scripts/checks/image-labels.sh` | SC2016 | `${{ steps.meta.outputs.annotations }}` is the literal Actions expression being searched for. |
| `scripts/gh/project.sh` | 2× SC2016 | GraphQL variables bound by the `-f` flags. |
| `scripts/deploy-probes/kubernetes.sh` | 2× SC2016 | `$h` and `$(ip route …)` belong to the busybox shell `kubectl run` starts. |
| `scripts/vendor/ckm-archetypes.sh` | 2× SC2016 | `$0`/`$1`/`$2` are the inner `bash -c` positionals. |
| `scripts/vendor/adl2-archetypes.sh` | 5× SC2016 | A block that writes a markdown document; every backtick in the printf formats is markdown code quoting. One directive on the compound, since the whole block has the one reason. |
| `scripts/checks/advisory-exceptions.sh` | 2× SC2001 | `sed 's/^/  /'` indents EVERY line of a multi-line report; `${//}` has no `^` anchor. |
| `scripts/checks/ci-conclusion-complete.sh` | 2× SC2001 | Same, bulleting a multi-line list. |
| `scripts/security/vex-generate.sh` | 2× SC2001 | Same. |
| `docker/postgres/initdb/10-ferroehr-init.sh` | SC2120, SC2119 | `psql_app` forwards flags like its `psql_super` twin; today's single caller passes none and hands the SQL on stdin. Dropping `"$@"` would make a future `psql_app -tAc …` silently drop its arguments. |

## Mutation proof

The lane was proven to fail, not just to pass.

1. **A finding in a tracked `.sh`.** Appended `unquoted=$HOME/x` + `ls $unquoted` to `scripts/checks/no-python.sh`:
   ```
   scripts/checks/no-python.sh:65:4: note: Double quote to prevent globbing and word splitting. [SC2086]
   shellcheck-lane: findings above. …
   exit=1
   ```
   Reverted; tree clean.

2. **The extensionless-discovery half.** Created a tracked `.githooks/pre-push-probe` with a bash shebang, an unused variable and an unquoted glob. The count went 93 → 94 and the lane failed naming both findings:
   ```
   .githooks/pre-push-probe:2:1: warning: unused_var appears unused. … [SC2034]
   .githooks/pre-push-probe:3:4: note: Double quote to prevent globbing and word splitting. [SC2086]
   exit=1
   ```
   Removed; back to `OK (93 shell programs, severity=style)`.

## Behaviour verification

The fixes are behaviour-preserving, checked rather than assumed:

- `bash -n` on all 21 touched scripts.
- `scripts/checks/ci-conclusion-complete.sh` → ok, 42 jobs.
- `scripts/checks/vex-advisories.sh` → ok, 3 VEX documents.
- `scripts/checks/docs-claims.sh --all` → OK, and mutation-proven: appending a fabricated backticked quote to `website/book/src/comparison.md` still trips the `in_files`-gated section, so the parameter-expansion rewrite did not re-break what #2779 fixed.
- `scripts/render/comparison.sh` re-run → zero drift in `website/book/generated/` and the perf SVG.
- `spdx-headers-text.sh`, `copyright-holder.sh`, `no-python.sh`, `image-labels.sh`, `conformance-numbers.sh` → all green.

No cargo command was run in this branch; no Rust source is touched.

## Register

`.claude/rules/reliability.md` gains the lane's entry in "The rules", in the existing enforcement-register style (tier 4, named script, named CI job, named tool pin).

`no-changelog`: CI-only. The 14 behavioural fixes are all provably invisible — dead assignments removed, ASCII-equivalent `tr` classes, renamed loop counters, an identical file count computed a different way, and a string split that the `docs-claims` mutation above proves still behaves.
