### PR TITLE
chore(build): the __eh_frame-too-large linker warning is adjudicated — accepted with the record at the profile table

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -404,6 +404,13 @@ criterion = { version = "0.8.2", features = ["html_reports"] }
 # code; dependencies get none (their debuginfo is never read in this repo).
 [profile.dev]
 debug = "line-tables-only"
+# rustc's `linker_messages` lint surfaces Apple ld's "__eh_frame section too
+# large (max 16MB)" compact-unwind fallback on every macOS dev/test link of
+# the big app binaries. Accepted (#2866): unwinding stays correct via the
+# dwarf tables and only panic-path speed is affected, while the levers that
+# would shrink the section (optimizing test builds, splitting test binaries)
+# cost every local test cycle or break the one-binary-per-crate rule. Never
+# answer it by allowing `linker_messages` workspace-wide.
 
 [profile.dev.package."*"]
 debug = false


### PR DESCRIPTION
Closes #2866.

Reproduced first-hand: every macOS test link of the app crates prints `ld: __eh_frame section too large (max 16MB) to encode dwarf unwind offsets in compact unwind table` via rustc's default-on `linker_messages` lint (measured on `cargo test -p ferroehr-server --no-run`: the `it` test binary and the `ferroehr` bin both warn).

**Adjudication: accepted, with the record beside `[profile.dev]` in the root Cargo.toml.**

- The warning is Apple ld falling back from the compact-unwind encoding to full dwarf unwind tables because the unoptimized dev/test binaries carry more than 16 MB of unwind entries. Unwinding remains fully correct — only exception-path (panic) speed is affected, immaterial for test binaries whose panics are assertion failures. Linux CI links ELF and never sees it.
- The levers were weighed and rejected: optimizing test builds shrinks the section but taxes every local test cycle for a cosmetic warning; splitting test binaries is banned by the one-integration-binary-per-crate rule; debug settings don't move it (eh_frame is unwind data, not debuginfo — the dev profile already carries `line-tables-only`).
- The lint is NOT turned off: `linker_messages` stays on (it surfaces real linker failures), and the record forbids the blind workspace-wide allow.

macOS-local link noise, CI-invisible; `no-changelog`.