### PR TITLE
fix(aql): predicates and projections see every element of a list-valued fragment path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- AQL predicates and projections now see every element of a list-valued
+  attribute (`links`, `context/participations`, composer `identifiers`,
+  `mappings`, ...). Previously the extraction took only the first match, so
+  `WHERE c/links/target/value = ...` missed a match on the second link and
+  `SELECT` over such a path served one value where the data held several —
+  silently. Comparisons, `LIKE`, `MATCHES` and `EXISTS` are any-match;
+  projection returns every match as one JSON array cell (`null` when nothing
+  matches).
+- An AQL node predicate written on the ROOT of an identified path
+  (`c[openEHR-EHR-COMPOSITION.report.v1]/name/value`) now constrains the
+  query — it was silently discarded, so the path answered as if the
+  predicate were not written. The two shapes that still have no lowering — a
+  predicate on a non-structure path step (`links[at0001]`) and a node
+  predicate on a whole-object projection — are refused with a typed error
+  instead of being ignored.
 - Reads serve the exact canonical bytes the commit accepted: `_type` first
   and every field at its spec-declared position — including the
   server-stamped `uid`, which now lands at its place in the document instead

--- a/app/ferroehr/src/aql/analyze.rs
+++ b/app/ferroehr/src/aql/analyze.rs
@@ -135,7 +135,6 @@ fn analyze_rm_path(
     let mut fragment: Vec<FragmentStep> = Vec::new();
     let mut in_fragment = false;
     let mut current = root_types.clone();
-    let mut multi_valued = false;
     // The candidate types of the *parent* of the final step, and the final
     // attribute name — used to coerce a `.../value` leaf under a temporal DV
     // parent to `Temporal` (its `value` is an ISO-8601 String; QUERY §Built-in
@@ -148,9 +147,6 @@ fn analyze_rm_path(
             parent_types = current.clone();
             last_name = Some(part.name.clone());
             let (step_types, is_multi) = resolve_attribute(&current, &part.name, profile)?;
-            if is_multi {
-                multi_valued = true;
-            }
             let predicate = part
                 .predicate
                 .as_ref()
@@ -195,7 +191,6 @@ fn analyze_rm_path(
         fragment,
         types: current,
         coercion,
-        multi_valued,
     })
 }
 

--- a/app/ferroehr/src/aql/ir.rs
+++ b/app/ferroehr/src/aql/ir.rs
@@ -328,8 +328,6 @@ pub struct LeafPath {
     pub types: TypeSet,
     /// The typed extraction/comparison strategy.
     pub coercion: Coercion,
-    /// Whether any step along the path is a list/set (⇒ multi-valued leaf).
-    pub multi_valued: bool,
 }
 
 impl LeafPath {
@@ -337,6 +335,15 @@ impl LeafPath {
     #[must_use]
     pub fn is_whole_object(&self) -> bool {
         self.fragment.is_empty()
+    }
+
+    /// Whether the fragment tail crosses a list/set-valued attribute — the
+    /// extraction then yields several items within ONE anchor node, and the
+    /// SQL layer lowers predicates existentially and projections as an array
+    /// cell.
+    #[must_use]
+    pub fn fragment_multi_valued(&self) -> bool {
+        self.fragment.iter().any(|s| s.multi_valued)
     }
 }
 

--- a/app/ferroehr/src/aql/sql/expr.rs
+++ b/app/ferroehr/src/aql/sql/expr.rs
@@ -53,6 +53,23 @@ pub(super) fn jsonb_path(data: Expr, jp: &str) -> Expr {
     )
 }
 
+/// `NULLIF(jsonb_path_query_array(data, '<jp>'::jsonpath), '[]'::jsonb)` —
+/// every fragment match as ONE jsonb array cell, SQL `NULL` when the path
+/// matches nothing (so absence keeps reading as a NULL cell / a false
+/// comparison, exactly as the scalar extraction reads it).
+pub(super) fn jsonb_path_array(data: Expr, jp: &str) -> Expr {
+    call(
+        "nullif",
+        vec![
+            call(
+                "jsonb_path_query_array",
+                vec![data, cast(Expr::val(jp.to_owned()), "jsonpath")],
+            ),
+            cast(Expr::val("[]"), "jsonb"),
+        ],
+    )
+}
+
 /// `<jsonb> #>> '{}'` — the scalar's text at the empty path.
 pub(super) fn as_text(e: Expr) -> Expr {
     e.binary(BinOper::Custom("#>>"), cast(Expr::val("{}"), "text[]"))

--- a/app/ferroehr/src/aql/sql/predicate.rs
+++ b/app/ferroehr/src/aql/sql/predicate.rs
@@ -54,9 +54,7 @@ impl Builder<'_> {
                 rhs,
                 coercion,
             } => self.compare_expr(lhs, *op, rhs, *coercion, positive),
-            IrExpr::Exists(target) => Ok(self
-                .value_expr(target, ValueMode::Projection)?
-                .is_not_null()),
+            IrExpr::Exists(target) => self.exists_path_expr(target),
             IrExpr::Like { path, pattern } => self.like_expr(path, pattern, positive),
             IrExpr::Const(b) => Ok(Expr::val(*b)),
             IrExpr::Matches {
@@ -65,6 +63,33 @@ impl Builder<'_> {
                 coercion,
             } => self.matches_expr(path, values, *coercion, positive),
         }
+    }
+
+    /// Lowers `EXISTS <path>` (QUERY master03 §EXISTS): true when the path has
+    /// a value on ANY node the anchored walk matches / ANY fragment item — the
+    /// existential shape is exact for pure existence in BOTH polarities (the
+    /// test is boolean, so the three-valued caveat on comparisons does not
+    /// apply). A leaf the existential lowering declines (uid synthesis, a
+    /// promoted column, a single-valued inline read) keeps the scalar
+    /// `IS NOT NULL` shape, which is exact there.
+    ///
+    /// # Errors
+    /// [`AqlError`] from the path lowerings.
+    fn exists_path_expr(&mut self, target: &PathTarget) -> Result<Expr, AqlError> {
+        if let Some(leaf) = Self::existential_leaf(target) {
+            let leaf = leaf.clone();
+            self.ensure_leaf_root(target)?;
+            if let Some(expr) = self.data_leaf_exists(
+                &leaf,
+                ValueMode::Projection,
+                sea_query::ExprTrait::is_not_null,
+            )? {
+                return Ok(expr);
+            }
+        }
+        Ok(self
+            .value_expr(target, ValueMode::Projection)?
+            .is_not_null())
     }
 
     /// Lowers a comparison, taking the first lowering that applies: the typed

--- a/app/ferroehr/src/aql/sql/select.rs
+++ b/app/ferroehr/src/aql/sql/select.rs
@@ -150,6 +150,16 @@ impl Builder<'_> {
     /// anchor → the source node; otherwise the anchor chain is joined in and its
     /// final node alias returned.
     fn whole_object_alias(&mut self, leaf: &LeafPath) -> Result<String, AqlError> {
+        // A root predicate on a whole-object projection has no lowering (the
+        // reassembly locators cannot carry a per-row guard yet): refuse loudly
+        // rather than serve the object as if the predicate were not written.
+        // TODO(#2927): decide and lower the guarded whole-object projection.
+        if leaf.root_predicate.is_some() {
+            return Err(crate::aql::error::SqlError::Unsupported(
+                "a node predicate on a whole-object projection is not supported".to_owned(),
+            )
+            .into());
+        }
         let src = self.source_node(leaf.source.0)?;
         if leaf.anchor.is_empty() {
             return Ok(src);

--- a/app/ferroehr/src/aql/sql/value.rs
+++ b/app/ferroehr/src/aql/sql/value.rs
@@ -85,16 +85,45 @@ impl Builder<'_> {
         if let Some(expr) = self.promoted_leaf_expr(leaf, mode) {
             return Ok(expr);
         }
+        reject_fragment_predicates(leaf)?;
         let src = self.source_node(leaf.source.0)?;
+        let root_conds = leaf
+            .root_predicate
+            .as_ref()
+            .map(|p| self.node_constraint_conds(&src, p))
+            .transpose()?;
         let jp = fragment_jsonpath(leaf);
+        // NOTE: QUERY master03 §Identified Paths is silent on projecting a
+        // list-valued fragment path — our own decision: every match as ONE
+        // jsonb array cell; scalar contexts keep the first-match extraction.
+        let projected_array =
+            matches!(mode, ValueMode::Projection) && jp.is_some() && leaf.fragment_multi_valued();
+        let extract = |data: Expr| -> Expr {
+            match (&jp, projected_array) {
+                (Some(jp), true) => super::expr::jsonb_path_array(data, jp),
+                _ => extract_base(data, jp.as_deref()),
+            }
+        };
 
         if leaf.anchor.is_empty() {
-            let base = extract_base(col(&src, "data"), jp.as_deref());
-            return Ok(coerce_value(base, mode, leaf));
+            let base = extract(col(&src, "data"));
+            let value = coerce_value(base, mode, leaf);
+            // A root predicate guards the inline read: the value only exists
+            // where the source node satisfies it (QUERY master03 §Identified
+            // Paths — a node predicate qualifies the object the path reads).
+            return Ok(match all_of(root_conds) {
+                Some(cond) => sea_query::CaseStatement::new().case(cond, value).into(),
+                None => value,
+            });
         }
 
         let (mut sub, last) = self.anchored_walk(leaf, &src)?;
-        let base = extract_base(col(&last, "data"), jp.as_deref());
+        if let Some(conds) = root_conds {
+            for cond in conds {
+                sub.and_where(cond);
+            }
+        }
+        let base = extract(col(&last, "data"));
         sub.expr(coerce_value(base, mode, leaf));
         sub.limit(1);
         Ok(Expr::from(sub))
@@ -146,25 +175,60 @@ impl Builder<'_> {
     /// cross-EHR profile showed collapsing cardinality estimates and
     /// materializing bitmap plans under `LIMIT`).
     ///
-    /// Returns `Ok(None)` when the leaf is not an anchored-walk extraction
-    /// (uid synthesis, a promoted column, or an inline fragment read) — the
-    /// caller falls back to the scalar comparison, which is exact there.
+    /// The same any-match rule covers a MULTI-VALUED FRAGMENT tail:
+    /// a path crossing a list-valued fragment attribute (`links`,
+    /// `participations`, `identifiers`, `mappings`, …) yields one item per
+    /// match through the set-returning `jsonb_path_query` in the subquery's
+    /// FROM, and the predicate holds when ANY item satisfies it — the scalar
+    /// `jsonb_path_query_first` saw only the first match.
+    ///
+    /// Returns `Ok(None)` when the leaf is a single-valued inline read, uid
+    /// synthesis, or a promoted column — the caller falls back to the scalar
+    /// comparison, which is exact there.
     pub(super) fn data_leaf_exists(
         &mut self,
         leaf: &LeafPath,
         mode: ValueMode,
         cond: impl FnOnce(Expr) -> Expr,
     ) -> Result<Option<Expr>, AqlError> {
-        if leaf.anchor.is_empty()
-            || self.version_uid_expr(leaf, mode).is_some()
+        if self.version_uid_expr(leaf, mode).is_some()
             || self.promoted_leaf_expr(leaf, mode).is_some()
         {
             return Ok(None);
         }
-        let src = self.source_node(leaf.source.0)?;
+        reject_fragment_predicates(leaf)?;
         let jp = fragment_jsonpath(leaf);
-        let (mut sub, last) = self.anchored_walk(leaf, &src)?;
-        let base = extract_base(col(&last, "data"), jp.as_deref());
+        let multi = jp.is_some() && leaf.fragment_multi_valued();
+        if leaf.anchor.is_empty() && !multi {
+            return Ok(None);
+        }
+        let src = self.source_node(leaf.source.0)?;
+        let mut sub;
+        let base;
+        if leaf.anchor.is_empty() {
+            // `multi` holds here, so the fragment jsonpath exists.
+            let Some(jp) = jp.as_deref() else {
+                return Ok(None);
+            };
+            sub = Query::select();
+            base = fragment_items(&mut sub, col(&src, "data"), jp, self.next_ctr());
+        } else {
+            let (walk, last) = self.anchored_walk(leaf, &src)?;
+            sub = walk;
+            base = match (jp.as_deref(), multi) {
+                (Some(jp), true) => {
+                    fragment_items(&mut sub, col(&last, "data"), jp, self.next_ctr())
+                }
+                _ => extract_base(col(&last, "data"), jp.as_deref()),
+            };
+        }
+        // The root predicate correlates against the source node: the value
+        // only exists where the source satisfies it.
+        if let Some(pred) = &leaf.root_predicate {
+            for c in self.node_constraint_conds(&src, pred)? {
+                sub.and_where(c);
+            }
+        }
         sub.expr(Expr::val(1));
         sub.and_where(cond(coerce_value(base, mode, leaf)));
         if self.streaming {
@@ -555,6 +619,44 @@ pub(super) fn ehr_field_expr(alias: &str, field: EhrField, system_id: &str) -> E
         EhrField::TimeCreated => col(alias, "time_created"),
         EhrField::SystemId => Expr::val(system_id.to_owned()),
     }
+}
+
+/// A predicate on a fragment step (below the anchor node) has no SQL lowering
+/// yet — refusing loudly keeps the engine's typed-reject rule: the silent
+/// alternative answers as if the predicate were not written.
+// TODO(#2927): lower fragment-step predicates as jsonpath filter expressions.
+fn reject_fragment_predicates(leaf: &LeafPath) -> Result<(), AqlError> {
+    match leaf.fragment.iter().find(|s| s.predicate.is_some()) {
+        Some(step) => Err(SqlError::Unsupported(format!(
+            "a predicate on the non-structure path step '{}' is not supported",
+            step.name
+        ))
+        .into()),
+        None => Ok(()),
+    }
+}
+
+/// AND-combine a lowered condition list, `None` for an absent/empty list.
+fn all_of(conds: Option<Vec<Expr>>) -> Option<Expr> {
+    conds.and_then(|c| c.into_iter().reduce(sea_query::ExprTrait::and))
+}
+
+/// Adds the set-returning `jsonb_path_query(<data>, '<jp>'::jsonpath)` to the
+/// subquery's FROM and returns the per-match item reference.
+///
+/// The call is implicitly LATERAL (a FROM function may reference columns of
+/// preceding FROM items — PostgreSQL docs §7.2.1.5 LATERAL Subqueries), and
+/// for a scalar-returning function the table alias doubles as the column name
+/// (§7.2.1.4 Table Functions).
+fn fragment_items(sub: &mut sea_query::SelectStatement, data: Expr, jp: &str, n: usize) -> Expr {
+    let alias = format!("f{n}");
+    sub.from_function(
+        sea_query::Func::cust(Alias::new("jsonb_path_query"))
+            .arg(data)
+            .arg(cast(Expr::val(jp.to_owned()), "jsonpath")),
+        Alias::new(alias.as_str()),
+    );
+    col(&alias, &alias)
 }
 
 // ── jsonpaths ───────────────────────────────────────────────────────────────

--- a/app/ferroehr/src/service/admin/dump_load.rs
+++ b/app/ferroehr/src/service/admin/dump_load.rs
@@ -1838,8 +1838,7 @@ impl FerroEhrService {
         let body = if lifecycle_state == DELETED_LIFECYCLE {
             Value::Null
         } else {
-            version_repo::read::stored_body_all(&self.pool, vo_id, sys_version)
-                .await?
+            version_repo::read::stored_body_all(&self.pool, vo_id, sys_version).await?
         };
         Ok(VersionRecord {
             vo_id,
@@ -1954,8 +1953,7 @@ impl FerroEhrService {
             let body = if lifecycle_state == DELETED_LIFECYCLE {
                 Value::Null
             } else {
-                version_repo::read::stored_body_all(&self.pool, vo_id, sys_version)
-                    .await?
+                version_repo::read::stored_body_all(&self.pool, vo_id, sys_version).await?
             };
             versions.push(VersionRecord {
                 vo_id,

--- a/app/ferroehr/tests/it/aql_planner.rs
+++ b/app/ferroehr/tests/it/aql_planner.rs
@@ -126,7 +126,10 @@ fn path_split_bp_example() {
     );
     assert_eq!(fragment_names(leaf), ["value", "magnitude"]);
     assert_eq!(leaf.coercion, Coercion::Magnitude, "magnitude is numeric");
-    assert!(leaf.multi_valued, "content/events/items are list-valued");
+    assert!(
+        leaf.anchor.iter().any(|s| s.multi_valued),
+        "content/events/items are list-valued anchor steps"
+    );
     // The leaf resolves to the numeric primitive(s) behind `magnitude`.
     assert!(leaf.types.contains("Real") || leaf.types.contains("Integer"));
 }
@@ -759,6 +762,146 @@ fn full_scalar_function_set_plans() {
 /// so every remaining `EXISTS` is a containment anchor (OR / NOT CONTAINS).
 fn anchor_exists(sql: &str) -> usize {
     sql.matches("EXISTS(SELECT").count()
+}
+
+/// A predicate whose leaf crosses a MULTI-VALUED FRAGMENT attribute
+/// (`LOCATABLE.links` — LINK is no structure root, so the whole list lives in
+/// the root node's fragment) lowers existentially through the set-returning
+/// `jsonb_path_query`, never the first-match scalar: QUERY master03 §WHERE is
+/// silent on multi-valued predicates, and any-match is the adjudicated
+/// semantics recorded on `data_leaf_exists`.
+#[test]
+fn multi_valued_fragment_predicate_lowers_existentially() {
+    let sql = build_sql(
+        "SELECT c/uid/value FROM EHR e CONTAINS COMPOSITION c \
+         WHERE c/links/target/value = 'ehr://x/1'",
+    );
+    assert!(
+        sql.contains("jsonb_path_query("),
+        "set-returning per-match extraction: {sql}"
+    );
+    assert!(
+        !sql.contains("jsonb_path_query_first"),
+        "no first-match scalar remains on the links predicate: {sql}"
+    );
+    assert!(sql.contains("EXISTS"), "existential shape: {sql}");
+}
+
+/// The same existential lowering applies when the multi-valued fragment sits
+/// UNDER an anchored structure walk (`context` is a structure hop,
+/// `participations` its list-valued fragment).
+#[test]
+fn anchored_multi_valued_fragment_predicate_is_existential() {
+    let sql = build_sql(
+        "SELECT c/uid/value FROM EHR e CONTAINS COMPOSITION c \
+         WHERE c/context/participations/performer/name = 'Dr Second'",
+    );
+    assert!(
+        sql.contains("jsonb_path_query(") && sql.contains("BETWEEN"),
+        "anchored walk + per-match extraction: {sql}"
+    );
+    assert!(sql.contains("EXISTS"), "existential shape: {sql}");
+}
+
+/// Projection over a multi-valued fragment path yields every match as ONE
+/// jsonb array cell (`jsonb_path_query_array`, NULL when nothing matches) —
+/// QUERY master03 §Identified Paths is silent; the array cell is the decided
+/// semantics (no element invisible, row cardinality untouched).
+#[test]
+fn multi_valued_fragment_projection_is_an_array_cell() {
+    let sql = build_sql("SELECT c/links/target/value FROM EHR e CONTAINS COMPOSITION c");
+    assert!(
+        sql.contains("jsonb_path_query_array("),
+        "array-cell projection: {sql}"
+    );
+    assert!(
+        sql.contains("nullif("),
+        "an empty match set is a NULL cell, not []: {sql}"
+    );
+}
+
+/// A single-valued fragment leaf keeps the exact first-match scalar
+/// extraction — the existential machinery only fires where multiplicity is
+/// real.
+#[test]
+fn single_valued_fragment_predicate_keeps_the_scalar_extraction() {
+    let sql = build_sql(
+        "SELECT c/uid/value FROM EHR e CONTAINS COMPOSITION c \
+         WHERE c/name/value = 'report'",
+    );
+    assert!(
+        sql.contains("jsonb_path_query_first"),
+        "single-valued stays scalar: {sql}"
+    );
+    assert!(
+        !sql.contains("jsonb_path_query("),
+        "no set-returning extraction for a single-valued leaf: {sql}"
+    );
+}
+
+/// `EXISTS <path>` over a multi-valued fragment lowers through the same
+/// per-match shape — exact in both polarities (the test is boolean, so the
+/// three-valued comparison caveat does not apply).
+#[test]
+fn exists_over_multi_valued_fragment_is_per_match() {
+    let sql = build_sql(
+        "SELECT c/uid/value FROM EHR e CONTAINS COMPOSITION c \
+         WHERE EXISTS c/links/target/value",
+    );
+    assert!(
+        sql.contains("jsonb_path_query(") && sql.contains("IS NOT NULL"),
+        "existence probes every match: {sql}"
+    );
+}
+
+/// A predicate on the path ROOT reaches the SQL: the leaf value only exists
+/// where the source node satisfies it (QUERY master03 §Identified Paths — a
+/// node predicate qualifies the object the path reads). Before the fix the
+/// constraint silently vanished and any composition's name matched.
+#[test]
+fn path_root_predicate_reaches_the_sql() {
+    let sql = build_sql(
+        "SELECT c/uid/value FROM EHR e CONTAINS COMPOSITION c \
+         WHERE c[openEHR-EHR-COMPOSITION.report.v1]/name/value = 'x'",
+    );
+    assert!(
+        sql.contains("arch_concept"),
+        "the root archetype predicate is lowered, not dropped: {sql}"
+    );
+    // Projection context: the guarded read is a CASE over the same condition.
+    let sql = build_sql(
+        "SELECT c[openEHR-EHR-COMPOSITION.report.v1]/name/value \
+         FROM EHR e CONTAINS COMPOSITION c",
+    );
+    assert!(
+        sql.contains("CASE WHEN") && sql.contains("arch_concept"),
+        "the projected read is guarded by the root predicate: {sql}"
+    );
+}
+
+/// A predicate on a FRAGMENT step and a root predicate on a whole-object
+/// projection are TYPED REJECTS: neither has a SQL lowering yet, and building
+/// the query without the constraint would answer as if it were not written.
+#[test]
+fn unlowerable_path_predicates_are_typed_rejects() {
+    for (q, needle) in [
+        (
+            "SELECT c/uid/value FROM EHR e CONTAINS COMPOSITION c \
+             WHERE c/links[at0001]/target/value = 'x'",
+            "non-structure path step 'links'",
+        ),
+        (
+            "SELECT c[openEHR-EHR-COMPOSITION.report.v1] \
+             FROM EHR e CONTAINS COMPOSITION c",
+            "whole-object projection",
+        ),
+    ] {
+        let err = build_err(q);
+        assert!(
+            err.to_string().contains(needle),
+            "{q:?} must reject with {needle:?}: {err}"
+        );
+    }
 }
 
 /// OR-containment under an EHR lowers to a disjunction of correlated

--- a/app/ferroehr/tests/it/service_aql.rs
+++ b/app/ferroehr/tests/it/service_aql.rs
@@ -1680,6 +1680,193 @@ async fn like_and_matches_are_any_match_on_multi_valued_paths() {
     assert_eq!(rows(&none).len(), 0, "no node satisfies: {none}");
 }
 
+/// A composition carrying MULTI-VALUED FRAGMENT attributes — two `links` on
+/// the root, two `context/participations`, two composer `identifiers` — where
+/// only the LAST element of each list satisfies the predicates below.
+fn multi_fragment_composition() -> Value {
+    let mut c = composition("multi-fragment", 7.0);
+    c["links"] = json!([
+        {
+            "_type": "LINK",
+            "meaning": { "_type": "DV_TEXT", "value": "problem" },
+            "type": { "_type": "DV_TEXT", "value": "clinical" },
+            "target": { "_type": "DV_EHR_URI", "value": "ehr://x/first" }
+        },
+        {
+            "_type": "LINK",
+            "meaning": { "_type": "DV_TEXT", "value": "issue" },
+            "type": { "_type": "DV_TEXT", "value": "clinical" },
+            "target": { "_type": "DV_EHR_URI", "value": "ehr://x/last" }
+        }
+    ]);
+    c["context"]["participations"] = json!([
+        {
+            "_type": "PARTICIPATION",
+            "function": { "_type": "DV_TEXT", "value": "observer" },
+            "performer": { "_type": "PARTY_IDENTIFIED", "name": "Dr First" }
+        },
+        {
+            "_type": "PARTICIPATION",
+            "function": { "_type": "DV_TEXT", "value": "assistant" },
+            "performer": { "_type": "PARTY_IDENTIFIED", "name": "Dr Second" }
+        }
+    ]);
+    c["composer"] = json!({
+        "_type": "PARTY_IDENTIFIED",
+        "name": "composer",
+        "identifiers": [
+            { "_type": "DV_IDENTIFIER", "id": "MRN-1" },
+            { "_type": "DV_IDENTIFIER", "id": "MRN-2" }
+        ]
+    });
+    c
+}
+
+/// Predicates over MULTI-VALUED FRAGMENT paths are any-match: with two
+/// `links`, two `context/participations` and two composer `identifiers` where
+/// only the LAST element satisfies each predicate, the row must return for
+/// `=`, `LIKE`, `MATCHES` and `EXISTS` alike — the first-match scalar
+/// extraction this replaces saw only element one. (QUERY master03 §WHERE is
+/// silent on multi-valued predicates — the any-match adjudication on
+/// `data_leaf_exists` covers the fragment half too.)
+#[tokio::test]
+async fn multi_valued_fragment_predicates_are_any_match() {
+    let db = testkit::db().await.expect("testkit database");
+    let svc = FerroEhrService::new(db.pool());
+    let ehr_id = create_ehr(&svc).await;
+    svc.create_composition(
+        ehr_id.parse().expect("ehr_id uuid"),
+        uv(&multi_fragment_composition(), "249", None),
+    )
+    .await
+    .expect("multi-fragment composition");
+    // A second composition with none of the list-valued attributes, so every
+    // predicate below also proves it does NOT match vacuously.
+    create_comp(&svc, &ehr_id, "plain", 1.0).await;
+
+    // `=` on the root fragment list (links), last element only.
+    let eq = run_aql(
+        &svc,
+        "SELECT c/name/value FROM EHR e CONTAINS COMPOSITION c \
+         WHERE c/links/target/value = 'ehr://x/last'",
+        ehr_scope(&ehr_id),
+    )
+    .await;
+    assert_eq!(rows(&eq).len(), 1, "= matches the LAST link: {eq}");
+    assert_eq!(rows(&eq)[0][0], json!("multi-fragment"));
+
+    // `=` on an anchored fragment list (context → participations), last only.
+    let anchored = run_aql(
+        &svc,
+        "SELECT c/name/value FROM EHR e CONTAINS COMPOSITION c \
+         WHERE c/context/participations/performer/name = 'Dr Second'",
+        ehr_scope(&ehr_id),
+    )
+    .await;
+    assert_eq!(
+        rows(&anchored).len(),
+        1,
+        "= matches the LAST participation: {anchored}"
+    );
+
+    // `LIKE` on the second identifier of the composer.
+    let like = run_aql(
+        &svc,
+        "SELECT c/name/value FROM EHR e CONTAINS COMPOSITION c \
+         WHERE c/composer/identifiers/id LIKE 'MRN-2*'",
+        ehr_scope(&ehr_id),
+    )
+    .await;
+    assert_eq!(
+        rows(&like).len(),
+        1,
+        "LIKE matches the LAST identifier: {like}"
+    );
+
+    // `MATCHES` against a set only the last link satisfies.
+    let matches = run_aql(
+        &svc,
+        "SELECT c/name/value FROM EHR e CONTAINS COMPOSITION c \
+         WHERE c/links/target/value MATCHES {'ehr://x/last', 'ehr://other'}",
+        ehr_scope(&ehr_id),
+    )
+    .await;
+    assert_eq!(rows(&matches).len(), 1, "MATCHES is any-match: {matches}");
+
+    // `EXISTS` distinguishes the composition carrying links from the plain
+    // one (the vendored base fixture has no links).
+    let exists = run_aql(
+        &svc,
+        "SELECT c/name/value FROM EHR e CONTAINS COMPOSITION c \
+         WHERE EXISTS c/links/target/value",
+        ehr_scope(&ehr_id),
+    )
+    .await;
+    assert_eq!(rows(&exists).len(), 1, "EXISTS is per-match: {exists}");
+    assert_eq!(rows(&exists)[0][0], json!("multi-fragment"));
+
+    // A predicate no element satisfies still returns nothing (no vacuous truth).
+    let none = run_aql(
+        &svc,
+        "SELECT c/name/value FROM EHR e CONTAINS COMPOSITION c \
+         WHERE c/links/target/value = 'ehr://x/absent'",
+        ehr_scope(&ehr_id),
+    )
+    .await;
+    assert_eq!(rows(&none).len(), 0, "no element satisfies: {none}");
+}
+
+/// Projection over a multi-valued fragment path serves EVERY match as one
+/// jsonb array cell, and NULL where the path matches nothing — QUERY master03
+/// §Identified Paths is silent on the shape; the array cell is the decided
+/// semantics (the first-match scalar served one target where the data held
+/// two).
+#[tokio::test]
+async fn multi_valued_fragment_projection_serves_every_match() {
+    let db = testkit::db().await.expect("testkit database");
+    let svc = FerroEhrService::new(db.pool());
+    let ehr_id = create_ehr(&svc).await;
+    svc.create_composition(
+        ehr_id.parse().expect("ehr_id uuid"),
+        uv(&multi_fragment_composition(), "249", None),
+    )
+    .await
+    .expect("multi-fragment composition");
+
+    let r = run_aql(
+        &svc,
+        "SELECT c/links/target/value, c/context/participations/performer/name \
+         FROM EHR e CONTAINS COMPOSITION c",
+        ehr_scope(&ehr_id),
+    )
+    .await;
+    assert_eq!(
+        rows(&r)[0][0],
+        json!(["ehr://x/first", "ehr://x/last"]),
+        "every link target projects, in document order: {r}"
+    );
+    assert_eq!(
+        rows(&r)[0][1],
+        json!(["Dr First", "Dr Second"]),
+        "every participation performer projects: {r}"
+    );
+
+    // The plain composition has no links: the cell is null, never [].
+    let ehr2 = create_ehr(&svc).await;
+    create_comp(&svc, &ehr2, "plain", 1.0).await;
+    let empty = run_aql(
+        &svc,
+        "SELECT c/links/target/value FROM EHR e CONTAINS COMPOSITION c",
+        ehr_scope(&ehr2),
+    )
+    .await;
+    assert_eq!(
+        rows(&empty)[0][0],
+        Value::Null,
+        "no match is a NULL cell: {empty}"
+    );
+}
+
 /// An uncoercible client binding is the CALLER's 400, never a 500 (#2593):
 /// measured live, `"not-a-date"` against a temporal predicate reached the
 /// driver as sqlstate 22007 and answered the opaque internal error.

--- a/website/book/src/querying-aql.md
+++ b/website/book/src/querying-aql.md
@@ -52,10 +52,13 @@ ORDER BY systolic DESC
   and RM attribute names (`value/magnitude`); `AS` names a column.
 - **`WHERE`** filters on typed leaf values, with comparisons, `EXISTS`, `LIKE`,
   `MATCHES`, and boolean combinators. Comparisons over multi-valued paths use
-  any-match semantics: when a path matches several nodes, the predicate holds if
-  **any** matched value satisfies it (the AQL specification is silent here;
-  any-match is this engine's documented convention, deterministic and
-  index-friendly).
+  any-match semantics: when a path matches several nodes or several elements of
+  a list attribute (`links`, `participations`, `identifiers`, ...), the
+  predicate holds if **any** matched value satisfies it (the AQL specification
+  is silent here; any-match is this engine's documented convention,
+  deterministic and index-friendly). Projecting a path that crosses a
+  list-valued attribute returns every match as one JSON array cell, and `null`
+  where nothing matches.
 - **`ORDER BY`**, **`LIMIT`**, and **`OFFSET`** behave as you expect; quantities
   order by their openEHR magnitude semantics.
 


### PR DESCRIPTION
Closes #2919.

**The any-match adjudication now covers the fragment half.** A predicate whose leaf crosses a list-valued fragment attribute (`LOCATABLE.links`, `EVENT_CONTEXT.participations`, `PARTY_IDENTIFIED.identifiers`, `DV_TEXT.mappings`, ...) lowers existentially through the set-returning `jsonb_path_query` — one item per match in the (implicitly LATERAL) FROM of the EXISTS subquery, the predicate conjoined over the coerced item — for `=` and friends, `LIKE`, `MATCHES`, and `EXISTS` alike, in both the inline (anchor-empty) and anchored-walk shapes. `jsonb_path_query_first` remains only where it is exact: single-valued fragments and the scalar contexts (ORDER BY, MIN/MAX/SUM/AVG, path-vs-path, negative-polarity comparisons — the same recorded polarity design the anchored lowering has carried since #1448).

**Projection over a multi-valued fragment path is decided:** every match as ONE jsonb array cell (`NULLIF(jsonb_path_query_array(...), '[]')` — SQL NULL when nothing matches, so absence keeps reading as a null cell and `COUNT`/`EXISTS` semantics stay exact). QUERY master03 §Identified Paths is silent; the `// NOTE:` on `data_leaf_expr` records the decision. `SELECT c/links/target/value` over two links now serves `["ehr://x/first","ehr://x/last"]` where it served one scalar.

**`LeafPath.multi_valued` is consumed via its step flags:** the dead whole-path aggregate is deleted; the SQL layer reads `fragment_multi_valued()` (the per-step flags analysis was already computing).

**En-route discovery, filed as #2927 and half-fixed here:** path-embedded predicates outside the anchor walk were SILENTLY DROPPED — `c[openEHR-EHR-COMPOSITION.report.v1]/name/value = 'x'` built SQL with no archetype condition, and `c/links[at0001]/...` discarded the constraint. The root predicate now lowers (CASE-guarded inline/anchored reads, conjoined in existential subqueries); the two shapes with no lowering yet — a fragment-step predicate, and a root predicate on a whole-object projection — are typed rejects carrying `TODO(#2927)`, per the engine's reject-never-silently-answer rule.

**Pinned by:** five planner SQL-shape tests (existential + array-cell + scalar-stays-scalar + EXISTS per-match + root-predicate reach/rejects) and two DB suites committing a composition with two links, two participations and two composer identifiers where only the LAST element matches — for `=` (root and anchored), `LIKE`, `MATCHES`, `EXISTS`, the array-cell projection, and the no-vacuous-truth negatives. The `EXISTS` control had to probe `links`: the vendored base fixture already carries a participation.

**The CNF wire case for LINK filtering** is filed as Veredictum#178 (catalogue changes live in the instrument's own tracker) with the any-match register ground spelled out; the local suites carry the behavioural pinning meanwhile.

Docs: the AQL book page's any-match paragraph now covers list attributes and states the array-cell projection shape; changelog entries under `### Fixed`.

Suites: ferroehr 998/998, ferroehr-rest 773/773, workspace clippy/fmt/comment-style/rustdoc clean. The zero-drift conformance run is recorded below before merge.
