### PR TITLE
ci(release): committed chart appVersion equals the workspace version (compose treatment)

### DIFF
--- a/.claude/rules/changelog.md
+++ b/.claude/rules/changelog.md
@@ -36,7 +36,9 @@ optional:
   job (the hosted sandbox carries NO release-cut step since #2724: its
   `Dockerfile.vercel` tracks the `:latest` release pointer and
   `sandbox-deploy.yml` redeploys + reseeds it automatically after the tag's
-  Containers run — `deploy/vercel/README.md`), + the book's pinned versions — `website/book/src/installation/
+  Containers run — `deploy/vercel/README.md`), + the chart's `appVersion` and
+  `artifacthub.io/images` tags (#2890, the same sweep — details in the Helm
+  chart bullet below), + the book's pinned versions — `website/book/src/installation/
   kubernetes.md` pins the chart `--version` and `image.tag`, and
   `website/book/src/verifying-releases.md` pins the release tag and the image
   tags in its examples; `docs-claims` catches all of them, the chart/image pins
@@ -48,11 +50,12 @@ optional:
   version match is missing**. Releases publish as OFFICIAL
   releases — `prerelease` is true only for an explicitly suffixed tag
   (`vX.Y.Z-rc1`, ...) — owner sign-off 2026-07-31.
-- **The Helm chart, in the SAME release PR:** bump the chart's own `version` —
-  EVERY release, not only on chart diffs: since #2779 the packaged chart's
-  release facts (appVersion, image tags, changes) are injected at package
-  time, so every release ships a DISTINCT packaged chart, and an unbumped
-  version collides with refuse-overwrite at the tag (#2818 — the pipeline's
+- **The Helm chart, in the SAME release PR:** set `appVersion` and the
+  `artifacthub.io/images` tags to X.Y.Z (the sweep step below), and bump the
+  chart's own `version` — EVERY release, not only on chart diffs: every
+  release ships a DISTINCT packaged chart (the changes annotation is injected
+  at package time), and an unbumped version collides with refuse-overwrite at
+  the tag (#2818 — the pipeline's
   `plan` refuses that tag before anything builds). Then
   regenerate whatever that change moved — the golden renders
   (`deploy/helm/validate.sh --update`) and the generated chart README
@@ -60,21 +63,22 @@ optional:
   README.md.gotmpl`). The chart version and `appVersion` are INDEPENDENT SemVer
   lines and stay so.
 
-  **`appVersion` is NOT a cut step any more (#2779), and neither are the
-  `artifacthub.io/images` tags.** The publish lane injects both from the tag
-  (`helm package --app-version ${TAG#v}` plus
-  `deploy/helm/release-facts.sh`), the same way it has injected
-  `artifacthub.io/changes` since #2107 and for the same reason: they are facts
-  about a release, and a committed copy is stale from the next merge onwards.
-  What stays committed is a between-releases DEFAULT, held only to being a real
-  released version whose image annotations and generated README agree with it —
-  `scripts/checks/chart-appversion.sh`, run by the `chart-appversion` CI job and
-  again by the release pipeline's `plan` at the tagged commit. Refreshing that
-  default is ordinary maintenance, not a release step — but bounded maintenance
-  (#2804): the guard also refuses a default more than ONE stable release behind
-  the newest changelog section (rc sections never qualify), so the release PR
-  that cuts X.Y.Z needn't touch it, and the next one fails until it is
-  refreshed.
+  **`appVersion` is an ordinary cut step again (#2890, the compose
+  treatment):** the same release-PR sweep that bumps the docker-compose.yml
+  image tags sets the chart's `appVersion` and the `artifacthub.io/images`
+  tags to X.Y.Z, then regenerates the chart README. The committed value
+  equals the workspace version at all times —
+  `scripts/checks/chart-appversion.sh` enforces the equality (run by the
+  `chart-appversion` CI job and again by the release pipeline's `plan` at the
+  tagged commit, where plan's own tag-equals-workspace check makes it
+  transitively `appVersion == ${TAG#v}`). The publish lane's package-time
+  injection (`helm package --app-version ${TAG#v}` plus
+  `deploy/helm/release-facts.sh`, #2779) stays as belt-and-braces and is what
+  keeps the between-releases `publish-chart.yml` dispatch correct;
+  `artifacthub.io/changes` remains inject-only (#2107). The accepted cost is
+  the window docker-compose.yml has always accepted: between the release
+  merge and the tag's Containers leg, the committed tags reference images not
+  yet published.
 - **The chart publishes as the release pipeline's `chart` leg** (`build-chart.yml`,
   called by `release.yml` after the scanned tags apply; `publish-chart.yml` is
   the dispatch-only dry-run/recovery lane between releases): it refuses to

--- a/.claude/rules/kubernetes-helm.md
+++ b/.claude/rules/kubernetes-helm.md
@@ -194,8 +194,7 @@ evidence if it ran in an enforcing namespace — say which.
 | `values.schema.json` accepts/rejects | `validate.sh` `schema_gate`, `fixture_gate` |
 | Golden render drift | CI compare against `deploy/helm/golden/` |
 | Chart version bump on packaged-content change | `chart-version-guard` |
-| The committed `appVersion` names a released version, and the image annotations + generated README agree with it | `chart-appversion-guard` → `scripts/checks/chart-appversion.sh` (mutation-proven). The PUBLISHED appVersion and image tags are INJECTED at package time, not guarded in the tree — #2779 |
-| The committed `appVersion` is FRESH: one of the two newest STABLE releases (an rc never qualifies) | the same guard, property 5 (#2804, mutation-proven). One-stable-behind is the deliberate slack that keeps #2779: the cutting release PR needn't refresh, the one after it fails until someone does — a deterministic guard, not a scheduled watcher |
+| The committed `appVersion` equals the workspace version, and the image annotations + generated README agree with it | `chart-appversion-guard` → `scripts/checks/chart-appversion.sh` (#2890, mutation-proven). The release PR bumps it in the same sweep as the compose tags; the package-time injection (#2779) stays as belt-and-braces for the release leg and the dispatch recovery lane |
 | Field-vs-`kubeVersion` availability | **review-enforced** — no tool knows which fields a manifest uses; §1 is the procedure |
 | Applied posture, admission, readiness gating, secret reads | `scripts/deploy-probe-k8s.sh` — observed on a live cluster, machine-readable record |
 | Live behaviour beyond those probes | **review-enforced** — the `/k8s-test` skill is the procedure; the PR quotes observations |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,14 +186,13 @@ jobs:
       # released. Each of these guards exists because its site shipped stale
       # once; they ran on pull requests only, so a cut whose main CI run was
       # cancelled re-verified nothing.
-      # NOT equality with the released version any more (#2779): the chart leg
-      # packages with `helm package --app-version ${TAG#v}` and rewrites the
-      # `artifacthub.io/images` tags at the same moment, so the PUBLISHED chart
-      # carries the released version whatever the tree says. What is still
-      # checked is what still has content — that the committed default names a
-      # version this project released, that the image annotation agrees with it,
-      # and that no injected annotation is committed. One script, so this and the
-      # `chart-appversion` CI job cannot drift apart (they were two copies).
+      # The committed appVersion equals the workspace version (#2890, the
+      # compose treatment), and this plan job has already asserted the tag
+      # equals the workspace version above — so re-running the guard here
+      # transitively pins appVersion == ${TAG#v}. The chart leg's
+      # `helm package --app-version ${TAG#v}` injection stays as belt-and-braces
+      # and keeps the between-releases dispatch lane correct. One script, so
+      # this and the `chart-appversion` CI job cannot drift apart.
       - name: The committed chart release facts are coherent
         run: bash scripts/checks/chart-appversion.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ workflow refuses a tag that has no matching section here.
 
 ### Changed
 
+- The Helm chart's committed `appVersion` now always equals the product
+  version, bumped in every release PR beside the compose image tags (chart
+  6.0.27). Published charts are unchanged — the release pipeline keeps
+  injecting the released version at package time — but a from-tree
+  `helm install` now defaults to the current version instead of a release
+  that could lag by one.
 - The repository's default branch is now `main` (renamed from `develop`;
   full history preserved, old GitHub URLs redirect). The moving development
   image tag follows the branch: pull `ghcr.io/rubentalstra/ferroehr:main`

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -19,24 +19,20 @@ type: application
 # A published OCI version is immutable by refusal rather than by the registry —
 # `helm push` over an existing tag replaces it silently — so a correction always
 # ships as a NEW version and the published one stands as it was.
-version: 6.0.26
-# The DEFAULT container image tag (overridable via image.tag) — no longer a
-# per-release fact (#2779).
+version: 6.0.27
+# The DEFAULT container image tag (overridable via image.tag). Equals the
+# workspace version in Cargo.toml, bumped in the release PR beside the
+# docker-compose.yml image tags — one version sweep, the compose treatment
+# (#2890; scripts/checks/chart-appversion.sh enforces the equality). The
+# publish lane still injects `helm package --app-version ${TAG#v}` and rewrites
+# the `artifacthub.io/images` tags below at package time (#2779) — the same
+# value the tree now carries for a release, and what keeps the between-releases
+# `publish-chart.yml` dispatch correct.
 #
-# A published chart's appVersion is injected at package time, from the tag being
-# released: `helm package --app-version ${TAG#v}`, beside the rewrite of the
-# `artifacthub.io/images` tags below and the `artifacthub.io/changes` injection
-# that has worked this way since #2107. The argument is the same for all three —
-# they are facts about a release, and a committed copy is stale from the next
-# merge onwards. So a release cut edits none of them, and the published chart is
-# correct whatever this line says.
-#
-# What this line therefore IS: the default for a chart packaged OUTSIDE a release
-# (the between-releases `publish-chart.yml` dispatch) and for anyone running
-# `helm template` or `helm install` against this directory. It names the most
-# recent release it was refreshed at and may lag; what it may NOT do is name a
-# version this project never released, which is what
-# scripts/checks/chart-appversion.sh holds it to (CHANGELOG.md is the authority).
+# The accepted window (adjudicated on #2890): between a release PR's merge and
+# the tag's Containers leg publishing the images, a from-tree install
+# references tags that do not exist yet — the window docker-compose.yml has
+# always accepted.
 #
 # It is NOT a promise that this tag accepts the chart's current `config`
 # defaults: values track development between releases, so the publish lane

--- a/deploy/helm/ferroehr/README.md
+++ b/deploy/helm/ferroehr/README.md
@@ -2,7 +2,7 @@
 
 Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.1.0 + AQL 1.1). A single static binary deployed with a hardened-by-default security posture: runs as a non-root, read-only-rootfs workload whose NetworkPolicy admits its serving port only, and that connects to an EXTERNAL PostgreSQL 18 as an unprivileged app role (migrations are run out of band by a separate migrator role).
 
-![Version: 6.0.26](https://img.shields.io/badge/Version-6.0.26-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.9](https://img.shields.io/badge/AppVersion-4.0.9-informational?style=flat-square)
+![Version: 6.0.27](https://img.shields.io/badge/Version-6.0.27-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.9](https://img.shields.io/badge/AppVersion-4.0.9-informational?style=flat-square)
 
 FerroEHR is a pure-Rust openEHR Clinical Data Repository: ITS-REST 1.1.0 at the
 API, AQL 1.1 as the query language, PostgreSQL 18-native storage, shipped as a
@@ -33,7 +33,7 @@ to add; `helm repo add` does not apply to this chart:
 
 ```console
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 6.0.26 \
+  --version 6.0.27 \
   --namespace ferroehr --create-namespace \
   --set database.existingSecret=ferroehr-db \
   --set image.tag=4.0.9
@@ -47,7 +47,7 @@ They are independent SemVer lines and they move independently:
 
 | What | Set with | This release |
 |---|---|---|
-| the **chart** (templates, defaults, this document) | `--version` | `6.0.26` |
+| the **chart** (templates, defaults, this document) | `--version` | `6.0.27` |
 | the **server image** | `image.tag` | `4.0.9` |
 
 `appVersion` is the image the chart defaults to; pinning `image.tag` explicitly
@@ -59,7 +59,7 @@ The chart carries two keyless Sigstore artifacts, and they answer different
 questions. A **cosign signature:** who signed this:
 
 ```console
-cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.26 \
+cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.27 \
   --certificate-identity-regexp '^https://github\.com/rubentalstra/FerroEHR/\.github/workflows/publish-chart\.yml@' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
@@ -67,7 +67,7 @@ cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.26 \
 A **SLSA build provenance attestation:** what source it was built from, and how:
 
 ```console
-gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:6.0.26 \
+gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:6.0.27 \
   -R rubentalstra/FerroEHR
 gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:4.0.9 \
   -R rubentalstra/FerroEHR

--- a/deploy/helm/golden/admin-ui.yaml
+++ b/deploy/helm/golden/admin-ui.yaml
@@ -18,7 +18,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the admin console: only its HTTP port, but from EVERY source — this policy narrows ports, NOT sources (adminUi.networkPolicy.ingressAllowAll=true). Set adminUi.networkPolicy.ingressFrom for a PHI workload. Egress admits the CDR Service and DNS only.
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -90,7 +90,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -118,7 +118,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -139,7 +139,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr-admin-ui
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -154,7 +154,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -184,7 +184,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -201,7 +201,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -332,7 +332,7 @@ metadata:
     kubernetes.io/description: >-
       In-cluster address for the FerroEHR admin console. The console is a REST client of the CDR and holds no data of its own; it is the human-facing surface, so this is the Service an Ingress normally publishes.
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -355,7 +355,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -385,7 +385,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR admin console: a Leptos SSR web UI that consumes the CDR strictly over ITS-REST. It never reaches the database, which the console NetworkPolicy enforces rather than assumes.
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -492,7 +492,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), and only from the networkPolicy.ingressFrom peers.
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -97,7 +97,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -118,7 +118,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -150,7 +150,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -176,7 +176,7 @@ kind: Secret
 metadata:
   name: ferroehr-config
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -197,7 +197,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -401,7 +401,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr-grafana-dashboard
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -652,7 +652,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -686,7 +686,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -919,7 +919,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -953,7 +953,7 @@ kind: Ingress
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -991,7 +991,7 @@ kind: ServiceMonitor
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"

--- a/deploy/helm/golden/basic-auth.yaml
+++ b/deploy/helm/golden/basic-auth.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -51,7 +51,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -72,7 +72,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -102,7 +102,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -119,7 +119,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -247,7 +247,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -277,7 +277,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -51,7 +51,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -72,7 +72,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -87,7 +87,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -212,7 +212,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"
@@ -242,7 +242,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.26
+    helm.sh/chart: ferroehr-6.0.27
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.9"

--- a/scripts/checks/chart-appversion.sh
+++ b/scripts/checks/chart-appversion.sh
@@ -2,70 +2,55 @@
 # SPDX-FileCopyrightText: FerroEHR contributors
 # SPDX-License-Identifier: MIT
 #
-# scripts/checks/chart-appversion.sh — what the chart's COMMITTED release facts
-# still have to be true about, now that the published ones are injected (#2779).
+# scripts/checks/chart-appversion.sh — the committed chart release facts track
+# the workspace version, the compose treatment (#2890).
 #
-# Until #2779, `appVersion` and the `artifacthub.io/images` tags were per-release
-# facts kept equal to the workspace version by hand at every cut, and guarded in
-# three places. They are not per-release facts any more: `build-chart.yml`
-# packages with `helm package --app-version <released version>` and rewrites the
-# image annotation's tags at the same moment, exactly as it already injects
-# `artifacthub.io/changes` — "facts about a release, and a committed copy would
-# be stale from the next merge onwards". So the PUBLISHED chart is correct by
-# construction and no longer depends on the tree at all.
+# The committed `appVersion` equals the workspace version in Cargo.toml, bumped
+# in the release PR beside the docker-compose.yml image tags — one sweep, one
+# philosophy for both committed artifacts. The publish lane still injects
+# `--app-version ${TAG#v}` and rewrites the `artifacthub.io/images` tags at
+# package time (#2779); since the tree now carries the same value, the
+# injection is belt-and-braces for the release leg and remains what makes the
+# dispatch-driven `publish-chart.yml` recovery lane correct between releases.
 #
-# What the committed values still ARE: the defaults for a chart packaged OUTSIDE
-# a release — the between-releases `publish-chart.yml` dispatch — and for anyone
-# who runs `helm template`/`helm install` against this directory. That leaves
-# three properties with real content, and this script is the one home for them:
+# The one accepted cost (adjudicated on #2890, the same window the compose
+# defaults have always accepted): between a release PR's merge and the tag's
+# Containers leg publishing the X.Y.Z images, a from-tree `helm install`
+# references image tags that do not exist yet. The window is ~30-60 minutes,
+# exists only during a cut, and buys a tree whose committed versions never lag.
 #
-#   1. `appVersion` names a version this project has actually RELEASED. A default
-#      image tag that was never published produces an ImagePullBackOff, and a
-#      future version is a promise the registry cannot keep. CHANGELOG.md is the
-#      machine authority: a released version has a `## [X.Y.Z]` section.
+# Four properties, each with real content:
+#
+#   1. `appVersion` equals the workspace version (Cargo.toml is the authority,
+#      the same source compose-image-tags.sh reads). A lagging default ships a
+#      chart whose images predate the tree's own configuration vocabulary; a
+#      diverging one means the release sweep missed a site.
 #   2. Every `artifacthub.io/images` tag equals `appVersion`. The two describe
-#      one thing — the product version this chart defaults to — and the injection
-#      rewrites both from one input, so a tree where they already disagree would
-#      publish an annotation the package's own appVersion contradicts.
+#      one thing — the product version this chart defaults to — and the
+#      package-time injection rewrites both from one input, so a tree where
+#      they disagree would publish an annotation the package's own appVersion
+#      contradicts.
 #   3. Chart.yaml carries NONE of the injected annotations. A committed
 #      `artifacthub.io/changes`, `containsSecurityUpdates` or `prerelease` key
 #      would collide with the injected one and leave the packaged metadata
 #      depending on YAML key-collision behaviour.
 #   4. The chart README — a GENERATED file, and the one Artifact Hub renders as
 #      the package front page — restates the same appVersion. It is generated
-#      FROM Chart.yaml, so a disagreement means it was never regenerated, and
-#      the injection has nothing to move: the v4.0.5 cut left it a release
-#      behind (6.0.19/4.0.4 against a 6.0.20/4.0.5 chart) and only a local
-#      `deploy/helm/validate.sh` noticed, because the CI drift check skips
-#      itself when helm-docs is not installed on the runner.
-#   5. `appVersion` is FRESH: one of the two newest STABLE releases in
-#      CHANGELOG.md (#2804). With the cut no longer bumping it (#2779), nothing
-#      moved the committed default and the gap between it and the tree's
-#      advancing `config` defaults grew unboundedly, unseen by any lane
-#      (chart-boot overrides the image; the dispatch judge uses sha-/main).
-#      "One stable behind" is the deliberate slack that keeps #2779's design:
-#      the release PR that cuts X.Y.Z does NOT have to refresh (that would
-#      re-impose the hand edit), but the one after it fails here until someone
-#      does — bounded lag, enforced by the guard tier that already runs,
-#      instead of a scheduled watcher filing issues. Stable sections only:
-#      an -rc default would hand production installs a pre-release image, so
-#      an rc never satisfies this arm even though property 1 accepts it as
-#      "released".
-#
-# What is deliberately NOT checked here any more: equality with the workspace
-# version. Asserting it would re-impose the hand edit this change removes.
+#      FROM Chart.yaml, so a disagreement means it was never regenerated.
 #
 # Usage: scripts/checks/chart-appversion.sh
 # Callers: the `chart-appversion` job in ci.yml, and the `plan` job of
-# release.yml (which re-runs the whole guard tier at the tagged commit).
+# release.yml (which re-runs the whole guard tier at the tagged commit; plan
+# separately asserts the tag equals the workspace version, so property 1 there
+# transitively pins appVersion == ${TAG#v}).
 
 set -euo pipefail
 cd "$(dirname "$0")/../.."
 
 CHART=deploy/helm/ferroehr/Chart.yaml
-CHANGELOG=CHANGELOG.md
+MANIFEST=Cargo.toml
 
-for required in "$CHART" "$CHANGELOG"; do
+for required in "$CHART" "$MANIFEST"; do
   [[ -f "$required" ]] || { echo "::error::missing $required" >&2; exit 1; }
 done
 
@@ -81,20 +66,15 @@ if [[ -z "$app" ]]; then
   exit 1
 fi
 
-# 1. A released version, per the changelog.
-if ! grep -qE "^## \[${app//./\\.}\]" "$CHANGELOG"; then
-  report "$CHART appVersion is $app, which has no '## [$app]' section in $CHANGELOG — the committed appVersion is the default image tag for a chart packaged outside a release, so it must name a version that was actually published. (A release no longer needs to bump it: build-chart.yml injects the released version with 'helm package --app-version'.)"
+workspace=$(sed -nE 's/^version = "(.*)"$/\1/p' "$MANIFEST" | head -1)
+if [[ -z "$workspace" ]]; then
+  report "could not read the workspace version from $MANIFEST."
+  exit 1
 fi
 
-# 5. Fresh: one of the two newest stable releases (rc/pre-release sections are
-#    skipped — a suffixed default would hand production installs a pre-release).
-stable=$(grep -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' "$CHANGELOG" | head -2 | tr -d '[]# ')
-stable1=$(printf '%s\n' "$stable" | sed -n 1p)
-stable2=$(printf '%s\n' "$stable" | sed -n 2p)
-if [[ -z "$stable1" ]]; then
-  report "$CHANGELOG has no stable '## [X.Y.Z]' section to hold the appVersion against."
-elif [[ "$app" != "$stable1" && "$app" != "$stable2" ]]; then
-  report "$CHART appVersion is $app, but the two newest stable releases are ${stable1} and ${stable2:-—}. The committed default may lag the newest cut by at most one stable release (#2804) — refresh it (appVersion + the artifacthub.io/images tags + the generated README: helm-docs --chart-search-root deploy/helm/ferroehr --template-files README.md.gotmpl)."
+# 1. appVersion equals the workspace version (the compose-image-tags contract).
+if [[ "$app" != "$workspace" ]]; then
+  report "$CHART appVersion is $app but the workspace version is $workspace — the release cut bumps appVersion beside the compose image tags (one version sweep, .claude/rules/changelog.md). Refresh appVersion + the artifacthub.io/images tags + the generated README: helm-docs --chart-search-root deploy/helm/ferroehr --template-files README.md.gotmpl"
 fi
 
 # 2. The image annotation agrees with it.
@@ -127,4 +107,4 @@ fi
 if [[ "$failures" -gt 0 ]]; then
   exit 1
 fi
-echo "chart-appversion: appVersion $app is a stable release at most one behind the newest ($stable1), the artifacthub.io/images tags and the generated README agree with it, and no injected annotation is committed — OK."
+echo "chart-appversion: appVersion $app equals the workspace version, the artifacthub.io/images tags and the generated README agree with it, and no injected annotation is committed — OK."

--- a/website/book/src/installation/kubernetes.md
+++ b/website/book/src/installation/kubernetes.md
@@ -38,7 +38,7 @@ kubectl -n ferroehr create secret generic ferroehr-db \
   --from-literal=FERROEHR__DB__URL='postgres://ferroehr_app:***@pg-host:5432/ferroehr?sslmode=verify-full'
 
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 6.0.26 -n ferroehr \
+  --version 6.0.27 -n ferroehr \
   --set database.existingSecret=ferroehr-db \
   --set image.tag=4.0.9
 ```
@@ -55,7 +55,7 @@ helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
 reference. To read the chart's metadata without installing it:
 
 ```shell
-helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.26
+helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.27
 ```
 
 ### Pin two versions, not one
@@ -68,7 +68,7 @@ against.
 
 | | Selects | Pin with | Line |
 |---|---|---|---|
-| Chart version | templates, values schema, defaults | `--version 6.0.26` | SemVer over the chart's own contract |
+| Chart version | templates, values schema, defaults | `--version 6.0.27` | SemVer over the chart's own contract |
 | Image tag | the server binary | `--set image.tag=4.0.9` (or `image.digest`) | the application's SemVer line |
 
 Always pin the image to an immutable version or, better, a `@sha256` digest,
@@ -167,7 +167,7 @@ metadata lists: the server, and the optional admin console.
 > the image itself as the authority:
 >
 > ```shell
-> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.26 \
+> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.27 \
 >   -s templates/configmap.yaml --set database.existingSecret=ferroehr-db \
 >   | sed -n '/ferroehr.toml/,$p' | sed '1d;s/^    //' > /tmp/ferroehr.toml
 > docker run --rm -v /tmp/ferroehr.toml:/etc/ferroehr/ferroehr.toml:ro \
@@ -556,7 +556,7 @@ config:
 
 ```shell
 helm upgrade ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 6.0.26 -n ferroehr --reuse-values \
+  --version 6.0.27 -n ferroehr --reuse-values \
   --set config.query.plan_cache_capacity=512
 ```
 
@@ -709,7 +709,7 @@ Preview an upgrade against what you have installed with
 `helm diff`, or render the new chart version and read it:
 
 ```shell
-helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.26 \
+helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.27 \
   -n ferroehr -f my-values.yaml | less
 ```
 


### PR DESCRIPTION
Closes #2890.

The committed chart `appVersion` now equals the workspace version, bumped in every release PR beside the docker-compose.yml image tags — one version sweep, one philosophy for both committed artifacts. The permanently-lagging tree, the "at most one behind" freshness bound (#2804), and the per-cut explanation all go away.

- `scripts/checks/chart-appversion.sh`: property 1 becomes equality with the workspace version (Cargo.toml, the same source `compose-image-tags.sh` reads); the released-in-changelog and freshness properties are gone; the annotation-agreement, no-injected-annotation and generated-README properties stay. Mutation-proven in both directions, unpiped exits: lagging appVersion → 1, mismatched images tag → 1, committed injected annotation → 1, stale README → 1, clean tree → 0.
- `release.yml` `plan`: re-running the guard at the tagged commit now transitively pins `appVersion == ${TAG#v}` (plan already asserts the tag equals the workspace version); the step comment states that.
- The chart leg's `helm package --app-version ${TAG#v}` injection stays as belt-and-braces and remains what keeps the dispatch-driven `publish-chart.yml` recovery lane correct — writes the same value the tree now carries.
- The adjudicated accepted cost is recorded in the guard header and Chart.yaml: between a release merge and its Containers leg, a from-tree install references images not yet published — the identical ~30-60-minute window the compose defaults have always accepted. The fallback design (a post-release automated fact-sync PR) was not needed; the issue's own target design is the pick.
- `.claude/rules/changelog.md`: appVersion is an ordinary cut step again (one sweep line beside the compose tags); the #2779 carve-out and the #2804 freshness paragraph are deleted. `.claude/rules/kubernetes-helm.md`: the two appVersion register rows collapse into the one equality row.
- Chart.yaml comment rewritten to the new contract; chart `version` 6.0.26 → 6.0.27 (packaged comments changed), README + goldens regenerated, the book's chart pin follows.

Gates: chart-appversion (clean + 4 mutations), compose-image-tags, actionlint (CI opts), shellcheck, docs-claims --all, helm validate — all green. Changelog entry added.
