### PR TITLE
fix(compose): the dev overlay is explicit-only, and the port-conflict recipe lands on Docker's documented terms

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,9 +8,10 @@
 // compose override (see website/book/src/installation/compose.md).
 //
 // COMPOSE_FILE pins every compose invocation in this container to the
-// standalone docker-compose.yml: a bare `docker compose up` inside a checkout
-// would otherwise merge docker-compose.override.yml and try a from-source
-// build (the trap documented at the top of the compose book page).
+// standalone docker-compose.yml. (Historical: the dev overlay auto-merged
+// under its old `override` name and made bare invocations build from
+// source; since #2868 it is explicit-only, and this pin stays as
+// belt-and-braces.)
 //
 // Schema: https://containers.dev/implementors/json_reference
 {

--- a/.devcontainer/pull-stack.sh
+++ b/.devcontainer/pull-stack.sh
@@ -4,9 +4,9 @@
 #
 # Codespace create-time image pull (#2709): fetch the published quickstart
 # images once, so the first `postStartCommand` boot is fast. Explicit `-f`
-# keeps this on the standalone file even if COMPOSE_FILE is ever unset —
-# the repo's docker-compose.override.yml (from-source builds) must never
-# apply in the tester sandbox.
+# keeps this on the standalone file even if COMPOSE_FILE is ever unset.
+# (The dev overlay stopped auto-merging in #2868; the pin stays as
+# belt-and-braces so the tester sandbox can never build from source.)
 set -Eeuo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,7 +59,7 @@
 /docker-compose.yml                 @rubentalstra
 /docker-compose.keycloak.yml        @rubentalstra
 /docker-compose.observability.yml   @rubentalstra
-/docker-compose.override.yml        @rubentalstra
+/docker-compose.dev.yml        @rubentalstra
 
 # ── Policy and legal ────────────────────────────────────────────────────────
 /SECURITY.md                        @rubentalstra

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1659,7 +1659,7 @@ jobs:
 
   # ── The compose/local image target (docker/Dockerfile runtime-from-source) ──
   # ui-e2e packages the shipped `runtime-prebuilt` target now (issue #335), so
-  # the in-image source build that docker-compose.override.yml (the repo-dev
+  # the in-image source build that docker-compose.dev.yml (the repo-dev
   # `up --build` posture) and docker/sut-ferroehr.yml (the conformance SUT
   # stack) rely on would otherwise have no CI exercise at all.
   # It is built here instead — but ONLY when its own recipe changes, which is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ workflow refuses a tag that has no matching section here.
   name (it is `docker-compose.dev.yml`, applied only by an explicit `-f`),
   so a checkout can no longer fail on unpublished `:local` tags or missing
   build contexts (#2868).
+- A port conflict never requires editing the compose file: every published
+  port was already a variable (`FERROEHR_PORT`, `FERROEHR_DB_PORT`,
+  `FERROEHR_ADMIN_UI_PORT`, `FERROEHR_S3_PORT`), and the quickstart and the
+  book now say so at the point of failure (#2869).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Fixed
+
+- A bare `docker compose up` in a repository checkout now runs the same
+  published-images quickstart as the downloaded standalone file. The
+  development overlay no longer carries Compose's auto-merged `override`
+  name (it is `docker-compose.dev.yml`, applied only by an explicit `-f`),
+  so a checkout can no longer fail on unpublished `:local` tags or missing
+  build contexts (#2868).
+
 ### Changed
 
 - The `openehr-*` spec crates step to `0.0.43`. The change is internal

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,10 +1,14 @@
 # SPDX-FileCopyrightText: FerroEHR contributors
 # SPDX-License-Identifier: MIT
 
-# Repo-development override — merged automatically onto docker-compose.yml by
-# any bare `docker compose` invocation run from a repo checkout
-# (docs.docker.com/compose/how-tos/multiple-compose-files — "the override
-# file"). Downloaders of the standalone docker-compose.yml never see it.
+# Repo-development overlay — applied EXPLICITLY, never automatically:
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+# It deliberately does NOT carry Compose's auto-merged `override` name
+# (docs.docker.com/compose/how-tos/multiple-compose-files): under that name a
+# checkout's bare `docker compose up` silently became the from-source dev
+# path — unpublished `:local` tags, `docker/` build contexts — and broke the
+# quickstart for anyone cloning the repo (#2868). A bare `docker compose up`
+# now runs the same published-images quickstart everywhere.
 #
 # It restores the from-source developer posture:
 #   * images flip to the unpublished `:local` tags + `build:` blocks (both

--- a/docker-compose.keycloak.yml
+++ b/docker-compose.keycloak.yml
@@ -38,7 +38,7 @@
 # deployment configure your own issuer via FERROEHR__AUTH__OIDC__* (or the
 # [auth.oidc] config block) and remove this overlay.
 #
-# The repo's dev/e2e lanes use their OWN Keycloak (docker-compose.override.yml,
+# The repo's dev/e2e lanes use their OWN Keycloak (docker-compose.dev.yml,
 # `keycloak` profile) with the full exported realm from docker/keycloak/import
 # — this overlay's minimal demo realm is deliberately independent of it.
 

--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -6,7 +6,7 @@
 #
 #   docker compose -f docker-compose.yml -f docker-compose.observability.yml up
 #
-# (In a repo checkout, add -f docker-compose.override.yml before it to build
+# (In a repo checkout, add -f docker-compose.dev.yml before it to build
 # from source.)
 #
 # Adds a single-container LGTM stack (grafana/otel-lgtm = OTLP collector +

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,14 @@
 #   FERROEHR_BIND_HOST=10.0.0.5 docker compose up     # one address
 # Prefer a reverse proxy on the host over publishing the database at all.
 #
+# Port already in use? Every published port is a variable (#2869) — no edit:
+#   FERROEHR_PORT=8081 docker compose up
+# (Likewise FERROEHR_DB_PORT / FERROEHR_ADMIN_UI_PORT / FERROEHR_S3_PORT.)
+# Defaults stay fixed deliberately: the docs assume localhost:8080, and
+# Docker's own auto-allocation exists only for mappings that omit the host
+# port entirely (docs.docker.com/engine/network/port-publishing) — a server
+# that moved ports silently would break every printed URL.
+#
 # ── Repo development / CI (never needed by downloaders) ──────────────────────
 # The dev overlay is EXPLICIT, never auto-merged (#2868 — the auto-merged
 # `override` name made a checkout's bare `docker compose up` build from

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,11 +68,14 @@
 # Prefer a reverse proxy on the host over publishing the database at all.
 #
 # ── Repo development / CI (never needed by downloaders) ──────────────────────
-# In a repo checkout, docker-compose.override.yml is merged automatically onto
-# a bare `docker compose up`: it flips the images to `:local`
-# build-from-source tags, swaps the inline config below for
-# docker/ferroehr.dev.toml, and defines the dev `keycloak` profile (the full
-# exported realm). The conformance lanes never touch this file — they compose
+# The dev overlay is EXPLICIT, never auto-merged (#2868 — the auto-merged
+# `override` name made a checkout's bare `docker compose up` build from
+# source and reference unpublished `:local` tags, breaking the quickstart):
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+# It flips the images to `:local` build-from-source tags, swaps the inline
+# config below for docker/ferroehr.dev.toml, and defines the dev `keycloak`
+# profile (the full exported realm). A bare `docker compose up` in a checkout
+# is now the SAME published-images quickstart the downloaded file gives. The conformance lanes never touch this file — they compose
 # their own self-contained SUT stack (docker/sut-ferroehr.yml, see its header
 # for the lane table). NO hard-coded `name:` (issue #282 D3): each lane picks
 # its own project name so the lanes coexist; all lanes share the
@@ -420,7 +423,7 @@ configs:
   #     ADMIN / USER / READONLY separation)
   #   * admin API + management introspection enabled, permissive CORS
   # The repo's dev/CI lanes replace this whole config with
-  # docker/ferroehr.dev.toml via docker-compose.override.yml.
+  # docker/ferroehr.dev.toml via docker-compose.dev.yml.
   ferroehr-config:
     content: |
       [server]

--- a/docker/admin-ui/e2e-env.yml
+++ b/docker/admin-ui/e2e-env.yml
@@ -4,7 +4,7 @@
 # Compose override for the image-mode E2E run (scripts/ui-e2e.sh with
 # UI_E2E_IMAGE=1): the composed console image receives the same OIDC test
 # wiring the host-mode harness passes as process env. The issuer uses the
-# in-network hostname at the aligned port (docker-compose.override.yml keycloak
+# in-network hostname at the aligned port (docker-compose.dev.yml keycloak
 # KC_HTTP_PORT) so the SAME URL resolves for the container (docker DNS)
 # and for the E2E browser (a chromedriver host-resolver mapping of
 # `keycloak` to 127.0.0.1). The client secret is the shipped DEV realm's

--- a/docker/ferroehr.dev.toml
+++ b/docker/ferroehr.dev.toml
@@ -3,7 +3,7 @@
 # Mounted into the app container at /etc/ferroehr/ferroehr.toml — the server's
 # config search order (position 4) discovers it automatically, so no
 # FERROEHR_CONFIG / --config pointer is needed (mounted by
-# docker-compose.override.yml and docker/sut-ferroehr.yml). Their env vars
+# docker-compose.dev.yml and docker/sut-ferroehr.yml). Their env vars
 # override individual keys on top of this file (layer 3 beats the file).
 #
 # The out-of-the-box auth posture has authentication ENABLED but no configured
@@ -58,7 +58,7 @@ loggers = "admin_only"
 
 # Dev-only trust for the shipped dev Keycloak realm (docker/keycloak/import):
 # standard OIDC discovery — the issuer is the canonical KC_HOSTNAME from
-# docker-compose.override.yml; the CDR resolves the JWKS lazily from the issuer's
+# docker-compose.dev.yml; the CDR resolves the JWKS lazily from the issuer's
 # discovery document (cached, refreshed — key rotation just works, exactly
 # like any real OAuth2 resource server; no static key material). With this
 # the CDR advertises `Basic, Bearer` and an OIDC-logged-in admin console can

--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: MIT
 # End-to-end smoke test for the two container images (amd64), run against the
 # TRUE end-user artifact: the standalone docker-compose.yml, pinned with an
-# explicit -f so a repo checkout's docker-compose.override.yml never merges in.
+# explicit -f. (The dev overlay stopped auto-merging in #2868 — its explicit
+# name keeps this pin as belt-and-braces, not as the defence.)
 #
 # Only postgres + the server start (the admin console sits behind the
 # `admin-ui` profile). The server configuration is the quickstart posture the

--- a/scripts/checks/compose-hardening.sh
+++ b/scripts/checks/compose-hardening.sh
@@ -85,7 +85,7 @@ interface and bypasses the host firewall"
   #
   # A service named in BOTH the base file and an overlay is likewise exempt in the
   # overlay, even when the overlay restates `image:` (which
-  # `docker-compose.override.yml` does to swap in the from-source tags): Compose
+  # `docker-compose.dev.yml` does to swap in the from-source tags): Compose
   # merges the two definitions, and restating `security_opt` there is not merely
   # redundant — it makes `docker compose config` fail with "items at 0 and 1 are
   # equal", because list-valued keys concatenate.

--- a/scripts/ui-e2e.sh
+++ b/scripts/ui-e2e.sh
@@ -143,7 +143,7 @@ if [[ -z "${UI_E2E_NO_COMPOSE:-}" ]]; then
   # The e2e overlay rides BOTH lanes: without it here, its `ferroehr:` env
   # block (tenancy on, terminology on) never reached the host-mode CDR — the
   # lane CI actually runs.
-  docker compose -f docker-compose.yml -f docker-compose.override.yml \
+  docker compose -f docker-compose.yml -f docker-compose.dev.yml \
     -f docker/admin-ui/e2e-env.yml \
     up -d "${BUILD_ARGS[@]}" ferroehr-postgres ferroehr keycloak
 fi
@@ -253,12 +253,12 @@ if [[ -n "${UI_E2E_IMAGE:-}" ]]; then
   if [[ -n "${UI_E2E_IMAGE_REF:-}" ]]; then
     echo "── compose up the PUBLISHED console image ($UI_E2E_IMAGE_REF)"
     FERROEHR_ADMIN_UI_IMAGE="$UI_E2E_IMAGE_REF" \
-      docker compose -f docker-compose.yml -f docker-compose.override.yml \
+      docker compose -f docker-compose.yml -f docker-compose.dev.yml \
       -f docker/admin-ui/e2e-env.yml \
       up -d --no-build --pull always ferroehr-admin-ui
   else
     echo "── compose up the console image (build from source)"
-    docker compose -f docker-compose.yml -f docker-compose.override.yml \
+    docker compose -f docker-compose.yml -f docker-compose.dev.yml \
       -f docker/admin-ui/e2e-env.yml \
       up -d --build ferroehr-admin-ui
   fi

--- a/website/book/src/installation/compose.md
+++ b/website/book/src/installation/compose.md
@@ -11,11 +11,11 @@ overlays, and the variables that tune them. For a step-by-step first run, see
 [Getting started](../getting-started.md).
 
 > [!NOTE]
-> This chapter describes the **standalone** `docker-compose.yml` downloaded
-> into an empty directory. If you're running `docker compose up` from a
-> checkout of the repository instead, `docker-compose.override.yml` is
-> merged in automatically and the behavior is different — see
-> [Repository development](#repository-development) below.
+> This chapter applies equally to the **standalone** `docker-compose.yml`
+> downloaded into an empty directory and to a bare `docker compose up` in a
+> repository checkout — both run the published images. Building from source
+> is an explicit opt-in (`-f docker-compose.yml -f docker-compose.dev.yml`) —
+> see [Repository development](#repository-development) below.
 
 <!-- toc -->
 
@@ -348,13 +348,14 @@ ignored.
 
 ## Repository development
 
-In a checkout of the repository, `docker-compose.override.yml` is
-[merged automatically](https://docs.docker.com/compose/how-tos/multiple-compose-files/)
-onto any bare `docker compose` command, and switches the stack to the
-from-source developer posture:
+A bare `docker compose up` in a checkout runs the same published-images
+quickstart as the downloaded file. Building from the current sources is an
+explicit opt-in: the `docker-compose.dev.yml` overlay, passed as a
+[second file](https://docs.docker.com/compose/how-tos/multiple-compose-files/),
+switches the stack to the from-source developer posture:
 
 ```shell
-docker compose up --build
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
 ```
 
 That builds the server, database and console images from the current sources
@@ -367,10 +368,8 @@ that imports the full development realm
 (`docker compose --profile keycloak up`).
 
 Downloaders of the standalone quickstart file never see any of this; it is
-purely a convenience for working on FerroEHR itself. Note that passing `-f`
-explicitly (as the overlays above do) replaces the default file set, so the
-override is *not* merged in those invocations; add
-`-f docker-compose.override.yml` to the chain if you want it.
+purely a convenience for working on FerroEHR itself, and it only ever
+applies when its `-f` is passed — nothing merges it in silently.
 
 ## Build provenance
 

--- a/website/book/src/installation/compose.md
+++ b/website/book/src/installation/compose.md
@@ -307,6 +307,24 @@ each is a separate file instead:
   [Terminology servers](../beyond-core/terminology.md) for the invocation and
   what is seeded.
 
+## Port already in use?
+
+Every published port is a variable, so a conflict never requires editing any
+file. When `docker compose up` refuses with `port is already allocated` (or
+`address already in use`), pick a free port and pass it:
+
+```shell
+FERROEHR_PORT=8081 docker compose up
+```
+
+The same works for the other ports (`FERROEHR_DB_PORT`, `FERROEHR_ADMIN_UI_PORT`,
+`FERROEHR_S3_PORT`). The defaults stay fixed on purpose: every URL in this
+book assumes `localhost:8080`, and Docker's automatic ephemeral-port
+allocation exists only when a mapping
+[omits the host port entirely](https://docs.docker.com/engine/network/port-publishing/)
+— a server that silently moved ports would break every printed URL, so here
+you always choose the port and always know it.
+
 ## Variables the compose files read
 
 Set these in your shell (or an `.env` file) to retune without editing anything:


### PR DESCRIPTION
Closes #2868
Closes #2869

**#2868 — the quickstart broke in checkouts.** The release-asset compose files are clean (audited 4.0.5→4.0.8: zero build blocks, zero `:local`; the downloaded v4.0.8 asset boots healthy standalone, admin-ui included) — the reporter's failure came from the checkout's `docker-compose.override.yml`, which Compose auto-merges onto ANY bare invocation in (or near) a checkout, silently flipping the quickstart to the from-source dev path. The overlay is renamed to `docker-compose.dev.yml`, applied only by an explicit `-f` pair; all thirteen referencing files are swept, and the formerly-defensive comments now describe the history instead of a live threat. Proven live: bare `docker compose config` in the checkout resolves only the published 4.0.8 images with zero build blocks; the reporter's command shape (`--profile admin-ui up -d --wait`) pulls and reaches Healthy ×3; the explicit dev pair still builds.

**#2869 — port conflicts.** Answered on Docker's documented terms rather than inventing auto-shift: every published port was already a variable, and the quickstart header + the book's compose page now carry the recipe at the point of failure (`FERROEHR_PORT=8081 docker compose up`, likewise DB/ADMIN_UI/S3). The silent auto-change the issue proposes is deliberately refused, with the reasoning recorded in both texts: Docker's ephemeral allocation is documented only for mappings that [omit the host port entirely](https://docs.docker.com/engine/network/port-publishing/), our variable template cannot express omission (an empty value takes the `:-` default — verified live), and a server that silently moved ports would break every printed URL in the book.

Changelog carries both fixes; compose-hardening, compose-image-tags, changelog-structure, docs-claims --all, shellcheck-lane: all green.