### PR TITLE
docs(sandbox): the DSN's real source is the Neon-injected DATABASE_URL

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -36,3 +36,4 @@
 - [No AI tells in prose](no-ai-tells-in-prose.md) — em dashes, not-X-but-Y, triads, buzzwords banned in all drafted prose
 - [Gate parity + caller sweeps](gate-parity-and-caller-sweeps.md) — local gate lines must mirror CI flags verbatim (the rustdoc --document-private-items escape); tightening a shared check obligates sweeping ALL its workflow callers (the #2806 chart-leg break)
 - [Veredictum: other session](veredictum-other-session.md) — owner 2026-08-27: never touch the Veredictum checkout/tracker/dispatches from here; read prior art from the remote; FerroEHR-side pin/integration stays fair game
+- [Sandbox DSN is Neon-injected](sandbox-dsn-is-neon-injected.md) — no hand-set FERROEHR__DB__URL exists; the Neon integration's DATABASE_URL(_UNPOOLED) is the DSN via config/alias.rs; never disconnect it without hand-setting the DSN first; grep the alias layer before calling an env var unused

--- a/.claude/memory/sandbox-dsn-is-neon-injected.md
+++ b/.claude/memory/sandbox-dsn-is-neon-injected.md
@@ -1,0 +1,26 @@
+---
+name: sandbox-dsn-is-neon-injected
+description: "The hosted sandbox's DSN is the Neon integration's injected DATABASE_URL(_UNPOOLED) via the config alias layer — the integration is load-bearing; never recommend disconnecting it without hand-setting the DSN first"
+metadata:
+  type: project
+---
+
+The hosted sandbox (sandbox.ferroehr.eu) has NO hand-set `FERROEHR__DB__URL`
+on the Vercel project. Its DSN is the Neon↔Vercel integration's injected
+`DATABASE_URL`/`DATABASE_URL_UNPOOLED`, which `app/ferroehr/src/config/alias.rs`
+maps to `db.url` (unpooled preferred, #2716 — built for exactly this).
+
+**Why:** on 2026-08-27 I claimed "the integration provides nothing" and urged
+disconnecting it (to kill its flaky branch-per-deployment provisioning step,
+#2846) — a disconnect would have removed the injected vars and taken the
+sandbox's database away. The owner caught it ("i did not add a manual
+FERROEHR__DB__URL"). The mistake: I verified the TOML carries no DSN and that
+the db was UP, then inferred the variable NAME without grepping the config
+loader for aliases.
+
+**How to apply:** the integration's env INJECTION stays connected; only its
+branch-per-deployment toggle is fair game when the provisioning step flakes.
+Before ever claiming an env var / integration is unused, grep the config
+alias + loader layer (`config/alias.rs`, `config/loader.rs`) — the FERROEHR__
+grammar is not the only spelling the server reads. Related:
+[[session-workflow-gotchas]].

--- a/Dockerfile.vercel
+++ b/Dockerfile.vercel
@@ -19,7 +19,12 @@
 # documented in deploy/vercel/README.md.
 #
 # The image serves a DEMO: no persistent filesystem exists on Vercel and the
-# database is an external PostgreSQL 18 DSN supplied as FERROEHR__DB__URL.
+# database DSN is the Neon integration's injected DATABASE_URL(_UNPOOLED),
+# which the config loader's alias layer maps to db.url (config/alias.rs,
+# unpooled preferred — #2716). The integration's env INJECTION is therefore
+# load-bearing; no hand-set FERROEHR__DB__URL exists on the project
+# (established the hard way, 2026-08-27: a disconnect would take the
+# database away).
 
 FROM ghcr.io/rubentalstra/ferroehr:latest
 
@@ -28,8 +33,8 @@ FROM ghcr.io/rubentalstra/ferroehr:latest
 USER 65532:65532
 
 # The sandbox posture (demo user, no admin/management surface, port 80 —
-# Vercel's default container port). The DSN arrives as FERROEHR__DB__URL
-# from the Vercel project settings.
+# Vercel's default container port). The DSN arrives as the Neon-injected
+# DATABASE_URL(_UNPOOLED) via the config env aliases.
 COPY deploy/vercel/ferroehr.sandbox.toml /etc/ferroehr/ferroehr.toml
 ENV FERROEHR_CONFIG=/etc/ferroehr/ferroehr.toml
 ENV PORT=80

--- a/deploy/vercel/README.md
+++ b/deploy/vercel/README.md
@@ -4,6 +4,18 @@ The sandbox is Vercel (container runtime) + Neon (PostgreSQL 18). It runs
 the latest published release image with a demo posture baked on top, and it
 resets to known demo data every night.
 
+The Neon↔Vercel integration is LOAD-BEARING for exactly one thing: its
+injected `DATABASE_URL`/`DATABASE_URL_UNPOOLED` is the server's DSN (the
+config aliases map it to `db.url`, unpooled preferred — #2716). No hand-set
+`FERROEHR__DB__URL` exists on the project, so the integration must stay
+connected — established the hard way on 2026-08-27, when disconnecting it
+was almost the "fix" for its OTHER half: the per-deployment branch
+provisioning, which is pure overhead here (nothing reads the per-deploy
+branch) and has a measured record of timing out and killing release-day
+deploys (#2846). If that step misbehaves again, disable deployment
+branching in the integration's settings — never disconnect the integration
+without first hand-setting the DSN.
+
 ## The delivery pipeline — one owner, explicit ordering
 
 Vercel never builds on its own: git-triggered deployments are OFF

--- a/deploy/vercel/ferroehr.sandbox.toml
+++ b/deploy/vercel/ferroehr.sandbox.toml
@@ -6,7 +6,8 @@
 # where a PUBLIC endpoint demands it: the admin API and the management
 # introspection stay OFF (defaults), so the public demo credentials can read
 # and write clinical data and nothing else. The database DSN comes from the
-# environment (FERROEHR__DB__URL), never from this file.
+# environment, never from this file — the Neon integration's injected
+# DATABASE_URL(_UNPOOLED), mapped to db.url by the config aliases (#2716).
 
 [server]
 # Vercel's default container port; the PORT environment convention lands on


### PR DESCRIPTION
Owner-caught correction of yesterday's wrong claim. The facts, verified in code: `config/alias.rs:83` maps `DATABASE_URL` → `FERROEHR__DB__URL`, the loader prefers `DATABASE_URL_UNPOOLED` (#2716, built for Neon), and the Vercel project carries no hand-set `FERROEHR__DB__URL` — so the Neon integration's env injection IS the sandbox's DSN, and the disconnect this session recommended (and the owner wisely reversed) would have taken the database away.

- `Dockerfile.vercel`, `ferroehr.sandbox.toml`, `deploy/vercel/README.md`: the DSN source stated truthfully, plus the standing rule — the integration stays connected; only its branch-per-deployment toggle (the flaky half, #2846) is fair game; never disconnect without hand-setting the DSN first.
- The #2846 thread carries the same correction.
- A project memory records the lesson: grep the config alias/loader layer before declaring an env var or integration unused.

`no-changelog`: internal delivery docs + memory.