### PR TITLE
refactor(quality): the twenty cognitive-complexity sites split into named helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Changed
+
+- The `openehr-*` spec crates step to `0.0.43`. The change is internal
+  structure only: over-complex functions in the ADL engine, the Simplified
+  Formats web-template builder and the ISO 8601 duration parser were split
+  into named, documented helpers. The wire behaviour, the generated output and
+  every gate are unchanged, and nothing an API consumer calls moved.
+
 ## [4.0.8] - 2026-08-27
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5426,7 +5426,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.42"
+version = "0.0.43"
 dependencies = [
  "indexmap 2.14.0",
  "openehr-am",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.42"
+version = "0.0.43"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.42"
+version = "0.0.43"
 dependencies = [
  "serde",
  "serde_json",
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.42"
+version = "0.0.43"
 dependencies = [
  "async-trait",
  "axum",
@@ -5500,7 +5500,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.42"
+version = "0.0.43"
 dependencies = [
  "assert_fs",
  "chumsky",
@@ -5514,7 +5514,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.42"
+version = "0.0.43"
 dependencies = [
  "chumsky",
  "logos",
@@ -5523,7 +5523,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.42"
+version = "0.0.43"
 dependencies = [
  "insta",
  "jsonschema",
@@ -5541,7 +5541,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.42"
+version = "0.0.43"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/app/ferroehr-rest/src/extensions/fhir.rs
+++ b/app/ferroehr-rest/src/extensions/fhir.rs
@@ -406,54 +406,77 @@ async fn run(state: AppState, op: &'static str, parts: RequestParts) -> Response
 /// No openEHR spec governs this — our own design/extension (the FHIR
 /// connector's configuration surface).
 async fn mapping_crud(state: &AppState, op: &'static str, parts: &RequestParts) -> Response {
-    let h = &parts.headers;
     match op {
-        "fhir_mapping_list" => match state.backend().fhir_mapping_list().await {
-            Ok(items) => negotiate::respond(h, StatusCode::OK, &items),
-            Err(e) => sm_error_outcome(e),
-        },
-        "fhir_mapping_create" => {
-            let body = match negotiate::json_value(h, &parts.body) {
-                Ok(b) => b,
-                Err(e) => return api_error_outcome(&e),
-            };
-            match state.backend().fhir_mapping_create(body).await {
-                Ok(created) => negotiate::respond(h, StatusCode::CREATED, &created),
-                Err(e) => sm_error_outcome(e),
-            }
-        }
-        "fhir_mapping_get" => match mapping_id(parts) {
-            Ok(id) => match state.backend().fhir_mapping_get(id).await {
-                Ok(item) => negotiate::respond(h, StatusCode::OK, &item),
-                Err(e) => sm_error_outcome(e),
-            },
-            Err(e) => api_error_outcome(&e.0),
-        },
-        "fhir_mapping_update" => match mapping_id(parts) {
-            Ok(id) => {
-                let body = match negotiate::json_value(h, &parts.body) {
-                    Ok(b) => b,
-                    Err(e) => return api_error_outcome(&e),
-                };
-                match state.backend().fhir_mapping_update(id, body).await {
-                    Ok(updated) => negotiate::respond(h, StatusCode::OK, &updated),
-                    Err(e) => sm_error_outcome(e),
-                }
-            }
-            Err(e) => api_error_outcome(&e.0),
-        },
-        "fhir_mapping_delete" => match mapping_id(parts) {
-            Ok(id) => match state.backend().fhir_mapping_delete(id).await {
-                Ok(()) => negotiate::empty(StatusCode::NO_CONTENT),
-                Err(e) => sm_error_outcome(e),
-            },
-            Err(e) => api_error_outcome(&e.0),
-        },
+        "fhir_mapping_list" => mapping_list(state, parts).await,
+        "fhir_mapping_create" => mapping_create(state, parts).await,
+        "fhir_mapping_get" => mapping_get(state, parts).await,
+        "fhir_mapping_update" => mapping_update(state, parts).await,
+        "fhir_mapping_delete" => mapping_delete(state, parts).await,
         other => operation_outcome(
             StatusCode::INTERNAL_SERVER_ERROR,
             "exception",
             &format!("unrouted FHIR connector operation: {other}"),
         ),
+    }
+}
+
+/// `GET /admin/fhir_mapping` — every stored template→resource mapping.
+async fn mapping_list(state: &AppState, parts: &RequestParts) -> Response {
+    match state.backend().fhir_mapping_list().await {
+        Ok(items) => negotiate::respond(&parts.headers, StatusCode::OK, &items),
+        Err(e) => sm_error_outcome(e),
+    }
+}
+
+/// `POST /admin/fhir_mapping` — register one template→resource mapping.
+async fn mapping_create(state: &AppState, parts: &RequestParts) -> Response {
+    let body = match negotiate::json_value(&parts.headers, &parts.body) {
+        Ok(b) => b,
+        Err(e) => return api_error_outcome(&e),
+    };
+    match state.backend().fhir_mapping_create(body).await {
+        Ok(created) => negotiate::respond(&parts.headers, StatusCode::CREATED, &created),
+        Err(e) => sm_error_outcome(e),
+    }
+}
+
+/// `GET /admin/fhir_mapping/{mapping_id}` — read one stored mapping.
+async fn mapping_get(state: &AppState, parts: &RequestParts) -> Response {
+    let id = match mapping_id(parts) {
+        Ok(id) => id,
+        Err(e) => return api_error_outcome(&e.0),
+    };
+    match state.backend().fhir_mapping_get(id).await {
+        Ok(item) => negotiate::respond(&parts.headers, StatusCode::OK, &item),
+        Err(e) => sm_error_outcome(e),
+    }
+}
+
+/// `PUT /admin/fhir_mapping/{mapping_id}` — replace one stored mapping.
+async fn mapping_update(state: &AppState, parts: &RequestParts) -> Response {
+    let id = match mapping_id(parts) {
+        Ok(id) => id,
+        Err(e) => return api_error_outcome(&e.0),
+    };
+    let body = match negotiate::json_value(&parts.headers, &parts.body) {
+        Ok(b) => b,
+        Err(e) => return api_error_outcome(&e),
+    };
+    match state.backend().fhir_mapping_update(id, body).await {
+        Ok(updated) => negotiate::respond(&parts.headers, StatusCode::OK, &updated),
+        Err(e) => sm_error_outcome(e),
+    }
+}
+
+/// `DELETE /admin/fhir_mapping/{mapping_id}` — drop one stored mapping.
+async fn mapping_delete(state: &AppState, parts: &RequestParts) -> Response {
+    let id = match mapping_id(parts) {
+        Ok(id) => id,
+        Err(e) => return api_error_outcome(&e.0),
+    };
+    match state.backend().fhir_mapping_delete(id).await {
+        Ok(()) => negotiate::empty(StatusCode::NO_CONTENT),
+        Err(e) => sm_error_outcome(e),
     }
 }
 

--- a/app/ferroehr-server/src/lib.rs
+++ b/app/ferroehr-server/src/lib.rs
@@ -24,6 +24,7 @@ use std::time::Duration;
 use anyhow::Context as _;
 use clap::{Parser, Subcommand};
 use ferroehr::config::management::EndpointLevels;
+use ferroehr::config::management::ManagementConfig;
 use ferroehr::system_log::config::AuditConfig;
 use ferroehr::system_log::sender::{AuditHandle, AuditSender, SubjectResolver};
 use ferroehr::telemetry::build_info::BuildInfo;
@@ -285,6 +286,131 @@ fn mounted_management_endpoints(levels: EndpointLevels) -> String {
 /// ingress sits in front", which is the ordinary deployment, so authentication
 /// over plaintext on a routable bind warns loudly and proceeds — the operator
 /// owns the edge.
+/// Assembles the platform service from the resolved config tree.
+///
+/// Every optional collaborator the service carries is attached here: the audit
+/// sender, the local Audit Record Repository read side (the ITI-81 retrieval,
+/// wired only when auditing AND the store are on), terminology, the subject
+/// proxy, and the multimedia store.
+///
+/// # Errors
+/// Any collaborator whose configuration is enabled but unbuildable — a slim
+/// build missing its cargo feature, or an unusable external dependency.
+fn assemble_service(
+    config: &ferroehr::config::FerroEhrConfig,
+    pool: &PgPool,
+    audit_sender: Option<AuditSender>,
+    outbox_enabled: bool,
+    signer: Arc<Signer>,
+) -> anyhow::Result<FerroEhrService> {
+    let audit_enabled = audit_sender.is_some();
+    let mut service = FerroEhrService::new(pool.clone())
+        .with_spec_profile(config.spec_profile)
+        .with_system_id(config.server.system_id.clone())
+        .with_signer(signer)
+        .with_outbox_enabled(outbox_enabled)
+        .with_query_config(&config.query);
+    if let Some(sender) = audit_sender {
+        service = service.with_audit(sender);
+    }
+    if audit_enabled && config.audit.store.enabled {
+        service =
+            service.with_audit_store(ferroehr::system_log::store::AuditStore::new(pool.clone()));
+    }
+
+    service = attach_terminology(service, config)?;
+    service = attach_subject_proxy(service, config)?;
+    attach_multimedia(service, config)
+}
+
+/// Wires authorization, which is active only when authentication is enabled:
+/// the RBAC gate plus the ABAC engine over the DB-backed attribute resolvers.
+///
+/// `None` when authentication is off, or when neither authorization layer is
+/// configured.
+///
+/// # Errors
+/// A misconfigured ABAC block (enabled but unbuildable) aborts BOOT —
+/// configuration that promises fine-grained authorization must never degrade
+/// to authz-off.
+fn wire_authz(
+    config: &ferroehr::config::FerroEhrConfig,
+    pool: &PgPool,
+    service: &Arc<FerroEhrService>,
+) -> anyhow::Result<Option<Arc<AuthzHandle>>> {
+    if !config.auth.enabled {
+        return Ok(None);
+    }
+    let authz = build_authz(
+        &config.authz,
+        &config.server.base_path,
+        authz_resolvers(pool.clone(), Arc::clone(service)),
+    )?;
+    if let Some(handle) = &authz {
+        tracing::info!(
+            rbac = handle.rbac_active(),
+            abac = handle.abac_active(),
+            "authorization enabled"
+        );
+    }
+    Ok(authz)
+}
+
+/// Logs the resolved runtime posture, one line per subsystem, immediately
+/// before the listener starts.
+///
+/// Each line carries that subsystem's own facts, so the listener line stays
+/// about the listener: authorization already logged its own line when it was
+/// built, and auditing and the management surface get theirs here.
+fn log_resolved_posture(
+    app_config: &AppConfig,
+    audit_enabled: bool,
+    audit: &AuditConfig,
+    management: &ManagementConfig,
+) {
+    tracing::info!(
+        mechanisms = %app_config.auth.advertised_mechanisms(),
+        enabled = app_config.auth.enabled,
+        "authentication configured"
+    );
+    if audit_enabled {
+        tracing::info!(
+            local_repository = audit.store.enabled,
+            syslog = audit.syslog.enabled,
+            fhir_feed = audit.fhir_feed.enabled,
+            queue_capacity = audit.queue_capacity,
+            fail_mode = ?audit.fail_mode,
+            resolve_subject = audit.resolve_subject,
+            "IHE ATNA audit enabled"
+        );
+    } else {
+        tracing::info!("IHE ATNA audit disabled");
+    }
+    if management.enabled {
+        tracing::info!(
+            base_path = %management.base_path,
+            listener = match management.port {
+                Some(port) => format!("own port {port}"),
+                None => "shared with the API".to_owned(),
+            },
+            mounted = %mounted_management_endpoints(management.endpoints),
+            "management surface enabled"
+        );
+    }
+    tracing::info!(
+        enabled = app_config.server.rate_limit.enabled,
+        principal_per_second = app_config.server.rate_limit.principal_per_second,
+        address_per_second = app_config.server.rate_limit.address_per_second,
+        "request-rate limiting configured"
+    );
+    tracing::info!(
+        bind = %app_config.server.bind,
+        base_path = %app_config.server.base_path,
+        tls = app_config.server.tls.enabled,
+        "starting ferroehr"
+    );
+}
+
 fn warn_boot_postures(config: &ferroehr::config::FerroEhrConfig) {
     if config.db.is_dev_default() {
         tracing::warn!(
@@ -450,7 +576,9 @@ fn attach_multimedia(
 /// Boot the server: config, telemetry, pool, migrations, audit, health, serve.
 #[expect(
     clippy::too_many_lines,
-    reason = "linear boot sequence; splitting it would obscure order"
+    reason = "the remaining body is one linear boot sequence of subsystem \
+              startups, each closed over by the next; splitting it further \
+              would obscure the order that makes it correct"
 )]
 async fn serve(config_path: Option<&Path>, overrides: &[(String, String)]) -> anyhow::Result<()> {
     // One load + one aggregated validate (all errors at once), then distribute.
@@ -534,26 +662,13 @@ async fn serve(config_path: Option<&Path>, overrides: &[(String, String)]) -> an
     tracing::info!(system_id = %config.server.system_id, "openEHR system identifier");
 
     let audit_enabled = audit_sender.is_some();
-    let mut service = FerroEhrService::new(pool.clone())
-        .with_spec_profile(config.spec_profile)
-        .with_system_id(config.server.system_id.clone())
-        .with_signer(signer)
-        .with_outbox_enabled(outbox_enabled)
-        .with_query_config(&config.query);
-    if let Some(sender) = audit_sender {
-        service = service.with_audit(sender);
-    }
-    // The local Audit Record Repository read side (the ITI-81 retrieval):
-    // wired whenever auditing + the store are on.
-    if audit_enabled && config.audit.store.enabled {
-        service =
-            service.with_audit_store(ferroehr::system_log::store::AuditStore::new(pool.clone()));
-    }
-
-    service = attach_terminology(service, &config)?;
-    service = attach_subject_proxy(service, &config)?;
-    service = attach_multimedia(service, &config)?;
-    let service = Arc::new(service);
+    let service = Arc::new(assemble_service(
+        &config,
+        &pool,
+        audit_sender,
+        outbox_enabled,
+        signer,
+    )?);
 
     // FHIR outbound emitter (off by default; carries PHI). Gated on `fhir`:
     // the outbound module exists only under ferroehr's `fhir` feature (which
@@ -596,26 +711,7 @@ async fn serve(config_path: Option<&Path>, overrides: &[(String, String)]) -> an
         env_snapshot,
     };
 
-    // Authorization — only wired when authentication is enabled: the RBAC gate
-    // plus the ABAC engine + DB-backed attribute resolvers. A misconfigured
-    // ABAC block (enabled but unbuildable) aborts BOOT — configuration that
-    // promises fine-grained authorization must never degrade to authz-off.
-    let authz = if config.auth.enabled {
-        build_authz(
-            &config.authz,
-            &config.server.base_path,
-            authz_resolvers(pool.clone(), Arc::clone(&service)),
-        )?
-    } else {
-        None
-    };
-    if let Some(handle) = &authz {
-        tracing::info!(
-            rbac = handle.rbac_active(),
-            abac = handle.abac_active(),
-            "authorization enabled"
-        );
-    }
+    let authz = wire_authz(&config, &pool, &service)?;
 
     // Assemble the REST adapter's runtime config view from the tree.
     let app_config = AppConfig {
@@ -636,50 +732,11 @@ async fn serve(config_path: Option<&Path>, overrides: &[(String, String)]) -> an
         .auth
         .require_mechanism()
         .map_err(|e| anyhow::anyhow!("{e}"))?;
-    // One line per subsystem, each carrying that subsystem's own facts. The
-    // listener line stays about the listener: `rbac` already has its own line
-    // above, and auditing and the management surface have theirs below, so
-    // repeating a bare `true` for each of them said less than nothing.
-    tracing::info!(
-        mechanisms = %app_config.auth.advertised_mechanisms(),
-        enabled = app_config.auth.enabled,
-        "authentication configured"
-    );
-    if audit_enabled {
-        tracing::info!(
-            local_repository = config.audit.store.enabled,
-            syslog = config.audit.syslog.enabled,
-            fhir_feed = config.audit.fhir_feed.enabled,
-            queue_capacity = config.audit.queue_capacity,
-            fail_mode = ?config.audit.fail_mode,
-            resolve_subject = config.audit.resolve_subject,
-            "IHE ATNA audit enabled"
-        );
-    } else {
-        tracing::info!("IHE ATNA audit disabled");
-    }
-    if observability.management.enabled {
-        tracing::info!(
-            base_path = %observability.management.base_path,
-            listener = match observability.management.port {
-                Some(port) => format!("own port {port}"),
-                None => "shared with the API".to_owned(),
-            },
-            mounted = %mounted_management_endpoints(observability.management.endpoints),
-            "management surface enabled"
-        );
-    }
-    tracing::info!(
-        enabled = app_config.server.rate_limit.enabled,
-        principal_per_second = app_config.server.rate_limit.principal_per_second,
-        address_per_second = app_config.server.rate_limit.address_per_second,
-        "request-rate limiting configured"
-    );
-    tracing::info!(
-        bind = %app_config.server.bind,
-        base_path = %app_config.server.base_path,
-        tls = app_config.server.tls.enabled,
-        "starting ferroehr"
+    log_resolved_posture(
+        &app_config,
+        audit_enabled,
+        &config.audit,
+        &observability.management,
     );
     ferroehr_rest::serve_full(app_config, service, authz, observability)
         .await

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-adl"
-version = "0.0.42"
+version = "0.0.43"
 description = "openEHR ADL 2.4.0: hand-written ADL2/cADL/ODIN parser, AOM2 validation catalogue, specialisation flattener, OPT2 generator, and ADL 1.4→2 conversion over the generated openehr_am::v2_4::aom2 model"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,11 +16,11 @@ include = ["src/**", "README.md", "LICENSE-MIT"]
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)
-openehr-base = { path = "../openehr-base", version = "0.0.42" }   # VersionStatus for the parsed HRID
-openehr-am = { path = "../openehr-am", version = "0.0.42" }       # v2_4 ArchetypeHrid (the identification target type)
-openehr-rm = { path = "../openehr-rm", version = "0.0.42" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
-openehr-lang = { path = "../openehr-lang", version = "0.0.42" }   # openehr_lang::odin — the ODIN section parser
-openehr-term = { path = "../openehr-term", version = "0.0.42" }   # the languages code set for the RM resource-meta rows
+openehr-base = { path = "../openehr-base", version = "0.0.43" }   # VersionStatus for the parsed HRID
+openehr-am = { path = "../openehr-am", version = "0.0.43" }       # v2_4 ArchetypeHrid (the identification target type)
+openehr-rm = { path = "../openehr-rm", version = "0.0.43" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
+openehr-lang = { path = "../openehr-lang", version = "0.0.43" }   # openehr_lang::odin — the ODIN section parser
+openehr-term = { path = "../openehr-term", version = "0.0.43" }   # the languages code set for the RM resource-meta rows
 uuid.workspace = true        # meta uid/build_uid (AUTHORED_ARCHETYPE.uid: Uuid)
 indexmap.workspace = true    # OdinValue::Object body (insertion-ordered map)
 

--- a/crates/openehr-adl/src/adl14/convert.rs
+++ b/crates/openehr-adl/src/adl14/convert.rs
@@ -29,6 +29,7 @@ use openehr_am::v2_4::aom2::archetype::archetype::Archetype;
 use openehr_am::v2_4::aom2::archetype::authored_archetype::{
     AuthoredArchetype, AuthoredArchetypeData,
 };
+use openehr_am::v2_4::aom2::constraint_model::c_attribute_tuple::CAttributeTuple;
 use openehr_am::v2_4::aom2::constraint_model::c_complex_object::CComplexObject;
 use openehr_am::v2_4::aom2::constraint_model::c_object::CObject;
 use openehr_am::v2_4::aom2::constraint_model::c_primitive_object::CPrimitiveObject;
@@ -828,18 +829,29 @@ fn convert_constraints_cco(cco: &mut CComplexObject, cx: &mut Converter<'_>, own
         }
     }
     for tuple in d.attribute_tuples.iter_mut().flatten() {
-        for member in tuple.members.iter_mut().flatten() {
-            for child in member.children.iter_mut().flatten() {
-                convert_constraints_obj(child, cx, &node_text);
-            }
+        convert_constraints_tuple(tuple, cx, &node_text);
+    }
+}
+
+/// Converts the terminology codes inside one `C_ATTRIBUTE_TUPLE` in place.
+///
+/// Both halves of the tuple carry constraints: the tuple MEMBERS' child
+/// objects, and the tuple ROWS, whose primitive members hold the actual
+/// terminology codes (ordinal symbols and the like).
+fn convert_constraints_tuple(
+    tuple: &mut CAttributeTuple,
+    cx: &mut Converter<'_>,
+    owner_text: &str,
+) {
+    for member in tuple.members.iter_mut().flatten() {
+        for child in member.children.iter_mut().flatten() {
+            convert_constraints_obj(child, cx, owner_text);
         }
-        // Tuple ROWS carry the actual primitive constraints — convert their
-        // terminology codes (ordinal symbols etc.) like attribute ones.
-        for row in tuple.tuples.iter_mut().flatten() {
-            for m in &mut row.members {
-                if let CPrimitiveObject::CTerminologyCode(tc) = m {
-                    convert_terminology_code(tc, cx, &node_text);
-                }
+    }
+    for row in tuple.tuples.iter_mut().flatten() {
+        for m in &mut row.members {
+            if let CPrimitiveObject::CTerminologyCode(tc) = m {
+                convert_terminology_code(tc, cx, owner_text);
             }
         }
     }

--- a/crates/openehr-adl/src/parse/refs.rs
+++ b/crates/openehr-adl/src/parse/refs.rs
@@ -15,10 +15,25 @@ use openehr_am::v2_4::aom2::constraint_model::c_complex_object::CComplexObject;
 use openehr_am::v2_4::aom2::constraint_model::c_complex_object_proxy::CComplexObjectProxy;
 use openehr_am::v2_4::aom2::constraint_model::c_object::CObject;
 use openehr_am::v2_4::beom::core::assertion::Assertion;
+use openehr_base::prelude::MultiplicityInterval;
 
 use crate::error::{SyntaxError, SyntaxErrorCode};
 use crate::parse::{Dialect, PResult, Parser};
 use openehr_lang::v1_1::lexer::Token;
+
+/// The variable part of an `ARCHETYPE_SLOT`: everything the source may state
+/// after the reference-model type and the node id.
+#[derive(Default)]
+struct SlotBody {
+    /// The ADL2-only `closed` marker (`ARCHETYPE_SLOT.is_closed`).
+    is_closed: bool,
+    /// A restated `occurrences` interval.
+    occurrences: Option<MultiplicityInterval>,
+    /// The `include` assertions of the `matches` block.
+    includes: Vec<Assertion>,
+    /// The `exclude` assertions of the `matches` block.
+    excludes: Vec<Assertion>,
+}
 
 // ── slots, archetype roots, internal references ───────────────────────────
 impl Parser<'_> {
@@ -185,62 +200,73 @@ impl Parser<'_> {
         let rm_type = self.parse_rm_type_id()?;
         let node_id = self.parse_slot_node_id()?;
 
-        let mut is_closed = false;
-        let mut occurrences = None;
-        let mut includes = Vec::new();
-        let mut excludes = Vec::new();
-
-        if matches!(self.peek(), Some(Token::SymClosed)) {
-            // ADL2-only: the `closed` slot marker (`ADL2/master04.3` §Archetype
-            // Slots; `ARCHETYPE_SLOT.is_closed`, redefinition rule VDSSC). The 1.4
-            // cADL keyword set (master05 §Keywords L51-52) has `allow_archetype`
-            // with `include`/`exclude` only.
-            if self.dialect == Dialect::Adl14 {
-                return self
-                    .adl2_only(SyntaxErrorCode::Sccog, "the archetype-slot 'closed' marker");
-            }
-            self.pos += 1;
-            is_closed = true;
+        let body = if matches!(self.peek(), Some(Token::SymClosed)) {
+            self.parse_closed_slot_marker()?
         } else {
-            if matches!(self.peek(), Some(Token::SymOccurrences)) {
-                occurrences = Some(self.parse_occurrences()?);
-            }
-            if self.at_negated_matches() {
-                return self.negated_matches_reject(SyntaxErrorCode::Sccog);
-            }
-            if self.eat(|t| matches!(t, Token::SymMatches)) {
-                self.expect(
-                    |t| matches!(t, Token::LCurly),
-                    SyntaxErrorCode::Sccog,
-                    "expecting '{' after 'matches' in a slot",
-                )?;
-                if self.eat(|t| matches!(t, Token::SymInclude)) {
-                    includes.extend(self.parse_slot_assertions()?);
-                }
-                if self.eat(|t| matches!(t, Token::SymExclude)) {
-                    excludes.extend(self.parse_slot_assertions()?);
-                }
-                self.expect(
-                    |t| matches!(t, Token::RCurly),
-                    SyntaxErrorCode::Sccog,
-                    "expecting '}' closing the slot body",
-                )?;
-            }
-        }
+            self.parse_open_slot_body()?
+        };
 
         Ok(CObject::ArchetypeSlot(ArchetypeSlot {
             parent: None,
             soc_parent: None,
             rm_type_name: rm_type,
-            occurrences,
+            occurrences: body.occurrences,
             node_id,
             alternative_ids: openehr_base::containers::present(Vec::new()),
             is_deprecated: None,
             sibling_order: None,
-            includes: openehr_base::containers::present(includes),
-            excludes: openehr_base::containers::present(excludes),
-            is_closed,
+            includes: openehr_base::containers::present(body.includes),
+            excludes: openehr_base::containers::present(body.excludes),
+            is_closed: body.is_closed,
         }))
+    }
+
+    /// Consumes the ADL2-only `closed` slot marker.
+    ///
+    /// `ADL2/master04.3` §Archetype Slots (`ARCHETYPE_SLOT.is_closed`,
+    /// redefinition rule VDSSC). The 1.4 cADL keyword set (master05 §Keywords
+    /// L51-52) has `allow_archetype` with `include`/`exclude` only, so the
+    /// marker is refused in that dialect.
+    fn parse_closed_slot_marker(&mut self) -> PResult<SlotBody> {
+        if self.dialect == Dialect::Adl14 {
+            return self.adl2_only(SyntaxErrorCode::Sccog, "the archetype-slot 'closed' marker");
+        }
+        self.pos += 1;
+        Ok(SlotBody {
+            is_closed: true,
+            ..Default::default()
+        })
+    }
+
+    /// Parses an open slot's optional occurrences and its
+    /// `matches { include … exclude … }` assertion block.
+    fn parse_open_slot_body(&mut self) -> PResult<SlotBody> {
+        let mut body = SlotBody::default();
+        if matches!(self.peek(), Some(Token::SymOccurrences)) {
+            body.occurrences = Some(self.parse_occurrences()?);
+        }
+        if self.at_negated_matches() {
+            return self.negated_matches_reject(SyntaxErrorCode::Sccog);
+        }
+        if self.eat(|t| matches!(t, Token::SymMatches)) {
+            self.expect(
+                |t| matches!(t, Token::LCurly),
+                SyntaxErrorCode::Sccog,
+                "expecting '{' after 'matches' in a slot",
+            )?;
+            if self.eat(|t| matches!(t, Token::SymInclude)) {
+                body.includes.extend(self.parse_slot_assertions()?);
+            }
+            if self.eat(|t| matches!(t, Token::SymExclude)) {
+                body.excludes.extend(self.parse_slot_assertions()?);
+            }
+            self.expect(
+                |t| matches!(t, Token::RCurly),
+                SyntaxErrorCode::Sccog,
+                "expecting '}' closing the slot body",
+            )?;
+        }
+        Ok(body)
     }
 
     /// Parse the assertion block after a slot `include`/`exclude` keyword

--- a/crates/openehr-adl/src/validate/specialisation.rs
+++ b/crates/openehr-adl/src/validate/specialisation.rs
@@ -185,33 +185,15 @@ impl<'a> ParentScan<'a> {
         current_parent_rm: &str,
         base_path: &str,
     ) {
-        // Resolve the owning parent object: through the differential path if the
-        // attribute carries one, else the current parent object.
-        let (owner, owner_rm): (&'a CComplexObject, String) =
-            if let Some(diff) = attr.differential_path.as_deref() {
-                if let Some(o) = self.resolve_object(diff) {
-                    (o, complex_rm_type(o).to_owned())
-                } else {
-                    // VDIFP: a differential path must exist in the flat parent
-                    // (`master04.5` §`C_ATTRIBUTE`, VDIFP L139-140).
-                    push_issue(
-                        &mut self.issues,
-                        ValidationCode::Vdifp,
-                        format!(
-                            "differential path {:?} does not resolve in the flat parent",
-                            full_attr_path(diff, &attr.rm_attribute_name)
-                        ),
-                        base_path,
-                    );
-                    return;
-                }
-            } else {
-                (current_parent, current_parent_rm.to_owned())
-            };
-
         let attr_path = match attr.differential_path.as_deref() {
             Some(diff) => full_attr_path(diff, &attr.rm_attribute_name),
             None => format!("{base_path}/{}", attr.rm_attribute_name),
+        };
+
+        let Some((owner, owner_rm)) =
+            self.resolve_owner(attr, current_parent, current_parent_rm, base_path)
+        else {
+            return;
         };
 
         let parent_attr = complex_attributes(owner)
@@ -219,24 +201,7 @@ impl<'a> ParentScan<'a> {
             .find(|a| a.rm_attribute_name == attr.rm_attribute_name);
 
         let Some(parent_attr) = parent_attr else {
-            if attr.differential_path.is_some() {
-                // A differential path whose leaf attribute is absent in the flat
-                // parent (VDIFP).
-                push_issue(
-                    &mut self.issues,
-                    ValidationCode::Vdifp,
-                    format!(
-                        "attribute {:?} of differential path does not exist in the flat parent",
-                        attr.rm_attribute_name
-                    ),
-                    &attr_path,
-                );
-                return;
-            }
-            // A brand-new attribute (ADD): every child object is a new node.
-            for child in attr.children.iter().flatten() {
-                self.check_new_object(child, &attr_path);
-            }
+            self.check_absent_parent_attribute(attr, &attr_path);
             return;
         };
 
@@ -250,42 +215,119 @@ impl<'a> ParentScan<'a> {
         // VSONCO L359-379, evaluated at the owning attribute.
         self.check_collective_occurrences(attr, parent_attr, &owner_rm, &attr_path);
 
-        // Per child object: match a congruent parent node (or, for a primitive
-        // leaf with no node id, the parent attribute's same-type leaf), else a
-        // new node.
+        self.check_redefined_children(attr, parent_attr, &owner_rm, &attr_path);
+    }
+
+    /// Resolve the parent object a child attribute redefines within, together
+    /// with its reference-model type name.
+    ///
+    /// The owner is reached through the differential path when the attribute
+    /// carries one, else it is the current parent object. `None` records VDIFP
+    /// — a differential path must exist in the flat parent (`master04.5`
+    /// §`C_ATTRIBUTE`, VDIFP L139-140).
+    fn resolve_owner(
+        &mut self,
+        attr: &'a CAttribute,
+        current_parent: &'a CComplexObject,
+        current_parent_rm: &str,
+        base_path: &str,
+    ) -> Option<(&'a CComplexObject, String)> {
+        let Some(diff) = attr.differential_path.as_deref() else {
+            return Some((current_parent, current_parent_rm.to_owned()));
+        };
+        if let Some(o) = self.resolve_object(diff) {
+            return Some((o, complex_rm_type(o).to_owned()));
+        }
+        push_issue(
+            &mut self.issues,
+            ValidationCode::Vdifp,
+            format!(
+                "differential path {:?} does not resolve in the flat parent",
+                full_attr_path(diff, &attr.rm_attribute_name)
+            ),
+            base_path,
+        );
+        None
+    }
+
+    /// Check a child attribute the flat parent's owning object does not declare.
+    ///
+    /// A differential path whose leaf attribute is absent is VDIFP; otherwise
+    /// the attribute is a brand-new one (ADD), so every child object is a new
+    /// node.
+    fn check_absent_parent_attribute(&mut self, attr: &'a CAttribute, attr_path: &str) {
+        if attr.differential_path.is_some() {
+            push_issue(
+                &mut self.issues,
+                ValidationCode::Vdifp,
+                format!(
+                    "attribute {:?} of differential path does not exist in the flat parent",
+                    attr.rm_attribute_name
+                ),
+                attr_path,
+            );
+            return;
+        }
         for child in attr.children.iter().flatten() {
-            let child_path = child_path(&attr_path, object_node_id(child));
+            self.check_new_object(child, attr_path);
+        }
+    }
+
+    /// Pair each child object of a redefined attribute with its flat-parent node.
+    ///
+    /// A child matches a congruent parent node — or, for a primitive leaf with
+    /// no node id, the parent attribute's same-type leaf; anything unmatched is
+    /// a newly added node.
+    fn check_redefined_children(
+        &mut self,
+        attr: &'a CAttribute,
+        parent_attr: &'a CAttribute,
+        owner_rm: &str,
+        attr_path: &str,
+    ) {
+        for child in attr.children.iter().flatten() {
+            let child_path = child_path(attr_path, object_node_id(child));
             if let Some(parent_obj) = find_congruent(parent_attr, child)
                 .or_else(|| pair_primitive_leaf(parent_attr, child))
             {
-                self.check_object_pair(child, parent_obj, attr, &owner_rm, &child_path);
+                self.check_object_pair(child, parent_obj, attr, owner_rm, &child_path);
             } else {
-                // VSONIF: a new object node added to a container attribute that
-                // already carries identified flattened siblings must itself be
-                // identified, so it is distinguishable from those siblings
-                // (`master04.5` §`C_OBJECT`, VSONIF L356-357).
-                //
-                // NOTE: master04.5 defers VSONIF's detailed rule to VACMI,
-                // which no vendored spec text defines; the decidable
-                // identification requirement is what this implements.
-                if object_node_id(child).is_empty()
-                    && !aom_type(child).is_primitive()
-                    && parent_attr
-                        .children
-                        .iter()
-                        .flatten()
-                        .any(|p| !object_node_id(p).is_empty())
-                {
-                    push_issue(
-                        &mut self.issues,
-                        ValidationCode::Vsonif,
-                        "a new object node in a specialised container must be identified (its flattened siblings are)",
-                        &child_path,
-                    );
-                }
-                self.check_new_object(child, &child_path);
+                self.check_added_object(child, parent_attr, &child_path);
             }
         }
+    }
+
+    /// Check an object node the specialisation adds to a container attribute.
+    fn check_added_object(
+        &mut self,
+        child: &'a CObject,
+        parent_attr: &'a CAttribute,
+        child_path: &str,
+    ) {
+        // VSONIF: a new object node added to a container attribute that already
+        // carries identified flattened siblings must itself be identified, so it
+        // is distinguishable from those siblings (`master04.5` §`C_OBJECT`,
+        // VSONIF L356-357).
+        //
+        // NOTE: master04.5 defers VSONIF's detailed rule to VACMI, which no
+        // vendored spec text defines; the decidable identification requirement
+        // is what this implements.
+        if object_node_id(child).is_empty()
+            && !aom_type(child).is_primitive()
+            && parent_attr
+                .children
+                .iter()
+                .flatten()
+                .any(|p| !object_node_id(p).is_empty())
+        {
+            push_issue(
+                &mut self.issues,
+                ValidationCode::Vsonif,
+                "a new object node in a specialised container must be identified (its flattened siblings are)",
+                child_path,
+            );
+        }
+        self.check_new_object(child, child_path);
     }
 
     /// The existence, cardinality and multiplicity conformance of a redefined

--- a/crates/openehr-am/Cargo.toml
+++ b/crates/openehr-am/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-am"
-version = "0.0.42"
+version = "0.0.43"
 description = "openEHR AM Archetype Model, generated from BMM: generations v1_4 (AM 1.4.0, ADL 1.4) and v2_4 (AM 2.4.0, ADL 2; current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,8 +13,8 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.42" }
-openehr-lang = { path = "../openehr-lang", version = "0.0.42" }
+openehr-base = { path = "../openehr-base", version = "0.0.43" }
+openehr-lang = { path = "../openehr-lang", version = "0.0.43" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also carries the untyped `Value` fields the generator

--- a/crates/openehr-base/Cargo.toml
+++ b/crates/openehr-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-base"
-version = "0.0.42"
+version = "0.0.43"
 description = "openEHR BASE foundation + base types, generated from BMM: generations v1_2 (BASE 1.2.0) and v1_3 (BASE 1.3.0, current)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-base/src/v1_2/foundation_types/time/iso8601_parse.rs
+++ b/crates/openehr-base/src/v1_2/foundation_types/time/iso8601_parse.rs
@@ -736,48 +736,81 @@ pub(crate) fn parse_duration(s: &str) -> Option<ParsedDuration> {
         seconds: 0,
         fractional_seconds: 0.0,
     };
-    let mut in_time = false;
-    let mut seen_any = false;
-    // The slot of the last designator consumed, in the order the production
-    // fixes; `-1` because `Y` is slot 0.
-    let mut last_slot: i8 = -1;
-    let mut seen_time_component = false;
+    let mut scan = DurationScan::default();
     loop {
         match it.peek() {
             None => break,
             Some('T') => {
-                if in_time {
+                if scan.in_time {
                     return None;
                 }
-                in_time = true;
+                scan.in_time = true;
                 it.next();
             }
             Some(c) if c.is_ascii_digit() => {
-                let (intval, fracval, has_frac) = read_duration_number(&mut it)?;
-                let designator = it.next()?;
-                let slot = apply_duration_component(&mut d, in_time, designator, intval, fracval)?;
-                if slot <= last_slot {
-                    return None;
-                }
-                last_slot = slot;
-                if in_time {
-                    seen_time_component = true;
-                }
-                if has_frac && !(in_time && designator == 'S') {
-                    return None; // only the seconds field carries a fraction
-                }
-                seen_any = true;
+                read_duration_component(&mut it, &mut d, &mut scan)?;
             }
             _ => return None,
         }
     }
-    if !seen_any {
+    if !scan.seen_any {
         return None; // `P`/`PT` with no components is not a duration
     }
-    if in_time && !seen_time_component {
+    if scan.in_time && !scan.seen_time_component {
         return None; // `P1YT` — the production has no bare trailing `T`
     }
     Some(d)
+}
+
+/// The scan state threaded through a duration's component loop.
+struct DurationScan {
+    /// Whether the `T` designator separating date from time was consumed.
+    in_time: bool,
+    /// Whether any component at all was read.
+    seen_any: bool,
+    /// Whether a component followed the `T` separator.
+    seen_time_component: bool,
+    /// The slot of the last designator consumed, in the order the production
+    /// fixes; `-1` because `Y` is slot 0.
+    last_slot: i8,
+}
+
+impl Default for DurationScan {
+    fn default() -> Self {
+        Self {
+            in_time: false,
+            seen_any: false,
+            seen_time_component: false,
+            last_slot: -1,
+        }
+    }
+}
+
+/// Reads one `<number><designator>` duration component and folds it into `d`.
+///
+/// `None` on any violation of the production: a designator out of the fixed
+/// slot order (which also rejects a repeated one), or a fraction on any field
+/// but the seconds.
+fn read_duration_component(
+    it: &mut std::iter::Peekable<std::str::Chars<'_>>,
+    d: &mut ParsedDuration,
+    scan: &mut DurationScan,
+) -> Option<()> {
+    let (intval, fracval, has_frac) = read_duration_number(it)?;
+    let designator = it.next()?;
+    let slot = apply_duration_component(d, scan.in_time, designator, intval, fracval)?;
+    if slot <= scan.last_slot {
+        return None;
+    }
+    scan.last_slot = slot;
+    if scan.in_time {
+        scan.seen_time_component = true;
+    }
+    if has_frac && !(scan.in_time && designator == 'S') {
+        return None; // only the seconds field carries a fraction
+    }
+    scan.seen_any = true;
+    Some(())
 }
 
 impl ParsedDuration {

--- a/crates/openehr-base/src/v1_3/foundation_types/time/iso8601_parse.rs
+++ b/crates/openehr-base/src/v1_3/foundation_types/time/iso8601_parse.rs
@@ -736,48 +736,81 @@ pub(crate) fn parse_duration(s: &str) -> Option<ParsedDuration> {
         seconds: 0,
         fractional_seconds: 0.0,
     };
-    let mut in_time = false;
-    let mut seen_any = false;
-    // The slot of the last designator consumed, in the order the production
-    // fixes; `-1` because `Y` is slot 0.
-    let mut last_slot: i8 = -1;
-    let mut seen_time_component = false;
+    let mut scan = DurationScan::default();
     loop {
         match it.peek() {
             None => break,
             Some('T') => {
-                if in_time {
+                if scan.in_time {
                     return None;
                 }
-                in_time = true;
+                scan.in_time = true;
                 it.next();
             }
             Some(c) if c.is_ascii_digit() => {
-                let (intval, fracval, has_frac) = read_duration_number(&mut it)?;
-                let designator = it.next()?;
-                let slot = apply_duration_component(&mut d, in_time, designator, intval, fracval)?;
-                if slot <= last_slot {
-                    return None;
-                }
-                last_slot = slot;
-                if in_time {
-                    seen_time_component = true;
-                }
-                if has_frac && !(in_time && designator == 'S') {
-                    return None; // only the seconds field carries a fraction
-                }
-                seen_any = true;
+                read_duration_component(&mut it, &mut d, &mut scan)?;
             }
             _ => return None,
         }
     }
-    if !seen_any {
+    if !scan.seen_any {
         return None; // `P`/`PT` with no components is not a duration
     }
-    if in_time && !seen_time_component {
+    if scan.in_time && !scan.seen_time_component {
         return None; // `P1YT` — the production has no bare trailing `T`
     }
     Some(d)
+}
+
+/// The scan state threaded through a duration's component loop.
+struct DurationScan {
+    /// Whether the `T` designator separating date from time was consumed.
+    in_time: bool,
+    /// Whether any component at all was read.
+    seen_any: bool,
+    /// Whether a component followed the `T` separator.
+    seen_time_component: bool,
+    /// The slot of the last designator consumed, in the order the production
+    /// fixes; `-1` because `Y` is slot 0.
+    last_slot: i8,
+}
+
+impl Default for DurationScan {
+    fn default() -> Self {
+        Self {
+            in_time: false,
+            seen_any: false,
+            seen_time_component: false,
+            last_slot: -1,
+        }
+    }
+}
+
+/// Reads one `<number><designator>` duration component and folds it into `d`.
+///
+/// `None` on any violation of the production: a designator out of the fixed
+/// slot order (which also rejects a repeated one), or a fraction on any field
+/// but the seconds.
+fn read_duration_component(
+    it: &mut std::iter::Peekable<std::str::Chars<'_>>,
+    d: &mut ParsedDuration,
+    scan: &mut DurationScan,
+) -> Option<()> {
+    let (intval, fracval, has_frac) = read_duration_number(it)?;
+    let designator = it.next()?;
+    let slot = apply_duration_component(d, scan.in_time, designator, intval, fracval)?;
+    if slot <= scan.last_slot {
+        return None;
+    }
+    scan.last_slot = slot;
+    if scan.in_time {
+        scan.seen_time_component = true;
+    }
+    if has_frac && !(scan.in_time && designator == 'S') {
+        return None; // only the seconds field carries a fraction
+    }
+    scan.seen_any = true;
+    Some(())
 }
 
 impl ParsedDuration {

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-its"
-version = "0.0.42"
+version = "0.0.43"
 description = "openEHR ITS (Implementation Technology Specifications): canonical JSON + canonical XML serialization of the RM, the generated ITS-REST 1.1.0 API contract, OPT 1.4 and AOM2 archetype XML codecs, and the Simplified Formats (FLAT / STRUCTURED / Web Template)"
 edition.workspace = true
 rust-version.workspace = true
@@ -41,14 +41,14 @@ regex = { workspace = true, optional = true }
 fancy-regex = { workspace = true, optional = true }
 # The generated XML (de)serializers impl the crate's ToXml/FromXml traits for the
 # RM/BASE spec types, so these are real (non-dev) deps.
-openehr-base = { path = "../openehr-base", version = "0.0.42", optional = true }
-openehr-rm = { path = "../openehr-rm", version = "0.0.42", optional = true }
+openehr-base = { path = "../openehr-base", version = "0.0.43", optional = true }
+openehr-rm = { path = "../openehr-rm", version = "0.0.43", optional = true }
 # The native canonical-JSON codec (`json_codec/generated`, emit-json) implements
 # `ToJson` for EVERY generated spec type the `OpenEhrType` derive covers, so it
 # spans all five spec crates (not just the RM/BASE the XML codec needs).
-openehr-lang = { path = "../openehr-lang", version = "0.0.42", optional = true }
-openehr-am = { path = "../openehr-am", version = "0.0.42", optional = true }
-openehr-term = { path = "../openehr-term", version = "0.0.42", optional = true }
+openehr-lang = { path = "../openehr-lang", version = "0.0.43", optional = true }
+openehr-am = { path = "../openehr-am", version = "0.0.43", optional = true }
+openehr-term = { path = "../openehr-term", version = "0.0.43", optional = true }
 
 # `full` — every ITS surface (canonical JSON/XML, the generated ITS-REST
 # contract, `opt14`, Simplified Formats). ON BY DEFAULT, so every consumer sees

--- a/crates/openehr-its/src/flat/webtemplate/builder_v2_4.rs
+++ b/crates/openehr-its/src/flat/webtemplate/builder_v2_4.rs
@@ -632,38 +632,50 @@ fn push_tuple_units(
             continue;
         }
         for row in tuple.tuples.iter().flatten() {
-            let mut unit_value = None;
-            let mut validation = WebTemplateValidation::default();
-            for (i, name) in names.iter().enumerate() {
-                match (*name, row.members.get(i)) {
-                    ("units", Some(CPrimitiveObject::CString(cs))) => {
-                        unit_value = cs
-                            .constraint
-                            .iter()
-                            .flatten()
-                            .find(|s| delimited_regex(s).is_none());
-                    }
-                    ("magnitude", Some(CPrimitiveObject::CReal(cr))) => {
-                        validation.range =
-                            cr.constraint.iter().flatten().next().and_then(real_range);
-                    }
-                    ("precision", Some(CPrimitiveObject::CInteger(ci))) => {
-                        validation.precision =
-                            ci.constraint.iter().flatten().next().and_then(int_range);
-                    }
-                    _ => {}
-                }
+            let Some((unit, validation)) = tuple_row_unit(row, &names) else {
+                continue;
+            };
+            let mut cv = WebTemplateCodedValue::new(unit, Some(unit.clone()));
+            cv.localized_labels = ctx.localized(term, unit);
+            if !validation.is_empty() {
+                cv.validation = Some(validation);
             }
-            if let Some(unit) = unit_value {
-                let mut cv = WebTemplateCodedValue::new(unit, Some(unit.clone()));
-                cv.localized_labels = ctx.localized(term, unit);
-                if !validation.is_empty() {
-                    cv.validation = Some(validation.clone());
-                }
-                units.list.push(cv);
-            }
+            units.list.push(cv);
         }
     }
+}
+
+/// Reads one `C_ATTRIBUTE_TUPLE` row as a unit plus the validation its
+/// co-varying members carry.
+///
+/// `names` positions the row's members by RM attribute name. `None` when the
+/// row's `units` member constrains no plain string (a delimited regex is a
+/// pattern, not a unit).
+fn tuple_row_unit<'a>(
+    row: &'a CPrimitiveTuple,
+    names: &[&str],
+) -> Option<(&'a String, WebTemplateValidation)> {
+    let mut unit_value = None;
+    let mut validation = WebTemplateValidation::default();
+    for (i, name) in names.iter().enumerate() {
+        match (*name, row.members.get(i)) {
+            ("units", Some(CPrimitiveObject::CString(cs))) => {
+                unit_value = cs
+                    .constraint
+                    .iter()
+                    .flatten()
+                    .find(|s| delimited_regex(s).is_none());
+            }
+            ("magnitude", Some(CPrimitiveObject::CReal(cr))) => {
+                validation.range = cr.constraint.iter().flatten().next().and_then(real_range);
+            }
+            ("precision", Some(CPrimitiveObject::CInteger(ci))) => {
+                validation.precision = ci.constraint.iter().flatten().next().and_then(int_range);
+            }
+            _ => {}
+        }
+    }
+    unit_value.map(|unit| (unit, validation))
 }
 
 fn quantity_inputs(ctx: &Ctx, term: &ArchetypeTerminology, co: &CObject) -> Vec<WebTemplateInput> {

--- a/crates/openehr-its/tests/it/flat.rs
+++ b/crates/openehr-its/tests/it/flat.rs
@@ -184,6 +184,72 @@ fn instability_diagnostic(
 
 // ── round-trip gate ────────────────────────────────────────────────────────────
 
+/// The accumulated FLAT round-trip result over the paired fixture corpus.
+#[derive(Default)]
+struct RoundTripTally {
+    /// Compositions for which a web template of the same `template_id` exists.
+    paired: usize,
+    /// Pairs whose second FLAT rendering equals the first.
+    stable: usize,
+    /// Reverse (`from_flat`) outputs the canonical RM reader accepts.
+    valid_rm: usize,
+    /// Round-trip errors and instability diagnostics, one line each.
+    failures: Vec<String>,
+    /// Reverse outputs the canonical RM reader refused, one line each.
+    invalid_rm: Vec<String>,
+}
+
+/// Round-trips every composition that has a web template and tallies the
+/// outcomes.
+fn tally_round_trips(
+    comps: &[(String, String, Value)],
+    wts: &BTreeMap<String, WebTemplate>,
+) -> RoundTripTally {
+    let mut tally = RoundTripTally::default();
+    for (name, tid, comp) in comps {
+        let Some(wt) = wts.get(tid) else { continue };
+        tally.paired += 1;
+
+        let (rm1, instability) = match flat_round_trip(name, tid, comp, wt) {
+            Ok(pair) => pair,
+            Err(message) => {
+                tally.failures.push(message);
+                continue;
+            }
+        };
+        match instability {
+            Some(diagnostic) => tally.failures.push(diagnostic),
+            None => tally.stable += 1,
+        }
+
+        // The reverse output should be valid canonical RM. One that will not
+        // even serialize counts as neither valid nor invalid, which the
+        // paired-count assertion catches.
+        let Ok(serialized) = serde_json::to_string(&rm1) else {
+            continue;
+        };
+        match openehr_its::json::from_canonical_json::<openehr_rm::prelude::Composition>(
+            &serialized,
+        ) {
+            Ok(_) => tally.valid_rm += 1,
+            Err(e) => tally.invalid_rm.push(format!("{name}: {e}")),
+        }
+    }
+    tally
+}
+
+/// Prints a diagnostic block on stderr, headed by its count. A no-op when
+/// there is nothing to report.
+fn eprint_diagnostics(label: &str, lines: &[String]) {
+    if lines.is_empty() {
+        return;
+    }
+    eprintln!("{label} ({}):", lines.len());
+    for line in lines {
+        eprintln!("  {line}");
+    }
+}
+
 #[test]
 fn flat_roundtrip_stable() {
     let wts = web_templates();
@@ -191,55 +257,23 @@ fn flat_roundtrip_stable() {
     assert!(!wts.is_empty(), "no web templates built");
     assert!(!comps.is_empty(), "no canonical compositions found");
 
-    let mut paired = 0usize;
-    let mut stable = 0usize;
-    let mut valid_rm = 0usize;
-    let mut failures: Vec<String> = Vec::new();
-    let mut invalid_rm: Vec<String> = Vec::new();
-
-    for (name, tid, comp) in &comps {
-        let Some(wt) = wts.get(tid) else { continue };
-        paired += 1;
-
-        let (rm1, instability) = match flat_round_trip(name, tid, comp, wt) {
-            Ok(pair) => pair,
-            Err(message) => {
-                failures.push(message);
-                continue;
-            }
-        };
-        match instability {
-            Some(diagnostic) => failures.push(diagnostic),
-            None => stable += 1,
-        }
-
-        // The reverse output should be valid canonical RM.
-        if let Ok(s) = serde_json::to_string(&rm1) {
-            match openehr_its::json::from_canonical_json::<openehr_rm::prelude::Composition>(&s) {
-                Ok(_) => valid_rm += 1,
-                Err(e) => invalid_rm.push(format!("{name}: {e}")),
-            }
-        }
-    }
+    let tally = tally_round_trips(&comps, &wts);
+    let RoundTripTally {
+        paired,
+        stable,
+        valid_rm,
+        failures,
+        invalid_rm,
+    } = tally;
 
     eprintln!(
         "FLAT round-trip: {paired} paired (composition, OPT) | stable = {stable} | rm1 valid-RM = {valid_rm}"
     );
-    if !invalid_rm.is_empty() {
-        eprintln!(
-            "rm1 not deserialising as openehr-rm Composition ({}):",
-            invalid_rm.len()
-        );
-        for f in &invalid_rm {
-            eprintln!("  {f}");
-        }
-    }
-    if !failures.is_empty() {
-        eprintln!("non-stable / errors ({}):", failures.len());
-        for f in &failures {
-            eprintln!("  {f}");
-        }
-    }
+    eprint_diagnostics(
+        "rm1 not deserialising as openehr-rm Composition",
+        &invalid_rm,
+    );
+    eprint_diagnostics("non-stable / errors", &failures);
 
     assert!(paired >= 15, "expected ≥15 paired fixtures, got {paired}");
     assert!(

--- a/crates/openehr-its/tests/it/xml_xsd_validity.rs
+++ b/crates/openehr-its/tests/it/xml_xsd_validity.rs
@@ -59,6 +59,7 @@ use openehr_its::xml::runtime::Namespace;
 use openehr_its::xml::to_canonical_xml_ns;
 use openehr_rm::prelude::{Composition, Folder};
 use openehr_rm::v1_2::model;
+use quick_xml::events::{BytesEnd, BytesStart, Event};
 use serde_json::{Value, json};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
@@ -256,62 +257,107 @@ fn read_types(bundle: &Bundle) -> BTreeMap<String, XsdType> {
 /// Only a TOP-LEVEL `complexType` (depth 1) names a type; nested anonymous
 /// ones contribute their members to the enclosing named type.
 fn read_types_from(xml: &str, types: &mut BTreeMap<String, XsdType>) {
-    use quick_xml::events::Event;
     let mut reader = quick_xml::Reader::from_str(xml);
     let mut current: Option<String> = None;
     let mut depth = 0usize;
     loop {
         let ev = reader.read_event().expect("well-formed vendored XSD");
-        let (element, empty) = match &ev {
-            Event::Start(e) => (e, false),
-            Event::Empty(e) => (e, true),
-            Event::End(e) => {
-                if local_name(e.name().as_ref()) == b"complexType" {
-                    depth = depth.saturating_sub(1);
-                    if depth == 0 {
-                        current = None;
-                    }
-                }
-                continue;
-            }
+        match &ev {
+            Event::Start(e) => record_element(e, false, &mut current, &mut depth, types),
+            Event::Empty(e) => record_element(e, true, &mut current, &mut depth, types),
+            Event::End(e) => close_element(e, &mut current, &mut depth),
             Event::Eof => return,
-            _ => continue,
-        };
-        let local = local_name(element.name().as_ref()).to_vec();
-        let attr = |k: &str| {
-            element
-                .attributes()
-                .flatten()
-                .find(|a| local_name(a.key.as_ref()) == k.as_bytes())
-                .map(|a| String::from_utf8_lossy(a.value.as_ref()).into_owned())
-        };
-        match local.as_slice() {
-            b"complexType" => {
-                if !empty {
-                    depth += 1;
-                }
-                if depth == 1 {
-                    current = attr("name");
-                    if let Some(n) = &current {
-                        types.entry(n.clone()).or_default();
-                    }
-                }
-            }
-            b"extension" | b"restriction" => {
-                if let (Some(n), Some(b)) = (current.as_ref(), attr("base")) {
-                    let entry = types.entry(n.clone()).or_default();
-                    if entry.base.is_none() {
-                        entry.base = Some(strip_prefix(&b));
-                    }
-                }
-            }
-            b"element" | b"attribute" => {
-                if let (Some(n), Some(m)) = (current.as_ref(), attr("name")) {
-                    types.entry(n.clone()).or_default().members.insert(m);
-                }
-            }
             _ => {}
         }
+    }
+}
+
+/// Reads one attribute of `element` by local name, prefix-insensitively.
+fn xsd_attr(element: &BytesStart<'_>, key: &str) -> Option<String> {
+    element
+        .attributes()
+        .flatten()
+        .find(|a| local_name(a.key.as_ref()) == key.as_bytes())
+        .map(|a| String::from_utf8_lossy(a.value.as_ref()).into_owned())
+}
+
+/// Leaves the `complexType` the reader is closing, clearing the current type
+/// name once the outermost one ends.
+fn close_element(element: &BytesEnd<'_>, current: &mut Option<String>, depth: &mut usize) {
+    if local_name(element.name().as_ref()) != b"complexType" {
+        return;
+    }
+    *depth = depth.saturating_sub(1);
+    if *depth == 0 {
+        *current = None;
+    }
+}
+
+/// Folds one opening (or self-closing) XSD element into `types`.
+///
+/// `empty` distinguishes `<xs:complexType/>` from `<xs:complexType>`, which is
+/// what keeps the nesting depth honest.
+fn record_element(
+    element: &BytesStart<'_>,
+    empty: bool,
+    current: &mut Option<String>,
+    depth: &mut usize,
+    types: &mut BTreeMap<String, XsdType>,
+) {
+    let local = local_name(element.name().as_ref()).to_vec();
+    match local.as_slice() {
+        b"complexType" => open_complex_type(element, empty, current, depth, types),
+        b"extension" | b"restriction" => record_base(element, current.as_deref(), types),
+        b"element" | b"attribute" => record_member(element, current.as_deref(), types),
+        _ => {}
+    }
+}
+
+/// Enters an `xs:complexType`, naming it only at depth 1 — a nested anonymous
+/// one contributes its members to the enclosing named type instead.
+fn open_complex_type(
+    element: &BytesStart<'_>,
+    empty: bool,
+    current: &mut Option<String>,
+    depth: &mut usize,
+    types: &mut BTreeMap<String, XsdType>,
+) {
+    if !empty {
+        *depth += 1;
+    }
+    if *depth != 1 {
+        return;
+    }
+    *current = xsd_attr(element, "name");
+    if let Some(n) = current {
+        types.entry(n.clone()).or_default();
+    }
+}
+
+/// Records the current type's `xs:extension`/`xs:restriction` `@base`. The
+/// first one wins: an inner derivation never overwrites the outer type's base.
+fn record_base(
+    element: &BytesStart<'_>,
+    current: Option<&str>,
+    types: &mut BTreeMap<String, XsdType>,
+) {
+    let (Some(n), Some(b)) = (current, xsd_attr(element, "base")) else {
+        return;
+    };
+    let entry = types.entry(n.to_owned()).or_default();
+    if entry.base.is_none() {
+        entry.base = Some(strip_prefix(&b));
+    }
+}
+
+/// Records one `xs:element`/`xs:attribute` name as a member of the current type.
+fn record_member(
+    element: &BytesStart<'_>,
+    current: Option<&str>,
+    types: &mut BTreeMap<String, XsdType>,
+) {
+    if let (Some(n), Some(m)) = (current, xsd_attr(element, "name")) {
+        types.entry(n.to_owned()).or_default().members.insert(m);
     }
 }
 

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-lang"
-version = "0.0.42"
+version = "0.0.43"
 description = "openEHR LANG BMM/P_BMM object model, generated from BMM: generations v1_0 (LANG 1.0.0) and v1_1 (LANG 1.1.0, current; the stable BMM v2.x unit beside the paused BMM3 unit), plus hand-written ODIN/BEL/EL readers"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["parser-implementations", "data-structures"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.42" }
+openehr-base = { path = "../openehr-base", version = "0.0.43" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the
 # generated types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) —
 # never a derive. `serde_json` also carries the untyped `Value` fields the

--- a/crates/openehr-query/Cargo.toml
+++ b/crates/openehr-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-query"
-version = "0.0.42"
+version = "0.0.43"
 description = "openEHR QUERY (AQL 1.1.0): hand-written lexer, parser, typed AST and canonical printer from the official grammar (no ANTLR runtime)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-rm"
-version = "0.0.42"
+version = "0.0.43"
 description = "openEHR RM Reference Model, generated from BMM: generations v1_1 (RM 1.1.0) and v1_2 (RM 1.2.0, current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,11 +13,11 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.42" }
+openehr-base = { path = "../openehr-base", version = "0.0.43" }
 # The terminology-backed RM class invariants (`validate::terminology`) resolve
 # openEHR terminology groups + code sets against the vendored TERM 3.1.0 bundle.
 # `openehr-term` itself depends only on `openehr-base`, so this is acyclic.
-openehr-term = { path = "../openehr-term", version = "0.0.42" }
+openehr-term = { path = "../openehr-term", version = "0.0.43" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also backs the untyped `Value` RM representation used by

--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-term"
-version = "0.0.42"
+version = "0.0.43"
 description = "openEHR TERM terminology data model, generated from BMM (generation v3_1 = TERM 3.1.0), plus the embedded official terminology XML bundle"
 edition.workspace = true
 rust-version.workspace = true
@@ -34,7 +34,7 @@ include = [
 ]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.42" }
+openehr-base = { path = "../openehr-base", version = "0.0.43" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive.

--- a/docs/conformance/ferroehr/CONFORMANCE_CERTIFICATE.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_CERTIFICATE.md
@@ -4,9 +4,9 @@
 
 | Field | Value |
 | --- | --- |
-| Solution | ferroehr 4.0.6-rc2 |
+| Solution | ferroehr 4.0.8 |
 | Vendor | Ruben Talstra |
-| Runner | veredictum 0.1.0-alpha.2 |
+| Runner | veredictum 0.1.0-alpha.6 |
 | Infrastructure | ixit.json#/environment |
 
 ## Scope of Test

--- a/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
@@ -1,7 +1,7 @@
 # Conformance Report
 
-SUT: FerroEHR 4.0.6-rc2 (sut `ferroehr`) · schedule cnf-2.0-w2 · ITS its-rest
-Runner: veredictum 0.1.0-alpha.2 · verification pack: passed
+SUT: FerroEHR 4.0.8 (sut `ferroehr`) · schedule cnf-2.0-w2 · ITS its-rest
+Runner: veredictum 0.1.0-alpha.6 · verification pack: passed
 
 ## Summary
 

--- a/docs/conformance/ferroehr/results.json
+++ b/docs/conformance/ferroehr/results.json
@@ -1,11 +1,11 @@
 {
   "sut": {
     "name": "ferroehr",
-    "version": "4.0.6-rc2"
+    "version": "4.0.8"
   },
   "runner": {
     "name": "veredictum",
-    "version": "0.1.0-alpha.2",
+    "version": "0.1.0-alpha.6",
     "verification_pack_status": "passed"
   },
   "schedule_release": "cnf-2.0-w2",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1281,7 +1281,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.42"
+version = "0.0.43"
 dependencies = [
  "indexmap",
  "openehr-am",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.42"
+version = "0.0.43"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.42"
+version = "0.0.43"
 dependencies = [
  "serde",
  "serde_json",
@@ -1317,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.42"
+version = "0.0.43"
 dependencies = [
  "async-trait",
  "axum",
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.42"
+version = "0.0.43"
 dependencies = [
  "chumsky",
  "indexmap",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.42"
+version = "0.0.43"
 dependencies = [
  "chumsky",
  "logos",
@@ -1364,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.42"
+version = "0.0.43"
 dependencies = [
  "openehr-base",
  "openehr-term",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.42"
+version = "0.0.43"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/scripts/lib/veredictum.sh
+++ b/scripts/lib/veredictum.sh
@@ -36,7 +36,7 @@
 # The pin. Bumping it is a deliberate change: the catalogue, the oracle and the
 # verdict pipeline all move together, so a bump is re-proven by a full
 # `scripts/conformance.sh` run against the committed baseline.
-VEREDICTUM_VERSION="0.1.0-alpha.2"
+VEREDICTUM_VERSION="0.1.0-alpha.6"
 VEREDICTUM_REPO="https://github.com/rubentalstra/Veredictum"
 
 veredictum_cache_root() {

--- a/tools/openehr-codegen/src/analyze/mod.rs
+++ b/tools/openehr-codegen/src/analyze/mod.rs
@@ -456,31 +456,42 @@ impl Model {
     /// from the struct entirely, so it never blocks either.
     fn constructible_classes(&self) -> BTreeSet<String> {
         let mut ok: BTreeSet<String> = BTreeSet::new();
-        loop {
-            let mut changed = false;
-            for (name, class) in &self.classes {
-                if ok.contains(name) || Self::is_mapped(name) {
-                    continue;
-                }
-                let constructible = if class.is_abstract {
-                    self.enum_variants(name)
-                        .iter()
-                        .any(|v| ok.contains(v) || Self::is_mapped(v))
-                } else {
-                    self.flattened_props(class)
-                        .iter()
-                        .all(|rp| self.prop_allows_construction(rp, &ok))
-                };
-                if constructible {
-                    ok.insert(name.clone());
-                    changed = true;
-                }
+        while self.mark_constructible_round(&mut ok) {}
+        ok
+    }
+
+    /// Runs one round of the constructibility fixpoint, marking every class the
+    /// already-known set now permits construction of.
+    ///
+    /// Returns whether `ok` grew — `false` is the fixpoint.
+    fn mark_constructible_round(&self, ok: &mut BTreeSet<String>) -> bool {
+        let mut changed = false;
+        for (name, class) in &self.classes {
+            if ok.contains(name) || Self::is_mapped(name) {
+                continue;
             }
-            if !changed {
-                break;
+            if self.class_is_constructible(name, class, ok) {
+                ok.insert(name.clone());
+                changed = true;
             }
         }
-        ok
+        changed
+    }
+
+    /// Whether one class is constructible given the classes already known to be.
+    ///
+    /// An abstract (untagged-enum) class is constructible if any variant is; a
+    /// concrete one iff every mandatory single-valued field's type is.
+    fn class_is_constructible(&self, name: &str, class: &BmmClass, ok: &BTreeSet<String>) -> bool {
+        if class.is_abstract {
+            return self
+                .enum_variants(name)
+                .iter()
+                .any(|v| ok.contains(v) || Self::is_mapped(v));
+        }
+        self.flattened_props(class)
+            .iter()
+            .all(|rp| self.prop_allows_construction(rp, ok))
     }
 
     /// Whether one property leaves its owner constructible, given the classes

--- a/tools/openehr-codegen/src/load/oas.rs
+++ b/tools/openehr-codegen/src/load/oas.rs
@@ -102,22 +102,30 @@ impl Oas {
         keep: &std::collections::BTreeSet<String>,
     ) -> std::collections::BTreeSet<String> {
         let mut wanted = keep.clone();
-        loop {
-            let mut added = false;
-            for (_, o) in bundles {
-                for (name, schema) in o.schemas() {
-                    if !wanted.contains(&name) {
-                        continue;
-                    }
-                    for base in Self::allof_bases(schema) {
-                        added |= wanted.insert(base);
-                    }
+        while Self::add_allof_bases(bundles, &mut wanted) {}
+        wanted
+    }
+
+    /// Adds every `allOf` base of the currently-wanted schemas across all
+    /// bundles — one round of [`Self::base_closure`]'s fixpoint.
+    ///
+    /// Returns whether `wanted` grew; `false` is the fixpoint.
+    fn add_allof_bases(
+        bundles: &[(&str, Oas)],
+        wanted: &mut std::collections::BTreeSet<String>,
+    ) -> bool {
+        let mut added = false;
+        for (_, o) in bundles {
+            for (name, schema) in o.schemas() {
+                if !wanted.contains(&name) {
+                    continue;
+                }
+                for base in Self::allof_bases(schema) {
+                    added |= wanted.insert(base);
                 }
             }
-            if !added {
-                return wanted;
-            }
         }
+        added
     }
 
     /// The component-schema names a schema's `allOf` members `$ref`.

--- a/tools/openehr-codegen/src/render/emit.rs
+++ b/tools/openehr-codegen/src/render/emit.rs
@@ -695,33 +695,9 @@ fn render_struct_def(
     local: &BTreeSet<String>,
     external: &External,
 ) -> String {
-    let gen_decl = if generics.is_empty() {
-        String::new()
-    } else {
-        format!("<{}>", generics.join(", "))
-    };
+    let gen_decl = generic_decl(generics);
     let mut b = String::new();
-    doc_block_or(
-        &mut b,
-        class.documentation.as_deref(),
-        "",
-        &synth_class_doc(&class.name),
-        &synth_class_summary(&class.name),
-    );
-    push_spec_alias(&mut b, &class.name, struct_ty, "");
-    // No serde/`_type` derive: canonical-JSON (de)serialization is provided by
-    // the emitted `ToJson`/`FromJson` impls in `openehr-its` (`emit-json`), not by
-    // a per-struct derive. The type is a plain data record.
-    //
-    // A class the construction map records as staying a plain record although a
-    // reader might expect a validating door carries that adjudication here, at
-    // the public fields it is about — silence over an unguarded identifier type
-    // is indistinguishable from an oversight.
-    if let Some(note) = construction::plain_record_note(&class.name) {
-        b.push_str(&format!("// NOTE: {note}\n"));
-    }
-    b.push_str("#[derive(Debug, Clone, PartialEq)]\n");
-    b.push_str(&format!("pub struct {struct_ty}{gen_decl} {{\n"));
+    push_struct_prologue(&mut b, class, struct_ty, &gen_decl);
 
     // A class with a validating construction door (`plan::construction`) emits
     // its fields `pub(crate)` instead of `pub`: outside this crate the only way
@@ -755,11 +731,8 @@ fn render_struct_def(
             push_back_reference_note(&mut b, &p.name, citation);
             continue;
         }
-        if rp.owner != class.name && prev_owner != Some(rp.owner.as_str()) {
-            // Blank line before a new `// inherited:` group, but not as the very
-            // first line inside the braces (rustfmt strips a leading blank line).
-            let sep = if first { "" } else { "\n" };
-            b.push_str(&format!("{sep}    // inherited: {}\n", rp.owner));
+        if let Some(header) = inherited_group_header(rp, &class.name, prev_owner, first) {
+            b.push_str(&header);
         }
         prev_owner = Some(rp.owner.as_str());
         first = false;
@@ -799,6 +772,123 @@ fn render_struct_def(
         ));
     }
     b
+}
+
+/// The `<A, B>` generic-parameter declaration for a parameter-name list, empty
+/// when there are none.
+fn generic_decl(params: &[String]) -> String {
+    if params.is_empty() {
+        String::new()
+    } else {
+        format!("<{}>", params.join(", "))
+    }
+}
+
+/// The imports every enum variant's payload embeds.
+///
+/// For a variant threaded over the enum's own params (`IntervalEvent<T>`) that
+/// is just the variant type; for a bound-filled variant
+/// (`DvInterval<DvOrdered>`) it also includes the auto-filled bound arguments.
+/// This mirrors the payload decision, so a bound type the payload never names
+/// is not imported.
+fn variant_imports(
+    model: &Model,
+    variants: &[String],
+    enum_generics: &[String],
+    ty: &str,
+    index: &BTreeMap<String, Vec<String>>,
+    external: &External,
+) -> BTreeSet<String> {
+    let mut imports: BTreeSet<String> = BTreeSet::new();
+    for d in variants {
+        let mut roots = BTreeSet::new();
+        let d_generic = !model.used_generic_params(d).is_empty();
+        if d_generic && !enum_generics.is_empty() {
+            roots.insert(d.clone());
+        } else {
+            model.effective_roots(&BmmType::Simple(d.clone()), &mut roots);
+        }
+        for r in roots {
+            add_import(&mut imports, &r, ty, index, external);
+        }
+    }
+    imports
+}
+
+/// The imports the in-file `{Name}Data` struct needs for the class's own fields.
+///
+/// The enum's own type is never imported into its own file, and a spec neither
+/// the local ident index nor an external prelude places is skipped.
+fn data_struct_imports(
+    model: &Model,
+    class: &BmmClass,
+    data_generics: &[String],
+    data_subst: &BTreeMap<String, String>,
+    ty: &str,
+    index: &BTreeMap<String, Vec<String>>,
+    external: &External,
+) -> Vec<String> {
+    model
+        .referenced_specs(class, data_generics, data_subst)
+        .iter()
+        .filter_map(|spec| {
+            let ident = naming::type_name(spec);
+            if ident == ty {
+                return None;
+            }
+            if let Some(chain) = index.get(&ident) {
+                Some(format!("use crate::{}::{};", chain.join("::"), ident))
+            } else {
+                external
+                    .module_of(spec)
+                    .map(|path| format!("use {path}::{ident};"))
+            }
+        })
+        .collect()
+}
+
+/// Appends the struct's doc block, spec alias, construction note and the
+/// `derive` + opening `pub struct` lines.
+///
+/// No serde/`_type` derive is emitted: canonical-JSON (de)serialization is
+/// provided by the emitted `ToJson`/`FromJson` impls in `openehr-its`
+/// (`emit-json`), so the type is a plain data record.
+fn push_struct_prologue(b: &mut String, class: &BmmClass, struct_ty: &str, gen_decl: &str) {
+    doc_block_or(
+        b,
+        class.documentation.as_deref(),
+        "",
+        &synth_class_doc(&class.name),
+        &synth_class_summary(&class.name),
+    );
+    push_spec_alias(b, &class.name, struct_ty, "");
+    // A class the construction map records as staying a plain record although a
+    // reader might expect a validating door carries that adjudication here, at
+    // the public fields it is about — silence over an unguarded identifier type
+    // is indistinguishable from an oversight.
+    if let Some(note) = construction::plain_record_note(&class.name) {
+        b.push_str(&format!("// NOTE: {note}\n"));
+    }
+    b.push_str("#[derive(Debug, Clone, PartialEq)]\n");
+    b.push_str(&format!("pub struct {struct_ty}{gen_decl} {{\n"));
+}
+
+/// The `// inherited: X` group header a property opens, if it starts a new
+/// inheritance group.
+///
+/// The header carries a blank line before it — but not as the very first line
+/// inside the braces, which rustfmt strips.
+fn inherited_group_header(
+    rp: &crate::analyze::ResolvedProp<'_>,
+    class_name: &str,
+    prev_owner: Option<&str>,
+    first: bool,
+) -> Option<String> {
+    if rp.owner == class_name || prev_owner == Some(rp.owner.as_str()) {
+        return None;
+    }
+    let sep = if first { "" } else { "\n" };
+    Some(format!("{sep}    // inherited: {}\n", rp.owner))
 }
 
 /// The NOTE emitted in place of an omitted back-reference field.
@@ -1222,11 +1312,7 @@ fn emit_enum(
         .into_iter()
         .map(|(n, _)| n)
         .collect();
-    let gen_decl = if enum_generics.is_empty() {
-        String::new()
-    } else {
-        format!("<{}>", enum_generics.join(", "))
-    };
+    let gen_decl = generic_decl(&enum_generics);
     let mut b = String::new();
 
     // Compute payloads first (so imports can be derived from what they touch).
@@ -1261,44 +1347,18 @@ fn emit_enum(
         ));
     }
 
-    // Imports: every emittable spec type each payload embeds. For a variant
-    // threaded over the enum's own params (`IntervalEvent<T>`) that is just the
-    // variant type; for a bound-filled variant (`DvInterval<DvOrdered>`) it also
-    // includes the auto-filled bound args. Mirror the payload decision so we do
-    // not import a bound type the payload never names.
-    let mut imports: BTreeSet<String> = BTreeSet::new();
-    for d in variants {
-        let mut roots = BTreeSet::new();
-        let d_generic = !model.used_generic_params(d).is_empty();
-        if d_generic && !enum_generics.is_empty() {
-            roots.insert(d.clone());
-        } else {
-            model.effective_roots(&BmmType::Simple(d.clone()), &mut roots);
-        }
-        for r in roots {
-            add_import(&mut imports, &r, &ty, index, external);
-        }
-    }
+    let mut imports = variant_imports(model, variants, &enum_generics, &ty, index, external);
     // The in-file `{Name}Data` struct pulls in imports for the class's own fields.
     if self_data {
-        imports.extend(
-            model
-                .referenced_specs(class, &data_generics, &data_subst)
-                .iter()
-                .filter_map(|spec| {
-                    let ident = naming::type_name(spec);
-                    if ident == ty {
-                        return None;
-                    }
-                    if let Some(chain) = index.get(&ident) {
-                        Some(format!("use crate::{}::{};", chain.join("::"), ident))
-                    } else {
-                        external
-                            .module_of(spec)
-                            .map(|path| format!("use {path}::{ident};"))
-                    }
-                }),
-        );
+        imports.extend(data_struct_imports(
+            model,
+            class,
+            &data_generics,
+            &data_subst,
+            &ty,
+            index,
+            external,
+        ));
     }
 
     // No serde: the canonical-JSON `_type` dispatch (abstract slots require
@@ -1549,29 +1609,39 @@ fn emit_enum_declaration(
 fn emit_enum_conversions(b: &mut String, ty: &str, is_int: bool, lits: &[EnumLit]) {
     b.push_str(&format!("impl {ty} {{\n"));
     if is_int {
-        b.push_str(
-            "    /// The `i32` wire value of this constant (the verbatim payload for\n    \
-             /// [`Self::Other`]).\n    #[must_use]\n    pub fn value(self) -> i32 {\n        match self {\n",
-        );
-        for lit in lits {
-            if let EnumLitWire::Int(v) = &lit.wire {
-                b.push_str(&format!("            Self::{} => {v},\n", lit.ident));
-            }
-        }
-        b.push_str("            Self::Other(__v) => __v,\n        }\n    }\n\n");
-        b.push_str(
-            "    /// This constant for an `i32` wire value, tolerating an unknown\n    \
-             /// value as [`Self::Other`] (total — never fails).\n    #[must_use]\n    \
-             pub fn from_value(__v: i32) -> Self {\n        match __v {\n",
-        );
-        for lit in lits {
-            if let EnumLitWire::Int(v) = &lit.wire {
-                b.push_str(&format!("            {v} => Self::{},\n", lit.ident));
-            }
-        }
-        b.push_str("            _ => Self::Other(__v),\n        }\n    }\n}\n\n");
-        return;
+        emit_int_wire_conversions(b, lits);
+    } else {
+        emit_str_wire_conversions(b, lits);
     }
+}
+
+/// The `i32`-valued enum's `value`/`from_value` pair, closing the `impl` block.
+fn emit_int_wire_conversions(b: &mut String, lits: &[EnumLit]) {
+    b.push_str(
+        "    /// The `i32` wire value of this constant (the verbatim payload for\n    \
+         /// [`Self::Other`]).\n    #[must_use]\n    pub fn value(self) -> i32 {\n        match self {\n",
+    );
+    for lit in lits {
+        if let EnumLitWire::Int(v) = &lit.wire {
+            b.push_str(&format!("            Self::{} => {v},\n", lit.ident));
+        }
+    }
+    b.push_str("            Self::Other(__v) => __v,\n        }\n    }\n\n");
+    b.push_str(
+        "    /// This constant for an `i32` wire value, tolerating an unknown\n    \
+         /// value as [`Self::Other`] (total — never fails).\n    #[must_use]\n    \
+         pub fn from_value(__v: i32) -> Self {\n        match __v {\n",
+    );
+    for lit in lits {
+        if let EnumLitWire::Int(v) = &lit.wire {
+            b.push_str(&format!("            {v} => Self::{},\n", lit.ident));
+        }
+    }
+    b.push_str("            _ => Self::Other(__v),\n        }\n    }\n}\n\n");
+}
+
+/// The string-valued enum's `as_str`/`from_wire` pair, closing the `impl` block.
+fn emit_str_wire_conversions(b: &mut String, lits: &[EnumLit]) {
     b.push_str(
         "    /// The wire string of this constant (the verbatim token for\n    \
          /// [`Self::Other`]).\n    #[must_use]\n    pub fn as_str(&self) -> &str {\n        match self {\n",

--- a/tools/openehr-codegen/src/render/emit_json.rs
+++ b/tools/openehr-codegen/src/render/emit_json.rs
@@ -255,59 +255,12 @@ fn undispatchable(ty: &JsonType) -> Option<(String, &'static str)> {
 /// caller passes them in dispatch priority. Every shadowed twin is listed in
 /// the emitted header, never dropped silently.
 pub(crate) fn emit_structural_file(schemas: &[JsonSchema<'_>]) -> String {
-    let mut arms: std::collections::BTreeMap<String, String> = std::collections::BTreeMap::new();
-    // `spec class -> its sorted declared wire keys`, the SAME closure the
-    // reader's undeclared-key refusal is emitted from — so the validation
-    // dispatcher can answer "is this key declared?" without a decode, and can
-    // never disagree with the reader.
-    let mut declared: std::collections::BTreeMap<String, Vec<String>> =
-        std::collections::BTreeMap::new();
-    let mut shadowed: Vec<(String, String, String)> = Vec::new();
-    let mut skipped: Vec<(String, &'static str)> = Vec::new();
-    for s in schemas {
-        for ty in s.model.json_types(s.schema) {
-            // A newtype / literal-enum shape writes its BARE payload (no `_type`
-            // member — see `emit_serialize`), and an untagged enum carries no
-            // `_type` of its own either (the active variant's payload supplies
-            // it, and every such payload is itself an emitted struct with its
-            // own arm). Neither is reachable as a `_type` dispatch key, so
-            // neither can have one — each is recorded, never silently dropped.
-            let (spec, rust, generics) = match &ty {
-                JsonType::Struct {
-                    spec,
-                    rust,
-                    generics,
-                    fields,
-                } => {
-                    let mut keys: Vec<String> =
-                        fields.iter().map(|f| f.wire_name.clone()).collect();
-                    keys.sort();
-                    declared.entry(spec.clone()).or_insert(keys);
-                    (spec, rust, generics)
-                }
-                other => {
-                    skipped.extend(undispatchable(other));
-                    continue;
-                }
-            };
-            let path = s.path_of(spec);
-            let fill = if generics.is_empty() {
-                String::new()
-            } else {
-                let args = vec![GENERIC_FILL; generics.len()].join(", ");
-                format!("<{args}>")
-            };
-            let expr = format!("{path}::{rust}{fill}");
-            match arms.entry(spec.clone()) {
-                std::collections::btree_map::Entry::Vacant(slot) => {
-                    slot.insert(expr);
-                }
-                std::collections::btree_map::Entry::Occupied(held) => {
-                    shadowed.push((spec.clone(), held.get().clone(), expr));
-                }
-            }
-        }
-    }
+    let StructuralInventory {
+        arms,
+        declared,
+        shadowed,
+        skipped,
+    } = structural_inventory(schemas);
 
     let mut b = String::new();
     b.push_str(
@@ -412,6 +365,85 @@ pub(crate) fn emit_structural_file(schemas: &[JsonSchema<'_>]) -> String {
     }
     b.push_str("_ => ::core::option::Option::None,\n}\n}\n");
     b
+}
+
+/// The `_type` dispatch inventory the structural-check file is emitted from.
+struct StructuralInventory {
+    /// `spec class` → the expression that decodes a node as it.
+    arms: std::collections::BTreeMap<String, String>,
+    /// `spec class` → its sorted declared wire keys, the SAME closure the
+    /// reader's undeclared-key refusal is emitted from — so the validation
+    /// dispatcher can answer "is this key declared?" without a decode, and can
+    /// never disagree with the reader.
+    declared: std::collections::BTreeMap<String, Vec<String>>,
+    /// `(spec class, the arm that won, the arm it shadowed)`.
+    shadowed: Vec<(String, String, String)>,
+    /// `(Rust shape, why it is unreachable as a `_type` dispatch key)`.
+    skipped: Vec<(String, &'static str)>,
+}
+
+/// Collects the dispatch inventory across every schema, in dispatch priority.
+///
+/// The FIRST schema declaring a spec class name wins; the loser is recorded as
+/// a shadowed twin, never dropped silently.
+fn structural_inventory(schemas: &[JsonSchema<'_>]) -> StructuralInventory {
+    let mut arms: std::collections::BTreeMap<String, String> = std::collections::BTreeMap::new();
+    let mut declared: std::collections::BTreeMap<String, Vec<String>> =
+        std::collections::BTreeMap::new();
+    let mut shadowed: Vec<(String, String, String)> = Vec::new();
+    let mut skipped: Vec<(String, &'static str)> = Vec::new();
+    for s in schemas {
+        for ty in s.model.json_types(s.schema) {
+            // A newtype / literal-enum shape writes its BARE payload (no `_type`
+            // member — see `emit_serialize`), and an untagged enum carries no
+            // `_type` of its own either (the active variant's payload supplies
+            // it, and every such payload is itself an emitted struct with its
+            // own arm). Neither is reachable as a `_type` dispatch key, so
+            // neither can have one — each is recorded, never silently dropped.
+            let JsonType::Struct {
+                spec,
+                rust,
+                generics,
+                fields,
+            } = &ty
+            else {
+                skipped.extend(undispatchable(&ty));
+                continue;
+            };
+            let mut keys: Vec<String> = fields.iter().map(|f| f.wire_name.clone()).collect();
+            keys.sort();
+            declared.entry(spec.clone()).or_insert(keys);
+
+            let expr = format!("{}::{rust}{}", s.path_of(spec), generic_fill(generics));
+            match arms.entry(spec.clone()) {
+                std::collections::btree_map::Entry::Vacant(slot) => {
+                    slot.insert(expr);
+                }
+                std::collections::btree_map::Entry::Occupied(held) => {
+                    shadowed.push((spec.clone(), held.get().clone(), expr));
+                }
+            }
+        }
+    }
+    StructuralInventory {
+        arms,
+        declared,
+        shadowed,
+        skipped,
+    }
+}
+
+/// The `<…>` bound-fill for a generic class's dispatch expression, empty for a
+/// non-generic one.
+///
+/// Generic classes are monomorphized with an opaque element type, so the
+/// container's own shape is checked and its elements are accepted verbatim.
+fn generic_fill(generics: &[String]) -> String {
+    if generics.is_empty() {
+        return String::new();
+    }
+    let args = vec![GENERIC_FILL; generics.len()].join(", ");
+    format!("<{args}>")
 }
 
 /// The spec class a [`JsonType`] realizes — the key its Rust path is resolved by

--- a/tools/openehr-codegen/src/render/emit_opt.rs
+++ b/tools/openehr-codegen/src/render/emit_opt.rs
@@ -489,56 +489,23 @@ impl<'a> OptModel<'a> {
     /// One element's generated field: its declared Rust type and its XML view.
     ///
     /// A single-valued reference to a generated enum is boxed — those slots
-    /// (`EXPR_ITEM`, `C_PRIMITIVE`, `STATE`) are recursive. A mandatory scalar
-    /// bool absent on the wire (openEHR `Interval` boundedness flags default
-    /// false) falls back to `false`, and some XSD-mandatory fields are omitted
-    /// by real-world OPT exports (Ocean/tool laxity), so they are defaulted
-    /// leniently — a wire adapter must ingest imperfect real OPTs.
+    /// (`EXPR_ITEM`, `C_PRIMITIVE`, `STATE`) are recursive. The container
+    /// wrapping is [`Self::declared_type`]'s and the wire fallback is
+    /// [`Self::scalar_default`]'s; an `xs:anyType` hash takes the separate
+    /// [`Self::hash_field`] shape.
     fn element_field(&self, e: &crate::load::xsd::XsdElem) -> OptField {
         let res = self.resolve(&e.type_name);
         let rust_name = naming::field_ident(&e.name);
         let (base, target) = Self::base_decl(&res, &e.type_name);
 
         if matches!(res, Resolved::Hash) {
-            let decl_type = if e.optional {
-                format!("Option<{base}>")
-            } else {
-                base
-            };
-            return OptField {
-                xml: XmlField {
-                    wire_name: e.name.clone(),
-                    rust_name,
-                    optional: e.optional,
-                    multiple: false,
-                    target: "OrderedDict".to_string(),
-                    map_value: Some("String".to_string()),
-                    default: None,
-                    nonempty: false,
-                },
-                decl_type,
-            };
+            return Self::hash_field(e, rust_name, base);
         }
 
         let inner = if !e.multiple && matches!(res, Resolved::Gen(_, true)) {
             format!("Box<{base}>")
         } else {
             base
-        };
-        let decl_type = if e.multiple {
-            format!("Vec<{inner}>")
-        } else if e.optional {
-            format!("Option<{inner}>")
-        } else {
-            inner
-        };
-        let scalar = !e.optional && !e.multiple;
-        let default = if scalar && matches!(res, Resolved::Primitive("bool")) {
-            Some("false".to_string())
-        } else if scalar {
-            lenient_default(&e.name, &e.type_name, self.target.prelude)
-        } else {
-            None
         };
         OptField {
             xml: XmlField {
@@ -548,11 +515,63 @@ impl<'a> OptModel<'a> {
                 multiple: e.multiple,
                 target,
                 map_value: None,
-                default,
+                default: self.scalar_default(e, &res),
+                nonempty: false,
+            },
+            decl_type: Self::declared_type(e, inner),
+        }
+    }
+
+    /// The generated field for an `xs:anyType` hash element: a string map,
+    /// never boxed and never defaulted.
+    fn hash_field(e: &crate::load::xsd::XsdElem, rust_name: String, base: String) -> OptField {
+        let decl_type = if e.optional {
+            format!("Option<{base}>")
+        } else {
+            base
+        };
+        OptField {
+            xml: XmlField {
+                wire_name: e.name.clone(),
+                rust_name,
+                optional: e.optional,
+                multiple: false,
+                target: "OrderedDict".to_string(),
+                map_value: Some("String".to_string()),
+                default: None,
                 nonempty: false,
             },
             decl_type,
         }
+    }
+
+    /// Wraps an element's inner type in the container its XSD multiplicity and
+    /// optionality call for.
+    fn declared_type(e: &crate::load::xsd::XsdElem, inner: String) -> String {
+        if e.multiple {
+            format!("Vec<{inner}>")
+        } else if e.optional {
+            format!("Option<{inner}>")
+        } else {
+            inner
+        }
+    }
+
+    /// The wire default for a mandatory scalar element, if it has one.
+    ///
+    /// An absent mandatory bool falls back to `false` (openEHR `Interval`
+    /// boundedness flags), and some XSD-mandatory fields are omitted by
+    /// real-world OPT exports (Ocean/tool laxity), so those are defaulted
+    /// leniently — a wire adapter must ingest imperfect real OPTs. A
+    /// multi-valued or optional element never defaults.
+    fn scalar_default(&self, e: &crate::load::xsd::XsdElem, res: &Resolved) -> Option<String> {
+        if e.optional || e.multiple {
+            return None;
+        }
+        if matches!(res, Resolved::Primitive("bool")) {
+            return Some("false".to_string());
+        }
+        lenient_default(&e.name, &e.type_name, self.target.prelude)
     }
 
     /// The closure's `xs:enumeration`-faceted simple types, name-ordered.

--- a/tools/openehr-codegen/src/render/model_query.rs
+++ b/tools/openehr-codegen/src/render/model_query.rs
@@ -47,7 +47,7 @@
 use crate::analyze::{
     External, Model, augment_with_reemit, class_paths, cross_schema_reemit, emittable_specs,
 };
-use crate::load::bmm::{BmmCardinality, BmmPropKind, BmmProperty, BmmSchema, BmmType};
+use crate::load::bmm::{BmmCardinality, BmmClass, BmmPropKind, BmmProperty, BmmSchema, BmmType};
 use crate::plan::composition::{self, compose};
 use crate::plan::overrides::{back_reference, class_binding};
 use crate::plan::{Emission, decide};
@@ -339,22 +339,7 @@ fn collect_generation(
         let skipped = matches!(emission, Emission::Skip);
         let generics = struct_generics(model, class);
         let subst = class_binding(name);
-        // Declared view: the class's own properties. Flattened view: every
-        // property the class CARRIES, resolved through the same
-        // `Model::flattened_props` the struct renderer walks — so the emission
-        // column is computed for the class that actually emits the field.
-        let declared: Vec<(String, &BmmProperty)> =
-            class.properties.iter().map(|p| (name.clone(), p)).collect();
-        let inherited: Vec<(String, &BmmProperty)> = if flattened {
-            model
-                .flattened_props(class)
-                .into_iter()
-                .map(|rp| (rp.owner, rp.prop))
-                .collect()
-        } else {
-            Vec::new()
-        };
-        let props = if flattened { inherited } else { declared };
+        let props = view_props(model, class, name, flattened);
         let package = packages
             .get(name)
             .cloned()
@@ -379,13 +364,45 @@ fn collect_generation(
                 declared_on: owner,
                 attribute: prop.name.clone(),
                 bmm_type: bmm_type_text(prop),
-                existence: if prop.is_mandatory { "1..1" } else { "0..1" },
+                existence: existence_text(prop),
                 container,
                 cardinality,
                 emission: shape,
             });
         }
     }
+}
+
+/// The properties one class contributes to the report, paired with the class
+/// each is declared on.
+///
+/// The DECLARED view is the class's own properties. The FLATTENED view is every
+/// property the class CARRIES, resolved through the same
+/// [`Model::flattened_props`] the struct renderer walks — so the emission column
+/// is computed for the class that actually emits the field.
+fn view_props<'a>(
+    model: &'a Model,
+    class: &'a BmmClass,
+    name: &str,
+    flattened: bool,
+) -> Vec<(String, &'a BmmProperty)> {
+    if flattened {
+        return model
+            .flattened_props(class)
+            .into_iter()
+            .map(|rp| (rp.owner, rp.prop))
+            .collect();
+    }
+    class
+        .properties
+        .iter()
+        .map(|p| (name.to_owned(), p))
+        .collect()
+}
+
+/// The `existence` column: one property's BMM existence range as spec text.
+fn existence_text(prop: &BmmProperty) -> &'static str {
+    if prop.is_mandatory { "1..1" } else { "0..1" }
 }
 
 /// The planned shape of a class, as the label the report prints.

--- a/tools/openehr-codegen/src/testsupport.rs
+++ b/tools/openehr-codegen/src/testsupport.rs
@@ -22,7 +22,7 @@ use crate::cli;
 use crate::load::bmm::BmmSchema;
 use crate::load::impls::SiblingImpls;
 use crate::load::oas;
-use crate::plan::composition::{self, compose};
+use crate::plan::composition::{self, ComposedUnit, compose};
 use crate::plan::overrides;
 use crate::plan::{Emission, decide};
 use crate::render::emit::{CrateGeneration, RenderUnit, emit_composed};
@@ -235,29 +235,54 @@ pub fn attribute_gaps(key: &str) -> Result<(Vec<AttributeGap>, usize), Error> {
     let mut checked = 0_usize;
     for g in &c.generations {
         for u in &g.units {
-            let used = u.model.used_as_type();
-            for (name, class) in &u.schema.classes {
-                let carriers = attribute_carriers(name, class, &u.model, &used);
-                for p in &class.properties {
-                    if overrides::back_reference(name, &p.name).is_some() {
-                        continue;
-                    }
-                    for carrier in &carriers {
-                        checked += 1;
-                        if !emitted_field_names(&u.model, carrier).contains(&p.name) {
-                            gaps.push(AttributeGap {
-                                file: u.spec.file.to_string(),
-                                class: name.clone(),
-                                attribute: p.name.clone(),
-                                detail: format!("missing from the emitted `{carrier}` fields"),
-                            });
-                        }
-                    }
-                }
-            }
+            checked += unit_attribute_gaps(u, &mut gaps);
         }
     }
     Ok((gaps, checked))
+}
+
+/// Collects one specification unit's attribute gaps into `gaps`, returning how
+/// many `(class, attribute, carrier)` triples were checked.
+fn unit_attribute_gaps(u: &ComposedUnit, gaps: &mut Vec<AttributeGap>) -> usize {
+    let used = u.model.used_as_type();
+    let mut checked = 0_usize;
+    for (name, class) in &u.schema.classes {
+        checked += class_attribute_gaps(u, name, class, &used, gaps);
+    }
+    checked
+}
+
+/// Collects one class's attribute gaps into `gaps`, returning how many
+/// `(attribute, carrier)` pairs were checked.
+///
+/// A back-referenced attribute is deliberately absent from every emitted field
+/// set (`overrides::back_reference`), so it is not a gap.
+fn class_attribute_gaps(
+    u: &ComposedUnit,
+    name: &str,
+    class: &crate::load::bmm::BmmClass,
+    used: &BTreeSet<String>,
+    gaps: &mut Vec<AttributeGap>,
+) -> usize {
+    let carriers = attribute_carriers(name, class, &u.model, used);
+    let mut checked = 0_usize;
+    for p in &class.properties {
+        if overrides::back_reference(name, &p.name).is_some() {
+            continue;
+        }
+        for carrier in &carriers {
+            checked += 1;
+            if !emitted_field_names(&u.model, carrier).contains(&p.name) {
+                gaps.push(AttributeGap {
+                    file: u.spec.file.to_string(),
+                    class: name.to_owned(),
+                    attribute: p.name.clone(),
+                    detail: format!("missing from the emitted `{carrier}` fields"),
+                });
+            }
+        }
+    }
+    checked
 }
 
 /// The emitted types that must carry a class's declared attributes.
@@ -1692,9 +1717,6 @@ fn hand_written_files(dir: &std::path::Path) -> Result<BTreeMap<String, String>,
 /// Returns an error if the composition fails to load or a crate tree cannot be
 /// read.
 pub fn generation_function_divergence(key: &str) -> Result<Vec<String>, Error> {
-    /// Per class: the functions the generation DECLARES, and those it realizes.
-    type ClassFunctions = BTreeMap<String, (BTreeSet<String>, BTreeSet<String>)>;
-
     let comp = compose(key)?;
     let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../../crates")
@@ -1702,42 +1724,74 @@ pub fn generation_function_divergence(key: &str) -> Result<Vec<String>, Error> {
         .join("src");
     let mut realized: Vec<(&str, ClassFunctions)> = Vec::new();
     for generation in &comp.generations {
-        let bodies = rust_bodies_by_stem(&src.join(generation.spec.module))?;
-        let mut per_class: ClassFunctions = BTreeMap::new();
-        for unit in &generation.units {
-            for (name, class) in &unit.schema.classes {
-                if let Some(entry) = class_function_status(name, class, &bodies) {
-                    per_class.insert(name.clone(), entry);
-                }
-            }
-        }
-        realized.push((generation.spec.module, per_class));
+        realized.push((
+            generation.spec.module,
+            generation_class_functions(generation, &src)?,
+        ));
     }
     let mut divergent = Vec::new();
     for (i, (module, classes)) in realized.iter().enumerate() {
         for (other_module, other_classes) in realized.iter().skip(i + 1) {
-            for (class, (_, functions)) in classes {
-                let Some((other_declared, other_found)) = other_classes.get(class) else {
-                    continue;
-                };
-                // Only a function BOTH generations declare can diverge. A
-                // generation pair like AM's `v1_4`/`v2_4` is two different
-                // specifications sharing class names, so a function one of
-                // them never declares is not a gap in the other — comparing
-                // against the realized set alone reported nine of those.
-                for f in functions.intersection(other_declared) {
-                    if !other_found.contains(f) {
-                        divergent.push(format!(
-                            "{class}.{f}: realized in {module}, missing in {other_module}"
-                        ));
-                    }
-                }
-            }
+            push_pair_divergences(module, classes, other_module, other_classes, &mut divergent);
         }
     }
     divergent.sort();
     divergent.dedup();
     Ok(divergent)
+}
+
+/// Per class: the functions a generation DECLARES, and those it realizes.
+type ClassFunctions = BTreeMap<String, (BTreeSet<String>, BTreeSet<String>)>;
+
+/// The declared/realized function tables of one generation's classes.
+///
+/// A class with no `*_impl.rs` sibling is absent from the table entirely
+/// (`class_function_status`), so it can never look like a divergence.
+///
+/// # Errors
+/// Returns an error if the generation's module tree cannot be read.
+fn generation_class_functions(
+    generation: &composition::ComposedGeneration,
+    src: &std::path::Path,
+) -> Result<ClassFunctions, Error> {
+    let bodies = rust_bodies_by_stem(&src.join(generation.spec.module))?;
+    let mut per_class: ClassFunctions = BTreeMap::new();
+    for unit in &generation.units {
+        for (name, class) in &unit.schema.classes {
+            if let Some(entry) = class_function_status(name, class, &bodies) {
+                per_class.insert(name.clone(), entry);
+            }
+        }
+    }
+    Ok(per_class)
+}
+
+/// Appends every function one generation of the pair realizes and the other
+/// does not.
+///
+/// Only a function BOTH generations declare can diverge. A generation pair like
+/// AM's `v1_4`/`v2_4` is two different specifications sharing class names, so a
+/// function one of them never declares is not a gap in the other — comparing
+/// against the realized set alone reported nine of those.
+fn push_pair_divergences(
+    module: &str,
+    classes: &ClassFunctions,
+    other_module: &str,
+    other_classes: &ClassFunctions,
+    out: &mut Vec<String>,
+) {
+    for (class, (_, functions)) in classes {
+        let Some((other_declared, other_found)) = other_classes.get(class) else {
+            continue;
+        };
+        for f in functions.intersection(other_declared) {
+            if !other_found.contains(f) {
+                out.push(format!(
+                    "{class}.{f}: realized in {module}, missing in {other_module}"
+                ));
+            }
+        }
+    }
 }
 
 /// The functions one class DECLARES and those its hand-written sibling
@@ -1843,30 +1897,48 @@ pub fn unrealized_bmm_functions(key: &str) -> Result<Vec<String>, Error> {
         let bodies = rust_bodies_by_stem(&src.join(generation.spec.module))?;
         for unit in &generation.units {
             for (name, class) in &unit.schema.classes {
-                if class.functions.is_empty() {
-                    continue;
-                }
-                // A class the emitter never gives a Rust type has nowhere to
-                // carry an inherent method, so its BMM functions are realized
-                // by the language rather than by us: `Integer.add` is `i32`'s
-                // `+`, and `impl i32` is not a thing anyone can write. The
-                // authority is the emitter's OWN decision maps, not a name
-                // heuristic — if a class starts emitting, it starts being
-                // measured, with no second list to keep in step.
-                if overrides::primitive(name).is_some() || overrides::is_mapped_class(name) {
-                    continue;
-                }
-                for function in &class.functions {
-                    if !function_is_realized(name, function, bodies_of(name, &bodies), &bodies) {
-                        missing.push(format!("{}/{name}.{function}", generation.spec.module));
-                    }
-                }
+                push_unrealized_functions(
+                    name,
+                    class,
+                    generation.spec.module,
+                    &bodies,
+                    &mut missing,
+                );
             }
         }
     }
     missing.sort();
     missing.dedup();
     Ok(missing)
+}
+
+/// Appends every BMM function of one class that no Rust method in `generation`
+/// realizes, as `<generation>/<CLASS>.<function>`.
+///
+/// A class the emitter never gives a Rust type has nowhere to carry an inherent
+/// method, so its BMM functions are realized by the language rather than by us:
+/// `Integer.add` is `i32`'s `+`, and `impl i32` is not a thing anyone can
+/// write. The authority is the emitter's OWN decision maps, not a name
+/// heuristic — if a class starts emitting, it starts being measured, with no
+/// second list to keep in step.
+fn push_unrealized_functions(
+    name: &str,
+    class: &crate::load::bmm::BmmClass,
+    generation: &str,
+    bodies: &BTreeMap<String, String>,
+    out: &mut Vec<String>,
+) {
+    if class.functions.is_empty()
+        || overrides::primitive(name).is_some()
+        || overrides::is_mapped_class(name)
+    {
+        return;
+    }
+    for function in &class.functions {
+        if !function_is_realized(name, function, bodies_of(name, bodies), bodies) {
+            out.push(format!("{generation}/{name}.{function}"));
+        }
+    }
 }
 
 /// The class's own two candidate bodies: its generated type file and its

--- a/tools/openehr-codegen/templates/openehr-base/foundation_types/time/iso8601_parse.rs
+++ b/tools/openehr-codegen/templates/openehr-base/foundation_types/time/iso8601_parse.rs
@@ -736,48 +736,81 @@ pub(crate) fn parse_duration(s: &str) -> Option<ParsedDuration> {
         seconds: 0,
         fractional_seconds: 0.0,
     };
-    let mut in_time = false;
-    let mut seen_any = false;
-    // The slot of the last designator consumed, in the order the production
-    // fixes; `-1` because `Y` is slot 0.
-    let mut last_slot: i8 = -1;
-    let mut seen_time_component = false;
+    let mut scan = DurationScan::default();
     loop {
         match it.peek() {
             None => break,
             Some('T') => {
-                if in_time {
+                if scan.in_time {
                     return None;
                 }
-                in_time = true;
+                scan.in_time = true;
                 it.next();
             }
             Some(c) if c.is_ascii_digit() => {
-                let (intval, fracval, has_frac) = read_duration_number(&mut it)?;
-                let designator = it.next()?;
-                let slot = apply_duration_component(&mut d, in_time, designator, intval, fracval)?;
-                if slot <= last_slot {
-                    return None;
-                }
-                last_slot = slot;
-                if in_time {
-                    seen_time_component = true;
-                }
-                if has_frac && !(in_time && designator == 'S') {
-                    return None; // only the seconds field carries a fraction
-                }
-                seen_any = true;
+                read_duration_component(&mut it, &mut d, &mut scan)?;
             }
             _ => return None,
         }
     }
-    if !seen_any {
+    if !scan.seen_any {
         return None; // `P`/`PT` with no components is not a duration
     }
-    if in_time && !seen_time_component {
+    if scan.in_time && !scan.seen_time_component {
         return None; // `P1YT` — the production has no bare trailing `T`
     }
     Some(d)
+}
+
+/// The scan state threaded through a duration's component loop.
+struct DurationScan {
+    /// Whether the `T` designator separating date from time was consumed.
+    in_time: bool,
+    /// Whether any component at all was read.
+    seen_any: bool,
+    /// Whether a component followed the `T` separator.
+    seen_time_component: bool,
+    /// The slot of the last designator consumed, in the order the production
+    /// fixes; `-1` because `Y` is slot 0.
+    last_slot: i8,
+}
+
+impl Default for DurationScan {
+    fn default() -> Self {
+        Self {
+            in_time: false,
+            seen_any: false,
+            seen_time_component: false,
+            last_slot: -1,
+        }
+    }
+}
+
+/// Reads one `<number><designator>` duration component and folds it into `d`.
+///
+/// `None` on any violation of the production: a designator out of the fixed
+/// slot order (which also rejects a repeated one), or a fraction on any field
+/// but the seconds.
+fn read_duration_component(
+    it: &mut std::iter::Peekable<std::str::Chars<'_>>,
+    d: &mut ParsedDuration,
+    scan: &mut DurationScan,
+) -> Option<()> {
+    let (intval, fracval, has_frac) = read_duration_number(it)?;
+    let designator = it.next()?;
+    let slot = apply_duration_component(d, scan.in_time, designator, intval, fracval)?;
+    if slot <= scan.last_slot {
+        return None;
+    }
+    scan.last_slot = slot;
+    if scan.in_time {
+        scan.seen_time_component = true;
+    }
+    if has_frac && !(scan.in_time && designator == 'S') {
+        return None; // only the seconds field carries a fraction
+    }
+    scan.seen_any = true;
+    Some(())
 }
 
 impl ParsedDuration {


### PR DESCRIPTION
> [!NOTE]
> The deferred conformance run landed on this branch (29f817f24): zero verdict drift on 0.0.43 + alpha.6 — the merge gate is satisfied.

Part of #2861.

SonarCloud reports 20 open `rust:S3776` findings — functions whose cognitive
complexity exceeds 15. All 20 are refactored here; none is accepted. Working
from the live MCP list rather than the issue's snapshot confirmed the same 20
sites, and in every one the complexity came from loop and branch NESTING that
the code's own comments already described as separate phases. Naming those
phases was the whole fix: no closed-vocabulary match surface turned up in this
batch, so there was nothing to re-adjudicate.

The four `shelldre:S7688` shell findings on the same issue were already fixed
and merged as #2863 and are untouched here; the MCP still reports them OPEN
only because that merge has not been re-analysed.

## What moved

**The application.** The FHIR mapping store's dispatcher was one `match` with
a nested `match` per arm — resolve the id, read the body, call the backend,
render. It becomes a five-arm route table over one small handler per HTTP
operation, each with the path it serves in its doc line. The boot sequence
sheds three phases it had already separated with comments: `assemble_service`
(the service and every optional collaborator it carries), `wire_authz` (the
RBAC/ABAC handle, `None` when authentication is off), and
`log_resolved_posture` (the per-subsystem startup lines). What is left is the
linear startup order, and its `too_many_lines` expectation stays with the
reason restated to say so.

**The spec crates.** The ADL specialisation checker hands each of its
production checks to a named function — owner resolution through a
differential path, the absent-parent-attribute case, the child pairing, and
the newly-added-object VSONIF rule, which now sits with its own citation
instead of five levels deep in a loop. The 1.4→2 conversion walk gives the
`C_ATTRIBUTE_TUPLE` half its own function. The archetype-slot parser splits
its two mutually exclusive bodies — the ADL2-only `closed` marker and the open
`matches { include … exclude … }` block — and returns a `SlotBody` value
rather than threading four mutable locals through an if/else. The Simplified
Formats web-template builder reads one tuple row through `tuple_row_unit`.

**The ISO 8601 duration parser** is a generation-twin template, so the change
was made in `tools/openehr-codegen/templates/…/iso8601_parse.rs` and `emit`
restamped the `v1_2` and `v1_3` copies. Its loop state becomes a
`DurationScan` (whose `last_slot` starts at `-1` in a hand-written `Default`,
per the inline-default rule) and its digit arm becomes
`read_duration_component`.

**The generator.** Both least-fixpoint computations (`base_closure`,
`constructible_classes`) become `while <one named round>() {}`, which is what
they always were. The struct renderer sheds its prologue and its
`// inherited:` group header; the enum renderer sheds its two import
computations; both share a new `generic_decl`. `emit_enum_conversions` splits
into its int and string halves — byte-identical output, verified by the drift
check. `emit_structural_file` separates collecting the `_type` dispatch
inventory from writing the file. `element_field` splits its container wrapping
and its wire default out. `model_query` gains `view_props` for the
declared-versus-flattened choice.

**The test harnesses.** The three `testsupport` projections nest one loop level
per named function, so a gap report reads as "per unit, per class" rather than
five loops deep. The two integration tests gain named helpers — a
`RoundTripTally` for the FLAT sweep and an element-folding pass for the XSD
inventory — with every assertion, count and threshold intact. No test was
weakened, skipped or deleted.

## Crate versions

Entries in `openehr-adl`, `openehr-its` and `openehr-base` change packaged
content, so the eight `openehr-*` crates step to `0.0.43` in lockstep, with
both lockfiles refreshed and a changelog entry for the step. The generated
output is unchanged apart from the two restamped template copies.

## Gates

Run and green:

- `cargo fmt --all` — clean
- `cargo clippy --workspace --exclude ferroehr-admin-ui --all-targets --all-features -- -D warnings` — clean
- `cargo nextest run --workspace` — **4859 passed, 0 failed, 6 skipped**
- `RUSTDOCFLAGS="-D warnings" cargo doc … --document-private-items` — clean
- `scripts/checks/codegen-drift.sh` — clean, which is what proves the template restamp is byte-exact
- `comment-style`, `typed-status`, `default-style`, `error-source-chain`, `shellcheck-lane` — all OK

Outstanding:

- **`bash scripts/conformance.sh` — NOT RUN (owner-deferred).** It must land green,
  with zero verdict drift, before this merges. It also has to clear the pin step
  described above, since that moves the catalogue and the oracle together.

## The CNF runner pin

`scripts/lib/veredictum.sh` moves from `0.1.0-alpha.2` to `0.1.0-alpha.6` in its
own commit, per an explicit owner instruction to run the newest published
version. crates.io publishes through alpha.6, so the pin was three releases
behind (alpha.3, alpha.4, alpha.6 unadopted; alpha.5 never published). Both
halves resolve — the binary reports `veredictum 0.1.0-alpha.6`, and
`refs/tags/v0.1.0-alpha.6` exists for the catalogue checkout.

This supersedes the "stay on alpha.2, bump separately under #2864" plan I had
argued for and that #2864 records; the owner overrode it. The reason I argued
for the split still stands as a *review* obligation rather than a scoping one:
the pin's own comment requires a bump to be re-proven by a full conformance run,
and bumping the instrument in the same cycle as a refactor means a verdict delta
is ambiguous between them. So the deferred run must attribute any delta
explicitly, per `.claude/rules/cnf-triage.md`, before either change is accepted.
It is kept in a separate commit precisely so it can be reverted alone if that
attribution goes against it.

Not `Closes` — the issue's final criterion is the dashboard count, which only
the post-merge analysis can confirm.