### PR TITLE
ci(repo): workflows and guards accept main beside develop (rename step 1)

### DIFF
--- a/.claude/hooks/crate_version_bump_guard.sh
+++ b/.claude/hooks/crate_version_bump_guard.sh
@@ -32,7 +32,7 @@ printf '%s' "$cmd" | grep -qE '(^|[;&|[:space:]])git[[:space:]]+push([[:space:]]
 printf '%s' "$cmd" | grep -q 'FERROEHR_SKIP_CRATE_BUMP_GUARD=1' && exit 0
 
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
-base="$(git merge-base HEAD origin/develop 2>/dev/null || true)"
+base="$(git merge-base HEAD origin/develop 2>/dev/null || git merge-base HEAD origin/main 2>/dev/null || true)"
 [ -n "$base" ] || exit 0
 
 changed="$(git diff --name-only "$base" HEAD 2>/dev/null || true)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ name: CI
 
 on:
   push:
-    branches: [develop]
+    branches: [develop, main]
   # The types are spelled out (#2777) because the implicit default is
   # `[opened, synchronize, reopened]` only: applying an escape-hatch label
   # (`no-changelog`, `no-chart-bump`, `no-crate-bump`, `no-ui-visual-change`)
@@ -665,7 +665,7 @@ jobs:
       # guards are the only cargo consumers in this job.
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
-          cache-save-if: ${{ github.ref == 'refs/heads/develop' }}
+          cache-save-if: ${{ (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main') }}
       # A packaged src file embedding a path its own package does not carry
       # compiles in this repository and breaks inside the published .crate.
       - name: Packaged sources embed only packaged files
@@ -835,7 +835,7 @@ jobs:
           persist-credentials: false
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
-          cache-save-if: ${{ github.ref == 'refs/heads/develop' }}
+          cache-save-if: ${{ (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main') }}
       - uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc # v2.86.7
         with:
           tool: cargo-deny
@@ -913,7 +913,7 @@ jobs:
         with:
           components: clippy
           target: wasm32-unknown-unknown
-          cache-save-if: ${{ github.ref == 'refs/heads/develop' }}
+          cache-save-if: ${{ (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main') }}
       # The console's `hydrate`/`ssr` features are mutually exclusive (a
       # compile_error! guard per the Cargo book §Mutually exclusive features),
       # so the workspace lane excludes it and the crate gets its own two
@@ -958,7 +958,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           components: clippy
-          cache-save-if: ${{ github.ref == 'refs/heads/develop' }}
+          cache-save-if: ${{ (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main') }}
       - run: cargo clippy --locked -p ferroehr-server --no-default-features --all-targets -- -D warnings
       - run: cargo clippy --locked -p ferroehr-server --no-default-features --features events --all-targets -- -D warnings
       - run: cargo clippy --locked -p ferroehr-server --no-default-features --features fhir --all-targets -- -D warnings
@@ -976,7 +976,7 @@ jobs:
     # is docs-only would otherwise never have its docs evaluated at all. This
     # job is ~1/10 the length of the test job, so re-evaluating the whole tree
     # on every develop push is cheap insurance.
-    if: needs.changes.outputs.code == 'true' || github.ref == 'refs/heads/develop'
+    if: needs.changes.outputs.code == 'true' || (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     timeout-minutes: 25
     permissions:
@@ -989,7 +989,7 @@ jobs:
           persist-credentials: false
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
-          cache-save-if: ${{ github.ref == 'refs/heads/develop' }}
+          cache-save-if: ${{ (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main') }}
       # --document-private-items: stale intra-doc links can hide behind
       # non-pub items the public build never evaluates (#1838; measured
       # cost ~10s incremental over the public-only run).
@@ -1021,7 +1021,7 @@ jobs:
           persist-credentials: false
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
-          cache-save-if: ${{ github.ref == 'refs/heads/develop' }}
+          cache-save-if: ${{ (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main') }}
       - uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc # v2.86.7
         with:
           tool: cargo-hack
@@ -1043,7 +1043,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           components: rustfmt
-          cache-save-if: ${{ github.ref == 'refs/heads/develop' }}
+          cache-save-if: ${{ (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main') }}
       - name: Regenerate and diff
         run: bash scripts/checks/codegen-drift.sh
 
@@ -1085,7 +1085,7 @@ jobs:
           persist-credentials: false
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
-          cache-save-if: ${{ github.ref == 'refs/heads/develop' }}
+          cache-save-if: ${{ (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main') }}
       - name: Enable required extensions + non-durable test tuning
         # libxml2-utils provides xmllint — the C14N XML parity gate shells out
         # to it (serialization.md); the runner image does not ship it.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ name: CodeQL
 # (CodeQL is not a required status check, so a skipped leg cannot block a merge.)
 on:
   push:
-    branches: [develop]
+    branches: [develop, main]
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"
@@ -33,7 +33,7 @@ on:
       - ".github/workflows/**"
       - ".github/actions/**"
   pull_request:
-    branches: [develop]
+    branches: [develop, main]
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -25,7 +25,7 @@ name: Containers
 
 on:
   push:
-    branches: [develop]
+    branches: [develop, main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ name: Docs
 
 on:
   push:
-    branches: [develop]     # redeploy dev docs + landing
+    branches: [develop, main]     # redeploy dev docs + landing
   pull_request:             # PR: build + lint + link-check ONLY (no deploy),
                             # and only when a site input changed (the `changes`
                             # gate below)

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -35,7 +35,7 @@ on:
     # `main` exists but nothing merges into it, so a `main` trigger analysed a
     # branch no work reaches and filed its revisions under a name the dashboard
     # never shows (#2777).
-    branches: [develop]
+    branches: [develop, main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/sandbox-deploy.yml
+++ b/.github/workflows/sandbox-deploy.yml
@@ -63,7 +63,7 @@ on:
         type: boolean
         default: true
   push:
-    branches: [develop]
+    branches: [develop, main]
     paths:
       - Dockerfile.vercel
       - vercel.json

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -42,7 +42,7 @@ on:
   schedule:
     - cron: '37 5 * * 1'
   push:
-    branches: [develop]
+    branches: [develop, main]
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -22,7 +22,7 @@ name: SonarQube Cloud
 
 on:
   push:
-    branches: [develop]
+    branches: [develop, main]
   pull_request:
     types: [opened, synchronize, reopened]
 
@@ -141,7 +141,7 @@ jobs:
         with:
           components: llvm-tools-preview
           cache-shared-key: sonar
-          cache-save-if: ${{ github.ref == 'refs/heads/develop' }}
+          cache-save-if: ${{ (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main') }}
       - uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc # v2.86.7
         with:
           tool: cargo-llvm-cov,cargo-nextest

--- a/scripts/checks/default-style.sh
+++ b/scripts/checks/default-style.sh
@@ -51,7 +51,7 @@ collect() {
   elif [[ "$#" -gt 0 ]]; then
     printf '%s\n' "$@"
   else
-    git diff --name-only origin/develop...HEAD -- '*.rs' 2>/dev/null || git ls-files '*.rs'
+    git diff --name-only origin/develop...HEAD -- '*.rs' 2>/dev/null || git diff --name-only origin/main...HEAD -- '*.rs' 2>/dev/null || git ls-files '*.rs'
   fi
 }
 

--- a/scripts/checks/docs-claims.sh
+++ b/scripts/checks/docs-claims.sh
@@ -74,6 +74,7 @@ collect() {
     printf '%s\n' "$@"
   else
     git diff --name-only origin/develop...HEAD -- "$BOOK/*.md" "$BOOK/**/*.md" 2>/dev/null \
+      || git diff --name-only origin/main...HEAD -- "$BOOK/*.md" "$BOOK/**/*.md" 2>/dev/null \
       || git ls-files "$BOOK/**/*.md" "$BOOK/*.md"
   fi
 }

--- a/scripts/checks/sql-string-building.sh
+++ b/scripts/checks/sql-string-building.sh
@@ -65,6 +65,7 @@ collect() {
   else
     # shellcheck disable=SC2086
     git diff --name-only origin/develop...HEAD -- $SCOPE 2>/dev/null ||
+      git diff --name-only origin/main...HEAD -- $SCOPE 2>/dev/null ||
       git ls-files -- $SCOPE
   fi
 }

--- a/scripts/checks/typed-status.sh
+++ b/scripts/checks/typed-status.sh
@@ -57,7 +57,7 @@ collect() {
   elif [[ "$#" -gt 0 ]]; then
     printf '%s\n' "$@"
   else
-    git diff --name-only origin/develop...HEAD -- '*.rs' 2>/dev/null || git ls-files '*.rs'
+    git diff --name-only origin/develop...HEAD -- '*.rs' 2>/dev/null || git diff --name-only origin/main...HEAD -- '*.rs' 2>/dev/null || git ls-files '*.rs'
   fi
 }
 


### PR DESCRIPTION
Step A1 of #2891 (PR 1 of 2): the dual-reference sweep that makes the tree valid on both branch names before the `develop` → `main` rename.

- Every branch-keyed workflow trigger becomes `branches: [develop, main]`: ci, containers, docs, sonar, codeql (push + PR), fossa, scorecard, sandbox-deploy.
- Every `github.ref == 'refs/heads/develop'` expression (the rust-cache `cache-save-if` sites and ci.yml's always-run-on-default-branch job condition) accepts either ref.
- The four diff-scoped guards (`typed-status`, `default-style`, `docs-claims`, `sql-string-building`) and the `crate_version_bump_guard` push hook try `origin/develop` first and fall back to `origin/main`, so they keep working in clones on either side of the rename. PR 2 (on `main`) removes the `develop` halves.

No user-visible change; `no-changelog`. Part of #2891 — does NOT close it.
