### PR TITLE
ci(hooks): shell edits get the same per-edit lint Rust already has

### DIFF
--- a/.claude/hooks/rust_fmt_clippy.sh
+++ b/.claude/hooks/rust_fmt_clippy.sh
@@ -25,8 +25,25 @@ else
   file_path="$(printf '%s' "$payload" | sed -n 's/.*"file_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"
 fi
 
+repo_root="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+
 case "${file_path:-}" in
 *.rs) ;;
+*.sh)
+  # Per-edit shell lint (#2825), the same one check the per-PR lane runs
+  # (scripts/checks/shellcheck-lane.sh in single-file mode), so a finding
+  # surfaces at the edit instead of at PR time. Skipped silently when the
+  # linter is absent; the PR lane still gates.
+  [ -f "$file_path" ] || exit 0
+  if command -v shellcheck >/dev/null 2>&1 \
+    && [ -x "$repo_root/scripts/checks/shellcheck-lane.sh" ]; then
+    findings="$("$repo_root/scripts/checks/shellcheck-lane.sh" "$file_path" 2>&1)" || {
+      printf '%s\n' "$findings" >&2
+      exit 2
+    }
+  fi
+  exit 0
+  ;;
 *) exit 0 ;;
 esac
 [ -f "$file_path" ] || exit 0


### PR DESCRIPTION
Closes #2825. The decision: add the hook — it costs one shellcheck invocation per `.sh` edit (milliseconds) and runs the lane's own script in single-file mode, so local and CI remain one check.

- `rust_fmt_clippy.sh` gains a `*.sh` case: `scripts/checks/shellcheck-lane.sh "$file"`, exit 2 feeding findings back as a correction; silent skip when shellcheck is not installed (the per-PR lane still gates); missing files exit 0.
- **It proved itself during its own construction**: the hook fired on the edit that added it and caught a genuine trap — a comment line beginning `# shellcheck …` is parsed by shellcheck as a malformed directive (SC1073/SC1072) — fixed before commit.
- Mutation proofs: an SC2086 fixture → exit 2 naming the finding; a clean fixture → 0; a nonexistent path → 0; the `.rs` branch unchanged (lib.rs edit-simulation → 0).

`no-changelog`: agent tooling.