### PR TITLE
fix(scripts): publish-crates.sh uses [[ ]] for its four conditionals

### DIFF
--- a/scripts/release/publish-crates.sh
+++ b/scripts/release/publish-crates.sh
@@ -87,7 +87,7 @@ do_publish() {
       ;;
     esac
   done
-  [ -z "$failed" ] || {
+  [[ -z "$failed" ]] || {
     echo "::error::failed to publish:$failed"
     return 1
   }
@@ -118,13 +118,13 @@ do_verify() {
           jq -r --arg v "$want" '.versions[]? | select(.num == $v) | .num' |
           head -1)" || got=""
       fi
-      [ -n "$got" ] && break
+      [[ -n "$got" ]] && break
       sleep 10
     done
     printf '%-16s %s\n' "$crate" "${got:-MISSING}"
-    [ -n "$got" ] || bad="$bad $crate"
+    [[ -n "$got" ]] || bad="$bad $crate"
   done
-  [ -z "$bad" ] || {
+  [[ -z "$bad" ]] || {
     echo "::error::the published set is SPLIT — these are not at $want:$bad"
     return 1
   }


### PR DESCRIPTION
The four `shelldre:S7688` findings from #2861 (lines 90/121/125/127 of the #2837 script). `bash -n`, the shellcheck lane, and a live `verify 0.0.42` read-back (all eight crates confirmed) — green. `no-changelog`: release tooling internals.