### PR TITLE
chore(spec): the create-body uid adjudication is recorded and pinned

### DIFF
--- a/app/ferroehr/src/versioning/change.rs
+++ b/app/ferroehr/src/versioning/change.rs
@@ -490,12 +490,19 @@ struct ResolvedWrite {
 /// carry it — the copied-uid recommendation for top-level types (RM common
 /// `master03-archetyped_package.adoc` §Unique Node Identification; ITS-REST
 /// `Resources.md` §Identifier types: the enclosing VERSION's uid "should be
-/// copied"; the full three-part form is this server's fixed handling,
-/// no released text fixes it). A client-supplied `uid` is overwritten — the version
-/// identity is server-assigned, and the previous behaviour (store verbatim,
-/// overwrite at bare read) served two shapes for one object. The EHR Extract
-/// import path does NOT run through here (foreign versions keep their
-/// carried bytes verbatim).
+/// copied"). The full three-part form is BASE `architecture_overview`
+/// master09 §Levels of Identification: "populated with a copy of the
+/// `OBJECT_VERSION_ID` from the containing `VERSION<X>` object" (the RM
+/// COMPOSITION class note's `object_id()` wording contradicts its own
+/// example — reported upstream).
+///
+/// NOTE: a client-supplied create-body `uid` is overwritten — no released
+/// operation states a body-uid semantic for the content-object creates, and
+/// the identifier names a version that does not exist until this commit
+/// mints it (the party-side twin of this adjudication is #1578).
+///
+/// The EHR Extract import path does NOT run through here (foreign versions
+/// keep their carried bytes verbatim).
 ///
 /// # Errors
 /// [`VersionIdError`] when `version_uid` is not a well-formed

--- a/app/ferroehr/tests/it/service_contribution.rs
+++ b/app/ferroehr/tests/it/service_contribution.rs
@@ -2300,3 +2300,44 @@ async fn concurrent_deactivation_is_seen_by_the_content_commit() {
         "the refusal names the deactivation: {refused:?}"
     );
 }
+
+/// A create body carrying its own `uid` succeeds, and the served identity is
+/// the SERVER-minted `OBJECT_VERSION_ID` — a version identifier names a
+/// version that does not exist until this commit mints it, and no released
+/// operation gives a create-body uid any semantics (`composition_create.yaml`
+/// states nothing; BASE `architecture_overview` master09 §Levels of
+/// Identification defines what the stored uid must carry — the containing
+/// VERSION's `OBJECT_VERSION_ID`; the adjudication is #2918, the party twin
+/// #1578).
+#[tokio::test]
+async fn create_body_uid_is_replaced_by_the_minted_identity() {
+    let db = testkit::db().await.expect("testkit database");
+    let svc = FerroEhrService::new(db.pool());
+    let ehr_id = create_ehr(&svc).await;
+    let ehr_uuid: ferroehr::ids::EhrId = ehr_id.parse().expect("ehr uuid");
+
+    let mut body = composition("client uid");
+    body["uid"] = json!({
+        "_type": "OBJECT_VERSION_ID",
+        "value": "11111111-1111-1111-1111-111111111111::client.example::7"
+    });
+    let committed = svc
+        .create_composition(ehr_uuid, uv(&body, "249", None))
+        .await
+        .expect("a schema-valid body uid never refuses the create");
+    let minted = committed.version_uid();
+    assert_ne!(
+        minted, "11111111-1111-1111-1111-111111111111::client.example::7",
+        "the identity is server-minted"
+    );
+
+    let served = svc
+        .get_composition_at_version(ehr_uuid, minted.parse().expect("OBJECT_VERSION_ID"))
+        .await
+        .expect("the committed version exists");
+    assert_eq!(
+        served["uid"]["value"],
+        json!(minted),
+        "the served body uid IS the identifier the create returned"
+    );
+}


### PR DESCRIPTION
Closes #2918.

**Re-verified first-hand:** `composition_create.yaml` and `directory_create.yaml` state nothing about a body `uid`; `ehr_status_update.yaml` names only the `If-Match` version uid — the content-object create is genuinely spec-silent on a client-supplied body uid, and `LOCATABLE.uid` (0..1) makes it schema-valid on the way in. BASE `architecture_overview` master09 §Levels of Identification fixes what the stored copy carries: the full `OBJECT_VERSION_ID` of the containing VERSION — which the RM COMPOSITION class note contradicts against its own example (`object_id()` wording, three-part example): reported upstream as #2933.

**The record, not the behaviour:** `stamp_version_uid` keeps replacing a client value with the minted identity (the version does not exist until this commit mints it; the party twin is #1578/AMB-132, the update-side mismatch rule #1522/AMB-78). Its doc now cites BASE master09 and carries the adjudication NOTE; `create_body_uid_is_replaced_by_the_minted_identity` pins a create carrying a client uid: it succeeds, and the read-back `uid/value` is the identifier the create returned.

**Register handoff:** Veredictum#202 (AMB-132 extension + one minted-identity wire case per create).

Docs/test-only + comments; no wire change.