### PR TITLE
chore(chart): the committed appVersion default refreshes to 4.0.9, chart 6.0.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Fixed
+
+- The v4.0.9 Helm chart publishes as **6.0.26** (appVersion 4.0.9). The
+  release's own chart leg failed on a CI guard defect before publishing, so
+  chart 6.0.25 never existed on the registry; 6.0.26 is the same chart with
+  the committed appVersion default refreshed to the released 4.0.9.
+
 ## [4.0.9] - 2026-08-28
 
 ### Fixed

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # A published OCI version is immutable by refusal rather than by the registry —
 # `helm push` over an existing tag replaces it silently — so a correction always
 # ships as a NEW version and the published one stands as it was.
-version: 6.0.25
+version: 6.0.26
 # The DEFAULT container image tag (overridable via image.tag) — no longer a
 # per-release fact (#2779).
 #
@@ -42,7 +42,7 @@ version: 6.0.25
 # defaults: values track development between releases, so the publish lane
 # re-checks the pairing against an image, and the `chart-boot` CI job replays it
 # against the image built from the tree.
-appVersion: "4.0.8"
+appVersion: "4.0.9"
 
 # A COMPATIBILITY floor, and a real one: 1.36 is the release where the newest
 # field this chart renders became stable.
@@ -156,7 +156,7 @@ annotations:
   # scan while leaving the false claim in place, so it is deliberately not used.
   artifacthub.io/images: |
     - name: ferroehr
-      image: ghcr.io/rubentalstra/ferroehr:4.0.8
+      image: ghcr.io/rubentalstra/ferroehr:4.0.9
       platforms:
         - linux/amd64
         - linux/arm64
@@ -165,7 +165,7 @@ annotations:
     # visible to anyone considering it. See #2193: this chart cannot deploy it
     # yet, so today the entry advertises intent rather than chart behaviour.
     - name: ferroehr-admin-ui
-      image: ghcr.io/rubentalstra/ferroehr-admin-ui:4.0.8
+      image: ghcr.io/rubentalstra/ferroehr-admin-ui:4.0.9
       platforms:
         - linux/amd64
         - linux/arm64

--- a/deploy/helm/ferroehr/README.md
+++ b/deploy/helm/ferroehr/README.md
@@ -2,7 +2,7 @@
 
 Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.1.0 + AQL 1.1). A single static binary deployed with a hardened-by-default security posture: runs as a non-root, read-only-rootfs workload whose NetworkPolicy admits its serving port only, and that connects to an EXTERNAL PostgreSQL 18 as an unprivileged app role (migrations are run out of band by a separate migrator role).
 
-![Version: 6.0.25](https://img.shields.io/badge/Version-6.0.25-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.8](https://img.shields.io/badge/AppVersion-4.0.8-informational?style=flat-square)
+![Version: 6.0.26](https://img.shields.io/badge/Version-6.0.26-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.9](https://img.shields.io/badge/AppVersion-4.0.9-informational?style=flat-square)
 
 FerroEHR is a pure-Rust openEHR Clinical Data Repository: ITS-REST 1.1.0 at the
 API, AQL 1.1 as the query language, PostgreSQL 18-native storage, shipped as a
@@ -33,10 +33,10 @@ to add; `helm repo add` does not apply to this chart:
 
 ```console
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 6.0.25 \
+  --version 6.0.26 \
   --namespace ferroehr --create-namespace \
   --set database.existingSecret=ferroehr-db \
-  --set image.tag=4.0.8
+  --set image.tag=4.0.9
 ```
 
 OCI registries require Helm 3.8 or newer.
@@ -47,8 +47,8 @@ They are independent SemVer lines and they move independently:
 
 | What | Set with | This release |
 |---|---|---|
-| the **chart** (templates, defaults, this document) | `--version` | `6.0.25` |
-| the **server image** | `image.tag` | `4.0.8` |
+| the **chart** (templates, defaults, this document) | `--version` | `6.0.26` |
+| the **server image** | `image.tag` | `4.0.9` |
 
 `appVersion` is the image the chart defaults to; pinning `image.tag` explicitly
 is what keeps an upgrade of one from silently moving the other.
@@ -59,7 +59,7 @@ The chart carries two keyless Sigstore artifacts, and they answer different
 questions. A **cosign signature:** who signed this:
 
 ```console
-cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.25 \
+cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.26 \
   --certificate-identity-regexp '^https://github\.com/rubentalstra/FerroEHR/\.github/workflows/publish-chart\.yml@' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
@@ -67,9 +67,9 @@ cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.25 \
 A **SLSA build provenance attestation:** what source it was built from, and how:
 
 ```console
-gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:6.0.25 \
+gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:6.0.26 \
   -R rubentalstra/FerroEHR
-gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:4.0.8 \
+gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:4.0.9 \
   -R rubentalstra/FerroEHR
 ```
 

--- a/deploy/helm/golden/admin-ui.yaml
+++ b/deploy/helm/golden/admin-ui.yaml
@@ -18,10 +18,10 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the admin console: only its HTTP port, but from EVERY source — this policy narrows ports, NOT sources (adminUi.networkPolicy.ingressAllowAll=true). Set adminUi.networkPolicy.ingressFrom for a PHI workload. Egress admits the CDR Service and DNS only.
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -90,10 +90,10 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -118,10 +118,10 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -139,10 +139,10 @@ kind: ServiceAccount
 metadata:
   name: ferroehr-admin-ui
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -154,10 +154,10 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 automountServiceAccountToken: false
@@ -184,10 +184,10 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -201,10 +201,10 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -332,10 +332,10 @@ metadata:
     kubernetes.io/description: >-
       In-cluster address for the FerroEHR admin console. The console is a REST client of the CDR and holds no data of its own; it is the human-facing surface, so this is the Service an Ingress normally publishes.
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -355,10 +355,10 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -385,10 +385,10 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR admin console: a Leptos SSR web UI that consumes the CDR strictly over ITS-REST. It never reaches the database, which the console NetworkPolicy enforces rather than assumes.
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -424,7 +424,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: admin-ui
-          image: "ghcr.io/rubentalstra/ferroehr-admin-ui:4.0.8"
+          image: "ghcr.io/rubentalstra/ferroehr-admin-ui:4.0.9"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -492,10 +492,10 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -543,7 +543,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:4.0.8"
+          image: "ghcr.io/rubentalstra/ferroehr:4.0.9"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -23,10 +23,10 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), and only from the networkPolicy.ingressFrom peers.
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -97,10 +97,10 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -118,10 +118,10 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -150,10 +150,10 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -176,10 +176,10 @@ kind: Secret
 metadata:
   name: ferroehr-config
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -197,10 +197,10 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -401,10 +401,10 @@ kind: ConfigMap
 metadata:
   name: ferroehr-grafana-dashboard
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     grafana_dashboard: "1"
@@ -652,10 +652,10 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -686,10 +686,10 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -739,7 +739,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:4.0.8"
+          image: "ghcr.io/rubentalstra/ferroehr:4.0.9"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -919,10 +919,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -953,10 +953,10 @@ kind: Ingress
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -991,10 +991,10 @@ kind: ServiceMonitor
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     release: kube-prometheus-stack

--- a/deploy/helm/golden/basic-auth.yaml
+++ b/deploy/helm/golden/basic-auth.yaml
@@ -23,10 +23,10 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -51,10 +51,10 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -72,10 +72,10 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 automountServiceAccountToken: false
@@ -102,10 +102,10 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -119,10 +119,10 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -247,10 +247,10 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -277,10 +277,10 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -328,7 +328,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:4.0.8"
+          image: "ghcr.io/rubentalstra/ferroehr:4.0.9"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -23,10 +23,10 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -51,10 +51,10 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -72,10 +72,10 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 automountServiceAccountToken: false
@@ -87,10 +87,10 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -212,10 +212,10 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -242,10 +242,10 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.25
+    helm.sh/chart: ferroehr-6.0.26
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.8"
+    app.kubernetes.io/version: "4.0.9"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -293,7 +293,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:4.0.8"
+          image: "ghcr.io/rubentalstra/ferroehr:4.0.9"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/website/book/src/installation/kubernetes.md
+++ b/website/book/src/installation/kubernetes.md
@@ -38,7 +38,7 @@ kubectl -n ferroehr create secret generic ferroehr-db \
   --from-literal=FERROEHR__DB__URL='postgres://ferroehr_app:***@pg-host:5432/ferroehr?sslmode=verify-full'
 
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 6.0.25 -n ferroehr \
+  --version 6.0.26 -n ferroehr \
   --set database.existingSecret=ferroehr-db \
   --set image.tag=4.0.9
 ```
@@ -55,7 +55,7 @@ helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
 reference. To read the chart's metadata without installing it:
 
 ```shell
-helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.25
+helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.26
 ```
 
 ### Pin two versions, not one
@@ -68,7 +68,7 @@ against.
 
 | | Selects | Pin with | Line |
 |---|---|---|---|
-| Chart version | templates, values schema, defaults | `--version 6.0.25` | SemVer over the chart's own contract |
+| Chart version | templates, values schema, defaults | `--version 6.0.26` | SemVer over the chart's own contract |
 | Image tag | the server binary | `--set image.tag=4.0.9` (or `image.digest`) | the application's SemVer line |
 
 Always pin the image to an immutable version or, better, a `@sha256` digest,
@@ -167,7 +167,7 @@ metadata lists: the server, and the optional admin console.
 > the image itself as the authority:
 >
 > ```shell
-> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.25 \
+> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.26 \
 >   -s templates/configmap.yaml --set database.existingSecret=ferroehr-db \
 >   | sed -n '/ferroehr.toml/,$p' | sed '1d;s/^    //' > /tmp/ferroehr.toml
 > docker run --rm -v /tmp/ferroehr.toml:/etc/ferroehr/ferroehr.toml:ro \
@@ -556,7 +556,7 @@ config:
 
 ```shell
 helm upgrade ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 6.0.25 -n ferroehr --reuse-values \
+  --version 6.0.26 -n ferroehr --reuse-values \
   --set config.query.plan_cache_capacity=512
 ```
 
@@ -709,7 +709,7 @@ Preview an upgrade against what you have installed with
 `helm diff`, or render the new chart version and read it:
 
 ```shell
-helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.25 \
+helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.26 \
   -n ferroehr -f my-values.yaml | less
 ```
 


### PR DESCRIPTION
The v4.0.9 chart leg died on the guard SIGPIPE (fixed in #2892) before publishing, so chart 6.0.25 never reached GHCR. The dispatch recovery lane deliberately packages the COMMITTED appVersion ("a between-releases dispatch invents no version"), so before dispatching, the committed default refreshes to 4.0.9 — ordinary maintenance under the freshness bound, and all three `4.0.9` images are verified present on GHCR (`4.0.9`, `4.0`, `latest` on ferroehr, ferroehr-admin-ui, ferroehr-postgres). Since the refresh changes packaged chart bytes, the chart version moves to 6.0.26 (6.0.25 was never published and never will be); the book's chart pin, generated README, and goldens follow.

After merge: `publish-chart.yml` dispatch with `publish: true` publishes chart 6.0.26 / appVersion 4.0.9 — the v4.0.9 release's chart, one version later than planned.

Guards locally green: validate.sh (all render checks), chart-appversion, docs-claims.