### PR TITLE
refactor(quality): clear the SonarQube dashboard's open findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Changed
+
+- The `openehr-*` spec crates step to `0.0.42`. The change is internal
+  structure only: long functions across the spec crates, the code generator and
+  the test harnesses were split into named, documented helpers, with the wire
+  behaviour, the generated output and every gate unchanged. Nothing an API
+  consumer calls moved.
+
 ## [4.0.6-rc3] - 2026-08-26
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5426,7 +5426,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "indexmap 2.14.0",
  "openehr-am",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "serde",
  "serde_json",
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "async-trait",
  "axum",
@@ -5500,7 +5500,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "assert_fs",
  "chumsky",
@@ -5514,7 +5514,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "chumsky",
  "logos",
@@ -5523,7 +5523,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "insta",
  "jsonschema",
@@ -5541,7 +5541,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/app/ferroehr-admin-ui/src/builder/lift.rs
+++ b/app/ferroehr-admin-ui/src/builder/lift.rs
@@ -659,6 +659,32 @@ fn lift_count_range(
     (leaf(base, CriterionKind::CountRange { min, max }), consumed)
 }
 
+/// The value list as code strings, or `None` when it is empty or carries a
+/// non-string member.
+fn code_list(items: &[ValueListItem]) -> Option<Vec<String>> {
+    let mut codes = Vec::with_capacity(items.len());
+    for item in items {
+        let ValueListItem::Primitive(Primitive::String(code)) = item else {
+            return None;
+        };
+        codes.push(code.clone());
+    }
+    (!codes.is_empty()).then_some(codes)
+}
+
+/// The value list as ordinals, or `None` when it is empty or carries a
+/// non-integer member.
+fn ordinal_list(items: &[ValueListItem]) -> Option<Vec<i64>> {
+    let mut values = Vec::with_capacity(items.len());
+    for item in items {
+        let ValueListItem::Primitive(Primitive::Integer(ordinal)) = item else {
+            return None;
+        };
+        values.push(*ordinal);
+    }
+    (!values.is_empty()).then_some(values)
+}
+
 /// Reduce one `WHERE` leaf to an [`Atom`], or refuse it.
 fn classify(expr: &WhereExpr) -> Result<Atom, LiftError> {
     let WhereExpr::Identified(condition) = expr else {
@@ -689,32 +715,14 @@ fn classify(expr: &WhereExpr) -> Result<Atom, LiftError> {
         } => {
             let (base, slot) = split_slot(path).ok_or_else(refuse)?;
             match slot {
-                Slot::CodeString => {
-                    let mut codes = Vec::with_capacity(items.len());
-                    for item in items {
-                        let ValueListItem::Primitive(Primitive::String(code)) = item else {
-                            return Err(refuse());
-                        };
-                        codes.push(code.clone());
-                    }
-                    if codes.is_empty() {
-                        return Err(refuse());
-                    }
-                    Ok(Atom::Codes { base, codes })
-                }
-                Slot::Value => {
-                    let mut values = Vec::with_capacity(items.len());
-                    for item in items {
-                        let ValueListItem::Primitive(Primitive::Integer(ordinal)) = item else {
-                            return Err(refuse());
-                        };
-                        values.push(*ordinal);
-                    }
-                    if values.is_empty() {
-                        return Err(refuse());
-                    }
-                    Ok(Atom::Ordinals { base, values })
-                }
+                Slot::CodeString => Ok(Atom::Codes {
+                    base,
+                    codes: code_list(items).ok_or_else(refuse)?,
+                }),
+                Slot::Value => Ok(Atom::Ordinals {
+                    base,
+                    values: ordinal_list(items).ok_or_else(refuse)?,
+                }),
                 _ => Err(refuse()),
             }
         }

--- a/app/ferroehr-admin-ui/src/builder/lower.rs
+++ b/app/ferroehr-admin-ui/src/builder/lower.rs
@@ -238,13 +238,7 @@ fn leaf(criterion: &Criterion) -> Result<WhereExpr, BuilderError> {
     let at = |suffix: &str| format!("{}/{suffix}", criterion.aql_path.trim_matches('/'));
     match &criterion.kind {
         CriterionKind::QuantityRange { min, max, units } => {
-            let mut parts = Vec::new();
-            if let Some(min) = min {
-                parts.push(compare_real(&at("magnitude"), CompOp::Ge, *min)?);
-            }
-            if let Some(max) = max {
-                parts.push(compare_real(&at("magnitude"), CompOp::Le, *max)?);
-            }
+            let mut parts = real_bounds(&at("magnitude"), *min, *max)?;
             if !units.is_empty() {
                 parts.push(compare_str(&at("units"), CompOp::Eq, units)?);
             }
@@ -258,60 +252,86 @@ fn leaf(criterion: &Criterion) -> Result<WhereExpr, BuilderError> {
             path: parse_path(COMP_VAR, &at("value"))?,
             operand: openehr_query::ast::LikeOperand::String(pattern.clone()),
         })),
-        CriterionKind::DateTimeRange { from, to } => {
-            let mut parts = Vec::new();
-            if !from.is_empty() {
-                parts.push(compare_str(&at("value"), CompOp::Ge, from)?);
-            }
-            if !to.is_empty() {
-                parts.push(compare_str(&at("value"), CompOp::Le, to)?);
-            }
-            all_of(parts)
-        }
-        CriterionKind::CountRange { min, max } => {
-            let mut parts = Vec::new();
-            if let Some(min) = min {
-                parts.push(compare_int(&at("magnitude"), CompOp::Ge, *min)?);
-            }
-            if let Some(max) = max {
-                parts.push(compare_int(&at("magnitude"), CompOp::Le, *max)?);
-            }
-            all_of(parts)
-        }
-        CriterionKind::OrdinalIn { values } => {
-            if values.is_empty() {
-                return Err(BuilderError::EmptyOrdinalList);
-            }
-            Ok(WhereExpr::Identified(IdentifiedExpr::Matches {
-                path: parse_path(COMP_VAR, &at("value"))?,
-                operand: MatchesOperand::ValueList(
-                    values
-                        .iter()
-                        .map(|v| ValueListItem::Primitive(Primitive::Integer(*v)))
-                        .collect(),
-                ),
-            }))
-        }
+        CriterionKind::DateTimeRange { from, to } => all_of(text_bounds(&at("value"), from, to)?),
+        CriterionKind::CountRange { min, max } => all_of(int_bounds(&at("magnitude"), *min, *max)?),
+        CriterionKind::OrdinalIn { values } => ordinal_in(&at("value"), values),
         CriterionKind::BooleanIs { value } => Ok(WhereExpr::Identified(IdentifiedExpr::Compare {
             lhs: CompareOperand::Path(parse_path(COMP_VAR, &at("value"))?),
             op: CompOp::Eq,
             rhs: Terminal::Primitive(Primitive::Boolean(*value)),
         })),
         CriterionKind::ProportionNumeratorRange { min, max } => {
-            let mut parts = Vec::new();
-            if let Some(min) = min {
-                parts.push(compare_real(&at("numerator"), CompOp::Ge, *min)?);
-            }
-            if let Some(max) = max {
-                parts.push(compare_real(&at("numerator"), CompOp::Le, *max)?);
-            }
-            all_of(parts)
+            all_of(real_bounds(&at("numerator"), *min, *max)?)
         }
         CriterionKind::Exists => Ok(WhereExpr::Identified(IdentifiedExpr::Exists(parse_path(
             COMP_VAR,
             &criterion.aql_path,
         )?))),
     }
+}
+
+/// The present bounds of a real-valued range, as comparisons on `path`.
+fn real_bounds(
+    path: &str,
+    min: Option<f64>,
+    max: Option<f64>,
+) -> Result<Vec<WhereExpr>, BuilderError> {
+    let mut parts = Vec::new();
+    if let Some(min) = min {
+        parts.push(compare_real(path, CompOp::Ge, min)?);
+    }
+    if let Some(max) = max {
+        parts.push(compare_real(path, CompOp::Le, max)?);
+    }
+    Ok(parts)
+}
+
+/// The present bounds of an integer-valued range, as comparisons on `path`.
+fn int_bounds(
+    path: &str,
+    min: Option<i64>,
+    max: Option<i64>,
+) -> Result<Vec<WhereExpr>, BuilderError> {
+    let mut parts = Vec::new();
+    if let Some(min) = min {
+        parts.push(compare_int(path, CompOp::Ge, min)?);
+    }
+    if let Some(max) = max {
+        parts.push(compare_int(path, CompOp::Le, max)?);
+    }
+    Ok(parts)
+}
+
+/// The present bounds of a lexical (ISO-8601 date/time) range, as comparisons
+/// on `path`. An empty string is an absent bound.
+fn text_bounds(path: &str, from: &str, to: &str) -> Result<Vec<WhereExpr>, BuilderError> {
+    let mut parts = Vec::new();
+    if !from.is_empty() {
+        parts.push(compare_str(path, CompOp::Ge, from)?);
+    }
+    if !to.is_empty() {
+        parts.push(compare_str(path, CompOp::Le, to)?);
+    }
+    Ok(parts)
+}
+
+/// `<path> MATCHES {values}` over an ordinal criterion's selected values.
+///
+/// # Errors
+/// [`BuilderError::EmptyOrdinalList`] when the criterion selects nothing.
+fn ordinal_in(path: &str, values: &[i64]) -> Result<WhereExpr, BuilderError> {
+    if values.is_empty() {
+        return Err(BuilderError::EmptyOrdinalList);
+    }
+    Ok(WhereExpr::Identified(IdentifiedExpr::Matches {
+        path: parse_path(COMP_VAR, path)?,
+        operand: MatchesOperand::ValueList(
+            values
+                .iter()
+                .map(|v| ValueListItem::Primitive(Primitive::Integer(*v)))
+                .collect(),
+        ),
+    }))
 }
 
 /// `<defining_code>/code_string MATCHES {codes}` plus an optional

--- a/app/ferroehr-admin-ui/src/clinical.rs
+++ b/app/ferroehr-admin-ui/src/clinical.rs
@@ -258,32 +258,7 @@ fn section(value: &Value, label: Option<&str>, key: String) -> RenderedSection {
             code: None,
         }));
     }
-    let headers = header_attributes(&rm_type);
-    let containers = child_attributes(&rm_type);
-    if headers.is_empty() && containers.is_empty() {
-        // A type with no table (a CONTRIBUTION, a VERSION, a demographic
-        // PARTY, an extension payload): walk what the document actually
-        // carries, minus the folded meta.
-        if let Some(map) = value.as_object() {
-            for (attribute, child) in map {
-                if is_folded(attribute) {
-                    continue;
-                }
-                push_attribute(&mut children, attribute, child, &key);
-            }
-        }
-    } else {
-        for attribute in headers {
-            if let Some(child) = value.get(*attribute) {
-                push_attribute(&mut children, attribute, child, &key);
-            }
-        }
-        for attribute in containers {
-            if let Some(child) = value.get(*attribute) {
-                push_attribute(&mut children, attribute, child, &key);
-            }
-        }
-    }
+    push_section_children(&mut children, value, &rm_type, &key);
     RenderedSection {
         key,
         title,
@@ -293,6 +268,33 @@ fn section(value: &Value, label: Option<&str>, key: String) -> RenderedSection {
             .and_then(Value::as_str)
             .map(str::to_owned),
         children,
+    }
+}
+
+/// Walks the attributes one RM object contributes to its section.
+///
+/// A type the display tables cover walks its declared header and container
+/// attributes, in that order. A type with no table (a CONTRIBUTION, a VERSION,
+/// a demographic PARTY, an extension payload) walks what the document actually
+/// carries, minus the folded meta.
+fn push_section_children(out: &mut Vec<RenderedNode>, value: &Value, rm_type: &str, key: &str) {
+    let headers = header_attributes(rm_type);
+    let containers = child_attributes(rm_type);
+    if headers.is_empty() && containers.is_empty() {
+        let Some(map) = value.as_object() else {
+            return;
+        };
+        for (attribute, child) in map {
+            if !is_folded(attribute) {
+                push_attribute(out, attribute, child, key);
+            }
+        }
+        return;
+    }
+    for attribute in headers.iter().chain(containers) {
+        if let Some(child) = value.get(*attribute) {
+            push_attribute(out, attribute, child, key);
+        }
     }
 }
 

--- a/app/ferroehr-admin-ui/src/pages/composition.rs
+++ b/app/ferroehr-admin-ui/src/pages/composition.rs
@@ -534,6 +534,74 @@ fn pane_view_from_url() -> PaneView {
         .unwrap_or_default()
 }
 
+/// Toasts the commit's outcome.
+///
+/// Both outcomes toast (an outside-world side-effect — rules §2; the console's
+/// mutation-feedback rule — crate CLAUDE.md); the resources refetch via
+/// `update.version()` in their own sources, and the CDR's diagnostic ALSO
+/// stays inline in the editor, next to the edited body.
+fn wire_commit_toast<I: Send + Sync + 'static>(
+    toaster: thaw::ToasterInjection,
+    update: Action<I, Result<String, crate::error::AdminUiError>>,
+) {
+    Effect::new(move |_| match update.value().get() {
+        Some(Ok(uid)) => {
+            let detail = if uid.is_empty() {
+                "A new version was committed.".to_owned()
+            } else {
+                format!("New version {uid}")
+            };
+            toast_success(toaster, "New version committed", &detail);
+        }
+        Some(Err(error)) => crate::feedback::toast_write_failure(
+            toaster,
+            "Commit failed",
+            "the new composition version",
+            &error,
+        ),
+        None => {}
+    });
+}
+
+/// Toasts the logical delete's outcome and leaves the screen on success.
+///
+/// A success returns to the EHR's compositions tab, whose list then reloads
+/// with the deleted composition gone. Navigation is an outside-world
+/// side-effect, so an Effect is its correct home (rules §2); it never runs on
+/// the server.
+fn wire_delete_outcome<I: Send + Sync + 'static>(
+    toaster: thaw::ToasterInjection,
+    delete: Action<I, Result<(), crate::error::AdminUiError>>,
+    ehr_id: Signal<String>,
+) {
+    let navigate = leptos_router::hooks::use_navigate();
+    Effect::new(move |_| match delete.value().get() {
+        Some(Ok(())) => {
+            toast_success(
+                toaster,
+                "Composition deleted",
+                "The composition was logically deleted — its version history stays readable.",
+            );
+            // The route param is percent-encoded through the shared href
+            // builder — never interpolated raw into a path (owner rule: all
+            // percent-coding goes through `urlencoding`).
+            navigate(
+                &format!(
+                    "{}?tab=compositions",
+                    crate::pages::ehrs::ehr_detail_href(&ehr_id.get_untracked())
+                ),
+                leptos_router::NavigateOptions::default(),
+            );
+        }
+        Some(Err(error)) => toast_error(
+            toaster,
+            "Delete failed",
+            &crate::feedback::logical_delete_failure_copy("this composition", &error),
+        ),
+        None => {}
+    });
+}
+
 /// The composition viewer screen.
 #[expect(
     clippy::must_use_candidate,
@@ -649,55 +717,8 @@ pub fn CompositionPage() -> impl IntoView {
     // refetch via `update.version()` in their sources above, and the CDR's
     // diagnostic ALSO stays inline in the editor, next to the edited body.
     let toaster = thaw::ToasterInjection::expect_context();
-    Effect::new(move |_| match update.value().get() {
-        Some(Ok(uid)) => {
-            let detail = if uid.is_empty() {
-                "A new version was committed.".to_owned()
-            } else {
-                format!("New version {uid}")
-            };
-            toast_success(toaster, "New version committed", &detail);
-        }
-        Some(Err(error)) => crate::feedback::toast_write_failure(
-            toaster,
-            "Commit failed",
-            "the new composition version",
-            &error,
-        ),
-        None => {}
-    });
-
-    // The logical delete's outcomes: both toast (the console's
-    // mutation-feedback rule — crate CLAUDE.md), and a success leaves this
-    // screen for the EHR's compositions tab, whose list then reloads with the
-    // deleted composition gone. Navigation is an outside-world side-effect, so
-    // an Effect is its correct home (rules §2); it never runs on the server.
-    let navigate = leptos_router::hooks::use_navigate();
-    Effect::new(move |_| match delete.value().get() {
-        Some(Ok(())) => {
-            toast_success(
-                toaster,
-                "Composition deleted",
-                "The composition was logically deleted — its version history stays readable.",
-            );
-            // The route param is percent-encoded through the shared href
-            // builder — never interpolated raw into a path (owner rule: all
-            // percent-coding goes through `urlencoding`).
-            navigate(
-                &format!(
-                    "{}?tab=compositions",
-                    crate::pages::ehrs::ehr_detail_href(&ehr_id.get_untracked())
-                ),
-                leptos_router::NavigateOptions::default(),
-            );
-        }
-        Some(Err(error)) => toast_error(
-            toaster,
-            "Delete failed",
-            &crate::feedback::logical_delete_failure_copy("this composition", &error),
-        ),
-        None => {}
-    });
+    wire_commit_toast(toaster, update);
+    wire_delete_outcome(toaster, delete, ehr_id);
 
     let toolbar = toolbar_section(
         format,

--- a/app/ferroehr-admin-ui/src/pages/composition.rs
+++ b/app/ferroehr-admin-ui/src/pages/composition.rs
@@ -542,7 +542,7 @@ fn pane_view_from_url() -> PaneView {
 /// stays inline in the editor, next to the edited body.
 fn wire_commit_toast<I: Send + Sync + 'static>(
     toaster: thaw::ToasterInjection,
-    update: Action<I, Result<String, crate::error::AdminUiError>>,
+    update: Action<I, Result<String, AdminUiError>>,
 ) {
     Effect::new(move |_| match update.value().get() {
         Some(Ok(uid)) => {
@@ -571,7 +571,7 @@ fn wire_commit_toast<I: Send + Sync + 'static>(
 /// the server.
 fn wire_delete_outcome<I: Send + Sync + 'static>(
     toaster: thaw::ToasterInjection,
-    delete: Action<I, Result<(), crate::error::AdminUiError>>,
+    delete: Action<I, Result<(), AdminUiError>>,
     ehr_id: Signal<String>,
 ) {
     let navigate = leptos_router::hooks::use_navigate();

--- a/app/ferroehr-admin-ui/src/pages/ehr_detail/directory/mod.rs
+++ b/app/ferroehr-admin-ui/src/pages/ehr_detail/directory/mod.rs
@@ -693,23 +693,7 @@ pub(super) fn directory_section(ehr_id: Signal<String>, selected: Memo<String>) 
         "Save failed",
         directory_toast_detail,
     );
-    Effect::new(move |_| match delete.value().get() {
-        Some(Ok(())) => crate::components::toast::toast_success(
-            toaster,
-            "Directory deleted",
-            "The directory was deleted.",
-        ),
-        Some(Err(error)) if is_conflict(&error) => conflict_toast(toaster),
-        Some(Err(error)) => {
-            crate::feedback::toast_write_failure(
-                toaster,
-                "Delete failed",
-                DIRECTORY_OBJECT,
-                &error,
-            );
-        }
-        None => {}
-    });
+    delete_toast(toaster, delete);
 
     // A version bump on any SUCCESSFUL write is the shared refetch trigger.
     // `Action::version` increments on failures too; refetching on a failed
@@ -718,46 +702,11 @@ pub(super) fn directory_section(ehr_id: Signal<String>, selected: Memo<String>) 
     // Each stamp Memo therefore sticks to its previous value on a failed
     // completion (the Memo's `prev` parameter), so only completed writes
     // reload (rules §6).
-    let create_ok = Memo::new(move |prev: Option<&usize>| {
-        let version = create.version().get();
-        if create.value().with(|v| matches!(v, Some(Ok(_)))) {
-            version
-        } else {
-            prev.copied().unwrap_or(0)
-        }
-    });
-    let update_ok = Memo::new(move |prev: Option<&usize>| {
-        let version = update.version().get();
-        if update.value().with(|v| matches!(v, Some(Ok(_)))) {
-            version
-        } else {
-            prev.copied().unwrap_or(0)
-        }
-    });
-    let delete_ok = Memo::new(move |prev: Option<&usize>| {
-        let version = delete.version().get();
-        if delete.value().with(|v| matches!(v, Some(Ok(())))) {
-            version
-        } else {
-            prev.copied().unwrap_or(0)
-        }
-    });
-    let restore_ok = Memo::new(move |prev: Option<&usize>| {
-        let version = restore.version().get();
-        if restore.value().with(|v| matches!(v, Some(Ok(_)))) {
-            version
-        } else {
-            prev.copied().unwrap_or(0)
-        }
-    });
-    let force_ok = Memo::new(move |prev: Option<&usize>| {
-        let version = force_save.version().get();
-        if force_save.value().with(|v| matches!(v, Some(Ok(_)))) {
-            version
-        } else {
-            prev.copied().unwrap_or(0)
-        }
-    });
+    let create_ok = completed_version(create);
+    let update_ok = completed_version(update);
+    let delete_ok = completed_version(delete);
+    let restore_ok = completed_version(restore);
+    let force_ok = completed_version(force_save);
     let write_version = Memo::new(move |_| {
         (
             create_ok.get(),
@@ -909,6 +858,54 @@ const DIRECTORY_OBJECT: &str = "the EHR's directory";
 /// `412` conflict with the distinct reload/save-anyway toast, and every other
 /// failure with the shared actionable copy under `failure_title`. The inline
 /// feedback pane keeps the verbatim diagnostic as well.
+/// Toasts the directory deletion's outcome — the one write whose success
+/// carries no version uid, so it does not fit [`write_toast`].
+fn delete_toast<I: Send + Sync + 'static>(
+    toaster: thaw::ToasterInjection,
+    delete: Action<I, Result<(), AdminUiError>>,
+) {
+    Effect::new(move |_| match delete.value().get() {
+        Some(Ok(())) => crate::components::toast::toast_success(
+            toaster,
+            "Directory deleted",
+            "The directory was deleted.",
+        ),
+        Some(Err(error)) if is_conflict(&error) => conflict_toast(toaster),
+        Some(Err(error)) => {
+            crate::feedback::toast_write_failure(
+                toaster,
+                "Delete failed",
+                DIRECTORY_OBJECT,
+                &error,
+            );
+        }
+        None => {}
+    });
+}
+
+/// One write action's version stamp, frozen at its previous value unless the
+/// last completion SUCCEEDED — the refetch trigger for the reads it affects.
+///
+/// `Action::version` increments on failures too; refetching on a failed save
+/// (a `412` conflict, a validation reject) would re-seed the working tree from
+/// the server and silently discard the user's unsaved edits. The stamp
+/// therefore sticks to its previous value on a failed completion (the Memo's
+/// `prev` parameter), so only completed writes reload (rules §6).
+fn completed_version<I, O>(action: Action<I, Result<O, AdminUiError>>) -> Memo<usize>
+where
+    I: Send + Sync + 'static,
+    O: Send + Sync + 'static,
+{
+    Memo::new(move |prev: Option<&usize>| {
+        let version = action.version().get();
+        if action.value().with(|v| matches!(v, Some(Ok(_)))) {
+            version
+        } else {
+            prev.copied().unwrap_or(0)
+        }
+    })
+}
+
 fn write_toast<I: Send + Sync + 'static>(
     toaster: thaw::ToasterInjection,
     action: Action<I, Result<String, AdminUiError>>,

--- a/app/ferroehr-admin-ui/src/pages/terminology.rs
+++ b/app/ferroehr-admin-ui/src/pages/terminology.rs
@@ -516,6 +516,27 @@ fn subsumption_card(selected: Signal<String>) -> AnyView {
     .into_any()
 }
 
+/// The refusal copy for an incomplete value-set form, or `None` when the form
+/// is ready to dispatch.
+///
+/// `candidate` is `Some` only for the membership test, which needs both fields.
+fn value_set_form_error(
+    terminology: &str,
+    value_set: &str,
+    candidate: Option<&str>,
+) -> Option<String> {
+    if let Some(message) = missing_selection(terminology) {
+        return Some(message);
+    }
+    let Some(candidate) = candidate else {
+        return value_set
+            .is_empty()
+            .then(|| "Type a value set id to expand.".to_owned());
+    };
+    (value_set.is_empty() || candidate.is_empty())
+        .then(|| "Both a value set id and a candidate code are needed.".to_owned())
+}
+
 /// The value-set card: expand a value set's members, then test one code's
 /// membership in it.
 #[expect(
@@ -544,12 +565,8 @@ fn value_set_card(selected: Signal<String>) -> AnyView {
     let on_expand = move |_| {
         let terminology = selected.get_untracked();
         let value_set = input_value(id_ref);
-        if let Some(message) = missing_selection(&terminology) {
+        if let Some(message) = value_set_form_error(&terminology, &value_set, None) {
             validation.set(Some(message));
-            return;
-        }
-        if value_set.is_empty() {
-            validation.set(Some("Type a value set id to expand.".to_owned()));
             return;
         }
         validation.set(None);
@@ -559,14 +576,8 @@ fn value_set_card(selected: Signal<String>) -> AnyView {
         let terminology = selected.get_untracked();
         let value_set = input_value(id_ref);
         let candidate = input_value(candidate_ref);
-        if let Some(message) = missing_selection(&terminology) {
+        if let Some(message) = value_set_form_error(&terminology, &value_set, Some(&candidate)) {
             validation.set(Some(message));
-            return;
-        }
-        if value_set.is_empty() || candidate.is_empty() {
-            validation.set(Some(
-                "Both a value set id and a candidate code are needed.".to_owned(),
-            ));
             return;
         }
         validation.set(None);

--- a/app/ferroehr-admin-ui/tests/it/e2e_docs_shots.rs
+++ b/app/ferroehr-admin-ui/tests/it/e2e_docs_shots.rs
@@ -301,6 +301,96 @@ async fn shot_to(h: &Harness, dir: &Path, slug: &str) {
     println!("captured {slug} -> {}", out.display());
 }
 
+/// Capture the stored-query screens: FIRST the true empty state (fresh
+/// database), then the populated screen and the dashboard that derives from
+/// it.
+///
+/// Three stored queries are seeded over the Definition API under TWO different
+/// namespaces, so the derived namespace grouping (and the dashboard's
+/// namespace tiles) have something real to show. Nothing is created through a
+/// group form: a query's group IS its namespace.
+async fn capture_stored_query_screens(
+    h: &Harness,
+    dir: &std::path::Path,
+    cdr: &str,
+    user: &str,
+    pass: &str,
+) {
+    let http = reqwest::Client::new();
+    // The cleanup below hits the ADMIN extension, which the plain
+    // `UI_E2E_BASIC_*` account has no ADMIN role for — so it carries the
+    // admin credential, read from the environment like every journey.
+    let admin_user = env("UI_E2E_ADMIN_USER").unwrap_or_else(|| "ferroehr-admin".to_owned());
+    let admin_pass = env("UI_E2E_ADMIN_PASS").unwrap_or_else(|| "ferroehr".to_owned());
+    // Self-cleaning: earlier runs may have seeded these — delete first (the
+    // admin extension endpoint; 404 = already absent) so the empty-state
+    // capture is honest.
+    for name in [
+        "org.example::recent-compositions",
+        "org.example::quantity-series",
+        "ehr.demo::cohort-watch",
+    ] {
+        let status = http
+            .delete(format!(
+                "{cdr}/ferroehr/rest/openehr/v1/admin/query/{name}/1.0.0"
+            ))
+            .basic_auth(&admin_user, Some(&admin_pass))
+            .send()
+            .await
+            .expect("clean stored query")
+            .status();
+        assert!(
+            status == StatusCode::NO_CONTENT || status == StatusCode::NOT_FOUND,
+            "stored-query cleanup -> {status}"
+        );
+    }
+    capture(h, dir, "/queries", "queries/queries-empty", None).await;
+    for (name, aql) in [
+        (
+            "org.example::recent-compositions",
+            "SELECT c/uid/value AS uid, c/context/start_time/value AS time                  FROM EHR e CONTAINS COMPOSITION c                  ORDER BY c/context/start_time/value DESC LIMIT 20",
+        ),
+        (
+            "org.example::quantity-series",
+            "SELECT c/context/start_time/value AS time,                  c/content[openEHR-EHR-EVALUATION.minimal.v1]/data[at0001]/items[at0002]/value/magnitude AS magnitude                  FROM EHR e CONTAINS COMPOSITION c",
+        ),
+        // A SECOND namespace, so the grouping renders more than one card
+        // (`ehr::…` is one of the spec's own qualified-name examples).
+        (
+            "ehr.demo::cohort-watch",
+            "SELECT COUNT(*) AS cohort FROM EHR e CONTAINS COMPOSITION c",
+        ),
+    ] {
+        let status = http
+            .put(format!(
+                "{cdr}/ferroehr/rest/openehr/v1/definition/query/{name}/1.0.0"
+            ))
+            .basic_auth(user, Some(pass))
+            .header("Content-Type", "text/plain")
+            .body(aql)
+            .send()
+            .await
+            .expect("seed stored query")
+            .status();
+        assert!(status.is_success(), "stored-query seed -> {status}");
+    }
+    // Capture the populated screen: rows + open-in-editor links on the left,
+    // and the DERIVED namespace cards on the right (both seeded namespaces
+    // present — no group was created by hand).
+    h.goto("/queries").await;
+    h.wait_css("a[href^='/queries/aql?load=']").await;
+    h.wait_css("[data-query-namespace=\"org.example\"]").await;
+    h.wait_css("[data-query-namespace=\"ehr.demo\"]").await;
+    shot_to(h, dir, "queries/queries").await;
+    // Re-capture the DASHBOARD now that stored queries exist: its namespace
+    // tiles are derived from this same listing, and the first pass (before
+    // seeding) could only show the empty state.
+    h.goto("/").await;
+    h.wait_css("footer").await;
+    h.wait_css("[data-namespace-tile]").await;
+    shot_to(h, dir, "dashboard/dashboard").await;
+}
+
 /// Capture the canonical documentation screenshots for every console screen.
 #[tokio::test]
 #[expect(
@@ -406,79 +496,7 @@ async fn capture_documentation_screenshots() {
         env("UI_E2E_BASIC_USER"),
         env("UI_E2E_BASIC_PASS"),
     ) {
-        let http = reqwest::Client::new();
-        // The cleanup below hits the ADMIN extension, which the plain
-        // `UI_E2E_BASIC_*` account has no ADMIN role for — so it carries the
-        // admin credential, read from the environment like every journey.
-        let admin_user = env("UI_E2E_ADMIN_USER").unwrap_or_else(|| "ferroehr-admin".to_owned());
-        let admin_pass = env("UI_E2E_ADMIN_PASS").unwrap_or_else(|| "ferroehr".to_owned());
-        // Self-cleaning: earlier runs may have seeded these — delete first
-        // (the admin extension endpoint; 404 = already absent) so the
-        // empty-state capture is honest.
-        for name in [
-            "org.example::recent-compositions",
-            "org.example::quantity-series",
-            "ehr.demo::cohort-watch",
-        ] {
-            let status = http
-                .delete(format!(
-                    "{cdr}/ferroehr/rest/openehr/v1/admin/query/{name}/1.0.0"
-                ))
-                .basic_auth(&admin_user, Some(&admin_pass))
-                .send()
-                .await
-                .expect("clean stored query")
-                .status();
-            assert!(
-                status == StatusCode::NO_CONTENT || status == StatusCode::NOT_FOUND,
-                "stored-query cleanup -> {status}"
-            );
-        }
-        capture(&h, &dir, "/queries", "queries/queries-empty", None).await;
-        for (name, aql) in [
-            (
-                "org.example::recent-compositions",
-                "SELECT c/uid/value AS uid, c/context/start_time/value AS time                  FROM EHR e CONTAINS COMPOSITION c                  ORDER BY c/context/start_time/value DESC LIMIT 20",
-            ),
-            (
-                "org.example::quantity-series",
-                "SELECT c/context/start_time/value AS time,                  c/content[openEHR-EHR-EVALUATION.minimal.v1]/data[at0001]/items[at0002]/value/magnitude AS magnitude                  FROM EHR e CONTAINS COMPOSITION c",
-            ),
-            // A SECOND namespace, so the grouping renders more than one card
-            // (`ehr::…` is one of the spec's own qualified-name examples).
-            (
-                "ehr.demo::cohort-watch",
-                "SELECT COUNT(*) AS cohort FROM EHR e CONTAINS COMPOSITION c",
-            ),
-        ] {
-            let status = http
-                .put(format!(
-                    "{cdr}/ferroehr/rest/openehr/v1/definition/query/{name}/1.0.0"
-                ))
-                .basic_auth(&user, Some(&pass))
-                .header("Content-Type", "text/plain")
-                .body(aql)
-                .send()
-                .await
-                .expect("seed stored query")
-                .status();
-            assert!(status.is_success(), "stored-query seed -> {status}");
-        }
-        // Capture the populated screen: rows + open-in-editor links on the
-        // left, and the DERIVED namespace cards on the right (both seeded
-        // namespaces present — no group was created by hand).
-        h.goto("/queries").await;
-        h.wait_css("a[href^='/queries/aql?load=']").await;
-        h.wait_css("[data-query-namespace=\"org.example\"]").await;
-        h.wait_css("[data-query-namespace=\"ehr.demo\"]").await;
-        shot_to(&h, &dir, "queries/queries").await;
-        // Re-capture the DASHBOARD now that stored queries exist: its namespace
-        // tiles are derived from this same listing, and the first pass (before
-        // seeding) could only show the empty state.
-        h.goto("/").await;
-        h.wait_css("footer").await;
-        h.wait_css("[data-namespace-tile]").await;
-        shot_to(&h, &dir, "dashboard/dashboard").await;
+        capture_stored_query_screens(&h, &dir, &cdr, &user, &pass).await;
     } else {
         capture(&h, &dir, "/queries", "queries/queries-empty", None).await;
         println!("SKIP docs-shots: stored-query seeding needs UI_E2E_CDR_URL/UI_E2E_BASIC_*");

--- a/app/ferroehr-admin-ui/tests/it/e2e_docs_shots.rs
+++ b/app/ferroehr-admin-ui/tests/it/e2e_docs_shots.rs
@@ -309,13 +309,7 @@ async fn shot_to(h: &Harness, dir: &Path, slug: &str) {
 /// namespaces, so the derived namespace grouping (and the dashboard's
 /// namespace tiles) have something real to show. Nothing is created through a
 /// group form: a query's group IS its namespace.
-async fn capture_stored_query_screens(
-    h: &Harness,
-    dir: &std::path::Path,
-    cdr: &str,
-    user: &str,
-    pass: &str,
-) {
+async fn capture_stored_query_screens(h: &Harness, dir: &Path, cdr: &str, user: &str, pass: &str) {
     let http = reqwest::Client::new();
     // The cleanup below hits the ADMIN extension, which the plain
     // `UI_E2E_BASIC_*` account has no ADMIN role for — so it carries the

--- a/app/ferroehr-ext/src/fhir/mapping.rs
+++ b/app/ferroehr-ext/src/fhir/mapping.rs
@@ -506,100 +506,161 @@ fn apply_entry(
             if let Some(v) = source(resource, entry)? {
                 flat.insert(entry.openehr_path.clone(), scalar(v, entry)?);
             }
+            Ok(())
         }
         Transform::Quantity { unit_path, unit } => {
-            if let Some(v) = source(resource, entry)? {
-                let magnitude = number(v, entry)?;
-                flat.insert(format!("{}|magnitude", entry.openehr_path), magnitude);
-            }
-            let unit_val = unit.clone().or_else(|| {
-                unit_path
-                    .as_deref()
-                    .and_then(|p| resolve(resource, p))
-                    .and_then(Value::as_str)
-                    .map(str::to_owned)
-            });
-            if let Some(u) = unit_val {
-                flat.insert(format!("{}|unit", entry.openehr_path), Value::String(u));
-            }
+            apply_quantity(resource, entry, unit_path.as_deref(), unit.as_deref(), flat)
         }
         Transform::Coded {
             system_path,
             display_path,
             translate,
         } => {
-            let fhir_path = entry
-                .fhir_path
-                .as_deref()
-                .ok_or_else(|| FhirMapError::CodedWithoutSource(entry.openehr_path.clone()))?;
-            let Some(code) = resolve(resource, fhir_path).and_then(Value::as_str) else {
-                if entry.required {
-                    return Err(FhirMapError::MissingField {
-                        fhir_path: fhir_path.to_owned(),
-                        openehr_path: entry.openehr_path.clone(),
-                    });
-                }
-                return Ok(());
+            let coded = CodedTransform {
+                system_path: system_path.as_deref(),
+                display_path: display_path.as_deref(),
+                translate: translate.as_ref(),
             };
-            let system = system_path
-                .as_deref()
-                .and_then(|p| resolve(resource, p))
-                .and_then(Value::as_str);
-            if let Some(translate) = translate {
-                let system = system.ok_or_else(|| {
-                    FhirMapError::TranslateWithoutSystem(entry.openehr_path.clone())
-                })?;
-                let Some(translated) = translations.get(system, code, &translate.target_system)
-                else {
-                    // No equivalent concept: writing the SOURCE code under the
-                    // TARGET terminology would be a silently wrong clinical
-                    // value, so a required entry refuses and an optional one
-                    // writes nothing.
-                    if entry.required {
-                        return Err(FhirMapError::Untranslatable {
-                            system: system.to_owned(),
-                            code: code.to_owned(),
-                            target_system: translate.target_system.clone(),
-                            openehr_path: entry.openehr_path.clone(),
-                        });
-                    }
-                    return Ok(());
-                };
-                flat.insert(
-                    format!("{}|code", entry.openehr_path),
-                    json!(translated.code),
-                );
-                let terminology = entry
-                    .code_map
-                    .get(&translate.target_system)
-                    .or_else(|| entry.code_map.get("*"))
-                    .map_or("local", String::as_str);
-                flat.insert(
-                    format!("{}|terminology", entry.openehr_path),
-                    json!(terminology),
-                );
-                // The translated concept's own display wins; the source
-                // resource's display_path text names the SOURCE concept.
-                if let Some(display) = &translated.display {
-                    flat.insert(format!("{}|value", entry.openehr_path), json!(display));
-                }
-                return Ok(());
-            }
-            flat.insert(format!("{}|code", entry.openehr_path), json!(code));
-            let terminology = system
-                .and_then(|s| entry.code_map.get(s))
-                .or_else(|| entry.code_map.get("*"))
-                .map_or("local", String::as_str);
-            flat.insert(
-                format!("{}|terminology", entry.openehr_path),
-                json!(terminology),
-            );
-            if let Some(dp) = display_path
-                && let Some(display) = resolve(resource, dp).and_then(Value::as_str)
-            {
-                flat.insert(format!("{}|value", entry.openehr_path), json!(display));
-            }
+            apply_coded(resource, entry, &coded, translations, flat)
         }
+    }
+}
+
+/// The `Coded` transform's own three fields, as a borrowed view.
+struct CodedTransform<'a> {
+    system_path: Option<&'a str>,
+    display_path: Option<&'a str>,
+    translate: Option<&'a CodeTranslate>,
+}
+
+/// Writes a `DV_QUANTITY`'s `|magnitude` and `|unit` leaves.
+///
+/// A literal `unit` wins over a `unit_path` read.
+///
+/// # Errors
+/// The source-read and numeric-conversion rejections of the entry.
+fn apply_quantity(
+    resource: &Value,
+    entry: &MappingEntry,
+    unit_path: Option<&str>,
+    unit: Option<&str>,
+    flat: &mut Map<String, Value>,
+) -> Result<(), FhirMapError> {
+    if let Some(v) = source(resource, entry)? {
+        let magnitude = number(v, entry)?;
+        flat.insert(format!("{}|magnitude", entry.openehr_path), magnitude);
+    }
+    let unit_val = unit.map(str::to_owned).or_else(|| {
+        unit_path
+            .and_then(|p| resolve(resource, p))
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+    });
+    if let Some(u) = unit_val {
+        flat.insert(format!("{}|unit", entry.openehr_path), Value::String(u));
+    }
+    Ok(())
+}
+
+/// Writes a coded leaf's `|code`, `|terminology` and `|value` pairs, applying
+/// a configured concept translation first.
+///
+/// # Errors
+/// [`FhirMapError::CodedWithoutSource`] for an entry with no FHIR path,
+/// [`FhirMapError::MissingField`] for a required entry whose source is absent,
+/// and the translation rejections of [`apply_translated_code`].
+fn apply_coded(
+    resource: &Value,
+    entry: &MappingEntry,
+    coded: &CodedTransform<'_>,
+    translations: &CodeTranslations,
+    flat: &mut Map<String, Value>,
+) -> Result<(), FhirMapError> {
+    let fhir_path = entry
+        .fhir_path
+        .as_deref()
+        .ok_or_else(|| FhirMapError::CodedWithoutSource(entry.openehr_path.clone()))?;
+    let Some(code) = resolve(resource, fhir_path).and_then(Value::as_str) else {
+        if entry.required {
+            return Err(FhirMapError::MissingField {
+                fhir_path: fhir_path.to_owned(),
+                openehr_path: entry.openehr_path.clone(),
+            });
+        }
+        return Ok(());
+    };
+    let system = coded
+        .system_path
+        .and_then(|p| resolve(resource, p))
+        .and_then(Value::as_str);
+    if let Some(translate) = coded.translate {
+        return apply_translated_code(entry, translate, system, code, translations, flat);
+    }
+    flat.insert(format!("{}|code", entry.openehr_path), json!(code));
+    let terminology = system
+        .and_then(|s| entry.code_map.get(s))
+        .or_else(|| entry.code_map.get("*"))
+        .map_or("local", String::as_str);
+    flat.insert(
+        format!("{}|terminology", entry.openehr_path),
+        json!(terminology),
+    );
+    if let Some(dp) = coded.display_path
+        && let Some(display) = resolve(resource, dp).and_then(Value::as_str)
+    {
+        flat.insert(format!("{}|value", entry.openehr_path), json!(display));
+    }
+    Ok(())
+}
+
+/// Writes the TRANSLATED concept for a coded leaf.
+///
+/// No equivalent concept means writing the SOURCE code under the TARGET
+/// terminology, which would be a silently wrong clinical value — so a required
+/// entry refuses and an optional one writes nothing. The translated concept's
+/// own display wins, because the source resource's `display_path` text names
+/// the SOURCE concept.
+///
+/// # Errors
+/// [`FhirMapError::TranslateWithoutSystem`] when the source coding names no
+/// system, and [`FhirMapError::Untranslatable`] for a required entry with no
+/// equivalent concept.
+fn apply_translated_code(
+    entry: &MappingEntry,
+    translate: &CodeTranslate,
+    system: Option<&str>,
+    code: &str,
+    translations: &CodeTranslations,
+    flat: &mut Map<String, Value>,
+) -> Result<(), FhirMapError> {
+    let system =
+        system.ok_or_else(|| FhirMapError::TranslateWithoutSystem(entry.openehr_path.clone()))?;
+    let Some(translated) = translations.get(system, code, &translate.target_system) else {
+        if entry.required {
+            return Err(FhirMapError::Untranslatable {
+                system: system.to_owned(),
+                code: code.to_owned(),
+                target_system: translate.target_system.clone(),
+                openehr_path: entry.openehr_path.clone(),
+            });
+        }
+        return Ok(());
+    };
+    flat.insert(
+        format!("{}|code", entry.openehr_path),
+        json!(translated.code),
+    );
+    let terminology = entry
+        .code_map
+        .get(&translate.target_system)
+        .or_else(|| entry.code_map.get("*"))
+        .map_or("local", String::as_str);
+    flat.insert(
+        format!("{}|terminology", entry.openehr_path),
+        json!(terminology),
+    );
+    if let Some(display) = &translated.display {
+        flat.insert(format!("{}|value", entry.openehr_path), json!(display));
     }
     Ok(())
 }

--- a/app/ferroehr-ext/src/fhir/reverse.rs
+++ b/app/ferroehr-ext/src/fhir/reverse.rs
@@ -105,31 +105,49 @@ fn reverse_entry(flat: &impl FlatLookup, entry: &MappingEntry, resource: &mut Va
                 set_at(resource, up, u.clone());
             }
         }
-        // NOTE: no openEHR spec governs FHIR conversion — our own design: a
-        // `translate` entry reverses to the stored (translated) coding, whose
-        // `|code`/`|terminology` pair is internally consistent.
         Transform::Coded {
             system_path,
             display_path,
             translate: _,
-        } => {
-            if let Some(code) = flat.lookup(&format!("{}|code", entry.openehr_path)) {
-                set_at(resource, fhir_path, code.clone());
-            }
-            if let Some(sp) = system_path
-                && let Some(term) = flat
-                    .lookup(&format!("{}|terminology", entry.openehr_path))
-                    .and_then(Value::as_str)
-                && let Some(system) = reverse_code_map(&entry.code_map, term)
-            {
-                set_at(resource, sp, Value::String(system));
-            }
-            if let Some(dp) = display_path
-                && let Some(display) = flat.lookup(&format!("{}|value", entry.openehr_path))
-            {
-                set_at(resource, dp, display.clone());
-            }
-        }
+        } => reverse_coded(
+            flat,
+            entry,
+            fhir_path,
+            system_path.as_deref(),
+            display_path.as_deref(),
+            resource,
+        ),
+    }
+}
+
+/// Reverses a coded leaf into its FHIR coding fields.
+///
+/// NOTE: no openEHR spec governs FHIR conversion — our own design: a
+/// `translate` entry reverses to the stored (translated) coding, whose
+/// `|code`/`|terminology` pair is internally consistent.
+fn reverse_coded(
+    flat: &impl FlatLookup,
+    entry: &MappingEntry,
+    fhir_path: &str,
+    system_path: Option<&str>,
+    display_path: Option<&str>,
+    resource: &mut Value,
+) {
+    if let Some(code) = flat.lookup(&format!("{}|code", entry.openehr_path)) {
+        set_at(resource, fhir_path, code.clone());
+    }
+    if let Some(sp) = system_path
+        && let Some(term) = flat
+            .lookup(&format!("{}|terminology", entry.openehr_path))
+            .and_then(Value::as_str)
+        && let Some(system) = reverse_code_map(&entry.code_map, term)
+    {
+        set_at(resource, sp, Value::String(system));
+    }
+    if let Some(dp) = display_path
+        && let Some(display) = flat.lookup(&format!("{}|value", entry.openehr_path))
+    {
+        set_at(resource, dp, display.clone());
     }
 }
 

--- a/app/ferroehr-rest/src/api/ehr/composition.rs
+++ b/app/ferroehr-rest/src/api/ehr/composition.rs
@@ -113,377 +113,431 @@ fn typed_composition(value: &Value) -> Result<Composition, RestError> {
     })
 }
 
-#[expect(
-    clippy::too_many_lines,
-    reason = "one arm per COMPOSITION operation: a flat match keeps every \
-              operation's wire behaviour readable in one place"
-)]
 pub(super) async fn run(
     state: AppState,
     op: &'static str,
     parts: RequestParts,
 ) -> Result<Response, RestError> {
-    let h = &parts.headers;
-    let q = parts.query.as_deref();
-    let ok = StatusCode::OK;
-    let created = StatusCode::CREATED;
-    let no_content = StatusCode::NO_CONTENT;
-    let base = state.config().server.base_path.clone();
-
     match op {
-        "composition_create" => {
-            let p = params::build::<CompositionCreateParams>(&parts.path, q, h)?;
-            let ehr_id = parse_ehr_id(&p.ehr_id)?;
-            // A FLAT/STRUCTURED (wt.flat/structured+json) body is rebuilt into a
-            // canonical composition; canonical JSON/XML pass through the RM
-            // decoder; any other Content-Type is 415.
-            let body = decode_composition_body(&state, h, &parts.body).await?;
-            let uv = super::mk_update_version(
-                h,
-                body,
-                super::CHANGE_CREATION,
-                "COMPOSITION creation",
-                None,
-            )?;
-            // The item-tag wrapper headers are parsed + invariant-checked
-            // BEFORE the commit, so a defective tag refuses the request while
-            // nothing is durable (the WRITE stays post-commit — see
-            // `pending_item_tags`).
-            let pending_tags = super::pending_item_tags(h)?;
-            let committed = state
-                .backend()
-                .create_composition(ehr_id, uv)
-                .await
-                .map_err(|e| RestError::from(ApiError::from(e)))?;
-            let uid = committed.version_uid();
-            // apply the openehr-item-tag / openehr-version-item-tag
-            // write-wrapper headers to the committed COMPOSITION
-            // (Requests_and_responses.md §…§Usage in Requests).
-            let stored_tags =
-                super::apply_item_tag_headers(&state, ehr_id, "COMPOSITION", &uid, pending_tags)
-                    .await?;
-            let meta = commit_meta(ehr_id, uid, &committed);
-            let mut resp =
-                composition_write_response(&state, h, &base, ehr_id, meta, created, created)
-                    .await?;
-            super::echo_item_tags(&mut resp, &stored_tags);
-            Ok(resp)
-        }
-        "composition_get" => {
-            let p = params::build::<CompositionGetParams>(&parts.path, q, h)?;
-            let ehr_id = parse_ehr_id(&p.ehr_id)?;
-            let uid = parse_uid_based_id(&p.uid_based_id)?;
-            // The service returns the read PLUS its version metadata (uid +
-            // commit instant): the served body is a BARE COMPOSITION, which
-            // carries no `commit_audit`, so the `Last-Modified` instant the
-            // spec derives from `VERSION.commit_audit.time_committed.value`
-            // (Requests_and_responses.md §"ETag and Last-Modified") can only
-            // come from the version row the service already read.
-            let read = if let Some(ovid) = uid.version {
-                state
-                    .backend()
-                    .composition_at_version_response(ehr_id, ovid)
-                    .await?
-            } else if p.version_at_time.is_some() {
-                state
-                    .backend()
-                    .composition_at_time_response(ehr_id, uid.vo_id, p.version_at_time)
-                    .await?
-            } else {
-                state
-                    .backend()
-                    .composition_latest_response(ehr_id, uid.vo_id)
-                    .await?
-            };
-            let RawServiceResponse { body, meta } = read;
-            // The negotiated representation decides whether the stored
-            // canonical text can pass through verbatim: a plain JSON accept
-            // with no multimedia expansion serves the stored bytes (the body
-            // is uid-stamped at commit); every other representation parses.
-            let expand = params::query_param(q, "expand_multimedia").as_deref() == Some("true");
-            let accept =
-                negotiate::resolve_accept(h, COMPOSITION_FORMATS, WireFormat::CanonicalJson);
-            let mut body = match body {
-                ReadBody::RawJson(text) if !expand && accept == Some(WireFormat::CanonicalJson) => {
-                    let mut out = negotiate::raw_json_body(ok, text);
-                    if let Some(meta) = &meta {
-                        negotiate::set_versioning_headers(&mut out, meta);
-                    }
-                    return Ok(out);
-                }
-                other => other.into_value().map_err(|e| {
-                    RestError::from(crate::overview::error::internal_fault(
-                        "re-parse the stored composition body",
-                        &e,
-                    ))
-                })?,
-            };
-            // A deleted version resolves to a null body → 204 No Content
-            // (composition_get.yaml `204_because_deleted*`).
-            if body.is_null() {
-                return Ok(negotiate::empty(no_content));
-            }
-            body = super::expand_multimedia_if_requested(&state, q, body).await?;
-            // Negotiate the representation across `Accept_LOCATABLE`: FLAT /
-            // STRUCTURED via the adapter, else canonical JSON/XML through
-            // `read_rm` (which answers 406 for an unfulfillable Accept).
-            // The version-identity headers are representation-independent —
-            // "the `ETag` value is independent of its resource serialization
-            // format (JSON/XML)" (§"ETag and Last-Modified") — so the
-            // simplified representations carry them too.
-            match accept {
-                Some(WireFormat::Flat) => {
-                    let mut out =
-                        crate::formats::dispatch::composition_flat_response(&state, ok, &body)
-                            .await?;
-                    if let Some(meta) = &meta {
-                        negotiate::set_versioning_headers(&mut out, meta);
-                    }
-                    return Ok(out);
-                }
-                Some(WireFormat::Structured) => {
-                    let mut out = crate::formats::dispatch::composition_structured_response(
-                        &state, ok, &body,
-                    )
-                    .await?;
-                    if let Some(meta) = &meta {
-                        negotiate::set_versioning_headers(&mut out, meta);
-                    }
-                    return Ok(out);
-                }
-                _ => {}
-            }
-            // 200_COMPOSITION_retrieved: ETag(version_uid) + Last-Modified
-            // (§"ETag and Last-Modified": both SHOULD accompany a resource
-            // with a unique state identifier).
-            let resp = ServiceResponse { body, meta };
-            Ok(negotiate::read_rm::<Composition>(
-                h,
-                &base,
-                Some("composition"),
-                &resp,
-                "composition",
-            ))
-        }
-        "composition_update" => {
-            let p = params::build::<CompositionUpdateParams>(&parts.path, q, h)?;
-            let ehr_id = parse_ehr_id(&p.ehr_id)?;
-            let uid = parse_uid_based_id(&p.uid_based_id)?;
-            let body = decode_composition_body(&state, h, &parts.body).await?;
-            // A body-supplied COMPOSITION.uid must identify the same
-            // versioned object as the path `uid_based_id` — never a silent
-            // write to the path's object.
-            // NOTE: the rule is OAS-grounded (docs text silent) with no
-            // assigned status; the fitting released row is 422
-            // (Requests_and_responses.md §HTTP status codes) — adjudicated.
-            if let Some(body_uid) = body.uid.as_ref() {
-                // The versioned object a body `uid` names is its
-                // OBJECT_VERSION_ID `object_id` (BASE `base_types` §Functions
-                // `object_id`). A non-UUID `object_id` cannot name the
-                // addressed object and a HIER_OBJECT_ID names no VERSION —
-                // both fail the comparison; a malformed identifier never gets
-                // here (the validating doors refuse it at parse, `400`).
-                let body_vo = match body_uid {
-                    UidBasedId::ObjectVersionId(ovid) => object_id_uuid(ovid),
-                    UidBasedId::HierObjectId(_) => None,
-                };
-                if body_vo != Some(uid.vo_id.0) {
-                    return Err(ApiError::Unprocessable(format!(
-                        "the body COMPOSITION.uid {:?} does not identify the \
-                         versioned object addressed by the request path ({})",
-                        body_uid.value(),
-                        uid.vo_id
-                    ))
-                    .into());
-                }
-            }
-            let uv = super::mk_update_version(
-                h,
-                body,
-                super::CHANGE_MODIFICATION,
-                "COMPOSITION update",
-                Some(require_if_match(&p.if_match)?),
-            )?;
-            // Judge the wrapper-header tags before the commit (see
-            // `pending_item_tags`); the write itself stays post-commit.
-            let pending_tags = super::pending_item_tags(h)?;
-            match state
-                .backend()
-                .update_composition(ehr_id, uid.vo_id, uv)
-                .await
-            {
-                Ok(committed) => {
-                    let new_uid = committed.version_uid();
-                    // apply item-tag write-wrapper headers to the new version.
-                    let stored_tags = super::apply_item_tag_headers(
-                        &state,
-                        ehr_id,
-                        "COMPOSITION",
-                        &new_uid,
-                        pending_tags,
-                    )
-                    .await?;
-                    let meta = commit_meta(ehr_id, new_uid, &committed);
-                    // The minimal-preference update is 204 — the docs text's
-                    // §"Prefer minimal…" ("If no response body is returned,
-                    // the service SHOULD use `204 No Content`") over the
-                    // released 204_version_updated.yaml ("returned when the
-                    // update operation was successful and the `Prefer` header
-                    // is missing or is set to `return=minimal`"); a bodyless
-                    // 200 matches neither declared response. Create stays
-                    // 201-only (composition_create.yaml declares no 204).
-                    let mut resp =
-                        composition_write_response(&state, h, &base, ehr_id, meta, no_content, ok)
-                            .await?;
-                    super::echo_item_tags(&mut resp, &stored_tags);
-                    Ok(resp)
-                }
-                Err(e @ ferroehr::service::error::ServiceError::VersionConflict(_)) => {
-                    let meta = state
-                        .backend()
-                        .composition_latest_meta(ehr_id, uid.vo_id)
-                        .await
-                        .ok()
-                        .flatten();
-                    Ok(negotiate::error_with_meta(
-                        ApiError::from(e),
-                        &base,
-                        Some("composition"),
-                        meta.as_ref(),
-                    ))
-                }
-                Err(e) => Err(RestError::from(ApiError::from(e))),
-            }
-        }
-        "composition_delete" => {
-            let p = params::build::<CompositionDeleteParams>(&parts.path, q, h)?;
-            let ehr_id = parse_ehr_id(&p.ehr_id)?;
-            // composition_delete.yaml: the uid_based_id MUST be an OBJECT_VERSION_ID
-            // (the preceding_version_uid to delete); a bare HIER_OBJECT_ID → 400.
-            let ovid = parse_version_uid(&p.uid_based_id)?;
-            let vo_id = object_id_uuid(&ovid).ok_or_else(|| {
-                ApiError::BadRequest(format!(
-                    "OBJECT_VERSION_ID object_id is not a UUID: {}",
-                    p.uid_based_id
-                ))
-            })?;
-            // The operation declares no `If-Match` parameter, but a RECEIVED
-            // one is honoured (overview §"If-Match and accidental
-            // overwrites": condition false → the method MUST NOT be
-            // performed). The service evaluates it AFTER its own 404/400/409
-            // pre-checks, per the RFC 9110 §13.2.1 precedence rule (ignore
-            // preconditions when the unconditioned answer is not 2xx/412);
-            // a malformed value is a 400 like every required-If-Match route.
-            let volunteered_if_match = match h.get("if-match").and_then(|v| v.to_str().ok()) {
-                Some(raw) => Some(require_if_match(raw)?),
-                None => None,
-            };
-            // A DELETE commits a `523|deleted|` version, so the committal
-            // request headers are accepted and merged here too (overview
-            // §"openehr-version and openehr-audit-details": PUT, POST and
-            // DELETE).
-            let update_audit = crate::overview::committal::committal_audit_for_delete(
-                h,
-                super::committer_proxy(),
-            )?;
-            match state
-                .backend()
-                .delete_composition(
-                    ehr_id,
-                    &ovid,
-                    volunteered_if_match.as_ref(),
-                    update_audit.as_ref(),
-                )
-                .await
-            {
-                Ok(committed) => {
-                    // 204_COMPOSITION_deleted: the deleted version's ETag +
-                    // Last-Modified — a logical delete commits a
-                    // `523|deleted|` VERSION, so its commit instant is the
-                    // resource's last modification (§"ETag and
-                    // Last-Modified"; RM common master06 §Logical Deletion).
-                    let uid = committed.version_uid();
-                    let resp = ServiceResponse::deleted(commit_meta(ehr_id, uid, &committed));
-                    Ok(negotiate::deleted_with_headers(
-                        &base,
-                        Some("composition"),
-                        &resp,
-                    ))
-                }
-                // 409_COMPOSITION_with_uid_based_id (stale / not-modifiable)
-                // and the volunteered-If-Match 412 → both decorated with the
-                // latest version_uid (overview §"If-Match and accidental
-                // overwrites": the 412 "SHOULD return also latest
-                // `version_uid` in the `ETag` response headers").
-                Err(
-                    e @ (ferroehr::service::error::ServiceError::Conflict(_)
-                    | ferroehr::service::error::ServiceError::VersionConflict(_)),
-                ) => {
-                    let meta = state
-                        .backend()
-                        .composition_latest_meta(ehr_id, VoId(vo_id))
-                        .await
-                        .ok()
-                        .flatten();
-                    Ok(negotiate::error_with_meta(
-                        ApiError::from(e),
-                        &base,
-                        Some("composition"),
-                        meta.as_ref(),
-                    ))
-                }
-                Err(e) => Err(RestError::from(ApiError::from(e))),
-            }
-        }
-        "composition_tags_get" => {
-            let p = params::build::<CompositionTagsGetParams>(&parts.path, q, h)?;
-            let ehr_id = parse_ehr_id(&p.ehr_id)?;
-            let tags = state
-                .backend()
-                .target_tags_get(ehr_id, p.uid_based_id, "COMPOSITION")
-                .await?;
-            Ok(negotiate::respond(
-                h,
-                ok,
-                &openehr_its::json::to_canonical_value(&tags),
-            ))
-        }
-        "composition_tags_update" => {
-            let p = params::build::<CompositionTagsUpdateParams>(&parts.path, q, h)?;
-            let ehr_id = parse_ehr_id(&p.ehr_id)?;
-            // Strict against `schemas/common/UpdateItemTag.yaml`
-            // (`additionalProperties: false`, `key` required): an undeclared
-            // member or a non-string `value`/`target_path` is a 400 naming the
-            // member, never a silent drop.
-            let body = negotiate::typed_json_vec::<UpdateItemTag>(h, &parts.body)?;
-            let tags = state
-                .backend()
-                .target_tags_replace(ehr_id, p.uid_based_id, "COMPOSITION", body)
-                .await?;
-            // composition_tags_update.yaml — 200 (the stored ITEM_TAG list)
-            // on `Prefer: return=representation`; 204 (`204_updated.yaml`)
-            // when `Prefer` is missing or `return=minimal` (the default —
-            // overview §Prefer), with `Preference-Applied` declaring which.
-            Ok(negotiate::write_collection(
-                h,
-                no_content,
-                ok,
-                &openehr_its::json::to_canonical_value(&tags),
-            ))
-        }
-        "composition_tags_delete" => {
-            let p = params::build::<CompositionTagsDeleteParams>(&parts.path, q, h)?;
-            let ehr_id = parse_ehr_id(&p.ehr_id)?;
-            state
-                .backend()
-                .target_tag_delete(ehr_id, p.uid_based_id, "COMPOSITION", p.key)
-                .await?;
-            Ok(negotiate::empty(no_content))
-        }
+        "composition_create" => create(state, parts).await,
+        "composition_get" => get(state, parts).await,
+        "composition_update" => Box::pin(update(state, parts)).await,
+        "composition_delete" => delete(state, parts).await,
+        "composition_tags_get" => tags_get(state, parts).await,
+        "composition_tags_update" => tags_update(state, parts).await,
+        "composition_tags_delete" => tags_delete(state, parts).await,
         other => Err(RestError(ApiError::Internal(format!(
             "unrouted ehr operation: {other}"
         )))),
     }
+}
+
+/// `composition_create` — commit a new COMPOSITION into an EHR.
+///
+/// # Errors
+/// The parameter, body-decode, commit and item-tag rejections the operation
+/// declares.
+async fn create(state: AppState, parts: RequestParts) -> Result<Response, RestError> {
+    let h = &parts.headers;
+    let q = parts.query.as_deref();
+    let created = StatusCode::CREATED;
+    let base = state.config().server.base_path.clone();
+    let p = params::build::<CompositionCreateParams>(&parts.path, q, h)?;
+    let ehr_id = parse_ehr_id(&p.ehr_id)?;
+    // A FLAT/STRUCTURED (wt.flat/structured+json) body is rebuilt into a
+    // canonical composition; canonical JSON/XML pass through the RM
+    // decoder; any other Content-Type is 415.
+    let body = decode_composition_body(&state, h, &parts.body).await?;
+    let uv = super::mk_update_version(
+        h,
+        body,
+        super::CHANGE_CREATION,
+        "COMPOSITION creation",
+        None,
+    )?;
+    // The item-tag wrapper headers are parsed + invariant-checked
+    // BEFORE the commit, so a defective tag refuses the request while
+    // nothing is durable (the WRITE stays post-commit — see
+    // `pending_item_tags`).
+    let pending_tags = super::pending_item_tags(h)?;
+    let committed = state
+        .backend()
+        .create_composition(ehr_id, uv)
+        .await
+        .map_err(|e| RestError::from(ApiError::from(e)))?;
+    let uid = committed.version_uid();
+    // apply the openehr-item-tag / openehr-version-item-tag
+    // write-wrapper headers to the committed COMPOSITION
+    // (Requests_and_responses.md §…§Usage in Requests).
+    let stored_tags =
+        super::apply_item_tag_headers(&state, ehr_id, "COMPOSITION", &uid, pending_tags).await?;
+    let meta = commit_meta(ehr_id, uid, &committed);
+    let mut resp =
+        composition_write_response(&state, h, &base, ehr_id, meta, created, created).await?;
+    super::echo_item_tags(&mut resp, &stored_tags);
+    Ok(resp)
+}
+
+/// `composition_get` — serve a COMPOSITION at a version, an instant, or its
+/// latest.
+///
+/// # Errors
+/// The parameter and read rejections the operation declares, plus a `406` for
+/// an unfulfillable `Accept`.
+async fn get(state: AppState, parts: RequestParts) -> Result<Response, RestError> {
+    let h = &parts.headers;
+    let q = parts.query.as_deref();
+    let ok = StatusCode::OK;
+    let no_content = StatusCode::NO_CONTENT;
+    let base = state.config().server.base_path.clone();
+    let p = params::build::<CompositionGetParams>(&parts.path, q, h)?;
+    let ehr_id = parse_ehr_id(&p.ehr_id)?;
+    let uid = parse_uid_based_id(&p.uid_based_id)?;
+    // The service returns the read PLUS its version metadata (uid +
+    // commit instant): the served body is a BARE COMPOSITION, which
+    // carries no `commit_audit`, so the `Last-Modified` instant the
+    // spec derives from `VERSION.commit_audit.time_committed.value`
+    // (Requests_and_responses.md §"ETag and Last-Modified") can only
+    // come from the version row the service already read.
+    let read = if let Some(ovid) = uid.version {
+        state
+            .backend()
+            .composition_at_version_response(ehr_id, ovid)
+            .await?
+    } else if p.version_at_time.is_some() {
+        state
+            .backend()
+            .composition_at_time_response(ehr_id, uid.vo_id, p.version_at_time)
+            .await?
+    } else {
+        state
+            .backend()
+            .composition_latest_response(ehr_id, uid.vo_id)
+            .await?
+    };
+    let RawServiceResponse { body, meta } = read;
+    // The negotiated representation decides whether the stored
+    // canonical text can pass through verbatim: a plain JSON accept
+    // with no multimedia expansion serves the stored bytes (the body
+    // is uid-stamped at commit); every other representation parses.
+    let expand = params::query_param(q, "expand_multimedia").as_deref() == Some("true");
+    let accept = negotiate::resolve_accept(h, COMPOSITION_FORMATS, WireFormat::CanonicalJson);
+    let mut body = match body {
+        ReadBody::RawJson(text) if !expand && accept == Some(WireFormat::CanonicalJson) => {
+            let mut out = negotiate::raw_json_body(ok, text);
+            if let Some(meta) = &meta {
+                negotiate::set_versioning_headers(&mut out, meta);
+            }
+            return Ok(out);
+        }
+        other => other.into_value().map_err(|e| {
+            RestError::from(crate::overview::error::internal_fault(
+                "re-parse the stored composition body",
+                &e,
+            ))
+        })?,
+    };
+    // A deleted version resolves to a null body → 204 No Content
+    // (composition_get.yaml `204_because_deleted*`).
+    if body.is_null() {
+        return Ok(negotiate::empty(no_content));
+    }
+    body = super::expand_multimedia_if_requested(&state, q, body).await?;
+    // Negotiate the representation across `Accept_LOCATABLE`: FLAT /
+    // STRUCTURED via the adapter, else canonical JSON/XML through
+    // `read_rm` (which answers 406 for an unfulfillable Accept).
+    // The version-identity headers are representation-independent —
+    // "the `ETag` value is independent of its resource serialization
+    // format (JSON/XML)" (§"ETag and Last-Modified") — so the
+    // simplified representations carry them too.
+    match accept {
+        Some(WireFormat::Flat) => {
+            let mut out =
+                crate::formats::dispatch::composition_flat_response(&state, ok, &body).await?;
+            if let Some(meta) = &meta {
+                negotiate::set_versioning_headers(&mut out, meta);
+            }
+            return Ok(out);
+        }
+        Some(WireFormat::Structured) => {
+            let mut out =
+                crate::formats::dispatch::composition_structured_response(&state, ok, &body)
+                    .await?;
+            if let Some(meta) = &meta {
+                negotiate::set_versioning_headers(&mut out, meta);
+            }
+            return Ok(out);
+        }
+        _ => {}
+    }
+    // 200_COMPOSITION_retrieved: ETag(version_uid) + Last-Modified
+    // (§"ETag and Last-Modified": both SHOULD accompany a resource
+    // with a unique state identifier).
+    let resp = ServiceResponse { body, meta };
+    Ok(negotiate::read_rm::<Composition>(
+        h,
+        &base,
+        Some("composition"),
+        &resp,
+        "composition",
+    ))
+}
+
+/// `composition_update` — commit a new version of a COMPOSITION.
+///
+/// # Errors
+/// The parameter, body-decode, precondition and commit rejections the
+/// operation declares.
+async fn update(state: AppState, parts: RequestParts) -> Result<Response, RestError> {
+    let h = &parts.headers;
+    let q = parts.query.as_deref();
+    let ok = StatusCode::OK;
+    let no_content = StatusCode::NO_CONTENT;
+    let base = state.config().server.base_path.clone();
+    let p = params::build::<CompositionUpdateParams>(&parts.path, q, h)?;
+    let ehr_id = parse_ehr_id(&p.ehr_id)?;
+    let uid = parse_uid_based_id(&p.uid_based_id)?;
+    let body = decode_composition_body(&state, h, &parts.body).await?;
+    // A body-supplied COMPOSITION.uid must identify the same
+    // versioned object as the path `uid_based_id` — never a silent
+    // write to the path's object.
+    // NOTE: the rule is OAS-grounded (docs text silent) with no
+    // assigned status; the fitting released row is 422
+    // (Requests_and_responses.md §HTTP status codes) — adjudicated.
+    if let Some(body_uid) = body.uid.as_ref() {
+        // The versioned object a body `uid` names is its
+        // OBJECT_VERSION_ID `object_id` (BASE `base_types` §Functions
+        // `object_id`). A non-UUID `object_id` cannot name the
+        // addressed object and a HIER_OBJECT_ID names no VERSION —
+        // both fail the comparison; a malformed identifier never gets
+        // here (the validating doors refuse it at parse, `400`).
+        let body_vo = match body_uid {
+            UidBasedId::ObjectVersionId(ovid) => object_id_uuid(ovid),
+            UidBasedId::HierObjectId(_) => None,
+        };
+        if body_vo != Some(uid.vo_id.0) {
+            return Err(ApiError::Unprocessable(format!(
+                "the body COMPOSITION.uid {:?} does not identify the \
+                         versioned object addressed by the request path ({})",
+                body_uid.value(),
+                uid.vo_id
+            ))
+            .into());
+        }
+    }
+    let uv = super::mk_update_version(
+        h,
+        body,
+        super::CHANGE_MODIFICATION,
+        "COMPOSITION update",
+        Some(require_if_match(&p.if_match)?),
+    )?;
+    // Judge the wrapper-header tags before the commit (see
+    // `pending_item_tags`); the write itself stays post-commit.
+    let pending_tags = super::pending_item_tags(h)?;
+    match state
+        .backend()
+        .update_composition(ehr_id, uid.vo_id, uv)
+        .await
+    {
+        Ok(committed) => {
+            let new_uid = committed.version_uid();
+            // apply item-tag write-wrapper headers to the new version.
+            let stored_tags = super::apply_item_tag_headers(
+                &state,
+                ehr_id,
+                "COMPOSITION",
+                &new_uid,
+                pending_tags,
+            )
+            .await?;
+            let meta = commit_meta(ehr_id, new_uid, &committed);
+            // The minimal-preference update is 204 — the docs text's
+            // §"Prefer minimal…" ("If no response body is returned,
+            // the service SHOULD use `204 No Content`") over the
+            // released 204_version_updated.yaml ("returned when the
+            // update operation was successful and the `Prefer` header
+            // is missing or is set to `return=minimal`"); a bodyless
+            // 200 matches neither declared response. Create stays
+            // 201-only (composition_create.yaml declares no 204).
+            let mut resp =
+                composition_write_response(&state, h, &base, ehr_id, meta, no_content, ok).await?;
+            super::echo_item_tags(&mut resp, &stored_tags);
+            Ok(resp)
+        }
+        Err(e @ ferroehr::service::error::ServiceError::VersionConflict(_)) => {
+            let meta = state
+                .backend()
+                .composition_latest_meta(ehr_id, uid.vo_id)
+                .await
+                .ok()
+                .flatten();
+            Ok(negotiate::error_with_meta(
+                ApiError::from(e),
+                &base,
+                Some("composition"),
+                meta.as_ref(),
+            ))
+        }
+        Err(e) => Err(RestError::from(ApiError::from(e))),
+    }
+}
+
+/// `composition_delete` — commit a `523|deleted|` version of a COMPOSITION.
+///
+/// # Errors
+/// The parameter, precondition and commit rejections the operation declares.
+async fn delete(state: AppState, parts: RequestParts) -> Result<Response, RestError> {
+    let h = &parts.headers;
+    let q = parts.query.as_deref();
+    let base = state.config().server.base_path.clone();
+    let p = params::build::<CompositionDeleteParams>(&parts.path, q, h)?;
+    let ehr_id = parse_ehr_id(&p.ehr_id)?;
+    // composition_delete.yaml: the uid_based_id MUST be an OBJECT_VERSION_ID
+    // (the preceding_version_uid to delete); a bare HIER_OBJECT_ID → 400.
+    let ovid = parse_version_uid(&p.uid_based_id)?;
+    let vo_id = object_id_uuid(&ovid).ok_or_else(|| {
+        ApiError::BadRequest(format!(
+            "OBJECT_VERSION_ID object_id is not a UUID: {}",
+            p.uid_based_id
+        ))
+    })?;
+    // The operation declares no `If-Match` parameter, but a RECEIVED
+    // one is honoured (overview §"If-Match and accidental
+    // overwrites": condition false → the method MUST NOT be
+    // performed). The service evaluates it AFTER its own 404/400/409
+    // pre-checks, per the RFC 9110 §13.2.1 precedence rule (ignore
+    // preconditions when the unconditioned answer is not 2xx/412);
+    // a malformed value is a 400 like every required-If-Match route.
+    let volunteered_if_match = match h.get("if-match").and_then(|v| v.to_str().ok()) {
+        Some(raw) => Some(require_if_match(raw)?),
+        None => None,
+    };
+    // A DELETE commits a `523|deleted|` version, so the committal
+    // request headers are accepted and merged here too (overview
+    // §"openehr-version and openehr-audit-details": PUT, POST and
+    // DELETE).
+    let update_audit =
+        crate::overview::committal::committal_audit_for_delete(h, super::committer_proxy())?;
+    match state
+        .backend()
+        .delete_composition(
+            ehr_id,
+            &ovid,
+            volunteered_if_match.as_ref(),
+            update_audit.as_ref(),
+        )
+        .await
+    {
+        Ok(committed) => {
+            // 204_COMPOSITION_deleted: the deleted version's ETag +
+            // Last-Modified — a logical delete commits a
+            // `523|deleted|` VERSION, so its commit instant is the
+            // resource's last modification (§"ETag and
+            // Last-Modified"; RM common master06 §Logical Deletion).
+            let uid = committed.version_uid();
+            let resp = ServiceResponse::deleted(commit_meta(ehr_id, uid, &committed));
+            Ok(negotiate::deleted_with_headers(
+                &base,
+                Some("composition"),
+                &resp,
+            ))
+        }
+        // 409_COMPOSITION_with_uid_based_id (stale / not-modifiable)
+        // and the volunteered-If-Match 412 → both decorated with the
+        // latest version_uid (overview §"If-Match and accidental
+        // overwrites": the 412 "SHOULD return also latest
+        // `version_uid` in the `ETag` response headers").
+        Err(
+            e @ (ferroehr::service::error::ServiceError::Conflict(_)
+            | ferroehr::service::error::ServiceError::VersionConflict(_)),
+        ) => {
+            let meta = state
+                .backend()
+                .composition_latest_meta(ehr_id, VoId(vo_id))
+                .await
+                .ok()
+                .flatten();
+            Ok(negotiate::error_with_meta(
+                ApiError::from(e),
+                &base,
+                Some("composition"),
+                meta.as_ref(),
+            ))
+        }
+        Err(e) => Err(RestError::from(ApiError::from(e))),
+    }
+}
+
+/// `composition_tags_get` — serve the item tags of a COMPOSITION.
+///
+/// # Errors
+/// The parameter and read rejections the operation declares.
+async fn tags_get(state: AppState, parts: RequestParts) -> Result<Response, RestError> {
+    let h = &parts.headers;
+    let q = parts.query.as_deref();
+    let ok = StatusCode::OK;
+    let p = params::build::<CompositionTagsGetParams>(&parts.path, q, h)?;
+    let ehr_id = parse_ehr_id(&p.ehr_id)?;
+    let tags = state
+        .backend()
+        .target_tags_get(ehr_id, p.uid_based_id, "COMPOSITION")
+        .await?;
+    Ok(negotiate::respond(
+        h,
+        ok,
+        &openehr_its::json::to_canonical_value(&tags),
+    ))
+}
+
+/// `composition_tags_update` — replace the item tags of a COMPOSITION.
+///
+/// # Errors
+/// The parameter and body rejections the operation declares — the body is
+/// strict against `schemas/common/UpdateItemTag.yaml`.
+async fn tags_update(state: AppState, parts: RequestParts) -> Result<Response, RestError> {
+    let h = &parts.headers;
+    let q = parts.query.as_deref();
+    let ok = StatusCode::OK;
+    let no_content = StatusCode::NO_CONTENT;
+    let p = params::build::<CompositionTagsUpdateParams>(&parts.path, q, h)?;
+    let ehr_id = parse_ehr_id(&p.ehr_id)?;
+    // Strict against `schemas/common/UpdateItemTag.yaml`
+    // (`additionalProperties: false`, `key` required): an undeclared
+    // member or a non-string `value`/`target_path` is a 400 naming the
+    // member, never a silent drop.
+    let body = negotiate::typed_json_vec::<UpdateItemTag>(h, &parts.body)?;
+    let tags = state
+        .backend()
+        .target_tags_replace(ehr_id, p.uid_based_id, "COMPOSITION", body)
+        .await?;
+    // composition_tags_update.yaml — 200 (the stored ITEM_TAG list)
+    // on `Prefer: return=representation`; 204 (`204_updated.yaml`)
+    // when `Prefer` is missing or `return=minimal` (the default —
+    // overview §Prefer), with `Preference-Applied` declaring which.
+    Ok(negotiate::write_collection(
+        h,
+        no_content,
+        ok,
+        &openehr_its::json::to_canonical_value(&tags),
+    ))
+}
+
+/// `composition_tags_delete` — remove one item tag of a COMPOSITION.
+///
+/// # Errors
+/// The parameter and delete rejections the operation declares.
+async fn tags_delete(state: AppState, parts: RequestParts) -> Result<Response, RestError> {
+    let h = &parts.headers;
+    let q = parts.query.as_deref();
+    let no_content = StatusCode::NO_CONTENT;
+    let p = params::build::<CompositionTagsDeleteParams>(&parts.path, q, h)?;
+    let ehr_id = parse_ehr_id(&p.ehr_id)?;
+    state
+        .backend()
+        .target_tag_delete(ehr_id, p.uid_based_id, "COMPOSITION", p.key)
+        .await?;
+    Ok(negotiate::empty(no_content))
 }
 
 /// The committed COMPOSITION version's [`ResourceMeta`]: the new

--- a/app/ferroehr-rest/src/api/ehr/directory.rs
+++ b/app/ferroehr-rest/src/api/ehr/directory.rs
@@ -33,134 +33,88 @@ use crate::overview::version_id::{parse_ehr_id, parse_version_uid, require_if_ma
 use crate::state::AppState;
 use crate::{negotiate, params};
 
-#[expect(
-    clippy::too_many_lines,
-    reason = "one arm per DIRECTORY operation: a flat match keeps every \
-              operation's wire behaviour readable in one place"
-)]
 pub(super) async fn run(
     state: AppState,
     op: &'static str,
     parts: RequestParts,
 ) -> Result<Response, RestError> {
+    // DIRECTORY (FOLDER) is not templated → no Simplified-Formats mapping;
+    // reject a simplified Content-Type/Accept uniformly (see `formats::dispatch`).
+    crate::formats::dispatch::guard_non_templated(&parts.headers)?;
+
+    match op {
+        "directory_get_at_time" => get_at_time(state, parts).await,
+        "directory_update" => Box::pin(update(state, parts)).await,
+        "directory_create" => create(state, parts).await,
+        "directory_delete" => delete(state, parts).await,
+        "directory_get_by_version_id" => get_by_version_id(state, parts).await,
+        other => Err(RestError(ApiError::Internal(format!(
+            "unrouted ehr operation: {other}"
+        )))),
+    }
+}
+
+/// `directory_get_at_time` — serve the EHR's directory as of an instant.
+///
+/// # Errors
+/// The parameter and read rejections the operation declares.
+async fn get_at_time(state: AppState, parts: RequestParts) -> Result<Response, RestError> {
     let h = &parts.headers;
     let q = parts.query.as_deref();
     let ok = StatusCode::OK;
-    let created = StatusCode::CREATED;
+    let no_content = StatusCode::NO_CONTENT;
+    let p = params::build::<DirectoryGetAtTimeParams>(&parts.path, q, h)?;
+    let ehr_id = parse_ehr_id(&p.ehr_id)?;
+    let resp = state
+        .backend()
+        .get_directory_at_time(ehr_id, p.version_at_time, p.path)
+        .await?;
+    // Deleted directory → 204 (directory_get_at_time.yaml 204_because_deleted_at_time).
+    if resp.body.is_null() {
+        return Ok(negotiate::empty(no_content));
+    }
+    // ETag + Last-Modified on the read too (overview §"ETag and
+    // Last-Modified": both SHOULD accompany versioned resources);
+    // no Location on GET (overview §Location).
+    // A FOLDER's DV_MULTIMEDIA is externalized by the same generic
+    // versioning path as a COMPOSITION's, so it re-inlines here.
+    let mut resp = resp;
+    resp.body = super::expand_multimedia_if_requested(&state, q, resp.body).await?;
+    let mut out = negotiate::respond_rm::<Folder>(h, ok, &resp.body, "folder");
+    if let Some(meta) = &resp.meta {
+        negotiate::set_versioning_headers(&mut out, meta);
+    }
+    Ok(out)
+}
+
+/// `directory_update` — commit a new version of the EHR's directory.
+///
+/// # Errors
+/// The parameter, precondition and commit rejections the operation declares.
+async fn update(state: AppState, parts: RequestParts) -> Result<Response, RestError> {
+    let h = &parts.headers;
+    let q = parts.query.as_deref();
+    let ok = StatusCode::OK;
     let no_content = StatusCode::NO_CONTENT;
     let base = state.config().server.base_path.clone();
-
-    // DIRECTORY (FOLDER) is not templated → no Simplified-Formats mapping;
-    // reject a simplified Content-Type/Accept uniformly (see `formats::dispatch`).
-    crate::formats::dispatch::guard_non_templated(h)?;
-
-    match op {
-        "directory_get_at_time" => {
-            let p = params::build::<DirectoryGetAtTimeParams>(&parts.path, q, h)?;
-            let ehr_id = parse_ehr_id(&p.ehr_id)?;
-            let resp = state
-                .backend()
-                .get_directory_at_time(ehr_id, p.version_at_time, p.path)
-                .await?;
-            // Deleted directory → 204 (directory_get_at_time.yaml 204_because_deleted_at_time).
-            if resp.body.is_null() {
-                return Ok(negotiate::empty(no_content));
-            }
-            // ETag + Last-Modified on the read too (overview §"ETag and
-            // Last-Modified": both SHOULD accompany versioned resources);
-            // no Location on GET (overview §Location).
-            // A FOLDER's DV_MULTIMEDIA is externalized by the same generic
-            // versioning path as a COMPOSITION's, so it re-inlines here.
-            let mut resp = resp;
-            resp.body = super::expand_multimedia_if_requested(&state, q, resp.body).await?;
-            let mut out = negotiate::respond_rm::<Folder>(h, ok, &resp.body, "folder");
-            if let Some(meta) = &resp.meta {
-                negotiate::set_versioning_headers(&mut out, meta);
-            }
-            Ok(out)
-        }
-        "directory_update" => {
-            let p = params::build::<DirectoryUpdateParams>(&parts.path, q, h)?;
-            let ehr_id = parse_ehr_id(&p.ehr_id)?;
-            let body = negotiate::rm_value::<Folder>(h, &parts.body)?;
-            let uv = super::mk_update_version(
-                h,
-                body,
-                super::CHANGE_MODIFICATION,
-                "DIRECTORY update",
-                Some(require_if_match(&p.if_match)?),
-            )?;
-            // 204_directory_updated (default) / 200_directory_updated
-            // (representation); ETag + Location on both. 412 → latest version_uid.
-            // Judge the wrapper-header tags before the commit (see
-            // `crate::api::ehr::pending_item_tags`); the write stays after it.
-            let pending_tags = super::pending_item_tags(h)?;
-            match state.backend().update_directory(ehr_id, uv).await {
-                Ok(meta) => {
-                    // apply item-tag write-wrapper headers to the new version.
-                    let stored_tags = super::apply_item_tag_headers(
-                        &state,
-                        ehr_id,
-                        "FOLDER",
-                        &meta.uid,
-                        pending_tags,
-                    )
-                    .await?;
-                    let repr = if negotiate::prefers_representation(h) {
-                        state
-                            .backend()
-                            .get_directory_at_time(ehr_id, None, None)
-                            .await?
-                            .body
-                    } else {
-                        Value::Null
-                    };
-                    let resp = ServiceResponse::new(repr, meta);
-                    let mut resp = negotiate::write_rm::<Folder>(
-                        h,
-                        &base,
-                        no_content,
-                        ok,
-                        Some("directory"),
-                        &resp,
-                        "folder",
-                    );
-                    super::echo_item_tags(&mut resp, &stored_tags);
-                    Ok(resp)
-                }
-                Err(e) if e.status == CallStatusType::VersionMismatch => {
-                    let meta = state
-                        .backend()
-                        .directory_latest_meta(ehr_id)
-                        .await
-                        .ok()
-                        .flatten();
-                    Ok(negotiate::error_with_meta(
-                        sm_api_error(e),
-                        &base,
-                        Some("directory"),
-                        meta.as_ref(),
-                    ))
-                }
-                Err(e) => Err(RestError::from(e)),
-            }
-        }
-        "directory_create" => {
-            let p = params::build::<DirectoryCreateParams>(&parts.path, q, h)?;
-            let ehr_id = parse_ehr_id(&p.ehr_id)?;
-            let body = negotiate::rm_value::<Folder>(h, &parts.body)?;
-            let uv = super::mk_update_version(
-                h,
-                body,
-                super::CHANGE_CREATION,
-                "DIRECTORY creation",
-                None,
-            )?;
-            // Judge the wrapper-header tags before the commit (see
-            // `crate::api::ehr::pending_item_tags`); the write stays after it.
-            let pending_tags = super::pending_item_tags(h)?;
-            let meta = state.backend().create_directory(ehr_id, uv).await?;
-            // apply item-tag write-wrapper headers to the committed FOLDER.
+    let p = params::build::<DirectoryUpdateParams>(&parts.path, q, h)?;
+    let ehr_id = parse_ehr_id(&p.ehr_id)?;
+    let body = negotiate::rm_value::<Folder>(h, &parts.body)?;
+    let uv = super::mk_update_version(
+        h,
+        body,
+        super::CHANGE_MODIFICATION,
+        "DIRECTORY update",
+        Some(require_if_match(&p.if_match)?),
+    )?;
+    // 204_directory_updated (default) / 200_directory_updated
+    // (representation); ETag + Location on both. 412 → latest version_uid.
+    // Judge the wrapper-header tags before the commit (see
+    // `crate::api::ehr::pending_item_tags`); the write stays after it.
+    let pending_tags = super::pending_item_tags(h)?;
+    match state.backend().update_directory(ehr_id, uv).await {
+        Ok(meta) => {
+            // apply item-tag write-wrapper headers to the new version.
             let stored_tags =
                 super::apply_item_tag_headers(&state, ehr_id, "FOLDER", &meta.uid, pending_tags)
                     .await?;
@@ -174,12 +128,11 @@ pub(super) async fn run(
                 Value::Null
             };
             let resp = ServiceResponse::new(repr, meta);
-            // 201_directory: ETag + Location; body only on return=representation.
             let mut resp = negotiate::write_rm::<Folder>(
                 h,
                 &base,
-                created,
-                created,
+                no_content,
+                ok,
                 Some("directory"),
                 &resp,
                 "folder",
@@ -187,78 +140,150 @@ pub(super) async fn run(
             super::echo_item_tags(&mut resp, &stored_tags);
             Ok(resp)
         }
-        "directory_delete" => {
-            let p = params::build::<DirectoryDeleteParams>(&parts.path, q, h)?;
-            let ehr_id = parse_ehr_id(&p.ehr_id)?;
-            // 204_because_deleted declares no headers; 412_directory → latest version_uid.
-            // A DELETE commits a `523|deleted|` version, so the committal
-            // request headers are accepted and merged here too (overview
-            // §"openehr-version and openehr-audit-details": PUT, POST and
-            // DELETE).
-            let update_audit = crate::overview::committal::committal_audit_for_delete(
-                h,
-                super::committer_proxy(),
-            )?;
-            match state
+        Err(e) if e.status == CallStatusType::VersionMismatch => {
+            let meta = state
                 .backend()
-                .delete_directory(
-                    ehr_id,
-                    Some(require_if_match(&p.if_match)?),
-                    update_audit.as_ref(),
-                )
+                .directory_latest_meta(ehr_id)
                 .await
-            {
-                // 204 with the NEW deleted version's weak ETag + Last-Modified
-                // (overview §"ETag and Last-Modified": both SHOULD accompany
-                // versioned resources; the delete commits a 523|deleted|
-                // version — RM common master06 §Logical Deletion).
-                Ok(resp) => Ok(negotiate::deleted_with_headers(
-                    &base,
-                    Some("directory"),
-                    &resp,
-                )),
-                Err(e) if e.status == CallStatusType::VersionMismatch => {
-                    let meta = state
-                        .backend()
-                        .directory_latest_meta(ehr_id)
-                        .await
-                        .ok()
-                        .flatten();
-                    Ok(negotiate::error_with_meta(
-                        sm_api_error(e),
-                        &base,
-                        Some("directory"),
-                        meta.as_ref(),
-                    ))
-                }
-                Err(e) => Err(RestError::from(e)),
-            }
+                .ok()
+                .flatten();
+            Ok(negotiate::error_with_meta(
+                sm_api_error(e),
+                &base,
+                Some("directory"),
+                meta.as_ref(),
+            ))
         }
-        "directory_get_by_version_id" => {
-            let p = params::build::<DirectoryGetByVersionIdParams>(&parts.path, q, h)?;
-            let ehr_id = parse_ehr_id(&p.ehr_id)?;
-            let ovid = parse_version_uid(&p.version_uid)?;
-            let resp = state
-                .backend()
-                .get_directory_at_version(ehr_id, ovid, p.path.as_deref())
-                .await?;
-            if resp.body.is_null() {
-                return Ok(negotiate::empty(no_content));
-            }
-            // ETag + Last-Modified on the version read (overview §"ETag and
-            // Last-Modified"); no Location on GET (overview §Location).
-            // A FOLDER's DV_MULTIMEDIA is externalized by the same generic
-            // versioning path as a COMPOSITION's, so it re-inlines here.
-            let mut resp = resp;
-            resp.body = super::expand_multimedia_if_requested(&state, q, resp.body).await?;
-            let mut out = negotiate::respond_rm::<Folder>(h, ok, &resp.body, "folder");
-            if let Some(meta) = &resp.meta {
-                negotiate::set_versioning_headers(&mut out, meta);
-            }
-            Ok(out)
-        }
-        other => Err(RestError(ApiError::Internal(format!(
-            "unrouted ehr operation: {other}"
-        )))),
+        Err(e) => Err(RestError::from(e)),
     }
+}
+
+/// `directory_create` — commit the EHR's first directory version.
+///
+/// # Errors
+/// The parameter and commit rejections the operation declares.
+async fn create(state: AppState, parts: RequestParts) -> Result<Response, RestError> {
+    let h = &parts.headers;
+    let q = parts.query.as_deref();
+    let created = StatusCode::CREATED;
+    let base = state.config().server.base_path.clone();
+    let p = params::build::<DirectoryCreateParams>(&parts.path, q, h)?;
+    let ehr_id = parse_ehr_id(&p.ehr_id)?;
+    let body = negotiate::rm_value::<Folder>(h, &parts.body)?;
+    let uv = super::mk_update_version(h, body, super::CHANGE_CREATION, "DIRECTORY creation", None)?;
+    // Judge the wrapper-header tags before the commit (see
+    // `crate::api::ehr::pending_item_tags`); the write stays after it.
+    let pending_tags = super::pending_item_tags(h)?;
+    let meta = state.backend().create_directory(ehr_id, uv).await?;
+    // apply item-tag write-wrapper headers to the committed FOLDER.
+    let stored_tags =
+        super::apply_item_tag_headers(&state, ehr_id, "FOLDER", &meta.uid, pending_tags).await?;
+    let repr = if negotiate::prefers_representation(h) {
+        state
+            .backend()
+            .get_directory_at_time(ehr_id, None, None)
+            .await?
+            .body
+    } else {
+        Value::Null
+    };
+    let resp = ServiceResponse::new(repr, meta);
+    // 201_directory: ETag + Location; body only on return=representation.
+    let mut resp = negotiate::write_rm::<Folder>(
+        h,
+        &base,
+        created,
+        created,
+        Some("directory"),
+        &resp,
+        "folder",
+    );
+    super::echo_item_tags(&mut resp, &stored_tags);
+    Ok(resp)
+}
+
+/// `directory_delete` — commit a `523|deleted|` version of the EHR's
+/// directory.
+///
+/// # Errors
+/// The parameter, precondition and commit rejections the operation declares.
+async fn delete(state: AppState, parts: RequestParts) -> Result<Response, RestError> {
+    let h = &parts.headers;
+    let q = parts.query.as_deref();
+    let base = state.config().server.base_path.clone();
+    let p = params::build::<DirectoryDeleteParams>(&parts.path, q, h)?;
+    let ehr_id = parse_ehr_id(&p.ehr_id)?;
+    // 204_because_deleted declares no headers; 412_directory → latest version_uid.
+    // A DELETE commits a `523|deleted|` version, so the committal
+    // request headers are accepted and merged here too (overview
+    // §"openehr-version and openehr-audit-details": PUT, POST and
+    // DELETE).
+    let update_audit =
+        crate::overview::committal::committal_audit_for_delete(h, super::committer_proxy())?;
+    match state
+        .backend()
+        .delete_directory(
+            ehr_id,
+            Some(require_if_match(&p.if_match)?),
+            update_audit.as_ref(),
+        )
+        .await
+    {
+        // 204 with the NEW deleted version's weak ETag + Last-Modified
+        // (overview §"ETag and Last-Modified": both SHOULD accompany
+        // versioned resources; the delete commits a 523|deleted|
+        // version — RM common master06 §Logical Deletion).
+        Ok(resp) => Ok(negotiate::deleted_with_headers(
+            &base,
+            Some("directory"),
+            &resp,
+        )),
+        Err(e) if e.status == CallStatusType::VersionMismatch => {
+            let meta = state
+                .backend()
+                .directory_latest_meta(ehr_id)
+                .await
+                .ok()
+                .flatten();
+            Ok(negotiate::error_with_meta(
+                sm_api_error(e),
+                &base,
+                Some("directory"),
+                meta.as_ref(),
+            ))
+        }
+        Err(e) => Err(RestError::from(e)),
+    }
+}
+
+/// `directory_get_by_version_id` — serve one version of the EHR's directory.
+///
+/// # Errors
+/// The parameter and read rejections the operation declares.
+async fn get_by_version_id(state: AppState, parts: RequestParts) -> Result<Response, RestError> {
+    let h = &parts.headers;
+    let q = parts.query.as_deref();
+    let ok = StatusCode::OK;
+    let no_content = StatusCode::NO_CONTENT;
+    let p = params::build::<DirectoryGetByVersionIdParams>(&parts.path, q, h)?;
+    let ehr_id = parse_ehr_id(&p.ehr_id)?;
+    let ovid = parse_version_uid(&p.version_uid)?;
+    let resp = state
+        .backend()
+        .get_directory_at_version(ehr_id, ovid, p.path.as_deref())
+        .await?;
+    if resp.body.is_null() {
+        return Ok(negotiate::empty(no_content));
+    }
+    // ETag + Last-Modified on the version read (overview §"ETag and
+    // Last-Modified"); no Location on GET (overview §Location).
+    // A FOLDER's DV_MULTIMEDIA is externalized by the same generic
+    // versioning path as a COMPOSITION's, so it re-inlines here.
+    let mut resp = resp;
+    resp.body = super::expand_multimedia_if_requested(&state, q, resp.body).await?;
+    let mut out = negotiate::respond_rm::<Folder>(h, ok, &resp.body, "folder");
+    if let Some(meta) = &resp.meta {
+        negotiate::set_versioning_headers(&mut out, meta);
+    }
+    Ok(out)
 }

--- a/app/ferroehr-rest/src/extensions/access/authn/mod.rs
+++ b/app/ferroehr-rest/src/extensions/access/authn/mod.rs
@@ -676,64 +676,13 @@ pub(crate) async fn middleware(
 
     match auth.authenticate(req.headers()).await {
         Ok(Authenticated { principal, fresh }) => {
-            // RBAC gate: resolve the matched operation's class and gate it
-            // against the caller's roles. `None` authz handle = auth-only.
-            if let Some(rbac) = layer.authz.as_deref().and_then(AuthzHandle::rbac) {
-                let matched = req
-                    .extensions()
-                    .get::<MatchedPath>()
-                    .map(|m| m.as_str().to_owned());
-                let class = rbac.class_for(req.method(), matched.as_deref());
-                // The coarse class gate, then the read-only restriction: a
-                // principal carrying the configured read-only role is refused on
-                // every write operation, overriding any grant. Both denials share
-                // the one 403 path below (no openEHR spec governs role semantics
-                // — our own design/extension).
-                let decision = match rbac.decide(class, &principal.roles) {
-                    RbacDecision::Deny(reason) => RbacDecision::Deny(reason),
-                    RbacDecision::Allow => {
-                        let is_write = rbac.is_write_for(req.method(), matched.as_deref());
-                        rbac.decide_readonly(is_write, &principal.roles)
-                    }
-                };
-                if let RbacDecision::Deny(reason) = decision {
-                    count_auth_failure(mechanism_label(principal.method), "403");
-                    // Attribute the 403 to the authenticated caller so the outer
-                    // ATNA audit layer records the denied access.
-                    let mut resp = RestError(ApiError::Forbidden(reason)).into_response();
-                    resp.extensions_mut().insert(principal);
-                    return resp;
-                }
+            if let Some(refusal) = rbac_refusal(&layer, &req, &principal) {
+                return refusal;
             }
             req.extensions_mut().insert(principal.clone());
             // Publish the principal for the service layer (committer attribution).
             let for_audit = principal.clone();
-            // Also publish the platform committer identity: a default-committer
-            // audit (a write whose request carried no committal headers) is
-            // attributed to the authenticated principal instead of the system
-            // identity (`AUDIT_DETAILS.committer` 1..1 — RM common master04
-            // §Audit Details).
-            let committer = ferroehr::service::committer::CommitterIdentity {
-                subject: for_audit.subject.clone(),
-                id_type: match for_audit.method {
-                    AuthMethod::Basic => "basic",
-                    AuthMethod::Bearer => "oauth2",
-                },
-                // A Bearer principal's subject was minted by the identity
-                // provider, so the issuing authority the audit records is the
-                // validated token issuer (`iss`, checked against the configured
-                // issuer in `jwt.rs` before the claim set is retained), never
-                // this server. Basic credentials are held locally and carry no
-                // external issuer, so the platform stamps its own product name.
-                issuer: match for_audit.method {
-                    AuthMethod::Basic => None,
-                    AuthMethod::Bearer => for_audit
-                        .claims
-                        .get("iss")
-                        .and_then(serde_json::Value::as_str)
-                        .map(str::to_owned),
-                },
-            };
+            let committer = committer_identity(&for_audit);
             let mut resp = REQUEST_PRINCIPAL
                 .scope(
                     Some(principal),
@@ -750,50 +699,105 @@ pub(crate) async fn middleware(
             }
             resp
         }
-        Err(e) => {
-            let api = e.to_api_error();
-            let status = api.status();
-            let mechanism = scheme_label(req.headers());
-            ferroehr::telemetry::metrics::metrics().auth_failures.add(
-                1,
-                &[
-                    opentelemetry::KeyValue::new("mechanism", mechanism),
-                    opentelemetry::KeyValue::new(
-                        "status",
-                        if status == StatusCode::FORBIDDEN {
-                            "403"
-                        } else {
-                            "401"
-                        },
-                    ),
-                ],
-            );
-            // A refusal that presented no credential is routine (an
-            // unauthenticated probe); a presented-and-rejected one is the
-            // operator's signal. Neither record carries the token or a claim
-            // value.
-            let reason = e.label();
-            if matches!(e, AuthError::MissingCredentials) {
-                tracing::debug!(mechanism, reason, "authentication refused");
-            } else {
-                tracing::warn!(mechanism, reason, detail = %e, "authentication refused");
-            }
-            // ITS-REST §Authentication and authorization: a `401` MUST carry a
-            // `WWW-Authenticate` challenge. RFC 6750 §3 additionally carries one
-            // on a bearer `403` — the `insufficient_scope` case — because there
-            // the challenge tells the client WHAT it lacks rather than that it is
-            // unauthenticated.
-            let needs_challenge =
-                matches!(status, StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN);
-            let challenge = auth.challenge(Some(&e));
-            let mut resp = RestError(api).into_response();
-            if needs_challenge {
-                resp.headers_mut()
-                    .insert(header::WWW_AUTHENTICATE, challenge);
-            }
-            resp
-        }
+        Err(e) => refusal_response(auth, req.headers(), &e),
     }
+}
+
+/// The RBAC gate over an authenticated caller: the matched operation's class
+/// against the caller's roles, then the read-only restriction.
+///
+/// A principal carrying the configured read-only role is refused on every
+/// write operation, overriding any grant. Both denials produce the same `403`,
+/// attributed to the authenticated caller so the outer ATNA audit layer
+/// records the denied access. A `None` authz handle is auth-only, and no
+/// openEHR spec governs role semantics — our own design/extension.
+fn rbac_refusal(layer: &AuthLayer, req: &Request, principal: &Principal) -> Option<Response> {
+    let rbac = layer.authz.as_deref().and_then(AuthzHandle::rbac)?;
+    let matched = req
+        .extensions()
+        .get::<MatchedPath>()
+        .map(|m| m.as_str().to_owned());
+    let class = rbac.class_for(req.method(), matched.as_deref());
+    let decision = match rbac.decide(class, &principal.roles) {
+        RbacDecision::Deny(reason) => RbacDecision::Deny(reason),
+        RbacDecision::Allow => {
+            let is_write = rbac.is_write_for(req.method(), matched.as_deref());
+            rbac.decide_readonly(is_write, &principal.roles)
+        }
+    };
+    let RbacDecision::Deny(reason) = decision else {
+        return None;
+    };
+    count_auth_failure(mechanism_label(principal.method), "403");
+    let mut resp = RestError(ApiError::Forbidden(reason)).into_response();
+    resp.extensions_mut().insert(principal.clone());
+    Some(resp)
+}
+
+/// The platform committer identity published for the service layer.
+///
+/// A default-committer audit (a write whose request carried no committal
+/// headers) is attributed to the authenticated principal instead of the system
+/// identity (`AUDIT_DETAILS.committer` 1..1 — RM common master04 §Audit
+/// Details). A Bearer principal's subject was minted by the identity provider,
+/// so the issuing authority the audit records is the validated token issuer
+/// (`iss`, checked against the configured issuer in `jwt.rs` before the claim
+/// set is retained), never this server; Basic credentials are held locally and
+/// carry no external issuer.
+fn committer_identity(principal: &Principal) -> ferroehr::service::committer::CommitterIdentity {
+    ferroehr::service::committer::CommitterIdentity {
+        subject: principal.subject.clone(),
+        id_type: match principal.method {
+            AuthMethod::Basic => "basic",
+            AuthMethod::Bearer => "oauth2",
+        },
+        issuer: match principal.method {
+            AuthMethod::Basic => None,
+            AuthMethod::Bearer => principal
+                .claims
+                .get("iss")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned),
+        },
+    }
+}
+
+/// The response for a refused authentication, metered and logged.
+///
+/// A refusal that presented no credential is routine (an unauthenticated
+/// probe); a presented-and-rejected one is the operator's signal. Neither
+/// record carries the token or a claim value.
+///
+/// ITS-REST §Authentication and authorization: a `401` MUST carry a
+/// `WWW-Authenticate` challenge. RFC 6750 §3 additionally carries one on a
+/// bearer `403` — the `insufficient_scope` case — because there the challenge
+/// tells the client WHAT it lacks rather than that it is unauthenticated.
+fn refusal_response(auth: &Authenticator, headers: &header::HeaderMap, e: &AuthError) -> Response {
+    let api = e.to_api_error();
+    let status = api.status();
+    let mechanism = scheme_label(headers);
+    count_auth_failure(
+        mechanism,
+        if status == StatusCode::FORBIDDEN {
+            "403"
+        } else {
+            "401"
+        },
+    );
+    let reason = e.label();
+    if matches!(e, AuthError::MissingCredentials) {
+        tracing::debug!(mechanism, reason, "authentication refused");
+    } else {
+        tracing::warn!(mechanism, reason, detail = %e, "authentication refused");
+    }
+    let needs_challenge = matches!(status, StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN);
+    let challenge = auth.challenge(Some(e));
+    let mut resp = RestError(api).into_response();
+    if needs_challenge {
+        resp.headers_mut()
+            .insert(header::WWW_AUTHENTICATE, challenge);
+    }
+    resp
 }
 
 /// The RFC 6750 §2.1 grammar and the challenge shapes, asserted per clause.

--- a/app/ferroehr-rest/src/extensions/access/authz/roles.rs
+++ b/app/ferroehr-rest/src/extensions/access/authz/roles.rs
@@ -30,33 +30,34 @@ use ferroehr::config::authz::RbacConfig;
 #[must_use]
 pub fn extract_roles(claims: &Map<String, Value>, paths: &[String]) -> Vec<String> {
     let mut roles: Vec<String> = Vec::new();
-    let mut push = |raw: &str| {
-        let norm = raw.trim().to_ascii_uppercase();
-        if !norm.is_empty() && !roles.contains(&norm) {
-            roles.push(norm);
-        }
-    };
     for path in paths {
         let Some(value) = lookup(claims, path) else {
             continue;
         };
         match value {
             Value::Array(items) => {
-                for item in items {
-                    if let Some(s) = item.as_str() {
-                        push(s);
-                    }
+                for item in items.iter().filter_map(Value::as_str) {
+                    push_role(&mut roles, item);
                 }
             }
             Value::String(s) => {
                 for token in s.split_whitespace() {
-                    push(token);
+                    push_role(&mut roles, token);
                 }
             }
             _ => {}
         }
     }
     roles
+}
+
+/// Appends one normalized role — trimmed and upper-cased — unless it is empty
+/// or already present (first-seen order is preserved).
+fn push_role(roles: &mut Vec<String>, raw: &str) {
+    let norm = raw.trim().to_ascii_uppercase();
+    if !norm.is_empty() && !roles.contains(&norm) {
+        roles.push(norm);
+    }
 }
 
 /// Resolve a dotted claim path to a string value (the ABAC `organization` /

--- a/app/ferroehr-rest/src/extensions/fhir.rs
+++ b/app/ferroehr-rest/src/extensions/fhir.rs
@@ -392,11 +392,22 @@ async fn run(state: AppState, op: &'static str, parts: RequestParts) -> Response
         );
     }
 
-    let h = &parts.headers;
     match op {
         "fhir_ingest" => ingest(&state, &parts).await,
         "fhir_validate" => validate(&state, &parts).await,
         "fhir_search" => search(&state, &parts).await,
+        _ => mapping_crud(&state, op, &parts).await,
+    }
+}
+
+/// The `fhir_mapping_*` CRUD surface over the stored template→resource
+/// mappings.
+///
+/// No openEHR spec governs this — our own design/extension (the FHIR
+/// connector's configuration surface).
+async fn mapping_crud(state: &AppState, op: &'static str, parts: &RequestParts) -> Response {
+    let h = &parts.headers;
+    match op {
         "fhir_mapping_list" => match state.backend().fhir_mapping_list().await {
             Ok(items) => negotiate::respond(h, StatusCode::OK, &items),
             Err(e) => sm_error_outcome(e),
@@ -411,14 +422,14 @@ async fn run(state: AppState, op: &'static str, parts: RequestParts) -> Response
                 Err(e) => sm_error_outcome(e),
             }
         }
-        "fhir_mapping_get" => match mapping_id(&parts) {
+        "fhir_mapping_get" => match mapping_id(parts) {
             Ok(id) => match state.backend().fhir_mapping_get(id).await {
                 Ok(item) => negotiate::respond(h, StatusCode::OK, &item),
                 Err(e) => sm_error_outcome(e),
             },
             Err(e) => api_error_outcome(&e.0),
         },
-        "fhir_mapping_update" => match mapping_id(&parts) {
+        "fhir_mapping_update" => match mapping_id(parts) {
             Ok(id) => {
                 let body = match negotiate::json_value(h, &parts.body) {
                     Ok(b) => b,
@@ -431,7 +442,7 @@ async fn run(state: AppState, op: &'static str, parts: RequestParts) -> Response
             }
             Err(e) => api_error_outcome(&e.0),
         },
-        "fhir_mapping_delete" => match mapping_id(&parts) {
+        "fhir_mapping_delete" => match mapping_id(parts) {
             Ok(id) => match state.backend().fhir_mapping_delete(id).await {
                 Ok(()) => negotiate::empty(StatusCode::NO_CONTENT),
                 Err(e) => sm_error_outcome(e),

--- a/app/ferroehr-rest/src/overview/negotiate.rs
+++ b/app/ferroehr-rest/src/overview/negotiate.rs
@@ -169,10 +169,32 @@ pub(crate) fn resolve_accept(
     if accept.trim().is_empty() {
         return Some(default);
     }
-    // ONE pass over the `Accept` ranges: each range is tokenized and
-    // q-parsed once, and every allowed format aggregates its best
-    // `(quality, specificity)` from that same pass (highest q, then
-    // specificity — the per-format aggregation `match_quality` describes).
+    let per_format = rank_allowed_formats(accept, allowed);
+    let mut best: Option<(WireFormat, f64, u8)> = None;
+    for (slot, &fmt) in per_format.iter().zip(allowed) {
+        let Some((q, spec)) = *slot else {
+            continue;
+        };
+        if q <= 0.0 {
+            // `;q=0` explicitly rejects the format (RFC 9110 §12.5.1).
+            continue;
+        }
+        let candidate = (fmt, q, spec);
+        best = Some(match best {
+            None => candidate,
+            Some(current) => choose(current, candidate, default),
+        });
+    }
+    best.map(|(fmt, _, _)| fmt)
+}
+
+/// The best `(quality, specificity)` each allowed format reaches across the
+/// `Accept` ranges, positionally aligned to `allowed`.
+///
+/// ONE pass over the ranges: each is tokenized and q-parsed once, and every
+/// allowed format aggregates its best pair from that same pass — highest q,
+/// then specificity.
+fn rank_allowed_formats(accept: &str, allowed: &[WireFormat]) -> Vec<Option<(f64, u8)>> {
     let mut per_format: Vec<Option<(f64, u8)>> = vec![None; allowed.len()];
     for range in accept.split(',') {
         let range = range.trim();
@@ -192,22 +214,7 @@ pub(crate) fn resolve_accept(
             });
         }
     }
-    let mut best: Option<(WireFormat, f64, u8)> = None;
-    for (slot, &fmt) in per_format.iter().zip(allowed) {
-        let Some((q, spec)) = *slot else {
-            continue;
-        };
-        if q <= 0.0 {
-            // `;q=0` explicitly rejects the format (RFC 9110 §12.5.1).
-            continue;
-        }
-        let candidate = (fmt, q, spec);
-        best = Some(match best {
-            None => candidate,
-            Some(current) => choose(current, candidate, default),
-        });
-    }
-    best.map(|(fmt, _, _)| fmt)
+    per_format
 }
 
 /// The specificity with which `token` matches `fmt` (compared

--- a/app/ferroehr-rest/src/smart/enforce.rs
+++ b/app/ferroehr-rest/src/smart/enforce.rs
@@ -216,18 +216,7 @@ pub fn evaluate(
     // PEP binds the patient context only when *nothing broader* permitted.
     let mut broadest: Option<Compartment> = None;
     for scope in &family_scopes {
-        if !scope.permissions.contains(permission) {
-            continue;
-        }
-        let id_ok = if let Some(id) = resource_id {
-            scope.resource.pattern().matches(id)
-        } else {
-            // No resolved id: only a broad `*`/`**` pattern can permit; a
-            // specific pattern is fail-closed against an unknown id.
-            let p = scope.resource.pattern().as_str();
-            p == "*" || p == "**"
-        };
-        if id_ok {
+        if scope.permissions.contains(permission) && scope_matches_id(scope, resource_id) {
             broadest = Some(broaden(broadest, scope.compartment));
         }
     }
@@ -273,6 +262,21 @@ fn claim_str(claims: &serde_json::Map<String, serde_json::Value>, key: &str) -> 
         .get(key)
         .and_then(serde_json::Value::as_str)
         .map(str::to_owned)
+}
+
+/// Whether one held scope's resource pattern covers the addressed resource.
+///
+/// With no resolved id, only a broad `*`/`**` pattern can permit — a specific
+/// pattern is fail-closed against an unknown id.
+fn scope_matches_id(
+    scope: &openehr_its::rest::smart_scopes::ResourceScope,
+    resource_id: Option<&str>,
+) -> bool {
+    let Some(id) = resource_id else {
+        let p = scope.resource.pattern().as_str();
+        return p == "*" || p == "**";
+    };
+    scope.resource.pattern().matches(id)
 }
 
 /// The broader of two compartments (breadth: System > User > Patient). Used so

--- a/app/ferroehr-server/src/lib.rs
+++ b/app/ferroehr-server/src/lib.rs
@@ -273,6 +273,180 @@ fn mounted_management_endpoints(levels: EndpointLevels) -> String {
     }
 }
 
+/// Announces the deployment postures that are legal but easy to leave on by
+/// accident, once logging is up.
+///
+/// The dev-default DSN is announced prominently rather than silently accepted
+/// (never a silent production trap). Permissive CORS is a deliberate
+/// weakening — every origin may read every response — and the kind of setting
+/// switched on for a demo and left on (OWASP REST Security Cheat Sheet). The
+/// HTTPS posture is stated rather than enforced: this server cannot tell
+/// "plaintext because misconfigured" from "plaintext because a TLS-terminating
+/// ingress sits in front", which is the ordinary deployment, so authentication
+/// over plaintext on a routable bind warns loudly and proceeds — the operator
+/// owns the edge.
+fn warn_boot_postures(config: &ferroehr::config::FerroEhrConfig) {
+    if config.db.is_dev_default() {
+        tracing::warn!(
+            url = db::DEFAULT_URL,
+            "[db].url is the built-in DEVELOPMENT DEFAULT ({}); no file/env/CLI value was \
+             supplied. Set db.url (FERROEHR__DB__URL / DATABASE_URL) for any non-dev deployment — \
+             production MUST override it.",
+            db::DEFAULT_URL,
+        );
+    }
+    if config.server.cors_permissive {
+        tracing::warn!(
+            "[server].cors_permissive is ON: any origin may read API responses. This is a \
+             DEVELOPMENT setting — configure explicit origins for any deployment reachable by \
+             a browser."
+        );
+    }
+    if config.auth.enabled && !config.server.tls.enabled && !binds_loopback(&config.server.bind) {
+        tracing::warn!(
+            bind = %config.server.bind,
+            "authentication is enabled but this listener is PLAINTEXT on a routable address. \
+             Credentials and bearer tokens will cross the wire unencrypted unless a \
+             TLS-terminating proxy fronts this port. Enable [server.tls] or ensure the ingress \
+             terminates TLS."
+        );
+    }
+}
+
+/// Connects the pool the deployment's tenancy mode calls for and prepares the
+/// schema.
+///
+/// Multi-tenant mode swaps in the tenant-scoped pool: every checked-out
+/// connection is stamped with the request's `ferroehr.tenant_id` session GUC,
+/// which the RLS `tenant_isolation` policy reads (no openEHR spec governs
+/// multi-tenancy — our own deployment extension). Single-tenant deployments
+/// keep the plain pool and pay no per-acquire cost.
+///
+/// # Errors
+/// A connection or migration failure, contextualized for the operator.
+async fn connect_pool(config: &ferroehr::config::FerroEhrConfig) -> anyhow::Result<PgPool> {
+    let pool = if config.tenancy.enabled {
+        db::connect_tenant_scoped(&config.db)
+            .await
+            .context("connecting to PostgreSQL (tenant-scoped)")?
+    } else {
+        db::connect(&config.db)
+            .await
+            .context("connecting to PostgreSQL")?
+    };
+    db::prepare(&config.db, &pool)
+        .await
+        .context("preparing the database schema")?;
+    Ok(pool)
+}
+
+/// Wires the opt-in external FHIR terminology servers — ALL configured
+/// providers, with the terminology→provider routing (a deployment binds
+/// several terminologies at once; BASE
+/// `architecture_overview/master12-terminology.adoc` §Overview).
+///
+/// # Errors
+/// A provider that cannot be built (a boot error: configuration promising a
+/// terminology binding must never degrade to no binding).
+fn attach_terminology(
+    service: FerroEhrService,
+    config: &ferroehr::config::FerroEhrConfig,
+) -> anyhow::Result<FerroEhrService> {
+    let Some(router) = ferroehr::service::terminology::router::TerminologyRouter::build(
+        &config.terminology.external,
+    )
+    .context("initialising the external terminology providers")?
+    else {
+        return Ok(service);
+    };
+    tracing::info!(
+        providers = %router.provider_names().collect::<Vec<_>>().join(", "),
+        fail_on_error = router.fail_on_error(),
+        "external FHIR terminology providers configured"
+    );
+    Ok(service.with_terminology_router(Arc::new(router)))
+}
+
+/// Wires the opt-in Subject Proxy FHIR-frame executor (fail-closed).
+///
+/// # Errors
+/// An executor that cannot be built.
+fn attach_subject_proxy(
+    service: FerroEhrService,
+    config: &ferroehr::config::FerroEhrConfig,
+) -> anyhow::Result<FerroEhrService> {
+    let Some(fhir) = config
+        .subject_proxy
+        .build()
+        .context("initialising the subject-proxy FHIR executor")?
+    else {
+        return Ok(service);
+    };
+    tracing::info!("subject-proxy FHIR-frame executor configured");
+    Ok(service.with_subject_proxy(Arc::new(fhir)))
+}
+
+/// Wires the opt-in `DV_MULTIMEDIA` externalization (the `multimedia` cargo
+/// feature; a slim build refuses an enabled config loudly).
+///
+/// A store that is only there to READ BACK already-offloaded blobs (the
+/// integration is off but an endpoint remains) must never stop the server
+/// starting: turning a feature off cannot be a way to break boot. So an
+/// unbuildable store is fatal only when the integration is enabled.
+///
+/// # Errors
+/// An unbuildable object store while the integration is enabled, or an enabled
+/// configuration in a build without the feature.
+fn attach_multimedia(
+    service: FerroEhrService,
+    config: &ferroehr::config::FerroEhrConfig,
+) -> anyhow::Result<FerroEhrService> {
+    #[cfg(feature = "multimedia")]
+    {
+        let engine = match ferroehr::extensions::multimedia::engine_from_config(&config.multimedia)
+        {
+            Ok(engine) => engine,
+            Err(e) if !config.multimedia.enabled => {
+                tracing::warn!(
+                    error = %e,
+                    "multimedia is disabled and its object store could not be built: \
+                     already-externalized content cannot be re-inlined, and a read that \
+                     asks for it will be refused rather than answered with the reference"
+                );
+                None
+            }
+            Err(e) => {
+                return Err(
+                    anyhow::Error::new(e).context("initialising the multimedia object store")
+                );
+            }
+        };
+        let Some(engine) = engine else {
+            return Ok(service);
+        };
+        if engine.offload_enabled() {
+            tracing::info!(
+                bucket = %config.multimedia.bucket,
+                threshold_bytes = config.multimedia.threshold_bytes,
+                "DV_MULTIMEDIA externalization enabled"
+            );
+        } else {
+            tracing::info!(
+                bucket = %config.multimedia.bucket,
+                "DV_MULTIMEDIA externalization disabled; the configured store stays \
+                 readable so already-externalized content can still be served"
+            );
+        }
+        Ok(service.with_multimedia(Arc::new(engine)))
+    }
+    #[cfg(not(feature = "multimedia"))]
+    {
+        ferroehr::extensions::multimedia::require_disabled(&config.multimedia)
+            .map_err(|e| anyhow::anyhow!(e))?;
+        Ok(service)
+    }
+}
+
 /// Boot the server: config, telemetry, pool, migrations, audit, health, serve.
 #[expect(
     clippy::too_many_lines,
@@ -299,62 +473,8 @@ async fn serve(config_path: Option<&Path>, overrides: &[(String, String)]) -> an
     let mut telemetry =
         telemetry::init(&telemetry_config, &build_info).context("initialising telemetry")?;
 
-    // Review condition 1: announce the dev-default DSN prominently (never a
-    // silent production trap) — now that logging is up.
-    if config.db.is_dev_default() {
-        tracing::warn!(
-            url = db::DEFAULT_URL,
-            "[db].url is the built-in DEVELOPMENT DEFAULT ({}); no file/env/CLI value was \
-             supplied. Set db.url (FERROEHR__DB__URL / DATABASE_URL) for any non-dev deployment — \
-             production MUST override it.",
-            db::DEFAULT_URL,
-        );
-    }
-
-    // Permissive CORS is a deliberate weakening — every origin may read every
-    // response — and it is the kind of setting that gets switched on for a demo
-    // and left on. Announced, never silent (OWASP REST Security Cheat Sheet).
-    if config.server.cors_permissive {
-        tracing::warn!(
-            "[server].cors_permissive is ON: any origin may read API responses. This is a \
-             DEVELOPMENT setting — configure explicit origins for any deployment reachable by \
-             a browser."
-        );
-    }
-
-    // The HTTPS posture, stated rather than enforced. The cheat sheet asks for
-    // HTTPS-only endpoints; this server cannot tell "plaintext because
-    // misconfigured" from "plaintext because a TLS-terminating ingress sits in
-    // front", which is the ordinary deployment. Refusing to boot would break
-    // every such deployment, so authentication over plaintext on a non-loopback
-    // bind warns loudly and proceeds — the operator owns the edge.
-    if config.auth.enabled && !config.server.tls.enabled && !binds_loopback(&config.server.bind) {
-        tracing::warn!(
-            bind = %config.server.bind,
-            "authentication is enabled but this listener is PLAINTEXT on a routable address. \
-             Credentials and bearer tokens will cross the wire unencrypted unless a \
-             TLS-terminating proxy fronts this port. Enable [server.tls] or ensure the ingress \
-             terminates TLS."
-        );
-    }
-
-    // Multi-tenant mode swaps in the tenant-scoped pool: every checked-out
-    // connection is stamped with the request's `ferroehr.tenant_id` session
-    // GUC, which the RLS `tenant_isolation` policy reads (no openEHR spec
-    // governs multi-tenancy — our own deployment extension). Single-tenant
-    // deployments keep the plain pool and pay no per-acquire cost.
-    let pool = if config.tenancy.enabled {
-        db::connect_tenant_scoped(&config.db)
-            .await
-            .context("connecting to PostgreSQL (tenant-scoped)")?
-    } else {
-        db::connect(&config.db)
-            .await
-            .context("connecting to PostgreSQL")?
-    };
-    db::prepare(&config.db, &pool)
-        .await
-        .context("preparing the database schema")?;
+    warn_boot_postures(&config);
+    let pool = connect_pool(&config).await?;
 
     // ATNA audit (fail-open at boot). A slim build cannot render the FHIR
     // `AuditEvent` the store and the ATX:FHIR Feed carry, so an enabled
@@ -430,80 +550,9 @@ async fn serve(config_path: Option<&Path>, overrides: &[(String, String)]) -> an
             service.with_audit_store(ferroehr::system_log::store::AuditStore::new(pool.clone()));
     }
 
-    // Opt-in external FHIR terminology servers — ALL configured providers,
-    // with the terminology→provider routing (a deployment binds several
-    // terminologies at once; BASE `architecture_overview/
-    // master12-terminology.adoc` §Overview).
-    if let Some(router) = ferroehr::service::terminology::router::TerminologyRouter::build(
-        &config.terminology.external,
-    )
-    .context("initialising the external terminology providers")?
-    {
-        tracing::info!(
-            providers = %router.provider_names().collect::<Vec<_>>().join(", "),
-            fail_on_error = router.fail_on_error(),
-            "external FHIR terminology providers configured"
-        );
-        service = service.with_terminology_router(Arc::new(router));
-    }
-
-    // Opt-in Subject Proxy FHIR-frame executor (fail-closed).
-    if let Some(fhir) = config
-        .subject_proxy
-        .build()
-        .context("initialising the subject-proxy FHIR executor")?
-    {
-        tracing::info!("subject-proxy FHIR-frame executor configured");
-        service = service.with_subject_proxy(Arc::new(fhir));
-    }
-
-    // Opt-in DV_MULTIMEDIA externalization (the `multimedia` cargo feature; a
-    // slim build refuses an enabled config loudly).
-    // A store that is only there to READ BACK already-offloaded blobs (the
-    // integration is off but an endpoint remains) must never stop the server
-    // starting: turning a feature off cannot be a way to break boot. So the
-    // failure is fatal only when the integration is enabled.
-    #[cfg(feature = "multimedia")]
-    {
-        let engine = match ferroehr::extensions::multimedia::engine_from_config(&config.multimedia)
-        {
-            Ok(engine) => engine,
-            Err(e) if !config.multimedia.enabled => {
-                tracing::warn!(
-                    error = %e,
-                    "multimedia is disabled and its object store could not be built: \
-                     already-externalized content cannot be re-inlined, and a read that \
-                     asks for it will be refused rather than answered with the reference"
-                );
-                None
-            }
-            Err(e) => {
-                return Err(
-                    anyhow::Error::new(e).context("initialising the multimedia object store")
-                );
-            }
-        };
-        if let Some(engine) = engine {
-            if engine.offload_enabled() {
-                tracing::info!(
-                    bucket = %config.multimedia.bucket,
-                    threshold_bytes = config.multimedia.threshold_bytes,
-                    "DV_MULTIMEDIA externalization enabled"
-                );
-            } else {
-                tracing::info!(
-                    bucket = %config.multimedia.bucket,
-                    "DV_MULTIMEDIA externalization disabled; the configured store stays \
-                     readable so already-externalized content can still be served"
-                );
-            }
-            service = service.with_multimedia(Arc::new(engine));
-        }
-    }
-    #[cfg(not(feature = "multimedia"))]
-    ferroehr::extensions::multimedia::require_disabled(&config.multimedia)
-        .map_err(|e| anyhow::anyhow!(e))?;
-
+    service = attach_terminology(service, &config)?;
+    service = attach_subject_proxy(service, &config)?;
+    service = attach_multimedia(service, &config)?;
     let service = Arc::new(service);
 
     // FHIR outbound emitter (off by default; carries PHI). Gated on `fhir`:

--- a/app/ferroehr/src/aql/exec.rs
+++ b/app/ferroehr/src/aql/exec.rs
@@ -16,6 +16,7 @@
 )]
 
 use serde_json::Value;
+use sqlx::postgres::PgRow;
 use sqlx::{PgPool, Row};
 use uuid::Uuid;
 
@@ -95,18 +96,53 @@ pub async fn execute(
         })
         .collect();
 
-    // Assemble the cells. Scalar cells read their JSON straight off the result
-    // row; whole-object cells contribute a subtree anchor that is batch-loaded in
-    // ONE round trip after the scan — never one follow-up SELECT per candidate
-    // row (fixes the AQL result-assembly N+1).
+    let Scan {
+        mut out_rows,
+        anchors,
+        pending,
+    } = scan_rows(&rows, &prepared.columns)?;
+
+    if !anchors.is_empty() {
+        crate::versioning::profile::gate_result_bodies(pool, profile, &anchors)
+            .await
+            .map_err(ExecError::Profile)?;
+        let subtrees = crate::storage::node_repo::read_subtrees_canonical(pool, &anchors)
+            .await
+            .map_err(ExecError::from)?;
+        fill_whole_object_cells(&mut out_rows, pending, subtrees);
+    }
+
+    Ok(QueryResult {
+        columns,
+        rows: out_rows,
+    })
+}
+
+/// The result of scanning the SQL rows: the assembled cells, the subtree
+/// anchors to batch-load, and the whole-object cells awaiting them.
+struct Scan {
+    out_rows: Vec<Vec<Value>>,
+    anchors: Vec<SubtreeAnchor>,
+    /// The whole-object cells to fill once the batch load resolves, by
+    /// `(row, column)` position.
+    pending: Vec<(usize, usize, SubtreeAnchor)>,
+}
+
+/// Assembles every cell of the result page.
+///
+/// Scalar cells read their JSON straight off the result row; whole-object
+/// cells contribute a subtree anchor that is batch-loaded in ONE round trip
+/// after the scan — never one follow-up SELECT per candidate row.
+///
+/// # Errors
+/// [`AqlError::Exec`] if a projected column is missing from the result row.
+fn scan_rows(rows: &[PgRow], columns: &[ColumnSpec]) -> Result<Scan, AqlError> {
     let mut out_rows: Vec<Vec<Value>> = Vec::with_capacity(rows.len());
     let mut anchors: Vec<SubtreeAnchor> = Vec::new();
-    // The whole-object cells to fill once the batch load resolves, by position.
     let mut pending: Vec<(usize, usize, SubtreeAnchor)> = Vec::new();
-
     for (ri, row) in rows.iter().enumerate() {
-        let mut cells = Vec::with_capacity(prepared.columns.len());
-        for (ci, spec) in prepared.columns.iter().enumerate() {
+        let mut cells = Vec::with_capacity(columns.len());
+        for (ci, spec) in columns.iter().enumerate() {
             match spec.kind {
                 CellKind::Scalar => {
                     let v: Option<Value> =
@@ -128,47 +164,47 @@ pub async fn execute(
         }
         out_rows.push(cells);
     }
+    Ok(Scan {
+        out_rows,
+        anchors,
+        pending,
+    })
+}
 
-    if !anchors.is_empty() {
-        crate::versioning::profile::gate_result_bodies(pool, profile, &anchors)
-            .await
-            .map_err(ExecError::Profile)?;
-        let mut subtrees = crate::storage::node_repo::read_subtrees_canonical(pool, &anchors)
-            .await
-            .map_err(ExecError::from)?;
-        // Each reassembled document MOVES into its last pending cell; only a
-        // repeated anchor (the same version projected more than once on the
-        // page) pays a clone for the earlier cells.
-        let mut remaining: std::collections::HashMap<SubtreeAnchor, usize> =
-            std::collections::HashMap::new();
-        for (_, _, anchor) in &pending {
-            *remaining.entry(*anchor).or_insert(0) += 1;
-        }
-        for (ri, ci, anchor) in pending {
-            let last_use = remaining.get_mut(&anchor).is_none_or(|n| {
-                *n -= 1;
-                *n == 0
-            });
-            let value = if last_use {
-                subtrees.remove(&anchor)
-            } else {
-                subtrees.get(&anchor).cloned()
-            };
-            // `(ri, ci)` was recorded while building `out_rows`, so the cell
-            // exists; fetched rather than indexed so a future refactor cannot
-            // turn a bookkeeping slip into a panic on a request path.
-            if let (Some(value), Some(cell)) =
-                (value, out_rows.get_mut(ri).and_then(|row| row.get_mut(ci)))
-            {
-                *cell = value;
-            }
+/// Moves each reassembled document into the cell that projected it.
+///
+/// A document MOVES into its last pending cell; only a repeated anchor (the
+/// same version projected more than once on the page) pays a clone for the
+/// earlier cells.
+fn fill_whole_object_cells(
+    out_rows: &mut [Vec<Value>],
+    pending: Vec<(usize, usize, SubtreeAnchor)>,
+    mut subtrees: std::collections::HashMap<SubtreeAnchor, Value>,
+) {
+    let mut remaining: std::collections::HashMap<SubtreeAnchor, usize> =
+        std::collections::HashMap::new();
+    for (_, _, anchor) in &pending {
+        *remaining.entry(*anchor).or_insert(0) += 1;
+    }
+    for (ri, ci, anchor) in pending {
+        let last_use = remaining.get_mut(&anchor).is_none_or(|n| {
+            *n -= 1;
+            *n == 0
+        });
+        let value = if last_use {
+            subtrees.remove(&anchor)
+        } else {
+            subtrees.get(&anchor).cloned()
+        };
+        // `(ri, ci)` was recorded while building `out_rows`, so the cell
+        // exists; fetched rather than indexed so a future refactor cannot turn
+        // a bookkeeping slip into a panic on a request path.
+        if let (Some(value), Some(cell)) =
+            (value, out_rows.get_mut(ri).and_then(|row| row.get_mut(ci)))
+        {
+            *cell = value;
         }
     }
-
-    Ok(QueryResult {
-        columns,
-        rows: out_rows,
-    })
 }
 
 /// The distinct EHR ids and template ids an AQL query touches.
@@ -245,7 +281,7 @@ fn sql_col(spec: &ColumnSpec, index: usize) -> Result<&str, AqlError> {
 /// `None` when the `vo_id` locator is SQL NULL (an outer-joined absent object) —
 /// the cell is then a JSON `null` with no subtree to load.
 fn whole_object_anchor(
-    row: &sqlx::postgres::PgRow,
+    row: &PgRow,
     spec: &ColumnSpec,
 ) -> Result<Option<SubtreeAnchor>, AqlError> {
     let vo_id: Option<VoId> = row.try_get(sql_col(spec, 0)?).map_err(ExecError::from)?;

--- a/app/ferroehr/src/aql/exec.rs
+++ b/app/ferroehr/src/aql/exec.rs
@@ -280,10 +280,7 @@ fn sql_col(spec: &ColumnSpec, index: usize) -> Result<&str, AqlError> {
 /// four locator columns (`vo_id`, `sys_version`, `num`, `num_cap`). Returns
 /// `None` when the `vo_id` locator is SQL NULL (an outer-joined absent object) —
 /// the cell is then a JSON `null` with no subtree to load.
-fn whole_object_anchor(
-    row: &PgRow,
-    spec: &ColumnSpec,
-) -> Result<Option<SubtreeAnchor>, AqlError> {
+fn whole_object_anchor(row: &PgRow, spec: &ColumnSpec) -> Result<Option<SubtreeAnchor>, AqlError> {
     let vo_id: Option<VoId> = row.try_get(sql_col(spec, 0)?).map_err(ExecError::from)?;
     let Some(vo_id) = vo_id else {
         return Ok(None);

--- a/app/ferroehr/src/aql/lower.rs
+++ b/app/ferroehr/src/aql/lower.rs
@@ -143,59 +143,15 @@ impl Planner {
             } => {
                 let id = self.next_id();
                 if rm_type == "EHR" {
-                    let predicates = predicate
-                        .as_ref()
-                        .map(Self::lower_ehr_predicate)
-                        .transpose()?
-                        .into_iter()
-                        .flatten()
-                        .collect();
-                    self.sources.push(Source::Ehr(EhrSource {
+                    self.lower_ehr_operand(id, variable.as_deref(), predicate.as_ref())?;
+                } else {
+                    self.lower_rm_operand(
                         id,
-                        var: variable.clone(),
-                        predicates,
-                    }));
-                    if let Some(v) = variable {
-                        self.bind(v, id, BindingKind::Ehr)?;
-                    }
-                    return Ok((id, inherited.cloned()));
-                }
-
-                // An RM structure/VO class. It must be addressable in the node
-                // store: at least one concrete descendant is a structure root.
-                let class = model::class(rm_type)
-                    .ok_or_else(|| AnalysisError::UnknownClass(rm_type.clone()))?;
-                if !crate::aql::analyze::profile_defines_class(self.bindings.profile, rm_type) {
-                    return Err(AnalysisError::ClassNotInProfile {
-                        class: rm_type.clone(),
-                        profile: self.bindings.profile.as_str(),
-                        generation: self.bindings.profile.rm().spec_version(),
-                    }
-                    .into());
-                }
-                let concrete =
-                    TypeSet::new(class.descendants.iter().map(|s| (*s).to_owned()).collect());
-                if !concrete.names().iter().any(|t| model::is_structure_root(t)) {
-                    return Err(AqlFeatureError::UnsupportedSourceClass(rm_type.clone()).into());
-                }
-
-                let constraint = predicate
-                    .as_ref()
-                    .map(resolve_node_predicate)
-                    .transpose()?
-                    .unwrap_or_default();
-                let scope = inherited.cloned().unwrap_or(VersionScope::Latest);
-                self.sources.push(Source::Rm(RmSource {
-                    id,
-                    var: variable.clone(),
-                    rm_type: concrete.clone(),
-                    archetype: constraint.archetype,
-                    name: constraint.name,
-                    standard: constraint.standard,
-                    scope,
-                }));
-                if let Some(v) = variable {
-                    self.bind(v, id, BindingKind::Rm(concrete))?;
+                        rm_type,
+                        variable.as_deref(),
+                        predicate.as_ref(),
+                        inherited,
+                    )?;
                 }
                 Ok((id, inherited.cloned()))
             }
@@ -222,6 +178,89 @@ impl Planner {
                 Ok((id, Some(scope)))
             }
         }
+    }
+
+    /// Registers an `EHR` operand as an EHR source and binds its variable.
+    ///
+    /// # Errors
+    /// The EHR-predicate lowering rejections, and a duplicate variable
+    /// binding.
+    fn lower_ehr_operand(
+        &mut self,
+        id: SourceId,
+        variable: Option<&str>,
+        predicate: Option<&openehr_query::ast::PathPredicate>,
+    ) -> Result<(), AqlError> {
+        let predicates = predicate
+            .map(Self::lower_ehr_predicate)
+            .transpose()?
+            .into_iter()
+            .flatten()
+            .collect();
+        self.sources.push(Source::Ehr(EhrSource {
+            id,
+            var: variable.map(str::to_owned),
+            predicates,
+        }));
+        if let Some(v) = variable {
+            self.bind(v, id, BindingKind::Ehr)?;
+        }
+        Ok(())
+    }
+
+    /// Registers an RM structure/VO-class operand as an RM source and binds
+    /// its variable.
+    ///
+    /// The class must be addressable in the node store: at least one concrete
+    /// descendant is a structure root.
+    ///
+    /// # Errors
+    /// [`AnalysisError::UnknownClass`] for a class the RM model does not
+    /// declare, [`AnalysisError::ClassNotInProfile`] for one outside the
+    /// active `spec_profile`'s generation set,
+    /// [`AqlFeatureError::UnsupportedSourceClass`] for a class no concrete
+    /// descendant of which is a structure root, plus the node-predicate
+    /// rejections and a duplicate variable binding.
+    fn lower_rm_operand(
+        &mut self,
+        id: SourceId,
+        rm_type: &str,
+        variable: Option<&str>,
+        predicate: Option<&openehr_query::ast::PathPredicate>,
+        inherited: Option<&VersionScope>,
+    ) -> Result<(), AqlError> {
+        let class =
+            model::class(rm_type).ok_or_else(|| AnalysisError::UnknownClass(rm_type.to_owned()))?;
+        if !crate::aql::analyze::profile_defines_class(self.bindings.profile, rm_type) {
+            return Err(AnalysisError::ClassNotInProfile {
+                class: rm_type.to_owned(),
+                profile: self.bindings.profile.as_str(),
+                generation: self.bindings.profile.rm().spec_version(),
+            }
+            .into());
+        }
+        let concrete = TypeSet::new(class.descendants.iter().map(|s| (*s).to_owned()).collect());
+        if !concrete.names().iter().any(|t| model::is_structure_root(t)) {
+            return Err(AqlFeatureError::UnsupportedSourceClass(rm_type.to_owned()).into());
+        }
+        let constraint = predicate
+            .map(resolve_node_predicate)
+            .transpose()?
+            .unwrap_or_default();
+        let scope = inherited.cloned().unwrap_or(VersionScope::Latest);
+        self.sources.push(Source::Rm(RmSource {
+            id,
+            var: variable.map(str::to_owned),
+            rm_type: concrete.clone(),
+            archetype: constraint.archetype,
+            name: constraint.name,
+            standard: constraint.standard,
+            scope,
+        }));
+        if let Some(v) = variable {
+            self.bind(v, id, BindingKind::Rm(concrete))?;
+        }
+        Ok(())
     }
 
     /// Resolve an EHR class predicate into standard EHR-field predicates. EHR

--- a/app/ferroehr/src/aql/sql/from.rs
+++ b/app/ferroehr/src/aql/sql/from.rs
@@ -409,79 +409,117 @@ impl Builder<'_> {
                 self.walk(b, ehr, vo)?;
                 Ok(g)
             }
-            // OR-containment (QUERY master03 §Containment — "Logical
-            // operators AND and OR"). The enclosing object satisfies either
-            // branch's containment; each branch lowers to a correlated `EXISTS`
-            // over the shared anchor, combined with `OR`. A top-level `OR` with
-            // no enclosing object is rejected (there is no row scope to
-            // correlate to). Variables bound only inside an `OR` branch are
-            // containment-filter-only — see the module NOTE.
-            ContainsTree::Or(a, b) => {
-                let anchor = match (&vo, ehr) {
-                    (Some(g), _) => ExistsAnchor::Vo(g.node.clone()),
-                    (None, Some(e)) => ExistsAnchor::Ehr(e.to_owned()),
-                    (None, None) => {
-                        return Err(SqlError::Unsupported(
-                            "OR at the top of the FROM tree without a containing object".to_owned(),
-                        )
-                        .into());
-                    }
-                };
-                let left = self.contained_exists(&anchor, a)?;
-                let right = self.contained_exists(&anchor, b)?;
-                self.q.and_where(left.or(right));
-                Ok(None)
-            }
+            ContainsTree::Or(a, b) => self.walk_or(a, b, ehr, vo.as_ref()),
             ContainsTree::Operand { source, contained } => {
-                let sid = source.0;
-                match self.ir.sources.get(sid) {
-                    Some(Source::Version(_)) => {
-                        let child = match contained.as_deref() {
-                            Some(Contained {
-                                link: Link::Contains,
-                                tree,
-                            }) => self.walk(tree, ehr, vo)?,
-                            Some(_) => {
-                                return Err(SqlError::Unsupported(
-                                    "VERSION NOT CONTAINS".to_owned(),
-                                )
-                                .into());
-                            }
-                            None => None,
-                        };
-                        if let Some(g) = &child {
-                            self.version_vo.insert(sid, g.vo.clone());
-                        }
-                        Ok(child)
-                    }
-                    Some(Source::Ehr(e)) => {
-                        let alias = format!("e{sid}");
-                        self.q.from_as(Ehr::Table, Alias::new(alias.as_str()));
-                        self.ehr_alias.insert(sid, alias.clone());
-                        let preds = e.predicates.clone();
-                        for p in &preds {
-                            self.push_ehr_predicate(&alias, p)?;
-                        }
-                        if let Some(c) = contained {
-                            self.contained_edge(c, Some(&alias), None)?;
-                        }
-                        Ok(None)
-                    }
-                    Some(Source::Rm(r)) => {
-                        let r = r.clone();
-                        let group = self.emit_rm(sid, &r, ehr, vo.as_ref())?;
-                        if let Some(c) = contained {
-                            self.contained_edge(c, ehr, Some(group.clone()))?;
-                        }
-                        Ok(Some(group))
-                    }
-                    None => Err(SqlError::Unsupported(
-                        "containment operand names an unknown source".to_owned(),
-                    )
-                    .into()),
-                }
+                self.walk_operand(source.0, contained.as_deref(), ehr, vo)
             }
         }
+    }
+
+    /// Lowers OR-containment (QUERY master03 §Containment — "Logical operators
+    /// AND and OR").
+    ///
+    /// The enclosing object satisfies either branch's containment, so each
+    /// branch lowers to a correlated `EXISTS` over the shared anchor, combined
+    /// with `OR`. Variables bound only inside an `OR` branch are
+    /// containment-filter-only — see the module NOTE.
+    ///
+    /// # Errors
+    /// [`SqlError::Unsupported`] for a top-level `OR` with no enclosing object
+    /// (there is no row scope to correlate to), plus the branch lowerings.
+    fn walk_or(
+        &mut self,
+        a: &ContainsTree,
+        b: &ContainsTree,
+        ehr: Option<&str>,
+        vo: Option<&VoGroup>,
+    ) -> Result<Option<VoGroup>, AqlError> {
+        let anchor = match (vo, ehr) {
+            (Some(g), _) => ExistsAnchor::Vo(g.node.clone()),
+            (None, Some(e)) => ExistsAnchor::Ehr(e.to_owned()),
+            (None, None) => {
+                return Err(SqlError::Unsupported(
+                    "OR at the top of the FROM tree without a containing object".to_owned(),
+                )
+                .into());
+            }
+        };
+        let left = self.contained_exists(&anchor, a)?;
+        let right = self.contained_exists(&anchor, b)?;
+        self.q.and_where(left.or(right));
+        Ok(None)
+    }
+
+    /// Lowers one containment operand: the source it names plus the edge it
+    /// carries.
+    ///
+    /// # Errors
+    /// [`SqlError::Unsupported`] when the operand names an unknown source, or
+    /// from the per-source lowerings.
+    fn walk_operand(
+        &mut self,
+        sid: usize,
+        contained: Option<&Contained>,
+        ehr: Option<&str>,
+        vo: Option<VoGroup>,
+    ) -> Result<Option<VoGroup>, AqlError> {
+        match self.ir.sources.get(sid) {
+            Some(Source::Version(_)) => self.walk_version_source(sid, contained, ehr, vo),
+            Some(Source::Ehr(e)) => {
+                let alias = format!("e{sid}");
+                self.q.from_as(Ehr::Table, Alias::new(alias.as_str()));
+                self.ehr_alias.insert(sid, alias.clone());
+                let preds = e.predicates.clone();
+                for p in &preds {
+                    self.push_ehr_predicate(&alias, p)?;
+                }
+                if let Some(c) = contained {
+                    self.contained_edge(c, Some(&alias), None)?;
+                }
+                Ok(None)
+            }
+            Some(Source::Rm(r)) => {
+                let r = r.clone();
+                let group = self.emit_rm(sid, &r, ehr, vo.as_ref())?;
+                if let Some(c) = contained {
+                    self.contained_edge(c, ehr, Some(group.clone()))?;
+                }
+                Ok(Some(group))
+            }
+            None => Err(SqlError::Unsupported(
+                "containment operand names an unknown source".to_owned(),
+            )
+            .into()),
+        }
+    }
+
+    /// Lowers a VERSION operand: it opens no relation of its own and adopts
+    /// the version group of the object it contains.
+    ///
+    /// # Errors
+    /// [`SqlError::Unsupported`] for `VERSION NOT CONTAINS`, plus the child
+    /// lowering.
+    fn walk_version_source(
+        &mut self,
+        sid: usize,
+        contained: Option<&Contained>,
+        ehr: Option<&str>,
+        vo: Option<VoGroup>,
+    ) -> Result<Option<VoGroup>, AqlError> {
+        let child = match contained {
+            Some(Contained {
+                link: Link::Contains,
+                tree,
+            }) => self.walk(tree, ehr, vo)?,
+            Some(_) => {
+                return Err(SqlError::Unsupported("VERSION NOT CONTAINS".to_owned()).into());
+            }
+            None => None,
+        };
+        if let Some(g) = &child {
+            self.version_vo.insert(sid, g.vo.clone());
+        }
+        Ok(child)
     }
 
     fn contained_edge(

--- a/app/ferroehr/src/aql/sql/predicate.rs
+++ b/app/ferroehr/src/aql/sql/predicate.rs
@@ -53,109 +53,147 @@ impl Builder<'_> {
                 op,
                 rhs,
                 coercion,
-            } => {
-                // Typed EHR-id equality: `e/ehr_id/value = <uuid>` as
-                // a uuid comparison on `ehr.id` instead of a text-cast on both
-                // sides (which blinded the btree on `ehr.id` and left the join
-                // unbounded). uuid equality is value-based — case-insensitive —
-                // which is also the identifier-equality semantics (BASE
-                // base_types master05 §Composite Identifiers and Case); a
-                // literal that is not a uuid can match no EHR (constant).
-                if let Some(expr) = self.ehr_id_typed_compare(lhs, *op, rhs)? {
-                    return Ok(expr);
-                }
-                // Existential lowering for an anchored data leaf compared to
-                // a bound value (any matched node satisfies) — positive
-                // polarity only.
-                if positive && let Some(expr) = self.exists_compare(lhs, *op, rhs, *coercion)? {
-                    return Ok(expr);
-                }
-                // a mixed-type (`Raw`) leaf compared to a numeric literal
-                // is compared numerically (with a NULL-guard); otherwise the Raw
-                // set falls through to text, exactly as every other Text leaf
-                // (QUERY master03 §Comparison operators).
-                let (l, r) = if *coercion == Coercion::Raw && raw_numeric_wanted(&[lhs, rhs]) {
-                    (
-                        self.operand_value_raw_numeric(lhs)?,
-                        self.operand_value_raw_numeric(rhs)?,
-                    )
-                } else {
-                    (
-                        self.operand_value(lhs, *coercion)?,
-                        self.operand_value(rhs, *coercion)?,
-                    )
-                };
-                Ok(l.binary(binoper(*op), r))
-            }
+            } => self.compare_expr(lhs, *op, rhs, *coercion, positive),
             IrExpr::Exists(target) => Ok(self
                 .value_expr(target, ValueMode::Projection)?
                 .is_not_null()),
-            IrExpr::Like { path, pattern } => {
-                let pat = match pattern {
-                    LikePattern::Literal(s) => aql_like_to_sql(s),
-                    LikePattern::Param(p) => aql_like_to_sql(&self.param_str(p)?),
-                };
-                // Existential lowering on an anchored multi-valued path
-                // (any-match, the same #1448 unification as `exists_compare`
-                // above): the scalar LIMIT-1 extraction's matched-node choice
-                // is order-undefined when the path matches several nodes —
-                // positive polarity only, like every existential arm.
-                if positive && let Some(leaf) = Self::existential_leaf(path) {
-                    let leaf = leaf.clone();
-                    self.ensure_leaf_root(path)?;
-                    let pat = pat.clone();
-                    if let Some(expr) =
-                        self.data_leaf_exists(&leaf, ValueMode::Value(Coercion::Text), |extract| {
-                            extract.like(pat)
-                        })?
-                    {
-                        return Ok(expr);
-                    }
-                }
-                let lhs = self.value_expr(path, ValueMode::Value(Coercion::Text))?;
-                Ok(lhs.like(pat))
-            }
+            IrExpr::Like { path, pattern } => self.like_expr(path, pattern, positive),
             IrExpr::Const(b) => Ok(Expr::val(*b)),
             IrExpr::Matches {
                 path,
                 values,
                 coercion,
-            } => {
-                // Matches (QUERY master03 §matches): a mixed-type
-                // leaf matched against numeric literals compares numerically.
-                let numeric = *coercion == Coercion::Raw
-                    && values.iter().any(|b| {
-                        matches!(b, Bind::Literal(TypedLit::Integer(_) | TypedLit::Real(_)))
-                    });
-                let mode = if numeric {
-                    ValueMode::RawNumeric
-                } else {
-                    ValueMode::Value(*coercion)
-                };
-                let mut members = Vec::with_capacity(values.len());
-                for b in values {
-                    let v = self.bind_value(b)?;
-                    members.push(if numeric {
-                        cast(Expr::val(v), "numeric")
-                    } else {
-                        coerce_rhs(v, *coercion)
-                    });
-                }
-                // The same #1448 existential unification as LIKE above.
-                if positive && let Some(leaf) = Self::existential_leaf(path) {
-                    let leaf = leaf.clone();
-                    self.ensure_leaf_root(path)?;
-                    let members = members.clone();
-                    if let Some(expr) =
-                        self.data_leaf_exists(&leaf, mode, |extract| extract.is_in(members))?
-                    {
-                        return Ok(expr);
-                    }
-                }
-                let lhs = self.value_expr(path, mode)?;
-                Ok(lhs.is_in(members))
+            } => self.matches_expr(path, values, *coercion, positive),
+        }
+    }
+
+    /// Lowers a comparison, taking the first lowering that applies: the typed
+    /// EHR-id fast path, the existential anchored-leaf shape, then the generic
+    /// operand comparison.
+    ///
+    /// # Errors
+    /// [`AqlError`] from the operand lowerings.
+    fn compare_expr(
+        &mut self,
+        lhs: &Operand,
+        op: CompOp,
+        rhs: &Operand,
+        coercion: Coercion,
+        positive: bool,
+    ) -> Result<Expr, AqlError> {
+        // Typed EHR-id equality: `e/ehr_id/value = <uuid>` as a uuid comparison
+        // on `ehr.id` instead of a text-cast on both sides (which blinded the
+        // btree on `ehr.id` and left the join unbounded). uuid equality is
+        // value-based — case-insensitive — which is also the
+        // identifier-equality semantics (BASE base_types master05 §Composite
+        // Identifiers and Case); a literal that is not a uuid can match no EHR
+        // (constant).
+        if let Some(expr) = self.ehr_id_typed_compare(lhs, op, rhs)? {
+            return Ok(expr);
+        }
+        // Existential lowering for an anchored data leaf compared to a bound
+        // value (any matched node satisfies) — positive polarity only.
+        if positive && let Some(expr) = self.exists_compare(lhs, op, rhs, coercion)? {
+            return Ok(expr);
+        }
+        // A mixed-type (`Raw`) leaf compared to a numeric literal is compared
+        // numerically (with a NULL-guard); otherwise the Raw set falls through
+        // to text, exactly as every other Text leaf (QUERY master03
+        // §Comparison operators).
+        let (l, r) = if coercion == Coercion::Raw && raw_numeric_wanted(&[lhs, rhs]) {
+            (
+                self.operand_value_raw_numeric(lhs)?,
+                self.operand_value_raw_numeric(rhs)?,
+            )
+        } else {
+            (
+                self.operand_value(lhs, coercion)?,
+                self.operand_value(rhs, coercion)?,
+            )
+        };
+        Ok(l.binary(binoper(op), r))
+    }
+
+    /// Lowers a LIKE, with the existential anchored-leaf shape in positive
+    /// positions.
+    ///
+    /// The existential lowering is the any-match unification `exists_compare`
+    /// applies: the scalar LIMIT-1 extraction's matched-node choice is
+    /// order-undefined when the path matches several nodes, so it fires in
+    /// positive polarity only, like every existential arm.
+    ///
+    /// # Errors
+    /// [`AqlError`] from the parameter and path lowerings.
+    fn like_expr(
+        &mut self,
+        path: &PathTarget,
+        pattern: &LikePattern,
+        positive: bool,
+    ) -> Result<Expr, AqlError> {
+        let pat = match pattern {
+            LikePattern::Literal(s) => aql_like_to_sql(s),
+            LikePattern::Param(p) => aql_like_to_sql(&self.param_str(p)?),
+        };
+        if positive && let Some(leaf) = Self::existential_leaf(path) {
+            let leaf = leaf.clone();
+            self.ensure_leaf_root(path)?;
+            let pat = pat.clone();
+            if let Some(expr) =
+                self.data_leaf_exists(&leaf, ValueMode::Value(Coercion::Text), |extract| {
+                    extract.like(pat)
+                })?
+            {
+                return Ok(expr);
             }
         }
+        let lhs = self.value_expr(path, ValueMode::Value(Coercion::Text))?;
+        Ok(lhs.like(pat))
+    }
+
+    /// Lowers a MATCHES (QUERY master03 §matches), with the same existential
+    /// anchored-leaf shape LIKE uses.
+    ///
+    /// A mixed-type leaf matched against numeric literals compares numerically.
+    ///
+    /// # Errors
+    /// [`AqlError`] from the member-value and path lowerings.
+    fn matches_expr(
+        &mut self,
+        path: &PathTarget,
+        values: &[Bind],
+        coercion: Coercion,
+        positive: bool,
+    ) -> Result<Expr, AqlError> {
+        let numeric = coercion == Coercion::Raw
+            && values
+                .iter()
+                .any(|b| matches!(b, Bind::Literal(TypedLit::Integer(_) | TypedLit::Real(_))));
+        let mode = if numeric {
+            ValueMode::RawNumeric
+        } else {
+            ValueMode::Value(coercion)
+        };
+        let mut members = Vec::with_capacity(values.len());
+        for b in values {
+            let v = self.bind_value(b)?;
+            members.push(if numeric {
+                cast(Expr::val(v), "numeric")
+            } else {
+                coerce_rhs(v, coercion)
+            });
+        }
+        if positive && let Some(leaf) = Self::existential_leaf(path) {
+            let leaf = leaf.clone();
+            self.ensure_leaf_root(path)?;
+            let members = members.clone();
+            if let Some(expr) =
+                self.data_leaf_exists(&leaf, mode, |extract| extract.is_in(members))?
+            {
+                return Ok(expr);
+            }
+        }
+        let lhs = self.value_expr(path, mode)?;
+        Ok(lhs.is_in(members))
     }
 
     /// The typed EHR-id comparison fast path: fires only for

--- a/app/ferroehr/src/config/authz.rs
+++ b/app/ferroehr/src/config/authz.rs
@@ -370,47 +370,63 @@ impl AbacConfig {
     /// Validate the ABAC section at boot (hard errors). Only called when
     /// `enabled`.
     fn validate(&self) -> Result<(), AuthzConfigError> {
-        for (kind, rule) in &self.policy {
-            if !POLICY_KINDS.contains(&kind.as_str()) {
-                return Err(AuthzConfigError::UnknownPolicyKind(kind.clone()));
-            }
-            if rule.parameters.contains(&AbacParam::Template) {
-                match kind.as_str() {
-                    "ehr" => return Err(AuthzConfigError::TemplateParamIllegal("ehr")),
-                    "ehr_status" => {
-                        return Err(AuthzConfigError::TemplateParamIllegal("ehr_status"));
-                    }
-                    _ => {}
-                }
-            }
-        }
+        self.validate_policy_rules()?;
         match self.engine {
-            AbacEngineKind::Remote => {
-                let server = self
-                    .remote
-                    .server
-                    .as_deref()
-                    .filter(|s| !s.trim().is_empty())
-                    .ok_or(AuthzConfigError::RemoteServerMissing)?;
-                if !server.ends_with('/') {
-                    return Err(AuthzConfigError::RemoteServerTrailingSlash(
-                        server.to_owned(),
-                    ));
-                }
-                for kind in REQUIRED_REMOTE_POLICY_KINDS {
-                    if !self.policy.contains_key(kind) {
-                        return Err(AuthzConfigError::RemotePolicyMissing(kind));
-                    }
-                }
-                if self.check_directory && !self.policy.contains_key("directory") {
-                    return Err(AuthzConfigError::RemotePolicyMissing("directory"));
-                }
-            }
+            AbacEngineKind::Remote => self.validate_remote_engine(),
             AbacEngineKind::Cedar => {
                 if self.cedar.policy_dir.is_none() {
                     return Err(AuthzConfigError::CedarDirMissing);
                 }
+                Ok(())
             }
+        }
+    }
+
+    /// Every configured policy rule names a known resource kind, and no rule
+    /// asks for a parameter its kind cannot carry.
+    ///
+    /// The `template` parameter is a property of committed content, so an
+    /// EHR-level or EHR_STATUS-level rule can never be given one.
+    fn validate_policy_rules(&self) -> Result<(), AuthzConfigError> {
+        for (kind, rule) in &self.policy {
+            if !POLICY_KINDS.contains(&kind.as_str()) {
+                return Err(AuthzConfigError::UnknownPolicyKind(kind.clone()));
+            }
+            if !rule.parameters.contains(&AbacParam::Template) {
+                continue;
+            }
+            match kind.as_str() {
+                "ehr" => return Err(AuthzConfigError::TemplateParamIllegal("ehr")),
+                "ehr_status" => return Err(AuthzConfigError::TemplateParamIllegal("ehr_status")),
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    /// The remote-PDP engine's own requirements: a base server URL with a
+    /// trailing slash, and a policy for every resource kind the PEP consults
+    /// (an unconfigured kind denies, and the missing rule is a boot error
+    /// rather than a silent refusal at request time).
+    fn validate_remote_engine(&self) -> Result<(), AuthzConfigError> {
+        let server = self
+            .remote
+            .server
+            .as_deref()
+            .filter(|s| !s.trim().is_empty())
+            .ok_or(AuthzConfigError::RemoteServerMissing)?;
+        if !server.ends_with('/') {
+            return Err(AuthzConfigError::RemoteServerTrailingSlash(
+                server.to_owned(),
+            ));
+        }
+        for kind in REQUIRED_REMOTE_POLICY_KINDS {
+            if !self.policy.contains_key(kind) {
+                return Err(AuthzConfigError::RemotePolicyMissing(kind));
+            }
+        }
+        if self.check_directory && !self.policy.contains_key("directory") {
+            return Err(AuthzConfigError::RemotePolicyMissing("directory"));
         }
         Ok(())
     }

--- a/app/ferroehr/src/config/loader.rs
+++ b/app/ferroehr/src/config/loader.rs
@@ -132,82 +132,8 @@ pub fn assemble<S: std::hash::BuildHasher>(
     overrides: &[(String, String)],
 ) -> Result<FerroEhrConfig, ConfigErrors> {
     let mut errors = strict::strict_env(env);
-
-    let file_content = match file {
-        Some(path) => match std::fs::read_to_string(path) {
-            Ok(content) => Some(content),
-            Err(e) => {
-                errors.push(ConfigError::new(format!(
-                    "reading config file {}: {e}",
-                    path.display()
-                )));
-                None
-            }
-        },
-        None => None,
-    };
-
-    // The two permanent conventional aliases (DATABASE_URL, RUST_LOG) —
-    // layered BELOW the canonical source so an `FERROEHR__` form always wins.
-    let mut alias_map: HashMap<String, String> = HashMap::new();
-    // A transaction-pooled endpoint (pgbouncer) hands statements to backend
-    // connections without the session `search_path`, which surfaces as
-    // intermittent 42P01 "relation does not exist" (#2716) — so when a
-    // managed-Postgres integration offers the DIRECT endpoint beside the
-    // pooled one (Neon injects both), the direct one wins within this layer.
-    if let Some(value) = env.get("DATABASE_URL_UNPOOLED") {
-        alias_map.insert("FERROEHR__DB__URL".to_owned(), value.clone());
-    }
-    for (external, canonical) in CONVENTIONAL {
-        if let Some(value) = env.get(*external) {
-            alias_map
-                .entry((*canonical).to_owned())
-                .or_insert_with(|| value.clone());
-        }
-    }
-    // The PaaS port convention: container platforms (Vercel, Cloud Run,
-    // Heroku) inject `PORT` and route traffic to it. It carries only the port
-    // half, so it maps to an all-interfaces bind rather than joining the 1:1
-    // CONVENTIONAL table — still layered BELOW `FERROEHR__SERVER__BIND`.
-    if let Some(port) = env.get("PORT") {
-        alias_map
-            .entry("FERROEHR__SERVER__BIND".to_owned())
-            .or_insert_with(|| format!("0.0.0.0:{port}"));
-    }
-    // The libpq environment convention (PostgreSQL's own variable set,
-    // https://www.postgresql.org/docs/current/libpq-envars.html): managed
-    // Postgres integrations (Neon on Vercel among them) inject PGHOST/PGUSER/
-    // PGPASSWORD/PGDATABASE instead of a URL. Assembled into a DSN BELOW both
-    // URL forms — a URL entry already claimed above wins — and preferring the
-    // direct `PGHOST_UNPOOLED` host over the pooled `PGHOST` (#2716, the
-    // same transaction-pooling reason as `DATABASE_URL_UNPOOLED` above).
-    if let Some(host) = env.get("PGHOST_UNPOOLED").or_else(|| env.get("PGHOST")) {
-        let mut dsn = String::from("postgres://");
-        if let Some(user) = env.get("PGUSER") {
-            dsn.push_str(&urlencoding::encode(user));
-            if let Some(password) = env.get("PGPASSWORD") {
-                dsn.push(':');
-                dsn.push_str(&urlencoding::encode(password));
-            }
-            dsn.push('@');
-        }
-        dsn.push_str(host);
-        if let Some(port) = env.get("PGPORT") {
-            dsn.push(':');
-            dsn.push_str(port);
-        }
-        dsn.push('/');
-        dsn.push_str(env.get("PGDATABASE").map_or("postgres", String::as_str));
-        if let Some(sslmode) = env.get("PGSSLMODE") {
-            dsn.push_str("?sslmode=");
-            dsn.push_str(sslmode);
-        }
-        // `or_insert_with`: a `DATABASE_URL` already claimed this entry in the
-        // CONVENTIONAL loop above, and it outranks the assembled form.
-        alias_map
-            .entry("FERROEHR__DB__URL".to_owned())
-            .or_insert(dsn);
-    }
+    let file_content = read_config_file(file, &mut errors);
+    let alias_map = conventional_aliases(env);
 
     // The canonical (uniform-grammar) `FERROEHR__…` variables. Allowlisted
     // infra names never carry the double prefix, so the prefix check alone
@@ -264,6 +190,96 @@ pub fn assemble<S: std::hash::BuildHasher>(
     } else {
         Err(ConfigErrors(errors))
     }
+}
+
+/// Reads the configuration file, recording an unreadable path as an error
+/// rather than aborting the pass (every problem is reported at once).
+fn read_config_file(file: Option<&Path>, errors: &mut Vec<ConfigError>) -> Option<String> {
+    let path = file?;
+    match std::fs::read_to_string(path) {
+        Ok(content) => Some(content),
+        Err(e) => {
+            errors.push(ConfigError::new(format!(
+                "reading config file {}: {e}",
+                path.display()
+            )));
+            None
+        }
+    }
+}
+
+/// The conventional (non-`FERROEHR__`) environment aliases, mapped onto their
+/// canonical keys.
+///
+/// This whole layer sits BELOW the canonical source, so an `FERROEHR__` form
+/// always wins. Within the layer, a transaction-pooled endpoint (pgbouncer)
+/// hands statements to backend connections without the session `search_path`,
+/// which surfaces as intermittent 42P01 "relation does not exist" (#2716) — so
+/// where a managed-Postgres integration offers the DIRECT endpoint beside the
+/// pooled one (Neon injects both), the direct one wins.
+fn conventional_aliases<S: std::hash::BuildHasher>(
+    env: &HashMap<String, String, S>,
+) -> HashMap<String, String> {
+    let mut alias_map: HashMap<String, String> = HashMap::new();
+    if let Some(value) = env.get("DATABASE_URL_UNPOOLED") {
+        alias_map.insert("FERROEHR__DB__URL".to_owned(), value.clone());
+    }
+    for (external, canonical) in CONVENTIONAL {
+        if let Some(value) = env.get(*external) {
+            alias_map
+                .entry((*canonical).to_owned())
+                .or_insert_with(|| value.clone());
+        }
+    }
+    // The PaaS port convention: container platforms (Vercel, Cloud Run,
+    // Heroku) inject `PORT` and route traffic to it. It carries only the port
+    // half, so it maps to an all-interfaces bind rather than joining the 1:1
+    // CONVENTIONAL table — still layered BELOW `FERROEHR__SERVER__BIND`.
+    if let Some(port) = env.get("PORT") {
+        alias_map
+            .entry("FERROEHR__SERVER__BIND".to_owned())
+            .or_insert_with(|| format!("0.0.0.0:{port}"));
+    }
+    if let Some(dsn) = libpq_dsn(env) {
+        // `or_insert`: a `DATABASE_URL` already claimed this entry in the
+        // CONVENTIONAL loop above, and it outranks the assembled form.
+        alias_map
+            .entry("FERROEHR__DB__URL".to_owned())
+            .or_insert(dsn);
+    }
+    alias_map
+}
+
+/// A DSN assembled from the libpq environment convention (PostgreSQL's own
+/// variable set, <https://www.postgresql.org/docs/current/libpq-envars.html>),
+/// which managed Postgres integrations (Neon on Vercel among them) inject
+/// instead of a URL.
+///
+/// The direct `PGHOST_UNPOOLED` host is preferred over the pooled `PGHOST`
+/// (#2716, the same transaction-pooling reason as `DATABASE_URL_UNPOOLED`).
+fn libpq_dsn<S: std::hash::BuildHasher>(env: &HashMap<String, String, S>) -> Option<String> {
+    let host = env.get("PGHOST_UNPOOLED").or_else(|| env.get("PGHOST"))?;
+    let mut dsn = String::from("postgres://");
+    if let Some(user) = env.get("PGUSER") {
+        dsn.push_str(&urlencoding::encode(user));
+        if let Some(password) = env.get("PGPASSWORD") {
+            dsn.push(':');
+            dsn.push_str(&urlencoding::encode(password));
+        }
+        dsn.push('@');
+    }
+    dsn.push_str(host);
+    if let Some(port) = env.get("PGPORT") {
+        dsn.push(':');
+        dsn.push_str(port);
+    }
+    dsn.push('/');
+    dsn.push_str(env.get("PGDATABASE").map_or("postgres", String::as_str));
+    if let Some(sslmode) = env.get("PGSSLMODE") {
+        dsn.push_str("?sslmode=");
+        dsn.push_str(sslmode);
+    }
+    Some(dsn)
 }
 
 /// An `FERROEHR_`-prefixed environment source over an injected map (the hermetic

--- a/app/ferroehr/src/config/mod.rs
+++ b/app/ferroehr/src/config/mod.rs
@@ -106,14 +106,38 @@ impl FerroEhrConfig {
     /// [`ConfigErrors`] carrying every failing rule.
     pub fn validate(&self) -> Result<(), ConfigErrors> {
         let mut errors = Vec::new();
+        self.validate_system_id(&mut errors);
+        self.validate_mechanisms(&mut errors);
+        self.validate_signing(&mut errors);
+        self.validate_key_sources(&mut errors);
+        errors.extend(multimedia_endpoint_errors(&self.multimedia));
+        // management.port must differ from the server.bind port.
+        if let Some(port) = self.management.port
+            && server_bind_port(&self.server.bind) == Some(port)
+        {
+            errors.push(ConfigError::semantic(format!(
+                "management.port ({port}) must differ from the server.bind port"
+            )));
+        }
+        validate_terminology(&self.terminology.external, &mut errors);
 
-        // server.system_id is stamped into every AUDIT_DETAILS
-        // (`System_id_valid`: "not system_id.is_empty", RM
-        // `docs/UML/classes/org.openehr.rm.common.audit_details.adoc`
-        // §Invariants) and occupies the `creating_system_id` position of every
-        // OBJECT_VERSION_ID this CDR mints (BASE
-        // `base_types/master05-identification_package.adoc` §Syntaxes), so it is
-        // judged here by the SAME validating `UID` constructor the reader uses.
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(ConfigErrors(errors))
+        }
+    }
+
+    /// `server.system_id` is judged by the SAME validating `UID` constructor
+    /// the reader uses.
+    ///
+    /// It is stamped into every `AUDIT_DETAILS` (`System_id_valid`: "not
+    /// `system_id.is_empty`", RM
+    /// `docs/UML/classes/org.openehr.rm.common.audit_details.adoc` §Invariants)
+    /// and occupies the `creating_system_id` position of every
+    /// `OBJECT_VERSION_ID` this CDR mints (BASE
+    /// `base_types/master05-identification_package.adoc` §Syntaxes).
+    fn validate_system_id(&self, errors: &mut Vec<ConfigError>) {
         if let Err(source) =
             openehr_base::v1_3::base_types::identification::uid::Uid::new(&self.server.system_id)
         {
@@ -126,24 +150,31 @@ impl FerroEhrConfig {
                 self.server.system_id
             )));
         }
+    }
 
-        // Authentication rules: the RFC-grounded shape of each configured
-        // mechanism (issuer, audience, leeway, key entropy, KDF cost floor).
+    /// The per-mechanism rules each security section owns.
+    ///
+    /// Authentication contributes the RFC-grounded shape of each configured
+    /// mechanism (issuer, audience, leeway, key entropy, KDF cost floor);
+    /// SMART adds the deprecated-grant rule plus everything the discovery
+    /// document publishes (endpoint scheme, the RFC 8414 §2 required fields,
+    /// PKCE).
+    fn validate_mechanisms(&self, errors: &mut Vec<ConfigError>) {
         if let Err(e) = self.auth.validate() {
             errors.push(ConfigError::semantic(format!("auth: {e}")));
         }
-        // Authorization rules (moved verbatim from the old AuthzConfig::validate).
         if let Err(e) = self.authz.validate() {
             errors.push(ConfigError::semantic(format!("authz: {e}")));
         }
-        // SMART: the deprecated-grant rule plus everything the discovery
-        // document publishes (endpoint scheme, the RFC 8414 §2 required fields,
-        // PKCE).
         if let Err(e) = self.smart.validate() {
             errors.push(ConfigError::semantic(format!("smart: {e}")));
         }
-        self.validate_smart_issuer(&mut errors);
-        // signing.mode = pgp ⇒ key_path set.
+        self.validate_smart_issuer(errors);
+    }
+
+    /// The signing section's own rules: a PGP mode needs a key, and a
+    /// passphrase is given inline or by file, never both.
+    fn validate_signing(&self, errors: &mut Vec<ConfigError>) {
         if matches!(
             self.signing.mode,
             crate::versioning::signature::config::Mode::Pgp
@@ -153,12 +184,20 @@ impl FerroEhrConfig {
                 "signing.mode = \"pgp\" requires signing.key_path".to_owned(),
             ));
         }
-        // Secret / *_file mutual exclusion.
         if self.signing.key_passphrase.is_some() && self.signing.key_passphrase_file.is_some() {
             errors.push(ConfigError::semantic(
                 "set only one of signing.key_passphrase / signing.key_passphrase_file".to_owned(),
             ));
         }
+    }
+
+    /// Every secret that can be given inline or by file is given exactly one
+    /// way, and the OIDC key material names exactly one source.
+    ///
+    /// A symmetric secret and a static JWKS are competing explicit key
+    /// sources; both configured is a contradiction, never resolved by silent
+    /// precedence.
+    fn validate_key_sources(&self, errors: &mut Vec<ConfigError>) {
         if let Some(oidc) = &self.auth.oidc {
             if oidc.hmac_secret.is_some() && oidc.hmac_secret_file.is_some() {
                 errors.push(ConfigError::semantic(
@@ -170,9 +209,6 @@ impl FerroEhrConfig {
                     "set only one of auth.oidc.jwks_json / auth.oidc.jwks_json_file".to_owned(),
                 ));
             }
-            // A symmetric secret and a static JWKS are competing explicit key
-            // sources; both configured is a contradiction, never resolved by
-            // silent precedence.
             let hmac_configured = oidc.hmac_secret.is_some() || oidc.hmac_secret_file.is_some();
             let jwks_configured = oidc.jwks_json.is_some() || oidc.jwks_json_file.is_some();
             if hmac_configured && jwks_configured {
@@ -192,22 +228,6 @@ impl FerroEhrConfig {
                  multimedia.secret_access_key_file"
                     .to_owned(),
             ));
-        }
-        errors.extend(multimedia_endpoint_errors(&self.multimedia));
-        // management.port must differ from the server.bind port.
-        if let Some(port) = self.management.port
-            && server_bind_port(&self.server.bind) == Some(port)
-        {
-            errors.push(ConfigError::semantic(format!(
-                "management.port ({port}) must differ from the server.bind port"
-            )));
-        }
-        validate_terminology(&self.terminology.external, &mut errors);
-
-        if errors.is_empty() {
-            Ok(())
-        } else {
-            Err(ConfigErrors(errors))
         }
     }
 
@@ -325,55 +345,78 @@ fn validate_terminology(
         }
     }
     for (name, provider) in &terminology.providers {
-        if provider.url.trim().is_empty() {
-            errors.push(ConfigError::semantic(format!(
-                "terminology.external.providers.{name}.url must not be empty (the FHIR R4B base \
-                 URL of the terminology server)"
-            )));
-        }
-        // A mutual-TLS identity is a certificate AND its key; half of one
-        // would connect with no client certificate at all, which the server
-        // rejects at handshake time — a boot error, not a runtime surprise.
-        match (&provider.client_cert_path, &provider.client_key_path) {
-            (Some(_), None) => errors.push(ConfigError::semantic(format!(
-                "terminology.external.providers.{name}.client_cert_path is set without \
-                 client_key_path (a client certificate needs its private key)"
-            ))),
-            (None, Some(_)) => errors.push(ConfigError::semantic(format!(
-                "terminology.external.providers.{name}.client_key_path is set without \
-                 client_cert_path (a private key needs its certificate)"
-            ))),
-            _ => {}
-        }
-        let Some(client) = provider.oauth2_client.as_deref() else {
-            continue;
-        };
-        if !terminology.oauth2_clients.contains_key(client) {
-            errors.push(ConfigError::semantic(format!(
-                "terminology.external.providers.{name}.oauth2_client names '{client}', which has \
-                 no [terminology.external.oauth2_clients.{client}]"
-            )));
-        }
+        validate_terminology_provider(name, provider, terminology, errors);
     }
     for (name, client) in &terminology.oauth2_clients {
-        if client.token_url.trim().is_empty() {
-            errors.push(ConfigError::semantic(format!(
-                "terminology.external.oauth2_clients.{name}.token_url must not be empty"
-            )));
-        }
-        if client.client_id.trim().is_empty() {
-            errors.push(ConfigError::semantic(format!(
-                "terminology.external.oauth2_clients.{name}.client_id must not be empty"
-            )));
-        }
-        if client.client_secret.as_ref().is_none_or(Secret::is_empty)
-            && client.client_secret_file.is_none()
-        {
-            errors.push(ConfigError::semantic(format!(
-                "terminology.external.oauth2_clients.{name} requires client_secret or \
-                 client_secret_file (the client-credentials grant authenticates the client)"
-            )));
-        }
+        validate_terminology_client(name, client, errors);
+    }
+}
+
+/// One `[terminology.external.providers.<name>]` block: its base URL, the
+/// completeness of any mutual-TLS identity, and the resolvability of its
+/// OAuth2 client reference.
+///
+/// A mutual-TLS identity is a certificate AND its key; half of one would
+/// connect with no client certificate at all, which the server rejects at
+/// handshake time — a boot error, not a runtime surprise.
+fn validate_terminology_provider(
+    name: &str,
+    provider: &crate::service::terminology::config::FhirProviderConfig,
+    terminology: &crate::service::terminology::config::ExternalTerminologyConfig,
+    errors: &mut Vec<ConfigError>,
+) {
+    if provider.url.trim().is_empty() {
+        errors.push(ConfigError::semantic(format!(
+            "terminology.external.providers.{name}.url must not be empty (the FHIR R4B base \
+             URL of the terminology server)"
+        )));
+    }
+    match (&provider.client_cert_path, &provider.client_key_path) {
+        (Some(_), None) => errors.push(ConfigError::semantic(format!(
+            "terminology.external.providers.{name}.client_cert_path is set without \
+             client_key_path (a client certificate needs its private key)"
+        ))),
+        (None, Some(_)) => errors.push(ConfigError::semantic(format!(
+            "terminology.external.providers.{name}.client_key_path is set without \
+             client_cert_path (a private key needs its certificate)"
+        ))),
+        _ => {}
+    }
+    let Some(client) = provider.oauth2_client.as_deref() else {
+        return;
+    };
+    if !terminology.oauth2_clients.contains_key(client) {
+        errors.push(ConfigError::semantic(format!(
+            "terminology.external.providers.{name}.oauth2_client names '{client}', which has \
+             no [terminology.external.oauth2_clients.{client}]"
+        )));
+    }
+}
+
+/// One `[terminology.external.oauth2_clients.<name>]` block: the
+/// client-credentials grant needs a token endpoint, a client id, and a secret.
+fn validate_terminology_client(
+    name: &str,
+    client: &crate::service::terminology::config::TerminologyOauth2Config,
+    errors: &mut Vec<ConfigError>,
+) {
+    if client.token_url.trim().is_empty() {
+        errors.push(ConfigError::semantic(format!(
+            "terminology.external.oauth2_clients.{name}.token_url must not be empty"
+        )));
+    }
+    if client.client_id.trim().is_empty() {
+        errors.push(ConfigError::semantic(format!(
+            "terminology.external.oauth2_clients.{name}.client_id must not be empty"
+        )));
+    }
+    if client.client_secret.as_ref().is_none_or(Secret::is_empty)
+        && client.client_secret_file.is_none()
+    {
+        errors.push(ConfigError::semantic(format!(
+            "terminology.external.oauth2_clients.{name} requires client_secret or \
+             client_secret_file (the client-credentials grant authenticates the client)"
+        )));
     }
 }
 

--- a/app/ferroehr/src/extensions/events/publisher.rs
+++ b/app/ferroehr/src/extensions/events/publisher.rs
@@ -189,31 +189,7 @@ async fn run(
         {
             tracing::debug!("event subscription sync deferred: {e}");
         }
-        // Drain until the outbox is empty or the broker/DB stalls.
-        loop {
-            if *shutdown.borrow() {
-                break;
-            }
-            match drain_batch(&pool, publisher.as_ref(), &config).await {
-                Ok(n) => {
-                    healthy.store(true, Ordering::Relaxed);
-                    // A full batch means more may remain — keep draining;
-                    // a short batch means the outbox is now empty.
-                    if usize::try_from(config.batch_size).unwrap_or(usize::MAX) > n {
-                        break;
-                    }
-                }
-                Err(DrainError::Publish(e)) => {
-                    healthy.store(false, Ordering::Relaxed);
-                    tracing::warn!("event publish stalled (broker unavailable?): {e}");
-                    break;
-                }
-                Err(DrainError::Db(e)) => {
-                    tracing::warn!("event outbox drain DB error: {e}");
-                    break;
-                }
-            }
-        }
+        drain_until_caught_up(&pool, publisher.as_ref(), &config, &shutdown, &healthy).await;
 
         // Retention prune (best-effort), on its own cadence.
         if last_prune.elapsed() >= prune_every {
@@ -238,6 +214,42 @@ async fn run(
         tracing::debug!("event publisher flushed {n} events on shutdown");
     }
     tracing::debug!("event publisher loop exited");
+}
+
+/// Drains the outbox until it is empty, the broker or DB stalls, or shutdown
+/// is signalled, keeping the health flag in step with broker delivery.
+///
+/// A full batch means more may remain — keep draining; a short batch means the
+/// outbox is now empty.
+async fn drain_until_caught_up(
+    pool: &PgPool,
+    publisher: &dyn EventPublisher,
+    config: &EventsConfig,
+    shutdown: &watch::Receiver<bool>,
+    healthy: &AtomicBool,
+) {
+    loop {
+        if *shutdown.borrow() {
+            return;
+        }
+        match drain_batch(pool, publisher, config).await {
+            Ok(n) => {
+                healthy.store(true, Ordering::Relaxed);
+                if usize::try_from(config.batch_size).unwrap_or(usize::MAX) > n {
+                    return;
+                }
+            }
+            Err(DrainError::Publish(e)) => {
+                healthy.store(false, Ordering::Relaxed);
+                tracing::warn!("event publish stalled (broker unavailable?): {e}");
+                return;
+            }
+            Err(DrainError::Db(e)) => {
+                tracing::warn!("event outbox drain DB error: {e}");
+                return;
+            }
+        }
+    }
 }
 
 /// Declare + bind the queue for every **enabled** subscription — but only when

--- a/app/ferroehr/src/extensions/fhir/outbound.rs
+++ b/app/ferroehr/src/extensions/fhir/outbound.rs
@@ -253,94 +253,25 @@ async fn process_batch(
     let mut processed = 0usize;
     let mut advanced = last_seq;
     let mut outcome: Result<usize, ProcessError> = Ok(0);
-    'rows: for row in &rows {
+    for row in &rows {
         let seq: i64 = row.try_get("seq")?;
         let envelope: Value = row.try_get("envelope")?;
-        let ehr_id = envelope
-            .get("ehr_id")
-            .and_then(Value::as_str)
-            .and_then(|s| Uuid::parse_str(s).ok());
-
-        let mut parked = false;
-        'versions: for version in envelope
-            .get("versions")
-            .and_then(Value::as_array)
-            .into_iter()
-            .flatten()
-        {
-            // Only COMPOSITION versions can map to a FHIR resource
-            // (EHR_STATUS/FOLDER carry no mappable template). The template is
-            // read from the COMPOSITION body by the service.
-            if version.get("kind").and_then(Value::as_str) != Some("COMPOSITION") {
-                continue;
+        match process_row(service, publisher, config, poison, seq, &envelope).await {
+            RowOutcome::Stop(e) => {
+                outcome = Err(e);
+                break;
             }
-            let (Some(vo_id), Some(sys_version)) = (
-                version
-                    .get("vo_id")
-                    .and_then(Value::as_str)
-                    .and_then(|s| Uuid::parse_str(s).ok())
-                    .map(VoId),
-                version
-                    .get("sys_version")
-                    .and_then(Value::as_i64)
-                    .and_then(|v| i32::try_from(v).ok()),
-            ) else {
-                continue;
-            };
-
-            let messages = match service
-                .fhir_outbound_messages(ehr_id, vo_id, sys_version)
-                .await
-            {
-                Ok(m) => m,
-                Err(e) => {
-                    // A mapping failure is deterministic for this row: charge
-                    // its park budget; once exhausted, dead-letter it to the
-                    // log and skip (the cursor advances past it below).
-                    let failed_passes = charge_poison(poison, seq);
-                    if failed_passes >= PARK_AFTER_FAILED_PASSES {
-                        tracing::error!(
-                            seq,
-                            vo_id = %vo_id,
-                            sys_version,
-                            error = %e,
-                            "fhir outbound: parking poison outbox row after \
-                             {PARK_AFTER_FAILED_PASSES} failed passes — row skipped \
-                             (dead-lettered to the log; fix the stored mapping/template \
-                             and re-commit to re-emit)"
-                        );
-                        *poison = None;
-                        parked = true;
-                        break 'versions;
-                    }
-                    outcome = Err(ProcessError::Map(e.to_string()));
-                    break 'rows;
-                }
-            };
-            for (resource_type, template_id, resource) in &messages {
-                let routing_key = routing_key(resource_type, template_id);
-                let payload = match resource_payload(resource_type, resource) {
-                    Ok(bytes) => bytes,
-                    Err(e) => {
-                        outcome = Err(e);
-                        break 'rows;
-                    }
-                };
-                if let Err(e) = publish_with_retry(publisher, &routing_key, &payload, config).await
-                {
-                    outcome = Err(ProcessError::Publish(e));
-                    break 'rows;
+            RowOutcome::Published { parked } => {
+                // The whole row published (or parked): it is safe to advance
+                // the cursor past it.
+                advanced = seq;
+                processed += 1;
+                if !parked {
+                    // The head row completed cleanly — any earlier failures on
+                    // it were transient; clear its budget.
+                    clear_poison_for(poison, seq);
                 }
             }
-        }
-        // The whole row published (or parked): it is safe to advance the
-        // cursor past it.
-        advanced = seq;
-        processed += 1;
-        if !parked {
-            // The head row completed cleanly — any earlier failures on it were
-            // transient; clear its budget.
-            clear_poison_for(poison, seq);
         }
     }
 
@@ -353,6 +284,101 @@ async fn process_batch(
         Err(e) => Err(e),
         Ok(_) => Ok(processed),
     }
+}
+
+/// What one outbox row's processing means for the rest of the batch.
+enum RowOutcome {
+    /// Every mappable version of the row published, or the row was parked —
+    /// the cursor may advance past it. `parked` says which.
+    Published { parked: bool },
+    /// The batch stops here; the already-published prefix keeps its cursor
+    /// advance, so a re-run resumes from this row.
+    Stop(ProcessError),
+}
+
+/// Publishes every mappable version of one outbox row.
+///
+/// Only COMPOSITION versions can map to a FHIR resource (`EHR_STATUS`/`FOLDER`
+/// carry no mappable template); the template is read from the COMPOSITION body
+/// by the service. A mapping failure is deterministic for the row, so it
+/// charges the row's park budget; once the budget is exhausted the row is
+/// dead-lettered to the log and skipped. Publish and payload failures are
+/// transient and stop the batch instead.
+async fn process_row(
+    service: &FerroEhrService,
+    publisher: &dyn EventPublisher,
+    config: &FhirOutboundConfig,
+    poison: &mut PoisonBudget,
+    seq: i64,
+    envelope: &Value,
+) -> RowOutcome {
+    let ehr_id = envelope
+        .get("ehr_id")
+        .and_then(Value::as_str)
+        .and_then(|s| Uuid::parse_str(s).ok());
+    for version in envelope
+        .get("versions")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        let Some((vo_id, sys_version)) = mappable_version(version) else {
+            continue;
+        };
+        let messages = match service
+            .fhir_outbound_messages(ehr_id, vo_id, sys_version)
+            .await
+        {
+            Ok(m) => m,
+            Err(e) => {
+                let failed_passes = charge_poison(poison, seq);
+                if failed_passes < PARK_AFTER_FAILED_PASSES {
+                    return RowOutcome::Stop(ProcessError::Map(e.to_string()));
+                }
+                tracing::error!(
+                    seq,
+                    vo_id = %vo_id,
+                    sys_version,
+                    error = %e,
+                    "fhir outbound: parking poison outbox row after \
+                     {PARK_AFTER_FAILED_PASSES} failed passes — row skipped \
+                     (dead-lettered to the log; fix the stored mapping/template \
+                     and re-commit to re-emit)"
+                );
+                *poison = None;
+                return RowOutcome::Published { parked: true };
+            }
+        };
+        for (resource_type, template_id, resource) in &messages {
+            let routing_key = routing_key(resource_type, template_id);
+            let payload = match resource_payload(resource_type, resource) {
+                Ok(bytes) => bytes,
+                Err(e) => return RowOutcome::Stop(e),
+            };
+            if let Err(e) = publish_with_retry(publisher, &routing_key, &payload, config).await {
+                return RowOutcome::Stop(ProcessError::Publish(e));
+            }
+        }
+    }
+    RowOutcome::Published { parked: false }
+}
+
+/// The versioned-object id and version ordinal of one announced version, or
+/// `None` when it is not a mappable COMPOSITION version.
+fn mappable_version(version: &Value) -> Option<(VoId, i32)> {
+    if version.get("kind").and_then(Value::as_str) != Some("COMPOSITION") {
+        return None;
+    }
+    let vo_id = version
+        .get("vo_id")
+        .and_then(Value::as_str)
+        .and_then(|s| Uuid::parse_str(s).ok())
+        .map(VoId)?;
+    let sys_version = version
+        .get("sys_version")
+        .and_then(Value::as_i64)
+        .and_then(|v| i32::try_from(v).ok())?;
+    Some((vo_id, sys_version))
 }
 
 /// Charge one failed pass against `seq`'s park budget, returning its

--- a/app/ferroehr/src/service/admin/dump_load.rs
+++ b/app/ferroehr/src/service/admin/dump_load.rs
@@ -1365,52 +1365,9 @@ impl FerroEhrService {
             let bytes = archive.read(segment)?;
             let records: Vec<EhrRecord> = serde_json::from_slice(&bytes)
                 .map_err(|e| unreadable_archive_entry(dir, segment, &e))?;
-            for mut record in records {
-                let ehr_id = record.ehr.id;
-                if self.ehr_row_exists(ehr_id).await? {
-                    // "import EHRs with duplicate EHR ids will fail" — reported,
-                    // not fatal; the rest of the archive still loads.
-                    reports.push(DumpLoadFailReport {
-                        entity_type: "EHR".to_owned(),
-                        entity_id: ehr_id.to_string(),
-                        dump_status: false,
-                        error: Some("an EHR with this id already exists".to_owned()),
-                    });
-                    continue;
-                }
-                // `openehr_canonical_xml`: pull each version's payload out of
-                // its `versions/*.xml` entry BEFORE the record's transaction
-                // opens, so an unreadable document costs that one record a
-                // report and commits nothing (the same per-entity shape the SM
-                // gives a duplicate id), instead of aborting the whole load.
-                if format == ExportFormat::OpenehrCanonicalXml
-                    && let Err(message) = resolve_version_documents(&mut archive, &mut record)
-                {
-                    reports.push(DumpLoadFailReport {
-                        entity_type: "EHR".to_owned(),
-                        entity_id: ehr_id.to_string(),
-                        dump_status: false,
-                        error: Some(format!(
-                            "the archive's canonical-XML version payload is unreadable: {message}"
-                        )),
-                    });
-                    continue;
-                }
-                match self.load_one_ehr(record).await {
-                    Ok(()) => {}
-                    // A per-EHR conflict — currently a subject this repository
-                    // already holds under another EHR (one EHR per subject, RM
-                    // ehr master04 §EHR Status), reachable only on a PARTIAL
-                    // load into a non-empty repository. Reported and skipped
-                    // (its transaction rolled back) exactly like a duplicate
-                    // EHR id, so the rest of the archive still loads.
-                    Err(ServiceError::Conflict(e)) => reports.push(DumpLoadFailReport {
-                        entity_type: "EHR".to_owned(),
-                        entity_id: ehr_id.to_string(),
-                        dump_status: false,
-                        error: Some(e.message),
-                    }),
-                    Err(e) => return Err(e.into()),
+            for record in records {
+                if let Some(report) = self.load_ehr_record(&mut archive, record, format).await? {
+                    reports.push(report);
                 }
             }
         }
@@ -1429,35 +1386,105 @@ impl FerroEhrService {
             let bytes = archive.read(segment)?;
             let records: Vec<DemographicRecord> = serde_json::from_slice(&bytes)
                 .map_err(|e| unreadable_archive_entry(dir, segment, &e))?;
-            for mut record in records {
-                if self.demographic_container_exists(record.vo_id).await? {
-                    reports.push(DumpLoadFailReport {
-                        entity_type: record.kind.clone(),
-                        entity_id: record.vo_id.to_string(),
-                        dump_status: false,
-                        error: Some(
-                            "a demographic container with this id already exists".to_owned(),
-                        ),
-                    });
-                    continue;
-                }
-                if format == ExportFormat::OpenehrCanonicalXml
-                    && let Err(message) = resolve_demographic_documents(&mut archive, &mut record)
+            for record in records {
+                if let Some(report) = self
+                    .load_demographic_record(&mut archive, record, format)
+                    .await?
                 {
-                    reports.push(DumpLoadFailReport {
-                        entity_type: record.kind.clone(),
-                        entity_id: record.vo_id.to_string(),
-                        dump_status: false,
-                        error: Some(format!(
-                            "the archive's canonical-XML version payload is unreadable: {message}"
-                        )),
-                    });
-                    continue;
+                    reports.push(report);
                 }
-                self.load_one_demographic(record).await?;
             }
         }
         Ok(reports)
+    }
+
+    /// Loads one archived EHR record, returning the per-entity failure report
+    /// where the record is skipped rather than loaded.
+    ///
+    /// A record is skipped — reported, never fatal, so the rest of the archive
+    /// still loads — when its EHR id is already taken ("import EHRs with
+    /// duplicate EHR ids will fail"), when its canonical-XML payload is
+    /// unreadable, or when it conflicts with a subject this repository already
+    /// holds under another EHR (one EHR per subject, RM ehr master04 §EHR
+    /// Status; reachable only on a PARTIAL load into a non-empty repository,
+    /// and its transaction is rolled back).
+    ///
+    /// # Errors
+    /// The storage errors of the existence check and the load itself.
+    async fn load_ehr_record(
+        &self,
+        archive: &mut ArchiveReader,
+        mut record: EhrRecord,
+        format: ExportFormat,
+    ) -> Result<Option<DumpLoadFailReport>, SmError> {
+        let ehr_id = record.ehr.id;
+        let report = |error: String| {
+            Ok(Some(DumpLoadFailReport {
+                entity_type: "EHR".to_owned(),
+                entity_id: ehr_id.to_string(),
+                dump_status: false,
+                error: Some(error),
+            }))
+        };
+        if self.ehr_row_exists(ehr_id).await? {
+            return report("an EHR with this id already exists".to_owned());
+        }
+        // `openehr_canonical_xml`: pull each version's payload out of its
+        // `versions/*.xml` entry BEFORE the record's transaction opens, so an
+        // unreadable document costs that one record a report and commits
+        // nothing (the same per-entity shape the SM gives a duplicate id),
+        // instead of aborting the whole load.
+        if format == ExportFormat::OpenehrCanonicalXml
+            && let Err(message) = resolve_version_documents(archive, &mut record)
+        {
+            return report(format!(
+                "the archive's canonical-XML version payload is unreadable: {message}"
+            ));
+        }
+        match self.load_one_ehr(record).await {
+            Ok(()) => Ok(None),
+            Err(ServiceError::Conflict(e)) => report(e.message),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Loads one archived demographic record, returning the per-entity failure
+    /// report where the record is skipped rather than loaded.
+    ///
+    /// A duplicate container id and an unreadable canonical-XML payload are
+    /// per-entity reports, never fatal — the same shape the SM gives duplicate
+    /// EHR ids.
+    ///
+    /// # Errors
+    /// The storage errors of the existence check and the load itself.
+    async fn load_demographic_record(
+        &self,
+        archive: &mut ArchiveReader,
+        mut record: DemographicRecord,
+        format: ExportFormat,
+    ) -> Result<Option<DumpLoadFailReport>, SmError> {
+        if self.demographic_container_exists(record.vo_id).await? {
+            return Ok(Some(DumpLoadFailReport {
+                entity_type: record.kind.clone(),
+                entity_id: record.vo_id.to_string(),
+                dump_status: false,
+                error: Some("a demographic container with this id already exists".to_owned()),
+            }));
+        }
+        if format == ExportFormat::OpenehrCanonicalXml
+            && let Err(message) = resolve_demographic_documents(archive, &mut record)
+        {
+            return Ok(Some(DumpLoadFailReport {
+                entity_type: record.kind.clone(),
+                entity_id: record.vo_id.to_string(),
+                dump_status: false,
+                error: Some(format!(
+                    "the archive's canonical-XML version payload is unreadable: {message}"
+                )),
+            }));
+        }
+        self.load_one_demographic(record).await?;
+        Ok(None)
     }
 
     /// Fetch every externalized `DV_MULTIMEDIA` blob referenced by the exported

--- a/app/ferroehr/src/service/definition/opt14_convert.rs
+++ b/app/ferroehr/src/service/definition/opt14_convert.rs
@@ -621,48 +621,8 @@ impl Decomposer<'_> {
             }
         }
 
-        // The flattened ontology (per-language) for this archetype: the top
-        // root's is the OPT `ontology`; an embedded root matches a
-        // `component_ontologies` entry by archetype id. The 1.4
-        // `constraint_definitions`/`constraint_bindings` sections merge into
-        // `term_definitions`/`term_bindings` — the ADL2 folding
-        // (`ADL2/master07.13-adl_terminology.adoc` §Terminology section).
         if let Some(ont) = self.ontology_for(archetype_id, is_top) {
-            for set in ont
-                .term_definitions
-                .iter()
-                .chain(&ont.constraint_definitions)
-            {
-                let bucket = term_definitions.entry(set.language.clone()).or_default();
-                for t in &set.items {
-                    bucket.insert(t.code.clone(), map_term(t));
-                }
-            }
-            // AOM2 binding targets are URIs (`term_bindings: Hash<String,
-            // Hash<String, Uri>>`); a 1.4 binding target that is a bare code
-            // (`20081-6`) is wrapped in the converter core's fabricated URN
-            // form so the ODIN target stays parseable.
-            for set in &ont.term_bindings {
-                let bucket = term_bindings.entry(set.terminology.clone()).or_default();
-                for item in &set.items {
-                    bucket.insert(
-                        item.code.clone(),
-                        binding_uri(&set.terminology, &item.value.code_string),
-                    );
-                }
-            }
-            // 1.4 constraint bindings carry their target as a plain string (a
-            // URI or terminology query) — merged under the same terminology
-            // key, ac-code → target (VTCBK keys).
-            for set in &ont.constraint_bindings {
-                let bucket = term_bindings.entry(set.terminology.clone()).or_default();
-                for item in &set.items {
-                    bucket.insert(
-                        item.code.clone(),
-                        binding_uri(&set.terminology, &item.value),
-                    );
-                }
-            }
+            merge_ontology(ont, &mut term_definitions, &mut term_bindings);
         }
 
         // Entries minted during the definition walk (reference-set ac codes).
@@ -679,34 +639,7 @@ impl Decomposer<'_> {
                 .insert(code.clone(), uri.clone());
         }
 
-        // A binding whose key is not a code DEFINED in this root's slice is
-        // unexpressible after decomposition (1.4 OPTs may bind path keys or
-        // codes scoped to another embedded root) and would raise VTTBK
-        // (`master03` §Validity Rules — binding keys must be defined codes).
-        // Drop it, reported in `conversion_details`: the binding's home is the
-        // root that defines the code, which carries it in its own slice.
-        let defined: std::collections::BTreeSet<String> = term_definitions
-            .values()
-            .flat_map(|by_code| by_code.keys().cloned())
-            .collect();
-        for (terminology, by_key) in &mut term_bindings {
-            let terminology = terminology.clone();
-            by_key.retain(|key, _| {
-                let keep = defined.contains(key.as_str());
-                if !keep {
-                    cx.notes.insert(
-                        format!("dropped_term_binding.{terminology}.{key}"),
-                        format!(
-                            "term binding [{terminology}::{key}] is outside this root's code \
-                             scope; dropped at OPT decomposition (its home is the root that \
-                             defines the code)"
-                        ),
-                    );
-                }
-                keep
-            });
-        }
-        term_bindings.retain(|_, by_key| !by_key.is_empty());
+        drop_out_of_scope_bindings(&term_definitions, &mut term_bindings, cx);
 
         ArchetypeTerminology {
             is_differential: false,
@@ -718,6 +651,89 @@ impl Decomposer<'_> {
             terminology_extracts: None,
         }
     }
+}
+
+/// Merges one flattened 1.4 ontology into the terminology being assembled.
+///
+/// The 1.4 `constraint_definitions`/`constraint_bindings` sections merge into
+/// `term_definitions`/`term_bindings` — the ADL2 folding
+/// (`ADL2/master07.13-adl_terminology.adoc` §Terminology section). AOM2
+/// binding targets are URIs (`term_bindings: Hash<String, Hash<String,
+/// Uri>>`), so a 1.4 target that is a bare code (`20081-6`) is wrapped in the
+/// converter core's fabricated URN form and stays parseable as ODIN; a
+/// constraint binding carries its target as a plain string (a URI or a
+/// terminology query) and merges under the same terminology key, ac-code →
+/// target (VTCBK keys).
+fn merge_ontology(
+    ont: &opt14::types::FlatArchetypeOntology,
+    term_definitions: &mut BTreeMap<String, BTreeMap<String, ArchetypeTerm>>,
+    term_bindings: &mut BTreeMap<String, BTreeMap<String, String>>,
+) {
+    for set in ont
+        .term_definitions
+        .iter()
+        .chain(&ont.constraint_definitions)
+    {
+        let bucket = term_definitions.entry(set.language.clone()).or_default();
+        for t in &set.items {
+            bucket.insert(t.code.clone(), map_term(t));
+        }
+    }
+    for set in &ont.term_bindings {
+        let bucket = term_bindings.entry(set.terminology.clone()).or_default();
+        for item in &set.items {
+            bucket.insert(
+                item.code.clone(),
+                binding_uri(&set.terminology, &item.value.code_string),
+            );
+        }
+    }
+    for set in &ont.constraint_bindings {
+        let bucket = term_bindings.entry(set.terminology.clone()).or_default();
+        for item in &set.items {
+            bucket.insert(
+                item.code.clone(),
+                binding_uri(&set.terminology, &item.value),
+            );
+        }
+    }
+}
+
+/// Drops every binding whose key is not a code DEFINED in this root's slice,
+/// recording each drop in `conversion_details`.
+///
+/// Such a binding is unexpressible after decomposition (1.4 OPTs may bind path
+/// keys or codes scoped to another embedded root) and would raise VTTBK
+/// (`master03` §Validity Rules — binding keys must be defined codes). The
+/// binding's home is the root that defines the code, which carries it in its
+/// own slice.
+fn drop_out_of_scope_bindings(
+    term_definitions: &BTreeMap<String, BTreeMap<String, ArchetypeTerm>>,
+    term_bindings: &mut BTreeMap<String, BTreeMap<String, String>>,
+    cx: &mut RootCx,
+) {
+    let defined: std::collections::BTreeSet<String> = term_definitions
+        .values()
+        .flat_map(|by_code| by_code.keys().cloned())
+        .collect();
+    for (terminology, by_key) in &mut *term_bindings {
+        let terminology = terminology.clone();
+        by_key.retain(|key, _| {
+            let keep = defined.contains(key.as_str());
+            if !keep {
+                cx.notes.insert(
+                    format!("dropped_term_binding.{terminology}.{key}"),
+                    format!(
+                        "term binding [{terminology}::{key}] is outside this root's code \
+                         scope; dropped at OPT decomposition (its home is the root that \
+                         defines the code)"
+                    ),
+                );
+            }
+            keep
+        });
+    }
+    term_bindings.retain(|_, by_key| !by_key.is_empty());
 }
 
 /// The maximum at-code number among a root's own node ids (not descending into

--- a/app/ferroehr/src/service/message/export.rs
+++ b/app/ferroehr/src/service/message/export.rs
@@ -194,34 +194,8 @@ impl FerroEhrService {
                         .await?,
                 );
             }
-            // link_depth (`EXTRACT_SPEC.link_depth`; `master09-semantics.adoc`
-            // §Creation Semantics: "for each instance of `DV_LINK` encountered
-            // … follow the links recursively … write the target Compositions in
-            // … set `is_primary` = False"). Only same-EHR targets exist in this
-            // repository; a link outside it cannot be included.
-            let mut depth = link_depth;
-            while depth > 0 {
-                let targets = link_target_uuids(&items);
-                let mut added = false;
-                for target in targets {
-                    if included.contains(&target) {
-                        continue;
-                    }
-                    let Some(kind) = self.ehr_vo_kind(ehr_id, target).await? else {
-                        continue;
-                    };
-                    items.push(
-                        self.build_openehr_content_item(ehr_id, target, &kind, sel, false)
-                            .await?,
-                    );
-                    included.push(target);
-                    added = true;
-                }
-                if !added {
-                    break;
-                }
-                depth -= 1;
-            }
+            self.follow_links(ehr_id, &mut items, &mut included, sel, link_depth)
+                .await?;
             let mut demographics = self.demographic_chapter_items(&items, sel).await?;
             rewrite_content_refs(&mut items);
             rewrite_content_refs(&mut demographics);
@@ -235,6 +209,50 @@ impl FerroEhrService {
             self.emit_extract_audit(ehr_id, EventActionCode::Read);
         }
         Ok(out)
+    }
+
+    /// Follows `link_depth` levels of `DV_LINK` targets, appending each
+    /// newly-reached versioned object as a non-primary content item.
+    ///
+    /// `EXTRACT_SPEC.link_depth`; `master09-semantics.adoc` §Creation
+    /// Semantics: "for each instance of `DV_LINK` encountered … follow the
+    /// links recursively … write the target Compositions in … set `is_primary`
+    /// = False". Only same-EHR targets exist in this repository; a link
+    /// outside it cannot be included.
+    ///
+    /// # Errors
+    /// The content-item build errors, and storage errors from the kind lookup.
+    async fn follow_links(
+        &self,
+        ehr_id: EhrId,
+        items: &mut Vec<Value>,
+        included: &mut Vec<VoId>,
+        sel: VersionSelection,
+        link_depth: i32,
+    ) -> Result<(), SmError> {
+        let mut depth = link_depth;
+        while depth > 0 {
+            let mut added = false;
+            for target in link_target_uuids(items) {
+                if included.contains(&target) {
+                    continue;
+                }
+                let Some(kind) = self.ehr_vo_kind(ehr_id, target).await? else {
+                    continue;
+                };
+                items.push(
+                    self.build_openehr_content_item(ehr_id, target, &kind, sel, false)
+                        .await?,
+                );
+                included.push(target);
+                added = true;
+            }
+            if !added {
+                break;
+            }
+            depth -= 1;
+        }
+        Ok(())
     }
 
     /// Whether an EHR with `ehr_id` exists (the `has_ehr` precondition of both
@@ -586,30 +604,6 @@ impl FerroEhrService {
         content_items: &[Value],
         sel: VersionSelection,
     ) -> Result<Vec<Value>, ServiceError> {
-        fn collect_party_ids(value: &Value, out: &mut Vec<VoId>) {
-            match value {
-                Value::Object(map) => {
-                    if map.get("_type").and_then(Value::as_str) == Some("PARTY_REF")
-                        && map.get("namespace").and_then(Value::as_str) == Some("demographic")
-                        && let Some(raw) = value.pointer("/id/value").and_then(Value::as_str)
-                        && let Ok(uuid) = raw.parse::<Uuid>()
-                        && !out.contains(&VoId(uuid))
-                    {
-                        // A demographic PARTY_REF id names a party versioned object.
-                        out.push(VoId(uuid));
-                    }
-                    for v in map.values() {
-                        collect_party_ids(v, out);
-                    }
-                }
-                Value::Array(list) => {
-                    for v in list {
-                        collect_party_ids(v, out);
-                    }
-                }
-                _ => {}
-            }
-        }
         let mut party_ids = Vec::new();
         for item in content_items {
             collect_party_ids(item, &mut party_ids);
@@ -904,40 +898,75 @@ fn strip_inline_multimedia(value: &mut Value) {
 /// content items — the candidate same-EHR link targets for `link_depth`
 /// following (`DV_EHR_URI` values carry the container/version uids).
 fn link_target_uuids(items: &[Value]) -> Vec<VoId> {
-    fn collect(value: &Value, out: &mut Vec<VoId>) {
-        match value {
-            Value::Object(map) => {
-                if let Some(links) = map.get("links").and_then(Value::as_array) {
-                    for link in links {
-                        if let Some(uri) = link.pointer("/target/value").and_then(Value::as_str) {
-                            for token in uri.split(|c: char| !c.is_ascii_hexdigit() && c != '-') {
-                                // A DV_LINK target uri names a versioned object.
-                                if let Ok(uuid) = token.parse::<Uuid>()
-                                    && !out.contains(&VoId(uuid))
-                                {
-                                    out.push(VoId(uuid));
-                                }
-                            }
-                        }
-                    }
-                }
-                for v in map.values() {
-                    collect(v, out);
-                }
-            }
-            Value::Array(list) => {
-                for v in list {
-                    collect(v, out);
-                }
-            }
-            _ => {}
-        }
-    }
     let mut out = Vec::new();
     for item in items {
-        collect(item, &mut out);
+        collect_link_targets(item, &mut out);
     }
     out
+}
+
+/// Walks one built content item, appending every distinct versioned-object
+/// UUID a `PARTY_REF` in the `demographic` namespace names.
+fn collect_party_ids(value: &Value, out: &mut Vec<VoId>) {
+    match value {
+        Value::Object(map) => {
+            if map.get("_type").and_then(Value::as_str) == Some("PARTY_REF")
+                && map.get("namespace").and_then(Value::as_str) == Some("demographic")
+                && let Some(raw) = value.pointer("/id/value").and_then(Value::as_str)
+                && let Ok(uuid) = raw.parse::<Uuid>()
+                && !out.contains(&VoId(uuid))
+            {
+                out.push(VoId(uuid));
+            }
+            for v in map.values() {
+                collect_party_ids(v, out);
+            }
+        }
+        Value::Array(list) => {
+            for v in list {
+                collect_party_ids(v, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Walks one built content item, appending every distinct versioned-object
+/// UUID its `LOCATABLE.links[].target` URIs mention.
+fn collect_link_targets(value: &Value, out: &mut Vec<VoId>) {
+    match value {
+        Value::Object(map) => {
+            if let Some(links) = map.get("links").and_then(Value::as_array) {
+                for link in links {
+                    push_link_target_uuids(link, out);
+                }
+            }
+            for v in map.values() {
+                collect_link_targets(v, out);
+            }
+        }
+        Value::Array(list) => {
+            for v in list {
+                collect_link_targets(v, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Appends the versioned-object UUIDs one `DV_LINK` target URI names.
+fn push_link_target_uuids(link: &Value, out: &mut Vec<VoId>) {
+    let Some(uri) = link.pointer("/target/value").and_then(Value::as_str) else {
+        return;
+    };
+    for token in uri.split(|c: char| !c.is_ascii_hexdigit() && c != '-') {
+        // A DV_LINK target uri names a versioned object.
+        if let Ok(uuid) = token.parse::<Uuid>()
+            && !out.contains(&VoId(uuid))
+        {
+            out.push(VoId(uuid));
+        }
+    }
 }
 
 /// The RM-named string tokens `EXTRACT_SPEC.extract_type` may carry, beside

--- a/app/ferroehr/src/service/message/import.rs
+++ b/app/ferroehr/src/service/message/import.rs
@@ -328,11 +328,6 @@ fn reject_duplicate_singleton_containers(containers: &[ImportContainer]) -> Resu
 /// item's `X_VERSIONED_*` wrapper contributes its `ORIGINAL_VERSION`s to one
 /// [`ImportContainer`]; branch / multi-system version trees are first-class
 /// (master06 §Distributed Versioning).
-#[expect(
-    clippy::too_many_lines,
-    reason = "the X_VERSIONED_* chapter walk in one pass, mirroring the \
-              container order of the extract"
-)]
 fn parse_import_containers(
     extract: &Extract,
 ) -> Result<(Vec<ImportContainer>, Vec<ImportContainer>), SmError> {
@@ -351,41 +346,9 @@ fn parse_import_containers(
             .and_then(Value::as_array)
             .unwrap_or(&empty)
         {
-            match item.get("_type").and_then(Value::as_str) {
-                Some("OPENEHR_CONTENT_ITEM") => {}
-                // NOTE: ISO 13606 / CDA generic content
-                // (`master06-generic_extract_package.adoc`
-                // `GENERIC_CONTENT_ITEM`) is outside this CDR's import scope.
-                Some("GENERIC_CONTENT_ITEM") => {
-                    return Err(SmError::precondition(
-                        "generic (ISO 13606 / CDA) content import is not supported",
-                    ));
-                }
-                // A folder structure entry carries no versioned content.
-                _ => continue,
-            }
-            // EXTRACT_CONTENT_ITEM.Item_validity: `is_masked xor item /= Void`
-            // (extract_content_item.adoc) — a masked wrapper carries no item, an
-            // unmasked one must.
-            let is_masked = item
-                .get("is_masked")
-                .and_then(Value::as_bool)
-                .unwrap_or(false);
-            let Some(xver) = item.get("item") else {
-                if is_masked {
-                    continue; // masked-out content — nothing to import
-                }
-                return Err(SmError::precondition(
-                    "EXTRACT_CONTENT_ITEM carries no item and is not masked \
-                     (Item_validity: is_masked xor item present)",
-                ));
+            let Some(xver) = content_item_payload(item)? else {
+                continue;
             };
-            if is_masked {
-                return Err(SmError::precondition(
-                    "EXTRACT_CONTENT_ITEM is masked but carries an item \
-                     (Item_validity: is_masked xor item present)",
-                ));
-            }
             let xtype = xver
                 .get("_type")
                 .and_then(Value::as_str)
@@ -394,37 +357,7 @@ fn parse_import_containers(
             // (master09-semantics.adoc §Creation Semantics demographics
             // chapter); each version's PARTY subtype fixes the container kind.
             if xtype == "X_VERSIONED_PARTY" {
-                for ov in xver
-                    .get("versions")
-                    .and_then(Value::as_array)
-                    .unwrap_or(&empty)
-                {
-                    let party_type = ov
-                        .pointer("/data/_type")
-                        .and_then(Value::as_str)
-                        .unwrap_or_default();
-                    let Some(kind) = Kind::from_type(party_type).filter(|k| k.is_demographic())
-                    else {
-                        return Err(SmError::precondition(format!(
-                            "X_VERSIONED_PARTY version data must be a PARTY subtype, \
-                             got {party_type:?}"
-                        )));
-                    };
-                    let (vo_id, version) = parse_imported_version(ov)?;
-                    match parties.get_mut(&vo_id) {
-                        Some(existing) => existing.versions.push(version),
-                        None => {
-                            parties.insert(
-                                vo_id,
-                                ImportContainer {
-                                    vo_id,
-                                    kind,
-                                    versions: vec![version],
-                                },
-                            );
-                        }
-                    }
-                }
+                collect_party_versions(xver, &mut parties)?;
                 continue;
             }
             let kind = kind_from_x_versioned(xtype).ok_or_else(|| {
@@ -433,45 +366,147 @@ fn parse_import_containers(
                      EHR_STATUS / EHR_ACCESS / FOLDER / demographics-chapter PARTYs)"
                 ))
             })?;
-
-            for ov in xver
-                .get("versions")
-                .and_then(Value::as_array)
-                .unwrap_or(&empty)
-            {
-                // creating_system_id is per VERSION (a copied tree legitimately
-                // mixes source-trunk versions with branch modifications made by
-                // other systems — master06 §Distributed Versioning).
-                let (vo_id, version) = parse_imported_version(ov)?;
-                match by_container.get_mut(&vo_id) {
-                    Some(existing) => {
-                        if existing.kind != kind {
-                            return Err(SmError::precondition(format!(
-                                "versioned object {vo_id} appears as both {} and {}",
-                                existing.kind.as_str(),
-                                kind.as_str()
-                            )));
-                        }
-                        existing.versions.push(version);
-                    }
-                    None => {
-                        by_container.insert(
-                            vo_id,
-                            ImportContainer {
-                                vo_id,
-                                kind,
-                                versions: vec![version],
-                            },
-                        );
-                    }
-                }
-            }
+            collect_content_versions(xver, kind, &mut by_container)?;
         }
     }
     Ok((
         by_container.into_values().collect(),
         parties.into_values().collect(),
     ))
+}
+
+/// The `X_VERSIONED_*` wrapper one `EXTRACT_CONTENT_ITEM` carries, or `None`
+/// for an entry with no versioned content (a masked item, a folder structure
+/// entry).
+///
+/// `EXTRACT_CONTENT_ITEM.Item_validity` is `is_masked xor item /= Void`
+/// (`extract_content_item.adoc`): a masked wrapper carries no item, an
+/// unmasked one must.
+///
+/// # Errors
+/// [`SmError::Precondition`] for generic (ISO 13606 / CDA) content — NOTE:
+/// `master06-generic_extract_package.adoc` `GENERIC_CONTENT_ITEM` is outside
+/// this CDR's import scope — or for either half of an `Item_validity`
+/// violation.
+fn content_item_payload(item: &Value) -> Result<Option<&Value>, SmError> {
+    match item.get("_type").and_then(Value::as_str) {
+        Some("OPENEHR_CONTENT_ITEM") => {}
+        Some("GENERIC_CONTENT_ITEM") => {
+            return Err(SmError::precondition(
+                "generic (ISO 13606 / CDA) content import is not supported",
+            ));
+        }
+        // A folder structure entry carries no versioned content.
+        _ => return Ok(None),
+    }
+    let is_masked = item
+        .get("is_masked")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    match (item.get("item"), is_masked) {
+        // Masked-out content — nothing to import.
+        (None, true) => Ok(None),
+        (None, false) => Err(SmError::precondition(
+            "EXTRACT_CONTENT_ITEM carries no item and is not masked \
+             (Item_validity: is_masked xor item present)",
+        )),
+        (Some(_), true) => Err(SmError::precondition(
+            "EXTRACT_CONTENT_ITEM is masked but carries an item \
+             (Item_validity: is_masked xor item present)",
+        )),
+        (Some(xver), false) => Ok(Some(xver)),
+    }
+}
+
+/// Collects the versions of one `X_VERSIONED_PARTY` wrapper into the
+/// demographic containers, keyed by cloned `vo_id`.
+///
+/// # Errors
+/// [`SmError::Precondition`] when a version's data is not a PARTY subtype, and
+/// the [`parse_imported_version`] rejections.
+fn collect_party_versions(
+    xver: &Value,
+    parties: &mut BTreeMap<VoId, ImportContainer>,
+) -> Result<(), SmError> {
+    let empty: Vec<Value> = Vec::new();
+    for ov in xver
+        .get("versions")
+        .and_then(Value::as_array)
+        .unwrap_or(&empty)
+    {
+        let party_type = ov
+            .pointer("/data/_type")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let Some(kind) = Kind::from_type(party_type).filter(|k| k.is_demographic()) else {
+            return Err(SmError::precondition(format!(
+                "X_VERSIONED_PARTY version data must be a PARTY subtype, \
+                 got {party_type:?}"
+            )));
+        };
+        let (vo_id, version) = parse_imported_version(ov)?;
+        push_version(parties, vo_id, kind, version);
+    }
+    Ok(())
+}
+
+/// Collects the versions of one EHR-owned `X_VERSIONED_*` wrapper into the
+/// content containers, keyed by cloned `vo_id`.
+///
+/// `creating_system_id` is per VERSION: a copied tree legitimately mixes
+/// source-trunk versions with branch modifications made by other systems
+/// (master06 §Distributed Versioning).
+///
+/// # Errors
+/// [`SmError::Precondition`] when one `vo_id` arrives under two kinds, and the
+/// [`parse_imported_version`] rejections.
+fn collect_content_versions(
+    xver: &Value,
+    kind: Kind,
+    by_container: &mut BTreeMap<VoId, ImportContainer>,
+) -> Result<(), SmError> {
+    let empty: Vec<Value> = Vec::new();
+    for ov in xver
+        .get("versions")
+        .and_then(Value::as_array)
+        .unwrap_or(&empty)
+    {
+        let (vo_id, version) = parse_imported_version(ov)?;
+        if let Some(existing) = by_container.get(&vo_id)
+            && existing.kind != kind
+        {
+            return Err(SmError::precondition(format!(
+                "versioned object {vo_id} appears as both {} and {}",
+                existing.kind.as_str(),
+                kind.as_str()
+            )));
+        }
+        push_version(by_container, vo_id, kind, version);
+    }
+    Ok(())
+}
+
+/// Appends one version to its container, creating the container on first
+/// receipt.
+fn push_version(
+    containers: &mut BTreeMap<VoId, ImportContainer>,
+    vo_id: VoId,
+    kind: Kind,
+    version: ImportVersion,
+) {
+    match containers.get_mut(&vo_id) {
+        Some(existing) => existing.versions.push(version),
+        None => {
+            containers.insert(
+                vo_id,
+                ImportContainer {
+                    vo_id,
+                    kind,
+                    versions: vec![version],
+                },
+            );
+        }
+    }
 }
 
 /// The wrapped original's `VERSION.commit_audit` (1..1), validated and returned

--- a/app/ferroehr/src/service/subject_proxy/extract.rs
+++ b/app/ferroehr/src/service/subject_proxy/extract.rs
@@ -161,59 +161,39 @@ fn coerce(raw: Raw, type_name: &str) -> Result<VariableValue, String> {
 /// examples (`Date`, `Quantity`, `Boolean`) plus the common scalar names.
 /// Unknown names (and `Any`) pass through unchecked.
 fn check_type(value: &Value, type_name: &str) -> Result<(), String> {
-    let mismatch = |want: &str| {
-        Err(format!(
-            "value {value} does not match declared type_name {want:?}"
-        ))
-    };
     // A null cell is "no data", acceptable for every declared type.
     if value.is_null() {
         return Ok(());
     }
-    match type_name.to_lowercase().as_str() {
-        "boolean" => {
-            if value.is_boolean() {
-                Ok(())
-            } else {
-                mismatch(type_name)
-            }
+    let matches = match type_name.to_lowercase().as_str() {
+        "boolean" => value.is_boolean(),
+        "integer" | "count" => value.is_i64() || value.is_u64() || is_rm_family(value, "DV_COUNT"),
+        "real" | "double" | "decimal" => value.is_number(),
+        "quantity" => value.is_number() || is_rm_family(value, "DV_QUANTITY"),
+        "string" | "text" => value.is_string() || is_rm_family(value, "DV_TEXT"),
+        "date" => {
+            return check_time_str(value, type_name, |s| s.parse::<jiff::civil::Date>().is_ok());
         }
-        "integer" | "count" => {
-            if value.is_i64() || value.is_u64() || is_rm_family(value, "DV_COUNT") {
-                Ok(())
-            } else {
-                mismatch(type_name)
-            }
+        "datetime" | "date_time" => {
+            return check_time_str(value, type_name, |s| {
+                s.parse::<jiff::Timestamp>().is_ok() || s.parse::<jiff::civil::DateTime>().is_ok()
+            });
         }
-        "real" | "double" | "decimal" => {
-            if value.is_number() {
-                Ok(())
-            } else {
-                mismatch(type_name)
-            }
+        "time" => {
+            return check_time_str(value, type_name, |s| s.parse::<jiff::civil::Time>().is_ok());
         }
-        "quantity" => {
-            if value.is_number() || is_rm_family(value, "DV_QUANTITY") {
-                Ok(())
-            } else {
-                mismatch(type_name)
-            }
+        "duration" => {
+            return check_time_str(value, type_name, |s| s.parse::<jiff::Span>().is_ok());
         }
-        "string" | "text" => {
-            if value.is_string() || is_rm_family(value, "DV_TEXT") {
-                Ok(())
-            } else {
-                mismatch(type_name)
-            }
-        }
-        "date" => check_time_str(value, type_name, |s| s.parse::<jiff::civil::Date>().is_ok()),
-        "datetime" | "date_time" => check_time_str(value, type_name, |s| {
-            s.parse::<jiff::Timestamp>().is_ok() || s.parse::<jiff::civil::DateTime>().is_ok()
-        }),
-        "time" => check_time_str(value, type_name, |s| s.parse::<jiff::civil::Time>().is_ok()),
-        "duration" => check_time_str(value, type_name, |s| s.parse::<jiff::Span>().is_ok()),
-        _ => Ok(()), // Any / unknown model type names: pass through
+        // Any / unknown model type names: pass through
+        _ => true,
+    };
+    if matches {
+        return Ok(());
     }
+    Err(format!(
+        "value {value} does not match declared type_name {type_name:?}"
+    ))
 }
 
 /// Temporal types arrive as ISO-8601 strings (or the matching RM `DV_*`

--- a/app/ferroehr/src/storage/codec.rs
+++ b/app/ferroehr/src/storage/codec.rs
@@ -175,23 +175,7 @@ fn prune_children(
 ) -> Result<(), StorageError> {
     let mut structure_attributes: Vec<String> = Vec::new();
     for (attribute, child) in map.iter() {
-        let prune = match child {
-            Value::Object(_) => is_structure(child),
-            Value::Array(items) if !items.is_empty() => {
-                let structure_count = items.iter().filter(|c| is_structure(c)).count();
-                if structure_count == 0 {
-                    false
-                } else if structure_count == items.len() {
-                    true
-                } else {
-                    return Err(StorageError::MixedArray {
-                        attribute: attribute.clone(),
-                    });
-                }
-            }
-            _ => false,
-        };
-        if prune {
+        if carries_structure(attribute, child)? {
             structure_attributes.push(attribute.clone());
         }
     }
@@ -209,6 +193,28 @@ fn prune_children(
         }
     }
     Ok(())
+}
+
+/// Whether one attribute's value carries structure children that become their
+/// own node rows.
+///
+/// # Errors
+/// [`StorageError::MixedArray`] when an array mixes structure and
+/// non-structure members — a shape the node model cannot represent.
+fn carries_structure(attribute: &str, child: &Value) -> Result<bool, StorageError> {
+    let Value::Array(items) = child else {
+        return Ok(is_structure(child));
+    };
+    let structure_count = items.iter().filter(|c| is_structure(c)).count();
+    if structure_count == 0 {
+        return Ok(false);
+    }
+    if structure_count == items.len() {
+        return Ok(true);
+    }
+    Err(StorageError::MixedArray {
+        attribute: attribute.to_owned(),
+    })
 }
 
 fn is_structure(v: &Value) -> bool {

--- a/app/ferroehr/src/system_log/fhir.rs
+++ b/app/ferroehr/src/system_log/fhir.rs
@@ -292,16 +292,7 @@ fn claimed_profiles(event: &AuditEvent, subject: Option<&str>) -> Vec<String> {
     let mut profiles = Vec::new();
     if event.outcome == EventOutcome::Success {
         let patient = event.object.is_patient_centric() && subject.is_some();
-        let name = match (event.object, event.action) {
-            (ObjectClass::Authentication | ObjectClass::Extract, _) => None,
-            (ObjectClass::Query, _) => Some(if patient { "PatientQuery" } else { "Query" }),
-            (_, EventActionCode::Create) => Some(if patient { "PatientCreate" } else { "Create" }),
-            (_, EventActionCode::Read) => Some(if patient { "PatientRead" } else { "Read" }),
-            (_, EventActionCode::Update) => Some(if patient { "PatientUpdate" } else { "Update" }),
-            (_, EventActionCode::Delete) => Some(if patient { "PatientDelete" } else { "Delete" }),
-            (_, EventActionCode::Execute) => None,
-        };
-        if let Some(name) = name {
+        if let Some(name) = balp_profile_name(event.object, event.action, patient) {
             profiles.push(format!("{BALP_PROFILE_BASE}/IHE.BasicAudit.{name}"));
         }
     }
@@ -311,6 +302,28 @@ fn claimed_profiles(event: &AuditEvent, subject: Option<&str>) -> Vec<String> {
         ));
     }
     profiles
+}
+
+/// The BALP basic-audit profile name one successful record claims, or `None`
+/// where the profile family defines none for that action.
+///
+/// `patient` selects the `Patient*` variant, which requires a resolved patient
+/// entity.
+const fn balp_profile_name(
+    object: ObjectClass,
+    action: EventActionCode,
+    patient: bool,
+) -> Option<&'static str> {
+    let (plain, patient_variant) = match (object, action) {
+        (ObjectClass::Authentication | ObjectClass::Extract, _) => return None,
+        (ObjectClass::Query, _) => ("Query", "PatientQuery"),
+        (_, EventActionCode::Create) => ("Create", "PatientCreate"),
+        (_, EventActionCode::Read) => ("Read", "PatientRead"),
+        (_, EventActionCode::Update) => ("Update", "PatientUpdate"),
+        (_, EventActionCode::Delete) => ("Delete", "PatientDelete"),
+        (_, EventActionCode::Execute) => return None,
+    };
+    Some(if patient { patient_variant } else { plain })
 }
 
 /// The FHIR action code for an audited action.

--- a/app/ferroehr/src/system_log/sender.rs
+++ b/app/ferroehr/src/system_log/sender.rs
@@ -246,6 +246,14 @@ struct Sinks {
     feed_notify: Option<Arc<Notify>>,
 }
 
+/// One drained event with its resolved subject id and rendered FHIR
+/// `AuditEvent` document, the unit every sink consumes.
+type DrainRecord = (AuditEvent, Option<String>, Option<serde_json::Value>);
+
+/// The drain's `ehr_id` → subject-id memo (an EHR's subject is immutable for
+/// audit purposes, so one lookup serves every later record).
+type SubjectCache = moka::future::Cache<String, Option<String>>;
+
 /// The ITI-20 ATX:FHIR Feed HTTP client.
 #[derive(Clone)]
 struct FeedClient {
@@ -395,11 +403,6 @@ pub async fn start(
     Ok((sender, AuditHandle { join, workers }))
 }
 
-#[expect(
-    clippy::too_many_lines,
-    reason = "one linear fan-out — batch → store → syslog → feed — whose order \
-              is the behaviour"
-)]
 async fn drain(
     mut rx: mpsc::Receiver<AuditEvent>,
     mut sinks: Sinks,
@@ -416,8 +419,7 @@ async fn drain(
     // The subject lookup memo: an EHR's subject id is immutable for audit
     // purposes at write-path rates, and one awaited per-event lookup was the
     // remaining drain bottleneck (a saturated queue at seeding-grade load).
-    // Distinct uncached ids of a batch resolve CONCURRENTLY, then memoize.
-    let subject_cache: moka::future::Cache<String, Option<String>> = moka::future::Cache::builder()
+    let subject_cache: SubjectCache = moka::future::Cache::builder()
         .max_capacity(100_000)
         .time_to_live(Duration::from_hours(1))
         .build();
@@ -427,193 +429,258 @@ async fn drain(
             break; // channel closed and drained
         }
 
-        // Optional subject enrichment — background only, never on the
-        // request path: dedupe the batch's EHR ids, resolve the uncached
-        // ones concurrently, memoize.
         if resolve_subject && let Some(resolve) = &resolver {
-            let mut pending: Vec<String> = batch
-                .iter()
-                .filter_map(|event| event.ehr_id.clone())
-                .filter(|ehr_id| !subject_cache.contains_key(ehr_id))
-                .collect();
-            pending.sort_unstable();
-            pending.dedup();
-            let mut lookups = tokio::task::JoinSet::new();
-            for ehr_id in pending {
-                let lookup = resolve(ehr_id.clone());
-                lookups.spawn(async move { (ehr_id, lookup.await) });
-            }
-            while let Some(joined) = lookups.join_next().await {
-                if let Ok((ehr_id, subject)) = joined {
-                    subject_cache.insert(ehr_id, subject).await;
-                }
-            }
+            memoize_subjects(&batch, resolve, &subject_cache).await;
         }
+        let records = render_batch(&mut batch, &ctx, &subject_cache, resolve_subject, &sinks).await;
 
-        // Render once per event; both the store and the FHIR feed consume
-        // the rendered document. No FHIR consumer means no rendering.
-        let render_fhir = sinks.store.is_some() || sinks.direct_feed.is_some();
-        let mut records: Vec<(AuditEvent, Option<String>, Option<serde_json::Value>)> =
-            Vec::with_capacity(batch.len());
-        for event in batch.drain(..) {
-            let subject = match (resolve_subject, &event.ehr_id) {
-                (true, Some(ehr_id)) => subject_cache.get(ehr_id).await.flatten(),
-                _ => None,
-            };
-            let rendered = render_fhir
-                .then(|| render_audit_event(&event, &ctx, subject.as_deref()))
-                .flatten();
-            records.push((event, subject, rendered));
-        }
-
-        // 1) The store — the durability anchor, written first. Without the
-        //    syslog sink no per-row delivery stamp is needed, so the whole
-        //    batch lands in ONE multi-row INSERT; with syslog on, the
-        //    per-event path keeps the row id for `delivered_syslog_at`.
-        let mut row_ids: Vec<Option<uuid::Uuid>> = vec![None; records.len()];
-        if let Some(store) = &sinks.store {
-            if sinks.syslog.is_none() {
-                let insert = || async { store.insert_batch(&records).await };
-                match insert
-                    .retry(
-                        ExponentialBuilder::default()
-                            .with_jitter()
-                            .with_max_times(2),
-                    )
-                    .await
-                {
-                    Ok(()) => {
-                        store_healthy.store(true, Ordering::Relaxed);
-                        #[expect(
-                            clippy::as_conversions,
-                            reason = "the batch record count widens exactly: usize is at \
-                                      most 64 bits on every supported target"
-                        )]
-                        crate::telemetry::metrics::metrics().atna_audit_sent.add(
-                            records.len() as u64,
-                            &[opentelemetry::KeyValue::new("sink", "store")],
-                        );
-                        if let Some(notify) = &sinks.feed_notify {
-                            notify.notify_one();
-                        }
-                    }
-                    Err(e) => {
-                        store_healthy.store(false, Ordering::Relaxed);
-                        #[expect(
-                            clippy::as_conversions,
-                            reason = "the batch record count widens exactly: usize is at \
-                                      most 64 bits on every supported target"
-                        )]
-                        crate::telemetry::metrics::metrics()
-                            .atna_audit_send_failed
-                            .add(
-                                records.len() as u64,
-                                &[opentelemetry::KeyValue::new("sink", "store")],
-                            );
-                        tracing::warn!("ATNA audit store batch write failed: {e}");
-                    }
-                }
-            } else {
-                for (index, (event, subject, rendered)) in records.iter().enumerate() {
-                    let Some(rendered) = rendered else {
-                        continue;
-                    };
-                    let insert =
-                        || async { store.insert(event, subject.as_deref(), rendered).await };
-                    match insert
-                        .retry(
-                            ExponentialBuilder::default()
-                                .with_jitter()
-                                .with_max_times(2),
-                        )
-                        .await
-                    {
-                        Ok(id) => {
-                            if let Some(slot) = row_ids.get_mut(index) {
-                                *slot = Some(id);
-                            }
-                            store_healthy.store(true, Ordering::Relaxed);
-                            crate::telemetry::metrics::metrics()
-                                .atna_audit_sent
-                                .add(1, &[opentelemetry::KeyValue::new("sink", "store")]);
-                            if let Some(notify) = &sinks.feed_notify {
-                                notify.notify_one();
-                            }
-                        }
-                        Err(e) => {
-                            store_healthy.store(false, Ordering::Relaxed);
-                            crate::telemetry::metrics::metrics()
-                                .atna_audit_send_failed
-                                .add(1, &[opentelemetry::KeyValue::new("sink", "store")]);
-                            tracing::warn!("ATNA audit store write failed: {e}");
-                        }
-                    }
-                }
-            }
-        }
-
-        // 2) The classic syslog feed (DICOM PS3.15 §A.5 XML per ITI-20) —
-        //    inherently sequential (one datagram/frame per record).
+        // The sink order is the behaviour: the store is the durability
+        // anchor and is written first, so a syslog send can stamp the row it
+        // already persisted.
+        let row_ids = write_to_store(&sinks, &records, &store_healthy).await;
         if let Some(transport) = &mut sinks.syslog {
-            for (index, (event, subject, _)) in records.iter().enumerate() {
-                let message = AuditMessage::build(event, &ctx, subject.as_deref());
-                match message.to_xml() {
-                    Ok(xml) => {
-                        let syslog =
-                            assemble_syslog(&ctx.server_ip, &ctx.source_id, &event.timestamp, &xml);
-                        match transport.send(&syslog).await {
-                            Ok(()) => {
-                                crate::telemetry::metrics::metrics()
-                                    .atna_audit_sent
-                                    .add(1, &[opentelemetry::KeyValue::new("sink", "syslog")]);
-                                if let (Some(store), Some(Some(id))) =
-                                    (&sinks.store, row_ids.get(index))
-                                {
-                                    store.mark_syslog_delivered(*id).await;
-                                }
-                            }
-                            Err(e) => {
-                                crate::telemetry::metrics::metrics()
-                                    .atna_audit_send_failed
-                                    .add(1, &[opentelemetry::KeyValue::new("sink", "syslog")]);
-                                tracing::warn!("ATNA audit syslog send failed: {e}");
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        crate::telemetry::metrics::metrics()
-                            .atna_audit_serialize_failed
-                            .add(1, &[]);
-                        tracing::warn!("ATNA audit message serialization failed: {e}");
-                    }
-                }
-            }
+            send_to_syslog(transport, &records, &row_ids, sinks.store.as_ref(), &ctx).await;
         }
-
-        // 3) The FHIR feed, in-drain only when the store is off (otherwise the
-        //    outbox worker owns delivery).
         if let Some(feed) = &sinks.direct_feed {
-            for (_, _, rendered) in &records {
-                let Some(body) = rendered else {
-                    continue;
-                };
-                match feed.post(body).await {
-                    Ok(()) => {
-                        crate::telemetry::metrics::metrics()
-                            .atna_audit_sent
-                            .add(1, &[opentelemetry::KeyValue::new("sink", "fhir_feed")]);
-                    }
-                    Err(e) => {
-                        crate::telemetry::metrics::metrics()
-                            .atna_audit_send_failed
-                            .add(1, &[opentelemetry::KeyValue::new("sink", "fhir_feed")]);
-                        tracing::warn!("ATNA audit FHIR feed send failed: {e}");
-                    }
-                }
-            }
+            send_to_direct_feed(feed, &records).await;
         }
     }
     tracing::debug!("ATNA audit drain: channel closed, task exiting");
+}
+
+/// Resolves the subject id of every EHR the batch references that the memo
+/// does not already hold, concurrently, and memoizes each answer.
+async fn memoize_subjects(batch: &[AuditEvent], resolve: &SubjectResolver, cache: &SubjectCache) {
+    let mut pending: Vec<String> = batch
+        .iter()
+        .filter_map(|event| event.ehr_id.clone())
+        .filter(|ehr_id| !cache.contains_key(ehr_id))
+        .collect();
+    pending.sort_unstable();
+    pending.dedup();
+    let mut lookups = tokio::task::JoinSet::new();
+    for ehr_id in pending {
+        let lookup = resolve(ehr_id.clone());
+        lookups.spawn(async move { (ehr_id, lookup.await) });
+    }
+    while let Some(joined) = lookups.join_next().await {
+        if let Ok((ehr_id, subject)) = joined {
+            cache.insert(ehr_id, subject).await;
+        }
+    }
+}
+
+/// Drains the batch into records, attaching each event's memoized subject and,
+/// when any FHIR consumer is enabled, its rendered `AuditEvent` document.
+///
+/// The document is rendered once here because both the store and the FHIR feed
+/// consume it; with neither sink enabled nothing is rendered at all.
+async fn render_batch(
+    batch: &mut Vec<AuditEvent>,
+    ctx: &AuditContext,
+    subject_cache: &SubjectCache,
+    resolve_subject: bool,
+    sinks: &Sinks,
+) -> Vec<DrainRecord> {
+    let render_fhir = sinks.store.is_some() || sinks.direct_feed.is_some();
+    let mut records: Vec<DrainRecord> = Vec::with_capacity(batch.len());
+    for event in batch.drain(..) {
+        let subject = match (resolve_subject, &event.ehr_id) {
+            (true, Some(ehr_id)) => subject_cache.get(ehr_id).await.flatten(),
+            _ => None,
+        };
+        let rendered = render_fhir
+            .then(|| render_audit_event(&event, ctx, subject.as_deref()))
+            .flatten();
+        records.push((event, subject, rendered));
+    }
+    records
+}
+
+/// Writes the batch to the local Audit Record Repository, returning the stored
+/// row id of each record (`None` where nothing was stored).
+///
+/// Without the syslog sink no per-row delivery stamp is ever needed, so the
+/// whole batch lands in ONE multi-row INSERT; with syslog on, the per-record
+/// path keeps each row id for `delivered_syslog_at`.
+async fn write_to_store(
+    sinks: &Sinks,
+    records: &[DrainRecord],
+    store_healthy: &AtomicBool,
+) -> Vec<Option<uuid::Uuid>> {
+    let Some(store) = &sinks.store else {
+        return vec![None; records.len()];
+    };
+    if sinks.syslog.is_none() {
+        store_whole_batch(store, records, store_healthy, sinks.feed_notify.as_ref()).await;
+        return vec![None; records.len()];
+    }
+    store_each_record(store, records, store_healthy, sinks.feed_notify.as_ref()).await
+}
+
+/// Persists the batch in one multi-row INSERT with bounded jittered retries,
+/// updating the store health flag the fail-closed mode reads.
+async fn store_whole_batch(
+    store: &AuditStore,
+    records: &[DrainRecord],
+    store_healthy: &AtomicBool,
+    feed_notify: Option<&Arc<Notify>>,
+) {
+    let insert = || async { store.insert_batch(records).await };
+    #[expect(
+        clippy::as_conversions,
+        reason = "the batch record count widens exactly: usize is at most 64 bits on \
+                  every supported target"
+    )]
+    let count = records.len() as u64;
+    match insert
+        .retry(
+            ExponentialBuilder::default()
+                .with_jitter()
+                .with_max_times(2),
+        )
+        .await
+    {
+        Ok(()) => {
+            store_healthy.store(true, Ordering::Relaxed);
+            crate::telemetry::metrics::metrics()
+                .atna_audit_sent
+                .add(count, &[opentelemetry::KeyValue::new("sink", "store")]);
+            if let Some(notify) = feed_notify {
+                notify.notify_one();
+            }
+        }
+        Err(e) => {
+            store_healthy.store(false, Ordering::Relaxed);
+            crate::telemetry::metrics::metrics()
+                .atna_audit_send_failed
+                .add(count, &[opentelemetry::KeyValue::new("sink", "store")]);
+            tracing::warn!("ATNA audit store batch write failed: {e}");
+        }
+    }
+}
+
+/// Persists the batch one record at a time, returning the row id of each
+/// record a syslog send may later stamp as delivered.
+async fn store_each_record(
+    store: &AuditStore,
+    records: &[DrainRecord],
+    store_healthy: &AtomicBool,
+    feed_notify: Option<&Arc<Notify>>,
+) -> Vec<Option<uuid::Uuid>> {
+    let mut row_ids: Vec<Option<uuid::Uuid>> = vec![None; records.len()];
+    for (index, (event, subject, rendered)) in records.iter().enumerate() {
+        let Some(rendered) = rendered else {
+            continue;
+        };
+        let insert = || async { store.insert(event, subject.as_deref(), rendered).await };
+        match insert
+            .retry(
+                ExponentialBuilder::default()
+                    .with_jitter()
+                    .with_max_times(2),
+            )
+            .await
+        {
+            Ok(id) => {
+                if let Some(slot) = row_ids.get_mut(index) {
+                    *slot = Some(id);
+                }
+                store_healthy.store(true, Ordering::Relaxed);
+                crate::telemetry::metrics::metrics()
+                    .atna_audit_sent
+                    .add(1, &[opentelemetry::KeyValue::new("sink", "store")]);
+                if let Some(notify) = feed_notify {
+                    notify.notify_one();
+                }
+            }
+            Err(e) => {
+                store_healthy.store(false, Ordering::Relaxed);
+                crate::telemetry::metrics::metrics()
+                    .atna_audit_send_failed
+                    .add(1, &[opentelemetry::KeyValue::new("sink", "store")]);
+                tracing::warn!("ATNA audit store write failed: {e}");
+            }
+        }
+    }
+    row_ids
+}
+
+/// Feeds every record to the classic ITI-20 syslog sink, which is inherently
+/// sequential: one datagram or frame per record.
+async fn send_to_syslog(
+    transport: &mut Transport,
+    records: &[DrainRecord],
+    row_ids: &[Option<uuid::Uuid>],
+    store: Option<&AuditStore>,
+    ctx: &AuditContext,
+) {
+    for (index, (event, subject, _)) in records.iter().enumerate() {
+        let row_id = row_ids.get(index).copied().flatten();
+        send_one_to_syslog(transport, event, subject.as_deref(), row_id, store, ctx).await;
+    }
+}
+
+/// Sends one record as DICOM PS3.15 §A.5 XML and, on success, stamps
+/// `delivered_syslog_at` on the row the store already holds for it.
+async fn send_one_to_syslog(
+    transport: &mut Transport,
+    event: &AuditEvent,
+    subject: Option<&str>,
+    row_id: Option<uuid::Uuid>,
+    store: Option<&AuditStore>,
+    ctx: &AuditContext,
+) {
+    let xml = match AuditMessage::build(event, ctx, subject).to_xml() {
+        Ok(xml) => xml,
+        Err(e) => {
+            crate::telemetry::metrics::metrics()
+                .atna_audit_serialize_failed
+                .add(1, &[]);
+            tracing::warn!("ATNA audit message serialization failed: {e}");
+            return;
+        }
+    };
+    let syslog = assemble_syslog(&ctx.server_ip, &ctx.source_id, &event.timestamp, &xml);
+    match transport.send(&syslog).await {
+        Ok(()) => {
+            crate::telemetry::metrics::metrics()
+                .atna_audit_sent
+                .add(1, &[opentelemetry::KeyValue::new("sink", "syslog")]);
+            if let (Some(store), Some(id)) = (store, row_id) {
+                store.mark_syslog_delivered(id).await;
+            }
+        }
+        Err(e) => {
+            crate::telemetry::metrics::metrics()
+                .atna_audit_send_failed
+                .add(1, &[opentelemetry::KeyValue::new("sink", "syslog")]);
+            tracing::warn!("ATNA audit syslog send failed: {e}");
+        }
+    }
+}
+
+/// Ships every rendered document to the ITI-20 ATX:FHIR Feed in-drain, the
+/// store-off path (with the store on, the outbox worker owns delivery).
+async fn send_to_direct_feed(feed: &FeedClient, records: &[DrainRecord]) {
+    for (_, _, rendered) in records {
+        let Some(body) = rendered else {
+            continue;
+        };
+        match feed.post(body).await {
+            Ok(()) => {
+                crate::telemetry::metrics::metrics()
+                    .atna_audit_sent
+                    .add(1, &[opentelemetry::KeyValue::new("sink", "fhir_feed")]);
+            }
+            Err(e) => {
+                crate::telemetry::metrics::metrics()
+                    .atna_audit_send_failed
+                    .add(1, &[opentelemetry::KeyValue::new("sink", "fhir_feed")]);
+                tracing::warn!("ATNA audit FHIR feed send failed: {e}");
+            }
+        }
+    }
 }
 
 /// The FHIR R4 `AuditEvent` document for one resolved record, or `None` when

--- a/app/ferroehr/src/validation/opt/primitive.rs
+++ b/app/ferroehr/src/validation/opt/primitive.rs
@@ -15,7 +15,9 @@
 //! (UML `c_quantity`/`c_ordinal`/`c_coded_text`; ADL1.4 master09).
 
 use openehr_base::prelude::CodePhrase;
-use openehr_its::opt14::types::{CDvOrdinal, CDvQuantity, CPrimitive};
+use openehr_its::opt14::types::{
+    CBoolean, CDvOrdinal, CDvQuantity, CInteger, CPrimitive, CReal, CString,
+};
 
 use super::RuleViolation;
 use super::interval::{int_in_range, real_in_range};
@@ -26,80 +28,10 @@ use super::interval::{int_in_range, real_in_range};
 /// syntax.
 pub(super) fn check_primitive(p: &CPrimitive, node_id: &str) -> Result<(), RuleViolation> {
     match p {
-        CPrimitive::CBoolean(b) => {
-            // C_BOOLEAN (AOM1.4 c_boolean class file, Description): true_valid
-            // and false_valid cannot both be False — the constraint would be
-            // unsatisfiable.
-            if !b.true_valid && !b.false_valid {
-                return Err(RuleViolation::new(
-                    "C_BOOLEAN_validity",
-                    format!(
-                        "node '{node_id}': true_valid and false_valid are both false — the \
-                         boolean constraint is unsatisfiable"
-                    ),
-                ));
-            }
-            if let Some(assumed) = b.assumed_value {
-                let ok = if assumed { b.true_valid } else { b.false_valid };
-                if !ok {
-                    return Err(RuleViolation::new(
-                        "Assumed_value_valid",
-                        format!(
-                            "node '{node_id}': the assumed boolean value {assumed} is not \
-                             permitted by the true_valid/false_valid flags"
-                        ),
-                    ));
-                }
-            }
-        }
-        CPrimitive::CString(s) => {
-            // Assumed_value_valid against a closed value list (C_STRING,
-            // AOM1.4 c_string class file; cADL: string constraints are
-            // case-sensitive).
-            if let Some(assumed) = &s.assumed_value
-                && !s.list.is_empty()
-                && s.list_open != Some(true)
-                && !s.list.contains(assumed)
-            {
-                return Err(RuleViolation::new(
-                    "Assumed_value_valid",
-                    format!(
-                        "node '{node_id}': the assumed string '{assumed}' is not in the closed \
-                         value list"
-                    ),
-                ));
-            }
-        }
-        CPrimitive::CInteger(c) => {
-            if let Some(assumed) = c.assumed_value {
-                let list_ok = c.list.is_empty() || c.list.contains(&assumed);
-                let range_ok = c.range.as_ref().is_none_or(|r| int_in_range(assumed, r));
-                if !list_ok || !range_ok {
-                    return Err(RuleViolation::new(
-                        "Assumed_value_valid",
-                        format!(
-                            "node '{node_id}': the assumed integer {assumed} is outside the \
-                             constrained list/range"
-                        ),
-                    ));
-                }
-            }
-        }
-        CPrimitive::CReal(c) => {
-            if let Some(assumed) = c.assumed_value {
-                let list_ok = c.list.is_empty() || c.list.contains(&assumed);
-                let range_ok = c.range.as_ref().is_none_or(|r| real_in_range(assumed, r));
-                if !list_ok || !range_ok {
-                    return Err(RuleViolation::new(
-                        "Assumed_value_valid",
-                        format!(
-                            "node '{node_id}': the assumed real {assumed} is outside the \
-                             constrained list/range"
-                        ),
-                    ));
-                }
-            }
-        }
+        CPrimitive::CBoolean(c) => check_boolean(c, node_id),
+        CPrimitive::CString(c) => check_string(c, node_id),
+        CPrimitive::CInteger(c) => check_integer(c, node_id),
+        CPrimitive::CReal(c) => check_real(c, node_id),
         // C_DATE/C_DATE_TIME/C_TIME invariant Pattern_validity:
         // `pattern /= Void implies valid_iso8601_*_constraint_pattern(pattern)`
         // (AOM1.4 c_date/c_date_time/c_time class files); the legal patterns
@@ -107,39 +39,129 @@ pub(super) fn check_primitive(p: &CPrimitive, node_id: &str) -> Result<(), RuleV
         // field-ordering are cADL §Constraints on Dates/Times (ADL1.4 master05
         // lines 858–892).
         CPrimitive::CDate(c) => {
-            if let Some(pattern) = &c.pattern
-                && !valid_date_pattern(pattern)
-            {
-                return Err(pattern_violation(node_id, pattern, "date"));
-            }
+            check_pattern(c.pattern.as_deref(), node_id, "date", valid_date_pattern)
         }
         CPrimitive::CTime(c) => {
-            if let Some(pattern) = &c.pattern
-                && !valid_time_pattern(pattern)
-            {
-                return Err(pattern_violation(node_id, pattern, "time"));
-            }
+            check_pattern(c.pattern.as_deref(), node_id, "time", valid_time_pattern)
         }
-        CPrimitive::CDateTime(c) => {
-            if let Some(pattern) = &c.pattern
-                && !valid_date_time_pattern(pattern)
-            {
-                return Err(pattern_violation(node_id, pattern, "date-time"));
-            }
-        }
+        CPrimitive::CDateTime(c) => check_pattern(
+            c.pattern.as_deref(),
+            node_id,
+            "date-time",
+            valid_date_time_pattern,
+        ),
         // C_DURATION: the pattern must be `P[Y][M][W][D][T[H][M][S]]` — openEHR
         // deviates from strict ISO 8601 by allowing `W` to be mixed with the
         // other designators (cADL §Duration Constraints, ADL1.4 master05 lines
         // 934–980).
-        CPrimitive::CDuration(c) => {
-            if let Some(pattern) = &c.pattern
-                && !valid_duration_pattern(pattern)
-            {
-                return Err(pattern_violation(node_id, pattern, "duration"));
-            }
-        }
+        CPrimitive::CDuration(c) => check_pattern(
+            c.pattern.as_deref(),
+            node_id,
+            "duration",
+            valid_duration_pattern,
+        ),
+    }
+}
+
+/// `C_BOOLEAN` satisfiability and `Assumed_value_valid`.
+///
+/// `true_valid` and `false_valid` cannot both be False — the constraint would
+/// be unsatisfiable (AOM1.4 `c_boolean` class file, Description).
+fn check_boolean(c: &CBoolean, node_id: &str) -> Result<(), RuleViolation> {
+    if !c.true_valid && !c.false_valid {
+        return Err(RuleViolation::new(
+            "C_BOOLEAN_validity",
+            format!(
+                "node '{node_id}': true_valid and false_valid are both false — the \
+                 boolean constraint is unsatisfiable"
+            ),
+        ));
+    }
+    let Some(assumed) = c.assumed_value else {
+        return Ok(());
+    };
+    let permitted = if assumed { c.true_valid } else { c.false_valid };
+    if permitted {
+        return Ok(());
+    }
+    Err(RuleViolation::new(
+        "Assumed_value_valid",
+        format!(
+            "node '{node_id}': the assumed boolean value {assumed} is not \
+             permitted by the true_valid/false_valid flags"
+        ),
+    ))
+}
+
+/// `C_STRING` `Assumed_value_valid` against a closed value list (AOM1.4
+/// `c_string` class file; cADL string constraints are case-sensitive).
+fn check_string(c: &CString, node_id: &str) -> Result<(), RuleViolation> {
+    if let Some(assumed) = &c.assumed_value
+        && !c.list.is_empty()
+        && c.list_open != Some(true)
+        && !c.list.contains(assumed)
+    {
+        return Err(RuleViolation::new(
+            "Assumed_value_valid",
+            format!(
+                "node '{node_id}': the assumed string '{assumed}' is not in the closed \
+                 value list"
+            ),
+        ));
     }
     Ok(())
+}
+
+/// `C_INTEGER` `Assumed_value_valid` against the constrained list and range.
+fn check_integer(c: &CInteger, node_id: &str) -> Result<(), RuleViolation> {
+    let Some(assumed) = c.assumed_value else {
+        return Ok(());
+    };
+    let list_ok = c.list.is_empty() || c.list.contains(&assumed);
+    let range_ok = c.range.as_ref().is_none_or(|r| int_in_range(assumed, r));
+    if list_ok && range_ok {
+        return Ok(());
+    }
+    Err(RuleViolation::new(
+        "Assumed_value_valid",
+        format!(
+            "node '{node_id}': the assumed integer {assumed} is outside the \
+             constrained list/range"
+        ),
+    ))
+}
+
+/// `C_REAL` `Assumed_value_valid` against the constrained list and range.
+fn check_real(c: &CReal, node_id: &str) -> Result<(), RuleViolation> {
+    let Some(assumed) = c.assumed_value else {
+        return Ok(());
+    };
+    let list_ok = c.list.is_empty() || c.list.contains(&assumed);
+    let range_ok = c.range.as_ref().is_none_or(|r| real_in_range(assumed, r));
+    if list_ok && range_ok {
+        return Ok(());
+    }
+    Err(RuleViolation::new(
+        "Assumed_value_valid",
+        format!(
+            "node '{node_id}': the assumed real {assumed} is outside the \
+             constrained list/range"
+        ),
+    ))
+}
+
+/// The `Pattern_validity` invariant of one temporal or duration leaf: a
+/// present pattern must satisfy its class's constraint-pattern grammar.
+fn check_pattern(
+    pattern: Option<&str>,
+    node_id: &str,
+    kind: &str,
+    valid: fn(&str) -> bool,
+) -> Result<(), RuleViolation> {
+    match pattern {
+        Some(pattern) if !valid(pattern) => Err(pattern_violation(node_id, pattern, kind)),
+        _ => Ok(()),
+    }
 }
 
 fn pattern_violation(node_id: &str, pattern: &str, kind: &str) -> RuleViolation {

--- a/app/ferroehr/src/validation/opt/terminology.rs
+++ b/app/ferroehr/src/validation/opt/terminology.rs
@@ -90,36 +90,15 @@ pub(super) fn check_term_bindings(
     opt: &OperationalTemplate,
     defined_at: &HashSet<String>,
 ) -> Result<(), RuleViolation> {
-    let check = |code: &str| -> Result<(), RuleViolation> {
-        // (Observed in the vendored blood-pressure corpus OPTs — evidence that
-        // the shape occurs, never the authority for accepting it.)
-        // NOTE (flattened-OPT tolerance): a *specialised* code (`at0.23`, AOM2
-        // §specialisation depth) names a code DEFINED IN THE PARENT archetype,
-        // which the released AM text never requires to be repeated locally.
-        let specialised = code.contains('.');
-        if code.starts_with('/')
-            || !archetype_node_id_is_term_code(code)
-            || specialised
-            || defined_at.contains(code)
-        {
-            return Ok(());
-        }
-        Err(RuleViolation::new(
-            "VTTBK",
-            format!(
-                "term binding key '{code}' is neither a defined archetype term (at-code) nor a path"
-            ),
-        ))
-    };
     for set in &opt.definition.term_bindings {
         for item in &set.items {
-            check(&item.code)?;
+            check_term_binding_key(&item.code, defined_at)?;
         }
     }
     for onto in flat_ontologies(opt) {
         for set in &onto.term_bindings {
             for item in &set.items {
-                check(&item.code)?;
+                check_term_binding_key(&item.code, defined_at)?;
             }
         }
     }
@@ -127,11 +106,35 @@ pub(super) fn check_term_bindings(
     for root in nested_roots(opt) {
         for set in &root.term_bindings {
             for item in &set.items {
-                check(&item.code)?;
+                check_term_binding_key(&item.code, defined_at)?;
             }
         }
     }
     Ok(())
+}
+
+/// One VTTBK key: a path, or a defined archetype term.
+///
+/// NOTE (flattened-OPT tolerance): a *specialised* code (`at0.23`, AOM2
+/// §specialisation depth) names a code DEFINED IN THE PARENT archetype, which
+/// the released AM text never requires to be repeated locally. (The shape is
+/// observed in the vendored blood-pressure corpus OPTs — evidence that it
+/// occurs, never the authority for accepting it.)
+fn check_term_binding_key(code: &str, defined_at: &HashSet<String>) -> Result<(), RuleViolation> {
+    let specialised = code.contains('.');
+    if code.starts_with('/')
+        || !archetype_node_id_is_term_code(code)
+        || specialised
+        || defined_at.contains(code)
+    {
+        return Ok(());
+    }
+    Err(RuleViolation::new(
+        "VTTBK",
+        format!(
+            "term binding key '{code}' is neither a defined archetype term (at-code) nor a path"
+        ),
+    ))
 }
 
 /// VTCBK: "terminology constraint binding key valid. Every constraint binding

--- a/app/ferroehr/src/versioning/contribution.rs
+++ b/app/ferroehr/src/versioning/contribution.rs
@@ -88,127 +88,180 @@ fn classify(
     has_preceding: bool,
     has_data: bool,
 ) -> Result<(Action, String), ServiceError> {
-    let code = match token {
-        Some(t) => change_type_code(t).ok_or_else(|| {
-            ServiceError::content_invalid(
-                Violation::new(format!(
-                    "{t:?} is not a code in the openEHR audit_change_type group"
-                ))
-                .with_path("change_type")
-                .with_invariant("AUDIT_DETAILS.Change_type_valid"),
-            )
-        })?,
-        // No client change type: infer creation vs modification from the
-        // presence of preceding_version_uid.
-        None if has_preceding => change_type::MODIFICATION.to_owned(),
-        None => change_type::CREATION.to_owned(),
-    };
+    let code = resolve_change_type(token, has_preceding)?;
     match code.as_str() {
-        change_type::CREATION => {
-            if has_preceding {
-                // The released `400_CONTRIBUTION` trigger is DIRECTIONAL —
-                // "first version of a MODIFICATION" — and does not cover this
-                // mirror case; no released text assigns it, so it is the
-                // adjudicated 422: a well-formed envelope whose
-                // change-control semantics cannot be followed (RM
-                // change_control §Contributions: creation commits a NEW
-                // VERSIONED_OBJECT).
-                return Err(ServiceError::content_invalid(
-                    Violation::new(
-                        "249|creation| is invalid for an existing object \
-                         (preceding_version_uid present); creation commits a new \
-                         VERSIONED_OBJECT",
-                    )
-                    .with_path("change_type")
-                    .with_invariant("RM change_control §Contributions"),
-                ));
-            }
-            if !has_data {
-                return Err(ServiceError::content_invalid(
-                    Violation::new("is required on a creation version").with_path("data"),
-                ));
-            }
-            Ok((Action::Create, code))
-        }
-        change_type::DELETED => {
-            if !has_preceding {
-                // A non-creation change type as a FIRST version — the released
-                // `400_CONTRIBUTION` trigger family ("the modification type
-                // does not match the operation - i.e. first version of a
-                // MODIFICATION") → 400.
-                return Err(ServiceError::precondition(
-                    "deleted (523) version requires preceding_version_uid — a first \
-                     version's change type is 249|creation| (ITS-REST contribution \
-                     400: the modification type does not match the operation)"
-                        .to_owned(),
-                ));
-            }
-            if has_data {
-                return Err(ServiceError::content_invalid(
-                    Violation::new(
-                        "must not be set on a deleted (523) version — its data attribute \
-                         is set to Void",
-                    )
-                    .with_path("data")
-                    .with_invariant("RM change_control §Contributions"),
-                ));
-            }
-            Ok((Action::Delete, code))
-        }
-        change_type::ATTESTATION => {
-            // 666 attaches to an existing ORIGINAL_VERSION identified by
-            // preceding_version_uid (master06 §Contributions;
-            // VERSIONED_OBJECT.commit_attestation pre has_version_id). Absent →
-            // the request cannot name its target: a 400, not a 422.
-            //
-            // NOTE: the same §Contributions row spells the code's home
-            // `ATTESTATION._commit_audit_._change_type_`, a path ATTESTATION
-            // cannot have; the repaired reading `ATTESTATION.change_type` is used.
-            if !has_preceding {
-                return Err(ServiceError::precondition(
-                    "change_type 666|attestation| requires preceding_version_uid to \
-                     identify the ORIGINAL_VERSION being attested (RM change_control \
-                     §Contributions; VERSIONED_OBJECT.commit_attestation pre \
-                     has_version_id)"
-                        .to_owned(),
-                ));
-            }
-            if has_data {
-                return Err(ServiceError::content_invalid(
-                    Violation::new(
-                        "must not be set on a 666 attestation version — attesting an \
-                         existing item adds no content",
-                    )
-                    .with_path("data")
-                    .with_invariant("RM change_control §Contributions"),
-                ));
-            }
-            Ok((Action::Attest, code))
-        }
+        change_type::CREATION => classify_creation(code, has_preceding, has_data),
+        change_type::DELETED => classify_deletion(code, has_preceding, has_data),
+        change_type::ATTESTATION => classify_attestation(code, has_preceding, has_data),
         // amendment 250 / modification 251 / synthesis 252 / unknown 253 /
         // restoration 816 / format conversion 817: a content-carrying new
         // version of an existing object; the code is preserved verbatim.
-        _ => {
-            if !has_preceding {
-                // THE released assignment: `400_CONTRIBUTION` — "the
-                // modification type does not match the operation - i.e. first
-                // version of a MODIFICATION" → 400.
-                return Err(ServiceError::precondition(format!(
-                    "change_type {code} requires preceding_version_uid — a first \
-                     version's change type is 249|creation| (ITS-REST contribution \
-                     400: the modification type does not match the operation; RM \
-                     change_control §Contributions)"
-                )));
-            }
-            if !has_data {
-                return Err(ServiceError::content_invalid(
-                    Violation::new(format!("is required on a change_type {code} version"))
-                        .with_path("data"),
-                ));
-            }
-            Ok((Action::Modify, code))
-        }
+        _ => classify_modification(code, has_preceding, has_data),
     }
+}
+
+/// The canonical numeric `audit_change_type` code of one version.
+///
+/// Without a client change type the code is inferred from the presence of
+/// `preceding_version_uid`: creation for a first version, modification
+/// otherwise.
+///
+/// # Errors
+/// [`ServiceError::Unprocessable`] when the supplied token is not a code of
+/// the openEHR `audit_change_type` group.
+fn resolve_change_type(token: Option<&str>, has_preceding: bool) -> Result<String, ServiceError> {
+    let Some(t) = token else {
+        if has_preceding {
+            return Ok(change_type::MODIFICATION.to_owned());
+        }
+        return Ok(change_type::CREATION.to_owned());
+    };
+    change_type_code(t).ok_or_else(|| {
+        ServiceError::content_invalid(
+            Violation::new(format!(
+                "{t:?} is not a code in the openEHR audit_change_type group"
+            ))
+            .with_path("change_type")
+            .with_invariant("AUDIT_DETAILS.Change_type_valid"),
+        )
+    })
+}
+
+/// Checks a `249|creation|` version: it commits a NEW `VERSIONED_OBJECT`, so it
+/// carries data and no preceding version.
+///
+/// # Errors
+/// [`ServiceError::Unprocessable`] for a preceding version (the released
+/// `400_CONTRIBUTION` trigger is DIRECTIONAL — "first version of a
+/// MODIFICATION" — and does not cover this mirror case, so it is the
+/// adjudicated 422: a well-formed envelope whose change-control semantics
+/// cannot be followed, RM `change_control` §Contributions) or for missing data.
+fn classify_creation(
+    code: String,
+    has_preceding: bool,
+    has_data: bool,
+) -> Result<(Action, String), ServiceError> {
+    if has_preceding {
+        return Err(ServiceError::content_invalid(
+            Violation::new(
+                "249|creation| is invalid for an existing object \
+                 (preceding_version_uid present); creation commits a new \
+                 VERSIONED_OBJECT",
+            )
+            .with_path("change_type")
+            .with_invariant("RM change_control §Contributions"),
+        ));
+    }
+    if !has_data {
+        return Err(ServiceError::content_invalid(
+            Violation::new("is required on a creation version").with_path("data"),
+        ));
+    }
+    Ok((Action::Create, code))
+}
+
+/// Checks a `523|deleted|` version: a new version of an existing object whose
+/// data attribute is set to Void.
+///
+/// # Errors
+/// [`ServiceError::BadRequest`] without a preceding version — a non-creation
+/// change type as a FIRST version is the released `400_CONTRIBUTION` trigger
+/// family ("the modification type does not match the operation - i.e. first
+/// version of a MODIFICATION"); [`ServiceError::Unprocessable`] when it
+/// carries data.
+fn classify_deletion(
+    code: String,
+    has_preceding: bool,
+    has_data: bool,
+) -> Result<(Action, String), ServiceError> {
+    if !has_preceding {
+        return Err(ServiceError::precondition(
+            "deleted (523) version requires preceding_version_uid — a first \
+             version's change type is 249|creation| (ITS-REST contribution \
+             400: the modification type does not match the operation)"
+                .to_owned(),
+        ));
+    }
+    if has_data {
+        return Err(ServiceError::content_invalid(
+            Violation::new(
+                "must not be set on a deleted (523) version — its data attribute \
+                 is set to Void",
+            )
+            .with_path("data")
+            .with_invariant("RM change_control §Contributions"),
+        ));
+    }
+    Ok((Action::Delete, code))
+}
+
+/// Checks a `666|attestation|` version: it attaches to an existing
+/// `ORIGINAL_VERSION` identified by `preceding_version_uid` and commits no new
+/// version (master06 §Contributions;
+/// `VERSIONED_OBJECT.commit_attestation` pre `has_version_id`).
+///
+/// NOTE: the same §Contributions row spells the code's home
+/// `ATTESTATION._commit_audit_._change_type_`, a path `ATTESTATION` cannot
+/// have; the repaired reading `ATTESTATION.change_type` is used.
+///
+/// # Errors
+/// [`ServiceError::BadRequest`] without a preceding version — the request
+/// cannot name its target, so it is a 400 rather than a 422;
+/// [`ServiceError::Unprocessable`] when it carries data.
+fn classify_attestation(
+    code: String,
+    has_preceding: bool,
+    has_data: bool,
+) -> Result<(Action, String), ServiceError> {
+    if !has_preceding {
+        return Err(ServiceError::precondition(
+            "change_type 666|attestation| requires preceding_version_uid to \
+             identify the ORIGINAL_VERSION being attested (RM change_control \
+             §Contributions; VERSIONED_OBJECT.commit_attestation pre \
+             has_version_id)"
+                .to_owned(),
+        ));
+    }
+    if has_data {
+        return Err(ServiceError::content_invalid(
+            Violation::new(
+                "must not be set on a 666 attestation version — attesting an \
+                 existing item adds no content",
+            )
+            .with_path("data")
+            .with_invariant("RM change_control §Contributions"),
+        ));
+    }
+    Ok((Action::Attest, code))
+}
+
+/// Checks a content-carrying modification version.
+///
+/// # Errors
+/// [`ServiceError::BadRequest`] without a preceding version — THE released
+/// assignment: `400_CONTRIBUTION`, "the modification type does not match the
+/// operation - i.e. first version of a MODIFICATION";
+/// [`ServiceError::Unprocessable`] when it carries no data.
+fn classify_modification(
+    code: String,
+    has_preceding: bool,
+    has_data: bool,
+) -> Result<(Action, String), ServiceError> {
+    if !has_preceding {
+        return Err(ServiceError::precondition(format!(
+            "change_type {code} requires preceding_version_uid — a first \
+             version's change type is 249|creation| (ITS-REST contribution \
+             400: the modification type does not match the operation; RM \
+             change_control §Contributions)"
+        )));
+    }
+    if !has_data {
+        return Err(ServiceError::content_invalid(
+            Violation::new(format!("is required on a change_type {code} version"))
+                .with_path("data"),
+        ));
+    }
+    Ok((Action::Modify, code))
 }
 
 /// One parsed `UPDATE_VERSION` of a CONTRIBUTION commit — the single-pass plan
@@ -378,11 +431,6 @@ fn reject_foreign_version_identity(version: &Value, index: usize) -> Result<(), 
 /// body-referenced modification target does not exist (the `400_CONTRIBUTION`
 /// scope); [`ServiceError::Conflict`] for a duplicate EHR singleton/directory;
 /// plus the commit-engine placement/storage/signing errors.
-#[expect(
-    clippy::too_many_lines,
-    reason = "the per-version classify + change-build loop, whose order is the \
-              CONTRIBUTION commit semantics"
-)]
 pub(crate) async fn commit_version_set(
     cx: &impl CommitEnv,
     ehr_id: Option<EhrId>,
@@ -404,53 +452,8 @@ pub(crate) async fn commit_version_set(
             )
         })?;
 
-    // A client-supplied CONTRIBUTION uid is honoured when unused and rejected
-    // when malformed or already in use (ITS-REST `contribution_create`; master06
-    // §CONTRIBUTION `uid`).
-    let supplied_uid = match body
-        .get("uid")
-        .and_then(|u| u.get("value"))
-        .and_then(Value::as_str)
-    {
-        None => None,
-        #[expect(
-            clippy::map_err_ignore,
-            reason = "the mapped error already echoes the rejected token; the \
-                      discarded `uuid::Error` adds only its own wording, which \
-                      is not part of the wire contract"
-        )]
-        Some(raw) => Some(raw.parse::<Uuid>().map_err(|_| {
-            ServiceError::content_invalid(
-                Violation::new(format!("{raw:?} is not a valid HIER_OBJECT_ID UUID"))
-                    .with_path("CONTRIBUTION.uid"),
-            )
-        })?),
-    };
-
-    // The CONTRIBUTION audit's `committer` is REQUIRED, exactly like its
-    // `change_type`: RM common `audit_details.adoc` §Attributes types `committer`
-    // 1..1 on the mandatory `CONTRIBUTION.audit`, and the released commit schema
-    // requires it on the wire (`NewContribution.yaml` over `UpdateAudit.yaml`).
-    // master06 §Committal (m4) then copies system_id/committer/time_committed of
-    // the CONTRIBUTION audit "into the commit_audit of each VERSION included in
-    // the CONTRIBUTION"; time_committed is always the server commit-act time.
-    let contrib_committer = match body.get("audit").and_then(|a| a.get("committer")) {
-        Some(supplied) => party_proxy(supplied)?,
-        None => {
-            return Err(ServiceError::content_invalid(
-                Violation::new(
-                    "is required on a CONTRIBUTION audit — the change set's committer is the \
-                     client's account of who committed it and is never invented by the server",
-                )
-                .with_path("CONTRIBUTION.audit.committer"),
-            ));
-        }
-    };
-    let contrib_system_id = body
-        .get("audit")
-        .and_then(|a| a.get("system_id"))
-        .and_then(Value::as_str)
-        .map_or_else(|| cx.effective_system_id(), str::to_owned);
+    let supplied_uid = parse_supplied_uid(body)?;
+    let (contrib_committer, contrib_system_id) = parse_contribution_committer(cx, body)?;
 
     // ── ONE parse pass over the version set ────────────────────────────────
     // Each UPDATE_VERSION is read exactly once into a typed plan entry:
@@ -461,125 +464,15 @@ pub(crate) async fn commit_version_set(
     // resolved to [`Change`]s without re-reading any JSON.
     let mut plan: Vec<PlannedVersion> = Vec::with_capacity(versions.len());
     for (index, version) in versions.iter().enumerate() {
-        reject_foreign_version_identity(version, index)?;
-        let token = version
-            .get("commit_audit")
-            .and_then(|a| a.get("change_type"))
-            .and_then(coded_value);
-        let data = version.get("data").cloned().filter(|d| !d.is_null());
-        // NOTE: a first version legitimately carries no `preceding_version_uid`
-        // (SM `update_version.adoc` types it `0..1`), and the SM glue serializes
-        // a `None` preceding to JSON `null`, so a `null` counts as absent.
-        let has_preceding = version
-            .get("preceding_version_uid")
-            .is_some_and(|v| !v.is_null());
-        let (action, code) = classify(token.as_deref(), has_preceding, data.is_some())
-            .map_err(|e| e.for_version_member(index))?;
-
-        let target = if action == Action::Create {
-            None
-        } else {
-            Some(parse_preceding(version).map_err(|e| e.for_version_member(index))?)
-        };
-        // m4: default committer/system_id from the CONTRIBUTION audit when the
-        // version item omits them (a "should be copied", so an explicit
-        // per-version value is honoured — NOTE: SHOULD, not MUST).
-        // A `666|attestation|` member's commit_audit is the ATTESTATION it
-        // attaches, not that member's own commit audit (master06
-        // §Contributions) — the attestation path owns it.
-        let audit = parse_audit(
-            version.get("commit_audit"),
-            code,
+        plan.push(plan_version(
+            version,
+            index,
             &contrib_committer,
             &contrib_system_id,
-            action != Action::Attest,
-        )
-        .map_err(|e| e.for_version_member(index))?;
-        let lifecycle_state = lifecycle_of(version);
-        // `UPDATE_VERSION.lifecycle_state` is REQUIRED on this wire (SM
-        // `master03-common_package.adoc` §Version Update Semantics: "must be
-        // supplied in all cases"; ITS-REST `schemas/ehr/UpdateVersion.yaml`
-        // lists it under `required`), and `other_input_version_uids` is NOT a
-        // member of it at all. Merge provenance is PRODUCE-only — accepting it
-        // here would let a client stamp arbitrary provenance onto a version this
-        // system never merged. Both are refused as the shape failures they are
-        // (`400_CONTRIBUTION`: "syntactically invalid … content").
-        // NOTE: the `666|attestation|` member is exempt from the lifecycle rule,
-        // and only it — it commits no new version (master06 §Contributions), so
-        // it has no version lifecycle state to supply; the RM governs the gap.
-        if version.get("other_input_version_uids").is_some() {
-            return Err(ServiceError::precondition(format!(
-                "versions[{index}]: other_input_version_uids is not a member of \
-                 UPDATE_VERSION — the released commit wire declares no merge shape \
-                 (ITS-REST UpdateVersion.yaml); merge provenance is served on reads \
-                 only (OriginalVersion.yaml)"
-            )));
-        }
-        if action != Action::Attest && lifecycle_state.is_none() {
-            return Err(ServiceError::precondition(format!(
-                "versions[{index}]: lifecycle_state is required on every CONTRIBUTION \
-                 version (SM master03 §Version Update Semantics: \"The lifecycle_state \
-                 must be supplied in all cases\"; ITS-REST UpdateVersion.yaml lists it \
-                 under required)"
-            )));
-        }
-        if action == Action::Delete {
-            reject_contradictory_delete_lifecycle(lifecycle_state.as_deref())
-                .map_err(|e| e.for_version_member(index))?;
-        }
-        // A `553|incomplete|` version gets relaxed content validation
-        // (master06 §Incomplete Content).
-        let incomplete = lifecycle_state
-            .as_deref()
-            .and_then(lifecycle_state_code)
-            .is_some_and(|c| c == state::INCOMPLETE);
-        plan.push(PlannedVersion {
-            index,
-            action,
-            target,
-            data,
-            audit,
-            commit_audit: version.get("commit_audit").cloned(),
-            lifecycle_state,
-            incomplete,
-            // A client UPDATE_VERSION.signature is stored verbatim; absent,
-            // the server signs (master06 §Digital Signature).
-            signature: version
-                .get("signature")
-                .and_then(Value::as_str)
-                .map(str::to_owned),
-            accompanying: attestation_partials(version),
-        });
+        )?);
     }
 
-    // ── ONE batched target read ────────────────────────────────────────────
-    let mut target_ids: Vec<VoId> = plan
-        .iter()
-        .filter_map(|v| v.target.map(|(vo_id, _)| vo_id))
-        .collect();
-    target_ids.sort_unstable();
-    target_ids.dedup();
-    let target_kinds: std::collections::HashMap<VoId, Kind> =
-        crate::storage::version_repo::meta::object_kinds(cx.pool(), &target_ids)
-            .await
-            .map_err(ServiceError::from)?
-            .into_iter()
-            .filter_map(|(id, kind)| Kind::from_type(&kind).map(|k| (id, k)))
-            .collect();
-    // Every target here is **body-referenced** (`preceding_version_uid` of a
-    // modification/deletion/attestation item), so a missing object is the
-    // `400_CONTRIBUTION` scope — the ITS-REST `contribution_create` operation
-    // declares `404` only for an unknown `ehr_id` (the URI resource), never for
-    // content the committed CONTRIBUTION refers to.
-    let require_kind = |vo_id: VoId| -> Result<Kind, ServiceError> {
-        target_kinds.get(&vo_id).copied().ok_or_else(|| {
-            ServiceError::precondition(format!(
-                "modification target does not exist: versioned object {vo_id} \
-                 (ITS-REST contribution 400 — the modification does not match \
-                 a stored object)"
-            ))
-        })
-    };
+    let target_kinds = read_target_kinds(cx, &plan).await?;
 
     // ── Resolve the plan to changes ────────────────────────────────────────
     let mut changes: Vec<(AuditInput, Change)> = Vec::with_capacity(plan.len());
@@ -587,225 +480,23 @@ pub(crate) async fn commit_version_set(
     let mut attests: Vec<PendingAttest> = Vec::new();
     for v in plan {
         if v.action == Action::Attest {
-            let Some((vo_id, expected)) = v.target else {
-                return Err(ServiceError::exception(
-                    "attest plan entry lost its parsed preceding target".to_owned(),
-                ));
-            };
-            let kind = require_kind(vo_id).map_err(|e| e.for_version_member(v.index))?;
-            check_kind_scope(kind, party_only).map_err(|e| e.for_version_member(v.index))?;
-            let partial = v.commit_audit.ok_or_else(|| {
-                ServiceError::content_invalid(
-                    Violation::new(
-                        "is required on a 666 attestation version (the UPDATE_ATTESTATION)",
-                    )
-                    .with_path("commit_audit"),
-                )
-            })?;
-            attests.push(PendingAttest {
-                vo_id,
-                kind,
-                expected,
-                partial: crate::versioning::attestation::AttestationInput::decode(&partial)?,
-            });
+            attests.push(plan_attestation(&target_kinds, v, party_only)?);
             continue;
         }
         // AUDIT_DETAILS.System_id_valid + committer PARTY invariants — a
         // client-supplied version commit_audit must be a valid RM instance.
         validate_commit_audit(&v.audit).map_err(|e| e.for_version_member(v.index))?;
-        let change = match v.action {
-            Action::Create => {
-                let data = v.data.ok_or_else(|| {
-                    ServiceError::content_invalid(
-                        Violation::new("is required on a creation version").with_path("data"),
-                    )
-                    .for_version_member(v.index)
-                })?;
-                let kind = data_kind(&data).map_err(|e| e.for_version_member(v.index))?;
-                check_kind_scope(kind, party_only).map_err(|e| e.for_version_member(v.index))?;
-                typed_decode_gate(kind, &data, v.incomplete)
-                    .map_err(|e| e.for_version_member(v.index))?;
-                // A CONTRIBUTION commit is a full commit route: its versions
-                // are validated exactly as a direct create/update, relaxed for
-                // a `553|incomplete|` lifecycle (master06 §Incomplete Content).
-                cx.validate_for_commit(kind, &data, v.incomplete)
-                    .await
-                    .map_err(|e| e.for_version_member(v.index))?;
-                // An EHR holds exactly one EHR_STATUS / EHR_ACCESS (RM ehr,
-                // EHR class); FOLDER hierarchies follow the CNF
-                // master08-func_tc_ehr_contribution E.2 criterion.
-                if let Some(ehr_id) = ehr_id {
-                    reject_duplicate_singleton(cx, ehr_id, kind, &data).await?;
-                }
-                // A COMPOSITION stamps `vo_version.template_id` exactly like
-                // the direct commit path — the template-delete 409 guard
-                // counts that column, so a contribution-committed composition
-                // must protect its template from physical deletion too
-                // (found by ECC `tpl/delete-opt-delete-specific-version`).
-                let template_id = (kind == Kind::Composition)
-                    .then(|| {
-                        crate::service::ehr::validation::composition_template_id(&data)
-                            .map(str::to_owned)
-                    })
-                    .flatten();
-                Change::Create {
-                    kind,
-                    canonical: data,
-                    template_id,
-                    signature: v.signature,
-                    lifecycle_state: v.lifecycle_state,
-                    attestations: accompanying(&v.accompanying)
-                        .map_err(|e| e.for_version_member(v.index))?,
-                }
-            }
-            Action::Modify => {
-                let data = v.data.ok_or_else(|| {
-                    ServiceError::content_invalid(
-                        Violation::new("is required on a modification version").with_path("data"),
-                    )
-                    .for_version_member(v.index)
-                })?;
-                let Some((vo_id, expected)) = v.target else {
-                    return Err(ServiceError::exception(
-                        "modify plan entry lost its parsed preceding target".to_owned(),
-                    ));
-                };
-                let kind = require_kind(vo_id).map_err(|e| e.for_version_member(v.index))?;
-                check_kind_scope(kind, party_only).map_err(|e| e.for_version_member(v.index))?;
-                typed_decode_gate(kind, &data, v.incomplete)
-                    .map_err(|e| e.for_version_member(v.index))?;
-                cx.validate_for_commit(kind, &data, v.incomplete)
-                    .await
-                    .map_err(|e| e.for_version_member(v.index))?;
-                // Same template stamping as the Create arm (the delete guard
-                // counts every version row, modifications included).
-                let template_id = (kind == Kind::Composition)
-                    .then(|| {
-                        crate::service::ehr::validation::composition_template_id(&data)
-                            .map(str::to_owned)
-                    })
-                    .flatten();
-                Change::Modify {
-                    vo_id,
-                    kind,
-                    canonical: data,
-                    expected: Some(expected),
-                    template_id,
-                    signature: v.signature,
-                    lifecycle_state: v.lifecycle_state,
-                    attestations: accompanying(&v.accompanying)
-                        .map_err(|e| e.for_version_member(v.index))?,
-                }
-            }
-            Action::Delete => {
-                let Some((vo_id, expected)) = v.target else {
-                    return Err(ServiceError::exception(
-                        "delete plan entry lost its parsed preceding target".to_owned(),
-                    ));
-                };
-                let kind = require_kind(vo_id).map_err(|e| e.for_version_member(v.index))?;
-                check_kind_scope(kind, party_only).map_err(|e| e.for_version_member(v.index))?;
-                // EHR.ehr_status is mandatory (RM ehr, EHR class:
-                // ehr_status 1..1) — deleting the only EHR_STATUS would
-                // leave the EHR violating its own invariant, so a delete
-                // member targeting it is refused as a version conflict.
-                if kind == Kind::EhrStatus {
-                    return Err(ServiceError::conflict(
-                        "the EHR_STATUS cannot be deleted — EHR.ehr_status is mandatory \
-                         (RM ehr, EHR class, ehr_status: 1..1)"
-                            .to_owned(),
-                    ));
-                }
-                Change::Delete {
-                    vo_id,
-                    kind,
-                    expected: Some(expected),
-                    signature: v.signature,
-                }
-            }
-            // The `666|attestation|` branch above collects every attest member
-            // and `continue`s before this match, so this arm is a typed guard
-            // against that branch ever stopping to cover the action — the same
-            // shape the lost-target arms above use.
-            Action::Attest => {
-                return Err(ServiceError::exception(
-                    "attestation version reached the change-building match".to_owned(),
-                ));
-            }
-        };
-        changes.push((v.audit, change));
+        changes.push(build_change(cx, &target_kinds, v, ehr_id, party_only).await?);
     }
 
-    // EHR_STATUS.is_modifiable = False forbids content writes (RM ehr master04
-    // §EHR Active Status): a CONTRIBUTION that creates/modifies/deletes any EHR
-    // content (everything other than the EHR_STATUS object) is refused when the
-    // EHR is deactivated. An EHR_STATUS-only CONTRIBUTION stays allowed (the
-    // EHR_STATUS "can always be written to" — the ehr_status class docs), and
-    // so is a REACTIVATING mixed CONTRIBUTION: content is refused exactly when
-    // the EHR is deactivated AND this change set carries no EHR_STATUS member
-    // with is_modifiable = true, order-independently over the atomic set.
-    // NOTE: no openEHR spec governs per-member gate timing (the versions list
-    // has no spec-assigned order semantics) — our own design, adjudicated
-    // with the full citation record on issue #2673.
     if let Some(ehr_id) = ehr_id
-        && changes.iter().any(|(_, c)| c.kind() != Kind::EhrStatus)
-        && !changes.iter().any(|(_, c)| match c {
-            Change::Create {
-                kind: Kind::EhrStatus,
-                canonical,
-                ..
-            }
-            | Change::Modify {
-                kind: Kind::EhrStatus,
-                canonical,
-                ..
-            } => canonical.pointer("/is_modifiable").and_then(Value::as_bool) == Some(true),
-            _ => false,
-        })
+        && needs_content_write_permission(&changes)
     {
         cx.ensure_content_writable(ehr_id).await?;
     }
 
-    // The CONTRIBUTION's own audit change type is the CLIENT's account of its
-    // change set, and it is REQUIRED: RM common `audit_details.adoc` §Attributes
-    // types `change_type` 1..1 on the mandatory `CONTRIBUTION.audit`, and the
-    // released commit schema says the same (`schemas/ehr/NewContribution.yaml`
-    // over `schemas/common/UpdateAudit.yaml`). It is refused rather than
-    // derived: master06 §Contributions calls the aggregate "approximate, and not
-    // expected to be used as a computable value", so a server guess would put an
-    // approximation into the audit trail under the client's name.
-    let contribution_code = {
-        let token = body
-            .get("audit")
-            .and_then(|a| a.get("change_type"))
-            .and_then(coded_value)
-            .ok_or_else(|| {
-                ServiceError::content_invalid(
-                    Violation::new(
-                        "is required on a CONTRIBUTION audit — the change set's own change \
-                         type is the client's account of it and is never derived by the server",
-                    )
-                    .with_path("CONTRIBUTION.audit.change_type"),
-                )
-            })?;
-        change_type_code(&token).ok_or_else(|| {
-            ServiceError::content_invalid(
-                Violation::new(format!(
-                    "{token:?} is not a code in the openEHR audit_change_type group"
-                ))
-                .with_path("contribution audit change_type")
-                .with_invariant("AUDIT_DETAILS.Change_type_valid"),
-            )
-        })?
-    };
-    let contribution_audit = parse_audit(
-        body.get("audit"),
-        contribution_code,
-        &contrib_committer,
-        &contrib_system_id,
-        true,
-    )?;
-    validate_commit_audit(&contribution_audit)?;
+    let contribution_audit =
+        parse_contribution_audit(body, &contrib_committer, &contrib_system_id)?;
 
     // Cross-area commit hooks — the single site of truth for the CONTRIBUTION
     // path (the direct create/update paths run the same fns inline on their own
@@ -847,50 +538,19 @@ pub(crate) async fn commit_version_set(
         })
         .collect();
 
-    let mut tx = cx.pool().begin().await?;
-    // VERSIONED_COMPOSITION cross-version invariants (RM ehr
-    // `versioned_composition.adoc`) run before the write of each COMPOSITION
-    // modify, in the commit tx.
-    for (_, change) in &changes {
-        if let Change::Modify {
-            vo_id,
-            kind: Kind::Composition,
-            canonical,
-            ..
-        } = change
-        {
-            cx.pre_composition_modify(&mut tx, *vo_id, canonical)
-                .await
-                .map_err(body_target_not_found_is_bad_request)?;
-        }
-    }
-    let outcome = change::commit_contribution(
-        &mut tx,
+    let outcome = write_contribution(
+        cx,
         ehr_id,
-        supplied_uid,
-        &contribution_audit,
-        changes,
-        attests,
-        &cx.signing_ctx(),
+        ContributionWrite {
+            supplied_uid,
+            audit: &contribution_audit,
+            changes,
+            attests,
+            status_commits,
+            folder_commits,
+        },
     )
-    .await
-    .map_err(body_target_not_found_is_bad_request)?;
-    // Every committed FOLDER's local-claiming item references must resolve,
-    // judged AFTER the set's own inserts so the verdict never depends on
-    // member order; a violation rolls the whole set back.
-    if let Some(ehr_id) = ehr_id {
-        for folder in &folder_commits {
-            cx.check_folder_item_refs(&mut tx, ehr_id, folder).await?;
-        }
-    }
-    // Keep the EHR's promoted subject columns in sync after each committed
-    // EHR_STATUS version (one EHR per subject — RM ehr master04 §EHR Status).
-    if let Some(ehr_id) = ehr_id {
-        for status in &status_commits {
-            cx.post_status_commit(&mut tx, ehr_id, status).await?;
-        }
-    }
-    tx.commit().await?;
+    .await?;
 
     // Meter the COMPOSITION versions this CONTRIBUTION landed, after the commit
     // (a rolled-back contribution counts nothing).
@@ -908,6 +568,576 @@ pub(crate) async fn commit_version_set(
     }
 
     Ok(outcome)
+}
+
+/// The resolved change set of one CONTRIBUTION, ready to write.
+struct ContributionWrite<'a> {
+    supplied_uid: Option<Uuid>,
+    audit: &'a AuditInput,
+    changes: Vec<(AuditInput, Change)>,
+    attests: Vec<PendingAttest>,
+    /// The `EHR_STATUS` bodies the set commits, captured before `changes` moves
+    /// into the commit engine (the subject-sync hook runs after the commit).
+    status_commits: Vec<Value>,
+    /// The FOLDER bodies the set commits, for the post-insert item-reference
+    /// check.
+    folder_commits: Vec<Value>,
+}
+
+/// Writes the resolved change set in one transaction, with the cross-area
+/// commit hooks around it.
+///
+/// This is the single site of truth for the CONTRIBUTION path; the direct
+/// create/update paths run the same hooks inline on their own write flow.
+///
+/// # Errors
+/// The `VERSIONED_COMPOSITION` cross-version rejections (RM ehr
+/// `versioned_composition.adoc`), the folder item-reference violations (judged
+/// AFTER the set's own inserts so the verdict never depends on member order; a
+/// violation rolls the whole set back), and the commit-engine
+/// placement/storage/signing errors.
+async fn write_contribution(
+    cx: &impl CommitEnv,
+    ehr_id: Option<EhrId>,
+    write: ContributionWrite<'_>,
+) -> Result<CommittedContribution, ServiceError> {
+    let mut tx = cx.pool().begin().await?;
+    for (_, change) in &write.changes {
+        if let Change::Modify {
+            vo_id,
+            kind: Kind::Composition,
+            canonical,
+            ..
+        } = change
+        {
+            cx.pre_composition_modify(&mut tx, *vo_id, canonical)
+                .await
+                .map_err(body_target_not_found_is_bad_request)?;
+        }
+    }
+    let outcome = change::commit_contribution(
+        &mut tx,
+        ehr_id,
+        write.supplied_uid,
+        write.audit,
+        write.changes,
+        write.attests,
+        &cx.signing_ctx(),
+    )
+    .await
+    .map_err(body_target_not_found_is_bad_request)?;
+    if let Some(ehr_id) = ehr_id {
+        for folder in &write.folder_commits {
+            cx.check_folder_item_refs(&mut tx, ehr_id, folder).await?;
+        }
+        // Keep the EHR's promoted subject columns in sync after each committed
+        // EHR_STATUS version (one EHR per subject — RM ehr master04 §EHR
+        // Status).
+        for status in &write.status_commits {
+            cx.post_status_commit(&mut tx, ehr_id, status).await?;
+        }
+    }
+    tx.commit().await?;
+    Ok(outcome)
+}
+
+/// The client-supplied CONTRIBUTION `uid`, honoured when unused and rejected
+/// when malformed (ITS-REST `contribution_create`; master06 §CONTRIBUTION
+/// `uid`).
+///
+/// # Errors
+/// [`ServiceError::Unprocessable`] when the supplied value is not a
+/// `HIER_OBJECT_ID` UUID.
+fn parse_supplied_uid(body: &Value) -> Result<Option<Uuid>, ServiceError> {
+    let Some(raw) = body
+        .get("uid")
+        .and_then(|u| u.get("value"))
+        .and_then(Value::as_str)
+    else {
+        return Ok(None);
+    };
+    #[expect(
+        clippy::map_err_ignore,
+        reason = "the mapped error already echoes the rejected token; the \
+                  discarded `uuid::Error` adds only its own wording, which \
+                  is not part of the wire contract"
+    )]
+    let uid = raw.parse::<Uuid>().map_err(|_| {
+        ServiceError::content_invalid(
+            Violation::new(format!("{raw:?} is not a valid HIER_OBJECT_ID UUID"))
+                .with_path("CONTRIBUTION.uid"),
+        )
+    })?;
+    Ok(Some(uid))
+}
+
+/// The CONTRIBUTION audit's committer and system id, which every version audit
+/// of the set defaults from.
+///
+/// The `committer` is REQUIRED, exactly like the `change_type`: RM common
+/// `audit_details.adoc` §Attributes types `committer` 1..1 on the mandatory
+/// `CONTRIBUTION.audit`, and the released commit schema requires it on the
+/// wire (`NewContribution.yaml` over `UpdateAudit.yaml`). master06 §Committal
+/// (m4) then copies `system_id`/`committer`/`time_committed` of the
+/// CONTRIBUTION audit "into the `commit_audit` of each VERSION included in the
+/// CONTRIBUTION"; `time_committed` is always the server commit-act time.
+///
+/// # Errors
+/// [`ServiceError::Unprocessable`] when the committer is absent or is not a
+/// valid `PARTY_PROXY`.
+fn parse_contribution_committer(
+    cx: &impl CommitEnv,
+    body: &Value,
+) -> Result<(openehr_rm::prelude::PartyProxy, String), ServiceError> {
+    let Some(supplied) = body.get("audit").and_then(|a| a.get("committer")) else {
+        return Err(ServiceError::content_invalid(
+            Violation::new(
+                "is required on a CONTRIBUTION audit — the change set's committer is the \
+                 client's account of who committed it and is never invented by the server",
+            )
+            .with_path("CONTRIBUTION.audit.committer"),
+        ));
+    };
+    let system_id = body
+        .get("audit")
+        .and_then(|a| a.get("system_id"))
+        .and_then(Value::as_str)
+        .map_or_else(|| cx.effective_system_id(), str::to_owned);
+    Ok((party_proxy(supplied)?, system_id))
+}
+
+/// The CONTRIBUTION's own audit, validated as an RM instance.
+///
+/// Its change type is the CLIENT's account of the change set, and it is
+/// REQUIRED: RM common `audit_details.adoc` §Attributes types `change_type`
+/// 1..1 on the mandatory `CONTRIBUTION.audit`, and the released commit schema
+/// says the same (`schemas/ehr/NewContribution.yaml` over
+/// `schemas/common/UpdateAudit.yaml`). It is refused rather than derived:
+/// master06 §Contributions calls the aggregate "approximate, and not expected
+/// to be used as a computable value", so a server guess would put an
+/// approximation into the audit trail under the client's name.
+///
+/// # Errors
+/// [`ServiceError::Unprocessable`] when the change type is absent, is not a
+/// code of the openEHR `audit_change_type` group, or the audit fails its RM
+/// invariants.
+fn parse_contribution_audit(
+    body: &Value,
+    contrib_committer: &openehr_rm::prelude::PartyProxy,
+    contrib_system_id: &str,
+) -> Result<AuditInput, ServiceError> {
+    let token = body
+        .get("audit")
+        .and_then(|a| a.get("change_type"))
+        .and_then(coded_value)
+        .ok_or_else(|| {
+            ServiceError::content_invalid(
+                Violation::new(
+                    "is required on a CONTRIBUTION audit — the change set's own change \
+                     type is the client's account of it and is never derived by the server",
+                )
+                .with_path("CONTRIBUTION.audit.change_type"),
+            )
+        })?;
+    let code = change_type_code(&token).ok_or_else(|| {
+        ServiceError::content_invalid(
+            Violation::new(format!(
+                "{token:?} is not a code in the openEHR audit_change_type group"
+            ))
+            .with_path("contribution audit change_type")
+            .with_invariant("AUDIT_DETAILS.Change_type_valid"),
+        )
+    })?;
+    let audit = parse_audit(
+        body.get("audit"),
+        code,
+        contrib_committer,
+        contrib_system_id,
+        true,
+    )?;
+    validate_commit_audit(&audit)?;
+    Ok(audit)
+}
+
+/// Reads one submitted `UPDATE_VERSION` into a typed plan entry.
+///
+/// This is the only pass that touches the member's JSON: it classifies the
+/// change (master06 §Change Type), parses the preceding target, merges the
+/// per-version audit (master06 §Committal m4 committer/`system_id` copy-down)
+/// and captures the lifecycle/signature/attestation envelope.
+///
+/// # Errors
+/// [`ServiceError::Unprocessable`] for a member-borne version identity, an
+/// unclassifiable change type, an unparsable preceding target or an invalid
+/// audit; [`ServiceError::Precondition`] for a member carrying
+/// `other_input_version_uids` (not a member of `UPDATE_VERSION` on this wire —
+/// merge provenance is PRODUCE-only, so accepting it would let a client stamp
+/// arbitrary provenance onto a version this system never merged) or omitting
+/// the required `lifecycle_state`. The `666|attestation|` member is exempt from
+/// the lifecycle rule, and only it: it commits no new version (master06
+/// §Contributions), so it has no version lifecycle state to supply.
+fn plan_version(
+    version: &Value,
+    index: usize,
+    contrib_committer: &openehr_rm::prelude::PartyProxy,
+    contrib_system_id: &str,
+) -> Result<PlannedVersion, ServiceError> {
+    reject_foreign_version_identity(version, index)?;
+    let token = version
+        .get("commit_audit")
+        .and_then(|a| a.get("change_type"))
+        .and_then(coded_value);
+    let data = version.get("data").cloned().filter(|d| !d.is_null());
+    // NOTE: a first version legitimately carries no `preceding_version_uid`
+    // (SM `update_version.adoc` types it `0..1`), and the SM glue serializes
+    // a `None` preceding to JSON `null`, so a `null` counts as absent.
+    let has_preceding = version
+        .get("preceding_version_uid")
+        .is_some_and(|v| !v.is_null());
+    let (action, code) = classify(token.as_deref(), has_preceding, data.is_some())
+        .map_err(|e| e.for_version_member(index))?;
+
+    let target = if action == Action::Create {
+        None
+    } else {
+        Some(parse_preceding(version).map_err(|e| e.for_version_member(index))?)
+    };
+    // m4: default committer/system_id from the CONTRIBUTION audit when the
+    // version item omits them (a "should be copied", so an explicit per-version
+    // value is honoured — NOTE: SHOULD, not MUST). A `666|attestation|`
+    // member's commit_audit is the ATTESTATION it attaches, not that member's
+    // own commit audit (master06 §Contributions) — the attestation path owns it.
+    let audit = parse_audit(
+        version.get("commit_audit"),
+        code,
+        contrib_committer,
+        contrib_system_id,
+        action != Action::Attest,
+    )
+    .map_err(|e| e.for_version_member(index))?;
+    let lifecycle_state = lifecycle_of(version);
+    if version.get("other_input_version_uids").is_some() {
+        return Err(ServiceError::precondition(format!(
+            "versions[{index}]: other_input_version_uids is not a member of \
+             UPDATE_VERSION — the released commit wire declares no merge shape \
+             (ITS-REST UpdateVersion.yaml); merge provenance is served on reads \
+             only (OriginalVersion.yaml)"
+        )));
+    }
+    if action != Action::Attest && lifecycle_state.is_none() {
+        return Err(ServiceError::precondition(format!(
+            "versions[{index}]: lifecycle_state is required on every CONTRIBUTION \
+             version (SM master03 §Version Update Semantics: \"The lifecycle_state \
+             must be supplied in all cases\"; ITS-REST UpdateVersion.yaml lists it \
+             under required)"
+        )));
+    }
+    if action == Action::Delete {
+        reject_contradictory_delete_lifecycle(lifecycle_state.as_deref())
+            .map_err(|e| e.for_version_member(index))?;
+    }
+    // A `553|incomplete|` version gets relaxed content validation (master06
+    // §Incomplete Content).
+    let incomplete = lifecycle_state
+        .as_deref()
+        .and_then(lifecycle_state_code)
+        .is_some_and(|c| c == state::INCOMPLETE);
+    Ok(PlannedVersion {
+        index,
+        action,
+        target,
+        data,
+        audit,
+        commit_audit: version.get("commit_audit").cloned(),
+        lifecycle_state,
+        incomplete,
+        // A client UPDATE_VERSION.signature is stored verbatim; absent, the
+        // server signs (master06 §Digital Signature).
+        signature: version
+            .get("signature")
+            .and_then(Value::as_str)
+            .map(str::to_owned),
+        accompanying: attestation_partials(version),
+    })
+}
+
+/// Reads the stored kind of every modification target of the plan in ONE
+/// batched statement.
+///
+/// # Errors
+/// Storage errors from the batched read.
+async fn read_target_kinds(
+    cx: &impl CommitEnv,
+    plan: &[PlannedVersion],
+) -> Result<std::collections::HashMap<VoId, Kind>, ServiceError> {
+    let mut target_ids: Vec<VoId> = plan
+        .iter()
+        .filter_map(|v| v.target.map(|(vo_id, _)| vo_id))
+        .collect();
+    target_ids.sort_unstable();
+    target_ids.dedup();
+    Ok(
+        crate::storage::version_repo::meta::object_kinds(cx.pool(), &target_ids)
+            .await
+            .map_err(ServiceError::from)?
+            .into_iter()
+            .filter_map(|(id, kind)| Kind::from_type(&kind).map(|k| (id, k)))
+            .collect(),
+    )
+}
+
+/// The stored kind of a body-referenced modification target.
+///
+/// Every target reached here is body-referenced (the `preceding_version_uid`
+/// of a modification/deletion/attestation member), so a missing object is the
+/// `400_CONTRIBUTION` scope — the ITS-REST `contribution_create` operation
+/// declares `404` only for an unknown `ehr_id` (the URI resource), never for
+/// content the committed CONTRIBUTION refers to.
+///
+/// # Errors
+/// [`ServiceError::Precondition`] when the target does not exist.
+fn require_kind(
+    kinds: &std::collections::HashMap<VoId, Kind>,
+    vo_id: VoId,
+) -> Result<Kind, ServiceError> {
+    kinds.get(&vo_id).copied().ok_or_else(|| {
+        ServiceError::precondition(format!(
+            "modification target does not exist: versioned object {vo_id} \
+             (ITS-REST contribution 400 — the modification does not match \
+             a stored object)"
+        ))
+    })
+}
+
+/// Resolves a `666|attestation|` member, which attests an existing version
+/// instead of committing a new one (master06 §Contributions).
+///
+/// # Errors
+/// [`ServiceError::Precondition`] for a missing target, [`ServiceError::Unprocessable`]
+/// for a scope-mismatched kind, a missing `commit_audit` (the
+/// `UPDATE_ATTESTATION` payload), or an undecodable attestation.
+fn plan_attestation(
+    kinds: &std::collections::HashMap<VoId, Kind>,
+    v: PlannedVersion,
+    party_only: bool,
+) -> Result<PendingAttest, ServiceError> {
+    let Some((vo_id, expected)) = v.target else {
+        return Err(ServiceError::exception(
+            "attest plan entry lost its parsed preceding target".to_owned(),
+        ));
+    };
+    let kind = require_kind(kinds, vo_id).map_err(|e| e.for_version_member(v.index))?;
+    check_kind_scope(kind, party_only).map_err(|e| e.for_version_member(v.index))?;
+    let partial = v.commit_audit.ok_or_else(|| {
+        ServiceError::content_invalid(
+            Violation::new("is required on a 666 attestation version (the UPDATE_ATTESTATION)")
+                .with_path("commit_audit"),
+        )
+    })?;
+    Ok(PendingAttest {
+        vo_id,
+        kind,
+        expected,
+        partial: crate::versioning::attestation::AttestationInput::decode(&partial)?,
+    })
+}
+
+/// Resolves one non-attestation plan entry into the [`Change`] the commit
+/// engine applies, paired with the audit that member committed under.
+///
+/// # Errors
+/// The per-member rejections of the create/modify/delete shapes — see
+/// [`create_change`], [`modify_change`] and [`delete_change`].
+async fn build_change(
+    cx: &impl CommitEnv,
+    kinds: &std::collections::HashMap<VoId, Kind>,
+    v: PlannedVersion,
+    ehr_id: Option<EhrId>,
+    party_only: bool,
+) -> Result<(AuditInput, Change), ServiceError> {
+    let change = match v.action {
+        Action::Create => create_change(cx, &v, ehr_id, party_only).await?,
+        Action::Modify => modify_change(cx, kinds, &v, party_only).await?,
+        Action::Delete => delete_change(kinds, &v, party_only)?,
+        // The `666|attestation|` branch collects every attest member and
+        // `continue`s before this call, so this arm is a typed guard against
+        // that branch ever stopping to cover the action — the same shape the
+        // lost-target arms use.
+        Action::Attest => {
+            return Err(ServiceError::exception(
+                "attestation version reached the change-building match".to_owned(),
+            ));
+        }
+    };
+    Ok((v.audit, change))
+}
+
+/// Validates one content-bearing member and returns the `template_id` its
+/// version row stamps.
+///
+/// A CONTRIBUTION commit is a full commit route: its versions are validated
+/// exactly as a direct create/update, relaxed for a `553|incomplete|`
+/// lifecycle (master06 §Incomplete Content). A COMPOSITION stamps
+/// `vo_version.template_id` exactly like the direct commit path — the
+/// template-delete `409` guard counts that column, so a
+/// contribution-committed composition must protect its template from physical
+/// deletion too.
+///
+/// # Errors
+/// [`ServiceError::Unprocessable`] for a scope-mismatched kind or content that
+/// fails the typed decode or the commit validation.
+async fn accept_content(
+    cx: &impl CommitEnv,
+    kind: Kind,
+    data: &Value,
+    incomplete: bool,
+    index: usize,
+    party_only: bool,
+) -> Result<Option<String>, ServiceError> {
+    check_kind_scope(kind, party_only).map_err(|e| e.for_version_member(index))?;
+    typed_decode_gate(kind, data, incomplete).map_err(|e| e.for_version_member(index))?;
+    cx.validate_for_commit(kind, data, incomplete)
+        .await
+        .map_err(|e| e.for_version_member(index))?;
+    Ok((kind == Kind::Composition)
+        .then(|| crate::service::ehr::validation::composition_template_id(data).map(str::to_owned))
+        .flatten())
+}
+
+/// Resolves a creation member. Its kind comes from the payload `_type`.
+///
+/// # Errors
+/// [`ServiceError::Unprocessable`] for missing `data`, an unrecognized kind or
+/// failed validation; [`ServiceError::Conflict`] for a duplicate EHR singleton
+/// or folder hierarchy (an EHR holds exactly one `EHR_STATUS`/`EHR_ACCESS` —
+/// RM ehr, EHR class; FOLDER hierarchies follow the CNF
+/// master08-func_tc_ehr_contribution E.2 criterion).
+async fn create_change(
+    cx: &impl CommitEnv,
+    v: &PlannedVersion,
+    ehr_id: Option<EhrId>,
+    party_only: bool,
+) -> Result<Change, ServiceError> {
+    let Some(data) = v.data.clone() else {
+        return Err(ServiceError::content_invalid(
+            Violation::new("is required on a creation version").with_path("data"),
+        )
+        .for_version_member(v.index));
+    };
+    let kind = data_kind(&data).map_err(|e| e.for_version_member(v.index))?;
+    let template_id = accept_content(cx, kind, &data, v.incomplete, v.index, party_only).await?;
+    if let Some(ehr_id) = ehr_id {
+        reject_duplicate_singleton(cx, ehr_id, kind, &data).await?;
+    }
+    Ok(Change::Create {
+        kind,
+        canonical: data,
+        template_id,
+        signature: v.signature.clone(),
+        lifecycle_state: v.lifecycle_state.clone(),
+        attestations: accompanying(&v.accompanying).map_err(|e| e.for_version_member(v.index))?,
+    })
+}
+
+/// Resolves a modification member. Its kind comes from the stored object.
+///
+/// # Errors
+/// [`ServiceError::Unprocessable`] for missing `data` or failed validation;
+/// [`ServiceError::Precondition`] when the target does not exist.
+async fn modify_change(
+    cx: &impl CommitEnv,
+    kinds: &std::collections::HashMap<VoId, Kind>,
+    v: &PlannedVersion,
+    party_only: bool,
+) -> Result<Change, ServiceError> {
+    let Some(data) = v.data.clone() else {
+        return Err(ServiceError::content_invalid(
+            Violation::new("is required on a modification version").with_path("data"),
+        )
+        .for_version_member(v.index));
+    };
+    let Some((vo_id, expected)) = v.target else {
+        return Err(ServiceError::exception(
+            "modify plan entry lost its parsed preceding target".to_owned(),
+        ));
+    };
+    let kind = require_kind(kinds, vo_id).map_err(|e| e.for_version_member(v.index))?;
+    let template_id = accept_content(cx, kind, &data, v.incomplete, v.index, party_only).await?;
+    Ok(Change::Modify {
+        vo_id,
+        kind,
+        canonical: data,
+        expected: Some(expected),
+        template_id,
+        signature: v.signature.clone(),
+        lifecycle_state: v.lifecycle_state.clone(),
+        attestations: accompanying(&v.accompanying).map_err(|e| e.for_version_member(v.index))?,
+    })
+}
+
+/// Resolves a deletion member.
+///
+/// # Errors
+/// [`ServiceError::Precondition`] when the target does not exist;
+/// [`ServiceError::Unprocessable`] for a scope-mismatched kind;
+/// [`ServiceError::Conflict`] when the member targets the `EHR_STATUS`, which
+/// is mandatory (RM ehr, EHR class: `ehr_status` 1..1) — deleting the only one
+/// would leave the EHR violating its own invariant.
+fn delete_change(
+    kinds: &std::collections::HashMap<VoId, Kind>,
+    v: &PlannedVersion,
+    party_only: bool,
+) -> Result<Change, ServiceError> {
+    let Some((vo_id, expected)) = v.target else {
+        return Err(ServiceError::exception(
+            "delete plan entry lost its parsed preceding target".to_owned(),
+        ));
+    };
+    let kind = require_kind(kinds, vo_id).map_err(|e| e.for_version_member(v.index))?;
+    check_kind_scope(kind, party_only).map_err(|e| e.for_version_member(v.index))?;
+    if kind == Kind::EhrStatus {
+        return Err(ServiceError::conflict(
+            "the EHR_STATUS cannot be deleted — EHR.ehr_status is mandatory \
+             (RM ehr, EHR class, ehr_status: 1..1)"
+                .to_owned(),
+        ));
+    }
+    Ok(Change::Delete {
+        vo_id,
+        kind,
+        expected: Some(expected),
+        signature: v.signature.clone(),
+    })
+}
+
+/// Whether this change set needs the EHR to be content-writable.
+///
+/// `EHR_STATUS.is_modifiable = False` forbids content writes (RM ehr master04
+/// §EHR Active Status), so a CONTRIBUTION that creates/modifies/deletes any
+/// EHR content is refused on a deactivated EHR. An EHR_STATUS-only
+/// CONTRIBUTION stays allowed (the `EHR_STATUS` "can always be written to" — the
+/// `ehr_status` class docs), and so does a REACTIVATING mixed CONTRIBUTION:
+/// content is refused exactly when the set carries no `EHR_STATUS` member with
+/// `is_modifiable = true`, order-independently over the atomic set.
+///
+/// NOTE: no openEHR spec governs per-member gate timing (the versions list has
+/// no spec-assigned order semantics) — our own design.
+fn needs_content_write_permission(changes: &[(AuditInput, Change)]) -> bool {
+    let carries_content = changes.iter().any(|(_, c)| c.kind() != Kind::EhrStatus);
+    let reactivates = changes.iter().any(|(_, c)| match c {
+        Change::Create {
+            kind: Kind::EhrStatus,
+            canonical,
+            ..
+        }
+        | Change::Modify {
+            kind: Kind::EhrStatus,
+            canonical,
+            ..
+        } => canonical.pointer("/is_modifiable").and_then(Value::as_bool) == Some(true),
+        _ => false,
+    });
+    carries_content && !reactivates
 }
 
 /// Reject the *creation* of a duplicate EHR structure. An EHR holds exactly

--- a/app/ferroehr/src/versioning/import.rs
+++ b/app/ferroehr/src/versioning/import.rs
@@ -307,6 +307,334 @@ async fn enforce_copy_closure(
     Ok(())
 }
 
+/// The local act of committal every version of one import shares: the fresh
+/// CONTRIBUTION, its audit, and the temporal base of the synthetic period
+/// chain (master06 §Committal and Audits).
+struct ImportAct<'a> {
+    ctx: &'a SigningCtx<'a>,
+    ehr_id: Option<EhrId>,
+    contribution_id: Uuid,
+    contribution_audit_id: Uuid,
+    /// The canonical `AUDIT_DETAILS` fragment of the local act, signed into
+    /// every wrapper.
+    local_commit_audit: &'a Value,
+    /// The local act's `change_type` code — `249|creation|` for an import
+    /// (master06 §Contributions, "import of item").
+    change_type: &'a str,
+    base: jiff::Timestamp,
+}
+
+/// One container being replayed: its identity and the ordered versions.
+struct ContainerCursor<'a> {
+    vo_id: VoId,
+    kind: Kind,
+    versions: &'a [ImportVersion],
+}
+
+/// Refuses a container that carries the same version identity twice.
+///
+/// The identity tuple is {`object_id`, `creating_system_id`,
+/// `version_tree_id`} (master06 §Distributed Versioning); the caller has
+/// already sorted the versions, so duplicates are adjacent.
+///
+/// # Errors
+/// [`ServiceError::Conflict`] naming the repeated version.
+fn reject_duplicate_identities(container: &ImportContainer) -> Result<(), ServiceError> {
+    for pair in container.versions.windows(2) {
+        let [first, second] = pair else { continue };
+        if first.creating_system_id == second.creating_system_id && first.tree == second.tree {
+            return Err(ServiceError::conflict(format!(
+                "version {}::{}::{} appears more than once in the import",
+                container.vo_id, first.creating_system_id, first.tree
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Prepares a container whose first receipt already happened (master06
+/// §Copying Case 3): the kind must match, the EHR must own it, every imported
+/// version must be strictly newer than the stored tip of its lineage, and a
+/// still-open stored tip closes at the import base.
+///
+/// # Errors
+/// [`ServiceError::Conflict`] on a foreign owner, a kind mismatch, or a
+/// re-imported trunk or branch version; storage errors from the lineage reads.
+async fn append_to_existing_clone(
+    tx: &mut PgConnection,
+    act: &ImportAct<'_>,
+    container: &ImportContainer,
+    state: &ContainerState,
+    existing_kind: Kind,
+) -> Result<(), ServiceError> {
+    if state.owner != act.ehr_id {
+        return Err(ServiceError::conflict(format!(
+            "versioned object {} already exists in another EHR",
+            container.vo_id
+        )));
+    }
+    if existing_kind != container.kind {
+        return Err(ServiceError::conflict(format!(
+            "versioned object {} is a {}, cannot import a {}",
+            container.vo_id,
+            existing_kind.as_str(),
+            container.kind.as_str()
+        )));
+    }
+    if let Some(first_trunk) = container
+        .versions
+        .iter()
+        .filter(|v| v.tree.is_trunk())
+        .map(|v| v.tree.trunk)
+        .min()
+        && first_trunk <= state.max_trunk
+    {
+        return Err(ServiceError::conflict(format!(
+            "versioned object {} already has trunk version {} — cannot \
+             re-import trunk version {first_trunk}",
+            container.vo_id, state.max_trunk
+        )));
+    }
+    if state.trunk_open && container.versions.iter().any(|v| v.tree.is_trunk()) {
+        crate::storage::version_repo::import::close_lineage_at(
+            tx,
+            container.vo_id,
+            &(String::new(), 0, 0),
+            act.base,
+        )
+        .await?;
+    }
+    advance_existing_branches(tx, act, container).await
+}
+
+/// The BRANCH mirror of the trunk checks in [`append_to_existing_clone`].
+///
+/// A later receipt may also advance an already-held branch lineage (master06
+/// §Copying — "previous copies have been made for the item"; §Semantics in
+/// Distributed Systems keeps lineages coexisting). Each incoming branch
+/// lineage must be strictly newer than the stored tip, and a still-open stored
+/// tip closes at the import base so the successor becomes that lineage's one
+/// open row.
+///
+/// # Errors
+/// [`ServiceError::Conflict`] on a re-imported branch version; storage errors
+/// from the lineage reads and closes.
+async fn advance_existing_branches(
+    tx: &mut PgConnection,
+    act: &ImportAct<'_>,
+    container: &ImportContainer,
+) -> Result<(), ServiceError> {
+    let mut incoming: BTreeMap<Lineage, i32> = BTreeMap::new();
+    for version in container.versions.iter().filter(|v| !v.tree.is_trunk()) {
+        let (trunk_version, branch_number, branch_version) = version.tree.columns();
+        let first = incoming
+            .entry((
+                version.creating_system_id.clone(),
+                trunk_version,
+                branch_number,
+            ))
+            .or_insert(branch_version);
+        *first = (*first).min(branch_version);
+    }
+    for (lineage, first_incoming) in &incoming {
+        let (max_stored, open) = crate::storage::version_repo::import::branch_lineage_state(
+            tx,
+            container.vo_id,
+            lineage,
+        )
+        .await?;
+        if max_stored > 0 && *first_incoming <= max_stored {
+            return Err(ServiceError::conflict(format!(
+                "versioned object {} already has branch version {}.{}.{max_stored} — \
+                 cannot re-import branch version {}.{}.{first_incoming}",
+                container.vo_id, lineage.1, lineage.2, lineage.1, lineage.2
+            )));
+        }
+        if open {
+            crate::storage::version_repo::import::close_lineage_at(
+                tx,
+                container.vo_id,
+                lineage,
+                act.base,
+            )
+            .await?;
+        }
+    }
+    Ok(())
+}
+
+/// Lands a container this store has never seen (master06 §Copying Case 2).
+///
+/// A first-received FOLDER container is a new folder hierarchy of the EHR (RM
+/// ehr master04 §Folders); every other kind needs no preparation.
+///
+/// # Errors
+/// Storage errors from the folder-rank insert.
+async fn land_first_receipt(
+    tx: &mut PgConnection,
+    act: &ImportAct<'_>,
+    container: &ImportContainer,
+) -> Result<(), ServiceError> {
+    if container.kind == Kind::Folder
+        && let Some(ehr_id) = act.ehr_id
+    {
+        crate::storage::version_repo::commit::insert_ehr_folder_rank(tx, ehr_id, container.vo_id)
+            .await?;
+    }
+    Ok(())
+}
+
+/// Replays one received original as an `IMPORTED_VERSION` row (plus its nodes
+/// and attestations), returning the PHI-free outbox entry announcing it.
+///
+/// The wrapper is signed over the bytes a later read will serve, never over
+/// the received JSON, so commit-time and read-time canonical forms are
+/// identical by construction (master06 §Digital Signature).
+///
+/// # Errors
+/// Decompose/reassemble failures on the received data, signing failures, and
+/// storage errors from the row, node and attestation writes.
+async fn import_one_version(
+    tx: &mut PgConnection,
+    act: &ImportAct<'_>,
+    cursor: &ContainerCursor<'_>,
+    index: usize,
+    ordinal: i32,
+) -> Result<Value, ServiceError> {
+    let Some(version) = cursor.versions.get(index) else {
+        return Err(ServiceError::exception(
+            "import cursor addressed a version past the end of the container".to_owned(),
+        ));
+    };
+    let (lower, upper) = local_period(cursor, index, act.base);
+    let (trunk_version, branch_number, branch_version) = version.tree.columns();
+    // The wrapped ORIGINAL_VERSION, reproduced exactly as received: its own
+    // contribution reference, commit audit (with the SOURCE `time_committed`)
+    // and signature, beside the identity/lifecycle/data columns the row already
+    // carries. master06 §Copying: "the `ORIGINAL_VERSION` instance is never
+    // modified — it remains a faithful copy of its original".
+    let wrapped_original = wrapped_fragment(version);
+    // The content, decomposed once: the node rows to write AND — through
+    // `reassemble` — the exact bytes a later read will serve.
+    let rows = if version.data.is_null() {
+        Vec::new()
+    } else {
+        decompose(version.data.clone())?
+    };
+    let served = if rows.is_empty() {
+        Value::Null
+    } else {
+        reassemble(&rows)?
+    };
+    let item = crate::versioning::wire::build_original_version(
+        &crate::versioning::wire::OriginalVersionParts {
+            creating_system_id: &version.creating_system_id,
+            vo_id: cursor.vo_id,
+            tree: version.tree,
+            preceding_version_uid: version.preceding_version_uid.as_deref(),
+            other_input_version_uids: &version.other_input_version_uids,
+            contribution: &version.contribution,
+            commit_audit: &version.commit_audit,
+            lifecycle_state: &version.lifecycle_state,
+            data: &served,
+            // The received original's own attestations are attributes of
+            // `item`, so they ride inside the wrapper's signed form: master06
+            // §Digital Signature says of an IMPORTED_VERSION that "all
+            // attributes of the object are serialised and then used to generate
+            // a signature". They are the version's at-committal attestations for
+            // this repository — the local act of importing supplies none of its
+            // own (§Copying: "the `ORIGINAL_VERSION` instance is never
+            // modified").
+            attestations: &version.attestations,
+            signature: version.signature.as_deref(),
+        },
+    )?;
+    // The wrapper's own signature, "which signifies the act of importing and
+    // making available locally an `ORIGINAL_VERSION` from another system"
+    // (master06 §Digital Signature).
+    let signature = crate::versioning::integrity::sign_imported_version(
+        act.ctx,
+        act.contribution_id,
+        act.local_commit_audit,
+        &item,
+    )?;
+    crate::storage::version_repo::import::insert_imported_vo_version(
+        tx,
+        &crate::storage::version_repo::import::ImportedVersionRow {
+            vo_id: cursor.vo_id,
+            kind: cursor.kind.as_str(),
+            ehr_id: act.ehr_id,
+            sys_version: ordinal,
+            trunk_version,
+            branch_number,
+            branch_version,
+            lifecycle_state: &version.lifecycle_state,
+            creating_system_id: &version.creating_system_id,
+            preceding_version_uid: version.preceding_version_uid.as_deref(),
+            other_input_version_uids: &version.other_input_version_uids,
+            contribution_id: act.contribution_id,
+            audit_id: act.contribution_audit_id,
+            signature: signature.as_deref(),
+            wrapped_original: &wrapped_original,
+            lower,
+            upper,
+            body: (!served.is_null()).then_some(&served),
+        },
+    )
+    .await?;
+    // A `523|deleted|` version stores no node rows (data is Void).
+    if !rows.is_empty() {
+        crate::storage::node_repo::write_nodes(tx, cursor.vo_id, ordinal, act.ehr_id, &rows)
+            .await?;
+    }
+    for attestation in &version.attestations {
+        crate::storage::version_repo::attestation::insert_attestation(
+            tx,
+            cursor.vo_id,
+            ordinal,
+            act.contribution_id,
+            // At committal: these rode in with the original and are inside the
+            // wrapper signature computed just above.
+            true,
+            attestation,
+        )
+        .await?;
+    }
+    // PHI-free outbox entry: identity + provenance only; no template_id. The
+    // announced `change_type` is the LOCAL act's.
+    Ok(serde_json::json!({
+        "vo_id": cursor.vo_id,
+        "kind": cursor.kind.as_str(),
+        "sys_version": ordinal,
+        "version_tree_id": version.tree.to_string(),
+        "change_type": act.change_type,
+        "template_id": Value::Null,
+    }))
+}
+
+/// The synthetic local period of one imported version: a strictly-increasing
+/// 1 µs step off the import base, closed by the next version ON THE SAME
+/// LINEAGE (if the import carries one).
+fn local_period(
+    cursor: &ContainerCursor<'_>,
+    index: usize,
+    base: jiff::Timestamp,
+) -> (jiff::Timestamp, Option<jiff::Timestamp>) {
+    let lower = base + jiff::SignedDuration::from_micros(i64::try_from(index).unwrap_or(0));
+    let Some(version) = cursor.versions.get(index) else {
+        return (lower, None);
+    };
+    let upper = cursor
+        .versions
+        .iter()
+        .skip(index + 1)
+        .position(|later| later.lineage() == version.lineage())
+        .map(|offset| {
+            base + jiff::SignedDuration::from_micros(i64::try_from(index + 1 + offset).unwrap_or(0))
+        });
+    (lower, upper)
+}
+
 /// NOTE (local temporal periods, master06 §Copying): all versions of an
 /// imported container are committed in the single local import act, so they get
 /// a synthetic strictly-increasing local `sys_period` chain (base = import time,
@@ -315,11 +643,6 @@ async fn enforce_copy_closure(
 /// local (more recent) act of committal"; the source chronology is not lost but
 /// moved inside the wrapped `ORIGINAL_VERSION`, where §Committal and Audits
 /// puts it.
-#[expect(
-    clippy::too_many_lines,
-    reason = "one linear import transaction; splitting it would obscure the \
-              replay order the version chain depends on"
-)]
 async fn commit_import_scoped(
     tx: &mut PgConnection,
     ctx: &SigningCtx<'_>,
@@ -346,6 +669,15 @@ async fn commit_import_scoped(
         contribution_audit_id,
     )
     .await?;
+    let act = ImportAct {
+        ctx,
+        ehr_id,
+        contribution_id,
+        contribution_audit_id,
+        local_commit_audit: &local_commit_audit,
+        change_type: &import_audit.change_type,
+        base,
+    };
     let mut outbox_versions: Vec<Value> = Vec::new();
 
     for mut container in containers {
@@ -353,252 +685,38 @@ async fn commit_import_scoped(
             continue;
         }
         enforce_copy_closure(tx, &container).await?;
-        // Version-tree order; reject a duplicated version identity within one
-        // import (the identity tuple is {object_id, creating_system_id,
+        // Version-tree order; a duplicated version identity within one import
+        // is a conflict (the identity tuple is {object_id, creating_system_id,
         // version_tree_id} — master06 §Distributed Versioning).
         container
             .versions
             .sort_by_key(|v| (v.lineage(), v.tree.columns()));
-        for pair in container.versions.windows(2) {
-            let [first, second] = pair else { continue };
-            if first.creating_system_id == second.creating_system_id && first.tree == second.tree {
-                return Err(ServiceError::conflict(format!(
-                    "version {}::{}::{} appears more than once in the import",
-                    container.vo_id, first.creating_system_id, first.tree
-                )));
-            }
-        }
+        reject_duplicate_identities(&container)?;
 
         let state = container_state(tx, container.vo_id).await?;
         if skip_existing && state.kind.is_some() {
             continue;
         }
-        if let Some(existing_kind) = state.kind {
-            // First receipt already happened (master06 §Copying Case 3): append
-            // to the existing clone — the kind must match, the EHR must own it,
-            // and every imported trunk version must be strictly newer.
-            if state.owner != ehr_id {
-                return Err(ServiceError::conflict(format!(
-                    "versioned object {} already exists in another EHR",
-                    container.vo_id
-                )));
+        match state.kind {
+            Some(existing_kind) => {
+                append_to_existing_clone(tx, &act, &container, &state, existing_kind).await?;
             }
-            if existing_kind != container.kind {
-                return Err(ServiceError::conflict(format!(
-                    "versioned object {} is a {}, cannot import a {}",
-                    container.vo_id,
-                    existing_kind.as_str(),
-                    container.kind.as_str()
-                )));
+            None => {
+                land_first_receipt(tx, &act, &container).await?;
             }
-            if let Some(first_trunk) = container
-                .versions
-                .iter()
-                .filter(|v| v.tree.is_trunk())
-                .map(|v| v.tree.trunk)
-                .min()
-                && first_trunk <= state.max_trunk
-            {
-                return Err(ServiceError::conflict(format!(
-                    "versioned object {} already has trunk version {} — cannot \
-                     re-import trunk version {first_trunk}",
-                    container.vo_id, state.max_trunk
-                )));
-            }
-            if state.trunk_open && container.versions.iter().any(|v| v.tree.is_trunk()) {
-                crate::storage::version_repo::import::close_lineage_at(
-                    tx,
-                    container.vo_id,
-                    &(String::new(), 0, 0),
-                    base,
-                )
-                .await?;
-            }
-            // The BRANCH mirror of the trunk checks above: a later receipt may
-            // also advance an already-held branch lineage (master06 §Copying —
-            // "previous copies have been made for the item"; §Semantics in
-            // Distributed Systems keeps lineages coexisting). Each incoming
-            // branch lineage must be strictly newer than the stored tip, and a
-            // still-open stored tip closes at the import base so the successor
-            // becomes the lineage's one open row.
-            let mut incoming_branch_lineages: BTreeMap<(String, i32, i32), i32> = BTreeMap::new();
-            for version in container.versions.iter().filter(|v| !v.tree.is_trunk()) {
-                let (trunk_version, branch_number, branch_version) = version.tree.columns();
-                let first = incoming_branch_lineages
-                    .entry((
-                        version.creating_system_id.clone(),
-                        trunk_version,
-                        branch_number,
-                    ))
-                    .or_insert(branch_version);
-                *first = (*first).min(branch_version);
-            }
-            for (lineage, first_incoming) in &incoming_branch_lineages {
-                let (max_stored, open) =
-                    crate::storage::version_repo::import::branch_lineage_state(
-                        tx,
-                        container.vo_id,
-                        lineage,
-                    )
-                    .await?;
-                if max_stored > 0 && *first_incoming <= max_stored {
-                    return Err(ServiceError::conflict(format!(
-                        "versioned object {} already has branch version {}.{}.{max_stored} — \
-                         cannot re-import branch version {}.{}.{first_incoming}",
-                        container.vo_id, lineage.1, lineage.2, lineage.1, lineage.2
-                    )));
-                }
-                if open {
-                    crate::storage::version_repo::import::close_lineage_at(
-                        tx,
-                        container.vo_id,
-                        lineage,
-                        base,
-                    )
-                    .await?;
-                }
-            }
-        } else if container.kind == Kind::Folder
-            && let Some(ehr_id) = ehr_id
-        {
-            // A first-received FOLDER container is a new folder hierarchy of the
-            // EHR (RM ehr master04 §Folders; master06 §Copying Case 2).
-            crate::storage::version_repo::commit::insert_ehr_folder_rank(
-                tx,
-                ehr_id,
-                container.vo_id,
-            )
-            .await?;
         }
 
         // Per-lineage period chains: within a lineage each version closes its
         // predecessor; each lineage's last version stays open. Lineages coexist.
+        let cursor = ContainerCursor {
+            vo_id: container.vo_id,
+            kind: container.kind,
+            versions: &container.versions,
+        };
         let mut ordinal = state.max_ordinal;
-        let versions = container.versions;
-        for (i, version) in versions.iter().enumerate() {
+        for index in 0..cursor.versions.len() {
             ordinal += 1;
-            // PHI-free outbox entry: identity + provenance only; no template_id.
-            // The announced `change_type` is the LOCAL act's — an import commits
-            // every wrapped original as `249|creation|` (master06 §Contributions,
-            // "import of item").
-            outbox_versions.push(serde_json::json!({
-                "vo_id": container.vo_id,
-                "kind": container.kind.as_str(),
-                "sys_version": ordinal,
-                "version_tree_id": version.tree.to_string(),
-                "change_type": import_audit.change_type,
-                "template_id": Value::Null,
-            }));
-            // Synthetic strictly-increasing local period; the next version ON
-            // THE SAME LINEAGE (if any) closes this one.
-            let lower = base + jiff::SignedDuration::from_micros(i64::try_from(i).unwrap_or(0));
-            let upper = versions
-                .iter()
-                .skip(i + 1)
-                .position(|later| later.lineage() == version.lineage())
-                .map(|offset| {
-                    base + jiff::SignedDuration::from_micros(
-                        i64::try_from(i + 1 + offset).unwrap_or(0),
-                    )
-                });
-            let (trunk_version, branch_number, branch_version) = version.tree.columns();
-            // The wrapped ORIGINAL_VERSION, reproduced exactly as received: its
-            // own contribution reference, commit audit (with the SOURCE
-            // `time_committed`) and signature, beside the identity/lifecycle/
-            // data columns the row already carries. master06 §Copying: "the
-            // `ORIGINAL_VERSION` instance is never modified — it remains a
-            // faithful copy of its original".
-            let wrapped_original = wrapped_fragment(version);
-            // The content, decomposed once: the node rows to write AND — through
-            // `reassemble` — the exact bytes a later read will serve. The
-            // wrapper is signed over THOSE, never over the received JSON, so
-            // commit-time and read-time canonical forms are identical by
-            // construction (the same rule the local commit path follows).
-            let rows = if version.data.is_null() {
-                Vec::new()
-            } else {
-                decompose(version.data.clone())?
-            };
-            let served = if rows.is_empty() {
-                Value::Null
-            } else {
-                reassemble(&rows)?
-            };
-            // The wrapper's own signature, "which signifies the act of
-            // importing and making available locally an `ORIGINAL_VERSION` from
-            // another system" (master06 §Digital Signature). Signed over the
-            // same IMPORTED_VERSION value the read path rebuilds.
-            let item = crate::versioning::wire::build_original_version(
-                &crate::versioning::wire::OriginalVersionParts {
-                    creating_system_id: &version.creating_system_id,
-                    vo_id: container.vo_id,
-                    tree: version.tree,
-                    preceding_version_uid: version.preceding_version_uid.as_deref(),
-                    other_input_version_uids: &version.other_input_version_uids,
-                    contribution: &version.contribution,
-                    commit_audit: &version.commit_audit,
-                    lifecycle_state: &version.lifecycle_state,
-                    data: &served,
-                    // The received original's own attestations are attributes of
-                    // `item`, so they ride inside the wrapper's signed form:
-                    // master06 §Digital Signature says of an IMPORTED_VERSION
-                    // that "all attributes of the object are serialised and then
-                    // used to generate a signature". They are the version's
-                    // at-committal attestations for this repository — the local
-                    // act of importing supplies none of its own (§Copying: "the
-                    // `ORIGINAL_VERSION` instance is never modified").
-                    attestations: &version.attestations,
-                    signature: version.signature.as_deref(),
-                },
-            )?;
-            let signature = crate::versioning::integrity::sign_imported_version(
-                ctx,
-                contribution_id,
-                &local_commit_audit,
-                &item,
-            )?;
-            crate::storage::version_repo::import::insert_imported_vo_version(
-                tx,
-                &crate::storage::version_repo::import::ImportedVersionRow {
-                    vo_id: container.vo_id,
-                    kind: container.kind.as_str(),
-                    ehr_id,
-                    sys_version: ordinal,
-                    trunk_version,
-                    branch_number,
-                    branch_version,
-                    lifecycle_state: &version.lifecycle_state,
-                    creating_system_id: &version.creating_system_id,
-                    preceding_version_uid: version.preceding_version_uid.as_deref(),
-                    other_input_version_uids: &version.other_input_version_uids,
-                    contribution_id,
-                    audit_id: contribution_audit_id,
-                    signature: signature.as_deref(),
-                    wrapped_original: &wrapped_original,
-                    lower,
-                    upper,
-                    body: (!served.is_null()).then_some(&served),
-                },
-            )
-            .await?;
-            // A `523|deleted|` version stores no node rows (data is Void).
-            if !rows.is_empty() {
-                crate::storage::node_repo::write_nodes(tx, container.vo_id, ordinal, ehr_id, &rows)
-                    .await?;
-            }
-            for attestation in &version.attestations {
-                crate::storage::version_repo::attestation::insert_attestation(
-                    tx,
-                    container.vo_id,
-                    ordinal,
-                    contribution_id,
-                    // At committal: these rode in with the original and are
-                    // inside the wrapper signature computed just above.
-                    true,
-                    attestation,
-                )
-                .await?;
-            }
+            outbox_versions.push(import_one_version(tx, &act, &cursor, index, ordinal).await?);
         }
     }
     if ctx.outbox_enabled && !outbox_versions.is_empty() {

--- a/app/ferroehr/tests/it/storage_spike.rs
+++ b/app/ferroehr/tests/it/storage_spike.rs
@@ -610,54 +610,54 @@ async fn storage_spike() {
 /// Spike reassembly: parents come before children; re-attach each pruned
 /// child at its path (inverse of the decomposer).
 fn reassemble(nodes: &[SpikeNode]) -> Value {
-    fn attach(target: &mut Value, rel_path: &str, child: Value) {
-        // rel_path like "content0." or "data.events1." — attribute [+index] steps
-        let mut current = target;
-        let steps: Vec<&str> = rel_path.trim_end_matches('.').split('.').collect();
-        for (i, step) in steps.iter().enumerate() {
-            let is_leaf = i == steps.len() - 1;
-            let (attr, idx) = split_step(step);
-            let map = current.as_object_mut().expect("object on path");
-            match idx {
-                None => {
-                    if is_leaf {
-                        map.insert(attr.to_owned(), child);
-                        return;
-                    }
-                    current = map.get_mut(attr).expect("ancestor attr");
-                }
-                Some(idx) => {
-                    let arr = map
-                        .entry(attr.to_owned())
-                        .or_insert_with(|| Value::Array(vec![]))
-                        .as_array_mut()
-                        .expect("array on path");
-                    if is_leaf {
-                        if arr.len() <= idx {
-                            arr.resize(idx + 1, Value::Null);
-                        }
-                        arr[idx] = child;
-                        return;
-                    }
-                    current = arr.get_mut(idx).expect("ancestor idx");
-                }
-            }
-        }
-    }
-    fn split_step(step: &str) -> (&str, Option<usize>) {
-        let digits = step.chars().rev().take_while(char::is_ascii_digit).count();
-        if digits == 0 {
-            (step, None)
-        } else {
-            let (attr, num) = step.split_at(step.len() - digits);
-            (attr, num.parse().ok())
-        }
-    }
-
     let mut root = nodes[0].data.clone();
     for node in &nodes[1..] {
         // path is absolute from the root; parent paths are prefixes
         attach(&mut root, &node.path, node.data.clone());
     }
     root
+}
+
+/// Attaches `child` at `rel_path` — `content0.` or `data.events1.`, i.e.
+/// attribute-plus-optional-index steps — under `target`.
+fn attach(target: &mut Value, rel_path: &str, child: Value) {
+    let mut current = target;
+    let steps: Vec<&str> = rel_path.trim_end_matches('.').split('.').collect();
+    for (i, step) in steps.iter().enumerate() {
+        let is_leaf = i == steps.len() - 1;
+        let (attr, idx) = split_step(step);
+        let map = current.as_object_mut().expect("object on path");
+        match idx {
+            None if is_leaf => {
+                map.insert(attr.to_owned(), child);
+                return;
+            }
+            None => current = map.get_mut(attr).expect("ancestor attr"),
+            Some(idx) => {
+                let arr = map
+                    .entry(attr.to_owned())
+                    .or_insert_with(|| Value::Array(vec![]))
+                    .as_array_mut()
+                    .expect("array on path");
+                if is_leaf {
+                    if arr.len() <= idx {
+                        arr.resize(idx + 1, Value::Null);
+                    }
+                    arr[idx] = child;
+                    return;
+                }
+                current = arr.get_mut(idx).expect("ancestor idx");
+            }
+        }
+    }
+}
+
+/// Splits one path step into its attribute name and optional array index.
+fn split_step(step: &str) -> (&str, Option<usize>) {
+    let digits = step.chars().rev().take_while(char::is_ascii_digit).count();
+    if digits == 0 {
+        return (step, None);
+    }
+    let (attr, num) = step.split_at(step.len() - digits);
+    (attr, num.parse().ok())
 }

--- a/app/ferroehr/tests/it/validation_opt.rs
+++ b/app/ferroehr/tests/it/validation_opt.rs
@@ -217,42 +217,6 @@ fn vcaex_widened_existence_on_mandatory_attribute() {
 /// §Attributes), i.e. an RM cardinality lower bound of 1 — and restate that
 /// attribute's cardinality interval. Everything else is the vendored valid OPT.
 fn cluster_items_cardinality(lower: i32, upper: Option<i32>) -> OperationalTemplate {
-    fn retype(objects: &mut [CObject], lower: i32, upper: Option<i32>) {
-        for object in objects {
-            let attributes = match object {
-                CObject::CComplexObject(c) => {
-                    if c.rm_type_name == "ITEM_TREE" {
-                        "CLUSTER".clone_into(&mut c.rm_type_name);
-                    }
-                    &mut c.attributes
-                }
-                CObject::CArchetypeRoot(c) => &mut c.attributes,
-                _ => continue,
-            };
-            for attribute in attributes.iter_mut() {
-                if let CAttribute::CMultipleAttribute(multiple) = attribute {
-                    if multiple.rm_attribute_name == "items" {
-                        // `CLUSTER.items` is RM-mandatory, so the fixture's
-                        // `{0..1}` existence must rise with the retype or VCAEX
-                        // (not VCACA) is what fires.
-                        multiple.existence.lower = Some(1);
-                        multiple.cardinality.interval = Intervalofinteger {
-                            lower_included: Some(true),
-                            upper_included: upper.map(|_| true),
-                            lower_unbounded: false,
-                            upper_unbounded: upper.is_none(),
-                            lower: Some(lower),
-                            upper,
-                        };
-                    }
-                    retype(&mut multiple.children, lower, upper);
-                } else if let CAttribute::CSingleAttribute(single) = attribute {
-                    retype(&mut single.children, lower, upper);
-                }
-            }
-        }
-    }
-
     let mut opt = parse(&minimal_xml());
     let mut roots = vec![CObject::CArchetypeRoot(opt.definition.clone())];
     retype(&mut roots, lower, upper);
@@ -261,6 +225,50 @@ fn cluster_items_cardinality(lower: i32, upper: Option<i32>) -> OperationalTempl
     };
     opt.definition = root.clone();
     opt
+}
+
+/// Retypes every `ITEM_TREE` in `objects` to `CLUSTER`, restating the stated
+/// cardinality of each `items` attribute it reaches.
+fn retype(objects: &mut [CObject], lower: i32, upper: Option<i32>) {
+    for object in objects {
+        let attributes = match object {
+            CObject::CComplexObject(c) => {
+                if c.rm_type_name == "ITEM_TREE" {
+                    "CLUSTER".clone_into(&mut c.rm_type_name);
+                }
+                &mut c.attributes
+            }
+            CObject::CArchetypeRoot(c) => &mut c.attributes,
+            _ => continue,
+        };
+        for attribute in attributes.iter_mut() {
+            retype_attribute(attribute, lower, upper);
+        }
+    }
+}
+
+/// Restates one attribute's cardinality when it is `items`, then descends.
+fn retype_attribute(attribute: &mut CAttribute, lower: i32, upper: Option<i32>) {
+    match attribute {
+        CAttribute::CMultipleAttribute(multiple) => {
+            if multiple.rm_attribute_name == "items" {
+                // `CLUSTER.items` is RM-mandatory, so the fixture's `{0..1}`
+                // existence must rise with the retype or VCAEX (not VCACA) is
+                // what fires.
+                multiple.existence.lower = Some(1);
+                multiple.cardinality.interval = Intervalofinteger {
+                    lower_included: Some(true),
+                    upper_included: upper.map(|_| true),
+                    lower_unbounded: false,
+                    upper_unbounded: upper.is_none(),
+                    lower: Some(lower),
+                    upper,
+                };
+            }
+            retype(&mut multiple.children, lower, upper);
+        }
+        CAttribute::CSingleAttribute(single) => retype(&mut single.children, lower, upper),
+    }
 }
 
 /// VCACA: "the cardinality of an attribute must conform, i.e. be the same or

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-adl"
-version = "0.0.41"
+version = "0.0.42"
 description = "openEHR ADL 2.4.0: hand-written ADL2/cADL/ODIN parser, AOM2 validation catalogue, specialisation flattener, OPT2 generator, and ADL 1.4→2 conversion over the generated openehr_am::v2_4::aom2 model"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,11 +16,11 @@ include = ["src/**", "README.md", "LICENSE-MIT"]
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)
-openehr-base = { path = "../openehr-base", version = "0.0.41" }   # VersionStatus for the parsed HRID
-openehr-am = { path = "../openehr-am", version = "0.0.41" }       # v2_4 ArchetypeHrid (the identification target type)
-openehr-rm = { path = "../openehr-rm", version = "0.0.41" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
-openehr-lang = { path = "../openehr-lang", version = "0.0.41" }   # openehr_lang::odin — the ODIN section parser
-openehr-term = { path = "../openehr-term", version = "0.0.41" }   # the languages code set for the RM resource-meta rows
+openehr-base = { path = "../openehr-base", version = "0.0.42" }   # VersionStatus for the parsed HRID
+openehr-am = { path = "../openehr-am", version = "0.0.42" }       # v2_4 ArchetypeHrid (the identification target type)
+openehr-rm = { path = "../openehr-rm", version = "0.0.42" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
+openehr-lang = { path = "../openehr-lang", version = "0.0.42" }   # openehr_lang::odin — the ODIN section parser
+openehr-term = { path = "../openehr-term", version = "0.0.42" }   # the languages code set for the RM resource-meta rows
 uuid.workspace = true        # meta uid/build_uid (AUTHORED_ARCHETYPE.uid: Uuid)
 indexmap.workspace = true    # OdinValue::Object body (insertion-ordered map)
 

--- a/crates/openehr-adl/src/adl14/convert.rs
+++ b/crates/openehr-adl/src/adl14/convert.rs
@@ -243,84 +243,11 @@ impl<'a> Converter<'a> {
     // ── code planning ──────────────────────────────────────────────────────
 
     fn plan_codes(&mut self, data: &AuthoredArchetypeData) {
-        let collapse = self.cfg.collapse_specialised_codes;
-        let root_code = match &data.definition {
-            CComplexObject::CComplexObject(d) => d.node_id.clone(),
-            CComplexObject::CArchetypeRoot(_) => String::new(),
-        };
-        // Existing node at-codes → shifted id-codes; track max id-number.
-        // Under collapse, dotted (specialised) codes are deferred: they get
-        // fresh flat ids above the max, in document order (the root always
-        // takes `id1` — VARCN's depth-0 root form).
-        let mut max_id = 1i64;
-        let mut max_at = 0i64;
-        let mut deferred_nodes: Vec<String> = Vec::new();
-        collect_node_codes(&data.definition, &mut |code| {
-            if code.is_empty() {
-                return;
-            }
-            if collapse && code.contains('.') {
-                if code == root_code {
-                    self.node_map.insert(code.to_owned(), "id1".to_owned());
-                } else if !self.node_map.contains_key(code)
-                    && !deferred_nodes.iter().any(|c| c == code)
-                {
-                    deferred_nodes.push(code.to_owned());
-                }
-                return;
-            }
-            let new = shift_code(code, "id");
-            if let Some(n) = first_num(&new) {
-                max_id = max_id.max(n);
-            }
-            self.node_map.insert(code.to_owned(), new);
-        });
-        // Value at-codes referenced in constraints (local single/list) →
-        // shifted at-codes; track max at-number. Dotted values collapse to
-        // fresh flat at-codes likewise.
-        let mut value_at_codes = std::collections::BTreeSet::new();
-        let mut deferred_values: Vec<String> = Vec::new();
-        collect_local_value_codes(&data.definition, &mut |code| {
-            if collapse && code.contains('.') {
-                if !deferred_values.iter().any(|c| c == code) {
-                    deferred_values.push(code.to_owned());
-                }
-                value_at_codes.insert(code.to_owned());
-                return;
-            }
-            let new = shift_code(code, "at");
-            if let Some(n) = first_num(&new) {
-                max_at = max_at.max(n);
-            }
-            value_at_codes.insert(code.to_owned());
-        });
-        self.value_at_codes = value_at_codes;
-        // Existing ac codes (terminology entries + bare constraint refs):
-        // synthesised/minted acs must allocate ABOVE the shifted range so a
-        // fresh `acN` never collides with an existing `ac000(N-1)` → `acN`.
-        let mut highest_ac = 0i64;
-        let mut track_ac = |code: &str| {
-            if AdlCodeDefinitionsData::is_value_set_code(code)
-                && !code.contains('.')
-                && let Some(n) = first_num(&shift_code(code, "ac"))
-            {
-                highest_ac = highest_ac.max(n);
-            }
-        };
-        for terms in data.terminology.term_definitions.values() {
-            for code in terms.keys() {
-                track_ac(code);
-            }
-        }
-        walk_constraints(&data.definition, &mut |raw, _| {
-            let body = raw.split_once(';').map_or(raw, |(b, _)| b);
-            if !body.contains("::") {
-                track_ac(body.trim());
-            }
-        });
+        let (max_id, deferred_nodes) = self.plan_node_codes(data);
+        let (max_at, deferred_values) = self.plan_value_codes(data);
         self.next_id = max_id + 1;
         self.next_at = max_at + 1;
-        self.next_ac = highest_ac + 1;
+        self.next_ac = highest_ac_number(data) + 1;
         for code in deferred_nodes {
             let fresh = self.alloc_id();
             self.log.note(format!(
@@ -335,6 +262,67 @@ impl<'a> Converter<'a> {
             ));
             self.value_map.insert(code, fresh);
         }
+    }
+
+    /// Maps every existing node at-code to its shifted id-code, returning the
+    /// highest id-number reached and the codes deferred by the collapse.
+    ///
+    /// Under collapse, dotted (specialised) codes are deferred: they get fresh
+    /// flat ids above the max, in document order (the root always takes `id1`
+    /// — VARCN's depth-0 root form).
+    fn plan_node_codes(&mut self, data: &AuthoredArchetypeData) -> (i64, Vec<String>) {
+        let collapse = self.cfg.collapse_specialised_codes;
+        let root_code = match &data.definition {
+            CComplexObject::CComplexObject(d) => d.node_id.clone(),
+            CComplexObject::CArchetypeRoot(_) => String::new(),
+        };
+        let mut max_id = 1i64;
+        let mut deferred: Vec<String> = Vec::new();
+        collect_node_codes(&data.definition, &mut |code| {
+            if code.is_empty() {
+                return;
+            }
+            if collapse && code.contains('.') {
+                if code == root_code {
+                    self.node_map.insert(code.to_owned(), "id1".to_owned());
+                } else if !self.node_map.contains_key(code) && !deferred.iter().any(|c| c == code) {
+                    deferred.push(code.to_owned());
+                }
+                return;
+            }
+            let new = shift_code(code, "id");
+            if let Some(n) = first_num(&new) {
+                max_id = max_id.max(n);
+            }
+            self.node_map.insert(code.to_owned(), new);
+        });
+        (max_id, deferred)
+    }
+
+    /// Records the value at-codes referenced in constraints (local single or
+    /// list), returning the highest at-number reached and the codes deferred
+    /// by the collapse.
+    fn plan_value_codes(&mut self, data: &AuthoredArchetypeData) -> (i64, Vec<String>) {
+        let collapse = self.cfg.collapse_specialised_codes;
+        let mut max_at = 0i64;
+        let mut value_at_codes = std::collections::BTreeSet::new();
+        let mut deferred: Vec<String> = Vec::new();
+        collect_local_value_codes(&data.definition, &mut |code| {
+            if collapse && code.contains('.') {
+                if !deferred.iter().any(|c| c == code) {
+                    deferred.push(code.to_owned());
+                }
+                value_at_codes.insert(code.to_owned());
+                return;
+            }
+            let new = shift_code(code, "at");
+            if let Some(n) = first_num(&new) {
+                max_at = max_at.max(n);
+            }
+            value_at_codes.insert(code.to_owned());
+        });
+        self.value_at_codes = value_at_codes;
+        (max_at, deferred)
     }
 
     fn alloc_id(&mut self) -> String {
@@ -547,15 +535,39 @@ impl<'a> Converter<'a> {
 
     // ── terminology rebuild ──────────────────────────────────────────────────
 
-    #[expect(
-        clippy::too_many_lines,
-        reason = "one linear terminology rebuild — definitions, then bindings, then value sets; the steps are sequential, not extractable units"
-    )]
     fn rebuild_terminology(&mut self, old: &ArchetypeTerminology) -> ArchetypeTerminology {
-        // `@ internal @` node terms are dropped in every language (the marker is
-        // authored in the original language; translations carry the openEHR
-        // untranslated form `*@ internal @(<lang>)`). Determine the internal
-        // node set once, from the original language.
+        let term_definitions = self.rebuild_term_definitions(old);
+        let term_bindings = self.rebuild_term_bindings(old);
+        let value_sets = self.rebuild_value_sets(old);
+        ArchetypeTerminology {
+            is_differential: old.is_differential,
+            original_language: old.original_language.clone(),
+            concept_code: self.root_id.clone(),
+            term_definitions,
+            term_bindings: if term_bindings.is_empty() {
+                None
+            } else {
+                Some(term_bindings)
+            },
+            value_sets: if value_sets.is_empty() {
+                None
+            } else {
+                Some(value_sets)
+            },
+            terminology_extracts: old.terminology_extracts.clone(),
+        }
+    }
+
+    /// The renumbered `term_definitions`, per language.
+    ///
+    /// `@ internal @` node terms are dropped in every language (the marker is
+    /// authored in the original language; translations carry the openEHR
+    /// untranslated form `*@ internal @(<lang>)`), so the internal node set is
+    /// determined once, from the original language.
+    fn rebuild_term_definitions(
+        &mut self,
+        old: &ArchetypeTerminology,
+    ) -> BTreeMap<String, BTreeMap<String, ArchetypeTerm>> {
         let internal_nodes: std::collections::BTreeSet<String> = old
             .term_definitions
             .get(&old.original_language)
@@ -572,40 +584,7 @@ impl<'a> Converter<'a> {
         for (lang, terms) in &old.term_definitions {
             let mut out: BTreeMap<String, ArchetypeTerm> = BTreeMap::new();
             for (code, term) in terms {
-                let is_node = self.node_map.contains_key(code);
-                // An ac-code (a merged 1.4 `constraint_definitions` entry —
-                // ADL2 merges that section into `term_definitions`,
-                // `master07.13` §Terminology section) keeps its ac prefix,
-                // shifted like every other code so the converted
-                // `C_TERMINOLOGY_CODE` ac constraints still resolve (VACDF).
-                if AdlCodeDefinitionsData::is_value_set_code(code) {
-                    let ac = self.collapsed_ac(code);
-                    out.insert(ac.clone(), term_with_code(term, ac));
-                    continue;
-                }
-                // A 1.4 at-code used as a value (`[local::atX]`) always yields an
-                // at-code term; used as a node id it yields an id-code term. A
-                // code that is both splits into both entries.
-                if self.value_at_codes.contains(code) || !is_node {
-                    let at = self.collapsed_value_at(code);
-                    out.insert(at.clone(), term_with_code(term, at));
-                }
-                if is_node {
-                    // Drop an `@ internal @` node term in every language
-                    // (reference-converter behaviour; validates clean).
-                    if internal_nodes.contains(code) {
-                        continue;
-                    }
-                    // The planned mapping, never a re-shift: under the
-                    // specialisation collapse a dotted code maps to a fresh
-                    // flat id that a plain shift would miss.
-                    let id = self
-                        .node_map
-                        .get(code)
-                        .cloned()
-                        .unwrap_or_else(|| shift_code(code, "id"));
-                    out.insert(id.clone(), term_with_code(term, id));
-                }
+                self.rebuild_term(code, term, &internal_nodes, &mut out);
             }
             // VCOSU re-mints: each freshly minted node id reuses the first
             // occurrence's rubric (the 1.4 source defined ONE term for the
@@ -633,8 +612,56 @@ impl<'a> Converter<'a> {
             }
             term_definitions.insert(lang.clone(), out);
         }
+        term_definitions
+    }
 
-        // Bindings: renumber existing binding keys, then add synthesised ones.
+    /// Renumbers one 1.4 term definition into its ADL2 entries.
+    ///
+    /// An ac-code (a merged 1.4 `constraint_definitions` entry — ADL2 merges
+    /// that section into `term_definitions`, `master07.13` §Terminology
+    /// section) keeps its ac prefix, shifted like every other code so the
+    /// converted `C_TERMINOLOGY_CODE` ac constraints still resolve (VACDF). A
+    /// 1.4 at-code used as a value (`[local::atX]`) always yields an at-code
+    /// term; used as a node id it yields an id-code term, and a code that is
+    /// both splits into both entries. An `@ internal @` node term is dropped
+    /// (reference-converter behaviour; validates clean).
+    fn rebuild_term(
+        &mut self,
+        code: &str,
+        term: &ArchetypeTerm,
+        internal_nodes: &std::collections::BTreeSet<String>,
+        out: &mut BTreeMap<String, ArchetypeTerm>,
+    ) {
+        if AdlCodeDefinitionsData::is_value_set_code(code) {
+            let ac = self.collapsed_ac(code);
+            out.insert(ac.clone(), term_with_code(term, ac));
+            return;
+        }
+        let is_node = self.node_map.contains_key(code);
+        if self.value_at_codes.contains(code) || !is_node {
+            let at = self.collapsed_value_at(code);
+            out.insert(at.clone(), term_with_code(term, at));
+        }
+        if !is_node || internal_nodes.contains(code) {
+            return;
+        }
+        // The planned mapping, never a re-shift: under the specialisation
+        // collapse a dotted code maps to a fresh flat id that a plain shift
+        // would miss.
+        let id = self
+            .node_map
+            .get(code)
+            .cloned()
+            .unwrap_or_else(|| shift_code(code, "id"));
+        out.insert(id.clone(), term_with_code(term, id));
+    }
+
+    /// The renumbered `term_bindings`: existing keys renamed, synthesised ones
+    /// added, and each VCOSU re-mint inheriting the first occurrence's binding.
+    fn rebuild_term_bindings(
+        &self,
+        old: &ArchetypeTerminology,
+    ) -> BTreeMap<String, BTreeMap<String, String>> {
         let mut term_bindings: BTreeMap<String, BTreeMap<String, String>> = old
             .term_bindings
             .clone()
@@ -656,7 +683,6 @@ impl<'a> Converter<'a> {
                     .insert(s.code.clone(), uri.clone());
             }
         }
-        // VCOSU re-mints inherit the first occurrence's binding, if any.
         for bindings in term_bindings.values_mut() {
             for (first, fresh) in &self.dup_mints {
                 if let Some(uri) = bindings.get(first).cloned() {
@@ -664,7 +690,12 @@ impl<'a> Converter<'a> {
                 }
             }
         }
+        term_bindings
+    }
 
+    /// The value sets: the 1.4 ones verbatim plus one per synthesised ac-code
+    /// that carries members.
+    fn rebuild_value_sets(&self, old: &ArchetypeTerminology) -> BTreeMap<String, ValueSet> {
         let mut value_sets: BTreeMap<String, ValueSet> = old.value_sets.clone().unwrap_or_default();
         for s in &self.synth {
             if let Some(members) = &s.value_set_members
@@ -679,24 +710,7 @@ impl<'a> Converter<'a> {
                 );
             }
         }
-
-        ArchetypeTerminology {
-            is_differential: old.is_differential,
-            original_language: old.original_language.clone(),
-            concept_code: self.root_id.clone(),
-            term_definitions,
-            term_bindings: if term_bindings.is_empty() {
-                None
-            } else {
-                Some(term_bindings)
-            },
-            value_sets: if value_sets.is_empty() {
-                None
-            } else {
-                Some(value_sets)
-            },
-            terminology_extracts: old.terminology_extracts.clone(),
-        }
+        value_sets
     }
 
     fn rename_binding_key(&self, key: &str) -> String {
@@ -895,6 +909,35 @@ fn rewrite_path(path: &str, cx: &Converter<'_>) -> String {
 /// The first segment's number is incremented by one (`at0000`→`id1`,
 /// `at0003.1`→`id4.1`), except the specialisation new-code prefix `at0`
 /// (`at0.89`→`id0.89` — number kept). No openEHR spec governs this — fixture-pinned.
+/// The highest ac-number the source already uses, across its terminology
+/// entries and its bare constraint refs.
+///
+/// Synthesised and minted acs must allocate ABOVE the shifted range, so a
+/// fresh `acN` never collides with an existing `ac000(N-1)` → `acN`.
+fn highest_ac_number(data: &AuthoredArchetypeData) -> i64 {
+    let mut highest = 0i64;
+    let mut track = |code: &str| {
+        if AdlCodeDefinitionsData::is_value_set_code(code)
+            && !code.contains('.')
+            && let Some(n) = first_num(&shift_code(code, "ac"))
+        {
+            highest = highest.max(n);
+        }
+    };
+    for terms in data.terminology.term_definitions.values() {
+        for code in terms.keys() {
+            track(code);
+        }
+    }
+    walk_constraints(&data.definition, &mut |raw, _| {
+        let body = raw.split_once(';').map_or(raw, |(b, _)| b);
+        if !body.contains("::") {
+            track(body.trim());
+        }
+    });
+    highest
+}
+
 fn shift_code(code: &str, prefix: &str) -> String {
     let bare = code
         .trim_start_matches("at")

--- a/crates/openehr-adl/src/adl14/convert.rs
+++ b/crates/openehr-adl/src/adl14/convert.rs
@@ -32,6 +32,7 @@ use openehr_am::v2_4::aom2::archetype::authored_archetype::{
 use openehr_am::v2_4::aom2::constraint_model::c_complex_object::CComplexObject;
 use openehr_am::v2_4::aom2::constraint_model::c_object::CObject;
 use openehr_am::v2_4::aom2::constraint_model::c_primitive_object::CPrimitiveObject;
+use openehr_am::v2_4::aom2::constraint_model::primitive::c_terminology_code::CTerminologyCode;
 use openehr_am::v2_4::aom2::definitions::adl_code_definitions::AdlCodeDefinitionsData;
 use openehr_am::v2_4::aom2::terminology::archetype_term::ArchetypeTerm;
 use openehr_am::v2_4::aom2::terminology::archetype_terminology::ArchetypeTerminology;
@@ -837,36 +838,30 @@ fn convert_constraints_cco(cco: &mut CComplexObject, cx: &mut Converter<'_>, own
         for row in tuple.tuples.iter_mut().flatten() {
             for m in &mut row.members {
                 if let CPrimitiveObject::CTerminologyCode(tc) = m {
-                    let (constraint, assumed) = cx.convert_constraint(&tc.constraint, &node_text);
-                    tc.constraint = constraint;
-                    if let Some(a) = assumed {
-                        tc.assumed_value = Some(openehr_base::prelude::TerminologyCode {
-                            terminology_id: "local".to_owned(),
-                            terminology_version: None,
-                            code_string: a,
-                            uri: None,
-                        });
-                    }
+                    convert_terminology_code(tc, cx, &node_text);
                 }
             }
         }
     }
 }
 
+/// Converts one `C_TERMINOLOGY_CODE`'s constraint and assumed value in place.
+fn convert_terminology_code(tc: &mut CTerminologyCode, cx: &mut Converter<'_>, owner_text: &str) {
+    let (constraint, assumed) = cx.convert_constraint(&tc.constraint, owner_text);
+    tc.constraint = constraint;
+    if let Some(a) = assumed {
+        tc.assumed_value = Some(openehr_base::prelude::TerminologyCode {
+            terminology_id: "local".to_owned(),
+            terminology_version: None,
+            code_string: a,
+            uri: None,
+        });
+    }
+}
+
 fn convert_constraints_obj(obj: &mut CObject, cx: &mut Converter<'_>, owner_text: &str) {
     match obj {
-        CObject::CTerminologyCode(tc) => {
-            let (constraint, assumed) = cx.convert_constraint(&tc.constraint, owner_text);
-            tc.constraint = constraint;
-            if let Some(a) = assumed {
-                tc.assumed_value = Some(openehr_base::prelude::TerminologyCode {
-                    terminology_id: "local".to_owned(),
-                    terminology_version: None,
-                    code_string: a,
-                    uri: None,
-                });
-            }
-        }
+        CObject::CTerminologyCode(tc) => convert_terminology_code(tc, cx, owner_text),
         CObject::CComplexObject(cco) => convert_constraints_cco(cco, cx, owner_text),
         _ => {}
     }
@@ -884,15 +879,8 @@ fn rewrite_path(path: &str, cx: &Converter<'_>) -> String {
             if let Some(end) = rest.find(']')
                 && let Some(code) = rest.get(..end)
             {
-                let mapped = if let Some(id) = cx.node_map.get(code) {
-                    id.clone()
-                } else if AdlCodeDefinitionsData::is_at_code(code) {
-                    shift_code(code, "id")
-                } else {
-                    code.to_owned()
-                };
                 out.push('[');
-                out.push_str(&mapped);
+                out.push_str(&converted_predicate_code(code, cx));
                 out.push(']');
                 for _ in 0..=end {
                     chars.next();
@@ -903,6 +891,20 @@ fn rewrite_path(path: &str, cx: &Converter<'_>) -> String {
         out.push(c);
     }
     out
+}
+
+/// The converted spelling of one path-predicate code.
+///
+/// A planned node code takes its planned id; any other at-code is shifted into
+/// the `id` space; anything else passes through.
+fn converted_predicate_code(code: &str, cx: &Converter<'_>) -> String {
+    if let Some(id) = cx.node_map.get(code) {
+        return id.clone();
+    }
+    if AdlCodeDefinitionsData::is_at_code(code) {
+        return shift_code(code, "id");
+    }
+    code.to_owned()
 }
 
 // ── code shifting ────────────────────────────────────────────────────────────

--- a/crates/openehr-adl/src/adl14/convert.rs
+++ b/crates/openehr-adl/src/adl14/convert.rs
@@ -483,27 +483,29 @@ impl<'a> Converter<'a> {
         });
 
         if at_codes.len() == 1 {
-            (at_codes.into_iter().next().unwrap_or_default(), assumed)
-        } else {
-            // A list → a synthesised ac-code value set.
-            let signature = at_codes.join(",");
-            let ac = if let Some(existing) = self.log.value_set(&signature) {
-                existing.to_owned()
-            } else {
-                let ac = self.alloc_ac();
-                self.log.record_value_set(&signature, &ac);
-                let (text, description) = synth_value_set_rubric(owner_text);
-                self.synth.push(Synth {
-                    code: ac.clone(),
-                    text,
-                    description,
-                    binding: None,
-                    value_set_members: Some(at_codes.clone()),
-                });
-                ac
-            };
-            (ac, assumed)
+            return (at_codes.into_iter().next().unwrap_or_default(), assumed);
         }
+        (self.value_set_ac(&at_codes, owner_text), assumed)
+    }
+
+    /// The synthesised ac-code value set for a code LIST, minted on first sight
+    /// and reused for an identical member signature (idempotent via the log).
+    fn value_set_ac(&mut self, at_codes: &[String], owner_text: &str) -> String {
+        let signature = at_codes.join(",");
+        if let Some(existing) = self.log.value_set(&signature) {
+            return existing.to_owned();
+        }
+        let ac = self.alloc_ac();
+        self.log.record_value_set(&signature, &ac);
+        let (text, description) = synth_value_set_rubric(owner_text);
+        self.synth.push(Synth {
+            code: ac.clone(),
+            text,
+            description,
+            binding: None,
+            value_set_members: Some(at_codes.to_vec()),
+        });
+        ac
     }
 
     /// The synthesised at-code for an external `terminology::code`, minting +
@@ -905,10 +907,6 @@ fn rewrite_path(path: &str, cx: &Converter<'_>) -> String {
 
 // ── code shifting ────────────────────────────────────────────────────────────
 
-/// Shift a 1.4 code to an ADL2 code with the given `prefix` (`"id"`/`"at"`).
-/// The first segment's number is incremented by one (`at0000`→`id1`,
-/// `at0003.1`→`id4.1`), except the specialisation new-code prefix `at0`
-/// (`at0.89`→`id0.89` — number kept). No openEHR spec governs this — fixture-pinned.
 /// The highest ac-number the source already uses, across its terminology
 /// entries and its bare constraint refs.
 ///
@@ -938,6 +936,10 @@ fn highest_ac_number(data: &AuthoredArchetypeData) -> i64 {
     highest
 }
 
+/// Shift a 1.4 code to an ADL2 code with the given `prefix` (`"id"`/`"at"`).
+/// The first segment's number is incremented by one (`at0000`→`id1`,
+/// `at0003.1`→`id4.1`), except the specialisation new-code prefix `at0`
+/// (`at0.89`→`id0.89` — number kept). No openEHR spec governs this — fixture-pinned.
 fn shift_code(code: &str, prefix: &str) -> String {
     let bare = code
         .trim_start_matches("at")

--- a/crates/openehr-adl/src/adl14/domain.rs
+++ b/crates/openehr-adl/src/adl14/domain.rs
@@ -218,51 +218,70 @@ struct Partition {
 /// cannot model is met — the whole block refuses rather than dropping a
 /// constraint.
 fn partition_list_rows(list: &OdinValue) -> Result<Vec<Partition>, DomainLoweringError> {
-    /// One `list` row: its member (name, value) pairs in source order.
-    type Row = Vec<(String, OdinValue)>;
     let rows = domain_list_rows(list);
-    let mut groups: Vec<(Vec<String>, Vec<&Row>)> = Vec::new();
-    for row in &rows {
+    group_rows_by_member_set(&rows)
+        .into_iter()
+        .map(|(names, group)| partition_of_group(&names, &group))
+        .collect()
+}
+
+/// One `list` row: its member (name, value) pairs in source order.
+type DomainRow = Vec<(String, OdinValue)>;
+
+/// Groups list rows by their member-name SET, in first-seen order.
+fn group_rows_by_member_set(rows: &[DomainRow]) -> Vec<(Vec<String>, Vec<&DomainRow>)> {
+    let mut groups: Vec<(Vec<String>, Vec<&DomainRow>)> = Vec::new();
+    for row in rows {
         let mut names: Vec<String> = Vec::new();
         for (k, _) in row {
             if !names.iter().any(|n| n == k) {
                 names.push(k.clone());
             }
         }
-        let same_set = |a: &[String], b: &[String]| {
-            a.len() == b.len() && a.iter().all(|n| b.iter().any(|m| m == n))
-        };
-        if let Some((_, members)) = groups.iter_mut().find(|(g, _)| same_set(g, &names)) {
-            members.push(row);
-        } else {
-            groups.push((names, vec![row]));
+        match groups.iter_mut().find(|(g, _)| same_member_set(g, &names)) {
+            Some((_, members)) => members.push(row),
+            None => groups.push((names, vec![row])),
         }
     }
-    let mut partitions = Vec::new();
-    for (names, rows) in groups {
-        let mut attributes: Vec<CAttribute> = Vec::new();
-        let mut attribute_tuples: Vec<CAttributeTuple> = Vec::new();
-        if names.len() >= 2 {
-            attribute_tuples.push(build_attribute_tuple(&names, &rows)?);
-        } else if let Some(name) = names.first() {
-            // Single attribute: merge the partition's values into one constraint.
-            let values: Vec<CPrimitiveObject> = rows
-                .iter()
-                .filter_map(|row| row.iter().find(|(k, _)| k == name))
-                .filter_map(|(_, v)| domain_value_to_primitive(name, v))
-                .collect();
-            if let Some(merged) = merge_primitives(values) {
-                attributes.push(cattr_single(name, primitive_to_cobject(merged)));
-            }
+    groups
+}
+
+/// Whether two member-name lists denote the same set.
+fn same_member_set(a: &[String], b: &[String]) -> bool {
+    a.len() == b.len() && a.iter().all(|n| b.iter().any(|m| m == n))
+}
+
+/// The alternative one co-varying row group contributes.
+///
+/// Two or more member names co-vary and become a `C_ATTRIBUTE_TUPLE`; a single
+/// name merges the group's values into one constraint; an all-empty row set
+/// (no names) contributes an alternative carrying only the shared prefix —
+/// "any value of the type".
+///
+/// # Errors
+/// Propagates [`build_attribute_tuple`]'s refusal for a tuple group.
+fn partition_of_group(
+    names: &[String],
+    rows: &[&DomainRow],
+) -> Result<Partition, DomainLoweringError> {
+    let mut attributes: Vec<CAttribute> = Vec::new();
+    let mut attribute_tuples: Vec<CAttributeTuple> = Vec::new();
+    if names.len() >= 2 {
+        attribute_tuples.push(build_attribute_tuple(names, rows)?);
+    } else if let Some(name) = names.first() {
+        let values: Vec<CPrimitiveObject> = rows
+            .iter()
+            .filter_map(|row| row.iter().find(|(k, _)| k == name))
+            .filter_map(|(_, v)| domain_value_to_primitive(name, v))
+            .collect();
+        if let Some(merged) = merge_primitives(values) {
+            attributes.push(cattr_single(name, primitive_to_cobject(merged)));
         }
-        // An all-empty row set (names empty) contributes an alternative
-        // carrying only the shared prefix — "any value of the type".
-        partitions.push(Partition {
-            attributes,
-            attribute_tuples,
-        });
     }
-    Ok(partitions)
+    Ok(Partition {
+        attributes,
+        attribute_tuples,
+    })
 }
 
 /// The `C_ATTRIBUTE_TUPLE` of one co-varying partition: one

--- a/crates/openehr-adl/src/adl14/domain.rs
+++ b/crates/openehr-adl/src/adl14/domain.rs
@@ -243,39 +243,7 @@ fn partition_list_rows(list: &OdinValue) -> Result<Vec<Partition>, DomainLowerin
         let mut attributes: Vec<CAttribute> = Vec::new();
         let mut attribute_tuples: Vec<CAttributeTuple> = Vec::new();
         if names.len() >= 2 {
-            let members: Vec<CAttribute> = names.iter().map(|n| cattr_empty(n)).collect::<Vec<_>>();
-            let mut tuples: Vec<CPrimitiveTuple> = Vec::new();
-            for row in &rows {
-                let mut prim_members = Vec::new();
-                for n in &names {
-                    // Every name is constrained by every row of this partition
-                    // BY CONSTRUCTION; a row value the primitive lowering
-                    // cannot model still refuses the whole block.
-                    let Some(v) = row
-                        .iter()
-                        .find(|(k, _)| k == n)
-                        .and_then(|(_, v)| domain_value_to_primitive(n, v))
-                    else {
-                        return Err(DomainLoweringError::Empty);
-                    };
-                    prim_members.push(v);
-                }
-                let Ok(prim_members) = openehr_base::containers::NonEmptyVec::new(prim_members)
-                else {
-                    // `C_PRIMITIVE_TUPLE.members` is `1..*`
-                    // (`docs/specs/openehr/AM/docs/AOM2/master04.5-constraint_model-class_definitions.adoc`
-                    // §C_PRIMITIVE_TUPLE); a row that matched no member name is
-                    // not a tuple row.
-                    return Err(DomainLoweringError::Empty);
-                };
-                tuples.push(CPrimitiveTuple {
-                    members: prim_members,
-                });
-            }
-            attribute_tuples.push(CAttributeTuple {
-                members: openehr_base::containers::present(members),
-                tuples: openehr_base::containers::present(tuples),
-            });
+            attribute_tuples.push(build_attribute_tuple(&names, &rows)?);
         } else if let Some(name) = names.first() {
             // Single attribute: merge the partition's values into one constraint.
             let values: Vec<CPrimitiveObject> = rows
@@ -295,6 +263,48 @@ fn partition_list_rows(list: &OdinValue) -> Result<Vec<Partition>, DomainLowerin
         });
     }
     Ok(partitions)
+}
+
+/// The `C_ATTRIBUTE_TUPLE` of one co-varying partition: one
+/// `C_PRIMITIVE_TUPLE` row per source row, in member order.
+///
+/// # Errors
+/// [`DomainLoweringError::Empty`] when a row value the primitive lowering
+/// cannot model is met — every name is constrained by every row of the
+/// partition BY CONSTRUCTION, so the whole block refuses rather than dropping
+/// a constraint — or when a row matched no member name at all
+/// (`C_PRIMITIVE_TUPLE.members` is `1..*`,
+/// `docs/specs/openehr/AM/docs/AOM2/master04.5-constraint_model-class_definitions.adoc`
+/// §`C_PRIMITIVE_TUPLE`).
+fn build_attribute_tuple(
+    names: &[String],
+    rows: &[&Vec<(String, OdinValue)>],
+) -> Result<CAttributeTuple, DomainLoweringError> {
+    let members: Vec<CAttribute> = names.iter().map(|n| cattr_empty(n)).collect();
+    let mut tuples: Vec<CPrimitiveTuple> = Vec::new();
+    for row in rows {
+        let mut prim_members = Vec::new();
+        for n in names {
+            let Some(v) = row
+                .iter()
+                .find(|(k, _)| k == n)
+                .and_then(|(_, v)| domain_value_to_primitive(n, v))
+            else {
+                return Err(DomainLoweringError::Empty);
+            };
+            prim_members.push(v);
+        }
+        let Ok(prim_members) = openehr_base::containers::NonEmptyVec::new(prim_members) else {
+            return Err(DomainLoweringError::Empty);
+        };
+        tuples.push(CPrimitiveTuple {
+            members: prim_members,
+        });
+    }
+    Ok(CAttributeTuple {
+        members: openehr_base::containers::present(members),
+        tuples: openehr_base::containers::present(tuples),
+    })
 }
 
 /// Lower a parsed 1.4 inline dADL domain block into one or more

--- a/crates/openehr-adl/src/adl14/lower.rs
+++ b/crates/openehr-adl/src/adl14/lower.rs
@@ -122,46 +122,7 @@ impl Parser<'_> {
                 SyntaxErrorCode::Stccp,
                 "expecting '::' in a qualified code",
             )?;
-            let mut codes: Vec<String> = Vec::new();
-            let mut assumed: Option<String> = None;
-            // An EMPTY code list — `[local::]`, `[openEHR::]` — names the
-            // terminology and constrains the code to nothing further. Real CKM
-            // content relies on it (`media_type matches {[openEHR::]}`), and
-            // the verbatim form (`terminology::`) is preserved for the
-            // converter exactly as the non-empty spelling is.
-            //
-            // NOTE: the compact empty spelling is docs-text SILENT; the
-            // normative `cadl14_primitives.g4` `c_qualified_term_code` makes
-            // the code-list group optional (`ADL1.4/master09` §Custom Syntax).
-            while !matches!(self.peek(), Some(Token::RBracket)) {
-                match self.peek().cloned() {
-                    // External codes may be bare integers (`[openehr:: 253, …]`)
-                    // as well as at/ac/id codes (`[local:: at0136, …]`).
-                    Some(
-                        Token::AtCode(c) | Token::AcCode(c) | Token::IdCode(c) | Token::Integer(c),
-                    ) => {
-                        self.pos += 1;
-                        codes.push(c);
-                    }
-                    _ => return self.err(SyntaxErrorCode::Stccp, "expecting an at/ac code"),
-                }
-                if self.eat(|t| matches!(t, Token::SymComma)) {
-                    continue;
-                }
-                if self.eat(|t| matches!(t, Token::SymSemiColon)) {
-                    match self.peek().cloned() {
-                        Some(Token::AtCode(a)) => {
-                            self.pos += 1;
-                            assumed = Some(a);
-                        }
-                        _ => {
-                            return self
-                                .err(SyntaxErrorCode::Stccp, "assumed value must be an at-code");
-                        }
-                    }
-                }
-                break;
-            }
+            let (codes, assumed) = self.parse_adl14_code_list()?;
             let list_span = start..self.cur_span().end;
             self.expect(
                 |t| matches!(t, Token::RBracket),
@@ -171,6 +132,57 @@ impl Parser<'_> {
             self.adl14_term_constraint(&terminology, &codes, assumed.as_deref(), list_span)?
         };
         Ok(adl14_terminology_code(constraint))
+    }
+
+    /// The code list of a 1.4 qualified term constraint, with its optional
+    /// `;assumed` value.
+    ///
+    /// An EMPTY code list — `[local::]`, `[openEHR::]` — names the terminology
+    /// and constrains the code to nothing further. Real CKM content relies on
+    /// it (`media_type matches {[openEHR::]}`), and the verbatim form
+    /// (`terminology::`) is preserved for the converter exactly as the
+    /// non-empty spelling is. External codes may be bare integers
+    /// (`[openehr:: 253, …]`) as well as at/ac/id codes
+    /// (`[local:: at0136, …]`).
+    ///
+    /// NOTE: the compact empty spelling is docs-text SILENT; the normative
+    /// `cadl14_primitives.g4` `c_qualified_term_code` makes the code-list group
+    /// optional (`ADL1.4/master09` §Custom Syntax).
+    ///
+    /// # Errors
+    /// [`SyntaxErrorCode::Stccp`] for a non-code list member or an assumed
+    /// value that is not an at-code.
+    fn parse_adl14_code_list(&mut self) -> PResult<(Vec<String>, Option<String>)> {
+        let mut codes: Vec<String> = Vec::new();
+        let mut assumed: Option<String> = None;
+        while !matches!(self.peek(), Some(Token::RBracket)) {
+            match self.peek().cloned() {
+                Some(
+                    Token::AtCode(c) | Token::AcCode(c) | Token::IdCode(c) | Token::Integer(c),
+                ) => {
+                    self.pos += 1;
+                    codes.push(c);
+                }
+                _ => return self.err(SyntaxErrorCode::Stccp, "expecting an at/ac code"),
+            }
+            if self.eat(|t| matches!(t, Token::SymComma)) {
+                continue;
+            }
+            if self.eat(|t| matches!(t, Token::SymSemiColon)) {
+                match self.peek().cloned() {
+                    Some(Token::AtCode(a)) => {
+                        self.pos += 1;
+                        assumed = Some(a);
+                    }
+                    _ => {
+                        return self
+                            .err(SyntaxErrorCode::Stccp, "assumed value must be an at-code");
+                    }
+                }
+            }
+            break;
+        }
+        Ok((codes, assumed))
     }
 
     /// Build the verbatim `terminology::code[,code]*[;assumed]` constraint string

--- a/crates/openehr-adl/src/adl14/walk.rs
+++ b/crates/openehr-adl/src/adl14/walk.rs
@@ -80,27 +80,38 @@ pub(super) fn collect_local_value_codes(def: &CComplexObject, f: &mut impl FnMut
 /// Visit every `C_TERMINOLOGY_CODE.constraint` (with its enclosing element
 /// rubric context — unused here, passed empty).
 pub(super) fn walk_constraints(def: &CComplexObject, f: &mut impl FnMut(&str, &str)) {
-    if let CComplexObject::CComplexObject(d) = def {
-        for attr in d.attributes.iter().flatten() {
-            for child in attr.children.iter().flatten() {
-                walk_constraints_obj(child, f);
-            }
+    let CComplexObject::CComplexObject(d) = def else {
+        return;
+    };
+    for attr in d.attributes.iter().flatten() {
+        for child in attr.children.iter().flatten() {
+            walk_constraints_obj(child, f);
         }
-        for tuple in d.attribute_tuples.iter().flatten() {
-            for member in tuple.members.iter().flatten() {
-                for child in member.children.iter().flatten() {
-                    walk_constraints_obj(child, f);
-                }
-            }
-            // Tuple ROWS carry the actual primitive constraints (e.g. ordinal
-            // `[value, symbol]` symbol codes) — visit their terminology codes
-            // so value at-codes are planned and converted like attribute ones.
-            for row in tuple.tuples.iter().flatten() {
-                for m in &row.members {
-                    if let CPrimitiveObject::CTerminologyCode(tc) = m {
-                        f(&tc.constraint, "");
-                    }
-                }
+    }
+    for tuple in d.attribute_tuples.iter().flatten() {
+        walk_tuple_constraints(tuple, f);
+    }
+}
+
+/// Visits the terminology codes of one attribute tuple: its members' children,
+/// and its ROWS.
+///
+/// Tuple rows carry the actual primitive constraints (e.g. ordinal
+/// `[value, symbol]` symbol codes), so their terminology codes are visited too
+/// and value at-codes get planned and converted like attribute ones.
+fn walk_tuple_constraints(
+    tuple: &openehr_am::v2_4::aom2::constraint_model::c_attribute_tuple::CAttributeTuple,
+    f: &mut impl FnMut(&str, &str),
+) {
+    for member in tuple.members.iter().flatten() {
+        for child in member.children.iter().flatten() {
+            walk_constraints_obj(child, f);
+        }
+    }
+    for row in tuple.tuples.iter().flatten() {
+        for m in &row.members {
+            if let CPrimitiveObject::CTerminologyCode(tc) = m {
+                f(&tc.constraint, "");
             }
         }
     }

--- a/crates/openehr-adl/src/flatten.rs
+++ b/crates/openehr-adl/src/flatten.rs
@@ -234,6 +234,82 @@ enum Overlaid {
 /// Overlay the children of one container/single attribute — the cloning +
 /// sibling-order core.
 ///
+/// Classifies each child node in source order as a redefinition of a
+/// congruent base node or a new extension, carrying its EXPLICIT sibling
+/// marker.
+///
+/// The parser attaches a marker only to the node immediately after the marker
+/// keyword; per `master09.04` L249 a marker anchors every following node until
+/// the next marker, so the run range is everything from the first
+/// explicitly-marked node onward.
+#[expect(
+    clippy::indexing_slicing,
+    reason = "`base_idx` is a `find_congruent_idx` result over `base_nodes`, so it is in bounds by construction"
+)]
+fn classify_children(
+    base_nodes: &[CObject],
+    child_attr: &CAttribute,
+) -> Vec<(Overlaid, Option<SiblingOrder>)> {
+    let mut classified: Vec<(Overlaid, Option<SiblingOrder>)> = Vec::new();
+    for child in child_attr.children.iter().flatten() {
+        let marker = sibling_order(child).cloned();
+        let overlaid = if let Some(base_idx) = find_congruent_idx(base_nodes, object_node_id(child))
+        {
+            let node = overlay_node(&base_nodes[base_idx], child);
+            Overlaid::Redef { base_idx, node }
+        } else {
+            let mut node = child.clone();
+            strip_sibling_order(&mut node);
+            Overlaid::New { node }
+        };
+        classified.push((overlaid, marker));
+    }
+    classified
+}
+
+/// Phase 1: the working list with every unmarked node at its default position
+/// — redefinitions in place or cloned, extensions appended
+/// (`master09.04` L272).
+///
+/// The cloning decision uses the WHOLE redef set, but only the default
+/// (pre-marker) redefs are placed here: run-range redefs are positioned by
+/// their run in phase 2, so a base node whose only redefinition is in the run
+/// range is dropped here for the run to place. Where cloning is needed the
+/// parent node survives and the default clone-redefs follow it
+/// (`master09.05` §Single and Multiple Specialisation).
+#[expect(
+    clippy::indexing_slicing,
+    reason = "`split` is a `position(..).unwrap_or(len)` over `classified`, so `classified[..split]` is valid"
+)]
+fn place_default_nodes(
+    base_attr: &CAttribute,
+    base_nodes: &[CObject],
+    classified: &[(Overlaid, Option<SiblingOrder>)],
+    split: usize,
+) -> Vec<CObject> {
+    let mut work: Vec<CObject> = Vec::new();
+    for (base_idx, base_node) in base_nodes.iter().enumerate() {
+        let all_redefs = redef_nodes_for(classified, base_idx);
+        if all_redefs.is_empty() {
+            work.push(base_node.clone());
+            continue;
+        }
+        let default_redefs = redef_nodes_for(&classified[..split], base_idx);
+        if !clone_not_needed(base_node, base_attr, &all_redefs) {
+            work.push(base_node.clone());
+        }
+        for node in default_redefs {
+            work.push(node.clone());
+        }
+    }
+    for (o, _) in &classified[..split] {
+        if let Overlaid::New { node } = o {
+            work.push(node.clone());
+        }
+    }
+    work
+}
+
 /// Two phases (`master09.04`/`master09.05`):
 /// 1. Build the working list with in-place redefinitions and cloning applied,
 ///    ignoring sibling markers (unmarked nodes placed at their default position:
@@ -244,7 +320,7 @@ enum Overlaid {
 ///    is itself placed by a later run is available first.
 #[expect(
     clippy::indexing_slicing,
-    reason = "every index here is in bounds by construction: `base_idx` is a `find_congruent_idx` result over `base_nodes`, `split` is a `position(..).unwrap_or(len)` so both `classified[..split]` and `classified[split..]` are valid, and `runs[i]` is guarded by the enclosing `i < runs.len()`"
+    reason = "every index here is in bounds by construction: `split` is a `position(..).unwrap_or(len)` so `classified[split..]` is valid, and `runs[i]` is guarded by the enclosing `i < runs.len()`"
 )]
 fn overlay_children(base_attr: &mut CAttribute, child_attr: &CAttribute, _level: usize) {
     let base_nodes = base_attr.children.clone();
@@ -254,60 +330,17 @@ fn overlay_children(base_attr: &mut CAttribute, child_attr: &CAttribute, _level:
     // the marker keyword; per `master09.04` L249 a marker anchors every following
     // node until the next marker, so the run range is everything from the first
     // explicitly-marked node onward.
-    let mut classified: Vec<(Overlaid, Option<SiblingOrder>)> = Vec::new();
-    for child in child_attr.children.iter().flatten() {
-        let marker = sibling_order(child).cloned();
-        let overlaid = if let Some(base_idx) = find_congruent_idx(
-            base_nodes.as_deref().unwrap_or_default(),
-            object_node_id(child),
-        ) {
-            let node = overlay_node(&base_nodes.as_deref().unwrap_or_default()[base_idx], child);
-            Overlaid::Redef { base_idx, node }
-        } else {
-            let mut node = child.clone();
-            strip_sibling_order(&mut node);
-            Overlaid::New { node }
-        };
-        classified.push((overlaid, marker));
-    }
+    let classified = classify_children(base_nodes.as_deref().unwrap_or_default(), child_attr);
     let split = classified
         .iter()
         .position(|(_, m)| m.is_some())
         .unwrap_or(classified.len());
-
-    // Phase 1: default placement of the pre-marker nodes (redefinitions in place
-    // or cloned; extensions appended). Cloning uses the WHOLE redef set for the
-    // decision but only places the default (pre-marker) redefs here — run-range
-    // redefs are positioned by their run in phase 2; a base node whose only
-    // redefinition is in the run range is dropped here for the run to place.
-    let mut work: Vec<CObject> = Vec::new();
-    for (base_idx, base_node) in base_nodes.iter().flatten().enumerate() {
-        let all_redefs = redef_nodes_for(&classified, base_idx);
-        if all_redefs.is_empty() {
-            work.push(base_node.clone());
-            continue;
-        }
-        let default_redefs = redef_nodes_for(&classified[..split], base_idx);
-        if clone_not_needed(base_node, base_attr, &all_redefs) {
-            // In-place replacement.
-            for node in default_redefs {
-                work.push(node.clone());
-            }
-        } else {
-            // Cloning: the parent node survives, default clone-redefs follow it
-            // (`master09.05` §Single and Multiple Specialisation).
-            work.push(base_node.clone());
-            for node in default_redefs {
-                work.push(node.clone());
-            }
-        }
-    }
-    // Pre-marker extension nodes go to the end (`master09.04` L272).
-    for (o, _) in &classified[..split] {
-        if let Overlaid::New { node } = o {
-            work.push(node.clone());
-        }
-    }
+    let mut work = place_default_nodes(
+        base_attr,
+        base_nodes.as_deref().unwrap_or_default(),
+        &classified,
+        split,
+    );
 
     // Phase 2: place the run-range nodes by their runs (dependency-ordered).
     let mut runs = build_runs(&classified[split..]);

--- a/crates/openehr-adl/src/parse/parser.rs
+++ b/crates/openehr-adl/src/parse/parser.rs
@@ -170,47 +170,115 @@ impl Parser<'_> {
     /// A type-headed object: `c_complex_object` or `c_regular_primitive_object`
     /// (`cadl2.g4`). Distinguished by whether the `matches { … }` body (or the
     /// bare, body-less form) holds attribute defs or a single inline primitive.
-    #[expect(
-        clippy::too_many_lines,
-        reason = "one linear parse of a type-headed object — node bracket, optional OPT ref, body; the steps are sequential, not extractable units"
-    )]
+    /// The `'[' ID_CODE [',' archetype_ref] ']'` node bracket, if present.
+    ///
+    /// The two-part form is the OPT-inlined `C_ARCHETYPE_ROOT`: a flattened
+    /// slot-filler or external reference carrying the full archetype id inside
+    /// the bracket and an inline body (OPT2 master03 §Artefact Structure +
+    /// §Flattening; the same shape as `cadl14.g4` `c_archetype_root`).
+    ///
+    /// NOTE: `cadl2.g4` requires `'[' ID_CODE ']'`, but a *missing* node id is
+    /// a semantic defect (VCOID, `AOM2/master08`), not a syntax error, so an
+    /// absent `[…]` yields an empty node id that validation flags.
+    ///
+    /// # Errors
+    /// A malformed bracket — a missing archetype id after `,`, or a missing
+    /// closing `]`.
+    fn parse_node_bracket(&mut self) -> PResult<(String, Option<String>)> {
+        if !self.eat(|t| matches!(t, Token::LBracket)) {
+            return Ok((String::new(), None));
+        }
+        let node_id = self.parse_node_id()?;
+        let mut archetype_ref: Option<String> = None;
+        if self.eat(|t| matches!(t, Token::SymComma)) {
+            match self.peek().cloned() {
+                Some(Token::ArchetypeId(a)) => {
+                    self.pos += 1;
+                    archetype_ref = Some(a);
+                }
+                _ => {
+                    return self.err(
+                        SyntaxErrorCode::Suaid,
+                        "expecting an archetype id after ',' in a node reference",
+                    );
+                }
+            }
+        }
+        self.expect(
+            |t| matches!(t, Token::RBracket),
+            SyntaxErrorCode::Sccog,
+            "expecting ']' after the node id",
+        )?;
+        Ok((node_id, archetype_ref))
+    }
+
+    /// The `matches { … }` body of a type-headed object: the deprecated
+    /// `matches {*}` any-form (`master04.2`), a single inline primitive
+    /// constraint, or an attribute-definition body.
+    ///
+    /// # Errors
+    /// An empty body, an unterminated body, or the nested constraint's own
+    /// syntax errors.
+    fn parse_matches_body(&mut self, rm_type: &str, node_id: &str) -> PResult<CObject> {
+        self.pos += 1; // SYM_MATCHES
+        self.expect(
+            |t| matches!(t, Token::LCurly),
+            SyntaxErrorCode::Scoat,
+            "expecting '{' after 'matches'",
+        )?;
+        if matches!(self.peek(), Some(Token::RCurly)) {
+            let span = self.cur_span();
+            self.push(
+                SyntaxErrorCode::Scoat,
+                "expecting attribute definition(s)",
+                span,
+            );
+            return Err(());
+        }
+        if self.eat(|t| matches!(t, Token::SymStar)) {
+            self.expect(
+                |t| matches!(t, Token::RCurly),
+                SyntaxErrorCode::Scoat,
+                "expecting '}' after '*'",
+            )?;
+            return Ok(complex_object(
+                rm_type.to_owned(),
+                node_id.to_owned(),
+                Vec::new(),
+                Vec::new(),
+                None,
+            ));
+        }
+        if self.body_is_inline_primitive() {
+            let mut prim = self.parse_c_inline_primitive(node_id.to_owned())?;
+            self.expect(
+                |t| matches!(t, Token::RCurly),
+                SyntaxErrorCode::Scas,
+                "expecting '}' after the primitive constraint",
+            )?;
+            // A regular primitive object carries the declared RM type name.
+            rm_type.clone_into(common_mut(&mut prim).0);
+            return Ok(prim);
+        }
+        let (attrs, tuples, default) = self.parse_object_body()?;
+        self.expect(
+            |t| matches!(t, Token::RCurly),
+            SyntaxErrorCode::Scoat,
+            "expecting '}' closing the object body",
+        )?;
+        Ok(complex_object(
+            rm_type.to_owned(),
+            node_id.to_owned(),
+            attrs,
+            tuples,
+            default,
+        ))
+    }
+
     fn parse_type_object(&mut self) -> PResult<CObject> {
         let type_span = self.cur_span();
         let rm_type = self.parse_rm_type_id()?;
-        // OPT-inlined `C_ARCHETYPE_ROOT` form `TYPE[id, archetype_ref] …`: a
-        // flattened slot-filler / external reference carries the full archetype
-        // id inside the node bracket and an inline body (OPT2 master03
-        // §Artefact Structure + §Flattening; the same `'[' ID_CODE ','
-        // archetype_ref ']'` shape as `cadl14.g4` `c_archetype_root`).
-        // NOTE: `cadl2.g4` requires `'[' ID_CODE ']'`, but a *missing* node id
-        // is a semantic defect (VCOID, `AOM2/master08`), not a syntax error, so
-        // an absent `[…]` yields an empty node id that validation flags.
-        let mut archetype_ref: Option<String> = None;
-        let node_id = if self.eat(|t| matches!(t, Token::LBracket)) {
-            let n = self.parse_node_id()?;
-            if self.eat(|t| matches!(t, Token::SymComma)) {
-                match self.peek().cloned() {
-                    Some(Token::ArchetypeId(a)) => {
-                        self.pos += 1;
-                        archetype_ref = Some(a);
-                    }
-                    _ => {
-                        return self.err(
-                            SyntaxErrorCode::Suaid,
-                            "expecting an archetype id after ',' in a node reference",
-                        );
-                    }
-                }
-            }
-            self.expect(
-                |t| matches!(t, Token::RBracket),
-                SyntaxErrorCode::Sccog,
-                "expecting ']' after the node id",
-            )?;
-            n
-        } else {
-            String::new()
-        };
+        let (node_id, archetype_ref) = self.parse_node_bracket()?;
         let occurrences = if matches!(self.peek(), Some(Token::SymOccurrences)) {
             Some(self.parse_occurrences()?)
         } else {
@@ -221,56 +289,7 @@ impl Parser<'_> {
             return self.negated_matches_reject(SyntaxErrorCode::Sccog);
         }
         let mut obj = if matches!(self.peek(), Some(Token::SymMatches)) {
-            self.pos += 1; // SYM_MATCHES
-            self.expect(
-                |t| matches!(t, Token::LCurly),
-                SyntaxErrorCode::Scoat,
-                "expecting '{' after 'matches'",
-            )?;
-            if matches!(self.peek(), Some(Token::RCurly)) {
-                // Empty object body — `expecting attribute definition(s)`.
-                let span = self.cur_span();
-                self.push(
-                    SyntaxErrorCode::Scoat,
-                    "expecting attribute definition(s)",
-                    span,
-                );
-                return Err(());
-            }
-            if self.eat(|t| matches!(t, Token::SymStar)) {
-                // Deprecated `matches {*}` == any (`master04.2`).
-                self.expect(
-                    |t| matches!(t, Token::RCurly),
-                    SyntaxErrorCode::Scoat,
-                    "expecting '}' after '*'",
-                )?;
-                complex_object(
-                    rm_type.clone(),
-                    node_id.clone(),
-                    Vec::new(),
-                    Vec::new(),
-                    None,
-                )
-            } else if self.body_is_inline_primitive() {
-                let prim = self.parse_c_inline_primitive(node_id.clone())?;
-                self.expect(
-                    |t| matches!(t, Token::RCurly),
-                    SyntaxErrorCode::Scas,
-                    "expecting '}' after the primitive constraint",
-                )?;
-                // A regular primitive object carries the declared RM type name.
-                let mut prim = prim;
-                common_mut(&mut prim).0.clone_from(&rm_type);
-                prim
-            } else {
-                let (attrs, tuples, default) = self.parse_object_body()?;
-                self.expect(
-                    |t| matches!(t, Token::RCurly),
-                    SyntaxErrorCode::Scoat,
-                    "expecting '}' closing the object body",
-                )?;
-                complex_object(rm_type.clone(), node_id.clone(), attrs, tuples, default)
-            }
+            self.parse_matches_body(&rm_type, &node_id)?
         } else if let Some(prim) = Self::primitive_any(&rm_type, &node_id) {
             // Body-less primitive type (e.g. `String[id2]`): an unconstrained
             // primitive object (`master04.5` regular primitive form).

--- a/crates/openehr-adl/src/parse/parser.rs
+++ b/crates/openehr-adl/src/parse/parser.rs
@@ -785,6 +785,26 @@ impl Parser<'_> {
         if self.eat(|t| matches!(t, Token::SymStar)) {
             return Ok(Vec::new()); // deprecated `matches {*}` == any.
         }
+        if let Some(objs) = self.parse_c_objects_whole_body()? {
+            return Ok(objs);
+        }
+        let mut objs = Vec::new();
+        while !matches!(self.peek(), Some(Token::RCurly) | None) {
+            match self.parse_adl14_sibling()? {
+                Some(alternatives) => objs.extend(alternatives),
+                None => objs.push(self.parse_c_regular_object_ordered()?),
+            }
+        }
+        Ok(objs)
+    }
+
+    /// The forms that constrain the WHOLE `matches {…}` body as one object.
+    ///
+    /// [`None`] means the body is a sibling list to be walked object by object.
+    ///
+    /// # Errors
+    /// Propagates the sub-parser's [`SyntaxError`](crate::error::SyntaxError).
+    fn parse_c_objects_whole_body(&mut self) -> PResult<Option<Vec<CObject>>> {
         // 1.4-only (converter front end; no openEHR spec — see `crate::adl14`):
         // a qualified/listed terminology constraint (`[local::at1]`,
         // `[local:: a, b ; c]`, `[openehr::524]`). A single `[local::code]` is
@@ -792,54 +812,49 @@ impl Parser<'_> {
         // must reach `parse_adl14_term_object` rather than the ADL2 inline
         // terminology-code path (which expects a bare `[at1]`/`[ac1]`).
         if self.dialect == Dialect::Adl14 && self.is_adl14_qualified_code_start() {
-            let obj = self.parse_adl14_term_object()?;
-            return Ok(vec![obj]);
+            return Ok(Some(vec![self.parse_adl14_term_object()?]));
         }
         // The 1.4 ordinal shorthand OPENS with a number, so it would otherwise
         // be swallowed by the inline-primitive path as an integer/real
         // constraint and then trip over the `|`. It keeps precedence here (as
-        // it always had) and is dispatched per-sibling inside the loop below.
+        // it always had) and is dispatched per-sibling by the caller's loop.
         let at_adl14_ordinal = self.dialect == Dialect::Adl14 && self.is_adl14_ordinal_start();
         if self.is_inline_primitive_start() && !at_adl14_ordinal {
-            let obj = self.parse_c_inline_primitive("Primitive_node_id".to_owned())?;
-            return Ok(vec![obj]);
+            return Ok(Some(vec![
+                self.parse_c_inline_primitive("Primitive_node_id".to_owned())?,
+            ]));
         }
-        let mut objs = Vec::new();
-        while !matches!(self.peek(), Some(Token::RCurly) | None) {
-            // 1.4-only: the pipe-ordinal shorthand `0|[local::at0005], 1|[…]`
-            // (`cadl14.g4` `c_ordinal`, one of the `c_non_primitive_object`
-            // alternatives — so it stands exactly where an object is expected).
-            // It is dispatched INSIDE the loop, not as a whole-body special
-            // case: an ordinal list is one alternative among the siblings of its
-            // block, so it may stand beside a regular complex object in either
-            // order. `ADL1.4/master05-cadl.adoc` §Mixed Structures is the
-            // reading: "at any given node, all three types can co-exist".
-            if self.dialect == Dialect::Adl14 && self.is_adl14_ordinal_start() {
-                objs.push(self.parse_adl14_ordinal()?);
-                continue;
-            }
-            // 1.4-only: an inline dADL domain block is intercepted here (not
-            // in `parse_c_regular_object`) because a block whose `list` rows
-            // constrain DIFFERENT member sets lowers to SEVERAL sibling
-            // alternatives (#1466) — the per-object path can only return one.
-            // A sibling-order marker before the block still routes through
-            // the single-object shim.
-            if self.dialect == Dialect::Adl14 {
-                match self.peek() {
-                    Some(Token::LParen) => {
-                        objs.extend(self.parse_adl14_domain_object(true)?);
-                        continue;
-                    }
-                    Some(Token::AlphaUcId(_)) if self.is_adl14_domain_block_start() => {
-                        objs.extend(self.parse_adl14_domain_object(false)?);
-                        continue;
-                    }
-                    _ => {}
-                }
-            }
-            objs.push(self.parse_c_regular_object_ordered()?);
+        Ok(None)
+    }
+
+    /// One ADL 1.4-only sibling form, when the cursor stands on one.
+    ///
+    /// The pipe-ordinal shorthand `0|[local::at0005], 1|[…]` (`cadl14.g4`
+    /// `c_ordinal`) and an inline dADL domain block are dispatched PER SIBLING
+    /// rather than as whole-body special cases: each is one alternative among
+    /// the siblings of its block, so it may stand beside a regular complex
+    /// object in either order (`ADL1.4/master05-cadl.adoc` §Mixed Structures:
+    /// "at any given node, all three types can co-exist"). A domain block whose
+    /// `list` rows constrain DIFFERENT member sets lowers to SEVERAL
+    /// alternatives, which is why the return is a list; a sibling-order marker
+    /// before the block still routes through the single-object shim.
+    ///
+    /// # Errors
+    /// Propagates the sub-parser's [`SyntaxError`](crate::error::SyntaxError).
+    fn parse_adl14_sibling(&mut self) -> PResult<Option<Vec<CObject>>> {
+        if self.dialect != Dialect::Adl14 {
+            return Ok(None);
         }
-        Ok(objs)
+        if self.is_adl14_ordinal_start() {
+            return Ok(Some(vec![self.parse_adl14_ordinal()?]));
+        }
+        match self.peek() {
+            Some(Token::LParen) => Ok(Some(self.parse_adl14_domain_object(true)?)),
+            Some(Token::AlphaUcId(_)) if self.is_adl14_domain_block_start() => {
+                Ok(Some(self.parse_adl14_domain_object(false)?))
+            }
+            _ => Ok(None),
+        }
     }
 
     /// The single-object shim over [`Parser::parse_adl14_domain_object`] for

--- a/crates/openehr-adl/src/parse/primitives.rs
+++ b/crates/openehr-adl/src/parse/primitives.rs
@@ -841,6 +841,31 @@ mod tests {
         }
     }
 
+    /// The `C_INTEGER` constraint list of the `index`-th attribute's first
+    /// child.
+    fn integer_constraints(d: &CComplexObjectData, index: usize) -> &[Interval<i32>] {
+        match &d.attributes.as_deref().unwrap_or_default()[index]
+            .children
+            .as_deref()
+            .unwrap_or_default()[0]
+        {
+            CObject::CInteger(ci) => ci.constraint.as_deref().unwrap_or_default(),
+            _ => panic!("expected CInteger"),
+        }
+    }
+
+    /// The first constraint of the `index`-th attribute, as a proper interval.
+    fn integer_proper(
+        d: &CComplexObjectData,
+        index: usize,
+    ) -> &openehr_base::v1_3::foundation_types::interval::proper_interval::ProperIntervalData<i32>
+    {
+        match &integer_constraints(d, index)[0] {
+            Interval::ProperInterval(ProperInterval::ProperInterval(pi)) => pi,
+            _ => panic!("expected proper interval"),
+        }
+    }
+
     #[test]
     fn integer_forms() {
         let cco = parse(
@@ -855,87 +880,29 @@ mod tests {
         );
         let d = data(&cco);
         // a: point 55
-        match &d.attributes.as_deref().unwrap_or_default()[0]
-            .children
-            .as_deref()
-            .unwrap_or_default()[0]
-        {
-            CObject::CInteger(ci) => match &ci.constraint.as_deref().unwrap_or_default()[0] {
-                Interval::PointInterval(p) => assert_eq!(p.lower, Some(55)),
-                Interval::ProperInterval(_) => panic!("expected point"),
-            },
-            _ => panic!("expected CInteger"),
+        match &integer_constraints(d, 0)[0] {
+            Interval::PointInterval(p) => assert_eq!(p.lower, Some(55)),
+            Interval::ProperInterval(_) => panic!("expected point"),
         }
         // b: three points
-        match &d.attributes.as_deref().unwrap_or_default()[1]
-            .children
-            .as_deref()
-            .unwrap_or_default()[0]
-        {
-            CObject::CInteger(ci) => assert_eq!(ci.constraint.as_ref().map_or(0, Vec::len), 3),
-            _ => panic!("expected CInteger"),
-        }
+        assert_eq!(integer_constraints(d, 1).len(), 3);
         // c: |0..100|
-        match &d.attributes.as_deref().unwrap_or_default()[2]
-            .children
-            .as_deref()
-            .unwrap_or_default()[0]
-        {
-            CObject::CInteger(ci) => match &ci.constraint.as_deref().unwrap_or_default()[0] {
-                Interval::ProperInterval(ProperInterval::ProperInterval(pi)) => {
-                    assert_eq!(pi.lower, Some(0));
-                    assert_eq!(pi.upper, Some(100));
-                    assert!(pi.lower_included && pi.upper_included);
-                }
-                _ => panic!("expected proper interval"),
-            },
-            _ => panic!("expected CInteger"),
-        }
+        let c = integer_proper(d, 2);
+        assert_eq!(c.lower, Some(0));
+        assert_eq!(c.upper, Some(100));
+        assert!(c.lower_included && c.upper_included);
         // d: |>0..<100| exclusive both
-        match &d.attributes.as_deref().unwrap_or_default()[3]
-            .children
-            .as_deref()
-            .unwrap_or_default()[0]
-        {
-            CObject::CInteger(ci) => match &ci.constraint.as_deref().unwrap_or_default()[0] {
-                Interval::ProperInterval(ProperInterval::ProperInterval(pi)) => {
-                    assert!(!pi.lower_included && !pi.upper_included);
-                }
-                _ => panic!("expected proper interval"),
-            },
-            _ => panic!("expected CInteger"),
-        }
+        let dd = integer_proper(d, 3);
+        assert!(!dd.lower_included && !dd.upper_included);
         // e: |>=10| lower bounded, upper unbounded
-        match &d.attributes.as_deref().unwrap_or_default()[4]
-            .children
-            .as_deref()
-            .unwrap_or_default()[0]
-        {
-            CObject::CInteger(ci) => match &ci.constraint.as_deref().unwrap_or_default()[0] {
-                Interval::ProperInterval(ProperInterval::ProperInterval(pi)) => {
-                    assert_eq!(pi.lower, Some(10));
-                    assert!(pi.lower_included);
-                    assert!(pi.upper_unbounded);
-                }
-                _ => panic!("expected proper interval"),
-            },
-            _ => panic!("expected CInteger"),
-        }
+        let e = integer_proper(d, 4);
+        assert_eq!(e.lower, Some(10));
+        assert!(e.lower_included);
+        assert!(e.upper_unbounded);
         // f: |-10..-5| negative endpoints
-        match &d.attributes.as_deref().unwrap_or_default()[5]
-            .children
-            .as_deref()
-            .unwrap_or_default()[0]
-        {
-            CObject::CInteger(ci) => match &ci.constraint.as_deref().unwrap_or_default()[0] {
-                Interval::ProperInterval(ProperInterval::ProperInterval(pi)) => {
-                    assert_eq!(pi.lower, Some(-10));
-                    assert_eq!(pi.upper, Some(-5));
-                }
-                _ => panic!("expected proper interval"),
-            },
-            _ => panic!("expected CInteger"),
-        }
+        let f = integer_proper(d, 5);
+        assert_eq!(f.lower, Some(-10));
+        assert_eq!(f.upper, Some(-5));
     }
 
     #[test]

--- a/crates/openehr-adl/src/parse/refs.rs
+++ b/crates/openehr-adl/src/parse/refs.rs
@@ -154,26 +154,36 @@ impl Parser<'_> {
     /// AOM 1.4 node-id rule (anonymous where no sibling disambiguation is
     /// needed) is enforced by VCOID in the 1.4 validation pass, not here;
     /// `cadl2.g4` mandates the bracket in ADL 2.
+    /// The slot's `'[' ID_CODE ']'` node id, which ADL 1.4 may omit.
+    ///
+    /// The AOM 1.4 node-id rule (anonymous where no sibling disambiguation is
+    /// needed) is enforced by VCOID in the 1.4 validation pass, not here;
+    /// `cadl2.g4` mandates the bracket in ADL 2.
+    ///
+    /// # Errors
+    /// A missing bracket in ADL 2, or a malformed node id.
+    fn parse_slot_node_id(&mut self) -> PResult<String> {
+        if self.dialect == Dialect::Adl14 && !matches!(self.peek(), Some(Token::LBracket)) {
+            return Ok(String::new());
+        }
+        self.expect(
+            |t| matches!(t, Token::LBracket),
+            SyntaxErrorCode::Sccog,
+            "expecting '[' after 'allow_archetype'",
+        )?;
+        let node_id = self.parse_node_id()?;
+        self.expect(
+            |t| matches!(t, Token::RBracket),
+            SyntaxErrorCode::Sccog,
+            "expecting ']' after the node id",
+        )?;
+        Ok(node_id)
+    }
+
     pub(crate) fn parse_archetype_slot(&mut self) -> PResult<CObject> {
         self.pos += 1; // SYM_ALLOW_ARCHETYPE
         let rm_type = self.parse_rm_type_id()?;
-        let node_id =
-            if self.dialect == Dialect::Adl14 && !matches!(self.peek(), Some(Token::LBracket)) {
-                String::new()
-            } else {
-                self.expect(
-                    |t| matches!(t, Token::LBracket),
-                    SyntaxErrorCode::Sccog,
-                    "expecting '[' after 'allow_archetype'",
-                )?;
-                let n = self.parse_node_id()?;
-                self.expect(
-                    |t| matches!(t, Token::RBracket),
-                    SyntaxErrorCode::Sccog,
-                    "expecting ']' after the node id",
-                )?;
-                n
-            };
+        let node_id = self.parse_slot_node_id()?;
 
         let mut is_closed = false;
         let mut occurrences = None;

--- a/crates/openehr-adl/src/print/definition.rs
+++ b/crates/openehr-adl/src/print/definition.rs
@@ -552,21 +552,21 @@ fn proper_str<T, F: Fn(&T) -> String>(
     p: &openehr_base::prelude::ProperIntervalData<T>,
     f: &F,
 ) -> String {
-    let two_sided = p.lower.is_some() && p.upper.is_some();
-    if two_sided {
-        let lo = p.lower.as_ref().map(f).unwrap_or_default();
-        let hi = p.upper.as_ref().map(f).unwrap_or_default();
-        let lp = if p.lower_included { "" } else { ">" };
-        let hp = if p.upper_included { "" } else { "<" };
-        format!("|{lp}{lo}..{hp}{hi}|")
-    } else if let Some(lo) = &p.lower {
-        let op = if p.lower_included { ">=" } else { ">" };
-        format!("|{op}{}|", f(lo))
-    } else if let Some(hi) = &p.upper {
-        let op = if p.upper_included { "<=" } else { "<" };
-        format!("|{op}{}|", f(hi))
-    } else {
-        String::new()
+    match (&p.lower, &p.upper) {
+        (Some(lo), Some(hi)) => {
+            let lp = if p.lower_included { "" } else { ">" };
+            let hp = if p.upper_included { "" } else { "<" };
+            format!("|{lp}{}..{hp}{}|", f(lo), f(hi))
+        }
+        (Some(lo), None) => {
+            let op = if p.lower_included { ">=" } else { ">" };
+            format!("|{op}{}|", f(lo))
+        }
+        (None, Some(hi)) => {
+            let op = if p.upper_included { "<=" } else { "<" };
+            format!("|{op}{}|", f(hi))
+        }
+        (None, None) => String::new(),
     }
 }
 

--- a/crates/openehr-adl/src/print/definition.rs
+++ b/crates/openehr-adl/src/print/definition.rs
@@ -48,26 +48,7 @@ impl Printer {
         }
         match obj {
             CObject::CComplexObject(CComplexObject::CComplexObject(d)) => {
-                let _ = write!(head, "{}{}", d.rm_type_name, node_bracket(&d.node_id));
-                head.push_str(&occ_suffix(d.occurrences.as_ref()));
-                let has_body = !d.attributes.as_ref().is_none_or(Vec::is_empty)
-                    || !d.attribute_tuples.as_ref().is_none_or(Vec::is_empty)
-                    || d.default_value.is_some();
-                if has_body {
-                    self.line(depth, &format!("{head} matches {{"));
-                    for a in d.attributes.iter().flatten() {
-                        self.attribute(a, depth + 1)?;
-                    }
-                    for t in d.attribute_tuples.iter().flatten() {
-                        self.attribute_tuple(t, depth + 1);
-                    }
-                    if let Some(dv) = &d.default_value {
-                        self.default_value(dv, depth + 1);
-                    }
-                    self.line(depth, "}");
-                } else {
-                    self.line(depth, &head);
-                }
+                self.complex_object(&mut head, d, depth)?;
             }
             CObject::CComplexObject(CComplexObject::CArchetypeRoot(r)) => {
                 self.archetype_root(&head, r, depth)?;
@@ -75,30 +56,66 @@ impl Printer {
             CObject::CComplexObjectProxy(pr) => self.proxy(&head, pr, depth),
             CObject::ArchetypeSlot(s) => self.slot(&head, s, depth)?,
             // Primitives with a real node id are regular primitive objects.
-            other => {
-                if let Some(prim) = cobject_to_primitive(other) {
-                    let (ty, node_id) = prim_type_and_node(other);
-                    if node_id == "Primitive_node_id" {
-                        // Inline primitive (only reached inside an attribute body).
-                        self.line(depth, &format!("{head}{}", primitive_inline(&prim)));
-                    } else {
-                        let value = primitive_inline(&prim);
-                        if value.is_empty() {
-                            self.line(depth, &format!("{head}{ty}{}", node_bracket(&node_id)));
-                        } else {
-                            self.line(
-                                depth,
-                                &format!(
-                                    "{head}{ty}{} matches {{{value}}}",
-                                    node_bracket(&node_id)
-                                ),
-                            );
-                        }
-                    }
-                }
-            }
+            other => self.primitive_object(&head, other, depth),
         }
         Ok(())
+    }
+
+    /// Prints a plain `C_COMPLEX_OBJECT`: its head line, and a `matches` body
+    /// when it carries attributes, attribute tuples or a default value.
+    ///
+    /// # Errors
+    /// [`PrintError`] from a nested attribute.
+    fn complex_object(
+        &mut self,
+        head: &mut String,
+        d: &openehr_am::v2_4::aom2::constraint_model::c_complex_object::CComplexObjectData,
+        depth: usize,
+    ) -> Result<(), PrintError> {
+        let _ = write!(head, "{}{}", d.rm_type_name, node_bracket(&d.node_id));
+        head.push_str(&occ_suffix(d.occurrences.as_ref()));
+        let has_body = !d.attributes.as_ref().is_none_or(Vec::is_empty)
+            || !d.attribute_tuples.as_ref().is_none_or(Vec::is_empty)
+            || d.default_value.is_some();
+        if !has_body {
+            self.line(depth, head);
+            return Ok(());
+        }
+        self.line(depth, &format!("{head} matches {{"));
+        for a in d.attributes.iter().flatten() {
+            self.attribute(a, depth + 1)?;
+        }
+        for t in d.attribute_tuples.iter().flatten() {
+            self.attribute_tuple(t, depth + 1);
+        }
+        if let Some(dv) = &d.default_value {
+            self.default_value(dv, depth + 1);
+        }
+        self.line(depth, "}");
+        Ok(())
+    }
+
+    /// Prints a primitive object: inline where it carries the placeholder node
+    /// id (only reached inside an attribute body), else as a node-identified
+    /// object with its `matches` value.
+    fn primitive_object(&mut self, head: &str, obj: &CObject, depth: usize) {
+        let Some(prim) = cobject_to_primitive(obj) else {
+            return;
+        };
+        let (ty, node_id) = prim_type_and_node(obj);
+        if node_id == "Primitive_node_id" {
+            self.line(depth, &format!("{head}{}", primitive_inline(&prim)));
+            return;
+        }
+        let value = primitive_inline(&prim);
+        if value.is_empty() {
+            self.line(depth, &format!("{head}{ty}{}", node_bracket(&node_id)));
+        } else {
+            self.line(
+                depth,
+                &format!("{head}{ty}{} matches {{{value}}}", node_bracket(&node_id)),
+            );
+        }
     }
 
     fn attribute(&mut self, a: &CAttribute, depth: usize) -> Result<(), PrintError> {

--- a/crates/openehr-adl/src/print/header.rs
+++ b/crates/openehr-adl/src/print/header.rs
@@ -32,43 +32,7 @@ impl Printer {
         } else {
             parts.keyword
         };
-        let mut meta = String::new();
-        if let Some(adl) = parts.adl_version {
-            let _ = write!(meta, "adl_version={adl}");
-        }
-        if let Some(rm) = parts.rm_release
-            && !rm.is_empty()
-        {
-            push_meta(&mut meta, &format!("rm_release={rm}"));
-        }
-        if let Some(uid) = parts.uid
-            && !is_nil(uid)
-        {
-            push_meta(&mut meta, &format!("uid={}", uid.value()));
-        }
-        if let Some(build) = parts.build_uid
-            && !is_nil(build)
-        {
-            push_meta(&mut meta, &format!("build_uid={}", build.value()));
-        }
-        if parts.is_generated {
-            push_meta(&mut meta, "generated");
-        }
-        if let Some(controlled) = parts.is_controlled {
-            push_meta(
-                &mut meta,
-                if controlled {
-                    "controlled"
-                } else {
-                    "uncontrolled"
-                },
-            );
-        }
-        if let Some(other) = parts.other_meta_data {
-            for (k, v) in other {
-                push_meta(&mut meta, &format!("{k}={v}"));
-            }
-        }
+        let meta = meta_clause(parts);
         if meta.is_empty() {
             self.line(0, keyword);
         } else {
@@ -267,6 +231,51 @@ impl Printer {
 
 /// Append one `key=value` item to the identification-line meta-data list,
 /// separating it from any preceding item with `; `.
+/// The `(…)` meta-data clause of the artefact declaration: the ADL and RM
+/// versions, the identifiers, and the standardised flags, `;`-separated in
+/// declaration order (`ADL2/master07.04` §Artefact declaration).
+///
+/// A nil `uid`/`build_uid` is the absent-value spelling the assembler stores
+/// and never prints.
+fn meta_clause(parts: &Parts<'_>) -> String {
+    let mut meta = String::new();
+    if let Some(adl) = parts.adl_version {
+        let _ = write!(meta, "adl_version={adl}");
+    }
+    if let Some(rm) = parts.rm_release
+        && !rm.is_empty()
+    {
+        push_meta(&mut meta, &format!("rm_release={rm}"));
+    }
+    if let Some(uid) = parts.uid
+        && !is_nil(uid)
+    {
+        push_meta(&mut meta, &format!("uid={}", uid.value()));
+    }
+    if let Some(build) = parts.build_uid
+        && !is_nil(build)
+    {
+        push_meta(&mut meta, &format!("build_uid={}", build.value()));
+    }
+    if parts.is_generated {
+        push_meta(&mut meta, "generated");
+    }
+    if let Some(controlled) = parts.is_controlled {
+        push_meta(
+            &mut meta,
+            if controlled {
+                "controlled"
+            } else {
+                "uncontrolled"
+            },
+        );
+    }
+    for (k, v) in parts.other_meta_data.into_iter().flatten() {
+        push_meta(&mut meta, &format!("{k}={v}"));
+    }
+    meta
+}
+
 fn push_meta(meta: &mut String, item: &str) {
     if !meta.is_empty() {
         meta.push_str("; ");

--- a/crates/openehr-adl/src/print/terminology.rs
+++ b/crates/openehr-adl/src/print/terminology.rs
@@ -19,26 +19,7 @@ impl Printer {
     }
 
     pub(super) fn terminology_body(&mut self, t: &ArchetypeTerminology, depth: usize) {
-        self.line(depth, "term_definitions = <");
-        for (lang, codes) in &t.term_definitions {
-            self.line(depth + 1, &format!("[{}] = <", quoted(lang)));
-            for (code, term) in codes {
-                self.line(depth + 2, &format!("[{}] = <", quoted(code)));
-                self.line(depth + 3, &format!("text = <{}>", quoted(&term.text)));
-                self.line(
-                    depth + 3,
-                    &format!("description = <{}>", quoted(&term.description)),
-                );
-                if let Some(items) = &term.other_items {
-                    for (k, v) in items {
-                        self.line(depth + 3, &format!("{k} = <{}>", quoted(v)));
-                    }
-                }
-                self.line(depth + 2, ">");
-            }
-            self.line(depth + 1, ">");
-        }
-        self.line(depth, ">");
+        self.term_definitions(t, depth);
         if let Some(bindings) = &t.term_bindings {
             self.line(depth, "term_bindings = <");
             for (terminology, map) in bindings {
@@ -53,18 +34,51 @@ impl Printer {
         if let Some(value_sets) = &t.value_sets {
             self.line(depth, "value_sets = <");
             for (id, vs) in value_sets {
-                self.line(depth + 1, &format!("[{}] = <", quoted(id)));
-                self.line(depth + 2, &format!("id = <{}>", quoted(&vs.id)));
-                let members = vs
-                    .members
-                    .iter()
-                    .map(|m| quoted(m))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                self.line(depth + 2, &format!("members = <{members}>"));
-                self.line(depth + 1, ">");
+                self.value_set(id, vs, depth + 1);
             }
             self.line(depth, ">");
         }
+    }
+
+    /// The `term_definitions` block: one nested ODIN object per language, then
+    /// per code.
+    fn term_definitions(&mut self, t: &ArchetypeTerminology, depth: usize) {
+        self.line(depth, "term_definitions = <");
+        for (lang, codes) in &t.term_definitions {
+            self.line(depth + 1, &format!("[{}] = <", quoted(lang)));
+            for (code, term) in codes {
+                self.line(depth + 2, &format!("[{}] = <", quoted(code)));
+                self.line(depth + 3, &format!("text = <{}>", quoted(&term.text)));
+                self.line(
+                    depth + 3,
+                    &format!("description = <{}>", quoted(&term.description)),
+                );
+                for (k, v) in term.other_items.iter().flatten() {
+                    self.line(depth + 3, &format!("{k} = <{}>", quoted(v)));
+                }
+                self.line(depth + 2, ">");
+            }
+            self.line(depth + 1, ">");
+        }
+        self.line(depth, ">");
+    }
+
+    /// One `value_sets` entry: its id and its comma-separated member list.
+    fn value_set(
+        &mut self,
+        id: &str,
+        vs: &openehr_am::v2_4::aom2::terminology::value_set::ValueSet,
+        depth: usize,
+    ) {
+        self.line(depth, &format!("[{}] = <", quoted(id)));
+        self.line(depth + 1, &format!("id = <{}>", quoted(&vs.id)));
+        let members = vs
+            .members
+            .iter()
+            .map(|m| quoted(m))
+            .collect::<Vec<_>>()
+            .join(", ");
+        self.line(depth + 1, &format!("members = <{members}>"));
+        self.line(depth, ">");
     }
 }

--- a/crates/openehr-adl/src/source.rs
+++ b/crates/openehr-adl/src/source.rs
@@ -322,14 +322,17 @@ impl Outer<'_> {
         classify_section(&self.keyword_at(idx)?)
     }
 
-    fn parse_artefact(&mut self, overlay: bool) -> Option<SourceArtefact> {
-        // Artefact kind keyword (accept an optional leading `flat`).
+    /// The artefact-kind keyword and its span, accepting an optional leading
+    /// `flat` (`ADL2/master07.04` §Artefact declaration).
+    ///
+    /// The span is the KEYWORD's, taken after any `flat` prefix, because the
+    /// caller reports missing-section defects against it.
+    fn parse_artefact_kind(&mut self) -> Option<(ArtefactKind, std::ops::Range<usize>)> {
         if self.keyword_at(self.pos).as_deref() == Some("flat") {
             self.pos += 1;
         }
         let kind_span = self.span_at(self.pos);
-        let kind = self.keyword_at(self.pos).as_deref().and_then(classify_kind);
-        let Some(kind) = kind else {
+        let Some(kind) = self.keyword_at(self.pos).as_deref().and_then(classify_kind) else {
             self.push(
                 SyntaxErrorCode::Sunk,
                 "expected an artefact keyword",
@@ -338,13 +341,12 @@ impl Outer<'_> {
             return None;
         };
         self.pos += 1;
+        Some((kind, kind_span))
+    }
 
-        let mut meta = ArtefactMeta::default();
-        if matches!(self.current(), Some(Token::LParen)) {
-            self.parse_meta(&mut meta);
-        }
-
-        // HRID.
+    /// The artefact's `ARCHETYPE_HRID`, which follows the kind keyword and its
+    /// optional meta-data clause.
+    fn parse_artefact_hrid(&mut self) -> Option<ArchetypeHrid> {
         let hrid_span = self.span_at(self.pos);
         let Some(Token::ArchetypeId(hrid_str)) = self.current().cloned() else {
             self.push(
@@ -355,13 +357,22 @@ impl Outer<'_> {
             return None;
         };
         self.pos += 1;
-        let hrid = match parse_hrid(&hrid_str) {
-            Ok(h) => h,
+        match parse_hrid(&hrid_str) {
+            Ok(h) => Some(h),
             Err(msg) => {
                 self.push(SyntaxErrorCode::Sarid, msg, hrid_span);
-                return None;
+                None
             }
-        };
+        }
+    }
+
+    fn parse_artefact(&mut self, overlay: bool) -> Option<SourceArtefact> {
+        let (kind, kind_span) = self.parse_artefact_kind()?;
+        let mut meta = ArtefactMeta::default();
+        if matches!(self.current(), Some(Token::LParen)) {
+            self.parse_meta(&mut meta);
+        }
+        let hrid = self.parse_artefact_hrid()?;
 
         let mut art = SourceArtefact {
             kind,

--- a/crates/openehr-adl/src/validate/bindings.rs
+++ b/crates/openehr-adl/src/validate/bindings.rs
@@ -54,44 +54,55 @@ pub(super) fn check_bindings(
     };
     for terms in bindings.values() {
         for key in terms.keys() {
-            if AdlCodeDefinitionsData::is_value_set_code(key) {
-                // VTCBK: a constraint (ac) binding key must be a defined ac-code.
-                if !defined.contains(key.as_str()) {
-                    issues.push(ValidationIssue::new(
-                        ValidationCode::Vtcbk,
-                        format!("constraint binding key {key:?} is not a defined ac-code"),
-                    ));
-                }
-            } else if AdlCodeDefinitionsData::is_at_code(key)
-                || AdlCodeDefinitionsData::is_id_code(key)
-            {
-                // VTTBK: a term binding key must be a defined at-code.
-                if !defined.contains(key.as_str()) {
-                    issues.push(ValidationIssue::new(
-                        ValidationCode::Vttbk,
-                        format!("term binding key {key:?} is not a defined at-code"),
-                    ));
-                }
-            } else if !key.starts_with('/') {
-                // VTTBK: a non-code key that is not even a path (a bare word) is
-                // never a valid binding target (master07 §Validity Rules).
-                issues.push(ValidationIssue::new(
-                    ValidationCode::Vttbk,
-                    format!("term binding key {key:?} is neither an at-code nor a path"),
-                ));
-            } else if has_node_id_predicate(key) {
-                // VTTBK: a node-id-predicated path must resolve within the
-                // archetype (master07 §Validity Rules). A pure-RM path (no
-                // predicate) is a reference-model concern (`super::rm`).
-                if resolve(v.definition, key) != Resolution::Found {
-                    issues.push(ValidationIssue::new(
-                        ValidationCode::Vttbk,
-                        format!("term binding key path {key:?} is not valid in the archetype"),
-                    ));
-                }
+            if let Some(issue) = binding_key_issue(v, defined, key) {
+                issues.push(issue);
             }
         }
     }
+}
+
+/// The VTTBK/VTCBK violation one binding key raises, or `None` when it is
+/// valid.
+///
+/// A constraint (ac) key must be a defined ac-code (VTCBK); a term key must be
+/// a defined at-code (VTTBK); a non-code key that is not even a path (a bare
+/// word) is never a valid binding target; and a node-id-predicated path must
+/// resolve within the archetype. A pure-RM path (no predicate) is a
+/// reference-model concern ([`super::rm`]).
+fn binding_key_issue(
+    v: &ArchetypeView<'_>,
+    defined: &BTreeSet<&str>,
+    key: &str,
+) -> Option<ValidationIssue> {
+    if AdlCodeDefinitionsData::is_value_set_code(key) {
+        return (!defined.contains(key)).then(|| {
+            ValidationIssue::new(
+                ValidationCode::Vtcbk,
+                format!("constraint binding key {key:?} is not a defined ac-code"),
+            )
+        });
+    }
+    if AdlCodeDefinitionsData::is_at_code(key) || AdlCodeDefinitionsData::is_id_code(key) {
+        return (!defined.contains(key)).then(|| {
+            ValidationIssue::new(
+                ValidationCode::Vttbk,
+                format!("term binding key {key:?} is not a defined at-code"),
+            )
+        });
+    }
+    if !key.starts_with('/') {
+        return Some(ValidationIssue::new(
+            ValidationCode::Vttbk,
+            format!("term binding key {key:?} is neither an at-code nor a path"),
+        ));
+    }
+    if has_node_id_predicate(key) && resolve(v.definition, key) != Resolution::Found {
+        return Some(ValidationIssue::new(
+            ValidationCode::Vttbk,
+            format!("term binding key path {key:?} is not valid in the archetype"),
+        ));
+    }
+    None
 }
 
 // ── the external terminology-service seam (VETDF) ──────────────────────────

--- a/crates/openehr-adl/src/validate/identification.rs
+++ b/crates/openehr-adl/src/validate/identification.rs
@@ -87,25 +87,7 @@ pub(super) fn check_identification(
     // So both are suppressed in the 1.4 dialect: applying the AOM2 rule would
     // reject every valid 1.4 archetype.
     if !is_overlay && dialect == Dialect::Adl2 {
-        match v.adl_version {
-            Some(a) if is_three_part_version(a) => {}
-            _ => out.push(ValidationIssue::new(
-                ValidationCode::Varav,
-                format!(
-                    "adl_version {:?} is not a valid 3-part version",
-                    v.adl_version
-                ),
-            )),
-        }
-        if !is_three_part_version(v.rm_release) {
-            out.push(ValidationIssue::new(
-                ValidationCode::Varrv,
-                format!(
-                    "rm_release {:?} is not a valid 3-part version",
-                    v.rm_release
-                ),
-            ));
-        }
+        check_version_formats(v, out);
     }
     if !is_overlay {
         // VDEOL / VARD: original language + description present (master03
@@ -131,6 +113,37 @@ pub(super) fn check_identification(
     // VALC: language conformance to the flat parent (master03 §Validity Rules,
     // G3) — needs the parent; runs only when resolvable.
     check_language_conformance(v, repo, out);
+}
+
+/// VARAV / VARRV: the `adl_version` / `rm_release` 3-part version formats
+/// (master03 §Validity Rules).
+///
+/// AOM2-only: an ADL 1.4 artefact carries a `1.4`-form `adl_version`
+/// (two-part, optional metadata) and NO `rm_release`, and AOM 1.4 defines no
+/// 3-part-version rule for either (ADL1.4 master08 §Syntax Specification,
+/// `arch_identification` meta-data; AOM1.4 master03 ARCHETYPE §Invariants —
+/// version validity is only `version = archetype_id.version_id`). So the
+/// caller suppresses both in the 1.4 dialect: applying the AOM2 rule would
+/// reject every valid 1.4 archetype.
+fn check_version_formats(v: &ArchetypeView<'_>, out: &mut Vec<ValidationIssue>) {
+    if !v.adl_version.is_some_and(is_three_part_version) {
+        out.push(ValidationIssue::new(
+            ValidationCode::Varav,
+            format!(
+                "adl_version {:?} is not a valid 3-part version",
+                v.adl_version
+            ),
+        ));
+    }
+    if !is_three_part_version(v.rm_release) {
+        out.push(ValidationIssue::new(
+            ValidationCode::Varrv,
+            format!(
+                "rm_release {:?} is not a valid 3-part version",
+                v.rm_release
+            ),
+        ));
+    }
 }
 
 /// VARCN (ADL 1.4, terminology half): the `concept` section's term must exist

--- a/crates/openehr-adl/src/validate/rm.rs
+++ b/crates/openehr-adl/src/validate/rm.rs
@@ -522,30 +522,47 @@ impl RmScan<'_> {
 
     /// The attribute-level RM checks (VCAEX / VCAM / VCACA / VACSO).
     fn check_attribute(&mut self, attr_path: &str, attr: &CAttribute, rm_attr: &RmAttr) {
-        // VCAEX: existence, if set, must conform to (be same-or-narrower than)
-        // the RM existence (master04.5 §Validity Rules: `C_ATTRIBUTE`).
-        if let Some(ex) = attr.existence.as_ref() {
-            let arch = bounds(ex);
-            if !rm_attr.existence.contains(arch) {
-                push_issue(
-                    &mut self.issues,
-                    ValidationCode::Vcaex,
-                    format!(
-                        "existence {} does not conform to the reference-model existence {}",
-                        display_bounds(arch),
-                        display_bounds(rm_attr.existence)
-                    ),
-                    attr_path,
-                );
-            }
+        self.check_existence_conformance(attr_path, attr, rm_attr);
+        self.check_arity(attr_path, attr, rm_attr);
+        self.check_cardinality_conformance(attr_path, attr, rm_attr);
+        if !rm_attr.is_multiple {
+            self.check_single_valued_child_occurrences(attr_path, attr);
         }
+    }
 
-        let has_cardinality = attr.cardinality.is_some();
+    /// VCAEX: existence, if set, must conform to (be same-or-narrower than) the
+    /// RM existence (master04.5 §Validity Rules: `C_ATTRIBUTE`).
+    fn check_existence_conformance(
+        &mut self,
+        attr_path: &str,
+        attr: &CAttribute,
+        rm_attr: &RmAttr,
+    ) {
+        let Some(ex) = attr.existence.as_ref() else {
+            return;
+        };
+        let arch = bounds(ex);
+        if !rm_attr.existence.contains(arch) {
+            push_issue(
+                &mut self.issues,
+                ValidationCode::Vcaex,
+                format!(
+                    "existence {} does not conform to the reference-model existence {}",
+                    display_bounds(arch),
+                    display_bounds(rm_attr.existence)
+                ),
+                attr_path,
+            );
+        }
+    }
 
-        // VCAM: single/multiple arity must match the RM. A cardinality declares
-        // the attribute a container; if the RM attribute is single-valued that
-        // is a mismatch (master04.5 §Validity Rules: `C_ATTRIBUTE`, VCAM).
-        if has_cardinality && !rm_attr.is_multiple {
+    /// VCAM: single/multiple arity must match the RM.
+    ///
+    /// A cardinality declares the attribute a container; if the RM attribute is
+    /// single-valued that is a mismatch (master04.5 §Validity Rules:
+    /// `C_ATTRIBUTE`, VCAM).
+    fn check_arity(&mut self, attr_path: &str, attr: &CAttribute, rm_attr: &RmAttr) {
+        if attr.cardinality.is_some() && !rm_attr.is_multiple {
             push_issue(
                 &mut self.issues,
                 ValidationCode::Vcam,
@@ -553,11 +570,19 @@ impl RmScan<'_> {
                 attr_path,
             );
         }
+    }
 
-        // VCACA: cardinality must conform to the RM container cardinality
-        // (master04.5 §Validity Rules: `C_ATTRIBUTE`). Only meaningful when the RM
-        // attribute is a container; a cardinality on a single-valued RM
-        // attribute is already VCAM above.
+    /// VCACA: cardinality must conform to the RM container cardinality
+    /// (master04.5 §Validity Rules: `C_ATTRIBUTE`).
+    ///
+    /// Only meaningful when the RM attribute is a container; a cardinality on a
+    /// single-valued RM attribute is already VCAM.
+    fn check_cardinality_conformance(
+        &mut self,
+        attr_path: &str,
+        attr: &CAttribute,
+        rm_attr: &RmAttr,
+    ) {
         if let (Some(card), true) = (attr.cardinality.as_ref(), rm_attr.is_multiple)
             && let Some(rm_card) = rm_attr.cardinality
         {
@@ -575,27 +600,27 @@ impl RmScan<'_> {
                 );
             }
         }
+    }
 
-        // VACSO: the occurrences of a child object of a single-valued attribute
-        // cannot have an upper limit greater than 1 (master04.5 §Validity Rules:
-        // `C_ATTRIBUTE` — the rules "for single-valued attributes, i.e. when
-        // `C_ATTRIBUTE`._is_multiple_ is False"). The single/multiple
-        // determination is the RM's, not the parser's cardinality heuristic.
-        if !rm_attr.is_multiple {
-            for child in attr.children.iter().flatten() {
-                if let Some(occ) = child_occurrences(child)
-                    && let Some(upper) = finite_upper(occ)
-                    && upper > 1
-                {
-                    push_issue(
-                        &mut self.issues,
-                        ValidationCode::Vacso,
-                        format!(
-                            "child of single-valued attribute has occurrences upper {upper} > 1"
-                        ),
-                        attr_path,
-                    );
-                }
+    /// VACSO: the occurrences of a child object of a single-valued attribute
+    /// cannot have an upper limit greater than 1 (master04.5 §Validity Rules:
+    /// `C_ATTRIBUTE` — the rules "for single-valued attributes, i.e. when
+    /// `C_ATTRIBUTE`.`is_multiple` is False").
+    ///
+    /// The single/multiple determination is the RM's, not the parser's
+    /// cardinality heuristic, so the caller gates on `rm_attr.is_multiple`.
+    fn check_single_valued_child_occurrences(&mut self, attr_path: &str, attr: &CAttribute) {
+        for child in attr.children.iter().flatten() {
+            if let Some(occ) = child_occurrences(child)
+                && let Some(upper) = finite_upper(occ)
+                && upper > 1
+            {
+                push_issue(
+                    &mut self.issues,
+                    ValidationCode::Vacso,
+                    format!("child of single-valued attribute has occurrences upper {upper} > 1"),
+                    attr_path,
+                );
             }
         }
     }

--- a/crates/openehr-adl/src/validate/rm.rs
+++ b/crates/openehr-adl/src/validate/rm.rs
@@ -608,34 +608,7 @@ impl RmScan<'_> {
             let child_path = child_path(attr_path, object_node_id(child));
 
             if !child_type.is_empty() {
-                if !self.rm.type_exists(child_type) {
-                    // VCORM: the object type must exist in the RM.
-                    push_issue(
-                        &mut self.issues,
-                        ValidationCode::Vcorm,
-                        format!(
-                            "object type {child_type:?} is not defined in the reference model ({})",
-                            self.rm.name()
-                        ),
-                        &child_path,
-                    );
-                } else if type_conforms(self.rm, child_type, &rm_attr.declared_type) == Some(false)
-                {
-                    // VCORMT: the object type must be the same as, or conform to,
-                    // the type declared for the owning attribute in the RM,
-                    // covariantly on any generic arguments (master04.5 §Validity
-                    // Rules: `C_OBJECT`, VCORMT; master04.2 §Rm_type_name and
-                    // Reference Model Type Matching).
-                    push_issue(
-                        &mut self.issues,
-                        ValidationCode::Vcormt,
-                        format!(
-                            "object type {child_type:?} does not conform to the attribute's reference-model type {:?}",
-                            rm_attr.declared_type
-                        ),
-                        &child_path,
-                    );
-                }
+                self.check_child_type(&child_path, child_type, &rm_attr.declared_type);
             }
 
             // VCORMEN / VCORMENV / VCORMENU: a primitive constraint on an
@@ -646,25 +619,8 @@ impl RmScan<'_> {
                 self.check_enumeration(&child_path, child, &en);
             }
 
-            // Interior-node VATID: a node under a multiply-valued attribute must
-            // have its id-code defined in the terminology; for a single-valued
-            // attribute a term definition is optional (master07
-            // §Overview). The flattened terminology of a specialised archetype
-            // is not available here, so this runs on the archetype's own
-            // terminology only.
             if rm_attr.is_multiple && !self.is_specialised {
-                let nid = object_node_id(child);
-                if (AdlCodeDefinitionsData::is_id_code(nid)
-                    || AdlCodeDefinitionsData::is_at_code(nid))
-                    && !self.defined.contains(nid)
-                {
-                    push_issue(
-                        &mut self.issues,
-                        ValidationCode::Vatid,
-                        format!("node id {nid:?} is not defined in the terminology"),
-                        &child_path,
-                    );
-                }
+                self.check_interior_node_id(&child_path, child);
             }
 
             if let CObject::CComplexObjectProxy(proxy) = child {
@@ -674,6 +630,57 @@ impl RmScan<'_> {
             if let CObject::CComplexObject(cco) = child {
                 self.walk_complex(&child_path, child_type, cco);
             }
+        }
+    }
+
+    /// VCORM / VCORMT: a child object's declared type must exist in the
+    /// reference model and be the same as, or conform to, the type declared
+    /// for the owning attribute — covariantly on any generic arguments
+    /// (master04.5 §Validity Rules: `C_OBJECT`, VCORMT; master04.2
+    /// §`Rm_type_name` and Reference Model Type Matching).
+    fn check_child_type(&mut self, child_path: &str, child_type: &str, declared_type: &str) {
+        if !self.rm.type_exists(child_type) {
+            push_issue(
+                &mut self.issues,
+                ValidationCode::Vcorm,
+                format!(
+                    "object type {child_type:?} is not defined in the reference model ({})",
+                    self.rm.name()
+                ),
+                child_path,
+            );
+            return;
+        }
+        if type_conforms(self.rm, child_type, declared_type) == Some(false) {
+            push_issue(
+                &mut self.issues,
+                ValidationCode::Vcormt,
+                format!(
+                    "object type {child_type:?} does not conform to the attribute's reference-model type {declared_type:?}"
+                ),
+                child_path,
+            );
+        }
+    }
+
+    /// Interior-node VATID: a node under a multiply-valued attribute must have
+    /// its id-code defined in the terminology.
+    ///
+    /// For a single-valued attribute a term definition is optional (master07
+    /// §Overview). The flattened terminology of a specialised archetype is not
+    /// available here, so the caller runs this on the archetype's own
+    /// terminology only.
+    fn check_interior_node_id(&mut self, child_path: &str, child: &CObject) {
+        let nid = object_node_id(child);
+        if (AdlCodeDefinitionsData::is_id_code(nid) || AdlCodeDefinitionsData::is_at_code(nid))
+            && !self.defined.contains(nid)
+        {
+            push_issue(
+                &mut self.issues,
+                ValidationCode::Vatid,
+                format!("node id {nid:?} is not defined in the terminology"),
+                child_path,
+            );
         }
     }
 
@@ -769,50 +776,52 @@ impl RmScan<'_> {
     /// Enumeration Types (no fuller openEHR spec text governs the partition).
     fn check_enumeration(&mut self, path: &str, child: &CObject, en: &RmEnum) {
         match child {
-            CObject::CInteger(c) => match en.underlying {
-                EnumUnderlying::Integer => {
-                    for v in integer_point_values(c.constraint.as_deref().unwrap_or_default()) {
-                        if !en.int_values.contains(&i64::from(v)) {
-                            push_issue(
-                                &mut self.issues,
-                                ValidationCode::Vcormenv,
-                                format!(
-                                    "integer value {v} is not a declared literal of the enumeration"
-                                ),
-                                path,
-                            );
-                        }
+            CObject::CInteger(c) => {
+                if en.underlying == EnumUnderlying::String {
+                    push_issue(
+                        &mut self.issues,
+                        ValidationCode::Vcormen,
+                        "an integer constraint is stated on a string-based enumeration slot",
+                        path,
+                    );
+                    return;
+                }
+                for v in integer_point_values(c.constraint.as_deref().unwrap_or_default()) {
+                    if !en.int_values.contains(&i64::from(v)) {
+                        push_issue(
+                            &mut self.issues,
+                            ValidationCode::Vcormenv,
+                            format!(
+                                "integer value {v} is not a declared literal of the enumeration"
+                            ),
+                            path,
+                        );
                     }
                 }
-                EnumUnderlying::String => push_issue(
-                    &mut self.issues,
-                    ValidationCode::Vcormen,
-                    "an integer constraint is stated on a string-based enumeration slot",
-                    path,
-                ),
-            },
-            CObject::CString(c) => match en.underlying {
-                EnumUnderlying::String => {
-                    for v in string_literal_values(c.constraint.as_deref().unwrap_or_default()) {
-                        if !en.str_values.iter().any(|lit| lit == v) {
-                            push_issue(
-                                &mut self.issues,
-                                ValidationCode::Vcormenu,
-                                format!(
-                                    "string value {v:?} is not a declared literal of the enumeration"
-                                ),
-                                path,
-                            );
-                        }
+            }
+            CObject::CString(c) => {
+                if en.underlying == EnumUnderlying::Integer {
+                    push_issue(
+                        &mut self.issues,
+                        ValidationCode::Vcormen,
+                        "a string constraint is stated on an integer-based enumeration slot",
+                        path,
+                    );
+                    return;
+                }
+                for v in string_literal_values(c.constraint.as_deref().unwrap_or_default()) {
+                    if !en.str_values.iter().any(|lit| lit == v) {
+                        push_issue(
+                            &mut self.issues,
+                            ValidationCode::Vcormenu,
+                            format!(
+                                "string value {v:?} is not a declared literal of the enumeration"
+                            ),
+                            path,
+                        );
                     }
                 }
-                EnumUnderlying::Integer => push_issue(
-                    &mut self.issues,
-                    ValidationCode::Vcormen,
-                    "a string constraint is stated on an integer-based enumeration slot",
-                    path,
-                ),
-            },
+            }
             // Any other primitive kind cannot constrain an enumeration
             // (VCORMEN); complex objects / proxies / slots / terminology codes
             // are not primitive enumeration constraints and are left to the

--- a/crates/openehr-adl/src/validate/slots.rs
+++ b/crates/openehr-adl/src/validate/slots.rs
@@ -74,42 +74,15 @@ impl<'a> ParentScan<'a> {
             // A narrowed / closed `ARCHETYPE_SLOT` (`master04.5` §`ARCHETYPE_SLOT`
             // VDSSID L462 / VDSSP L468 / VDSSC L471).
             CObject::ArchetypeSlot(child_slot) => {
-                // VDSSID: a redefining slot must have an identical node id.
-                if child_slot.node_id != parent_slot.node_id {
-                    push_issue(
-                        &mut self.issues,
-                        ValidationCode::Vdssid,
-                        format!(
-                            "specialised slot node id {:?} is not identical to the parent slot id {:?}",
-                            child_slot.node_id, parent_slot.node_id
-                        ),
-                        path,
-                    );
-                }
-                // VDSSP: the parent slot must not already be closed.
-                if parent_slot.is_closed {
-                    push_issue(
-                        &mut self.issues,
-                        ValidationCode::Vdssp,
-                        "cannot specialise a slot that is already closed in the flat parent",
-                        path,
-                    );
-                }
-                // VDSSC: a specialised slot may be closed OR narrowed, not both.
-                //
-                // NOTE: the vendored `masterAppB` slot grammar admits `closed`
-                // XOR a `matches` body, so this guard can only fire for AOM
-                // input that was not parsed from ADL2 source.
-                let narrows = !child_slot.includes.as_ref().is_none_or(Vec::is_empty)
-                    || !child_slot.excludes.as_ref().is_none_or(Vec::is_empty);
-                if child_slot.is_closed && narrows {
-                    push_issue(
-                        &mut self.issues,
-                        ValidationCode::Vdssc,
-                        "a specialised slot cannot be both closed and narrowed",
-                        path,
-                    );
-                }
+                self.check_slot_identity(child_slot, parent_slot, path);
+                // VDSSM: a specialised slot must narrow the parent slot or be
+                // closed (`master04.5` §`ARCHETYPE_SLOT`), i.e. be a PROPER subset
+                // of its admitted-archetype set. Regex-language subset is
+                // undecidable, so three decidable checks stand in: no
+                // `includes`/`excludes` is no narrowing; one structurally identical
+                // to the parent's is a restatement; and a child `include` naming a
+                // literal archetype id the parent does not admit is a widening.
+                let narrows = slot_narrows(child_slot);
                 // VDSSM: a specialised slot must narrow the parent slot or be
                 // closed (`master04.5` §`ARCHETYPE_SLOT`), i.e. be a PROPER subset
                 // of its admitted-archetype set. Regex-language subset is
@@ -151,6 +124,48 @@ impl<'a> ParentScan<'a> {
                 }
             }
             _ => {}
+        }
+    }
+
+    /// The identity and closure rules of a specialised slot (`master04.5`
+    /// §`ARCHETYPE_SLOT`): VDSSID (identical node id), VDSSP (the parent slot
+    /// must not already be closed), VDSSC (closed OR narrowed, never both).
+    ///
+    /// NOTE: the vendored `masterAppB` slot grammar admits `closed` XOR a
+    /// `matches` body, so the VDSSC guard can only fire for AOM input that was
+    /// not parsed from ADL2 source.
+    fn check_slot_identity(
+        &mut self,
+        child_slot: &ArchetypeSlot,
+        parent_slot: &ArchetypeSlot,
+        path: &str,
+    ) {
+        if child_slot.node_id != parent_slot.node_id {
+            push_issue(
+                &mut self.issues,
+                ValidationCode::Vdssid,
+                format!(
+                    "specialised slot node id {:?} is not identical to the parent slot id {:?}",
+                    child_slot.node_id, parent_slot.node_id
+                ),
+                path,
+            );
+        }
+        if parent_slot.is_closed {
+            push_issue(
+                &mut self.issues,
+                ValidationCode::Vdssp,
+                "cannot specialise a slot that is already closed in the flat parent",
+                path,
+            );
+        }
+        if child_slot.is_closed && slot_narrows(child_slot) {
+            push_issue(
+                &mut self.issues,
+                ValidationCode::Vdssc,
+                "a specialised slot cannot be both closed and narrowed",
+                path,
+            );
         }
     }
 
@@ -221,6 +236,13 @@ impl<'a> ParentScan<'a> {
 /// An assertion the printer refuses has no comparison key, so the two lists are
 /// reported as different: VDSSM fires only on a proven restatement, and an
 /// unrenderable assertion proves nothing.
+/// Whether a slot states any narrowing at all — an `includes` or `excludes`
+/// assertion.
+fn slot_narrows(slot: &ArchetypeSlot) -> bool {
+    !slot.includes.as_ref().is_none_or(Vec::is_empty)
+        || !slot.excludes.as_ref().is_none_or(Vec::is_empty)
+}
+
 fn slot_assertions_equal(a: &[Assertion], b: &[Assertion]) -> bool {
     let rendered = |list: &[Assertion]| {
         list.iter()

--- a/crates/openehr-adl/src/validate/specialisation.rs
+++ b/crates/openehr-adl/src/validate/specialisation.rs
@@ -1237,14 +1237,13 @@ terminology
             && let AuthoredArchetype::AuthoredArchetype(data) = inner.as_mut()
             && let CComplexObject::CComplexObject(root) = &mut data.definition
         {
-            for a in root.attributes.iter_mut().flatten() {
-                if a.rm_attribute_name == "items" {
-                    for c in a.children.iter_mut().flatten() {
-                        if let CObject::CComplexObject(CComplexObject::CComplexObject(el)) = c {
-                            el.node_id.clear();
-                        }
-                    }
-                }
+            for a in root
+                .attributes
+                .iter_mut()
+                .flatten()
+                .filter(|a| a.rm_attribute_name == "items")
+            {
+                strip_child_node_ids(a);
             }
         }
         let issues = validate_against_flat_parent(
@@ -1255,6 +1254,15 @@ terminology
         );
         let raised: Vec<&str> = issues.iter().map(|i| i.code.mnemonic()).collect();
         assert!(raised.contains(&"VSONIF"), "raised {raised:?}");
+    }
+
+    /// Clears the node id of every complex-object child of `attr`.
+    fn strip_child_node_ids(attr: &mut CAttribute) {
+        for c in attr.children.iter_mut().flatten() {
+            if let CObject::CComplexObject(CComplexObject::CComplexObject(el)) = c {
+                el.node_id.clear();
+            }
+        }
     }
 
     #[test]

--- a/crates/openehr-adl/src/validate/specialisation.rs
+++ b/crates/openehr-adl/src/validate/specialisation.rs
@@ -240,42 +240,7 @@ impl<'a> ParentScan<'a> {
             return;
         };
 
-        // VSANCE: existence conformance to the flat parent (`master04.5`
-        // §`C_ATTRIBUTE`, VSANCE L142-143).
-        if !attr.existence_conforms_to(parent_attr) {
-            push_issue(
-                &mut self.issues,
-                ValidationCode::Vsance,
-                "redefined existence does not conform to the flat parent",
-                &attr_path,
-            );
-        }
-        // VSANCC: cardinality conformance to the flat parent (`master04.5`
-        // §`C_ATTRIBUTE`, VSANCC L171-172).
-        if !attr.cardinality_conforms_to(parent_attr) {
-            push_issue(
-                &mut self.issues,
-                ValidationCode::Vsancc,
-                "redefined cardinality does not conform to the flat parent",
-                &attr_path,
-            );
-        }
-
-        // VSAM: the multiplicity (single- vs multiply-valued) of a redefined
-        // attribute must conform to the parent (`master04.5` §`C_ATTRIBUTE`, VSAM
-        // L145-146). A restated cardinality makes the attribute a container; if
-        // the reference-model attribute is single-valued that is a mismatch.
-        if attr.cardinality.is_some()
-            && let Some(rm_attr) = self.rm.attribute(&owner_rm, &attr.rm_attribute_name)
-            && !rm_attr.is_multiple
-        {
-            push_issue(
-                &mut self.issues,
-                ValidationCode::Vsam,
-                "a redefined single-valued attribute cannot be given a cardinality (multiplicity mismatch)",
-                &attr_path,
-            );
-        }
+        self.check_attribute_multiplicity(attr, parent_attr, &owner_rm, &attr_path);
 
         // VSSM: sibling order node id must be in the same flat-parent container
         // (`master04.5` §`C_OBJECT`, VSSM L391).
@@ -323,6 +288,74 @@ impl<'a> ParentScan<'a> {
         }
     }
 
+    /// The existence, cardinality and multiplicity conformance of a redefined
+    /// attribute to its flat parent (`master04.5` §`C_ATTRIBUTE`: VSANCE
+    /// L142-143, VSANCC L171-172, VSAM L145-146).
+    ///
+    /// A restated cardinality makes the attribute a container, so a
+    /// single-valued reference-model attribute given one is a multiplicity
+    /// mismatch.
+    fn check_attribute_multiplicity(
+        &mut self,
+        attr: &CAttribute,
+        parent_attr: &CAttribute,
+        owner_rm: &str,
+        attr_path: &str,
+    ) {
+        if !attr.existence_conforms_to(parent_attr) {
+            push_issue(
+                &mut self.issues,
+                ValidationCode::Vsance,
+                "redefined existence does not conform to the flat parent",
+                attr_path,
+            );
+        }
+        if !attr.cardinality_conforms_to(parent_attr) {
+            push_issue(
+                &mut self.issues,
+                ValidationCode::Vsancc,
+                "redefined cardinality does not conform to the flat parent",
+                attr_path,
+            );
+        }
+        if attr.cardinality.is_some()
+            && let Some(rm_attr) = self.rm.attribute(owner_rm, &attr.rm_attribute_name)
+            && !rm_attr.is_multiple
+        {
+            push_issue(
+                &mut self.issues,
+                ValidationCode::Vsam,
+                "a redefined single-valued attribute cannot be given a cardinality (multiplicity mismatch)",
+                attr_path,
+            );
+        }
+    }
+
+    /// The prohibition (`occurrences {0}`) rules — `master04.5` §`C_OBJECT`
+    /// VSONPT L382 / VSONPI L385.
+    ///
+    /// VSONPT: a prohibition is only valid where the matching parent node is
+    /// the same AOM type. VSONPI: a prohibited redefinition must carry exactly
+    /// the parent node id.
+    fn check_prohibited_redefinition(&mut self, child: &CObject, parent: &CObject, path: &str) {
+        if aom_type(child) != aom_type(parent) {
+            push_issue(
+                &mut self.issues,
+                ValidationCode::Vsonpt,
+                "prohibited (occurrences {0}) redefinition must match the parent AOM type",
+                path,
+            );
+        }
+        if object_node_id(child) != object_node_id(parent) {
+            push_issue(
+                &mut self.issues,
+                ValidationCode::Vsonpi,
+                "prohibited redefinition must have the same node id as the parent node",
+                path,
+            );
+        }
+    }
+
     /// Object-level conformance of a redefined child node to its congruent flat
     /// parent node.
     fn check_object_pair(
@@ -333,29 +366,8 @@ impl<'a> ParentScan<'a> {
         owner_rm: &str,
         path: &str,
     ) {
-        // Prohibition (`occurrences {0}`) rules — `master04.5` §`C_OBJECT` VSONPT
-        // L382 / VSONPI L385.
         if is_prohibited(child_occurrences(child)) {
-            // VSONPT: prohibition only if the matching parent node is the same
-            // AOM type.
-            if aom_type(child) != aom_type(parent) {
-                push_issue(
-                    &mut self.issues,
-                    ValidationCode::Vsonpt,
-                    "prohibited (occurrences {0}) redefinition must match the parent AOM type",
-                    path,
-                );
-            }
-            // VSONPI: a prohibited redefinition must carry exactly the parent
-            // node id.
-            if object_node_id(child) != object_node_id(parent) {
-                push_issue(
-                    &mut self.issues,
-                    ValidationCode::Vsonpi,
-                    "prohibited redefinition must have the same node id as the parent node",
-                    path,
-                );
-            }
+            self.check_prohibited_redefinition(child, parent, path);
         }
 
         // Slot handling: a redefinition of an `ARCHETYPE_SLOT` in the parent.
@@ -423,36 +435,41 @@ impl<'a> ParentScan<'a> {
         // Reference-model type conformance of the redefined object.
         self.check_rm_type_conformance(child, parent, owning_attr, owner_rm, path);
 
-        // Leaf value redefinition (VPOV / VUNK) for primitive nodes.
         if aom_type(child).is_primitive() && aom_type(parent).is_primitive() {
-            // A terminology-code leaf pair is compared with value-set expansion
-            // against the flattened terminologies (`master04.5`
-            // §`C_TERMINOLOGY_NODE` L663-699), which `c_value_conforms_to` cannot
-            // see; other primitive leaves use the terminology-agnostic conformance.
-            if let (CObject::CTerminologyCode(c), CObject::CTerminologyCode(p)) = (child, parent) {
-                self.check_terminology_leaf(c, p, path);
-            } else {
-                match conformance::c_value_conforms_to(child, parent) {
-                    ValueConformance::Conforms => {}
-                    ValueConformance::Violates => push_issue(
-                        &mut self.issues,
-                        ValidationCode::Vpov,
-                        "redefined leaf value constraint is not within the parent value constraint",
-                        path,
-                    ),
-                    ValueConformance::Unknown => push_issue(
-                        &mut self.issues,
-                        ValidationCode::Vunk,
-                        "redefined leaf value constraint cannot be verified against the parent",
-                        path,
-                    ),
-                }
-            }
+            self.check_leaf_value_redefinition(child, parent, path);
         }
 
         // Recurse into complex children (VSONT already passed).
         if let (CObject::CComplexObject(cco), CObject::CComplexObject(pco)) = (child, parent) {
             self.walk_attributes(cco, pco, complex_rm_type(pco), path);
+        }
+    }
+
+    /// Leaf value redefinition (VPOV / VUNK) for a primitive node pair.
+    ///
+    /// A terminology-code leaf pair is compared with value-set expansion
+    /// against the flattened terminologies (`master04.5` §`C_TERMINOLOGY_NODE`
+    /// L663-699), which `c_value_conforms_to` cannot see; every other
+    /// primitive leaf uses the terminology-agnostic conformance.
+    fn check_leaf_value_redefinition(&mut self, child: &CObject, parent: &CObject, path: &str) {
+        if let (CObject::CTerminologyCode(c), CObject::CTerminologyCode(p)) = (child, parent) {
+            self.check_terminology_leaf(c, p, path);
+            return;
+        }
+        match conformance::c_value_conforms_to(child, parent) {
+            ValueConformance::Conforms => {}
+            ValueConformance::Violates => push_issue(
+                &mut self.issues,
+                ValidationCode::Vpov,
+                "redefined leaf value constraint is not within the parent value constraint",
+                path,
+            ),
+            ValueConformance::Unknown => push_issue(
+                &mut self.issues,
+                ValidationCode::Vunk,
+                "redefined leaf value constraint cannot be verified against the parent",
+                path,
+            ),
         }
     }
 

--- a/crates/openehr-adl/src/validate/structure.rs
+++ b/crates/openehr-adl/src/validate/structure.rs
@@ -216,7 +216,7 @@ impl StructureScan<'_> {
 
     /// VCOSU (AOM 1.4 sibling scope): in the 1.4 dialect node ids are only
     /// *sibling*-unique — children under the same container attribute must have
-    /// distinct node ids (AOM1.4 master04 §Node_id and Paths — "guarantees
+    /// distinct node ids (AOM1.4 master04 §`Node_id` and Paths — "guarantees
     /// sibling node unique identification").
     ///
     /// ADL2 uses the stronger archetype-wide uniqueness (`walk_object` / the

--- a/crates/openehr-adl/src/validate/structure.rs
+++ b/crates/openehr-adl/src/validate/structure.rs
@@ -480,107 +480,86 @@ impl StructureScan<'_> {
     }
 
     fn check_primitive_assumed(&mut self, path: &str, obj: &CObject) {
-        match obj {
-            CObject::CBoolean(b) => {
-                if let Some(av) = b.assumed_value
-                    && !b.constraint.as_ref().is_none_or(Vec::is_empty)
-                    && !b.constraint.as_ref().is_some_and(|c| c.contains(&av))
-                {
-                    self.vobav("boolean assumed value is not in the constraint", path);
-                }
-            }
-            CObject::CInteger(i) => {
-                // The generated model types the integer assumed value as `f64`;
-                // a valid integer assumed value is a whole number lying in some
-                // constraint interval.
-                if let Some(av) = i.assumed_value
-                    && !i.constraint.as_ref().is_none_or(Vec::is_empty)
-                {
-                    #[expect(
-                        clippy::as_conversions,
-                        clippy::cast_possible_truncation,
-                        reason = "guarded by fract()"
-                    )]
-                    let inside = av.fract() == 0.0
-                        && i.constraint.iter().flatten().any(|iv| iv.has(&(av as i32)));
-                    if !inside {
-                        self.vobav(
-                            "integer assumed value is not within any constraint interval",
-                            path,
-                        );
-                    }
-                }
-            }
-            CObject::CReal(r) => {
-                if let Some(av) = r.assumed_value
-                    && !r.constraint.as_ref().is_none_or(Vec::is_empty)
-                    && !r.constraint.iter().flatten().any(|iv| iv.has(&av))
-                {
-                    self.vobav(
-                        "real assumed value is not within any constraint interval",
-                        path,
-                    );
-                }
-            }
-            // The temporal primitives carry their assumed value + constraint as
-            // `Interval<Iso8601_*>`; `openehr-base` now provides ISO 8601 ordering
-            // (`PartialOrd`), so the same point-in-interval VOBAV test applies.
-            // Temporal values are only partially ordered (partial dates,
-            // timezone normalisation), so use `has_definite`: a violation is
-            // raised only when the assumed value is definitely outside EVERY
-            // interval; an incomparable (undecidable) pairing leaves containment
-            // unknown and never raises.
-            CObject::CDate(d) => {
-                if let Some(av) = &d.assumed_value
-                    && temporal_assumed_violates(d.constraint.as_deref().unwrap_or_default(), av)
-                {
-                    self.vobav(
-                        "date assumed value is not within any constraint interval",
-                        path,
-                    );
-                }
-            }
-            CObject::CTime(t) => {
-                if let Some(av) = &t.assumed_value
-                    && temporal_assumed_violates(t.constraint.as_deref().unwrap_or_default(), av)
-                {
-                    self.vobav(
-                        "time assumed value is not within any constraint interval",
-                        path,
-                    );
-                }
-            }
-            CObject::CDateTime(dt) => {
-                if let Some(av) = &dt.assumed_value
-                    && temporal_assumed_violates(dt.constraint.as_deref().unwrap_or_default(), av)
-                {
-                    self.vobav(
-                        "date/time assumed value is not within any constraint interval",
-                        path,
-                    );
-                }
-            }
-            CObject::CDuration(du) => {
-                if let Some(av) = &du.assumed_value
-                    && temporal_assumed_violates(du.constraint.as_deref().unwrap_or_default(), av)
-                {
-                    self.vobav(
-                        "duration assumed value is not within any constraint interval",
-                        path,
-                    );
-                }
-            }
-            CObject::CString(s) => {
-                if let Some(av) = &s.assumed_value
-                    && !s.constraint.as_ref().is_none_or(Vec::is_empty)
-                    && !s.constraint.iter().flatten().any(|c| c == av)
-                {
-                    self.vobav("string assumed value is not in the constraint list", path);
-                }
-            }
-            _ => {}
+        let violation = match obj {
+            CObject::CBoolean(b) => b
+                .assumed_value
+                .is_some_and(|av| {
+                    !b.constraint.as_ref().is_none_or(Vec::is_empty)
+                        && !b.constraint.as_ref().is_some_and(|c| c.contains(&av))
+                })
+                .then_some("boolean assumed value is not in the constraint"),
+            CObject::CInteger(i) => integer_assumed_violates(i)
+                .then_some("integer assumed value is not within any constraint interval"),
+            CObject::CReal(r) => r
+                .assumed_value
+                .is_some_and(|av| {
+                    !r.constraint.as_ref().is_none_or(Vec::is_empty)
+                        && !r.constraint.iter().flatten().any(|iv| iv.has(&av))
+                })
+                .then_some("real assumed value is not within any constraint interval"),
+            CObject::CDate(d) => d
+                .assumed_value
+                .as_ref()
+                .is_some_and(|av| {
+                    temporal_assumed_violates(d.constraint.as_deref().unwrap_or_default(), av)
+                })
+                .then_some("date assumed value is not within any constraint interval"),
+            CObject::CTime(t) => t
+                .assumed_value
+                .as_ref()
+                .is_some_and(|av| {
+                    temporal_assumed_violates(t.constraint.as_deref().unwrap_or_default(), av)
+                })
+                .then_some("time assumed value is not within any constraint interval"),
+            CObject::CDateTime(dt) => dt
+                .assumed_value
+                .as_ref()
+                .is_some_and(|av| {
+                    temporal_assumed_violates(dt.constraint.as_deref().unwrap_or_default(), av)
+                })
+                .then_some("date/time assumed value is not within any constraint interval"),
+            CObject::CDuration(du) => du
+                .assumed_value
+                .as_ref()
+                .is_some_and(|av| {
+                    temporal_assumed_violates(du.constraint.as_deref().unwrap_or_default(), av)
+                })
+                .then_some("duration assumed value is not within any constraint interval"),
+            CObject::CString(s) => s
+                .assumed_value
+                .as_ref()
+                .is_some_and(|av| {
+                    !s.constraint.as_ref().is_none_or(Vec::is_empty)
+                        && !s.constraint.iter().flatten().any(|c| c == av)
+                })
+                .then_some("string assumed value is not in the constraint list"),
+            _ => None,
+        };
+        if let Some(msg) = violation {
+            self.vobav(msg, path);
         }
     }
+}
+
+/// VOBAV for `C_INTEGER`: the generated model types the integer assumed value
+/// as `f64`, so a valid assumed value is a whole number lying in some
+/// constraint interval.
+fn integer_assumed_violates(
+    i: &openehr_am::v2_4::aom2::constraint_model::primitive::c_integer::CInteger,
+) -> bool {
+    let Some(av) = i.assumed_value else {
+        return false;
+    };
+    if i.constraint.as_ref().is_none_or(Vec::is_empty) {
+        return false;
+    }
+    #[expect(
+        clippy::as_conversions,
+        clippy::cast_possible_truncation,
+        reason = "guarded by fract()"
+    )]
+    let inside = av.fract() == 0.0 && i.constraint.iter().flatten().any(|iv| iv.has(&(av as i32)));
+    !inside
 }
 
 /// VOBAV for an ordered temporal primitive: a non-empty constraint list is

--- a/crates/openehr-adl/src/validate/structure.rs
+++ b/crates/openehr-adl/src/validate/structure.rs
@@ -147,33 +147,7 @@ impl StructureScan<'_> {
         // needs the supplier repository, so it runs in the specialisation
         // validator ([`super::slots`], `master08` §Phase 2), not here.
         if let CComplexObject::CArchetypeRoot(r) = cco {
-            if r.node_id.is_empty() {
-                push_issue(
-                    &mut self.issues,
-                    ValidationCode::Varxnc,
-                    "C_ARCHETYPE_ROOT has no node id",
-                    path,
-                );
-            }
-            if r.rm_type_name.is_empty() {
-                push_issue(
-                    &mut self.issues,
-                    ValidationCode::Varxtv,
-                    "C_ARCHETYPE_ROOT has no RM type",
-                    path,
-                );
-            }
-            if !r.archetype_ref.is_empty() && !is_archetype_id(&r.archetype_ref) {
-                push_issue(
-                    &mut self.issues,
-                    ValidationCode::Varxav,
-                    format!(
-                        "C_ARCHETYPE_ROOT reference {:?} is not a valid archetype id",
-                        r.archetype_ref
-                    ),
-                    path,
-                );
-            }
+            self.check_archetype_root(path, r);
         }
 
         // VCATU: sibling attributes uniquely named (master04.5 §`C_COMPLEX_OBJECT`).
@@ -193,32 +167,77 @@ impl StructureScan<'_> {
         }
 
         for attr in complex_attributes(cco) {
-            // VCOSU (AOM 1.4 sibling scope): in the 1.4 dialect node ids are only
-            // *sibling*-unique — children under the same container attribute must
-            // have distinct node ids (AOM1.4 master04 §Node_id and Paths —
-            // "guarantees sibling node unique identification"). ADL2 uses the
-            // stronger archetype-wide uniqueness (walk_object above / the flat-form walk),
-            // so this sibling-scoped pass is 1.4-only.
             if self.dialect == Dialect::Adl14 {
-                let mut sibling_ids: BTreeSet<&str> = BTreeSet::new();
-                for child in attr.children.iter().flatten() {
-                    let cid = object_node_id(child);
-                    if !cid.is_empty()
-                        && (AdlCodeDefinitionsData::is_id_code(cid)
-                            || AdlCodeDefinitionsData::is_at_code(cid))
-                        && !sibling_ids.insert(cid)
-                    {
-                        let cpath = child_path(&format!("{path}/{}", attr.rm_attribute_name), cid);
-                        push_issue(
-                            &mut self.issues,
-                            ValidationCode::Vcosu,
-                            format!("node id {cid:?} is not unique among siblings"),
-                            &cpath,
-                        );
-                    }
-                }
+                self.check_sibling_node_ids(path, attr);
             }
             self.walk_attribute(path, attr);
+        }
+    }
+
+    /// VARXNC / VARXAV / VARXTV: `C_ARCHETYPE_ROOT` validity (master08 §Phase 1
+    /// §Various Structure Validation).
+    ///
+    /// NOTE: VARXR (external-reference *resolution*) is a phase-2 check that
+    /// needs the supplier repository, so it runs in the specialisation
+    /// validator ([`super::slots`], `master08` §Phase 2), not here.
+    fn check_archetype_root(
+        &mut self,
+        path: &str,
+        r: &openehr_am::v2_4::aom2::constraint_model::c_archetype_root::CArchetypeRoot,
+    ) {
+        if r.node_id.is_empty() {
+            push_issue(
+                &mut self.issues,
+                ValidationCode::Varxnc,
+                "C_ARCHETYPE_ROOT has no node id",
+                path,
+            );
+        }
+        if r.rm_type_name.is_empty() {
+            push_issue(
+                &mut self.issues,
+                ValidationCode::Varxtv,
+                "C_ARCHETYPE_ROOT has no RM type",
+                path,
+            );
+        }
+        if !r.archetype_ref.is_empty() && !is_archetype_id(&r.archetype_ref) {
+            push_issue(
+                &mut self.issues,
+                ValidationCode::Varxav,
+                format!(
+                    "C_ARCHETYPE_ROOT reference {:?} is not a valid archetype id",
+                    r.archetype_ref
+                ),
+                path,
+            );
+        }
+    }
+
+    /// VCOSU (AOM 1.4 sibling scope): in the 1.4 dialect node ids are only
+    /// *sibling*-unique — children under the same container attribute must have
+    /// distinct node ids (AOM1.4 master04 §Node_id and Paths — "guarantees
+    /// sibling node unique identification").
+    ///
+    /// ADL2 uses the stronger archetype-wide uniqueness (`walk_object` / the
+    /// flat-form walk), so this sibling-scoped pass is 1.4-only.
+    fn check_sibling_node_ids(&mut self, path: &str, attr: &CAttribute) {
+        let mut sibling_ids: BTreeSet<&str> = BTreeSet::new();
+        for child in attr.children.iter().flatten() {
+            let cid = object_node_id(child);
+            if !cid.is_empty()
+                && (AdlCodeDefinitionsData::is_id_code(cid)
+                    || AdlCodeDefinitionsData::is_at_code(cid))
+                && !sibling_ids.insert(cid)
+            {
+                let cpath = child_path(&format!("{path}/{}", attr.rm_attribute_name), cid);
+                push_issue(
+                    &mut self.issues,
+                    ValidationCode::Vcosu,
+                    format!("node id {cid:?} is not unique among siblings"),
+                    &cpath,
+                );
+            }
         }
     }
 

--- a/crates/openehr-adl/src/validate/terminology.rs
+++ b/crates/openehr-adl/src/validate/terminology.rs
@@ -37,17 +37,12 @@ use crate::parse::Dialect;
 use crate::paths::child_path;
 use openehr_am::v2_4::aom2::definitions::adl_code_definitions::AdlCodeDefinitionsData;
 
-#[expect(
-    clippy::too_many_lines,
-    reason = "the individual rules are already extracted into helpers below; the remaining length is the number of terminology codes checked in sequence"
-)]
 pub(super) fn check_terminology(
     v: &ArchetypeView<'_>,
     dialect: Dialect,
     issues: &mut Vec<ValidationIssue>,
 ) {
     let term = v.terminology;
-    let level = v.specialisation_level();
 
     // Union of all defined codes across languages (a code defined in any
     // language counts as defined for the definedness checks).
@@ -62,12 +57,35 @@ pub(super) fn check_terminology(
     let root = CObject::CComplexObject(v.definition.clone());
     collect_usage(&root, &mut usage);
 
-    // VATID: the root concept code must be defined in the terminology (master08
-    // §Code Validation; NOTE-flagged, no full vendored text).
-    //
-    // NOTE: the per-node id-code definedness half is a reference-model check
-    // (master07 §Overview: a term definition is optional for children of a
-    // single-valued attribute), so it runs in [`super::rm`].
+    check_root_concept_code(v, &defined, issues);
+    check_node_id_definedness(v, dialect, &usage, &defined, issues);
+    check_referenced_codes(v, &usage, &defined, issues);
+    check_assumed_values(term, &usage, issues);
+    check_defined_code_levels(v, dialect, &defined, issues);
+    check_defined_code_forms(&defined, issues);
+    // VTLC: every code defined in one language must be defined in all languages
+    // (master07 §Validity Rules).
+    check_language_coverage(term, issues);
+    check_declared_languages(v, term, issues);
+    // VTVSID / VTVSMD / VTVSUQ: value-set integrity (master07 §Validity Rules).
+    check_value_sets(term, &defined, !v.is_specialised(), issues);
+    // VTTBK / VTCBK: term/constraint binding key validity (master07 §Validity
+    // Rules).
+    check_bindings(v, &defined, issues);
+    check_unused_codes(v, dialect, &usage, &defined, issues);
+}
+
+/// VATID: the root concept code must be defined in the terminology (master08
+/// §Code Validation; NOTE-flagged, no full vendored text).
+///
+/// NOTE: the per-node id-code definedness half is a reference-model check
+/// (master07 §Overview: a term definition is optional for children of a
+/// single-valued attribute), so it runs in [`super::rm`].
+fn check_root_concept_code(
+    v: &ArchetypeView<'_>,
+    defined: &BTreeSet<&str>,
+    issues: &mut Vec<ValidationIssue>,
+) {
     let root_id = complex_node_id(v.definition);
     if !root_id.is_empty()
         && (AdlCodeDefinitionsData::is_id_code(root_id)
@@ -79,33 +97,54 @@ pub(super) fn check_terminology(
             format!("root concept code {root_id:?} is not defined in the terminology"),
         ));
     }
+}
 
-    // VATDF (ADL 1.4, node-id half): in ADL 1.4 EVERY at-code used as a node
-    // identifier in the definition must be defined in the ontology's
-    // term_definitions (ADL1.4 master08 §Validity Rules VATDF; AOM1.4
-    // `ARCHETYPE.node_ids_valid`). ADL2 defers interior-node-id definedness to
-    // the RM phase, but the 1.4 formalism has no such optionality for a code
-    // that IS present — "each archetype term used as a node identifier … must
-    // be defined". A non-specialised 1.4 archetype is its own flat form, so the
-    // phase-1 subset closes VATDF's interior half for a 1.4 upload.
-    if dialect == Dialect::Adl14 && !v.is_specialised() {
-        for code in &usage.node_codes {
-            if AdlCodeDefinitionsData::is_at_code(code) && !defined.contains(code.as_str()) {
-                issues.push(ValidationIssue::new(
-                    ValidationCode::Vatdf,
-                    format!("node identifier code {code:?} is not defined in the terminology"),
-                ));
-            }
+/// VATDF (ADL 1.4, node-id half): in ADL 1.4 EVERY at-code used as a node
+/// identifier in the definition must be defined in the ontology's
+/// `term_definitions` (ADL1.4 master08 §Validity Rules VATDF; AOM1.4
+/// `ARCHETYPE.node_ids_valid`).
+///
+/// ADL2 defers interior-node-id definedness to the RM phase, but the 1.4
+/// formalism has no such optionality for a code that IS present — "each
+/// archetype term used as a node identifier … must be defined". A
+/// non-specialised 1.4 archetype is its own flat form, so the phase-1 subset
+/// closes VATDF's interior half for a 1.4 upload.
+fn check_node_id_definedness(
+    v: &ArchetypeView<'_>,
+    dialect: Dialect,
+    usage: &CodeUsage,
+    defined: &BTreeSet<&str>,
+    issues: &mut Vec<ValidationIssue>,
+) {
+    if dialect != Dialect::Adl14 || v.is_specialised() {
+        return;
+    }
+    for code in &usage.node_codes {
+        if AdlCodeDefinitionsData::is_at_code(code) && !defined.contains(code.as_str()) {
+            issues.push(ValidationIssue::new(
+                ValidationCode::Vatdf,
+                format!("node identifier code {code:?} is not defined in the terminology"),
+            ));
         }
     }
+}
 
-    // VATDF: at-codes used in term constraints defined in the terminology of the
-    // flattened form (master03 §Validity Rules). For a specialised archetype the
-    // flat form is not available here, so this runs only when the archetype
-    // is its own flat form (non-specialised); the specialised flat-form half runs
-    // in [`super::flat`].
-    // VACDF: ac-codes defined in the current archetype (master03 — "current",
-    // not flattened; runs for all). VATCD: code level <= archetype level.
+/// The definedness and level rules over the codes the definition references.
+///
+/// VATDF: at-codes used in term constraints defined in the terminology of the
+/// flattened form (master03 §Validity Rules). For a specialised archetype the
+/// flat form is not available here, so this runs only when the archetype is
+/// its own flat form (non-specialised); the specialised flat-form half runs in
+/// [`super::flat`]. VACDF: ac-codes defined in the current archetype (master03
+/// — "current", not flattened; runs for all). VATCD: at/id codes at a level
+/// greater than the archetype level.
+fn check_referenced_codes(
+    v: &ArchetypeView<'_>,
+    usage: &CodeUsage,
+    defined: &BTreeSet<&str>,
+    issues: &mut Vec<ValidationIssue>,
+) {
+    let level = v.specialisation_level();
     let flat_self = !v.is_specialised();
     for code in &usage.value_codes {
         if AdlCodeDefinitionsData::is_at_code(code) {
@@ -123,7 +162,6 @@ pub(super) fn check_terminology(
                 format!("constraint code {code:?} is not defined in the terminology"),
             ));
         }
-        // VATCD: at/id codes at a level greater than the archetype level.
         if !AdlCodeDefinitionsData::is_value_set_code(code)
             && let Some(d) = codes::specialisation_depth(code)
             && d > level
@@ -134,9 +172,15 @@ pub(super) fn check_terminology(
             ));
         }
     }
+}
 
-    // VATDA: an assumed value at-code must be a member of the referenced value
-    // set (master03 §Validity Rules).
+/// VATDA: an assumed value at-code must be a member of the referenced value
+/// set (master03 §Validity Rules).
+fn check_assumed_values(
+    term: &openehr_am::v2_4::aom2::terminology::archetype_terminology::ArchetypeTerminology,
+    usage: &CodeUsage,
+    issues: &mut Vec<ValidationIssue>,
+) {
     for (path, ac, assumed) in &usage.assumed_refs {
         let members = term
             .value_sets
@@ -153,42 +197,56 @@ pub(super) fn check_terminology(
             );
         }
     }
+}
 
-    // VTSD: every defined term/constraint code is at the archetype's
-    // specialisation level (differential) or the same-or-less (flat)
-    // (master07 §Validity Rules). ac-codes are a flat code space (master07
-    // §Specialisation Depth) so only an over-level ac-code is invalid, never the
-    // strict differential-equality test.
-    for code in &defined {
-        if let Some(d) = codes::specialisation_depth(code) {
-            // A 1.4 specialised archetype is a FLAT artefact (its ontology
-            // legitimately carries inherited codes at lower levels alongside
-            // the level-N additions), even though the 1.4-shaped model is
-            // marked `is_differential` for the converter's re-differentiation
-            // pass. So the 1.4 dialect always uses the flat-form rule
-            // (`d <= level`), never the differential `d == level`
-            // (AOM1.4 master07 §Specialisation Depth).
-            let differential = v.is_differential && dialect == Dialect::Adl2;
-            let bad = if AdlCodeDefinitionsData::is_value_set_code(code) {
-                d > level
-            } else if differential {
-                d != level
-            } else {
-                d > level
-            };
-            if bad {
-                issues.push(ValidationIssue::new(
-                    ValidationCode::Vtsd,
-                    format!("terminology code {code:?} specialisation level {d} is invalid for archetype level {level}"),
-                ));
-            }
+/// VTSD: every defined term/constraint code is at the archetype's
+/// specialisation level (differential) or the same-or-less (flat) (master07
+/// §Validity Rules).
+///
+/// ac-codes are a flat code space (master07 §Specialisation Depth), so only an
+/// over-level ac-code is invalid, never the strict differential-equality test.
+/// A 1.4 specialised archetype is a FLAT artefact (its ontology legitimately
+/// carries inherited codes at lower levels alongside the level-N additions),
+/// even though the 1.4-shaped model is marked `is_differential` for the
+/// converter's re-differentiation pass — so the 1.4 dialect always uses the
+/// flat-form rule (`d <= level`), never the differential `d == level` (AOM1.4
+/// master07 §Specialisation Depth).
+fn check_defined_code_levels(
+    v: &ArchetypeView<'_>,
+    dialect: Dialect,
+    defined: &BTreeSet<&str>,
+    issues: &mut Vec<ValidationIssue>,
+) {
+    let level = v.specialisation_level();
+    let differential = v.is_differential && dialect == Dialect::Adl2;
+    for code in defined {
+        let Some(d) = codes::specialisation_depth(code) else {
+            continue;
+        };
+        let bad = if AdlCodeDefinitionsData::is_value_set_code(code) {
+            d > level
+        } else if differential {
+            d != level
+        } else {
+            d > level
+        };
+        if bad {
+            issues.push(ValidationIssue::new(
+                ValidationCode::Vtsd,
+                format!(
+                    "terminology code {code:?} specialisation level {d} is invalid for archetype level {level}"
+                ),
+            ));
         }
     }
+}
 
-    // VATCV (defined-code form): every defined code must be a valid code form
-    // (master08 §Code Validation). Value-code form on definition-referenced
-    // codes is covered in the walk.
-    for code in &defined {
+/// VATCV (defined-code form): every defined code must be a valid code form
+/// (master08 §Code Validation).
+///
+/// Value-code form on definition-referenced codes is covered in the walk.
+fn check_defined_code_forms(defined: &BTreeSet<&str>, issues: &mut Vec<ValidationIssue>) {
+    for code in defined {
         if !AdlCodeDefinitionsData::is_valid_code(code) {
             issues.push(ValidationIssue::new(
                 ValidationCode::Vatcv,
@@ -196,13 +254,15 @@ pub(super) fn check_terminology(
             ));
         }
     }
+}
 
-    // VTLC: every code defined in one language must be defined in all languages
-    // (master07 §Validity Rules).
-    check_language_coverage(term, issues);
-
-    // VOTM: every language declared in description/translations must have
-    // term_definitions (master03 §Validity Rules).
+/// VOTM: every language declared in description/translations must have
+/// `term_definitions` (master03 §Validity Rules).
+fn check_declared_languages(
+    v: &ArchetypeView<'_>,
+    term: &openehr_am::v2_4::aom2::terminology::archetype_terminology::ArchetypeTerminology,
+    issues: &mut Vec<ValidationIssue>,
+) {
     for l in languages(v) {
         if !term.term_definitions.contains_key(&l) {
             issues.push(ValidationIssue::new(
@@ -211,46 +271,48 @@ pub(super) fn check_terminology(
             ));
         }
     }
+}
 
-    // VTVSID / VTVSMD / VTVSUQ: value-set integrity (master07 §Validity Rules).
-    check_value_sets(term, &defined, !v.is_specialised(), issues);
-
-    // VTTBK / VTCBK: term/constraint binding key validity (master07 §Validity
-    // Rules).
-    check_bindings(v, &defined, issues);
-
-    // WOUC is suppressed in the 1.4 dialect: 1.4 value codes are carried inside
-    // the verbatim terminology-constraint strings (not recognised as ADL2 code
-    // usage), so the "unused" heuristic is unreliable on a 1.4-shaped model and
-    // would flag legitimately-used codes.
-    //
-    // NOTE: no openEHR spec governs WOUC (a defined at/ac code never used in the
-    // definition) — our own design/extension.
-    if dialect == Dialect::Adl2 {
-        let mut used_all: BTreeSet<&str> = usage.value_codes.iter().map(String::as_str).collect();
-        used_all.extend(usage.node_codes.iter().map(String::as_str));
-        // value-set membership also counts as "use" of a member at-code.
-        if let Some(vs) = term.value_sets.as_ref() {
-            for set in vs.values() {
-                used_all.insert(set.id.as_str());
-                for m in &set.members {
-                    used_all.insert(m.as_str());
-                }
+/// WOUC: a defined at/ac code never used in the definition.
+///
+/// NOTE: no openEHR spec governs WOUC — our own design/extension. It is
+/// suppressed in the 1.4 dialect: 1.4 value codes are carried inside the
+/// verbatim terminology-constraint strings (not recognised as ADL2 code
+/// usage), so the "unused" heuristic is unreliable on a 1.4-shaped model and
+/// would flag legitimately-used codes.
+fn check_unused_codes(
+    v: &ArchetypeView<'_>,
+    dialect: Dialect,
+    usage: &CodeUsage,
+    defined: &BTreeSet<&str>,
+    issues: &mut Vec<ValidationIssue>,
+) {
+    if dialect != Dialect::Adl2 {
+        return;
+    }
+    let mut used_all: BTreeSet<&str> = usage.value_codes.iter().map(String::as_str).collect();
+    used_all.extend(usage.node_codes.iter().map(String::as_str));
+    // value-set membership also counts as "use" of a member at-code.
+    if let Some(vs) = v.terminology.value_sets.as_ref() {
+        for set in vs.values() {
+            used_all.insert(set.id.as_str());
+            for m in &set.members {
+                used_all.insert(m.as_str());
             }
         }
-        for code in &defined {
-            // The root concept code and id-code node ids are structural, not
-            // "unused" terms; WOUC targets value at-codes and ac-codes.
-            if (AdlCodeDefinitionsData::is_at_code(code)
-                || AdlCodeDefinitionsData::is_value_set_code(code))
-                && *code != complex_node_id(v.definition)
-                && !used_all.contains(code)
-            {
-                issues.push(ValidationIssue::new(
-                    ValidationCode::Wouc,
-                    format!("terminology code {code:?} is defined but unused in the definition"),
-                ));
-            }
+    }
+    for code in defined {
+        // The root concept code and id-code node ids are structural, not
+        // "unused" terms; WOUC targets value at-codes and ac-codes.
+        if (AdlCodeDefinitionsData::is_at_code(code)
+            || AdlCodeDefinitionsData::is_value_set_code(code))
+            && *code != complex_node_id(v.definition)
+            && !used_all.contains(code)
+        {
+            issues.push(ValidationIssue::new(
+                ValidationCode::Wouc,
+                format!("terminology code {code:?} is defined but unused in the definition"),
+            ));
         }
     }
 }

--- a/crates/openehr-adl/src/validate/terminology.rs
+++ b/crates/openehr-adl/src/validate/terminology.rs
@@ -352,42 +352,53 @@ fn check_value_sets(
         return;
     };
     for set in vs.values() {
-        // VTVSID: the value-set id must be defined in the terminology of the
-        // current archetype (master07 — "current", runs for all).
-        if !defined.contains(set.id.as_str()) {
+        check_value_set(set, defined, flat_self, issues);
+    }
+}
+
+/// One value set's integrity rules (master07 §Validity Rules).
+///
+/// VTVSID: the id must be defined in the terminology of the current archetype
+/// ("current", runs for all). VTVSUQ: members must be unique within the set.
+/// VTVSMD: members must be defined in the terminology of the *flattened* form,
+/// which runs only when the archetype is its own flat form — the specialised
+/// flat-form half runs in [`super::flat`].
+fn check_value_set(
+    set: &openehr_am::v2_4::aom2::terminology::value_set::ValueSet,
+    defined: &BTreeSet<&str>,
+    flat_self: bool,
+    issues: &mut Vec<ValidationIssue>,
+) {
+    if !defined.contains(set.id.as_str()) {
+        issues.push(ValidationIssue::new(
+            ValidationCode::Vtvsid,
+            format!(
+                "value set id {:?} is not defined in the terminology",
+                set.id
+            ),
+        ));
+    }
+    let mut seen = BTreeSet::new();
+    for m in &set.members {
+        if !seen.insert(m.as_str()) {
             issues.push(ValidationIssue::new(
-                ValidationCode::Vtvsid,
+                ValidationCode::Vtvsuq,
+                format!("value set {:?} has a duplicate member {m:?}", set.id),
+            ));
+        }
+    }
+    if !flat_self {
+        return;
+    }
+    for m in &set.members {
+        if !defined.contains(m.as_str()) {
+            issues.push(ValidationIssue::new(
+                ValidationCode::Vtvsmd,
                 format!(
-                    "value set id {:?} is not defined in the terminology",
+                    "value set {:?} member {m:?} is not defined in the terminology",
                     set.id
                 ),
             ));
-        }
-        // VTVSUQ: members must be unique within the value set.
-        let mut seen = BTreeSet::new();
-        for m in &set.members {
-            if !seen.insert(m.as_str()) {
-                issues.push(ValidationIssue::new(
-                    ValidationCode::Vtvsuq,
-                    format!("value set {:?} has a duplicate member {m:?}", set.id),
-                ));
-            }
-        }
-        // VTVSMD: members must be defined in the terminology of the *flattened*
-        // form (master07). Runs only when the archetype is its own flat form; the
-        // specialised flat-form half runs in [`super::flat`].
-        if flat_self {
-            for m in &set.members {
-                if !defined.contains(m.as_str()) {
-                    issues.push(ValidationIssue::new(
-                        ValidationCode::Vtvsmd,
-                        format!(
-                            "value set {:?} member {m:?} is not defined in the terminology",
-                            set.id
-                        ),
-                    ));
-                }
-            }
         }
     }
 }

--- a/crates/openehr-adl/src/validate/terminology.rs
+++ b/crates/openehr-adl/src/validate/terminology.rs
@@ -425,27 +425,7 @@ fn collect_usage_at(obj: &CObject, path: &str, usage: &mut CodeUsage) {
         usage.node_codes.insert(nid.to_owned());
     }
     match obj {
-        CObject::CComplexObject(cco) => {
-            for attr in complex_attributes(cco) {
-                let apath = format!("{path}/{}", attr.rm_attribute_name);
-                for child in attr.children.iter().flatten() {
-                    let cpath = child_path(&apath, object_node_id(child));
-                    collect_usage_at(child, &cpath, usage);
-                }
-            }
-            // Second-order tuples (e.g. ordinals) carry primitive constraints
-            // outside the normal attribute tree (master04.4); collect their
-            // terminology-code values too.
-            for tuple in complex_attribute_tuples(cco) {
-                for prim_tuple in tuple.tuples.iter().flatten() {
-                    for member in &prim_tuple.members {
-                        if let CPrimitiveObject::CTerminologyCode(tc) = member {
-                            usage.value_codes.extend(constraint_codes(&tc.constraint));
-                        }
-                    }
-                }
-            }
-        }
+        CObject::CComplexObject(cco) => collect_complex_usage(cco, path, usage),
         CObject::CTerminologyCode(tc) => {
             let codes = constraint_codes(&tc.constraint);
             if let Some(a) = tc.assumed_value.as_ref()
@@ -460,6 +440,34 @@ fn collect_usage_at(obj: &CObject, path: &str, usage: &mut CodeUsage) {
             usage.value_codes.extend(codes);
         }
         _ => {}
+    }
+}
+
+/// Walks a complex object's attribute children and its second-order tuples.
+///
+/// The tuples (e.g. ordinals) carry primitive constraints outside the normal
+/// attribute tree (master04.4), so their terminology-code values are collected
+/// too.
+fn collect_complex_usage(
+    cco: &openehr_am::v2_4::aom2::constraint_model::c_complex_object::CComplexObject,
+    path: &str,
+    usage: &mut CodeUsage,
+) {
+    for attr in complex_attributes(cco) {
+        let apath = format!("{path}/{}", attr.rm_attribute_name);
+        for child in attr.children.iter().flatten() {
+            let cpath = child_path(&apath, object_node_id(child));
+            collect_usage_at(child, &cpath, usage);
+        }
+    }
+    for tuple in complex_attribute_tuples(cco) {
+        for prim_tuple in tuple.tuples.iter().flatten() {
+            for member in &prim_tuple.members {
+                if let CPrimitiveObject::CTerminologyCode(tc) = member {
+                    usage.value_codes.extend(constraint_codes(&tc.constraint));
+                }
+            }
+        }
     }
 }
 

--- a/crates/openehr-adl/tests/it/corpus_coverage.rs
+++ b/crates/openehr-adl/tests/it/corpus_coverage.rs
@@ -83,41 +83,47 @@ fn classify(rel: &str, is_adl: bool) -> Option<Category> {
         return Some(Category::Adl14Cadl);
     }
     // adl2-reference fixtures.
-    let r = rel.strip_prefix("adl2-reference/")?;
-    if r.starts_with("validity/templates/") {
-        return Some(Category::ValidityTemplates);
-    }
-    if r.starts_with("validity/legacy_adl_1.4/") {
-        return Some(if is_adl {
-            Category::ValidityLegacy14Adl
-        } else {
-            Category::ValidityLegacy14Adls
-        });
-    }
-    if r.starts_with("validity/") {
-        return Some(Category::Validity);
-    }
-    if r.starts_with("robustness/") {
-        return Some(Category::Robustness);
-    }
-    if r.starts_with("upgrade/upgrade_from_14/") {
-        return Some(if is_adl {
-            Category::Upgrade14Source
-        } else {
-            Category::Upgrade14Target
-        });
-    }
-    if r.starts_with("upgrade/upgrade_from_15/") {
-        return Some(Category::Upgrade15);
-    }
-    if r.starts_with("features/") {
-        return Some(if is_adl {
-            Category::FeaturesAdl
-        } else {
-            Category::FeaturesAdls
-        });
-    }
-    None
+    classify_reference(rel.strip_prefix("adl2-reference/")?, is_adl)
+}
+
+/// The `adl2-reference` sub-tree prefixes and the category each claims.
+///
+/// Order is load-bearing: the first matching prefix wins, so a narrower tree
+/// (`validity/templates/`) precedes the tree that contains it (`validity/`). The
+/// two categories are the ADL 1.4-source and ADL 2-source spellings; a tree that
+/// does not distinguish them repeats one category.
+const REFERENCE_CATEGORIES: &[(&str, Category, Category)] = &[
+    (
+        "validity/templates/",
+        Category::ValidityTemplates,
+        Category::ValidityTemplates,
+    ),
+    (
+        "validity/legacy_adl_1.4/",
+        Category::ValidityLegacy14Adl,
+        Category::ValidityLegacy14Adls,
+    ),
+    ("validity/", Category::Validity, Category::Validity),
+    ("robustness/", Category::Robustness, Category::Robustness),
+    (
+        "upgrade/upgrade_from_14/",
+        Category::Upgrade14Source,
+        Category::Upgrade14Target,
+    ),
+    (
+        "upgrade/upgrade_from_15/",
+        Category::Upgrade15,
+        Category::Upgrade15,
+    ),
+    ("features/", Category::FeaturesAdl, Category::FeaturesAdls),
+];
+
+/// The category an `adl2-reference` path (prefix already stripped) is claimed by.
+fn classify_reference(r: &str, is_adl: bool) -> Option<Category> {
+    REFERENCE_CATEGORIES
+        .iter()
+        .find(|(prefix, _, _)| r.starts_with(prefix))
+        .map(|(_, adl, adls)| if is_adl { *adl } else { *adls })
 }
 
 /// Every ADL source file (`.adls` / `.adl`) under `dir`, keyed on full path.

--- a/crates/openehr-adl/tests/it/corpus_validity_integrity.rs
+++ b/crates/openehr-adl/tests/it/corpus_validity_integrity.rs
@@ -25,7 +25,7 @@ use openehr_adl::artefact::ArchetypeRepository;
 use openehr_adl::assemble::parse_artefact;
 use openehr_adl::parse::Dialect;
 use openehr_adl::validate::catalogue::Severity;
-use openehr_adl::validate::validate_source_integrity;
+use openehr_adl::validate::{ValidationIssue, validate_source_integrity};
 
 const CORPUS: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/corpus/adl2-reference");
 
@@ -164,6 +164,73 @@ struct Counts {
     syntax_or_fail: usize,
 }
 
+/// What one corpus file's `regression` tag turned out to mean.
+///
+/// A `Violation` carries the message tail; the caller prefixes the file name.
+enum TagOutcome {
+    ExactCode,
+    PassClean,
+    Deferred(String),
+    SyntaxOrFail,
+    Violation(String),
+}
+
+/// A `PASS`/untagged file: clean iff phase 1 raised no error (warnings allowed).
+fn judge_clean(error_codes: &[String]) -> TagOutcome {
+    if error_codes.is_empty() {
+        TagOutcome::PassClean
+    } else {
+        TagOutcome::Violation(format!("PASS/untagged but raised {error_codes:?}"))
+    }
+}
+
+/// A `FAIL`-tagged file that nonetheless parses: expect at least one typed error.
+fn judge_fail(error_codes: &[String]) -> TagOutcome {
+    if error_codes.is_empty() {
+        TagOutcome::Violation("FAIL-tagged but no phase-1 error raised".to_owned())
+    } else {
+        TagOutcome::SyntaxOrFail
+    }
+}
+
+/// A tag naming a code the validator actively raises: it must be raised exactly.
+fn judge_firing_code(tag: &str, error_codes: &[String], issues: &[ValidationIssue]) -> TagOutcome {
+    if error_codes.iter().any(|c| c == tag) || issues.iter().any(|i| i.code.mnemonic() == tag) {
+        TagOutcome::ExactCode
+    } else {
+        TagOutcome::Violation(format!("expected {tag} but raised {error_codes:?}"))
+    }
+}
+
+/// A phase-2/3/RM code, or a not-yet-run phase-1 code: assert no false positive.
+fn judge_deferred_code(tag: &str, error_codes: &[String]) -> TagOutcome {
+    if error_codes.is_empty() {
+        TagOutcome::Deferred(tag.to_owned())
+    } else {
+        TagOutcome::Violation(format!(
+            "deferred tag {tag} but phase-1 raised {error_codes:?}"
+        ))
+    }
+}
+
+/// Classifies one parsed corpus file against its authoritative `regression` tag.
+fn judge_tagged_outcome(
+    tag: Option<&str>,
+    error_codes: &[String],
+    issues: &[ValidationIssue],
+) -> TagOutcome {
+    match tag {
+        None | Some("PASS") => judge_clean(error_codes),
+        Some("FAIL") => judge_fail(error_codes),
+        // A syntax-tagged file that nonetheless parsed — the syntax defect is
+        // milder than a hard parse error; accept any typed error or none
+        // (owned by the parse gates).
+        Some(t) if is_syntax_tag(t) => TagOutcome::SyntaxOrFail,
+        Some(t) if INTEGRITY_FIRING.contains(&t) => judge_firing_code(t, error_codes, issues),
+        Some(t) => judge_deferred_code(t, error_codes),
+    }
+}
+
 #[test]
 fn corpus_integrity_outcomes() {
     let repo = build_repository();
@@ -218,51 +285,15 @@ fn corpus_integrity_outcomes() {
                 .map(|i| i.code.mnemonic().to_owned())
                 .collect();
 
-            match tag.as_deref() {
-                // PASS or absent ⇒ clean (no phase-1 errors; warnings allowed).
-                None | Some("PASS") => {
-                    if error_codes.is_empty() {
-                        counts.pass_clean += 1;
-                    } else {
-                        violations
-                            .push(format!("{name}: PASS/untagged but raised {error_codes:?}"));
-                    }
+            match judge_tagged_outcome(tag.as_deref(), &error_codes, &issues) {
+                TagOutcome::ExactCode => counts.exact_code += 1,
+                TagOutcome::PassClean => counts.pass_clean += 1,
+                TagOutcome::SyntaxOrFail => counts.syntax_or_fail += 1,
+                TagOutcome::Deferred(code) => {
+                    counts.deferred += 1;
+                    *deferred_by_code.entry(code).or_default() += 1;
                 }
-                Some("FAIL") => {
-                    // FAIL parses here; expect at least one typed error.
-                    if error_codes.is_empty() {
-                        violations.push(format!("{name}: FAIL-tagged but no phase-1 error raised"));
-                    } else {
-                        counts.syntax_or_fail += 1;
-                    }
-                }
-                Some(t) if is_syntax_tag(t) => {
-                    // A syntax-tagged file that nonetheless parsed — the syntax
-                    // defect is milder than a hard parse error; accept any
-                    // typed error or none (owned by the parse gates).
-                    counts.syntax_or_fail += 1;
-                }
-                Some(t) if INTEGRITY_FIRING.contains(&t) => {
-                    if error_codes.iter().any(|c| c == t)
-                        || issues.iter().any(|i| i.code.mnemonic() == t)
-                    {
-                        counts.exact_code += 1;
-                    } else {
-                        violations.push(format!("{name}: expected {t} but raised {error_codes:?}"));
-                    }
-                }
-                // A phase-2/3/RM code, or a not-yet-run phase-1 code: assert no
-                // phase-1 error false positive.
-                Some(t) => {
-                    if error_codes.is_empty() {
-                        counts.deferred += 1;
-                        *deferred_by_code.entry(t.to_owned()).or_default() += 1;
-                    } else {
-                        violations.push(format!(
-                            "{name}: deferred tag {t} but phase-1 raised {error_codes:?}"
-                        ));
-                    }
-                }
+                TagOutcome::Violation(message) => violations.push(format!("{name}: {message}")),
             }
         }
     }

--- a/crates/openehr-adl/tests/it/corpus_validity_parent_conformance.rs
+++ b/crates/openehr-adl/tests/it/corpus_validity_parent_conformance.rs
@@ -160,6 +160,92 @@ fn corpus_tuple_narrowing_raises_no_tuple_code() {
     assert!(raised.contains(&"VTPNC"), "widened row: raised {raised:?}");
 }
 
+/// The phase-2 verdict for one specialisation fixture.
+///
+/// A `Violation` carries the message tail; the caller prefixes the file name.
+enum ParentOutcome {
+    /// The fixture's tagged code was raised exactly.
+    ExactCode,
+    /// A `PASS`/untagged fixture raised no error.
+    PassClean,
+    /// The parent is deliberately absent and the typed outcome says so.
+    ParentNotFound,
+    /// A level-0 support archetype, not a phase-2 subject.
+    NonSpecialised,
+    /// The fixture's outcome contradicts its tag.
+    Violation(String),
+}
+
+/// Judges one specialisation fixture against its authoritative `regression` tag.
+fn judge_parent_fixture(
+    src: &str,
+    tag: Option<&str>,
+    repo: &ArchetypeRepository,
+    rm: ProductionRmModel,
+) -> ParentOutcome {
+    let Ok(archetype) = parse_artefact(src, Dialect::Adl2) else {
+        // A non-parsing fixture is owned by the parse gates; a FAIL tag is a
+        // valid outcome here.
+        if tag == Some("FAIL") {
+            return ParentOutcome::ParentNotFound;
+        }
+        return ParentOutcome::Violation(format!("failed to parse (tag {tag:?})"));
+    };
+
+    // FAIL fixtures whose parent is deliberately absent assert the typed
+    // parent-not-found outcome (INVENTORY §5).
+    if tag == Some("FAIL") {
+        return match resolve_flat_parent(&archetype, repo) {
+            FlatParent::NotFound => ParentOutcome::ParentNotFound,
+            other => ParentOutcome::Violation(format!(
+                "FAIL fixture expected parent-not-found, got {other:?}"
+            )),
+        };
+    }
+
+    // Non-specialised support archetypes (the level-0 parents that live in this
+    // directory) are not phase-2 subjects — their RM/phase-1 validation is the
+    // reference-model / phase-1 harnesses' concern (and some exercise an
+    // emit-rm-model gap, e.g. spec_test_obs3's DV_QUANTITY attributes).
+    if matches!(
+        resolve_flat_parent(&archetype, repo),
+        FlatParent::NotSpecialised
+    ) {
+        return ParentOutcome::NonSpecialised;
+    }
+
+    let Ok(issues) = validate_source(src, Some(repo), &rm, &NoTerminologyResolver) else {
+        return ParentOutcome::Violation("validate_source parse error".to_owned());
+    };
+    let error_codes: Vec<String> = issues
+        .iter()
+        .filter(|i| i.severity == Severity::Error)
+        .map(|i| i.code.mnemonic().to_owned())
+        .collect();
+    judge_parent_codes(tag, &error_codes)
+}
+
+/// The verdict for a fixture that reached phase-2 validation.
+fn judge_parent_codes(tag: Option<&str>, error_codes: &[String]) -> ParentOutcome {
+    match tag {
+        None | Some("PASS") => {
+            if error_codes.is_empty() {
+                ParentOutcome::PassClean
+            } else {
+                ParentOutcome::Violation(format!("PASS/untagged but raised {error_codes:?}"))
+            }
+        }
+        Some(t) if PARENT_CONFORMANCE_FIRING.contains(&t) => {
+            if error_codes.iter().any(|c| c == t) {
+                ParentOutcome::ExactCode
+            } else {
+                ParentOutcome::Violation(format!("expected {t} but raised {error_codes:?}"))
+            }
+        }
+        Some(t) => ParentOutcome::Violation(format!("unhandled tag {t} (raised {error_codes:?})")),
+    }
+}
+
 #[test]
 fn corpus_parent_conformance_outcomes() {
     let repo = build_repository();
@@ -185,73 +271,12 @@ fn corpus_parent_conformance_outcomes() {
         };
         let tag = read_tag_raw(&src).map(|t| normalise_tag(&t));
 
-        let Ok(archetype) = parse_artefact(&src, Dialect::Adl2) else {
-            // A non-parsing fixture is owned by the parse gates; a FAIL tag is a
-            // valid outcome here.
-            if tag.as_deref() == Some("FAIL") {
-                counts.parent_not_found += 1;
-            } else {
-                violations.push(format!("{name}: failed to parse (tag {tag:?})"));
-            }
-            continue;
-        };
-
-        // FAIL fixtures whose parent is deliberately absent assert the typed
-        // parent-not-found outcome (INVENTORY §5).
-        if tag.as_deref() == Some("FAIL") {
-            match resolve_flat_parent(&archetype, &repo) {
-                FlatParent::NotFound => {
-                    counts.parent_not_found += 1;
-                }
-                other => violations.push(format!(
-                    "{name}: FAIL fixture expected parent-not-found, got {other:?}"
-                )),
-            }
-            continue;
-        }
-
-        // Non-specialised support archetypes (the level-0 parents that live in
-        // this directory) are not phase-2 subjects — their RM/phase-1 validation
-        // is the reference-model / phase-1 harnesses' concern (and some exercise
-        // an emit-rm-model gap, e.g. spec_test_obs3's DV_QUANTITY attributes).
-        if matches!(
-            resolve_flat_parent(&archetype, &repo),
-            FlatParent::NotSpecialised
-        ) {
-            counts.non_specialised += 1;
-            continue;
-        }
-
-        let Ok(issues) = validate_source(&src, Some(&repo), &rm, &NoTerminologyResolver) else {
-            violations.push(format!("{name}: validate_source parse error"));
-            continue;
-        };
-        let error_codes: Vec<String> = issues
-            .iter()
-            .filter(|i| i.severity == Severity::Error)
-            .map(|i| i.code.mnemonic().to_owned())
-            .collect();
-
-        match tag.as_deref() {
-            None | Some("PASS") => {
-                if error_codes.is_empty() {
-                    counts.pass_clean += 1;
-                } else {
-                    violations.push(format!("{name}: PASS/untagged but raised {error_codes:?}"));
-                }
-            }
-            Some(t) if PARENT_CONFORMANCE_FIRING.contains(&t) => {
-                if error_codes.iter().any(|c| c == t) {
-                    counts.exact_code += 1;
-                } else {
-                    violations.push(format!("{name}: expected {t} but raised {error_codes:?}"));
-                }
-            }
-            Some(t) => {
-                violations.push(format!(
-                    "{name}: unhandled tag {t} (raised {error_codes:?})"
-                ));
-            }
+        match judge_parent_fixture(&src, tag.as_deref(), &repo, rm) {
+            ParentOutcome::ExactCode => counts.exact_code += 1,
+            ParentOutcome::PassClean => counts.pass_clean += 1,
+            ParentOutcome::ParentNotFound => counts.parent_not_found += 1,
+            ParentOutcome::NonSpecialised => counts.non_specialised += 1,
+            ParentOutcome::Violation(message) => violations.push(format!("{name}: {message}")),
         }
     }
 

--- a/crates/openehr-adl/tests/it/corpus_validity_rm.rs
+++ b/crates/openehr-adl/tests/it/corpus_validity_rm.rs
@@ -361,6 +361,94 @@ const RECLAIMED: &[&str] = &[
     "validity/consistency/openEHR-TEST_PKG-ENTRY.VATID_id_code_in_node_not_in_terminology.v1.0.0.adls",
 ];
 
+/// The reference-model verdict for one corpus fixture.
+///
+/// A `Violation` carries the message tail; the caller prefixes the file name.
+enum RmOutcome {
+    /// The tagged RM code was raised.
+    ExactCode,
+    /// A `VSAM`-tagged fixture raised the non-specialised VCAM instead.
+    NormalisedVcam,
+    /// A `PASS`/untagged fixture raised no error.
+    PassClean,
+    /// A non-RM tag, owned by another harness; only spurious RM errors matter.
+    Deferred,
+    /// The fixture's outcome contradicts its tag.
+    Violation(String),
+}
+
+/// Judges one `rm_checking` fixture against its authoritative `regression` tag.
+fn judge_rm_fixture(
+    src: &str,
+    tag: Option<&str>,
+    production: ProductionRmModel,
+    test_model: &BmmRmModel,
+) -> RmOutcome {
+    let Ok(archetype) = parse_artefact(src, Dialect::Adl2) else {
+        return RmOutcome::Violation("failed to parse".to_owned());
+    };
+    // Pick the governing reference model from the archetype HRID.
+    let rm: &dyn RmModel = if production_model_governs(&archetype) {
+        &production
+    } else {
+        test_model
+    };
+    // Full gated validation (phase 1 → phase 2 RM); if phase 1 is unclean the RM
+    // pass is gated off, so fall back to the ungated RM pass to keep the
+    // assertion about the RM code meaningful.
+    let Ok(issues) = validate_source(src, None, rm, &NoTerminologyResolver) else {
+        return RmOutcome::Violation("validate_source re-parse error".to_owned());
+    };
+    let gated = error_codes(&issues);
+    let rm_only = gated.is_empty()
+        || issues
+            .iter()
+            .all(|i| RM_FIRING.contains(&i.code.mnemonic()) || i.severity != Severity::Error);
+    let codes = if rm_only {
+        gated.clone()
+    } else {
+        error_codes(&validate_rm_conformance(&archetype, rm, Dialect::Adl2))
+    };
+    judge_rm_codes(tag, &gated, &codes)
+}
+
+/// The verdict for a fixture whose RM codes have been collected.
+///
+/// `gated` is the full gated pass's error set (what a `PASS` tag is judged
+/// against); `codes` is the RM-pass set the firing assertions read.
+fn judge_rm_codes(tag: Option<&str>, gated: &[String], codes: &[String]) -> RmOutcome {
+    match tag {
+        None | Some("PASS") => {
+            if gated.is_empty() {
+                RmOutcome::PassClean
+            } else {
+                RmOutcome::Violation(format!("PASS/untagged but raised {codes:?}"))
+            }
+        }
+        // A non-specialised RM-arity violation: master04.5 VSAM is the
+        // *specialised* form (vs the parent archetype); with no parent the
+        // applicable rule is VCAM (master04.5 §Validity Rules: C_ATTRIBUTE,
+        // VCAM). Assert VCAM is raised.
+        Some("VSAM") => {
+            if codes.iter().any(|c| c == "VCAM") {
+                RmOutcome::NormalisedVcam
+            } else {
+                RmOutcome::Violation(format!("VSAM tag expected VCAM but raised {codes:?}"))
+            }
+        }
+        Some(t) if RM_FIRING.contains(&t) => {
+            if codes.iter().any(|c| c == t) {
+                RmOutcome::ExactCode
+            } else {
+                RmOutcome::Violation(format!("expected {t} but raised {codes:?}"))
+            }
+        }
+        // A non-RM tag (e.g. VARDT is phase-1, owned by the phase-1 harness):
+        // assert only that the RM pass raises no spurious RM error.
+        Some(_) => RmOutcome::Deferred,
+    }
+}
+
 #[test]
 fn corpus_rm_outcomes() {
     let production = ProductionRmModel;
@@ -392,73 +480,12 @@ fn corpus_rm_outcomes() {
         };
         let tag = read_tag_raw(&src);
 
-        let Ok(archetype) = parse_artefact(&src, Dialect::Adl2) else {
-            violations.push(format!("{name}: failed to parse"));
-            continue;
-        };
-
-        // Pick the governing reference model from the archetype HRID.
-        let rm: &dyn RmModel = if production_model_governs(&archetype) {
-            &production
-        } else {
-            &test_model
-        };
-
-        // Full gated validation (phase 1 → phase 2 RM); if phase 1 is unclean
-        // the RM pass is gated off, so fall back to the ungated RM pass to keep
-        // the assertion about the RM code meaningful.
-        let Ok(issues) = validate_source(&src, None, rm, &NoTerminologyResolver) else {
-            violations.push(format!("{name}: validate_source re-parse error"));
-            continue;
-        };
-        let mut codes = error_codes(&issues);
-        if codes.is_empty() {
-            // no phase-1/phase-2 error; also compute the raw RM pass for the
-            // firing assertions (some tags name an RM code on an otherwise
-            // phase-1-clean archetype — the gated pass already ran it).
-        } else if issues
-            .iter()
-            .all(|i| RM_FIRING.contains(&i.code.mnemonic()) || i.severity != Severity::Error)
-        {
-            // errors are RM-firing codes — good.
-        } else {
-            // phase-1 error gated the RM pass; run the RM pass directly.
-            codes = error_codes(&validate_rm_conformance(&archetype, rm, Dialect::Adl2));
-        }
-
-        match tag.as_deref() {
-            None | Some("PASS") => {
-                if error_codes(&issues).is_empty() {
-                    counts.pass_clean += 1;
-                } else {
-                    violations.push(format!("{name}: PASS/untagged but raised {codes:?}"));
-                }
-            }
-            Some("VSAM") => {
-                // A non-specialised RM-arity violation: master04.5 VSAM is the
-                // *specialised* form (vs the parent archetype); with no parent
-                // the applicable rule is VCAM (master04.5 §Validity Rules:
-                // C_ATTRIBUTE, VCAM). Assert VCAM is raised.
-                if codes.iter().any(|c| c == "VCAM") {
-                    counts.normalised_vcam += 1;
-                } else {
-                    violations.push(format!(
-                        "{name}: VSAM tag expected VCAM but raised {codes:?}"
-                    ));
-                }
-            }
-            Some(t) if RM_FIRING.contains(&t) => {
-                if codes.iter().any(|c| c == t) {
-                    counts.exact_code += 1;
-                } else {
-                    violations.push(format!("{name}: expected {t} but raised {codes:?}"));
-                }
-            }
-            // A non-RM tag (e.g. VARDT is phase-1, owned by the phase-1 harness):
-            // assert only that the RM pass raises no spurious RM error.
-            Some(_) => {
-                counts.deferred += 1;
-            }
+        match judge_rm_fixture(&src, tag.as_deref(), production, &test_model) {
+            RmOutcome::ExactCode => counts.exact_code += 1,
+            RmOutcome::NormalisedVcam => counts.normalised_vcam += 1,
+            RmOutcome::PassClean => counts.pass_clean += 1,
+            RmOutcome::Deferred => counts.deferred += 1,
+            RmOutcome::Violation(message) => violations.push(format!("{name}: {message}")),
         }
     }
 

--- a/crates/openehr-am/Cargo.toml
+++ b/crates/openehr-am/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-am"
-version = "0.0.41"
+version = "0.0.42"
 description = "openEHR AM Archetype Model, generated from BMM: generations v1_4 (AM 1.4.0, ADL 1.4) and v2_4 (AM 2.4.0, ADL 2; current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,8 +13,8 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.41" }
-openehr-lang = { path = "../openehr-lang", version = "0.0.41" }
+openehr-base = { path = "../openehr-base", version = "0.0.42" }
+openehr-lang = { path = "../openehr-lang", version = "0.0.42" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also carries the untyped `Value` fields the generator

--- a/crates/openehr-base/Cargo.toml
+++ b/crates/openehr-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-base"
-version = "0.0.41"
+version = "0.0.42"
 description = "openEHR BASE foundation + base types, generated from BMM: generations v1_2 (BASE 1.2.0) and v1_3 (BASE 1.3.0, current)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-base/src/v1_2/foundation_types/time/iso8601_parse.rs
+++ b/crates/openehr-base/src/v1_2/foundation_types/time/iso8601_parse.rs
@@ -672,6 +672,44 @@ fn apply_duration_component(
     }
 }
 
+/// One duration component's number: its integer part, its fractional part,
+/// and whether a fraction was written at all.
+///
+/// A decimal sign with no digits after it is refused (`P1.D`).
+fn read_duration_number(
+    it: &mut std::iter::Peekable<std::str::Chars<'_>>,
+) -> Option<(u64, f64, bool)> {
+    let mut num = String::new();
+    while let Some(c) = it.peek() {
+        if !c.is_ascii_digit() {
+            break;
+        }
+        num.push(*c);
+        it.next();
+    }
+    let has_frac = matches!(it.peek(), Some('.' | ','));
+    let mut frac = String::new();
+    if has_frac {
+        it.next();
+        while let Some(c) = it.peek() {
+            if !c.is_ascii_digit() {
+                break;
+            }
+            frac.push(*c);
+            it.next();
+        }
+    }
+    let intval = num.parse::<u64>().ok()?;
+    if !has_frac {
+        return Some((intval, 0.0, false));
+    }
+    if frac.is_empty() {
+        return None;
+    }
+    let fracval = format!("0.{frac}").parse::<f64>().ok()?;
+    Some((intval, fracval, true))
+}
+
 pub(crate) fn parse_duration(s: &str) -> Option<ParsedDuration> {
     let mut it = s.chars().peekable();
     let negative = match it.peek() {
@@ -715,38 +753,8 @@ pub(crate) fn parse_duration(s: &str) -> Option<ParsedDuration> {
                 it.next();
             }
             Some(c) if c.is_ascii_digit() => {
-                let mut num = String::new();
-                while let Some(c) = it.peek() {
-                    if c.is_ascii_digit() {
-                        num.push(*c);
-                        it.next();
-                    } else {
-                        break;
-                    }
-                }
-                let mut frac = String::new();
-                let has_frac = matches!(it.peek(), Some('.' | ','));
-                if has_frac {
-                    it.next();
-                    while let Some(c) = it.peek() {
-                        if c.is_ascii_digit() {
-                            frac.push(*c);
-                            it.next();
-                        } else {
-                            break;
-                        }
-                    }
-                }
+                let (intval, fracval, has_frac) = read_duration_number(&mut it)?;
                 let designator = it.next()?;
-                let intval = num.parse::<u64>().ok()?;
-                let fracval = if has_frac {
-                    if frac.is_empty() {
-                        return None;
-                    }
-                    format!("0.{frac}").parse::<f64>().ok()?
-                } else {
-                    0.0
-                };
                 let slot = apply_duration_component(&mut d, in_time, designator, intval, fracval)?;
                 if slot <= last_slot {
                     return None;

--- a/crates/openehr-base/src/v1_3/foundation_types/time/iso8601_parse.rs
+++ b/crates/openehr-base/src/v1_3/foundation_types/time/iso8601_parse.rs
@@ -672,6 +672,44 @@ fn apply_duration_component(
     }
 }
 
+/// One duration component's number: its integer part, its fractional part,
+/// and whether a fraction was written at all.
+///
+/// A decimal sign with no digits after it is refused (`P1.D`).
+fn read_duration_number(
+    it: &mut std::iter::Peekable<std::str::Chars<'_>>,
+) -> Option<(u64, f64, bool)> {
+    let mut num = String::new();
+    while let Some(c) = it.peek() {
+        if !c.is_ascii_digit() {
+            break;
+        }
+        num.push(*c);
+        it.next();
+    }
+    let has_frac = matches!(it.peek(), Some('.' | ','));
+    let mut frac = String::new();
+    if has_frac {
+        it.next();
+        while let Some(c) = it.peek() {
+            if !c.is_ascii_digit() {
+                break;
+            }
+            frac.push(*c);
+            it.next();
+        }
+    }
+    let intval = num.parse::<u64>().ok()?;
+    if !has_frac {
+        return Some((intval, 0.0, false));
+    }
+    if frac.is_empty() {
+        return None;
+    }
+    let fracval = format!("0.{frac}").parse::<f64>().ok()?;
+    Some((intval, fracval, true))
+}
+
 pub(crate) fn parse_duration(s: &str) -> Option<ParsedDuration> {
     let mut it = s.chars().peekable();
     let negative = match it.peek() {
@@ -715,38 +753,8 @@ pub(crate) fn parse_duration(s: &str) -> Option<ParsedDuration> {
                 it.next();
             }
             Some(c) if c.is_ascii_digit() => {
-                let mut num = String::new();
-                while let Some(c) = it.peek() {
-                    if c.is_ascii_digit() {
-                        num.push(*c);
-                        it.next();
-                    } else {
-                        break;
-                    }
-                }
-                let mut frac = String::new();
-                let has_frac = matches!(it.peek(), Some('.' | ','));
-                if has_frac {
-                    it.next();
-                    while let Some(c) = it.peek() {
-                        if c.is_ascii_digit() {
-                            frac.push(*c);
-                            it.next();
-                        } else {
-                            break;
-                        }
-                    }
-                }
+                let (intval, fracval, has_frac) = read_duration_number(&mut it)?;
                 let designator = it.next()?;
-                let intval = num.parse::<u64>().ok()?;
-                let fracval = if has_frac {
-                    if frac.is_empty() {
-                        return None;
-                    }
-                    format!("0.{frac}").parse::<f64>().ok()?
-                } else {
-                    0.0
-                };
                 let slot = apply_duration_component(&mut d, in_time, designator, intval, fracval)?;
                 if slot <= last_slot {
                     return None;

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-its"
-version = "0.0.41"
+version = "0.0.42"
 description = "openEHR ITS (Implementation Technology Specifications): canonical JSON + canonical XML serialization of the RM, the generated ITS-REST 1.1.0 API contract, OPT 1.4 and AOM2 archetype XML codecs, and the Simplified Formats (FLAT / STRUCTURED / Web Template)"
 edition.workspace = true
 rust-version.workspace = true
@@ -41,14 +41,14 @@ regex = { workspace = true, optional = true }
 fancy-regex = { workspace = true, optional = true }
 # The generated XML (de)serializers impl the crate's ToXml/FromXml traits for the
 # RM/BASE spec types, so these are real (non-dev) deps.
-openehr-base = { path = "../openehr-base", version = "0.0.41", optional = true }
-openehr-rm = { path = "../openehr-rm", version = "0.0.41", optional = true }
+openehr-base = { path = "../openehr-base", version = "0.0.42", optional = true }
+openehr-rm = { path = "../openehr-rm", version = "0.0.42", optional = true }
 # The native canonical-JSON codec (`json_codec/generated`, emit-json) implements
 # `ToJson` for EVERY generated spec type the `OpenEhrType` derive covers, so it
 # spans all five spec crates (not just the RM/BASE the XML codec needs).
-openehr-lang = { path = "../openehr-lang", version = "0.0.41", optional = true }
-openehr-am = { path = "../openehr-am", version = "0.0.41", optional = true }
-openehr-term = { path = "../openehr-term", version = "0.0.41", optional = true }
+openehr-lang = { path = "../openehr-lang", version = "0.0.42", optional = true }
+openehr-am = { path = "../openehr-am", version = "0.0.42", optional = true }
+openehr-term = { path = "../openehr-term", version = "0.0.42", optional = true }
 
 # `full` — every ITS surface (canonical JSON/XML, the generated ITS-REST
 # contract, `opt14`, Simplified Formats). ON BY DEFAULT, so every consumer sees

--- a/crates/openehr-its/src/flat/build.rs
+++ b/crates/openehr-its/src/flat/build.rs
@@ -1304,11 +1304,25 @@ fn finish_identity(
     template_id: &str,
 ) {
     let rm_type = concrete_type(&node.rm_type);
+    if fill_non_locatable(obj, rm_type) {
+        return;
+    }
+    stamp_locatable_identity(obj, node, rm_type);
+    fill_time_anchor(obj, rm_type);
+    stamp_archetype_details(obj, node, is_root, template_id);
+    fill_mandatory_entry_attributes(obj, node, rm_type);
+}
+
+/// Completes a node whose RM class is not `LOCATABLE`, reporting whether it did.
+///
+/// A `true` return means the node needs none of the locatable identity,
+/// archetype-details or ENTRY-attribute filling that follows it.
+fn fill_non_locatable(obj: &mut Map<String, Value>, rm_type: &str) -> bool {
     if rm_type.starts_with("DV_") || rm_type == "CODE_PHRASE" {
-        return; // leaves already complete
+        return true; // leaves already complete
     }
     if rm_type == "EVENT_CONTEXT" {
-        return; // PATHABLE, not LOCATABLE; fields come from ctx/
+        return true; // PATHABLE, not LOCATABLE; fields come from ctx/
     }
     // PARTICIPATION is not LOCATABLE (RM common
     // `UML/classes/org.openehr.rm.common.participation.adoc` declares exactly
@@ -1318,7 +1332,7 @@ fn finish_identity(
     if rm_type == "PARTICIPATION" {
         obj.entry("performer".to_owned())
             .or_insert_with(|| json!({"_type": "PARTY_SELF"}));
-        return;
+        return true;
     }
     // PARTY_PROXY subtypes are not LOCATABLE either, and `PARTY_IDENTIFIED.name`
     // is a plain String, never a `DV_TEXT` (RM common
@@ -1333,9 +1347,13 @@ fn finish_identity(
         {
             obj.insert("name".to_owned(), json!("Example party"));
         }
-        return;
+        return true;
     }
-    stamp_locatable_identity(obj, node, rm_type);
+    false
+}
+
+/// Fills the mandatory time anchor of the two RM classes that carry one.
+fn fill_time_anchor(obj: &mut Map<String, Value>, rm_type: &str) {
     match rm_type {
         "POINT_EVENT" | "INTERVAL_EVENT" => {
             obj.entry("time".to_owned())
@@ -1347,29 +1365,55 @@ fn finish_identity(
         }
         _ => {}
     }
+}
+
+/// Stamps `archetype_details` on an archetype-root node.
+fn stamp_archetype_details(
+    obj: &mut Map<String, Value>,
+    node: &WebTemplateNode,
+    is_root: bool,
+    template_id: &str,
+) {
     let is_root_arch = node
         .node_id
         .as_deref()
         .is_some_and(openehr_rm::v1_2::paths::is_archetype_root_node_id);
-    if is_root_arch {
-        obj.entry("archetype_details".to_owned())
-            .or_insert_with(|| {
-                let mut a = Map::new();
-                a.insert("_type".into(), json!("ARCHETYPED"));
-                a.insert(
-                    "archetype_id".into(),
-                    json!({"_type": "ARCHETYPE_ID", "value": node.node_id}),
-                );
-                if is_root && !template_id.is_empty() {
-                    a.insert(
-                        "template_id".into(),
-                        json!({"_type": "TEMPLATE_ID", "value": template_id}),
-                    );
-                }
-                a.insert("rm_version".into(), json!(RM_VERSION));
-                Value::Object(a)
-            });
+    if !is_root_arch {
+        return;
     }
+    obj.entry("archetype_details".to_owned())
+        .or_insert_with(|| {
+            let mut a = Map::new();
+            a.insert("_type".into(), json!("ARCHETYPED"));
+            a.insert(
+                "archetype_id".into(),
+                json!({"_type": "ARCHETYPE_ID", "value": node.node_id}),
+            );
+            if is_root && !template_id.is_empty() {
+                a.insert(
+                    "template_id".into(),
+                    json!({"_type": "TEMPLATE_ID", "value": template_id}),
+                );
+            }
+            a.insert("rm_version".into(), json!(RM_VERSION));
+            Value::Object(a)
+        });
+}
+
+/// Fills the RM-mandatory ENTRY attributes the simplified form carried no
+/// content under.
+///
+/// When the template constrains the attribute to a node-identified structural
+/// child, the recorded structural stub's identity is stamped — a value the
+/// closed-archetype walk admits (AOM 1.4
+/// `master04-constraint_model_package.adoc` §Valid_value). Unconstrained
+/// attributes get the spec-legal `at0001` "Any" placeholder (ADL 1.4
+/// `master05-cadl.adoc` §"Any" Constraints).
+fn fill_mandatory_entry_attributes(
+    obj: &mut Map<String, Value>,
+    node: &WebTemplateNode,
+    rm_type: &str,
+) {
     if matches!(
         rm_type,
         "OBSERVATION" | "EVALUATION" | "INSTRUCTION" | "ACTION" | "ADMIN_ENTRY" | "GENERIC_ENTRY"
@@ -1377,13 +1421,6 @@ fn finish_identity(
         obj.entry("subject".to_owned())
             .or_insert_with(|| json!({"_type": "PARTY_SELF"}));
     }
-    // RM-mandatory structural attributes the simplified form carried no
-    // content under. When the template constrains the attribute to a
-    // node-identified structural child, the recorded structural stub's
-    // identity is stamped — a value the closed-archetype walk admits
-    // (AOM 1.4 `master04-constraint_model_package.adoc` §Valid_value).
-    // Unconstrained attributes get the spec-legal `at0001` "Any"
-    // placeholder (ADL 1.4 `master05-cadl.adoc` §"Any" Constraints).
     match rm_type {
         "OBSERVATION" => {
             obj.entry("data".to_owned())

--- a/crates/openehr-its/src/flat/build.rs
+++ b/crates/openehr-its/src/flat/build.rs
@@ -295,27 +295,7 @@ fn build(
     slots: &[(Vec<PathSegment>, String)],
 ) -> Result<Option<Value>, FlatError> {
     if node.has_input() {
-        if is_null_flavoured(sim) {
-            return Ok(None);
-        }
-        let mut dv = map::build_leaf(sim, base_type(&node.rm_type), Some(node), path)?;
-        // Value-level `_` attributes (`_normal_range`, `_mapping`,
-        // `_accuracy`, `_language`, …) attach to the DV value itself;
-        // ELEMENT-level ones are routed onto the wrapping ELEMENT by
-        // `place` (master05 per-type tables vs §ELEMENT); the few the leaf
-        // builder itself consumed are skipped (`leaf_consumes_segment`).
-        if let Value::Object(m) = &mut dv {
-            let base = base_type(&node.rm_type);
-            for (seg, child) in &sim.children {
-                if seg.starts_with('_')
-                    && !is_element_level(seg)
-                    && !leaf_consumes_segment(base, seg)
-                {
-                    apply_rm_attr(m, seg, &child.occurrences, base, path)?;
-                }
-            }
-        }
-        return Ok(Some(dv));
+        return build_leaf(node, sim, path);
     }
 
     let mut obj = Map::new();
@@ -325,77 +305,8 @@ fn build(
     // HISTORY is materialised (see below).
     let mut history_origin: Option<String> = None;
 
-    for child in &node.children {
-        if !child_is_walked(node, child) {
-            continue;
-        }
-        let Some(sim_child) = sim.children.get(&child.id).or_else(|| {
-            child
-                .alt_json_id
-                .as_deref()
-                .and_then(|a| sim.children.get(a))
-        }) else {
-            continue;
-        };
-        let rel = rmpath::relative(&node.aql_path, &child.aql_path);
-        for (i, occ) in sim_child.occurrences.iter().enumerate() {
-            if occ.is_empty() {
-                continue; // a preserved index hole
-            }
-            let child_path = format!("{path}/{}:{i}", child.id);
-            let child_val = build(child, occ, &child_path, slots)?;
-            place(&mut obj, &rel, child_val, child, occ, &child_path, slots)?;
-        }
-    }
-
-    // Container-level `_` RM attribute families addressed to this node.
-    for (seg, child) in &sim.children {
-        if seg.starts_with('_') {
-            apply_rm_attr(
-                &mut obj,
-                seg,
-                &child.occurrences,
-                base_type(&node.rm_type),
-                path,
-            )?;
-            continue;
-        }
-        // Only a template child the walk above ACTUALLY processes counts as
-        // handled. A child the in-context routing skipped
-        // ([`child_is_walked`]) must fall through to the direct-RM-path
-        // fallback below, or its datum would be neither honoured nor
-        // rejected — the one outcome master04 §Validation forbids.
-        let known = node.children.iter().any(|c| {
-            (c.id == *seg || c.alt_json_id.as_deref() == Some(seg)) && child_is_walked(node, c)
-        });
-        let ctx_covered = node.rm_type == "COMPOSITION"
-            && matches!(
-                seg.as_str(),
-                "language" | "territory" | "composer" | "category"
-            );
-        if known || ctx_covered {
-            continue;
-        }
-        // A direct RM-attribute path the master05 per-type mapping tables
-        // declare addressable on this node even when the OPT leaves it
-        // unconstrained (so the compacted web-template carries no child for
-        // it) — e.g. `ACTION/time`, `ACTION/ism_transition` (master05
-        // §§ACTION, ISM_TRANSITION). Built here from the datum sub-tree.
-        if place_direct_rm_path(
-            &mut obj,
-            &node.rm_type,
-            seg,
-            &child.occurrences,
-            path,
-            &mut history_origin,
-        )? {
-            continue;
-        }
-        // Otherwise the identifier matches no template child and no
-        // spec-listed RM path (master04 §Validation: field identifiers match
-        // WT metadata structure).
-        return Err(FlatError::UnknownPath(format!("{path}/{seg}")));
-    }
+    walk_template_children(node, sim, path, slots, &mut obj)?;
+    apply_container_attrs(node, sim, path, &mut obj, &mut history_origin)?;
     // Datum parts on a container node are only legal via |raw
     // (master04 §Raw canonical JSON) or as one of the few datum suffixes the
     // master05 per-type tables place on a container; anything else is an
@@ -419,6 +330,127 @@ fn build(
         apply_interval_flags(m, &node.rm_type);
     }
     Ok(Some(value))
+}
+
+/// Builds the DATA_VALUE of an input-carrying (leaf) node.
+///
+/// `Ok(None)` is the value-less ELEMENT of [`is_null_flavoured`]. Value-level
+/// `_` attributes (`_normal_range`, `_mapping`, `_accuracy`, `_language`, …)
+/// attach to the DV value itself; ELEMENT-level ones are routed onto the
+/// wrapping ELEMENT by [`place`] (master05 per-type tables vs §ELEMENT), and
+/// the few the leaf builder itself consumed are skipped
+/// ([`leaf_consumes_segment`]).
+///
+/// # Errors
+/// [`FlatError`] from the leaf build or an unusable RM attribute.
+fn build_leaf(
+    node: &WebTemplateNode,
+    sim: &SimNode,
+    path: &str,
+) -> Result<Option<Value>, FlatError> {
+    if is_null_flavoured(sim) {
+        return Ok(None);
+    }
+    let base = base_type(&node.rm_type);
+    let mut dv = map::build_leaf(sim, base, Some(node), path)?;
+    if let Value::Object(m) = &mut dv {
+        for (seg, child) in &sim.children {
+            if seg.starts_with('_') && !is_element_level(seg) && !leaf_consumes_segment(base, seg) {
+                apply_rm_attr(m, seg, &child.occurrences, base, path)?;
+            }
+        }
+    }
+    Ok(Some(dv))
+}
+
+/// Builds every template child the walk covers into `obj`.
+///
+/// # Errors
+/// [`FlatError`] from a child's own build or its placement.
+fn walk_template_children(
+    node: &WebTemplateNode,
+    sim: &SimNode,
+    path: &str,
+    slots: &[(Vec<PathSegment>, String)],
+    obj: &mut Map<String, Value>,
+) -> Result<(), FlatError> {
+    for child in &node.children {
+        if !child_is_walked(node, child) {
+            continue;
+        }
+        let Some(sim_child) = sim.children.get(&child.id).or_else(|| {
+            child
+                .alt_json_id
+                .as_deref()
+                .and_then(|a| sim.children.get(a))
+        }) else {
+            continue;
+        };
+        let rel = rmpath::relative(&node.aql_path, &child.aql_path);
+        for (i, occ) in sim_child.occurrences.iter().enumerate() {
+            if occ.is_empty() {
+                continue; // a preserved index hole
+            }
+            let child_path = format!("{path}/{}:{i}", child.id);
+            let child_val = build(child, occ, &child_path, slots)?;
+            place(obj, &rel, child_val, child, occ, &child_path, slots)?;
+        }
+    }
+    Ok(())
+}
+
+/// Applies the datum segments addressed to a container node itself.
+///
+/// Only a template child the walk ACTUALLY processes counts as handled: a
+/// child the in-context routing skipped ([`child_is_walked`]) must fall
+/// through to the direct-RM-path fallback, or its datum would be neither
+/// honoured nor rejected — the one outcome master04 §Validation forbids. The
+/// fallback covers a direct RM-attribute path the master05 per-type mapping
+/// tables declare addressable on this node even when the OPT leaves it
+/// unconstrained (so the compacted web template carries no child for it) —
+/// e.g. `ACTION/time`, `ACTION/ism_transition` (master05 §§ACTION,
+/// ISM_TRANSITION).
+///
+/// # Errors
+/// [`FlatError::UnknownPath`] when an identifier matches no template child and
+/// no spec-listed RM path (master04 §Validation: field identifiers match WT
+/// metadata structure), plus the RM-attribute rejections.
+fn apply_container_attrs(
+    node: &WebTemplateNode,
+    sim: &SimNode,
+    path: &str,
+    obj: &mut Map<String, Value>,
+    history_origin: &mut Option<String>,
+) -> Result<(), FlatError> {
+    for (seg, child) in &sim.children {
+        if seg.starts_with('_') {
+            apply_rm_attr(obj, seg, &child.occurrences, base_type(&node.rm_type), path)?;
+            continue;
+        }
+        let known = node.children.iter().any(|c| {
+            (c.id == *seg || c.alt_json_id.as_deref() == Some(seg)) && child_is_walked(node, c)
+        });
+        let ctx_covered = node.rm_type == "COMPOSITION"
+            && matches!(
+                seg.as_str(),
+                "language" | "territory" | "composer" | "category"
+            );
+        if known || ctx_covered {
+            continue;
+        }
+        if place_direct_rm_path(
+            obj,
+            &node.rm_type,
+            seg,
+            &child.occurrences,
+            path,
+            history_origin,
+        )? {
+            continue;
+        }
+        return Err(FlatError::UnknownPath(format!("{path}/{seg}")));
+    }
+    Ok(())
 }
 
 /// Whether a leaf occurrence expresses a **value-less** ELEMENT: no datum part
@@ -699,24 +731,7 @@ fn place_direct_rm_path(
             if let Some(node) = occ
                 && !obj.contains_key(attr)
             {
-                // A bare `|code` binds to the row's openEHR terminology group,
-                // resolving its rubric exactly as the equivalent `ctx/`
-                // shortcut does (master06 §setting: "either value or code is
-                // accepted"). Once the client spells out `|value` or
-                // `|terminology`, the datum parts stand as given
-                // (master05 §DV_CODED_TEXT).
-                let bound = node
-                    .attrs
-                    .get("code")
-                    .and_then(Value::as_str)
-                    .filter(|_| {
-                        !node.attrs.contains_key("value") && !node.attrs.contains_key("terminology")
-                    })
-                    .map(|code| map::coded_from_group(group, code));
-                let value = match bound {
-                    Some(v) => v,
-                    None => map::build_leaf(node, "DV_CODED_TEXT", None, &sub_path)?,
-                };
+                let value = coded_group_value(node, group, &sub_path)?;
                 obj.insert(attr.to_owned(), value);
             }
         }
@@ -742,6 +757,29 @@ fn place_direct_rm_path(
         }
     }
     Ok(true)
+}
+
+/// The DV_CODED_TEXT of a direct RM path bound to an openEHR terminology
+/// group.
+///
+/// A bare `|code` binds to the row's group, resolving its rubric exactly as
+/// the equivalent `ctx/` shortcut does (master06 §setting: "either value or
+/// code is accepted"). Once the client spells out `|value` or `|terminology`,
+/// the datum parts stand as given (master05 §DV_CODED_TEXT).
+///
+/// # Errors
+/// [`FlatError`] from the leaf build.
+fn coded_group_value(node: &SimNode, group: &str, sub_path: &str) -> Result<Value, FlatError> {
+    let bound = node
+        .attrs
+        .get("code")
+        .and_then(Value::as_str)
+        .filter(|_| !node.attrs.contains_key("value") && !node.attrs.contains_key("terminology"))
+        .map(|code| map::coded_from_group(group, code));
+    match bound {
+        Some(v) => Ok(v),
+        None => map::build_leaf(node, "DV_CODED_TEXT", None, sub_path),
+    }
 }
 
 /// Build an `ACTION.ism_transition` (ISM_TRANSITION) from its simplified
@@ -833,126 +871,178 @@ fn place(
     if rel.is_empty() {
         return Ok(());
     }
-    let id_idx = rel.iter().rposition(|s| is_multiple(&s.attribute));
     // Per relative segment, the template-constrained concrete type of the
     // structural wrapper at that absolute path (empty ⇒ fall back to `infer_type`).
     let types = wrapper_types(&child.aql_path, rel.len(), slots);
-    place_rec(
-        parent,
+    let placement = Placement {
         rel,
-        0,
-        id_idx,
-        child_value,
+        id_idx: rel.iter().rposition(|s| is_multiple(&s.attribute)),
         child,
         occ,
         path,
-        &types,
+        types: &types,
         slots,
-    )
+    };
+    place_rec(parent, 0, child_value, &placement)
 }
 
-#[expect(
-    clippy::too_many_arguments,
-    clippy::too_many_lines,
-    reason = "a recursive placement cursor, not an API: the arguments thread the cursor state through the recursion, and the structural-case body runs just over the line limit"
-)]
+/// The invariant context of one placement walk: the relative path being
+/// materialised, the child it terminates at, that child's occurrence, and the
+/// template's wrapper types. Only the receiving map, the segment cursor and
+/// the value being placed move through the recursion.
+struct Placement<'a> {
+    rel: &'a [PathSegment],
+    /// The index of the child's OWN repeating array level, if it has one.
+    id_idx: Option<usize>,
+    child: &'a WebTemplateNode,
+    occ: &'a SimNode,
+    path: &'a str,
+    types: &'a [Option<String>],
+    slots: &'a [(Vec<PathSegment>, String)],
+}
+
+/// Materialise the wrapper chain of one relative segment, recursing into the
+/// next.
+///
+/// # Errors
+/// [`FlatError`] from a nested placement or an ELEMENT attribute family.
 #[expect(
     clippy::indexing_slicing,
     reason = "`i` is a cursor into `rel` that the recursion only advances while `i + 1 < rel.len()` (the `last` guard), so `rel[i]` and `rel[i + 1..]` are in bounds at every call"
 )]
 fn place_rec(
     cur: &mut Map<String, Value>,
-    rel: &[PathSegment],
     i: usize,
-    id_idx: Option<usize>,
     child_value: Option<Value>,
-    child: &WebTemplateNode,
-    occ: &SimNode,
-    path: &str,
-    types: &[Option<String>],
-    slots: &[(Vec<PathSegment>, String)],
+    p: &Placement<'_>,
 ) -> Result<(), FlatError> {
-    let seg = &rel[i];
-    let node_id = seg.predicate.archetype_node_id.as_deref();
-    let last = i + 1 == rel.len();
-
-    if Some(i) == id_idx {
-        // The child's own (repeating) array level.
-        let arr = cur
-            .entry(seg.attribute.clone())
-            .or_insert_with(|| json!([]))
-            .as_array_mut();
-        let Some(arr) = arr else { return Ok(()) };
-        if last {
-            // The child value is itself the array element (a container child).
-            let Some(mut el) = child_value else {
-                return Ok(());
-            };
-            set_node_id(&mut el, node_id);
-            arr.push(el);
-        } else {
-            // Wrap: the remaining path (e.g. `/value`) lives inside a new
-            // ELEMENT (or deeper structural) node.
-            let mut el = new_struct(
-                seg,
-                rel.get(i + 1),
-                child.name.as_deref(),
-                child.name_coded.as_ref(),
-                types.get(i).and_then(Option::as_deref),
-            );
-            if let Value::Object(m) = &mut el {
-                place(m, &rel[i + 1..], child_value, child, occ, path, slots)?;
-                // The ELEMENT wrapper's own `_` attribute family
-                // (master05 §ELEMENT).
-                apply_element_attrs(m, occ, path)?;
-            }
-            arr.push(el);
-        }
-        return Ok(());
+    if Some(i) == p.id_idx {
+        return place_own_level(cur, i, child_value, p);
     }
+    if is_multiple(&p.rel[i].attribute) {
+        return place_structural_level(cur, i, child_value, p);
+    }
+    place_single_attribute(cur, i, child_value, p)
+}
 
-    if is_multiple(&seg.attribute) {
-        // A structural (single-occurrence) array level: find-or-create by
-        // node id.
-        let arr = cur
-            .entry(seg.attribute.clone())
-            .or_insert_with(|| json!([]))
-            .as_array_mut();
-        let Some(arr) = arr else { return Ok(()) };
-        let pos = arr
-            .iter()
-            .position(|e| e.get("archetype_node_id").and_then(Value::as_str) == node_id);
-        let idx = if let Some(p) = pos {
-            p
-        } else {
-            arr.push(new_struct(
-                seg,
-                rel.get(i + 1),
-                None,
-                None,
-                types.get(i).and_then(Option::as_deref),
-            ));
-            arr.len() - 1
+/// The child's own (repeating) array level: the value is either the array
+/// element itself (a container child) or is wrapped in a fresh ELEMENT — or
+/// deeper structural — node carrying the rest of the path.
+///
+/// # Errors
+/// [`FlatError`] from the nested placement or the ELEMENT attribute family.
+#[expect(
+    clippy::indexing_slicing,
+    reason = "`i` indexes `rel` under the same cursor invariant as `place_rec`"
+)]
+fn place_own_level(
+    cur: &mut Map<String, Value>,
+    i: usize,
+    child_value: Option<Value>,
+    p: &Placement<'_>,
+) -> Result<(), FlatError> {
+    let seg = &p.rel[i];
+    let Some(arr) = cur
+        .entry(seg.attribute.clone())
+        .or_insert_with(|| json!([]))
+        .as_array_mut()
+    else {
+        return Ok(());
+    };
+    if i + 1 == p.rel.len() {
+        let Some(mut el) = child_value else {
+            return Ok(());
         };
-        if let Some(Value::Object(m)) = arr.get_mut(idx) {
-            place_rec(
-                m,
-                rel,
-                i + 1,
-                id_idx,
-                child_value,
-                child,
-                occ,
-                path,
-                types,
-                slots,
-            )?;
-        }
+        set_node_id(&mut el, seg.predicate.archetype_node_id.as_deref());
+        arr.push(el);
         return Ok(());
     }
+    let mut el = new_struct(
+        seg,
+        p.rel.get(i + 1),
+        p.child.name.as_deref(),
+        p.child.name_coded.as_ref(),
+        p.types.get(i).and_then(Option::as_deref),
+    );
+    if let Value::Object(m) = &mut el {
+        place(
+            m,
+            &p.rel[i + 1..],
+            child_value,
+            p.child,
+            p.occ,
+            p.path,
+            p.slots,
+        )?;
+        // The ELEMENT wrapper's own `_` attribute family (master05 §ELEMENT).
+        apply_element_attrs(m, p.occ, p.path)?;
+    }
+    arr.push(el);
+    Ok(())
+}
 
-    // A single-valued (object) attribute.
-    if last {
+/// A structural (single-occurrence) array level: find-or-create the element
+/// carrying this node id, then recurse into it.
+///
+/// # Errors
+/// [`FlatError`] from the nested placement.
+#[expect(
+    clippy::indexing_slicing,
+    reason = "`i` indexes `rel` under the same cursor invariant as `place_rec`"
+)]
+fn place_structural_level(
+    cur: &mut Map<String, Value>,
+    i: usize,
+    child_value: Option<Value>,
+    p: &Placement<'_>,
+) -> Result<(), FlatError> {
+    let seg = &p.rel[i];
+    let node_id = seg.predicate.archetype_node_id.as_deref();
+    let Some(arr) = cur
+        .entry(seg.attribute.clone())
+        .or_insert_with(|| json!([]))
+        .as_array_mut()
+    else {
+        return Ok(());
+    };
+    let existing = arr
+        .iter()
+        .position(|e| e.get("archetype_node_id").and_then(Value::as_str) == node_id);
+    let idx = if let Some(pos) = existing {
+        pos
+    } else {
+        arr.push(new_struct(
+            seg,
+            p.rel.get(i + 1),
+            None,
+            None,
+            p.types.get(i).and_then(Option::as_deref),
+        ));
+        arr.len() - 1
+    };
+    if let Some(Value::Object(m)) = arr.get_mut(idx) {
+        place_rec(m, i + 1, child_value, p)?;
+    }
+    Ok(())
+}
+
+/// A single-valued (object) attribute: the value lands here, or a fresh
+/// structural node carries the rest of the path.
+///
+/// # Errors
+/// [`FlatError`] from the nested placement or the ELEMENT attribute family.
+#[expect(
+    clippy::indexing_slicing,
+    reason = "`i` indexes `rel` under the same cursor invariant as `place_rec`"
+)]
+fn place_single_attribute(
+    cur: &mut Map<String, Value>,
+    i: usize,
+    child_value: Option<Value>,
+    p: &Placement<'_>,
+) -> Result<(), FlatError> {
+    let seg = &p.rel[i];
+    if i + 1 == p.rel.len() {
         let wraps_element = seg.attribute == "value";
         if let Some(child_value) = child_value {
             cur.insert(seg.attribute.clone(), child_value);
@@ -960,7 +1050,7 @@ fn place_rec(
         if wraps_element {
             // The map receiving `value` is the compacted-away ELEMENT
             // wrapper; apply its `_` attribute family (master05 §ELEMENT).
-            apply_element_attrs(cur, occ, path)?;
+            apply_element_attrs(cur, p.occ, p.path)?;
         }
         return Ok(());
     }
@@ -969,26 +1059,15 @@ fn place_rec(
             seg.attribute.clone(),
             new_struct(
                 seg,
-                rel.get(i + 1),
+                p.rel.get(i + 1),
                 None,
                 None,
-                types.get(i).and_then(Option::as_deref),
+                p.types.get(i).and_then(Option::as_deref),
             ),
         );
     }
     if let Some(Value::Object(m)) = cur.get_mut(&seg.attribute) {
-        place_rec(
-            m,
-            rel,
-            i + 1,
-            id_idx,
-            child_value,
-            child,
-            occ,
-            path,
-            types,
-            slots,
-        )?;
+        place_rec(m, i + 1, child_value, p)?;
     }
     Ok(())
 }
@@ -1479,10 +1558,6 @@ fn apply_entry_defaults(value: &mut Value, defaults: &ctx::CtxDefaults) {
     walk_entry_defaults(value, defaults);
 }
 
-#[expect(
-    clippy::too_many_lines,
-    reason = "one recursive walk over the ENTRY-default families; the length is the size of that family set"
-)]
 fn walk_entry_defaults(value: &mut Value, defaults: &ctx::CtxDefaults) {
     match value {
         Value::Array(items) => {
@@ -1496,85 +1571,10 @@ fn walk_entry_defaults(value: &mut Value, defaults: &ctx::CtxDefaults) {
                 .and_then(Value::as_str)
                 .unwrap_or_default()
                 .to_owned();
-            if matches!(
-                rm_type.as_str(),
-                "OBSERVATION"
-                    | "EVALUATION"
-                    | "INSTRUCTION"
-                    | "ACTION"
-                    | "ADMIN_ENTRY"
-                    | "GENERIC_ENTRY"
-            ) {
-                if let Some(language) = defaults.language_code_phrase() {
-                    obj.entry("language".to_owned()).or_insert(language);
-                }
-                obj.entry("encoding".to_owned())
-                    .or_insert_with(|| code_phrase("IANA_character-sets", "UTF-8"));
-                if let Some(provider) = &defaults.provider {
-                    obj.entry("provider".to_owned())
-                        .or_insert_with(|| provider.clone());
-                }
-                if let Some(wf) = &defaults.work_flow_id {
-                    obj.entry("workflow_id".to_owned())
-                        .or_insert_with(|| wf.clone());
-                }
-                // NOTE: master06 §Participation also names
-                // `ENTRY.other_participations`, but master05's explicit
-                // `_other_participation:i` path form wins, so ctx lands here only.
-            }
+            apply_common_entry_defaults(obj, &rm_type, defaults);
             match rm_type.as_str() {
-                "OBSERVATION" => {
-                    let origin = defaults
-                        .history_origin
-                        .clone()
-                        .unwrap_or_else(|| defaults.time.clone());
-                    if let Some(Value::Object(history)) = obj.get_mut("data") {
-                        let origin_value = history
-                            .entry("origin".to_owned())
-                            .or_insert_with(|| dv_date_time(&origin));
-                        if origin_value.get("value").and_then(Value::as_str) == Some(DEFAULT_TIME) {
-                            *origin_value = dv_date_time(&origin);
-                        }
-                        let origin_now = origin_value.clone();
-                        // EVENT.time defaults to the history origin
-                        // (master06 §time).
-                        if let Some(Value::Array(events)) = history.get_mut("events") {
-                            for event in events {
-                                if let Value::Object(ev) = event {
-                                    let time = ev
-                                        .entry("time".to_owned())
-                                        .or_insert_with(|| origin_now.clone());
-                                    if time.get("value").and_then(Value::as_str)
-                                        == Some(DEFAULT_TIME)
-                                    {
-                                        *time = origin_now.clone();
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                "ACTION" => {
-                    let time = defaults
-                        .action_time
-                        .clone()
-                        .unwrap_or_else(|| defaults.time.clone());
-                    let entry = obj
-                        .entry("time".to_owned())
-                        .or_insert_with(|| dv_date_time(&time));
-                    if entry.get("value").and_then(Value::as_str) == Some(DEFAULT_TIME) {
-                        *entry = dv_date_time(&time);
-                    }
-                    if let Some(state) = &defaults.action_ism_current_state {
-                        let ism = obj
-                            .entry("ism_transition".to_owned())
-                            .or_insert_with(|| json!({"_type": "ISM_TRANSITION"}));
-                        if let Value::Object(ism) = ism {
-                            ism.entry("current_state".to_owned())
-                                .or_insert_with(|| state.clone());
-                        }
-                    }
-                }
+                "OBSERVATION" => apply_observation_defaults(obj, defaults),
+                "ACTION" => apply_action_defaults(obj, defaults),
                 "INSTRUCTION" => {
                     if let Some(narrative) = &defaults.instruction_narrative {
                         obj.entry("narrative".to_owned())
@@ -1595,6 +1595,95 @@ fn walk_entry_defaults(value: &mut Value, defaults: &ctx::CtxDefaults) {
             }
         }
         _ => {}
+    }
+}
+
+/// The defaults every ENTRY subtype takes: language, encoding, provider and
+/// workflow id.
+///
+/// NOTE: master06 §Participation also names `ENTRY.other_participations`, but
+/// master05's explicit `_other_participation:i` path form wins, so ctx lands
+/// here only.
+fn apply_common_entry_defaults(
+    obj: &mut Map<String, Value>,
+    rm_type: &str,
+    defaults: &ctx::CtxDefaults,
+) {
+    if !matches!(
+        rm_type,
+        "OBSERVATION" | "EVALUATION" | "INSTRUCTION" | "ACTION" | "ADMIN_ENTRY" | "GENERIC_ENTRY"
+    ) {
+        return;
+    }
+    if let Some(language) = defaults.language_code_phrase() {
+        obj.entry("language".to_owned()).or_insert(language);
+    }
+    obj.entry("encoding".to_owned())
+        .or_insert_with(|| code_phrase("IANA_character-sets", "UTF-8"));
+    if let Some(provider) = &defaults.provider {
+        obj.entry("provider".to_owned())
+            .or_insert_with(|| provider.clone());
+    }
+    if let Some(wf) = &defaults.work_flow_id {
+        obj.entry("workflow_id".to_owned())
+            .or_insert_with(|| wf.clone());
+    }
+}
+
+/// The OBSERVATION defaults: the HISTORY origin, and each EVENT's time, which
+/// defaults to that origin (master06 §time).
+fn apply_observation_defaults(obj: &mut Map<String, Value>, defaults: &ctx::CtxDefaults) {
+    let origin = defaults
+        .history_origin
+        .clone()
+        .unwrap_or_else(|| defaults.time.clone());
+    let Some(Value::Object(history)) = obj.get_mut("data") else {
+        return;
+    };
+    let origin_value = history
+        .entry("origin".to_owned())
+        .or_insert_with(|| dv_date_time(&origin));
+    if origin_value.get("value").and_then(Value::as_str) == Some(DEFAULT_TIME) {
+        *origin_value = dv_date_time(&origin);
+    }
+    let origin_now = origin_value.clone();
+    let Some(Value::Array(events)) = history.get_mut("events") else {
+        return;
+    };
+    for event in events {
+        if let Value::Object(ev) = event {
+            let time = ev
+                .entry("time".to_owned())
+                .or_insert_with(|| origin_now.clone());
+            if time.get("value").and_then(Value::as_str) == Some(DEFAULT_TIME) {
+                *time = origin_now.clone();
+            }
+        }
+    }
+}
+
+/// The ACTION defaults: the action time and the ISM transition's current
+/// state.
+fn apply_action_defaults(obj: &mut Map<String, Value>, defaults: &ctx::CtxDefaults) {
+    let time = defaults
+        .action_time
+        .clone()
+        .unwrap_or_else(|| defaults.time.clone());
+    let entry = obj
+        .entry("time".to_owned())
+        .or_insert_with(|| dv_date_time(&time));
+    if entry.get("value").and_then(Value::as_str) == Some(DEFAULT_TIME) {
+        *entry = dv_date_time(&time);
+    }
+    let Some(state) = &defaults.action_ism_current_state else {
+        return;
+    };
+    let ism = obj
+        .entry("ism_transition".to_owned())
+        .or_insert_with(|| json!({"_type": "ISM_TRANSITION"}));
+    if let Value::Object(ism) = ism {
+        ism.entry("current_state".to_owned())
+            .or_insert_with(|| state.clone());
     }
 }
 

--- a/crates/openehr-its/src/flat/example.rs
+++ b/crates/openehr-its/src/flat/example.rs
@@ -200,104 +200,13 @@ fn walk(
     }
 
     let groups = child_groups(node);
-    let mut emitted = false;
-    let mut included: Vec<&str> = Vec::new();
-    // Materialised instances per container cardinality (`max != -1`), so the
-    // populated levels never overrun a container's upper bound — an *optional*
-    // child is skipped once its cardinality is full (a mandatory one still
-    // materialises; a template whose mandatory children alone exceed the bound
-    // is contradictory and the validator's job to report).
-    let mut card_counts = vec![0usize; node.cardinalities.len()];
-    let card_idx = |child: &WebTemplateNode| {
-        node.cardinalities
-            .iter()
-            .position(|c| c.max != -1 && child.aql_path.starts_with(c.path.as_str()))
+    let cx = WalkCtx {
+        prefix,
+        opt_depth,
+        level,
     };
-
-    for child in &groups {
-        // A template may constrain an attribute the RM does not declare — the
-        // deployed OPT 1.4 corpus carries `ELEMENT.null_flavor` (the US
-        // archetype-tooling spelling of RM `null_flavour`,
-        // `docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.data_structures.element.adoc`
-        // §Attributes) and other RM-1.0.x leftovers. Such a constraint is
-        // tolerated when VALIDATING a template, but materializing it here would
-        // author an example that is not a conformant RM instance, so the
-        // example generator skips it. The generated RM model is the oracle.
-        if !rm_declares(&child.aql_path) {
-            continue;
-        }
-        let child_opt = opt_depth + usize::from(is_optional(child));
-        let include = match level {
-            DetailLevel::Required => child_opt == 0,
-            DetailLevel::Medium | DetailLevel::Complete => true,
-        };
-        if include {
-            // An OPTIONAL node whose coded-name constraint is display/rubric-
-            // incoherent (see `CodedName::incoherent`) is omitted: no instance
-            // form of it is accepted by every conforming consumer, and an
-            // example exists to be committable everywhere. A MANDATORY one is
-            // still emitted in our spec-faithful form.
-            if is_optional(child)
-                && (child.name_coded.as_ref().is_some_and(|cn| cn.incoherent)
-                    || is_unsatisfiable_leaf(child))
-            {
-                continue;
-            }
-            let ci = card_idx(child);
-            let card_full = |counts: &[usize]| {
-                ci.is_some_and(|i| {
-                    let max = node
-                        .cardinalities
-                        .get(i)
-                        .map_or(usize::MAX, |c| usize::try_from(c.max).unwrap_or(usize::MAX));
-                    counts.get(i).is_some_and(|&n| n >= max)
-                })
-            };
-            if is_optional(child) && card_full(&card_counts) {
-                continue;
-            }
-            included.push(child.aql_path.as_str());
-            let child_prefix = format!("{prefix}/{}", seg_for(child));
-            // A mandatory child must materialise even when all of *its* children
-            // are optional (else the mandatory node would go missing).
-            let child_force = !is_optional(child);
-            let child_emitted = walk(child, &child_prefix, child_opt, level, child_force, out);
-            emitted |= child_emitted;
-            if child_emitted && let Some(slot) = ci.and_then(|i| card_counts.get_mut(i)) {
-                *slot += 1;
-            }
-            // `Complete` demonstrates repetition: a second occurrence of any
-            // repeating node that materialised (cardinality permitting).
-            if level == DetailLevel::Complete
-                && child_emitted
-                && is_repeating(child)
-                && !card_full(&card_counts)
-            {
-                let second_prefix = format!("{prefix}/{}:1", child.id);
-                let second_emitted = walk(child, &second_prefix, child_opt, level, false, out);
-                emitted |= second_emitted;
-                if second_emitted && let Some(slot) = ci.and_then(|i| card_counts.get_mut(i)) {
-                    *slot += 1;
-                }
-            }
-        }
-    }
-
-    // Cardinality satisfaction: for every container attribute constrained to
-    // `min >= 1`, ensure at least one child under it is materialised (committable
-    // skeleton), even if the level would otherwise skip it.
-    for card in &node.cardinalities {
-        if card.min.unwrap_or(0) < 1 {
-            continue;
-        }
-        let satisfied = included.iter().any(|p| p.starts_with(card.path.as_str()));
-        if !satisfied
-            && let Some(child) = groups.iter().find(|c| c.aql_path.starts_with(&card.path))
-        {
-            let child_prefix = format!("{prefix}/{}", seg_for(child));
-            emitted |= walk(child, &child_prefix, opt_depth, level, true, out);
-        }
-    }
+    let (mut emitted, included) = walk_children(node, &groups, &cx, out);
+    emitted |= satisfy_cardinalities(node, &groups, &included, &cx, out);
 
     // A forced (mandatory) container with nothing yet: drill its first child to a
     // leaf so the node is not emitted empty.
@@ -309,6 +218,151 @@ fn walk(
         emitted |= walk(child, &child_prefix, opt_depth, level, true, out);
     }
 
+    emitted
+}
+
+/// The invariant context of one walk level: the flat-path prefix, the optional
+/// depth reached, and the requested detail level.
+struct WalkCtx<'a> {
+    prefix: &'a str,
+    opt_depth: usize,
+    level: DetailLevel,
+}
+
+/// Walks every child group of a container, returning whether anything was
+/// emitted and which child paths were included.
+fn walk_children<'a>(
+    node: &'a WebTemplateNode,
+    groups: &[&'a WebTemplateNode],
+    cx: &WalkCtx<'_>,
+    out: &mut Map<String, Value>,
+) -> (bool, Vec<&'a str>) {
+    let mut emitted = false;
+    let mut included: Vec<&str> = Vec::new();
+    // Materialised instances per container cardinality (`max != -1`), so the
+    // populated levels never overrun a container's upper bound — an *optional*
+    // child is skipped once its cardinality is full (a mandatory one still
+    // materialises; a template whose mandatory children alone exceed the bound
+    // is contradictory and the validator's job to report).
+    let mut card_counts = vec![0usize; node.cardinalities.len()];
+    for child in groups {
+        // A template may constrain an attribute the RM does not declare — the
+        // deployed OPT 1.4 corpus carries `ELEMENT.null_flavor` (the US
+        // archetype-tooling spelling of RM `null_flavour`,
+        // `docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.data_structures.element.adoc`
+        // §Attributes) and other RM-1.0.x leftovers. Such a constraint is
+        // tolerated when VALIDATING a template, but materializing it here would
+        // author an example that is not a conformant RM instance, so the
+        // example generator skips it. The generated RM model is the oracle.
+        if !rm_declares(&child.aql_path) {
+            continue;
+        }
+        let child_opt = cx.opt_depth + usize::from(is_optional(child));
+        let include = match cx.level {
+            DetailLevel::Required => child_opt == 0,
+            DetailLevel::Medium | DetailLevel::Complete => true,
+        };
+        if !include || skips_optional(child) {
+            continue;
+        }
+        let ci = cardinality_index(node, child);
+        if is_optional(child) && cardinality_full(node, ci, &card_counts) {
+            continue;
+        }
+        included.push(child.aql_path.as_str());
+        emitted |= walk_child(node, child, cx, &mut card_counts, out);
+    }
+    (emitted, included)
+}
+
+/// Whether an OPTIONAL child is omitted from the example.
+///
+/// A node whose coded-name constraint is display/rubric-incoherent (see
+/// `CodedName::incoherent`) or whose leaf is unsatisfiable has no instance
+/// form every conforming consumer accepts, and an example exists to be
+/// committable everywhere. A MANDATORY one is still emitted in our
+/// spec-faithful form.
+fn skips_optional(child: &WebTemplateNode) -> bool {
+    is_optional(child)
+        && (child.name_coded.as_ref().is_some_and(|cn| cn.incoherent)
+            || is_unsatisfiable_leaf(child))
+}
+
+/// The index of the bounded container cardinality a child sits under, if any.
+fn cardinality_index(node: &WebTemplateNode, child: &WebTemplateNode) -> Option<usize> {
+    node.cardinalities
+        .iter()
+        .position(|c| c.max != -1 && child.aql_path.starts_with(c.path.as_str()))
+}
+
+/// Whether the container cardinality at `index` has reached its upper bound.
+fn cardinality_full(node: &WebTemplateNode, index: Option<usize>, counts: &[usize]) -> bool {
+    index.is_some_and(|i| {
+        let max = node
+            .cardinalities
+            .get(i)
+            .map_or(usize::MAX, |c| usize::try_from(c.max).unwrap_or(usize::MAX));
+        counts.get(i).is_some_and(|&n| n >= max)
+    })
+}
+
+/// Walks one included child, materialising a second occurrence at the
+/// `Complete` level to demonstrate repetition (cardinality permitting).
+fn walk_child(
+    node: &WebTemplateNode,
+    child: &WebTemplateNode,
+    cx: &WalkCtx<'_>,
+    card_counts: &mut [usize],
+    out: &mut Map<String, Value>,
+) -> bool {
+    let ci = cardinality_index(node, child);
+    let child_opt = cx.opt_depth + usize::from(is_optional(child));
+    let child_prefix = format!("{}/{}", cx.prefix, seg_for(child));
+    // A mandatory child must materialise even when all of *its* children are
+    // optional (else the mandatory node would go missing).
+    let child_force = !is_optional(child);
+    let mut emitted = walk(child, &child_prefix, child_opt, cx.level, child_force, out);
+    if emitted && let Some(slot) = ci.and_then(|i| card_counts.get_mut(i)) {
+        *slot += 1;
+    }
+    if cx.level == DetailLevel::Complete
+        && emitted
+        && is_repeating(child)
+        && !cardinality_full(node, ci, card_counts)
+    {
+        let second_prefix = format!("{}/{}:1", cx.prefix, child.id);
+        let second_emitted = walk(child, &second_prefix, child_opt, cx.level, false, out);
+        emitted |= second_emitted;
+        if second_emitted && let Some(slot) = ci.and_then(|i| card_counts.get_mut(i)) {
+            *slot += 1;
+        }
+    }
+    emitted
+}
+
+/// Cardinality satisfaction: for every container attribute constrained to
+/// `min >= 1`, ensure at least one child under it is materialised (a
+/// committable skeleton), even where the level would otherwise skip it.
+fn satisfy_cardinalities(
+    node: &WebTemplateNode,
+    groups: &[&WebTemplateNode],
+    included: &[&str],
+    cx: &WalkCtx<'_>,
+    out: &mut Map<String, Value>,
+) -> bool {
+    let mut emitted = false;
+    for card in &node.cardinalities {
+        if card.min.unwrap_or(0) < 1 {
+            continue;
+        }
+        let satisfied = included.iter().any(|p| p.starts_with(card.path.as_str()));
+        if !satisfied
+            && let Some(child) = groups.iter().find(|c| c.aql_path.starts_with(&card.path))
+        {
+            let child_prefix = format!("{}/{}", cx.prefix, seg_for(child));
+            emitted |= walk(child, &child_prefix, cx.opt_depth, cx.level, true, out);
+        }
+    }
     emitted
 }
 

--- a/crates/openehr-its/src/flat/example.rs
+++ b/crates/openehr-its/src/flat/example.rs
@@ -906,61 +906,51 @@ fn example_temporal(node: &WebTemplateNode, rm: &str) -> String {
         Some(p) => (p, ""),
         None => ("", ""),
     };
-    // Date segments: year always; month/day kept unless the pattern prohibits
-    // them (an omitted month forces the day off — ISO 8601 partial precision
-    // truncates right-to-left).
-    let date_full = ["2022", "02", "03"];
-    let date = |pat: &str| -> String {
-        let segs: Vec<&str> = if pat.is_empty() {
-            Vec::new()
-        } else {
-            pat.splitn(3, '-').collect()
-        };
-        let mut out = String::from(date_full[0]);
-        for (i, part) in date_full.iter().enumerate().skip(1) {
-            if segs.get(i).is_some_and(|s| *s == "XX") {
-                break;
-            }
-            out.push('-');
-            out.push_str(part);
-        }
-        out
-    };
-    let time_full = ["04", "05", "06"];
-    let time = |pat: &str| -> String {
-        let segs: Vec<&str> = if pat.is_empty() {
-            Vec::new()
-        } else {
-            pat.splitn(3, ':').collect()
-        };
-        let mut out = String::from(time_full[0]);
-        for (i, part) in time_full.iter().enumerate().skip(1) {
-            if segs.get(i).is_some_and(|s| *s == "XX") {
-                break;
-            }
-            out.push(':');
-            out.push_str(part);
-        }
-        out
-    };
     let tz = if node.tz_validity == Some(1003) {
         ""
     } else {
         "Z"
     };
+    let date = temporal_segments(pat_date, DATE_SEGMENTS, '-');
     match rm {
-        "DV_DATE" => date(pat_date),
-        "DV_TIME" => format!("{}{tz}", time(pat_time)),
+        "DV_DATE" => date,
+        "DV_TIME" => format!("{}{tz}", temporal_segments(pat_time, TIME_SEGMENTS, ':')),
         // DV_DATE_TIME: a time part prohibited outright (pattern `…TXX:…`)
         // truncates to the date.
-        _ => {
-            if pat_time.starts_with("XX") {
-                date(pat_date)
-            } else {
-                format!("{}T{}{tz}", date(pat_date), time(pat_time))
-            }
-        }
+        _ if pat_time.starts_with("XX") => date,
+        _ => format!(
+            "{date}T{}{tz}",
+            temporal_segments(pat_time, TIME_SEGMENTS, ':')
+        ),
     }
+}
+
+/// The example date's segments, coarsest first.
+const DATE_SEGMENTS: [&str; 3] = ["2022", "02", "03"];
+
+/// The example time's segments, coarsest first.
+const TIME_SEGMENTS: [&str; 3] = ["04", "05", "06"];
+
+/// Renders one temporal half, dropping every segment the pattern prohibits.
+///
+/// The leading segment is always present; the rest are kept until the pattern
+/// marks one `XX`, since ISO 8601 partial precision truncates right-to-left —
+/// an omitted month forces the day off with it.
+fn temporal_segments(pattern: &str, full: [&str; 3], separator: char) -> String {
+    let segments: Vec<&str> = if pattern.is_empty() {
+        Vec::new()
+    } else {
+        pattern.splitn(3, separator).collect()
+    };
+    let mut out = String::from(full[0]);
+    for (i, part) in full.iter().enumerate().skip(1) {
+        if segments.get(i).is_some_and(|s| *s == "XX") {
+            break;
+        }
+        out.push(separator);
+        out.push_str(part);
+    }
+    out
 }
 
 /// A deterministic duration example honouring the `C_DURATION` allowed-fields
@@ -1061,32 +1051,40 @@ fn iso_seconds(value: &str) -> f64 {
         return 0.0;
     };
     let (date_part, time_part) = rest.split_once('T').unwrap_or((rest, ""));
+    iso_part_seconds(date_part, false) + iso_part_seconds(time_part, true)
+}
+
+/// Total seconds of one half of an ISO-8601 duration string.
+///
+/// `in_time` selects the time-half reading of the ambiguous `M` designator
+/// (minutes rather than months).
+fn iso_part_seconds(part: &str, in_time: bool) -> f64 {
     let mut total = 0.0;
-    let mut accumulate = |part: &str, in_time: bool| {
-        let mut num = String::new();
-        for ch in part.chars() {
-            if ch.is_ascii_digit() || ch == '.' || ch == ',' {
-                num.push(if ch == ',' { '.' } else { ch });
-            } else {
-                let n: f64 = num.parse().unwrap_or(0.0);
-                num.clear();
-                let secs = match (ch, in_time) {
-                    ('Y', false) => 31_557_600.0,
-                    ('M', false) => 2_629_800.0,
-                    ('W', false) => 604_800.0,
-                    ('D', false) => 86_400.0,
-                    ('H', true) => 3_600.0,
-                    ('M', true) => 60.0,
-                    ('S', true) => 1.0,
-                    _ => 0.0,
-                };
-                total += n * secs;
-            }
+    let mut num = String::new();
+    for ch in part.chars() {
+        if ch.is_ascii_digit() || ch == '.' || ch == ',' {
+            num.push(if ch == ',' { '.' } else { ch });
+            continue;
         }
-    };
-    accumulate(date_part, false);
-    accumulate(time_part, true);
+        let n: f64 = num.parse().unwrap_or(0.0);
+        num.clear();
+        total += n * iso_designator_seconds(ch, in_time);
+    }
     total
+}
+
+/// The RM's nominal length in seconds of one ISO-8601 duration designator.
+fn iso_designator_seconds(designator: char, in_time: bool) -> f64 {
+    match (designator, in_time) {
+        ('Y', false) => 31_557_600.0,
+        ('M', false) => 2_629_800.0,
+        ('W', false) => 604_800.0,
+        ('D', false) => 86_400.0,
+        ('H', true) => 3_600.0,
+        ('M', true) => 60.0,
+        ('S', true) => 1.0,
+        _ => 0.0,
+    }
 }
 
 /// A deterministic boolean example: `false` when the archetype allows only

--- a/crates/openehr-its/src/flat/flatten.rs
+++ b/crates/openehr-its/src/flat/flatten.rs
@@ -146,49 +146,53 @@ fn walk(node: &WebTemplateNode, rm: &Value, out: &mut SimNode) {
     map::emit_rm_attrs(rm, base_type(&node.rm_type), out);
 
     for child in &node.children {
-        if covered_by_ctx(node, child) {
-            continue;
-        }
-        let rel = rmpath::relative(&node.aql_path, &child.aql_path);
-        // Polymorphic choice alternatives share one aqlPath; emit only under
-        // the alternative whose rm type matches this value's `_type`. The
-        // filter must apply to EVERY member of a choice group — the first
-        // alternative carries no `alt_json_id`, so sharing an aqlPath with a
-        // sibling is the group marker.
-        let in_choice = child.alt_json_id.is_some()
-            || node
-                .children
-                .iter()
-                .any(|c| c.id != child.id && c.aql_path == child.aql_path);
-        let occurrences = occurrences_of(child, rm, &rel, in_choice);
-        if occurrences.is_empty() {
-            continue;
-        }
-        let repeating = child.max == -1 || child.max > 1;
-        if repeating {
-            out.children.entry(child.id.clone()).or_default().indexed = true;
-        }
-        for (i, occurrence) in occurrences.iter().enumerate() {
-            if occurrence
-                .value
-                .is_some_and(|v| is_default_entry_context(child, v))
-            {
-                continue;
-            }
-            let slot = out.place_mut(&child.id, u32::try_from(i).unwrap_or(u32::MAX));
-            if let Some(value) = occurrence.value {
-                walk(child, value, slot);
-            }
-            // The leaf's wrapping ELEMENT carries its own `_` attribute
-            // family (`master05 §ELEMENT`: `_uid`, `_null_flavour`,
-            // `_null_reason`, `_link:i`, `_feeder_audit`); the leaf walk
-            // above saw only the DV value, so surface the wrapper's here.
-            if let Some(element) = occurrence.element {
-                map::emit_rm_attrs(element, "ELEMENT", slot);
-            }
+        if !covered_by_ctx(node, child) {
+            walk_child(node, child, rm, out);
         }
     }
     emit_direct_rm_paths(node, rm, out);
+}
+
+/// Emits every occurrence of one template child under its simplified slot.
+///
+/// Polymorphic choice alternatives share one `aqlPath`, so an occurrence is
+/// emitted only under the alternative whose RM type matches the value's
+/// `_type`. That filter must apply to EVERY member of a choice group — the
+/// first alternative carries no `alt_json_id`, so sharing an `aqlPath` with a
+/// sibling is the group marker.
+fn walk_child(node: &WebTemplateNode, child: &WebTemplateNode, rm: &Value, out: &mut SimNode) {
+    let rel = rmpath::relative(&node.aql_path, &child.aql_path);
+    let in_choice = child.alt_json_id.is_some()
+        || node
+            .children
+            .iter()
+            .any(|c| c.id != child.id && c.aql_path == child.aql_path);
+    let occurrences = occurrences_of(child, rm, &rel, in_choice);
+    if occurrences.is_empty() {
+        return;
+    }
+    if child.max == -1 || child.max > 1 {
+        out.children.entry(child.id.clone()).or_default().indexed = true;
+    }
+    for (i, occurrence) in occurrences.iter().enumerate() {
+        if occurrence
+            .value
+            .is_some_and(|v| is_default_entry_context(child, v))
+        {
+            continue;
+        }
+        let slot = out.place_mut(&child.id, u32::try_from(i).unwrap_or(u32::MAX));
+        if let Some(value) = occurrence.value {
+            walk(child, value, slot);
+        }
+        // The leaf's wrapping ELEMENT carries its own `_` attribute family
+        // (`master05 §ELEMENT`: `_uid`, `_null_flavour`, `_null_reason`,
+        // `_link:i`, `_feeder_audit`); the leaf walk above saw only the DV
+        // value, so surface the wrapper's here.
+        if let Some(element) = occurrence.element {
+            map::emit_rm_attrs(element, "ELEMENT", slot);
+        }
+    }
 }
 
 /// One emitted occurrence of a template child: the RM value its relative path

--- a/crates/openehr-its/src/flat/flatten.rs
+++ b/crates/openehr-its/src/flat/flatten.rs
@@ -316,73 +316,105 @@ fn attr_emitted(node: &WebTemplateNode, out: &SimNode, attr: &str) -> bool {
 /// `setting` are NOT emitted here — they surface through the `ctx/` vocabulary
 /// (master06; [`crate::flat::ctx`]) to avoid a duplicate encoding of the same datum.
 fn emit_direct_rm_paths(node: &WebTemplateNode, rm: &Value, out: &mut SimNode) {
-    let mut leaf = |name: &str, rm_type: &str, value: Option<&Value>| {
-        if attr_emitted(node, out, name) {
-            return;
-        }
-        if let Some(v) = value.filter(|v| !v.is_null()) {
-            map::emit_leaf(v, rm_type, None, out.occurrence_mut(name, None));
-        }
-    };
     match base_type(&node.rm_type) {
-        "ACTION" => {
-            leaf("time", "DV_DATE_TIME", rm.get("time"));
-            if !attr_emitted(node, out, "ism_transition")
-                && let Some(ism) = rm.get("ism_transition").filter(|v| !v.is_null())
-            {
-                emit_ism_transition(ism, out.occurrence_mut("ism_transition", None));
-            }
-        }
+        "ACTION" => emit_action_paths(node, rm, out),
         // master05 §ISM_TRANSITION: the three coded rows are addressable on the
         // transition node itself, so one the template leaves unconstrained is
-        // emitted here rather than lost (the `leaf` closure skips whatever the
+        // emitted here rather than lost ([`emit_direct_leaf`] skips whatever the
         // template-child walk already realized).
         "ISM_TRANSITION" => {
-            leaf("current_state", "DV_CODED_TEXT", rm.get("current_state"));
-            leaf("transition", "DV_CODED_TEXT", rm.get("transition"));
-            leaf("careflow_step", "DV_CODED_TEXT", rm.get("careflow_step"));
-        }
-        "INSTRUCTION" => leaf("narrative", "DV_TEXT", rm.get("narrative")),
-        "OBSERVATION" => {
-            // `history_origin` maps to the nested `data.origin` (master05
-            // §OBSERVATION); the HISTORY is compacted away, so `origin` is
-            // never a template leaf child — emit it unless the walk already did.
-            if !out.children.contains_key("history_origin")
-                && let Some(origin) = rm.pointer("/data/origin/value")
-            {
-                out.occurrence_mut("history_origin", None)
-                    .attrs
-                    .insert(String::new(), origin.clone());
+            for attr in ["current_state", "transition", "careflow_step"] {
+                emit_direct_leaf(node, out, attr, "DV_CODED_TEXT", rm.get(attr));
             }
         }
-        "ACTIVITY" => {
-            leaf("timing", "DV_PARSABLE", rm.get("timing"));
-            // `action_archetype_id` is the match-all `/.*/` when unset
-            // (master05 §ACTIVITY: "Will be set to /.*/ if not set explicit.");
-            // that default is re-synthesised on build, so emitting it would
-            // desync the round-trip — emit only an explicit non-default value.
-            if !attr_emitted(node, out, "action_archetype_id")
-                && let Some(aid) = rm.get("action_archetype_id").and_then(Value::as_str)
-                && aid != "/.*/"
-            {
-                out.occurrence_mut("action_archetype_id", None)
-                    .attrs
-                    .insert(String::new(), Value::String(aid.to_owned()));
-            }
+        "INSTRUCTION" => {
+            emit_direct_leaf(node, out, "narrative", "DV_TEXT", rm.get("narrative"));
         }
-        "POINT_EVENT" | "EVENT" => leaf("time", "DV_DATE_TIME", rm.get("time")),
-        "INTERVAL_EVENT" => {
-            leaf("time", "DV_DATE_TIME", rm.get("time"));
-            leaf("width", "DV_DURATION", rm.get("width"));
-            leaf("math_function", "DV_CODED_TEXT", rm.get("math_function"));
-            // master05 §INTERVAL_EVENT: `|sample_count` (INTEGER) is a datum
-            // suffix on the event node itself, not a sub-path — the section's
-            // second example spells it `…/any_event:0|sample_count: 5`.
-            if let Some(n) = rm.get("sample_count").filter(|v| !v.is_null()) {
-                out.attrs.insert("sample_count".to_owned(), n.clone());
-            }
+        "OBSERVATION" => emit_history_origin(rm, out),
+        "ACTIVITY" => emit_activity_paths(node, rm, out),
+        "POINT_EVENT" | "EVENT" => {
+            emit_direct_leaf(node, out, "time", "DV_DATE_TIME", rm.get("time"));
         }
+        "INTERVAL_EVENT" => emit_interval_event_paths(node, rm, out),
         _ => {}
+    }
+}
+
+/// Emits one datum under `name` unless the template-child walk already did.
+fn emit_direct_leaf(
+    node: &WebTemplateNode,
+    out: &mut SimNode,
+    name: &str,
+    rm_type: &str,
+    value: Option<&Value>,
+) {
+    if attr_emitted(node, out, name) {
+        return;
+    }
+    if let Some(v) = value.filter(|v| !v.is_null()) {
+        map::emit_leaf(v, rm_type, None, out.occurrence_mut(name, None));
+    }
+}
+
+/// Emits the ACTION rows the template left unconstrained (master05 §ACTION).
+fn emit_action_paths(node: &WebTemplateNode, rm: &Value, out: &mut SimNode) {
+    emit_direct_leaf(node, out, "time", "DV_DATE_TIME", rm.get("time"));
+    if !attr_emitted(node, out, "ism_transition")
+        && let Some(ism) = rm.get("ism_transition").filter(|v| !v.is_null())
+    {
+        emit_ism_transition(ism, out.occurrence_mut("ism_transition", None));
+    }
+}
+
+/// Emits `history_origin`, which maps to the nested `data.origin` (master05
+/// §OBSERVATION).
+///
+/// The HISTORY is compacted away, so `origin` is never a template leaf child —
+/// it is emitted here unless the walk already produced it.
+fn emit_history_origin(rm: &Value, out: &mut SimNode) {
+    if !out.children.contains_key("history_origin")
+        && let Some(origin) = rm.pointer("/data/origin/value")
+    {
+        out.occurrence_mut("history_origin", None)
+            .attrs
+            .insert(String::new(), origin.clone());
+    }
+}
+
+/// Emits the ACTIVITY rows the template left unconstrained (master05 §ACTIVITY).
+fn emit_activity_paths(node: &WebTemplateNode, rm: &Value, out: &mut SimNode) {
+    emit_direct_leaf(node, out, "timing", "DV_PARSABLE", rm.get("timing"));
+    // `action_archetype_id` is the match-all `/.*/` when unset (master05
+    // §ACTIVITY: "Will be set to /.*/ if not set explicit."); that default is
+    // re-synthesised on build, so emitting it would desync the round-trip —
+    // emit only an explicit non-default value.
+    if !attr_emitted(node, out, "action_archetype_id")
+        && let Some(aid) = rm.get("action_archetype_id").and_then(Value::as_str)
+        && aid != "/.*/"
+    {
+        out.occurrence_mut("action_archetype_id", None)
+            .attrs
+            .insert(String::new(), Value::String(aid.to_owned()));
+    }
+}
+
+/// Emits the INTERVAL_EVENT rows the template left unconstrained (master05
+/// §INTERVAL_EVENT).
+fn emit_interval_event_paths(node: &WebTemplateNode, rm: &Value, out: &mut SimNode) {
+    emit_direct_leaf(node, out, "time", "DV_DATE_TIME", rm.get("time"));
+    emit_direct_leaf(node, out, "width", "DV_DURATION", rm.get("width"));
+    emit_direct_leaf(
+        node,
+        out,
+        "math_function",
+        "DV_CODED_TEXT",
+        rm.get("math_function"),
+    );
+    // `|sample_count` (INTEGER) is a datum suffix on the event node itself, not
+    // a sub-path — the section's second example spells it
+    // `…/any_event:0|sample_count: 5`.
+    if let Some(n) = rm.get("sample_count").filter(|v| !v.is_null()) {
+        out.attrs.insert("sample_count".to_owned(), n.clone());
     }
 }
 

--- a/crates/openehr-its/src/flat/map/data_values.rs
+++ b/crates/openehr-its/src/flat/map/data_values.rs
@@ -395,16 +395,7 @@ pub(super) fn build_leaf(
 /// on demand when a walker routes a `_`-child to it instead.
 fn attach_value_internal(map: &mut Map<String, Value>, base: &str, node: &SimNode) {
     if is_text_family(base) {
-        if let Some(cp) = single(node, "_language").and_then(build_code_phrase) {
-            map.insert("language".to_owned(), cp);
-        }
-        if let Some(cp) = single(node, "_encoding").and_then(build_code_phrase) {
-            map.insert("encoding".to_owned(), cp);
-        }
-        let mappings = build_indexed(node, "_mapping", build_term_mapping);
-        if !mappings.is_empty() {
-            map.insert("mappings".to_owned(), Value::Array(mappings));
-        }
+        attach_text_internal(map, node);
     }
     if base == "DV_PARSABLE" || base == "DV_MULTIMEDIA" {
         if let Some(child) = single(node, "_charset").and_then(build_code_phrase) {
@@ -421,23 +412,44 @@ fn attach_value_internal(map: &mut Map<String, Value>, base: &str, node: &SimNod
         map.insert("thumbnail".to_owned(), dv);
     }
     if DV_ORDERED.contains(&base) {
-        if let Some(child) = single(node, "_normal_range") {
-            map.insert("normal_range".to_owned(), build_interval(child, base));
-        }
-        let ranges = build_indexed(node, "_other_reference_ranges", |n| {
-            build_reference_range(n, base)
-        });
-        if !ranges.is_empty() {
-            map.insert("other_reference_ranges".to_owned(), Value::Array(ranges));
-        }
-        if matches!(base, "DV_DATE" | "DV_DATE_TIME" | "DV_TIME")
-            && let Some(acc) = single(node, "_accuracy").and_then(SimNode::bare)
-        {
-            map.insert(
-                "accuracy".to_owned(),
-                json!({"_type": "DV_DURATION", "value": acc.clone()}),
-            );
-        }
+        attach_ordered_internal(map, base, node);
+    }
+}
+
+/// The text-family value-internal families: `language`, `encoding` and the
+/// `_mapping:i` list.
+fn attach_text_internal(map: &mut Map<String, Value>, node: &SimNode) {
+    if let Some(cp) = single(node, "_language").and_then(build_code_phrase) {
+        map.insert("language".to_owned(), cp);
+    }
+    if let Some(cp) = single(node, "_encoding").and_then(build_code_phrase) {
+        map.insert("encoding".to_owned(), cp);
+    }
+    let mappings = build_indexed(node, "_mapping", build_term_mapping);
+    if !mappings.is_empty() {
+        map.insert("mappings".to_owned(), Value::Array(mappings));
+    }
+}
+
+/// The DV_ORDERED value-internal families: the normal range, the other
+/// reference ranges, and (temporal types only) the accuracy duration.
+fn attach_ordered_internal(map: &mut Map<String, Value>, base: &str, node: &SimNode) {
+    if let Some(child) = single(node, "_normal_range") {
+        map.insert("normal_range".to_owned(), build_interval(child, base));
+    }
+    let ranges = build_indexed(node, "_other_reference_ranges", |n| {
+        build_reference_range(n, base)
+    });
+    if !ranges.is_empty() {
+        map.insert("other_reference_ranges".to_owned(), Value::Array(ranges));
+    }
+    if matches!(base, "DV_DATE" | "DV_DATE_TIME" | "DV_TIME")
+        && let Some(acc) = single(node, "_accuracy").and_then(SimNode::bare)
+    {
+        map.insert(
+            "accuracy".to_owned(),
+            json!({"_type": "DV_DURATION", "value": acc.clone()}),
+        );
     }
 }
 

--- a/crates/openehr-its/src/flat/map/parties.rs
+++ b/crates/openehr-its/src/flat/map/parties.rs
@@ -286,34 +286,45 @@ pub(super) fn emit_participation(p: &Value, out: &mut SimNode) {
     if let Some(m) = p.pointer("/mode/value") {
         out.attrs.insert("mode".to_owned(), m.clone());
     }
-    let Some(performer) = p.get("performer").filter(|v| !v.is_null()) else {
-        return;
-    };
+    if let Some(performer) = p.get("performer").filter(|v| !v.is_null()) {
+        emit_performer(performer, out);
+    }
+}
+
+/// The inlined performer of a PARTICIPATION: its `|name`/`|id`/`|id_scheme`/
+/// `|id_namespace` suffixes, the `|identifiers_<field>:i` list, and a
+/// PARTY_RELATED `/relationship` child.
+///
+/// Performer identifiers are inlined as `|identifiers_<field>:i` suffixes
+/// (master05 §PARTICIPATION), not the `_identifier:i` sub-path form.
+fn emit_performer(performer: &Value, out: &mut SimNode) {
     if let Some(name) = performer.get("name").filter(|v| !v.is_null()) {
         out.attrs.insert("name".to_owned(), name.clone());
     }
-    if let Some(id) = performer.pointer("/external_ref/id/value") {
-        out.attrs.insert("id".to_owned(), id.clone());
+    for (pointer, suffix) in [
+        ("/external_ref/id/value", "id"),
+        ("/external_ref/id/scheme", "id_scheme"),
+        ("/external_ref/namespace", "id_namespace"),
+    ] {
+        if let Some(v) = performer.pointer(pointer) {
+            out.attrs.insert(suffix.to_owned(), v.clone());
+        }
     }
-    if let Some(s) = performer.pointer("/external_ref/id/scheme") {
-        out.attrs.insert("id_scheme".to_owned(), s.clone());
-    }
-    if let Some(ns) = performer.pointer("/external_ref/namespace") {
-        out.attrs.insert("id_namespace".to_owned(), ns.clone());
-    }
-    // Performer identifiers are inlined as `|identifiers_<field>:i` suffixes
-    // (master05 §PARTICIPATION), not the `_identifier:i` sub-path form.
-    if let Some(ids) = performer.get("identifiers").and_then(Value::as_array) {
-        for (i, id) in ids.iter().enumerate() {
-            for (field, suffix) in [
-                ("id", "identifiers_id"),
-                ("issuer", "identifiers_issuer"),
-                ("assigner", "identifiers_assigner"),
-                ("type", "identifiers_type"),
-            ] {
-                if let Some(v) = id.get(field).filter(|v| !v.is_null()) {
-                    out.attrs.insert(format!("{suffix}:{i}"), v.clone());
-                }
+    for (i, id) in performer
+        .get("identifiers")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .enumerate()
+    {
+        for (field, suffix) in [
+            ("id", "identifiers_id"),
+            ("issuer", "identifiers_issuer"),
+            ("assigner", "identifiers_assigner"),
+            ("type", "identifiers_type"),
+        ] {
+            if let Some(v) = id.get(field).filter(|v| !v.is_null()) {
+                out.attrs.insert(format!("{suffix}:{i}"), v.clone());
             }
         }
     }

--- a/crates/openehr-its/src/flat/map/structures.rs
+++ b/crates/openehr-its/src/flat/map/structures.rs
@@ -29,10 +29,6 @@ use crate::flat::sim::SimNode;
 // ── RM → sim ──────────────────────────────────────────────────────────────────
 
 /// Emit the `_`-prefixed families present on `rm` (see [`super::emit_rm_attrs`]).
-#[expect(
-    clippy::too_many_lines,
-    reason = "one dispatch over the `_`-attribute families; the length is the size of that family set, not logic"
-)]
 pub(super) fn emit_rm_attrs(rm: &Value, rm_type: &str, out: &mut SimNode) {
     let ty = rm
         .get("_type")
@@ -40,87 +36,12 @@ pub(super) fn emit_rm_attrs(rm: &Value, rm_type: &str, out: &mut SimNode) {
         .unwrap_or_else(|| super::base_type(rm_type));
 
     if is_locatable(ty) {
-        if let Some(uid) = rm.pointer("/uid/value") {
-            out.occurrence_mut("_uid", None)
-                .attrs
-                .insert(String::new(), uid.clone());
-        }
-        if let Some(links) = rm.get("links").and_then(Value::as_array) {
-            for (i, link) in links.iter().enumerate() {
-                emit_link(
-                    link,
-                    out.occurrence_mut("_link", Some(u32::try_from(i).unwrap_or(u32::MAX))),
-                );
-            }
-        }
-        if let Some(fa) = rm.get("feeder_audit").filter(|v| !v.is_null()) {
-            emit_feeder_audit(fa, out.occurrence_mut("_feeder_audit", None));
-        }
+        emit_locatable_attrs(rm, out);
     }
-
     match ty {
-        "ELEMENT" => {
-            if let Some(nf) = rm.get("null_flavour").filter(|v| !v.is_null()) {
-                data_values::emit_leaf(
-                    nf,
-                    "DV_CODED_TEXT",
-                    None,
-                    out.occurrence_mut("_null_flavour", None),
-                );
-            }
-            if let Some(nr) = rm.get("null_reason").filter(|v| !v.is_null()) {
-                data_values::emit_leaf(
-                    nr,
-                    "DV_TEXT",
-                    None,
-                    out.occurrence_mut("_null_reason", None),
-                );
-            }
-        }
+        "ELEMENT" => emit_element_attrs(rm, out),
         "OBSERVATION" | "EVALUATION" | "INSTRUCTION" | "ACTION" | "ADMIN_ENTRY" => {
-            if let Some(o) = rm.get("guideline_id").filter(|v| !v.is_null()) {
-                parties::emit_object_ref(o, out.occurrence_mut("_guideline_id", None));
-            }
-            if let Some(o) = rm.get("workflow_id").filter(|v| !v.is_null()) {
-                parties::emit_object_ref(o, out.occurrence_mut("_work_flow_id", None));
-            }
-            if let Some(p) = rm.get("provider").filter(|v| !v.is_null()) {
-                parties::emit_party(p, out.occurrence_mut("_provider", None));
-            }
-            if let Some(parts) = rm.get("other_participations").and_then(Value::as_array) {
-                for (i, p) in parts.iter().enumerate() {
-                    parties::emit_participation(
-                        p,
-                        out.occurrence_mut(
-                            "_other_participation",
-                            Some(u32::try_from(i).unwrap_or(u32::MAX)),
-                        ),
-                    );
-                }
-            }
-            if ty == "INSTRUCTION" {
-                if let Some(et) = rm.get("expiry_time").filter(|v| !v.is_null()) {
-                    data_values::emit_leaf(
-                        et,
-                        "DV_DATE_TIME",
-                        None,
-                        out.occurrence_mut("_expiry_time", None),
-                    );
-                }
-                if let Some(wf) = rm.get("wf_definition").filter(|v| !v.is_null()) {
-                    data_values::emit_leaf(
-                        wf,
-                        "DV_PARSABLE",
-                        None,
-                        out.occurrence_mut("_wf_definition", None),
-                    );
-                }
-            }
-            if ty == "ACTION"
-                && let Some(det) = rm.get("instruction_details").filter(|v| !v.is_null())
-            {
-                emit_instruction_details(det, out.occurrence_mut("_instruction_details", None));
-            }
+            emit_entry_attrs(rm, ty, out);
         }
         // A PARTY arm here would emit the family a second time onto the same
         // node: idempotent, invisible on the wire, and a trap for the next
@@ -129,47 +50,142 @@ pub(super) fn emit_rm_attrs(rm: &Value, rm_type: &str, out: &mut SimNode) {
         // NOTE: no PARTY arm — the party `_identifier:i` family (master05
         // §§PARTY_IDENTIFIED, PARTY_RELATED) is emitted by
         // [`parties::emit_party`], which every route to a party node uses.
-        "ISM_TRANSITION" => {
-            if let Some(reasons) = rm.get("reason").and_then(Value::as_array) {
-                for (i, r) in reasons.iter().enumerate() {
-                    data_values::emit_leaf(
-                        r,
-                        "DV_TEXT",
-                        None,
-                        out.occurrence_mut("_reason", Some(u32::try_from(i).unwrap_or(u32::MAX))),
-                    );
-                }
-            }
-        }
-        // EVENT_CONTEXT `_`-families (master05 §EVENT_CONTEXT). A composition's
-        // context is normally surfaced through the `ctx/` vocabulary (see
-        // `crate::flat::ctx`); these emit only when a walker renders an EVENT_CONTEXT
-        // node through the tree instead.
-        "EVENT_CONTEXT" => {
-            // end_time/location surface as the lossless ctx/ scalars
-            // (master06 §§end_time, location) — not re-emitted here; the
-            // `_end_time`/`_location` path forms stay accepted on input.
-            if let Some(hcf) = rm.get("health_care_facility").filter(|v| !v.is_null()) {
-                parties::emit_party(hcf, out.occurrence_mut("_health_care_facility", None));
-            }
-            if let Some(parts) = rm.get("participations").and_then(Value::as_array) {
-                for (i, p) in parts.iter().enumerate() {
-                    parties::emit_participation(
-                        p,
-                        out.occurrence_mut(
-                            "_participation",
-                            Some(u32::try_from(i).unwrap_or(u32::MAX)),
-                        ),
-                    );
-                }
-            }
-        }
+        "ISM_TRANSITION" => emit_ism_transition_attrs(rm, out),
+        "EVENT_CONTEXT" => emit_event_context_attrs(rm, out),
         _ => {}
     }
 
     // The value-internal families of a `DV_*` leaf (ranges / accuracy / text
     // meta / multimedia thumbnail+charset+language).
     data_values::emit_value_internal(rm, ty, out);
+}
+
+/// The LOCATABLE families: `_uid`, the `_link:i` list and `_feeder_audit`
+/// (master05 §LOCATABLE).
+fn emit_locatable_attrs(rm: &Value, out: &mut SimNode) {
+    if let Some(uid) = rm.pointer("/uid/value") {
+        out.occurrence_mut("_uid", None)
+            .attrs
+            .insert(String::new(), uid.clone());
+    }
+    if let Some(links) = rm.get("links").and_then(Value::as_array) {
+        for (i, link) in links.iter().enumerate() {
+            emit_link(
+                link,
+                out.occurrence_mut("_link", Some(u32::try_from(i).unwrap_or(u32::MAX))),
+            );
+        }
+    }
+    if let Some(fa) = rm.get("feeder_audit").filter(|v| !v.is_null()) {
+        emit_feeder_audit(fa, out.occurrence_mut("_feeder_audit", None));
+    }
+}
+
+/// The ELEMENT families: `_null_flavour` and `_null_reason` (master05
+/// §ELEMENT).
+fn emit_element_attrs(rm: &Value, out: &mut SimNode) {
+    if let Some(nf) = rm.get("null_flavour").filter(|v| !v.is_null()) {
+        data_values::emit_leaf(
+            nf,
+            "DV_CODED_TEXT",
+            None,
+            out.occurrence_mut("_null_flavour", None),
+        );
+    }
+    if let Some(nr) = rm.get("null_reason").filter(|v| !v.is_null()) {
+        data_values::emit_leaf(
+            nr,
+            "DV_TEXT",
+            None,
+            out.occurrence_mut("_null_reason", None),
+        );
+    }
+}
+
+/// The ENTRY families, plus the INSTRUCTION and ACTION additions (master05
+/// §§ENTRY, INSTRUCTION, ACTION).
+fn emit_entry_attrs(rm: &Value, ty: &str, out: &mut SimNode) {
+    if let Some(o) = rm.get("guideline_id").filter(|v| !v.is_null()) {
+        parties::emit_object_ref(o, out.occurrence_mut("_guideline_id", None));
+    }
+    if let Some(o) = rm.get("workflow_id").filter(|v| !v.is_null()) {
+        parties::emit_object_ref(o, out.occurrence_mut("_work_flow_id", None));
+    }
+    if let Some(p) = rm.get("provider").filter(|v| !v.is_null()) {
+        parties::emit_party(p, out.occurrence_mut("_provider", None));
+    }
+    if let Some(parts) = rm.get("other_participations").and_then(Value::as_array) {
+        for (i, p) in parts.iter().enumerate() {
+            parties::emit_participation(
+                p,
+                out.occurrence_mut(
+                    "_other_participation",
+                    Some(u32::try_from(i).unwrap_or(u32::MAX)),
+                ),
+            );
+        }
+    }
+    if ty == "INSTRUCTION" {
+        if let Some(et) = rm.get("expiry_time").filter(|v| !v.is_null()) {
+            data_values::emit_leaf(
+                et,
+                "DV_DATE_TIME",
+                None,
+                out.occurrence_mut("_expiry_time", None),
+            );
+        }
+        if let Some(wf) = rm.get("wf_definition").filter(|v| !v.is_null()) {
+            data_values::emit_leaf(
+                wf,
+                "DV_PARSABLE",
+                None,
+                out.occurrence_mut("_wf_definition", None),
+            );
+        }
+    }
+    if ty == "ACTION"
+        && let Some(det) = rm.get("instruction_details").filter(|v| !v.is_null())
+    {
+        emit_instruction_details(det, out.occurrence_mut("_instruction_details", None));
+    }
+}
+
+/// The ISM_TRANSITION family: the `_reason:i` DV_TEXT list (master05
+/// §ISM_TRANSITION).
+fn emit_ism_transition_attrs(rm: &Value, out: &mut SimNode) {
+    let Some(reasons) = rm.get("reason").and_then(Value::as_array) else {
+        return;
+    };
+    for (i, r) in reasons.iter().enumerate() {
+        data_values::emit_leaf(
+            r,
+            "DV_TEXT",
+            None,
+            out.occurrence_mut("_reason", Some(u32::try_from(i).unwrap_or(u32::MAX))),
+        );
+    }
+}
+
+/// The EVENT_CONTEXT families (master05 §EVENT_CONTEXT).
+///
+/// A composition's context is normally surfaced through the `ctx/` vocabulary
+/// (see [`crate::flat::ctx`]); these emit only when a walker renders an
+/// EVENT_CONTEXT node through the tree instead. `end_time`/`location` surface
+/// as the lossless `ctx/` scalars (master06 §§end_time, location) and are not
+/// re-emitted here; their `_end_time`/`_location` path forms stay accepted on
+/// input.
+fn emit_event_context_attrs(rm: &Value, out: &mut SimNode) {
+    if let Some(hcf) = rm.get("health_care_facility").filter(|v| !v.is_null()) {
+        parties::emit_party(hcf, out.occurrence_mut("_health_care_facility", None));
+    }
+    if let Some(parts) = rm.get("participations").and_then(Value::as_array) {
+        for (i, p) in parts.iter().enumerate() {
+            parties::emit_participation(
+                p,
+                out.occurrence_mut("_participation", Some(u32::try_from(i).unwrap_or(u32::MAX))),
+            );
+        }
+    }
 }
 
 fn is_locatable(ty: &str) -> bool {

--- a/crates/openehr-its/src/flat/tdd.rs
+++ b/crates/openehr-its/src/flat/tdd.rs
@@ -160,62 +160,70 @@ fn parse_tree(xml: &str) -> Result<El, FlatError> {
     let mut stack: Vec<El> = Vec::new();
     let mut root: Option<El> = None;
 
-    let start_el = |e: &quick_xml::events::BytesStart<'_>| -> Result<El, FlatError> {
-        let mut attrs = Vec::new();
-        for a in e.attributes() {
-            let a =
-                a.map_err(|err| FlatError::Conversion(format!("malformed TDD attribute: {err}")))?;
-            let key = String::from_utf8_lossy(a.key.as_ref()).into_owned();
-            let val = String::from_utf8_lossy(&a.value).into_owned();
-            attrs.push((key, val));
-        }
-        Ok(El {
-            name: local_name(e.name().as_ref()),
-            attrs,
-            text: String::new(),
-            children: Vec::new(),
-        })
-    };
-
-    let close = |stack: &mut Vec<El>, root: &mut Option<El>| {
-        if let Some(done) = stack.pop() {
-            match stack.last_mut() {
-                Some(parent) => parent.children.push(done),
-                None => *root = Some(done),
-            }
-        }
-    };
-
     loop {
         match reader
             .read_event()
             .map_err(|e| FlatError::Conversion(format!("TDD is not well-formed XML: {e}")))?
         {
-            Event::Start(e) => stack.push(start_el(&e)?),
+            Event::Start(e) => stack.push(start_element(&e)?),
             Event::Empty(e) => {
-                stack.push(start_el(&e)?);
-                close(&mut stack, &mut root);
+                stack.push(start_element(&e)?);
+                close_element(&mut stack, &mut root);
             }
-            Event::End(_) => close(&mut stack, &mut root),
+            Event::End(_) => close_element(&mut stack, &mut root),
             Event::Text(t) => {
-                if let Some(top) = stack.last_mut() {
-                    let txt = t
-                        .decode()
-                        .map_err(|e| FlatError::Conversion(format!("TDD text decode: {e}")))?;
-                    top.text.push_str(txt.trim());
-                }
+                let txt = t
+                    .decode()
+                    .map_err(|e| FlatError::Conversion(format!("TDD text decode: {e}")))?;
+                push_text(&mut stack, txt.trim());
             }
             Event::CData(t) => {
-                if let Some(top) = stack.last_mut() {
-                    let bytes = t.into_inner();
-                    top.text.push_str(&String::from_utf8_lossy(&bytes));
-                }
+                let bytes = t.into_inner();
+                push_text(&mut stack, &String::from_utf8_lossy(&bytes));
             }
             Event::Eof => break,
             _ => {}
         }
     }
     root.ok_or_else(|| FlatError::Conversion("TDD has no root element".into()))
+}
+
+/// Reads one start tag into a childless [`El`].
+///
+/// # Errors
+/// Returns [`FlatError::Conversion`] if an attribute is malformed.
+fn start_element(e: &quick_xml::events::BytesStart<'_>) -> Result<El, FlatError> {
+    let mut attrs = Vec::new();
+    for a in e.attributes() {
+        let a =
+            a.map_err(|err| FlatError::Conversion(format!("malformed TDD attribute: {err}")))?;
+        let key = String::from_utf8_lossy(a.key.as_ref()).into_owned();
+        let val = String::from_utf8_lossy(&a.value).into_owned();
+        attrs.push((key, val));
+    }
+    Ok(El {
+        name: local_name(e.name().as_ref()),
+        attrs,
+        text: String::new(),
+        children: Vec::new(),
+    })
+}
+
+/// Closes the innermost open element, attaching it to its parent or the root.
+fn close_element(stack: &mut Vec<El>, root: &mut Option<El>) {
+    if let Some(done) = stack.pop() {
+        match stack.last_mut() {
+            Some(parent) => parent.children.push(done),
+            None => *root = Some(done),
+        }
+    }
+}
+
+/// Appends character data to the innermost open element, if there is one.
+fn push_text(stack: &mut [El], text: &str) {
+    if let Some(top) = stack.last_mut() {
+        top.text.push_str(text);
+    }
 }
 
 /// Re-serialise an [`El`] subtree to a standalone canonical-XML document so the
@@ -458,63 +466,73 @@ pub fn from_tdd(tdd_xml: &str, wt: &WebTemplate) -> Result<Value, FlatError> {
 /// the build. Everything else is content the TDS does not define.
 const WRAPPER_METADATA: [&str; 6] = ["name", "uid", "links", "feeder_audit", "origin", "time"];
 
-#[expect(
-    clippy::indexing_slicing,
-    reason = "`simple`, `matched` and `wrapper` are all sized `el.children.len()` and every index into them is either a `match_indices(el, ..)` position over those same children or the `enumerate()` index of the same iteration, so all are in bounds by construction"
-)]
 fn check_conformance(el: &El, wt: &WebTemplateNode, rm_type: &str) -> Result<(), FlatError> {
-    // Direct children consumed as simple in-context attributes.
-    let simple: Vec<bool> = el
-        .children
-        .iter()
-        .map(|c| simple_attr(rm_type, &c.name).is_some())
-        .collect();
-
-    // Children matched by some web-template child (with the matched
-    // template node, to recurse), at any depth of the scoped search.
-    let mut matched: Vec<Option<&WebTemplateNode>> = vec![None; el.children.len()];
-    let mut wrapper: Vec<bool> = vec![false; el.children.len()];
-    for wc in &wt.children {
-        for (idx, is_direct) in match_indices(el, node_display(wc)) {
-            if is_direct {
-                matched[idx] = Some(wc);
-            } else {
-                // The match sits deeper: the direct child at `idx` is a
-                // wrapper on the path to it. The deeper levels are checked
-                // by the recursion below only for DIRECT matches; wrapper
-                // interiors are re-checked against the SAME context.
-                wrapper[idx] = true;
-            }
-        }
-    }
-
-    for (idx, child) in el.children.iter().enumerate() {
-        if simple[idx] {
-            continue;
-        }
-        if let Some(wc) = matched[idx] {
-            if !wc.has_input() {
+    for (child, role) in el.children.iter().zip(classify_children(el, wt, rm_type)) {
+        match role {
+            ChildRole::Matched(wc) if !wc.has_input() => {
                 check_conformance(child, wc, concrete_type(&wc.rm_type))?;
             }
-            continue;
-        }
-        if wrapper[idx] {
             // A wrapper is transparent: its children are checked against the
             // same template node so a junk sibling BESIDE the real match is
             // still caught.
-            check_conformance(child, wt, rm_type)?;
-            continue;
+            ChildRole::Wrapper => check_conformance(child, wt, rm_type)?,
+            ChildRole::Unmatched if !WRAPPER_METADATA.contains(&child.name.as_str()) => {
+                return Err(FlatError::Conversion(format!(
+                    "TDD element <{}> (under <{}>) matches no node of the operational template — \
+                     the document does not conform to the template-derived TDS",
+                    child.name, el.name
+                )));
+            }
+            ChildRole::Simple | ChildRole::Matched(_) | ChildRole::Unmatched => {}
         }
-        if WRAPPER_METADATA.contains(&child.name.as_str()) {
-            continue;
-        }
-        return Err(FlatError::Conversion(format!(
-            "TDD element <{}> (under <{}>) matches no node of the operational template — \
-             the document does not conform to the template-derived TDS",
-            child.name, el.name
-        )));
     }
     Ok(())
+}
+
+/// How one direct child of a TDD element relates to its template node.
+enum ChildRole<'a> {
+    /// Consumed as a simple in-context attribute.
+    Simple,
+    /// Matched by this web-template child.
+    Matched(&'a WebTemplateNode),
+    /// A wrapper on the path to a deeper match.
+    Wrapper,
+    /// Matched by no web-template child at any depth.
+    Unmatched,
+}
+
+/// Classifies every direct child of `el` against `wt`'s children, in order.
+///
+/// A match deeper than a direct child marks that direct child a wrapper: the
+/// deeper levels are recursed into only for DIRECT matches, so wrapper
+/// interiors are re-checked against the SAME context.
+fn classify_children<'a>(el: &El, wt: &'a WebTemplateNode, rm_type: &str) -> Vec<ChildRole<'a>> {
+    let matches: Vec<(usize, bool, &WebTemplateNode)> = wt
+        .children
+        .iter()
+        .flat_map(|wc| {
+            match_indices(el, node_display(wc))
+                .into_iter()
+                .map(move |(idx, is_direct)| (idx, is_direct, wc))
+        })
+        .collect();
+    el.children
+        .iter()
+        .enumerate()
+        .map(|(idx, c)| {
+            if simple_attr(rm_type, &c.name).is_some() {
+                return ChildRole::Simple;
+            }
+            // Last direct match wins, as the single-pass classification did.
+            if let Some((_, _, wc)) = matches.iter().rev().find(|(i, d, _)| *i == idx && *d) {
+                return ChildRole::Matched(wc);
+            }
+            if matches.iter().any(|(i, d, _)| *i == idx && !*d) {
+                return ChildRole::Wrapper;
+            }
+            ChildRole::Unmatched
+        })
+        .collect()
 }
 
 /// For each shallowest match of `display` in `parent`'s subtree (the same

--- a/crates/openehr-its/src/flat/tdd.rs
+++ b/crates/openehr-its/src/flat/tdd.rs
@@ -562,10 +562,22 @@ fn build_node(
         }
     }
 
-    // Simple in-context RM attributes — read directly from the TDD (faithful).
-    let mut i = 0;
-    while let Some(child) = el.children.get(i) {
-        i += 1;
+    build_simple_attrs(el, rm_type, &mut obj)?;
+    build_content_children(el, wt, rm_type, path, &mut obj)?;
+    Ok(Value::Object(obj))
+}
+
+/// Reads the simple in-context RM attributes directly off the TDD element
+/// (faithful — no template mediation).
+///
+/// # Errors
+/// [`FlatError`] when a typed attribute's text does not parse.
+fn build_simple_attrs(
+    el: &El,
+    rm_type: &str,
+    obj: &mut Map<String, Value>,
+) -> Result<(), FlatError> {
+    for child in &el.children {
         let Some(hint) = simple_attr(rm_type, &child.name) else {
             continue;
         };
@@ -573,38 +585,52 @@ fn build_node(
             Simple::Text => {
                 obj.insert(child.name.clone(), json!(child.text));
             }
+            Simple::Typed(ty) if is_multi_simple(&child.name) => {
+                let arr = obj
+                    .entry(child.name.clone())
+                    .or_insert_with(|| json!([]))
+                    .as_array_mut();
+                if let Some(arr) = arr {
+                    arr.push(parse_typed(child, ty)?);
+                }
+            }
             Simple::Typed(ty) => {
-                if is_multi_simple(&child.name) {
-                    let arr = obj
-                        .entry(child.name.clone())
-                        .or_insert_with(|| json!([]))
-                        .as_array_mut();
-                    if let Some(arr) = arr {
-                        arr.push(parse_typed(child, ty)?);
-                    }
-                } else if !obj.contains_key(&child.name) {
+                if !obj.contains_key(&child.name) {
                     obj.insert(child.name.clone(), parse_typed(child, ty)?);
                 }
             }
         }
     }
+    Ok(())
+}
 
-    // Content children — driven by the web-template node tree. Each web-template
-    // child is located in the TDD by name (scoped) and placed at its relative
-    // aqlPath, re-materialising the wrapper chain the TDD/template compacted.
+/// Builds the content children, driven by the web-template node tree.
+///
+/// Each web-template child is located in the TDD by name (scoped) and placed
+/// at its relative `aqlPath`, re-materialising the wrapper chain the
+/// TDD/template compacted. A node the WebTemplate synthesizes for a *simple*
+/// RM in-context attribute (COMPOSITION context/language/territory/composer,
+/// ENTRY language/encoding/subject — `ITS-REST simplified_formats master04`
+/// §"Web Template Metadata", the `inContext` marker) is skipped: it is already
+/// built from the TDD element by [`build_simple_attrs`], and walking it again
+/// would rebuild it partially (e.g. an EVENT_CONTEXT without its mandatory
+/// `start_time`) and overwrite the faithful value. `category` and the per-EVENT
+/// `time` are real tree data and still build through the walk.
+///
+/// # Errors
+/// [`FlatError`] from a child's leaf parse or nested build.
+fn build_content_children(
+    el: &El,
+    wt: &WebTemplateNode,
+    rm_type: &str,
+    path: &str,
+    obj: &mut Map<String, Value>,
+) -> Result<(), FlatError> {
     for wc in &wt.children {
         let rel = rmpath::relative(path, &wc.aql_path);
         if rel.is_empty() {
             continue;
         }
-        // A node the WebTemplate synthesizes for a *simple* RM in-context
-        // attribute (COMPOSITION context/language/territory/composer, ENTRY
-        // language/encoding/subject — `ITS-REST simplified_formats master04`
-        // §"Web Template Metadata", the `inContext` marker) is already built
-        // above from the TDD element by `simple_attr`; walking it again would
-        // rebuild it partially (e.g. an EVENT_CONTEXT without its mandatory
-        // `start_time`) and overwrite the faithful value. `category` and the
-        // per-EVENT `time` are real tree data and still build through the walk.
         if (wc.in_context == Some(true) || wc.rm_type == "EVENT_CONTEXT")
             && rel
                 .last()
@@ -612,8 +638,7 @@ fn build_node(
         {
             continue;
         }
-        let matches = find_matches(el, node_display(wc));
-        for cel in matches {
+        for cel in find_matches(el, node_display(wc)) {
             let child_value = if wc.has_input() {
                 // A leaf: the ELEMENT wrapper is materialised by `place`; the
                 // datum is the leaf element's `<value>` fragment.
@@ -621,11 +646,10 @@ fn build_node(
             } else {
                 build_node(cel, wc, concrete_type(&wc.rm_type), &wc.aql_path, false)?
             };
-            place(&mut obj, &rel, child_value, wc);
+            place(obj, &rel, child_value, wc);
         }
     }
-
-    Ok(Value::Object(obj))
+    Ok(())
 }
 
 /// The `DATA_VALUE` of a leaf, parsed as the web-template-declared concrete type.

--- a/crates/openehr-its/src/flat/validation/leaf.rs
+++ b/crates/openehr-its/src/flat/validation/leaf.rs
@@ -185,19 +185,9 @@ fn check_ordinal(v: &mut Validator, instance: &Value, wt: &WebTemplateNode) {
     if input.list.is_empty() || input.list_open == Some(true) {
         return;
     }
-    // DV_ORDINAL/DV_SCALE encode their coded symbol under `symbol/defining_code`.
-    let defining_code = instance.get("symbol").and_then(|s| s.get("defining_code"));
-    let code = defining_code
-        .and_then(|c| c.get("code_string"))
-        .and_then(Value::as_str);
-    let terminology = defining_code
-        .and_then(|c| c.get("terminology_id"))
-        .and_then(|t| t.get("value"))
-        .and_then(Value::as_str);
-    if !terminology_matches(input.terminology.as_deref(), terminology) {
+    let Some(code) = checkable_symbol_code(instance, input) else {
         return;
-    }
-    let Some(code) = code else { return };
+    };
 
     // Entries whose symbol matches the instance code.
     let same_symbol: Vec<&WebTemplateCodedValue> =
@@ -229,19 +219,9 @@ fn check_ordinal(v: &mut Validator, instance: &Value, wt: &WebTemplateNode) {
     let Some(inst_value) = instance.get("value") else {
         return; // value absent — the RM-invariant pass owns structural presence.
     };
-    let pair_ok = same_symbol.iter().any(|cv| {
-        if is_scale {
-            match (cv.scale, inst_value.as_f64()) {
-                (Some(s), Some(iv)) => (s - iv).abs() < 1e-9,
-                _ => false,
-            }
-        } else {
-            match (cv.ordinal, inst_value.as_i64()) {
-                (Some(o), Some(iv)) => i64::from(o) == iv,
-                _ => false,
-            }
-        }
-    });
+    let pair_ok = same_symbol
+        .iter()
+        .any(|cv| paired_value_matches(cv, is_scale, inst_value));
     if !pair_ok {
         v.push(
             &wt.aql_path,
@@ -252,6 +232,39 @@ fn check_ordinal(v: &mut Validator, instance: &Value, wt: &WebTemplateNode) {
             ValidationKind::CodedValue,
         );
     }
+}
+
+/// The instance's ordinal symbol code, when the constraint is checkable at all.
+///
+/// DV_ORDINAL/DV_SCALE encode their coded symbol under `symbol/defining_code`;
+/// a code whose terminology differs from the constraint's is not checkable here
+/// and yields [`None`].
+fn checkable_symbol_code<'a>(instance: &'a Value, input: &WebTemplateInput) -> Option<&'a str> {
+    let defining_code = instance.get("symbol").and_then(|s| s.get("defining_code"));
+    let terminology = defining_code
+        .and_then(|c| c.get("terminology_id"))
+        .and_then(|t| t.get("value"))
+        .and_then(Value::as_str);
+    if !terminology_matches(input.terminology.as_deref(), terminology) {
+        return None;
+    }
+    defining_code
+        .and_then(|c| c.get("code_string"))
+        .and_then(Value::as_str)
+}
+
+/// Whether one constrained entry's paired numeric equals the instance value.
+fn paired_value_matches(entry: &WebTemplateCodedValue, is_scale: bool, inst_value: &Value) -> bool {
+    if is_scale {
+        return matches!(
+            (entry.scale, inst_value.as_f64()),
+            (Some(s), Some(iv)) if (s - iv).abs() < 1e-9
+        );
+    }
+    matches!(
+        (entry.ordinal, inst_value.as_i64()),
+        (Some(o), Some(iv)) if i64::from(o) == iv
+    )
 }
 
 /// Report a coded value that is not among the constrained options. Checked for
@@ -586,63 +599,81 @@ fn check_duration(v: &mut Validator, instance: &Value, wt: &WebTemplateNode) {
     let Some(fields) = duration_fields(value) else {
         return; // Malformed ISO duration — the RM-invariant pass owns that.
     };
-    // Allowed-fields check only when the builder filtered the inputs (a full
-    // 7-field set means the pattern allowed everything / there was no pattern).
+    check_duration_fields_allowed(v, value, &fields, wt);
+    check_duration_range(v, value, &fields, wt);
+}
+
+/// Reports every duration field the `C_DURATION` pattern does not allow.
+///
+/// The check runs only when the builder filtered the inputs: a full 7-field set
+/// means the pattern allowed everything, or there was no pattern.
+fn check_duration_fields_allowed(
+    v: &mut Validator,
+    value: &str,
+    fields: &[(&'static str, f64)],
+    wt: &WebTemplateNode,
+) {
     let allowed: Vec<&str> = wt
         .inputs
         .iter()
         .filter_map(|i| i.suffix.as_deref())
         .collect();
-    if !allowed.is_empty() && allowed.len() < 7 {
-        for (name, _) in fields.iter().filter(|(_, n)| *n != 0.0) {
-            if !allowed.contains(name) {
-                v.push(
-                    &wt.aql_path,
-                    format!(
-                        "duration '{value}' uses the '{name}' field the C_DURATION pattern \
-                         does not allow"
-                    ),
-                    ValidationKind::PatternError,
-                );
-            }
-        }
+    if allowed.is_empty() || allowed.len() >= 7 {
+        return;
     }
-    if let Some(range) = &wt.duration_range {
-        let secs = duration_seconds(&fields);
-        // Bound inclusivity follows the AOM interval flags carried in the
-        // range ops (BASE foundation_types Interval — an exclusive `> PT0S`
-        // rejects PT0S).
-        let min_ok = range
-            .min
-            .as_ref()
-            .and_then(Value::as_str)
-            .and_then(|b| duration_fields(b).map(|f| duration_seconds(&f)))
-            .is_none_or(|b| {
-                if range.min_op.as_deref() == Some(">") {
-                    secs > b
-                } else {
-                    secs >= b
-                }
-            });
-        let max_ok = range
-            .max
-            .as_ref()
-            .and_then(Value::as_str)
-            .and_then(|b| duration_fields(b).map(|f| duration_seconds(&f)))
-            .is_none_or(|b| {
-                if range.max_op.as_deref() == Some("<") {
-                    secs < b
-                } else {
-                    secs <= b
-                }
-            });
-        if !min_ok || !max_ok {
+    for (name, _) in fields.iter().filter(|(_, n)| *n != 0.0) {
+        if !allowed.contains(name) {
             v.push(
                 &wt.aql_path,
-                format!("duration '{value}' is outside the constrained range"),
-                ValidationKind::RangeError,
+                format!(
+                    "duration '{value}' uses the '{name}' field the C_DURATION pattern \
+                     does not allow"
+                ),
+                ValidationKind::PatternError,
             );
         }
+    }
+}
+
+/// Reports a duration outside the node's constrained range.
+///
+/// Bound inclusivity follows the AOM interval flags carried in the range ops
+/// (BASE `foundation_types` Interval — an exclusive `> PT0S` rejects `PT0S`).
+fn check_duration_range(
+    v: &mut Validator,
+    value: &str,
+    fields: &[(&'static str, f64)],
+    wt: &WebTemplateNode,
+) {
+    let Some(range) = &wt.duration_range else {
+        return;
+    };
+    let secs = duration_seconds(fields);
+    let bound = |b: &Option<Value>| -> Option<f64> {
+        b.as_ref()
+            .and_then(Value::as_str)
+            .and_then(|s| duration_fields(s).map(|f| duration_seconds(&f)))
+    };
+    let min_ok = bound(&range.min).is_none_or(|b| {
+        if range.min_op.as_deref() == Some(">") {
+            secs > b
+        } else {
+            secs >= b
+        }
+    });
+    let max_ok = bound(&range.max).is_none_or(|b| {
+        if range.max_op.as_deref() == Some("<") {
+            secs < b
+        } else {
+            secs <= b
+        }
+    });
+    if !min_ok || !max_ok {
+        v.push(
+            &wt.aql_path,
+            format!("duration '{value}' is outside the constrained range"),
+            ValidationKind::RangeError,
+        );
     }
 }
 
@@ -656,32 +687,41 @@ fn duration_fields(value: &str) -> Option<Vec<(&'static str, f64)>> {
         None => (rest, ""),
     };
     let mut out = Vec::new();
-    let mut parse = |part: &str, in_time: bool| -> Option<()> {
-        let mut num = String::new();
-        for ch in part.chars() {
-            if ch.is_ascii_digit() || ch == '.' || ch == ',' {
-                num.push(if ch == ',' { '.' } else { ch });
-            } else {
-                let n: f64 = num.parse().ok()?;
-                num.clear();
-                let name = match (ch, in_time) {
-                    ('Y', false) => "year",
-                    ('M', false) => "month",
-                    ('W', false) => "week",
-                    ('D', false) => "day",
-                    ('H', true) => "hour",
-                    ('M', true) => "minute",
-                    ('S', true) => "second",
-                    _ => return None,
-                };
-                out.push((name, n));
-            }
-        }
-        if num.is_empty() { Some(()) } else { None }
-    };
-    parse(date_part, false)?;
-    parse(time_part, true)?;
+    push_duration_part(date_part, false, &mut out)?;
+    push_duration_part(time_part, true, &mut out)?;
     Some(out)
+}
+
+/// Appends one half of an ISO-8601 duration to `out`.
+///
+/// `in_time` selects the time-half reading of the ambiguous `M` designator
+/// (minutes rather than months). Returns [`None`] on an unparseable half.
+fn push_duration_part(part: &str, in_time: bool, out: &mut Vec<(&'static str, f64)>) -> Option<()> {
+    let mut num = String::new();
+    for ch in part.chars() {
+        if ch.is_ascii_digit() || ch == '.' || ch == ',' {
+            num.push(if ch == ',' { '.' } else { ch });
+            continue;
+        }
+        let n: f64 = num.parse().ok()?;
+        num.clear();
+        out.push((duration_field_name(ch, in_time)?, n));
+    }
+    if num.is_empty() { Some(()) } else { None }
+}
+
+/// The `DV_DURATION` field one ISO-8601 designator names, if it names one.
+fn duration_field_name(designator: char, in_time: bool) -> Option<&'static str> {
+    match (designator, in_time) {
+        ('Y', false) => Some("year"),
+        ('M', false) => Some("month"),
+        ('W', false) => Some("week"),
+        ('D', false) => Some("day"),
+        ('H', true) => Some("hour"),
+        ('M', true) => Some("minute"),
+        ('S', true) => Some("second"),
+        _ => None,
+    }
 }
 
 /// Total seconds of a parsed duration, using the RM's nominal field lengths

--- a/crates/openehr-its/src/flat/validation/leaf.rs
+++ b/crates/openehr-its/src/flat/validation/leaf.rs
@@ -726,58 +726,39 @@ fn temporal_pattern_ok(pattern: &str, value: &str) -> bool {
     } else {
         (val_date, val_time)
     };
-    // Date part: year is always required; month/day per the pattern segment.
-    let pat_segs: Vec<&str> = if pat_date.is_empty() {
+    // Date part: year is always required, so its segment is skipped;
+    // month/day are judged per the pattern segment. Time part: hours, minutes
+    // and seconds are all judged.
+    segments_match(pat_date, val_date, '-', 1) && segments_match(pat_time, val_time, ':', 0)
+}
+
+/// Whether the field presence of one temporal half satisfies its pattern half.
+///
+/// The two are split on `sep` into at most three segments; `skip` drops the
+/// leading segments that carry no optionality (the year). A `??` segment
+/// accepts either presence, an `XX` segment requires absence, and any other
+/// segment requires presence (ADL 1.4 `master05-cadl.adoc` §"Date, Time and
+/// Date/Time" Patterns).
+fn segments_match(pattern: &str, value: &str, sep: char, skip: usize) -> bool {
+    let pat_segs: Vec<&str> = if pattern.is_empty() {
         Vec::new()
     } else {
-        pat_date.splitn(3, '-').collect()
+        pattern.splitn(3, sep).collect()
     };
-    let val_count = if val_date.is_empty() {
+    let val_count = if value.is_empty() {
         0
     } else {
-        val_date.splitn(3, '-').count()
+        value.splitn(3, sep).count()
     };
-    for (i, seg) in pat_segs.iter().enumerate().skip(1) {
+    for (i, seg) in pat_segs.iter().enumerate().skip(skip) {
         let present = val_count > i;
-        match *seg {
-            "??" => {}
-            "XX" => {
-                if present {
-                    return false;
-                }
-            }
-            _ => {
-                if !present {
-                    return false;
-                }
-            }
-        }
-    }
-    // Time part: hours/minutes/seconds per the pattern segment.
-    let pat_t: Vec<&str> = if pat_time.is_empty() {
-        Vec::new()
-    } else {
-        pat_time.splitn(3, ':').collect()
-    };
-    let val_t_count = if val_time.is_empty() {
-        0
-    } else {
-        val_time.splitn(3, ':').count()
-    };
-    for (i, seg) in pat_t.iter().enumerate() {
-        let present = val_t_count > i;
-        match *seg {
-            "??" => {}
-            "XX" => {
-                if present {
-                    return false;
-                }
-            }
-            _ => {
-                if !present {
-                    return false;
-                }
-            }
+        let ok = match *seg {
+            "??" => true,
+            "XX" => !present,
+            _ => present,
+        };
+        if !ok {
+            return false;
         }
     }
     true

--- a/crates/openehr-its/src/flat/validation/mod.rs
+++ b/crates/openehr-its/src/flat/validation/mod.rs
@@ -801,10 +801,6 @@ impl Validator {
     /// L60-62) is a positive-only cascade, silent on unmatched instance nodes;
     /// closed-world rejection follows the AOM2 direction + de-facto CDR behaviour
     /// and lands only behind the ECC zero-drift gate.
-    #[expect(
-        clippy::indexing_slicing,
-        reason = "`slot_counts` is sized `ca.slots.len()` and every index into it is a `position`/`enumerate` index over those same slots, so all are in bounds by construction"
-    )]
     fn check_closure(&mut self, instance: &Value, wt: &WebTemplateNode, plan: &NodeWalk) {
         for (ca, segs) in wt.closed_attributes.iter().zip(&plan.closed) {
             let Some(segments) = segs else {
@@ -814,68 +810,97 @@ impl Validator {
                 continue;
             };
             for container in &rmpath::navigate(&[instance], intermediate) {
-                let mut slot_counts = vec![0usize; ca.slots.len()];
-                for child in children_under_attr(container, &last.attribute) {
-                    let Some(nid) = child
-                        .get("archetype_node_id")
-                        .and_then(Value::as_str)
-                        .filter(|s| !s.is_empty())
-                    else {
-                        // Not a LOCATABLE (RM metadata / PATHABLE value): not
-                        // subject to sibling closure.
-                        continue;
-                    };
-                    if ca.allowed_ids.iter().any(|a| a == nid) {
-                        continue; // Matches a fixed sibling alternative.
-                    }
-                    // NOTE: an unmatched archetype-rooted child is admitted where
-                    // the attribute declares no ARCHETYPE_SLOT, OPT 1.4 flattening
-                    // not enumerating the slot-fill universe; slots still gate.
-                    if ca.slots.is_empty()
-                        && openehr_rm::v1_2::paths::is_archetype_root_node_id(nid)
-                    {
-                        continue;
-                    }
-                    let ct = child.get("_type").and_then(Value::as_str).unwrap_or("");
-                    match ca.slots.iter().position(|s| slot_admits(s, ct, nid)) {
-                        Some(i) => slot_counts[i] += 1,
-                        None => self.push(
-                            &ca.path,
-                            format!(
-                                "unexpected node '{nid}' under '{}': no matching archetype \
-                                 constraint or slot",
-                                last.attribute
-                            ),
-                            ValidationKind::Unexpected,
+                let slot_counts = self.match_closed_children(container, ca, &last.attribute);
+                self.check_slot_occurrences(ca, &last.attribute, &slot_counts);
+            }
+        }
+    }
+
+    /// Matches every child under one closed attribute against its fixed
+    /// sibling alternatives and its slots, recording an "unexpected node" for
+    /// each child neither admits, and returns the per-slot filler counts.
+    ///
+    /// A child with no `archetype_node_id` is not a LOCATABLE (RM metadata /
+    /// PATHABLE value) and is not subject to sibling closure.
+    ///
+    /// NOTE: an unmatched archetype-rooted child is admitted where the
+    /// attribute declares no ARCHETYPE_SLOT, OPT 1.4 flattening not
+    /// enumerating the slot-fill universe; slots still gate.
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "`counts` is sized `ca.slots.len()` and the index is a `position` over those same slots, so it is in bounds by construction"
+    )]
+    fn match_closed_children(
+        &mut self,
+        container: &Value,
+        ca: &crate::flat::webtemplate::model::WebTemplateClosedAttribute,
+        attribute: &str,
+    ) -> Vec<usize> {
+        let mut counts = vec![0usize; ca.slots.len()];
+        for child in children_under_attr(container, attribute) {
+            let Some(nid) = child
+                .get("archetype_node_id")
+                .and_then(Value::as_str)
+                .filter(|s| !s.is_empty())
+            else {
+                continue;
+            };
+            if ca.allowed_ids.iter().any(|a| a == nid) {
+                continue; // Matches a fixed sibling alternative.
+            }
+            if ca.slots.is_empty() && openehr_rm::v1_2::paths::is_archetype_root_node_id(nid) {
+                continue;
+            }
+            let ct = child.get("_type").and_then(Value::as_str).unwrap_or("");
+            match ca.slots.iter().position(|s| slot_admits(s, ct, nid)) {
+                Some(i) => counts[i] += 1,
+                None => self.push(
+                    &ca.path,
+                    format!(
+                        "unexpected node '{nid}' under '{attribute}': no matching archetype \
+                         constraint or slot"
+                    ),
+                    ValidationKind::Unexpected,
+                ),
+            }
+        }
+        counts
+    }
+
+    /// Checks each slot's occurrences against the fillers matched to it.
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "`counts` is sized `ca.slots.len()` and the index is the `enumerate` index over those same slots, so it is in bounds by construction"
+    )]
+    fn check_slot_occurrences(
+        &mut self,
+        ca: &crate::flat::webtemplate::model::WebTemplateClosedAttribute,
+        attribute: &str,
+        counts: &[usize],
+    ) {
+        for (i, slot) in ca.slots.iter().enumerate() {
+            let count = i32::try_from(counts[i]).unwrap_or(i32::MAX);
+            if counts[i] == 0 {
+                if slot.min >= 1 {
+                    self.push(
+                        &ca.path,
+                        format!(
+                            "mandatory archetype slot (occurrences {}..) under '{attribute}' \
+                             has no filler",
+                            slot.min
                         ),
-                    }
+                        ValidationKind::Required,
+                    );
                 }
-                // Slot occurrences on the matched fillers.
-                for (i, slot) in ca.slots.iter().enumerate() {
-                    let count = i32::try_from(slot_counts[i]).unwrap_or(i32::MAX);
-                    if slot_counts[i] == 0 {
-                        if slot.min >= 1 {
-                            self.push(
-                                &ca.path,
-                                format!(
-                                    "mandatory archetype slot (occurrences {}..) under '{}' \
-                                     has no filler",
-                                    slot.min, last.attribute
-                                ),
-                                ValidationKind::Required,
-                            );
-                        }
-                    } else if slot.max != -1 && count > slot.max {
-                        self.push(
-                            &ca.path,
-                            format!(
-                                "too many slot fillers under '{}': found {}, expected at most {}",
-                                last.attribute, slot_counts[i], slot.max
-                            ),
-                            ValidationKind::Occurrences,
-                        );
-                    }
-                }
+            } else if slot.max != -1 && count > slot.max {
+                self.push(
+                    &ca.path,
+                    format!(
+                        "too many slot fillers under '{attribute}': found {}, expected at most {}",
+                        counts[i], slot.max
+                    ),
+                    ValidationKind::Occurrences,
+                );
             }
         }
     }

--- a/crates/openehr-its/src/flat/validation/mod.rs
+++ b/crates/openehr-its/src/flat/validation/mod.rs
@@ -1017,33 +1017,15 @@ impl Validator {
             .map(|&i| &wt_parent.children[i])
             .collect();
         let first = members[0];
-        // The identity segment is the last one carrying a predicate; if none
-        // carries one, the last segment (a plain single-valued attribute).
-        let identity_idx = segments
-            .iter()
-            .rposition(|s| !s.predicate.is_empty())
-            .unwrap_or(segments.len() - 1);
-        // A node whose RM type does NOT inherit `LOCATABLE` carries no
-        // `archetype_node_id` in canonical JSON (only `LOCATABLE` adds it — RM
-        // common `UML/classes/org.openehr.rm.common.locatable.adoc`; `EVENT_CONTEXT`
-        // inherits `PATHABLE` directly — RM
-        // `UML/classes/org.openehr.rm.composition.event_context.adoc` §Inherit), so
-        // it is matched STRUCTURALLY by attribute position, predicate stripped. Only
-        // the TERMINAL-identity case reads `first.rm_type`: with a trailing plain
-        // attribute the identity node is the archetyped `LOCATABLE` intermediate.
+        let identity_idx = identity_index(segments);
+        // Only the TERMINAL-identity case reads `first.rm_type`: with a trailing
+        // plain attribute the identity node is the archetyped `LOCATABLE`
+        // intermediate.
         let raw_id_seg = &segments[identity_idx];
         let trailing = &segments[identity_idx + 1..];
         let identity_is_locatable = !trailing.is_empty() || is_locatable(&first.rm_type);
-        let structural_match = !identity_is_locatable && !raw_id_seg.predicate.is_empty();
-        let structural_id_seg;
-        let id_seg: &PathSegment = if structural_match {
-            let mut stripped = raw_id_seg.clone();
-            stripped.predicate = openehr_rm::v1_2::paths::Predicate::default();
-            structural_id_seg = stripped;
-            &structural_id_seg
-        } else {
-            raw_id_seg
-        };
+        let structural_id_seg = structural_identity(raw_id_seg, identity_is_locatable);
+        let id_seg: &PathSegment = structural_id_seg.as_ref().unwrap_or(raw_id_seg);
 
         // Navigate the intermediate segments to the container node(s).
         let containers = rmpath::navigate(&[parent], &segments[..identity_idx]);
@@ -1058,17 +1040,7 @@ impl Validator {
         let occ_applies = identity_is_locatable
             && id_seg.predicate.archetype_node_id.is_some()
             && !members.iter().any(|c| c.in_context == Some(true));
-        let group_min = members
-            .iter()
-            .filter_map(|c| c.min)
-            .min()
-            .unwrap_or(0)
-            .max(0);
-        let group_max = if members.iter().any(|c| c.max == -1) {
-            -1
-        } else {
-            members.iter().map(|c| c.max).max().unwrap_or(-1)
-        };
+        let (group_min, group_max) = group_occurrences(&members);
 
         for container in &containers {
             let matched = select_group_children(container, id_seg, names);
@@ -1076,13 +1048,25 @@ impl Validator {
                 self.emit_occurrences(&first.aql_path, group_min, group_max, matched.len());
             }
             for node in matched {
-                for target in rmpath::navigate(&[node], trailing) {
-                    if members.len() == 1 {
-                        self.walk(target, first);
-                    } else {
-                        self.visit_choice(target, &members);
-                    }
-                }
+                self.walk_group_targets(node, trailing, &members);
+            }
+        }
+    }
+
+    /// Walks every target the trailing segments reach under one matched node.
+    ///
+    /// A single-member group walks its one template node; a choice group is
+    /// dispatched to [`Self::visit_choice`].
+    fn walk_group_targets(
+        &mut self,
+        node: &Value,
+        trailing: &[PathSegment],
+        members: &[&WebTemplateNode],
+    ) {
+        for target in rmpath::navigate(&[node], trailing) {
+            match members {
+                [only] => self.walk(target, only),
+                _ => self.visit_choice(target, members),
             }
         }
     }
@@ -1256,6 +1240,54 @@ fn select_group_children<'a>(
         }
         (_, None) => rmpath::select_children_matched(container, id_seg, true),
     }
+}
+
+/// The index of the group's identity segment.
+///
+/// That is the last segment carrying a predicate; if none carries one, the last
+/// segment (a plain single-valued attribute).
+fn identity_index(segments: &[PathSegment]) -> usize {
+    segments
+        .iter()
+        .rposition(|s| !s.predicate.is_empty())
+        .unwrap_or(segments.len() - 1)
+}
+
+/// The predicate-stripped identity segment for a structurally-matched node.
+///
+/// A node whose RM type does NOT inherit `LOCATABLE` carries no
+/// `archetype_node_id` in canonical JSON (only `LOCATABLE` adds it — RM common
+/// `UML/classes/org.openehr.rm.common.locatable.adoc`; `EVENT_CONTEXT` inherits
+/// `PATHABLE` directly — RM
+/// `UML/classes/org.openehr.rm.composition.event_context.adoc` §Inherit), so it
+/// is matched by attribute position instead. [`None`] means the raw segment
+/// applies unchanged.
+fn structural_identity(
+    raw_id_seg: &PathSegment,
+    identity_is_locatable: bool,
+) -> Option<PathSegment> {
+    if identity_is_locatable || raw_id_seg.predicate.is_empty() {
+        return None;
+    }
+    let mut stripped = raw_id_seg.clone();
+    stripped.predicate = openehr_rm::v1_2::paths::Predicate::default();
+    Some(stripped)
+}
+
+/// The group's combined occurrence bounds: the loosest of its members'.
+fn group_occurrences(members: &[&WebTemplateNode]) -> (i32, i32) {
+    let min = members
+        .iter()
+        .filter_map(|c| c.min)
+        .min()
+        .unwrap_or(0)
+        .max(0);
+    let max = if members.iter().any(|c| c.max == -1) {
+        -1
+    } else {
+        members.iter().map(|c| c.max).max().unwrap_or(-1)
+    };
+    (min, max)
 }
 
 /// Whether an RM type inherits `LOCATABLE` and therefore carries an

--- a/crates/openehr-its/src/flat/webtemplate/builder.rs
+++ b/crates/openehr-its/src/flat/webtemplate/builder.rs
@@ -431,6 +431,62 @@ fn create_node(
     node
 }
 
+/// Builds the child nodes of one constraint attribute into `children`.
+///
+/// The careflow-state alternatives of `ism_transition` collapse into the one
+/// transition node master05 §ISM_TRANSITION maps, so they are built without
+/// their at-code identity (see [`shape::MERGED_ATTRIBUTE`]) and the merged
+/// node takes the ATTRIBUTE's occurrences — one required transition per ACTION
+/// instance, not one per careflow state. An unfilled slot or a constraint ref
+/// yields no node.
+fn build_attribute_children(
+    ctx: &Ctx,
+    attr: &crate::opt14::types::CAttribute,
+    node: &WebTemplateNode,
+    arch_id: &str,
+    children: &mut Vec<WebTemplateNode>,
+) {
+    let attr_name = inputs::attribute_name(attr);
+    // The openEHR terminology group a child's coded value binds to, fixed by
+    // (this node's RM type, the attribute) — used to resolve rubrics from the
+    // correct group (SPECPR-51 code collisions; see `inputs::openehr_group`).
+    let child_group = inputs::openehr_group(&node.rm_type, attr_name);
+    let merged = attr_name == shape::MERGED_ATTRIBUTE;
+    let identity = if merged {
+        shape::Identity::AttributeOnly
+    } else {
+        shape::Identity::Archetyped
+    };
+    let mut built = Vec::new();
+    for child_co in inputs::attribute_children(attr) {
+        if matches!(
+            child_co,
+            CObject::ArchetypeSlot(_) | CObject::ConstraintRef(_)
+        ) {
+            continue;
+        }
+        built.push(build_node(
+            ctx,
+            Some(attr),
+            child_co,
+            &node.aql_path,
+            arch_id,
+            child_group,
+            identity,
+        ));
+    }
+    if !merged {
+        children.extend(built);
+        return;
+    }
+    if let Some(mut transition) = shape::merge_alternatives(built) {
+        let (min, max) = occurrences(attribute_existence(attr));
+        transition.min = min;
+        transition.max = max;
+        children.push(transition);
+    }
+}
+
 fn build_children(
     ctx: &Ctx,
     co: &CObject,
@@ -444,57 +500,10 @@ fn build_children(
     let mut children = Vec::new();
     if recurse_attrs {
         for attr in inputs::attributes(co) {
-            let attr_name = inputs::attribute_name(attr);
-            if attr_name == "name" {
-                // The `name` attribute is never a child node — it names the node
-                // (master04 §"Field Identifiers": names generate the node id).
-                continue;
-            }
-            // The openEHR terminology group a child's coded value binds to, fixed
-            // by (this node's RM type, the attribute) — used to resolve rubrics
-            // from the correct group (SPECPR-51 code collisions; see
-            // `inputs::openehr_group`).
-            let child_group = inputs::openehr_group(&node.rm_type, attr_name);
-            // The careflow-state alternatives of `ism_transition` collapse into
-            // the one transition node master05 §ISM_TRANSITION maps, so they are
-            // built without their at-code identity (see
-            // [`shape::MERGED_ATTRIBUTE`]).
-            let merged = attr_name == shape::MERGED_ATTRIBUTE;
-            let identity = if merged {
-                shape::Identity::AttributeOnly
-            } else {
-                shape::Identity::Archetyped
-            };
-            let mut built = Vec::new();
-            for child_co in inputs::attribute_children(attr) {
-                if matches!(
-                    child_co,
-                    CObject::ArchetypeSlot(_) | CObject::ConstraintRef(_)
-                ) {
-                    continue; // Unfilled slot / constraint ref: no node.
-                }
-                built.push(build_node(
-                    ctx,
-                    Some(attr),
-                    child_co,
-                    &node.aql_path,
-                    arch_id,
-                    child_group,
-                    identity,
-                ));
-            }
-            if merged {
-                if let Some(mut transition) = shape::merge_alternatives(built) {
-                    // The merged node's occurrences are the ATTRIBUTE's — one
-                    // required transition per ACTION instance, not one per
-                    // careflow state.
-                    let (min, max) = occurrences(attribute_existence(attr));
-                    transition.min = min;
-                    transition.max = max;
-                    children.push(transition);
-                }
-            } else {
-                children.extend(built);
+            // The `name` attribute is never a child node — it names the node
+            // (master04 §"Field Identifiers": names generate the node id).
+            if inputs::attribute_name(attr) != "name" {
+                build_attribute_children(ctx, attr, node, arch_id, &mut children);
             }
         }
     }
@@ -632,37 +641,7 @@ fn capture_leaf_constraints(co: &CObject, node: &mut WebTemplateNode) {
     }
     capture_size_range(co, node);
     capture_leaf_existence(co, node);
-    if let Some(CPrimitive::CDuration(d)) = inputs::primitive_under(co, "value")
-        && let Some(range) = &d.range
-    {
-        let min = if range.lower_unbounded {
-            None
-        } else {
-            range.lower.clone()
-        };
-        let max = if range.upper_unbounded {
-            None
-        } else {
-            range.upper.clone()
-        };
-        if min.is_some() || max.is_some() {
-            // Inclusivity comes from the AOM interval flags (BASE
-            // foundation_types Interval: lower_included/upper_included) —
-            // an exclusive bound (`> PT0S`) must not degrade to `>=`.
-            let min_strict = range.lower_included == Some(false);
-            let max_strict = range.upper_included == Some(false);
-            node.duration_range = Some(super::model::WebTemplateRange {
-                min_op: min
-                    .as_ref()
-                    .map(|_| if min_strict { ">" } else { ">=" }.to_owned()),
-                min: min.map(serde_json::Value::String),
-                max_op: max
-                    .as_ref()
-                    .map(|_| if max_strict { "<" } else { "<=" }.to_owned()),
-                max: max.map(serde_json::Value::String),
-            });
-        }
-    }
+    capture_duration_range(co, node);
     // C_TIME/C_DATE_TIME timezone_validity (VALIDITY_KIND: OPT 1.4 XSD 1001 =
     // mandatory, 1002 = optional, 1003 = disallowed). C_DATE has no timezone.
     node.tz_validity = match inputs::primitive_under(co, "value") {
@@ -670,13 +649,58 @@ fn capture_leaf_constraints(co: &CObject, node: &mut WebTemplateNode) {
         Some(CPrimitive::CDateTime(c)) => c.timezone_validity.map(validity_code),
         _ => None,
     };
-    // C_QUANTITY.property (openEHR `property`-group code): captured so the
-    // instance's `units` can be checked against the property's unit set
-    // (`AM/docs/UML/classes/org.openehr.am.aom14.c_quantity.adoc` §C_QUANTITY:
-    // `property` = "Name of physical property for Quantities being
-    // constrained"). Only the openEHR-terminology property code is meaningful,
-    // and the placeholder "0" (Ocean Template Designer's unconstrained property)
-    // is treated as no constraint (matching the OPT-side C_DV_QUANTITY check).
+    capture_quantity_property(co, node);
+    capture_code_lists(co, node);
+}
+
+/// `C_DURATION.range` on `value` → [`WebTemplateNode::duration_range`] (AOM 1.4
+/// §`C_DURATION`).
+///
+/// Inclusivity comes from the AOM interval flags (BASE `foundation_types`
+/// Interval: `lower_included`/`upper_included`) — an exclusive bound
+/// (`> PT0S`) must not degrade to `>=`.
+fn capture_duration_range(co: &CObject, node: &mut WebTemplateNode) {
+    let Some(CPrimitive::CDuration(d)) = inputs::primitive_under(co, "value") else {
+        return;
+    };
+    let Some(range) = &d.range else { return };
+    let min = if range.lower_unbounded {
+        None
+    } else {
+        range.lower.clone()
+    };
+    let max = if range.upper_unbounded {
+        None
+    } else {
+        range.upper.clone()
+    };
+    if min.is_none() && max.is_none() {
+        return;
+    }
+    let min_strict = range.lower_included == Some(false);
+    let max_strict = range.upper_included == Some(false);
+    node.duration_range = Some(super::model::WebTemplateRange {
+        min_op: min
+            .as_ref()
+            .map(|_| if min_strict { ">" } else { ">=" }.to_owned()),
+        min: min.map(serde_json::Value::String),
+        max_op: max
+            .as_ref()
+            .map(|_| if max_strict { "<" } else { "<=" }.to_owned()),
+        max: max.map(serde_json::Value::String),
+    });
+}
+
+/// `C_QUANTITY.property` (an openEHR `property`-group code), captured so the
+/// instance's `units` can be checked against the property's unit set
+/// (`AM/docs/UML/classes/org.openehr.am.aom14.c_quantity.adoc` §C_QUANTITY:
+/// `property` = "Name of physical property for Quantities being
+/// constrained").
+///
+/// Only the openEHR-terminology property code is meaningful, and the
+/// placeholder "0" (Ocean Template Designer's unconstrained property) is
+/// treated as no constraint, matching the OPT-side `C_DV_QUANTITY` check.
+fn capture_quantity_property(co: &CObject, node: &mut WebTemplateNode) {
     if let CObject::CDvQuantity(q) = co
         && let Some(property) = &q.property
         && property
@@ -688,13 +712,25 @@ fn capture_leaf_constraints(co: &CObject, node: &mut WebTemplateNode) {
     {
         node.quantity_property = Some(property.code_string.clone());
     }
-    // An explicitly `local`-scoped closed code list admits ONLY local codes, so
-    // a foreign-terminology instance code violates it
-    // (`AM/docs/UML/classes/org.openehr.am.aom14.c_coded_text.adoc`
-    // §C_CODED_TEXT: `code_list` is "a list of codes FROM the terminology").
-    // The `wt+json` `inputs` mapping strips the implicit `local`, so the
-    // explicit scoping is recorded on the node instead (validation-only); a
-    // `C_CODE_PHRASE` naming no terminology is not flagged.
+}
+
+/// The `C_CODE_PHRASE` code lists the `inputs` mapping does not carry: the
+/// explicit `local` scoping of `defining_code`, and the lists on every other
+/// coded attribute (e.g. `DV_MULTIMEDIA.media_type`) → AOM 1.4
+/// §`C_CODE_PHRASE`.
+///
+/// An explicitly `local`-scoped closed code list admits ONLY local codes, so a
+/// foreign-terminology instance code violates it
+/// (`AM/docs/UML/classes/org.openehr.am.aom14.c_coded_text.adoc`
+/// §C_CODED_TEXT: `code_list` is "a list of codes FROM the terminology"). The
+/// `wt+json` `inputs` mapping strips the implicit `local`, so the explicit
+/// scoping is recorded on the node instead (validation-only); a
+/// `C_CODE_PHRASE` naming no terminology is not flagged.
+///
+/// NOTE: `AM/docs/AOM1.4/master04-constraint_model_package.adoc` §Reference
+/// Objects resolves a CONSTRAINT_REF through an external terminology query,
+/// not a local code list, so it is not captured as a leaf constraint.
+fn capture_code_lists(co: &CObject, node: &mut WebTemplateNode) {
     let defining_cp = match co {
         CObject::CCodePhrase(cp) => Some(cp),
         _ => inputs::attr_children(co, "defining_code").find_map(|c| match c {
@@ -711,9 +747,6 @@ fn capture_leaf_constraints(co: &CObject, node: &mut WebTemplateNode) {
     {
         node.coded_terminology_local = true;
     }
-    // NOTE: `AM/docs/AOM1.4/master04-constraint_model_package.adoc` §Reference
-    // Objects resolves a CONSTRAINT_REF through an external terminology query,
-    // not a local code list, so it is not captured as a leaf constraint.
     for attr in inputs::attributes(co) {
         let attr_name = inputs::attribute_name(attr);
         if attr_name == "defining_code" {

--- a/crates/openehr-its/src/flat/webtemplate/builder.rs
+++ b/crates/openehr-its/src/flat/webtemplate/builder.rs
@@ -392,32 +392,14 @@ fn create_node(
     let coded_name = archetyped
         .then(|| coded_name_constraint(co, ctx, arch_id, name_constraint.as_deref()))
         .flatten();
-    if let Some((value, coded)) = coded_name {
-        node.name = Some(value.clone());
-        node.localized_name = Some(value);
-        node.name_coded = Some(coded);
-    } else if let Some(nc) = &name_constraint {
-        node.name = Some(nc.clone());
-        node.localized_name = Some(nc.clone());
-    } else if !name_code.is_empty() {
-        node.name = ctx.text(arch_id, name_code, &ctx.default_language);
-        node.localized_name.clone_from(&node.name);
-        for lang in &ctx.languages {
-            if let Some(r) = ctx.rubric(arch_id, lang, name_code) {
-                if let Some(t) = &r.text {
-                    node.localized_names.insert(lang.clone(), t.clone());
-                }
-                if let Some(d) = &r.description {
-                    node.localized_descriptions.insert(lang.clone(), d.clone());
-                }
-            }
-        }
-    }
-    node.name_code = if name_code.is_empty() {
-        None
-    } else {
-        Some(name_code.to_owned())
-    };
+    apply_node_naming(
+        &mut node,
+        ctx,
+        arch_id,
+        name_code,
+        name_constraint.as_deref(),
+        coded_name,
+    );
     // Node-level external term bindings: the archetype root's `term_bindings`
     // whose item code matches this node's constraint node id (master04
     // §"Web Template Metadata": the node-level `termBindings` map).
@@ -429,6 +411,52 @@ fn create_node(
     // Value-sets to Archetypes").
     node.constraint_bindings = constraint_bindings_of(ctx, co, arch_id);
     node
+}
+
+/// Fills a node's name, localized names/descriptions and name code.
+///
+/// A coded name constraint wins over an explicit plain `name/value`, which wins
+/// over the node rubric; only the rubric route carries per-language text.
+fn apply_node_naming(
+    node: &mut WebTemplateNode,
+    ctx: &Ctx,
+    arch_id: &str,
+    name_code: &str,
+    name_constraint: Option<&str>,
+    coded_name: Option<(String, CodedName)>,
+) {
+    if let Some((value, coded)) = coded_name {
+        node.name = Some(value.clone());
+        node.localized_name = Some(value);
+        node.name_coded = Some(coded);
+    } else if let Some(nc) = name_constraint {
+        node.name = Some(nc.to_owned());
+        node.localized_name = Some(nc.to_owned());
+    } else if !name_code.is_empty() {
+        node.name = ctx.text(arch_id, name_code, &ctx.default_language);
+        node.localized_name.clone_from(&node.name);
+        apply_localized_rubrics(node, ctx, arch_id, name_code);
+    }
+    node.name_code = if name_code.is_empty() {
+        None
+    } else {
+        Some(name_code.to_owned())
+    };
+}
+
+/// Records the node rubric's per-language text and description.
+fn apply_localized_rubrics(node: &mut WebTemplateNode, ctx: &Ctx, arch_id: &str, name_code: &str) {
+    for lang in &ctx.languages {
+        let Some(r) = ctx.rubric(arch_id, lang, name_code) else {
+            continue;
+        };
+        if let Some(t) = &r.text {
+            node.localized_names.insert(lang.clone(), t.clone());
+        }
+        if let Some(d) = &r.description {
+            node.localized_descriptions.insert(lang.clone(), d.clone());
+        }
+    }
 }
 
 /// Builds the child nodes of one constraint attribute into `children`.
@@ -929,45 +957,64 @@ fn existence_constraints(co: &CObject, node_path: &str) -> Vec<WebTemplateExiste
 /// rule 2): `name`/`value`/`category`/`context` etc. hold non-LOCATABLE values
 /// that carry no `archetype_node_id` and so are never subject to sibling closure.
 fn closed_attributes(co: &CObject, node_path: &str) -> Vec<WebTemplateClosedAttribute> {
-    let mut out = Vec::new();
-    for attr in inputs::attributes(co) {
-        let attr_name = inputs::attribute_name(attr);
-        if attr_name == "name" {
-            continue; // The name is matched by predicate, not closure (master04 §"Field Identifiers").
-        }
-        // An unresolved internal-ref / constraint-ref makes the admissible set
-        // uncertain (target resolution is a documented builder scope gap); leave
-        // such an attribute OPEN rather than risk over-rejecting.
-        if inputs::attribute_children(attr).iter().any(|c| {
-            matches!(
-                c,
-                CObject::ArchetypeInternalRef(_) | CObject::ConstraintRef(_)
-            )
-        }) {
+    inputs::attributes(co)
+        .iter()
+        .filter_map(|attr| closed_attribute(attr, node_path))
+        .collect()
+}
+
+/// The closure record for one constraint attribute, or [`None`] when the
+/// attribute stays open.
+///
+/// An attribute stays open when it is the predicate-matched `name` (master04
+/// §"Field Identifiers"), when an unresolved internal-ref / constraint-ref makes
+/// the admissible set uncertain (target resolution is a documented builder scope
+/// gap — leave it open rather than risk over-rejecting), or when it constrains
+/// no node-id alternative and no slot.
+fn closed_attribute(
+    attr: &crate::opt14::types::CAttribute,
+    node_path: &str,
+) -> Option<WebTemplateClosedAttribute> {
+    let attr_name = inputs::attribute_name(attr);
+    if attr_name == "name" {
+        return None;
+    }
+    if inputs::attribute_children(attr).iter().any(|c| {
+        matches!(
+            c,
+            CObject::ArchetypeInternalRef(_) | CObject::ConstraintRef(_)
+        )
+    }) {
+        return None;
+    }
+    let (allowed_ids, slots) = admissible_children(attr);
+    if allowed_ids.is_empty() && slots.is_empty() {
+        return None;
+    }
+    Some(WebTemplateClosedAttribute {
+        path: format!("{node_path}/{attr_name}"),
+        allowed_ids,
+        slots,
+    })
+}
+
+/// The archetype node ids and slots one attribute admits as children.
+fn admissible_children(
+    attr: &crate::opt14::types::CAttribute,
+) -> (Vec<String>, Vec<WebTemplateArchetypeSlot>) {
+    let mut allowed_ids: Vec<String> = Vec::new();
+    let mut slots: Vec<WebTemplateArchetypeSlot> = Vec::new();
+    for child in inputs::attribute_children(attr) {
+        if let CObject::ArchetypeSlot(s) = child {
+            slots.push(archetype_slot(s));
             continue;
         }
-        let mut allowed_ids: Vec<String> = Vec::new();
-        let mut slots: Vec<WebTemplateArchetypeSlot> = Vec::new();
-        for child in inputs::attribute_children(attr) {
-            if let CObject::ArchetypeSlot(s) = child {
-                slots.push(archetype_slot(s));
-                continue;
-            }
-            let id = object_archetype_node_id(child);
-            if !id.is_empty() {
-                allowed_ids.push(id);
-            }
+        let id = object_archetype_node_id(child);
+        if !id.is_empty() {
+            allowed_ids.push(id);
         }
-        if allowed_ids.is_empty() && slots.is_empty() {
-            continue; // Open attribute (no node-id alternatives, no slot).
-        }
-        out.push(WebTemplateClosedAttribute {
-            path: format!("{node_path}/{attr_name}"),
-            allowed_ids,
-            slots,
-        });
     }
-    out
+    (allowed_ids, slots)
 }
 
 // ── structural stubs (constrained-but-content-less ENTRY structural attrs) ────

--- a/crates/openehr-its/src/flat/webtemplate/builder_v2_4.rs
+++ b/crates/openehr-its/src/flat/webtemplate/builder_v2_4.rs
@@ -53,6 +53,7 @@ use openehr_am::v2_4::aom2::constraint_model::c_attribute_tuple::CAttributeTuple
 use openehr_am::v2_4::aom2::constraint_model::c_complex_object::CComplexObject;
 use openehr_am::v2_4::aom2::constraint_model::c_object::CObject;
 use openehr_am::v2_4::aom2::constraint_model::c_primitive_object::CPrimitiveObject;
+use openehr_am::v2_4::aom2::constraint_model::c_primitive_tuple::CPrimitiveTuple;
 use openehr_am::v2_4::aom2::constraint_model::primitive::c_boolean::CBoolean;
 use openehr_am::v2_4::aom2::constraint_model::primitive::c_integer::CInteger;
 use openehr_am::v2_4::aom2::constraint_model::primitive::c_real::CReal;
@@ -736,50 +737,62 @@ fn ordinal_input(
             continue;
         }
         for row in tuple.tuples.iter().flatten() {
-            let mut code = None;
-            // `DV_ORDINAL.value` is an Integer; `DV_SCALE.value` is a Real —
-            // tracked separately so no lossy `f64 as i32` cast is needed.
-            let mut ordinal = 0_i32;
-            let mut scale_value = 0_f64;
-            for (i, name) in names.iter().enumerate() {
-                match (*name, row.members.get(i)) {
-                    ("symbol", Some(CPrimitiveObject::CTerminologyCode(ctc))) => {
-                        code = expand_codes(term, &ctc.constraint).into_iter().next();
-                    }
-                    ("value", Some(CPrimitiveObject::CInteger(ci))) => {
-                        ordinal = ci
-                            .constraint
-                            .iter()
-                            .flatten()
-                            .next()
-                            .and_then(point_i32)
-                            .unwrap_or(0);
-                        scale_value = f64::from(ordinal);
-                    }
-                    ("value", Some(CPrimitiveObject::CReal(cr))) => {
-                        scale_value = cr
-                            .constraint
-                            .iter()
-                            .flatten()
-                            .next()
-                            .and_then(point_f64)
-                            .unwrap_or(0.0);
-                    }
-                    _ => {}
-                }
+            let Some((code, ordinal, scale_value)) = ordinal_row(term, &names, row) else {
+                continue;
+            };
+            let mut cv = coded_value(ctx, term, &code);
+            if scale {
+                cv.scale = Some(scale_value);
+            } else {
+                cv.ordinal = Some(ordinal);
             }
-            if let Some(code) = code {
-                let mut cv = coded_value(ctx, term, &code);
-                if scale {
-                    cv.scale = Some(scale_value);
-                } else {
-                    cv.ordinal = Some(ordinal);
-                }
-                input.list.push(cv);
-            }
+            input.list.push(cv);
         }
     }
     input
+}
+
+/// One tuple row read into its symbol code and the two paired numeric readings.
+///
+/// `DV_ORDINAL.value` is an Integer and `DV_SCALE.value` a Real, so both are
+/// tracked and no lossy `f64 as i32` cast is needed. A row with no symbol code
+/// yields [`None`].
+fn ordinal_row(
+    term: &ArchetypeTerminology,
+    names: &[&str],
+    row: &CPrimitiveTuple,
+) -> Option<(String, i32, f64)> {
+    let mut code = None;
+    let mut ordinal = 0_i32;
+    let mut scale_value = 0_f64;
+    for (i, name) in names.iter().enumerate() {
+        match (*name, row.members.get(i)) {
+            ("symbol", Some(CPrimitiveObject::CTerminologyCode(ctc))) => {
+                code = expand_codes(term, &ctc.constraint).into_iter().next();
+            }
+            ("value", Some(CPrimitiveObject::CInteger(ci))) => {
+                ordinal = ci
+                    .constraint
+                    .iter()
+                    .flatten()
+                    .next()
+                    .and_then(point_i32)
+                    .unwrap_or(0);
+                scale_value = f64::from(ordinal);
+            }
+            ("value", Some(CPrimitiveObject::CReal(cr))) => {
+                scale_value = cr
+                    .constraint
+                    .iter()
+                    .flatten()
+                    .next()
+                    .and_then(point_f64)
+                    .unwrap_or(0.0);
+            }
+            _ => {}
+        }
+    }
+    Some((code?, ordinal, scale_value))
 }
 
 fn boolean_input(co: &CObject) -> WebTemplateInput {

--- a/crates/openehr-its/src/flat/webtemplate/builder_v2_4.rs
+++ b/crates/openehr-its/src/flat/webtemplate/builder_v2_4.rs
@@ -333,6 +333,54 @@ fn create_node(
     node
 }
 
+/// Builds the child nodes of one AOM2 constraint attribute into `children`.
+///
+/// The careflow-state alternatives of `ism_transition` collapse into the one
+/// transition node master05 §ISM_TRANSITION maps, so they are built without
+/// their at-code identity (see [`shape::MERGED_ATTRIBUTE`]) and the merged
+/// node takes the ATTRIBUTE's occurrences — one required transition per ACTION
+/// instance, not one per careflow state (AOM2 leaves `existence` unset unless
+/// it overrides the RM, where `ACTION.ism_transition` is 1..1). An unfilled
+/// slot or a residual proxy yields no node.
+fn build_attribute_children(
+    ctx: &Ctx,
+    term: &ArchetypeTerminology,
+    attr: &CAttribute,
+    node: &WebTemplateNode,
+    children: &mut Vec<WebTemplateNode>,
+) {
+    let merged = attr.rm_attribute_name == shape::MERGED_ATTRIBUTE;
+    let identity = if merged {
+        shape::Identity::AttributeOnly
+    } else {
+        shape::Identity::Archetyped
+    };
+    let mut built = Vec::new();
+    for child_co in attr.children.iter().flatten() {
+        if is_leaf_ignored(child_co) {
+            continue;
+        }
+        built.push(build_node(
+            ctx,
+            term,
+            Some(attr),
+            child_co,
+            &node.aql_path,
+            identity,
+        ));
+    }
+    if !merged {
+        children.extend(built);
+        return;
+    }
+    if let Some(mut transition) = shape::merge_alternatives(built) {
+        let (min, max) = attr.existence.as_ref().map_or((Some(1), 1), occ);
+        transition.min = min;
+        transition.max = max;
+        children.push(transition);
+    }
+}
+
 fn build_children(
     ctx: &Ctx,
     term: &ArchetypeTerminology,
@@ -345,46 +393,9 @@ fn build_children(
     let mut children = Vec::new();
     if recurse_attrs {
         for attr in co_attributes(co) {
-            if attr.rm_attribute_name == "name" {
-                continue; // The name attribute names the node (master04 §"Field Identifiers").
-            }
-            // The careflow-state alternatives of `ism_transition` collapse into
-            // the one transition node master05 §ISM_TRANSITION maps, so they are
-            // built without their at-code identity (see
-            // [`shape::MERGED_ATTRIBUTE`]).
-            let merged = attr.rm_attribute_name == shape::MERGED_ATTRIBUTE;
-            let identity = if merged {
-                shape::Identity::AttributeOnly
-            } else {
-                shape::Identity::Archetyped
-            };
-            let mut built = Vec::new();
-            for child_co in attr.children.iter().flatten() {
-                if is_leaf_ignored(child_co) {
-                    continue; // Unfilled slot / proxy: no node.
-                }
-                built.push(build_node(
-                    ctx,
-                    term,
-                    Some(attr),
-                    child_co,
-                    &node.aql_path,
-                    identity,
-                ));
-            }
-            if merged {
-                if let Some(mut transition) = shape::merge_alternatives(built) {
-                    // The merged node's occurrences are the ATTRIBUTE's — one
-                    // required transition per ACTION instance, not one per
-                    // careflow state. AOM2 leaves `existence` unset unless it
-                    // overrides the RM, where `ACTION.ism_transition` is 1..1.
-                    let (min, max) = attr.existence.as_ref().map_or((Some(1), 1), occ);
-                    transition.min = min;
-                    transition.max = max;
-                    children.push(transition);
-                }
-            } else {
-                children.extend(built);
+            // The name attribute names the node (master04 §"Field Identifiers").
+            if attr.rm_attribute_name != "name" {
+                build_attribute_children(ctx, term, attr, node, &mut children);
             }
         }
     }
@@ -600,13 +611,15 @@ fn external_coded_inputs() -> Vec<WebTemplateInput> {
     ]
 }
 
-fn quantity_inputs(ctx: &Ctx, term: &ArchetypeTerminology, co: &CObject) -> Vec<WebTemplateInput> {
-    let mut magnitude = WebTemplateInput::new(WebTemplateInputType::Decimal, Some("magnitude"));
-    let mut units = WebTemplateInput::new(WebTemplateInputType::CodedText, Some("unit"));
-
-    // The co-varying `[magnitude, units]` (and optional `precision`) tuple rows
-    // (AOM2 `C_ATTRIBUTE_TUPLE`); each row fixes one unit with its magnitude
-    // range/precision.
+/// Appends the units of the co-varying `[magnitude, units]` (and optional
+/// `precision`) tuple rows (AOM2 `C_ATTRIBUTE_TUPLE`); each row fixes one unit
+/// with its magnitude range and precision.
+fn push_tuple_units(
+    ctx: &Ctx,
+    term: &ArchetypeTerminology,
+    co: &CObject,
+    units: &mut WebTemplateInput,
+) {
     for tuple in co_attribute_tuples(co) {
         let names: Vec<&str> = tuple
             .members
@@ -650,6 +663,13 @@ fn quantity_inputs(ctx: &Ctx, term: &ArchetypeTerminology, co: &CObject) -> Vec<
             }
         }
     }
+}
+
+fn quantity_inputs(ctx: &Ctx, term: &ArchetypeTerminology, co: &CObject) -> Vec<WebTemplateInput> {
+    let mut magnitude = WebTemplateInput::new(WebTemplateInputType::Decimal, Some("magnitude"));
+    let mut units = WebTemplateInput::new(WebTemplateInputType::CodedText, Some("unit"));
+
+    push_tuple_units(ctx, term, co, &mut units);
 
     // The plain (non-tuple) `units`/`magnitude` attribute forms.
     for cs in cstrings_under(co, "units") {
@@ -1020,24 +1040,7 @@ fn closed_attributes(co: &CObject, node_path: &str) -> Vec<WebTemplateClosedAttr
         {
             continue;
         }
-        let mut allowed_ids: Vec<String> = Vec::new();
-        let mut slots: Vec<WebTemplateArchetypeSlot> = Vec::new();
-        for child in attr.children.iter().flatten() {
-            match child {
-                CObject::ArchetypeSlot(s) => slots.push(archetype_slot(s)),
-                // A node-identified LOCATABLE alternative (an at/id-coded
-                // C_COMPLEX_OBJECT, or an inlined C_ARCHETYPE_ROOT carrying its
-                // interface archetype id). Primitive value constraints never
-                // participate in sibling closure.
-                CObject::CComplexObject(_) => {
-                    let id = object_archetype_node_id(child);
-                    if !id.is_empty() {
-                        allowed_ids.push(id);
-                    }
-                }
-                _ => {}
-            }
-        }
+        let (allowed_ids, slots) = admissible_children(attr);
         if allowed_ids.is_empty() && slots.is_empty() {
             continue; // Open attribute (no node-id alternatives, no slot).
         }
@@ -1048,6 +1051,30 @@ fn closed_attributes(co: &CObject, node_path: &str) -> Vec<WebTemplateClosedAttr
         });
     }
     out
+}
+
+/// The admissible child identities of one attribute: its node-identified
+/// LOCATABLE alternatives and its archetype slots.
+///
+/// An alternative is an at/id-coded `C_COMPLEX_OBJECT`, or an inlined
+/// `C_ARCHETYPE_ROOT` carrying its interface archetype id; primitive value
+/// constraints never participate in sibling closure.
+fn admissible_children(attr: &CAttribute) -> (Vec<String>, Vec<WebTemplateArchetypeSlot>) {
+    let mut allowed_ids: Vec<String> = Vec::new();
+    let mut slots: Vec<WebTemplateArchetypeSlot> = Vec::new();
+    for child in attr.children.iter().flatten() {
+        match child {
+            CObject::ArchetypeSlot(s) => slots.push(archetype_slot(s)),
+            CObject::CComplexObject(_) => {
+                let id = object_archetype_node_id(child);
+                if !id.is_empty() {
+                    allowed_ids.push(id);
+                }
+            }
+            _ => {}
+        }
+    }
+    (allowed_ids, slots)
 }
 
 /// The validation-only slot record from an AOM2 `ARCHETYPE_SLOT`: its constrained

--- a/crates/openehr-its/src/flat/webtemplate/inputs.rs
+++ b/crates/openehr-its/src/flat/webtemplate/inputs.rs
@@ -347,50 +347,56 @@ fn count_input(co: &CObject) -> WebTemplateInput {
 
 fn ordinal_input(co: &CObject, labels: &dyn Labels, scale: bool) -> WebTemplateInput {
     let mut input = WebTemplateInput::new(WebTemplateInputType::CodedText, None);
-    if let CObject::CDvOrdinal(ord) = co {
-        for entry in &ord.list {
-            let dc = &entry.symbol.defining_code;
-            let term = &dc.terminology_id.value;
-            let mut cv = coded_value(term, &dc.code_string, labels, None);
-            // The label should be the ordinal symbol rubric; prefer the symbol value.
-            if !entry.symbol.value.is_empty() {
-                cv.label = Some(entry.symbol.value.clone());
-            }
-            if scale {
-                cv.scale = Some(f64::from(entry.value));
-            } else {
-                cv.ordinal = Some(entry.value);
-            }
-            input.list.push(cv);
-        }
+    let CObject::CDvOrdinal(ord) = co else {
+        push_generic_ordinal_codes(co, labels, &mut input);
         return input;
-    }
-    // Generic C_COMPLEX_OBJECT form: AOM 1.4 has no `C_DV_SCALE` constrainer
-    // (AM `masterAppA-domain_extension.adoc` defines an integer-valued
-    // `C_ORDINAL` only), so a DV_SCALE constrains its coded `symbol` through
-    // `symbol.defining_code` as a `C_CODE_PHRASE` `code_list` (RM `data_types`
-    // §`DV_SCALE`). Surface that code set as the coded `list` so the walk
-    // enforces symbol membership; the numeric `value` set is captured
-    // separately. No paired `(symbol, value)` numeric is recorded — the generic
-    // form loses the pairing — so the coded values carry no `ordinal`/`scale`.
-    for symbol_child in attr_children(co, "symbol") {
-        for dc_child in attr_children(symbol_child, "defining_code") {
-            if let CObject::CCodePhrase(cp) = dc_child {
-                let term = cp.terminology_id.as_ref().map(|t| t.value.clone());
-                for code in &cp.code_list {
-                    let cv = coded_value(term.as_deref().unwrap_or("local"), code, labels, None);
-                    if let Some(t) = &term
-                        && !t.is_empty()
-                        && t != "local"
-                    {
-                        input.terminology = Some(t.clone());
-                    }
-                    input.list.push(cv);
-                }
-            }
+    };
+    for entry in &ord.list {
+        let dc = &entry.symbol.defining_code;
+        let mut cv = coded_value(&dc.terminology_id.value, &dc.code_string, labels, None);
+        // The label should be the ordinal symbol rubric; prefer the symbol value.
+        if !entry.symbol.value.is_empty() {
+            cv.label = Some(entry.symbol.value.clone());
         }
+        if scale {
+            cv.scale = Some(f64::from(entry.value));
+        } else {
+            cv.ordinal = Some(entry.value);
+        }
+        input.list.push(cv);
     }
     input
+}
+
+/// The coded values of the generic `C_COMPLEX_OBJECT` ordinal/scale form.
+///
+/// AOM 1.4 has no `C_DV_SCALE` constrainer (AM
+/// `masterAppA-domain_extension.adoc` defines an integer-valued `C_ORDINAL`
+/// only), so a DV_SCALE constrains its coded `symbol` through
+/// `symbol.defining_code` as a `C_CODE_PHRASE` `code_list` (RM `data_types`
+/// §`DV_SCALE`). That code set surfaces as the coded `list` so the walk
+/// enforces symbol membership; the numeric `value` set is captured separately.
+/// No paired `(symbol, value)` numeric is recorded — the generic form loses
+/// the pairing — so the coded values carry no `ordinal`/`scale`.
+fn push_generic_ordinal_codes(co: &CObject, labels: &dyn Labels, input: &mut WebTemplateInput) {
+    for symbol_child in attr_children(co, "symbol") {
+        for dc_child in attr_children(symbol_child, "defining_code") {
+            let CObject::CCodePhrase(cp) = dc_child else {
+                continue;
+            };
+            let term = cp.terminology_id.as_ref().map(|t| t.value.clone());
+            for code in &cp.code_list {
+                let cv = coded_value(term.as_deref().unwrap_or("local"), code, labels, None);
+                if let Some(t) = &term
+                    && !t.is_empty()
+                    && t != "local"
+                {
+                    input.terminology = Some(t.clone());
+                }
+                input.list.push(cv);
+            }
+        }
+    }
 }
 
 // ── DV_BOOLEAN ───────────────────────────────────────────────────────────────

--- a/crates/openehr-its/src/flat/webtemplate/shape.rs
+++ b/crates/openehr-its/src/flat/webtemplate/shape.rs
@@ -738,37 +738,23 @@ fn compact_multiple_coded_texts(children: &mut Vec<WebTemplateNode>) {
     // (keep, drop) pairs whose coded lists are unioned.
     let mut merges: Vec<(usize, usize)> = Vec::new();
     for idxs in groups.values() {
-        if idxs.len() != 2 {
-            continue; // Only an exact pair is compacted.
-        }
-        let (a, b) = (idxs[0], idxs[1]);
+        // Only an exact pair of coded-text siblings is compacted.
+        let [a, b] = idxs[..] else { continue };
         if !is_coded_text(&children[a]) || !is_coded_text(&children[b]) {
             continue;
         }
-        let constrained_a = is_input_constrained(&children[a]);
-        let constrained_b = is_input_constrained(&children[b]);
-        if constrained_a && !constrained_b {
-            to_remove.push(b);
-        } else if constrained_b && !constrained_a {
-            to_remove.push(a);
-        } else {
-            merges.push((a, b));
+        match (
+            is_input_constrained(&children[a]),
+            is_input_constrained(&children[b]),
+        ) {
+            (true, false) => to_remove.push(b),
+            (false, true) => to_remove.push(a),
+            _ => merges.push((a, b)),
         }
     }
 
     for (keep, drop) in merges {
-        let drop_list = children[drop]
-            .inputs
-            .first()
-            .map(|i| i.list.clone())
-            .unwrap_or_default();
-        if let Some(input) = children[keep].inputs.first_mut() {
-            for cv in drop_list {
-                if !input.list.iter().any(|existing| existing.value == cv.value) {
-                    input.list.push(cv);
-                }
-            }
-        }
+        union_coded_lists(children, keep, drop);
         to_remove.push(drop);
     }
 
@@ -776,6 +762,27 @@ fn compact_multiple_coded_texts(children: &mut Vec<WebTemplateNode>) {
     to_remove.dedup();
     for i in to_remove.into_iter().rev() {
         children.remove(i);
+    }
+}
+
+/// Unions the dropped sibling's coded list into the kept one, deduplicated by
+/// code with first-seen order preserved.
+#[expect(
+    clippy::indexing_slicing,
+    reason = "both indices are `enumerate()` indices into `children` and nothing is removed before this runs, so they are in bounds by construction"
+)]
+fn union_coded_lists(children: &mut [WebTemplateNode], keep: usize, drop: usize) {
+    let drop_list = children[drop]
+        .inputs
+        .first()
+        .map(|i| i.list.clone())
+        .unwrap_or_default();
+    if let Some(input) = children[keep].inputs.first_mut() {
+        for cv in drop_list {
+            if !input.list.iter().any(|existing| existing.value == cv.value) {
+                input.list.push(cv);
+            }
+        }
     }
 }
 

--- a/crates/openehr-its/src/rest/smart_scopes.rs
+++ b/crates/openehr-its/src/rest/smart_scopes.rs
@@ -246,31 +246,35 @@ impl fmt::Display for Pattern {
 fn glob_match(pat: &[u8], text: &[u8]) -> bool {
     match pat.split_first() {
         None => text.is_empty(),
-        Some((&b'*', after_star)) => {
-            if let Some(rest) = after_star.strip_prefix(b"*") {
-                // `**` — consume 0..=len bytes of anything.
+        Some((&b'*', after_star)) => match after_star.strip_prefix(b"*") {
+            // `**` — consume 0..=len bytes of anything.
+            Some(rest) => {
                 (0..=text.len()).any(|i| text.get(i..).is_some_and(|tail| glob_match(rest, tail)))
-            } else {
-                // `*` — consume bytes, stopping before any `:`.
-                let mut i = 0;
-                loop {
-                    let Some(tail) = text.get(i..) else {
-                        return false;
-                    };
-                    if glob_match(after_star, tail) {
-                        return true;
-                    }
-                    if tail.first().is_none_or(|&b| b == b':') {
-                        return false;
-                    }
-                    i += 1;
-                }
             }
-        }
+            None => match_single_star(after_star, text),
+        },
         Some((&c, pat_rest)) => match text.split_first() {
             Some((&t, text_rest)) if t == c => glob_match(pat_rest, text_rest),
             _ => false,
         },
+    }
+}
+
+/// The single-`*` case of [`glob_match`]: consume bytes, stopping before any
+/// `:` so the star never crosses the `::` namespace delimiter.
+fn match_single_star(after_star: &[u8], text: &[u8]) -> bool {
+    let mut i = 0;
+    loop {
+        let Some(tail) = text.get(i..) else {
+            return false;
+        };
+        if glob_match(after_star, tail) {
+            return true;
+        }
+        if tail.first().is_none_or(|&b| b == b':') {
+            return false;
+        }
+        i += 1;
     }
 }
 

--- a/crates/openehr-its/src/rm_instance/mod.rs
+++ b/crates/openehr-its/src/rm_instance/mod.rs
@@ -298,31 +298,15 @@ pub(crate) fn rm_invariant_pass(
     bounds: LowerBounds,
 ) {
     let Some(obj) = v.as_object() else { return };
-    // One projection pass over the node's entries collects every field the
-    // per-node checks below read, so none of them pays a hashed map lookup
-    // (this runs for every node of every commit; the only remaining per-node
-    // gets are gated behind a matching `_type`).
-    let mut ty: Option<&str> = None;
-    let mut node_id: Option<&str> = None;
-    let mut has_archetype_details = false;
-    let mut details_archetype_id: Option<&str> = None;
-    for (k, val) in obj {
-        match k.as_str() {
-            "_type" => ty = val.as_str(),
-            "archetype_node_id" => node_id = val.as_str(),
-            "archetype_details" => {
-                has_archetype_details = !val.is_null();
-                details_archetype_id = val
-                    .get("archetype_id")
-                    .and_then(|a| a.get("value"))
-                    .and_then(Value::as_str);
-            }
-            _ => {}
-        }
-    }
+    let fields = NodeFields::of(obj);
+    let (node_id, has_archetype_details, details_archetype_id) = (
+        fields.node_id,
+        fields.has_archetype_details,
+        fields.details_archetype_id,
+    );
     // The node's effective RM type: the wire tag, else the parent's
     // concretely-declared attribute type (untagged nodes are legal there).
-    let ty = ty.or(declared);
+    let ty = fields.ty.or(declared);
     let mut inv = Vec::new();
     if let Some(effective) = ty {
         // The core (fast/typed) RM invariants only — the terminology-backed
@@ -369,56 +353,111 @@ pub(crate) fn rm_invariant_pass(
         push(out, p, iv.message, ValidationKind::Invariant);
     }
     for (k, val) in obj {
-        if k.starts_with('_') {
-            continue;
+        if !k.starts_with('_') {
+            descend_attribute(out, k, val, path, ty, bounds);
         }
-        let child_declared = ty.and_then(|t| declared_concrete_type(t, k));
-        // The declared-slot-type conformance rule (the WRONGNESS half of slot
-        // typing, never relaxed — RM common master06 §Incomplete Content):
-        // a TAGGED child must claim the slot's declared type or a subtype.
-        // One model-driven rule for single slots and list members alike; the
-        // shallow-pruned typed dispatch cannot see it (each pruned member
-        // re-dispatches on its own `_type`), so the walk owns it.
-        let slot_check = |item: &Value, out: &mut Vec<ValidationMessage>, path: &str| {
-            if let (Some(parent), Some(wire)) = (ty, item.get("_type").and_then(Value::as_str))
-                && let Some(iv) =
-                    openehr_rm::v1_2::validate::check_declared_slot_type(parent, k, wire)
-            {
-                push(out, norm_path(path), iv.message, ValidationKind::Invariant);
-            }
+    }
+}
+
+/// The node fields every per-node check reads, collected in ONE projection
+/// pass so none of them pays a hashed map lookup.
+///
+/// This runs for every node of every commit; the only remaining per-node gets
+/// are gated behind a matching `_type`.
+struct NodeFields<'a> {
+    ty: Option<&'a str>,
+    node_id: Option<&'a str>,
+    has_archetype_details: bool,
+    details_archetype_id: Option<&'a str>,
+}
+
+impl<'a> NodeFields<'a> {
+    fn of(obj: &'a serde_json::Map<String, Value>) -> Self {
+        let mut fields = NodeFields {
+            ty: None,
+            node_id: None,
+            has_archetype_details: false,
+            details_archetype_id: None,
         };
-        match val {
-            Value::Array(a) => {
-                for (i, item) in a.iter().enumerate() {
-                    if item.is_object() {
-                        let base = path.len();
-                        let _ = write!(path, "/{k}[{i}]");
-                        slot_check(item, out, path);
-                        rm_invariant_pass(out, item, path, child_declared, bounds);
-                        path.truncate(base);
-                    } else if let Some(iv) = ty.and_then(|parent| {
-                        openehr_rm::v1_2::validate::check_slot_member_is_object(parent, k)
-                    }) {
-                        // A scalar member of a class-typed list slot is the
-                        // same positive contradiction a foreign `_type` is —
-                        // its declared type is an RM class, which no JSON
-                        // scalar can be.
-                        let base = path.len();
-                        let _ = write!(path, "/{k}[{i}]");
-                        push(out, norm_path(path), iv.message, ValidationKind::Invariant);
-                        path.truncate(base);
-                    }
+        for (k, val) in obj {
+            match k.as_str() {
+                "_type" => fields.ty = val.as_str(),
+                "archetype_node_id" => fields.node_id = val.as_str(),
+                "archetype_details" => {
+                    fields.has_archetype_details = !val.is_null();
+                    fields.details_archetype_id = val
+                        .get("archetype_id")
+                        .and_then(|a| a.get("value"))
+                        .and_then(Value::as_str);
                 }
+                _ => {}
             }
-            Value::Object(_) => {
+        }
+        fields
+    }
+}
+
+/// Descends into one attribute of a node, checking each member's declared slot
+/// type on the way down.
+fn descend_attribute(
+    out: &mut Vec<ValidationMessage>,
+    k: &str,
+    val: &Value,
+    path: &mut String,
+    ty: Option<&str>,
+    bounds: LowerBounds,
+) {
+    let child_declared = ty.and_then(|t| declared_concrete_type(t, k));
+    match val {
+        Value::Array(a) => {
+            for (i, item) in a.iter().enumerate() {
                 let base = path.len();
-                let _ = write!(path, "/{k}");
-                slot_check(val, out, path);
-                rm_invariant_pass(out, val, path, child_declared, bounds);
+                let _ = write!(path, "/{k}[{i}]");
+                if item.is_object() {
+                    check_slot_type(out, ty, k, item, path);
+                    rm_invariant_pass(out, item, path, child_declared, bounds);
+                } else if let Some(iv) = ty.and_then(|parent| {
+                    openehr_rm::v1_2::validate::check_slot_member_is_object(parent, k)
+                }) {
+                    // A scalar member of a class-typed list slot is the same
+                    // positive contradiction a foreign `_type` is — its
+                    // declared type is an RM class, which no JSON scalar can
+                    // be.
+                    push(out, norm_path(path), iv.message, ValidationKind::Invariant);
+                }
                 path.truncate(base);
             }
-            _ => {}
         }
+        Value::Object(_) => {
+            let base = path.len();
+            let _ = write!(path, "/{k}");
+            check_slot_type(out, ty, k, val, path);
+            rm_invariant_pass(out, val, path, child_declared, bounds);
+            path.truncate(base);
+        }
+        _ => {}
+    }
+}
+
+/// The declared-slot-type conformance rule (the WRONGNESS half of slot typing,
+/// never relaxed — RM common master06 §Incomplete Content): a TAGGED child
+/// must claim the slot's declared type or a subtype.
+///
+/// One model-driven rule for single slots and list members alike; the
+/// shallow-pruned typed dispatch cannot see it (each pruned member
+/// re-dispatches on its own `_type`), so the walk owns it.
+fn check_slot_type(
+    out: &mut Vec<ValidationMessage>,
+    parent_ty: Option<&str>,
+    attribute: &str,
+    item: &Value,
+    path: &str,
+) {
+    if let (Some(parent), Some(wire)) = (parent_ty, item.get("_type").and_then(Value::as_str))
+        && let Some(iv) =
+            openehr_rm::v1_2::validate::check_declared_slot_type(parent, attribute, wire)
+    {
+        push(out, norm_path(path), iv.message, ValidationKind::Invariant);
     }
 }
 

--- a/crates/openehr-its/tests/it/ckm_full_pack.rs
+++ b/crates/openehr-its/tests/it/ckm_full_pack.rs
@@ -107,6 +107,50 @@ fn collect_element_value_defects(node: &Value, path: &str, out: &mut Vec<String>
     }
 }
 
+/// What one packed template's parse + example generation produced.
+enum TemplateOutcome {
+    /// The file could not be read at all.
+    ReadFailed(String),
+    /// Parsed, built and generated defect-free examples.
+    Clean,
+    /// The OPT parse or the WebTemplate build refused it.
+    Refused(String),
+    /// Examples were generated but carry RM-shape defects.
+    Defects(Vec<String>),
+}
+
+/// Parses one packed OPT and checks the examples it generates at every level.
+fn examine_template(path: &Path, name: &str) -> TemplateOutcome {
+    let xml = match std::fs::read_to_string(path) {
+        Ok(xml) => xml,
+        Err(e) => return TemplateOutcome::ReadFailed(format!("{name}: read failed: {e}")),
+    };
+    let opt = match opt14::from_xml(&xml) {
+        Ok(opt) => opt,
+        Err(e) => return TemplateOutcome::Refused(format!("{name}: OPT parse failed: {e}")),
+    };
+    let wt = match build_web_template(&opt) {
+        Ok(wt) => wt,
+        Err(e) => {
+            return TemplateOutcome::Refused(format!("{name}: WebTemplate build failed: {e}"));
+        }
+    };
+    let mut defects = Vec::new();
+    for level in [
+        DetailLevel::Required,
+        DetailLevel::Medium,
+        DetailLevel::Complete,
+    ] {
+        let example = example_composition(&wt, level);
+        collect_element_value_defects(&example, &format!("{name}@{level:?}"), &mut defects);
+    }
+    if defects.is_empty() {
+        TemplateOutcome::Clean
+    } else {
+        TemplateOutcome::Defects(defects)
+    }
+}
+
 /// Every OPT of the full CKM library parses, builds a WebTemplate, and
 /// generates RM-shape-valid examples at every detail level.
 #[test]
@@ -129,61 +173,24 @@ fn full_ckm_pack_parses_and_generates_valid_examples() {
     for path in &files {
         let name = file_name(path);
         let verdict = adjudication(&name);
-        let xml = match std::fs::read_to_string(path) {
-            Ok(xml) => xml,
-            Err(e) => {
-                let _ = writeln!(findings, "{name}: read failed: {e}");
-                continue;
+        match examine_template(path, &name) {
+            // A read failure is never adjudicable: the corpus itself is broken.
+            TemplateOutcome::ReadFailed(message) => {
+                let _ = writeln!(findings, "{message}");
             }
-        };
-
-        let opt = match opt14::from_xml(&xml) {
-            Ok(opt) => opt,
-            Err(e) => {
-                match verdict {
-                    Some(_) => adjudicated += 1,
-                    None => {
-                        let _ = writeln!(findings, "{name}: OPT parse failed: {e}");
-                    }
+            TemplateOutcome::Clean => {
+                if verdict.is_some() {
+                    unexpectedly_accepted.push(name.clone());
                 }
-                continue;
+                parsed += 1;
             }
-        };
-
-        let wt = match build_web_template(&opt) {
-            Ok(wt) => wt,
-            Err(e) => {
-                match verdict {
-                    Some(_) => adjudicated += 1,
-                    None => {
-                        let _ = writeln!(findings, "{name}: WebTemplate build failed: {e}");
-                    }
-                }
-                continue;
+            TemplateOutcome::Refused(message) if verdict.is_none() => {
+                let _ = writeln!(findings, "{message}");
             }
-        };
-
-        let mut defects = Vec::new();
-        for level in [
-            DetailLevel::Required,
-            DetailLevel::Medium,
-            DetailLevel::Complete,
-        ] {
-            let example = example_composition(&wt, level);
-            collect_element_value_defects(&example, &format!("{name}@{level:?}"), &mut defects);
-        }
-        if defects.is_empty() {
-            if verdict.is_some() {
-                unexpectedly_accepted.push(name.clone());
+            TemplateOutcome::Defects(defects) if verdict.is_none() => {
+                let _ = writeln!(findings, "{}", defects.join("\n"));
             }
-            parsed += 1;
-        } else {
-            match verdict {
-                Some(_) => adjudicated += 1,
-                None => {
-                    let _ = writeln!(findings, "{}", defects.join("\n"));
-                }
-            }
+            TemplateOutcome::Refused(_) | TemplateOutcome::Defects(_) => adjudicated += 1,
         }
     }
 

--- a/crates/openehr-its/tests/it/fidelity.rs
+++ b/crates/openehr-its/tests/it/fidelity.rs
@@ -92,43 +92,61 @@ fn semantic_eq(
 ) -> Result<(), String> {
     use serde_json::Value;
     match (input, output) {
-        (Value::Object(im), Value::Object(om)) => {
-            for (k, iv) in im {
-                match om.get(k) {
-                    Some(ov) => semantic_eq(iv, ov, &format!("{path}.{k}"))?,
-                    None if is_omittable(iv) => {}
-                    None => {
-                        return Err(format!(
-                            "{path}.{k}: present in input, dropped from output ({})",
-                            preview(iv)
-                        ));
-                    }
-                }
-            }
-            for (k, ov) in om {
-                if !im.contains_key(k) && !is_default_materialization(k, ov) {
-                    return Err(format!(
-                        "{path}.{k}: emitted in output but absent from input ({})",
-                        preview(ov)
-                    ));
-                }
-            }
-            Ok(())
-        }
-        (Value::Array(ia), Value::Array(oa)) => {
-            if ia.len() != oa.len() {
-                return Err(format!("{path}: array length {} vs {}", ia.len(), oa.len()));
-            }
-            for (i, (a, b)) in ia.iter().zip(oa).enumerate() {
-                semantic_eq(a, b, &format!("{path}[{i}]"))?;
-            }
-            Ok(())
-        }
+        (Value::Object(im), Value::Object(om)) => objects_semantic_eq(im, om, path),
+        (Value::Array(ia), Value::Array(oa)) => arrays_semantic_eq(ia, oa, path),
         // `5` (Integer) and `5.0` (Real) are the same magnitude on the wire.
         (Value::Number(a), Value::Number(b)) if a.as_f64() == b.as_f64() => Ok(()),
         _ if input == output => Ok(()),
         _ => Err(format!("{path}: {} vs {}", preview(input), preview(output))),
     }
+}
+
+/// Compares two objects member by member, in both directions.
+fn objects_semantic_eq(
+    input: &serde_json::Map<String, serde_json::Value>,
+    output: &serde_json::Map<String, serde_json::Value>,
+    path: &str,
+) -> Result<(), String> {
+    for (k, iv) in input {
+        match output.get(k) {
+            Some(ov) => semantic_eq(iv, ov, &format!("{path}.{k}"))?,
+            None if is_omittable(iv) => {}
+            None => {
+                return Err(format!(
+                    "{path}.{k}: present in input, dropped from output ({})",
+                    preview(iv)
+                ));
+            }
+        }
+    }
+    for (k, ov) in output {
+        if !input.contains_key(k) && !is_default_materialization(k, ov) {
+            return Err(format!(
+                "{path}.{k}: emitted in output but absent from input ({})",
+                preview(ov)
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Compares two arrays element by element, lengths first.
+fn arrays_semantic_eq(
+    input: &[serde_json::Value],
+    output: &[serde_json::Value],
+    path: &str,
+) -> Result<(), String> {
+    if input.len() != output.len() {
+        return Err(format!(
+            "{path}: array length {} vs {}",
+            input.len(),
+            output.len()
+        ));
+    }
+    for (i, (a, b)) in input.iter().zip(output).enumerate() {
+        semantic_eq(a, b, &format!("{path}[{i}]"))?;
+    }
+    Ok(())
 }
 
 /// An input field we may legitimately drop: `OpenEhrType` omits `None` (`null`)

--- a/crates/openehr-its/tests/it/flat.rs
+++ b/crates/openehr-its/tests/it/flat.rs
@@ -137,6 +137,51 @@ fn sorted(m: &serde_json::Map<String, Value>) -> BTreeMap<String, Value> {
     m.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
 }
 
+/// One pair's FLAT round-trip: `to_flat` → `from_flat` → `to_flat` again.
+///
+/// Returns the rebuilt RM value plus the instability diagnostic (`None` when the
+/// two FLAT renderings agree), or the conversion failure to record.
+fn flat_round_trip(
+    name: &str,
+    tid: &str,
+    comp: &Value,
+    wt: &WebTemplate,
+) -> Result<(Value, Option<String>), String> {
+    let flat0 = composition_to_flat(comp, wt).map_err(|e| format!("{name}: to_flat: {e}"))?;
+    let rm1 =
+        composition_from_flat(&flat0, wt, NOW).map_err(|e| format!("{name}: from_flat: {e}"))?;
+    let flat1 = composition_to_flat(&rm1, wt)
+        .map_err(|e| format!("{name}: composition_to_flat(rm1): {e}"))?;
+    let m0 = sorted(&flat0);
+    let m1 = sorted(&flat1);
+    if m0 == m1 {
+        return Ok((rm1, None));
+    }
+    Ok((rm1, Some(instability_diagnostic(name, tid, &m0, &m1))))
+}
+
+/// A short, deterministic account of how two FLAT renderings differ.
+fn instability_diagnostic(
+    name: &str,
+    tid: &str,
+    m0: &BTreeMap<String, Value>,
+    m1: &BTreeMap<String, Value>,
+) -> String {
+    let only0: Vec<_> = m0.keys().filter(|k| !m1.contains_key(*k)).take(4).collect();
+    let only1: Vec<_> = m1.keys().filter(|k| !m0.contains_key(*k)).take(4).collect();
+    let changed: Vec<_> = m0
+        .iter()
+        .filter(|(k, v)| m1.get(*k).is_some_and(|v1| v1 != *v))
+        .map(|(k, _)| k)
+        .take(4)
+        .collect();
+    format!(
+        "{name} ({tid}): {} keys → {} keys | only-in-flat0={only0:?} only-in-flat1={only1:?} changed={changed:?}",
+        m0.len(),
+        m1.len()
+    )
+}
+
 // ── round-trip gate ────────────────────────────────────────────────────────────
 
 #[test]
@@ -156,46 +201,16 @@ fn flat_roundtrip_stable() {
         let Some(wt) = wts.get(tid) else { continue };
         paired += 1;
 
-        let flat0 = match composition_to_flat(comp, wt) {
-            Ok(f) => f,
-            Err(e) => {
-                failures.push(format!("{name}: to_flat: {e}"));
+        let (rm1, instability) = match flat_round_trip(name, tid, comp, wt) {
+            Ok(pair) => pair,
+            Err(message) => {
+                failures.push(message);
                 continue;
             }
         };
-        let rm1 = match composition_from_flat(&flat0, wt, NOW) {
-            Ok(v) => v,
-            Err(e) => {
-                failures.push(format!("{name}: from_flat: {e}"));
-                continue;
-            }
-        };
-        let flat1 = match composition_to_flat(&rm1, wt) {
-            Ok(f) => f,
-            Err(e) => {
-                failures.push(format!("{name}: composition_to_flat(rm1): {e}"));
-                continue;
-            }
-        };
-
-        if sorted(&flat0) == sorted(&flat1) {
-            stable += 1;
-        } else {
-            let m0 = sorted(&flat0);
-            let m1 = sorted(&flat1);
-            let only0: Vec<_> = m0.keys().filter(|k| !m1.contains_key(*k)).take(4).collect();
-            let only1: Vec<_> = m1.keys().filter(|k| !m0.contains_key(*k)).take(4).collect();
-            let changed: Vec<_> = m0
-                .iter()
-                .filter(|(k, v)| m1.get(*k).is_some_and(|v1| v1 != *v))
-                .map(|(k, _)| k)
-                .take(4)
-                .collect();
-            failures.push(format!(
-                "{name} ({tid}): {} keys → {} keys | only-in-flat0={only0:?} only-in-flat1={only1:?} changed={changed:?}",
-                m0.len(),
-                m1.len()
-            ));
+        match instability {
+            Some(diagnostic) => failures.push(diagnostic),
+            None => stable += 1,
         }
 
         // The reverse output should be valid canonical RM.

--- a/crates/openehr-its/tests/it/model_walkgen.rs
+++ b/crates/openehr-its/tests/it/model_walkgen.rs
@@ -116,68 +116,85 @@ fn generate(
     if depth > 12 {
         return Value::Object(obj);
     }
-    let generic_params =
-        openehr_rm::v1_2::model::class(class).map_or(&[][..], |c| c.generic_params);
     for attr in openehr_rm::v1_2::model::attributes(class) {
-        if !attr.is_mandatory && !rich {
-            continue;
-        }
-        // Rich mode still skips optional RECURSIVE containment (folders in
-        // folders, links, feeder audit) to keep instances finite and small.
-        if !attr.is_mandatory && depth > 2 {
-            continue;
-        }
-        // Canonical JSON carries `List<Octet>` (DV_MULTIMEDIA.data etc.) as
-        // an inline base64 STRING, not a JSON array (ITS-JSON) — the one
-        // container shape the codec re-forms.
-        if attr.declared_type == "Octet"
-            && matches!(attr.container, openehr_rm::v1_2::model::Container::List)
-        {
-            obj.insert(attr.name.to_owned(), json!("AA=="));
-            continue;
-        }
-        // An attribute the class constrains beyond its declared primitive type.
-        if let Some(v) = constrained_attribute(class, attr.name) {
+        if let Some(v) = attribute_value(class, attr, args, rich, depth, unknown) {
             obj.insert(attr.name.to_owned(), v);
-            continue;
         }
-        // Bare-generic-parameter substitution: an attribute whose declared
-        // type equals a parameter's bound takes the caller's argument.
-        let substituted: Option<(&str, Vec<&openehr_rm::v1_2::model::RmTypeRef>)> = generic_params
-            .iter()
-            .zip(args.iter())
-            .find(|(p, _)| p.conforms_to.unwrap_or("Any") == attr.declared_type)
-            .map(|(_, a)| (a.name, a.params.iter().collect()));
-        let (ty, ty_args) = substituted.unwrap_or_else(|| {
-            let mut ty_args: Vec<&openehr_rm::v1_2::model::RmTypeRef> =
-                attr.type_params.iter().collect();
-            // A BARE reference to a generic class (the BMM drops the argument:
-            // `IMPORTED_VERSION.item: ORIGINAL_VERSION`) is monomorphized by the
-            // emitter with the enclosing scope's type argument (`item:
-            // OriginalVersion<T>`), so thread the caller's argument the same way
-            // — the emitted type is what the codec enforces, and an unthreaded
-            // element is not an instance of it.
-            if ty_args.is_empty()
-                && !args.is_empty()
-                && openehr_rm::v1_2::model::class(attr.declared_type)
-                    .is_some_and(|c| !c.generic_params.is_empty())
-            {
-                ty_args = args.to_vec();
-            }
-            (attr.declared_type, ty_args)
-        });
-        let element = value_for(ty, &ty_args, rich, depth, unknown);
-        let Some(element) = element else { continue };
-        let v = match attr.container {
-            openehr_rm::v1_2::model::Container::None => element,
-            openehr_rm::v1_2::model::Container::List | openehr_rm::v1_2::model::Container::Set => {
-                json!([element])
-            }
-            openehr_rm::v1_2::model::Container::Hash => json!({ "x": element }),
-        };
-        obj.insert(attr.name.to_owned(), v);
     }
     Value::Object(obj)
+}
+
+/// The generated value for one attribute, or `None` when it is skipped.
+///
+/// Skipped: an optional attribute outside rich mode, and (in rich mode too)
+/// optional RECURSIVE containment below depth 2 — folders in folders, links,
+/// feeder audit — which keeps instances finite and small.
+fn attribute_value(
+    class: &str,
+    attr: &'static openehr_rm::v1_2::model::RmAttribute,
+    args: &[&openehr_rm::v1_2::model::RmTypeRef],
+    rich: bool,
+    depth: usize,
+    unknown: &mut BTreeSet<String>,
+) -> Option<Value> {
+    if !attr.is_mandatory && (!rich || depth > 2) {
+        return None;
+    }
+    // Canonical JSON carries `List<Octet>` (DV_MULTIMEDIA.data etc.) as an
+    // inline base64 STRING, not a JSON array (ITS-JSON) — the one container
+    // shape the codec re-forms.
+    if attr.declared_type == "Octet"
+        && matches!(attr.container, openehr_rm::v1_2::model::Container::List)
+    {
+        return Some(json!("AA=="));
+    }
+    // An attribute the class constrains beyond its declared primitive type.
+    if let Some(v) = constrained_attribute(class, attr.name) {
+        return Some(v);
+    }
+    let (ty, ty_args) = attribute_type(class, attr, args);
+    let element = value_for(ty, &ty_args, rich, depth, unknown)?;
+    Some(match attr.container {
+        openehr_rm::v1_2::model::Container::None => element,
+        openehr_rm::v1_2::model::Container::List | openehr_rm::v1_2::model::Container::Set => {
+            json!([element])
+        }
+        openehr_rm::v1_2::model::Container::Hash => json!({ "x": element }),
+    })
+}
+
+/// The effective type (and type arguments) of one attribute in `class`'s scope.
+///
+/// An attribute whose declared type equals a generic parameter's bound takes the
+/// caller's argument. A BARE reference to a generic class (the BMM drops the
+/// argument: `IMPORTED_VERSION.item: ORIGINAL_VERSION`) is monomorphized by the
+/// emitter with the enclosing scope's type argument (`item: OriginalVersion<T>`),
+/// so the caller's argument is threaded the same way — the emitted type is what
+/// the codec enforces, and an unthreaded element is not an instance of it.
+fn attribute_type<'a>(
+    class: &str,
+    attr: &'static openehr_rm::v1_2::model::RmAttribute,
+    args: &[&'a openehr_rm::v1_2::model::RmTypeRef],
+) -> (&'static str, Vec<&'a openehr_rm::v1_2::model::RmTypeRef>) {
+    let generic_params =
+        openehr_rm::v1_2::model::class(class).map_or(&[][..], |c| c.generic_params);
+    let substituted = generic_params
+        .iter()
+        .zip(args.iter())
+        .find(|(p, _)| p.conforms_to.unwrap_or("Any") == attr.declared_type)
+        .map(|(_, a)| (a.name, a.params.iter().collect()));
+    substituted.unwrap_or_else(|| {
+        let mut ty_args: Vec<&openehr_rm::v1_2::model::RmTypeRef> =
+            attr.type_params.iter().collect();
+        if ty_args.is_empty()
+            && !args.is_empty()
+            && openehr_rm::v1_2::model::class(attr.declared_type)
+                .is_some_and(|c| !c.generic_params.is_empty())
+        {
+            ty_args = args.to_vec();
+        }
+        (attr.declared_type, ty_args)
+    })
 }
 
 /// A value of declared type `ty` (with its generic arguments): a model class
@@ -192,25 +209,11 @@ fn value_for(
 ) -> Option<Value> {
     if let Some(class) = openehr_rm::v1_2::model::class(ty) {
         let concrete = if class.is_abstract {
-            // Deterministic non-recursive preference: the concrete descendant
-            // with the FEWEST mandatory class-typed attributes (ELEMENT over
-            // CLUSTER for an ITEM slot), so mandatory recursion terminates.
-            let mut best: Option<(&str, usize)> = None;
-            for d in class.descendants {
-                let cost = openehr_rm::v1_2::model::attributes(d)
-                    .filter(|a| {
-                        a.is_mandatory && openehr_rm::v1_2::model::class(a.declared_type).is_some()
-                    })
-                    .count();
-                if best.is_none_or(|(_, c)| cost < c) {
-                    best = Some((d, cost));
-                }
-            }
-            best?.0.to_owned()
+            cheapest_descendant(class.descendants)?
         } else {
-            class.name.to_owned()
+            class.name
         };
-        return Some(generate(&concrete, ty_args, rich, depth + 1, unknown));
+        return Some(generate(concrete, ty_args, rich, depth + 1, unknown));
     }
     if let Some(e) = openehr_rm::v1_2::model::enumeration(ty) {
         return e.literals.first().map(|l| match l.value {
@@ -223,6 +226,26 @@ fn value_for(
         unknown.insert(ty.to_owned());
     }
     p
+}
+
+/// The concrete descendant to instantiate for an abstract slot.
+///
+/// Deterministic non-recursive preference: the descendant with the FEWEST
+/// mandatory class-typed attributes (ELEMENT over CLUSTER for an ITEM slot), so
+/// mandatory recursion terminates.
+fn cheapest_descendant(descendants: &[&'static str]) -> Option<&'static str> {
+    descendants
+        .iter()
+        .map(|d| {
+            let cost = openehr_rm::v1_2::model::attributes(d)
+                .filter(|a| {
+                    a.is_mandatory && openehr_rm::v1_2::model::class(a.declared_type).is_some()
+                })
+                .count();
+            (*d, cost)
+        })
+        .min_by_key(|(_, cost)| *cost)
+        .map(|(d, _)| d)
 }
 
 /// Every concrete class of the static model, in declaration order.

--- a/crates/openehr-its/tests/it/opt14_corpus.rs
+++ b/crates/openehr-its/tests/it/opt14_corpus.rs
@@ -199,6 +199,57 @@ fn every_opt_template_round_trips() {
     }
 }
 
+/// The child objects of one OPT constraint attribute.
+fn opt_attribute_children(
+    a: &openehr_its::opt14::types::CAttribute,
+) -> &[openehr_its::opt14::types::CObject] {
+    match a {
+        openehr_its::opt14::types::CAttribute::CSingleAttribute(s) => &s.children,
+        openehr_its::opt14::types::CAttribute::CMultipleAttribute(m) => &m.children,
+    }
+}
+
+/// Collects every inline `C_ARCHETYPE_ROOT` term definition in the tree.
+fn collect_opt_terms<'a>(
+    obj: &'a openehr_its::opt14::types::CObject,
+    out: &mut Vec<&'a openehr_its::opt14::types::ArchetypeTerm>,
+) {
+    use openehr_its::opt14::types::{CAttribute, CObject};
+    let attrs: &[CAttribute] = match obj {
+        CObject::CArchetypeRoot(r) => {
+            out.extend(&r.term_definitions);
+            &r.attributes
+        }
+        CObject::CComplexObject(c) => &c.attributes,
+        CObject::TComplexObject(t) => &t.attributes,
+        _ => return,
+    };
+    for a in attrs {
+        for c in opt_attribute_children(a) {
+            collect_opt_terms(c, out);
+        }
+    }
+}
+
+/// Every term whose items are in the document order `text` then `description`,
+/// paired with that key order.
+fn text_first_orders(
+    opt: &openehr_its::opt14::types::OperationalTemplate,
+) -> Vec<(String, Vec<String>)> {
+    let mut terms: Vec<&openehr_its::opt14::types::ArchetypeTerm> =
+        opt.definition.term_definitions.iter().collect();
+    for a in &opt.definition.attributes {
+        for c in opt_attribute_children(a) {
+            collect_opt_terms(c, &mut terms);
+        }
+    }
+    terms
+        .iter()
+        .filter(|t| t.items.keys().collect::<Vec<_>>() == ["text", "description"])
+        .map(|t| (t.code.clone(), t.items.keys().cloned().collect()))
+        .collect()
+}
+
 /// `StringDictionaryItem` groups are XSD ordered sequences; the model must
 /// preserve document order (`IndexMap`). `IndexMap`'s `PartialEq` is
 /// order-insensitive, so the round-trip gate above cannot see reordering —
@@ -207,50 +258,6 @@ fn every_opt_template_round_trips() {
 /// `description`), which an alphabetically-sorted container would invert.
 #[test]
 fn string_dictionary_order_preserved() {
-    use openehr_its::opt14::types::{ArchetypeTerm, CAttribute, CObject};
-
-    /// Collect every inline `C_ARCHETYPE_ROOT` term definition in the tree.
-    fn collect_terms<'a>(obj: &'a CObject, out: &mut Vec<&'a ArchetypeTerm>) {
-        let attrs: &[CAttribute] = match obj {
-            CObject::CArchetypeRoot(r) => {
-                out.extend(&r.term_definitions);
-                &r.attributes
-            }
-            CObject::CComplexObject(c) => &c.attributes,
-            CObject::TComplexObject(t) => &t.attributes,
-            _ => return,
-        };
-        for a in attrs {
-            let children = match a {
-                CAttribute::CSingleAttribute(s) => &s.children,
-                CAttribute::CMultipleAttribute(m) => &m.children,
-            };
-            for c in children {
-                collect_terms(c, out);
-            }
-        }
-    }
-
-    fn text_first_orders(
-        opt: &openehr_its::opt14::types::OperationalTemplate,
-    ) -> Vec<(String, Vec<String>)> {
-        let mut terms: Vec<&ArchetypeTerm> = opt.definition.term_definitions.iter().collect();
-        for a in &opt.definition.attributes {
-            let children = match a {
-                CAttribute::CSingleAttribute(s) => &s.children,
-                CAttribute::CMultipleAttribute(m) => &m.children,
-            };
-            for c in children {
-                collect_terms(c, &mut terms);
-            }
-        }
-        terms
-            .iter()
-            .filter(|t| t.items.keys().collect::<Vec<_>>() == ["text", "description"])
-            .map(|t| (t.code.clone(), t.items.keys().cloned().collect()))
-            .collect()
-    }
-
     let dir = corpus_dir();
     let path = dir.join("knowledge/operational_templates/Generic Laboratory Test Report.v0.opt");
     let xml = std::fs::read_to_string(&path).expect("read opt");

--- a/crates/openehr-its/tests/it/rm_validation.rs
+++ b/crates/openehr-its/tests/it/rm_validation.rs
@@ -413,6 +413,18 @@ fn collect_nodes<'a>(v: &'a Value, out: &mut Vec<&'a Value>) {
 /// [`crate::common::twinned`] substitutes it, so honouring the exclusions
 /// costs the battery no coverage; an excluded document with no twin is
 /// dropped.
+/// Records one corpus JSON file, substituting an excluded document's valid twin.
+fn push_corpus_file(path: std::path::PathBuf, files: &mut Vec<std::path::PathBuf>) {
+    if crate::common::excluded(&crate::common::corpus_rel(&path)).is_none() {
+        files.push(path);
+        return;
+    }
+    let twin = crate::common::twinned(&path);
+    if twin != path {
+        files.push(twin);
+    }
+}
+
 fn corpus_files() -> Vec<std::path::PathBuf> {
     let mut roots = vec![std::path::PathBuf::from(concat!(
         env!("CARGO_MANIFEST_DIR"),
@@ -432,14 +444,7 @@ fn corpus_files() -> Vec<std::path::PathBuf> {
             if path.is_dir() {
                 roots.push(path);
             } else if path.extension().and_then(std::ffi::OsStr::to_str) == Some("json") {
-                if crate::common::excluded(&crate::common::corpus_rel(&path)).is_some() {
-                    let twin = crate::common::twinned(&path);
-                    if twin != path {
-                        files.push(twin);
-                    }
-                    continue;
-                }
-                files.push(path);
+                push_corpus_file(path, &mut files);
             }
         }
     }
@@ -524,28 +529,7 @@ fn corpus_equivalence_mutated_nodes() {
                 if key == "_type" || !seen.insert((ty.clone(), key.clone())) {
                     continue;
                 }
-                // Removal.
-                let mut removed = map.clone();
-                removed.shift_remove(&key);
-                let removed = Value::Object(removed);
-                assert_eq!(
-                    two_tier(&removed),
-                    typed(&removed),
-                    "divergence removing {ty}.{key}"
-                );
-                checked += 1;
-                // Shape battery.
-                for m in mutations {
-                    let mut mutated = map.clone();
-                    mutated.insert(key.clone(), m.clone());
-                    let mutated = Value::Object(mutated);
-                    assert_eq!(
-                        two_tier(&mutated),
-                        typed(&mutated),
-                        "divergence mutating {ty}.{key} to {m}"
-                    );
-                    checked += 1;
-                }
+                checked += assert_key_equivalence(map, &ty, &key, mutations);
             }
             // An unknown key must stay ignored on both paths.
             if seen.insert((ty.clone(), "__unknown__".into())) {
@@ -563,6 +547,35 @@ fn corpus_equivalence_mutated_nodes() {
     }
     eprintln!("mutation equivalence: {checked} mutated nodes checked");
     assert!(checked > 500, "mutation battery too small: {checked}");
+}
+
+/// Asserts the two paths agree on one key's removal and on every mutated shape,
+/// returning how many comparisons were made.
+fn assert_key_equivalence(
+    map: &serde_json::Map<String, Value>,
+    ty: &str,
+    key: &str,
+    mutations: &[Value],
+) -> usize {
+    let mut removed = map.clone();
+    removed.shift_remove(key);
+    let removed = Value::Object(removed);
+    assert_eq!(
+        two_tier(&removed),
+        typed(&removed),
+        "divergence removing {ty}.{key}"
+    );
+    for m in mutations {
+        let mut mutated = map.clone();
+        mutated.insert(key.to_owned(), m.clone());
+        let mutated = Value::Object(mutated);
+        assert_eq!(
+            two_tier(&mutated),
+            typed(&mutated),
+            "divergence mutating {ty}.{key} to {m}"
+        );
+    }
+    1 + mutations.len()
 }
 
 /// The hot commit shape must actually ride the fast path: on the populated IPS

--- a/crates/openehr-its/tests/it/structured.rs
+++ b/crates/openehr-its/tests/it/structured.rs
@@ -163,6 +163,26 @@ fn index_normalised(map: &serde_json::Map<String, Value>) -> BTreeMap<String, Va
 
 // ── STRUCTURED round-trip + RM validation ─────────────────────────────────────
 
+/// One pair's STRUCTURED round-trip: `to_structured` → `from_structured` →
+/// `to_structured` again.
+///
+/// Returns the rebuilt RM value and whether the two STRUCTURED renderings agree,
+/// or the conversion failure to record.
+fn structured_round_trip(
+    name: &str,
+    comp: &Value,
+    wt: &WebTemplate,
+) -> Result<(Value, bool), String> {
+    let s0 =
+        composition_to_structured(comp, wt).map_err(|e| format!("{name}: to_structured: {e}"))?;
+    let rm1 = composition_from_structured(&s0, wt, NOW)
+        .map_err(|e| format!("{name}: from_structured: {e}"))?;
+    let s1 = composition_to_structured(&rm1, wt)
+        .map_err(|e| format!("{name}: to_structured(rm1): {e}"))?;
+    let is_stable = s0 == s1;
+    Ok((rm1, is_stable))
+}
+
 #[test]
 fn structured_roundtrip_and_rm_validation() {
     let wts = web_templates();
@@ -180,29 +200,14 @@ fn structured_roundtrip_and_rm_validation() {
         let Some(wt) = wts.get(tid) else { continue };
         paired += 1;
 
-        let s0 = match composition_to_structured(comp, wt) {
-            Ok(s) => s,
-            Err(e) => {
-                failures.push(format!("{name}: to_structured: {e}"));
+        let (rm1, is_stable) = match structured_round_trip(name, comp, wt) {
+            Ok(pair) => pair,
+            Err(message) => {
+                failures.push(message);
                 continue;
             }
         };
-        let rm1 = match composition_from_structured(&s0, wt, NOW) {
-            Ok(v) => v,
-            Err(e) => {
-                failures.push(format!("{name}: from_structured: {e}"));
-                continue;
-            }
-        };
-        let s1 = match composition_to_structured(&rm1, wt) {
-            Ok(s) => s,
-            Err(e) => {
-                failures.push(format!("{name}: to_structured(rm1): {e}"));
-                continue;
-            }
-        };
-
-        if s0 == s1 {
+        if is_stable {
             stable += 1;
         } else {
             failures.push(format!("{name} ({tid}): STRUCTURED not stable"));

--- a/crates/openehr-its/tests/it/webtemplate.rs
+++ b/crates/openehr-its/tests/it/webtemplate.rs
@@ -403,17 +403,8 @@ fn ontology_term_bindings_populate_node_and_coded_value_bindings() {
         .expect("build Across - Visual Acuity Report");
 
     // Node-level: a node bound to SNOMED-CT 422673001.
-    let mut node_binding: Option<
-        openehr_its::flat::webtemplate::model::WebTemplateBindingCodedValue,
-    > = None;
-    for_each_node(&wt.tree, &mut |n| {
-        if let Some(b) = n.term_bindings.get("SNOMED-CT")
-            && b.value == "422673001"
-        {
-            node_binding = Some(b.clone());
-        }
-    });
-    let node_binding = node_binding.expect("a node bound to SNOMED-CT 422673001");
+    let node_binding =
+        find_node_binding(&wt, "422673001").expect("a node bound to SNOMED-CT 422673001");
     assert_eq!(node_binding.terminology_id, "SNOMED-CT");
     // Better JSON shape/order: `value` then `terminologyId`.
     assert_eq!(
@@ -422,34 +413,73 @@ fn ontology_term_bindings_populate_node_and_coded_value_bindings() {
     );
 
     // Coded-value-level: a coded option bound to SNOMED-CT 362503005.
-    let mut cv_binding: Option<
-        openehr_its::flat::webtemplate::model::WebTemplateBindingCodedValue,
-    > = None;
+    let cv_binding = find_coded_value_binding(&wt, "362503005")
+        .expect("a coded value bound to SNOMED-CT 362503005");
+    assert_eq!(cv_binding.terminology_id, "SNOMED-CT");
+
+    assert_every_binding_well_formed(&wt);
+}
+
+/// The SNOMED-CT node-level binding carrying `value`, if the tree has one.
+fn find_node_binding(
+    wt: &openehr_its::flat::webtemplate::model::WebTemplate,
+    value: &str,
+) -> Option<openehr_its::flat::webtemplate::model::WebTemplateBindingCodedValue> {
+    let mut found = None;
+    for_each_node(&wt.tree, &mut |n| {
+        if let Some(b) = n.term_bindings.get("SNOMED-CT")
+            && b.value == value
+        {
+            found = Some(b.clone());
+        }
+    });
+    found
+}
+
+/// The SNOMED-CT coded-value binding carrying `value`, if the tree has one.
+fn find_coded_value_binding(
+    wt: &openehr_its::flat::webtemplate::model::WebTemplate,
+    value: &str,
+) -> Option<openehr_its::flat::webtemplate::model::WebTemplateBindingCodedValue> {
+    let mut found = None;
     for_each_node(&wt.tree, &mut |n| {
         for input in &n.inputs {
             for cv in &input.list {
                 if let Some(b) = cv.term_bindings.get("SNOMED-CT")
-                    && b.value == "362503005"
+                    && b.value == value
                 {
-                    cv_binding = Some(b.clone());
+                    found = Some(b.clone());
                 }
             }
         }
     });
-    let cv_binding = cv_binding.expect("a coded value bound to SNOMED-CT 362503005");
-    assert_eq!(cv_binding.terminology_id, "SNOMED-CT");
+    found
+}
 
-    // Every emitted binding — node- or coded-value-level — is well-formed.
+/// Every emitted binding — node- or coded-value-level — is well-formed.
+fn assert_every_binding_well_formed(wt: &openehr_its::flat::webtemplate::model::WebTemplate) {
     for_each_node(&wt.tree, &mut |n| {
         for (term, b) in &n.term_bindings {
             assert!(!term.is_empty(), "empty terminology key at {}", n.aql_path);
-            assert!(!b.value.is_empty() && !b.terminology_id.is_empty());
+            assert!(
+                !b.value.is_empty() && !b.terminology_id.is_empty(),
+                "incomplete node binding at {}",
+                n.aql_path
+            );
         }
         for input in &n.inputs {
             for cv in &input.list {
                 for (term, b) in &cv.term_bindings {
-                    assert!(!term.is_empty());
-                    assert!(!b.value.is_empty() && !b.terminology_id.is_empty());
+                    assert!(
+                        !term.is_empty(),
+                        "empty terminology key on a coded value at {}",
+                        n.aql_path
+                    );
+                    assert!(
+                        !b.value.is_empty() && !b.terminology_id.is_empty(),
+                        "incomplete coded-value binding at {}",
+                        n.aql_path
+                    );
                 }
             }
         }

--- a/crates/openehr-its/tests/it/xml_xsd_validity.rs
+++ b/crates/openehr-its/tests/it/xml_xsd_validity.rs
@@ -240,71 +240,79 @@ fn strip_prefix(qname: &str) -> String {
 
 /// Parse a bundle's `xs:complexType` inventory (name -> base + own members).
 fn read_types(bundle: &Bundle) -> BTreeMap<String, XsdType> {
-    use quick_xml::events::Event;
     let root = schemas_root();
     let mut types: BTreeMap<String, XsdType> = BTreeMap::new();
     for f in bundle.files {
         let path = root.join(f);
         let xml = std::fs::read_to_string(&path)
             .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
-        let mut reader = quick_xml::Reader::from_str(&xml);
-        let mut current: Option<String> = None;
-        let mut depth = 0usize;
-        loop {
-            let ev = reader.read_event().expect("well-formed vendored XSD");
-            let (element, empty) = match &ev {
-                Event::Start(e) => (e, false),
-                Event::Empty(e) => (e, true),
-                Event::End(e) => {
-                    if local_name(e.name().as_ref()) == b"complexType" {
-                        depth = depth.saturating_sub(1);
-                        if depth == 0 {
-                            current = None;
-                        }
-                    }
-                    continue;
-                }
-                Event::Eof => break,
-                _ => continue,
-            };
-            let local = local_name(element.name().as_ref()).to_vec();
-            let attr = |k: &str| {
-                element
-                    .attributes()
-                    .flatten()
-                    .find(|a| local_name(a.key.as_ref()) == k.as_bytes())
-                    .map(|a| String::from_utf8_lossy(a.value.as_ref()).into_owned())
-            };
-            match local.as_slice() {
-                b"complexType" => {
-                    if !empty {
-                        depth += 1;
-                    }
-                    if depth == 1 {
-                        current = attr("name");
-                        if let Some(n) = &current {
-                            types.entry(n.clone()).or_default();
-                        }
-                    }
-                }
-                b"extension" | b"restriction" => {
-                    if let (Some(n), Some(b)) = (current.as_ref(), attr("base")) {
-                        let entry = types.entry(n.clone()).or_default();
-                        if entry.base.is_none() {
-                            entry.base = Some(strip_prefix(&b));
-                        }
-                    }
-                }
-                b"element" | b"attribute" => {
-                    if let (Some(n), Some(m)) = (current.as_ref(), attr("name")) {
-                        types.entry(n.clone()).or_default().members.insert(m);
-                    }
-                }
-                _ => {}
-            }
-        }
+        read_types_from(&xml, &mut types);
     }
     types
+}
+
+/// Read one XSD document's `xs:complexType` inventory into `types`.
+///
+/// Only a TOP-LEVEL `complexType` (depth 1) names a type; nested anonymous
+/// ones contribute their members to the enclosing named type.
+fn read_types_from(xml: &str, types: &mut BTreeMap<String, XsdType>) {
+    use quick_xml::events::Event;
+    let mut reader = quick_xml::Reader::from_str(xml);
+    let mut current: Option<String> = None;
+    let mut depth = 0usize;
+    loop {
+        let ev = reader.read_event().expect("well-formed vendored XSD");
+        let (element, empty) = match &ev {
+            Event::Start(e) => (e, false),
+            Event::Empty(e) => (e, true),
+            Event::End(e) => {
+                if local_name(e.name().as_ref()) == b"complexType" {
+                    depth = depth.saturating_sub(1);
+                    if depth == 0 {
+                        current = None;
+                    }
+                }
+                continue;
+            }
+            Event::Eof => return,
+            _ => continue,
+        };
+        let local = local_name(element.name().as_ref()).to_vec();
+        let attr = |k: &str| {
+            element
+                .attributes()
+                .flatten()
+                .find(|a| local_name(a.key.as_ref()) == k.as_bytes())
+                .map(|a| String::from_utf8_lossy(a.value.as_ref()).into_owned())
+        };
+        match local.as_slice() {
+            b"complexType" => {
+                if !empty {
+                    depth += 1;
+                }
+                if depth == 1 {
+                    current = attr("name");
+                    if let Some(n) = &current {
+                        types.entry(n.clone()).or_default();
+                    }
+                }
+            }
+            b"extension" | b"restriction" => {
+                if let (Some(n), Some(b)) = (current.as_ref(), attr("base")) {
+                    let entry = types.entry(n.clone()).or_default();
+                    if entry.base.is_none() {
+                        entry.base = Some(strip_prefix(&b));
+                    }
+                }
+            }
+            b"element" | b"attribute" => {
+                if let (Some(n), Some(m)) = (current.as_ref(), attr("name")) {
+                    types.entry(n.clone()).or_default().members.insert(m);
+                }
+            }
+            _ => {}
+        }
+    }
 }
 
 /// Flattened (own + inherited) member names of `name`.

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-lang"
-version = "0.0.41"
+version = "0.0.42"
 description = "openEHR LANG BMM/P_BMM object model, generated from BMM: generations v1_0 (LANG 1.0.0) and v1_1 (LANG 1.1.0, current; the stable BMM v2.x unit beside the paused BMM3 unit), plus hand-written ODIN/BEL/EL readers"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["parser-implementations", "data-structures"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.41" }
+openehr-base = { path = "../openehr-base", version = "0.0.42" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the
 # generated types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) —
 # never a derive. `serde_json` also carries the untyped `Value` fields the

--- a/crates/openehr-query/Cargo.toml
+++ b/crates/openehr-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-query"
-version = "0.0.41"
+version = "0.0.42"
 description = "openEHR QUERY (AQL 1.1.0): hand-written lexer, parser, typed AST and canonical printer from the official grammar (no ANTLR runtime)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-query/src/parser.rs
+++ b/crates/openehr-query/src/parser.rs
@@ -189,43 +189,8 @@ fn unescape(inner: &str) -> String {
             'r' => push_escaped(&mut out, &mut chars, '\r'),
             't' => push_escaped(&mut out, &mut chars, '\t'),
             'v' => push_escaped(&mut out, &mut chars, '\u{0B}'),
-            'u' => {
-                chars.next(); // consume 'u'
-                // Look ahead (without consuming) at the next four chars.
-                let hex: String = chars.clone().take(4).collect();
-                if hex.len() == 4
-                    && let Ok(cp) = u32::from_str_radix(&hex, 16)
-                    && let Some(ch) = char::from_u32(cp)
-                {
-                    for _ in 0..4 {
-                        chars.next();
-                    }
-                    out.push(ch);
-                } else {
-                    out.push('\\');
-                    out.push('u');
-                }
-            }
-            '0'..='7' => {
-                chars.next(); // consume first octal digit
-                let mut digits = String::new();
-                digits.push(next);
-                while digits.len() < 3
-                    && let Some(&d) = chars.peek()
-                    && ('0'..='7').contains(&d)
-                {
-                    digits.push(d);
-                    chars.next();
-                }
-                if let Ok(cp) = u32::from_str_radix(&digits, 8)
-                    && let Some(ch) = char::from_u32(cp)
-                {
-                    out.push(ch);
-                } else {
-                    out.push('\\');
-                    out.push_str(&digits);
-                }
-            }
+            'u' => push_utf8_escape(&mut out, &mut chars),
+            '0'..='7' => push_octal_escape(&mut out, &mut chars, next),
             _ => out.push('\\'),
         }
     }
@@ -236,6 +201,58 @@ fn unescape(inner: &str) -> String {
 fn push_escaped(out: &mut String, chars: &mut std::iter::Peekable<std::str::Chars<'_>>, ch: char) {
     chars.next();
     out.push(ch);
+}
+
+/// Decode a `UTF8CHAR` escape (`\uHHHH`), consuming its four hex digits.
+///
+/// An escape that is not four hex digits naming a scalar value is passed
+/// through verbatim (`\u` retained), keeping [`unescape`] total.
+fn push_utf8_escape(out: &mut String, chars: &mut std::iter::Peekable<std::str::Chars<'_>>) {
+    chars.next(); // consume 'u'
+    // Look ahead (without consuming) at the next four chars.
+    let hex: String = chars.clone().take(4).collect();
+    if hex.len() == 4
+        && let Ok(cp) = u32::from_str_radix(&hex, 16)
+        && let Some(ch) = char::from_u32(cp)
+    {
+        for _ in 0..4 {
+            chars.next();
+        }
+        out.push(ch);
+        return;
+    }
+    out.push('\\');
+    out.push('u');
+}
+
+/// Decode an `OCTAL_ESC` escape (`\` plus one to three octal digits), whose
+/// `first` digit has already been peeked.
+///
+/// A sequence naming no scalar value is passed through verbatim, keeping
+/// [`unescape`] total.
+fn push_octal_escape(
+    out: &mut String,
+    chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
+    first: char,
+) {
+    chars.next(); // consume the first octal digit
+    let mut digits = String::new();
+    digits.push(first);
+    while digits.len() < 3
+        && let Some(&d) = chars.peek()
+        && ('0'..='7').contains(&d)
+    {
+        digits.push(d);
+        chars.next();
+    }
+    if let Ok(cp) = u32::from_str_radix(&digits, 8)
+        && let Some(ch) = char::from_u32(cp)
+    {
+        out.push(ch);
+        return;
+    }
+    out.push('\\');
+    out.push_str(&digits);
 }
 
 /// A lexed numeric literal, tagged by the grammar token it came from.

--- a/crates/openehr-query/src/printer.rs
+++ b/crates/openehr-query/src/printer.rs
@@ -14,9 +14,10 @@
 use std::fmt::Write;
 
 use crate::ast::{
-    AggregateCall, ClassExprOperand, ColumnExpr, CompareOperand, ContainsExpr, FunctionCall,
-    IdentifiedExpr, IdentifiedPath, LikeOperand, MatchesOperand, SelectQuery, StatFunc, Terminal,
-    TerminologyFunction, TopDirection, ValueListItem, VersionPredicate, WhereExpr, comp_op_text,
+    AggregateCall, ClassExprOperand, ColumnExpr, CompareOperand, ContainsConstraint, ContainsExpr,
+    FunctionCall, IdentifiedExpr, IdentifiedPath, LikeOperand, MatchesOperand, SelectQuery,
+    StatFunc, Terminal, TerminologyFunction, TopDirection, ValueListItem, VersionPredicate,
+    WhereExpr, comp_op_text,
 };
 
 /// Render a whole query as canonical AQL text.
@@ -30,21 +31,7 @@ pub fn to_aql(query: &SelectQuery) -> String {
         out.push_str(" WHERE ");
         where_expr(&mut out, where_, WhereCtx::Top);
     }
-    if !query.order_by.is_empty() {
-        out.push_str(" ORDER BY ");
-        for (i, ob) in query.order_by.iter().enumerate() {
-            if i > 0 {
-                out.push_str(", ");
-            }
-            identified_path(&mut out, &ob.path);
-            if let Some(order) = ob.order {
-                out.push_str(match order {
-                    crate::ast::SortOrder::Ascending => " ASC",
-                    crate::ast::SortOrder::Descending => " DESC",
-                });
-            }
-        }
-    }
+    order_by_clause(&mut out, query);
     if let Some(limit) = &query.limit {
         let _ = write!(out, " LIMIT {}", limit.limit);
         if let Some(offset) = limit.offset {
@@ -52,6 +39,27 @@ pub fn to_aql(query: &SelectQuery) -> String {
         }
     }
     out
+}
+
+/// The `ORDER BY` clause, with each term's explicit direction where the query
+/// states one.
+fn order_by_clause(out: &mut String, query: &SelectQuery) {
+    if query.order_by.is_empty() {
+        return;
+    }
+    out.push_str(" ORDER BY ");
+    for (i, ob) in query.order_by.iter().enumerate() {
+        if i > 0 {
+            out.push_str(", ");
+        }
+        identified_path(out, &ob.path);
+        if let Some(order) = ob.order {
+            out.push_str(match order {
+                crate::ast::SortOrder::Ascending => " ASC",
+                crate::ast::SortOrder::Descending => " DESC",
+            });
+        }
+    }
 }
 
 /// Escapes a raw string for embedding in an AQL single-quoted literal.
@@ -215,31 +223,41 @@ enum ContainsCtx {
     Nested,
 }
 
+/// One class operand and its optional `[NOT] CONTAINS` constraint.
+///
+/// `containsExpr: classExprOperand (NOT? CONTAINS containsExpr)?` makes the
+/// CONTAINS operand a whole `containsExpr`, so it absorbs any `AND`/`OR` that
+/// follows it: an unparenthesised `A CONTAINS B` used as a boolean operand
+/// would re-parse with the operator moved INSIDE its scope, which changes what
+/// the query means — hence the parens.
+fn contained_expr(
+    out: &mut String,
+    operand: &ClassExprOperand,
+    contains: Option<&ContainsConstraint>,
+    ctx: ContainsCtx,
+) {
+    let parens = contains.is_some() && !matches!(ctx, ContainsCtx::Top | ContainsCtx::Nested);
+    if parens {
+        out.push('(');
+    }
+    class_operand(out, operand);
+    if let Some(constraint) = contains {
+        if constraint.negated {
+            out.push_str(" NOT CONTAINS ");
+        } else {
+            out.push_str(" CONTAINS ");
+        }
+        contains_expr(out, &constraint.expr, ContainsCtx::Nested);
+    }
+    if parens {
+        out.push(')');
+    }
+}
+
 fn contains_expr(out: &mut String, expr: &ContainsExpr, ctx: ContainsCtx) {
     match expr {
         ContainsExpr::Contained { operand, contains } => {
-            // `containsExpr: classExprOperand (NOT? CONTAINS containsExpr)?`
-            // makes the CONTAINS operand a whole `containsExpr`, so it absorbs
-            // any `AND`/`OR` that follows it: an unparenthesised `A CONTAINS B`
-            // used as a boolean operand would re-parse with the operator moved
-            // INSIDE its scope, which changes what the query means.
-            let parens =
-                contains.is_some() && !matches!(ctx, ContainsCtx::Top | ContainsCtx::Nested);
-            if parens {
-                out.push('(');
-            }
-            class_operand(out, operand);
-            if let Some(constraint) = contains {
-                if constraint.negated {
-                    out.push_str(" NOT CONTAINS ");
-                } else {
-                    out.push_str(" CONTAINS ");
-                }
-                contains_expr(out, &constraint.expr, ContainsCtx::Nested);
-            }
-            if parens {
-                out.push(')');
-            }
+            contained_expr(out, operand, contains.as_deref(), ctx);
         }
         ContainsExpr::And(a, b) => {
             // `AND` binds tighter than `OR`, so only a right-hand `AND` (which

--- a/crates/openehr-query/tests/it/corpus.rs
+++ b/crates/openehr-query/tests/it/corpus.rs
@@ -92,6 +92,20 @@ fn wrap_fragment(fragment: &str) -> String {
     format!("SELECT e/ehr_id/value FROM EHR e WHERE {}", fragment.trim())
 }
 
+/// Parses one query and round-trips it through the printer.
+///
+/// The whole official corpus must satisfy parse → print → parse with an
+/// identical AST; the error is the failure message to record.
+fn round_trip_failure(query: &str) -> Result<(), String> {
+    let ast = openehr_query::parser::parse_str(query).map_err(|e| e.to_string())?;
+    let printed = openehr_query::printer::to_aql(&ast);
+    match openehr_query::parser::parse_str(&printed) {
+        Ok(reparsed) if reparsed == ast => Ok(()),
+        Ok(_) => Err(format!("printer round-trip drifted the AST via: {printed}")),
+        Err(e) => Err(format!("printed AQL failed to reparse: {printed}\n  {e}")),
+    }
+}
+
 #[test]
 fn official_aql_corpus_parses() {
     let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("vendor/examples");
@@ -121,25 +135,9 @@ fn official_aql_corpus_parses() {
             } else {
                 wrap_fragment(&block)
             };
-            match openehr_query::parser::parse_str(&query) {
-                Ok(ast) => {
-                    parsed += 1;
-                    // Printer round-trip: parse → print → parse must
-                    // reproduce the same AST for the whole official corpus.
-                    let printed = openehr_query::printer::to_aql(&ast);
-                    match openehr_query::parser::parse_str(&printed) {
-                        Ok(reparsed) if reparsed == ast => {}
-                        Ok(_) => failures.push((
-                            query.clone(),
-                            format!("printer round-trip drifted the AST via: {printed}"),
-                        )),
-                        Err(e) => failures.push((
-                            query.clone(),
-                            format!("printed AQL failed to reparse: {printed}\n  {e}"),
-                        )),
-                    }
-                }
-                Err(e) => failures.push((query, e.to_string())),
+            match round_trip_failure(&query) {
+                Ok(()) => parsed += 1,
+                Err(message) => failures.push((query, message)),
             }
         }
     }

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-rm"
-version = "0.0.41"
+version = "0.0.42"
 description = "openEHR RM Reference Model, generated from BMM: generations v1_1 (RM 1.1.0) and v1_2 (RM 1.2.0, current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,11 +13,11 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.41" }
+openehr-base = { path = "../openehr-base", version = "0.0.42" }
 # The terminology-backed RM class invariants (`validate::terminology`) resolve
 # openEHR terminology groups + code sets against the vendored TERM 3.1.0 bundle.
 # `openehr-term` itself depends only on `openehr-base`, so this is acyclic.
-openehr-term = { path = "../openehr-term", version = "0.0.41" }
+openehr-term = { path = "../openehr-term", version = "0.0.42" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also backs the untyped `Value` RM representation used by

--- a/crates/openehr-rm/src/v1_1/paths.rs
+++ b/crates/openehr-rm/src/v1_1/paths.rs
@@ -490,24 +490,30 @@ impl Predicate {
         }
         if let Some(uid) = &self.uid {
             if wrote {
-                write!(f, " and uid='{uid}'")?;
-            } else {
-                write!(f, "uid='{uid}'")?;
+                f.write_str(" and ")?;
             }
+            write!(f, "uid='{uid}'")?;
             wrote = true;
         }
         for cmp in &self.comparisons {
             if wrote {
                 f.write_str(" and ")?;
             }
-            write!(f, "{}", cmp.path.join("/"))?;
-            match &cmp.value {
-                CmpLiteral::Str(s) => write!(f, " {} '{s}'", cmp.op.token())?,
-                CmpLiteral::Num(n) => write!(f, " {} {n}", cmp.op.token())?,
-            }
+            cmp.render(f)?;
             wrote = true;
         }
         f.write_str("]")
+    }
+}
+
+impl Comparison {
+    /// Render one comparison term of a predicate (`path op literal`).
+    fn render(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.path.join("/"))?;
+        match &self.value {
+            CmpLiteral::Str(s) => write!(f, " {} '{s}'", self.op.token()),
+            CmpLiteral::Num(n) => write!(f, " {} {n}", self.op.token()),
+        }
     }
 }
 
@@ -879,29 +885,32 @@ pub fn parent_of<'a>(root: &'a Value, item: &Value) -> Option<&'a Value> {
 /// parent; array elements report the object holding the array.
 fn walk_for_parent<'a>(node: &'a Value, item: &Value) -> Option<&'a Value> {
     match node {
-        Value::Object(map) => {
-            for child in map.values() {
-                if std::ptr::eq(child, item) {
-                    return Some(node);
-                }
-                if let Value::Array(items) = child {
-                    if items.iter().any(|v| std::ptr::eq(v, item)) {
-                        return Some(node);
-                    }
-                    for v in items {
-                        if let Some(found) = walk_for_parent(v, item) {
-                            return Some(found);
-                        }
-                    }
-                } else if let Some(found) = walk_for_parent(child, item) {
-                    return Some(found);
-                }
-            }
-            None
-        }
+        Value::Object(map) => map
+            .values()
+            .find_map(|child| parent_through_member(node, child, item)),
         Value::Array(items) => items.iter().find_map(|v| walk_for_parent(v, item)),
         _ => None,
     }
+}
+
+/// The RM parent reached through one member of `owner`: `owner` itself when
+/// the member IS the item (or holds it directly in an array), else whatever
+/// the member's own subtree reports.
+fn parent_through_member<'a>(
+    owner: &'a Value,
+    child: &'a Value,
+    item: &Value,
+) -> Option<&'a Value> {
+    if std::ptr::eq(child, item) {
+        return Some(owner);
+    }
+    let Value::Array(items) = child else {
+        return walk_for_parent(child, item);
+    };
+    if items.iter().any(|v| std::ptr::eq(v, item)) {
+        return Some(owner);
+    }
+    items.iter().find_map(|v| walk_for_parent(v, item))
 }
 
 /// Depth-first search for `item` (pointer identity), accumulating the

--- a/crates/openehr-rm/src/v1_1/validate/fast.rs
+++ b/crates/openehr-rm/src/v1_1/validate/fast.rs
@@ -82,7 +82,7 @@
 
 use serde_json::{Map, Value};
 
-use crate::v1_1::model::{Container, RmClass};
+use crate::v1_1::model::{Container, RmAttribute, RmClass};
 use crate::v1_1::validate::generated;
 use crate::v1_1::validate::{
     valid_iso8601_date, valid_iso8601_date_time, valid_iso8601_duration, valid_iso8601_time,
@@ -231,69 +231,13 @@ fn node_conforms(obj: &Map<String, Value>, class: &'static RmClass, shallow: boo
         let Some(attr) = class.attributes.iter().find(|a| a.name == key) else {
             continue;
         };
-        match attr.container {
-            Container::None => {
-                if v.is_null() {
-                    // The derive's shadow reads every field as `Option`, so a
-                    // JSON `null` is "absent": fine for an optional attribute,
-                    // `missing field` for a mandatory one.
-                    if attr.is_mandatory {
-                        return false;
-                    }
-                    continue;
-                }
-                if attr.is_mandatory {
-                    mandatory_seen += 1;
-                }
-                if generic_any_slot(class.name, attr.name) {
-                    continue;
-                }
-                if !value_conforms(v, attr.declared_type, shallow) {
-                    return false;
-                }
-            }
-            Container::List | Container::Set => match v {
-                Value::Array(items) => {
-                    let lower_bound_one =
-                        attr.cardinality.is_some_and(|c| c.lower >= 1) || attr.nonempty;
-                    if attr.is_mandatory {
-                        mandatory_seen += 1;
-                    }
-                    // A `1..*` container emits as `NonEmptyVec<T>`, whose
-                    // constructor refuses an empty list — so an empty array does
-                    // NOT deserialize and this checker must not vouch.
-                    if lower_bound_one && items.is_empty() {
-                        return false;
-                    }
-                    if shallow {
-                        // Mirror `prune_child_nodes`: the prune keeps the FIRST
-                        // member of any object array as the structural witness,
-                        // which the typed decode inspects — so this checker
-                        // inspects it too. An empty array on a non-NonEmptyVec
-                        // field trivially deserializes; a non-empty all-scalar
-                        // array is kept verbatim and typed-checked — don't
-                        // vouch for it.
-                        if let Some(first) = items.first() {
-                            if !items.iter().any(Value::is_object) {
-                                return false;
-                            }
-                            if !value_conforms(first, attr.declared_type, true) {
-                                return false;
-                            }
-                        }
-                    } else {
-                        for item in items {
-                            if !value_conforms(item, attr.declared_type, false) {
-                                return false;
-                            }
-                        }
-                    }
-                }
-                // `Vec` never deserializes from a non-array (incl. `null`).
-                _ => return false,
-            },
-            // No `Hash` attribute is modelled here.
-            Container::Hash => return false,
+        match attribute_conforms(v, attr, class, shallow) {
+            AttrCheck::Refused => return false,
+            // A mandatory attribute the wire leaves absent is `missing field`
+            // to the typed reader.
+            AttrCheck::Absent if attr.is_mandatory => return false,
+            AttrCheck::Conforms if attr.is_mandatory => mandatory_seen += 1,
+            AttrCheck::Absent | AttrCheck::Conforms => {}
         }
     }
     // Absent attributes: an OPTIONAL container defaults to `None` and an
@@ -302,6 +246,93 @@ fn node_conforms(obj: &Map<String, Value>, class: &'static RmClass, shallow: boo
     // (a mandatory container is a plain `Vec`/`NonEmptyVec` field the reader
     // requires). Every mandatory attribute must therefore have been seen.
     mandatory_seen == class.attributes.iter().filter(|a| a.is_mandatory).count()
+}
+
+/// What the typed reader would make of one attribute's wire value.
+enum AttrCheck {
+    /// JSON `null`, which the reader's `Option` shadow treats as absent.
+    Absent,
+    /// The value verifiably deserializes as the attribute's declared shape.
+    Conforms,
+    /// The typed reader would refuse the value, so this checker cannot vouch.
+    Refused,
+}
+
+/// Checks one attribute's wire value against its declared container shape.
+fn attribute_conforms(
+    v: &Value,
+    attr: &'static RmAttribute,
+    class: &'static RmClass,
+    shallow: bool,
+) -> AttrCheck {
+    match attr.container {
+        Container::None => single_conforms(v, attr, class, shallow),
+        Container::List | Container::Set => list_conforms(v, attr, shallow),
+        // No `Hash` attribute is modelled here.
+        Container::Hash => AttrCheck::Refused,
+    }
+}
+
+/// Checks a single-valued attribute's wire value.
+fn single_conforms(
+    v: &Value,
+    attr: &'static RmAttribute,
+    class: &'static RmClass,
+    shallow: bool,
+) -> AttrCheck {
+    if v.is_null() {
+        return AttrCheck::Absent;
+    }
+    if generic_any_slot(class.name, attr.name) {
+        return AttrCheck::Conforms;
+    }
+    if value_conforms(v, attr.declared_type, shallow) {
+        AttrCheck::Conforms
+    } else {
+        AttrCheck::Refused
+    }
+}
+
+/// Checks a container attribute's wire value.
+///
+/// A `1..*` container emits as `NonEmptyVec<T>`, whose constructor refuses an
+/// empty list — so an empty array does NOT deserialize and this checker must
+/// not vouch for it.
+fn list_conforms(v: &Value, attr: &'static RmAttribute, shallow: bool) -> AttrCheck {
+    // `Vec` never deserializes from a non-array (incl. `null`).
+    let Value::Array(items) = v else {
+        return AttrCheck::Refused;
+    };
+    let lower_bound_one = attr.cardinality.is_some_and(|c| c.lower >= 1) || attr.nonempty;
+    if lower_bound_one && items.is_empty() {
+        return AttrCheck::Refused;
+    }
+    let members_conform = if shallow {
+        shallow_members_conform(items, attr)
+    } else {
+        items
+            .iter()
+            .all(|item| value_conforms(item, attr.declared_type, false))
+    };
+    if members_conform {
+        AttrCheck::Conforms
+    } else {
+        AttrCheck::Refused
+    }
+}
+
+/// Checks the structural witness of a pruned array.
+///
+/// This mirrors `prune_child_nodes`: the prune keeps the FIRST member of any
+/// object array as the witness, which the typed decode inspects — so this
+/// checker inspects it too. An empty array on a non-`NonEmptyVec` field
+/// trivially deserializes; a non-empty all-scalar array is kept verbatim and
+/// typed-checked, so it is not vouched for here.
+fn shallow_members_conform(items: &[Value], attr: &'static RmAttribute) -> bool {
+    let Some(first) = items.first() else {
+        return true;
+    };
+    items.iter().any(Value::is_object) && value_conforms(first, attr.declared_type, true)
 }
 
 /// Whether a single value verifiably deserializes as the declared spec type.

--- a/crates/openehr-rm/src/v1_1/validate/incomplete.rs
+++ b/crates/openehr-rm/src/v1_1/validate/incomplete.rs
@@ -45,7 +45,7 @@
 
 use serde_json::Value;
 
-use crate::v1_1::model::{Container, class};
+use crate::v1_1::model::{Container, RmAttribute, class};
 
 /// The `POINT_EVENT`/`INTERVAL_EVENT` `data` slot, whose generic parameter the
 /// validation dispatcher erases to `serde_json::Value` — so any non-absent
@@ -96,53 +96,52 @@ pub fn mandatory_data_present(ty: &str, value: &Value) -> bool {
         if attr.declared_type == "Octet" {
             continue;
         }
-        let member = value.get(attr.name).filter(|v| !v.is_null());
-        match attr.container {
+        // No `Hash` attribute is judged here (none is modelled by the
+        // structural checkers either).
+        if attr.container == Container::Hash {
+            continue;
+        }
+        let Some(member) = value.get(attr.name).filter(|v| !v.is_null()) else {
+            if attr.is_mandatory {
+                return false;
+            }
+            continue;
+        };
+        let present = match attr.container {
             Container::None => {
-                let Some(member) = member else {
-                    if attr.is_mandatory {
-                        return false;
-                    }
-                    continue;
-                };
-                if generic_any_slot(ty, attr.name) {
-                    continue;
-                }
-                if member.is_object()
-                    && let Some(child) = effective_type(member, attr.declared_type)
-                    && !mandatory_data_present(child, member)
-                {
-                    return false;
-                }
+                generic_any_slot(ty, attr.name) || single_member_present(member, attr)
             }
-            Container::List | Container::Set => {
-                let Some(member) = member else {
-                    if attr.is_mandatory {
-                        return false;
-                    }
-                    continue;
-                };
-                let Some(items) = member.as_array() else {
-                    continue;
-                };
-                if items.is_empty() && attr.cardinality.is_some_and(|c| c.lower >= 1) {
-                    return false;
-                }
-                for item in items {
-                    if item.is_object()
-                        && let Some(child) = effective_type(item, attr.declared_type)
-                        && !mandatory_data_present(child, item)
-                    {
-                        return false;
-                    }
-                }
-            }
-            // No `Hash` attribute is judged here (none is modelled by the
-            // structural checkers either).
-            Container::Hash => {}
+            _ => list_members_present(member, attr),
+        };
+        if !present {
+            return false;
         }
     }
     true
+}
+
+/// Whether a single-valued member carries the mandatory data of its own
+/// declared type.
+fn single_member_present(member: &Value, attr: &RmAttribute) -> bool {
+    if !member.is_object() {
+        return true;
+    }
+    let Some(child) = effective_type(member, attr.declared_type) else {
+        return true;
+    };
+    mandatory_data_present(child, member)
+}
+
+/// Whether a container member satisfies its declared lower bound and each of
+/// its object members carries their own mandatory data.
+fn list_members_present(member: &Value, attr: &RmAttribute) -> bool {
+    let Some(items) = member.as_array() else {
+        return true;
+    };
+    if items.is_empty() && attr.cardinality.is_some_and(|c| c.lower >= 1) {
+        return false;
+    }
+    items.iter().all(|item| single_member_present(item, attr))
 }
 
 /// Whether `value` positively CONTRADICTS its declared RM type `ty`.

--- a/crates/openehr-rm/src/v1_2/paths.rs
+++ b/crates/openehr-rm/src/v1_2/paths.rs
@@ -490,24 +490,30 @@ impl Predicate {
         }
         if let Some(uid) = &self.uid {
             if wrote {
-                write!(f, " and uid='{uid}'")?;
-            } else {
-                write!(f, "uid='{uid}'")?;
+                f.write_str(" and ")?;
             }
+            write!(f, "uid='{uid}'")?;
             wrote = true;
         }
         for cmp in &self.comparisons {
             if wrote {
                 f.write_str(" and ")?;
             }
-            write!(f, "{}", cmp.path.join("/"))?;
-            match &cmp.value {
-                CmpLiteral::Str(s) => write!(f, " {} '{s}'", cmp.op.token())?,
-                CmpLiteral::Num(n) => write!(f, " {} {n}", cmp.op.token())?,
-            }
+            cmp.render(f)?;
             wrote = true;
         }
         f.write_str("]")
+    }
+}
+
+impl Comparison {
+    /// Render one comparison term of a predicate (`path op literal`).
+    fn render(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.path.join("/"))?;
+        match &self.value {
+            CmpLiteral::Str(s) => write!(f, " {} '{s}'", self.op.token()),
+            CmpLiteral::Num(n) => write!(f, " {} {n}", self.op.token()),
+        }
     }
 }
 
@@ -879,29 +885,32 @@ pub fn parent_of<'a>(root: &'a Value, item: &Value) -> Option<&'a Value> {
 /// parent; array elements report the object holding the array.
 fn walk_for_parent<'a>(node: &'a Value, item: &Value) -> Option<&'a Value> {
     match node {
-        Value::Object(map) => {
-            for child in map.values() {
-                if std::ptr::eq(child, item) {
-                    return Some(node);
-                }
-                if let Value::Array(items) = child {
-                    if items.iter().any(|v| std::ptr::eq(v, item)) {
-                        return Some(node);
-                    }
-                    for v in items {
-                        if let Some(found) = walk_for_parent(v, item) {
-                            return Some(found);
-                        }
-                    }
-                } else if let Some(found) = walk_for_parent(child, item) {
-                    return Some(found);
-                }
-            }
-            None
-        }
+        Value::Object(map) => map
+            .values()
+            .find_map(|child| parent_through_member(node, child, item)),
         Value::Array(items) => items.iter().find_map(|v| walk_for_parent(v, item)),
         _ => None,
     }
+}
+
+/// The RM parent reached through one member of `owner`: `owner` itself when
+/// the member IS the item (or holds it directly in an array), else whatever
+/// the member's own subtree reports.
+fn parent_through_member<'a>(
+    owner: &'a Value,
+    child: &'a Value,
+    item: &Value,
+) -> Option<&'a Value> {
+    if std::ptr::eq(child, item) {
+        return Some(owner);
+    }
+    let Value::Array(items) = child else {
+        return walk_for_parent(child, item);
+    };
+    if items.iter().any(|v| std::ptr::eq(v, item)) {
+        return Some(owner);
+    }
+    items.iter().find_map(|v| walk_for_parent(v, item))
 }
 
 /// Depth-first search for `item` (pointer identity), accumulating the

--- a/crates/openehr-rm/src/v1_2/validate/fast.rs
+++ b/crates/openehr-rm/src/v1_2/validate/fast.rs
@@ -82,7 +82,7 @@
 
 use serde_json::{Map, Value};
 
-use crate::v1_2::model::{Container, RmClass};
+use crate::v1_2::model::{Container, RmAttribute, RmClass};
 use crate::v1_2::validate::generated;
 use crate::v1_2::validate::{
     valid_iso8601_date, valid_iso8601_date_time, valid_iso8601_duration, valid_iso8601_time,
@@ -231,69 +231,13 @@ fn node_conforms(obj: &Map<String, Value>, class: &'static RmClass, shallow: boo
         let Some(attr) = class.attributes.iter().find(|a| a.name == key) else {
             continue;
         };
-        match attr.container {
-            Container::None => {
-                if v.is_null() {
-                    // The derive's shadow reads every field as `Option`, so a
-                    // JSON `null` is "absent": fine for an optional attribute,
-                    // `missing field` for a mandatory one.
-                    if attr.is_mandatory {
-                        return false;
-                    }
-                    continue;
-                }
-                if attr.is_mandatory {
-                    mandatory_seen += 1;
-                }
-                if generic_any_slot(class.name, attr.name) {
-                    continue;
-                }
-                if !value_conforms(v, attr.declared_type, shallow) {
-                    return false;
-                }
-            }
-            Container::List | Container::Set => match v {
-                Value::Array(items) => {
-                    let lower_bound_one =
-                        attr.cardinality.is_some_and(|c| c.lower >= 1) || attr.nonempty;
-                    if attr.is_mandatory {
-                        mandatory_seen += 1;
-                    }
-                    // A `1..*` container emits as `NonEmptyVec<T>`, whose
-                    // constructor refuses an empty list — so an empty array does
-                    // NOT deserialize and this checker must not vouch.
-                    if lower_bound_one && items.is_empty() {
-                        return false;
-                    }
-                    if shallow {
-                        // Mirror `prune_child_nodes`: the prune keeps the FIRST
-                        // member of any object array as the structural witness,
-                        // which the typed decode inspects — so this checker
-                        // inspects it too. An empty array on a non-NonEmptyVec
-                        // field trivially deserializes; a non-empty all-scalar
-                        // array is kept verbatim and typed-checked — don't
-                        // vouch for it.
-                        if let Some(first) = items.first() {
-                            if !items.iter().any(Value::is_object) {
-                                return false;
-                            }
-                            if !value_conforms(first, attr.declared_type, true) {
-                                return false;
-                            }
-                        }
-                    } else {
-                        for item in items {
-                            if !value_conforms(item, attr.declared_type, false) {
-                                return false;
-                            }
-                        }
-                    }
-                }
-                // `Vec` never deserializes from a non-array (incl. `null`).
-                _ => return false,
-            },
-            // No `Hash` attribute is modelled here.
-            Container::Hash => return false,
+        match attribute_conforms(v, attr, class, shallow) {
+            AttrCheck::Refused => return false,
+            // A mandatory attribute the wire leaves absent is `missing field`
+            // to the typed reader.
+            AttrCheck::Absent if attr.is_mandatory => return false,
+            AttrCheck::Conforms if attr.is_mandatory => mandatory_seen += 1,
+            AttrCheck::Absent | AttrCheck::Conforms => {}
         }
     }
     // Absent attributes: an OPTIONAL container defaults to `None` and an
@@ -302,6 +246,93 @@ fn node_conforms(obj: &Map<String, Value>, class: &'static RmClass, shallow: boo
     // (a mandatory container is a plain `Vec`/`NonEmptyVec` field the reader
     // requires). Every mandatory attribute must therefore have been seen.
     mandatory_seen == class.attributes.iter().filter(|a| a.is_mandatory).count()
+}
+
+/// What the typed reader would make of one attribute's wire value.
+enum AttrCheck {
+    /// JSON `null`, which the reader's `Option` shadow treats as absent.
+    Absent,
+    /// The value verifiably deserializes as the attribute's declared shape.
+    Conforms,
+    /// The typed reader would refuse the value, so this checker cannot vouch.
+    Refused,
+}
+
+/// Checks one attribute's wire value against its declared container shape.
+fn attribute_conforms(
+    v: &Value,
+    attr: &'static RmAttribute,
+    class: &'static RmClass,
+    shallow: bool,
+) -> AttrCheck {
+    match attr.container {
+        Container::None => single_conforms(v, attr, class, shallow),
+        Container::List | Container::Set => list_conforms(v, attr, shallow),
+        // No `Hash` attribute is modelled here.
+        Container::Hash => AttrCheck::Refused,
+    }
+}
+
+/// Checks a single-valued attribute's wire value.
+fn single_conforms(
+    v: &Value,
+    attr: &'static RmAttribute,
+    class: &'static RmClass,
+    shallow: bool,
+) -> AttrCheck {
+    if v.is_null() {
+        return AttrCheck::Absent;
+    }
+    if generic_any_slot(class.name, attr.name) {
+        return AttrCheck::Conforms;
+    }
+    if value_conforms(v, attr.declared_type, shallow) {
+        AttrCheck::Conforms
+    } else {
+        AttrCheck::Refused
+    }
+}
+
+/// Checks a container attribute's wire value.
+///
+/// A `1..*` container emits as `NonEmptyVec<T>`, whose constructor refuses an
+/// empty list — so an empty array does NOT deserialize and this checker must
+/// not vouch for it.
+fn list_conforms(v: &Value, attr: &'static RmAttribute, shallow: bool) -> AttrCheck {
+    // `Vec` never deserializes from a non-array (incl. `null`).
+    let Value::Array(items) = v else {
+        return AttrCheck::Refused;
+    };
+    let lower_bound_one = attr.cardinality.is_some_and(|c| c.lower >= 1) || attr.nonempty;
+    if lower_bound_one && items.is_empty() {
+        return AttrCheck::Refused;
+    }
+    let members_conform = if shallow {
+        shallow_members_conform(items, attr)
+    } else {
+        items
+            .iter()
+            .all(|item| value_conforms(item, attr.declared_type, false))
+    };
+    if members_conform {
+        AttrCheck::Conforms
+    } else {
+        AttrCheck::Refused
+    }
+}
+
+/// Checks the structural witness of a pruned array.
+///
+/// This mirrors `prune_child_nodes`: the prune keeps the FIRST member of any
+/// object array as the witness, which the typed decode inspects — so this
+/// checker inspects it too. An empty array on a non-`NonEmptyVec` field
+/// trivially deserializes; a non-empty all-scalar array is kept verbatim and
+/// typed-checked, so it is not vouched for here.
+fn shallow_members_conform(items: &[Value], attr: &'static RmAttribute) -> bool {
+    let Some(first) = items.first() else {
+        return true;
+    };
+    items.iter().any(Value::is_object) && value_conforms(first, attr.declared_type, true)
 }
 
 /// Whether a single value verifiably deserializes as the declared spec type.

--- a/crates/openehr-rm/src/v1_2/validate/incomplete.rs
+++ b/crates/openehr-rm/src/v1_2/validate/incomplete.rs
@@ -45,7 +45,7 @@
 
 use serde_json::Value;
 
-use crate::v1_2::model::{Container, class};
+use crate::v1_2::model::{Container, RmAttribute, class};
 
 /// The `POINT_EVENT`/`INTERVAL_EVENT` `data` slot, whose generic parameter the
 /// validation dispatcher erases to `serde_json::Value` — so any non-absent
@@ -96,53 +96,52 @@ pub fn mandatory_data_present(ty: &str, value: &Value) -> bool {
         if attr.declared_type == "Octet" {
             continue;
         }
-        let member = value.get(attr.name).filter(|v| !v.is_null());
-        match attr.container {
+        // No `Hash` attribute is judged here (none is modelled by the
+        // structural checkers either).
+        if attr.container == Container::Hash {
+            continue;
+        }
+        let Some(member) = value.get(attr.name).filter(|v| !v.is_null()) else {
+            if attr.is_mandatory {
+                return false;
+            }
+            continue;
+        };
+        let present = match attr.container {
             Container::None => {
-                let Some(member) = member else {
-                    if attr.is_mandatory {
-                        return false;
-                    }
-                    continue;
-                };
-                if generic_any_slot(ty, attr.name) {
-                    continue;
-                }
-                if member.is_object()
-                    && let Some(child) = effective_type(member, attr.declared_type)
-                    && !mandatory_data_present(child, member)
-                {
-                    return false;
-                }
+                generic_any_slot(ty, attr.name) || single_member_present(member, attr)
             }
-            Container::List | Container::Set => {
-                let Some(member) = member else {
-                    if attr.is_mandatory {
-                        return false;
-                    }
-                    continue;
-                };
-                let Some(items) = member.as_array() else {
-                    continue;
-                };
-                if items.is_empty() && attr.cardinality.is_some_and(|c| c.lower >= 1) {
-                    return false;
-                }
-                for item in items {
-                    if item.is_object()
-                        && let Some(child) = effective_type(item, attr.declared_type)
-                        && !mandatory_data_present(child, item)
-                    {
-                        return false;
-                    }
-                }
-            }
-            // No `Hash` attribute is judged here (none is modelled by the
-            // structural checkers either).
-            Container::Hash => {}
+            _ => list_members_present(member, attr),
+        };
+        if !present {
+            return false;
         }
     }
     true
+}
+
+/// Whether a single-valued member carries the mandatory data of its own
+/// declared type.
+fn single_member_present(member: &Value, attr: &RmAttribute) -> bool {
+    if !member.is_object() {
+        return true;
+    }
+    let Some(child) = effective_type(member, attr.declared_type) else {
+        return true;
+    };
+    mandatory_data_present(child, member)
+}
+
+/// Whether a container member satisfies its declared lower bound and each of
+/// its object members carries their own mandatory data.
+fn list_members_present(member: &Value, attr: &RmAttribute) -> bool {
+    let Some(items) = member.as_array() else {
+        return true;
+    };
+    if items.is_empty() && attr.cardinality.is_some_and(|c| c.lower >= 1) {
+        return false;
+    }
+    items.iter().all(|item| single_member_present(item, attr))
 }
 
 /// Whether `value` positively CONTRADICTS its declared RM type `ty`.

--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-term"
-version = "0.0.41"
+version = "0.0.42"
 description = "openEHR TERM terminology data model, generated from BMM (generation v3_1 = TERM 3.1.0), plus the embedded official terminology XML bundle"
 edition.workspace = true
 rust-version.workspace = true
@@ -34,7 +34,7 @@ include = [
 ]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.41" }
+openehr-base = { path = "../openehr-base", version = "0.0.42" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive.

--- a/crates/openehr-term/src/measurement.rs
+++ b/crates/openehr-term/src/measurement.rs
@@ -79,22 +79,7 @@ fn parse_atom_or_factor(b: &[u8], mut pos: usize) -> Option<usize> {
     let start = pos;
     while let Some(&c) = b.get(pos) {
         match c {
-            b'[' => {
-                pos += 1;
-                while let Some(&inner) = b.get(pos) {
-                    if inner == b']' {
-                        break;
-                    }
-                    if !(0x21..=0x7e).contains(&inner) || inner == b'[' {
-                        return None;
-                    }
-                    pos += 1;
-                }
-                if pos >= b.len() {
-                    return None; // unbalanced '['
-                }
-                pos += 1; // ']'
-            }
+            b'[' => pos = parse_bracket_segment(b, pos)?,
             b'.' | b'/' | b'(' | b')' | b'{' | b'}' | b']' => break,
             // exponent digits/sign are consumed by parse_exponent_opt; inside
             // an atom, digits terminate the symbol part (e.g. `mm3`).
@@ -103,6 +88,27 @@ fn parse_atom_or_factor(b: &[u8], mut pos: usize) -> Option<usize> {
         }
     }
     (pos > start).then_some(pos)
+}
+
+/// One balanced `[...]` segment of an atom, entered on its opening bracket.
+///
+/// Returns the position after the closing `]`, or `None` for an unbalanced or
+/// non-printable segment.
+fn parse_bracket_segment(b: &[u8], mut pos: usize) -> Option<usize> {
+    pos += 1;
+    while let Some(&inner) = b.get(pos) {
+        if inner == b']' {
+            break;
+        }
+        if !(0x21..=0x7e).contains(&inner) || inner == b'[' {
+            return None;
+        }
+        pos += 1;
+    }
+    if pos >= b.len() {
+        return None; // unbalanced '['
+    }
+    Some(pos + 1) // past ']'
 }
 
 /// exponent = ['+'|'-'] digits — but bare trailing digits are already consumed

--- a/crates/openehr-term/tests/it/xsd_conformance.rs
+++ b/crates/openehr-term/tests/it/xsd_conformance.rs
@@ -89,10 +89,9 @@ fn check_attrs(label: &str, node: &roxmltree::Node, required: &[&str], optional:
 /// elements each holding `concept` (1..*), with every codeset preceding
 /// every group (`xs:sequence`).
 #[expect(
-    clippy::too_many_lines,
     clippy::expect_used,
     clippy::panic,
-    reason = "one XSD document type = one walker mirroring the schema top to bottom (splitting would scatter the rule mirror); a failed lookup after its own presence assertion, and an undeclared element, ARE the test failure (Book ch11 assertion idiom)"
+    reason = "a failed lookup after its own presence assertion, and an undeclared element, ARE the test failure (Book ch11 assertion idiom)"
 )]
 fn check_terminology_doc(label: &str, xml: &str, groups_allowed: bool, external_id_required: bool) {
     let doc = roxmltree::Document::parse(xml).expect("well-formed XML");
@@ -132,50 +131,7 @@ fn check_terminology_doc(label: &str, xml: &str, groups_allowed: bool, external_
                     "{label}: <codeset> after <group> — the xs:sequence puts every codeset first"
                 );
                 seen_codeset = true;
-                let cs_label = format!(
-                    "{label}/codeset[{}]",
-                    child.attribute("openehr_id").unwrap_or("?")
-                );
-                let required: &[&str] = if external_id_required {
-                    // openehr_external_terminologies.xsd: external_id use="required".
-                    &["issuer", "openehr_id", "external_id"]
-                } else {
-                    &["issuer", "openehr_id"]
-                };
-                check_attrs(
-                    &cs_label,
-                    &child,
-                    required,
-                    &["external_id", "name", "status"],
-                );
-                for a in ["issuer", "openehr_id"] {
-                    let v = child.attribute(a).expect("checked required above");
-                    assert!(is_ncname(v), "{cs_label}: @{a}={v:?} is not an NCName");
-                }
-                if let Some(v) = child.attribute("external_id") {
-                    assert!(
-                        is_ncname(v),
-                        "{cs_label}: @external_id={v:?} is not an NCName"
-                    );
-                }
-                let mut codes = 0usize;
-                for code in child.children().filter(roxmltree::Node::is_element) {
-                    assert_eq!(
-                        code.tag_name().name(),
-                        "code",
-                        "{cs_label}: only <code> children are declared"
-                    );
-                    codes += 1;
-                    check_attrs(&cs_label, &code, &["value"], &["description", "status"]);
-                    assert!(
-                        !code.children().any(|n| n.is_element()),
-                        "{cs_label}: <code> is empty-content in the XSD"
-                    );
-                }
-                assert!(
-                    codes >= 1,
-                    "{cs_label}: <code> is maxOccurs=unbounded, min 1"
-                );
+                check_codeset(label, &child, external_id_required);
             }
             "group" => {
                 assert!(
@@ -183,41 +139,7 @@ fn check_terminology_doc(label: &str, xml: &str, groups_allowed: bool, external_
                     "{label}: <group> is not declared by this schema"
                 );
                 seen_group = true;
-                let g_label = format!(
-                    "{label}/group[{}]",
-                    child.attribute("openehr_id").unwrap_or("?")
-                );
-                check_attrs(&g_label, &child, &["name", "openehr_id"], &["status"]);
-                let id = child
-                    .attribute("openehr_id")
-                    .expect("checked required above");
-                assert!(
-                    is_ncname(id),
-                    "{g_label}: @openehr_id={id:?} is not an NCName"
-                );
-                let mut concepts = 0usize;
-                for concept in child.children().filter(roxmltree::Node::is_element) {
-                    assert_eq!(
-                        concept.tag_name().name(),
-                        "concept",
-                        "{g_label}: only <concept> children are declared"
-                    );
-                    concepts += 1;
-                    check_attrs(&g_label, &concept, &["id", "rubric"], &["status"]);
-                    let cid = concept.attribute("id").expect("checked required above");
-                    assert!(
-                        cid.parse::<i64>().is_ok(),
-                        "{g_label}: concept@id={cid:?} is not an xs:integer"
-                    );
-                    assert!(
-                        !concept.children().any(|n| n.is_element()),
-                        "{g_label}: <concept> is empty-content in the XSD"
-                    );
-                }
-                assert!(
-                    concepts >= 1,
-                    "{g_label}: <concept> is maxOccurs=unbounded, min 1"
-                );
+                check_group(label, &child);
             }
             other => panic!("{label}: element <{other}> is not declared by the schema"),
         }
@@ -232,6 +154,101 @@ fn check_terminology_doc(label: &str, xml: &str, groups_allowed: bool, external_
             "{label}: <group> is minOccurs>=1 in the sequence"
         );
     }
+}
+
+/// One `<codeset>` element and its `<code>` children against the XSD.
+#[expect(
+    clippy::expect_used,
+    reason = "a failed lookup after its own presence assertion IS the test failure (Book ch11 assertion idiom)"
+)]
+fn check_codeset(label: &str, child: &roxmltree::Node<'_, '_>, external_id_required: bool) {
+    let cs_label = format!(
+        "{label}/codeset[{}]",
+        child.attribute("openehr_id").unwrap_or("?")
+    );
+    let required: &[&str] = if external_id_required {
+        // openehr_external_terminologies.xsd: external_id use="required".
+        &["issuer", "openehr_id", "external_id"]
+    } else {
+        &["issuer", "openehr_id"]
+    };
+    check_attrs(
+        &cs_label,
+        child,
+        required,
+        &["external_id", "name", "status"],
+    );
+    for a in ["issuer", "openehr_id"] {
+        let v = child.attribute(a).expect("checked required above");
+        assert!(is_ncname(v), "{cs_label}: @{a}={v:?} is not an NCName");
+    }
+    if let Some(v) = child.attribute("external_id") {
+        assert!(
+            is_ncname(v),
+            "{cs_label}: @external_id={v:?} is not an NCName"
+        );
+    }
+    let mut codes = 0usize;
+    for code in child.children().filter(roxmltree::Node::is_element) {
+        assert_eq!(
+            code.tag_name().name(),
+            "code",
+            "{cs_label}: only <code> children are declared"
+        );
+        codes += 1;
+        check_attrs(&cs_label, &code, &["value"], &["description", "status"]);
+        assert!(
+            !code.children().any(|n| n.is_element()),
+            "{cs_label}: <code> is empty-content in the XSD"
+        );
+    }
+    assert!(
+        codes >= 1,
+        "{cs_label}: <code> is maxOccurs=unbounded, min 1"
+    );
+}
+
+/// One `<group>` element and its `<concept>` children against the XSD.
+#[expect(
+    clippy::expect_used,
+    reason = "a failed lookup after its own presence assertion IS the test failure (Book ch11 assertion idiom)"
+)]
+fn check_group(label: &str, child: &roxmltree::Node<'_, '_>) {
+    let g_label = format!(
+        "{label}/group[{}]",
+        child.attribute("openehr_id").unwrap_or("?")
+    );
+    check_attrs(&g_label, child, &["name", "openehr_id"], &["status"]);
+    let id = child
+        .attribute("openehr_id")
+        .expect("checked required above");
+    assert!(
+        is_ncname(id),
+        "{g_label}: @openehr_id={id:?} is not an NCName"
+    );
+    let mut concepts = 0usize;
+    for concept in child.children().filter(roxmltree::Node::is_element) {
+        assert_eq!(
+            concept.tag_name().name(),
+            "concept",
+            "{g_label}: only <concept> children are declared"
+        );
+        concepts += 1;
+        check_attrs(&g_label, &concept, &["id", "rubric"], &["status"]);
+        let cid = concept.attribute("id").expect("checked required above");
+        assert!(
+            cid.parse::<i64>().is_ok(),
+            "{g_label}: concept@id={cid:?} is not an xs:integer"
+        );
+        assert!(
+            !concept.children().any(|n| n.is_element()),
+            "{g_label}: <concept> is empty-content in the XSD"
+        );
+    }
+    assert!(
+        concepts >= 1,
+        "{g_label}: <concept> is maxOccurs=unbounded, min 1"
+    );
 }
 
 #[test]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1281,7 +1281,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "indexmap",
  "openehr-am",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "serde",
  "serde_json",
@@ -1317,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "async-trait",
  "axum",
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "chumsky",
  "indexmap",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "chumsky",
  "logos",
@@ -1364,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "openehr-base",
  "openehr-term",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/scripts/gh/retry-net.sh
+++ b/scripts/gh/retry-net.sh
@@ -67,7 +67,7 @@ poll_until() {
     if "$@"; then
       return 0
     fi
-    if [ "$(date +%s)" -ge "$deadline" ]; then
+    if [[ "$(date +%s)" -ge "$deadline" ]]; then
       return 1
     fi
     sleep "$interval"
@@ -90,7 +90,7 @@ retry_state() {
     if "$@"; then
       return 0
     fi
-    if [ "$attempt" -lt "$attempts" ]; then
+    if [[ "$attempt" -lt "$attempts" ]]; then
       echo "${what} attempt ${attempt} failed; retrying in $(( attempt * 10 ))s"
       sleep $(( attempt * 10 ))
     fi

--- a/tools/openehr-codegen/src/analyze/invariants.rs
+++ b/tools/openehr-codegen/src/analyze/invariants.rs
@@ -209,66 +209,14 @@ fn classify_leaf(toks: &[String]) -> Bucket {
     let joined = toks.join(" ");
     let has = |needle: &str| toks.iter().any(|t| t.contains(needle));
 
-    // ── Complex: quantifiers / lambdas / arithmetic (true structural depth) ──
-    if has("for_all") || has("forall") || has("exists") || toks.iter().any(|t| t == "for") {
-        return Bucket::Complex("quantifier over a collection");
+    if let Some(bucket) = structural_depth(toks, &has) {
+        return bucket;
     }
-    if toks.iter().any(|t| t == "|") {
-        return Bucket::Complex("lambda predicate");
+    if let Some(bucket) = missing_runtime_hook(&has) {
+        return bucket;
     }
-    // A boolean-returning *method* call (a BMM function, not a stored property):
-    // the emitter has no field to project it from, so it is not mechanically
-    // evaluable. `is_empty`/`empty` are handled as the recognised emptiness
-    // methods below; `is_justified` (ITEM_TAG) is a real function call.
-    if has(".is_justified") {
-        return Bucket::Complex("boolean method call (a BMM function, not a field)");
-    }
-    if has(".diff") || has(".to_seconds") || has(".mod") || has(".floor") || has(".item") {
-        return Bucket::Complex("cross-object arithmetic / navigation");
-    }
-    if toks
-        .iter()
-        .any(|t| matches!(t.as_str(), "-" | "+" | "*" | "/"))
-    {
-        return Bucket::Complex("arithmetic over related objects");
-    }
-
-    // ── Runtime-hook-missing: terminology / code-set / repository / aggregate ──
-    // Checked before the generic membership/navigation signals below: the
-    // terminology/code-set predicates read as `.has_code…` (a `.has` substring),
-    // and a code lookup is a missing *hook*, not irreducible structural depth.
-    if has("terminology") || has("Terminology") || has("has_code_for_group_id") {
-        return Bucket::RuntimeHookMissing("openEHR terminology service");
-    }
-    if has("code_set") || has("has_code") {
-        return Bucket::RuntimeHookMissing("openEHR code-set access");
-    }
-    if has("repository") {
-        return Bucket::RuntimeHookMissing("demographic repository access");
-    }
-    if has("all_versions")
-        || has("all_version_ids")
-        || has("version_count")
-        || has("latest_version")
-    {
-        return Bucket::RuntimeHookMissing("versioned-object aggregate model");
-    }
-
-    // ── Complex: membership / cross-object navigation ──
-    if has(".has") || has("has_object") || has("has_key") {
-        return Bucket::Complex("membership over a related collection");
-    }
-    if toks.iter().any(|t| t == "self")
-        || has("parent.")
-        || has(".source")
-        || has(".target")
-        || has(".relationships")
-        || has(".reverse_relationships")
-        || has(".description")
-        || has(".data")
-        || has(".origin")
-    {
-        return Bucket::Complex("cross-object navigation");
+    if let Some(bucket) = cross_object_navigation(toks, &has) {
+        return bucket;
     }
 
     // ── Emittable leaf forms ──
@@ -284,6 +232,85 @@ fn classify_leaf(toks: &[String]) -> Bucket {
         return Bucket::Emitted;
     }
     Bucket::Complex("unrecognised leaf form")
+}
+
+/// True structural depth: quantifiers, lambdas, boolean method calls and
+/// arithmetic over related objects.
+///
+/// A boolean-returning *method* call is a BMM function, not a stored property,
+/// so the emitter has no field to project it from and it is not mechanically
+/// evaluable. `is_empty`/`empty` are the recognised emptiness methods handled
+/// as emittable atoms; `is_justified` (`ITEM_TAG`) is a real function call.
+fn structural_depth(toks: &[String], has: &impl Fn(&str) -> bool) -> Option<Bucket> {
+    if has("for_all") || has("forall") || has("exists") || toks.iter().any(|t| t == "for") {
+        return Some(Bucket::Complex("quantifier over a collection"));
+    }
+    if toks.iter().any(|t| t == "|") {
+        return Some(Bucket::Complex("lambda predicate"));
+    }
+    if has(".is_justified") {
+        return Some(Bucket::Complex(
+            "boolean method call (a BMM function, not a field)",
+        ));
+    }
+    if has(".diff") || has(".to_seconds") || has(".mod") || has(".floor") || has(".item") {
+        return Some(Bucket::Complex("cross-object arithmetic / navigation"));
+    }
+    if toks
+        .iter()
+        .any(|t| matches!(t.as_str(), "-" | "+" | "*" | "/"))
+    {
+        return Some(Bucket::Complex("arithmetic over related objects"));
+    }
+    None
+}
+
+/// The runtime hooks the emitter has no access to: terminology, code sets, the
+/// demographic repository, and the versioned-object aggregate model.
+///
+/// Checked before the generic membership/navigation signals, because the
+/// terminology/code-set predicates read as `.has_code…` (a `.has` substring)
+/// and a code lookup is a missing *hook*, not irreducible structural depth.
+fn missing_runtime_hook(has: &impl Fn(&str) -> bool) -> Option<Bucket> {
+    if has("terminology") || has("Terminology") || has("has_code_for_group_id") {
+        return Some(Bucket::RuntimeHookMissing("openEHR terminology service"));
+    }
+    if has("code_set") || has("has_code") {
+        return Some(Bucket::RuntimeHookMissing("openEHR code-set access"));
+    }
+    if has("repository") {
+        return Some(Bucket::RuntimeHookMissing("demographic repository access"));
+    }
+    if has("all_versions")
+        || has("all_version_ids")
+        || has("version_count")
+        || has("latest_version")
+    {
+        return Some(Bucket::RuntimeHookMissing(
+            "versioned-object aggregate model",
+        ));
+    }
+    None
+}
+
+/// Membership over a related collection, and navigation off `self`.
+fn cross_object_navigation(toks: &[String], has: &impl Fn(&str) -> bool) -> Option<Bucket> {
+    if has(".has") || has("has_object") || has("has_key") {
+        return Some(Bucket::Complex("membership over a related collection"));
+    }
+    if toks.iter().any(|t| t == "self")
+        || has("parent.")
+        || has(".source")
+        || has(".target")
+        || has(".relationships")
+        || has(".reverse_relationships")
+        || has(".description")
+        || has(".data")
+        || has(".origin")
+    {
+        return Some(Bucket::Complex("cross-object navigation"));
+    }
+    None
 }
 
 /// Whether a leaf is one of the simple emittable atoms: an emptiness/`Void`

--- a/tools/openehr-codegen/src/analyze/mod.rs
+++ b/tools/openehr-codegen/src/analyze/mod.rs
@@ -474,39 +474,9 @@ impl Model {
                         .iter()
                         .any(|v| ok.contains(v) || Self::is_mapped(v))
                 } else {
-                    self.flattened_props(class).iter().all(|rp| {
-                        // Only a mandatory, single-valued, non-back-reference
-                        // field can force construction of another value.
-                        if !rp.prop.is_mandatory {
-                            return true;
-                        }
-                        if back_reference(&rp.owner, &rp.prop.name).is_some() {
-                            return true;
-                        }
-                        let BmmPropKind::Single(t) = &rp.prop.kind else {
-                            return true;
-                        };
-                        // A single-valued property whose type is a container
-                        // generic (`List`/`Array`/`Set`/`Hash` → `Vec`/`BTreeMap`)
-                        // renders as an indirection that can be empty, so it never
-                        // blocks construction (mirrors `field_type`'s
-                        // `already_indirect`).
-                        if let BmmType::Generic { root, .. } = t
-                            && matches!(root.as_str(), "List" | "Array" | "Set" | "Hash")
-                        {
-                            return true;
-                        }
-                        let mut roots = BTreeSet::new();
-                        self.effective_roots(t, &mut roots);
-                        // A root blocks construction only if it is a *defined
-                        // model class* not yet known constructible. A generic
-                        // parameter (`EVENT.data: T`), `Any`, or a cross-schema
-                        // type (rendered as `serde_json::Value`) is not a model
-                        // class here — it is caller-filled/mapped and never blocks.
-                        roots
-                            .iter()
-                            .all(|r| Self::is_mapped(r) || self.get(r).is_none() || ok.contains(r))
-                    })
+                    self.flattened_props(class)
+                        .iter()
+                        .all(|rp| self.prop_allows_construction(rp, &ok))
                 };
                 if constructible {
                     ok.insert(name.clone());
@@ -518,6 +488,37 @@ impl Model {
             }
         }
         ok
+    }
+
+    /// Whether one property leaves its owner constructible, given the classes
+    /// already known constructible.
+    ///
+    /// Only a mandatory, single-valued, non-back-reference field can force
+    /// construction of another value. A single-valued property whose type is a
+    /// container generic (`List`/`Array`/`Set`/`Hash` → `Vec`/`BTreeMap`)
+    /// renders as an indirection that can be empty, so it never blocks
+    /// construction (mirroring `field_type`'s `already_indirect`). Of the
+    /// remaining roots, one blocks only if it is a *defined model class* not
+    /// yet known constructible: a generic parameter (`EVENT.data: T`), `Any`,
+    /// or a cross-schema type (rendered as `serde_json::Value`) is not a model
+    /// class here — it is caller-filled/mapped and never blocks.
+    fn prop_allows_construction(&self, rp: &ResolvedProp<'_>, ok: &BTreeSet<String>) -> bool {
+        if !rp.prop.is_mandatory || back_reference(&rp.owner, &rp.prop.name).is_some() {
+            return true;
+        }
+        let BmmPropKind::Single(t) = &rp.prop.kind else {
+            return true;
+        };
+        if let BmmType::Generic { root, .. } = t
+            && matches!(root.as_str(), "List" | "Array" | "Set" | "Hash")
+        {
+            return true;
+        }
+        let mut roots = BTreeSet::new();
+        self.effective_roots(t, &mut roots);
+        roots
+            .iter()
+            .all(|r| Self::is_mapped(r) || self.get(r).is_none() || ok.contains(r))
     }
 
     /// The concrete emittable classes of `schema` that are **not**

--- a/tools/openehr-codegen/src/analyze/mod.rs
+++ b/tools/openehr-codegen/src/analyze/mod.rs
@@ -205,25 +205,18 @@ impl Model {
         // through its variants (e.g. ARCHETYPE_CONSTRAINT ↔ ARCHETYPE_SLOT,
         // EXPR_ITEM ↔ EXPR_BINARY_OPERATOR). Traverse them too.
         if class.is_abstract {
-            for d in self.enum_variants(from) {
-                if d == target || self.reaches(&d, target, seen) {
-                    return true;
-                }
-            }
-            return false;
+            return self
+                .enum_variants(from)
+                .iter()
+                .any(|d| d == target || self.reaches(d, target, seen));
         }
-        for rp in self.flattened_props(class) {
-            if let BmmPropKind::Single(t) = &rp.prop.kind {
-                let root = t.root_name();
-                if Self::is_mapped(root) {
-                    continue;
-                }
-                if root == target || self.reaches(root, target, seen) {
-                    return true;
-                }
-            }
-        }
-        false
+        self.flattened_props(class).iter().any(|rp| {
+            let BmmPropKind::Single(t) = &rp.prop.kind else {
+                return false;
+            };
+            let root = t.root_name();
+            !Self::is_mapped(root) && (root == target || self.reaches(root, target, seen))
+        })
     }
 
     /// The *immediate* concrete, emittable subtypes of `name` — the variants of

--- a/tools/openehr-codegen/src/cli.rs
+++ b/tools/openehr-codegen/src/cli.rs
@@ -1305,53 +1305,78 @@ fn declare_hand_written_modules(
         if !anchor.exists() || !anchor_generated {
             continue;
         }
-        let mut hand_written: Vec<String> = Vec::new();
-        for entry in std::fs::read_dir(&dir)? {
-            let p = entry?.path();
-            let Some(stem) = p.file_stem().and_then(std::ffi::OsStr::to_str) else {
-                continue;
-            };
-            if p.is_dir() {
-                // A hand-written module directory: it has a `mod.rs` that is not
-                // generated. A fully-generated subpackage's `mod.rs` is already
-                // declared by the parent's generated module tree, so skip it.
-                let child_mod = p.join("mod.rs");
-                if child_mod.exists() && !is_generated_file(&child_mod) {
-                    hand_written.push(stem.to_owned());
-                }
-            } else if p.extension().and_then(std::ffi::OsStr::to_str) == Some("rs")
-                && !matches!(stem, "mod" | "lib" | "prelude")
-                && (!is_generated_file(&p) || emit_templates::is_template_stamped(&p))
-            {
-                // Template-stamped copies are generated files, but the
-                // generated module tree does not know them — they are woven
-                // exactly like the hand-written siblings they replace.
-                hand_written.push(stem.to_owned());
-            }
-        }
+        let hand_written = hand_written_module_stems(&dir)?;
         if hand_written.is_empty() {
             continue;
         }
-        hand_written.sort();
-        let mut body = std::fs::read_to_string(&anchor)?;
-        let mut appended = false;
-        for m in hand_written {
-            let decl = format!("pub mod {m};");
-            if !body.contains(&decl) {
-                if !appended {
-                    body.push_str("\n// hand-written modules (spec behaviour), auto-declared:\n");
-                    appended = true;
-                }
-                body.push_str(&decl);
-                body.push('\n');
-            }
-        }
-        if appended {
-            std::fs::write(&anchor, &body)?;
+        if append_module_declarations(&anchor, &hand_written)? {
             written.push(anchor);
         }
     }
     Ok(())
+}
+
+/// The module stems in `dir` the generated module tree does not declare,
+/// sorted.
+///
+/// A hand-written module DIRECTORY is one whose own `mod.rs` is not generated;
+/// a fully-generated subpackage's `mod.rs` is already declared by the parent's
+/// generated module tree and is skipped. Template-stamped copies ARE generated
+/// files, but the generated module tree does not know them — they are woven
+/// exactly like the hand-written siblings they replace.
+///
+/// # Errors
+/// A directory that cannot be read.
+fn hand_written_module_stems(dir: &Path) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let mut stems: Vec<String> = Vec::new();
+    for entry in std::fs::read_dir(dir)? {
+        let p = entry?.path();
+        let Some(stem) = p.file_stem().and_then(std::ffi::OsStr::to_str) else {
+            continue;
+        };
+        if p.is_dir() {
+            let child_mod = p.join("mod.rs");
+            if child_mod.exists() && !is_generated_file(&child_mod) {
+                stems.push(stem.to_owned());
+            }
+        } else if p.extension().and_then(std::ffi::OsStr::to_str) == Some("rs")
+            && !matches!(stem, "mod" | "lib" | "prelude")
+            && (!is_generated_file(&p) || emit_templates::is_template_stamped(&p))
+        {
+            stems.push(stem.to_owned());
+        }
+    }
+    stems.sort();
+    Ok(stems)
+}
+
+/// Appends the missing `pub mod` declarations to a generated anchor,
+/// reporting whether it was modified.
+///
+/// # Errors
+/// A read or write failure on the anchor.
+fn append_module_declarations(
+    anchor: &Path,
+    stems: &[String],
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let mut body = std::fs::read_to_string(anchor)?;
+    let mut appended = false;
+    for m in stems {
+        let decl = format!("pub mod {m};");
+        if body.contains(&decl) {
+            continue;
+        }
+        if !appended {
+            body.push_str("\n// hand-written modules (spec behaviour), auto-declared:\n");
+            appended = true;
+        }
+        body.push_str(&decl);
+        body.push('\n');
+    }
+    if appended {
+        std::fs::write(anchor, &body)?;
+    }
+    Ok(appended)
 }
 
 /// Recursively collect subdirectories of `dir` into `out`.

--- a/tools/openehr-codegen/src/load/oas.rs
+++ b/tools/openehr-codegen/src/load/oas.rs
@@ -81,8 +81,27 @@ impl Oas {
         bundles: &[(&str, Oas)],
         keep: &std::collections::BTreeSet<String>,
     ) -> Oas {
+        let wanted = Self::base_closure(bundles, keep);
+        let mut schemas = serde_json::Map::new();
+        for (_, o) in bundles {
+            for (name, schema) in o.schemas() {
+                if wanted.contains(&name) && !schemas.contains_key(&name) {
+                    schemas.insert(name, schema.clone());
+                }
+            }
+        }
+        Oas {
+            root: serde_json::json!({ "components": { "schemas": schemas } }),
+        }
+    }
+
+    /// The transitive `allOf`-base closure of `keep`, as a least fixpoint: a
+    /// base may compose a base of its own.
+    fn base_closure(
+        bundles: &[(&str, Oas)],
+        keep: &std::collections::BTreeSet<String>,
+    ) -> std::collections::BTreeSet<String> {
         let mut wanted = keep.clone();
-        // Fixpoint over the `allOf` bases of everything already wanted.
         loop {
             let mut added = false;
             for (_, o) in bundles {
@@ -96,19 +115,8 @@ impl Oas {
                 }
             }
             if !added {
-                break;
+                return wanted;
             }
-        }
-        let mut schemas = serde_json::Map::new();
-        for (_, o) in bundles {
-            for (name, schema) in o.schemas() {
-                if wanted.contains(&name) && !schemas.contains_key(&name) {
-                    schemas.insert(name, schema.clone());
-                }
-            }
-        }
-        Oas {
-            root: serde_json::json!({ "components": { "schemas": schemas } }),
         }
     }
 

--- a/tools/openehr-codegen/src/load/xsd.rs
+++ b/tools/openehr-codegen/src/load/xsd.rs
@@ -96,6 +96,70 @@ pub(crate) struct XsdElem {
     pub multiple: bool,
 }
 
+/// Collects one document's named `group` / `attributeGroup` definitions.
+///
+/// A group may be declared in one file of an `xs:include` chain and referenced
+/// from another, so the caller scans every file before resolving any
+/// complexType. First declaration wins (the caller curates a conflict-free
+/// set).
+fn collect_groups(doc: &roxmltree::Document<'_>, groups: &mut XsdGroups) {
+    for node in doc
+        .root_element()
+        .children()
+        .filter(roxmltree::Node::is_element)
+    {
+        let Some(name) = node.attribute("name") else {
+            continue;
+        };
+        match local(&node) {
+            "group" => {
+                let mut items = Vec::new();
+                collect_content_particles(node, &mut items, &mut Vec::new());
+                groups.elements.entry(name.to_owned()).or_insert(items);
+            }
+            "attributeGroup" => {
+                let mut items = Vec::new();
+                collect_content_particles(node, &mut Vec::new(), &mut items);
+                groups.attributes.entry(name.to_owned()).or_insert(items);
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Collects one document's `complexType`s (with every group reference expanded
+/// in place) and its named `simpleType`s.
+///
+/// # Errors
+/// A complexType the parser cannot resolve.
+fn collect_types(
+    doc: &roxmltree::Document<'_>,
+    groups: &XsdGroups,
+    types: &mut BTreeMap<String, XsdType>,
+    simple_types: &mut BTreeMap<String, XsdSimpleType>,
+) -> Result<(), String> {
+    for node in doc
+        .root_element()
+        .children()
+        .filter(roxmltree::Node::is_element)
+    {
+        match local(&node) {
+            "complexType" => {
+                if let Some(t) = parse_complex_type(node, groups)? {
+                    types.entry(t.name.clone()).or_insert(t);
+                }
+            }
+            "simpleType" => {
+                if let Some(t) = parse_simple_type(node) {
+                    simple_types.entry(t.name.clone()).or_insert(t);
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
 impl XsdModel {
     /// Parse a curated set of XSD files into one merged model. Later files do
     /// not override types already seen (the caller curates a conflict-free set).
@@ -112,29 +176,7 @@ impl XsdModel {
                 .map_err(|e| format!("read {}: {e}", path.display()))?;
             let doc = roxmltree::Document::parse(&text)
                 .map_err(|e| format!("parse {}: {e}", path.display()))?;
-            for node in doc
-                .root_element()
-                .children()
-                .filter(roxmltree::Node::is_element)
-            {
-                match local(&node) {
-                    "group" => {
-                        if let Some(name) = node.attribute("name") {
-                            let mut items = Vec::new();
-                            collect_content_particles(node, &mut items, &mut Vec::new());
-                            groups.elements.entry(name.to_owned()).or_insert(items);
-                        }
-                    }
-                    "attributeGroup" => {
-                        if let Some(name) = node.attribute("name") {
-                            let mut items = Vec::new();
-                            collect_content_particles(node, &mut Vec::new(), &mut items);
-                            groups.attributes.entry(name.to_owned()).or_insert(items);
-                        }
-                    }
-                    _ => {}
-                }
-            }
+            collect_groups(&doc, &mut groups);
         }
 
         // Pass 2: the complexTypes, with every group reference expanded in
@@ -153,23 +195,8 @@ impl XsdModel {
             {
                 namespace = ns.to_string();
             }
-            for node in root.children().filter(roxmltree::Node::is_element) {
-                match local(&node) {
-                    "complexType" => {
-                        if let Some(t) = parse_complex_type(node, &groups)
-                            .map_err(|e| format!("{}: {e}", path.display()))?
-                        {
-                            types.entry(t.name.clone()).or_insert(t);
-                        }
-                    }
-                    "simpleType" => {
-                        if let Some(t) = parse_simple_type(node) {
-                            simple_types.entry(t.name.clone()).or_insert(t);
-                        }
-                    }
-                    _ => {}
-                }
-            }
+            collect_types(&doc, &groups, &mut types, &mut simple_types)
+                .map_err(|e| format!("{}: {e}", path.display()))?;
         }
         Ok(Self {
             namespace,

--- a/tools/openehr-codegen/src/render/emit.rs
+++ b/tools/openehr-codegen/src/render/emit.rs
@@ -1026,32 +1026,7 @@ pub(crate) fn field_type(
 ) -> String {
     match &p.kind {
         BmmPropKind::Single(t) => {
-            let overridden = type_override(&class.name, &p.name);
-            let mut inner = match overridden {
-                Some(rust) => rust.to_string(),
-                None => model.render_type(t, generics, subst, local, external),
-            };
-            // Box a field that would make the struct infinitely sized: direct
-            // self-recursion, mutual recursion (RESOURCE_DESCRIPTION ↔
-            // AUTHORED_RESOURCE), and F-bounded recursion through an auto-filled
-            // generic arg (DV_QUANTITY → normal_range: DvInterval<DvOrdered>,
-            // and DvOrdered's variants include DV_QUANTITY). We check every spec
-            // name the rendered type embeds by value, not just its head.
-            // A type already behind an indirection (`Vec`, `BTreeMap`,
-            // `BTreeSet`) breaks the cycle on its own — boxing it is redundant.
-            let already_indirect =
-                inner.starts_with("Vec<") || inner.starts_with("std::collections::");
-            let cyclic = overridden.is_none() && !already_indirect && {
-                let mut roots = BTreeSet::new();
-                model.effective_roots(t, &mut roots);
-                roots.iter().any(|r| {
-                    !Model::is_mapped(r)
-                        && (r == &class.name || model.reaches(r, &class.name, &mut BTreeSet::new()))
-                })
-            };
-            if cyclic {
-                inner = format!("Box<{inner}>");
-            }
+            let inner = single_field_type(model, class, p, t, generics, subst, local, external);
             if p.is_mandatory {
                 inner
             } else {
@@ -1060,44 +1035,123 @@ pub(crate) fn field_type(
         }
         BmmPropKind::Container {
             item, cardinality, ..
-        } => {
-            // A byte buffer (`Array<Octet>` / `List<Octet>`, e.g.
-            // `DV_MULTIMEDIA.data`) is inline base64 *text* on the canonical
-            // wire, not a JSON array — carry the base64 verbatim as a `String`
-            // (decoding is a behaviour-layer concern), like other broader-than-a-
-            // crate openEHR types. Optionality follows the property.
-            if item.root_name() == "Octet" {
-                return if p.is_mandatory {
-                    "String".to_string()
-                } else {
-                    "Option<String>".to_string()
-                };
-            }
-            // NOTE: a container property's Rust shape follows its BMM existence
-            // and cardinality — the emission table in this crate's `CLAUDE.md`
-            // §Container shapes carries the adjudication and its citations.
-            let item_ty = model.render_type(item, generics, subst, local, external);
-            let lower_bound_one = cardinality.as_ref().is_some_and(|c| c.lower >= 1)
-                && !crate::plan::overrides::cardinality_contradicted(&class.name, &p.name);
-            let nonempty_when_present = crate::analyze::nonempty_optional_lists_cached(model)
-                .iter()
-                .any(|(decl, attr)| {
-                    attr == &p.name && (decl == &class.name || model.inherits(&class.name, decl))
-                });
-            match (p.is_mandatory, lower_bound_one, nonempty_when_present) {
-                (true, true, _) => {
-                    format!("{}::NonEmptyVec<{item_ty}>", external.containers_path())
-                }
-                (true, false, _) => format!("Vec<{item_ty}>"),
-                (false, _, true) => {
-                    format!(
-                        "Option<{}::NonEmptyVec<{item_ty}>>",
-                        external.containers_path()
-                    )
-                }
-                (false, _, false) => format!("Option<Vec<{item_ty}>>"),
-            }
+        } => container_field_type(
+            model,
+            class,
+            p,
+            ContainerShape { item, cardinality },
+            generics,
+            subst,
+            local,
+            external,
+        ),
+    }
+}
+
+/// The item type and declared cardinality of a container property.
+#[derive(Clone, Copy)]
+struct ContainerShape<'a> {
+    item: &'a BmmType,
+    cardinality: &'a Option<crate::load::bmm::BmmCardinality>,
+}
+
+/// The inner Rust type of a single-valued property, boxed where leaving it by
+/// value would make the struct infinitely sized.
+///
+/// The cycle may be direct self-recursion, mutual recursion
+/// (`RESOURCE_DESCRIPTION` ↔ `AUTHORED_RESOURCE`), or F-bounded recursion through
+/// an auto-filled generic arg (`DV_QUANTITY` → `normal_range:
+/// DvInterval<DvOrdered>`, and `DvOrdered`'s variants include `DV_QUANTITY`), so
+/// every spec name the rendered type embeds by value is checked, not just its
+/// head. A type already behind an indirection (`Vec`, `BTreeMap`, `BTreeSet`)
+/// breaks the cycle on its own, and boxing it would be redundant.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the field-shape decision threads the same resolution tables `field_type` takes; bundling them would hide which each renderer reads"
+)]
+fn single_field_type(
+    model: &Model,
+    class: &BmmClass,
+    p: &crate::load::bmm::BmmProperty,
+    t: &BmmType,
+    generics: &[String],
+    subst: &BTreeMap<String, String>,
+    local: &BTreeSet<String>,
+    external: &External,
+) -> String {
+    let overridden = type_override(&class.name, &p.name);
+    let inner = match overridden {
+        Some(rust) => rust.to_string(),
+        None => model.render_type(t, generics, subst, local, external),
+    };
+    let already_indirect = inner.starts_with("Vec<") || inner.starts_with("std::collections::");
+    let cyclic = overridden.is_none() && !already_indirect && {
+        let mut roots = BTreeSet::new();
+        model.effective_roots(t, &mut roots);
+        roots.iter().any(|r| {
+            !Model::is_mapped(r)
+                && (r == &class.name || model.reaches(r, &class.name, &mut BTreeSet::new()))
+        })
+    };
+    if cyclic {
+        format!("Box<{inner}>")
+    } else {
+        inner
+    }
+}
+
+/// The Rust type of a container property.
+///
+/// A byte buffer (`Array<Octet>` / `List<Octet>`, e.g. `DV_MULTIMEDIA.data`) is
+/// inline base64 *text* on the canonical wire, not a JSON array, so it carries
+/// the base64 verbatim as a `String` (decoding is a behaviour-layer concern),
+/// like other broader-than-a-crate openEHR types; its optionality follows the
+/// property.
+///
+/// NOTE: every other container's shape follows its BMM existence and
+/// cardinality — the emission table in this crate's `CLAUDE.md` §Container
+/// shapes carries the adjudication and its citations.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the field-shape decision threads the same resolution tables `field_type` takes; bundling them would hide which each renderer reads"
+)]
+fn container_field_type(
+    model: &Model,
+    class: &BmmClass,
+    p: &crate::load::bmm::BmmProperty,
+    shape: ContainerShape<'_>,
+    generics: &[String],
+    subst: &BTreeMap<String, String>,
+    local: &BTreeSet<String>,
+    external: &External,
+) -> String {
+    if shape.item.root_name() == "Octet" {
+        return if p.is_mandatory {
+            "String".to_string()
+        } else {
+            "Option<String>".to_string()
+        };
+    }
+    let item_ty = model.render_type(shape.item, generics, subst, local, external);
+    let lower_bound_one = shape.cardinality.as_ref().is_some_and(|c| c.lower >= 1)
+        && !crate::plan::overrides::cardinality_contradicted(&class.name, &p.name);
+    let nonempty_when_present = crate::analyze::nonempty_optional_lists_cached(model)
+        .iter()
+        .any(|(decl, attr)| {
+            attr == &p.name && (decl == &class.name || model.inherits(&class.name, decl))
+        });
+    match (p.is_mandatory, lower_bound_one, nonempty_when_present) {
+        (true, true, _) => {
+            format!("{}::NonEmptyVec<{item_ty}>", external.containers_path())
         }
+        (true, false, _) => format!("Vec<{item_ty}>"),
+        (false, _, true) => {
+            format!(
+                "Option<{}::NonEmptyVec<{item_ty}>>",
+                external.containers_path()
+            )
+        }
+        (false, _, false) => format!("Option<Vec<{item_ty}>>"),
     }
 }
 

--- a/tools/openehr-codegen/src/render/emit.rs
+++ b/tools/openehr-codegen/src/render/emit.rs
@@ -1001,33 +1001,37 @@ fn decode_entities(s: &str) -> String {
     let mut out = String::new();
     let mut chars = s.chars().peekable();
     while let Some(c) = chars.next() {
-        if c == '&' && chars.peek() == Some(&'#') {
-            chars.next();
-            let mut num = String::new();
-            while let Some(&d) = chars.peek() {
-                if d == ';' {
-                    chars.next();
-                    break;
-                }
-                if d.is_ascii_digit() {
-                    num.push(d);
-                    chars.next();
-                } else {
-                    break;
-                }
-            }
-            if let Some(ch) = num.parse::<u32>().ok().and_then(char::from_u32) {
-                out.push(ch);
-            } else {
-                out.push('&');
-                out.push('#');
-                out.push_str(&num);
-            }
-        } else {
+        if c != '&' || chars.peek() != Some(&'#') {
             out.push(c);
+            continue;
+        }
+        chars.next();
+        let num = read_reference_digits(&mut chars);
+        if let Some(ch) = num.parse::<u32>().ok().and_then(char::from_u32) {
+            out.push(ch);
+        } else {
+            out.push_str("&#");
+            out.push_str(&num);
         }
     }
     out
+}
+
+/// Reads a numeric character reference's digits, consuming a closing `;`.
+fn read_reference_digits(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) -> String {
+    let mut num = String::new();
+    while let Some(&d) = chars.peek() {
+        if d == ';' {
+            chars.next();
+            break;
+        }
+        if !d.is_ascii_digit() {
+            break;
+        }
+        num.push(d);
+        chars.next();
+    }
+    num
 }
 
 /// Decode a single-character BMM literal body: numeric references first, then an
@@ -1492,14 +1496,38 @@ fn emit_enum_literals(class: &BmmClass, enumeration: &BmmEnumeration, has_siblin
         &synth_class_summary(spec),
     );
     push_spec_alias(&mut b, spec, &ty, "");
-    let derive = if is_int {
+    emit_enum_declaration(&mut b, &ty, spec, payload, is_int, &lits);
+
+    emit_enum_conversions(&mut b, &ty, is_int, &lits);
+    emit_enum_try_from(&mut b, &ty, spec, &err_ty, is_int, &lits);
+
+    // Canonical-JSON (de)serialization is the emitted `ToJson`/`FromJson` impl in
+    // `openehr-its` (`emit-json`): `ToJson` writes `as_str`/`value` (the constant
+    // token or verbatim `Other` payload) and `FromJson` maps the bare primitive
+    // through the total `from_wire`/`from_value`, byte-identical to the primitive
+    // it replaces. No serde impl is emitted here.
+
+    emit_enum_error_type(&mut b, &ty, spec, &err_ty, err_inner, is_int);
+    b
+}
+
+/// The enum declaration: its derive, one variant per constant, and the
+/// tolerant `Other` payload variant.
+fn emit_enum_declaration(
+    b: &mut String,
+    ty: &str,
+    spec: &str,
+    payload: &str,
+    is_int: bool,
+    lits: &[EnumLit],
+) {
+    b.push_str(if is_int {
         "#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]\n"
     } else {
         "#[derive(Debug, Clone, PartialEq, Eq, Hash)]\n"
-    };
-    b.push_str(derive);
+    });
     b.push_str(&format!("pub enum {ty} {{\n"));
-    for lit in &lits {
+    for lit in lits {
         match &lit.wire {
             EnumLitWire::Str(s) => b.push_str(&format!("    /// `{s}`\n")),
             EnumLitWire::Int(v) => b.push_str(&format!("    /// `{}` = {v}\n", lit.name)),
@@ -1514,18 +1542,6 @@ fn emit_enum_literals(class: &BmmClass, enumeration: &BmmEnumeration, has_siblin
          /// the bare `{payload}` it replaces.\n    \
          Other({payload}),\n}}\n\n"
     ));
-
-    emit_enum_conversions(&mut b, &ty, is_int, &lits);
-    emit_enum_try_from(&mut b, &ty, spec, &err_ty, is_int, &lits);
-
-    // Canonical-JSON (de)serialization is the emitted `ToJson`/`FromJson` impl in
-    // `openehr-its` (`emit-json`): `ToJson` writes `as_str`/`value` (the constant
-    // token or verbatim `Other` payload) and `FromJson` maps the bare primitive
-    // through the total `from_wire`/`from_value`, byte-identical to the primitive
-    // it replaces. No serde impl is emitted here.
-
-    emit_enum_error_type(&mut b, &ty, spec, &err_ty, err_inner, is_int);
-    b
 }
 
 /// The enum's inherent wire conversions: the total `as_str`/`value` writer and
@@ -1805,75 +1821,11 @@ fn doc_block(b: &mut String, doc: Option<&str>, indent: &str) {
 
 fn doc_block_summarized(b: &mut String, doc: Option<&str>, indent: &str, summary_hint: &str) {
     let Some(doc) = doc else { return };
-    // Spec prose carries example blocks (ODIN snippets, `YYYY-MM-DDTHH:MM:SS`
-    // date formats) that rustdoc would compile as Rust doctests and choke on.
-    // Neutralize both forms it recognizes so the docs render as text, never run:
-    //   - a bare ``` fence → tag the opening as ```text (closing stays bare);
-    //   - a run of 4-space-indented lines → wrap it in a ```text fence.
-    // Prose OUTSIDE those blocks additionally goes through `sanitize_doc_prose`
-    // (bare URLs, stray brackets/angle brackets — the rustdoc deny-lints).
-    let mut out: Vec<String> = Vec::new();
-    // Pending prose lines, sanitized as one segment so a code span may span
-    // lines (the BMM has such spans, e.g. `BMM_SCHEMA_DESCRIPTOR.schema_id`).
-    let mut prose: Vec<&str> = Vec::new();
-    let flush = |prose: &mut Vec<&str>, out: &mut Vec<String>| {
-        if prose.is_empty() {
-            return;
-        }
-        let sanitized = sanitize_doc_prose(&prose.join("\n"));
-        out.extend(sanitized.split('\n').map(str::to_string));
-        prose.clear();
-    };
-
-    let mut in_fence = false; // inside an explicit ``` fence
-    let mut in_indent = false; // inside an auto-wrapped indented block
+    let mut block = DocBlock::default();
     for line in doc.lines() {
-        let line = line.trim_end();
-        let stripped = line.trim_start();
-        let lead = line.len() - stripped.len();
-
-        if stripped.starts_with("```") && !in_indent {
-            flush(&mut prose, &mut out);
-            if in_fence {
-                in_fence = false;
-                out.push(line.to_string());
-            } else {
-                in_fence = true;
-                out.push(if stripped == "```" {
-                    line.replacen("```", "```text", 1)
-                } else {
-                    line.to_string()
-                });
-            }
-            continue;
-        }
-        if in_fence {
-            out.push(line.to_string());
-            continue;
-        }
-
-        let is_indent_line = lead >= 4 && !stripped.is_empty();
-        if is_indent_line && !in_indent {
-            flush(&mut prose, &mut out);
-            out.push("```text".to_string());
-            in_indent = true;
-        } else if in_indent && !is_indent_line && !stripped.is_empty() {
-            out.push("```".to_string());
-            in_indent = false;
-        }
-        if in_indent {
-            out.push(line.to_string());
-        } else {
-            prose.push(line);
-        }
+        block.push_line(line.trim_end());
     }
-    flush(&mut prose, &mut out);
-    if in_indent {
-        out.push("```".to_string());
-    }
-    if in_fence {
-        out.push("```".to_string());
-    }
+    let mut out = block.finish();
     split_long_first_paragraph(&mut out, summary_hint);
 
     for line in &out {
@@ -1882,6 +1834,100 @@ fn doc_block_summarized(b: &mut String, doc: Option<&str>, indent: &str, summary
         } else {
             b.push_str(&format!("{indent}/// {line}\n"));
         }
+    }
+}
+
+/// The line-by-line rewriter behind [`doc_block_summarized`].
+///
+/// Spec prose carries example blocks (ODIN snippets, `YYYY-MM-DDTHH:MM:SS` date
+/// formats) that rustdoc would compile as Rust doctests and choke on. Both forms
+/// it recognizes are neutralized so the docs render as text, never run: a bare
+/// triple-backtick fence has its opening tagged `text` (the closing stays bare),
+/// and a run of 4-space-indented lines is wrapped in a `text` fence. Prose
+/// OUTSIDE those blocks additionally goes through [`sanitize_doc_prose`] (bare
+/// URLs, stray brackets/angle brackets — the rustdoc deny-lints).
+#[derive(Default)]
+struct DocBlock<'a> {
+    /// The rewritten lines, in order.
+    out: Vec<String>,
+    /// Pending prose lines, sanitized as one segment so a code span may span
+    /// lines (the BMM has such spans, e.g. `BMM_SCHEMA_DESCRIPTOR.schema_id`).
+    prose: Vec<&'a str>,
+    /// Inside an explicit triple-backtick fence.
+    in_fence: bool,
+    /// Inside an auto-wrapped indented block.
+    in_indent: bool,
+}
+
+impl<'a> DocBlock<'a> {
+    /// Sanitizes and emits the pending prose segment, if any.
+    fn flush_prose(&mut self) {
+        if self.prose.is_empty() {
+            return;
+        }
+        let sanitized = sanitize_doc_prose(&self.prose.join("\n"));
+        self.out.extend(sanitized.split('\n').map(str::to_string));
+        self.prose.clear();
+    }
+
+    /// Takes one already-right-trimmed source line.
+    fn push_line(&mut self, line: &'a str) {
+        let stripped = line.trim_start();
+        if stripped.starts_with("```") && !self.in_indent {
+            self.toggle_fence(line, stripped);
+            return;
+        }
+        if self.in_fence {
+            self.out.push(line.to_string());
+            return;
+        }
+        let lead = line.len() - stripped.len();
+        self.track_indent_block(lead >= 4 && !stripped.is_empty(), stripped.is_empty());
+        if self.in_indent {
+            self.out.push(line.to_string());
+        } else {
+            self.prose.push(line);
+        }
+    }
+
+    /// Opens or closes an explicit fence, tagging a bare opening as `text`.
+    fn toggle_fence(&mut self, line: &str, stripped: &str) {
+        self.flush_prose();
+        if self.in_fence {
+            self.in_fence = false;
+            self.out.push(line.to_string());
+            return;
+        }
+        self.in_fence = true;
+        self.out.push(if stripped == "```" {
+            line.replacen("```", "```text", 1)
+        } else {
+            line.to_string()
+        });
+    }
+
+    /// Opens or closes the auto-wrapped fence around an indented run.
+    fn track_indent_block(&mut self, is_indent_line: bool, is_blank: bool) {
+        if is_indent_line && !self.in_indent {
+            self.flush_prose();
+            self.out.push("```text".to_string());
+            self.in_indent = true;
+        } else if self.in_indent && !is_indent_line && !is_blank {
+            self.out.push("```".to_string());
+            self.in_indent = false;
+        }
+    }
+
+    /// Flushes the tail state and yields the rewritten lines.
+    fn finish(mut self) -> Vec<String> {
+        self.flush_prose();
+        if self.in_indent {
+            self.out.push("```".to_string());
+        }
+        if self.in_fence {
+            self.out.push("```".to_string());
+        }
+        self.out
     }
 }
 
@@ -1988,35 +2034,9 @@ fn sanitize_doc_prose(text: &str) -> String {
     let mut rest = text;
     while let Some(c) = rest.chars().next() {
         match c {
-            '`' => {
-                let open = backtick_run(rest);
-                // A matched pair delimits a code span: copy it verbatim, closing
-                // run included. An unmatched run is escaped instead.
-                if let Some(offset) = find_backtick_run(after(rest, open), open) {
-                    let end = open + offset + open;
-                    out.push_str(upto(rest, end));
-                    rest = after(rest, end);
-                } else {
-                    for _ in 0..open {
-                        out.push_str("\\`");
-                    }
-                    rest = after(rest, open);
-                }
-            }
+            '`' => rest = copy_code_span(rest, &mut out),
             'h' if rest.starts_with("http://") || rest.starts_with("https://") => {
-                let url = read_url(rest);
-                let tail = after(rest, url.len());
-                // asciidoc link form `https://host/path[label]`. A parenthesis in
-                // the URL would end the Markdown destination early, so such a
-                // link stays an autolink with escaped brackets.
-                let plain_dest = !url.contains(['(', ')']);
-                if let Some((consumed, label)) = read_link_label(tail).filter(|_| plain_dest) {
-                    out.push_str(&format!("[{label}]({url})"));
-                    rest = after(tail, consumed);
-                } else {
-                    out.push_str(&format!("<{url}>"));
-                    rest = tail;
-                }
+                rest = copy_url(rest, &mut out);
             }
             '[' | ']' | '<' | '>' => {
                 out.push('\\');
@@ -2030,6 +2050,40 @@ fn sanitize_doc_prose(text: &str) -> String {
         }
     }
     out
+}
+
+/// Copies a backtick run to `out`, returning the unconsumed remainder.
+///
+/// A matched pair delimits a code span: it is copied verbatim, closing run
+/// included. An unmatched run is escaped instead.
+fn copy_code_span<'a>(rest: &'a str, out: &mut String) -> &'a str {
+    let open = backtick_run(rest);
+    if let Some(offset) = find_backtick_run(after(rest, open), open) {
+        let end = open + offset + open;
+        out.push_str(upto(rest, end));
+        return after(rest, end);
+    }
+    for _ in 0..open {
+        out.push_str("\\`");
+    }
+    after(rest, open)
+}
+
+/// Copies a URL to `out` as Markdown, returning the unconsumed remainder.
+///
+/// The asciidoc link form `https://host/path[label]` becomes a Markdown link. A
+/// parenthesis in the URL would end the Markdown destination early, so such a
+/// link stays an autolink with escaped brackets.
+fn copy_url<'a>(rest: &'a str, out: &mut String) -> &'a str {
+    let url = read_url(rest);
+    let tail = after(rest, url.len());
+    let plain_dest = !url.contains(['(', ')']);
+    if let Some((consumed, label)) = read_link_label(tail).filter(|_| plain_dest) {
+        out.push_str(&format!("[{label}]({url})"));
+        return after(tail, consumed);
+    }
+    out.push_str(&format!("<{url}>"));
+    tail
 }
 
 /// `s` after its first `n` bytes — total (empty when `n` is out of range or not

--- a/tools/openehr-codegen/src/render/emit.rs
+++ b/tools/openehr-codegen/src/render/emit.rs
@@ -752,13 +752,7 @@ fn render_struct_def(
         // `*_impl.rs`. This is the only sanctioned way to break a mandatory
         // construction cycle — a forward composition is never relaxed.
         if let Some(citation) = back_reference(&rp.owner, &p.name) {
-            b.push_str(&format!(
-                "    // NOTE: `{}` (BMM-mandatory back-reference) omitted — {}. \
-                 A back-reference is not forward-owned data and never appears on \
-                 the canonical wire; emitting it as an owning field would make \
-                 this type non-constructible.\n",
-                p.name, citation
-            ));
+            push_back_reference_note(&mut b, &p.name, citation);
             continue;
         }
         if rp.owner != class.name && prev_owner != Some(rp.owner.as_str()) {
@@ -788,14 +782,8 @@ fn render_struct_def(
         // NOTE is conditional on the degrade actually happening, so a
         // composition where the type IS resolvable (the AM24 re-emission of
         // `EL_CASE`, where `C_OBJECT` is local) emits the typed field with no note.
-        if rust_ty.contains("serde_json::Value")
-            && let Some(adj) =
-                untyped_field(&rp.owner, &p.name).or_else(|| untyped_field(&class.name, &p.name))
-        {
-            b.push_str(&format!(
-                "    // NOTE: free-form JSON is adjudicated here, not accidental — {}. {}\n",
-                adj.citation, adj.reason
-            ));
+        if rust_ty.contains("serde_json::Value") {
+            push_untyped_field_note(&mut b, &rp.owner, &class.name, &p.name);
         }
         b.push_str(&format!("    {field_vis} {ident}: {rust_ty},\n"));
         emitted.push((ident, rust_ty));
@@ -811,6 +799,39 @@ fn render_struct_def(
         ));
     }
     b
+}
+
+/// The NOTE emitted in place of an omitted back-reference field.
+///
+/// A designated owner/parent back-reference is a non-data navigational
+/// association, never forward-owned data and never on the canonical wire;
+/// emitting it as an owning field makes the type a non-constructible infinite
+/// value. This is the only sanctioned way to break a mandatory construction
+/// cycle — a forward composition is never relaxed.
+fn push_back_reference_note(b: &mut String, prop: &str, citation: &str) {
+    b.push_str(&format!(
+        "    // NOTE: `{prop}` (BMM-mandatory back-reference) omitted — {citation}. \
+         A back-reference is not forward-owned data and never appears on \
+         the canonical wire; emitting it as an owning field would make \
+         this type non-constructible.\n"
+    ));
+}
+
+/// The NOTE emitted beside a field that degraded to free-form JSON *and*
+/// carries an adjudication.
+///
+/// Silence over an untyped slot in a generated spec crate is
+/// indistinguishable from an oversight. The note is conditional on the degrade
+/// actually happening, so a composition where the type IS resolvable (the AM24
+/// re-emission of `EL_CASE`, where `C_OBJECT` is local) emits the typed field
+/// with no note.
+fn push_untyped_field_note(b: &mut String, owner: &str, class: &str, prop: &str) {
+    if let Some(adj) = untyped_field(owner, prop).or_else(|| untyped_field(class, prop)) {
+        b.push_str(&format!(
+            "    // NOTE: free-form JSON is adjudicated here, not accidental — {}. {}\n",
+            adj.citation, adj.reason
+        ));
+    }
 }
 
 /// The read accessors + door NOTE for a class whose fields are `pub(crate)`

--- a/tools/openehr-codegen/src/render/emit.rs
+++ b/tools/openehr-codegen/src/render/emit.rs
@@ -1135,7 +1135,6 @@ fn emit_enum(
         format!("<{}>", enum_generics.join(", "))
     };
     let mut b = String::new();
-    let no_subst = BTreeMap::new();
 
     // Compute payloads first (so imports can be derived from what they touch).
     // Each entry is `(variant ident, payload type, doc line)` — a variant is a
@@ -1143,45 +1142,7 @@ fn emit_enum(
     // a closed slot, so the line is synthesized from the subtype's spec name.
     let payloads: Vec<(String, String, String)> = variants
         .iter()
-        .map(|d| {
-            let variant = naming::type_name(d);
-            let d_generic = !model.used_generic_params(d).is_empty();
-            let payload = if d_generic && !enum_generics.is_empty() {
-                // Same subtype family: thread the enum's own params (`Event<T>`
-                // → `PointEvent(PointEvent<T>)`).
-                format!("{variant}<{}>", enum_generics.join(", "))
-            } else {
-                // Non-generic enum (e.g. `DataValue`) with a generic variant:
-                // bound-fill the variant (`DvInterval(DvInterval<DvOrdered>)`).
-                model.render_type(
-                    &BmmType::Simple(d.clone()),
-                    &enum_generics,
-                    &no_subst,
-                    local,
-                    external,
-                )
-            };
-            // Box a variant that would make the enum infinitely sized: either
-            // the payload embeds the enum type by value via a bound-filled arg
-            // (`EL_TERMINAL` ⊇ `EL_CASE_TABLE<EL_TERMINAL>`), or the variant's
-            // own fields reach back to the enum (`BMM_TYPE` ⊇ `BMM_CONTAINER_TYPE`
-            // whose `base_type` is a `BMM_TYPE`). A `Vec`/map payload already
-            // breaks the cycle.
-            let already_indirect =
-                payload.starts_with("Vec<") || payload.starts_with("std::collections::");
-            let cyclic = !already_indirect && {
-                let mut roots = BTreeSet::new();
-                model.effective_roots(&BmmType::Simple(d.clone()), &mut roots);
-                roots.contains(&class.name) || model.reaches(d, &class.name, &mut BTreeSet::new())
-            };
-            let payload = if cyclic {
-                format!("Box<{payload}>")
-            } else {
-                payload
-            };
-            let doc = format!("The `{d}` subtype of `{}`.", class.name);
-            (variant, payload, doc)
-        })
+        .map(|d| enum_variant_payload(model, class, d, &enum_generics, local, external))
         .collect();
 
     // A polymorphic *concrete* class also carries its own instances: append a
@@ -1359,6 +1320,56 @@ fn enum_literals(enumeration: &BmmEnumeration) -> Vec<EnumLit> {
         .collect()
 }
 
+/// One untagged-enum variant as `(ident, payload type, doc line)`.
+///
+/// A variant is a public item `missing_docs` checks, and the BMM has no
+/// per-subtype text for a closed slot, so the doc line is synthesized from the
+/// subtype's spec name.
+///
+/// The payload threads the enum's own generic params when the subtype belongs
+/// to the same generic family (`Event<T>` → `PointEvent(PointEvent<T>)`), and
+/// otherwise bound-fills the variant (`DvInterval(DvInterval<DvOrdered>)`). It
+/// is boxed when leaving it by value would make the enum infinitely sized:
+/// either the payload embeds the enum type through a bound-filled argument
+/// (`EL_TERMINAL` ⊇ `EL_CASE_TABLE<EL_TERMINAL>`), or the variant's own fields
+/// reach back to the enum (`BMM_TYPE` ⊇ `BMM_CONTAINER_TYPE` whose `base_type`
+/// is a `BMM_TYPE`). A `Vec`/map payload already breaks the cycle.
+fn enum_variant_payload(
+    model: &Model,
+    class: &BmmClass,
+    subtype: &str,
+    enum_generics: &[String],
+    local: &BTreeSet<String>,
+    external: &External,
+) -> (String, String, String) {
+    let variant = naming::type_name(subtype);
+    let subtype_generic = !model.used_generic_params(subtype).is_empty();
+    let payload = if subtype_generic && !enum_generics.is_empty() {
+        format!("{variant}<{}>", enum_generics.join(", "))
+    } else {
+        model.render_type(
+            &BmmType::Simple(subtype.to_owned()),
+            enum_generics,
+            &BTreeMap::new(),
+            local,
+            external,
+        )
+    };
+    let already_indirect = payload.starts_with("Vec<") || payload.starts_with("std::collections::");
+    let cyclic = !already_indirect && {
+        let mut roots = BTreeSet::new();
+        model.effective_roots(&BmmType::Simple(subtype.to_owned()), &mut roots);
+        roots.contains(&class.name) || model.reaches(subtype, &class.name, &mut BTreeSet::new())
+    };
+    let payload = if cyclic {
+        format!("Box<{payload}>")
+    } else {
+        payload
+    };
+    let doc = format!("The `{subtype}` subtype of `{}`.", class.name);
+    (variant, payload, doc)
+}
+
 /// Emit a BMM enumeration class as a real Rust enum: one variant per named
 /// constant, plus a tolerance-preserving `Other(String|i32)` catch-all.
 ///
@@ -1415,14 +1426,29 @@ fn emit_enum_literals(class: &BmmClass, enumeration: &BmmEnumeration, has_siblin
          Other({payload}),\n}}\n\n"
     ));
 
-    // Inherent conversions.
+    emit_enum_conversions(&mut b, &ty, is_int, &lits);
+    emit_enum_try_from(&mut b, &ty, spec, &err_ty, is_int, &lits);
+
+    // Canonical-JSON (de)serialization is the emitted `ToJson`/`FromJson` impl in
+    // `openehr-its` (`emit-json`): `ToJson` writes `as_str`/`value` (the constant
+    // token or verbatim `Other` payload) and `FromJson` maps the bare primitive
+    // through the total `from_wire`/`from_value`, byte-identical to the primitive
+    // it replaces. No serde impl is emitted here.
+
+    emit_enum_error_type(&mut b, &ty, spec, &err_ty, err_inner, is_int);
+    b
+}
+
+/// The enum's inherent wire conversions: the total `as_str`/`value` writer and
+/// its tolerant `from_wire`/`from_value` reader.
+fn emit_enum_conversions(b: &mut String, ty: &str, is_int: bool, lits: &[EnumLit]) {
     b.push_str(&format!("impl {ty} {{\n"));
     if is_int {
         b.push_str(
             "    /// The `i32` wire value of this constant (the verbatim payload for\n    \
              /// [`Self::Other`]).\n    #[must_use]\n    pub fn value(self) -> i32 {\n        match self {\n",
         );
-        for lit in &lits {
+        for lit in lits {
             if let EnumLitWire::Int(v) = &lit.wire {
                 b.push_str(&format!("            Self::{} => {v},\n", lit.ident));
             }
@@ -1433,37 +1459,46 @@ fn emit_enum_literals(class: &BmmClass, enumeration: &BmmEnumeration, has_siblin
              /// value as [`Self::Other`] (total — never fails).\n    #[must_use]\n    \
              pub fn from_value(__v: i32) -> Self {\n        match __v {\n",
         );
-        for lit in &lits {
+        for lit in lits {
             if let EnumLitWire::Int(v) = &lit.wire {
                 b.push_str(&format!("            {v} => Self::{},\n", lit.ident));
             }
         }
         b.push_str("            _ => Self::Other(__v),\n        }\n    }\n}\n\n");
-    } else {
-        b.push_str(
-            "    /// The wire string of this constant (the verbatim token for\n    \
-             /// [`Self::Other`]).\n    #[must_use]\n    pub fn as_str(&self) -> &str {\n        match self {\n",
-        );
-        for lit in &lits {
-            if let EnumLitWire::Str(s) = &lit.wire {
-                b.push_str(&format!("            Self::{} => {s:?},\n", lit.ident));
-            }
-        }
-        b.push_str("            Self::Other(__s) => __s.as_str(),\n        }\n    }\n\n");
-        b.push_str(
-            "    /// This constant for a wire string, tolerating an unknown token\n    \
-             /// as [`Self::Other`] (total — never fails).\n    #[must_use]\n    \
-             pub fn from_wire(__s: &str) -> Self {\n        match __s {\n",
-        );
-        for lit in &lits {
-            if let EnumLitWire::Str(s) = &lit.wire {
-                b.push_str(&format!("            {s:?} => Self::{},\n", lit.ident));
-            }
-        }
-        b.push_str("            _ => Self::Other(__s.to_owned()),\n        }\n    }\n}\n\n");
+        return;
     }
+    b.push_str(
+        "    /// The wire string of this constant (the verbatim token for\n    \
+         /// [`Self::Other`]).\n    #[must_use]\n    pub fn as_str(&self) -> &str {\n        match self {\n",
+    );
+    for lit in lits {
+        if let EnumLitWire::Str(s) = &lit.wire {
+            b.push_str(&format!("            Self::{} => {s:?},\n", lit.ident));
+        }
+    }
+    b.push_str("            Self::Other(__s) => __s.as_str(),\n        }\n    }\n\n");
+    b.push_str(
+        "    /// This constant for a wire string, tolerating an unknown token\n    \
+         /// as [`Self::Other`] (total — never fails).\n    #[must_use]\n    \
+         pub fn from_wire(__s: &str) -> Self {\n        match __s {\n",
+    );
+    for lit in lits {
+        if let EnumLitWire::Str(s) = &lit.wire {
+            b.push_str(&format!("            {s:?} => Self::{},\n", lit.ident));
+        }
+    }
+    b.push_str("            _ => Self::Other(__s.to_owned()),\n        }\n    }\n}\n\n");
+}
 
-    // Strict `TryFrom` seam (never yields `Other`).
+/// The strict `TryFrom` seam, which never yields `Other`.
+fn emit_enum_try_from(
+    b: &mut String,
+    ty: &str,
+    spec: &str,
+    err_ty: &str,
+    is_int: bool,
+    lits: &[EnumLit],
+) {
     if is_int {
         b.push_str(&format!(
             "impl ::core::convert::TryFrom<i64> for {ty} {{\n    type Error = {err_ty};\n\n    \
@@ -1471,7 +1506,7 @@ fn emit_enum_literals(class: &BmmClass, enumeration: &BmmEnumeration, has_siblin
              /// (unlike [`Self::from_value`], which is total).\n    \
              fn try_from(__v: i64) -> ::core::result::Result<Self, Self::Error> {{\n        match __v {{\n"
         ));
-        for lit in &lits {
+        for lit in lits {
             if let EnumLitWire::Int(v) = &lit.wire {
                 b.push_str(&format!(
                     "            {v} => ::core::result::Result::Ok(Self::{}),\n",
@@ -1482,33 +1517,37 @@ fn emit_enum_literals(class: &BmmClass, enumeration: &BmmEnumeration, has_siblin
         b.push_str(&format!(
             "            _ => ::core::result::Result::Err({err_ty}(__v)),\n        }}\n    }}\n}}\n\n"
         ));
-    } else {
-        b.push_str(&format!(
-            "impl ::core::convert::TryFrom<&str> for {ty} {{\n    type Error = {err_ty};\n\n    \
-             /// # Errors\n    /// Returns [`{err_ty}`] when `__s` is not a `{spec}` value\n    \
-             /// (unlike [`Self::from_wire`], which is total).\n    \
-             fn try_from(__s: &str) -> ::core::result::Result<Self, Self::Error> {{\n        match __s {{\n"
-        ));
-        for lit in &lits {
-            if let EnumLitWire::Str(s) = &lit.wire {
-                b.push_str(&format!(
-                    "            {s:?} => ::core::result::Result::Ok(Self::{}),\n",
-                    lit.ident
-                ));
-            }
-        }
-        b.push_str(&format!(
-            "            _ => ::core::result::Result::Err({err_ty}(__s.to_owned())),\n        }}\n    }}\n}}\n\n"
-        ));
+        return;
     }
+    b.push_str(&format!(
+        "impl ::core::convert::TryFrom<&str> for {ty} {{\n    type Error = {err_ty};\n\n    \
+         /// # Errors\n    /// Returns [`{err_ty}`] when `__s` is not a `{spec}` value\n    \
+         /// (unlike [`Self::from_wire`], which is total).\n    \
+         fn try_from(__s: &str) -> ::core::result::Result<Self, Self::Error> {{\n        match __s {{\n"
+    ));
+    for lit in lits {
+        if let EnumLitWire::Str(s) = &lit.wire {
+            b.push_str(&format!(
+                "            {s:?} => ::core::result::Result::Ok(Self::{}),\n",
+                lit.ident
+            ));
+        }
+    }
+    b.push_str(&format!(
+        "            _ => ::core::result::Result::Err({err_ty}(__s.to_owned())),\n        }}\n    }}\n}}\n\n"
+    ));
+}
 
-    // Canonical-JSON (de)serialization is the emitted `ToJson`/`FromJson` impl in
-    // `openehr-its` (`emit-json`): `ToJson` writes `as_str`/`value` (the constant
-    // token or verbatim `Other` payload) and `FromJson` maps the bare primitive
-    // through the total `from_wire`/`from_value`, byte-identical to the primitive
-    // it replaces. No serde impl is emitted here.
-
-    // The strict-seam error type (hand-rolled Display + Error, no `thiserror`).
+/// The strict seam's error type (hand-rolled `Display` + `Error`, no
+/// `thiserror` in the generated crates).
+fn emit_enum_error_type(
+    b: &mut String,
+    ty: &str,
+    spec: &str,
+    err_ty: &str,
+    err_inner: &str,
+    is_int: bool,
+) {
     b.push_str(&format!(
         "/// The error returned by [`{ty}::try_from`] for a value outside the `{spec}`\n\
          /// constant set.\n#[derive(Debug, Clone, PartialEq, Eq)]\npub struct {err_ty}(pub {err_inner});\n\n"
@@ -1524,7 +1563,6 @@ fn emit_enum_literals(class: &BmmClass, enumeration: &BmmEnumeration, has_siblin
          ::core::write!(f, {fmt:?}, self.0)\n    }}\n}}\n\n"
     ));
     b.push_str(&format!("impl ::std::error::Error for {err_ty} {{}}\n"));
-    b
 }
 
 // ── import + header helpers ──────────────────────────────────────────────────

--- a/tools/openehr-codegen/src/render/emit.rs
+++ b/tools/openehr-codegen/src/render/emit.rs
@@ -947,32 +947,46 @@ fn const_literal(c: &BmmConstant, siblings: &BTreeSet<&str>) -> (String, String)
         serde_json::Value::Number(n) => ("i64".to_string(), format!("{}", n.as_i64().unwrap_or(0))),
         serde_json::Value::Bool(b) => ("bool".to_string(), format!("{b}")),
         serde_json::Value::String(s) => {
-            let t = s.trim();
-            if let Some(inner) = strip_delims(t, '"') {
-                ("&str".to_string(), format!("{:?}", decode_entities(inner)))
-            } else if let Some(inner) = strip_delims(t, '\'') {
-                ("char".to_string(), format!("{:?}", decode_char(inner)))
-            } else if siblings.contains(t) {
-                let rust_ty = if is_real { "f64" } else { "i64" };
-                (
-                    rust_ty.to_string(),
-                    format!("Self::{}", naming::const_ident(t)),
-                )
-            } else if c.type_name == "Boolean" {
-                (
-                    "bool".to_string(),
-                    format!("{}", t.eq_ignore_ascii_case("true")),
-                )
-            } else {
-                // A bareword that is neither a sibling nor a boolean: emit as a
-                // string literal (verbatim), the safest total decoding.
-                ("&str".to_string(), format!("{t:?}"))
-            }
+            string_const_literal(s.trim(), &c.type_name, is_real, siblings)
         }
         serde_json::Value::Null | serde_json::Value::Array(_) | serde_json::Value::Object(_) => {
             ("&str".to_string(), "\"\"".to_string())
         }
     }
+}
+
+/// Decode a STRING-valued BMM constant to a Rust `(type, literal)` pair.
+///
+/// A quoted `"…"` is a `&str`, a quoted `'…'` a `char`, a bareword naming a
+/// sibling constant a `Self::OTHER` cross-reference, and a bareword under a
+/// `Boolean` type a bool. Anything else is emitted verbatim as a string
+/// literal — the safest total decoding.
+fn string_const_literal(
+    t: &str,
+    type_name: &str,
+    is_real: bool,
+    siblings: &BTreeSet<&str>,
+) -> (String, String) {
+    if let Some(inner) = strip_delims(t, '"') {
+        return ("&str".to_string(), format!("{:?}", decode_entities(inner)));
+    }
+    if let Some(inner) = strip_delims(t, '\'') {
+        return ("char".to_string(), format!("{:?}", decode_char(inner)));
+    }
+    if siblings.contains(t) {
+        let rust_ty = if is_real { "f64" } else { "i64" };
+        return (
+            rust_ty.to_string(),
+            format!("Self::{}", naming::const_ident(t)),
+        );
+    }
+    if type_name == "Boolean" {
+        return (
+            "bool".to_string(),
+            format!("{}", t.eq_ignore_ascii_case("true")),
+        );
+    }
+    ("&str".to_string(), format!("{t:?}"))
 }
 
 /// Strip a matching pair of delimiter characters (`"…"` or `'…'`) from `s`,

--- a/tools/openehr-codegen/src/render/emit_json.rs
+++ b/tools/openehr-codegen/src/render/emit_json.rs
@@ -217,6 +217,33 @@ pub(crate) fn emit_file(schemas: &[JsonSchema<'_>], krate: &str) -> String {
 /// monomorphization the hand-written typed dispatch uses for the same classes.
 const GENERIC_FILL: &str = "::serde_json::Value";
 
+/// Why a non-struct JSON type is unreachable as a `_type` dispatch key.
+///
+/// A newtype or literal-enum shape writes its BARE payload (no `_type` member
+/// — see `emit_serialize`), and an untagged enum carries no `_type` of its own
+/// either (the active variant's payload supplies it, and every such payload is
+/// itself an emitted struct with its own arm). Each is recorded in the emitted
+/// header, never silently dropped.
+///
+/// A struct yields `None`: it IS dispatchable, and the caller handles it.
+fn undispatchable(ty: &JsonType) -> Option<(String, &'static str)> {
+    match ty {
+        JsonType::Enum { rust, .. } => Some((
+            rust.clone(),
+            "untagged enum: the wire `_type` is the active variant's, which has its own arm",
+        )),
+        JsonType::Newtype { rust, .. } => Some((
+            rust.clone(),
+            "transparent newtype: serializes as its bare primitive payload, never `_type`-tagged",
+        )),
+        JsonType::EnumLiterals { rust, .. } => Some((
+            rust.clone(),
+            "BMM enumeration: a literal token/integer on the wire, never `_type`-tagged",
+        )),
+        JsonType::Struct { .. } => None,
+    }
+}
+
 /// Emit the generated `structural_check` dispatch file: `_type` → deserialize
 /// the node into that class's generated Rust type and discard the value, so the
 /// codec is the single structural-conformance authority for EVERY emitted class
@@ -258,25 +285,8 @@ pub(crate) fn emit_structural_file(schemas: &[JsonSchema<'_>]) -> String {
                     declared.entry(spec.clone()).or_insert(keys);
                     (spec, rust, generics)
                 }
-                JsonType::Enum { rust, .. } => {
-                    skipped.push((
-                        rust.clone(),
-                        "untagged enum: the wire `_type` is the active variant's, which has its own arm",
-                    ));
-                    continue;
-                }
-                JsonType::Newtype { rust, .. } => {
-                    skipped.push((
-                        rust.clone(),
-                        "transparent newtype: serializes as its bare primitive payload, never `_type`-tagged",
-                    ));
-                    continue;
-                }
-                JsonType::EnumLiterals { rust, .. } => {
-                    skipped.push((
-                        rust.clone(),
-                        "BMM enumeration: a literal token/integer on the wire, never `_type`-tagged",
-                    ));
+                other => {
+                    skipped.extend(undispatchable(other));
                     continue;
                 }
             };

--- a/tools/openehr-codegen/src/render/emit_opt.rs
+++ b/tools/openehr-codegen/src/render/emit_opt.rs
@@ -481,21 +481,32 @@ impl<'a> OptModel<'a> {
             });
         }
         for e in &elems {
-            let res = self.resolve(&e.type_name);
-            let rust_name = naming::field_ident(&e.name);
-            let (base, target) = Self::base_decl(&res, &e.type_name);
-            let is_hash = matches!(res, Resolved::Hash);
-            let is_gen_enum = matches!(res, Resolved::Gen(_, true));
-            let is_bool = matches!(res, Resolved::Primitive("bool"));
+            out.push(self.element_field(e));
+        }
+        out
+    }
 
-            let (decl_type, xml_field);
-            if is_hash {
-                decl_type = if e.optional {
-                    format!("Option<{base}>")
-                } else {
-                    base
-                };
-                xml_field = XmlField {
+    /// One element's generated field: its declared Rust type and its XML view.
+    ///
+    /// A single-valued reference to a generated enum is boxed — those slots
+    /// (`EXPR_ITEM`, `C_PRIMITIVE`, `STATE`) are recursive. A mandatory scalar
+    /// bool absent on the wire (openEHR `Interval` boundedness flags default
+    /// false) falls back to `false`, and some XSD-mandatory fields are omitted
+    /// by real-world OPT exports (Ocean/tool laxity), so they are defaulted
+    /// leniently — a wire adapter must ingest imperfect real OPTs.
+    fn element_field(&self, e: &crate::load::xsd::XsdElem) -> OptField {
+        let res = self.resolve(&e.type_name);
+        let rust_name = naming::field_ident(&e.name);
+        let (base, target) = Self::base_decl(&res, &e.type_name);
+
+        if matches!(res, Resolved::Hash) {
+            let decl_type = if e.optional {
+                format!("Option<{base}>")
+            } else {
+                base
+            };
+            return OptField {
+                xml: XmlField {
                     wire_name: e.name.clone(),
                     rust_name,
                     optional: e.optional,
@@ -504,51 +515,44 @@ impl<'a> OptModel<'a> {
                     map_value: Some("String".to_string()),
                     default: None,
                     nonempty: false,
-                };
-            } else {
-                // Box a single-valued reference to a generated enum: those slots
-                // (`EXPR_ITEM`, `C_PRIMITIVE`, `STATE`) are recursive.
-                let inner = if !e.multiple && is_gen_enum {
-                    format!("Box<{base}>")
-                } else {
-                    base
-                };
-                decl_type = if e.multiple {
-                    format!("Vec<{inner}>")
-                } else if e.optional {
-                    format!("Option<{inner}>")
-                } else {
-                    inner
-                };
-                // A mandatory scalar bool absent on the wire (openEHR `Interval`
-                // boundedness flags default false) → fall back to `false`. Some
-                // XSD-mandatory fields are omitted by real-world OPT exports
-                // (Ocean/tool laxity) — default them leniently so those templates
-                // still parse (a wire adapter must ingest imperfect real OPTs).
-                let default = if is_bool && !e.optional && !e.multiple {
-                    Some("false".to_string())
-                } else if !e.optional && !e.multiple {
-                    lenient_default(&e.name, &e.type_name, self.target.prelude)
-                } else {
-                    None
-                };
-                xml_field = XmlField {
-                    wire_name: e.name.clone(),
-                    rust_name,
-                    optional: e.optional && !e.multiple,
-                    multiple: e.multiple,
-                    target,
-                    map_value: None,
-                    default,
-                    nonempty: false,
-                };
-            }
-            out.push(OptField {
-                xml: xml_field,
+                },
                 decl_type,
-            });
+            };
         }
-        out
+
+        let inner = if !e.multiple && matches!(res, Resolved::Gen(_, true)) {
+            format!("Box<{base}>")
+        } else {
+            base
+        };
+        let decl_type = if e.multiple {
+            format!("Vec<{inner}>")
+        } else if e.optional {
+            format!("Option<{inner}>")
+        } else {
+            inner
+        };
+        let scalar = !e.optional && !e.multiple;
+        let default = if scalar && matches!(res, Resolved::Primitive("bool")) {
+            Some("false".to_string())
+        } else if scalar {
+            lenient_default(&e.name, &e.type_name, self.target.prelude)
+        } else {
+            None
+        };
+        OptField {
+            xml: XmlField {
+                wire_name: e.name.clone(),
+                rust_name,
+                optional: e.optional && !e.multiple,
+                multiple: e.multiple,
+                target,
+                map_value: None,
+                default,
+                nonempty: false,
+            },
+            decl_type,
+        }
     }
 
     /// The closure's `xs:enumeration`-faceted simple types, name-ordered.

--- a/tools/openehr-codegen/src/render/emit_rest.rs
+++ b/tools/openehr-codegen/src/render/emit_rest.rs
@@ -784,35 +784,67 @@ fn emit_struct(
          {deny_attr}pub struct {ty_name}{generics} {{\n"
     );
     for (pname, pschema) in props {
-        let ident = field_id(pname);
-        let mut ty = if generic_field == Some(pname.as_str()) {
-            "T".to_string()
-        } else {
-            ctx.rust_type(pschema)
-        };
-        if !required.contains(pname.as_str()) {
-            ty = format!("Option<{ty}>");
-        }
-        // A struct field is a public item `missing_docs` checks; the OAS
-        // property name is the honest, deterministic summary.
-        let _ = writeln!(b, "    /// The `{pname}` property of `{name}`.");
-        // A docs-text-wins correction carries its citation into the
-        // generated code (the OAS lists the field as required; the
-        // ITS-REST docs text wins).
-        if let Some(ov) = crate::plan::overrides::rest_optional_override(ty_name, pname) {
-            let _ = writeln!(b, "    /// OPTIONAL by the docs text — {}", ov.citation);
-            let _ = writeln!(b, "    /// ({})", ov.reason);
-        }
-        if let Some(rename) = naming::serde_rename(pname, &ident) {
-            let _ = writeln!(b, "    #[serde(rename = \"{rename}\")]");
-        }
-        if !required.contains(pname.as_str()) {
-            b.push_str(SKIP_NONE_ATTR);
-        }
-        let _ = writeln!(b, "    pub {ident}: {ty},");
+        emit_struct_field(
+            b,
+            StructField {
+                owner: name,
+                ty_name,
+                pname,
+                pschema,
+                is_generic: generic_field == Some(pname.as_str()),
+                is_required: required.contains(pname.as_str()),
+            },
+            ctx,
+        );
     }
     emit_additional_properties(b, name, schema, ctx);
     b.push_str("}\n\n");
+}
+
+/// One DTO field's emission inputs.
+#[derive(Clone, Copy)]
+struct StructField<'a> {
+    /// The OAS component schema name the field belongs to.
+    owner: &'a str,
+    /// The Rust type name of the emitted DTO.
+    ty_name: &'a str,
+    /// The OAS property name.
+    pname: &'a str,
+    /// The OAS property schema.
+    pschema: &'a Value,
+    /// Whether the field carries the DTO's generic parameter.
+    is_generic: bool,
+    /// Whether the field is required after the docs-text-wins corrections.
+    is_required: bool,
+}
+
+/// Emits one DTO field: its doc line, serde attributes and typed declaration.
+fn emit_struct_field(b: &mut String, f: StructField<'_>, ctx: &Ctx) {
+    let ident = field_id(f.pname);
+    let mut ty = if f.is_generic {
+        "T".to_string()
+    } else {
+        ctx.rust_type(f.pschema)
+    };
+    if !f.is_required {
+        ty = format!("Option<{ty}>");
+    }
+    // A struct field is a public item `missing_docs` checks; the OAS property
+    // name is the honest, deterministic summary.
+    let _ = writeln!(b, "    /// The `{}` property of `{}`.", f.pname, f.owner);
+    // A docs-text-wins correction carries its citation into the generated code
+    // (the OAS lists the field as required; the ITS-REST docs text wins).
+    if let Some(ov) = crate::plan::overrides::rest_optional_override(f.ty_name, f.pname) {
+        let _ = writeln!(b, "    /// OPTIONAL by the docs text — {}", ov.citation);
+        let _ = writeln!(b, "    /// ({})", ov.reason);
+    }
+    if let Some(rename) = naming::serde_rename(f.pname, &ident) {
+        let _ = writeln!(b, "    #[serde(rename = \"{rename}\")]");
+    }
+    if !f.is_required {
+        b.push_str(SKIP_NONE_ATTR);
+    }
+    let _ = writeln!(b, "    pub {ident}: {ty},");
 }
 
 /// Emit an OAS `discriminator.mapping` schema as a `_type`-dispatched enum.

--- a/tools/openehr-codegen/src/render/emit_rest.rs
+++ b/tools/openehr-codegen/src/render/emit_rest.rs
@@ -158,47 +158,57 @@ const GENERIC_OVER: &[(&str, &str)] = &[("UpdateVersion", "data")];
 
 /// The `$ref` names a schema reaches, skipping a genericized field's subtree.
 fn ref_names_of(name: &str, schema: &Value, out: &mut BTreeSet<String>) {
-    fn walk(v: &Value, skip_field: Option<&str>, out: &mut BTreeSet<String>) {
-        match v {
-            Value::Object(m) => {
-                if let Some(r) = m.get("$ref").and_then(Value::as_str)
-                    && let Some(n) = r.rsplit('/').next()
-                {
-                    out.insert(n.to_string());
-                }
-                for (k, val) in m {
-                    if skip_field == Some(k.as_str()) {
-                        continue;
-                    }
-                    // Only skip the generic field at the `properties` level;
-                    // pass the skip marker just one level below `properties`.
-                    if k == "properties"
-                        && let Value::Object(props) = val
-                    {
-                        for (pk, pv) in props {
-                            if skip_field == Some(pk.as_str()) {
-                                continue;
-                            }
-                            walk(pv, None, out);
-                        }
-                        continue;
-                    }
-                    walk(val, None, out);
-                }
-            }
-            Value::Array(a) => {
-                for item in a {
-                    walk(item, skip_field, out);
-                }
-            }
-            _ => {}
-        }
-    }
     let skip = GENERIC_OVER
         .iter()
         .find(|(n, _)| *n == name)
         .map(|(_, f)| *f);
-    walk(schema, skip, out);
+    walk_refs(schema, skip, out);
+}
+
+/// Walks a schema value collecting every `$ref` target name.
+///
+/// `skip_field` is dropped only at the `properties` level, so the marker is
+/// passed exactly one level below `properties` and nowhere else.
+fn walk_refs(v: &Value, skip_field: Option<&str>, out: &mut BTreeSet<String>) {
+    match v {
+        Value::Object(m) => {
+            if let Some(r) = m.get("$ref").and_then(Value::as_str)
+                && let Some(n) = r.rsplit('/').next()
+            {
+                out.insert(n.to_string());
+            }
+            for (k, val) in m {
+                if skip_field == Some(k.as_str()) {
+                    continue;
+                }
+                match val {
+                    Value::Object(props) if k == "properties" => {
+                        walk_property_refs(props, skip_field, out);
+                    }
+                    _ => walk_refs(val, None, out),
+                }
+            }
+        }
+        Value::Array(a) => {
+            for item in a {
+                walk_refs(item, skip_field, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Walks a `properties` map, skipping the genericized field's subtree.
+fn walk_property_refs(
+    props: &serde_json::Map<String, Value>,
+    skip_field: Option<&str>,
+    out: &mut BTreeSet<String>,
+) {
+    for (pk, pv) in props {
+        if skip_field != Some(pk.as_str()) {
+            walk_refs(pv, None, out);
+        }
+    }
 }
 
 /// A canonical (key-sorted) representation for schema-identity comparison.
@@ -450,47 +460,51 @@ struct Ctx<'a> {
 }
 
 impl Ctx<'_> {
+    /// Map a `$ref` schema to its Rust type.
+    ///
+    /// A schema whose KEY does not match its class — the released bundles
+    /// rename `CLUSTER` to `Clstr` and give every generic INSTANTIATION its own
+    /// flat key — is resolved through the monomorphization map read from each
+    /// schema's own `title` (see `plan::overrides::OAS_MONOMORPHIZATIONS`);
+    /// without it these emit as `allOf`-truncated DTOs that drop their
+    /// inherited members and the spec type's strict reader.
+    ///
+    /// RM/BASE spec types resolve to the TYPED spec structs: since the
+    /// foundation rewrite (#1702) every spec type carries emitted manual
+    /// `serde::Serialize`/`Deserialize` impls (its crate's `json_serde.rs`),
+    /// and those impls ARE the strict canonical-JSON reader — so a typed field
+    /// is strict by construction where an untyped `Value` silently accepted
+    /// anything (#1712). A GENERIC-over hoisted schema has a group-local alias
+    /// (bare name); every other hoisted schema lives in `super::common`. A ref
+    /// to something emitted nowhere is resolved and mapped structurally.
+    fn ref_type(&self, name: &str, schema: &Value) -> String {
+        if let Some(spec) = oas_monomorphization(name) {
+            return spec.to_string();
+        }
+        if let Some(path) = self.names.rm.get(name) {
+            return path.clone();
+        }
+        if let Some(path) = self.names.base.get(name) {
+            return path.clone();
+        }
+        if self.hoisted.contains(name) && !self.in_common {
+            if GENERIC_OVER.iter().any(|(n, _)| *n == name) {
+                return dto_type(name);
+            }
+            return format!("super::common::{}", dto_type(name));
+        }
+        if self.dtos.contains(name) {
+            return dto_type(name);
+        }
+        self.rust_type(self.oas.resolve(schema))
+    }
+
     /// Map an OAS schema to a Rust type. RM `$ref`s resolve to the spec crate
     /// preludes; local DTO refs to the bare name; unknown/complex shapes degrade
     /// to `serde_json::Value` (the same honest fallback the BMM emitter uses).
     fn rust_type(&self, schema: &Value) -> String {
-        // A `$ref` (possibly to a name we resolve without following it).
         if let Some(name) = Oas::ref_name(schema) {
-            // A schema whose KEY does not match its class — the released
-            // bundles rename `CLUSTER` to `Clstr` and give every generic
-            // INSTANTIATION its own flat key. The mapping is read from each
-            // schema's own `title` (see `plan::overrides::OAS_MONOMORPHIZATIONS`);
-            // without it these emit as `allOf`-truncated DTOs that drop their
-            // inherited members and the spec type's strict reader.
-            if let Some(spec) = oas_monomorphization(&name) {
-                return spec.to_string();
-            }
-            // RM/BASE spec types resolve to the TYPED spec structs: since the
-            // foundation rewrite (#1702) every spec type carries emitted manual
-            // `serde::Serialize`/`Deserialize` impls (its crate's
-            // `json_serde.rs`), and those impls ARE the strict canonical-JSON
-            // reader — so a typed field is strict by construction where an
-            // untyped `Value` silently accepted anything (issue #1712; the
-            // former "no serde derive" rationale this branch carried is gone).
-            if let Some(path) = self.names.rm.get(&name) {
-                return path.clone();
-            }
-            if let Some(path) = self.names.base.get(&name) {
-                return path.clone();
-            }
-            if self.hoisted.contains(&name) && !self.in_common {
-                // A GENERIC-over schema has a group-local alias (bare name);
-                // every other hoisted schema lives in `super::common`.
-                if GENERIC_OVER.iter().any(|(n, _)| *n == name) {
-                    return dto_type(&name);
-                }
-                return format!("super::common::{}", dto_type(&name));
-            }
-            if self.dtos.contains(&name) {
-                return dto_type(&name);
-            }
-            // A ref to something not emitted anywhere → resolve + map structurally.
-            return self.rust_type(self.oas.resolve(schema));
+            return self.ref_type(&name, schema);
         }
         // `allOf` COMPOSITION. A schema whose only structural content is a
         // single-`$ref` `allOf` is a pure alias for its referent — OAS 3.0

--- a/tools/openehr-codegen/src/render/emit_xml.rs
+++ b/tools/openehr-codegen/src/render/emit_xml.rs
@@ -279,78 +279,8 @@ pub(crate) fn emit_to_xml(
             generics,
             fields,
         } => {
-            let (hdr, args) = generic_header(generics, "crate::xml::runtime::ToXml");
-            let by_wire: BTreeMap<&str, &XmlField> =
-                fields.iter().map(|f| (f.wire_name.as_str(), f)).collect();
-            let _ = write!(
-                b,
-                "impl{hdr} crate::xml::runtime::ToXml for {path}::{rust}{args} {{\n\
-                 fn xml_type_name(&self) -> &'static str {{ \"{spec}\" }}\n\
-                 fn write_xml(&self, w: &mut crate::xml::runtime::XmlWriter, tag: &str, declared: Option<&str>) -> Result<(), crate::xml::runtime::XmlError> {{\n\
-                 let mut __attrs: Vec<(&str, String)> = Vec::new();\n\
-                 if let Some(d) = declared {{ if d != \"{spec}\" {{ __attrs.push((\"xsi:type\", \"{spec}\".to_string())); }} }}\n"
-            );
-            // Wire order + attr/element split from the XSD; else BMM order, no attrs.
-            let (attrs, mut elems): (Vec<String>, Vec<String>) = if xsd.types.contains_key(spec) {
-                let (a, e) = xsd.flattened(spec);
-                (
-                    a.iter().map(|x| x.name.clone()).collect(),
-                    e.iter().map(|x| x.name.clone()).collect(),
-                )
-            } else {
-                (
-                    Vec::new(),
-                    fields.iter().map(|f| f.wire_name.clone()).collect(),
-                )
-            };
-            // append any allowlisted BMM-only field (no XSD slot) as a
-            // deterministic trailing element in BMM order, so it is not dropped.
-            // (Non-allowlisted BMM-only fields already failed the guard above.)
-            for f in bmm_only_fields(spec, fields, xsd) {
-                elems.push(f.wire_name.clone());
-            }
-            // A validated class's fields are `pub(crate)` (the construction-door
-            // scheme), so this codec — a different crate — reads them through the
-            // emitted accessor.
-            let validated = construction::is_validated(spec);
-            let read = |f: &XmlField| {
-                if validated {
-                    format!("{}()", f.rust_name)
-                } else {
-                    f.rust_name.clone()
-                }
-            };
-            for aname in &attrs {
-                if let Some(f) = by_wire.get(aname.as_str()) {
-                    if f.optional {
-                        let _ = writeln!(
-                            b,
-                            "if let Some(v) = &self.{} {{ __attrs.push((\"{}\", v.to_string())); }}",
-                            read(f),
-                            f.wire_name
-                        );
-                    } else {
-                        let _ = writeln!(
-                            b,
-                            "__attrs.push((\"{}\", self.{}.to_string()));",
-                            f.wire_name,
-                            read(f)
-                        );
-                    }
-                } else {
-                    unmatched.push((spec.clone(), aname.clone()));
-                }
-            }
-            b.push_str("let mut __e = quick_xml::events::BytesStart::new(tag);\n");
-            b.push_str("for (k, v) in &__attrs { __e.push_attribute((*k, v.as_str())); }\n");
-            b.push_str("w.write_start(__e)?;\n");
-            for ename in &elems {
-                match by_wire.get(ename.as_str()) {
-                    Some(f) => emit_write_field(b, f, validated),
-                    None => unmatched.push((spec.clone(), ename.clone())),
-                }
-            }
-            b.push_str("w.write_end(tag)?;\nOk(())\n}\n}\n\n");
+            let target = XmlTarget { spec, rust, path };
+            emit_struct_to_xml(b, &target, generics, fields, xsd, unmatched);
         }
         XmlType::Enum {
             rust,
@@ -406,6 +336,89 @@ pub(crate) fn emit_to_xml(
                  {text}\n}}\n}}\n\n"
             );
         }
+    }
+}
+
+/// Emits `impl ToXml` for a struct: the `xsi:type` attribute, the XSD-ordered
+/// attributes, and the elements.
+///
+/// Wire order and the attribute/element split come from the XSD; a type the
+/// XSD does not cover falls back to BMM order with no attributes. Any
+/// allowlisted BMM-only field (no XSD slot) is appended as a deterministic
+/// trailing element in BMM order so it is never dropped — a non-allowlisted
+/// one has already failed the emitter guard.
+fn emit_struct_to_xml(
+    b: &mut String,
+    target: &XmlTarget<'_>,
+    generics: &[String],
+    fields: &[XmlField],
+    xsd: &XsdModel,
+    unmatched: &mut Vec<(String, String)>,
+) {
+    let (hdr, args) = generic_header(generics, "crate::xml::runtime::ToXml");
+    let (spec, rust, path) = (target.spec, target.rust, target.path);
+    let by_wire: BTreeMap<&str, &XmlField> =
+        fields.iter().map(|f| (f.wire_name.as_str(), f)).collect();
+    let _ = write!(
+        b,
+        "impl{hdr} crate::xml::runtime::ToXml for {path}::{rust}{args} {{\n\
+         fn xml_type_name(&self) -> &'static str {{ \"{spec}\" }}\n\
+         fn write_xml(&self, w: &mut crate::xml::runtime::XmlWriter, tag: &str, declared: Option<&str>) -> Result<(), crate::xml::runtime::XmlError> {{\n\
+         let mut __attrs: Vec<(&str, String)> = Vec::new();\n\
+         if let Some(d) = declared {{ if d != \"{spec}\" {{ __attrs.push((\"xsi:type\", \"{spec}\".to_string())); }} }}\n"
+    );
+    let (attrs, mut elems): (Vec<String>, Vec<String>) = if xsd.types.contains_key(spec) {
+        let (a, e) = xsd.flattened(spec);
+        (
+            a.iter().map(|x| x.name.clone()).collect(),
+            e.iter().map(|x| x.name.clone()).collect(),
+        )
+    } else {
+        (
+            Vec::new(),
+            fields.iter().map(|f| f.wire_name.clone()).collect(),
+        )
+    };
+    for f in bmm_only_fields(spec, fields, xsd) {
+        elems.push(f.wire_name.clone());
+    }
+    // A validated class's fields are `pub(crate)` (the construction-door
+    // scheme), so this codec — a different crate — reads them through the
+    // emitted accessor.
+    let validated = construction::is_validated(spec);
+    for aname in &attrs {
+        match by_wire.get(aname.as_str()) {
+            Some(f) => emit_write_attr(b, f, validated),
+            None => unmatched.push((spec.to_owned(), aname.clone())),
+        }
+    }
+    b.push_str("let mut __e = quick_xml::events::BytesStart::new(tag);\n");
+    b.push_str("for (k, v) in &__attrs { __e.push_attribute((*k, v.as_str())); }\n");
+    b.push_str("w.write_start(__e)?;\n");
+    for ename in &elems {
+        match by_wire.get(ename.as_str()) {
+            Some(f) => emit_write_field(b, f, validated),
+            None => unmatched.push((spec.to_owned(), ename.clone())),
+        }
+    }
+    b.push_str("w.write_end(tag)?;\nOk(())\n}\n}\n\n");
+}
+
+/// Pushes one XSD attribute onto the start tag's attribute list.
+fn emit_write_attr(b: &mut String, f: &XmlField, validated: bool) {
+    let read = if validated {
+        format!("{}()", f.rust_name)
+    } else {
+        f.rust_name.clone()
+    };
+    let wire = &f.wire_name;
+    if f.optional {
+        let _ = writeln!(
+            b,
+            "if let Some(v) = &self.{read} {{ __attrs.push((\"{wire}\", v.to_string())); }}"
+        );
+    } else {
+        let _ = writeln!(b, "__attrs.push((\"{wire}\", self.{read}.to_string()));");
     }
 }
 

--- a/tools/openehr-codegen/src/render/emit_xml.rs
+++ b/tools/openehr-codegen/src/render/emit_xml.rs
@@ -437,32 +437,7 @@ fn emit_write_field(b: &mut String, f: &XmlField, validated: bool) {
     // `<name id="key">value</name>` wire shape; only the map container differs,
     // and both iterate as `(k, v)` here.
     if f.target == "Hash" || f.target == "OrderedDict" {
-        let rust = accessor(&f.rust_name);
-        let (name, rust) = (&f.wire_name, &rust);
-        if f.map_value.as_deref() == Some("String") {
-            // `Hash<String, String>` → repeated `<name id="key">value</name>`
-            // (the openEHR `StringDictionaryItem` shape).
-            if f.optional {
-                let _ = writeln!(
-                    b,
-                    "if let Some(m) = &self.{rust} {{ for (k, v) in m {{ w.write_kv_element(\"{name}\", k, v)?; }} }}"
-                );
-            } else {
-                let _ = writeln!(
-                    b,
-                    "for (k, v) in &self.{rust} {{ w.write_kv_element(\"{name}\", k, v)?; }}"
-                );
-            }
-        } else {
-            // `Hash<String, ComplexType>` (translations, RESOURCE_ANNOTATIONS):
-            // archetype-resource metadata serialized via ADL/AOM, off the RM
-            // canonical-XML wire; its RM-XML shape is not spec-defined here.
-            let _ = writeln!(
-                b,
-                "// NOTE: Hash<String, {}> field `{rust}` is off the RM canonical-XML wire (resource metadata); not serialized.",
-                f.map_value.as_deref().unwrap_or("?")
-            );
-        }
+        emit_write_map_field(b, f, &accessor(&f.rust_name));
         return;
     }
     let rust = accessor(&f.rust_name);
@@ -492,6 +467,35 @@ fn emit_write_field(b: &mut String, f: &XmlField, validated: bool) {
         let _ = writeln!(
             b,
             "self.{rust}.write_xml(w, \"{name}\", Some(\"{target}\"))?;"
+        );
+    }
+}
+
+/// Emits the write half of a map-typed field.
+///
+/// `Hash<String, String>` writes repeated `<name id="key">value</name>` (the
+/// openEHR `StringDictionaryItem` shape). A complex map value (translations,
+/// `RESOURCE_ANNOTATIONS`) is archetype-resource metadata serialized via
+/// ADL/AOM, off the RM canonical-XML wire, so it is not serialized at all.
+fn emit_write_map_field(b: &mut String, f: &XmlField, rust: &str) {
+    let name = &f.wire_name;
+    if f.map_value.as_deref() != Some("String") {
+        let _ = writeln!(
+            b,
+            "// NOTE: Hash<String, {}> field `{rust}` is off the RM canonical-XML wire (resource metadata); not serialized.",
+            f.map_value.as_deref().unwrap_or("?")
+        );
+        return;
+    }
+    if f.optional {
+        let _ = writeln!(
+            b,
+            "if let Some(m) = &self.{rust} {{ for (k, v) in m {{ w.write_kv_element(\"{name}\", k, v)?; }} }}"
+        );
+    } else {
+        let _ = writeln!(
+            b,
+            "for (k, v) in &self.{rust} {{ w.write_kv_element(\"{name}\", k, v)?; }}"
         );
     }
 }

--- a/tools/openehr-codegen/src/render/emit_xml.rs
+++ b/tools/openehr-codegen/src/render/emit_xml.rs
@@ -501,193 +501,8 @@ pub(crate) fn emit_from_xml(
             generics,
             fields,
         } => {
-            let (hdr, args) = generic_header(generics, "crate::xml::runtime::FromXml");
-            let attrs = attr_names(spec, xsd);
-            let is_attr = |f: &XmlField| attrs.contains(&f.wire_name);
-            // `Hash<String, String>` / `OrderedDict` are parsed inline
-            // (StringDictionaryItem); `Hash<String, ComplexType>` is off-wire and
-            // defaulted. `OrderedDict` (OPT `opt14`) accumulates into an
-            // order-preserving `IndexMap`; `Hash` (RM) into a `BTreeMap`.
-            let is_str_hash = |f: &XmlField| {
-                (f.target == "Hash" || f.target == "OrderedDict")
-                    && f.map_value.as_deref() == Some("String")
-            };
-            let is_cplx_hash =
-                |f: &XmlField| f.target == "Hash" && f.map_value.as_deref() != Some("String");
-            let _ = write!(
-                b,
-                "impl{hdr} crate::xml::runtime::FromXml for {path}::{rust}{args} {{\n\
-                 fn from_xml(reader: &mut crate::xml::runtime::XmlReader, start: &crate::xml::runtime::StartTag) -> Result<Self, crate::xml::runtime::XmlError> {{\n"
-            );
-            // Accumulators for element fields. Types are intentionally left to
-            // inference — each `__x` is pinned by its construction site below
-            // (`field: __x…`), so boxing and type overrides resolve without
-            // naming (and repeating the import of) the field type here.
-            for f in fields.iter().filter(|f| !is_attr(f) && !is_cplx_hash(f)) {
-                let var = acc_var(&f.rust_name);
-                if is_str_hash(f) {
-                    if f.target == "OrderedDict" {
-                        let _ = writeln!(b, "let mut {var} = indexmap::IndexMap::new();");
-                    } else {
-                        let _ = writeln!(b, "let mut {var} = std::collections::BTreeMap::new();");
-                    }
-                } else if f.multiple {
-                    let _ = writeln!(b, "let mut {var} = Vec::new();");
-                } else {
-                    let _ = writeln!(b, "let mut {var} = None;");
-                }
-            }
-            b.push_str("loop { match reader.read()? {\n");
-            b.push_str("crate::xml::runtime::XmlEvent::Start(__c) => match __c.name.as_str() {\n");
-            for f in fields.iter().filter(|f| !is_attr(f) && !is_cplx_hash(f)) {
-                let var = acc_var(&f.rust_name);
-                if is_str_hash(f) {
-                    // StringDictionaryItem: `<name id="key">value</name>`.
-                    let _ = writeln!(
-                        b,
-                        "\"{}\" => {{ let __k = __c.attr(\"id\").unwrap_or(\"\").to_string(); let __v: String = crate::xml::runtime::FromXml::from_xml(reader, &__c)?; {var}.insert(__k, __v); }}",
-                        f.wire_name
-                    );
-                } else if f.multiple {
-                    let _ = writeln!(
-                        b,
-                        "\"{}\" => {{ {var}.push(crate::xml::runtime::FromXml::from_xml(reader, &__c)?); }}",
-                        f.wire_name
-                    );
-                } else {
-                    let _ = writeln!(
-                        b,
-                        "\"{}\" => {{ {var} = Some(crate::xml::runtime::FromXml::from_xml(reader, &__c)?); }}",
-                        f.wire_name
-                    );
-                }
-            }
-            b.push_str("_ => reader.skip_element()?,\n},\n");
-            b.push_str("crate::xml::runtime::XmlEvent::End => break,\n");
-            b.push_str("crate::xml::runtime::XmlEvent::Text(_) => {}\n");
-            b.push_str("crate::xml::runtime::XmlEvent::Eof => return Err(crate::xml::runtime::XmlError::Parse(\"unexpected EOF\".into())),\n");
-            b.push_str("} }\n");
-            // Construct. Each field's value expression is built first, so a
-            // class with a validating construction door (`plan::construction`)
-            // can hand the same expressions to its constructor instead of a
-            // struct literal — one read path, one grammar.
-            let mut values: Vec<(String, String)> = Vec::new();
-            for f in fields {
-                let fname = &f.rust_name;
-                let expr = if is_attr(f) {
-                    if f.optional {
-                        format!("start.attr(\"{}\").map(|s| s.to_string())", f.wire_name)
-                    } else {
-                        format!(
-                            "start.attr(\"{}\").ok_or_else(|| crate::xml::runtime::XmlError::Parse(\"missing attribute {}\".into()))?.to_string()",
-                            f.wire_name, f.wire_name
-                        )
-                    }
-                } else if is_cplx_hash(f) {
-                    "Default::default()".to_owned()
-                } else if is_str_hash(f) {
-                    let var = acc_var(fname);
-                    if f.optional {
-                        format!("if {var}.is_empty() {{ None }} else {{ Some({var}) }}")
-                    } else {
-                        var
-                    }
-                } else if f.multiple && f.optional {
-                    // Zero occurrences of a repeated element is indistinguishable
-                    // from the attribute's absence in XML, so it reads back as
-                    // `None` (see `emit_write_field`). A present-implies-non-empty
-                    // field (`Option<NonEmptyVec<T>>`, #1730) builds through the
-                    // fallible constructor — the branch guarantees non-emptiness,
-                    // so the error arm is unreachable but honest.
-                    let var = acc_var(fname);
-                    if f.nonempty {
-                        format!(
-                            "if {var}.is_empty() {{ None }} else {{ Some(openehr_base::containers::NonEmptyVec::new({var}).map_err(|__e| crate::xml::runtime::XmlError::Parse(::std::format!(\"element {}: {{__e}}\", ).into()))?) }}",
-                            f.wire_name
-                        )
-                    } else {
-                        format!("if {var}.is_empty() {{ None }} else {{ Some({var}) }}")
-                    }
-                } else if f.nonempty {
-                    // A `1..*` container goes through its own constructor, so a
-                    // document with zero occurrences is refused at parse.
-                    format!(
-                        "openehr_base::containers::NonEmptyVec::new({}).map_err(|__e| crate::xml::runtime::XmlError::Parse(::std::format!(\"element {}: {{__e}}\", ).into()))?",
-                        acc_var(fname),
-                        f.wire_name
-                    )
-                } else if f.multiple || f.optional {
-                    acc_var(fname)
-                } else if let Some(default) = &f.default {
-                    // Mandatory field archie omits at its default (Interval flags):
-                    // use the default when the element is absent.
-                    format!("{}.unwrap_or({default})", acc_var(fname))
-                } else {
-                    format!(
-                        "{}.ok_or_else(|| crate::xml::runtime::XmlError::Parse(\"missing element {}\".into()))?",
-                        acc_var(fname),
-                        f.wire_name
-                    )
-                };
-                values.push((fname.clone(), expr));
-            }
-            if let Some((params, fallible)) = construction::validated_ctor(spec) {
-                {
-                    assert_eq!(
-                        params.len(),
-                        values.len(),
-                        "construction map declares {} constructor parameter(s) for {spec}, \
-                         but the XML field view has {} field(s)",
-                        params.len(),
-                        values.len()
-                    );
-                    // Bind each read BY FIELD NAME to a local of the
-                    // constructor's DECLARED parameter type (no inference
-                    // ambiguity), calling in the table's declared order — one
-                    // canonical door signature across generations whose BMMs
-                    // declare the fields in different orders.
-                    let mut names = Vec::new();
-                    for (i, (param, ty)) in params.iter().enumerate() {
-                        let Some((_, expr)) = values.iter().find(|(fname, _)| fname == param)
-                        else {
-                            panic!(
-                                "construction map parameter {param:?} of {spec} names no \
-                                 XML field (fields: {:?})",
-                                values.iter().map(|(f, _)| f).collect::<Vec<_>>()
-                            )
-                        };
-                        let ty = if let Some(env) = door_env {
-                            door_param(env, ty)
-                        } else {
-                            assert!(
-                                !ty.starts_with('@'),
-                                "door class {spec} with a @-typed parameter emitted without \
-                                 a door environment (an emit-opt closure generating a door \
-                                 class is a table/closure bug)"
-                            );
-                            (*ty).to_owned()
-                        };
-                        let _ = writeln!(b, "let __a{i}: {ty} = {expr};");
-                        names.push(format!("__a{i}"));
-                    }
-                    let args = names.join(", ");
-                    if fallible {
-                        let _ = writeln!(
-                            b,
-                            "{path}::{rust}::new({args}).map_err(|__e| crate::xml::runtime::XmlError::Parse(::std::format!(\"{spec}: {{__e}}\").into()))"
-                        );
-                    } else {
-                        let _ = writeln!(b, "Ok({path}::{rust}::new({args}))");
-                    }
-                }
-            } else {
-                let _ = writeln!(b, "Ok({path}::{rust} {{");
-                for (fname, expr) in &values {
-                    let _ = writeln!(b, "{fname}: {expr},");
-                }
-                b.push_str("})\n");
-            }
-            b.push_str("}\n}\n\n");
+            let target = XmlTarget { spec, rust, path };
+            emit_struct_from_xml(b, &target, generics, fields, xsd, door_env);
         }
         XmlType::Enum {
             spec,
@@ -696,42 +511,8 @@ pub(crate) fn emit_from_xml(
             dispatch,
             ..
         } => {
-            let (hdr, args) = generic_header(generics, "crate::xml::runtime::FromXml");
-            let self_ident = dispatch
-                .iter()
-                .find(|(x, _)| x == spec)
-                .map(|(_, i)| i.clone());
-            let _ = write!(
-                b,
-                "impl{hdr} crate::xml::runtime::FromXml for {path}::{rust}{args} {{\n\
-                 fn from_xml(reader: &mut crate::xml::runtime::XmlReader, start: &crate::xml::runtime::StartTag) -> Result<Self, crate::xml::runtime::XmlError> {{\n\
-                 match start.xsi_type() {{\n"
-            );
-            for (xsi, ident) in dispatch {
-                let _ = writeln!(
-                    b,
-                    "Some(\"{xsi}\") => Ok({path}::{rust}::{ident}(crate::xml::runtime::FromXml::from_xml(reader, start)?)),"
-                );
-            }
-            match self_ident {
-                Some(ident) => {
-                    let _ = writeln!(
-                        b,
-                        "None => Ok({path}::{rust}::{ident}(crate::xml::runtime::FromXml::from_xml(reader, start)?)),"
-                    );
-                }
-                None => {
-                    let _ = writeln!(
-                        b,
-                        "None => Err(crate::xml::runtime::XmlError::Parse(\"{rust}: missing xsi:type\".into())),"
-                    );
-                }
-            }
-            let _ = writeln!(
-                b,
-                "Some(other) => Err(crate::xml::runtime::XmlError::Parse(format!(\"{rust}: unknown xsi:type {{other}}\"))),"
-            );
-            b.push_str("}\n}\n}\n\n");
+            let target = XmlTarget { spec, rust, path };
+            emit_enum_from_xml(b, &target, generics, dispatch);
         }
         XmlType::Newtype { rust, .. } => {
             let _ = write!(
@@ -765,4 +546,352 @@ pub(crate) fn emit_from_xml(
             );
         }
     }
+}
+
+/// The item one `FromXml` impl is emitted for: its openEHR spec name, its Rust
+/// identifier, and the module path the identifier lives at.
+struct XmlTarget<'a> {
+    spec: &'a str,
+    rust: &'a str,
+    path: &'a str,
+}
+
+/// How one field of a struct is read back off the wire.
+enum ReadShape {
+    /// An XSD attribute on the type's own start tag.
+    Attribute,
+    /// `Hash<String, ComplexType>` — off-wire, so it reads back as the default.
+    ComplexHash,
+    /// `Hash<String, String>` / `OrderedDict`, parsed inline as the openEHR
+    /// `StringDictionaryItem` shape. `OrderedDict` (OPT `opt14`) accumulates
+    /// into an order-preserving `IndexMap`, `Hash` (RM) into a `BTreeMap`.
+    StringHash { ordered: bool },
+    /// A repeated child element.
+    Multiple,
+    /// A single child element.
+    Single,
+}
+
+/// Classifies how one field of an XSD-covered struct is read back.
+fn read_shape(f: &XmlField, attrs: &BTreeSet<String>) -> ReadShape {
+    if attrs.contains(&f.wire_name) {
+        return ReadShape::Attribute;
+    }
+    let is_dict = f.target == "Hash" || f.target == "OrderedDict";
+    if is_dict && f.map_value.as_deref() == Some("String") {
+        return ReadShape::StringHash {
+            ordered: f.target == "OrderedDict",
+        };
+    }
+    if f.target == "Hash" {
+        return ReadShape::ComplexHash;
+    }
+    if f.multiple {
+        return ReadShape::Multiple;
+    }
+    ReadShape::Single
+}
+
+/// Emits `impl FromXml` for a struct: accumulators, the child-element read
+/// loop, and the construction that consumes them.
+fn emit_struct_from_xml(
+    b: &mut String,
+    target: &XmlTarget<'_>,
+    generics: &[String],
+    fields: &[XmlField],
+    xsd: &XsdModel,
+    door_env: Option<&XmlSchema<'_>>,
+) {
+    let (hdr, args) = generic_header(generics, "crate::xml::runtime::FromXml");
+    let attrs = attr_names(target.spec, xsd);
+    let (path, rust) = (target.path, target.rust);
+    let _ = write!(
+        b,
+        "impl{hdr} crate::xml::runtime::FromXml for {path}::{rust}{args} {{\n\
+         fn from_xml(reader: &mut crate::xml::runtime::XmlReader, start: &crate::xml::runtime::StartTag) -> Result<Self, crate::xml::runtime::XmlError> {{\n"
+    );
+    emit_read_accumulators(b, fields, &attrs);
+    emit_read_loop(b, fields, &attrs);
+    // Each field's value expression is built first, so a class with a
+    // validating construction door (`plan::construction`) can hand the same
+    // expressions to its constructor instead of a struct literal — one read
+    // path, one grammar.
+    let values: Vec<(String, String)> = fields
+        .iter()
+        .map(|f| (f.rust_name.clone(), read_expr(f, &attrs)))
+        .collect();
+    emit_read_construction(b, target, &values, door_env);
+    b.push_str("}\n}\n\n");
+}
+
+/// Declares one accumulator local per element field.
+///
+/// Their types are deliberately left to inference — each `__x` is pinned by
+/// its construction site (`field: __x…`), so boxing and type overrides resolve
+/// without naming (and re-importing) the field type here.
+fn emit_read_accumulators(b: &mut String, fields: &[XmlField], attrs: &BTreeSet<String>) {
+    for f in fields {
+        let var = acc_var(&f.rust_name);
+        match read_shape(f, attrs) {
+            ReadShape::Attribute | ReadShape::ComplexHash => {}
+            ReadShape::StringHash { ordered: true } => {
+                let _ = writeln!(b, "let mut {var} = indexmap::IndexMap::new();");
+            }
+            ReadShape::StringHash { ordered: false } => {
+                let _ = writeln!(b, "let mut {var} = std::collections::BTreeMap::new();");
+            }
+            ReadShape::Multiple => {
+                let _ = writeln!(b, "let mut {var} = Vec::new();");
+            }
+            ReadShape::Single => {
+                let _ = writeln!(b, "let mut {var} = None;");
+            }
+        }
+    }
+}
+
+/// Emits the event loop that dispatches each child element into its
+/// accumulator, skipping elements the type does not declare.
+fn emit_read_loop(b: &mut String, fields: &[XmlField], attrs: &BTreeSet<String>) {
+    b.push_str("loop { match reader.read()? {\n");
+    b.push_str("crate::xml::runtime::XmlEvent::Start(__c) => match __c.name.as_str() {\n");
+    for f in fields {
+        let var = acc_var(&f.rust_name);
+        let wire = &f.wire_name;
+        match read_shape(f, attrs) {
+            ReadShape::Attribute | ReadShape::ComplexHash => {}
+            // StringDictionaryItem: `<name id="key">value</name>`.
+            ReadShape::StringHash { .. } => {
+                let _ = writeln!(
+                    b,
+                    "\"{wire}\" => {{ let __k = __c.attr(\"id\").unwrap_or(\"\").to_string(); let __v: String = crate::xml::runtime::FromXml::from_xml(reader, &__c)?; {var}.insert(__k, __v); }}"
+                );
+            }
+            ReadShape::Multiple => {
+                let _ = writeln!(
+                    b,
+                    "\"{wire}\" => {{ {var}.push(crate::xml::runtime::FromXml::from_xml(reader, &__c)?); }}"
+                );
+            }
+            ReadShape::Single => {
+                let _ = writeln!(
+                    b,
+                    "\"{wire}\" => {{ {var} = Some(crate::xml::runtime::FromXml::from_xml(reader, &__c)?); }}"
+                );
+            }
+        }
+    }
+    b.push_str("_ => reader.skip_element()?,\n},\n");
+    b.push_str("crate::xml::runtime::XmlEvent::End => break,\n");
+    b.push_str("crate::xml::runtime::XmlEvent::Text(_) => {}\n");
+    b.push_str("crate::xml::runtime::XmlEvent::Eof => return Err(crate::xml::runtime::XmlError::Parse(\"unexpected EOF\".into())),\n");
+    b.push_str("} }\n");
+}
+
+/// The Rust expression that yields one field's value once the read loop has
+/// finished.
+fn read_expr(f: &XmlField, attrs: &BTreeSet<String>) -> String {
+    match read_shape(f, attrs) {
+        ReadShape::Attribute => attr_read_expr(f),
+        ReadShape::ComplexHash => "Default::default()".to_owned(),
+        ReadShape::StringHash { .. } => {
+            let var = acc_var(&f.rust_name);
+            if f.optional {
+                format!("if {var}.is_empty() {{ None }} else {{ Some({var}) }}")
+            } else {
+                var
+            }
+        }
+        ReadShape::Multiple | ReadShape::Single => element_read_expr(f),
+    }
+}
+
+/// The value expression for a field carried as an XSD attribute.
+fn attr_read_expr(f: &XmlField) -> String {
+    let wire = &f.wire_name;
+    if f.optional {
+        format!("start.attr(\"{wire}\").map(|s| s.to_string())")
+    } else {
+        format!(
+            "start.attr(\"{wire}\").ok_or_else(|| crate::xml::runtime::XmlError::Parse(\"missing attribute {wire}\".into()))?.to_string()"
+        )
+    }
+}
+
+/// The value expression for a field carried as one or more child elements.
+fn element_read_expr(f: &XmlField) -> String {
+    let var = acc_var(&f.rust_name);
+    let wire = &f.wire_name;
+    let nonempty_new = format!(
+        "openehr_base::containers::NonEmptyVec::new({var}).map_err(|__e| crate::xml::runtime::XmlError::Parse(::std::format!(\"element {wire}: {{__e}}\", ).into()))?"
+    );
+    if f.multiple && f.optional {
+        // Zero occurrences of a repeated element is indistinguishable from the
+        // attribute's absence in XML, so it reads back as `None` (see
+        // `emit_write_field`). A present-implies-non-empty field
+        // (`Option<NonEmptyVec<T>>`, #1730) builds through the fallible
+        // constructor — the branch guarantees non-emptiness, so the error arm
+        // is unreachable but honest.
+        let some = if f.nonempty {
+            nonempty_new
+        } else {
+            var.clone()
+        };
+        return format!("if {var}.is_empty() {{ None }} else {{ Some({some}) }}");
+    }
+    if f.nonempty {
+        // A `1..*` container goes through its own constructor, so a document
+        // with zero occurrences is refused at parse.
+        return nonempty_new;
+    }
+    if f.multiple || f.optional {
+        return var;
+    }
+    if let Some(default) = &f.default {
+        // Mandatory field archie omits at its default (Interval flags): use the
+        // default when the element is absent.
+        return format!("{var}.unwrap_or({default})");
+    }
+    format!(
+        "{var}.ok_or_else(|| crate::xml::runtime::XmlError::Parse(\"missing element {wire}\".into()))?"
+    )
+}
+
+/// Emits the construction of the read value — through the class's validating
+/// constructor where the construction map declares one, otherwise a struct
+/// literal.
+fn emit_read_construction(
+    b: &mut String,
+    target: &XmlTarget<'_>,
+    values: &[(String, String)],
+    door_env: Option<&XmlSchema<'_>>,
+) {
+    let (path, rust) = (target.path, target.rust);
+    let Some((params, fallible)) = construction::validated_ctor(target.spec) else {
+        let _ = writeln!(b, "Ok({path}::{rust} {{");
+        for (fname, expr) in values {
+            let _ = writeln!(b, "{fname}: {expr},");
+        }
+        b.push_str("})\n");
+        return;
+    };
+    let args = emit_ctor_bindings(b, target, params, values, door_env);
+    if fallible {
+        let _ = writeln!(
+            b,
+            "{path}::{rust}::new({args}).map_err(|__e| crate::xml::runtime::XmlError::Parse(::std::format!(\"{}: {{__e}}\").into()))",
+            target.spec
+        );
+    } else {
+        let _ = writeln!(b, "Ok({path}::{rust}::new({args}))");
+    }
+}
+
+/// Binds each read value to a local of the constructor's DECLARED parameter
+/// type, in the construction map's declared order, and returns the argument
+/// list for the call.
+///
+/// The binding is BY FIELD NAME, not by position: it keeps one canonical door
+/// signature across generations whose BMMs declare the fields in different
+/// orders, and it leaves no inference ambiguity at the call.
+///
+/// # Panics
+/// If the construction map's parameter list and the XML field view disagree —
+/// either in length, or on a parameter naming no field. Both are table bugs.
+fn emit_ctor_bindings(
+    b: &mut String,
+    target: &XmlTarget<'_>,
+    params: &[(&str, &str)],
+    values: &[(String, String)],
+    door_env: Option<&XmlSchema<'_>>,
+) -> String {
+    let spec = target.spec;
+    assert_eq!(
+        params.len(),
+        values.len(),
+        "construction map declares {} constructor parameter(s) for {spec}, \
+         but the XML field view has {} field(s)",
+        params.len(),
+        values.len()
+    );
+    let mut names = Vec::new();
+    for (i, (param, ty)) in params.iter().enumerate() {
+        let Some((_, expr)) = values.iter().find(|(fname, _)| fname == param) else {
+            panic!(
+                "construction map parameter {param:?} of {spec} names no XML field \
+                 (fields: {:?})",
+                values.iter().map(|(f, _)| f).collect::<Vec<_>>()
+            )
+        };
+        let ty = door_param_type(door_env, ty, spec);
+        let _ = writeln!(b, "let __a{i}: {ty} = {expr};");
+        names.push(format!("__a{i}"));
+    }
+    names.join(", ")
+}
+
+/// Resolves one constructor parameter's declared type against the door
+/// environment.
+///
+/// # Panics
+/// If a `@`-typed (class-resolved) parameter is emitted without a door
+/// environment — a table or closure bug in the emit-opt closure.
+fn door_param_type(door_env: Option<&XmlSchema<'_>>, ty: &str, spec: &str) -> String {
+    let Some(env) = door_env else {
+        assert!(
+            !ty.starts_with('@'),
+            "door class {spec} with a @-typed parameter emitted without a door \
+             environment (an emit-opt closure generating a door class is a \
+             table/closure bug)"
+        );
+        return ty.to_owned();
+    };
+    door_param(env, ty)
+}
+
+/// Emits `impl FromXml` for an untagged enum: the `xsi:type` dispatch into the
+/// variant that owns each concrete descendant.
+fn emit_enum_from_xml(
+    b: &mut String,
+    target: &XmlTarget<'_>,
+    generics: &[String],
+    dispatch: &[(String, String)],
+) {
+    let (hdr, args) = generic_header(generics, "crate::xml::runtime::FromXml");
+    let (path, rust, spec) = (target.path, target.rust, target.spec);
+    let self_ident = dispatch
+        .iter()
+        .find(|(x, _)| x == spec)
+        .map(|(_, i)| i.clone());
+    let _ = write!(
+        b,
+        "impl{hdr} crate::xml::runtime::FromXml for {path}::{rust}{args} {{\n\
+         fn from_xml(reader: &mut crate::xml::runtime::XmlReader, start: &crate::xml::runtime::StartTag) -> Result<Self, crate::xml::runtime::XmlError> {{\n\
+         match start.xsi_type() {{\n"
+    );
+    for (xsi, ident) in dispatch {
+        let _ = writeln!(
+            b,
+            "Some(\"{xsi}\") => Ok({path}::{rust}::{ident}(crate::xml::runtime::FromXml::from_xml(reader, start)?)),"
+        );
+    }
+    match self_ident {
+        Some(ident) => {
+            let _ = writeln!(
+                b,
+                "None => Ok({path}::{rust}::{ident}(crate::xml::runtime::FromXml::from_xml(reader, start)?)),"
+            );
+        }
+        None => {
+            let _ = writeln!(
+                b,
+                "None => Err(crate::xml::runtime::XmlError::Parse(\"{rust}: missing xsi:type\".into())),"
+            );
+        }
+    }
+    let _ = writeln!(
+        b,
+        "Some(other) => Err(crate::xml::runtime::XmlError::Parse(format!(\"{rust}: unknown xsi:type {{other}}\"))),"
+    );
+    b.push_str("}\n}\n}\n\n");
 }

--- a/tools/openehr-codegen/src/render/model_query.rs
+++ b/tools/openehr-codegen/src/render/model_query.rs
@@ -355,6 +355,10 @@ fn collect_generation(
             Vec::new()
         };
         let props = if flattened { inherited } else { declared };
+        let package = packages
+            .get(name)
+            .cloned()
+            .unwrap_or_else(|| ABSENT.to_string());
         for (decl, (owner, prop)) in props.into_iter().enumerate() {
             let shape = if skipped {
                 NOT_EMITTED.to_string()
@@ -367,10 +371,7 @@ fn collect_generation(
             out.rows.push(Row {
                 component,
                 bmm: bmm.clone(),
-                package: packages
-                    .get(name)
-                    .cloned()
-                    .unwrap_or_else(|| ABSENT.to_string()),
+                package: package.clone(),
                 class: name.clone(),
                 class_abstract: class.is_abstract,
                 class_emission,

--- a/tools/openehr-codegen/src/render/model_types.rs
+++ b/tools/openehr-codegen/src/render/model_types.rs
@@ -36,90 +36,111 @@ impl Model {
         external: &External,
     ) -> String {
         match t {
-            BmmType::Simple(n) => {
-                if let Some(concrete) = subst.get(n) {
-                    // A bound ancestor-generic parameter: render the concrete.
-                    self.render_type(
-                        &BmmType::Simple(concrete.clone()),
-                        generics,
-                        subst,
-                        local,
-                        external,
-                    )
-                } else if let Some(p) = primitive(n) {
-                    p.to_string()
-                } else if generics.iter().any(|g| g == n) {
-                    n.clone()
-                } else if n == "Any" {
-                    "serde_json::Value".to_string()
-                } else if let Some(carrier) = open_extension_point(n) {
-                    carrier.to_string()
-                } else if local.contains(n) || external.contains(n) {
-                    // A bare reference to a *generic* class (BMM omits the args,
-                    // e.g. `normal_range: DV_INTERVAL`) is filled with each type
-                    // parameter's bound (`DV_INTERVAL` → `DvInterval<DvOrdered>`).
-                    // An *unbounded* parameter (the versioned-content `T` of the
-                    // VERSION family) is threaded from the enclosing scope's type
-                    // params (`generics`, then bound `subst` values), so it stays
-                    // strongly typed instead of degrading to `serde_json::Value`.
-                    match self.generic_param_bounds(n) {
-                        Some(bounds) => {
-                            let mut content = Self::scope_content_types(generics, subst);
-                            let args: Vec<String> = bounds
-                                .iter()
-                                .map(|b| match b {
-                                    Some(bound) => self.render_type(
-                                        &BmmType::Simple(bound.clone()),
-                                        generics,
-                                        subst,
-                                        local,
-                                        external,
-                                    ),
-                                    None => content
-                                        .next()
-                                        .unwrap_or_else(|| "serde_json::Value".to_string()),
-                                })
-                                .collect();
-                            format!("{}<{}>", naming::type_name(n), args.join(", "))
-                        }
-                        None => naming::type_name(n),
-                    }
-                } else {
-                    "serde_json::Value".to_string()
-                }
-            }
+            BmmType::Simple(n) => self.render_simple(n, generics, subst, local, external),
             BmmType::Generic { root, params } => {
                 let ps: Vec<String> = params
                     .iter()
                     .map(|p| self.render_type(p, generics, subst, local, external))
                     .collect();
-                // Foundation container generics map to Rust collections; a
-                // container with the wrong arity (e.g. the deeply-nested
-                // free-form `Hash` in RESOURCE_ANNOTATIONS) is free-form JSON.
-                // Arity is matched structurally (slice patterns), never by index.
-                match (root.as_str(), ps.as_slice()) {
-                    ("Hash", [key, value]) => {
-                        format!("std::collections::BTreeMap<{key}, {value}>")
-                    }
-                    ("List" | "Array", [item]) => format!("Vec<{item}>"),
-                    ("Set", [item]) => format!("std::collections::BTreeSet<{item}>"),
-                    // A container of the wrong arity (e.g. the deeply-nested
-                    // free-form `Hash` in RESOURCE_ANNOTATIONS) or a type neither
-                    // emitted here nor by a dependency → free-form JSON.
-                    ("Hash" | "List" | "Array" | "Set", _) => "serde_json::Value".to_string(),
-                    (r, _) if !local.contains(r) && !external.contains(r) => {
-                        "serde_json::Value".to_string()
-                    }
-                    // Respect the class's *effective* arity: a class whose only
-                    // param was unused is monomorphized (emitted non-generic), so
-                    // a reference must drop the explicit args (`REFERENCE_RANGE<X>`
-                    // → `ReferenceRange`).
-                    (r, _) => match self.generic_param_bounds(r) {
-                        None => naming::type_name(r),
-                        Some(_) => format!("{}<{}>", naming::type_name(r), ps.join(", ")),
-                    },
-                }
+                self.render_container(root, &ps, local, external)
             }
+        }
+    }
+
+    /// Render a simple (non-container) BMM type reference.
+    ///
+    /// A bare reference to a *generic* class (the BMM omits the args, e.g.
+    /// `normal_range: DV_INTERVAL`) is filled with each type parameter's bound
+    /// (`DV_INTERVAL` → `DvInterval<DvOrdered>`). An *unbounded* parameter (the
+    /// versioned-content `T` of the VERSION family) is threaded from the
+    /// enclosing scope's type params (`generics`, then bound `subst` values),
+    /// so it stays strongly typed instead of degrading to `serde_json::Value`.
+    fn render_simple(
+        &self,
+        n: &str,
+        generics: &[String],
+        subst: &BTreeMap<String, String>,
+        local: &BTreeSet<String>,
+        external: &External,
+    ) -> String {
+        if let Some(concrete) = subst.get(n) {
+            // A bound ancestor-generic parameter: render the concrete.
+            return self.render_type(
+                &BmmType::Simple(concrete.clone()),
+                generics,
+                subst,
+                local,
+                external,
+            );
+        }
+        if let Some(p) = primitive(n) {
+            return p.to_string();
+        }
+        if generics.iter().any(|g| g == n) {
+            return n.to_owned();
+        }
+        if n == "Any" {
+            return "serde_json::Value".to_string();
+        }
+        if let Some(carrier) = open_extension_point(n) {
+            return carrier.to_string();
+        }
+        if !local.contains(n) && !external.contains(n) {
+            return "serde_json::Value".to_string();
+        }
+        let Some(bounds) = self.generic_param_bounds(n) else {
+            return naming::type_name(n);
+        };
+        let mut content = Self::scope_content_types(generics, subst);
+        let args: Vec<String> = bounds
+            .iter()
+            .map(|b| match b {
+                Some(bound) => self.render_type(
+                    &BmmType::Simple(bound.clone()),
+                    generics,
+                    subst,
+                    local,
+                    external,
+                ),
+                None => content
+                    .next()
+                    .unwrap_or_else(|| "serde_json::Value".to_string()),
+            })
+            .collect();
+        format!("{}<{}>", naming::type_name(n), args.join(", "))
+    }
+
+    /// Render a generic BMM type reference over its already-rendered arguments.
+    ///
+    /// Foundation container generics map to Rust collections, matched
+    /// structurally by arity (slice patterns), never by index. A container of
+    /// the wrong arity (e.g. the deeply-nested free-form `Hash` in
+    /// `RESOURCE_ANNOTATIONS`) or a type neither emitted here nor by a dependency
+    /// degrades to free-form JSON. A non-container respects the class's
+    /// *effective* arity: a class whose only param was unused is monomorphized
+    /// (emitted non-generic), so a reference must drop the explicit args
+    /// (`REFERENCE_RANGE<X>` → `ReferenceRange`).
+    fn render_container(
+        &self,
+        root: &str,
+        ps: &[String],
+        local: &BTreeSet<String>,
+        external: &External,
+    ) -> String {
+        match (root, ps) {
+            ("Hash", [key, value]) => {
+                format!("std::collections::BTreeMap<{key}, {value}>")
+            }
+            ("List" | "Array", [item]) => format!("Vec<{item}>"),
+            ("Set", [item]) => format!("std::collections::BTreeSet<{item}>"),
+            ("Hash" | "List" | "Array" | "Set", _) => "serde_json::Value".to_string(),
+            (r, _) if !local.contains(r) && !external.contains(r) => {
+                "serde_json::Value".to_string()
+            }
+            (r, _) => match self.generic_param_bounds(r) {
+                None => naming::type_name(r),
+                Some(_) => format!("{}<{}>", naming::type_name(r), ps.join(", ")),
+            },
         }
     }
 

--- a/tools/openehr-codegen/src/testsupport.rs
+++ b/tools/openehr-codegen/src/testsupport.rs
@@ -1706,28 +1706,9 @@ pub fn generation_function_divergence(key: &str) -> Result<Vec<String>, Error> {
         let mut per_class: ClassFunctions = BTreeMap::new();
         for unit in &generation.units {
             for (name, class) in &unit.schema.classes {
-                let stem = name.to_lowercase();
-                let Some(sibling) = bodies.get(&format!("{stem}_impl")) else {
-                    continue;
-                };
-                let own = bodies.get(&stem).map(String::as_str).unwrap_or_default();
-                let declared: BTreeSet<String> = class.functions.iter().cloned().collect();
-                let found = class
-                    .functions
-                    .iter()
-                    .filter(|f| {
-                        // Both spellings: a BMM name that is a Rust keyword is
-                        // realized as a raw identifier (`fn r#type(`).
-                        let item = format!("fn {f}(");
-                        let raw = format!("fn r#{f}(");
-                        sibling.contains(&item)
-                            || own.contains(&item)
-                            || sibling.contains(&raw)
-                            || own.contains(&raw)
-                    })
-                    .cloned()
-                    .collect();
-                per_class.insert(name.clone(), (declared, found));
+                if let Some(entry) = class_function_status(name, class, &bodies) {
+                    per_class.insert(name.clone(), entry);
+                }
             }
         }
         realized.push((generation.spec.module, per_class));
@@ -1757,6 +1738,36 @@ pub fn generation_function_divergence(key: &str) -> Result<Vec<String>, Error> {
     divergent.sort();
     divergent.dedup();
     Ok(divergent)
+}
+
+/// The functions one class DECLARES and those its hand-written sibling
+/// realizes, or `None` when the class has no `*_impl.rs` sibling at all.
+///
+/// Both spellings are recognised: a BMM name that is a Rust keyword is
+/// realized as a raw identifier (`fn r#type(`).
+fn class_function_status(
+    name: &str,
+    class: &crate::load::bmm::BmmClass,
+    bodies: &BTreeMap<String, String>,
+) -> Option<(BTreeSet<String>, BTreeSet<String>)> {
+    let stem = name.to_lowercase();
+    let sibling = bodies.get(&format!("{stem}_impl"))?;
+    let own = bodies.get(&stem).map(String::as_str).unwrap_or_default();
+    let declared: BTreeSet<String> = class.functions.iter().cloned().collect();
+    let found = class
+        .functions
+        .iter()
+        .filter(|f| {
+            let item = format!("fn {f}(");
+            let raw = format!("fn r#{f}(");
+            sibling.contains(&item)
+                || own.contains(&item)
+                || sibling.contains(&raw)
+                || own.contains(&raw)
+        })
+        .cloned()
+        .collect();
+    Some((declared, found))
 }
 
 /// Whether `body` applies items to `rust_type` — an `impl` block on it, or the
@@ -1845,37 +1856,10 @@ pub fn unrealized_bmm_functions(key: &str) -> Result<Vec<String>, Error> {
                 if overrides::primitive(name).is_some() || overrides::is_mapped_class(name) {
                     continue;
                 }
-                let stem = name.to_lowercase();
-                let sibling = bodies
-                    .get(&format!("{stem}_impl"))
-                    .map(String::as_str)
-                    .unwrap_or_default();
-                let own = bodies.get(&stem).map(String::as_str).unwrap_or_default();
-                let rust_type = naming::type_name(name);
                 for function in &class.functions {
-                    // A BMM name that is a Rust keyword is realized as a RAW
-                    // identifier (`BMM_CLASS.type` → `pub fn r#type(`), so the
-                    // witness has to accept both spellings or it can never
-                    // credit those functions at all.
-                    let item = format!("fn {function}(");
-                    let raw_item = format!("fn r#{function}(");
-                    let realized = |body: &str| body.contains(&item) || body.contains(&raw_item);
-                    if realized(sibling) || realized(own) {
-                        continue;
+                    if !function_is_realized(name, function, bodies_of(name, &bodies), &bodies) {
+                        missing.push(format!("{}/{name}.{function}", generation.spec.module));
                     }
-                    // A method can be realized by a MACRO applied elsewhere in the
-                    // generation, so the witness searches the whole generation —
-                    // but it must name the type as an impl TARGET, not merely
-                    // mention it: a mention credited `VERSION.data` to
-                    // `imported_version_impl.rs`, a false NEGATIVE that silently
-                    // drops a real gap (#2247).
-                    if bodies
-                        .values()
-                        .any(|body| realized(body) && targets_type(body, &rust_type))
-                    {
-                        continue;
-                    }
-                    missing.push(format!("{}/{name}.{function}", generation.spec.module));
                 }
             }
         }
@@ -1883,6 +1867,46 @@ pub fn unrealized_bmm_functions(key: &str) -> Result<Vec<String>, Error> {
     missing.sort();
     missing.dedup();
     Ok(missing)
+}
+
+/// The class's own two candidate bodies: its generated type file and its
+/// hand-written `*_impl.rs` sibling.
+fn bodies_of<'a>(name: &str, bodies: &'a BTreeMap<String, String>) -> [&'a str; 2] {
+    let stem = name.to_lowercase();
+    [
+        bodies
+            .get(&format!("{stem}_impl"))
+            .map(String::as_str)
+            .unwrap_or_default(),
+        bodies.get(&stem).map(String::as_str).unwrap_or_default(),
+    ]
+}
+
+/// Whether one BMM function is realized anywhere in its generation.
+///
+/// A BMM name that is a Rust keyword is realized as a RAW identifier
+/// (`BMM_CLASS.type` → `pub fn r#type(`), so both spellings count or those
+/// functions could never be credited at all. A method may also be realized by
+/// a MACRO applied elsewhere in the generation, so the witness searches every
+/// body — but such a body must name the type as an impl TARGET, not merely
+/// mention it: a mention credited `VERSION.data` to `imported_version_impl.rs`,
+/// a false NEGATIVE that silently drops a real gap (#2247).
+fn function_is_realized(
+    name: &str,
+    function: &str,
+    own: [&str; 2],
+    bodies: &BTreeMap<String, String>,
+) -> bool {
+    let item = format!("fn {function}(");
+    let raw_item = format!("fn r#{function}(");
+    let realized = |body: &str| body.contains(&item) || body.contains(&raw_item);
+    if own.iter().any(|body| realized(body)) {
+        return true;
+    }
+    let rust_type = naming::type_name(name);
+    bodies
+        .values()
+        .any(|body| realized(body) && targets_type(body, &rust_type))
 }
 
 /// Every `.rs` file under `dir` as file-stem → the CONCATENATED bodies of every

--- a/tools/openehr-codegen/src/testsupport.rs
+++ b/tools/openehr-codegen/src/testsupport.rs
@@ -150,41 +150,50 @@ pub fn completeness(key: &str) -> Result<Vec<Completeness>, Error> {
     let mut out = Vec::new();
     for g in &c.generations {
         for u in &g.units {
-            let used = u.model.used_as_type();
-            let mut planned = 0;
-            let mut skipped_mapped = 0;
-            let mut skipped_abstract_unused = 0;
-            let mut silently_dropped = Vec::new();
-            for (name, class) in &u.schema.classes {
-                match decide(&u.model, class, &used) {
-                    Emission::Skip => {
-                        if Model::is_mapped(name) {
-                            skipped_mapped += 1;
-                        } else if class.is_abstract
-                            && u.model.enum_variants(name).is_empty()
-                            && !used.contains(name)
-                        {
-                            skipped_abstract_unused += 1;
-                        } else {
-                            silently_dropped.push(name.clone());
-                        }
-                    }
-                    _ => planned += 1,
-                }
-            }
-            silently_dropped.sort();
-            out.push(Completeness {
-                key: key.to_string(),
-                file: u.spec.file.to_string(),
-                total: u.schema.classes.len(),
-                planned,
-                skipped_mapped,
-                skipped_abstract_unused,
-                silently_dropped,
-            });
+            let mut breakdown = unit_completeness(&u.model, &u.schema);
+            breakdown.key = key.to_string();
+            breakdown.file = u.spec.file.to_string();
+            out.push(breakdown);
         }
     }
     Ok(out)
+}
+
+/// The completeness breakdown of one BMM specification unit.
+///
+/// A skipped class is accounted for by WHY it is skipped: a mapped type, an
+/// abstract class with no variants that nothing references, or — the one that
+/// matters — a silent drop.
+fn unit_completeness(model: &Model, schema: &BmmSchema) -> Completeness {
+    let used = model.used_as_type();
+    let mut planned = 0;
+    let mut skipped_mapped = 0;
+    let mut skipped_abstract_unused = 0;
+    let mut silently_dropped = Vec::new();
+    for (name, class) in &schema.classes {
+        if !matches!(decide(model, class, &used), Emission::Skip) {
+            planned += 1;
+            continue;
+        }
+        if Model::is_mapped(name) {
+            skipped_mapped += 1;
+        } else if class.is_abstract && model.enum_variants(name).is_empty() && !used.contains(name)
+        {
+            skipped_abstract_unused += 1;
+        } else {
+            silently_dropped.push(name.clone());
+        }
+    }
+    silently_dropped.sort();
+    Completeness {
+        key: String::new(),
+        file: String::new(),
+        total: schema.classes.len(),
+        planned,
+        skipped_mapped,
+        skipped_abstract_unused,
+        silently_dropped,
+    }
 }
 
 /// One BMM-declared attribute that reaches no emitted Rust field — the
@@ -227,35 +236,15 @@ pub fn attribute_gaps(key: &str) -> Result<(Vec<AttributeGap>, usize), Error> {
     for g in &c.generations {
         for u in &g.units {
             let used = u.model.used_as_type();
-            // Emitted field names per class (flattened, back-references omitted —
-            // exactly what `render_struct_def` writes).
-            let fields = |class_name: &str| -> BTreeSet<String> {
-                u.model.get(class_name).map_or_else(BTreeSet::new, |cls| {
-                    u.model
-                        .flattened_props(cls)
-                        .iter()
-                        .filter(|rp| overrides::back_reference(&rp.owner, &rp.prop.name).is_none())
-                        .map(|rp| rp.prop.name.clone())
-                        .collect()
-                })
-            };
             for (name, class) in &u.schema.classes {
-                let carriers: Vec<String> = match decide(&u.model, class, &used) {
-                    Emission::Struct | Emission::PolyEnum(_) => vec![name.clone()],
-                    Emission::Enum(variants) => variants,
-                    // A literal enumeration and a transparent newtype are scalars on
-                    // the wire and declare no attributes of their own; a mapped or
-                    // unused-abstract class emits nothing (the name-level
-                    // completeness check accounts for it).
-                    Emission::EnumLiterals(_) | Emission::Newtype(_) | Emission::Skip => Vec::new(),
-                };
+                let carriers = attribute_carriers(name, class, &u.model, &used);
                 for p in &class.properties {
                     if overrides::back_reference(name, &p.name).is_some() {
                         continue;
                     }
                     for carrier in &carriers {
                         checked += 1;
-                        if !fields(carrier).contains(&p.name) {
+                        if !emitted_field_names(&u.model, carrier).contains(&p.name) {
                             gaps.push(AttributeGap {
                                 file: u.spec.file.to_string(),
                                 class: name.clone(),
@@ -269,6 +258,39 @@ pub fn attribute_gaps(key: &str) -> Result<(Vec<AttributeGap>, usize), Error> {
         }
     }
     Ok((gaps, checked))
+}
+
+/// The emitted types that must carry a class's declared attributes.
+///
+/// A struct (or a polymorphic slot's `{Name}Data`) carries them itself; a
+/// closed subtype set carries them through each concrete variant. A literal
+/// enumeration and a transparent newtype are scalars on the wire and declare
+/// no attributes of their own; a mapped or unused-abstract class emits
+/// nothing, which the name-level completeness check accounts for.
+fn attribute_carriers(
+    name: &str,
+    class: &crate::load::bmm::BmmClass,
+    model: &Model,
+    used: &BTreeSet<String>,
+) -> Vec<String> {
+    match decide(model, class, used) {
+        Emission::Struct | Emission::PolyEnum(_) => vec![name.to_owned()],
+        Emission::Enum(variants) => variants,
+        Emission::EnumLiterals(_) | Emission::Newtype(_) | Emission::Skip => Vec::new(),
+    }
+}
+
+/// The emitted field names of a class — flattened, back-references omitted:
+/// exactly what `render_struct_def` writes.
+fn emitted_field_names(model: &Model, class_name: &str) -> BTreeSet<String> {
+    model.get(class_name).map_or_else(BTreeSet::new, |cls| {
+        model
+            .flattened_props(cls)
+            .iter()
+            .filter(|rp| overrides::back_reference(&rp.owner, &rp.prop.name).is_none())
+            .map(|rp| rp.prop.name.clone())
+            .collect()
+    })
 }
 
 /// A file path or prelude identifier claimed by more than one BMM generation of

--- a/tools/openehr-codegen/src/testsupport.rs
+++ b/tools/openehr-codegen/src/testsupport.rs
@@ -2021,34 +2021,45 @@ pub fn untyped_enumeration_facets() -> Result<Vec<UntypedFacet>, Error> {
                 });
             }
         }
-
-        let declared = model.declared_field_types();
-        for (spec, fields) in &declared {
-            let by_wire: BTreeMap<&str, &str> = fields
-                .iter()
-                .map(|(w, d)| (w.as_str(), d.as_str()))
-                .collect();
-            for elem in xsd.flattened(spec).1 {
-                let Some(rust) = faceted.get(elem.type_name.as_str()) else {
-                    continue;
-                };
-                if !by_wire
-                    .get(elem.name.as_str())
-                    .is_some_and(|d| d.contains(rust.as_str()))
-                {
-                    out.push(UntypedFacet {
-                        closure: name.to_owned(),
-                        simple_type: elem.type_name.clone(),
-                        problem: "an element slot of a faceted simple type is not typed to its enum",
-                        detail: format!("{spec}.{}", elem.name),
-                    });
-                }
-            }
+        for (spec, fields) in &model.declared_field_types() {
+            push_untyped_facet_slots(name, spec, fields, &faceted, &xsd, &mut out);
         }
     }
     out.sort();
     out.dedup();
     Ok(out)
+}
+
+/// Reports every element slot of one emitted type whose faceted simple type
+/// did not reach the field's declared Rust type.
+fn push_untyped_facet_slots(
+    closure: &str,
+    spec: &str,
+    fields: &[(String, String)],
+    faceted: &BTreeMap<&str, String>,
+    xsd: &crate::load::xsd::XsdModel,
+    out: &mut Vec<UntypedFacet>,
+) {
+    let by_wire: BTreeMap<&str, &str> = fields
+        .iter()
+        .map(|(w, d)| (w.as_str(), d.as_str()))
+        .collect();
+    for elem in xsd.flattened(spec).1 {
+        let Some(rust) = faceted.get(elem.type_name.as_str()) else {
+            continue;
+        };
+        if !by_wire
+            .get(elem.name.as_str())
+            .is_some_and(|d| d.contains(rust.as_str()))
+        {
+            out.push(UntypedFacet {
+                closure: closure.to_owned(),
+                simple_type: elem.type_name.clone(),
+                problem: "an element slot of a faceted simple type is not typed to its enum",
+                detail: format!("{spec}.{}", elem.name),
+            });
+        }
+    }
 }
 
 /// A place where the concrete-only `xsi:type` reading would LOSE a document
@@ -2102,30 +2113,15 @@ pub fn lost_dispatch_variants() -> Result<Vec<LostVariant>, Error> {
         for declared in &slot_types {
             let variants: BTreeSet<String> = model.descendants(declared).into_iter().collect();
             for abstract_ty in model.types.values().filter(|t| t.is_abstract) {
-                if !model.is_a(&abstract_ty.name, declared) {
-                    continue;
-                }
-                // The abstract type itself is correctly absent; every concrete
-                // type BELOW it is a shape a document can present at this slot.
-                for concrete in model.descendants(&abstract_ty.name) {
-                    if !variants.contains(&concrete) {
-                        out.push(LostVariant {
-                            closure: name.to_owned(),
-                            declared: declared.clone(),
-                            via_abstract: abstract_ty.name.clone(),
-                            lost: concrete,
-                            problem: "a concrete descendant is missing from the variant set",
-                        });
-                    }
-                }
-                if variants.contains(&abstract_ty.name) {
-                    out.push(LostVariant {
-                        closure: name.to_owned(),
-                        declared: declared.clone(),
-                        via_abstract: abstract_ty.name.clone(),
-                        lost: abstract_ty.name.clone(),
-                        problem: "an abstract type appears as an xsi:type variant",
-                    });
+                if model.is_a(&abstract_ty.name, declared) {
+                    push_lost_variants(
+                        name,
+                        declared,
+                        &abstract_ty.name,
+                        &variants,
+                        &model,
+                        &mut out,
+                    );
                 }
             }
         }
@@ -2133,4 +2129,40 @@ pub fn lost_dispatch_variants() -> Result<Vec<LostVariant>, Error> {
     out.sort();
     out.dedup();
     Ok(out)
+}
+
+/// Reports the shapes one abstract intermediate loses at one slot.
+///
+/// The abstract type itself is correctly absent from the variant set; every
+/// concrete type BELOW it is a shape a document can present at this slot, so a
+/// missing one is a loss — and the abstract type appearing AS a variant is the
+/// mirror defect.
+fn push_lost_variants(
+    closure: &str,
+    declared: &str,
+    abstract_ty: &str,
+    variants: &BTreeSet<String>,
+    model: &crate::load::xsd::XsdModel,
+    out: &mut Vec<LostVariant>,
+) {
+    for concrete in model.descendants(abstract_ty) {
+        if !variants.contains(&concrete) {
+            out.push(LostVariant {
+                closure: closure.to_owned(),
+                declared: declared.to_owned(),
+                via_abstract: abstract_ty.to_owned(),
+                lost: concrete,
+                problem: "a concrete descendant is missing from the variant set",
+            });
+        }
+    }
+    if variants.contains(abstract_ty) {
+        out.push(LostVariant {
+            closure: closure.to_owned(),
+            declared: declared.to_owned(),
+            via_abstract: abstract_ty.to_owned(),
+            lost: abstract_ty.to_owned(),
+            problem: "an abstract type appears as an xsi:type variant",
+        });
+    }
 }

--- a/tools/openehr-codegen/templates/openehr-base/foundation_types/time/iso8601_parse.rs
+++ b/tools/openehr-codegen/templates/openehr-base/foundation_types/time/iso8601_parse.rs
@@ -672,6 +672,44 @@ fn apply_duration_component(
     }
 }
 
+/// One duration component's number: its integer part, its fractional part,
+/// and whether a fraction was written at all.
+///
+/// A decimal sign with no digits after it is refused (`P1.D`).
+fn read_duration_number(
+    it: &mut std::iter::Peekable<std::str::Chars<'_>>,
+) -> Option<(u64, f64, bool)> {
+    let mut num = String::new();
+    while let Some(c) = it.peek() {
+        if !c.is_ascii_digit() {
+            break;
+        }
+        num.push(*c);
+        it.next();
+    }
+    let has_frac = matches!(it.peek(), Some('.' | ','));
+    let mut frac = String::new();
+    if has_frac {
+        it.next();
+        while let Some(c) = it.peek() {
+            if !c.is_ascii_digit() {
+                break;
+            }
+            frac.push(*c);
+            it.next();
+        }
+    }
+    let intval = num.parse::<u64>().ok()?;
+    if !has_frac {
+        return Some((intval, 0.0, false));
+    }
+    if frac.is_empty() {
+        return None;
+    }
+    let fracval = format!("0.{frac}").parse::<f64>().ok()?;
+    Some((intval, fracval, true))
+}
+
 pub(crate) fn parse_duration(s: &str) -> Option<ParsedDuration> {
     let mut it = s.chars().peekable();
     let negative = match it.peek() {
@@ -715,38 +753,8 @@ pub(crate) fn parse_duration(s: &str) -> Option<ParsedDuration> {
                 it.next();
             }
             Some(c) if c.is_ascii_digit() => {
-                let mut num = String::new();
-                while let Some(c) = it.peek() {
-                    if c.is_ascii_digit() {
-                        num.push(*c);
-                        it.next();
-                    } else {
-                        break;
-                    }
-                }
-                let mut frac = String::new();
-                let has_frac = matches!(it.peek(), Some('.' | ','));
-                if has_frac {
-                    it.next();
-                    while let Some(c) = it.peek() {
-                        if c.is_ascii_digit() {
-                            frac.push(*c);
-                            it.next();
-                        } else {
-                            break;
-                        }
-                    }
-                }
+                let (intval, fracval, has_frac) = read_duration_number(&mut it)?;
                 let designator = it.next()?;
-                let intval = num.parse::<u64>().ok()?;
-                let fracval = if has_frac {
-                    if frac.is_empty() {
-                        return None;
-                    }
-                    format!("0.{frac}").parse::<f64>().ok()?
-                } else {
-                    0.0
-                };
                 let slot = apply_duration_component(&mut d, in_time, designator, intval, fracval)?;
                 if slot <= last_slot {
                     return None;

--- a/tools/openehr-codegen/templates/openehr-rm/paths.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/paths.rs
@@ -490,24 +490,30 @@ impl Predicate {
         }
         if let Some(uid) = &self.uid {
             if wrote {
-                write!(f, " and uid='{uid}'")?;
-            } else {
-                write!(f, "uid='{uid}'")?;
+                f.write_str(" and ")?;
             }
+            write!(f, "uid='{uid}'")?;
             wrote = true;
         }
         for cmp in &self.comparisons {
             if wrote {
                 f.write_str(" and ")?;
             }
-            write!(f, "{}", cmp.path.join("/"))?;
-            match &cmp.value {
-                CmpLiteral::Str(s) => write!(f, " {} '{s}'", cmp.op.token())?,
-                CmpLiteral::Num(n) => write!(f, " {} {n}", cmp.op.token())?,
-            }
+            cmp.render(f)?;
             wrote = true;
         }
         f.write_str("]")
+    }
+}
+
+impl Comparison {
+    /// Render one comparison term of a predicate (`path op literal`).
+    fn render(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.path.join("/"))?;
+        match &self.value {
+            CmpLiteral::Str(s) => write!(f, " {} '{s}'", self.op.token()),
+            CmpLiteral::Num(n) => write!(f, " {} {n}", self.op.token()),
+        }
     }
 }
 
@@ -879,29 +885,32 @@ pub fn parent_of<'a>(root: &'a Value, item: &Value) -> Option<&'a Value> {
 /// parent; array elements report the object holding the array.
 fn walk_for_parent<'a>(node: &'a Value, item: &Value) -> Option<&'a Value> {
     match node {
-        Value::Object(map) => {
-            for child in map.values() {
-                if std::ptr::eq(child, item) {
-                    return Some(node);
-                }
-                if let Value::Array(items) = child {
-                    if items.iter().any(|v| std::ptr::eq(v, item)) {
-                        return Some(node);
-                    }
-                    for v in items {
-                        if let Some(found) = walk_for_parent(v, item) {
-                            return Some(found);
-                        }
-                    }
-                } else if let Some(found) = walk_for_parent(child, item) {
-                    return Some(found);
-                }
-            }
-            None
-        }
+        Value::Object(map) => map
+            .values()
+            .find_map(|child| parent_through_member(node, child, item)),
         Value::Array(items) => items.iter().find_map(|v| walk_for_parent(v, item)),
         _ => None,
     }
+}
+
+/// The RM parent reached through one member of `owner`: `owner` itself when
+/// the member IS the item (or holds it directly in an array), else whatever
+/// the member's own subtree reports.
+fn parent_through_member<'a>(
+    owner: &'a Value,
+    child: &'a Value,
+    item: &Value,
+) -> Option<&'a Value> {
+    if std::ptr::eq(child, item) {
+        return Some(owner);
+    }
+    let Value::Array(items) = child else {
+        return walk_for_parent(child, item);
+    };
+    if items.iter().any(|v| std::ptr::eq(v, item)) {
+        return Some(owner);
+    }
+    items.iter().find_map(|v| walk_for_parent(v, item))
 }
 
 /// Depth-first search for `item` (pointer identity), accumulating the

--- a/tools/openehr-codegen/templates/openehr-rm/validate/fast.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/validate/fast.rs
@@ -82,7 +82,7 @@
 
 use serde_json::{Map, Value};
 
-use crate::v1_2::model::{Container, RmClass};
+use crate::v1_2::model::{Container, RmAttribute, RmClass};
 use crate::v1_2::validate::generated;
 use crate::v1_2::validate::{
     valid_iso8601_date, valid_iso8601_date_time, valid_iso8601_duration, valid_iso8601_time,
@@ -231,69 +231,13 @@ fn node_conforms(obj: &Map<String, Value>, class: &'static RmClass, shallow: boo
         let Some(attr) = class.attributes.iter().find(|a| a.name == key) else {
             continue;
         };
-        match attr.container {
-            Container::None => {
-                if v.is_null() {
-                    // The derive's shadow reads every field as `Option`, so a
-                    // JSON `null` is "absent": fine for an optional attribute,
-                    // `missing field` for a mandatory one.
-                    if attr.is_mandatory {
-                        return false;
-                    }
-                    continue;
-                }
-                if attr.is_mandatory {
-                    mandatory_seen += 1;
-                }
-                if generic_any_slot(class.name, attr.name) {
-                    continue;
-                }
-                if !value_conforms(v, attr.declared_type, shallow) {
-                    return false;
-                }
-            }
-            Container::List | Container::Set => match v {
-                Value::Array(items) => {
-                    let lower_bound_one =
-                        attr.cardinality.is_some_and(|c| c.lower >= 1) || attr.nonempty;
-                    if attr.is_mandatory {
-                        mandatory_seen += 1;
-                    }
-                    // A `1..*` container emits as `NonEmptyVec<T>`, whose
-                    // constructor refuses an empty list — so an empty array does
-                    // NOT deserialize and this checker must not vouch.
-                    if lower_bound_one && items.is_empty() {
-                        return false;
-                    }
-                    if shallow {
-                        // Mirror `prune_child_nodes`: the prune keeps the FIRST
-                        // member of any object array as the structural witness,
-                        // which the typed decode inspects — so this checker
-                        // inspects it too. An empty array on a non-NonEmptyVec
-                        // field trivially deserializes; a non-empty all-scalar
-                        // array is kept verbatim and typed-checked — don't
-                        // vouch for it.
-                        if let Some(first) = items.first() {
-                            if !items.iter().any(Value::is_object) {
-                                return false;
-                            }
-                            if !value_conforms(first, attr.declared_type, true) {
-                                return false;
-                            }
-                        }
-                    } else {
-                        for item in items {
-                            if !value_conforms(item, attr.declared_type, false) {
-                                return false;
-                            }
-                        }
-                    }
-                }
-                // `Vec` never deserializes from a non-array (incl. `null`).
-                _ => return false,
-            },
-            // No `Hash` attribute is modelled here.
-            Container::Hash => return false,
+        match attribute_conforms(v, attr, class, shallow) {
+            AttrCheck::Refused => return false,
+            // A mandatory attribute the wire leaves absent is `missing field`
+            // to the typed reader.
+            AttrCheck::Absent if attr.is_mandatory => return false,
+            AttrCheck::Conforms if attr.is_mandatory => mandatory_seen += 1,
+            AttrCheck::Absent | AttrCheck::Conforms => {}
         }
     }
     // Absent attributes: an OPTIONAL container defaults to `None` and an
@@ -302,6 +246,93 @@ fn node_conforms(obj: &Map<String, Value>, class: &'static RmClass, shallow: boo
     // (a mandatory container is a plain `Vec`/`NonEmptyVec` field the reader
     // requires). Every mandatory attribute must therefore have been seen.
     mandatory_seen == class.attributes.iter().filter(|a| a.is_mandatory).count()
+}
+
+/// What the typed reader would make of one attribute's wire value.
+enum AttrCheck {
+    /// JSON `null`, which the reader's `Option` shadow treats as absent.
+    Absent,
+    /// The value verifiably deserializes as the attribute's declared shape.
+    Conforms,
+    /// The typed reader would refuse the value, so this checker cannot vouch.
+    Refused,
+}
+
+/// Checks one attribute's wire value against its declared container shape.
+fn attribute_conforms(
+    v: &Value,
+    attr: &'static RmAttribute,
+    class: &'static RmClass,
+    shallow: bool,
+) -> AttrCheck {
+    match attr.container {
+        Container::None => single_conforms(v, attr, class, shallow),
+        Container::List | Container::Set => list_conforms(v, attr, shallow),
+        // No `Hash` attribute is modelled here.
+        Container::Hash => AttrCheck::Refused,
+    }
+}
+
+/// Checks a single-valued attribute's wire value.
+fn single_conforms(
+    v: &Value,
+    attr: &'static RmAttribute,
+    class: &'static RmClass,
+    shallow: bool,
+) -> AttrCheck {
+    if v.is_null() {
+        return AttrCheck::Absent;
+    }
+    if generic_any_slot(class.name, attr.name) {
+        return AttrCheck::Conforms;
+    }
+    if value_conforms(v, attr.declared_type, shallow) {
+        AttrCheck::Conforms
+    } else {
+        AttrCheck::Refused
+    }
+}
+
+/// Checks a container attribute's wire value.
+///
+/// A `1..*` container emits as `NonEmptyVec<T>`, whose constructor refuses an
+/// empty list — so an empty array does NOT deserialize and this checker must
+/// not vouch for it.
+fn list_conforms(v: &Value, attr: &'static RmAttribute, shallow: bool) -> AttrCheck {
+    // `Vec` never deserializes from a non-array (incl. `null`).
+    let Value::Array(items) = v else {
+        return AttrCheck::Refused;
+    };
+    let lower_bound_one = attr.cardinality.is_some_and(|c| c.lower >= 1) || attr.nonempty;
+    if lower_bound_one && items.is_empty() {
+        return AttrCheck::Refused;
+    }
+    let members_conform = if shallow {
+        shallow_members_conform(items, attr)
+    } else {
+        items
+            .iter()
+            .all(|item| value_conforms(item, attr.declared_type, false))
+    };
+    if members_conform {
+        AttrCheck::Conforms
+    } else {
+        AttrCheck::Refused
+    }
+}
+
+/// Checks the structural witness of a pruned array.
+///
+/// This mirrors `prune_child_nodes`: the prune keeps the FIRST member of any
+/// object array as the witness, which the typed decode inspects — so this
+/// checker inspects it too. An empty array on a non-`NonEmptyVec` field
+/// trivially deserializes; a non-empty all-scalar array is kept verbatim and
+/// typed-checked, so it is not vouched for here.
+fn shallow_members_conform(items: &[Value], attr: &'static RmAttribute) -> bool {
+    let Some(first) = items.first() else {
+        return true;
+    };
+    items.iter().any(Value::is_object) && value_conforms(first, attr.declared_type, true)
 }
 
 /// Whether a single value verifiably deserializes as the declared spec type.

--- a/tools/openehr-codegen/templates/openehr-rm/validate/incomplete.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/validate/incomplete.rs
@@ -45,7 +45,7 @@
 
 use serde_json::Value;
 
-use crate::v1_2::model::{Container, class};
+use crate::v1_2::model::{Container, RmAttribute, class};
 
 /// The `POINT_EVENT`/`INTERVAL_EVENT` `data` slot, whose generic parameter the
 /// validation dispatcher erases to `serde_json::Value` — so any non-absent
@@ -96,53 +96,52 @@ pub fn mandatory_data_present(ty: &str, value: &Value) -> bool {
         if attr.declared_type == "Octet" {
             continue;
         }
-        let member = value.get(attr.name).filter(|v| !v.is_null());
-        match attr.container {
+        // No `Hash` attribute is judged here (none is modelled by the
+        // structural checkers either).
+        if attr.container == Container::Hash {
+            continue;
+        }
+        let Some(member) = value.get(attr.name).filter(|v| !v.is_null()) else {
+            if attr.is_mandatory {
+                return false;
+            }
+            continue;
+        };
+        let present = match attr.container {
             Container::None => {
-                let Some(member) = member else {
-                    if attr.is_mandatory {
-                        return false;
-                    }
-                    continue;
-                };
-                if generic_any_slot(ty, attr.name) {
-                    continue;
-                }
-                if member.is_object()
-                    && let Some(child) = effective_type(member, attr.declared_type)
-                    && !mandatory_data_present(child, member)
-                {
-                    return false;
-                }
+                generic_any_slot(ty, attr.name) || single_member_present(member, attr)
             }
-            Container::List | Container::Set => {
-                let Some(member) = member else {
-                    if attr.is_mandatory {
-                        return false;
-                    }
-                    continue;
-                };
-                let Some(items) = member.as_array() else {
-                    continue;
-                };
-                if items.is_empty() && attr.cardinality.is_some_and(|c| c.lower >= 1) {
-                    return false;
-                }
-                for item in items {
-                    if item.is_object()
-                        && let Some(child) = effective_type(item, attr.declared_type)
-                        && !mandatory_data_present(child, item)
-                    {
-                        return false;
-                    }
-                }
-            }
-            // No `Hash` attribute is judged here (none is modelled by the
-            // structural checkers either).
-            Container::Hash => {}
+            _ => list_members_present(member, attr),
+        };
+        if !present {
+            return false;
         }
     }
     true
+}
+
+/// Whether a single-valued member carries the mandatory data of its own
+/// declared type.
+fn single_member_present(member: &Value, attr: &RmAttribute) -> bool {
+    if !member.is_object() {
+        return true;
+    }
+    let Some(child) = effective_type(member, attr.declared_type) else {
+        return true;
+    };
+    mandatory_data_present(child, member)
+}
+
+/// Whether a container member satisfies its declared lower bound and each of
+/// its object members carries their own mandatory data.
+fn list_members_present(member: &Value, attr: &RmAttribute) -> bool {
+    let Some(items) = member.as_array() else {
+        return true;
+    };
+    if items.is_empty() && attr.cardinality.is_some_and(|c| c.lower >= 1) {
+        return false;
+    }
+    items.iter().all(|item| single_member_present(item, attr))
 }
 
 /// Whether `value` positively CONTRADICTS its declared RM type `ty`.

--- a/website/landing/index.html
+++ b/website/landing/index.html
@@ -8,11 +8,16 @@
        specification — `frame-ancestors`, `report-uri` and `sandbox` are ignored
        in meta form (CSP3 §3.3) — but it still blocks an injected external
        script or an exfiltrating connection, which is the realistic risk here. -->
-  <!-- script-src carries no inline allowance: the page's only <script> is an
-       application/ld+json DATA BLOCK, which browsers never execute, so CSP's
-       script-src does not govern it
-       (https://html.spec.whatwg.org/multipage/scripting.html#data-block). -->
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'">
+  <!-- Neither script-src nor style-src carries an inline allowance. The page's
+       only <script> is an application/ld+json DATA BLOCK, which browsers never
+       execute, so script-src does not govern it
+       (https://html.spec.whatwg.org/multipage/scripting.html#data-block); the
+       page carries no <style> element and no style attribute, so every rule
+       comes from the same-origin stylesheet. The inline <svg> elements style
+       themselves with presentation attributes (fill, stroke), which are not
+       CSS and are outside style-src
+       (https://www.w3.org/TR/CSP3/#directive-style-src). -->
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'">
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <title>FerroEHR — a pure-Rust openEHR Clinical Data Repository</title>
   <meta name="description" content="FerroEHR is a pure-Rust openEHR Clinical Data Repository: ITS-REST 1.1.0, AQL 1.1, PostgreSQL 18-native storage, shipped as a single self-contained binary. Spec-compliant and machine-verified.">


### PR DESCRIPTION
Clears every open finding the SonarQube dashboard reports on `develop`, worked from the live MCP list rather than the issue body's snapshot. The live list held **168** findings — 163 `rust:S3776`, 2 `rust:S107`, 2 `shelldre:S7688`, 1 `Web:S7039` — against the snapshot's 238; the difference is the snapshot ageing behind several merges, not a scope change.

## What changed

**163 × `rust:S3776` (cognitive complexity) — refactored, none suppressed.** Each
site's separable phases became named functions with doc comments, several
gathered around a small borrow-only context struct so no signature crossed seven
parameters. The refactors are behaviour-preserving by construction, and six
places where a naive extraction would have changed observable behaviour were
written differently instead: the per-call `map_err` that keeps contribution wire
messages byte-identical; the kind-mismatch check that belongs only to the content
import path; the load-bearing match-arm ORDER in the BALP profile mapper; the
artefact-kind span taken after `flat` is skipped; the `Container::Hash` skip that
must precede the absence check; and the cardinality-full skip that must return to
the caller so the example walker's `included` set is unchanged.

Two of them removed a hazard rather than relocating it. The TDD conformance walk
lost its `#[expect(clippy::indexing_slicing)]` outright — three parallel index
vectors became one role enum per child, so there is no indexing left to justify —
and the web-template binding assertions gained failure messages, which
`missing_assert_message` cannot ask for inside a `#[test]` fn.

**2 × `rust:S107` — accepted through the MCP.** Both sites are Leptos
`#[component]` functions (`AuthedChrome`, `ConfirmDialog`). A component's
parameter list IS the framework's named-argument surface: the macro generates a
props struct that callers fill by name in `view!`, so a hand-written struct would
add a second, redundant one. One call, applied to both, recorded with that
reason.

**1 × `Web:S7039` — fixed.** `website/landing/index.html` allowed
`'unsafe-inline'` in `style-src`. The page has no `<style>` element and no
`style=` attribute (verified), so the allowance protected nothing; it is gone,
and the header's comment now cites CSP3 §style-src for why the SVG presentation
attributes the page does use are unaffected — they are not CSS.

**2 × `shelldre:S7688` — fixed.** `[ … ]` → `[[ … ]]` in
`scripts/gh/retry-net.sh`; `bash -n` and `shellcheck` clean.

## Generated code

Nine sites were in `tools/openehr-codegen` or its generation-twin templates.
Nothing under a `// @generated` banner was hand-edited: the emitter and the
templates changed, then the full set was regenerated (`emit emit-json emit-xml
emit-rest emit-opt emit-aom2 emit-rm-model emit-validate`). `git status` was
clean afterwards — zero generated-tree drift, the per-generation twin copies
included.

Packaged `crates/*` content changed, so the eight spec crates step in lockstep to
`0.0.42`, with their internal `version =` requirements and `fuzz/Cargo.lock`.

## Gates

- `cargo clippy --workspace --exclude ferroehr-admin-ui --all-targets --all-features -- -D warnings` — clean
- `cargo clippy -p ferroehr-admin-ui --all-targets --features ssr -- -D warnings` — clean
- `cargo clippy -p ferroehr-admin-ui --target wasm32-unknown-unknown --features hydrate -- -D warnings` — clean
- `cargo nextest run --workspace` — 4859 passed, 0 failed
- `cargo fmt --all` — clean
- codegen regeneration — zero drift
- `bash scripts/conformance.sh` — 1102 case-records, 1064 passed / 0 failed / 0 errored / 38 n-a; 43 capability verdicts, 0 review findings. `verdicts.json` and every badge byte-identical to the committed baseline — zero verdict drift. The only artifact difference in the whole set was the SUT version label (`4.0.6-rc2` -> `4.0.6-rc3`, the baseline predating the rc3 bump), which was reverted rather than mixed into a refactor PR.

No test was weakened, skipped or deleted; no expectation was adjusted.

Closes #2752
