### PR TITLE
ci(chart): the README drift check runs in CI, and the contradicted cosign paragraph goes

### DIFF
--- a/.github/workflows/build-chart.yml
+++ b/.github/workflows/build-chart.yml
@@ -408,23 +408,6 @@ jobs:
       # A keyless cosign SIGNATURE over the pushed digest. Distinct from the
       # attestation below and not redundant with it: the attestation answers
       # "built from this source, this way", the signature answers "signed by this
-      # workflow" — and the signature is the artifact a Helm consumer's tooling
-      # and Artifact Hub's listing actually look for.
-      #
-      # `--new-bundle-format=false` is a DECISION, not inertia. cosign 3 defaults
-      # to the protobuf bundle attached as an OCI 1.1 referring artifact, and
-      # GHCR implements no referrers API at all — measured against the published
-      # chart, `GET /v2/rubentalstra/charts/ferroehr/referrers/<digest>` answers
-      # `404 MANIFEST_UNKNOWN`, so a referring artifact reaches the registry only
-      # through the OCI fallback TAG (`sha256-<hex>`), which on this repository is
-      # the very index the attestation step below already writes. Two writers to
-      # one index is a way to lose the attestation, for no gain: Artifact Hub
-      # checks the classic `sha256-<hex>.sig` tag FIRST (tag-based discovery in
-      # `HasCosignSignature`, `internal/oci/oci.go`), and a plain tag needs no
-      # registry capability whatever. Revisit when GHCR serves referrers.
-      # A keyless cosign SIGNATURE over the pushed digest. Distinct from the
-      # attestation below and not redundant with it: the attestation answers
-      # "built from this source, this way", the signature answers "signed by this
       # workflow" — and the signature is what a Helm consumer's tooling and
       # Artifact Hub's listing actually look for.
       #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1161,6 +1161,25 @@ jobs:
           echo "${YQ_SHA256}  /tmp/yq" | sha256sum -c -
           sudo install -m 0755 /tmp/yq /usr/local/bin/yq
           yq --version
+      # The README drift check needs helm-docs, and validate.sh's self-skip when
+      # it is absent is how the v4.0.5 README shipped a release stale through a
+      # green lane (#2806) — so the tool is installed here (pinned in
+      # deploy/helm/.tool-versions beside helm, checksum-verified like yq) and
+      # validate.sh now FAILS in CI instead of skipping when it is missing.
+      - name: Install the pinned helm-docs
+        env:
+          VERSION_FILE: deploy/helm/.tool-versions
+          HELM_DOCS_SHA256: a8cf72ada34fad93285ba2a452b38bdc5bd52cc9a571236244ec31022928d6cc
+        run: |
+          set -euo pipefail
+          version="$(awk '$1 == "helm-docs" { print $2 }' "$VERSION_FILE")"
+          [ -n "$version" ] || { echo "::error::no helm-docs line in $VERSION_FILE"; exit 1; }
+          curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors -o /tmp/helm-docs.tar.gz \
+            "https://github.com/norwoodj/helm-docs/releases/download/v${version}/helm-docs_${version}_Linux_x86_64.tar.gz"
+          echo "${HELM_DOCS_SHA256}  /tmp/helm-docs.tar.gz" | sha256sum -c -
+          tar -xzf /tmp/helm-docs.tar.gz -C /tmp helm-docs
+          sudo install -m 0755 /tmp/helm-docs /usr/local/bin/helm-docs
+          helm-docs --version
       # No --update: the goldens in the tree must already match this render.
       - name: Chart validation + golden renders
         run: bash deploy/helm/validate.sh

--- a/deploy/helm/.tool-versions
+++ b/deploy/helm/.tool-versions
@@ -12,3 +12,9 @@
 # `deploy/helm/validate.sh --update` in the SAME change, which is how it moved
 # to 4.2.3 (the current release) during the chart rewrite.
 helm 4.2.3
+# The chart README generator (#2806). Pinned for the same reason as helm: the
+# README drift check byte-compares generated output, and helm-docs's rendering
+# is only byte-stable within a release. CI installs exactly this version
+# (checksum-verified in the helm-golden job); validate.sh FAILS in CI when it
+# is absent, because the self-skip is how the v4.0.5 README shipped stale.
+helm-docs 1.14.2

--- a/deploy/helm/ferroehr/README.md
+++ b/deploy/helm/ferroehr/README.md
@@ -2,7 +2,7 @@
 
 Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.1.0 + AQL 1.1). A single static binary deployed with a hardened-by-default security posture: runs as a non-root, read-only-rootfs workload whose NetworkPolicy admits its serving port only, and that connects to an EXTERNAL PostgreSQL 18 as an unprivileged app role (migrations are run out of band by a separate migrator role).
 
-![Version: 6.0.20](https://img.shields.io/badge/Version-6.0.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.5](https://img.shields.io/badge/AppVersion-4.0.5-informational?style=flat-square)
+![Version: 6.0.21](https://img.shields.io/badge/Version-6.0.21-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.5](https://img.shields.io/badge/AppVersion-4.0.5-informational?style=flat-square)
 
 FerroEHR is a pure-Rust openEHR Clinical Data Repository: ITS-REST 1.1.0 at the
 API, AQL 1.1 as the query language, PostgreSQL 18-native storage, shipped as a
@@ -33,7 +33,7 @@ to add; `helm repo add` does not apply to this chart:
 
 ```console
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 6.0.20 \
+  --version 6.0.21 \
   --namespace ferroehr --create-namespace \
   --set database.existingSecret=ferroehr-db \
   --set image.tag=4.0.5
@@ -47,7 +47,7 @@ They are independent SemVer lines and they move independently:
 
 | What | Set with | This release |
 |---|---|---|
-| the **chart** (templates, defaults, this document) | `--version` | `6.0.20` |
+| the **chart** (templates, defaults, this document) | `--version` | `6.0.21` |
 | the **server image** | `image.tag` | `4.0.5` |
 
 `appVersion` is the image the chart defaults to; pinning `image.tag` explicitly
@@ -59,7 +59,7 @@ The chart carries two keyless Sigstore artifacts, and they answer different
 questions. A **cosign signature:** who signed this:
 
 ```console
-cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.20 \
+cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.21 \
   --certificate-identity-regexp '^https://github\.com/rubentalstra/FerroEHR/\.github/workflows/publish-chart\.yml@' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
@@ -67,7 +67,7 @@ cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.20 \
 A **SLSA build provenance attestation:** what source it was built from, and how:
 
 ```console
-gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:6.0.20 \
+gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:6.0.21 \
   -R rubentalstra/FerroEHR
 gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:4.0.5 \
   -R rubentalstra/FerroEHR

--- a/deploy/helm/validate.sh
+++ b/deploy/helm/validate.sh
@@ -740,7 +740,16 @@ if command -v helm-docs >/dev/null 2>&1; then
     FAIL=1
   fi
 else
-  printf '%s\n' "helm-docs: not installed — skipping the chart README drift check"
+  # Locally a missing helm-docs is a note; in CI it is a FAILURE (#2806): the
+  # self-skip is how the v4.0.5 README shipped a release stale — the lane ran
+  # green with the one check that would have caught it silently absent.
+  if [[ "${CI:-}" == "true" ]]; then
+    red "helm-docs: not installed — CI must install the pinned helm-docs"
+    red "(deploy/helm/.tool-versions); a silent skip is how a stale README ships."
+    FAIL=1
+  else
+    printf '%s\n' "helm-docs: not installed — skipping the chart README drift check"
+  fi
 fi
 
 # ── What a green run above does NOT mean ─────────────────────────────────────


### PR DESCRIPTION
Closes #2806. Both residues, plus a live catch:

1. **The drift check now runs in CI.** `helm-docs 1.14.2` joins `deploy/helm/.tool-versions` (pinned for the same byte-stability reason as helm), the helm-golden lane installs it checksum-verified (the yq pattern — the sha256 is release-asset-verified, and a future version bump fails the checksum loudly until it is updated alongside), and `validate.sh` FAILS under `CI=true` when the tool is absent instead of self-skipping — the silent skip is exactly how the v4.0.5 README shipped a release stale. Locally the skip note stays.
2. **It caught real drift on its first run**: the rc2 cut bumped the chart to 6.0.21 without regenerating the README — the committed file still taught `--version 6.0.20` in the install example, the badge, and the release table. Regenerated here (5 lines, all version strings).
3. **The duplicate cosign paragraph in build-chart.yml collapses to the measured truth**: the stale "`--new-bundle-format=false` is a DECISION" half claimed a flag that cosign v3.1.3 refuses outright; the surviving half carries the measured refusal message and the tag-fallback chain in both directions.

Mutation proof, run live: helm-docs hidden + `CI=true` → exit 1, `helm-docs: not installed — CI must install the pinned helm-docs`; `CI=false` → the local note, run continues; restored → the real drift finding, then `chart README matches values.yaml`, exit 0. `actionlint` + `zizmor --min-severity=low`: no new findings (the nine SC2016 infos in build-chart.yml pre-exist on develop and are covered by the committed actionlint config).

`no-changelog`: CI lane + generated-file refresh + a workflow comment.