### PR TITLE
ci(cache): ui-e2e-console cache key covers scripts/cargo-leptos.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1494,7 +1494,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ui-e2e-console-stage
-          key: ui-e2e-console-1.97.1-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', '.cargo/**', 'crates/**', 'app/ferroehr-admin-ui/**') }}
+          key: ui-e2e-console-1.97.1-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', '.cargo/**', 'crates/**', 'app/ferroehr-admin-ui/**', 'scripts/cargo-leptos.sh') }}
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         if: steps.console-cache.outputs.cache-hit != 'true'
         with:


### PR DESCRIPTION
Closes #2884.

The `ui-e2e-console` job's exact-key cache covers everything the staged console build reads, except the `scripts/cargo-leptos.sh` wrapper the build step itself invokes (found at #2881). Today the wrapper only gates cargo-lock behaviour, so the omission was harmless — but a future wrapper change that shapes what gets staged would hit a stale cache silently. The wrapper joins the `hashFiles` list.

No user-visible change: `no-changelog`.