### PR TITLE
chore(docker): CARGO_BUILD_JOBS=2 stays the default — adjudicated, with the one-variable escape documented

### DIFF
--- a/docker/admin-ui/Dockerfile
+++ b/docker/admin-ui/Dockerfile
@@ -96,7 +96,12 @@ COPY . .
 ENV LEPTOS_TAILWIND_VERSION=${TAILWIND_VERSION}
 # Serial-compile escape hatch for memory-constrained hosts, same knob as
 # docker/Dockerfile (cargo reads CARGO_BUILD_JOBS from the environment —
-# doc.rust-lang.org/cargo/reference/environment-variables.html).
+# doc.rust-lang.org/cargo/reference/environment-variables.html). The default
+# stays 2 (adjudicated on #2883): every CI lane builds at 2, and jobs=1 would
+# roughly double every build to spare the rare constrained host. A cold build
+# OOM-killed rustc at 2 on an 8-core/24 GB arm64 host that was also running a
+# stack (#2881); `CARGO_BUILD_JOBS=1 docker compose … build` completed there —
+# the compose dev overlay forwards the variable.
 ARG CARGO_BUILD_JOBS=2
 ENV CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS}
 # `cargo leptos` reads its configuration from the console crate's own manifest

--- a/website/book/src/installation/compose.md
+++ b/website/book/src/installation/compose.md
@@ -423,6 +423,17 @@ Downloaders of the standalone quickstart file never see any of this; it is
 purely a convenience for working on FerroEHR itself, and it only ever
 applies when its `-f` is passed — nothing merges it in silently.
 
+> [!TIP]
+> A cold from-source build compiles at two parallel rustc jobs by default,
+> and a release-optimization compile can hold several gigabytes per job. If
+> the build gets OOM-killed on a memory-constrained host (observed on a
+> 24 GB machine that was also running another stack), rerun it serially —
+> slower, but it completes:
+>
+> ```shell
+> CARGO_BUILD_JOBS=1 docker compose -f docker-compose.yml -f docker-compose.dev.yml build
+> ```
+
 ## Build provenance
 
 Images built by CI (and any `docker compose build` you drive from a checkout)


### PR DESCRIPTION
Closes #2883.

Adjudication: the from-source builder default stays `CARGO_BUILD_JOBS=2`. Every CI lane builds at 2, and lowering the default to 1 would roughly double every build to spare the rare memory-constrained host. The measured hit (#2881: a cold build OOM-killed rustc on an 8-core/24 GB arm64 host that was also running a stack; jobs=1 completed) is recorded at the knob in `docker/admin-ui/Dockerfile`, and the one-variable escape — `CARGO_BUILD_JOBS=1 docker compose -f docker-compose.yml -f docker-compose.dev.yml build`, forwarded by the dev overlay's build args — is documented where compose users hit it: the Dockerfile comment and the book's compose page (Repository development section). `docker/Dockerfile` already carried the same escape note.

Book page updated in the same PR per the docs rule; changelog: docs/tooling only, `no-changelog`.