### PR TITLE
fix(aql): fragment-step and whole-object root predicates lower instead of rejecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,10 +55,11 @@ workflow refuses a tag that has no matching section here.
 - An AQL node predicate written on the ROOT of an identified path
   (`c[openEHR-EHR-COMPOSITION.report.v1]/name/value`) now constrains the
   query — it was silently discarded, so the path answered as if the
-  predicate were not written. The two shapes that still have no lowering — a
-  predicate on a non-structure path step (`links[at0001]`) and a node
-  predicate on a whole-object projection — are refused with a typed error
-  instead of being ignored.
+  predicate were not written. A predicate on a non-structure path step
+  (`links[meaning/value = ...]`) lowers as a SQL/JSON path filter selecting
+  the matching elements, and a root predicate on a whole-object projection
+  serves the object where the source matches and a `null` cell where it
+  does not.
 - Reads serve the exact canonical bytes the commit accepted: `_type` first
   and every field at its spec-declared position — including the
   server-stamped `uid`, which now lands at its place in the document instead

--- a/app/ferroehr/src/aql/sql/expr.rs
+++ b/app/ferroehr/src/aql/sql/expr.rs
@@ -45,26 +45,30 @@ pub(super) fn to_jsonb(e: Expr) -> Expr {
     call("to_jsonb", vec![e])
 }
 
-/// `jsonb_path_query_first(data, '<jp>'::jsonpath)`.
-pub(super) fn jsonb_path(data: Expr, jp: &str) -> Expr {
-    call(
-        "jsonb_path_query_first",
-        vec![data, cast(Expr::val(jp.to_owned()), "jsonpath")],
-    )
+/// `jsonb_path_query_first(data, '<jp>'::jsonpath[, vars])` — `vars` carries
+/// the filter-expression variables of a predicated fragment path, always as a
+/// bound jsonb parameter (never spliced into the path text).
+pub(super) fn jsonb_path(data: Expr, jp: &str, vars: Option<Expr>) -> Expr {
+    let mut args = vec![data, cast(Expr::val(jp.to_owned()), "jsonpath")];
+    if let Some(vars) = vars {
+        args.push(vars);
+    }
+    call("jsonb_path_query_first", args)
 }
 
 /// `NULLIF(jsonb_path_query_array(data, '<jp>'::jsonpath), '[]'::jsonb)` —
 /// every fragment match as ONE jsonb array cell, SQL `NULL` when the path
 /// matches nothing (so absence keeps reading as a NULL cell / a false
 /// comparison, exactly as the scalar extraction reads it).
-pub(super) fn jsonb_path_array(data: Expr, jp: &str) -> Expr {
+pub(super) fn jsonb_path_array(data: Expr, jp: &str, vars: Option<Expr>) -> Expr {
+    let mut args = vec![data, cast(Expr::val(jp.to_owned()), "jsonpath")];
+    if let Some(vars) = vars {
+        args.push(vars);
+    }
     call(
         "nullif",
         vec![
-            call(
-                "jsonb_path_query_array",
-                vec![data, cast(Expr::val(jp.to_owned()), "jsonpath")],
-            ),
+            call("jsonb_path_query_array", args),
             cast(Expr::val("[]"), "jsonb"),
         ],
     )
@@ -82,9 +86,9 @@ pub(super) fn cast(e: Expr, ty: &str) -> Expr {
 
 /// The jsonb extraction base: `jsonb_path_query_first(<data>, jp)` when a
 /// fragment path is present, else the raw `<data>` expression.
-pub(super) fn extract_base(data: Expr, jp: Option<&str>) -> Expr {
+pub(super) fn extract_base(data: Expr, jp: Option<&str>, vars: Option<Expr>) -> Expr {
     match jp {
-        Some(jp) => jsonb_path(data, jp),
+        Some(jp) => jsonb_path(data, jp, vars),
         None => data,
     }
 }

--- a/app/ferroehr/src/aql/sql/predicate.rs
+++ b/app/ferroehr/src/aql/sql/predicate.rs
@@ -504,10 +504,12 @@ impl Builder<'_> {
                 let code_extract = as_text(jsonb_path(
                     col(node, "data"),
                     "$.name.defining_code.code_string",
+                    None,
                 ));
                 let term_extract = as_text(jsonb_path(
                     col(node, "data"),
                     "$.name.defining_code.terminology_id.value",
+                    None,
                 ));
                 Ok(code_extract
                     .eq(Expr::val(code.clone()))
@@ -518,7 +520,7 @@ impl Builder<'_> {
 
     pub(super) fn std_cond(&self, node: &str, sp: &StdPredicate) -> Result<Expr, AqlError> {
         let jp = jsonpath(&sp.path);
-        let lhs = as_text(jsonb_path(col(node, "data"), &jp));
+        let lhs = as_text(jsonb_path(col(node, "data"), &jp, None));
         let rhs = cast(Expr::val(self.bind_value(&sp.value)?), "text");
         Ok(lhs.binary(binoper(sp.op), rhs))
     }

--- a/app/ferroehr/src/aql/sql/select.rs
+++ b/app/ferroehr/src/aql/sql/select.rs
@@ -129,13 +129,32 @@ impl Builder<'_> {
         leaf: &LeafPath,
     ) -> Result<ColumnSpec, AqlError> {
         let anchor = self.whole_object_alias(leaf)?;
+        // A root predicate guards the projection: a row whose source node does
+        // not satisfy it serves a NULL cell, never a dropped row — expressed by
+        // CASE-guarding the vo_id locator alone (the executor short-circuits a
+        // NULL vo_id to a null cell before reading the other three).
+        let root_cond = match &leaf.root_predicate {
+            Some(pred) => {
+                let src = self.source_node(leaf.source.0)?;
+                self.node_constraint_conds(&src, pred)?
+                    .into_iter()
+                    .reduce(sea_query::ExprTrait::and)
+            }
+            None => None,
+        };
         let cols = ["vo", "sv", "num", "cap"];
         let node_cols = ["vo_id", "sys_version", "num", "num_cap"];
         let mut sql_cols = Vec::with_capacity(4);
         for (suffix, ncol) in cols.iter().zip(node_cols) {
             let sql_col = format!("col{i}_{suffix}");
-            self.q
-                .expr_as(col(&anchor, ncol), Alias::new(sql_col.as_str()));
+            let locator = col(&anchor, ncol);
+            let expr: Expr = match (&root_cond, ncol) {
+                (Some(cond), "vo_id") => sea_query::CaseStatement::new()
+                    .case(cond.clone(), locator)
+                    .into(),
+                _ => locator,
+            };
+            self.q.expr_as(expr, Alias::new(sql_col.as_str()));
             sql_cols.push(sql_col);
         }
         Ok(ColumnSpec {
@@ -150,16 +169,6 @@ impl Builder<'_> {
     /// anchor → the source node; otherwise the anchor chain is joined in and its
     /// final node alias returned.
     fn whole_object_alias(&mut self, leaf: &LeafPath) -> Result<String, AqlError> {
-        // A root predicate on a whole-object projection has no lowering (the
-        // reassembly locators cannot carry a per-row guard yet): refuse loudly
-        // rather than serve the object as if the predicate were not written.
-        // TODO(#2927): decide and lower the guarded whole-object projection.
-        if leaf.root_predicate.is_some() {
-            return Err(crate::aql::error::SqlError::Unsupported(
-                "a node predicate on a whole-object projection is not supported".to_owned(),
-            )
-            .into());
-        }
         let src = self.source_node(leaf.source.0)?;
         if leaf.anchor.is_empty() {
             return Ok(src);

--- a/app/ferroehr/src/aql/sql/value.rs
+++ b/app/ferroehr/src/aql/sql/value.rs
@@ -85,23 +85,24 @@ impl Builder<'_> {
         if let Some(expr) = self.promoted_leaf_expr(leaf, mode) {
             return Ok(expr);
         }
-        reject_fragment_predicates(leaf)?;
         let src = self.source_node(leaf.source.0)?;
         let root_conds = leaf
             .root_predicate
             .as_ref()
             .map(|p| self.node_constraint_conds(&src, p))
             .transpose()?;
-        let jp = fragment_jsonpath(leaf);
+        let fragment = self.fragment_path(leaf)?;
+        let jp = fragment.as_ref().map(|(jp, _)| jp.clone());
         // NOTE: QUERY master03 §Identified Paths is silent on projecting a
         // list-valued fragment path — our own decision: every match as ONE
         // jsonb array cell; scalar contexts keep the first-match extraction.
         let projected_array =
             matches!(mode, ValueMode::Projection) && jp.is_some() && leaf.fragment_multi_valued();
         let extract = |data: Expr| -> Expr {
+            let vars = fragment.as_ref().and_then(|(_, v)| v.clone());
             match (&jp, projected_array) {
-                (Some(jp), true) => super::expr::jsonb_path_array(data, jp),
-                _ => extract_base(data, jp.as_deref()),
+                (Some(jp), true) => super::expr::jsonb_path_array(data, jp, vars),
+                _ => extract_base(data, jp.as_deref(), vars),
             }
         };
 
@@ -196,9 +197,8 @@ impl Builder<'_> {
         {
             return Ok(None);
         }
-        reject_fragment_predicates(leaf)?;
-        let jp = fragment_jsonpath(leaf);
-        let multi = jp.is_some() && leaf.fragment_multi_valued();
+        let fragment = self.fragment_path(leaf)?;
+        let multi = fragment.is_some() && leaf.fragment_multi_valued();
         if leaf.anchor.is_empty() && !multi {
             return Ok(None);
         }
@@ -207,19 +207,22 @@ impl Builder<'_> {
         let base;
         if leaf.anchor.is_empty() {
             // `multi` holds here, so the fragment jsonpath exists.
-            let Some(jp) = jp.as_deref() else {
+            let Some((jp, vars)) = fragment else {
                 return Ok(None);
             };
             sub = Query::select();
-            base = fragment_items(&mut sub, col(&src, "data"), jp, self.next_ctr());
+            base = fragment_items(&mut sub, col(&src, "data"), &jp, vars, self.next_ctr());
         } else {
             let (walk, last) = self.anchored_walk(leaf, &src)?;
             sub = walk;
-            base = match (jp.as_deref(), multi) {
-                (Some(jp), true) => {
-                    fragment_items(&mut sub, col(&last, "data"), jp, self.next_ctr())
+            base = match (fragment, multi) {
+                (Some((jp, vars)), true) => {
+                    fragment_items(&mut sub, col(&last, "data"), &jp, vars, self.next_ctr())
                 }
-                _ => extract_base(col(&last, "data"), jp.as_deref()),
+                (fragment, _) => {
+                    let (jp, vars) = fragment.unzip();
+                    extract_base(col(&last, "data"), jp.as_deref(), vars.flatten())
+                }
             };
         }
         // The root predicate correlates against the source node: the value
@@ -359,6 +362,93 @@ impl Builder<'_> {
         }
         let alias = self.node_alias.get(&leaf.source.0)?;
         Some(col(alias, entry.column))
+    }
+
+    /// The leaf's fragment jsonpath plus the bound filter variables of any
+    /// predicated fragment step, or `None` when the leaf addresses the whole
+    /// anchor node.
+    ///
+    /// A step predicate lowers to a jsonpath filter expression on the step's
+    /// member accessor (`$.links ? (@.archetype_node_id == $p0).target.value`
+    /// — QUERY master03 §Node predicate / §Standard predicate); every
+    /// compared value travels in the `vars` jsonb PARAMETER (`$p0`, `$p1`, …),
+    /// never spliced into the path text, and member names are lexer-restricted
+    /// identifiers. An archetype constraint on a fragment step is plain
+    /// equality on `archetype_node_id` — fragment objects are not `node` rows,
+    /// so the subsumption columns do not exist there; an HRID compares as the
+    /// written string.
+    #[expect(
+        clippy::disallowed_types,
+        reason = "the jsonpath vars object is SQL/JSON wire material (the bound \
+                  third argument of jsonb_path_query*), not an RM value — no \
+                  generated type models it"
+    )]
+    fn fragment_path(&self, leaf: &LeafPath) -> Result<Option<(String, Option<Expr>)>, AqlError> {
+        if leaf.fragment.is_empty() {
+            return Ok(None);
+        }
+        let mut jp = String::from("$");
+        let mut vars = serde_json::Map::new();
+        let var = |v: serde_json::Value, vars: &mut serde_json::Map<String, serde_json::Value>| {
+            let name = format!("p{}", vars.len());
+            vars.insert(name.clone(), v);
+            name
+        };
+        for step in &leaf.fragment {
+            let _ = write!(jp, ".{}", step.name);
+            let Some(pred) = &step.predicate else {
+                continue;
+            };
+            let mut conds: Vec<String> = Vec::new();
+            if let Some(a) = &pred.archetype {
+                let value = match a {
+                    crate::aql::ir::ArchetypeConstraint::NodeCode(c)
+                    | crate::aql::ir::ArchetypeConstraint::Archetype(c) => c.clone(),
+                    crate::aql::ir::ArchetypeConstraint::Param(p) => self.param_str(p)?,
+                };
+                let v = var(serde_json::Value::String(value), &mut vars);
+                conds.push(format!("@.archetype_node_id == ${v}"));
+            }
+            if let Some(n) = &pred.name {
+                match n {
+                    crate::aql::ir::NameConstraint::Value(s) => {
+                        let v = var(serde_json::Value::String(s.clone()), &mut vars);
+                        conds.push(format!("@.name.value == ${v}"));
+                    }
+                    crate::aql::ir::NameConstraint::Param(p) => {
+                        let v = var(serde_json::Value::String(self.param_str(p)?), &mut vars);
+                        conds.push(format!("@.name.value == ${v}"));
+                    }
+                    crate::aql::ir::NameConstraint::TermCode { terminology, code } => {
+                        let c = var(serde_json::Value::String(code.clone()), &mut vars);
+                        conds.push(format!("@.name.defining_code.code_string == ${c}"));
+                        let t = var(serde_json::Value::String(terminology.clone()), &mut vars);
+                        conds.push(format!("@.name.defining_code.terminology_id.value == ${t}"));
+                    }
+                }
+            }
+            for sp in &pred.standard {
+                let value = jsonpath_scalar(self.bind_value(&sp.value)?)?;
+                let v = var(value, &mut vars);
+                let mut lhs = String::from("@");
+                for part in &sp.path {
+                    let _ = write!(lhs, ".{part}");
+                }
+                conds.push(format!("{lhs} {} ${v}", jsonpath_op(sp.op)));
+            }
+            if !conds.is_empty() {
+                let _ = write!(jp, " ? ({})", conds.join(" && "));
+            }
+        }
+        let vars_expr = if vars.is_empty() {
+            None
+        } else {
+            Some(cast(
+                Expr::val(serde_json::Value::Object(vars).to_string()),
+                "jsonb",
+            ))
+        };
+        Ok(Some((jp, vars_expr)))
     }
 
     /// Resolve a leaf's source to a node alias present in the FROM.
@@ -650,57 +740,74 @@ pub(super) fn ehr_field_expr(alias: &str, field: EhrField, system_id: &str) -> E
     }
 }
 
-/// A predicate on a fragment step (below the anchor node) has no SQL lowering
-/// yet — refusing loudly keeps the engine's typed-reject rule: the silent
-/// alternative answers as if the predicate were not written.
-// TODO(#2927): lower fragment-step predicates as jsonpath filter expressions.
-fn reject_fragment_predicates(leaf: &LeafPath) -> Result<(), AqlError> {
-    match leaf.fragment.iter().find(|s| s.predicate.is_some()) {
-        Some(step) => Err(SqlError::Unsupported(format!(
-            "a predicate on the non-structure path step '{}' is not supported",
-            step.name
-        ))
-        .into()),
-        None => Ok(()),
-    }
-}
-
 /// AND-combine a lowered condition list, `None` for an absent/empty list.
 fn all_of(conds: Option<Vec<Expr>>) -> Option<Expr> {
     conds.and_then(|c| c.into_iter().reduce(sea_query::ExprTrait::and))
 }
 
-/// Adds the set-returning `jsonb_path_query(<data>, '<jp>'::jsonpath)` to the
-/// subquery's FROM and returns the per-match item reference.
+/// Adds the set-returning `jsonb_path_query(<data>, '<jp>'::jsonpath[, vars])`
+/// to the subquery's FROM and returns the per-match item reference.
 ///
 /// The call is implicitly LATERAL (a FROM function may reference columns of
 /// preceding FROM items — PostgreSQL docs §7.2.1.5 LATERAL Subqueries), and
 /// for a scalar-returning function the table alias doubles as the column name
 /// (§7.2.1.4 Table Functions).
-fn fragment_items(sub: &mut sea_query::SelectStatement, data: Expr, jp: &str, n: usize) -> Expr {
+fn fragment_items(
+    sub: &mut sea_query::SelectStatement,
+    data: Expr,
+    jp: &str,
+    vars: Option<Expr>,
+    n: usize,
+) -> Expr {
     let alias = format!("f{n}");
-    sub.from_function(
-        sea_query::Func::cust(Alias::new("jsonb_path_query"))
-            .arg(data)
-            .arg(cast(Expr::val(jp.to_owned()), "jsonpath")),
-        Alias::new(alias.as_str()),
-    );
+    let mut func = sea_query::Func::cust(Alias::new("jsonb_path_query"))
+        .arg(data)
+        .arg(cast(Expr::val(jp.to_owned()), "jsonpath"));
+    if let Some(vars) = vars {
+        func = func.arg(vars);
+    }
+    sub.from_function(func, Alias::new(alias.as_str()));
     col(&alias, &alias)
 }
 
 // ── jsonpaths ───────────────────────────────────────────────────────────────
 
-/// Build the fragment jsonpath (`$.a.b`) for a leaf, or `None` when the leaf
-/// addresses the whole anchor node.
-pub(super) fn fragment_jsonpath(leaf: &LeafPath) -> Option<String> {
-    if leaf.fragment.is_empty() {
-        return None;
+/// The jsonpath filter-expression operator for an AQL comparison operator
+/// (PostgreSQL docs §9.16.2 — the SQL/JSON path comparison operators).
+fn jsonpath_op(op: openehr_query::lexer::CompOp) -> &'static str {
+    match op {
+        openehr_query::lexer::CompOp::Eq => "==",
+        openehr_query::lexer::CompOp::Ne => "!=",
+        openehr_query::lexer::CompOp::Lt => "<",
+        openehr_query::lexer::CompOp::Le => "<=",
+        openehr_query::lexer::CompOp::Gt => ">",
+        openehr_query::lexer::CompOp::Ge => ">=",
     }
-    let mut jp = String::from("$");
-    for step in &leaf.fragment {
-        let _ = write!(jp, ".{}", step.name);
-    }
-    Some(jp)
+}
+
+/// A bound predicate value as the JSON scalar a jsonpath `vars` object
+/// carries. A non-scalar bind cannot appear in a filter comparison and is a
+/// typed reject.
+#[expect(
+    clippy::disallowed_types,
+    reason = "the jsonpath vars object is SQL/JSON wire material (the bound \
+              third argument of jsonb_path_query*), not an RM value — no \
+              generated type models it"
+)]
+fn jsonpath_scalar(value: sea_query::Value) -> Result<serde_json::Value, AqlError> {
+    Ok(match value {
+        sea_query::Value::String(Some(s)) => serde_json::Value::String(s),
+        sea_query::Value::Bool(Some(b)) => serde_json::Value::Bool(b),
+        sea_query::Value::BigInt(Some(i)) => serde_json::Value::from(i),
+        sea_query::Value::Int(Some(i)) => serde_json::Value::from(i),
+        sea_query::Value::Double(Some(f)) => serde_json::Value::from(f),
+        other => {
+            return Err(SqlError::Unsupported(format!(
+                "a fragment-step predicate compares against a non-scalar value ({other:?})"
+            ))
+            .into());
+        }
+    })
 }
 
 /// Build a jsonpath from a relative object path (`[a, b]` → `$.a.b`) — a node

--- a/app/ferroehr/tests/it/aql_planner.rs
+++ b/app/ferroehr/tests/it/aql_planner.rs
@@ -879,29 +879,43 @@ fn path_root_predicate_reaches_the_sql() {
     );
 }
 
-/// A predicate on a FRAGMENT step and a root predicate on a whole-object
-/// projection are TYPED REJECTS: neither has a SQL lowering yet, and building
-/// the query without the constraint would answer as if it were not written.
+/// A predicate on a FRAGMENT step lowers to a jsonpath FILTER whose compared
+/// values travel in the bound `vars` jsonb argument (the third
+/// `jsonb_path_query*` argument), never spliced into the path text — QUERY
+/// master03 §Node predicate / §Standard predicate at a non-structure step.
 #[test]
-fn unlowerable_path_predicates_are_typed_rejects() {
-    for (q, needle) in [
-        (
-            "SELECT c/uid/value FROM EHR e CONTAINS COMPOSITION c \
-             WHERE c/links[at0001]/target/value = 'x'",
-            "non-structure path step 'links'",
-        ),
-        (
-            "SELECT c[openEHR-EHR-COMPOSITION.report.v1] \
-             FROM EHR e CONTAINS COMPOSITION c",
-            "whole-object projection",
-        ),
-    ] {
-        let err = build_err(q);
-        assert!(
-            err.to_string().contains(needle),
-            "{q:?} must reject with {needle:?}: {err}"
-        );
-    }
+fn fragment_step_predicate_lowers_to_a_jsonpath_filter() {
+    let sql = build_sql(
+        "SELECT c/uid/value FROM EHR e CONTAINS COMPOSITION c \
+         WHERE c/links[meaning/value = 'issue']/target/value = 'x'",
+    );
+    assert!(
+        sql.contains("AS jsonb)"),
+        "the filter variables bind as the jsonb vars argument: {sql}"
+    );
+    assert!(
+        sql.contains("jsonb_path_query("),
+        "the predicated multi-valued fragment stays existential: {sql}"
+    );
+}
+
+/// A root predicate on a whole-object projection guards the `vo_id` locator:
+/// a non-matching row serves a NULL cell (the executor short-circuits a NULL
+/// `vo_id`), never a dropped row.
+#[test]
+fn whole_object_root_predicate_guards_the_locator() {
+    let sql = build_sql(
+        "SELECT c[openEHR-EHR-COMPOSITION.report.v1] \
+         FROM EHR e CONTAINS COMPOSITION c",
+    );
+    assert!(
+        sql.contains("CASE WHEN") && sql.contains("arch_concept"),
+        "the vo_id locator is CASE-guarded by the predicate: {sql}"
+    );
+    assert!(
+        sql.contains(r#""vo_id" END"#),
+        "the guard wraps the vo_id locator: {sql}"
+    );
 }
 
 /// OR-containment under an EHR lowers to a disjunction of correlated

--- a/app/ferroehr/tests/it/service_aql.rs
+++ b/app/ferroehr/tests/it/service_aql.rs
@@ -2014,6 +2014,96 @@ async fn multi_valued_fragment_projection_serves_every_match() {
     );
 }
 
+/// A predicate ON a fragment step lowers as a jsonpath filter and selects the
+/// matching element — the SECOND link here, so a first-element shortcut fails
+/// this (QUERY master03 §Standard predicate at a non-structure step; the
+/// filter values bind as jsonpath vars, never spliced).
+#[tokio::test]
+async fn fragment_step_predicates_filter_the_matching_elements() {
+    let db = testkit::db().await.expect("testkit database");
+    let svc = FerroEhrService::new(db.pool());
+    let ehr_id = create_ehr(&svc).await;
+    svc.create_composition(
+        ehr_id.parse().expect("ehr_id uuid"),
+        uv(&multi_fragment_composition(), "249", None),
+    )
+    .await
+    .expect("multi-fragment composition");
+
+    // Projection: only the filtered (second) link's target projects.
+    let filtered = run_aql(
+        &svc,
+        "SELECT c/links[meaning/value = 'issue']/target/value \
+         FROM EHR e CONTAINS COMPOSITION c",
+        ehr_scope(&ehr_id),
+    )
+    .await;
+    assert_eq!(
+        rows(&filtered)[0][0],
+        json!(["ehr://x/last"]),
+        "the filter selects the SECOND link: {filtered}"
+    );
+
+    // Predicate: the filtered comparison matches through the second element.
+    let hit = run_aql(
+        &svc,
+        "SELECT c/name/value FROM EHR e CONTAINS COMPOSITION c \
+         WHERE c/links[meaning/value = 'issue']/target/value = 'ehr://x/last'",
+        ehr_scope(&ehr_id),
+    )
+    .await;
+    assert_eq!(rows(&hit).len(), 1, "filtered any-match: {hit}");
+
+    // A filter no element satisfies yields nothing (no vacuous truth).
+    let miss = run_aql(
+        &svc,
+        "SELECT c/name/value FROM EHR e CONTAINS COMPOSITION c \
+         WHERE c/links[meaning/value = 'absent']/target/value = 'ehr://x/last'",
+        ehr_scope(&ehr_id),
+    )
+    .await;
+    assert_eq!(rows(&miss).len(), 0, "no element passes the filter: {miss}");
+}
+
+/// A root predicate on a WHOLE-OBJECT projection serves the object where the
+/// source matches and a NULL cell where it does not — row cardinality
+/// untouched (QUERY master03 §Identified Paths; the NULL-cell shape mirrors
+/// the guarded leaf reads).
+#[tokio::test]
+async fn whole_object_root_predicate_serves_null_for_non_matches() {
+    let db = testkit::db().await.expect("testkit database");
+    let svc = FerroEhrService::new(db.pool());
+    let ehr_id = create_ehr(&svc).await;
+    create_comp(&svc, &ehr_id, "minimal-root", 1.0).await;
+
+    let r = run_aql(
+        &svc,
+        "SELECT c[openEHR-EHR-COMPOSITION.report.v1], c/name/value \
+         FROM EHR e CONTAINS COMPOSITION c",
+        ehr_scope(&ehr_id),
+    )
+    .await;
+    assert_eq!(rows(&r).len(), 1, "the row survives: {r}");
+    assert_eq!(
+        rows(&r)[0][0],
+        Value::Null,
+        "a non-matching root serves a NULL cell: {r}"
+    );
+
+    let matching = run_aql(
+        &svc,
+        "SELECT c[openEHR-EHR-COMPOSITION.minimal.v1] \
+         FROM EHR e CONTAINS COMPOSITION c",
+        ehr_scope(&ehr_id),
+    )
+    .await;
+    assert_eq!(
+        rows(&matching)[0][0]["_type"],
+        json!("COMPOSITION"),
+        "the matching root serves the whole object: {matching}"
+    );
+}
+
 /// An uncoercible client binding is the CALLER's 400, never a 500 (#2593):
 /// measured live, `"not-a-date"` against a temporal predicate reached the
 /// driver as sqlstate 22007 and answered the opaque internal error.


### PR DESCRIPTION
Closes #2927.

**Fragment-step predicates lower as SQL/JSON path filters.** A node predicate on a non-structure path step (`c/links[meaning/value = 'issue']/target/value`) renders a jsonpath filter on that step's member accessor (`$.links ? (@.meaning.value == $p0).target.value`), composed by the new `fragment_path` builder: archetype constraints as `archetype_node_id` equality (fragment objects are not `node` rows — no subsumption columns exist there, stated in the doc), name constraints via `name.value` / the coded pair, standard predicates via the jsonpath comparison operators. **Every compared value travels in the bound `vars` jsonb argument** (`$p0`, `$p1`, …) of the three-argument `jsonb_path_query*` forms — never spliced into the path text — and member names are lexer-restricted identifiers, so no query text reaches the jsonpath language. The #2919-era typed reject and its `TODO(#2927)` are gone.

**A root predicate on a whole-object projection serves NULL for non-matches.** `emit_whole_object` CASE-guards the `vo_id` locator alone; the executor already short-circuits a NULL `vo_id` to a null cell before reading the other locators, so a non-matching row keeps its row with a `null` cell — the same shape as the guarded leaf reads — and the reject in `whole_object_alias` is deleted.

**Pinned by:** the flipped planner tests (`fragment_step_predicate_lowers_to_a_jsonpath_filter` — the bound jsonb vars argument + the existential shape; `whole_object_root_predicate_guards_the_locator` — the CASE-guarded locator) and two DB suites where the predicate selects the NON-FIRST element: the filtered projection returns exactly the second link's target, the filtered comparison matches through it, a filter no element satisfies yields nothing, and the whole-object guard serves the object for a matching root and `null` for a non-match with row cardinality untouched.

Changelog: the #2919 entry's "typed reject" sentence updated to the delivered lowering (same Unreleased cycle). Conformance run deferred by owner instruction to the pre-release full run.
