### PR TITLE
test(aql): ROUND's half-away-from-zero mode is pinned

### DIFF
--- a/app/ferroehr/src/aql/sql/predicate.rs
+++ b/app/ferroehr/src/aql/sql/predicate.rs
@@ -345,6 +345,9 @@ impl Builder<'_> {
             ScalarFn::Ceil => Expr::cust_with_exprs("(ceil($1))::int8", [num(self, 0)?]),
             ScalarFn::Floor => Expr::cust_with_exprs("(floor($1))::int8", [num(self, 0)?]),
             // ROUND(expression[, decimal]) — decimal defaults to 0.
+            // NOTE: QUERY master03 §ROUND fixes no mode; the `::numeric` cast
+            // pins half-away-from-zero (PostgreSQL docs §Mathematical
+            // Functions — numeric ties round away from zero), test-pinned.
             ScalarFn::Round => match args.len() {
                 1 => Expr::cust_with_exprs("round(($1)::numeric, 0)", [num(self, 0)?]),
                 _ => Expr::cust_with_exprs(

--- a/app/ferroehr/tests/it/service_aql.rs
+++ b/app/ferroehr/tests/it/service_aql.rs
@@ -1252,6 +1252,35 @@ async fn scalar_functions_execute() {
     assert_eq!(row[4], json!(81.5), "ROUND to 1 decimal");
     assert_eq!(row[5], json!(1.5), "MOD(81.5, 2)");
 
+    // ROUND's rounding mode is half-AWAY-FROM-ZERO, in both signs and at a
+    // decimal place — QUERY master03 §ROUND fixes no mode, so the adjudicated
+    // mode is pinned here: a lowering change that drops the ::numeric cast
+    // (double precision rounds ties to EVEN: 2.5 → 2) flips these
+    // assertions, never a clinical number silently.
+    for (magnitude, decimals, expected, label) in [
+        (2.5, None, json!(3), "ROUND(2.5) = 3, away from zero"),
+        (-2.5, None, json!(-3), "ROUND(-2.5) = -3, away from zero"),
+        (
+            0.125,
+            Some(2),
+            json!(0.13),
+            "ROUND(0.125, 2) = 0.13 at a decimal place",
+        ),
+    ] {
+        let ehr = create_ehr(&svc).await;
+        create_comp(&svc, &ehr, "ties", magnitude).await;
+        let call = match decimals {
+            None => format!("round(o/{MAG_PATH})"),
+            Some(d) => format!("round(o/{MAG_PATH}, {d})"),
+        };
+        let aql = format!(
+            "SELECT {call} FROM EHR e CONTAINS COMPOSITION c \
+             CONTAINS OBSERVATION o[{OBS_ARCHETYPE}]"
+        );
+        let r = run_aql(&svc, &aql, ehr_scope(&ehr)).await;
+        assert_eq!(rows(&r)[0][0], expected, "{label}: {r}");
+    }
+
     // Date/time functions: shape checks (values are 'now').
     let r = run_aql(
         &svc,


### PR DESCRIPTION
Closes #2922.

QUERY master03 §ROUND fixes no rounding mode ('returns the rounded expression argument to decimal places' — nothing more), and the community reproducibility thread (discourse t/17055) is exactly about implementations silently disagreeing on ties. Today's behaviour is deterministic only by the `::numeric` cast in the lowering: PostgreSQL rounds `numeric` ties away from zero and `double precision` ties to even.

The mode is now recorded as a `// NOTE:` at the lowering (spec-silent; the PostgreSQL mathematical-functions doc is the citation) and pinned by three DB assertions — `ROUND(2.5) = 3`, `ROUND(-2.5) = -3`, `ROUND(0.125, 2) = 0.13` — so a future cast change flips a test, never a clinical number.

Test-only + one comment; no wire change (no changelog entry needed — behaviour is unchanged and now pinned).