### PR TITLE
ci(admin-ui): the published console image is driven through a real browser login before it ships

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -85,8 +85,9 @@ jobs:
         with:
           # The app filter mirrors the ui-e2e-binary cache key in ci.yml (the
           # inputs the server build reads); admin_ui mirrors the ui-e2e-console
-          # key plus its own Dockerfile. Shared workspace manifests appear in
-          # both — a lockfile bump rebuilds both images, correctly.
+          # key plus its own Dockerfile and the compose file its smoke lane
+          # drives. Shared workspace manifests appear in both — a lockfile bump
+          # rebuilds both images, correctly.
           filters: |
             app:
               - 'crates/**'
@@ -110,6 +111,7 @@ jobs:
               - 'rust-toolchain.toml'
               - '.cargo/**'
               - 'docker/admin-ui/**'
+              - 'docker-compose.yml'
               - '.github/workflows/containers.yml'
             postgres:
               - 'docker/postgres/**'
@@ -495,16 +497,22 @@ jobs:
   # a console whose pages 404 their own wasm published green (issue #2550,
   # found live on the 3.20.0 image during #2164). This smoke drives the very
   # image this run pushed: every asset the served page references must exist
-  # in the artifact that serves it.
+  # in the artifact that serves it, AND a real browser must log in through
+  # them — the second half exists because 4.0.8 shipped a console nobody had
+  # ever driven in a browser (#2871).
   admin-ui-smoke:
-    name: admin-ui asset-chain smoke (amd64)
+    name: admin-ui smoke (amd64)
     runs-on: ubuntu-26.04
-    timeout-minutes: 10
+    timeout-minutes: 20
     permissions:
       contents: read
       packages: read # pull the image this run just pushed
     needs: admin-ui-image
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -546,6 +554,22 @@ jobs:
           done <<< "$assets"
           docker stop adminui-smoke >/dev/null
           [ "$fail" = 0 ] || { echo "the pushed console image references assets it does not ship (#2550)"; exit 1; }
+
+      - name: Build the postgres image (amd64; COPY-only, seconds)
+        run: docker build -t ferroehr-postgres:smoke docker/postgres
+
+      # The asset-chain step proves the image SERVES its assets; nothing proved
+      # a browser can log in THROUGH them, and 4.0.8 shipped with this lane
+      # green (#2871). The CDR and its database are FIXTURES — the last develop
+      # build of the server image, which this lane never re-tags — while the
+      # console is the artifact under test.
+      - name: Browser-driven login against the pushed console image
+        shell: bash
+        run: |
+          FERROEHR_ADMIN_UI_IMAGE=ferroehr-admin-ui:smoke \
+          FERROEHR_IMAGE="${APP_IMAGE}:develop" \
+          FERROEHR_POSTGRES_IMAGE=ferroehr-postgres:smoke \
+            bash docker/admin-ui/login-smoke.sh
 
   # ── Smoke test (amd64): pull the pushed image, compose up, exercise the API ──
   smoke:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,8 @@
 #         ├─ admin-ui-binary ── admin-ui-image ─┼─ scan-and-tag ─┬─ chart
 #         ├─ postgres-image ────────────────┘                    └─ sandbox
 #         ├─ docs-freeze
-#         └─ (smoke, admin-ui-smoke hang off their image)
+#         └─ (smoke hangs off app-image; admin-ui-smoke off both images —
+#             it drives the console against this run's own CDR)
 #   announce ── needs everything, if: always()
 #
 # `crates` is the one leg that PAUSES: it runs in the `crates-io` environment,
@@ -803,18 +804,26 @@ jobs:
   # a console whose pages 404 their own wasm published green (issue #2550,
   # found live on the 3.20.0 image during #2164). This smoke drives the very
   # image this run pushed: every asset the served page references must exist
-  # in the artifact that serves it.
+  # in the artifact that serves it, AND a real browser must log in through
+  # them — the second half exists because 4.0.8 shipped a console nobody had
+  # ever driven in a browser (#2871).
   admin-ui-smoke:
-    name: admin-ui asset-chain smoke (amd64)
+    name: admin-ui smoke (amd64)
     runs-on: ubuntu-26.04
-    timeout-minutes: 10
+    timeout-minutes: 20
     permissions:
       contents: read
       packages: read # pull the image this run just pushed
-    needs: admin-ui-image
+    needs: [admin-ui-image, app-image]
     env:
       ADMIN_UI_IMAGE: ghcr.io/${{ github.repository_owner }}/ferroehr-admin-ui
+      APP_IMAGE: ghcr.io/${{ github.repository_owner }}/ferroehr
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }} # == plan's pinned commit: the dispatch-at-tag refusal makes them equal (#2790)
+
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -856,6 +865,28 @@ jobs:
           done <<< "$assets"
           docker stop adminui-smoke >/dev/null
           [ "$fail" = 0 ] || { echo "the pushed console image references assets it does not ship (#2550)"; exit 1; }
+
+      - name: Pull pushed app image (by digest)
+        env:
+          DIGEST: ${{ needs.app-image.outputs.digest }}
+        run: |
+          docker pull "${APP_IMAGE}@${DIGEST}"
+          docker tag  "${APP_IMAGE}@${DIGEST}" ferroehr:smoke
+
+      - name: Build the postgres image (amd64; COPY-only, seconds)
+        run: docker build -t ferroehr-postgres:smoke docker/postgres
+
+      # The asset-chain step proves the image SERVES its assets; nothing proved
+      # a browser can log in THROUGH them, and 4.0.8 shipped with this lane
+      # green (#2871). Both CDR images are this run's own, so the release that
+      # ships the console proves the console it ships.
+      - name: Browser-driven login against the pushed console image
+        shell: bash
+        run: |
+          FERROEHR_ADMIN_UI_IMAGE=ferroehr-admin-ui:smoke \
+          FERROEHR_IMAGE=ferroehr:smoke \
+          FERROEHR_POSTGRES_IMAGE=ferroehr-postgres:smoke \
+            bash docker/admin-ui/login-smoke.sh
 
   # ── Smoke test (amd64): pull the pushed image, compose up, exercise the API ──
   smoke:

--- a/docker/admin-ui/login-smoke.sh
+++ b/docker/admin-ui/login-smoke.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+# Browser-driven login against the BUILT console image (issue #2871).
+#
+# The asset-chain smoke beside this one proves the pushed image SERVES every
+# /pkg asset its own page references. Nothing proved a browser can log in
+# through them: the host `scripts/ui-e2e.sh` battery drives a browser, but at a
+# console cargo-leptos built on the runner, never at the shipped artifact. This
+# closes that gap by driving real Chrome over the W3C WebDriver protocol
+# (curl + jq — this repository authors no JavaScript) and asserting BOTH
+# halves of a working login:
+#
+#   1. the browser leaves /login and lands on the authenticated Dashboard;
+#   2. the credential POST was a hydrated `fetch`, not the no-JS form
+#      navigation — a console whose WASM never attaches still logs in through
+#      progressive enhancement (the #2164 class), so (1) alone passes on a
+#      broken client bundle.
+#
+# Required (no defaults — a gate that passes without its artifact is not a
+# gate):
+#   FERROEHR_ADMIN_UI_IMAGE   the console image under test
+#   FERROEHR_IMAGE            the CDR the console authenticates against
+#   FERROEHR_POSTGRES_IMAGE   the CDR's database
+# The two CDR images are FIXTURES; the console image is the artifact under test.
+# CHROMEDRIVER, else CHROMEWEBDRIVER (the GitHub runner images' variable),
+# else `chromedriver` on PATH selects the driver binary.
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+for var in FERROEHR_ADMIN_UI_IMAGE FERROEHR_IMAGE FERROEHR_POSTGRES_IMAGE; do
+  if [[ -z "${!var:-}" ]]; then
+    echo "FATAL: $var is unset — this gate must run against explicit images" >&2
+    exit 1
+  fi
+done
+
+if [[ -n "${CHROMEDRIVER:-}" ]]; then
+  DRIVER_BIN="$CHROMEDRIVER"
+elif [[ -n "${CHROMEWEBDRIVER:-}" ]]; then
+  DRIVER_BIN="$CHROMEWEBDRIVER/chromedriver"
+else
+  DRIVER_BIN="chromedriver"
+fi
+command -v "$DRIVER_BIN" >/dev/null 2>&1 || {
+  echo "FATAL: no chromedriver at '$DRIVER_BIN' (set CHROMEDRIVER)" >&2
+  exit 1
+}
+
+# Own compose project + the console's profile on EVERY call, so the teardown
+# below can see the console container and can never reach another stack
+# (docs.docker.com/compose/how-tos/project-name, /profiles).
+export COMPOSE_PROJECT_NAME=ferroehr-ui-login-smoke
+export COMPOSE_PROFILES=admin-ui
+# The standalone quickstart file only: an explicit -f suppresses the automatic
+# override merge, so this drives what a downloader runs
+# (docs.docker.com/compose/how-tos/multiple-compose-files).
+COMPOSE=(docker compose -f "$ROOT_DIR/docker-compose.yml")
+CONSOLE_PORT="${FERROEHR_ADMIN_UI_PORT:-3000}"
+CONSOLE_URL="http://127.0.0.1:${CONSOLE_PORT}"
+DRIVER_URL="http://127.0.0.1:9515"
+DRIVER_PID=""
+SESSION=""
+
+cleanup() {
+  if [[ -n "$SESSION" ]]; then
+    curl -sS -X DELETE "$DRIVER_URL/session/$SESSION" >/dev/null 2>&1 || true
+  fi
+  [[ -n "$DRIVER_PID" ]] && kill "$DRIVER_PID" 2>/dev/null || true
+  echo "::group::console logs"
+  "${COMPOSE[@]}" logs ferroehr-admin-ui || true
+  echo "::endgroup::"
+  "${COMPOSE[@]}" down -v --remove-orphans || true
+}
+trap cleanup EXIT
+
+echo "── compose up (postgres + CDR + the console image under test)"
+echo "   console: $FERROEHR_ADMIN_UI_IMAGE"
+"${COMPOSE[@]}" up -d --wait ferroehr-postgres ferroehr ferroehr-admin-ui
+
+echo "── chromedriver: $DRIVER_BIN"
+"$DRIVER_BIN" --port=9515 --allowed-ips=127.0.0.1 >/tmp/chromedriver.log 2>&1 &
+DRIVER_PID=$!
+for _ in $(seq 1 30); do
+  if curl -sf "$DRIVER_URL/status" | jq -e '.value.ready' >/dev/null 2>&1; then break; fi
+  sleep 1
+done
+curl -sf "$DRIVER_URL/status" | jq -e '.value.ready' >/dev/null || {
+  echo "FATAL: chromedriver never became ready" >&2
+  cat /tmp/chromedriver.log >&2
+  exit 1
+}
+
+# The performance log is what distinguishes the hydrated `fetch` dispatch from
+# the no-JS form navigation; the browser log carries any WASM panic.
+SESSION=$(curl -sS -X POST "$DRIVER_URL/session" \
+  -H 'Content-Type: application/json' \
+  -d '{"capabilities":{"alwaysMatch":{"browserName":"chrome",
+        "goog:loggingPrefs":{"browser":"ALL","performance":"ALL"},
+        "goog:chromeOptions":{
+          "args":["--headless=new","--disable-gpu","--window-size=1440,900"],
+          "perfLoggingPrefs":{"enableNetwork":true}}}}}' \
+  | jq -r '.value.sessionId // empty')
+[[ -n "$SESSION" ]] || {
+  echo "FATAL: chromedriver refused a session" >&2
+  cat /tmp/chromedriver.log >&2
+  exit 1
+}
+S="$DRIVER_URL/session/$SESSION"
+
+# A found element is a single-key object keyed by a spec-fixed UUID; a missing
+# one is an object carrying `error`, which must NOT read as an element id
+# (w3c.github.io/webdriver — Web Element, Handling Errors).
+find_element() {
+  curl -sS -X POST "$S/element" -H 'Content-Type: application/json' \
+    -d "{\"using\":\"css selector\",\"value\":\"$1\"}" \
+    | jq -r '.value | select(type == "object") | select(has("error") | not)
+             | to_entries[0].value'
+}
+send_keys() {
+  local out
+  out=$(curl -sS -X POST "$S/element/$1/value" -H 'Content-Type: application/json' \
+    -d "{\"text\":\"$2\"}")
+  jq -e '.value == null' >/dev/null <<<"$out" || {
+    echo "FATAL: typing into the login form was refused: $(jq -c '.value' <<<"$out")" >&2
+    exit 1
+  }
+}
+current_url() { curl -sS "$S/url" | jq -r '.value'; }
+dump_browser_log() {
+  echo "── browser log"
+  curl -sS -X POST "$S/se/log" -H 'Content-Type: application/json' \
+    -d '{"type":"browser"}' | jq -r '.value[]? | "\(.level) \(.message)"' || true
+}
+
+echo "── driving the login form at $CONSOLE_URL/login"
+curl -sS -X POST "$S/url" -H 'Content-Type: application/json' \
+  -d "{\"url\":\"$CONSOLE_URL/login\"}" >/dev/null
+
+USER_EL=""
+for _ in $(seq 1 30); do
+  USER_EL=$(find_element 'input[name=username]')
+  [[ -n "$USER_EL" ]] && break
+  sleep 1
+done
+[[ -n "$USER_EL" ]] || {
+  echo "FATAL: the console never rendered a username input" >&2
+  dump_browser_log
+  exit 1
+}
+PASS_EL=$(find_element 'input[name=password]')
+SUBMIT_EL=$(find_element 'button[type=submit]')
+[[ -n "$PASS_EL" && -n "$SUBMIT_EL" ]] || {
+  echo "FATAL: the login form is missing its password input or submit button" >&2
+  exit 1
+}
+
+# The quickstart Basic user the compose `configs:` block carries inline.
+send_keys "$USER_EL" ferroehr
+send_keys "$PASS_EL" ferroehr
+# A real click, never form.submit(): the reported defect was a hydrated submit
+# listener that consumed the click and dispatched nothing, which only a click
+# through the button can observe.
+CLICK=$(curl -sS -X POST "$S/element/$SUBMIT_EL/click" \
+  -H 'Content-Type: application/json' -d '{}')
+jq -e '.value == null' >/dev/null <<<"$CLICK" || {
+  echo "FATAL: the submit click was refused: $(jq -c '.value' <<<"$CLICK")" >&2
+  dump_browser_log
+  exit 1
+}
+
+URL=""
+for _ in $(seq 1 20); do
+  URL="$(current_url)"
+  case "$URL" in */login*) sleep 1 ;; *) break ;; esac
+done
+TITLE=$(curl -sS "$S/title" | jq -r '.value')
+echo "   url=$URL"
+echo "   title=$TITLE"
+
+# Read the performance log once (reading drains it) and keep the login POST's
+# resource type: `Fetch` is the hydrated ActionForm dispatch, `Document` is the
+# progressive-enhancement form navigation.
+LOGIN_TYPES=$(curl -sS -X POST "$S/se/log" -H 'Content-Type: application/json' \
+  -d '{"type":"performance"}' \
+  | jq -r '.value[]?.message' \
+  | jq -r 'select(.message.method == "Network.requestWillBeSent")
+           | select(.message.params.request.url | contains("/api/login_basic"))
+           | .message.params.type' || true)
+echo "   login POST resource types: ${LOGIN_TYPES:-<none>}"
+
+case "$URL" in
+  */login*)
+    echo "::error::the console image cannot be logged into from a browser: the submit click left the page on /login (issue #2871)"
+    dump_browser_log
+    exit 1
+    ;;
+esac
+case "$TITLE" in
+  Dashboard*) ;;
+  *)
+    echo "::error::the login landed on '$URL' with title '$TITLE', not the Dashboard"
+    dump_browser_log
+    exit 1
+    ;;
+esac
+grep -qx 'Fetch' <<<"$LOGIN_TYPES" || {
+  echo "::error::the credential POST was not a hydrated fetch (${LOGIN_TYPES:-no login POST observed}) — the shipped WASM never attached and the no-JS form carried the login (the #2164 class)"
+  dump_browser_log
+  exit 1
+}
+
+dump_browser_log
+echo "── the console image logs in through a real browser: Dashboard reached, hydrated fetch dispatched"


### PR DESCRIPTION
Refs #2871.

The issue asks for two things. The coverage hole is closed here, and the new
gate is mutation-proven. The root cause is not, because there is nothing to
point at: **the shipped `4.0.8` console image logs in correctly from a real
browser on this machine, in every configuration I could put it in.** The
evidence is below. That half of the issue stays open.

## What this adds

`docker/admin-ui/login-smoke.sh`, a browser-driven login against the BUILT
console image, wired into the `admin-ui-smoke` job in both `containers.yml`
(develop) and `release.yml` (the release pipeline). It composes the standalone
quickstart with the `admin-ui` profile, drives real Chrome over the W3C
WebDriver protocol with `curl` and `jq` (no JavaScript is authored anywhere),
and asserts both halves of a working login:

1. the browser leaves `/login` and lands on the authenticated Dashboard;
2. the credential POST was a hydrated `fetch`, not the no-JS form navigation.

Assertion 2 is not decoration. A console whose WASM never attaches still logs
in through progressive enhancement, so assertion 1 alone passes on a broken
client bundle. That is the shape of #2164, where a published image 404'd its
own wasm and every gate stayed green.

The coverage hole was real. `scripts/ui-e2e.sh` drives a browser, but at a
console `cargo-leptos` builds on the runner, and the `admin-ui-smoke` lane
checked asset bytes and status codes. Nothing had ever driven a browser at the
published artifact.

## Mutation proof of the new gate

Run locally against `ghcr.io/rubentalstra/ferroehr-admin-ui:4.0.8`, with the
released CDR and postgres images as fixtures:

| run | mutation | gate |
|---|---|---|
| baseline | none | **exit 0**. `url=/`, `title=Dashboard · FerroEHR-admin`, `login POST resource types: Fetch` |
| A | console started with `LEPTOS_OUTPUT_NAME` pointing at a name the image does not ship (the #2164 class) | **exit 1**. The browser still reached the Dashboard (`resource types: Document`), and the gate failed on the hydrated-fetch assertion |
| B | console pointed at an unreachable CDR | **exit 1**. `url=/login`, failed on the still-on-`/login` assertion |

Mutation A is the important one. The login succeeded and the page title was
right. Only the second assertion caught it.

## Why the root-cause half has no fix in it

The reproduction harness from the issue was rebuilt verbatim (chromedriver
151, Chrome 151, `--headless=new --disable-gpu`, fill both fields, click
`button[type=submit]`) and driven at the running v4.0.8 release compose. Every
run logged in.

| # | artifact | how it was driven | outcome |
|---|---|---|---|
| 1 | shipped `:4.0.8` image | click, 3 s settle | Dashboard, `Fetch` POST |
| 2 | shipped `:4.0.8` image | click with no settle, x3 | Dashboard x3 |
| 3 | shipped `:4.0.8` image | without `--no-sandbox` | Dashboard |
| 4 | shipped `:4.0.8` image | headed Chrome | Dashboard |
| 5 | shipped `:4.0.8` image | entered via `/`, redirected to `/login` | Dashboard |
| 6 | shipped `:4.0.8` image | `localhost` origin instead of `127.0.0.1` | Dashboard |
| 7 | shipped `:4.0.8` image | CDP CPU throttle x6 and x20 | Dashboard |
| 8 | shipped `:4.0.8` image | submit by Enter instead of click | Dashboard |
| 9 | shipped `:4.0.8` image | click at 0/150/400/800/1500 ms after navigation, x20 throttle | Dashboard, `Fetch`, every slot |
| 10 | shipped `:4.0.8` image | log in, restart the console so the in-memory session store is wiped, log in again on the stale cookie | Dashboard |
| 11 | shipped `:4.0.8` image | the new gate, on a fresh compose stack | pass |
| 12 | host `cargo leptos build --release` (the image recipe: `wasm-release`, `opt-level=z`, `lto`, `codegen-units=1`, wasm-opt) | click | Dashboard, `Fetch` POST |
| 13 | host `cargo leptos build` (the ui-e2e recipe: dev profile, no wasm-opt) | click | Dashboard, `Fetch` POST |

Rows 12 and 13 are the A/B the issue asked for, and they agree: no
profile-attributable difference exists. Row 12's wasm is 7 590 010 bytes
against the shipped image's 7 583 195, so the host build reproduces the image
recipe. In every passing row the credential POST is a `Fetch`, so hydration
ran and the ActionForm dispatched. None of these rows is the no-JS fallback
rescuing the flow.

The reported symptom, a click consumed with no fetch, no console message and
no error, is a real shape. `leptos-0.8.20/src/form.rs:113`: the submit handler
returns immediately when `ev.default_prevented()` is already true, and does
nothing observable. But nothing in this artifact produces it here. Something
in the reporting environment did.

Three things would settle it: the exact chromedriver session capabilities from
that run, whether the browser profile was a fresh one, and whether that page
had a prior submit in flight. The submit button carries `prop:disabled` while
the action is pending and the CDR request timeout is 30 s, so a hung first
attempt leaves the button inert for that window, which looks exactly like a
swallowed click.

## Where it runs, and when it reaches users

`containers.yml` gates develop pushes. `release.yml` gates the tag, as a
`needs` edge on both images, so the release that ships the console proves the
console it ships. The release lane drives this run's own CDR image; the
develop lane uses `:develop` as a fixture, because the app image is not
rebuilt on a console-only push.

**The gate only protects the next cut.** It cannot retro-verify `4.0.8`. The
evidence for that image is the table above, gathered by hand.

## Gates

- `bash scripts/checks/shellcheck-lane.sh docker/admin-ui/login-smoke.sh`: OK (severity=style)
- `actionlint` on both workflows: no new findings. The 14 pre-existing SC2016 infos in `release.yml` are identical before and after.
- `zizmor --min-severity=low` on both workflows: no findings
- `cargo clippy -p ferroehr-admin-ui --all-targets --features ssr -- -D warnings`: exit 0
- `cargo clippy -p ferroehr-admin-ui --target wasm32-unknown-unknown --features hydrate -- -D warnings`: exit 0
- `cargo nextest run -p ferroehr-admin-ui --features ssr`: exit 0, 511 tests run, 511 passed, 0 skipped
- `leptosfmt --check app/ferroehr-admin-ui/src`: exit 0
- `cargo fmt --all --check`: exit 0

No Rust file changed in this PR; the console battery ran as a regression check.

No `CHANGELOG.md` entry: this is a CI gate with no user-visible behaviour
change, which is what the `no-changelog` label exists for.
