### PR TITLE
ci(sandbox): every deploy verification waits for a specific version — no more blind greens

### DIFF
--- a/.github/workflows/sandbox-deploy.yml
+++ b/.github/workflows/sandbox-deploy.yml
@@ -150,6 +150,7 @@ jobs:
           # Only compared against the served version string, never executed.
           EXPECTED: ${{ inputs.expected-version }}
           JOB_ID: ${{ steps.ping.outputs.job-id }}
+          IMAGE: ghcr.io/rubentalstra/ferroehr
         run: |
           set -euo pipefail
           if [ -z "$HOOK_URL" ]; then
@@ -162,10 +163,31 @@ jobs:
           # first 200 proves the new deployment is live AND migrated.
           # A bare 200 is NOT proof of the new deployment — the OLD one
           # answers 200 too (measured: the 4.0.4 dispatch went green while
-          # the sandbox still served 4.0.3). A release run is told the version
-          # the tag names and waits for exactly it; other runs log what is
-          # served.
+          # the sandbox still served 4.0.3, and the v4.0.10 recovery dispatch
+          # went green while it still served 4.0.9). A release run is told the
+          # version the tag names; EVERY other run derives its expectation
+          # from the `:latest` image's own version label, anonymously — the
+          # deploy always builds FROM `:latest`, so what that image declares
+          # is exactly what a successful promotion must serve.
           expected="${EXPECTED:-}"
+          if [ -z "$expected" ]; then
+            tok=$(curl -fsS "https://ghcr.io/token?scope=repository:${IMAGE#ghcr.io/}:pull" | sed -nE 's/.*"token":"([^"]+)".*/\1/p')
+            idx=$(curl -fsS -H "Authorization: Bearer ${tok}" \
+              -H "Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json" \
+              "https://ghcr.io/v2/${IMAGE#ghcr.io/}/manifests/latest")
+            child=$(printf '%s' "$idx" | jq -r '[.manifests[] | select(.platform.os == "linux")][0].digest // empty')
+            cfg=$(curl -fsS -H "Authorization: Bearer ${tok}" \
+              -H "Accept: application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json" \
+              "https://ghcr.io/v2/${IMAGE#ghcr.io/}/manifests/${child}" | jq -r '.config.digest // empty')
+            expected=$(curl -fsSL -H "Authorization: Bearer ${tok}" \
+              "https://ghcr.io/v2/${IMAGE#ghcr.io/}/blobs/${cfg}" \
+              | jq -r '.config.Labels["org.opencontainers.image.version"] // empty')
+            if [ -z "$expected" ]; then
+              echo "::error::could not derive the expected version from :latest's org.opencontainers.image.version label — a verification that cannot decide must not pass (the image-labels guard keeps the label present, so an unreadable label is a registry/read defect to look at, not a shrug)." >&2
+              exit 1
+            fi
+            echo "expectation derived from :latest — waiting for '${expected}'"
+          fi
           deadline=$(( $(date +%s) + 1200 ))
           sleep 60
           while :; do

--- a/deploy/vercel/README.md
+++ b/deploy/vercel/README.md
@@ -55,7 +55,14 @@ The deploy job verifies in two layers (#2846, after the v4.0.7 cut spent
    release tag's image digest on GHCR before any ping — the needs-edge's
    guarantee, re-asserted where it is consumed, with anonymous registry
    reads.
-2. **The served-version poll** is the acceptance; the hook response's job
+2. **The served-version poll** is the acceptance, and it is version-bound on
+   EVERY path: a release run waits for the tag's version, and a push or
+   dispatch run derives its expectation from the `:latest` image's own
+   `org.opencontainers.image.version` label (anonymous registry read) — the
+   deploy always builds from `:latest`, so that label is exactly what a
+   successful promotion must serve. Before this, a non-release run passed on
+   any 200, and the v4.0.10 recovery dispatch went green while the sandbox
+   still served 4.0.9. The hook response's job
    id is captured for the record, and the timeout message states what was
    already proven (the image side) so the remaining suspect (Vercel's own
    build/promotion — historically a flaky Neon integration step, #2846) is


### PR DESCRIPTION
Part of #2910 (the CI half; the Vercel-side Production Branch flip is the owner half).

The v4.0.10 night measured the gap twice: the recovery `workflow_dispatch` and the push-path run both went green while the sandbox still served 4.0.9, because a non-release run's poll accepted ANY 200 (`expected: any`) — the same blindness the 4.0.4 dispatch had already shown. A verification that cannot fail is not one.

Now the poll is version-bound on every path: a release run keeps waiting for the tag's version, and every other run derives its expectation from the `:latest` image's own `org.opencontainers.image.version` label via the same anonymous GHCR reads the precondition already uses (token → index → linux child manifest → config blob → label). The deploy always builds `FROM …:latest`, so that label is exactly what a successful promotion must serve. An underivable label fails loudly (fail-closed — the image-labels guard keeps the label present, so an unreadable one is a real defect, never a shrug). No stored Vercel credential enters the picture; the #2846 refusal stands.

deploy/vercel/README.md's verification contract updated in the same PR. `no-changelog`: CI + ops docs.