### PR TITLE
fix(watchers): label creation fails loudly, and a dispatch never cancels a running probe

### DIFF
--- a/.fossabot.yml
+++ b/.fossabot.yml
@@ -29,7 +29,8 @@ defaults:
   minimumReleaseAge: 7
 
   # CVSS 7.0 (HIGH) and above is treated as security-critical and prioritised.
-  # This is deliberately the same floor the container image scan enforces
-  # (`image-scan.yml` gates on fixable HIGH/CRITICAL), so a vulnerability does
-  # not count as urgent in one lane and routine in another.
+  # This is deliberately the same floor the container image scan acts on
+  # (`image-scan.yml` files an issue on fixable HIGH/CRITICAL and stays green,
+  # #2778), so a vulnerability does not count as urgent in one lane and
+  # routine in another.
   securityCvssThreshold: 7.0

--- a/.github/workflows/latest-deps.yml
+++ b/.github/workflows/latest-deps.yml
@@ -31,9 +31,13 @@ on:
   workflow_dispatch:
 
 # A scheduled probe: only the newest run is interesting, so cancel freely.
+# cancel-in-progress stays FALSE like the other watchers (#2797): schedule and
+# workflow_dispatch both resolve to the default branch's ref, so a manual
+# dispatch with `true` would silently cancel a running scheduled probe
+# mid-45-minute build instead of queuing behind it.
 concurrency:
   group: latest-deps-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions: {}
 

--- a/scripts/watch/spec-release.sh
+++ b/scripts/watch/spec-release.sh
@@ -127,8 +127,12 @@ EOF
   if [[ "$DRY_RUN" = "1" ]]; then
     sed 's/^/    │ /' "$tmp/body.md"
   else
-    # Ensure the per-release collection label exists (idempotent).
-    gh label create "$up_label" --description "Changes arriving with the upstream $comp Release-$latest" --color BFD4F2 2>/dev/null || true
+    # Ensure the per-release collection label exists. --force makes an existing
+    # label a success (it re-applies the deterministic description/colour), so
+    # a real failure — permissions, transport — fails the probe loudly HERE
+    # instead of surfacing later as a confusing `gh issue create` refusal of a
+    # label that never got made (#2797).
+    gh label create "$up_label" --force --description "Changes arriving with the upstream $comp Release-$latest" --color BFD4F2
   fi
   # `--on-existing skip` re-runs the dedup at filing time: a race that lands a
   # covering issue between the check above and here must not double-file, and


### PR DESCRIPTION
Closes #2797. The issue's three items, each verified:

1. **The label-create swallow goes.** `gh label create … 2>/dev/null || true` hid every failure; the filing then refused a nonexistent label with a message pointing nowhere near the cause. Now `--force`, no redirection, no `|| true`: an existing label is a success (proven live against `upstream:ITS-XML-2.0.0` — exit 0, deterministic description/colour re-applied), and a real failure aborts the probe at its own line (`set -euo pipefail`) with gh's own message. Also proven: the un-forced create on an existing label prints `already exists; use --force` — the message the old swallow was eating.
2. **`latest-deps.yml` → `cancel-in-progress: false`**, matching every other watcher. `schedule` and `workflow_dispatch` both resolve to the default branch's ref, so `true` meant a manual dispatch silently killed a running scheduled probe mid-45-minute build. A comment records the reasoning at the stanza.
3. **`.fossabot.yml`** comment: image-scan "files an issue on fixable HIGH/CRITICAL and stays green (#2778)" — the lane stopped gating in #2778; the shared CVSS-7.0-floor claim stands.

Gates: `shellcheck-lane.sh` on the script, `actionlint` + `zizmor --min-severity=low` on the workflow — all clean.

`no-changelog`: watcher-internal machinery and a config comment.