### PR TITLE
fix(docs): COMPARISON.md regenerates clean

### DIFF
--- a/docs/conformance/COMPARISON.md
+++ b/docs/conformance/COMPARISON.md
@@ -19,8 +19,8 @@
 
 | | ferroehr | EHRbase |
 |---|---|---|
-| Product | ferroehr 4.0.6-rc2 | ehrbase 2.34.0 |
-| Run date | 2026-08-26 | 2026-08-14 |
+| Product | ferroehr 4.0.8 | ehrbase 2.34.0 |
+| Run date | 2026-08-27 | 2026-08-14 |
 | Party statement | committed with the runner (declares ITS-REST pin, signing, terminology posture) | committed with the runner |
 | Stack | the project's own compose stack, built from the current sources | a dedicated compose stack of the official EHRbase images |
 
@@ -58,7 +58,7 @@ claimed. The verdict-bearing comparison below is therefore each party's
 
 ## In-scope outcomes
 
-Runs compared: **ferroehr** (run of 2026-08-26) vs **EHRbase
+Runs compared: **ferroehr** (run of 2026-08-27) vs **EHRbase
 2.34.0** (run of 2026-08-14) — the SAME catalogue through the same
 runner, each with its own committed party statement. Per the presentation
 rule, the headline is each party's VERDICT SCOPE (the cases its own

--- a/website/book/src/conformance-assets/conformance-chapter-bars.svg
+++ b/website/book/src/conformance-assets/conformance-chapter-bars.svg
@@ -71,7 +71,7 @@ text { fill: #c3c2b7; }
 <line x1="3" y1="0" x2="3" y2="6" class="na-line"/>
 </pattern>
 </defs>
-<text x="24" y="28" class="title">Schedule outcomes by chapter — ferroehr 4.0.6-rc2</text>
+<text x="24" y="28" class="title">Schedule outcomes by chapter — ferroehr 4.0.8</text>
 <rect x="24" y="38" width="14" height="14" rx="3" class="bar-passed"/><text x="31" y="49" class="seg-label" text-anchor="middle">✓</text><text x="44" y="49" class="muted">passed</text><rect x="103.2" y="38" width="14" height="14" rx="3" class="bar-failed"/><text x="110.2" y="49" class="seg-label" text-anchor="middle">✕</text><text x="123.2" y="49" class="muted">FAILED</text><rect x="182.4" y="38" width="14" height="14" rx="3" class="bar-errored"/><text x="189.4" y="49" class="seg-label-dim" text-anchor="middle">?</text><text x="202.4" y="49" class="muted">errored</text><rect x="268.8" y="38" width="14" height="14" rx="3" fill="url(#na-hatch)"/><text x="275.8" y="49" class="seg-label-dim" text-anchor="middle">○</text><text x="288.8" y="49" class="muted">cited N/A (not executed)</text><text x="884" y="49" class="muted" text-anchor="end">this chart's scale: 142 cases = full bar</text>
 <rect x="24" y="66" width="860" height="20" rx="4" class="chap-row"/><text x="34" y="80.5" class="chap-name">EHR</text><text x="700" y="80.5" class="muted" text-anchor="end">492 cases</text>
 <text x="752" y="80.5" class="count count-passed count-strong" text-anchor="end">✓ 474</text><text x="878" y="80.5" class="count count-na count-strong" text-anchor="end">○ 18</text>

--- a/website/book/src/conformance-assets/conformance-heat-grid.svg
+++ b/website/book/src/conformance-assets/conformance-heat-grid.svg
@@ -41,7 +41,7 @@ text { fill: #c3c2b7; }
 }
 </style>
 
-<text x="24" y="28" class="title">Capability conformance — ferroehr 4.0.6-rc2</text>
+<text x="24" y="28" class="title">Capability conformance — ferroehr 4.0.8</text>
 <rect x="24" y="38" width="14" height="14" rx="3" class="ev-passed"/><text x="31" y="49" class="cell-label" text-anchor="middle" font-size="10">✓</text><text x="42" y="49" class="muted">passed</text><rect x="103.2" y="38" width="14" height="14" rx="3" class="ev-failed"/><text x="110.2" y="49" class="cell-label" text-anchor="middle" font-size="10">✕</text><text x="121.2" y="49" class="muted">FAILED</text><rect x="182.4" y="38" width="14" height="14" rx="3" class="ev-inconclusive"/><text x="189.4" y="49" class="cell-label-dim" text-anchor="middle" font-size="10">?</text><text x="200.4" y="49" class="muted">INCONCLUSIVE</text><rect x="304.8" y="38" width="14" height="14" rx="3" class="ev-not-evidenced"/><text x="311.8" y="49" class="cell-label-dim" text-anchor="middle" font-size="10">○</text><text x="322.8" y="49" class="muted">not evidenced</text><rect x="434.4" y="38" width="14" height="14" rx="3" class="ev-not-claimed"/><text x="441.4" y="49" class="cell-label-dim" text-anchor="middle" font-size="10">–</text><text x="452.4" y="49" class="muted">not claimed</text><text x="998" y="49" class="muted" text-anchor="end">solid border = required in tier · dashed = optional</text>
 <text x="24" y="82" class="title" font-size="12">CORE</text>
 <rect x="24" y="90" width="190" height="26" rx="5" class="ev-passed cell-optional"/><text x="37" y="107" class="cell-label" text-anchor="middle">✓</text><text x="50" y="107" class="cell-label sm">Adl14ArchetypeProvisioning</text>


### PR DESCRIPTION
The party-documents drift gate stayed red because #2873's fix cherry-picked a render produced during the shared-tree collision — half the identity refresh (line 58) without the other half (the line-19 Product/Run-date rows). Regenerated whole on clean develop via the full render set; a local re-render is diff-clean, which is the gate's own definition of green. `no-changelog`: derived documents.