### PR TITLE
fix(aql): folder containment resolves FOLDER.items references, never the EHR cartesian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- `FOLDER f CONTAINS COMPOSITION c` now resolves the folder's `items`
+  references (transitively over its sub-folders) instead of returning every
+  composition in the EHR — the containment edge was silently dropped for any
+  versioned object under a non-EHR parent, and the same defect made
+  `NOT CONTAINS` vacuously false under a folder and let `ORDER BY` change the
+  row count of `EHR e CONTAINS FOLDER f`. `FOLDER CONTAINS FOLDER` is now a
+  strict sub-folder match (no self-pairs), and a `CONTAINS` pair the RM
+  defines no containment relationship for (such as
+  `COMPOSITION CONTAINS COMPOSITION`) is a typed refusal instead of a
+  cartesian product (#2880).
+
 - The quickstart no longer publishes PostgreSQL to a host port, so a natively
   installed PostgreSQL (the classic Windows collision: the installer's
   auto-started `postgresql-x64-*` service holding 5432) can no longer fail

--- a/app/ferroehr/src/aql/error.rs
+++ b/app/ferroehr/src/aql/error.rs
@@ -140,6 +140,17 @@ pub enum AqlFeatureError {
     #[error("FROM source class `{0}` is not in scope (demographic/off-scope class; QUERY §FROM)")]
     UnsupportedSourceClass(String),
 
+    /// A `CONTAINS` pair the RM defines no containment relationship for — a
+    /// versioned-object root under a parent that cannot contain it (e.g.
+    /// `COMPOSITION CONTAINS COMPOSITION`, `FOLDER CONTAINS EHR_STATUS`).
+    /// Folder containment of versioned objects is `FOLDER.items` reference
+    /// resolution (RM common master05); everything else this refuses used to
+    /// answer a silent cartesian product (#2880).
+    #[error(
+        "`{0} CONTAINS {1}` has no RM containment relationship (QUERY §FROM/Containment; RM common master05)"
+    )]
+    UnsupportedContainment(String, String),
+
     /// Branch (non-trunk) version addressing. Trunk-only per the storage design
     /// NOTE. QUERY §Predicates/Standard predicate (version).
     #[error("branch version addressing is not supported (trunk-only; QUERY §Predicates)")]

--- a/app/ferroehr/src/aql/sql/from.rs
+++ b/app/ferroehr/src/aql/sql/from.rs
@@ -34,10 +34,80 @@ use super::{Builder, VoGroup};
 enum ExistsAnchor {
     /// Interval-anchored inside a node subtree of a shared versioned object:
     /// `num BETWEEN parent.num AND parent.num_cap`, same `(vo_id, sys_version)`.
-    Vo(String),
+    /// Carries the anchor operand's resolved types so the edge classifier can
+    /// decide the join shape (#2880).
+    Vo(String, crate::aql::ir::TypeSet),
     /// Contained in an EHR as its own versioned object: `ehr_id` join + version
     /// scope.
     Ehr(String),
+}
+
+/// How a `CONTAINS` edge renders in SQL, decided from the RM relationship
+/// between the parent and child operand types (#2880).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EdgeKind {
+    /// Content inside the parent's own node subtree: same `(vo_id,
+    /// sys_version)`, inclusive interval join. The child shares the parent's
+    /// version group.
+    Structural,
+    /// `FOLDER CONTAINS <versioned object>`: reference resolution through
+    /// `FOLDER.items` `OBJECT_REF`s, transitively over the folder subtree (RM
+    /// common master05 — folders hold *references* to versioned objects; RM
+    /// ehr master04 §Folders). The child opens its own version group.
+    FolderItems,
+    /// `FOLDER CONTAINS FOLDER`: the by-value `folders` nesting inside one
+    /// versioned folder tree — a STRICT descendant interval, or the same-typed
+    /// pair matches itself.
+    FolderSubtree,
+}
+
+/// Classifies a `CONTAINS` edge, or refuses a pair the RM defines no
+/// containment for (the class that used to answer a silent cartesian, #2880).
+fn classify_edge(
+    parent: &crate::aql::ir::TypeSet,
+    child: &crate::aql::ir::TypeSet,
+) -> Result<EdgeKind, AqlError> {
+    let child_is_vo_root = !child.is_empty() && child.names().iter().all(|t| is_vo_root_type(t));
+    if !child_is_vo_root {
+        return Ok(EdgeKind::Structural);
+    }
+    let parent_all_folder = !parent.is_empty() && parent.names().iter().all(|t| t == "FOLDER");
+    let child_all_folder = child.names().iter().all(|t| t == "FOLDER");
+    let child_no_folder = !child.names().iter().any(|t| t == "FOLDER");
+    match (parent_all_folder, child_all_folder, child_no_folder) {
+        (true, true, _) => Ok(EdgeKind::FolderSubtree),
+        (true, _, true) => Ok(EdgeKind::FolderItems),
+        _ => Err(crate::aql::error::AqlFeatureError::UnsupportedContainment(
+            parent.names().join("|"),
+            child.names().join("|"),
+        )
+        .into()),
+    }
+}
+
+/// The `FOLDER.items` reference-resolution correlation (#2880): some folder
+/// row in the parent's subtree (the parent row itself included — transitive
+/// containment) carries an `items` `OBJECT_REF` whose uid root equals the
+/// child's versioned-object id. The ref uid is compared as TEXT against the
+/// child's `vo_id`, taking the segment before `::` (an `OBJECT_VERSION_ID`
+/// still names its object root — the same resolution the directory commit
+/// validator performs), so a malformed or foreign ref yields no match rather
+/// than a cast error.
+fn folder_items_exists(parent_node: &str, child_node: &str) -> Expr {
+    let sf = format!("{parent_node}_items_sf");
+    let mut sub = Query::select();
+    sub.expr(Expr::val(1));
+    sub.from_as(Node::Table, Alias::new(sf.as_str()));
+    sub.and_where(col(&sf, "vo_id").eq(col(parent_node, "vo_id")));
+    sub.and_where(col(&sf, "sys_version").eq(col(parent_node, "sys_version")));
+    sub.and_where(col(&sf, "num").between(col(parent_node, "num"), col(parent_node, "num_cap")));
+    sub.and_where(col(&sf, "rm_type").eq(Expr::val("FOLDER")));
+    sub.and_where(Expr::cust_with_exprs(
+        "EXISTS (SELECT 1 FROM jsonb_array_elements(COALESCE($1 -> 'items', '[]'::jsonb)) AS item \
+         WHERE split_part(item.value #>> '{id,value}', '::', 1) = ($2)::text)",
+        [col(&sf, "data"), col(child_node, "vo_id")],
+    ));
+    Expr::exists(sub)
 }
 
 /// The streaming-shape plan: the linear containment chain eligible for the
@@ -80,6 +150,13 @@ pub(super) fn streaming_plan(ir: &QueryIr) -> Option<StreamPlan> {
         return None;
     };
     if r.rm_type.is_empty() || !r.rm_type.names().iter().all(|t| is_vo_root_type(t)) {
+        return None;
+    }
+    // A FOLDER root is ineligible: the streaming shape binds the root at
+    // `num = 0`, but `EHR CONTAINS FOLDER` matches every folder node
+    // (containment is transitive — QUERY master03 §Containment), which only
+    // the flat shape's whole-table scan serves (#2880).
+    if r.rm_type.names().iter().any(|t| t == "FOLDER") {
         return None;
     }
     let mut plan = StreamPlan {
@@ -435,7 +512,7 @@ impl Builder<'_> {
         vo: Option<&VoGroup>,
     ) -> Result<Option<VoGroup>, AqlError> {
         let anchor = match (vo, ehr) {
-            (Some(g), _) => ExistsAnchor::Vo(g.node.clone()),
+            (Some(g), _) => ExistsAnchor::Vo(g.node.clone(), g.types.clone()),
             (None, Some(e)) => ExistsAnchor::Ehr(e.to_owned()),
             (None, None) => {
                 return Err(SqlError::Unsupported(
@@ -542,8 +619,10 @@ impl Builder<'_> {
                 // negated. This generalises NOT CONTAINS to compound (AND/OR)
                 // and further-nested operands (QUERY master03 §Containment,
                 // §NOT).
-                let inner =
-                    self.contained_exists(&ExistsAnchor::Vo(parent.node.clone()), &c.tree)?;
+                let inner = self.contained_exists(
+                    &ExistsAnchor::Vo(parent.node.clone(), parent.types.clone()),
+                    &c.tree,
+                )?;
                 self.q.and_where(inner.not());
                 Ok(())
             }
@@ -564,23 +643,39 @@ impl Builder<'_> {
             self.q.and_where(cond);
         }
 
-        let is_vo_root =
-            !r.rm_type.is_empty() && r.rm_type.names().iter().all(|t| is_vo_root_type(t));
+        // The edge kind is classified from the RM relationship of the two
+        // operands' types (#2880). Before this, the join shape was inferred
+        // from the CHILD alone (VO root or not) — a VO-root child under a
+        // non-EHR parent silently dropped the parent edge entirely and
+        // answered a cartesian product.
+        let edge = match vo {
+            Some(parent) => Some(classify_edge(&parent.types, &r.rm_type)?),
+            None => None,
+        };
 
-        // A VO root (or a top-level source with no enclosing group) opens its own
-        // `vo_version` group; otherwise the source is content sharing the parent
-        // group's version and interval-joining into its node subtree.
-        if let (false, Some(parent)) = (is_vo_root, vo) {
+        if let (Some(EdgeKind::Structural | EdgeKind::FolderSubtree), Some(parent)) = (edge, vo) {
             self.q
                 .and_where(col(&node, "vo_id").eq(col(&parent.node, "vo_id")));
             self.q
                 .and_where(col(&node, "sys_version").eq(col(&parent.node, "sys_version")));
-            self.q.and_where(
-                col(&node, "num").between(col(&parent.node, "num"), col(&parent.node, "num_cap")),
-            );
+            if edge == Some(EdgeKind::FolderSubtree) {
+                // STRICT descendant: a folder trivially sits in its own
+                // inclusive interval, so `FOLDER CONTAINS FOLDER` with the
+                // inclusive join would self-match every folder row.
+                self.q
+                    .and_where(col(&node, "num").gt(col(&parent.node, "num")));
+                self.q
+                    .and_where(col(&node, "num").lte(col(&parent.node, "num_cap")));
+            } else {
+                self.q.and_where(
+                    col(&node, "num")
+                        .between(col(&parent.node, "num"), col(&parent.node, "num_cap")),
+                );
+            }
             Ok(VoGroup {
                 node,
                 vo: parent.vo.clone(),
+                types: r.rm_type.clone(),
             })
         } else {
             let voa = format!("v{sid}");
@@ -607,7 +702,18 @@ impl Builder<'_> {
                 self.q.and_where(col(&voa, "ehr_id").eq(col(e, "id")));
                 self.roots_linked_to_ehr.insert(node.clone());
             }
-            Ok(VoGroup { node, vo: voa })
+            // FolderItems: the child's own version group is open; the
+            // reference edge itself is the correlated `items` lookup over the
+            // parent folder's subtree (RM common master05 — folders hold
+            // references to versioned objects).
+            if let (Some(EdgeKind::FolderItems), Some(parent)) = (edge, vo) {
+                self.q.and_where(folder_items_exists(&parent.node, &node));
+            }
+            Ok(VoGroup {
+                node,
+                vo: voa,
+                types: r.rm_type.clone(),
+            })
         }
     }
 
@@ -640,12 +746,15 @@ impl Builder<'_> {
                 let mut sub = Query::select();
                 sub.expr(Expr::val(1));
                 sub.from_as(Node::Table, Alias::new(alias.as_str()));
-                self.anchor_correlation(&mut sub, anchor, &alias, &r.scope)?;
+                self.anchor_correlation(&mut sub, anchor, &alias, &r.rm_type, &r.scope)?;
                 for cond in self.rm_conds(&alias, &r)? {
                     sub.and_where(cond);
                 }
                 if let Some(c) = contained {
-                    let inner = self.contained_exists(&ExistsAnchor::Vo(alias.clone()), &c.tree)?;
+                    let inner = self.contained_exists(
+                        &ExistsAnchor::Vo(alias.clone(), r.rm_type.clone()),
+                        &c.tree,
+                    )?;
                     match c.link {
                         Link::Contains => sub.and_where(inner),
                         Link::NotContains => sub.and_where(inner.not()),
@@ -657,22 +766,59 @@ impl Builder<'_> {
     }
 
     /// Correlate an `EXISTS` subquery's operand node (`alias`) to its anchor:
-    /// interval containment for a shared VO, or an `ehr_id` join + version scope
-    /// for a VO contained in an EHR.
+    /// the classified containment edge for a VO anchor (structural interval,
+    /// strict folder-subtree interval, or the `FOLDER.items` reference
+    /// resolution — #2880), or an `ehr_id` join + version scope for a VO
+    /// contained in an EHR.
     fn anchor_correlation(
         &mut self,
         sub: &mut SelectStatement,
         anchor: &ExistsAnchor,
         alias: &str,
+        child_types: &crate::aql::ir::TypeSet,
         scope: &VersionScope,
     ) -> Result<(), AqlError> {
         match anchor {
-            ExistsAnchor::Vo(parent) => {
-                sub.and_where(col(alias, "vo_id").eq(col(parent, "vo_id")));
-                sub.and_where(col(alias, "sys_version").eq(col(parent, "sys_version")));
-                sub.and_where(
-                    col(alias, "num").between(col(parent, "num"), col(parent, "num_cap")),
-                );
+            ExistsAnchor::Vo(parent, parent_types) => {
+                match classify_edge(parent_types, child_types)? {
+                    EdgeKind::Structural => {
+                        sub.and_where(col(alias, "vo_id").eq(col(parent, "vo_id")));
+                        sub.and_where(col(alias, "sys_version").eq(col(parent, "sys_version")));
+                        sub.and_where(
+                            col(alias, "num").between(col(parent, "num"), col(parent, "num_cap")),
+                        );
+                    }
+                    EdgeKind::FolderSubtree => {
+                        sub.and_where(col(alias, "vo_id").eq(col(parent, "vo_id")));
+                        sub.and_where(col(alias, "sys_version").eq(col(parent, "sys_version")));
+                        sub.and_where(col(alias, "num").gt(col(parent, "num")));
+                        sub.and_where(col(alias, "num").lte(col(parent, "num_cap")));
+                    }
+                    EdgeKind::FolderItems => {
+                        // The child is its own versioned object: bind its
+                        // version spine + scope (the Ehr arm's shape), then
+                        // the reference edge over the anchor folder's subtree.
+                        let voa = format!("xv{}", self.next_ctr());
+                        sub.from_as(VoVersion::Table, Alias::new(voa.as_str()));
+                        sub.and_where(col(alias, "vo_id").eq(col(&voa, "vo_id")));
+                        sub.and_where(col(alias, "sys_version").eq(col(&voa, "sys_version")));
+                        match scope {
+                            VersionScope::Latest => {
+                                sub.and_where(call("upper_inf", vec![col(&voa, "sys_period")]));
+                                sub.and_where(col(&voa, "branch_number").eq(Expr::val(0)));
+                            }
+                            VersionScope::All => {}
+                            VersionScope::Predicate(_) => {
+                                return Err(SqlError::Unsupported(
+                                    "a version predicate on an OR/NOT-CONTAINS branch VO"
+                                        .to_owned(),
+                                )
+                                .into());
+                            }
+                        }
+                        sub.and_where(folder_items_exists(parent, alias));
+                    }
+                }
                 Ok(())
             }
             ExistsAnchor::Ehr(e) => {

--- a/app/ferroehr/src/aql/sql/mod.rs
+++ b/app/ferroehr/src/aql/sql/mod.rs
@@ -162,6 +162,9 @@ pub struct ScopeQuery {
 struct VoGroup {
     node: String,
     vo: String,
+    /// The resolved RM types of the operand that created this group — the
+    /// containment-edge classifier's parent side (#2880).
+    types: crate::aql::ir::TypeSet,
 }
 
 /// The extraction/coercion mode of a value expression.

--- a/app/ferroehr/tests/it/aql_planner.rs
+++ b/app/ferroehr/tests/it/aql_planner.rs
@@ -1555,3 +1555,96 @@ fn stable_profile_gate_matches_the_released_model() {
         );
     }
 }
+
+// ── containment-edge classification (#2880) ──────────────────────────────────
+
+/// Plan `q` and expect the SQL BUILD (not planning) to refuse it.
+fn build_err(q: &str) -> AqlError {
+    let ir = plan_ok(q);
+    let ctx = SqlCtx {
+        system_id: "sys.example.com".to_owned(),
+        ehr_ids: Vec::new(),
+        subject_scope: None,
+        limit: None,
+        offset: None,
+        archetype_lineage: Arc::new(ArchetypeLineage::default()),
+    };
+    ferroehr::aql::sql::build(&ir, &Params::new(), &ctx)
+        .err()
+        .unwrap_or_else(|| panic!("expected the SQL build to refuse {q:?}"))
+}
+
+/// `FOLDER CONTAINS COMPOSITION` resolves through `FOLDER.items` `OBJECT_REF`s
+/// (RM common master05 — folders hold references to versioned objects), over
+/// the whole folder subtree: the ref uid roots are compared against the
+/// child's `vo_id`.
+#[test]
+fn folder_contains_composition_resolves_items_refs() {
+    let sql = build_sql("SELECT c/uid/value FROM EHR e CONTAINS FOLDER f CONTAINS COMPOSITION c");
+    assert!(
+        sql.contains("jsonb_array_elements") && sql.contains("'items'"),
+        "the edge is the items reference lookup: {sql}"
+    );
+    assert!(
+        sql.contains("split_part"),
+        "the ref uid root is compared, not the full OBJECT_VERSION_ID: {sql}"
+    );
+}
+
+/// `FOLDER CONTAINS FOLDER` is the by-value `folders` nesting inside one
+/// versioned folder tree — a STRICT descendant interval, or every folder
+/// would trivially contain itself.
+#[test]
+fn folder_contains_folder_is_a_strict_descendant() {
+    let sql = build_sql("SELECT f2/name/value FROM EHR e CONTAINS FOLDER f1 CONTAINS FOLDER f2");
+    assert!(
+        sql.contains(r#""n2"."num" > "n1"."num""#)
+            && sql.contains(r#""n2"."num" <= "n1"."num_cap""#),
+        "strict interval, no self-pair: {sql}"
+    );
+    assert!(
+        !sql.contains("BETWEEN"),
+        "the inclusive self-matching interval is gone: {sql}"
+    );
+}
+
+/// A `CONTAINS` pair the RM defines no containment relationship for is a
+/// typed refusal, never a silent cartesian (the pre-#2880 behaviour).
+#[test]
+fn versioned_object_under_versioned_object_is_refused() {
+    let err =
+        build_err("SELECT c2/uid/value FROM EHR e CONTAINS COMPOSITION c1 CONTAINS COMPOSITION c2");
+    assert!(
+        err.to_string().contains("no RM containment relationship"),
+        "typed containment refusal, got: {err}"
+    );
+}
+
+/// `FOLDER f NOT CONTAINS COMPOSITION` negates the same reference edge — the
+/// anti-join probes `FOLDER.items`, not the (vacuously true) node interval.
+#[test]
+fn not_contains_under_folder_uses_the_reference_edge() {
+    let sql =
+        build_sql("SELECT f/name/value FROM EHR e CONTAINS FOLDER f NOT CONTAINS COMPOSITION c");
+    assert!(
+        sql.contains("NOT EXISTS") || sql.contains("NOT (EXISTS"),
+        "the exclusion is an anti-join: {sql}"
+    );
+    assert!(
+        sql.contains("jsonb_array_elements") && sql.contains("'items'"),
+        "the negated edge is the items reference lookup: {sql}"
+    );
+}
+
+/// A FOLDER root never takes the streaming shape: the streaming root binds
+/// `num = 0`, but `EHR CONTAINS FOLDER` matches every folder node
+/// (containment is transitive — QUERY master03 §Containment), so the flat
+/// shape owns it.
+#[test]
+fn folder_root_never_streams() {
+    let sql = build_sql_limited("SELECT f/name/value FROM EHR e CONTAINS FOLDER f");
+    assert!(
+        !sql.contains("JOIN LATERAL"),
+        "FOLDER roots take the flat shape: {sql}"
+    );
+}

--- a/app/ferroehr/tests/it/service_aql.rs
+++ b/app/ferroehr/tests/it/service_aql.rs
@@ -1715,3 +1715,175 @@ async fn an_uncoercible_temporal_binding_is_the_callers_400() {
         err.message
     );
 }
+
+// ── folder containment (#2880) ───────────────────────────────────────────────
+
+/// An `items` entry referencing a this-system versioned composition.
+fn folder_ref(comp_root: &str) -> Value {
+    json!({
+        "_type": "OBJECT_REF",
+        "namespace": "local",
+        "type": "VERSIONED_COMPOSITION",
+        "id": { "_type": "HIER_OBJECT_ID", "value": comp_root }
+    })
+}
+
+/// The uid root of an `OBJECT_VERSION_ID` string.
+fn uid_root(ovid: &str) -> String {
+    ovid.split("::").next().expect("uid root").to_owned()
+}
+
+/// `FOLDER CONTAINS COMPOSITION` resolves the `FOLDER.items` `OBJECT_REF`s,
+/// transitively over the folder subtree, and only those (RM common master05
+/// — folders reference versioned objects; QUERY master03 §Containment —
+/// CONTAINS is the parent/child relationship, not co-residence in one EHR).
+#[tokio::test]
+async fn folder_containment_resolves_references() {
+    let db = testkit::db().await.expect("testkit database");
+    let svc = FerroEhrService::new(db.pool());
+    let ehr_id = create_ehr(&svc).await;
+    let ehr_uuid = ferroehr::ids::EhrId(ehr_id.parse::<Uuid>().expect("ehr uuid"));
+
+    // cB is multiply-classified (course-1 AND course-2 — RM common master05
+    // names multiple classification as the design intent); cD is committed
+    // but referenced by NO folder.
+    let ca = uid_root(&create_comp(&svc, &ehr_id, "cA", 1.0).await);
+    let cb = uid_root(&create_comp(&svc, &ehr_id, "cB", 2.0).await);
+    let cc = uid_root(&create_comp(&svc, &ehr_id, "cC", 3.0).await);
+    let cd = uid_root(&create_comp(&svc, &ehr_id, "cD", 4.0).await);
+
+    let sub = |name: &str, items: Vec<Value>| {
+        json!({
+            "_type": "FOLDER",
+            "archetype_node_id": "openEHR-EHR-FOLDER.generic.v1",
+            "name": { "_type": "DV_TEXT", "value": name },
+            "items": items
+        })
+    };
+    let directory = json!({
+        "_type": "FOLDER",
+        "archetype_node_id": "openEHR-EHR-FOLDER.generic.v1",
+        "name": { "_type": "DV_TEXT", "value": "episodes" },
+        "items": [folder_ref(&ca)],
+        "folders": [
+            sub("course-1", vec![folder_ref(&cb)]),
+            sub("course-2", vec![folder_ref(&cb), folder_ref(&cc)]),
+        ]
+    });
+    svc.create_directory(ehr_uuid, uv(&directory, "249", None))
+        .await
+        .expect("create_directory");
+
+    // The full pair set, transitive: episodes reaches every subtree ref.
+    let r = run_aql(
+        &svc,
+        "SELECT f/name/value, c/uid/value \
+         FROM EHR e CONTAINS FOLDER f CONTAINS COMPOSITION c",
+        ehr_scope(&ehr_id),
+    )
+    .await;
+    let pairs: std::collections::BTreeSet<(String, String)> = rows(&r)
+        .iter()
+        .map(|row| {
+            (
+                row[0].as_str().expect("folder name").to_owned(),
+                uid_root(row[1].as_str().expect("composition uid")),
+            )
+        })
+        .collect();
+    let expected: std::collections::BTreeSet<(String, String)> = [
+        ("episodes", &ca),
+        ("episodes", &cb),
+        ("episodes", &cc),
+        ("course-1", &cb),
+        ("course-2", &cb),
+        ("course-2", &cc),
+    ]
+    .into_iter()
+    .map(|(f, c)| (f.to_owned(), c.clone()))
+    .collect();
+    assert_eq!(
+        pairs, expected,
+        "exactly the reference pairs, transitively — never the EHR cartesian"
+    );
+    assert_eq!(
+        rows(&r).len(),
+        6,
+        "one row per (folder, referenced object) pair"
+    );
+    assert!(
+        !pairs.iter().any(|(_, c)| *c == cd),
+        "the unreferenced composition appears under no folder"
+    );
+
+    // Scoped to one sub-folder.
+    let r = run_aql(
+        &svc,
+        "SELECT c/uid/value FROM EHR e CONTAINS FOLDER f CONTAINS COMPOSITION c \
+         WHERE f/name/value = 'course-2'",
+        ehr_scope(&ehr_id),
+    )
+    .await;
+    assert_eq!(rows(&r).len(), 2, "course-2 references exactly cB and cC");
+
+    // FOLDER CONTAINS FOLDER: strict ancestor/descendant pairs only.
+    let r = run_aql(
+        &svc,
+        "SELECT f1/name/value, f2/name/value FROM EHR e CONTAINS FOLDER f1 CONTAINS FOLDER f2",
+        ehr_scope(&ehr_id),
+    )
+    .await;
+    let folder_pairs: std::collections::BTreeSet<(String, String)> = rows(&r)
+        .iter()
+        .map(|row| {
+            (
+                row[0].as_str().expect("parent").to_owned(),
+                row[1].as_str().expect("child").to_owned(),
+            )
+        })
+        .collect();
+    assert_eq!(
+        folder_pairs,
+        [("episodes", "course-1"), ("episodes", "course-2")]
+            .into_iter()
+            .map(|(a, b)| (a.to_owned(), b.to_owned()))
+            .collect(),
+        "no self-pairs, no inverted pairs"
+    );
+
+    // EHR CONTAINS FOLDER matches every folder node — the same answer with
+    // and without ORDER BY (the pre-fix streaming shape returned only the
+    // root when unordered).
+    let unordered = run_aql(
+        &svc,
+        "SELECT f/name/value FROM EHR e CONTAINS FOLDER f",
+        ehr_scope(&ehr_id),
+    )
+    .await;
+    let ordered = run_aql(
+        &svc,
+        "SELECT f/name/value FROM EHR e CONTAINS FOLDER f ORDER BY f/name/value",
+        ehr_scope(&ehr_id),
+    )
+    .await;
+    assert_eq!(rows(&unordered).len(), 3, "root + two sub-folders");
+    assert_eq!(
+        rows(&ordered).len(),
+        rows(&unordered).len(),
+        "ORDER BY never changes the row count"
+    );
+
+    // NOT CONTAINS negates the same reference edge: every folder here has a
+    // reference in its subtree, so the anti-join is empty.
+    let r = run_aql(
+        &svc,
+        "SELECT f/name/value FROM EHR e CONTAINS FOLDER f NOT CONTAINS COMPOSITION c",
+        ehr_scope(&ehr_id),
+    )
+    .await;
+    assert_eq!(
+        rows(&r).len(),
+        0,
+        "no folder is without a referenced composition in its subtree"
+    );
+}

--- a/website/book/src/querying-aql.md
+++ b/website/book/src/querying-aql.md
@@ -40,7 +40,12 @@ ORDER BY systolic DESC
   `.v2` data.
 - **`CONTAINS`** expresses structural containment: "an EHR that contains a
   composition that contains a blood-pressure observation". Chains can nest
-  several deep, and combine with `AND`, `OR`, and `NOT`.
+  several deep, and combine with `AND`, `OR`, and `NOT`. Folder containment
+  follows the RM's reference model: `FOLDER f CONTAINS COMPOSITION c` matches
+  the compositions a folder's `items` reference, transitively over the
+  folder's sub-tree, and `FOLDER f1 CONTAINS FOLDER f2` matches strict
+  sub-folders. A pair the RM defines no containment relationship for (say
+  `COMPOSITION CONTAINS COMPOSITION`) is refused with a typed error.
 - **`SELECT`** projects values by path. Paths use archetype node ids (`at0004`)
   and RM attribute names (`value/magnitude`); `AS` names a column.
 - **`WHERE`** filters on typed leaf values, with comparisons, `EXISTS`, `LIKE`,


### PR DESCRIPTION
Closes #2880.

`FROM EHR e CONTAINS FOLDER f CONTAINS COMPOSITION c` returned every composition in the EHR: the SQL generator inferred each join from the CHILD operand alone, so a versioned-object child under a non-EHR parent silently dropped the parent edge and produced an EHR-bounded cartesian. The same root defect made `NOT CONTAINS` under a folder vacuously true (the inner EXISTS interval-joined two different versioned objects, which never matches, so the negation always held), and the LIMIT-streaming shape bound a FOLDER root at `num = 0` only, so adding `ORDER BY` changed the row count of `EHR e CONTAINS FOLDER f`.

## The fix

Every `CONTAINS` edge is now classified from the RM relationship of its two operands before any SQL is emitted (`classify_edge`, `app/ferroehr/src/aql/sql/from.rs`):

- **Structural** (child is not a versioned-object root): the existing same-`(vo_id, sys_version)` inclusive nested-set interval join — unchanged.
- **FolderItems** (`FOLDER CONTAINS <versioned object>`): the child opens its own version group and the edge is a correlated `EXISTS` resolving the folder's `items` `OBJECT_REF`s — over the parent folder's whole subtree, so containment is transitive, with the ref uid root compared as text against the child's `vo_id` (a malformed or foreign ref yields no match, never a cast error). Spec ground: RM common master05 (a FOLDER carries `items: List<OBJECT_REF>` — folders contain versioned objects by reference, and multiple classification is the design intent); RM ehr master04 §Folders; QUERY master03 §Containment (the left operand is the parent object of the right).
- **FolderSubtree** (`FOLDER CONTAINS FOLDER`): the by-value `folders` nesting inside one versioned folder tree — a STRICT descendant interval (`num > parent.num AND num <= parent.num_cap`), because the inclusive interval self-matches every folder row.
- **Anything else** with a versioned-object child under a non-EHR parent (e.g. `COMPOSITION CONTAINS COMPOSITION`) is a typed `UnsupportedContainment` refusal naming both sides — never a silent wrong answer.

The same classifier drives the OR/NOT-CONTAINS `EXISTS` anchors (`ExistsAnchor::Vo` now carries the parent operand's types), which fixes the NOT-CONTAINS inversion; and `streaming_plan` refuses FOLDER-typed roots, so `EHR e CONTAINS FOLDER f` takes the flat shape and returns every folder node with and without `ORDER BY`.

## Verification

- Five planner tests pin the generated SQL: the `jsonb_array_elements`/`split_part` reference edge, the strict folder-subtree interval, the typed refusal, the negated reference edge, the streaming exclusion (`app/ferroehr/tests/it/aql_planner.rs`).
- A real-database integration test rebuilds the issue's scenario (`app/ferroehr/tests/it/service_aql.rs::folder_containment_resolves_references`): a directory tree (root + two courses), a multiply-classified composition, one unreferenced composition. Asserted: exactly the 6 transitive `(folder, composition)` pairs and nothing else; sub-folder scoping; strict folder pairs (no self/inverted pairs); `EHR CONTAINS FOLDER` = 3 rows with AND without `ORDER BY`; `NOT CONTAINS` = 0; the unreferenced composition appears nowhere.
- Gates: fmt, workspace clippy (all-features, deny warnings), rustdoc (private items), workspace nextest 4865/4865, docs-claims.
- Conformance: zero drift vs the committed baseline (run attached below before merge).

## Instrument + follow-up

- The catalogue had zero folder-AQL coverage — filed as rubentalstra/Veredictum#156 (P0) with the positive/negative case list and a mutation-proof acceptance criterion.
- `FOLDER CONTAINS FOLDER` over items-referenced VERSIONED_FOLDERs is a spec-silence adjudication, filed as #2887.

User-facing docs: the book's AQL page now states the folder-containment semantics and the typed refusal; CHANGELOG `[Unreleased]` carries the entry.

