### PR TITLE
fix(rest): reads serve the canonical bytes verbatim — the body column stops being jsonb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Fixed
+
+- Reads serve the exact canonical bytes the commit accepted: `_type` first
+  and every field at its spec-declared position — including the
+  server-stamped `uid`, which now lands at its place in the document instead
+  of the end. Previously the stored body passed through a `jsonb` column
+  and PostgreSQL's own key ordering leaked onto the wire (reported by the
+  community). Dump archives carry the same faithful bytes, so an
+  export/load round-trip is byte-equal again.
+
 ## [4.0.10] - 2026-08-29
 
 ### Added

--- a/app/ferroehr-rest/tests/it/protocol_tail.rs
+++ b/app/ferroehr-rest/tests/it/protocol_tail.rs
@@ -115,6 +115,46 @@ fn vo_of(ovid: &str) -> &str {
     ovid.split("::").next().expect("vo uuid")
 }
 
+/// [`commit_ips_composition`] with a caller-supplied composition body.
+async fn commit_composition_body(app: &Router, body: Value) -> (String, String) {
+    let (status, h, _b) = send(
+        app,
+        Request::builder()
+            .method("POST")
+            .uri(format!("{BASE}/ehr"))
+            .body(Body::empty())
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let ehr_id = etag_uid(&h);
+
+    let (status, _h, resp) = send(
+        app,
+        Request::builder()
+            .method("POST")
+            .uri(format!("{BASE}/definition/template/adl1.4"))
+            .header(header::CONTENT_TYPE, "application/xml")
+            .body(Body::from(opt_xml()))
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "OPT upload: {resp}");
+
+    let (status, h, resp) = send(
+        app,
+        Request::builder()
+            .method("POST")
+            .uri(format!("{BASE}/ehr/{ehr_id}/composition"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "composition commit: {resp}");
+    (ehr_id, etag_uid(&h))
+}
+
 /// Create an EHR, upload the IPS OPT, and commit the IPS composition; return the
 /// `(ehr_id, version_uid)` of the committed COMPOSITION.
 async fn commit_ips_composition(app: &Router) -> (String, String) {
@@ -847,17 +887,26 @@ async fn composition_version_serves_xml_with_signature() {
     assert!(body.contains("sha256:"), "digest signature value: {body}");
 }
 
-/// The JSON-accept composition GET serves the stored body text VERBATIM (the
-/// raw passthrough): the response opens with the commit-time `uid` stamp —
-/// jsonb renders object keys length-first, so the stamped body's text starts
-/// with its own `uid` — still parses as the same canonical value, and the
-/// version-addressed variant passes through identically. An XML accept on the
-/// same resource still parses and re-serializes (the passthrough is
+/// The JSON-accept composition GET serves the stored canonical body BYTES
+/// verbatim (#2913): `_type` first, every field at its BMM-declared position —
+/// including the server-stamped `uid`, which the RM BMM declares third on
+/// LOCATABLE (after `name` and `archetype_node_id`), exercised here by a
+/// commit whose request body carries NO `uid`. The served text is
+/// byte-identical to the canonical codec's own re-encoding, and the
+/// version-addressed variant passes through the same bytes. An XML accept on
+/// the same resource still parses and re-serializes (the passthrough is
 /// representation-local).
 #[tokio::test]
 async fn composition_get_serves_stored_json_verbatim() {
     let (_pg, app) = app().await;
-    let (ehr_id, v1) = commit_ips_composition(&app).await;
+    // The committed body must be uid-less so the stamped-field PLACEMENT is
+    // what the byte comparison exercises (the borutjures case on #2913).
+    let mut fixture = canonical_composition();
+    fixture
+        .as_object_mut()
+        .expect("a JSON object")
+        .remove("uid");
+    let (ehr_id, v1) = commit_composition_body(&app, fixture).await;
     let vo = vo_of(&v1);
 
     let get = |uri: String, accept: &'static str| {
@@ -868,7 +917,6 @@ async fn composition_get_serves_stored_json_verbatim() {
             .body(Body::empty())
             .unwrap()
     };
-    let prefix = format!("{{\"uid\": {{\"_type\": \"OBJECT_VERSION_ID\", \"value\": \"{v1}\"}}");
 
     // The latest read.
     let (status, h, body) = send(
@@ -885,12 +933,33 @@ async fn composition_get_serves_stored_json_verbatim() {
         Some("application/json")
     );
     assert!(
-        body.starts_with(&prefix),
-        "the stored text passes through, opening with the commit-time uid stamp: {body}"
+        body.starts_with("{\"_type\":\"COMPOSITION\""),
+        "the canonical encoding opens with _type: {body}"
     );
     let parsed: Value = serde_json::from_str(&body).expect("the passthrough text is JSON");
+    let keys: Vec<&str> = parsed
+        .as_object()
+        .expect("a JSON object")
+        .keys()
+        .take(4)
+        .map(String::as_str)
+        .collect();
+    assert_eq!(
+        keys,
+        ["_type", "name", "archetype_node_id", "uid"],
+        "the stamped uid sits at its BMM-declared position"
+    );
     assert_eq!(parsed["uid"]["value"], Value::String(v1.clone()));
-    assert_eq!(parsed["_type"], Value::String("COMPOSITION".to_owned()));
+
+    // The served bytes ARE the codec's encoding: parsing them into the typed
+    // RM value and re-encoding reproduces the identical text.
+    let typed: openehr_rm::v1_2::composition::composition::Composition =
+        openehr_its::json::from_canonical_value(&parsed).expect("served body decodes as typed RM");
+    let reencoded = openehr_its::json::to_canonical_json(&typed);
+    assert_eq!(
+        body, reencoded,
+        "the served bytes are byte-identical to the canonical codec's encoding"
+    );
 
     // The version-addressed read takes the same passthrough.
     let (status, _h, at_version) = send(
@@ -902,7 +971,7 @@ async fn composition_get_serves_stored_json_verbatim() {
     )
     .await;
     assert_eq!(status, StatusCode::OK, "body: {at_version}");
-    assert!(at_version.starts_with(&prefix), "body: {at_version}");
+    assert_eq!(at_version, body, "both reads serve the same stored bytes");
 
     // XML negotiation still parses and re-serializes the same resource.
     let (status, h, xml) = send(

--- a/app/ferroehr/migrations/ehr/0001_baseline.sql
+++ b/app/ferroehr/migrations/ehr/0001_baseline.sql
@@ -409,14 +409,18 @@ CREATE TABLE vo_version (
     contribution_id uuid NOT NULL,
     audit_id        uuid NOT NULL,
     template_id     text,
-    -- The version's assembled canonical body (openEHR canonical JSON, the
-    -- openehr-its encoding), materialized at write from the SAME in-memory
-    -- value the node rows are decomposed from — a point read serves one
-    -- detoast instead of re-aggregating the node subtree (TOAST keeps it
-    -- out of the main row, so meta-only scans stay slim). The node rows
-    -- remain the AQL source of truth; NULL on a logically deleted version
-    -- (no content — RM common master06 §Logical Deletion).
-    body            jsonb COMPRESSION lz4,
+    -- The version's canonical body BYTES (openEHR canonical JSON, the
+    -- openehr-its encoding), materialized at write from the accepted,
+    -- uid-stamped value before node decomposition — a point read serves
+    -- these bytes verbatim, one detoast, no re-aggregation (TOAST keeps it
+    -- out of the main row, so meta-only scans stay slim). Deliberately
+    -- text, NOT jsonb: jsonb re-orders object keys internally, and the
+    -- served wire must keep the codec's _type-first, BMM-declared field
+    -- order (#2913). The node rows remain the AQL source of truth; NULL on
+    -- a logically deleted version (no content — RM common master06
+    -- §Logical Deletion). The rare SQL that inspects the body casts
+    -- (body::jsonb).
+    body            text COMPRESSION lz4,
     CONSTRAINT pk_vo_version PRIMARY KEY (vo_id, sys_version),
     CONSTRAINT uq_vo_version_tree UNIQUE
         (vo_id, creating_system_id, trunk_version, branch_number, branch_version),

--- a/app/ferroehr/src/service/admin/dump_load.rs
+++ b/app/ferroehr/src/service/admin/dump_load.rs
@@ -1838,7 +1838,8 @@ impl FerroEhrService {
         let body = if lifecycle_state == DELETED_LIFECYCLE {
             Value::Null
         } else {
-            node_repo::read_version_canonical_all(&self.pool, vo_id, sys_version).await?
+            version_repo::read::stored_body_all(&self.pool, vo_id, sys_version)
+                .await?
         };
         Ok(VersionRecord {
             vo_id,
@@ -1953,7 +1954,8 @@ impl FerroEhrService {
             let body = if lifecycle_state == DELETED_LIFECYCLE {
                 Value::Null
             } else {
-                node_repo::read_version_canonical_all(&self.pool, vo_id, sys_version).await?
+                version_repo::read::stored_body_all(&self.pool, vo_id, sys_version)
+                    .await?
             };
             versions.push(VersionRecord {
                 vo_id,

--- a/app/ferroehr/src/service/admin/integrity.rs
+++ b/app/ferroehr/src/service/admin/integrity.rs
@@ -262,13 +262,18 @@ impl FerroEhrService {
     /// The materialized body of one stored version, read one version at a time
     /// so the sweep holds a single document in memory.
     async fn stored_body(&self, key: &VersionKey) -> Result<Option<Value>, ServiceError> {
-        let row: Option<(Option<Value>,)> =
+        let row: Option<(Option<String>,)> =
             sqlx::query_as("SELECT body FROM vo_version_all WHERE vo_id = $1 AND sys_version = $2")
                 .bind(key.vo_id)
                 .bind(key.sys_version)
                 .fetch_optional(&self.pool)
                 .await?;
-        Ok(row.and_then(|(body,)| body))
+        row.and_then(|(body,)| body)
+            .map(|text| {
+                serde_json::from_str(&text)
+                    .map_err(|e| ServiceError::internal("parse the stored canonical body", e))
+            })
+            .transpose()
     }
 }
 

--- a/app/ferroehr/src/storage/error.rs
+++ b/app/ferroehr/src/storage/error.rs
@@ -72,6 +72,12 @@ pub enum StorageError {
     /// A driver/pool/query error from `sqlx`.
     #[error("database: {0}")]
     Database(#[from] sqlx::Error),
+
+    /// A stored `vo_version.body` text failed to parse as JSON — storage
+    /// corruption, never a caller error (the column holds the canonical bytes
+    /// the commit serialized, #2913).
+    #[error("stored canonical body does not parse: {0}")]
+    BodyDecode(#[source] serde_json::Error),
 }
 
 impl From<StorageError> for crate::service::status::SmError {
@@ -107,7 +113,8 @@ impl From<StorageError> for crate::service::status::SmError {
             // body carries the curated message and the detail is traced.
             StorageError::NotAStructureRoot(_)
             | StorageError::MixedArray { .. }
-            | StorageError::InvalidRows(_) => {
+            | StorageError::InvalidRows(_)
+            | StorageError::BodyDecode(_) => {
                 tracing::error!(
                     error = %e,
                     "storage bridge: node-codec invariant violated → 500"

--- a/app/ferroehr/src/storage/node_repo.rs
+++ b/app/ferroehr/src/storage/node_repo.rs
@@ -536,10 +536,9 @@ async fn read_root_bodies(
     let mut by_key: HashMap<(Uuid, i32), Value> = rows
         .into_iter()
         .map(|row| {
-            Ok((
-                (row.try_get("vo_id")?, row.try_get("sys_version")?),
-                row.try_get("body")?,
-            ))
+            let text: String = row.try_get("body")?;
+            let value: Value = serde_json::from_str(&text).map_err(StorageError::BodyDecode)?;
+            Ok(((row.try_get("vo_id")?, row.try_get("sys_version")?), value))
         })
         .collect::<Result<_, StorageError>>()?;
     for anchor in roots {
@@ -569,8 +568,8 @@ pub async fn first_version_root(
     // Two text scalars off the materialized body — never a fragment fetch and
     // a Value parse for a two-field comparison.
     Ok(sqlx::query_as(
-        "SELECT body ->> 'archetype_node_id', \
-         body #>> '{category,defining_code,code_string}' \
+        "SELECT (body)::jsonb ->> 'archetype_node_id', \
+         (body)::jsonb #>> '{category,defining_code,code_string}' \
          FROM vo_version_all WHERE vo_id = $1 AND body IS NOT NULL \
          ORDER BY sys_version LIMIT 1",
     )

--- a/app/ferroehr/src/storage/version_repo/commit.rs
+++ b/app/ferroehr/src/storage/version_repo/commit.rs
@@ -246,10 +246,11 @@ pub struct FoldedVersion<'a> {
     /// `spec_profile` gate consults. No openEHR spec governs runtime
     /// generation selection — our own design/extension.
     pub stable_compatible: bool,
-    /// The assembled canonical body (`vo_version.body`) — the SAME in-memory
-    /// value the node rows are decomposed from; `None` on a logical delete
-    /// (no content — RM common master06 §Logical Deletion).
-    pub body: Option<&'a Value>,
+    /// The canonical body BYTES (`vo_version.body`, text — #2913): the
+    /// accepted, uid-stamped value serialized BEFORE node decomposition, so a
+    /// point read serves the codec's field order verbatim; `None` on a
+    /// logical delete (no content — RM common master06 §Logical Deletion).
+    pub body: Option<&'a str>,
     /// The commit instant: the database `now()` the caller read on this
     /// request (the placement read, the writability gate, or the owning
     /// CONTRIBUTION's committal), stored as the audit `time_committed` and

--- a/app/ferroehr/src/storage/version_repo/import.rs
+++ b/app/ferroehr/src/storage/version_repo/import.rs
@@ -121,7 +121,12 @@ pub async fn insert_imported_vo_version(
     .bind(row.audit_id)
     .bind(row.signature)
     .bind(row.wrapped_original)
-    .bind(row.body)
+    .bind(
+        row.body
+            .map(serde_json::to_string)
+            .transpose()
+            .map_err(StorageError::BodyDecode)?,
+    )
     .execute(&mut *tx)
     .await?;
     Ok(())
@@ -260,7 +265,7 @@ pub async fn insert_versions_verbatim(
     let mut sig_client: Vec<bool> = Vec::with_capacity(n);
     let mut creating: Vec<&str> = Vec::with_capacity(n);
     let mut wrappeds: Vec<Option<&Value>> = Vec::with_capacity(n);
-    let mut bodies: Vec<Option<&Value>> = Vec::with_capacity(n);
+    let mut bodies: Vec<Option<String>> = Vec::with_capacity(n);
     for r in rows {
         vo_ids.push(r.vo_id.0);
         kinds.push(r.kind);
@@ -281,7 +286,12 @@ pub async fn insert_versions_verbatim(
         sig_client.push(r.signature_client_supplied);
         creating.push(r.creating_system_id);
         wrappeds.push(r.wrapped_original);
-        bodies.push(r.body);
+        bodies.push(
+            r.body
+                .map(serde_json::to_string)
+                .transpose()
+                .map_err(StorageError::BodyDecode)?,
+        );
     }
     sqlx::query(
         "INSERT INTO vo_version (vo_id, kind, ehr_id, sys_version, trunk_version, branch_number, \
@@ -296,7 +306,7 @@ pub async fn insert_versions_verbatim(
          FROM unnest($1::uuid[], $2::text[], $3::uuid[], $4::int[], $5::int[], $6::int[], \
          $7::int[], $8::text[], $9::jsonb[], $10::text[], $11::text[], $12::text[], \
          $13::uuid[], $14::uuid[], $15::text[], $16::text[], $17::bool[], $18::text[], \
-         $19::jsonb[], $20::jsonb[]) \
+         $19::jsonb[], $20::text[]) \
          AS t(vo_id, kind, ehr_id, sys_version, trunk_version, branch_number, branch_version, \
          preceding_version_uid, other_input, lower, upper, lifecycle_state, contribution_id, \
          audit_id, template_id, signature, sig_client, creating_system_id, wrapped_original, \

--- a/app/ferroehr/src/storage/version_repo/meta.rs
+++ b/app/ferroehr/src/storage/version_repo/meta.rs
@@ -348,7 +348,7 @@ pub async fn persistent_template_exists(
         "SELECT EXISTS(SELECT 1 FROM vo_version WHERE ehr_id = $1 AND kind = 'COMPOSITION' \
          AND upper_inf(sys_period) AND branch_number = 0 AND lifecycle_state <> $2 \
          AND template_id = $3 \
-         AND body #>> '{category,defining_code,code_string}' = $4)",
+         AND (body)::jsonb #>> '{category,defining_code,code_string}' = $4)",
     )
     .bind(ehr_id)
     .bind(deleted_state)
@@ -635,7 +635,7 @@ pub async fn current_composition_meta(
     const SQL: &str = "SELECT v.ehr_id, v.lifecycle_state, v.trunk_version, v.branch_number, \
                        v.branch_version, v.creating_system_id, a.time_committed, \
                        e.is_modifiable, \
-                       v.body #>> '{archetype_details,template_id,value}' AS stored_template, \
+                       (v.body)::jsonb #>> '{archetype_details,template_id,value}' AS stored_template, \
                        fv.found AS first_found, fv.ani AS first_ani, \
                        fv.category AS first_category \
                        FROM vo_version_all v \
@@ -643,8 +643,8 @@ pub async fn current_composition_meta(
                        JOIN ehr e ON e.id = v.ehr_id \
                        LEFT JOIN LATERAL ( \
                            SELECT true AS found, \
-                                  f.body ->> 'archetype_node_id' AS ani, \
-                                  f.body #>> '{category,defining_code,code_string}' AS category \
+                                  (f.body)::jsonb ->> 'archetype_node_id' AS ani, \
+                                  (f.body)::jsonb #>> '{category,defining_code,code_string}' AS category \
                            FROM vo_version_all f \
                            WHERE f.vo_id = $1 AND f.body IS NOT NULL \
                            ORDER BY f.sys_version LIMIT 1 \

--- a/app/ferroehr/src/storage/version_repo/placement.rs
+++ b/app/ferroehr/src/storage/version_repo/placement.rs
@@ -238,7 +238,7 @@ pub async fn update_placement(
         "LEFT JOIN audit a ON a.id = tip.audit_id ",
         "LEFT JOIN ehr e ON e.id = tip.ehr_id ",
         "LEFT JOIN LATERAL ( ",
-        "    SELECT b.body #>> '{archetype_details,template_id,value}' AS stored_template ",
+        "    SELECT (b.body)::jsonb #>> '{archetype_details,template_id,value}' AS stored_template ",
         "    FROM (SELECT body FROM vo_version ",
         "          WHERE vo_id = $1 AND sys_version = tip.sys_version ",
         "          UNION ALL ",
@@ -250,8 +250,8 @@ pub async fn update_placement(
         // extractions OUTSIDE it: evaluated inline, the planner computes the
         // extractions for every version row below the sort.
         "    SELECT true AS found, ",
-        "           b.body ->> 'archetype_node_id' AS ani, ",
-        "           b.body #>> '{category,defining_code,code_string}' AS category ",
+        "           (b.body)::jsonb ->> 'archetype_node_id' AS ani, ",
+        "           (b.body)::jsonb #>> '{category,defining_code,code_string}' AS category ",
         "    FROM (SELECT f.sys_version, f.body ",
         "          FROM (SELECT sys_version, body FROM vo_version ",
         "                WHERE vo_id = $1 AND body IS NOT NULL ",

--- a/app/ferroehr/src/storage/version_repo/read.rs
+++ b/app/ferroehr/src/storage/version_repo/read.rs
@@ -169,10 +169,10 @@ macro_rules! version_select {
     };
 }
 
-/// [`version_select!`] with the body as the database's own jsonb text
-/// rendering (`v.body::text`) — the raw-read column list for the JSON-accept
-/// passthrough ([`read_current_raw`] / [`read_version_raw`]). Every other
-/// column is identical.
+/// [`version_select!`] — with the body column already text (#2913), the
+/// raw-read list for the JSON-accept passthrough ([`read_current_raw`] /
+/// [`read_version_raw`]) is the same column list; the macro pair survives so
+/// the two intents keep their own names.
 macro_rules! version_select_raw {
     ($tail:literal) => {
         concat!(
@@ -180,7 +180,7 @@ macro_rules! version_select_raw {
             "v.branch_version, v.lifecycle_state, v.creating_system_id, v.preceding_version_uid, ",
             "v.other_input_version_uids, v.contribution_id, v.template_id, v.signature, ",
             "v.signature_client_supplied, v.wrapped_original, v.stable_compatible, ",
-            "v.body::text AS body, ",
+            "v.body, ",
             "a.system_id, a.change_type, a.description, a.committer, a.attestation, ",
             "a.time_committed, ",
             "att.attestations_at_committal, att.attestations_after_committal ",
@@ -203,14 +203,15 @@ macro_rules! version_select_raw {
 /// a logical delete), so the whole version read is the ONE statement that
 /// produced `row`, on whichever tier's connection ran it.
 fn stored_version(vo_id: VoId, row: &PgRow) -> Result<StoredVersion, StorageError> {
-    let canonical = row
-        .try_get::<Option<Value>, _>("body")?
-        .unwrap_or(Value::Null);
+    let canonical = match row.try_get::<Option<String>, _>("body")? {
+        Some(text) => serde_json::from_str(&text).map_err(StorageError::BodyDecode)?,
+        None => Value::Null,
+    };
     stored_version_fields(vo_id, row, canonical, None)
 }
 
-/// [`stored_version`] for a raw-read row (`v.body::text AS body`): the body
-/// arrives as the database's own jsonb text rendering, kept verbatim in
+/// [`stored_version`] for a raw-read row: the body text arrives as the
+/// stored canonical bytes (#2913), kept verbatim in
 /// [`StoredVersion::canonical_text`] with `canonical = Value::Null` — the
 /// JSON-accept passthrough source (the caller parses the text wherever a
 /// typed value is still needed).
@@ -697,4 +698,32 @@ pub async fn read_current_directory(
         .as_ref()
         .map(stored_version_by_row)
         .transpose()
+}
+
+/// The stored canonical body BYTES of one version, across both storage tiers
+/// (`vo_version_all`), parsed back to a value with the stored key order kept.
+///
+/// This is the dump/export source (#2913): the archived payload carries the
+/// codec's own field order because it IS the committed bytes — a node-row
+/// reassembly would surface the `node.data` fragments' jsonb key order
+/// instead. `Value::Null` for a deleted version or an absent row.
+///
+/// # Errors
+/// [`StorageError::Database`] on row I/O; [`StorageError::BodyDecode`] when a
+/// stored body does not parse (storage corruption).
+pub async fn stored_body_all(
+    pool: &PgPool,
+    vo_id: VoId,
+    sys_version: i32,
+) -> Result<Value, StorageError> {
+    let row: Option<(Option<String>,)> =
+        sqlx::query_as("SELECT body FROM vo_version_all WHERE vo_id = $1 AND sys_version = $2")
+            .bind(vo_id)
+            .bind(sys_version)
+            .fetch_optional(pool)
+            .await?;
+    match row.and_then(|(body,)| body) {
+        Some(text) => serde_json::from_str(&text).map_err(StorageError::BodyDecode),
+        None => Ok(Value::Null),
+    }
 }

--- a/app/ferroehr/src/versioning/change.rs
+++ b/app/ferroehr/src/versioning/change.rs
@@ -440,6 +440,10 @@ struct ResolvedWrite {
     client_signature: Option<String>,
     /// The decomposed node rows (empty for a logical delete — data Void).
     rows: Vec<NodeRow>,
+    /// The canonical body BYTES, serialized from the accepted, uid-stamped
+    /// value BEFORE decomposition — the stored `vo_version.body` text a point
+    /// read serves verbatim (#2913). `None` for a logical delete.
+    canonical_text: Option<String>,
     /// Whether the RELEASED generation set can express this body — the
     /// commit-time `vo_version.stable_compatible` stamp
     /// ([`crate::versioning::profile::stable_compatible`]).
@@ -505,10 +509,35 @@ fn stamp_version_uid(canonical: &mut Value, version_uid: &str) -> Result<(), Ver
                 raw: version_uid.to_owned(),
                 source,
             })?;
-        map.insert(
-            "uid".to_owned(),
-            openehr_its::json::to_canonical_value(&uid),
-        );
+        let value = openehr_its::json::to_canonical_value(&uid);
+        if map.contains_key("uid") {
+            // Replacing keeps the key's existing position.
+            map.insert("uid".to_owned(), value);
+        } else {
+            // A fresh `uid` must land at its BMM-declared position — the RM
+            // BMM declares LOCATABLE as (name, archetype_node_id, uid, …), so
+            // in the canonical encoding it follows `archetype_node_id`. A
+            // plain insert appends at the map's end, and the stored body is
+            // now served byte-verbatim (#2913), so placement is wire-visible.
+            let anchor = ["archetype_node_id", "name", "_type"]
+                .iter()
+                .find_map(|k| map.keys().position(|key| key == k));
+            let at = anchor.map_or(0, |i| i + 1);
+            let original_len = map.len();
+            let mut rebuilt = serde_json::Map::with_capacity(original_len + 1);
+            for (i, (k, v)) in std::mem::take(map).into_iter().enumerate() {
+                if i == at {
+                    rebuilt.insert("uid".to_owned(), value.clone());
+                }
+                rebuilt.insert(k, v);
+            }
+            if rebuilt.len() == original_len {
+                // `at` sat past the last entry (the anchor was last, or the
+                // map was empty) — the uid closes the map instead.
+                rebuilt.insert("uid".to_owned(), value);
+            }
+            *map = rebuilt;
+        }
     }
     Ok(())
 }
@@ -599,6 +628,7 @@ async fn apply_change(
             // node rows reassemble to these bytes, and the released-generation
             // reader's answer is what a later `stable` deployment reads back.
             let stable_compatible = profile::stable_compatible(ctx.spec_profile, kind, &canonical);
+            let canonical_text = Some(canonical_body_text(&canonical)?);
             let rows = decompose(canonical)?;
             let time_committed = match known_now {
                 Some(ts) => ts,
@@ -616,6 +646,7 @@ async fn apply_change(
                 close_ordinal: None,
                 client_signature: signature,
                 rows,
+                canonical_text,
                 stable_compatible,
                 attestations,
                 is_first_folder: kind == Kind::Folder && ehr_id.is_some(),
@@ -655,6 +686,7 @@ async fn apply_change(
                 &object_version_id(vo_id, &ctx.system_id, next.tree),
             )?;
             let stable_compatible = profile::stable_compatible(ctx.spec_profile, kind, &canonical);
+            let canonical_text = Some(canonical_body_text(&canonical)?);
             let rows = decompose(canonical)?;
             ResolvedWrite {
                 kind,
@@ -668,6 +700,7 @@ async fn apply_change(
                 close_ordinal: next.close_ordinal,
                 client_signature: signature,
                 rows,
+                canonical_text,
                 stable_compatible,
                 attestations,
                 is_first_folder: false,
@@ -698,6 +731,7 @@ async fn apply_change(
                 close_ordinal: next.close_ordinal,
                 client_signature: signature,
                 rows: Vec::new(),
+                canonical_text: None,
                 // A deleted version's data is Void (master06 §Logical
                 // Deletion): there is no body a generation could fail to
                 // express.
@@ -769,7 +803,7 @@ async fn commit_resolved(
     .map(openehr_its::json::to_canonical_value)
     .collect();
 
-    let (body, signature, signature_client_supplied) =
+    let (signature, signature_client_supplied) =
         body_and_signature(ctx, audit, contribution_id, &r, &at_committal_attestations)?;
 
     let folded = crate::storage::version_repo::commit::FoldedVersion {
@@ -787,7 +821,7 @@ async fn commit_resolved(
         signature: signature.as_deref(),
         signature_client_supplied,
         stable_compatible: r.stable_compatible,
-        body: body.as_ref(),
+        body: r.canonical_text.as_deref(),
         time_committed: r.time_committed,
         rows: &r.rows,
         // The superseded lineage tip closes inside the SAME statement (its
@@ -854,11 +888,28 @@ async fn commit_resolved(
     ))
 }
 
-/// Reassemble the version body ONCE and derive the signature over it.
+/// Serialize the accepted, uid-stamped canonical value to the body BYTES a
+/// point read serves verbatim (`vo_version.body` — #2913: text, taken BEFORE
+/// node decomposition, so the served wire keeps the codec's `_type`-first,
+/// BMM-declared field order).
 ///
-/// The value the signature covers, the stored `vo_version.body`, and the value
-/// point reads serve are the same bytes by construction — the rows are the
-/// ones `write_nodes` stores; empty rows = logical delete (`None` body).
+/// # Errors
+/// [`ServiceError`] when the value cannot serialize (a non-finite number —
+/// unreachable for a codec-produced canonical value, refused loudly anyway).
+fn canonical_body_text(canonical: &Value) -> Result<String, ServiceError> {
+    serde_json::to_string(canonical)
+        .map_err(|e| ServiceError::internal("serialize the canonical body", e))
+}
+
+/// Reassemble the version body from the node rows and derive the signature
+/// over it.
+///
+/// The signature input is the reassembled value; the stored `vo_version.body`
+/// is the pre-decomposition text ([`canonical_body_text`]). The two are the
+/// same VALUE by decompose/reassemble fidelity, and the signature
+/// canonicalization is RFC 8785 (key-order-insensitive), so signing the
+/// reassembled form still proves the stored and served bytes. Empty rows =
+/// logical delete (Void body is signed — master06 §Logical Deletion).
 ///
 /// # Errors
 /// The reassembly [`ServiceError`] or the signer's failure.
@@ -868,21 +919,20 @@ fn body_and_signature(
     contribution_id: Uuid,
     r: &ResolvedWrite,
     at_committal_attestations: &[Value],
-) -> Result<(Option<Value>, Option<String>, bool), ServiceError> {
+) -> Result<(Option<String>, bool), ServiceError> {
     let body = if r.rows.is_empty() {
         None
     } else {
         Some(reassemble(&r.rows)?)
     };
-    let (signature, client_supplied) = version_signature(
+    version_signature(
         ctx,
         audit,
         contribution_id,
         r,
         body.as_ref(),
         at_committal_attestations,
-    )?;
-    Ok((body, signature, client_supplied))
+    )
 }
 
 /// The signature stored with the version, and whether it is **client-supplied**

--- a/app/ferroehr/tests/it/persistence.rs
+++ b/app/ferroehr/tests/it/persistence.rs
@@ -852,14 +852,16 @@ async fn materialized_body_matches_node_reassembly_on_a_real_commit() {
     let ehr_id = service.create_ehr(None).await.expect("ehr create");
 
     // The EHR create commits an EHR_STATUS through the full commit path.
-    let (vo, body): (Uuid, Option<Value>) = sqlx::query_as(
+    let (vo, body): (Uuid, Option<String>) = sqlx::query_as(
         "SELECT vo_id, body FROM vo_version WHERE ehr_id = $1 AND kind = 'EHR_STATUS'",
     )
     .bind(ehr_id.0)
     .fetch_one(&pool)
     .await
     .expect("status version row");
-    let body = body.expect("a content-bearing version materializes its body");
+    let body: Value =
+        serde_json::from_str(&body.expect("a content-bearing version materializes its body"))
+            .expect("the stored body text parses");
     let reassembled = read_version_canonical(&pool, ferroehr::ids::VoId(vo), 1)
         .await
         .expect("node reassembly");

--- a/app/ferroehr/tests/it/storage_parity.rs
+++ b/app/ferroehr/tests/it/storage_parity.rs
@@ -215,7 +215,7 @@ async fn a_tampered_version_body_is_reported_as_content_differs() {
     // The other copy: the materialized projection every point read serves.
     tamper(
         &pool,
-        "UPDATE vo_version SET body = jsonb_set(body, '{archetype_node_id}', '\"tampered\"') \
+        "UPDATE vo_version SET body = (jsonb_set((body)::jsonb, '{archetype_node_id}', '\"tampered\"'))::text \
          WHERE vo_id = $1 AND sys_version = $2",
         vo_id,
         sys_version,

--- a/docs/conformance/ferroehr/CONFORMANCE_CERTIFICATE.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_CERTIFICATE.md
@@ -4,7 +4,7 @@
 
 | Field | Value |
 | --- | --- |
-| Solution | ferroehr 4.0.9 |
+| Solution | ferroehr 4.0.10 |
 | Vendor | Ruben Talstra |
 | Runner | veredictum 0.1.0-alpha.6 |
 | Infrastructure | ixit.json#/environment |

--- a/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
@@ -1,6 +1,6 @@
 # Conformance Report
 
-SUT: FerroEHR 4.0.9 (sut `ferroehr`) · schedule cnf-2.0-w2 · ITS its-rest
+SUT: FerroEHR 4.0.10 (sut `ferroehr`) · schedule cnf-2.0-w2 · ITS its-rest
 Runner: veredictum 0.1.0-alpha.6 · verification pack: passed
 
 ## Summary

--- a/docs/conformance/ferroehr/results.json
+++ b/docs/conformance/ferroehr/results.json
@@ -1,7 +1,7 @@
 {
   "sut": {
     "name": "ferroehr",
-    "version": "4.0.9"
+    "version": "4.0.10"
   },
   "runner": {
     "name": "veredictum",


### PR DESCRIPTION
Closes #2913.

**The fix, at the layer the defect lived:** `vo_version.body` becomes `text COMPRESSION lz4` (greenfield baseline edit; the cold mirror follows via `LIKE`), and the stored bytes are the accepted, uid-stamped canonical value serialized BEFORE node decomposition — so a point read serves the codec's `_type`-first, BMM-declared field order verbatim instead of PostgreSQL's jsonb key ordering (length-then-bytes), which is what the community observed on the wire.

**The stamped uid lands at its BMM position** (the borutjures refinement): `stamp_version_uid` now places a fresh `uid` after `archetype_node_id` (the RM BMM declares LOCATABLE as name, archetype_node_id, uid, links) instead of appending to the map's end; a client-supplied `uid` keeps its position by in-place replace.

**Signature semantics unchanged:** the `VERSION.signature` canonicalization is RFC 8785 (key-order-insensitive), so signing the node-row reassembly still proves the stored and served bytes; verified in place with the doc updated.

**Every body consumer dispositioned:**
- The typed read path parses the stored text (order kept via `preserve_order`); the raw JSON-accept passthrough serves the column verbatim — that IS the fix's serving path.
- The rare SQL that inspects the body casts (`(body)::jsonb #>>/->>`): the template/category lookups in `meta.rs`/`placement.rs`, the node-repo category probe, the tag-category filter.
- AQL whole-object assembly (`read_root_bodies`) parses the text — whole-object cells now carry canonical order too.
- **Dump/export reads the stored bytes instead of reassembling from node rows** (`stored_body_all`, tier-spanning): the node `data` fragments are jsonb and leaked their ordering into archives — the export/load round-trip is byte-equal again, pinned by the existing round-trip suite. The storage-parity sweep keeps the node-reassembly reader (comparing the two is its whole point).
- Import/archive-load bind serialized text; `StorageError::BodyDecode` names the (corruption-only) parse failure, mapped to the codec-fault 500.

**Pinned by:** the rewritten `composition_get_serves_stored_json_verbatim` — a create carrying NO body `uid`, whose GET must open with `_type`, carry `["_type","name","archetype_node_id","uid"]` as the leading keys, and be **byte-identical to the canonical codec's own re-encoding** of itself, with the version-addressed read serving the same bytes. (The old test pinned the jsonb artifact — the body opening with `uid` — and is replaced by the strictly stronger contract, per the adjudicated semantics change.)

Suites: ferroehr 989/989, ferroehr-rest 773/773; fmt/clippy/comment-style/typed-status clean. Zero-drift conformance run + the read-latency sanity check land as comments before merge. Changelog `### Fixed` entry included (wire-visible).
