### PR TITLE
fix(contribution): the is_modifiable gate is evaluated inside the commit transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- The `is_modifiable` content-write gate is evaluated inside the commit
+  transaction, under a row lock, instead of a separate read before it — a
+  deactivation committed concurrently with a content write is now always
+  observed (one or the other strictly wins; previously the content commit
+  could land on a just-deactivated EHR). The gate's semantics are unchanged:
+  the atomic change set is judged as a whole — a deactivating set may carry
+  its final content, a reactivating set enables its own content, and
+  `EHR_STATUS` itself is always writable.
 - AQL date/time comparisons work on reduced-precision values. openEHR admits
   partial date/times (`2019`, `1985-06`), but one stored anywhere in the
   scanned data made every temporal comparison on that path fail as a 400

--- a/app/ferroehr/src/service/commit_env.rs
+++ b/app/ferroehr/src/service/commit_env.rs
@@ -72,10 +72,6 @@ impl CommitEnv for FerroEhrService {
         FerroEhrService::ensure_ehr_exists(self, ehr_id).await
     }
 
-    async fn ensure_content_writable(&self, ehr_id: EhrId) -> Result<(), ServiceError> {
-        FerroEhrService::ensure_content_writable(self, ehr_id).await
-    }
-
     async fn current_vo(
         &self,
         ehr_id: EhrId,

--- a/app/ferroehr/src/service/ehr/composition.rs
+++ b/app/ferroehr/src/service/ehr/composition.rs
@@ -490,7 +490,7 @@ impl FerroEhrService {
         // Active Status); the 409 outcome and its ordering (after the deleted
         // 404, before the template 422) are unchanged.
         if pre.is_modifiable == Some(false) {
-            return Err(Self::not_modifiable_error(ehr_id));
+            return Err(crate::versioning::change::not_modifiable_error(ehr_id));
         }
         // Reject an update whose body declares a *different* template than the
         // stored composition it supersedes — a semantic 422. NOTE: no openEHR
@@ -694,7 +694,7 @@ impl FerroEhrService {
         // (after the already-deleted 400, before the stale-precondition 409)
         // unchanged.
         if !current.is_modifiable {
-            return Err(Self::not_modifiable_error(ehr_id));
+            return Err(crate::versioning::change::not_modifiable_error(ehr_id));
         }
         let current_tree = TreeId::from_columns(
             current.trunk_version,
@@ -832,7 +832,7 @@ impl FerroEhrService {
         // `None` (no current EHR_STATUS) is treated as modifiable, so the guard
         // never spuriously blocks — identical to `ensure_content_writable`.
         if is_modifiable == Some(false) {
-            return Err(Self::not_modifiable_error(ehr_id));
+            return Err(crate::versioning::change::not_modifiable_error(ehr_id));
         }
         Ok(now)
     }

--- a/app/ferroehr/src/service/ehr/directory.rs
+++ b/app/ferroehr/src/service/ehr/directory.rs
@@ -316,7 +316,7 @@ impl FerroEhrService {
         // pre-read; the 409 outcome and its ordering (after validate_folder's
         // 422) are unchanged.
         if !is_modifiable {
-            return Err(Self::not_modifiable_error(ehr_id));
+            return Err(crate::versioning::change::not_modifiable_error(ehr_id));
         }
 
         let mut tx = self.pool.begin().await?;
@@ -361,7 +361,7 @@ impl FerroEhrService {
         // Active Status) — folded from the standalone `ensure_content_writable`
         // side-SELECT into the merged pre-read; the 409 outcome is unchanged.
         if !is_modifiable {
-            return Err(Self::not_modifiable_error(ehr_id));
+            return Err(crate::versioning::change::not_modifiable_error(ehr_id));
         }
 
         let mut tx = self.pool.begin().await?;

--- a/app/ferroehr/src/service/ehr/status.rs
+++ b/app/ferroehr/src/service/ehr/status.rs
@@ -427,8 +427,10 @@ impl FerroEhrService {
     /// EHR are modifiable"; "an EHR's 'contents' consist of everything other
     /// than the `EHR_STATUS` object". The `EHR_STATUS` object itself "is
     /// always modifiable", so this guard is applied to COMPOSITION / DIRECTORY
-    /// / content-CONTRIBUTION writes only — the
-    /// [`crate::versioning::CommitEnv`] `ensure_content_writable` hook.
+    /// / content writes only. This pooled read is the direct write paths'
+    /// FAST-FAIL convenience; the CONTRIBUTION engine evaluates the flag
+    /// inside its commit transaction under a row lock
+    /// ([`crate::versioning::change::ensure_content_writable_tx`]).
     ///
     /// NOTE (wire): ITS-REST 1.1.0 does not enumerate a status code for a
     /// write to a non-modifiable EHR (`composition_create.yaml` lists only
@@ -441,13 +443,6 @@ impl FerroEhrService {
     /// # Errors
     /// [`ServiceError::Conflict`] when the EHR is not modifiable;
     /// [`ServiceError::Database`] if the flag read fails.
-    #[expect(
-        clippy::same_name_method,
-        reason = "the `CommitEnv` seam (service/commit_env.rs) deliberately \
-                  mirrors these chapter method names so the versioning layer \
-                  calls them by their own vocabulary; that impl disambiguates \
-                  explicitly with `FerroEhrService::<name>(self, …)`"
-    )]
     pub(in crate::service) async fn ensure_content_writable(
         &self,
         ehr_id: EhrId,
@@ -455,22 +450,8 @@ impl FerroEhrService {
         if self.ehr_is_modifiable(ehr_id).await? {
             Ok(())
         } else {
-            Err(Self::not_modifiable_error(ehr_id))
+            Err(crate::versioning::change::not_modifiable_error(ehr_id))
         }
-    }
-
-    /// The `409 Conflict` for a content write to a deactivated EHR
-    /// (`EHR_STATUS.is_modifiable = false`) — see
-    /// [`Self::ensure_content_writable`] for the NOTE on the status-code
-    /// choice. Shared with the combined
-    /// [`Self::ensure_ehr_content_writable`] pre-check so the message stays
-    /// single-sourced.
-    pub(in crate::service) fn not_modifiable_error(ehr_id: EhrId) -> ServiceError {
-        ServiceError::conflict(format!(
-            "EHR {ehr_id} is not modifiable (EHR_STATUS.is_modifiable = false); its \
-             contents cannot be created, updated or deleted (RM ehr master04 §EHR Active \
-             Status). Set EHR_STATUS.is_modifiable = true to reactivate it."
-        ))
     }
 
     /// Keep the EHR's promoted subject columns (`ehr.subject_id` /

--- a/app/ferroehr/src/storage/ehr_repo.rs
+++ b/app/ferroehr/src/storage/ehr_repo.rs
@@ -385,6 +385,35 @@ pub async fn ehr_is_modifiable(pool: &PgPool, ehr_id: EhrId) -> Result<Option<bo
     )
 }
 
+/// The in-transaction, row-locked read of the promoted `ehr.is_modifiable`
+/// flag — the commit engine's content-write gate.
+///
+/// The lock serializes the gate against a concurrent `EHR_STATUS` flip (whose
+/// own commit updates this row): `FOR SHARE` for a content-only change set
+/// (concurrent content commits stay parallel), `FOR NO KEY UPDATE` when the
+/// set itself writes an `EHR_STATUS` (taking the exclusive lock up front
+/// avoids the share-then-upgrade deadlock). Plain reads are unaffected by
+/// either. `None` when the EHR row does not exist. No openEHR spec governs
+/// the promoted column or the locking — our own storage design.
+///
+/// # Errors
+/// Returns [`StorageError::Database`] on a driver failure.
+pub async fn ehr_is_modifiable_locked(
+    tx: &mut PgConnection,
+    ehr_id: EhrId,
+    exclusive: bool,
+) -> Result<Option<bool>, StorageError> {
+    let sql = if exclusive {
+        "SELECT is_modifiable FROM ehr WHERE id = $1 FOR NO KEY UPDATE"
+    } else {
+        "SELECT is_modifiable FROM ehr WHERE id = $1 FOR SHARE"
+    };
+    Ok(sqlx::query_scalar(sql)
+        .bind(ehr_id)
+        .fetch_optional(tx)
+        .await?)
+}
+
 /// The two content-write pre-checks plus the server clock in ONE round trip:
 /// whether the EHR exists, whether it is modifiable, and the database `now()`.
 ///

--- a/app/ferroehr/src/versioning/change.rs
+++ b/app/ferroehr/src/versioning/change.rs
@@ -1014,6 +1014,52 @@ async fn write_single_outbox(
 /// [`ServiceError::Unprocessable`] for an out-of-group / non-first lifecycle
 /// state; the [`commit_resolved`] storage/signing errors; a multimedia offload
 /// failure as [`ServiceError::Internal`].
+/// The `409 Conflict` for a content write to a deactivated EHR
+/// (`EHR_STATUS.is_modifiable = false`) — RM ehr master04 §EHR Active Status
+/// forbids writes to everything except the `EHR_STATUS` object. ITS-REST
+/// 1.1.0 enumerates no status code for this outcome; `409` is the closest
+/// HTTP semantics (RFC 9110 §15.5.10 — the write conflicts with the current
+/// state of the target resource).
+pub(crate) fn not_modifiable_error(ehr_id: EhrId) -> ServiceError {
+    ServiceError::conflict(format!(
+        "EHR {ehr_id} is not modifiable (EHR_STATUS.is_modifiable = false); its \
+         contents cannot be created, updated or deleted (RM ehr master04 §EHR Active \
+         Status). Set EHR_STATUS.is_modifiable = true to reactivate it."
+    ))
+}
+
+/// The content-write gate, evaluated INSIDE the commit transaction.
+///
+/// Reads the promoted `ehr.is_modifiable` under a row lock
+/// ([`crate::storage::ehr_repo::ehr_is_modifiable_locked`]), so the value that
+/// governs the change set is the one this transaction serializes against — a
+/// concurrent `EHR_STATUS` flip either commits first and is seen, or waits
+/// for this commit; a pre-transaction read could act on a flag another
+/// commit was flipping at that instant. A missing EHR row reads as
+/// modifiable (the existence gate answers 404 on its own).
+///
+/// NOTE: RM ehr master04 §EHR Active Status defines what the flag forbids;
+/// no released text states WHEN it is evaluated relative to a commit — the
+/// in-transaction snapshot is our own recorded semantics (#2673).
+///
+/// # Errors
+/// [`ServiceError::Conflict`] when the EHR is not modifiable;
+/// [`ServiceError::Database`] if the locked read fails.
+pub(crate) async fn ensure_content_writable_tx(
+    tx: &mut PgConnection,
+    ehr_id: EhrId,
+    exclusive: bool,
+) -> Result<(), ServiceError> {
+    let modifiable = crate::storage::ehr_repo::ehr_is_modifiable_locked(tx, ehr_id, exclusive)
+        .await?
+        .unwrap_or(true);
+    if modifiable {
+        Ok(())
+    } else {
+        Err(not_modifiable_error(ehr_id))
+    }
+}
+
 #[expect(
     clippy::too_many_arguments,
     reason = "the write parameters, named individually; a parameter struct \

--- a/app/ferroehr/src/versioning/contribution.rs
+++ b/app/ferroehr/src/versioning/contribution.rs
@@ -489,11 +489,10 @@ pub(crate) async fn commit_version_set(
         changes.push(build_change(cx, &target_kinds, v, ehr_id, party_only).await?);
     }
 
-    if let Some(ehr_id) = ehr_id
-        && needs_content_write_permission(&changes)
-    {
-        cx.ensure_content_writable(ehr_id).await?;
-    }
+    // Whether the set needs the content-write gate; the gate itself runs
+    // INSIDE the commit transaction (`write_contribution`), under a row lock,
+    // so no pre-transaction read can race a concurrent EHR_STATUS flip.
+    let needs_content_permission = needs_content_write_permission(&changes);
 
     let contribution_audit =
         parse_contribution_audit(body, &contrib_committer, &contrib_system_id)?;
@@ -548,6 +547,7 @@ pub(crate) async fn commit_version_set(
             attests,
             status_commits,
             folder_commits,
+            needs_content_permission,
         },
     )
     .await?;
@@ -582,6 +582,9 @@ struct ContributionWrite<'a> {
     /// The FOLDER bodies the set commits, for the post-insert item-reference
     /// check.
     folder_commits: Vec<Value>,
+    /// Whether the set needs the content-write gate
+    /// ([`needs_content_write_permission`]); evaluated in-transaction.
+    needs_content_permission: bool,
 }
 
 /// Writes the resolved change set in one transaction, with the cross-area
@@ -602,6 +605,17 @@ async fn write_contribution(
     write: ContributionWrite<'_>,
 ) -> Result<CommittedContribution, ServiceError> {
     let mut tx = cx.pool().begin().await?;
+    // The content-write gate, under a row lock (RM ehr master04 §EHR Active
+    // Status; the in-transaction evaluation is our own recorded semantics —
+    // see `change::ensure_content_writable_tx`). A set that itself writes an
+    // EHR_STATUS takes the exclusive lock up front (its own commit updates
+    // the same row), avoiding a share-then-upgrade deadlock.
+    if let Some(ehr_id) = ehr_id
+        && write.needs_content_permission
+    {
+        change::ensure_content_writable_tx(&mut tx, ehr_id, !write.status_commits.is_empty())
+            .await?;
+    }
     for (_, change) in &write.changes {
         if let Change::Modify {
             vo_id,

--- a/app/ferroehr/src/versioning/mod.rs
+++ b/app/ferroehr/src/versioning/mod.rs
@@ -213,13 +213,14 @@ pub(crate) struct SigningCtx<'a> {
 /// The cross-area hooks the CONTRIBUTION commit orchestration
 /// ([`contribution::commit_version_set`]) needs from the service layer. Each
 /// hook is owned by another register: content validation (validation register),
-/// EHR existence + `is_modifiable` write guard + `current_vo` (EHR register),
-/// `EHR_ACCESS` cache invalidation (EHR register), committer default (EHR
-/// register). `crate::service::FerroEhrService` implements it; versioning owns
-/// only the change-set decision logic. `default_committer` is the EHR worker's
-/// `committer()`; `ensure_ehr_exists` closes the `Pre_has_ehr` check (SM `i_ehr_contribution.adoc`
-/// §`commit_contribution` `Pre_has_ehr`); `ensure_content_writable` is the
-/// `EHR_STATUS` `is_modifiable` guard.
+/// EHR existence + `current_vo` (EHR register), `EHR_ACCESS` cache
+/// invalidation (EHR register), committer default (EHR register).
+/// `crate::service::FerroEhrService` implements it; versioning owns only the
+/// change-set decision logic. `default_committer` is the EHR worker's
+/// `committer()`; `ensure_ehr_exists` closes the `Pre_has_ehr` check (SM
+/// `i_ehr_contribution.adoc` §`commit_contribution` `Pre_has_ehr`). The
+/// `is_modifiable` content-write guard is NOT a hook: it runs inside the
+/// commit transaction ([`change::ensure_content_writable_tx`]).
 ///
 /// The two in-transaction hooks ([`Self::pre_composition_modify`] and
 /// [`Self::post_status_commit`]) are the cross-version invariant / promoted-
@@ -258,8 +259,6 @@ pub(crate) trait CommitEnv {
     ) -> Result<(), ServiceError>;
     /// the target EHR must exist before a CONTRIBUTION is committed to it.
     async fn ensure_ehr_exists(&self, ehr_id: EhrId) -> Result<(), ServiceError>;
-    /// The `EHR_STATUS` `is_modifiable = False` content-write guard.
-    async fn ensure_content_writable(&self, ehr_id: EhrId) -> Result<(), ServiceError>;
     /// The current versioned object of `kind` in `ehr_id`, if any (for the
     /// EHR-singleton create guard).
     async fn current_vo(

--- a/app/ferroehr/tests/it/service_contribution.rs
+++ b/app/ferroehr/tests/it/service_contribution.rs
@@ -2251,3 +2251,52 @@ async fn reactivating_contribution_unlocks_its_own_content() {
         .await
         .expect("content write after the reactivating commit");
 }
+
+/// The content-write gate reads `is_modifiable` INSIDE the commit transaction
+/// under a row lock: a deactivation already holding the EHR row when the
+/// content CONTRIBUTION arrives commits first, and the content commit
+/// observes the flipped flag — the pre-transaction read this replaces saw the
+/// still-`true` committed value and let the content land after the
+/// deactivation. (The flip is a raw column update here: the pin targets the
+/// gate's locked read, and the promoted `ehr.is_modifiable` column is exactly
+/// what the gate reads.)
+#[tokio::test]
+async fn concurrent_deactivation_is_seen_by_the_content_commit() {
+    let db = testkit::db().await.expect("testkit database");
+    let svc = FerroEhrService::new(db.pool());
+    let ehr_id = create_ehr(&svc).await;
+    let ehr_uuid: ferroehr::ids::EhrId = ehr_id.parse().expect("ehr uuid");
+
+    // An open transaction flips the flag and HOLDS the row lock.
+    let mut flip = db.pool().begin().await.expect("begin the flip tx");
+    sqlx::query("UPDATE ehr SET is_modifiable = false WHERE id = $1")
+        .bind(ehr_uuid)
+        .execute(&mut *flip)
+        .await
+        .expect("uncommitted deactivation");
+
+    // The content CONTRIBUTION must block on the gate's row lock, then see
+    // the committed flip and refuse.
+    let pool = db.pool();
+    let racing = tokio::spawn(async move {
+        let svc = FerroEhrService::new(pool);
+        let ehr_uuid: ferroehr::ids::EhrId = ehr_id.parse().expect("ehr uuid");
+        let content = json!({
+            "versions": [ member(composition("raced"), ("249", "creation"), None) ],
+            "audit": { "change_type": change_type("249", "creation"), "committer": committer("author") }
+        });
+        svc.create_ehr_contribution(ehr_uuid, content).await
+    });
+    // Give the racing commit time to reach the in-transaction gate and block.
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+    flip.commit().await.expect("commit the deactivation");
+
+    let refused = racing
+        .await
+        .expect("the racing task completes")
+        .expect_err("the content commit observes the concurrent deactivation");
+    assert!(
+        refused.message.contains("not modifiable"),
+        "the refusal names the deactivation: {refused:?}"
+    );
+}


### PR DESCRIPTION
Closes #2914.

**The adjudication (already recorded on #2673, now completed):** the atomic change set is judged AS A WHOLE, order-independently — no released text assigns `CONTRIBUTION.versions` any order semantics (the List-vs-"Set of references" contradiction is #2674), the commit is one atomic act (RM common master06 §Committal and Audits), and RM ehr master04 §EHR Active Status defines only what the flag forbids. Sequential per-member semantics would invent an ordering the spec does not carry; the set semantics were already implemented and pinned (`deactivating_contribution_carries_its_final_content`, `reactivating_contribution_unlocks_its_own_content` — both flip directions, list order proven irrelevant). What this PR fixes is WHERE the flag is read.

**The evaluation moves inside the commit transaction, under a row lock.** `change::ensure_content_writable_tx` reads the promoted `ehr.is_modifiable` with `FOR SHARE` (content-only sets — concurrent content commits stay parallel) or `FOR NO KEY UPDATE` (sets that themselves write an `EHR_STATUS`, taking the exclusive lock up front so no share-then-upgrade deadlock exists). A concurrent deactivation now strictly orders against the commit: it either commits first and is observed, or waits. The racy pre-transaction `CommitEnv::ensure_content_writable` hook is deleted (trait + impl); the direct write paths keep their pooled read as a fast-fail convenience, documented as such. The 409 constructor is single-sourced in `versioning::change::not_modifiable_error` (six service call sites repointed).

**Pinned by** `concurrent_deactivation_is_seen_by_the_content_commit`: an open transaction flips the flag and holds the row; the racing content CONTRIBUTION blocks on the gate's lock, then observes the committed flip and refuses — under the old pre-transaction read it committed content onto the just-deactivated EHR.

**The register + wire cases** are handed to the instrument as Veredictum#201 (the evaluation-timing register entry plus five atomic-set cases, spec-cited). The community thread (discourse t/17230) gets the outcome summary — reply text in the closing comment.

Suites/gates: full ferroehr suite, workspace clippy, fmt, comment-style all green. Changelog `### Fixed` entry (semantics unchanged; the race is the fix). Conformance run deferred by owner instruction to the pre-release full run.
