### PR TITLE
feat(rm): DV_TEXT plain_no_newlines refuses newlines; upstream adjudication notes recorded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Added
+
+- Validation enforces the one testable rule of `DV_TEXT.formatting`: a value
+  formatted `"plain_no_newlines"` is refused when the text contains a
+  newline (RM: "newlines are not allowed"). Every other formatting value
+  stays unvalidated — markdown, `"plain"`, the deprecated CSS form, and
+  unknown names all remain legal, with or without newlines.
+
 ### Fixed
 
 - The `is_modifiable` content-write gate is evaluated inside the commit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5426,7 +5426,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.45"
+version = "0.0.47"
 dependencies = [
  "indexmap 2.14.0",
  "openehr-am",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.45"
+version = "0.0.47"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.45"
+version = "0.0.47"
 dependencies = [
  "serde",
  "serde_json",
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.45"
+version = "0.0.47"
 dependencies = [
  "async-trait",
  "axum",
@@ -5500,7 +5500,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.45"
+version = "0.0.47"
 dependencies = [
  "assert_fs",
  "chumsky",
@@ -5514,7 +5514,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.45"
+version = "0.0.47"
 dependencies = [
  "chumsky",
  "logos",
@@ -5523,7 +5523,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.45"
+version = "0.0.47"
 dependencies = [
  "insta",
  "jsonschema",
@@ -5541,7 +5541,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.45"
+version = "0.0.47"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-adl"
-version = "0.0.45"
+version = "0.0.47"
 description = "openEHR ADL 2.4.0: hand-written ADL2/cADL/ODIN parser, AOM2 validation catalogue, specialisation flattener, OPT2 generator, and ADL 1.4→2 conversion over the generated openehr_am::v2_4::aom2 model"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,11 +16,11 @@ include = ["src/**", "README.md", "LICENSE-MIT"]
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)
-openehr-base = { path = "../openehr-base", version = "0.0.45" }   # VersionStatus for the parsed HRID
-openehr-am = { path = "../openehr-am", version = "0.0.45" }       # v2_4 ArchetypeHrid (the identification target type)
-openehr-rm = { path = "../openehr-rm", version = "0.0.45" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
-openehr-lang = { path = "../openehr-lang", version = "0.0.45" }   # openehr_lang::odin — the ODIN section parser
-openehr-term = { path = "../openehr-term", version = "0.0.45" }   # the languages code set for the RM resource-meta rows
+openehr-base = { path = "../openehr-base", version = "0.0.47" }   # VersionStatus for the parsed HRID
+openehr-am = { path = "../openehr-am", version = "0.0.47" }       # v2_4 ArchetypeHrid (the identification target type)
+openehr-rm = { path = "../openehr-rm", version = "0.0.47" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
+openehr-lang = { path = "../openehr-lang", version = "0.0.47" }   # openehr_lang::odin — the ODIN section parser
+openehr-term = { path = "../openehr-term", version = "0.0.47" }   # the languages code set for the RM resource-meta rows
 uuid.workspace = true        # meta uid/build_uid (AUTHORED_ARCHETYPE.uid: Uuid)
 indexmap.workspace = true    # OdinValue::Object body (insertion-ordered map)
 

--- a/crates/openehr-adl/src/validate/rm.rs
+++ b/crates/openehr-adl/src/validate/rm.rs
@@ -538,6 +538,9 @@ impl RmScan<'_> {
         attr: &CAttribute,
         rm_attr: &RmAttr,
     ) {
+        // NOTE: ADL 1.4 master05 §existence states a {1..1} default when
+        // unstated — applied literally it fails published CKM content, so an
+        // unstated existence deliberately defers to the RM (reported upstream).
         let Some(ex) = attr.existence.as_ref() else {
             return;
         };

--- a/crates/openehr-am/Cargo.toml
+++ b/crates/openehr-am/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-am"
-version = "0.0.45"
+version = "0.0.47"
 description = "openEHR AM Archetype Model, generated from BMM: generations v1_4 (AM 1.4.0, ADL 1.4) and v2_4 (AM 2.4.0, ADL 2; current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,8 +13,8 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.45" }
-openehr-lang = { path = "../openehr-lang", version = "0.0.45" }
+openehr-base = { path = "../openehr-base", version = "0.0.47" }
+openehr-lang = { path = "../openehr-lang", version = "0.0.47" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also carries the untyped `Value` fields the generator

--- a/crates/openehr-base/Cargo.toml
+++ b/crates/openehr-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-base"
-version = "0.0.45"
+version = "0.0.47"
 description = "openEHR BASE foundation + base types, generated from BMM: generations v1_2 (BASE 1.2.0) and v1_3 (BASE 1.3.0, current)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-its"
-version = "0.0.45"
+version = "0.0.47"
 description = "openEHR ITS (Implementation Technology Specifications): canonical JSON + canonical XML serialization of the RM, the generated ITS-REST 1.1.0 API contract, OPT 1.4 and AOM2 archetype XML codecs, and the Simplified Formats (FLAT / STRUCTURED / Web Template)"
 edition.workspace = true
 rust-version.workspace = true
@@ -41,14 +41,14 @@ regex = { workspace = true, optional = true }
 fancy-regex = { workspace = true, optional = true }
 # The generated XML (de)serializers impl the crate's ToXml/FromXml traits for the
 # RM/BASE spec types, so these are real (non-dev) deps.
-openehr-base = { path = "../openehr-base", version = "0.0.45", optional = true }
-openehr-rm = { path = "../openehr-rm", version = "0.0.45", optional = true }
+openehr-base = { path = "../openehr-base", version = "0.0.47", optional = true }
+openehr-rm = { path = "../openehr-rm", version = "0.0.47", optional = true }
 # The native canonical-JSON codec (`json_codec/generated`, emit-json) implements
 # `ToJson` for EVERY generated spec type the `OpenEhrType` derive covers, so it
 # spans all five spec crates (not just the RM/BASE the XML codec needs).
-openehr-lang = { path = "../openehr-lang", version = "0.0.45", optional = true }
-openehr-am = { path = "../openehr-am", version = "0.0.45", optional = true }
-openehr-term = { path = "../openehr-term", version = "0.0.45", optional = true }
+openehr-lang = { path = "../openehr-lang", version = "0.0.47", optional = true }
+openehr-am = { path = "../openehr-am", version = "0.0.47", optional = true }
+openehr-term = { path = "../openehr-term", version = "0.0.47", optional = true }
 
 # `full` — every ITS surface (canonical JSON/XML, the generated ITS-REST
 # contract, `opt14`, Simplified Formats). ON BY DEFAULT, so every consumer sees

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-lang"
-version = "0.0.45"
+version = "0.0.47"
 description = "openEHR LANG BMM/P_BMM object model, generated from BMM: generations v1_0 (LANG 1.0.0) and v1_1 (LANG 1.1.0, current; the stable BMM v2.x unit beside the paused BMM3 unit), plus hand-written ODIN/BEL/EL readers"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["parser-implementations", "data-structures"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.45" }
+openehr-base = { path = "../openehr-base", version = "0.0.47" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the
 # generated types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) —
 # never a derive. `serde_json` also carries the untyped `Value` fields the

--- a/crates/openehr-lang/src/v1_1/bmm/core/bmm_model_impl.rs
+++ b/crates/openehr-lang/src/v1_1/bmm/core/bmm_model_impl.rs
@@ -405,7 +405,13 @@ impl BmmModel {
     ///
     /// A non-generic descendant against a generic ancestor is therefore NOT
     /// conformant — the rule set admits generic parameters only on the
-    /// descendant side.
+    /// descendant side. Deliberate: the published algorithm's final case
+    /// returns exactly `not valid_generic_type_name(anc_type)`
+    /// (`master06-core-types.adoc` §Type Conformance), so a simple class
+    /// closing a generic ancestor (`Multiplicity_interval` against
+    /// `Interval<Ordered>`) has NO published substitution rule; the gap is
+    /// reported upstream, and this stays the faithful reading until a rule
+    /// is published.
     ///
     /// An open ancestor parameter is "replaced with their appropriate
     /// constrainer types, or Any": the constrainer is resolved POSITIONALLY

--- a/crates/openehr-query/Cargo.toml
+++ b/crates/openehr-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-query"
-version = "0.0.45"
+version = "0.0.47"
 description = "openEHR QUERY (AQL 1.1.0): hand-written lexer, parser, typed AST and canonical printer from the official grammar (no ANTLR runtime)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-rm"
-version = "0.0.45"
+version = "0.0.47"
 description = "openEHR RM Reference Model, generated from BMM: generations v1_1 (RM 1.1.0) and v1_2 (RM 1.2.0, current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,11 +13,11 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.45" }
+openehr-base = { path = "../openehr-base", version = "0.0.47" }
 # The terminology-backed RM class invariants (`validate::terminology`) resolve
 # openEHR terminology groups + code sets against the vendored TERM 3.1.0 bundle.
 # `openehr-term` itself depends only on `openehr-base`, so this is acyclic.
-openehr-term = { path = "../openehr-term", version = "0.0.45" }
+openehr-term = { path = "../openehr-term", version = "0.0.47" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also backs the untyped `Value` RM representation used by

--- a/crates/openehr-rm/src/v1_1/data_types/text/dv_text_impl.rs
+++ b/crates/openehr-rm/src/v1_1/data_types/text/dv_text_impl.rs
@@ -25,6 +25,15 @@ impl Validate for DvText {
             DvText::DvCodedText(t) => ("DV_CODED_TEXT", &t.value, t.formatting.as_deref()),
         };
         crate::v1_1::validate::generated::dv_text_core(ty, value, formatting, out);
+        // NOTE: RM data_types master05 §Text package — "plain_no_newlines":
+        // "newlines are not allowed"; every OTHER formatting value stays
+        // unvalidated, deliberately (the value space is open).
+        if formatting == Some("plain_no_newlines") && value.contains(['\n', '\r']) {
+            out.push(InvariantViolation::here(format!(
+                "formatting \"plain_no_newlines\" forbids newlines in value on type {ty} \
+                 (RM data_types master05 §Text package)"
+            )));
+        }
     }
 }
 
@@ -69,5 +78,45 @@ mod tests {
             out.iter().any(|m| m.message.contains("Formatting_valid")),
             "empty formatting must fail: {out:?}"
         );
+    }
+
+    fn formatted(value: &str, formatting: &str) -> DvText {
+        let mut t = text(value);
+        if let DvText::DvText(d) = &mut t {
+            d.formatting = Some(formatting.to_owned());
+        }
+        t
+    }
+
+    /// `"plain_no_newlines"` — "newlines are not allowed" (RM data_types
+    /// master05 §Text package): both twins, plus the open value space — a
+    /// newline under any OTHER formatting (or none) stays legal, including
+    /// the deprecated CSS form and an unknown name.
+    #[test]
+    fn plain_no_newlines_forbids_newlines_and_nothing_else() {
+        let mut out = Vec::new();
+        formatted("one line", "plain_no_newlines").validate_invariants(&mut out);
+        assert!(out.is_empty(), "no newline passes: {out:?}");
+
+        for value in ["two\nlines", "carriage\rreturn"] {
+            let mut out = Vec::new();
+            formatted(value, "plain_no_newlines").validate_invariants(&mut out);
+            assert!(
+                out.iter().any(|m| m.message.contains("plain_no_newlines")),
+                "{value:?} must fail under plain_no_newlines: {out:?}"
+            );
+        }
+
+        for formatting in ["plain", "markdown", "font-weight : bold;", "custom-name"] {
+            let mut out = Vec::new();
+            formatted("two\nlines", formatting).validate_invariants(&mut out);
+            assert!(
+                out.is_empty(),
+                "the value space stays open — {formatting:?} with a newline passes: {out:?}"
+            );
+        }
+        let mut out = Vec::new();
+        text("two\nlines").validate_invariants(&mut out);
+        assert!(out.is_empty(), "Void formatting allows newlines: {out:?}");
     }
 }

--- a/crates/openehr-rm/src/v1_2/data_types/text/dv_text_impl.rs
+++ b/crates/openehr-rm/src/v1_2/data_types/text/dv_text_impl.rs
@@ -25,6 +25,15 @@ impl Validate for DvText {
             DvText::DvCodedText(t) => ("DV_CODED_TEXT", &t.value, t.formatting.as_deref()),
         };
         crate::v1_2::validate::generated::dv_text_core(ty, value, formatting, out);
+        // NOTE: RM data_types master05 §Text package — "plain_no_newlines":
+        // "newlines are not allowed"; every OTHER formatting value stays
+        // unvalidated, deliberately (the value space is open).
+        if formatting == Some("plain_no_newlines") && value.contains(['\n', '\r']) {
+            out.push(InvariantViolation::here(format!(
+                "formatting \"plain_no_newlines\" forbids newlines in value on type {ty} \
+                 (RM data_types master05 §Text package)"
+            )));
+        }
     }
 }
 
@@ -69,5 +78,45 @@ mod tests {
             out.iter().any(|m| m.message.contains("Formatting_valid")),
             "empty formatting must fail: {out:?}"
         );
+    }
+
+    fn formatted(value: &str, formatting: &str) -> DvText {
+        let mut t = text(value);
+        if let DvText::DvText(d) = &mut t {
+            d.formatting = Some(formatting.to_owned());
+        }
+        t
+    }
+
+    /// `"plain_no_newlines"` — "newlines are not allowed" (RM data_types
+    /// master05 §Text package): both twins, plus the open value space — a
+    /// newline under any OTHER formatting (or none) stays legal, including
+    /// the deprecated CSS form and an unknown name.
+    #[test]
+    fn plain_no_newlines_forbids_newlines_and_nothing_else() {
+        let mut out = Vec::new();
+        formatted("one line", "plain_no_newlines").validate_invariants(&mut out);
+        assert!(out.is_empty(), "no newline passes: {out:?}");
+
+        for value in ["two\nlines", "carriage\rreturn"] {
+            let mut out = Vec::new();
+            formatted(value, "plain_no_newlines").validate_invariants(&mut out);
+            assert!(
+                out.iter().any(|m| m.message.contains("plain_no_newlines")),
+                "{value:?} must fail under plain_no_newlines: {out:?}"
+            );
+        }
+
+        for formatting in ["plain", "markdown", "font-weight : bold;", "custom-name"] {
+            let mut out = Vec::new();
+            formatted("two\nlines", formatting).validate_invariants(&mut out);
+            assert!(
+                out.is_empty(),
+                "the value space stays open — {formatting:?} with a newline passes: {out:?}"
+            );
+        }
+        let mut out = Vec::new();
+        text("two\nlines").validate_invariants(&mut out);
+        assert!(out.is_empty(), "Void formatting allows newlines: {out:?}");
     }
 }

--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-term"
-version = "0.0.45"
+version = "0.0.47"
 description = "openEHR TERM terminology data model, generated from BMM (generation v3_1 = TERM 3.1.0), plus the embedded official terminology XML bundle"
 edition.workspace = true
 rust-version.workspace = true
@@ -34,7 +34,7 @@ include = [
 ]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.45" }
+openehr-base = { path = "../openehr-base", version = "0.0.47" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1281,7 +1281,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.45"
+version = "0.0.47"
 dependencies = [
  "indexmap",
  "openehr-am",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.45"
+version = "0.0.47"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.45"
+version = "0.0.47"
 dependencies = [
  "serde",
  "serde_json",
@@ -1317,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.45"
+version = "0.0.47"
 dependencies = [
  "async-trait",
  "axum",
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.45"
+version = "0.0.47"
 dependencies = [
  "chumsky",
  "indexmap",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.45"
+version = "0.0.47"
 dependencies = [
  "chumsky",
  "logos",
@@ -1364,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.45"
+version = "0.0.47"
 dependencies = [
  "openehr-base",
  "openehr-term",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.45"
+version = "0.0.47"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/tools/openehr-codegen/templates/openehr-rm/data_types/text/dv_text_impl.rs
+++ b/tools/openehr-codegen/templates/openehr-rm/data_types/text/dv_text_impl.rs
@@ -25,6 +25,15 @@ impl Validate for DvText {
             DvText::DvCodedText(t) => ("DV_CODED_TEXT", &t.value, t.formatting.as_deref()),
         };
         crate::v1_2::validate::generated::dv_text_core(ty, value, formatting, out);
+        // NOTE: RM data_types master05 §Text package — "plain_no_newlines":
+        // "newlines are not allowed"; every OTHER formatting value stays
+        // unvalidated, deliberately (the value space is open).
+        if formatting == Some("plain_no_newlines") && value.contains(['\n', '\r']) {
+            out.push(InvariantViolation::here(format!(
+                "formatting \"plain_no_newlines\" forbids newlines in value on type {ty} \
+                 (RM data_types master05 §Text package)"
+            )));
+        }
     }
 }
 
@@ -69,5 +78,45 @@ mod tests {
             out.iter().any(|m| m.message.contains("Formatting_valid")),
             "empty formatting must fail: {out:?}"
         );
+    }
+
+    fn formatted(value: &str, formatting: &str) -> DvText {
+        let mut t = text(value);
+        if let DvText::DvText(d) = &mut t {
+            d.formatting = Some(formatting.to_owned());
+        }
+        t
+    }
+
+    /// `"plain_no_newlines"` — "newlines are not allowed" (RM data_types
+    /// master05 §Text package): both twins, plus the open value space — a
+    /// newline under any OTHER formatting (or none) stays legal, including
+    /// the deprecated CSS form and an unknown name.
+    #[test]
+    fn plain_no_newlines_forbids_newlines_and_nothing_else() {
+        let mut out = Vec::new();
+        formatted("one line", "plain_no_newlines").validate_invariants(&mut out);
+        assert!(out.is_empty(), "no newline passes: {out:?}");
+
+        for value in ["two\nlines", "carriage\rreturn"] {
+            let mut out = Vec::new();
+            formatted(value, "plain_no_newlines").validate_invariants(&mut out);
+            assert!(
+                out.iter().any(|m| m.message.contains("plain_no_newlines")),
+                "{value:?} must fail under plain_no_newlines: {out:?}"
+            );
+        }
+
+        for formatting in ["plain", "markdown", "font-weight : bold;", "custom-name"] {
+            let mut out = Vec::new();
+            formatted("two\nlines", formatting).validate_invariants(&mut out);
+            assert!(
+                out.is_empty(),
+                "the value space stays open — {formatting:?} with a newline passes: {out:?}"
+            );
+        }
+        let mut out = Vec::new();
+        text("two\nlines").validate_invariants(&mut out);
+        assert!(out.is_empty(), "Void formatting allows newlines: {out:?}");
     }
 }


### PR DESCRIPTION
Closes #2924.

**`plain_no_newlines` enforcement (#2924):** RM data_types master05 §Text package — "newlines are not allowed - the text is a simple 'atom'". The check lives in the hand-written `dv_text_impl.rs` generation-twin TEMPLATE (normative prose, not a BMM invariant — never a generated file), stamped into both RM generations; it refuses `\n`/`\r` under exactly that formatting value, message carrying the RM citation. The value space stays open, deliberately (discourse t/17205 is the cautionary tale): markdown, `"plain"`, the deprecated CSS `name:value;` form and unknown names pass with or without newlines — pinned beside the refusal/acceptance twins (`plain_no_newlines_forbids_newlines_and_nothing_else`, both generations). Changelog `### Added`.

**Two verified upstream reports gain their in-repo adjudication notes** (the code half of #2921/#2923, which close as standing records once this lands):
- `openehr-lang` `type_conforms_to`: re-verified first-hand — the published algorithm's final case returns `not valid_generic_type_name(anc_type)`, so a simple class closing a generic ancestor conforms NEVER; the doc now states the faithful-reading adjudication in place (published crate: decision + released ground, no tracker tokens).
- `openehr-adl` VCAEX: re-verified first-hand — ADL 1.4 master05's stated `{1..1}` default, applied literally, fails published CKM content (`blood_pressure.v2` carries no explicit existence anywhere); the unstated-existence-defers-to-RM skip now carries its NOTE.

Register handoff for both: Veredictum#206. Spec-crate content changed → the eight crates bump to 0.0.47 in lockstep (fuzz lockfile refreshed).

Suites: openehr-rm 665, openehr-lang 339, openehr-adl 303, plus the full openehr-its/ferroehr/ferroehr-rest battery; workspace clippy clean. Conformance run deferred by owner instruction to the pre-release full run.
