### PR TITLE
fix(docs): eight intra-doc links name the precondition constructor, not a phantom variant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ cargo clippy --workspace --exclude ferroehr-admin-ui --all-targets --all-feature
 cargo clippy -p ferroehr-admin-ui --all-targets --features ssr -- -D warnings
 cargo clippy -p ferroehr-admin-ui --target wasm32-unknown-unknown --features hydrate -- -D warnings
 cargo fmt --all
-RUSTDOCFLAGS="-D warnings" cargo doc --workspace --exclude ferroehr-admin-ui --all-features --no-deps   # the rustdoc gate (intra-doc links, doc lints)
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --exclude ferroehr-admin-ui --all-features --no-deps --document-private-items   # the rustdoc gate — CI docs PRIVATE items too (a link in a private helper's docs gates the build)
 RUSTDOCFLAGS="-D warnings" cargo doc -p ferroehr-admin-ui --features ssr --no-deps                      # the console's own rustdoc gate (same CI job, second step)
 cargo deny check   # subsumes cargo-audit: same RustSec DB + yanked/licenses/bans/sources
 # conformance pipeline (the acceptance instrument) — the CNF 2.0 runner:

--- a/app/ferroehr/src/service/message/import.rs
+++ b/app/ferroehr/src/service/message/import.rs
@@ -384,7 +384,7 @@ fn parse_import_containers(
 /// unmasked one must.
 ///
 /// # Errors
-/// [`SmError::Precondition`] for generic (ISO 13606 / CDA) content — NOTE:
+/// [`SmError::precondition`] for generic (ISO 13606 / CDA) content — NOTE:
 /// `master06-generic_extract_package.adoc` `GENERIC_CONTENT_ITEM` is outside
 /// this CDR's import scope — or for either half of an `Item_validity`
 /// violation.
@@ -422,7 +422,7 @@ fn content_item_payload(item: &Value) -> Result<Option<&Value>, SmError> {
 /// demographic containers, keyed by cloned `vo_id`.
 ///
 /// # Errors
-/// [`SmError::Precondition`] when a version's data is not a PARTY subtype, and
+/// [`SmError::precondition`] when a version's data is not a PARTY subtype, and
 /// the [`parse_imported_version`] rejections.
 fn collect_party_versions(
     xver: &Value,
@@ -458,7 +458,7 @@ fn collect_party_versions(
 /// (master06 §Distributed Versioning).
 ///
 /// # Errors
-/// [`SmError::Precondition`] when one `vo_id` arrives under two kinds, and the
+/// [`SmError::precondition`] when one `vo_id` arrives under two kinds, and the
 /// [`parse_imported_version`] rejections.
 fn collect_content_versions(
     xver: &Value,

--- a/app/ferroehr/src/versioning/contribution.rs
+++ b/app/ferroehr/src/versioning/contribution.rs
@@ -769,7 +769,7 @@ fn parse_contribution_audit(
 /// # Errors
 /// [`ServiceError::Unprocessable`] for a member-borne version identity, an
 /// unclassifiable change type, an unparsable preceding target or an invalid
-/// audit; [`ServiceError::Precondition`] for a member carrying
+/// audit; [`ServiceError::precondition`] for a member carrying
 /// `other_input_version_uids` (not a member of `UPDATE_VERSION` on this wire —
 /// merge provenance is PRODUCE-only, so accepting it would let a client stamp
 /// arbitrary provenance onto a version this system never merged) or omitting
@@ -895,7 +895,7 @@ async fn read_target_kinds(
 /// content the committed CONTRIBUTION refers to.
 ///
 /// # Errors
-/// [`ServiceError::Precondition`] when the target does not exist.
+/// [`ServiceError::precondition`] when the target does not exist.
 fn require_kind(
     kinds: &std::collections::HashMap<VoId, Kind>,
     vo_id: VoId,
@@ -913,7 +913,7 @@ fn require_kind(
 /// instead of committing a new one (master06 §Contributions).
 ///
 /// # Errors
-/// [`ServiceError::Precondition`] for a missing target, [`ServiceError::Unprocessable`]
+/// [`ServiceError::precondition`] for a missing target, [`ServiceError::Unprocessable`]
 /// for a scope-mismatched kind, a missing `commit_audit` (the
 /// `UPDATE_ATTESTATION` payload), or an undecodable attestation.
 fn plan_attestation(
@@ -1043,7 +1043,7 @@ async fn create_change(
 ///
 /// # Errors
 /// [`ServiceError::Unprocessable`] for missing `data` or failed validation;
-/// [`ServiceError::Precondition`] when the target does not exist.
+/// [`ServiceError::precondition`] when the target does not exist.
 async fn modify_change(
     cx: &impl CommitEnv,
     kinds: &std::collections::HashMap<VoId, Kind>,
@@ -1078,7 +1078,7 @@ async fn modify_change(
 /// Resolves a deletion member.
 ///
 /// # Errors
-/// [`ServiceError::Precondition`] when the target does not exist;
+/// [`ServiceError::precondition`] when the target does not exist;
 /// [`ServiceError::Unprocessable`] for a scope-mismatched kind;
 /// [`ServiceError::Conflict`] when the member targets the `EHR_STATUS`, which
 /// is mandatory (RM ehr, EHR class: `ehr_status` 1..1) — deleting the only one


### PR DESCRIPTION
Fixes the develop rustdoc failure after #2832.

The refactor's new helper docs linked `SmError::Precondition` / `ServiceError::Precondition` — no such variants exist; both types expose a `precondition(..)` constructor, which is exactly what every one of the eight sites calls, so the case-corrected links now state the real contract.

Root cause of the escape: CI's rustdoc job passes `--document-private-items`; the CLAUDE.md gate line (which the #2832 worker ran) did not, so broken links in PRIVATE helpers' docs were invisible locally. The gate line now matches CI verbatim — reproduced the failure locally with the CI flags, and the fixed tree exits 0 under them.

`no-changelog`: doc links + a gate-line correction.