### PR TITLE
fix(compose): the quickstart publishes no database port — host access is an explicit overlay

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -370,6 +370,7 @@ jobs:
             docker-compose.yml
             docker-compose.keycloak.yml
             docker-compose.observability.yml
+            docker-compose.db-publish.yml
             ferroehr-${{ needs.plan.outputs.tag }}.spdx.json
           # Releases publish as OFFICIAL releases (owner sign-off
           # 2026-07-31, superseding the 2026-07-11 always-prerelease rule);
@@ -472,7 +473,8 @@ jobs:
             "ferroehr-${TAG}.spdx.json" \
             "docker-compose.yml" \
             "docker-compose.keycloak.yml" \
-            "docker-compose.observability.yml"; do
+            "docker-compose.observability.yml" \
+            "docker-compose.db-publish.yml"; do
             printf '%s\n' "$assets" | grep -Fxq "$asset" || missing="$missing $asset"
           done
           [ -z "$missing" ] || {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- The quickstart no longer publishes PostgreSQL to a host port, so a natively
+  installed PostgreSQL (the classic Windows collision: the installer's
+  auto-started `postgresql-x64-*` service holding 5432) can no longer fail
+  `docker compose up`. Host access for psql/GUI clients is the new
+  `docker-compose.db-publish.yml` overlay, attached to releases beside the
+  base file; in-stack access needs no port
+  (`docker compose exec ferroehr-postgres psql`) (#2879).
 - The admin console stops re-downloading its whole WebAssembly bundle on every
   page load. Its `/pkg/` filenames now carry a content hash and are served
   `public, max-age=31536000, immutable`, so a browser reuses them until the

--- a/docker-compose.db-publish.yml
+++ b/docker-compose.db-publish.yml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+#
+# OPT-IN overlay: publish PostgreSQL to a host port, for psql or GUI clients
+# (pgAdmin, DBeaver) running on the host. The quickstart deliberately
+# publishes no database port (#2879): nothing in the stack needs it — the
+# server reaches the database over the compose network — and the 5432
+# default collided with natively installed PostgreSQL (on Windows the EDB
+# installer registers an auto-started postgresql-x64-* service holding it).
+#
+# Usage, beside the base file:
+#   docker compose -f docker-compose.yml -f docker-compose.db-publish.yml up
+#   FERROEHR_DB_PORT=5433 docker compose -f docker-compose.yml \
+#     -f docker-compose.db-publish.yml up          # when 5432 is taken
+#
+# In-stack access needs no port at all:
+#   docker compose exec ferroehr-postgres psql -U postgres -d ferroehr
+#
+# The bind host defaults to loopback like every published port in the base
+# file; the base file's header carries the firewall/DNAT warning that applies
+# if you widen it.
+services:
+  ferroehr-postgres:
+    ports:
+      - "${FERROEHR_BIND_HOST:-127.0.0.1}:${FERROEHR_DB_PORT:-5432}:5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,9 +58,10 @@
 # Every published port binds the LOOPBACK interface by default
 # (127.0.0.1:HOST:CONTAINER). This matters more than it looks: a published port
 # is DNAT'd by rules Docker inserts ahead of the host firewall's own chains, so
-# `ufw deny 5432` does NOT stop a container port published on 0.0.0.0
-# (docs.docker.com/engine/network/packet-filtering-firewalls). Running this file
-# unchanged on a public host therefore used to expose PostgreSQL to the internet.
+# `ufw deny 8080` does NOT stop a container port published on 0.0.0.0
+# (docs.docker.com/engine/network/packet-filtering-firewalls). The database
+# publishes NO host port at all (#2879); host psql/GUI access is the explicit
+# docker-compose.db-publish.yml overlay.
 #
 # To reach the stack from another machine, name the interface explicitly:
 #   FERROEHR_BIND_HOST=0.0.0.0 docker compose up      # every interface
@@ -87,7 +88,7 @@
 # their own self-contained SUT stack (docker/sut-ferroehr.yml, see its header
 # for the lane table). NO hard-coded `name:` (issue #282 D3): each lane picks
 # its own project name so the lanes coexist; all lanes share the
-# 8080/3000/5432/8081 host port block, so they run one at a time on defaults —
+# 8080/3000/8081 host port block, so they run one at a time on defaults —
 # override the *_PORT env vars for true parallel coexistence.
 
 services:
@@ -131,8 +132,13 @@ services:
       - wal_compression=${BENCH_PG_WAL_COMPRESSION:-lz4}
     volumes:
       - ferroehr-pgdata:/var/lib/postgresql
-    ports:
-      - "${FERROEHR_BIND_HOST:-127.0.0.1}:${FERROEHR_DB_PORT:-5432}:5432"
+    # NO host port, deliberately (#2879): the server reaches the database over
+    # the compose network, so a host publish serves only host psql/GUI clients
+    # — and on Windows the default 5432 collided with the EDB installer's
+    # auto-started postgresql-x64-* service, failing the quickstart's first
+    # command. Host access is the docker-compose.db-publish.yml overlay;
+    # in-stack access needs no port: docker compose exec ferroehr-postgres
+    # psql -U postgres -d ferroehr.
     # Isolation floor. The entrypoint starts as root to chown the data directory
     # and then drops to `postgres`, so it needs exactly the capabilities that
     # requires and nothing else — not the ~14 the default set grants.

--- a/scripts/deploy-probes/compose.sh
+++ b/scripts/deploy-probes/compose.sh
@@ -16,6 +16,9 @@
 COMPOSE_PROJECT="ferroehr-probe"
 export FERROEHR_PORT="${PROBE_CDR_PORT:-18080}"
 export FERROEHR_S3_PORT="${PROBE_S3_PORT:-18333}"
+# Inert against the base file since #2879 (the quickstart publishes no DB
+# port); kept for runs that add the db-publish overlay so a probe stack still
+# coexists with a developer's own.
 export FERROEHR_DB_PORT="${PROBE_DB_PORT:-15432}"
 CDR="http://localhost:${FERROEHR_PORT}"
 S3="http://localhost:${FERROEHR_S3_PORT}"

--- a/scripts/deploy-probes/kubernetes.sh
+++ b/scripts/deploy-probes/kubernetes.sh
@@ -129,8 +129,14 @@ k8s_try_db_hosts() {
 }
 
 k8s_db_up() {
+  # The db-publish overlay is required here (#2879): the quickstart file
+  # publishes no database port, and this probe is the one consumer that
+  # genuinely needs one (cluster pods reach the compose postgres through the
+  # Docker Desktop gateway).
   FERROEHR_BIND_HOST=0.0.0.0 FERROEHR_DB_PORT="$K8S_DB_PORT" \
-    docker compose -p "$COMPOSE_PROJECT" up -d ferroehr-postgres >/dev/null 2>&1
+    docker compose -p "$COMPOSE_PROJECT" \
+    -f docker-compose.yml -f docker-compose.db-publish.yml \
+    up -d ferroehr-postgres >/dev/null 2>&1
   local _i
   for _i in $(seq 1 40); do
     docker compose -p "$COMPOSE_PROJECT" exec -T ferroehr-postgres \

--- a/website/book/src/installation/compose.md
+++ b/website/book/src/installation/compose.md
@@ -100,11 +100,11 @@ Swagger UI at `http://localhost:8080/ferroehr/rest/swagger-ui`.
 > **Every published port binds the loopback interface by default**
 > (`127.0.0.1:HOST:CONTAINER`), and that is a security property rather than a
 > style choice: a published port is DNAT'd by rules Docker inserts *ahead* of
-> the host firewall's own chains, so a `ufw deny 5432` does not stop a port
+> the host firewall's own chains, so a `ufw deny 8080` does not stop a port
 > published on `0.0.0.0`. To reach the stack from another machine, name the
 > interface explicitly (`FERROEHR_BIND_HOST=0.0.0.0 docker compose up`, or a
-> single address) and prefer a reverse proxy on the host over publishing the
-> database at all.
+> single address). The database publishes no host port at all — see
+> [Connecting to the database](#connecting-to-the-database).
 
 > [!NOTE]
 > Third-party base images are pinned by digest (`name:tag@sha256:…`), not by a
@@ -317,13 +317,47 @@ file. When `docker compose up` refuses with `port is already allocated` (or
 FERROEHR_PORT=8081 docker compose up
 ```
 
-The same works for the other ports (`FERROEHR_DB_PORT`, `FERROEHR_ADMIN_UI_PORT`,
-`FERROEHR_S3_PORT`). The defaults stay fixed on purpose: every URL in this
-book assumes `localhost:8080`, and Docker's automatic ephemeral-port
-allocation exists only when a mapping
+The same works for the other ports (`FERROEHR_ADMIN_UI_PORT`,
+`FERROEHR_S3_PORT`; PostgreSQL publishes no host port — see
+[Connecting to the database](#connecting-to-the-database)). The defaults stay
+fixed on purpose: every URL in this book assumes `localhost:8080`, and
+Docker's automatic ephemeral-port allocation exists only when a mapping
 [omits the host port entirely](https://docs.docker.com/engine/network/port-publishing/)
 — a server that silently moved ports would break every printed URL, so here
 you always choose the port and always know it.
+
+> [!NOTE]
+> **On Windows** the refusal reads differently: `Ports are not available:
+> exposing port TCP 127.0.0.1:8080 … bind: Only one usage of each socket
+> address … is normally permitted` when another program holds the port, or
+> `… An attempt was made to access a socket in a way forbidden by its access
+> permissions` when the port sits in a Windows reserved range. The remedy is
+> the same variable; to see the reserved ranges, run
+> `netsh interface ipv4 show excludedportrange protocol=tcp`. (The classic
+> Windows collision — a natively installed PostgreSQL service holding 5432 —
+> no longer affects the quickstart, which publishes no database port.)
+
+## Connecting to the database
+
+The quickstart publishes no PostgreSQL host port: the server reaches the
+database over the compose network, so nothing needs one, and a published
+5432 collided with natively installed PostgreSQL (on Windows the installer
+registers an auto-started `postgresql-x64-*` service). For a psql session,
+no port is needed at all:
+
+```shell
+docker compose exec ferroehr-postgres psql -U postgres -d ferroehr
+```
+
+For a GUI client on the host (pgAdmin, DBeaver), add the `db-publish`
+overlay, downloaded from the same release beside the base file:
+
+```shell
+docker compose -f docker-compose.yml -f docker-compose.db-publish.yml up
+```
+
+It publishes `127.0.0.1:5432` (retune with `FERROEHR_DB_PORT`, widen with
+`FERROEHR_BIND_HOST` — the warning above applies).
 
 ## Variables the compose files read
 
@@ -337,7 +371,7 @@ Set these in your shell (or an `.env` file) to retune without editing anything:
 | `FERROEHR_BIND_HOST` | `127.0.0.1` | Host interface every published port binds. |
 | `FERROEHR_PORT` | `8080` | Host port mapped to the server. |
 | `FERROEHR_ADMIN_UI_PORT` | `3000` | Host port mapped to the admin console. |
-| `FERROEHR_DB_PORT` | `5432` | Host port mapped to PostgreSQL. |
+| `FERROEHR_DB_PORT` | not published | Host port for PostgreSQL, read only by the `db-publish` overlay (default `5432` there). |
 | `FERROEHR_S3_PORT` | `8333` | Host port mapped to the S3 gateway (the `s3` profile). |
 | `FERROEHR_CPUS` / `FERROEHR_MEM` | `4` / `4G` | Server container resource ceiling. |
 | `FERROEHR_DB_CPUS` / `FERROEHR_DB_MEM` | `4` / `4G` | Database container resource ceiling. |


### PR DESCRIPTION
Closes #2879.

Research-grounded (the full validation is on the issue): nothing in the quickstart needs the DB on a host port; the 5432 publish existed for host-client convenience and fails the first command on any machine with native PostgreSQL — the default Windows state. Official-postgres-image precedent: no DB publish in its own compose example.

- `docker-compose.yml`: the `ports:` entry leaves `ferroehr-postgres`, with the reasoning at the site; header narratives updated (the DNAT warning re-anchored on 8080, 5432 out of the lane port block).
- **New `docker-compose.db-publish.yml`** (keycloak-overlay pattern): opt-in host publish, loopback-bound, `FERROEHR_DB_PORT` tunable; joins the release assets and the draft-completeness check in release.yml.
- `scripts/deploy-probes/kubernetes.sh` (the one true consumer) passes the overlay explicitly; `compose.sh`'s export re-commented as overlay-scoped.
- Book: a "Connecting to the database" section (exec-psql portless, the overlay for GUI clients), the Windows error wordings + `netsh … excludedportrange` note in "Port already in use?", the variables table updated.
- CHANGELOG `### Fixed` entry.

Live proofs: bare `up` → server Healthy, `compose port ferroehr-postgres 5432` empty, `exec psql` answers; overlay config publishes `127.0.0.1:5432`. Guards: hardening, image-tags, docs-claims `--all`, shellcheck-lane, changelog-structure — green.