### PR TITLE
fix(aql): partial-precision date/times compare through the total temporal floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- AQL date/time comparisons work on reduced-precision values. openEHR admits
+  partial date/times (`2019`, `1985-06`), but one stored anywhere in the
+  scanned data made every temporal comparison on that path fail as a 400
+  ("your request is malformed" — for a data property). Both sides of a
+  temporal comparison now floor a partial value to the first instant it
+  contains (first month/day, zero time), the same completion the promoted
+  timestamp column uses, so stored partials compare, order, and match
+  `NOW()` instead of erroring. A comparison value that is not an ISO 8601
+  date/time at all is still the caller's 400, now named at plan time; non-ISO
+  forms PostgreSQL happened to parse (e.g. `June 15, 2020`) are refused —
+  AQL temporal literals are ISO 8601.
 - AQL predicates and projections now see every element of a list-valued
   attribute (`links`, `context/participations`, composer `identifiers`,
   `mappings`, ...). Previously the extraction took only the first match, so

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5426,7 +5426,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "indexmap 2.14.0",
  "openehr-am",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "serde",
  "serde_json",
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "async-trait",
  "axum",
@@ -5500,7 +5500,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "assert_fs",
  "chumsky",
@@ -5514,7 +5514,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "chumsky",
  "logos",
@@ -5523,7 +5523,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "insta",
  "jsonschema",
@@ -5541,7 +5541,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/app/ferroehr/migrations/ext/0001_openehr_functions.sql
+++ b/app/ferroehr/migrations/ext/0001_openehr_functions.sql
@@ -246,48 +246,87 @@ BEGIN
     END IF;
 END $$;
 
--- ext.openehr_timestamp — a fail-safe ISO-8601 → timestamptz conversion.
+-- ext.openehr_timestamp — a total ISO-8601 → timestamptz reading.
 --
 -- No openEHR spec governs storage columns or their derivation — this is our own
--- design (docs/architecture.md §Storage). It exists so promoted timestamp
--- columns (the first being node.context_start, the ehr baseline) are populated
--- identically at write time and in their one-time backfill: both feed the raw
--- canonical leaf text (e.g. EVENT_CONTEXT.start_time.value) through this
--- function.
+-- design (docs/architecture.md §Storage). It is the ONE partial-precision
+-- semantics the product carries on the temporal read/write paths: the promoted
+-- timestamp columns (node.context_start) are populated through it at write +
+-- backfill, and the AQL engine's temporal comparisons/orderings
+-- (app/ferroehr/src/aql/sql/value.rs, Coercion::Temporal) extract through it —
+-- so the promoted fast path and the jsonb lowering can never disagree.
 --
--- The body is exactly PostgreSQL's own text::timestamptz input parser, so for
--- every value the AQL engine's query-time cast ((… #>> '{}')::timestamptz)
--- already accepted, this returns the byte-identical instant — the promoted
--- column is a true drop-in for the correlated-subquery lowering
--- (app/ferroehr/src/aql/sql/value.rs). The EXCEPTION handler turns any
--- non-castable text (ISO-8601 partial precision such as `2021`, or malformed
--- input) into NULL instead of erroring, so a write can never fail on a value
--- the query path would merely have rejected (QUERY master03 §Built-in
--- Types/Dates and Times documents partial precision as the boundary). STRICT
--- short-circuits NULL input (a persistent COMPOSITION without context, RM ehr
--- master03 §COMPOSITION.context [0..1]) to NULL with no subtransaction cost.
+-- Full-precision input takes PostgreSQL's own text::timestamptz parser
+-- verbatim. RM data_types master07 §Partial Date/Times admits reduced
+-- precision (`2021`, `1985-06`, `12:00`), which that parser refuses — a valid
+-- stored value must never make a query error (SQLSTATE 22007 answered the
+-- caller a 400 for a data property) — so partial precision is FLOOR-completed
+-- instead: a partial date assumes the first month/day, a partial time assumes
+-- 0, a time-only value anchors on 0001-01-01 (the same floor the
+-- openehr_date_days/time_seconds family documents, and the completion
+-- strategy prior art converged on). Mixed-precision ordering is genuinely
+-- unspecified upstream (confirmed report #1493 / register AMB-29); the floor
+-- is our own recorded semantics and does not depend on its resolution.
+-- Malformed input returns NULL (a comparison miss), never an error.
+-- STRICT short-circuits NULL input (a persistent COMPOSITION without context,
+-- RM ehr master03 §COMPOSITION.context [0..1]) with no subtransaction cost.
 --
--- STABLE, not IMMUTABLE: text::timestamptz depends on the session TimeZone for
--- offset-less inputs, so this must not back an expression index; it is only
--- used in DML (the write INSERT and the backfill), where STABLE is correct.
--- Canonical DV_DATE_TIME values carrying an explicit offset/Z are
--- TimeZone-independent.
--- ISO 8601 permits a COMMA decimal sign on the fractional second (canonical
--- DV_DATE_TIME values may carry it; BASE foundation_types master06), which
--- PostgreSQL's timestamptz input rejects. A comma cannot occur elsewhere in a
--- valid ISO timestamp, so it normalizes to the dot before the cast — matching
--- the AQL engine's query-time normalization (app/ferroehr/src/aql/sql/value.rs).
+-- STABLE, not IMMUTABLE: text::timestamptz (and the offset-less completion
+-- branch) depend on the session TimeZone, so this must not back an expression
+-- index; it runs in DML and query expressions, where STABLE is correct.
+-- Values carrying an explicit offset/Z are TimeZone-independent.
+-- ISO 8601 permits a COMMA decimal sign on the fractional second (BASE
+-- foundation_types master06), which PostgreSQL rejects; a comma cannot occur
+-- elsewhere in a valid ISO value, so it normalizes to the dot first.
 CREATE FUNCTION openehr_timestamp(v text) RETURNS timestamptz
 LANGUAGE plpgsql STABLE STRICT PARALLEL SAFE AS $$
+DECLARE
+    s text := replace(v, ',', '.');
+    date_part text;
+    time_part text;
+    dcomp text;
+    y int; mo int := 1; d int := 1;
+    sod numeric := 0;
+    ts timestamp;
 BEGIN
-    RETURN replace(v, ',', '.')::timestamptz;
+    BEGIN
+        RETURN s::timestamptz;
+    EXCEPTION WHEN others THEN
+        NULL; -- reduced precision or malformed: fall through to the completion
+    END;
+    IF s ~ '^[Tt]' OR s ~ '^\d{1,2}:' THEN
+        -- time-only: floor onto 0001-01-01
+        time_part := regexp_replace(s, '^[Tt]', '');
+        y := 1;
+    ELSE
+        date_part := split_part(s, 'T', 1);
+        time_part := split_part(s, 'T', 2);
+        dcomp := replace(date_part, '-', '');
+        IF dcomp !~ '^(\d{4}|\d{6}|\d{8})$' THEN
+            RETURN NULL;
+        END IF;
+        y := substring(dcomp FROM 1 FOR 4)::int;
+        IF length(dcomp) >= 6 THEN mo := substring(dcomp FROM 5 FOR 2)::int; END IF;
+        IF length(dcomp) >= 8 THEN d := substring(dcomp FROM 7 FOR 2)::int; END IF;
+    END IF;
+    IF time_part <> '' THEN
+        sod := openehr_time_seconds(time_part);
+        IF sod IS NULL THEN RETURN NULL; END IF;
+    END IF;
+    ts := make_date(y, mo, d)::timestamp + make_interval(secs => sod::double precision);
+    IF time_part ~ '([Zz]|[+-]\d{2}:?\d{0,2})$' THEN
+        RETURN (ts - make_interval(secs => openehr_tz_offset_seconds(time_part)::double precision))
+               AT TIME ZONE 'UTC';
+    END IF;
+    -- offset-less: session-TimeZone reading, matching the native-cast branch
+    RETURN ts::timestamptz;
 EXCEPTION WHEN others THEN
     RETURN NULL;
 END;
 $$;
 
 COMMENT ON FUNCTION ext.openehr_timestamp(text) IS
-    'Fail-safe ISO-8601 text -> timestamptz: PostgreSQL''s own timestamptz parser, returning NULL on any non-castable (partial-precision or malformed) input instead of erroring. Feeds promoted timestamp columns (node.context_start) at write + backfill. STABLE (TimeZone-dependent for offset-less inputs); not legal in index expressions.';
+    'Total ISO-8601 text -> timestamptz: PostgreSQL''s own parser for full precision, floor completion for reduced precision (partial dates assume the first month/day, partial times 0, time-only values anchor on 0001-01-01), NULL for malformed input — never an error. The ONE partial-temporal semantics: feeds the promoted timestamp columns (node.context_start) AND the AQL temporal coercion. STABLE (TimeZone-dependent for offset-less inputs); not legal in index expressions.';
 
 -- Grants mirror ext/0001: the runtime writer executes this on the write path
 -- (promoted-column population); the reader may see it via the backfill. The

--- a/app/ferroehr/src/aql/error.rs
+++ b/app/ferroehr/src/aql/error.rs
@@ -334,6 +334,17 @@ pub enum SqlError {
     /// (should have been caught by [`super::plan`]; a defensive guard).
     #[error("unbound query parameter `${0}` at SQL build time")]
     UnboundParameter(String),
+
+    /// A temporal comparison bound that is no ISO-8601 date/time/date-time in
+    /// any accepted precision — the caller's own value (→ 400). The message
+    /// deliberately names the defect class only, never the value or a driver
+    /// type.
+    #[error(
+        "a query value in a date/time comparison cannot be coerced to an \
+         ISO-8601 date, time or date-time (reduced precision is accepted); \
+         correct the value"
+    )]
+    UncoercibleTemporal,
 }
 
 /// An execution / `RESULT_SET` assembly failure.

--- a/app/ferroehr/src/aql/sql/predicate.rs
+++ b/app/ferroehr/src/aql/sql/predicate.rs
@@ -204,7 +204,7 @@ impl Builder<'_> {
             members.push(if numeric {
                 cast(Expr::val(v), "numeric")
             } else {
-                coerce_rhs(v, coercion)
+                coerce_rhs(v, coercion)?
             });
         }
         if positive && let Some(leaf) = Self::existential_leaf(path) {
@@ -438,8 +438,8 @@ impl Builder<'_> {
     ) -> Result<Expr, AqlError> {
         match op {
             Operand::Path(t) => self.value_expr(t, ValueMode::Value(coercion)),
-            Operand::Literal(lit) => Ok(coerce_rhs(super::expr::literal_value(lit), coercion)),
-            Operand::Param(p) => Ok(coerce_rhs(self.param_value(p)?, coercion)),
+            Operand::Literal(lit) => coerce_rhs(super::expr::literal_value(lit), coercion),
+            Operand::Param(p) => coerce_rhs(self.param_value(p)?, coercion),
             Operand::Function { func, args } => {
                 let expr = self.scalar_fn_expr(*func, args)?;
                 // A function operand joins the comparison in the requested

--- a/app/ferroehr/src/aql/sql/value.rs
+++ b/app/ferroehr/src/aql/sql/value.rs
@@ -452,17 +452,10 @@ pub(super) fn coerce_value(base: Expr, mode: ValueMode, leaf: &LeafPath) -> Expr
             }
         }
         ValueMode::Value(Coercion::Boolean) => cast(as_text(base), "boolean"),
-        // ISO 8601 permits a COMMA decimal sign on the fractional second (BASE
-        // foundation_types master06); PostgreSQL's timestamptz input does not,
-        // and a comma cannot occur elsewhere in a valid ISO timestamp, so it
-        // normalizes to the dot before the cast.
-        // NOTE: temporal comparison casts the ISO-8601 leaf text to timestamptz
-        // — precise for full timestamps; partial-precision values (`2019`,
-        // `12:00`) are a documented gap (QUERY master03 §Dates and Times).
-        ValueMode::Value(Coercion::Temporal) => cast(
-            Expr::cust_with_exprs("replace($1, ',', '.')", [as_text(base)]),
-            "timestamptz",
-        ),
+        // NOTE: RM data_types master07 §Partial Date/Times admits reduced
+        // precision, so the leaf reads through the total `ext.openehr_timestamp`
+        // — floor completion, NULL for garbage (the recorded semantics, #1493).
+        ValueMode::Value(Coercion::Temporal) => call("openehr_timestamp", vec![as_text(base)]),
         ValueMode::Value(Coercion::Text | Coercion::Raw) => as_text(base),
         // a mixed-type (`Raw`) leaf being compared/matched against a
         // numeric literal — extract numerically, but guard on the stored jsonb
@@ -475,18 +468,54 @@ pub(super) fn coerce_value(base: Expr, mode: ValueMode, leaf: &LeafPath) -> Expr
 
 /// Cast a bound right-hand-side value to match the comparison coercion
 /// (QUERY master03 §Comparison operators).
-pub(super) fn coerce_rhs(value: sea_query::Value, coercion: Coercion) -> Expr {
-    match coercion {
+///
+/// A temporal bound routes through the same total `ext.openehr_timestamp` the
+/// leaf side uses (floor completion for reduced precision), after a plan-time
+/// shape check: a bound that is no ISO-8601 date/time at all is the CALLER's
+/// defect and refuses as a typed error — never a silent empty result and
+/// never a driver error surfacing as a 500.
+///
+/// # Errors
+/// [`SqlError::UncoercibleTemporal`] when a temporal bound is not an ISO-8601
+/// date, time, or date-time (reduced precision is accepted).
+pub(super) fn coerce_rhs(value: sea_query::Value, coercion: Coercion) -> Result<Expr, AqlError> {
+    Ok(match coercion {
         Coercion::Magnitude => cast(Expr::val(value), "numeric"),
         Coercion::Boolean => cast(Expr::val(value), "boolean"),
-        // Comma-fraction normalization as on the leaf side (ISO 8601 permits
-        // the comma decimal sign; PostgreSQL's timestamptz input does not).
-        Coercion::Temporal => cast(
-            Expr::cust_with_exprs("replace($1, ',', '.')", [cast(Expr::val(value), "text")]),
-            "timestamptz",
-        ),
+        Coercion::Temporal => {
+            if let sea_query::Value::String(Some(s)) = &value
+                && !is_iso_temporal(s)
+            {
+                return Err(SqlError::UncoercibleTemporal.into());
+            }
+            call("openehr_timestamp", vec![cast(Expr::val(value), "text")])
+        }
         Coercion::Text | Coercion::Raw => cast(Expr::val(value), "text"),
-    }
+    })
+}
+
+/// Whether `s` is an ISO-8601 date, time, or date-time literal in the shapes
+/// the temporal floor accepts — reduced precision and compact forms included
+/// (BASE `foundation_types` master06 §Time Types). Purely a plan-time shape
+/// gate: the SQL-side completion is the semantics.
+fn is_iso_temporal(s: &str) -> bool {
+    static ISO_TEMPORAL: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+        // The separator set includes the space form PostgreSQL's own parser
+        // accepts, so previously-working SQL-style literals keep working.
+        let time = r"\d{2}(:\d{2}(:\d{2}([.,]\d+)?)?|\d{2}(\d{2}([.,]\d+)?)?)?";
+        let offset = r"([Zz]|[+-]\d{2}(:?\d{2})?)?";
+        let date = r"\d{4}(-\d{2}(-\d{2})?|\d{2}(\d{2})?)?";
+        #[expect(
+            clippy::expect_used,
+            reason = "a hardcoded regex literal should always compile; covered by \
+                      the temporal planner tests"
+        )]
+        regex::Regex::new(&format!(
+            "^({date}([Tt ]{time}{offset})?|[Tt]?{time}{offset})$"
+        ))
+        .expect("hardcoded ISO-8601 shape regex should be valid")
+    });
+    ISO_TEMPORAL.is_match(s)
 }
 
 /// Guarded numeric extraction for a mixed-type (`Raw`) leaf: number-typed jsonb

--- a/app/ferroehr/tests/it/aql_planner.rs
+++ b/app/ferroehr/tests/it/aql_planner.rs
@@ -1081,8 +1081,8 @@ fn non_promoted_temporal_leaf_falls_back_to_subquery() {
         "OBSERVATION time is not the promoted composition leaf: {sql}"
     );
     assert!(
-        sql.contains("jsonb_path_query_first") && sql.contains("timestamptz"),
-        "the general temporal lowering (extraction + ::timestamptz) is used: {sql}"
+        sql.contains("jsonb_path_query_first") && sql.contains("openehr_timestamp("),
+        "the general temporal lowering (extraction + the total floor) is used: {sql}"
     );
 }
 

--- a/app/ferroehr/tests/it/service_aql.rs
+++ b/app/ferroehr/tests/it/service_aql.rs
@@ -1286,6 +1286,124 @@ fn composition_at(name: &str, magnitude: f64, start_time: &str) -> Value {
     c
 }
 
+/// A composition whose context carries `start_time` AND `end_time` at the
+/// given (possibly reduced) precision — one value on both the promoted path
+/// (`start_time` → `node.context_start`) and the plain jsonb path
+/// (`end_time`).
+fn composition_spanning(name: &str, temporal: &str) -> Value {
+    let mut c = composition_at(name, 1.0, temporal);
+    c["context"]["end_time"] = json!({ "_type": "DV_DATE_TIME", "value": temporal });
+    c
+}
+
+/// Partial-precision date/times (RM `data_types` master07 §Partial Date/Times)
+/// compare and order instead of erroring: the temporal coercion routes both
+/// sides through the total `ext.openehr_timestamp` floor (partial dates
+/// assume the first month/day), so a stored `2019` or `1985-06` — and a
+/// reduced-precision comparison literal — answers rows, never the SQLSTATE
+/// 22007-driven 400 it answered before. Exercised on BOTH lowerings: the
+/// promoted `context_start` column (`start_time`) and the jsonb extraction
+/// (`end_time`).
+#[tokio::test]
+async fn partial_precision_temporals_compare_and_order() {
+    let db = testkit::db().await.expect("testkit database");
+    let svc = FerroEhrService::new(db.pool());
+    let ehr_id = create_ehr(&svc).await;
+    for (name, temporal) in [
+        ("year-only", "2019"),
+        ("year-month", "1985-06"),
+        ("full", "2020-06-15T10:00:00Z"),
+    ] {
+        svc.create_composition(
+            ehr_id.parse().expect("ehr_id uuid"),
+            uv(&composition_spanning(name, temporal), "249", None),
+        )
+        .await
+        .unwrap_or_else(|e| panic!("create ({name}): {e:?}"));
+    }
+
+    for path in ["c/context/start_time/value", "c/context/end_time/value"] {
+        // `<` against a partial literal: 2019 and 1985-06 floor before 2020.
+        let lt = run_aql(
+            &svc,
+            &format!("SELECT c/name/value FROM EHR e CONTAINS COMPOSITION c WHERE {path} < '2020'"),
+            ehr_scope(&ehr_id),
+        )
+        .await;
+        assert_eq!(
+            rows(&lt).len(),
+            2,
+            "{path} < '2020' floors both sides: {lt}"
+        );
+
+        // `>` against a partial literal: everything after 1985-01-01.
+        let gt = run_aql(
+            &svc,
+            &format!("SELECT c/name/value FROM EHR e CONTAINS COMPOSITION c WHERE {path} > '1985'"),
+            ehr_scope(&ehr_id),
+        )
+        .await;
+        assert_eq!(rows(&gt).len(), 3, "{path} > '1985': {gt}");
+
+        // `=` at equal reduced precision (floor equality).
+        let eq = run_aql(
+            &svc,
+            &format!(
+                "SELECT c/name/value FROM EHR e CONTAINS COMPOSITION c WHERE {path} = '1985-06'"
+            ),
+            ehr_scope(&ehr_id),
+        )
+        .await;
+        assert_eq!(rows(&eq).len(), 1, "{path} = '1985-06': {eq}");
+        assert_eq!(rows(&eq)[0][0], json!("year-month"));
+
+        // Against NOW(): every stored value precedes the query instant.
+        let now = run_aql(
+            &svc,
+            &format!("SELECT c/name/value FROM EHR e CONTAINS COMPOSITION c WHERE {path} < NOW()"),
+            ehr_scope(&ehr_id),
+        )
+        .await;
+        assert_eq!(rows(&now).len(), 3, "{path} < NOW(): {now}");
+
+        // ORDER BY floors partials onto the same axis.
+        let ordered = run_aql(
+            &svc,
+            &format!("SELECT c/name/value FROM EHR e CONTAINS COMPOSITION c ORDER BY {path} ASC"),
+            ehr_scope(&ehr_id),
+        )
+        .await;
+        let names: Vec<&str> = rows(&ordered)
+            .iter()
+            .map(|r| r[0].as_str().expect("name"))
+            .collect();
+        assert_eq!(
+            names,
+            ["year-month", "year-only", "full"],
+            "{path} orders by the floored instant: {ordered}"
+        );
+    }
+
+    // A time-only value floors onto 0001-01-01 at the function seam (a
+    // DV_TIME value cannot legally sit on these DV_DATE_TIME attributes, so
+    // the seam is pinned directly).
+    let anchored: Option<String> =
+        sqlx::query_scalar("SELECT ext.openehr_timestamp('12:00')::text")
+            .fetch_one(&db.pool())
+            .await
+            .expect("time-only floors, never errors");
+    assert!(
+        anchored.is_some_and(|t| t.starts_with("0001-01-01 12:00:00")),
+        "time-only anchors on 0001-01-01"
+    );
+    let garbage: Option<String> =
+        sqlx::query_scalar("SELECT ext.openehr_timestamp('not-a-date')::text")
+            .fetch_one(&db.pool())
+            .await
+            .expect("garbage is NULL, never an error");
+    assert_eq!(garbage, None, "malformed stored text is a comparison miss");
+}
+
 /// A persistent COMPOSITION with no `context` (RM ehr master03
 /// §COMPOSITION.context [0..1]) — its promoted `context_start` is NULL.
 fn composition_persistent(name: &str, magnitude: f64) -> Value {

--- a/app/ferroehr/tests/it/sql_injection.rs
+++ b/app/ferroehr/tests/it/sql_injection.rs
@@ -645,8 +645,11 @@ fn every_quoted_identifier_comes_from_the_closed_set() {
     };
     for query in [
         "SELECT c/name/value FROM COMPOSITION c",
+        // The literal is a (partial) ISO value: a temporal comparison bound is
+        // shape-checked at plan time, and a non-temporal string would refuse
+        // before any SQL exists to scan.
         "SELECT c/name/value FROM EHR e CONTAINS COMPOSITION c CONTAINS OBSERVATION o \
-         WHERE o/data/origin/value = 'x'",
+         WHERE o/data/origin/value = '2020'",
         "SELECT o/data FROM COMPOSITION c CONTAINS OBSERVATION o",
     ] {
         let prepared = build_with(query, &Params::new(), &streaming);

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-adl"
-version = "0.0.44"
+version = "0.0.45"
 description = "openEHR ADL 2.4.0: hand-written ADL2/cADL/ODIN parser, AOM2 validation catalogue, specialisation flattener, OPT2 generator, and ADL 1.4→2 conversion over the generated openehr_am::v2_4::aom2 model"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,11 +16,11 @@ include = ["src/**", "README.md", "LICENSE-MIT"]
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)
-openehr-base = { path = "../openehr-base", version = "0.0.44" }   # VersionStatus for the parsed HRID
-openehr-am = { path = "../openehr-am", version = "0.0.44" }       # v2_4 ArchetypeHrid (the identification target type)
-openehr-rm = { path = "../openehr-rm", version = "0.0.44" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
-openehr-lang = { path = "../openehr-lang", version = "0.0.44" }   # openehr_lang::odin — the ODIN section parser
-openehr-term = { path = "../openehr-term", version = "0.0.44" }   # the languages code set for the RM resource-meta rows
+openehr-base = { path = "../openehr-base", version = "0.0.45" }   # VersionStatus for the parsed HRID
+openehr-am = { path = "../openehr-am", version = "0.0.45" }       # v2_4 ArchetypeHrid (the identification target type)
+openehr-rm = { path = "../openehr-rm", version = "0.0.45" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
+openehr-lang = { path = "../openehr-lang", version = "0.0.45" }   # openehr_lang::odin — the ODIN section parser
+openehr-term = { path = "../openehr-term", version = "0.0.45" }   # the languages code set for the RM resource-meta rows
 uuid.workspace = true        # meta uid/build_uid (AUTHORED_ARCHETYPE.uid: Uuid)
 indexmap.workspace = true    # OdinValue::Object body (insertion-ordered map)
 

--- a/crates/openehr-am/Cargo.toml
+++ b/crates/openehr-am/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-am"
-version = "0.0.44"
+version = "0.0.45"
 description = "openEHR AM Archetype Model, generated from BMM: generations v1_4 (AM 1.4.0, ADL 1.4) and v2_4 (AM 2.4.0, ADL 2; current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,8 +13,8 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.44" }
-openehr-lang = { path = "../openehr-lang", version = "0.0.44" }
+openehr-base = { path = "../openehr-base", version = "0.0.45" }
+openehr-lang = { path = "../openehr-lang", version = "0.0.45" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also carries the untyped `Value` fields the generator

--- a/crates/openehr-base/Cargo.toml
+++ b/crates/openehr-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-base"
-version = "0.0.44"
+version = "0.0.45"
 description = "openEHR BASE foundation + base types, generated from BMM: generations v1_2 (BASE 1.2.0) and v1_3 (BASE 1.3.0, current)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-base/src/v1_2/foundation_types/time/iso8601_date_impl.rs
+++ b/crates/openehr-base/src/v1_2/foundation_types/time/iso8601_date_impl.rs
@@ -53,6 +53,11 @@
 //! of `X` precedes every completion of `Y`; `Some(Equal)` only for equal raw
 //! strings, so differently-written equal values (`20200615` vs `2020-06-15`)
 //! report incomparable, never equal.
+//!
+//! A consumer needing a TOTAL order (a query engine sorting stored values)
+//! must choose its own completion policy (e.g. flooring a partial to its
+//! first instant) — a deliberately different reading from this partial
+//! comparison, which never invents an order the value does not carry.
 
 use std::cmp::Ordering;
 

--- a/crates/openehr-base/src/v1_3/foundation_types/time/iso8601_date_impl.rs
+++ b/crates/openehr-base/src/v1_3/foundation_types/time/iso8601_date_impl.rs
@@ -53,6 +53,11 @@
 //! of `X` precedes every completion of `Y`; `Some(Equal)` only for equal raw
 //! strings, so differently-written equal values (`20200615` vs `2020-06-15`)
 //! report incomparable, never equal.
+//!
+//! A consumer needing a TOTAL order (a query engine sorting stored values)
+//! must choose its own completion policy (e.g. flooring a partial to its
+//! first instant) — a deliberately different reading from this partial
+//! comparison, which never invents an order the value does not carry.
 
 use std::cmp::Ordering;
 

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-its"
-version = "0.0.44"
+version = "0.0.45"
 description = "openEHR ITS (Implementation Technology Specifications): canonical JSON + canonical XML serialization of the RM, the generated ITS-REST 1.1.0 API contract, OPT 1.4 and AOM2 archetype XML codecs, and the Simplified Formats (FLAT / STRUCTURED / Web Template)"
 edition.workspace = true
 rust-version.workspace = true
@@ -41,14 +41,14 @@ regex = { workspace = true, optional = true }
 fancy-regex = { workspace = true, optional = true }
 # The generated XML (de)serializers impl the crate's ToXml/FromXml traits for the
 # RM/BASE spec types, so these are real (non-dev) deps.
-openehr-base = { path = "../openehr-base", version = "0.0.44", optional = true }
-openehr-rm = { path = "../openehr-rm", version = "0.0.44", optional = true }
+openehr-base = { path = "../openehr-base", version = "0.0.45", optional = true }
+openehr-rm = { path = "../openehr-rm", version = "0.0.45", optional = true }
 # The native canonical-JSON codec (`json_codec/generated`, emit-json) implements
 # `ToJson` for EVERY generated spec type the `OpenEhrType` derive covers, so it
 # spans all five spec crates (not just the RM/BASE the XML codec needs).
-openehr-lang = { path = "../openehr-lang", version = "0.0.44", optional = true }
-openehr-am = { path = "../openehr-am", version = "0.0.44", optional = true }
-openehr-term = { path = "../openehr-term", version = "0.0.44", optional = true }
+openehr-lang = { path = "../openehr-lang", version = "0.0.45", optional = true }
+openehr-am = { path = "../openehr-am", version = "0.0.45", optional = true }
+openehr-term = { path = "../openehr-term", version = "0.0.45", optional = true }
 
 # `full` — every ITS surface (canonical JSON/XML, the generated ITS-REST
 # contract, `opt14`, Simplified Formats). ON BY DEFAULT, so every consumer sees

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-lang"
-version = "0.0.44"
+version = "0.0.45"
 description = "openEHR LANG BMM/P_BMM object model, generated from BMM: generations v1_0 (LANG 1.0.0) and v1_1 (LANG 1.1.0, current; the stable BMM v2.x unit beside the paused BMM3 unit), plus hand-written ODIN/BEL/EL readers"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["parser-implementations", "data-structures"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.44" }
+openehr-base = { path = "../openehr-base", version = "0.0.45" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the
 # generated types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) —
 # never a derive. `serde_json` also carries the untyped `Value` fields the

--- a/crates/openehr-query/Cargo.toml
+++ b/crates/openehr-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-query"
-version = "0.0.44"
+version = "0.0.45"
 description = "openEHR QUERY (AQL 1.1.0): hand-written lexer, parser, typed AST and canonical printer from the official grammar (no ANTLR runtime)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-rm"
-version = "0.0.44"
+version = "0.0.45"
 description = "openEHR RM Reference Model, generated from BMM: generations v1_1 (RM 1.1.0) and v1_2 (RM 1.2.0, current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,11 +13,11 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.44" }
+openehr-base = { path = "../openehr-base", version = "0.0.45" }
 # The terminology-backed RM class invariants (`validate::terminology`) resolve
 # openEHR terminology groups + code sets against the vendored TERM 3.1.0 bundle.
 # `openehr-term` itself depends only on `openehr-base`, so this is acyclic.
-openehr-term = { path = "../openehr-term", version = "0.0.44" }
+openehr-term = { path = "../openehr-term", version = "0.0.45" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also backs the untyped `Value` RM representation used by

--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-term"
-version = "0.0.44"
+version = "0.0.45"
 description = "openEHR TERM terminology data model, generated from BMM (generation v3_1 = TERM 3.1.0), plus the embedded official terminology XML bundle"
 edition.workspace = true
 rust-version.workspace = true
@@ -34,7 +34,7 @@ include = [
 ]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.44" }
+openehr-base = { path = "../openehr-base", version = "0.0.45" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1281,7 +1281,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "indexmap",
  "openehr-am",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "serde",
  "serde_json",
@@ -1317,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "async-trait",
  "axum",
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "chumsky",
  "indexmap",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "chumsky",
  "logos",
@@ -1364,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "openehr-base",
  "openehr-term",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/tools/openehr-codegen/templates/openehr-base/foundation_types/time/iso8601_date_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-base/foundation_types/time/iso8601_date_impl.rs
@@ -53,6 +53,11 @@
 //! of `X` precedes every completion of `Y`; `Some(Equal)` only for equal raw
 //! strings, so differently-written equal values (`20200615` vs `2020-06-15`)
 //! report incomparable, never equal.
+//!
+//! A consumer needing a TOTAL order (a query engine sorting stored values)
+//! must choose its own completion policy (e.g. flooring a partial to its
+//! first instant) — a deliberately different reading from this partial
+//! comparison, which never invents an order the value does not carry.
 
 use std::cmp::Ordering;
 

--- a/website/book/src/querying-aql.md
+++ b/website/book/src/querying-aql.md
@@ -61,6 +61,11 @@ ORDER BY systolic DESC
   where nothing matches.
 - **`ORDER BY`**, **`LIMIT`**, and **`OFFSET`** behave as you expect; quantities
   order by their openEHR magnitude semantics.
+- **Date/time comparisons accept reduced precision** on both sides: openEHR
+  admits partial values (`2019`, `1985-06`), and the engine compares them by
+  flooring to the first instant they contain (a partial date assumes the first
+  month/day, a partial time assumes zero). A comparison value that is not an
+  ISO 8601 date/time at all is refused with a 400.
 
 ## Running a query over HTTP
 


### PR DESCRIPTION
Closes #2920.

**One partial-temporal semantics, at the one function both paths share.** `ext.openehr_timestamp` becomes a TOTAL ISO-8601 → timestamptz reading: PostgreSQL's own parser for full precision (byte-identical instants for everything that worked before), floor completion for reduced precision — a partial date assumes the first month/day, a partial time assumes 0, a time-only value anchors on 0001-01-01 — and NULL for malformed stored text, never an error. `Coercion::Temporal` now routes BOTH sides of a comparison through it, so a stored `2019` or `1985-06` compares, orders, and matches `NOW()` instead of turning every temporal comparison on its path into a 400 (SQLSTATE 22007, the #2593 mapping). The same function already populates the promoted `context_start` column at write time, so the promoted fast path (which keeps its timestamptz index service — a STABLE function over a constant bound is index-servable) and the jsonb lowering can never disagree; partials now land in the promoted column as their floored instant instead of NULL.

**The caller's 400 stays a 400, named earlier:** a comparison bound that is no ISO-8601 date/time in any accepted precision refuses at PLAN time (`SqlError::UncoercibleTemporal` — "cannot be coerced", no value echo, no driver vocabulary) instead of surfacing as a database error. Non-ISO forms PostgreSQL happened to parse (`June 15, 2020`) are refused — QUERY master03's temporal literals are ISO 8601; the space-separated `YYYY-MM-DD HH:MM` form stays accepted. The #2593 22007/22008/22P02 mapping remains for the other coercions.

**The divergence is stated at both sites** (acceptance): the in-memory `Iso8601Date` ordering keeps its interval reading (a partial denotes the interval of its completions), and its module doc now says a consumer needing a TOTAL order must choose a completion policy — the AQL site's NOTE cross-references the upstream silence (#1493 / AMB-29). That doc lives in a generation-twin template, so the eight `openehr-*` crates bump to 0.0.45 in lockstep (fuzz lockfile refreshed).

**Pinned by:** `partial_precision_temporals_compare_and_order` — `2019` / `1985-06` / full-precision values stored on BOTH lowerings (the promoted `start_time` and the jsonb `end_time`), compared with `<`, `>`, `=`, ordered, and matched against `NOW()`, asserting rows never errors; the time-only anchor and garbage-is-NULL pinned at the function seam; the #2593 caller-400 test unchanged and green (now failing at plan time). The injection corpus's temporal fixture literal became a valid ISO value — a non-temporal string on that path now refuses before any SQL exists to scan, which is the designed behaviour.

Suites: ferroehr 999/999, ferroehr-rest 773/773, workspace clippy/fmt/rustdoc/comment-style clean; codegen drift check green modulo the committed regeneration. **The zero-drift conformance run is deferred by owner instruction** (the full run lands before the release cut); the first attempt died at SUT boot in Docker (the same image + stack boots healthy on inspection — a Docker-side hiccup, not a code path).

Docs: the AQL book page documents the floor semantics + the ISO-only refusal; changelog `### Fixed` entry.
