### PR TITLE
chore(compose): the measured resident envelope rides the server's memory limit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -264,6 +264,11 @@ services:
     # docker VM; a 2cpu/1Gi cap halved the measured knee). Production limits
     # are the Helm values' concern (deploy/helm/ferroehr/values.yaml);
     # override via env for a constrained profile.
+    # The server's measured resident envelope (#2872 soaks, 4.0.9 image):
+    # ~22 MiB at boot, ~70 MiB after hours of idle, ~125 MiB warm steady
+    # state under and after sustained load — a designed plateau (caches +
+    # pool), zero growth slope. The 4G default is headroom, not a forecast;
+    # watch `process_resident_memory_bytes` on the metrics surface.
     deploy:
       resources:
         limits:


### PR DESCRIPTION
The #2872 adjudication's last deliverable: the quickstart's 4G server limit now carries the measured envelope (boot ~22 MiB, idle plateau ~70 MiB, warm steady state ~125 MiB — the full soak record lands on the issue) and points operators at `process_resident_memory_bytes` (#2906). Comment-only; the guards stay green. `no-changelog`.