### PR TITLE
chore(sandbox): the refused token-gated watch goes — dead code carries no adjudication

### DIFF
--- a/.github/workflows/sandbox-deploy.yml
+++ b/.github/workflows/sandbox-deploy.yml
@@ -140,47 +140,10 @@ jobs:
           echo "job-id=${job_id}" >> "$GITHUB_OUTPUT"
           echo "sandbox deploy triggered (hook job ${job_id:-<no id in response>})"
 
-      # The deployment's OWN state, when a read-scoped token exists (#2846):
-      # a failed Vercel build fails THIS run within one poll interval, naming
-      # the deployment — instead of hiding behind the blind version poll below
-      # for its full timeout. Without the token the step self-skips and the
-      # version poll's timeout message carries the diagnosis split.
-      - name: Watch the triggered deployment (linked, token-gated)
-        env:
-          VERCEL_TOKEN: ${{ secrets.SANDBOX_VERCEL_TOKEN }}
-          PROJECT_ID: ${{ secrets.SANDBOX_VERCEL_PROJECT_ID }}
-          PINGED_AT: ${{ steps.ping.outputs.pinged-at }}
-        run: |
-          set -euo pipefail
-          if [ -z "$VERCEL_TOKEN" ] || [ -z "$PROJECT_ID" ]; then
-            echo "SANDBOX_VERCEL_TOKEN/SANDBOX_VERCEL_PROJECT_ID not set — deployment-state watch skipped (#2846); the version poll below is the only verification."
-            exit 0
-          fi
-          since_ms=$(( PINGED_AT * 1000 ))
-          deadline=$(( $(date +%s) + 1200 ))
-          dep_id=""
-          while :; do
-            page=$(curl -fsS -m 30 -H "Authorization: Bearer ${VERCEL_TOKEN}" \
-              "https://api.vercel.com/v6/deployments?projectId=${PROJECT_ID}&target=production&limit=5&since=${since_ms}" || true)
-            if [ -z "$dep_id" ]; then
-              dep_id=$(printf '%s' "$page" | jq -r '.deployments | sort_by(-.created) | .[0].uid // empty')
-              [ -n "$dep_id" ] && echo "watching deployment ${dep_id}"
-            fi
-            state=$(printf '%s' "$page" | jq -r --arg id "$dep_id" '.deployments[] | select(.uid == $id) | .readyState // .state // empty')
-            case "$state" in
-              READY) echo "deployment ${dep_id} is READY"; break ;;
-              ERROR | CANCELED)
-                echo "::error::deployment ${dep_id} ended ${state} — the Vercel build failed; read its build log on the Vercel dashboard. The image side was proven correct before the ping." >&2
-                exit 1 ;;
-              *) echo "deployment ${dep_id:-<not created yet>}: ${state:-pending}" ;;
-            esac
-            if [ "$(date +%s)" -ge "$deadline" ]; then
-              echo "::error::no READY deployment 20 minutes after the ping (last state: ${state:-none created}) — check the Vercel dashboard." >&2
-              exit 1
-            fi
-            sleep 20
-          done
-
+      # NOTE: no deployment-state watch exists, deliberately (#2846): Vercel
+      # offers no read-only tokens, so watching the triggered deployment would
+      # cost a stored full-access credential — refused; the version poll below
+      # is the verification, and its timeout message carries the diagnosis.
       - name: Wait for the sandbox to serve again
         env:
           HOOK_URL: ${{ secrets.SANDBOX_DEPLOY_HOOK_URL }}
@@ -213,7 +176,7 @@ jobs:
               break
             fi
             if [ "$(date +%s)" -ge "$deadline" ]; then
-              echo "::error::the sandbox serves '${served:-nothing}' (expected '${expected:-any}') 20 minutes after the deploy ping. The image side was proven correct before the ping (:latest == the release image), so the failing half is Vercel's own build or promotion — read the build log on the Vercel dashboard (hook job ${JOB_ID:-unknown}); with SANDBOX_VERCEL_TOKEN set, the linked watch above would have named the failed deployment directly (#2846)." >&2
+              echo "::error::the sandbox serves '${served:-nothing}' (expected '${expected:-any}') 20 minutes after the deploy ping. The image side was proven correct before the ping (:latest == the release image), so the failing half is Vercel's own build or promotion — read the build log on the Vercel dashboard (hook job ${JOB_ID:-unknown}). Known flaky suspect: a Neon integration step ahead of the container build (#2846)." >&2
               exit 1
             fi
             echo "sandbox serves '${served:-nothing}'; waiting for '${expected:-any}'"

--- a/deploy/vercel/README.md
+++ b/deploy/vercel/README.md
@@ -36,21 +36,23 @@ Sandbox failures live in the two sandbox-named workflows (Sandbox deploy,
 Sandbox reseed) and nowhere else. CI, Containers, the chart and release
 lanes carry no sandbox steps, so a sandbox outage can never redden them.
 
-The deploy job verifies in three layers (#2846, after the v4.0.7 cut spent
+The deploy job verifies in two layers (#2846, after the v4.0.7 cut spent
 20 blind minutes on a Vercel-side build failure):
 
 1. **Precondition** (release calls): `:latest`'s digest must equal the
    release tag's image digest on GHCR before any ping — the needs-edge's
-   guarantee, re-asserted where it is consumed.
-2. **Linked watch** (token-gated): the hook response's job id is captured,
-   and with `SANDBOX_VERCEL_TOKEN` + `SANDBOX_VERCEL_PROJECT_ID` set the job
-   polls the triggered deployment's own state — a Vercel build `ERROR`
-   fails the run within one interval naming the deployment, instead of
-   hiding behind the version poll. Owner setup: a read-scope token from the
-   Vercel dashboard + the project id, `gh secret set` both.
-3. **The served-version poll** stays the final acceptance either way; its
-   timeout message states what was already proven (the image side) so the
-   remaining suspect (Vercel's build/promotion) is named, not guessed.
+   guarantee, re-asserted where it is consumed, with anonymous registry
+   reads.
+2. **The served-version poll** is the acceptance; the hook response's job
+   id is captured for the record, and the timeout message states what was
+   already proven (the image side) so the remaining suspect (Vercel's own
+   build/promotion — historically a flaky Neon integration step, #2846) is
+   named, not guessed.
+
+Watching the triggered deployment's own state was considered and REFUSED
+(#2846): Vercel offers no read-only tokens, so it would cost a stored
+full-access credential for a diagnostics-only win — against this
+repository's no-long-lived-tokens posture.
 
 ## Two build-log warnings that are understood, not unnoticed (#2773)
 


### PR DESCRIPTION
The residue sweep after #2846's no-token adjudication — nothing left behind:

- **The token-gated watch step is deleted** (it would self-skip forever; permanently-dead code is a false capability claim). A `NOTE` at the site records the refusal and its ground. The credential-free layers stand: the `:latest` digest precondition, the captured hook job id, and the timeout diagnosis — which now names the measured flaky suspect (the Neon integration step) instead of pointing at a removed step.
- **`deploy/vercel/README.md`** describes the real two-layer verification and records the refused option, so nobody re-proposes it without meeting the recorded ground.
- Swept outside this diff (recorded here): the unused GitHub `Production` environment deleted (empty, referenced by no workflow — docs.yml uses `github-pages`); the orphaned `badges` branch deleted (the pre-Sonar coverage-badge machinery; every current badge serves from develop artifacts or SonarCloud); the consumed one-shot handoff files removed from ~/Downloads; no `SANDBOX_VERCEL_*` secret exists on GitHub (the project-id the owner added went to the Vercel dashboard — harmless there, removable at leisure).

`actionlint` + `zizmor --min-severity=low`: clean. `no-changelog`: delivery machinery + settings hygiene.