### PR TITLE
perf(admin-ui): the /pkg bundle is content-hashed and cached for a year

### DIFF
--- a/.claude/rules/leptos-ui.md
+++ b/.claude/rules/leptos-ui.md
@@ -290,8 +290,10 @@ in the root `[workspace.dependencies]`: Leptos 0.8 SSR/full-stack,
 - Gates for every UI change: `cargo clippy -p ferroehr-admin-ui
   --all-targets` green on native **and**
   `--target wasm32-unknown-unknown` (lib); `cargo nextest run -p
-  ferroehr-admin-ui`; `leptosfmt` + `cargo fmt` clean; `cargo leptos build`
-  completes. Target-dir discipline from CLAUDE.md applies unchanged.
+  ferroehr-admin-ui`; `leptosfmt` + `cargo fmt` clean;
+  `bash scripts/cargo-leptos.sh build` completes — always the wrapper, never a
+  bare `cargo leptos`, which resolves the workspace through an unlocked
+  `cargo metadata` of its own and rewrites `Cargo.lock`. Target-dir discipline from CLAUDE.md applies unchanged.
 - `console_error_panic_hook` is set in the hydrate entry point (real stack
   traces in the browser — `getting_started/leptos_dx`). RustRover users:
   leptosfmt runs via the FileWatchers plugin (no rust-analyzer there).

--- a/.claude/skills/ui-gates/SKILL.md
+++ b/.claude/skills/ui-gates/SKILL.md
@@ -46,8 +46,9 @@ cargo nextest run -p ferroehr-admin-ui --features ssr
 
 # 4. Full build (server bin + WASM + assets) — only when the change
 #    touches the build surface (Cargo.toml, styles, assets, features);
-#    otherwise report it as skipped-with-reason
-cargo leptos build
+#    otherwise report it as skipped-with-reason. ALWAYS through the wrapper:
+#    a bare `cargo leptos` re-resolves and rewrites Cargo.lock (#2877).
+bash scripts/cargo-leptos.sh build
 
 # 5. E2E journeys (merge-gating in CI; local requires Docker) — Rust-native
 #    thirtyfour/WebDriver over the composed stack (.claude/rules/leptos-ui.md §10)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,8 @@ jobs:
           # scripts/ is NOT build-relevant by default: the cargo jobs never
           # execute repo scripts, so a new watcher/site/release script must
           # not cost a Rust run. Allowlist the ONLY scripts a code-gated CI
-          # job actually executes (the drift check and the e2e harness).
+          # job actually executes (the drift check, the e2e harness, and the
+          # frozen-lockfile cargo-leptos wrapper the console build runs).
           # The deployment harness drives the composed stack, so it is relevant
           # to its own scripts, the compose files, and the server image — and to
           # the code, since what it probes IS the server.
@@ -225,7 +226,7 @@ jobs:
             echo "deploy=false" >> "$GITHUB_OUTPUT"
           fi
           code_relevant=$(echo "$changed" | grep -vE '^scripts/' || true)
-          if echo "$changed" | grep -qE '^scripts/(checks/codegen-drift|ui-e2e)\.sh$'; then
+          if echo "$changed" | grep -qE '^scripts/(checks/codegen-drift|ui-e2e|cargo-leptos)\.sh$'; then
             echo "code=true" >> "$GITHUB_OUTPUT"
           # `corpus/` is the shared vendored breadth corpus the crate and
           # application suites read (it moved out of `tools/` with the
@@ -244,7 +245,7 @@ jobs:
           # Dockerfile change, or a change to the job's own build recipe each
           # alter what is under test, and without them a build/caching-only PR
           # could not even run the job it changes.
-          if echo "$changed" | grep -qE '^(app/ferroehr-admin-ui/|scripts/ui-e2e\.sh$|docker-compose\.yml$|docker-compose\.override\.yml$|docker-compose\.keycloak\.yml$|docker/Dockerfile$|docker/admin-ui/|docker/keycloak/|docker/postgres/|Cargo\.lock$|\.github/workflows/ci\.yml$)' ; then
+          if echo "$changed" | grep -qE '^(app/ferroehr-admin-ui/|scripts/ui-e2e\.sh$|scripts/cargo-leptos\.sh$|docker-compose\.yml$|docker-compose\.override\.yml$|docker-compose\.keycloak\.yml$|docker/Dockerfile$|docker/admin-ui/|docker/keycloak/|docker/postgres/|Cargo\.lock$|\.github/workflows/ci\.yml$)' ; then
             echo "admin_ui=true" >> "$GITHUB_OUTPUT"
           else
             echo "admin_ui=false" >> "$GITHUB_OUTPUT"
@@ -1540,12 +1541,15 @@ jobs:
           # FIRST, cargo-leptos LAST, stage immediately.
           cargo nextest archive -p ferroehr-admin-ui --features ssr \
             --archive-file ui-e2e-tests.tar.zst
-          (cd app/ferroehr-admin-ui && cargo leptos build)
+          bash scripts/cargo-leptos.sh build
           # One staging tree = one artifact = one cache path. The console
           # binary's executable bit is restored by the battery job (GitHub
-          # artifacts do not preserve file permissions).
+          # artifacts do not preserve file permissions). hash.txt is the
+          # content-hash manifest the renderer reads the /pkg filenames back
+          # from; without it the console 404s its own hashed wasm.
           mkdir -p ui-e2e-console-stage/site
           cp target/debug/ferroehr-admin-ui ui-e2e-console-stage/
+          cp target/debug/hash.txt ui-e2e-console-stage/
           cp ui-e2e-tests.tar.zst ui-e2e-console-stage/
           cp -R target/site/. ui-e2e-console-stage/site/
       - name: sccache statistics
@@ -1625,6 +1629,8 @@ jobs:
           set -euo pipefail
           mkdir -p target/debug target/site
           install -m0755 ui-e2e-console-stage/ferroehr-admin-ui target/debug/ferroehr-admin-ui
+          # leptos resolves the hash manifest as current_exe().parent()/hash.txt.
+          cp ui-e2e-console-stage/hash.txt target/debug/hash.txt
           cp -R ui-e2e-console-stage/site/. target/site/
           test -f ui-e2e-console-stage/ui-e2e-tests.tar.zst
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -112,6 +112,10 @@ jobs:
               - '.cargo/**'
               - 'docker/admin-ui/**'
               - 'docker-compose.yml'
+              # The frozen-lockfile wrapper the console site build runs, and
+              # the battery its smoke lane drives.
+              - 'scripts/cargo-leptos.sh'
+              - 'scripts/ui-e2e.sh'
               - '.github/workflows/containers.yml'
             postgres:
               - 'docker/postgres/**'
@@ -384,8 +388,11 @@ jobs:
           curl -sSfL -o /usr/local/bin/tailwindcss \
             https://github.com/tailwindlabs/tailwindcss/releases/download/v4.3.3/tailwindcss-linux-x64
           chmod +x /usr/local/bin/tailwindcss
-          cd app/ferroehr-admin-ui
-          LEPTOS_TAILWIND_VERSION=v4.3.3 cargo leptos build --release
+          LEPTOS_TAILWIND_VERSION=v4.3.3 bash scripts/cargo-leptos.sh build --release
+          # hash.txt names the content hashes of the files in this bundle, so
+          # it travels WITH the bundle; the image COPYs it beside the binary,
+          # which is where leptos reads it from.
+          cp target/release/hash.txt target/site/hash.txt
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: matrix.platform == 'amd64'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -700,8 +700,11 @@ jobs:
             https://github.com/tailwindlabs/tailwindcss/releases/download/v4.3.3/tailwindcss-linux-x64 \
             -o /usr/local/bin/tailwindcss
           chmod +x /usr/local/bin/tailwindcss
-          cd app/ferroehr-admin-ui
-          LEPTOS_TAILWIND_VERSION=v4.3.3 cargo leptos build --release
+          LEPTOS_TAILWIND_VERSION=v4.3.3 bash scripts/cargo-leptos.sh build --release
+          # hash.txt names the content hashes of the files in this bundle, so
+          # it travels WITH the bundle; the image COPYs it beside the binary,
+          # which is where leptos reads it from.
+          cp target/release/hash.txt target/site/hash.txt
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: matrix.platform == 'amd64'

--- a/.github/workflows/ui-e2e-published.yml
+++ b/.github/workflows/ui-e2e-published.yml
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
+# The full admin-console E2E battery against the PUBLISHED console image
+# (issue #2876).
+#
+# scripts/ui-e2e.sh has carried a shipped-artifact mode
+# (UI_E2E_IMAGE/UI_E2E_IMAGE_REF) since the console lane was built, and nothing
+# ever called it: every gate ran the battery against a console cargo-leptos
+# built on the runner. A capability no lane runs is decoration, so this is its
+# caller.
+#
+# WHY WEEKLY AND NOT THE RELEASE PIPELINE. Measured 2026-08-28 against a
+# locally built image on an arm64 host: 139 journeys in 256s, and 7m17s for
+# everything the battery does once the images exist (compose up, Keycloak
+# setup, REST seeding, console start, chromedriver, the journeys, teardown).
+# What is NOT cheap is the input it needs — the e2e test binaries, compiled
+# from this checkout. release.yml is a PUBLISHING pipeline, and a publishing
+# lane restores no build cache (.claude/rules/reliability.md), so that compile
+# would be fully cold there; ci.yml budgets 45 minutes for the same compile
+# WITH sccache. Paying that on the critical path of every release buys little:
+# the highest-value slice of this battery — a real browser logging in through
+# the shipped artifact — the release already gates, via
+# docker/admin-ui/login-smoke.sh. Here the compile caches like any test lane
+# and the wall clock gates nothing.
+#
+# WHAT IT DRIVES. The three images of the latest RELEASE, and the repository
+# checked out at that release's own tag — the journeys and the artifact they
+# drive have to be the same generation, which is exactly what a run against
+# `develop` would not guarantee.
+#
+# RUN COLOUR. This is a test battery, not a probe: a failing journey is a real
+# defect in the shipped console and the run goes RED.
+name: ui-e2e (published images)
+
+on:
+  schedule:
+    # Weekly, Tuesday 05:23 UTC. Off the hour: GitHub documents that runs
+    # scheduled on the hour are delayed by load spikes
+    # (https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule).
+    - cron: "23 5 * * 2"
+  workflow_dispatch:
+    inputs:
+      release-tag:
+        description: "Release tag to drive (default: the latest release)"
+        required: false
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: ui-e2e-published
+  cancel-in-progress: false
+
+jobs:
+  battery:
+    name: ui-e2e (published console image)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      packages: read # pull the published images
+    steps:
+      # Resolved BEFORE the checkout, because it decides what to check out.
+      - name: Resolve the release under test
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          REQUESTED: ${{ inputs.release-tag }}
+        run: |
+          set -euo pipefail
+          tag="$REQUESTED"
+          if [ -z "$tag" ]; then
+            tag=$(gh api "repos/${REPO}/releases/latest" --jq '.tag_name')
+          fi
+          # Strict, because this value becomes a checkout `ref` and three image
+          # tags: anything that is not a release tag is refused here rather
+          # than resolved into something surprising later.
+          if ! printf '%s' "$tag" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
+            echo "::error::'$tag' is not a vX.Y.Z release tag"
+            exit 1
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+          echo "Driving release $tag"
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ steps.release.outputs.tag }}
+
+      # The e2e test binaries compile from this checkout; nothing here is
+      # release input, so an ordinary test-lane cache applies.
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+      - uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc # v2.86.7
+        with:
+          tool: cargo-nextest
+
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # UI_E2E_IMAGE_REF is the console artifact under test; the two CDR images
+      # are FIXTURES, pinned to the same release so a red run names the console
+      # rather than a version skew. UI_E2E_NO_BUILD keeps compose from
+      # rebuilding either of them from this checkout.
+      - name: Run the battery against the published images
+        env:
+          UI_E2E_IMAGE: "1"
+          UI_E2E_IMAGE_REF: ghcr.io/${{ github.repository_owner }}/ferroehr-admin-ui:${{ steps.release.outputs.version }}
+          UI_E2E_NO_BUILD: "1"
+          FERROEHR_IMAGE: ghcr.io/${{ github.repository_owner }}/ferroehr:${{ steps.release.outputs.version }}
+          FERROEHR_POSTGRES_IMAGE: ghcr.io/${{ github.repository_owner }}/ferroehr-postgres:${{ steps.release.outputs.version }}
+        run: bash scripts/ui-e2e.sh
+
+      - name: Upload journey screenshots
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ui-e2e-published-screenshots
+          path: target/ui-e2e/screenshots/
+          if-no-files-found: ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- The admin console stops re-downloading its whole WebAssembly bundle on every
+  page load. Its `/pkg/` filenames now carry a content hash and are served
+  `public, max-age=31536000, immutable`, so a browser reuses them until the
+  console is rebuilt — measured on the shipped image, a second page load
+  transfers 0 bytes of `/pkg` instead of 7.6 MB. Documents keep `no-store`
+  unchanged: they carry patient data and a per-request CSP nonce (#2875).
 - A bare `docker compose up` in a repository checkout now runs the same
   published-images quickstart as the downloaded standalone file. The
   development overlay no longer carries Compose's auto-merged `override`
@@ -30,6 +36,17 @@ workflow refuses a tag that has no matching section here.
 
 ### Changed
 
+- Console builds no longer touch `Cargo.lock`. `cargo leptos` resolves the
+  workspace through an unlocked `cargo metadata` call of its own, which had
+  silently re-resolved a transitive dependency during a build; every
+  invocation now runs through a wrapper that refuses a stale lockfile up front
+  and passes `--locked` to both compile legs, matching every other build in
+  the repository (#2877).
+- The full browser e2e battery now runs against the PUBLISHED console image, in
+  a weekly lane that drives the latest release's three images at that release's
+  own tag. The battery's shipped-artifact mode had no caller at all; the
+  release pipeline keeps gating the login journey through the image it pushes
+  (#2876).
 - The `openehr-*` spec crates step to `0.0.43`. The change is internal
   structure only: over-complex functions in the ADL engine, the Simplified
   Formats web-template builder and the ISO 8601 duration parser were split

--- a/app/ferroehr-admin-ui/CLAUDE.md
+++ b/app/ferroehr-admin-ui/CLAUDE.md
@@ -220,7 +220,8 @@ unwinding to WORK, not to be fast. Do not re-file it, and do not silence
 `/ui-gates`: clippy on **native (`--features ssr`) and wasm32 (hydrate)**
 targets, `cargo nextest run -p ferroehr-admin-ui --features ssr` (the
 featureless crate ships nowhere and skips every ssr-gated test), leptosfmt
-(src + tests) + cargo fmt, cargo-leptos build; E2E journeys (the `e2e_*`
+(src + tests) + cargo fmt, `bash scripts/cargo-leptos.sh build` (the wrapper,
+never a bare `cargo leptos` — it rewrites `Cargo.lock`, #2877); E2E journeys (the `e2e_*`
 modules under `tests/it/`, skip-with-reason via `UI_E2E_BASE_URL`)
 merge-gate in CI; a UI-visual change re-captures the `website/book`
 screenshots (`ui-screenshot-guard`).

--- a/app/ferroehr-admin-ui/Cargo.toml
+++ b/app/ferroehr-admin-ui/Cargo.toml
@@ -193,3 +193,11 @@ bin-default-features = false
 lib-features = ["hydrate"]
 lib-default-features = false
 lib-profile-release = "wasm-release"
+# Content-hashed /pkg filenames (`ferroehr-admin-ui.<md5>.wasm`). This is what
+# makes the year-long immutable Cache-Control the server sends for /pkg
+# TRUE rather than a promise: a rebuilt asset is a different URL, so a cached
+# copy can never be stale. The manifest cargo-leptos writes beside the server
+# binary (`hash.txt`) is what the renderer reads the names back from, so it
+# ships next to the binary in the image; the runtime half is the separate
+# `LEPTOS_HASH_FILES` variable, which the binary reads at startup.
+hash-files = true

--- a/app/ferroehr-admin-ui/src/app.rs
+++ b/app/ferroehr-admin-ui/src/app.rs
@@ -13,11 +13,17 @@
 //! the root `<Title formatter=…/>`.
 
 use leptos::prelude::*;
-use leptos_meta::{MetaTags, Stylesheet, Title, provide_meta_context};
+use leptos_meta::{HashedStylesheet, MetaTags, Title, provide_meta_context};
 use leptos_router::components::{ParentRoute, Route, Router, Routes};
 use leptos_router::path;
 
 /// The full HTML document shell rendered by the server.
+///
+/// The stylesheet link is emitted HERE, not from a component body, because it
+/// is the one `<head>` element whose href depends on the build's content
+/// hashes: `HashedStylesheet` reads the cargo-leptos hash manifest through
+/// [`LeptosOptions`], which exists only on the server
+/// (<https://docs.rs/leptos_meta/0.8/leptos_meta/fn.HashedStylesheet.html>).
 #[must_use]
 pub fn shell(options: LeptosOptions) -> impl IntoView {
     view! {
@@ -31,7 +37,8 @@ pub fn shell(options: LeptosOptions) -> impl IntoView {
                 <meta charset="utf-8" />
                 <meta name="viewport" content="width=device-width, initial-scale=1" />
                 <AutoReload options=options.clone() />
-                <HydrationScripts options />
+                <HydrationScripts options=options.clone() />
+                <HashedStylesheet options id="leptos" />
                 <MetaTags />
             </head>
             <body>
@@ -95,7 +102,6 @@ pub fn App() -> impl IntoView {
         }
     });
     view! {
-        <Stylesheet id="leptos" href="/pkg/ferroehr-admin-ui.css" />
         <Title formatter=console_title text=PRODUCT />
         <thaw::ConfigProvider
             theme_id="ferroehr-admin".to_owned()

--- a/app/ferroehr-admin-ui/src/server.rs
+++ b/app/ferroehr-admin-ui/src/server.rs
@@ -163,8 +163,10 @@ fn is_public_path(path: &str) -> bool {
 ///   one of those and leave the console unstyled.
 /// - `X-Frame-Options: DENY` plus `frame-ancestors 'none'` — belt and braces
 ///   against clickjacking a console that performs administrative writes.
-/// - `Cache-Control: no-store` — the console renders patient data into HTML,
-///   and it is also what keeps a nonced document out of any shared cache.
+/// - `Cache-Control` — `no-store` on every document, because the console
+///   renders patient data into HTML and because a nonced document must never
+///   sit in a shared cache; the hashed `/pkg/*` bundle is the one exception
+///   ([`cache_control_for`]).
 ///
 /// `Strict-Transport-Security` is left to the TLS edge, for the same reason as
 /// on the API: RFC 6797 §7.2 makes it inert over plain HTTP.
@@ -184,10 +186,66 @@ fn with_security_headers(router: axum::Router<LeptosOptions>) -> axum::Router<Le
             http::header::X_FRAME_OPTIONS,
             http::HeaderValue::from_static("DENY"),
         ))
-        .layer(SetResponseHeaderLayer::overriding(
-            http::header::CACHE_CONTROL,
-            http::HeaderValue::from_static("no-store"),
-        ))
+        .layer(axum::middleware::from_fn(cache_control_layer))
+}
+
+/// The hydration bundle's caching directive: RFC 9111 §5.2.2.9 `public` +
+/// §5.2.2.1 `max-age`, and RFC 8246 `immutable`.
+///
+/// One year is the conventional ceiling for a content-addressed asset
+/// (<https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control#caching_static_assets_with_hashed_filenames>),
+/// and `immutable` is what stops the browser revalidating on a reload it would
+/// otherwise treat as a reason to ask again (RFC 8246 §2).
+const IMMUTABLE_ASSET_CACHE_CONTROL: &str = "public, max-age=31536000, immutable";
+
+/// The console default: never store the response anywhere (RFC 9111 §5.2.2.5).
+const NO_STORE_CACHE_CONTROL: &str = "no-store";
+
+/// Stamps each response with the caching directive its path and status earn.
+async fn cache_control_layer(
+    request: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    let path = request.uri().path().to_owned();
+    let mut response = next.run(request).await;
+    let value = cache_control_for(&path, response.status());
+    response
+        .headers_mut()
+        .insert(http::header::CACHE_CONTROL, value);
+    response
+}
+
+/// Which `Cache-Control` value one response carries.
+///
+/// `/pkg/` is the cargo-leptos hydration bundle and NOTHING else: the WASM,
+/// its JS glue, and the stylesheet. Their filenames carry a content hash
+/// (`hash-files` in the crate manifest), so a changed asset is a changed URL
+/// and a cached copy can never go stale — which is what makes `immutable` an
+/// honest claim rather than a bet on the deploy cadence. The bundle holds no
+/// patient data either: the console reaches the CDR through its own server
+/// functions, so nothing clinical is ever compiled into it.
+///
+/// `/pkg/snippets/` is carved back out because cargo-leptos deliberately does
+/// NOT hash those files — the WebAssembly looks for them by their unhashed
+/// names — so their URLs are stable across builds and caching one for a year
+/// would pin a stale copy. This build emits none today; the carve-out is what
+/// keeps that from becoming a silent defect if a dependency ever adds one.
+///
+/// Everything else keeps `no-store`, unchanged and for unchanged reasons —
+/// the console renders patient data into HTML, and each document carries a
+/// per-request CSP nonce that must not be replayed out of a cache.
+///
+/// A refused or missing asset is never cached: only a served body (2xx) and
+/// the `304` a revalidation answers with take the immutable directive, so a
+/// deploy racing a request cannot freeze a 404 into a browser for a year.
+fn cache_control_for(path: &str, status: http::StatusCode) -> http::HeaderValue {
+    let cacheable = status.is_success() || status == http::StatusCode::NOT_MODIFIED;
+    let hashed_asset = path.starts_with("/pkg/") && !path.starts_with("/pkg/snippets/");
+    if hashed_asset && cacheable {
+        http::HeaderValue::from_static(IMMUTABLE_ASSET_CACHE_CONTROL)
+    } else {
+        http::HeaderValue::from_static(NO_STORE_CACHE_CONTROL)
+    }
 }
 
 /// Mints this response's script nonce and answers with the policy that names
@@ -259,7 +317,10 @@ mod tests {
         reason = "the exchange helpers panic to report a broken fixture, which is how a test fails (Book ch11); clippy's allow-*-in-tests scoping covers only the #[test] fns themselves"
     )]
 
-    use super::{console_csp, csp_nonce_layer, is_public_path, provide_request_nonce};
+    use super::{
+        IMMUTABLE_ASSET_CACHE_CONTROL, NO_STORE_CACHE_CONTROL, cache_control_for, console_csp,
+        csp_nonce_layer, is_public_path, provide_request_nonce,
+    };
     use tower::util::ServiceExt;
 
     /// A sample policy for the directive assertions; the value stands in for a
@@ -288,6 +349,65 @@ mod tests {
         for guarded in ["/", "/templates", "/queries/builder", "/ehrs", "/nonsense"] {
             assert!(!is_public_path(guarded), "{guarded} must be guarded");
         }
+    }
+
+    /// The hydration bundle is the ONLY thing that may be cached, and every
+    /// document — the sign-in screen included — keeps `no-store`: the console
+    /// renders patient data into HTML and stamps a per-request CSP nonce on
+    /// it.
+    #[test]
+    fn only_the_hashed_bundle_is_cacheable() {
+        let ok = http::StatusCode::OK;
+        for asset in [
+            "/pkg/ferroehr-admin-ui.RUlUrl0ZR7DGPjuVWkKtwA.wasm",
+            "/pkg/ferroehr-admin-ui.RUlUrl0ZR7DGPjuVWkKtwA.js",
+            "/pkg/ferroehr-admin-ui.RUlUrl0ZR7DGPjuVWkKtwA.css",
+        ] {
+            assert_eq!(
+                cache_control_for(asset, ok),
+                IMMUTABLE_ASSET_CACHE_CONTROL,
+                "{asset} is content-hashed and must be cacheable"
+            );
+        }
+        for document in [
+            "/",
+            "/login",
+            "/ehrs",
+            "/favicon.ico",
+            "/api/current_session",
+        ] {
+            assert_eq!(
+                cache_control_for(document, ok),
+                NO_STORE_CACHE_CONTROL,
+                "{document} may carry patient data or a nonce and must not be stored"
+            );
+        }
+        assert_eq!(
+            cache_control_for("/pkg/snippets/some-dep/inline0.js", ok),
+            NO_STORE_CACHE_CONTROL,
+            "cargo-leptos leaves snippet filenames unhashed, so their URLs repeat across builds"
+        );
+    }
+
+    /// A missing or refused asset must never be frozen into a browser for a
+    /// year; a revalidation's `304` must keep the directive it revalidated.
+    #[test]
+    fn a_refused_asset_is_never_cached() {
+        for refused in [
+            http::StatusCode::NOT_FOUND,
+            http::StatusCode::FOUND,
+            http::StatusCode::INTERNAL_SERVER_ERROR,
+        ] {
+            assert_eq!(
+                cache_control_for("/pkg/ferroehr-admin-ui.js", refused),
+                NO_STORE_CACHE_CONTROL,
+                "a {refused} for a /pkg path must not be cached"
+            );
+        }
+        assert_eq!(
+            cache_control_for("/pkg/ferroehr-admin-ui.js", http::StatusCode::NOT_MODIFIED),
+            IMMUTABLE_ASSET_CACHE_CONTROL
+        );
     }
 
     /// Returns the named directive of `policy`, panicking if it is absent.

--- a/app/ferroehr-admin-ui/tests/it/ssr_shell.rs
+++ b/app/ferroehr-admin-ui/tests/it/ssr_shell.rs
@@ -422,6 +422,26 @@ async fn the_login_screen_is_served_without_a_session() {
     );
 }
 
+/// The document links its stylesheet from the SHELL's `<head>`.
+///
+/// The link cannot come from a component body any more: with content-hashed
+/// `/pkg` filenames its href is a build fact the server reads out of the
+/// cargo-leptos hash manifest, which only the shell has (`LeptosOptions`).
+/// Losing it renders a console that works and looks broken, and no other test
+/// would notice — the screens assert their own markup, never the head.
+#[tokio::test]
+async fn the_shell_links_the_bundle_stylesheet_from_the_document_head() {
+    let pass = render_route("/login").await;
+    let head = pass
+        .html
+        .split_once("<body")
+        .map_or(pass.html.as_str(), |(head, _)| head);
+    assert!(
+        head.contains(r#"rel="stylesheet""#) && head.contains("/pkg/ferroehr-admin-ui.css"),
+        "the shell must link the bundle stylesheet in <head>: {head}"
+    );
+}
+
 /// The in-view guard (`AppShell`'s `<Redirect/>`) still stands behind the
 /// router layer: rendered bare (no axum service, so no login guard), a
 /// guarded URL keeps answering `302 → /login` on the response line — the

--- a/docker/admin-ui/Dockerfile
+++ b/docker/admin-ui/Dockerfile
@@ -109,12 +109,21 @@ WORKDIR /app/app/ferroehr-admin-ui
 # (docs.docker.com/guides/rust/develop — the same shape as docker/Dockerfile).
 # `sharing=locked` serializes every cargo build over the one workspace cache —
 # including the server image's, when compose builds both images at once.
+#
+# The build runs through scripts/cargo-leptos.sh, which freezes Cargo.lock —
+# `cargo leptos` re-resolves it otherwise, and an image build silently
+# re-resolving the workspace is a build nobody can reproduce (#2877).
+#
+# hash.txt is the content-hash manifest cargo-leptos writes beside the server
+# binary; it travels WITH the site bundle it describes, and the runtime stages
+# put it back beside the binary, which is the only place leptos reads it from.
 RUN --mount=type=cache,target=/app/target,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-    cargo leptos build --release \
+    bash /app/scripts/cargo-leptos.sh build --release \
     && mkdir -p /out \
     && cp /app/target/release/ferroehr-admin-ui /out/ \
-    && cp -r /app/target/site /out/site
+    && cp -r /app/target/site /out/site \
+    && cp /app/target/release/hash.txt /out/site/hash.txt
 
 # ── runtime-base: the SHARED final base (digest-pinned distroless, non-root) ───
 # gcr.io/distroless/cc-debian13:nonroot, digest-pinned, resolved 2026-07-24 —
@@ -133,9 +142,16 @@ FROM gcr.io/distroless/cc-debian13:nonroot@sha256:a77defd6fedbb3392b175ba8ea3d1c
 # the distroless `:nonroot` tag sets, so this states the base uid rather than
 # choosing one.
 USER 65532:65532
+# LEPTOS_HASH_FILES is the RUNTIME half of the crate manifest's `hash-files`:
+# leptos_config reads it from the environment at startup (there is no
+# compile-time fallback the way LEPTOS_OUTPUT_NAME has one), and it is what
+# makes the renderer name the content-hashed /pkg files this image ships
+# instead of the unhashed names it would otherwise 404 on. It must stay in
+# step with the manifest key and with hash.txt below — all three or none.
 ENV LEPTOS_SITE_ROOT=/site \
     LEPTOS_SITE_ADDR=0.0.0.0:3000 \
-    LEPTOS_OUTPUT_NAME=ferroehr-admin-ui
+    LEPTOS_OUTPUT_NAME=ferroehr-admin-ui \
+    LEPTOS_HASH_FILES=true
 EXPOSE 3000
 # Shell-less image: the healthcheck is the binary's own subcommand, which probes
 # its own /login and exits 0 (2xx/3xx) / 1 otherwise.
@@ -166,6 +182,9 @@ LABEL org.opencontainers.image.title="FerroEHR admin console" \
 FROM runtime-base AS runtime-from-source
 COPY --from=builder /out/ferroehr-admin-ui /usr/local/bin/ferroehr-admin-ui
 COPY --from=builder /out/site /site
+# The manifest travels inside the site bundle it describes; leptos resolves it
+# as current_exe().parent()/hash.txt, so it is placed beside the binary too.
+COPY --from=builder /out/site/hash.txt /usr/local/bin/hash.txt
 
 # ── runtime-prebuilt: CI (COPY the context-provided native binary + site) ──────
 # The server binary is built natively per architecture on the CI runners
@@ -178,3 +197,7 @@ FROM runtime-base AS runtime-prebuilt
 ARG TARGETARCH
 COPY --chmod=0755 bin/${TARGETARCH}/ferroehr-admin-ui /usr/local/bin/ferroehr-admin-ui
 COPY site /site
+# Same placement as the from-source stage: the manifest rides the
+# (arch-independent) site artifact and is copied beside the binary, which is
+# where leptos looks for it.
+COPY site/hash.txt /usr/local/bin/hash.txt

--- a/scripts/cargo-leptos.sh
+++ b/scripts/cargo-leptos.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+# `cargo leptos` for the admin console, with the workspace lockfile frozen.
+#
+# Every other build in this repository runs `--locked`; the console's did not,
+# and a console build re-resolved and rewrote Cargo.lock in the working tree
+# (#2877). `cargo leptos` cannot simply be handed the flag: before it compiles
+# anything it resolves the workspace through its own `cargo metadata` call
+# (cargo_metadata's MetadataCommand, which cargo-leptos passes no extra flags
+# to), and cargo exposes no environment variable for `--locked` — the
+# environment-variables reference lists one only for `--offline`
+# (CARGO_NET_OFFLINE), and an offline cargo still re-resolves from the local
+# registry cache. Measured on the pinned toolchain: `cargo metadata` against a
+# lockfile with one entry removed silently re-resolved it to a NEWER version.
+#
+# So the lock is frozen in two moves:
+#   1. a `cargo metadata --locked` PRECHECK — it fails loud if the committed
+#      lockfile does not already satisfy every manifest, and it runs before
+#      cargo-leptos exists, so cargo-leptos's own unlocked metadata call then
+#      finds nothing to change;
+#   2. `--locked` passed through to both compile legs (`--lib-cargo-args` /
+#      `--bin-cargo-args`), so neither can re-resolve either.
+#
+# Usage: scripts/cargo-leptos.sh build [--release] [...]
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONSOLE_DIR="$ROOT/app/ferroehr-admin-ui"
+
+if ! cargo metadata --locked --format-version 1 \
+  --manifest-path "$CONSOLE_DIR/Cargo.toml" >/dev/null; then
+  echo "FATAL: Cargo.lock does not satisfy the workspace manifests." >&2
+  echo "       Re-resolve deliberately (cargo check --workspace) and commit the" >&2
+  echo "       lockfile change; a console build must never do it silently." >&2
+  exit 1
+fi
+
+# `cargo leptos` reads its configuration from the console crate's own manifest
+# directory, so the build runs from there.
+cd "$CONSOLE_DIR"
+exec cargo leptos "$@" \
+  --lib-cargo-args=--locked \
+  --bin-cargo-args=--locked

--- a/scripts/ui-e2e.sh
+++ b/scripts/ui-e2e.sh
@@ -13,9 +13,14 @@
 #                       image (docker compose build of docker/admin-ui/
 #                       Dockerfile + the e2e-env override) instead of a host
 #                       cargo-leptos build — the shipped-artifact battery.
+#                       Its caller is the weekly
+#                       .github/workflows/ui-e2e-published.yml lane, which
+#                       drives the latest release's published images; measured
+#                       2026-08-28 at 139 journeys in 256s (7m17s for the whole
+#                       battery once the images exist).
 #   UI_E2E_IMAGE_REF    with UI_E2E_IMAGE: use this exact (already published)
-#                       image reference instead of building — CI verifies the
-#                       very artifact containers.yml pushed.
+#                       image reference instead of building — the weekly lane
+#                       verifies the very artifact the release pushed.
 #   UI_E2E_NO_COMPOSE   if set, assume CDR+Keycloak are already up.
 #   UI_E2E_NO_BUILD     if set, `up --no-build` the compose stack (use images
 #                       already present as the `*_IMAGE` refs) instead of
@@ -36,7 +41,8 @@
 #   UI_E2E_SHOTS_ONLY   if set, skip the journeys entirely (capture pass only).
 #   UI_E2E_DOCS_SHOTS   if set, also run the --docs-shots capture pass
 #                       (canonical per-screen screenshots for website/book).
-#   CHROMEDRIVER        chromedriver binary (default: chromedriver on PATH).
+#   CHROMEDRIVER        chromedriver binary; else CHROMEWEBDRIVER (the GitHub
+#                       runner images' variable), else chromedriver on PATH.
 #
 # The journeys themselves read:
 #   UI_E2E_BASE_URL        the console origin (set by this script)
@@ -265,17 +271,25 @@ if [[ -n "${UI_E2E_IMAGE:-}" ]]; then
 else
   if [[ -n "${UI_E2E_PREBUILT_CONSOLE:-}" ]]; then
     echo "── using the prebuilt console (UI_E2E_PREBUILT_CONSOLE)"
-    for p in "$ROOT/target/debug/ferroehr-admin-ui" "$ROOT/target/site/pkg"; do
+    # hash.txt is as load-bearing as the binary: without it the renderer names
+    # the unhashed /pkg files, which the hashed bundle does not contain.
+    for p in "$ROOT/target/debug/ferroehr-admin-ui" "$ROOT/target/debug/hash.txt" \
+             "$ROOT/target/site/pkg"; do
       [[ -e "$p" ]] || { echo "FATAL: UI_E2E_PREBUILT_CONSOLE set but $p is missing" >&2; exit 1; }
     done
   else
     echo "── building the console (cargo-leptos)"
-    (cd app/ferroehr-admin-ui && LEPTOS_TAILWIND_VERSION=v4.3.3 cargo leptos build)
+    LEPTOS_TAILWIND_VERSION=v4.3.3 bash scripts/cargo-leptos.sh build
   fi
   echo "── starting the console on $CONSOLE_ADDR"
+  # LEPTOS_HASH_FILES is the runtime half of the crate manifest's `hash-files`
+  # (leptos_config reads it from the environment, with no compile-time
+  # fallback): it is what makes the served page name the content-hashed /pkg
+  # files this build produced.
   LEPTOS_SITE_ROOT="$ROOT/target/site" \
   LEPTOS_SITE_ADDR="$CONSOLE_ADDR" \
   LEPTOS_OUTPUT_NAME="ferroehr-admin-ui" \
+  LEPTOS_HASH_FILES="true" \
   FERROEHR_ADMIN__CDR__BASE_URL="$CDR_URL" \
   FERROEHR_ADMIN__AUTH__OIDC__ENABLED="true" \
   FERROEHR_ADMIN__AUTH__OIDC__ISSUER="http://keycloak:8081/auth/realms/ferroehr" \
@@ -300,7 +314,17 @@ curl -sf "$CONSOLE_URL/login" \
     done
 
 # ── 4. chromedriver ──────────────────────────────────────────────────────────
-CHROMEDRIVER_BIN="${CHROMEDRIVER:-chromedriver}"
+# CHROMEWEBDRIVER is the GitHub runner images' own variable and the driver is
+# NOT on their PATH, so a lane that did not spell the path out would fail on a
+# runner that ships chromedriver (the login-smoke gate resolves it the same
+# way).
+if [[ -n "${CHROMEDRIVER:-}" ]]; then
+  CHROMEDRIVER_BIN="$CHROMEDRIVER"
+elif [[ -n "${CHROMEWEBDRIVER:-}" ]]; then
+  CHROMEDRIVER_BIN="$CHROMEWEBDRIVER/chromedriver"
+else
+  CHROMEDRIVER_BIN="chromedriver"
+fi
 if ! command -v "$CHROMEDRIVER_BIN" >/dev/null; then
   echo "FATAL: chromedriver not found (set CHROMEDRIVER)" >&2
   exit 1

--- a/website/book/src/security.md
+++ b/website/book/src/security.md
@@ -398,7 +398,15 @@ commonly reached behind a terminating proxy. Set it at the proxy or ingress that
 owns TLS; sending it from here would be inert at best and misleading at worst.
 
 **The admin console** additionally carries the browser set with a real CSP, because
-it serves HTML and hydrates WebAssembly.
+it serves HTML and hydrates WebAssembly. Its `Cache-Control` has one scoped
+exception to `no-store`: the hydration bundle under `/pkg/` is served
+`public, max-age=31536000, immutable`. Those filenames carry a content hash, so
+a rebuilt asset is a different URL and a cached copy can never be stale, and the
+bundle holds nothing clinical — the console reaches the CDR through its own
+server functions, never from the browser. Every document still carries
+`no-store`, because documents carry patient data and a per-request CSP nonce.
+A `/pkg/` response that is not a served body (a `404`, a redirect) is never
+cached either.
 
 **The published documentation site cannot carry response headers at all:** it is
 static files on GitHub Pages, so its policy travels as a `<meta http-equiv>`


### PR DESCRIPTION
The console re-downloaded its entire WebAssembly bundle on every page load. The
router-wide `no-store` layer — written for PHI-bearing HTML and the nonced
document, and still right for both — also covered `/pkg`, so a 7.6 MB wasm came
down again on every navigation that left the SPA.

## What changed

**Hashing first, then caching** — in that order, because caching an asset whose
URL can be reused is a promise you cannot keep.

`hash-files = true` in the console's `[package.metadata.leptos]` makes
cargo-leptos rename the wasm, the JS glue and the stylesheet to
`ferroehr-admin-ui.<md5>.<ext>`. Three things follow from that:

- The manifest cargo-leptos writes (`hash.txt`) is how the renderer reads those
  names back. It is written beside the server binary at build time, travels
  inside the site bundle it describes, and both image targets `COPY` it beside
  the binary — the only place `leptos` looks for it
  (`current_exe().parent()/hash.txt`).
- `LEPTOS_HASH_FILES` is the RUNTIME half, read from the environment with no
  compile-time fallback. It is set in the image and in the e2e harness's
  console launch.
- The stylesheet link moves out of the `App` body into the shell's `<head>`:
  `HashedStylesheet` reads the manifest through `LeptosOptions`, which exists
  only on the server. A new SSR test pins that the head links the bundle
  stylesheet, because no screen test looks at the head and a console that works
  and looks broken would otherwise ship unnoticed.

Then `app/ferroehr-admin-ui/src/server.rs` replaces the blanket
`SetResponseHeaderLayer` with a path-and-status-scoped middleware:

| Response | `Cache-Control` |
|---|---|
| `/pkg/…` served body (2xx) or `304` | `public, max-age=31536000, immutable` |
| `/pkg/snippets/…` | `no-store` |
| `/pkg/…` non-2xx (404, redirect, 5xx) | `no-store` |
| every document, `/api/…`, `/favicon.ico` | `no-store` |

`public` and `max-age` are RFC 9111 §5.2.2.9 / §5.2.2.1, `immutable` is
RFC 8246 §2, and one year is MDN's ceiling for a content-addressed asset. The
snippets carve-out is not decoration: cargo-leptos deliberately leaves
`pkg/snippets/**` unhashed, because the WebAssembly loads those by their
unhashed names. This build emits none today; the carve-out is what keeps that
from becoming a silent staleness bug if a dependency ever adds one. The
non-2xx rule stops a deploy racing a request from freezing a 404 into a browser
for a year.

The `no-store` doc comment stays true and is restated precisely: documents
carry patient data AND a per-request CSP nonce, and the bundle carries neither
— the console reaches the CDR through its own server functions, so nothing
clinical is ever compiled into it.

## Measurements

All against `ghcr.io/rubentalstra/ferroehr-admin-ui:local`, built from this
branch with `docker compose -f docker-compose.yml -f docker-compose.dev.yml
build ferroehr-admin-ui` (arm64, `runtime-from-source`).

Served headers (`curl -I`):

| Path | Bytes | `Cache-Control` |
|---|---|---|
| `/pkg/ferroehr-admin-ui.T6CUt0y92MaXnHXeId3Czw.wasm` | 7,580,842 | `public, max-age=31536000, immutable` |
| `/pkg/ferroehr-admin-ui.xjhUtSmblxmqlCDdOixZXw.js` | 35,557 | `public, max-age=31536000, immutable` |
| `/pkg/ferroehr-admin-ui.9y4C0KcLcx6yS08tdpdy8Q.css` | 32,212 | `public, max-age=31536000, immutable` |
| `/login` | — | `no-store` |
| `/pkg/nope.wasm` (404) | — | `no-store` |

Second-page-load transfer, Chrome driven over W3C WebDriver (curl + jq, no
authored JavaScript), reading `performance.getEntriesByType("resource")` on the
SECOND navigation of one session:

| Asset | 1st load `transferSize` | 2nd load `transferSize` |
|---|---|---|
| wasm | 7,581,142 | **0** |
| js | 35,857 | **0** |
| css | 32,512 | **0** |
| **total** | **7,649,511** | **0** |

`docker/admin-ui/login-smoke.sh` against that image with the 4.0.8 CDR and
postgres images as fixtures: **pass** — `title=Dashboard · FerroEHR-admin`,
`login POST resource types: Fetch` (the hydrated dispatch, not the no-JS
fallback).

Closes #2875

## cargo-leptos stops mutating Cargo.lock

`cargo leptos` cannot simply be handed `--locked`. Before it compiles anything
it resolves the workspace through its own `cargo metadata` call
(`cargo_metadata::MetadataCommand`, no passthrough), and cargo exposes no
environment variable for `--locked` — the environment-variables reference lists
one only for `--offline`. So the fix is a wrapper, `scripts/cargo-leptos.sh`,
that freezes the lock in two moves: a `cargo metadata --locked` PRECHECK that
fails loud before cargo-leptos exists (after which its own unlocked call finds
nothing to change), and `--locked` passed through to both compile legs via
`--lib-cargo-args` / `--bin-cargo-args`.

Every invocation now goes through it: `scripts/ui-e2e.sh`,
`docker/admin-ui/Dockerfile`, `ci.yml`, `release.yml`, `containers.yml`, and the
`/ui-gates` skill + rule text.

**Mutation proof**, on the pinned toolchain, with the `chacha20` entry deleted
from the committed `Cargo.lock`:

| Path | Exit | `git diff --stat Cargo.lock` after |
|---|---|---|
| the wrapper (`scripts/cargo-leptos.sh build`) | **1**, `FATAL: Cargo.lock does not satisfy the workspace manifests` | unchanged (only my deletion) |
| the unwrapped entry point (`cargo metadata`, as cargo-leptos runs it) | 0 | **re-resolved: chacha20 0.10.1 → 0.10.2** |

That second row is the reported symptom, reproduced exactly. On the unmutated
lockfile a full `cargo leptos build` through the wrapper leaves
`git diff --exit-code Cargo.lock` clean, and both in-container build legs show
`--locked` in their echoed cargo command lines.

Closes #2877

## The shipped-image battery gets a caller

`scripts/ui-e2e.sh`'s `UI_E2E_IMAGE`/`UI_E2E_IMAGE_REF` mode was documented,
maintained, and called by nothing. It is wired, not deleted:
`.github/workflows/ui-e2e-published.yml` runs it weekly against the latest
release's three published images, with the repository checked out at that
release's own tag so the journeys and the artifact are the same generation.

**Measured once, locally, in image mode** (arm64, `UI_E2E_IMAGE=1`):
**139 journeys in 256.2 s, 139 passed / 0 failed**, and **7m17s** for
everything the battery does once the images exist — compose up, Keycloak
password + redirect-URI setup, REST seeding, console start, chromedriver, the
journeys, teardown. (Total wall clock was 21m41s, dominated by a cold
from-source build of both images: the CDR image alone took 863.7 s.)

The decision on that number: **not** the release path. The battery is cheap;
its INPUT is not — the e2e test binaries compile from the checkout, and a
publishing lane restores no build cache (`.claude/rules/reliability.md`), so
that compile would be fully cold in `release.yml`, where `ci.yml` budgets 45
minutes for the same compile *with* sccache. The highest-value slice of this
battery — a real browser logging in through the shipped artifact — the release
already gates, via the `login-smoke.sh` step added in #2874. Weekly, the
compile caches like any test lane and the wall clock gates nothing. The
number and the reasoning are recorded in the script header and the workflow
header.

Workflow estate rules hold: SHA-pinned `uses:`, `permissions: {}` at workflow
level with the minimum per job, `persist-credentials: false`, every context
value through `env:`. The resolved tag is validated against a strict release-tag
pattern before it becomes a checkout `ref` and three image tags. `actionlint`
(with the repo's SC2016 exclusion) and `zizmor --min-severity=low` over
`.github/workflows/` + `.github/actions/` are clean.

Closes #2876

## Also carried

- The `changes` filters in `ci.yml` and `containers.yml` now name
  `scripts/cargo-leptos.sh` (and `scripts/ui-e2e.sh` in `containers.yml`): they
  are console build/gate inputs, and a change to one of them must run the jobs
  that execute it.
- `scripts/ui-e2e.sh` resolves `CHROMEWEBDRIVER` the way `login-smoke.sh` does
  — the GitHub runner images set it and do not put chromedriver on `PATH`.
- `website/book/src/security.md` states the `/pkg` exception to the console's
  `no-store` and why the bundle can carry it.

## Gates

| Gate | Result |
|---|---|
| `cargo clippy -p ferroehr-admin-ui --all-targets --features ssr -- -D warnings` | clean |
| `cargo clippy -p ferroehr-admin-ui --lib --target wasm32-unknown-unknown --no-default-features --features hydrate -- -D warnings` | clean |
| `cargo nextest run -p ferroehr-admin-ui --features ssr` | 514 passed, 0 skipped |
| `RUSTDOCFLAGS="-D warnings" cargo doc -p ferroehr-admin-ui --features ssr --no-deps` | clean |
| `leptosfmt --check` + `cargo fmt --all` | clean |
| `bash scripts/cargo-leptos.sh build` | completes; `Cargo.lock` byte-identical |
| `bash scripts/ui-e2e.sh` (image mode) | 139 passed |
| `docker/admin-ui/login-smoke.sh` (local image) | pass |
| `shellcheck-lane`, `comment-style`, `typed-status`, `default-style`, `docs-claims`, `spdx-headers`, `image-labels`, `changelog-structure`, `no-python`, `spec-citations`, `error-hygiene`, `ci-conclusion-complete` | all OK |
| `actionlint`, `zizmor --min-severity=low` | clean |

`no-ui-visual-change` applies: the console's rendered output is byte-identical
apart from the asset filenames — the stylesheet link moved between two
server-rendered positions in `<head>`, and everything else is response headers,
build configuration and CI.
