### PR TITLE
chore(sandbox): the two per-deploy build warnings are adjudicated and recorded

### DIFF
--- a/deploy/vercel/README.md
+++ b/deploy/vercel/README.md
@@ -36,6 +36,35 @@ Sandbox failures live in the two sandbox-named workflows (Sandbox deploy,
 Sandbox reseed) and nowhere else. CI, Containers, the chart and release
 lanes carry no sandbox steps, so a sandbox outage can never redden them.
 
+## Two build-log warnings that are understood, not unnoticed (#2773)
+
+Every Vercel build of `Dockerfile.vercel` prints two warnings. Both were
+adjudicated first-hand against Vercel's own documentation (read 2026-08-27)
+and neither has a configuration that removes it, so they will keep printing —
+this section is what makes them read as understood.
+
+1. `HEALTHCHECK is not supported for OCI image format and will be ignored.`
+   The published app image bakes a `HEALTHCHECK` (`docker/Dockerfile`) for
+   compose/podman consumers; Vercel's buildah builds the sandbox derivative
+   in OCI format, which has no healthcheck field, so the instruction is
+   dropped from the sandbox image only. The drop is provably inert here:
+   the service configuration reference
+   (<https://vercel.com/docs/services/config-reference>) offers no
+   healthCheck or probe key, and the container-images model expects exactly
+   one thing of the image — an HTTP server on `PORT`
+   (<https://vercel.com/docs/functions/container-images>). Nothing on the
+   platform ever reads a container healthcheck; readiness on this pipeline
+   is our own post-deploy poll of `/ferroehr/rest/status`. Removing the
+   instruction from the base image would silence the warning by taking the
+   healthcheck away from every compose user — the wrong trade.
+2. `Build output contains no "functions" or "static" directory` — the
+   framework-output check firing on a container-only project. The service
+   config reference has no key that declares container-only output
+   (`outputDirectory` configures where a framework build writes, not what
+   kind of output exists), so the warning is a known false alarm of the
+   container preset: the deploy is real (the `services`/`rewrites` config
+   routes it) and the workflow's version poll proves it serves.
+
 ## What is deliberately NOT here
 
 - No hand-maintained image pin: `:latest` is moved by the image lane on


### PR DESCRIPTION
Closes #2773.

Both warnings adjudicated first-hand against Vercel's documentation (2026-08-27), and neither has a configuration that removes it — so the outcome is the recorded understanding the issue asked for, in `deploy/vercel/README.md`:

1. **The HEALTHCHECK drop is provably inert on Vercel.** The [service configuration reference](https://vercel.com/docs/services/config-reference) accepts no healthCheck/probe key of any kind, and the [container-images model](https://vercel.com/docs/functions/container-images) expects exactly one thing of the image: an HTTP server on `PORT`. Nothing on the platform reads a container healthcheck; readiness on this pipeline is the workflow's own `/ferroehr/rest/status` poll. The instruction stays in `docker/Dockerfile` because compose/podman consumers of the published image DO read it — silencing the warning by deleting it would trade a cosmetic log line for a real capability.
2. **The empty-output warning is a known false alarm of the container preset.** No service key declares container-only output (`outputDirectory` configures where a framework build writes, not what kind of output exists). The deploy is real — `services`/`rewrites` route it, and the version poll proves it serves.

The third criterion (a subsequent deploy's log shows the intended end state) is exercised by this merge itself: `deploy/vercel/**` is a posture trigger, so the push redeploys the sandbox; the intended end state is exactly "both warnings still print, both documented" since no silencing configuration exists.

`no-changelog`: an internal delivery-doc record.