### PR TITLE
test(aql): FOLDER NOT CONTAINS FOLDER pins the union edge's anchor arm

### DIFF
--- a/app/ferroehr/tests/it/aql_planner.rs
+++ b/app/ferroehr/tests/it/aql_planner.rs
@@ -1626,6 +1626,32 @@ fn versioned_object_under_versioned_object_is_refused() {
     );
 }
 
+/// `FOLDER f1 NOT CONTAINS FOLDER f2` negates the union edge (#2887): the
+/// anti-join's branch carries its own version spine and the by-value strict
+/// interval OR the items-reference lookup — the same shape the positive edge
+/// renders.
+#[test]
+fn not_contains_folder_negates_the_union_edge() {
+    let sql =
+        build_sql("SELECT f1/name/value FROM EHR e CONTAINS FOLDER f1 NOT CONTAINS FOLDER f2");
+    assert!(
+        sql.contains("NOT EXISTS") || sql.contains("NOT (EXISTS"),
+        "the exclusion is an anti-join: {sql}"
+    );
+    assert!(
+        sql.contains(") OR EXISTS") || sql.contains(") OR (EXISTS"),
+        "the negated edge unites the by-value branch with the reference branch: {sql}"
+    );
+    assert!(
+        sql.contains("jsonb_array_elements") && sql.contains("'items'"),
+        "the reference branch is the items lookup: {sql}"
+    );
+    assert!(
+        sql.contains("upper_inf"),
+        "the branch folder binds its own version spine at latest scope: {sql}"
+    );
+}
+
 /// `FOLDER f NOT CONTAINS COMPOSITION` negates the same reference edge — the
 /// anti-join probes `FOLDER.items`, not the (vacuously true) node interval.
 #[test]

--- a/app/ferroehr/tests/it/service_aql.rs
+++ b/app/ferroehr/tests/it/service_aql.rs
@@ -2048,4 +2048,24 @@ async fn folder_contains_folder_reaches_items_referenced_versioned_folders() {
         vec![("shared-plan".to_owned(), cx.clone())],
         "cX is reached from course-1 only across the explicit second hop"
     );
+
+    // The negated twin: NOT CONTAINS excludes over the SAME union edge, so
+    // the only folder with no folder child — by value or by reference — is
+    // the leaf.
+    let r = run_aql(
+        &svc,
+        "SELECT f1/name/value \
+         FROM EHR e CONTAINS FOLDER f1 NOT CONTAINS FOLDER f2",
+        ehr_scope(&ehr_id),
+    )
+    .await;
+    let childless: Vec<String> = rows(&r)
+        .iter()
+        .map(|row| row[0].as_str().expect("folder name").to_owned())
+        .collect();
+    assert_eq!(
+        childless,
+        vec!["plan-week-1".to_owned()],
+        "every non-leaf folder has a union-edge child, so only the leaf survives the anti-join"
+    );
 }


### PR DESCRIPTION
The #2887 union edge landed with its FROM-path fully pinned but the OR/NOT-CONTAINS anchor arm undriven — exactly the 18 uncovered new-code lines the post-merge quality gate flagged (`new_coverage` 47.1% over a 34-line denominator, all 18 in `aql/sql/from.rs`). The negated twin deserved a pin regardless: an anti-join over the wrong edge is the silent-wrong-answer class.

- Planner: `not_contains_folder_negates_the_union_edge` pins the anti-join SQL — NOT EXISTS whose branch carries the by-value strict interval OR the items-reference lookup, on the branch folder's own version spine at latest scope.
- Integration: the #2887 scenario gains the anti-join semantics — with every non-leaf folder holding a union-edge child (by value or by reference), `FOLDER f1 NOT CONTAINS FOLDER f2` answers exactly the leaf.

The remaining unexercised lines in the arm are the version-predicate typed refusal (the explainable-refusal class). `no-changelog`: tests only.