### PR TITLE
feat(telemetry): process_resident_memory_bytes joins the sampled gauges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Added
+
+- The metrics surface gains `process_resident_memory_bytes` (the standard
+  Prometheus name), sampled from procfs every five seconds beside the pool
+  and runtime gauges — so "is the server's memory growing?" is a dashboard
+  read instead of a shell into the host. Absent on platforms without
+  procfs.
+
 ### Changed
 
 - AQL `FOLDER f1 CONTAINS FOLDER f2` now also matches the folders of a

--- a/app/ferroehr/src/telemetry/metrics.rs
+++ b/app/ferroehr/src/telemetry/metrics.rs
@@ -105,6 +105,9 @@ pub const TOKIO_WORKERS: &str = "tokio_workers";
 pub const TOKIO_GLOBAL_QUEUE_DEPTH: &str = "tokio_global_queue_depth";
 /// Tokio alive tasks.
 pub const TOKIO_ALIVE_TASKS: &str = "tokio_alive_tasks";
+/// Process resident set size (unit: bytes — the exporter appends `_bytes`,
+/// yielding the standard Prometheus `process_resident_memory_bytes`).
+pub const PROCESS_RESIDENT_MEMORY: &str = "process_resident_memory";
 
 // ── Bucket ladders ───────────────────────────────────────────────────────────
 
@@ -486,6 +489,7 @@ mod tests {
             TOKIO_WORKERS,
             TOKIO_GLOBAL_QUEUE_DEPTH,
             TOKIO_ALIVE_TASKS,
+            PROCESS_RESIDENT_MEMORY,
         ];
         for name in names {
             for suffix in ["_total", "_seconds", "_bytes"] {

--- a/app/ferroehr/src/telemetry/samplers.rs
+++ b/app/ferroehr/src/telemetry/samplers.rs
@@ -22,7 +22,8 @@ use sqlx::postgres::Postgres;
 use tokio::task::JoinHandle;
 
 use super::metrics::{
-    DB_POOL_CONNECTIONS, TOKIO_ALIVE_TASKS, TOKIO_GLOBAL_QUEUE_DEPTH, TOKIO_WORKERS,
+    DB_POOL_CONNECTIONS, PROCESS_RESIDENT_MEMORY, TOKIO_ALIVE_TASKS, TOKIO_GLOBAL_QUEUE_DEPTH,
+    TOKIO_WORKERS,
 };
 
 /// How often the sampler reads gauges + runs recorder upkeep.
@@ -82,6 +83,19 @@ struct Sample {
     workers: u64,
     global_queue_depth: u64,
     alive_tasks: u64,
+    resident_bytes: Option<u64>,
+}
+
+/// Reads the process resident set from `/proc/self/status` (`VmRSS`, kibibytes
+/// per proc(5)), `None` where procfs is absent (macOS development hosts).
+fn resident_bytes() -> Option<u64> {
+    // NOTE: `Result → Option` is the decision here (reliability.md class): no
+    // procfs, or a VmRSS line this shape cannot read, means the gauge is
+    // legitimately absent on this platform — not a swallowed defect.
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    let line = status.lines().find(|l| l.starts_with("VmRSS:"))?;
+    let kib: u64 = line.split_whitespace().nth(1)?.parse().ok()?;
+    kib.checked_mul(1024)
 }
 
 /// Read the pool + runtime gauges.
@@ -104,6 +118,7 @@ fn sample(pool: &PgPool) -> Sample {
         workers: rt.num_workers() as u64,
         global_queue_depth: rt.global_queue_depth() as u64,
         alive_tasks: rt.num_alive_tasks() as u64,
+        resident_bytes: resident_bytes(),
     }
 }
 
@@ -113,6 +128,7 @@ struct OtelGauges {
     workers: opentelemetry::metrics::Gauge<u64>,
     global_queue_depth: opentelemetry::metrics::Gauge<u64>,
     alive_tasks: opentelemetry::metrics::Gauge<u64>,
+    resident_memory: opentelemetry::metrics::Gauge<u64>,
 }
 
 impl OtelGauges {
@@ -122,6 +138,15 @@ impl OtelGauges {
             workers: meter.u64_gauge(TOKIO_WORKERS).build(),
             global_queue_depth: meter.u64_gauge(TOKIO_GLOBAL_QUEUE_DEPTH).build(),
             alive_tasks: meter.u64_gauge(TOKIO_ALIVE_TASKS).build(),
+            resident_memory: meter
+                .u64_gauge(PROCESS_RESIDENT_MEMORY)
+                .with_description(
+                    "Process resident set size; the designed residents are the moka \
+                     template/WebTemplate caches, the sqlx pool, the verified-credential \
+                     cache and the ATNA audit queue (#2872)",
+                )
+                .with_unit("By")
+                .build(),
         }
     }
 
@@ -132,5 +157,8 @@ impl OtelGauges {
         self.workers.record(s.workers, &[]);
         self.global_queue_depth.record(s.global_queue_depth, &[]);
         self.alive_tasks.record(s.alive_tasks, &[]);
+        if let Some(rss) = s.resident_bytes {
+            self.resident_memory.record(rss, &[]);
+        }
     }
 }

--- a/app/ferroehr/tests/it/telemetry_samplers.rs
+++ b/app/ferroehr/tests/it/telemetry_samplers.rs
@@ -137,6 +137,16 @@ async fn the_sampler_records_the_pool_and_runtime_gauges_until_aborted() {
         );
     }
 
+    // The RSS gauge reads /proc/self/status, so it exists exactly where procfs
+    // does: present on Linux (what every deployment runs), absent elsewhere.
+    #[cfg(target_os = "linux")]
+    assert!(
+        names
+            .iter()
+            .any(|n| n == ferroehr::telemetry::metrics::PROCESS_RESIDENT_MEMORY),
+        "the sampler must record the resident-set gauge on Linux, exported: {names:?}"
+    );
+
     // The task is a loop, not a one-shot: it is still running, and the handle
     // the telemetry guard holds is what ends it.
     assert!(!handle.is_finished(), "the sampler runs until aborted");


### PR DESCRIPTION
Part of #2872 (the metrics-exposure half of its adjudication — the soak numbers and the close land on the issue).

The background sampler now reads `VmRSS` from `/proc/self/status` (kibibytes per proc(5)) on its existing five-second tick and records it as `process_resident_memory` with unit bytes — rendering as the standard Prometheus `process_resident_memory_bytes` on both surfaces (the pull endpoint and OTLP push, one provider by construction). The gauge's description names the designed residents the #2872 adjudication holds the number against (the moka template/WebTemplate caches, the sqlx pool, the verified-credential cache, the ATNA audit queue). Where procfs is absent (macOS dev hosts) the gauge is absent rather than zero — the `Result → Option` conversion carries its NOTE per the reliability rule.

Pinned by: the sampler integration test now asserts the gauge is exported on Linux (cfg-gated — CI's runner is the platform every deployment runs); the no-Prometheus-suffix name test covers the new constant.

Gates: clippy -p ferroehr clean, telemetry suites 31/31 + the extended pin, fmt, comment-style. Changelog `### Added` entry included.