### PR TITLE
fix(chart): the chart lane installs helm-docs, and the committed default refreshes to 4.0.6

### DIFF
--- a/.github/workflows/build-chart.yml
+++ b/.github/workflows/build-chart.yml
@@ -160,6 +160,25 @@ jobs:
           echo "${YQ_SHA256}  /tmp/yq" | sha256sum -c -
           sudo install -m 0755 /tmp/yq /usr/local/bin/yq
           yq --version
+      # validate.sh FAILS in CI when helm-docs is absent (#2806) — the README
+      # drift check is load-bearing here, since this lane packages what it
+      # validated. The v4.0.6 chart leg failed on exactly this: #2806 gave the
+      # tool to ci.yml's helm-golden job and missed this second caller.
+      - name: Install the pinned helm-docs
+        env:
+          VERSION_FILE: deploy/helm/.tool-versions
+          HELM_DOCS_SHA256: a8cf72ada34fad93285ba2a452b38bdc5bd52cc9a571236244ec31022928d6cc
+        run: |
+          set -euo pipefail
+          source scripts/gh/retry-net.sh
+          version="$(awk '$1 == "helm-docs" { print $2 }' "$VERSION_FILE")"
+          [ -n "$version" ] || { echo "::error::no helm-docs line in $VERSION_FILE"; exit 1; }
+          retry_read "https://github.com/norwoodj/helm-docs/releases/download/v${version}/helm-docs_${version}_Linux_x86_64.tar.gz" \
+            -o /tmp/helm-docs.tar.gz
+          echo "${HELM_DOCS_SHA256}  /tmp/helm-docs.tar.gz" | sha256sum -c -
+          tar -xzf /tmp/helm-docs.tar.gz -C /tmp helm-docs
+          sudo install -m 0755 /tmp/helm-docs /usr/local/bin/helm-docs
+          helm-docs --version
       - name: Chart validation + golden renders
         run: bash deploy/helm/validate.sh
 

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -42,7 +42,7 @@ version: 6.0.22
 # defaults: values track development between releases, so the publish lane
 # re-checks the pairing against an image, and the `chart-boot` CI job replays it
 # against the image built from the tree.
-appVersion: "4.0.5"
+appVersion: "4.0.6"
 
 # A COMPATIBILITY floor, and a real one: 1.36 is the release where the newest
 # field this chart renders became stable.
@@ -156,7 +156,7 @@ annotations:
   # scan while leaving the false claim in place, so it is deliberately not used.
   artifacthub.io/images: |
     - name: ferroehr
-      image: ghcr.io/rubentalstra/ferroehr:4.0.5
+      image: ghcr.io/rubentalstra/ferroehr:4.0.6
       platforms:
         - linux/amd64
         - linux/arm64
@@ -165,7 +165,7 @@ annotations:
     # visible to anyone considering it. See #2193: this chart cannot deploy it
     # yet, so today the entry advertises intent rather than chart behaviour.
     - name: ferroehr-admin-ui
-      image: ghcr.io/rubentalstra/ferroehr-admin-ui:4.0.5
+      image: ghcr.io/rubentalstra/ferroehr-admin-ui:4.0.6
       platforms:
         - linux/amd64
         - linux/arm64

--- a/deploy/helm/ferroehr/README.md
+++ b/deploy/helm/ferroehr/README.md
@@ -2,7 +2,7 @@
 
 Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.1.0 + AQL 1.1). A single static binary deployed with a hardened-by-default security posture: runs as a non-root, read-only-rootfs workload whose NetworkPolicy admits its serving port only, and that connects to an EXTERNAL PostgreSQL 18 as an unprivileged app role (migrations are run out of band by a separate migrator role).
 
-![Version: 6.0.22](https://img.shields.io/badge/Version-6.0.22-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.5](https://img.shields.io/badge/AppVersion-4.0.5-informational?style=flat-square)
+![Version: 6.0.22](https://img.shields.io/badge/Version-6.0.22-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.6](https://img.shields.io/badge/AppVersion-4.0.6-informational?style=flat-square)
 
 FerroEHR is a pure-Rust openEHR Clinical Data Repository: ITS-REST 1.1.0 at the
 API, AQL 1.1 as the query language, PostgreSQL 18-native storage, shipped as a
@@ -36,7 +36,7 @@ helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
   --version 6.0.22 \
   --namespace ferroehr --create-namespace \
   --set database.existingSecret=ferroehr-db \
-  --set image.tag=4.0.5
+  --set image.tag=4.0.6
 ```
 
 OCI registries require Helm 3.8 or newer.
@@ -48,7 +48,7 @@ They are independent SemVer lines and they move independently:
 | What | Set with | This release |
 |---|---|---|
 | the **chart** (templates, defaults, this document) | `--version` | `6.0.22` |
-| the **server image** | `image.tag` | `4.0.5` |
+| the **server image** | `image.tag` | `4.0.6` |
 
 `appVersion` is the image the chart defaults to; pinning `image.tag` explicitly
 is what keeps an upgrade of one from silently moving the other.
@@ -69,7 +69,7 @@ A **SLSA build provenance attestation:** what source it was built from, and how:
 ```console
 gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:6.0.22 \
   -R rubentalstra/FerroEHR
-gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:4.0.5 \
+gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:4.0.6 \
   -R rubentalstra/FerroEHR
 ```
 

--- a/deploy/helm/golden/admin-ui.yaml
+++ b/deploy/helm/golden/admin-ui.yaml
@@ -21,7 +21,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -93,7 +93,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -121,7 +121,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -142,7 +142,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -157,7 +157,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 automountServiceAccountToken: false
@@ -187,7 +187,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -204,7 +204,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -335,7 +335,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -358,7 +358,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -388,7 +388,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -424,7 +424,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: admin-ui
-          image: "ghcr.io/rubentalstra/ferroehr-admin-ui:4.0.5"
+          image: "ghcr.io/rubentalstra/ferroehr-admin-ui:4.0.6"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -495,7 +495,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -543,7 +543,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:4.0.5"
+          image: "ghcr.io/rubentalstra/ferroehr:4.0.6"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -26,7 +26,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -100,7 +100,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -121,7 +121,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -153,7 +153,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -179,7 +179,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -200,7 +200,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -404,7 +404,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     grafana_dashboard: "1"
@@ -655,7 +655,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -689,7 +689,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -739,7 +739,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:4.0.5"
+          image: "ghcr.io/rubentalstra/ferroehr:4.0.6"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -922,7 +922,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -956,7 +956,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -994,7 +994,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     release: kube-prometheus-stack

--- a/deploy/helm/golden/basic-auth.yaml
+++ b/deploy/helm/golden/basic-auth.yaml
@@ -26,7 +26,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -54,7 +54,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -75,7 +75,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 automountServiceAccountToken: false
@@ -105,7 +105,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -122,7 +122,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -250,7 +250,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -280,7 +280,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -328,7 +328,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:4.0.5"
+          image: "ghcr.io/rubentalstra/ferroehr:4.0.6"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -26,7 +26,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -54,7 +54,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -75,7 +75,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 automountServiceAccountToken: false
@@ -90,7 +90,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -215,7 +215,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -245,7 +245,7 @@ metadata:
     helm.sh/chart: ferroehr-6.0.22
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.5"
+    app.kubernetes.io/version: "4.0.6"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -293,7 +293,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:4.0.5"
+          image: "ghcr.io/rubentalstra/ferroehr:4.0.6"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
The v4.0.6 release run's one red leg (`chart / package + publish`) was the #2806 tightening biting its own blind spot: `validate.sh` now fails under `CI=true` without helm-docs, and #2806 installed the tool only in ci.yml's helm-golden job — build-chart.yml is the second caller, and the release chart leg died on `helm-docs: not installed`. Everything else in the run is green and published (release, binaries, images + tags, sandbox, docs freeze); only chart 6.0.22 is unpublished.

- **build-chart.yml installs the pinned helm-docs** (version from `deploy/helm/.tool-versions`, sha256-verified, `retry_read` like its yq twin).
- **The committed appVersion default refreshes to 4.0.6** — ordinary #2779 maintenance (`chart-appversion.sh`: stable[0], annotations + README + goldens regenerated, `validate.sh` exit 0) — and it makes the documented recovery exact: a plain `publish-chart.yml` dispatch packages 6.0.22 with appVersion 4.0.6, and since `[Unreleased]` is empty post-cut, the injection's designed fallback publishes the `[4.0.6]` changelog section (the recover-a-failed-tag-publish case, third live use after 6.0.13/6.0.14).

After merge: dispatch `publish-chart.yml` with `publish: true` to publish chart 6.0.22.

`actionlint` + `zizmor --min-severity=low` on the workflow: clean. `docs-claims --all`: OK.

`no-changelog`: CI lane + committed-default maintenance; the chart's own release record is the [4.0.6] changelog section it will ship with.