### PR TITLE
fix(watchers): key-mode dedup matches whole words, never substrings

### DIFF
--- a/.github/actions/file-watcher-issue/file-issue.sh
+++ b/.github/actions/file-watcher-issue/file-issue.sh
@@ -35,10 +35,12 @@
 #     number, date or version in it would open a new issue every run) and put
 #     the varying detail in the body.
 #   * `--dedup-key K` (repeatable) — the key is a token that must appear in the
-#     title: a match is an issue whose title contains EVERY key,
-#     case-insensitively. This is what the spec watchers need, where the Jira
-#     key or the component-plus-version pair identifies the work and the rest of
-#     the title is free text.
+#     title: a match is an issue whose title contains EVERY key as a whole
+#     WORD (regex word boundaries, case-insensitive — #2796: RM/AM/SM occur
+#     inside "the ARM build" and "transform", so substring containment could
+#     dedup a genuine release against an unrelated issue). This is what the
+#     spec watchers need, where the Jira key or the component-plus-version
+#     pair identifies the work and the rest of the title is free text.
 #
 # BODY BY FILE ONLY. Watcher bodies carry remote content — upstream release
 # notes, scanner output, third-party server messages — which must never be
@@ -124,9 +126,16 @@ find_existing() {
     printf '%s' "$json" | jq -r --arg t "$title" \
       'map(select(.title == $t)) | .[0].number // empty'
   else
+    # Word-boundary containment, not substring (#2796): the short component
+    # tokens RM/AM/SM occur inside ordinary words ("the ARM build",
+    # "transform"), so a plain contains() could dedup a genuine notification
+    # against an unrelated issue. Each key is regex-escaped, then must match
+    # between word boundaries, case-insensitively.
     printf '%s' "$json" | jq -r --args \
-      'map(select((.title | ascii_downcase) as $t
-                  | all($ARGS.positional[]; . as $k | $t | contains($k | ascii_downcase))))
+      'map(select(.title as $t
+                  | all($ARGS.positional[];
+                        gsub("(?<c>[.\\\\+*?()|\\[\\]{}^$-])"; "\\" + .c) as $rx
+                        | $t | test("\\b" + $rx + "\\b"; "i"))))
        | .[0].number // empty' -- "${dedup_keys[@]}"
   fi
 }


### PR DESCRIPTION
Closes #2796.

The filing engine's `--dedup-key` mode matched keys by jq `contains()` — case-insensitive substring — so the short component tokens RM/AM/SM, which occur inside ordinary words, could dedup a genuine release notification against an unrelated issue. The keys are now regex-escaped and matched with `test("\b…\b"; "i")`.

Mutation proof (the exact jq filter, driven with fixtures):

| keys | old (`contains`) | new (word-boundary) |
|---|---|---|
| `RM` + `1.2.0` | **#1 "the ARM build transforms 1.2.0 outputs"** — the false dedup | #2 "spec-update(RM): openEHR RM Release-1.2.0 published" |
| `SM` | — | #3 "chore: transform the SM layer" (whole word still matches) |
| `AM` (embedded only) | — | empty (no false match) |
| `rm` + `release-1.2.0` | — | #2 (case-insensitivity kept) |

Live read-only smoke: `find --state all --dedup-key SPECAM-91` still resolves the real #157. Escaping covers the version tokens' dots and dashes (`1.2.0` → `1\.2\.0`). `bash -n`, `shellcheck-lane.sh` on the file: clean.

`no-changelog`: watcher-internal filing machinery.