### PR TITLE
fix(sandbox): the deploy verification is linked to the deployment it triggers

### DIFF
--- a/.github/workflows/sandbox-deploy.yml
+++ b/.github/workflows/sandbox-deploy.yml
@@ -93,7 +93,39 @@ jobs:
     timeout-minutes: 30
     permissions: {}
     steps:
+      # The needs-edge's guarantee, re-asserted at the point of use (#2846): a
+      # release call means `:latest` must ALREADY be the tag's image, because
+      # the Vercel build is `FROM …:latest`. A stale tag fails here, before
+      # any ping — never as a 20-minute blind poll. Anonymous registry reads:
+      # the images are public.
+      - name: The :latest tag is the release image
+        if: inputs.expected-version != ''
+        env:
+          EXPECTED: ${{ inputs.expected-version }}
+          IMAGE: ghcr.io/rubentalstra/ferroehr
+        run: |
+          set -euo pipefail
+          tok=$(curl -fsS "https://ghcr.io/token?scope=repository:${IMAGE#ghcr.io/}:pull" | sed -nE 's/.*"token":"([^"]+)".*/\1/p')
+          digest_of() {
+            curl -fsS -o /dev/null -w '%{header_json}' \
+              -H "Authorization: Bearer ${tok}" \
+              -H "Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json" \
+              "https://ghcr.io/v2/${IMAGE#ghcr.io/}/manifests/$1" \
+              | sed -nE 's/.*"docker-content-digest":\["([^"]+)"\].*/\1/p'
+          }
+          latest=$(digest_of latest)
+          tagged=$(digest_of "$EXPECTED")
+          if [ -z "$latest" ] || [ -z "$tagged" ] || [ "$latest" != "$tagged" ]; then
+            echo "::error:::latest (${latest:-unreadable}) is not the ${EXPECTED} image (${tagged:-unreadable}) — the deploy would rebuild the OLD release; the tag-apply leg must land first." >&2
+            exit 1
+          fi
+          echo ":latest == ${EXPECTED} (${latest})"
+
+      # The hook response is CAPTURED, not discarded (#2846): it carries the
+      # created job's id — the only handle linking this run to the deployment
+      # it triggered.
       - name: Trigger the Vercel deploy
+        id: ping
         env:
           HOOK_URL: ${{ secrets.SANDBOX_DEPLOY_HOOK_URL }}
         run: |
@@ -102,14 +134,59 @@ jobs:
             echo "::error::SANDBOX_DEPLOY_HOOK_URL is empty — create the Deploy Hook on the Vercel project (Settings → Git → Deploy Hooks, branch develop) and run: gh secret set SANDBOX_DEPLOY_HOOK_URL" >&2
             exit 1
           fi
-          curl -fsS -X POST "$HOOK_URL" -o /dev/null
-          echo "sandbox deploy triggered"
+          echo "pinged-at=$(date +%s)" >> "$GITHUB_OUTPUT"
+          body=$(curl -fsS -X POST "$HOOK_URL")
+          job_id=$(printf '%s' "$body" | sed -nE 's/.*"id":"([^"]+)".*/\1/p')
+          echo "job-id=${job_id}" >> "$GITHUB_OUTPUT"
+          echo "sandbox deploy triggered (hook job ${job_id:-<no id in response>})"
+
+      # The deployment's OWN state, when a read-scoped token exists (#2846):
+      # a failed Vercel build fails THIS run within one poll interval, naming
+      # the deployment — instead of hiding behind the blind version poll below
+      # for its full timeout. Without the token the step self-skips and the
+      # version poll's timeout message carries the diagnosis split.
+      - name: Watch the triggered deployment (linked, token-gated)
+        env:
+          VERCEL_TOKEN: ${{ secrets.SANDBOX_VERCEL_TOKEN }}
+          PROJECT_ID: ${{ secrets.SANDBOX_VERCEL_PROJECT_ID }}
+          PINGED_AT: ${{ steps.ping.outputs.pinged-at }}
+        run: |
+          set -euo pipefail
+          if [ -z "$VERCEL_TOKEN" ] || [ -z "$PROJECT_ID" ]; then
+            echo "SANDBOX_VERCEL_TOKEN/SANDBOX_VERCEL_PROJECT_ID not set — deployment-state watch skipped (#2846); the version poll below is the only verification."
+            exit 0
+          fi
+          since_ms=$(( PINGED_AT * 1000 ))
+          deadline=$(( $(date +%s) + 1200 ))
+          dep_id=""
+          while :; do
+            page=$(curl -fsS -m 30 -H "Authorization: Bearer ${VERCEL_TOKEN}" \
+              "https://api.vercel.com/v6/deployments?projectId=${PROJECT_ID}&target=production&limit=5&since=${since_ms}" || true)
+            if [ -z "$dep_id" ]; then
+              dep_id=$(printf '%s' "$page" | jq -r '.deployments | sort_by(-.created) | .[0].uid // empty')
+              [ -n "$dep_id" ] && echo "watching deployment ${dep_id}"
+            fi
+            state=$(printf '%s' "$page" | jq -r --arg id "$dep_id" '.deployments[] | select(.uid == $id) | .readyState // .state // empty')
+            case "$state" in
+              READY) echo "deployment ${dep_id} is READY"; break ;;
+              ERROR | CANCELED)
+                echo "::error::deployment ${dep_id} ended ${state} — the Vercel build failed; read its build log on the Vercel dashboard. The image side was proven correct before the ping." >&2
+                exit 1 ;;
+              *) echo "deployment ${dep_id:-<not created yet>}: ${state:-pending}" ;;
+            esac
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "::error::no READY deployment 20 minutes after the ping (last state: ${state:-none created}) — check the Vercel dashboard." >&2
+              exit 1
+            fi
+            sleep 20
+          done
 
       - name: Wait for the sandbox to serve again
         env:
           HOOK_URL: ${{ secrets.SANDBOX_DEPLOY_HOOK_URL }}
           # Only compared against the served version string, never executed.
           EXPECTED: ${{ inputs.expected-version }}
+          JOB_ID: ${{ steps.ping.outputs.job-id }}
         run: |
           set -euo pipefail
           if [ -z "$HOOK_URL" ]; then
@@ -136,7 +213,7 @@ jobs:
               break
             fi
             if [ "$(date +%s)" -ge "$deadline" ]; then
-              echo "::error::the sandbox serves '${served:-nothing}' (expected '${expected:-any}') 20 minutes after the deploy ping." >&2
+              echo "::error::the sandbox serves '${served:-nothing}' (expected '${expected:-any}') 20 minutes after the deploy ping. The image side was proven correct before the ping (:latest == the release image), so the failing half is Vercel's own build or promotion — read the build log on the Vercel dashboard (hook job ${JOB_ID:-unknown}); with SANDBOX_VERCEL_TOKEN set, the linked watch above would have named the failed deployment directly (#2846)." >&2
               exit 1
             fi
             echo "sandbox serves '${served:-nothing}'; waiting for '${expected:-any}'"

--- a/deploy/vercel/README.md
+++ b/deploy/vercel/README.md
@@ -36,6 +36,22 @@ Sandbox failures live in the two sandbox-named workflows (Sandbox deploy,
 Sandbox reseed) and nowhere else. CI, Containers, the chart and release
 lanes carry no sandbox steps, so a sandbox outage can never redden them.
 
+The deploy job verifies in three layers (#2846, after the v4.0.7 cut spent
+20 blind minutes on a Vercel-side build failure):
+
+1. **Precondition** (release calls): `:latest`'s digest must equal the
+   release tag's image digest on GHCR before any ping — the needs-edge's
+   guarantee, re-asserted where it is consumed.
+2. **Linked watch** (token-gated): the hook response's job id is captured,
+   and with `SANDBOX_VERCEL_TOKEN` + `SANDBOX_VERCEL_PROJECT_ID` set the job
+   polls the triggered deployment's own state — a Vercel build `ERROR`
+   fails the run within one interval naming the deployment, instead of
+   hiding behind the version poll. Owner setup: a read-scope token from the
+   Vercel dashboard + the project id, `gh secret set` both.
+3. **The served-version poll** stays the final acceptance either way; its
+   timeout message states what was already proven (the image side) so the
+   remaining suspect (Vercel's build/promotion) is named, not guessed.
+
 ## Two build-log warnings that are understood, not unnoticed (#2773)
 
 Every Vercel build of `Dockerfile.vercel` prints two warnings. Both were


### PR DESCRIPTION
Part of #2846 (the token secrets + a live exercise remain owner-side, so no auto-close).

The v4.0.7 sandbox leg's 20 blind minutes, rewritten as three assertions:

1. **Precondition** (release calls only): `:latest` digest == the tag's image digest via anonymous GHCR manifest HEADs — proven live (4.0.7 matches; a deliberate 4.0.5 comparison is detected as the designed failure). A stale tag now fails before any ping.
2. **Linkage**: the hook POST's response is captured (the job id), and the new token-gated step polls the triggered deployment's own `readyState` — `ERROR`/`CANCELED` fails within one 20s interval naming the deployment; `READY` hands off to the version poll. Self-skips with a log line when the secrets are absent.
3. **The version poll** stays the final acceptance; its timeout error now states the image side was proven, so the diagnosis starts at Vercel's build log instead of at zero.

Owner clicks recorded on #2846: a read-scope Vercel token + the project id (`gh secret set SANDBOX_VERCEL_TOKEN SANDBOX_VERCEL_PROJECT_ID`); `secrets: inherit` already flows them. `actionlint` + `zizmor --min-severity=low`: clean.

`no-changelog`: delivery-pipeline machinery.