### PR TITLE
feat(aql): FOLDER CONTAINS FOLDER unites the by-value subtree with items-referenced versioned folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ workflow refuses a tag that has no matching section here.
 
 ### Changed
 
+- AQL `FOLDER f1 CONTAINS FOLDER f2` now also matches the folders of a
+  `VERSIONED_FOLDER` that a folder's `items` reference — the same
+  reference-resolution ground as `FOLDER CONTAINS COMPOSITION`, one
+  reference hop (chain `CONTAINS` to follow further hops). Strict
+  sub-folder matching is unchanged.
 - The Helm chart's committed `appVersion` now always equals the product
   version, bumped in every release PR beside the compose image tags (chart
   6.0.27). Published charts are unchanged — the release pipeline keeps

--- a/app/ferroehr/src/aql/sql/from.rs
+++ b/app/ferroehr/src/aql/sql/from.rs
@@ -55,10 +55,14 @@ enum EdgeKind {
     /// common master05 — folders hold *references* to versioned objects; RM
     /// ehr master04 §Folders). The child opens its own version group.
     FolderItems,
-    /// `FOLDER CONTAINS FOLDER`: the by-value `folders` nesting inside one
-    /// versioned folder tree — a STRICT descendant interval, or the same-typed
-    /// pair matches itself.
-    FolderSubtree,
+    /// `FOLDER CONTAINS FOLDER`: the union of the by-value `folders` nesting
+    /// (a STRICT descendant interval — the inclusive join would self-match
+    /// every folder row) and an items-referenced `VERSIONED_FOLDER`'s folder
+    /// rows (RM common master05: `items` references name versioned objects
+    /// "logically in this folder", with no target-type restriction — the same
+    /// ground as `FolderItems`; one reference hop, adjudicated on #2887). The
+    /// child opens its own version group either way.
+    FolderChild,
 }
 
 /// Classifies a `CONTAINS` edge, or refuses a pair the RM defines no
@@ -75,7 +79,7 @@ fn classify_edge(
     let child_all_folder = child.names().iter().all(|t| t == "FOLDER");
     let child_no_folder = !child.names().iter().any(|t| t == "FOLDER");
     match (parent_all_folder, child_all_folder, child_no_folder) {
-        (true, true, _) => Ok(EdgeKind::FolderSubtree),
+        (true, true, _) => Ok(EdgeKind::FolderChild),
         (true, _, true) => Ok(EdgeKind::FolderItems),
         _ => Err(crate::aql::error::AqlFeatureError::UnsupportedContainment(
             parent.names().join("|"),
@@ -108,6 +112,18 @@ fn folder_items_exists(parent_node: &str, child_node: &str) -> Expr {
         [col(&sf, "data"), col(child_node, "vo_id")],
     ));
     Expr::exists(sub)
+}
+
+/// The by-value half of the `FOLDER CONTAINS FOLDER` union edge (#2887): the
+/// child row is a STRICT nested-set descendant of the parent row inside the
+/// same versioned folder tree (same `(vo_id, sys_version)`; strict, because
+/// the inclusive interval would self-match every folder row).
+fn folder_by_value_child(parent_node: &str, child_node: &str) -> Expr {
+    col(child_node, "vo_id")
+        .eq(col(parent_node, "vo_id"))
+        .and(col(child_node, "sys_version").eq(col(parent_node, "sys_version")))
+        .and(col(child_node, "num").gt(col(parent_node, "num")))
+        .and(col(child_node, "num").lte(col(parent_node, "num_cap")))
 }
 
 /// The streaming-shape plan: the linear containment chain eligible for the
@@ -653,25 +669,14 @@ impl Builder<'_> {
             None => None,
         };
 
-        if let (Some(EdgeKind::Structural | EdgeKind::FolderSubtree), Some(parent)) = (edge, vo) {
+        if let (Some(EdgeKind::Structural), Some(parent)) = (edge, vo) {
             self.q
                 .and_where(col(&node, "vo_id").eq(col(&parent.node, "vo_id")));
             self.q
                 .and_where(col(&node, "sys_version").eq(col(&parent.node, "sys_version")));
-            if edge == Some(EdgeKind::FolderSubtree) {
-                // STRICT descendant: a folder trivially sits in its own
-                // inclusive interval, so `FOLDER CONTAINS FOLDER` with the
-                // inclusive join would self-match every folder row.
-                self.q
-                    .and_where(col(&node, "num").gt(col(&parent.node, "num")));
-                self.q
-                    .and_where(col(&node, "num").lte(col(&parent.node, "num_cap")));
-            } else {
-                self.q.and_where(
-                    col(&node, "num")
-                        .between(col(&parent.node, "num"), col(&parent.node, "num_cap")),
-                );
-            }
+            self.q.and_where(
+                col(&node, "num").between(col(&parent.node, "num"), col(&parent.node, "num_cap")),
+            );
             Ok(VoGroup {
                 node,
                 vo: parent.vo.clone(),
@@ -708,6 +713,17 @@ impl Builder<'_> {
             // references to versioned objects).
             if let (Some(EdgeKind::FolderItems), Some(parent)) = (edge, vo) {
                 self.q.and_where(folder_items_exists(&parent.node, &node));
+            }
+            // FolderChild: the union edge (#2887) — a by-value strict
+            // descendant in the parent's own tree, or any folder row of an
+            // items-referenced VERSIONED_FOLDER. The child's own version
+            // group serves both branches: in the by-value branch the child's
+            // spine row IS the parent's (same vo_id + sys_version).
+            if let (Some(EdgeKind::FolderChild), Some(parent)) = (edge, vo) {
+                self.q.and_where(
+                    folder_by_value_child(&parent.node, &node)
+                        .or(folder_items_exists(&parent.node, &node)),
+                );
             }
             Ok(VoGroup {
                 node,
@@ -788,11 +804,35 @@ impl Builder<'_> {
                             col(alias, "num").between(col(parent, "num"), col(parent, "num_cap")),
                         );
                     }
-                    EdgeKind::FolderSubtree => {
-                        sub.and_where(col(alias, "vo_id").eq(col(parent, "vo_id")));
-                        sub.and_where(col(alias, "sys_version").eq(col(parent, "sys_version")));
-                        sub.and_where(col(alias, "num").gt(col(parent, "num")));
-                        sub.and_where(col(alias, "num").lte(col(parent, "num_cap")));
+                    EdgeKind::FolderChild => {
+                        // The union edge (#2887): a by-value strict
+                        // descendant, or any folder row of an items-referenced
+                        // VERSIONED_FOLDER — the latter needs the child's own
+                        // version spine + scope (the FolderItems shape below;
+                        // by-value rows satisfy it too, sharing the parent's
+                        // spine row).
+                        let voa = format!("xv{}", self.next_ctr());
+                        sub.from_as(VoVersion::Table, Alias::new(voa.as_str()));
+                        sub.and_where(col(alias, "vo_id").eq(col(&voa, "vo_id")));
+                        sub.and_where(col(alias, "sys_version").eq(col(&voa, "sys_version")));
+                        match scope {
+                            VersionScope::Latest => {
+                                sub.and_where(call("upper_inf", vec![col(&voa, "sys_period")]));
+                                sub.and_where(col(&voa, "branch_number").eq(Expr::val(0)));
+                            }
+                            VersionScope::All => {}
+                            VersionScope::Predicate(_) => {
+                                return Err(SqlError::Unsupported(
+                                    "a version predicate on an OR/NOT-CONTAINS branch VO"
+                                        .to_owned(),
+                                )
+                                .into());
+                            }
+                        }
+                        sub.and_where(
+                            folder_by_value_child(parent, alias)
+                                .or(folder_items_exists(parent, alias)),
+                        );
                     }
                     EdgeKind::FolderItems => {
                         // The child is its own versioned object: bind its

--- a/app/ferroehr/tests/it/aql_planner.rs
+++ b/app/ferroehr/tests/it/aql_planner.rs
@@ -1591,20 +1591,26 @@ fn folder_contains_composition_resolves_items_refs() {
     );
 }
 
-/// `FOLDER CONTAINS FOLDER` is the by-value `folders` nesting inside one
-/// versioned folder tree — a STRICT descendant interval, or every folder
-/// would trivially contain itself.
+/// `FOLDER CONTAINS FOLDER` is the union edge (#2887): a by-value STRICT
+/// descendant (or every folder would trivially contain itself) OR any folder
+/// row of an items-referenced `VERSIONED_FOLDER` (RM common master05 — the
+/// `items` references name versioned objects "logically in this folder",
+/// with no target-type restriction).
 #[test]
-fn folder_contains_folder_is_a_strict_descendant() {
+fn folder_contains_folder_unites_subtree_and_items_reference() {
     let sql = build_sql("SELECT f2/name/value FROM EHR e CONTAINS FOLDER f1 CONTAINS FOLDER f2");
     assert!(
         sql.contains(r#""n2"."num" > "n1"."num""#)
             && sql.contains(r#""n2"."num" <= "n1"."num_cap""#),
-        "strict interval, no self-pair: {sql}"
+        "the by-value branch is a strict interval, no self-pair: {sql}"
     );
     assert!(
-        !sql.contains("BETWEEN"),
-        "the inclusive self-matching interval is gone: {sql}"
+        sql.contains(") OR EXISTS") || sql.contains(") OR (EXISTS"),
+        "the by-value branch is united with the items-reference branch: {sql}"
+    );
+    assert!(
+        sql.contains("jsonb_array_elements") && sql.contains("'items'"),
+        "the reference branch is the items lookup: {sql}"
     );
 }
 

--- a/app/ferroehr/tests/it/service_aql.rs
+++ b/app/ferroehr/tests/it/service_aql.rs
@@ -1887,3 +1887,165 @@ async fn folder_containment_resolves_references() {
         "no folder is without a referenced composition in its subtree"
     );
 }
+
+/// `FOLDER CONTAINS FOLDER` is the union edge (#2887): the by-value
+/// `folders` nesting AND the folder rows of an items-referenced
+/// `VERSIONED_FOLDER` (RM common master05 — `items` references name
+/// versioned objects "logically in this folder", with no target-type
+/// restriction). One reference hop; the referenced tree's own refs are
+/// reached by explicit chaining, as the second query pins.
+#[tokio::test]
+async fn folder_contains_folder_reaches_items_referenced_versioned_folders() {
+    let db = testkit::db().await.expect("testkit database");
+    let svc = FerroEhrService::new(db.pool());
+    let ehr_id = create_ehr(&svc).await;
+    let ehr_uuid = ferroehr::ids::EhrId(ehr_id.parse::<Uuid>().expect("ehr uuid"));
+
+    // cX is referenced from the SECOND versioned folder, so it is reachable
+    // from the directory only across the folder-reference hop.
+    let cx = uid_root(&create_comp(&svc, &ehr_id, "cX", 1.0).await);
+
+    // The directory goes in FIRST (a creation-FOLDER contribution takes the
+    // empty directory slot, so the additional hierarchy must come second),
+    // and its reference is added by update AFTER the target exists (a
+    // dangling local items ref is refused at commit).
+    let folder = |name: &str, items: Vec<Value>, folders: Vec<Value>| {
+        let mut f = json!({
+            "_type": "FOLDER",
+            "archetype_node_id": "openEHR-EHR-FOLDER.generic.v1",
+            "name": { "_type": "DV_TEXT", "value": name }
+        });
+        if !items.is_empty() {
+            f["items"] = Value::Array(items);
+        }
+        if !folders.is_empty() {
+            f["folders"] = Value::Array(folders);
+        }
+        f
+    };
+    let directory_v1 = folder("episodes", vec![], vec![folder("course-1", vec![], vec![])]);
+    let meta = svc
+        .create_directory(ehr_uuid, uv(&directory_v1, "249", None))
+        .await
+        .expect("create_directory");
+
+    // The second VERSIONED_FOLDER (an additional EHR.folders hierarchy — RM
+    // ehr master04 §Folders), committed through a CONTRIBUTION: a root with
+    // one by-value sub-folder and an items ref to cX.
+    let coded = |code: &str, value: &str| {
+        json!({
+            "_type": "DV_CODED_TEXT",
+            "value": value,
+            "defining_code": {
+                "_type": "CODE_PHRASE",
+                "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" },
+                "code_string": code
+            }
+        })
+    };
+    let shared_plan = folder(
+        "shared-plan",
+        vec![folder_ref(&cx)],
+        vec![folder("plan-week-1", vec![], vec![])],
+    );
+    let contribution = json!({
+        "versions": [{
+            "commit_audit": {
+                "change_type": coded("249", "creation"),
+                "committer": { "_type": "PARTY_IDENTIFIED", "name": "folder author" }
+            },
+            "lifecycle_state": coded("532", "complete"),
+            "data": shared_plan
+        }],
+        "audit": {
+            "change_type": coded("249", "creation"),
+            "committer": { "_type": "PARTY_IDENTIFIED", "name": "folder author" }
+        }
+    });
+    let created = svc
+        .create_ehr_contribution(ehr_uuid, contribution)
+        .await
+        .expect("commit the second versioned folder");
+    let vf_ovid = created.body["versions"][0]["id"]["value"]
+        .as_str()
+        .expect("folder version id")
+        .to_owned();
+    let vf_root = uid_root(&vf_ovid);
+
+    // course-1's items now reference the second VERSIONED_FOLDER.
+    let vf_ref = json!({
+        "_type": "OBJECT_REF",
+        "namespace": "local",
+        "type": "VERSIONED_FOLDER",
+        "id": { "_type": "HIER_OBJECT_ID", "value": vf_root }
+    });
+    let directory_v2 = folder(
+        "episodes",
+        vec![],
+        vec![folder("course-1", vec![vf_ref], vec![])],
+    );
+    svc.update_directory(ehr_uuid, uv(&directory_v2, "251", Some(&meta.uid)))
+        .await
+        .expect("update_directory with the folder reference");
+
+    // The full (parent, child) folder pair set: by-value nesting inside each
+    // tree, plus the reference hop from any folder whose subtree items name
+    // the second VERSIONED_FOLDER — which contributes the referenced tree's
+    // root AND its by-value descendants.
+    let r = run_aql(
+        &svc,
+        "SELECT f1/name/value, f2/name/value \
+         FROM EHR e CONTAINS FOLDER f1 CONTAINS FOLDER f2",
+        ehr_scope(&ehr_id),
+    )
+    .await;
+    let pairs: std::collections::BTreeSet<(String, String)> = rows(&r)
+        .iter()
+        .map(|row| {
+            (
+                row[0].as_str().expect("parent name").to_owned(),
+                row[1].as_str().expect("child name").to_owned(),
+            )
+        })
+        .collect();
+    let expected: std::collections::BTreeSet<(String, String)> = [
+        ("episodes", "course-1"),
+        ("episodes", "shared-plan"),
+        ("episodes", "plan-week-1"),
+        ("course-1", "shared-plan"),
+        ("course-1", "plan-week-1"),
+        ("shared-plan", "plan-week-1"),
+    ]
+    .into_iter()
+    .map(|(a, b)| (a.to_owned(), b.to_owned()))
+    .collect();
+    assert_eq!(
+        pairs, expected,
+        "the union edge, one reference hop, no dupes"
+    );
+
+    // The chained hop composes: the referenced folder's own items refs are
+    // that folder's OWN containment edge.
+    let r = run_aql(
+        &svc,
+        "SELECT f2/name/value, c/uid/value \
+         FROM EHR e CONTAINS FOLDER f1 CONTAINS FOLDER f2 CONTAINS COMPOSITION c \
+         WHERE f1/name/value = 'course-1'",
+        ehr_scope(&ehr_id),
+    )
+    .await;
+    let chained: Vec<(String, String)> = rows(&r)
+        .iter()
+        .map(|row| {
+            (
+                row[0].as_str().expect("folder name").to_owned(),
+                uid_root(row[1].as_str().expect("composition uid")),
+            )
+        })
+        .collect();
+    assert_eq!(
+        chained,
+        vec![("shared-plan".to_owned(), cx.clone())],
+        "cX is reached from course-1 only across the explicit second hop"
+    );
+}

--- a/docs/conformance/ferroehr/CONFORMANCE_CERTIFICATE.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_CERTIFICATE.md
@@ -4,7 +4,7 @@
 
 | Field | Value |
 | --- | --- |
-| Solution | ferroehr 4.0.8 |
+| Solution | ferroehr 4.0.9 |
 | Vendor | Ruben Talstra |
 | Runner | veredictum 0.1.0-alpha.6 |
 | Infrastructure | ixit.json#/environment |

--- a/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
@@ -1,6 +1,6 @@
 # Conformance Report
 
-SUT: FerroEHR 4.0.8 (sut `ferroehr`) · schedule cnf-2.0-w2 · ITS its-rest
+SUT: FerroEHR 4.0.9 (sut `ferroehr`) · schedule cnf-2.0-w2 · ITS its-rest
 Runner: veredictum 0.1.0-alpha.6 · verification pack: passed
 
 ## Summary

--- a/docs/conformance/ferroehr/results.json
+++ b/docs/conformance/ferroehr/results.json
@@ -1,7 +1,7 @@
 {
   "sut": {
     "name": "ferroehr",
-    "version": "4.0.8"
+    "version": "4.0.9"
   },
   "runner": {
     "name": "veredictum",

--- a/website/book/src/querying-aql.md
+++ b/website/book/src/querying-aql.md
@@ -44,7 +44,9 @@ ORDER BY systolic DESC
   follows the RM's reference model: `FOLDER f CONTAINS COMPOSITION c` matches
   the compositions a folder's `items` reference, transitively over the
   folder's sub-tree, and `FOLDER f1 CONTAINS FOLDER f2` matches strict
-  sub-folders. A pair the RM defines no containment relationship for (say
+  sub-folders plus the folders of a versioned folder the `items` reference —
+  one reference hop, so a chain of references is expressed by chaining
+  `CONTAINS`. A pair the RM defines no containment relationship for (say
   `COMPOSITION CONTAINS COMPOSITION`) is refused with a typed error.
 - **`SELECT`** projects values by path. Paths use archetype node ids (`at0004`)
   and RM attribute names (`value/magnitude`); `AS` names a column.


### PR DESCRIPTION
Closes #2887.

**Adjudication (first-hand from the vendored texts): IN, one reference hop.** QUERY master03 §Containment defines `CONTAINS` as the parent/child hierarchy and says nothing about reference edges; RM common master05 declares `FOLDER.items: List<OBJECT_REF>` as "references to other (usually) versioned objects **logically in this folder**" with no target-type restriction, and a `VERSIONED_FOLDER`'s every version "is a Folder structure". The same RM sentence that grounds `FOLDER CONTAINS COMPOSITION`'s items resolution therefore grounds the folder-typed target: refusing exactly the parallel edge for `VERSIONED_FOLDER` targets would make the envelope asymmetric on no spec ground. The hop is NOT transitive across further referenced versioned folders — that closure is cycle-prone (folder A referencing B referencing A) and unbounded in SQL, and the chain is expressible explicitly (`f1 CONTAINS f2 CONTAINS f3`), each edge evaluated pairwise.

**The engine change** (`app/ferroehr/src/aql/sql/from.rs`): the `FOLDER CONTAINS FOLDER` edge (`EdgeKind::FolderSubtree` → `FolderChild`) becomes the union — a by-value STRICT nested-set descendant in the parent's own tree, OR any folder row of an items-referenced `VERSIONED_FOLDER` (the existing `folder_items_exists` correlation over the parent's subtree). The child now opens its own version group in both branches (in the by-value branch its spine row IS the parent's, so latest/ALL_VERSIONS scoping is unchanged); the same union renders in the OR/NOT-CONTAINS anchor correlation. Streaming is untouched — folder edges were already flat-shape-only.

**Pinned by:** the planner test (`folder_contains_folder_unites_subtree_and_items_reference`: strict interval + OR + items lookup in the SQL) and a real-database integration test (`folder_contains_folder_reaches_items_referenced_versioned_folders`): a directory whose sub-folder references a second VERSIONED_FOLDER committed through a CONTRIBUTION — the exact six-pair union set (no duplicates, reference root + its by-value descendants, one hop only), plus the chained `f1 CONTAINS f2 CONTAINS COMPOSITION c` hop across the reference. The #2888 suite still passes unchanged.

Book envelope updated (querying-aql.md); changelog entry added. Conformance zero-drift run quoted in a comment before merge (the aql-engine rule).

The ambiguity-register entry (spec silence, disposition: RM-grounded acceptance, one hop) is Veredictum-side material — the ready-to-land entry text is on the issue.
