### PR TITLE
chore(docs): a release cut no longer shows a cancelled Docs run

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,9 +28,20 @@ env:
   SITE_ORIGIN: "https://ferroehr.eu"
   SITE_BASE: ""
 
+# Cancel only PR runs (#2845). Push and dispatch runs QUEUE instead: at every
+# release cut the merge push starts a Docs run and the pipeline's docs-freeze
+# leg dispatches a second one ~90s later — with blanket cancellation the push
+# run died as a scary-looking "Cancelled" row on every healthy cut (three in a
+# row before this was adjudicated). Queuing costs one ~3-minute redundant
+# build per cut; the deploy job's own `pages` group already serializes the
+# actual deploys, and the dispatch run lands last with the frozen version.
+# Residual: GitHub still displaces a QUEUED run when a third arrives for the
+# same group (pending-displacement ignores this setting), so a rapid burst of
+# 3+ develop pushes can still show one Cancelled row — rare, and equally
+# benign.
 concurrency:
   group: docs-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions: {}
 


### PR DESCRIPTION
Closes #2845, taking the issue's option (c) — stop the row from appearing, rather than documenting it away:

- `cancel-in-progress` becomes `${{ github.event_name == 'pull_request' }}`: PR runs keep rapid-push cancellation, while push and dispatch runs QUEUE — so at a cut, the merge-push run completes and the docs-freeze dispatch lands last with the frozen version. No Cancelled row.
- The cost is one ~3-minute redundant build per cut; the deploy job's own `pages` group (`cancel-in-progress: false`) already serializes actual deployments, so ordering and the final served content are unchanged.
- The stanza's comment records the adjudication and the honest residual: GitHub's pending-displacement replaces a QUEUED run regardless of this setting, so a burst of 3+ develop pushes can still show one Cancelled row — rare, and equally benign.

Concurrency semantics aren't locally mutation-provable; the live proof is the next release cut showing two green Docs rows instead of Cancelled+Ready. `actionlint` + `zizmor --min-severity=low`: clean.

`no-changelog`: CI hygiene.