### PR TITLE
chore(quality): duplication-program extractions — one home per clone family

### DIFF
--- a/.claude/rules/ai-code-review.md
+++ b/.claude/rules/ai-code-review.md
@@ -49,7 +49,12 @@ findings:
 
 Both were adjudicated per-cluster from the live MCP ranking on #2862, where
 the before/after numbers are recorded. Do not widen either list without the
-same per-cluster case.
+same per-cluster case. #2915 widened `sonar.cpd.exclusions` by two pinned
+expectation TABLES — `vendor_bmm_schema.rs` (the per-fixture adjudication
+register over the 43 vendored BMM schemas) and `model_query.rs` (the
+model-query report pinned row-for-row) — on the decision-map argument: each
+"duplicated" run is a decided record, and compressing the rows hides the
+adjudication the file exists to carry.
 
 ## New Code = since the last release (#2657)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5493,6 +5493,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "sha2 0.11.0",
+ "testkit",
  "thiserror 2.0.20",
  "tokio",
  "uuid",

--- a/app/ferroehr-rest/tests/it/canonical_json_literals.rs
+++ b/app/ferroehr-rest/tests/it/canonical_json_literals.rs
@@ -5,26 +5,13 @@
 //! `openehr-*` types, never hand-written as `json!` literals.
 //!
 //! A `json!` literal carrying a `"_type"` key is, by definition, a hand-rolled
-//! canonical openEHR fragment: `_type` is the canonical-JSON discriminator the
-//! native codec emits (`openehr-its`, `emit-json`), so nothing else has any
-//! business writing it. Hand-written shapes drift from the model — wrong
-//! attribute order, a missing mandatory attribute, a stale spelling after a
-//! spec-pin bump — and none of that is caught by a compiler. Building the
-//! generated type and serializing it through
-//! `openehr_its::json::to_canonical_value` makes every one of those a build
-//! error instead (issue #1686).
-//!
-//! This gate scans **this crate's own** `src/`. Unit-test fixtures inside
-//! `#[cfg(test)]` modules are deliberately out of scope: a test fixture is an
-//! input to assert against, not a served wire shape, and pinning literals
-//! there is exactly how a codec regression gets caught.
-//!
-//! To add a site, classify it and put it in [`ALLOWLIST`] with a one-line
-//! reason — every entry must name why that file's literals are NOT a
-//! synthesized canonical shape. A stale entry (allowlisted file with no
-//! remaining literals) fails too, so the list cannot rot.
-
-use std::path::{Path, PathBuf};
+//! canonical openEHR fragment — the scanner mechanics live in
+//! [`testkit::json_literals`] (shared by every crate's gate); this file owns
+//! ONLY this crate's adjudications. To add a site, classify it and put it in
+//! [`ALLOWLIST`] with a one-line reason — every entry must name why that
+//! file's literals are NOT a synthesized canonical shape. A stale entry
+//! (allowlisted file with no remaining literals) fails too, so the list
+//! cannot rot (issue #1686).
 
 /// Files whose `_type`-carrying `json!` literals are classified as something
 /// other than a synthesized canonical shape, each with the reason.
@@ -55,131 +42,14 @@ const ALLOWLIST: &[(&str, &str)] = &[
          documentation illustrations, never served wire",
     ),
 ];
-/// Every `json!` invocation in `src` whose body carries a `"_type"` key,
-/// as `(crate-relative path, 1-based line)`.
-///
-/// # Errors
-/// Any I/O failure walking or reading the crate's own `src/` tree.
-fn offending_sites() -> std::io::Result<Vec<(String, usize)>> {
-    let src = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
-    let mut out = Vec::new();
-    collect(&src, "", &mut out)?;
-    out.sort();
-    Ok(out)
-}
-
-/// Recursively walk `dir` (reached at crate-relative `prefix`), appending each
-/// offending site to `out`.
-fn collect(dir: &Path, prefix: &str, out: &mut Vec<(String, usize)>) -> std::io::Result<()> {
-    for entry in std::fs::read_dir(dir)? {
-        let entry = entry?;
-        let name = entry.file_name().to_string_lossy().into_owned();
-        let relative = if prefix.is_empty() {
-            name
-        } else {
-            format!("{prefix}/{name}")
-        };
-        let path = entry.path();
-        if path.is_dir() {
-            collect(&path, &relative, out)?;
-            continue;
-        }
-        if path.extension().is_none_or(|e| e != "rs") {
-            continue;
-        }
-        let text = std::fs::read_to_string(&path)?;
-        // Unit tests live in a trailing `#[cfg(test)] mod tests` (the repo's
-        // test-placement rule), so everything from the first line-initial
-        // `#[cfg(test)]` on is fixture territory and out of scope.
-        let production = match text.find("\n#[cfg(test)]") {
-            Some(at) => text.get(..at).unwrap_or(&text),
-            None => &text,
-        };
-        for start in json_macro_bodies(production) {
-            let line = production
-                .get(..start)
-                .map_or(1, |before| before.matches('\n').count() + 1);
-            out.push((relative.clone(), line));
-        }
-    }
-    Ok(())
-}
-
-/// Byte offsets of every `json!` invocation in `src` whose delimited body
-/// contains a `"_type"` key.
-fn json_macro_bodies(src: &str) -> Vec<usize> {
-    let bytes = src.as_bytes();
-    let mut hits = Vec::new();
-    let mut from = 0;
-    while let Some(rel) = src.get(from..).and_then(|rest| rest.find("json!")) {
-        let at = from + rel;
-        from = at + "json!".len();
-        // `serde_json::json!` is the same macro; `foojson!` is not.
-        let preceded_by_ident = at
-            .checked_sub(1)
-            .and_then(|i| bytes.get(i))
-            .is_some_and(|c| c.is_ascii_alphanumeric() || *c == b'_');
-        if preceded_by_ident {
-            continue;
-        }
-        let Some(open) = src
-            .get(from..)
-            .and_then(|rest| rest.find(|c: char| !c.is_whitespace()).map(|i| from + i))
-        else {
-            continue;
-        };
-        if !matches!(bytes.get(open), Some(b'(' | b'{' | b'[')) {
-            continue;
-        }
-        if let Some(end) = matching_delimiter(bytes, open)
-            && src.get(open..=end).is_some_and(|b| b.contains("\"_type\""))
-        {
-            hits.push(at);
-        }
-    }
-    hits
-}
-
-/// The index of the delimiter closing the one at `open`, skipping over string
-/// literals so a brace inside a JSON string cannot unbalance the scan.
-fn matching_delimiter(bytes: &[u8], open: usize) -> Option<usize> {
-    let mut depth = 0_i32;
-    let mut in_string = false;
-    let mut escaped = false;
-    for (i, byte) in bytes.iter().enumerate().skip(open) {
-        if in_string {
-            match byte {
-                _ if escaped => escaped = false,
-                b'\\' => escaped = true,
-                b'"' => in_string = false,
-                _ => {}
-            }
-            continue;
-        }
-        match byte {
-            b'"' => in_string = true,
-            b'(' | b'{' | b'[' => depth += 1,
-            b')' | b'}' | b']' => {
-                depth -= 1;
-                if depth == 0 {
-                    return Some(i);
-                }
-            }
-            _ => {}
-        }
-    }
-    None
-}
 
 /// No production `json!` literal outside the classified allowlist synthesizes a
 /// canonical openEHR shape.
 #[test]
 fn canonical_shapes_are_built_from_the_generated_types() {
-    let sites = offending_sites().expect("the crate's src/ tree should be readable");
-    let unlisted: Vec<&(String, usize)> = sites
-        .iter()
-        .filter(|(file, _)| !ALLOWLIST.iter().any(|(listed, _)| listed == file))
-        .collect();
+    let sites = testkit::json_literals::offending_sites(env!("CARGO_MANIFEST_DIR"))
+        .expect("the crate's src/ tree should be readable");
+    let unlisted = testkit::json_literals::unlisted(&sites, ALLOWLIST);
 
     assert!(
         unlisted.is_empty(),
@@ -204,12 +74,9 @@ fn canonical_shapes_are_built_from_the_generated_types() {
 /// silent licence to reintroduce hand-written canonical JSON.
 #[test]
 fn the_allowlist_carries_no_stale_entries() {
-    let sites = offending_sites().expect("the crate's src/ tree should be readable");
-    let stale: Vec<&str> = ALLOWLIST
-        .iter()
-        .filter(|(listed, _)| !sites.iter().any(|(file, _)| file == listed))
-        .map(|(listed, _)| *listed)
-        .collect();
+    let sites = testkit::json_literals::offending_sites(env!("CARGO_MANIFEST_DIR"))
+        .expect("the crate's src/ tree should be readable");
+    let stale = testkit::json_literals::stale_entries(&sites, ALLOWLIST);
 
     assert!(
         stale.is_empty(),

--- a/app/ferroehr/src/service/admin/dump_load.rs
+++ b/app/ferroehr/src/service/admin/dump_load.rs
@@ -369,6 +369,25 @@ struct AttestationRow {
     data: Value,
 }
 
+impl AttestationRow {
+    /// One exported attestation from its `vo_attestation_all` row — the one
+    /// mapping every export path shares.
+    fn from_row(r: &sqlx::postgres::PgRow) -> Result<Self, ServiceError> {
+        Ok(Self {
+            id: r.try_get("id")?,
+            vo_id: r.try_get("vo_id")?,
+            sys_version: r.try_get("sys_version")?,
+            contribution_id: r.try_get("contribution_id")?,
+            time_committed: r
+                .try_get::<jiff_sqlx::Timestamp, _>("time_committed")?
+                .to_jiff()
+                .to_string(),
+            at_committal: r.try_get("at_committal")?,
+            data: r.try_get("data")?,
+        })
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 struct FolderRankRow {
     rank: i32,
@@ -473,6 +492,22 @@ struct ItemTagRow {
     value: Option<String>,
     target_path: Option<String>,
     created_at: String,
+}
+
+impl ItemTagRow {
+    /// One exported tag from its `item_tag` row — the one mapping every
+    /// export path shares.
+    fn from_row(r: &sqlx::postgres::PgRow) -> Result<Self, ServiceError> {
+        Ok(Self {
+            id: r.try_get("id")?,
+            target_vo_id: r.try_get("target_vo_id")?,
+            target_type: r.try_get("target_type")?,
+            key: r.try_get("key")?,
+            value: r.try_get("value")?,
+            target_path: r.try_get("target_path")?,
+            created_at: r.try_get("created_at")?,
+        })
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1764,18 +1799,7 @@ impl FerroEhrService {
         .await?;
         let mut attestations = Vec::with_capacity(attestation_rows.len());
         for r in attestation_rows {
-            attestations.push(AttestationRow {
-                id: r.try_get("id")?,
-                vo_id: r.try_get("vo_id")?,
-                sys_version: r.try_get("sys_version")?,
-                contribution_id: r.try_get("contribution_id")?,
-                time_committed: r
-                    .try_get::<jiff_sqlx::Timestamp, _>("time_committed")?
-                    .to_jiff()
-                    .to_string(),
-                at_committal: r.try_get("at_committal")?,
-                data: r.try_get("data")?,
-            });
+            attestations.push(AttestationRow::from_row(&r)?);
         }
 
         let tag_rows = sqlx::query(
@@ -1788,15 +1812,7 @@ impl FerroEhrService {
         .await?;
         let mut item_tags = Vec::with_capacity(tag_rows.len());
         for r in tag_rows {
-            item_tags.push(ItemTagRow {
-                id: r.try_get("id")?,
-                target_vo_id: r.try_get("target_vo_id")?,
-                target_type: r.try_get("target_type")?,
-                key: r.try_get("key")?,
-                value: r.try_get("value")?,
-                target_path: r.try_get("target_path")?,
-                created_at: r.try_get("created_at")?,
-            });
+            item_tags.push(ItemTagRow::from_row(&r)?);
         }
 
         let archive_rows = sqlx::query(
@@ -1941,44 +1957,7 @@ impl FerroEhrService {
         .await?;
         let mut versions = Vec::with_capacity(version_rows.len());
         for r in version_rows {
-            let vo_id: VoId = r.try_get("vo_id")?;
-            let sys_version: i32 = r.try_get("sys_version")?;
-            let lifecycle_state: String = r.try_get("lifecycle_state")?;
-            // A deleted version has no node rows; its body stays `null`. An
-            // export covers the WHOLE repository, so the content is read across
-            // both storage tiers (`crate::storage::version_repo::tier`).
-            // NOTE: no openEHR spec governs the `spec_profile` gate — our own
-            // design/extension: a dump replicates stored bytes for restore
-            // rather than serving an RM body, so it reads ungated.
-            let body = if lifecycle_state == DELETED_LIFECYCLE {
-                Value::Null
-            } else {
-                version_repo::read::stored_body_all(&self.pool, vo_id, sys_version).await?
-            };
-            versions.push(VersionRecord {
-                vo_id,
-                kind: r.try_get("kind")?,
-                sys_version,
-                trunk_version: r.try_get("trunk_version")?,
-                branch_number: r.try_get("branch_number")?,
-                branch_version: r.try_get("branch_version")?,
-                preceding_version_uid: r.try_get("preceding_version_uid")?,
-                other_input_version_uids: r.try_get("other_input_version_uids")?,
-                sys_period_lower: r.try_get("lo")?,
-                sys_period_upper: r.try_get("hi")?,
-                lifecycle_state,
-                contribution_id: r.try_get("contribution_id")?,
-                audit_id: r.try_get("audit_id")?,
-                template_id: r.try_get("template_id")?,
-                signature: r.try_get("signature")?,
-                signature_client_supplied: r.try_get("signature_client_supplied")?,
-                creating_system_id: r.try_get("creating_system_id")?,
-                wrapped_original: r.try_get("wrapped_original")?,
-                body,
-                // Filled in by `externalize_version_documents` when the export
-                // is `openehr_canonical_xml`.
-                body_entry: None,
-            });
+            versions.push(self.version_record_of(&r).await?);
         }
 
         let folder_rank_rows =
@@ -2003,15 +1982,7 @@ impl FerroEhrService {
         .await?;
         let mut item_tags = Vec::with_capacity(tag_rows.len());
         for r in tag_rows {
-            item_tags.push(ItemTagRow {
-                id: r.try_get("id")?,
-                target_vo_id: r.try_get("target_vo_id")?,
-                target_type: r.try_get("target_type")?,
-                key: r.try_get("key")?,
-                value: r.try_get("value")?,
-                target_path: r.try_get("target_path")?,
-                created_at: r.try_get("created_at")?,
-            });
+            item_tags.push(ItemTagRow::from_row(&r)?);
         }
 
         let archive_rows = sqlx::query(
@@ -2042,18 +2013,7 @@ impl FerroEhrService {
         .await?;
         let mut attestations = Vec::with_capacity(attestation_rows.len());
         for r in attestation_rows {
-            attestations.push(AttestationRow {
-                id: r.try_get("id")?,
-                vo_id: r.try_get("vo_id")?,
-                sys_version: r.try_get("sys_version")?,
-                contribution_id: r.try_get("contribution_id")?,
-                time_committed: r
-                    .try_get::<jiff_sqlx::Timestamp, _>("time_committed")?
-                    .to_jiff()
-                    .to_string(),
-                at_committal: r.try_get("at_committal")?,
-                data: r.try_get("data")?,
-            });
+            attestations.push(AttestationRow::from_row(&r)?);
         }
 
         Ok(EhrRecord {

--- a/app/ferroehr/tests/it/admin_fixture.rs
+++ b/app/ferroehr/tests/it/admin_fixture.rs
@@ -24,12 +24,10 @@ use serde_json::{Value, json};
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use openehr_rm::prelude::PartyProxy;
-
 use ferroehr::ids::EhrId;
 use ferroehr::service::FerroEhrService;
-use ferroehr::service::version_update::{change_type_coded, lifecycle_state_coded};
-use openehr_its::rest::generated::common::{UpdateAudit, UpdateAuditData, UpdateVersion};
+
+use crate::fixtures::{uid, uv, vo_of};
 
 /// Returns a fresh migrated database, its pool, and a service over it.
 ///
@@ -43,49 +41,6 @@ pub(crate) async fn repository() -> (testkit::TestDb, PgPool, FerroEhrService) {
 }
 
 /// Returns the `uid.value` (`OBJECT_VERSION_ID`) of a versioned-object body.
-pub(crate) fn uid(v: &Value) -> &str {
-    v["uid"]["value"].as_str().expect("uid.value")
-}
-
-/// Returns the bare versioned-object UUID of an `OBJECT_VERSION_ID`.
-///
-/// The grammar is `object_version_id = object_id, '::', creating_system_id,
-/// '::', version_tree_id` (BASE `base_types/master05-identification_package.adoc`
-/// §Syntaxes), so the object identifier is everything before the first
-/// separator.
-pub(crate) fn vo_of(ovid: &str) -> &str {
-    ovid.split("::").next().expect("vo uuid")
-}
-
-/// Builds the SM `UPDATE_VERSION` commit envelope for a bare-RM write.
-///
-/// `change_code` is the `openehr` terminology change-type code (`249` create,
-/// `251` modification); `preceding` names the version this one supersedes.
-pub(crate) fn uv<T: serde::de::DeserializeOwned>(
-    data: &Value,
-    change_code: &str,
-    preceding: Option<&str>,
-) -> UpdateVersion<T> {
-    UpdateVersion {
-        preceding_version_uid: preceding.map(|p| p.parse().expect("OBJECT_VERSION_ID")),
-        lifecycle_state: lifecycle_state_coded("532"),
-        attestations: None,
-        data: openehr_its::json::from_canonical_value(data)
-            .expect("the fixture commit body decodes as its RM type"),
-        commit_audit: UpdateAudit::UpdateAudit(UpdateAuditData {
-            _type: None,
-            system_id: None,
-            change_type: change_type_coded(change_code),
-            description: None,
-            committer: openehr_its::json::from_canonical_value::<PartyProxy>(
-                &json!({ "_type": "PARTY_IDENTIFIED", "name": "conformance tester" }),
-            )
-            .expect("committer"),
-        }),
-        signature: None,
-    }
-}
-
 /// Seeds an EHR carrying multiple versioned-object kinds and versions.
 ///
 /// `EHR_STATUS` (create → update = two versions) plus the `EHR_ACCESS` minted at

--- a/app/ferroehr/tests/it/canonical_json_literals.rs
+++ b/app/ferroehr/tests/it/canonical_json_literals.rs
@@ -5,26 +5,13 @@
 //! `openehr-*` types, never hand-written as `json!` literals.
 //!
 //! A `json!` literal carrying a `"_type"` key is, by definition, a hand-rolled
-//! canonical openEHR fragment: `_type` is the canonical-JSON discriminator the
-//! native codec emits (`openehr-its`, `emit-json`), so nothing else has any
-//! business writing it. Hand-written shapes drift from the model — wrong
-//! attribute order, a missing mandatory attribute, a stale spelling after a
-//! spec-pin bump — and none of that is caught by a compiler. Building the
-//! generated type and serializing it through
-//! `openehr_its::json::to_canonical_value` makes every one of those a build
-//! error instead (issue #1686).
-//!
-//! This gate scans **this crate's own** `src/`. Unit-test fixtures inside
-//! `#[cfg(test)]` modules are deliberately out of scope: a test fixture is an
-//! input to assert against, not a served wire shape, and pinning literals
-//! there is exactly how a codec regression gets caught.
-//!
-//! To add a site, classify it and put it in [`ALLOWLIST`] with a one-line
-//! reason — every entry must name why that file's literals are NOT a
-//! synthesized canonical shape. A stale entry (allowlisted file with no
-//! remaining literals) fails too, so the list cannot rot.
-
-use std::path::{Path, PathBuf};
+//! canonical openEHR fragment — the scanner mechanics live in
+//! [`testkit::json_literals`] (shared by every crate's gate); this file owns
+//! ONLY this crate's adjudications. To add a site, classify it and put it in
+//! [`ALLOWLIST`] with a one-line reason — every entry must name why that
+//! file's literals are NOT a synthesized canonical shape. A stale entry
+//! (allowlisted file with no remaining literals) fails too, so the list
+//! cannot rot (issue #1686).
 
 /// Files whose `_type`-carrying `json!` literals are classified as something
 /// other than a synthesized canonical shape, each with the reason.
@@ -54,131 +41,13 @@ const ALLOWLIST: &[(&str, &str)] = &[
     ),
 ];
 
-/// Every `json!` invocation in `src` whose body carries a `"_type"` key,
-/// as `(crate-relative path, 1-based line)`.
-///
-/// # Errors
-/// Any I/O failure walking or reading the crate's own `src/` tree.
-fn offending_sites() -> std::io::Result<Vec<(String, usize)>> {
-    let src = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
-    let mut out = Vec::new();
-    collect(&src, "", &mut out)?;
-    out.sort();
-    Ok(out)
-}
-
-/// Recursively walk `dir` (reached at crate-relative `prefix`), appending each
-/// offending site to `out`.
-fn collect(dir: &Path, prefix: &str, out: &mut Vec<(String, usize)>) -> std::io::Result<()> {
-    for entry in std::fs::read_dir(dir)? {
-        let entry = entry?;
-        let name = entry.file_name().to_string_lossy().into_owned();
-        let relative = if prefix.is_empty() {
-            name
-        } else {
-            format!("{prefix}/{name}")
-        };
-        let path = entry.path();
-        if path.is_dir() {
-            collect(&path, &relative, out)?;
-            continue;
-        }
-        if path.extension().is_none_or(|e| e != "rs") {
-            continue;
-        }
-        let text = std::fs::read_to_string(&path)?;
-        // Unit tests live in a trailing `#[cfg(test)] mod tests` (the repo's
-        // test-placement rule), so everything from the first line-initial
-        // `#[cfg(test)]` on is fixture territory and out of scope.
-        let production = match text.find("\n#[cfg(test)]") {
-            Some(at) => text.get(..at).unwrap_or(&text),
-            None => &text,
-        };
-        for start in json_macro_bodies(production) {
-            let line = production
-                .get(..start)
-                .map_or(1, |before| before.matches('\n').count() + 1);
-            out.push((relative.clone(), line));
-        }
-    }
-    Ok(())
-}
-
-/// Byte offsets of every `json!` invocation in `src` whose delimited body
-/// contains a `"_type"` key.
-fn json_macro_bodies(src: &str) -> Vec<usize> {
-    let bytes = src.as_bytes();
-    let mut hits = Vec::new();
-    let mut from = 0;
-    while let Some(rel) = src.get(from..).and_then(|rest| rest.find("json!")) {
-        let at = from + rel;
-        from = at + "json!".len();
-        // `serde_json::json!` is the same macro; `foojson!` is not.
-        let preceded_by_ident = at
-            .checked_sub(1)
-            .and_then(|i| bytes.get(i))
-            .is_some_and(|c| c.is_ascii_alphanumeric() || *c == b'_');
-        if preceded_by_ident {
-            continue;
-        }
-        let Some(open) = src
-            .get(from..)
-            .and_then(|rest| rest.find(|c: char| !c.is_whitespace()).map(|i| from + i))
-        else {
-            continue;
-        };
-        if !matches!(bytes.get(open), Some(b'(' | b'{' | b'[')) {
-            continue;
-        }
-        if let Some(end) = matching_delimiter(bytes, open)
-            && src.get(open..=end).is_some_and(|b| b.contains("\"_type\""))
-        {
-            hits.push(at);
-        }
-    }
-    hits
-}
-
-/// The index of the delimiter closing the one at `open`, skipping over string
-/// literals so a brace inside a JSON string cannot unbalance the scan.
-fn matching_delimiter(bytes: &[u8], open: usize) -> Option<usize> {
-    let mut depth = 0_i32;
-    let mut in_string = false;
-    let mut escaped = false;
-    for (i, byte) in bytes.iter().enumerate().skip(open) {
-        if in_string {
-            match byte {
-                _ if escaped => escaped = false,
-                b'\\' => escaped = true,
-                b'"' => in_string = false,
-                _ => {}
-            }
-            continue;
-        }
-        match byte {
-            b'"' => in_string = true,
-            b'(' | b'{' | b'[' => depth += 1,
-            b')' | b'}' | b']' => {
-                depth -= 1;
-                if depth == 0 {
-                    return Some(i);
-                }
-            }
-            _ => {}
-        }
-    }
-    None
-}
-
 /// No production `json!` literal outside the classified allowlist synthesizes a
 /// canonical openEHR shape.
 #[test]
 fn canonical_shapes_are_built_from_the_generated_types() {
-    let sites = offending_sites().expect("the crate's src/ tree should be readable");
-    let unlisted: Vec<&(String, usize)> = sites
-        .iter()
-        .filter(|(file, _)| !ALLOWLIST.iter().any(|(listed, _)| listed == file))
-        .collect();
+    let sites = testkit::json_literals::offending_sites(env!("CARGO_MANIFEST_DIR"))
+        .expect("the crate's src/ tree should be readable");
+    let unlisted = testkit::json_literals::unlisted(&sites, ALLOWLIST);
 
     assert!(
         unlisted.is_empty(),
@@ -187,9 +56,9 @@ fn canonical_shapes_are_built_from_the_generated_types() {
          generated `openehr-rm`/`openehr-base` type and serialize it with \
          `openehr_its::json::to_canonical_value` instead — that is what keeps \
          attribute order and mandatory attributes correct by construction. If \
-         a site is genuinely a verbatim pass-through, an internal \
-         (non-canonical) shape, or an OAS documentation example, add its file \
-         to the ALLOWLIST in this test with a one-line reason.\nSites:\n{}",
+         a site is genuinely a verbatim pass-through or an internal \
+         (non-canonical) shape, add its file to the ALLOWLIST in this test \
+         with a one-line reason.\nSites:\n{}",
         unlisted.len(),
         unlisted
             .iter()
@@ -203,12 +72,9 @@ fn canonical_shapes_are_built_from_the_generated_types() {
 /// silent licence to reintroduce hand-written canonical JSON.
 #[test]
 fn the_allowlist_carries_no_stale_entries() {
-    let sites = offending_sites().expect("the crate's src/ tree should be readable");
-    let stale: Vec<&str> = ALLOWLIST
-        .iter()
-        .filter(|(listed, _)| !sites.iter().any(|(file, _)| file == listed))
-        .map(|(listed, _)| *listed)
-        .collect();
+    let sites = testkit::json_literals::offending_sites(env!("CARGO_MANIFEST_DIR"))
+        .expect("the crate's src/ tree should be readable");
+    let stale = testkit::json_literals::stale_entries(&sites, ALLOWLIST);
 
     assert!(
         stale.is_empty(),

--- a/app/ferroehr/tests/it/directory_item_refs.rs
+++ b/app/ferroehr/tests/it/directory_item_refs.rs
@@ -9,85 +9,12 @@
 //! commit transaction, after the set's inserts, so the verdict never
 //! depends on member order).
 
-#![expect(
-    clippy::expect_used,
-    reason = "clippy's in-test lint scoping (clippy.toml `allow-*-in-tests`) only \
-              reaches `#[test]`-annotated functions, so it misses this integration \
-              module's helpers and async bodies; panicking assertions are the \
-              intended shape here (the Rust Book ch11)"
-)]
-
 use serde_json::{Value, json};
 
 use ferroehr::service::status::{CallStatusType, SmError};
-use ferroehr::service::version_update::{change_type_coded, lifecycle_state_coded};
 use ferroehr::service::{DEFAULT_SYSTEM_ID, FerroEhrService};
-use openehr_its::rest::generated::common::{UpdateAudit, UpdateAuditData, UpdateVersion};
-use openehr_rm::prelude::PartyProxy;
 
-/// The SM `UPDATE_VERSION` commit envelope for a bare-RM write.
-fn uv<T: serde::de::DeserializeOwned>(
-    data: &Value,
-    change_code: &str,
-    preceding: Option<&str>,
-) -> UpdateVersion<T> {
-    UpdateVersion {
-        preceding_version_uid: preceding.map(|p| p.parse().expect("OBJECT_VERSION_ID")),
-        lifecycle_state: lifecycle_state_coded("532"),
-        attestations: None,
-        data: openehr_its::json::from_canonical_value(data)
-            .expect("the fixture commit body decodes as its RM type"),
-        commit_audit: UpdateAudit::UpdateAudit(UpdateAuditData {
-            _type: None,
-            system_id: None,
-            change_type: change_type_coded(change_code),
-            description: None,
-            committer: openehr_its::json::from_canonical_value::<PartyProxy>(
-                &json!({ "_type": "PARTY_IDENTIFIED", "name": "conformance tester" }),
-            )
-            .expect("committer"),
-        }),
-        signature: None,
-    }
-}
-
-/// A minimal valid RM COMPOSITION (`language`/`territory`/`category`/
-/// `composer` are `1..1`).
-fn composition(name: &str) -> Value {
-    json!({
-        "_type": "COMPOSITION",
-        "archetype_node_id": "openEHR-EHR-COMPOSITION.encounter.v1",
-        "archetype_details": {
-            "_type": "ARCHETYPED",
-            "archetype_id": {
-                "_type": "ARCHETYPE_ID",
-                "value": "openEHR-EHR-COMPOSITION.encounter.v1"
-            },
-            "rm_version": "1.2.0"
-        },
-        "name": { "_type": "DV_TEXT", "value": name },
-        "language": {
-            "_type": "CODE_PHRASE",
-            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_639-1" },
-            "code_string": "en"
-        },
-        "territory": {
-            "_type": "CODE_PHRASE",
-            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_3166-1" },
-            "code_string": "NL"
-        },
-        "category": {
-            "_type": "DV_CODED_TEXT",
-            "value": "event",
-            "defining_code": {
-                "_type": "CODE_PHRASE",
-                "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" },
-                "code_string": "433"
-            }
-        },
-        "composer": { "_type": "PARTY_IDENTIFIED", "name": "conformance tester" }
-    })
-}
+use crate::fixtures::{composition, uv};
 
 /// A root FOLDER whose single `items` entry references `(namespace, id)`.
 fn folder_with_item(namespace: &str, id_value: &str) -> Value {

--- a/app/ferroehr/tests/it/fixtures.rs
+++ b/app/ferroehr/tests/it/fixtures.rs
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: FerroEHR contributors
+// SPDX-License-Identifier: MIT
+
+//! The shared SM commit-fixture family the topic modules import.
+//!
+//! Every suite that drives a write through the service layer needs the same
+//! pieces: a `PARTY_IDENTIFIED` committer, an `openehr` change-type
+//! `DV_CODED_TEXT`, a minimal valid RM COMPOSITION, and the SM
+//! `UPDATE_VERSION` envelope carrying them (SM
+//! `UML/classes/update_version.adoc`). They live here once, so the per-suite
+//! copies cannot drift apart.
+//!
+//! A suite whose fixture identity is load-bearing (an assertion reads the
+//! composer or committer name) takes the parameterized builder rather than a
+//! private copy.
+
+#![expect(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "clippy's in-test lint scoping (clippy.toml `allow-*-in-tests`) only \
+              reaches `#[test]`-annotated functions, so it misses this module's \
+              fixture helpers; a failing fixture must panic at the fixture (the \
+              Rust Book ch11)"
+)]
+
+use serde_json::{Value, json};
+
+use ferroehr::service::version_update::{change_type_coded, lifecycle_state_coded};
+use openehr_its::rest::generated::common::{UpdateAudit, UpdateAuditData, UpdateVersion};
+use openehr_rm::prelude::PartyProxy;
+
+/// The identity the shared fixtures write as — both the COMPOSITION `composer`
+/// and the commit `committer`.
+const TESTER: &str = "conformance tester";
+
+/// Returns a `PARTY_IDENTIFIED` committer named `name`, as canonical JSON.
+pub(crate) fn committer(name: &str) -> Value {
+    json!({ "_type": "PARTY_IDENTIFIED", "name": name })
+}
+
+/// Returns a `PARTY_IDENTIFIED` committer named `name`, as the typed RM value.
+pub(crate) fn committer_proxy(name: &str) -> PartyProxy {
+    openehr_its::json::from_canonical_value(&committer(name)).expect("committer")
+}
+
+/// Returns the wire `DV_CODED_TEXT` naming `openehr` terminology `code` with
+/// rubric `value`.
+///
+/// The `audit_change_type` group codes this carries are listed in RM common
+/// `master06-change_control_package.adoc` §Contributions.
+pub(crate) fn change_type(code: &str, value: &str) -> Value {
+    json!({
+        "_type": "DV_CODED_TEXT", "value": value,
+        "defining_code": {
+            "_type": "CODE_PHRASE",
+            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" },
+            "code_string": code
+        }
+    })
+}
+
+/// Returns a minimal *valid* RM COMPOSITION named `name`, composed by
+/// `composer`.
+///
+/// `language`, `territory`, `category` and `composer` are all `1..1` (RM ehr,
+/// COMPOSITION class), so typed RM validation rejects a fixture without them.
+/// No template is referenced, so the fixture needs no `template_store` row.
+pub(crate) fn composition_by(name: &str, composer: &str) -> Value {
+    json!({
+        "_type": "COMPOSITION",
+        "archetype_node_id": "openEHR-EHR-COMPOSITION.encounter.v1",
+        "archetype_details": {
+            "_type": "ARCHETYPED",
+            "archetype_id": {
+                "_type": "ARCHETYPE_ID",
+                "value": "openEHR-EHR-COMPOSITION.encounter.v1"
+            },
+            "rm_version": "1.2.0"
+        },
+        "name": { "_type": "DV_TEXT", "value": name },
+        "language": {
+            "_type": "CODE_PHRASE",
+            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_639-1" },
+            "code_string": "en"
+        },
+        "territory": {
+            "_type": "CODE_PHRASE",
+            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_3166-1" },
+            "code_string": "NL"
+        },
+        "category": {
+            "_type": "DV_CODED_TEXT",
+            "value": "event",
+            "defining_code": {
+                "_type": "CODE_PHRASE",
+                "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" },
+                "code_string": "433"
+            }
+        },
+        "composer": { "_type": "PARTY_IDENTIFIED", "name": composer }
+    })
+}
+
+/// Returns a minimal *valid* RM COMPOSITION named `name`.
+pub(crate) fn composition(name: &str) -> Value {
+    composition_by(name, TESTER)
+}
+
+/// Returns the SM `UPDATE_VERSION` commit envelope for a bare-RM write.
+///
+/// `change_code` is the `openehr` `audit_change_type` code the version's audit
+/// records (`249` creation, `251` modification, `523` deleted); `preceding`
+/// names the version this one supersedes (RM common
+/// `master06-change_control_package.adoc` §Contributions).
+pub(crate) fn uv<T: serde::de::DeserializeOwned>(
+    data: &Value,
+    change_code: &str,
+    preceding: Option<&str>,
+) -> UpdateVersion<T> {
+    UpdateVersion {
+        preceding_version_uid: preceding.map(|p| p.parse().expect("OBJECT_VERSION_ID")),
+        lifecycle_state: lifecycle_state_coded("532"),
+        attestations: None,
+        data: openehr_its::json::from_canonical_value(data)
+            .expect("the fixture commit body decodes as its RM type"),
+        commit_audit: UpdateAudit::UpdateAudit(UpdateAuditData {
+            _type: None,
+            system_id: None,
+            change_type: change_type_coded(change_code),
+            description: None,
+            committer: committer_proxy(TESTER),
+        }),
+        signature: None,
+    }
+}
+
+/// The committed version's `uid/value` string off a served body.
+pub(crate) fn uid(v: &Value) -> &str {
+    v["uid"]["value"].as_str().expect("uid.value")
+}
+
+/// The bare versioned-object UUID of an `OBJECT_VERSION_ID` — everything
+/// before the first separator (`object_version_id = object_id, '::',
+/// creating_system_id, '::', version_tree_id`; BASE
+/// `base_types/master05-identification_package.adoc` §Syntaxes).
+pub(crate) fn vo_of(ovid: &str) -> &str {
+    ovid.split("::").next().expect("vo uuid")
+}
+
+/// A minimal valid root FOLDER (RM ehr master04 §Folders).
+pub(crate) fn folder(name: &str) -> Value {
+    json!({
+        "_type": "FOLDER",
+        "archetype_node_id": "openEHR-EHR-FOLDER.generic.v1",
+        "name": { "_type": "DV_TEXT", "value": name }
+    })
+}

--- a/app/ferroehr/tests/it/main.rs
+++ b/app/ferroehr/tests/it/main.rs
@@ -36,6 +36,7 @@ mod directory_item_refs;
 mod events_amqp;
 mod fhir_ingest_translate;
 mod fhir_outbound_amqp;
+mod fixtures;
 mod item_tag_fixture;
 mod multimedia_s3;
 mod opt_resource_meta;

--- a/app/ferroehr/tests/it/service_admin.rs
+++ b/app/ferroehr/tests/it/service_admin.rs
@@ -35,7 +35,9 @@ use uuid::Uuid;
 
 use ferroehr::service::FerroEhrService;
 
-use crate::admin_fixture::{count_for_ehr, party_relationship, repository, seed_full_ehr, uid, uv};
+use crate::admin_fixture::{count_for_ehr, party_relationship, repository, seed_full_ehr};
+use crate::fixtures::uid;
+use crate::fixtures::uv;
 use crate::typed_body::typed;
 use ferroehr::service::demographic::types::PartyKind;
 use ferroehr::service::platform_service::PlatformService;

--- a/app/ferroehr/tests/it/service_branching.rs
+++ b/app/ferroehr/tests/it/service_branching.rs
@@ -39,94 +39,16 @@
 )]
 
 use ferroehr::service::FerroEhrService;
-use ferroehr::service::version_update::{change_type_coded, lifecycle_state_coded};
-use openehr_its::rest::generated::common::{UpdateAudit, UpdateAuditData, UpdateVersion};
-use openehr_rm::prelude::PartyProxy;
 use serde_json::{Value, json};
 use uuid::Uuid;
+
+use crate::fixtures::{change_type, committer, composition, uv};
 
 /// The service's own system id (`DEFAULT_SYSTEM_ID`) — the local
 /// `creating_system_id` every non-import write records.
 const LOCAL: &str = "ferroehr.local";
 /// The pretend foreign system a copied version tree originates from.
 const FOREIGN: &str = "sysA.example.org";
-
-fn uv<T: serde::de::DeserializeOwned>(
-    data: &Value,
-    change_code: &str,
-    preceding: Option<&str>,
-) -> UpdateVersion<T> {
-    UpdateVersion {
-        preceding_version_uid: preceding.map(|p| p.parse().expect("OBJECT_VERSION_ID")),
-        lifecycle_state: lifecycle_state_coded("532"),
-        attestations: None,
-        data: openehr_its::json::from_canonical_value(data)
-            .expect("the fixture commit body decodes as its RM type"),
-        commit_audit: UpdateAudit::UpdateAudit(UpdateAuditData {
-            _type: None,
-            system_id: None,
-            change_type: change_type_coded(change_code),
-            description: None,
-            committer: openehr_its::json::from_canonical_value::<PartyProxy>(
-                &json!({ "_type": "PARTY_IDENTIFIED", "name": "branching tester" }),
-            )
-            .expect("committer"),
-        }),
-        signature: None,
-    }
-}
-
-/// A minimal *valid* RM COMPOSITION.
-fn composition(name: &str) -> Value {
-    json!({
-        "_type": "COMPOSITION",
-        "archetype_node_id": "openEHR-EHR-COMPOSITION.encounter.v1",
-        "archetype_details": {
-            "_type": "ARCHETYPED",
-            "archetype_id": {
-                "_type": "ARCHETYPE_ID",
-                "value": "openEHR-EHR-COMPOSITION.encounter.v1"
-            },
-            "rm_version": "1.2.0"
-        },
-        "name": { "_type": "DV_TEXT", "value": name },
-        "language": {
-            "_type": "CODE_PHRASE",
-            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_639-1" },
-            "code_string": "en"
-        },
-        "territory": {
-            "_type": "CODE_PHRASE",
-            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_3166-1" },
-            "code_string": "NL"
-        },
-        "category": {
-            "_type": "DV_CODED_TEXT",
-            "value": "event",
-            "defining_code": {
-                "_type": "CODE_PHRASE",
-                "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" },
-                "code_string": "433"
-            }
-        },
-        "composer": { "_type": "PARTY_IDENTIFIED", "name": "branching tester" }
-    })
-}
-
-fn committer(name: &str) -> Value {
-    json!({ "_type": "PARTY_IDENTIFIED", "name": name })
-}
-
-fn change_type(code: &str, value: &str) -> Value {
-    json!({
-        "_type": "DV_CODED_TEXT", "value": value,
-        "defining_code": {
-            "_type": "CODE_PHRASE",
-            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" },
-            "code_string": code
-        }
-    })
-}
 
 /// A CONTRIBUTION body modifying one composition (`251|modification|`).
 fn modify_contribution(data: &Value, preceding: &str) -> Value {

--- a/app/ferroehr/tests/it/service_contribution.rs
+++ b/app/ferroehr/tests/it/service_contribution.rs
@@ -15,7 +15,6 @@
 
 #![expect(
     clippy::expect_used,
-    clippy::unwrap_used,
     clippy::indexing_slicing,
     reason = "clippy's in-test lint scoping (clippy.toml `allow-*-in-tests`) only \
               reaches `#[test]`-annotated functions, so it misses this integration \
@@ -33,88 +32,10 @@ use ferroehr::service::error::ServiceError;
 use ferroehr::service::status::{CallStatusType, SmError};
 
 use ferroehr::service::list::Page;
-use ferroehr::service::version_update::{change_type_coded, lifecycle_state_coded};
-use openehr_its::rest::generated::common::{UpdateAudit, UpdateAuditData, UpdateVersion};
-use openehr_rm::prelude::PartyProxy;
+use ferroehr::service::version_update::lifecycle_state_coded;
 use serde_json::{Value, json};
 
-/// The SM `UPDATE_VERSION` commit envelope for a bare-RM composition write.
-fn uv<T: serde::de::DeserializeOwned>(
-    data: &Value,
-    change_code: &str,
-    preceding: Option<&str>,
-) -> UpdateVersion<T> {
-    UpdateVersion {
-        preceding_version_uid: preceding.map(|p| p.parse().expect("OBJECT_VERSION_ID")),
-        lifecycle_state: lifecycle_state_coded("532"),
-        attestations: None,
-        data: openehr_its::json::from_canonical_value(data)
-            .expect("the fixture commit body decodes as its RM type"),
-        commit_audit: UpdateAudit::UpdateAudit(UpdateAuditData {
-            _type: None,
-            system_id: None,
-            change_type: change_type_coded(change_code),
-            description: None,
-            committer: openehr_its::json::from_canonical_value::<PartyProxy>(
-                &json!({ "_type": "PARTY_IDENTIFIED", "name": "conformance tester" }),
-            )
-            .expect("committer"),
-        }),
-        signature: None,
-    }
-}
-
-/// A minimal *valid* RM COMPOSITION (mirrors the signing-test fixture).
-fn composition(name: &str) -> Value {
-    json!({
-        "_type": "COMPOSITION",
-        "archetype_node_id": "openEHR-EHR-COMPOSITION.encounter.v1",
-        "archetype_details": {
-            "_type": "ARCHETYPED",
-            "archetype_id": {
-                "_type": "ARCHETYPE_ID",
-                "value": "openEHR-EHR-COMPOSITION.encounter.v1"
-            },
-            "rm_version": "1.2.0"
-        },
-        "name": { "_type": "DV_TEXT", "value": name },
-        "language": {
-            "_type": "CODE_PHRASE",
-            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_639-1" },
-            "code_string": "en"
-        },
-        "territory": {
-            "_type": "CODE_PHRASE",
-            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_3166-1" },
-            "code_string": "NL"
-        },
-        "category": {
-            "_type": "DV_CODED_TEXT",
-            "value": "event",
-            "defining_code": {
-                "_type": "CODE_PHRASE",
-                "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" },
-                "code_string": "433"
-            }
-        },
-        "composer": { "_type": "PARTY_IDENTIFIED", "name": "conformance tester" }
-    })
-}
-
-fn committer(name: &str) -> Value {
-    json!({ "_type": "PARTY_IDENTIFIED", "name": name })
-}
-
-fn change_type(code: &str, value: &str) -> Value {
-    json!({
-        "_type": "DV_CODED_TEXT", "value": value,
-        "defining_code": {
-            "_type": "CODE_PHRASE",
-            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" },
-            "code_string": code
-        }
-    })
-}
+use crate::fixtures::{change_type, committer, composition, uv, vo_of};
 
 /// A wire `UPDATE_ATTESTATION` partial (the server completes it).
 fn attestation(reason: &str, is_pending: bool) -> Value {
@@ -150,10 +71,6 @@ fn first_version_uid(contribution: &Value) -> String {
         .to_owned()
 }
 
-fn vo_of(ovid: &str) -> String {
-    ovid.split("::").next().unwrap().to_owned()
-}
-
 #[tokio::test]
 async fn accompanying_attestation_then_standalone_666_attestation() {
     let db = testkit::db().await.expect("testkit database");
@@ -184,7 +101,7 @@ async fn accompanying_attestation_then_standalone_666_attestation() {
     let vo_id = vo_of(&ovid_v1);
 
     // Reading the ORIGINAL_VERSION exposes the completed ATTESTATION.
-    let ov = read_version(&svc, &ehr_id, &vo_id, &ovid_v1).await;
+    let ov = read_version(&svc, &ehr_id, vo_id, &ovid_v1).await;
     let atts = ov["attestations"].as_array().expect("attestations array");
     assert_eq!(atts.len(), 1, "one attestation after step 1");
     let att = &atts[0];
@@ -236,7 +153,7 @@ async fn accompanying_attestation_then_standalone_666_attestation() {
     );
 
     // The ORIGINAL_VERSION now lists both attestations.
-    let ov = read_version(&svc, &ehr_id, &vo_id, &ovid_v1).await;
+    let ov = read_version(&svc, &ehr_id, vo_id, &ovid_v1).await;
     assert_eq!(
         ov["attestations"].as_array().map(Vec::len),
         Some(2),
@@ -712,7 +629,7 @@ async fn contribution_honors_the_five_lifecycle_states() {
         .await
         .expect("create incomplete (553) → 201");
     let ovid_v1 = first_version_uid(&created.body);
-    let vo_id = vo_of(&ovid_v1);
+    let vo_id = vo_of(&ovid_v1).to_owned();
 
     let ov1 = read_version(&svc, &ehr_id, &vo_id, &ovid_v1).await;
     assert_eq!(
@@ -905,7 +822,7 @@ async fn version_commit_audit_defaults_from_the_contribution_audit() {
     for v in created.body["versions"].as_array().expect("versions") {
         let ovid = v["id"]["value"].as_str().expect("ovid").to_owned();
         let vo = vo_of(&ovid);
-        let ov = read_version(&svc, &ehr_id, &vo, &ovid).await;
+        let ov = read_version(&svc, &ehr_id, vo, &ovid).await;
         let sys = ov["commit_audit"]["system_id"]
             .as_str()
             .expect("system_id")
@@ -1489,7 +1406,7 @@ async fn incomplete_admits_missing_composition_data_but_never_wrong_data() {
         .expect("a 553 commit accepts absent mandatory data (master06 §Incomplete Content)");
     let ovid = first_version_uid(&created.body);
     assert_eq!(
-        lifecycle_code_of(&svc, &ehr_id, &vo_of(&ovid), &ovid).await,
+        lifecycle_code_of(&svc, &ehr_id, vo_of(&ovid), &ovid).await,
         "553"
     );
 
@@ -1730,7 +1647,7 @@ async fn merge_provenance_is_refused_on_the_commit_wire() {
         .await
         .expect("the same member without the undeclared property commits");
     let v2 = first_version_uid(&committed.body);
-    let ov = read_version(&svc, &ehr_id, &vo_of(&v2), &v2).await;
+    let ov = read_version(&svc, &ehr_id, vo_of(&v2), &v2).await;
     assert!(
         ov.get("other_input_version_uids").is_none(),
         "a locally committed version carries no merge provenance, got {ov:?}"
@@ -1828,7 +1745,7 @@ async fn foreign_version_identity_is_refused_on_the_commit_wire() {
         .await
         .expect("the same member without the undeclared keys commits");
     let v2 = first_version_uid(&committed.body);
-    let ov = read_version(&svc, &ehr_id, &vo_of(&v2), &v2).await;
+    let ov = read_version(&svc, &ehr_id, vo_of(&v2), &v2).await;
     assert_eq!(
         ov["_type"], "ORIGINAL_VERSION",
         "a locally committed version is an ORIGINAL_VERSION, got {ov:?}"

--- a/app/ferroehr/tests/it/service_dump_load.rs
+++ b/app/ferroehr/tests/it/service_dump_load.rs
@@ -51,8 +51,9 @@ use ferroehr::ids::EhrId;
 use ferroehr::service::FerroEhrService;
 
 use crate::admin_fixture::{
-    archive_dir, count_for_ehr, repository, seed_full_ehr, truncate_to_half, uid, uv,
+    archive_dir, count_for_ehr, repository, seed_full_ehr, truncate_to_half,
 };
+use crate::fixtures::{change_type, committer, composition, uid, uv};
 use crate::typed_body::typed;
 use ferroehr::service::admin::types::{
     CompressionFormat, DumpLoadFailReport, ExportFormat, ExportSpec,
@@ -474,46 +475,6 @@ async fn sevenz_compressed_export_round_trips_through_the_detected_container() {
 // enumeration never reaches this layer (the REST edge refuses it,
 // `admin_extension_http.rs`) and a non-positive `segment_split_size` is proved
 // below.
-
-/// A minimal *valid* RM COMPOSITION: `language`, `territory`, `category` and
-/// `composer` are all `1..1` (RM ehr, COMPOSITION class), so typed RM
-/// validation rejects a fixture without them. No template is referenced, so
-/// the fixture needs no `template_store` row.
-fn composition(name: &str) -> Value {
-    json!({
-        "_type": "COMPOSITION",
-        "archetype_node_id": "openEHR-EHR-COMPOSITION.encounter.v1",
-        "archetype_details": {
-            "_type": "ARCHETYPED",
-            "archetype_id": {
-                "_type": "ARCHETYPE_ID",
-                "value": "openEHR-EHR-COMPOSITION.encounter.v1"
-            },
-            "rm_version": "1.2.0"
-        },
-        "name": { "_type": "DV_TEXT", "value": name },
-        "language": {
-            "_type": "CODE_PHRASE",
-            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_639-1" },
-            "code_string": "en"
-        },
-        "territory": {
-            "_type": "CODE_PHRASE",
-            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_3166-1" },
-            "code_string": "NL"
-        },
-        "category": {
-            "_type": "DV_CODED_TEXT",
-            "value": "event",
-            "defining_code": {
-                "_type": "CODE_PHRASE",
-                "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" },
-                "code_string": "433"
-            }
-        },
-        "composer": { "_type": "PARTY_IDENTIFIED", "name": "conformance tester" }
-    })
-}
 
 /// Every versioned-object kind an EHR-scoped dump can carry, in one EHR:
 /// `EHR_STATUS` (two versions), a directory `FOLDER`, a `COMPOSITION` with two
@@ -1055,23 +1016,6 @@ fn attested_contribution() -> Value {
             "committer": committer("author")
         }
     })
-}
-
-/// A `DV_CODED_TEXT` in the `openehr` terminology (`code_string` + rubric).
-fn change_type(code: &str, value: &str) -> Value {
-    json!({
-        "_type": "DV_CODED_TEXT", "value": value,
-        "defining_code": {
-            "_type": "CODE_PHRASE",
-            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" },
-            "code_string": code
-        }
-    })
-}
-
-/// A `PARTY_IDENTIFIED` committer named `name`.
-fn committer(name: &str) -> Value {
-    json!({ "_type": "PARTY_IDENTIFIED", "name": name })
 }
 
 /// The 666-only after-committal CONTRIBUTION attesting `ovid` — fixture of the

--- a/app/ferroehr/tests/it/service_ehr.rs
+++ b/app/ferroehr/tests/it/service_ehr.rs
@@ -9,7 +9,6 @@
 //! metadata (`.meta`, from which the HTTP edge derives `ETag`/`Location`).
 
 #![expect(
-    clippy::expect_used,
     clippy::indexing_slicing,
     reason = "clippy's in-test lint scoping (clippy.toml `allow-*-in-tests`) only \
               reaches `#[test]`-annotated functions, so it misses this integration \
@@ -32,84 +31,16 @@ use ferroehr::service::error::ServiceError;
 use ferroehr::service::status::{CallStatusType, SmError};
 use ferroehr::versioning::change::Committed;
 
+use crate::fixtures::{change_type, composition, folder, uid, uv};
 use crate::item_tag_fixture::ehr_tag;
 
 use crate::typed_body::typed;
-use ferroehr::service::version_update::{Committal, change_type_coded, lifecycle_state_coded};
-use openehr_its::rest::generated::common::{UpdateAudit, UpdateAuditData, UpdateVersion};
+use ferroehr::service::version_update::{Committal, change_type_coded};
+use openehr_its::rest::generated::common::{UpdateAudit, UpdateAuditData};
 
 /// The `uid.value` (`OBJECT_VERSION_ID`) of a versioned-object body.
-fn uid(v: &Value) -> &str {
-    v["uid"]["value"].as_str().expect("uid.value")
-}
-
-/// The SM `UPDATE_VERSION` commit envelope for a bare-RM write.
-fn uv<T: serde::de::DeserializeOwned>(
-    data: &Value,
-    change_code: &str,
-    preceding: Option<&str>,
-) -> UpdateVersion<T> {
-    UpdateVersion {
-        preceding_version_uid: preceding.map(|p| p.parse().expect("OBJECT_VERSION_ID")),
-        lifecycle_state: lifecycle_state_coded("532"),
-        attestations: None,
-        data: openehr_its::json::from_canonical_value(data)
-            .expect("the fixture commit body decodes as its RM type"),
-        commit_audit: UpdateAudit::UpdateAudit(UpdateAuditData {
-            _type: None,
-            system_id: None,
-            change_type: change_type_coded(change_code),
-            description: None,
-            committer: openehr_its::json::from_canonical_value::<PartyProxy>(
-                &json!({ "_type": "PARTY_IDENTIFIED", "name": "conformance tester" }),
-            )
-            .expect("committer"),
-        }),
-        signature: None,
-    }
-}
-
 fn has_key(tags: &[ItemTag], k: &str) -> bool {
     tags.iter().any(|t| t.key() == k)
-}
-
-/// A minimal *valid* RM COMPOSITION: `language`, `territory`, `category`, and
-/// `composer` are all `1..1` (RM ehr, COMPOSITION class), so the typed RM
-/// validation rejects a fixture without them.
-fn composition(name: &str) -> Value {
-    json!({
-        "_type": "COMPOSITION",
-        "archetype_node_id": "openEHR-EHR-COMPOSITION.encounter.v1",
-        "archetype_details": {
-            "_type": "ARCHETYPED",
-            "archetype_id": {
-                "_type": "ARCHETYPE_ID",
-                "value": "openEHR-EHR-COMPOSITION.encounter.v1"
-            },
-            "rm_version": "1.2.0"
-        },
-        "name": { "_type": "DV_TEXT", "value": name },
-        "language": {
-            "_type": "CODE_PHRASE",
-            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_639-1" },
-            "code_string": "en"
-        },
-        "territory": {
-            "_type": "CODE_PHRASE",
-            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_3166-1" },
-            "code_string": "NL"
-        },
-        "category": {
-            "_type": "DV_CODED_TEXT",
-            "value": "event",
-            "defining_code": {
-                "_type": "CODE_PHRASE",
-                "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" },
-                "code_string": "433"
-            }
-        },
-        "composer": { "_type": "PARTY_IDENTIFIED", "name": "conformance tester" }
-    })
 }
 
 /// A COMPOSITION with **no** `template_id` but a terminology-invalid `category`
@@ -126,14 +57,6 @@ fn composition_with_bad_category() -> Value {
 /// A minimal *valid* root FOLDER (a folder-hierarchy root). `validate_folder`
 /// requires `name` and forbids inline content-by-value, which a bare root
 /// satisfies (RM ehr, DIRECTORY package).
-fn folder(name: &str) -> Value {
-    json!({
-        "_type": "FOLDER",
-        "archetype_node_id": "openEHR-EHR-FOLDER.generic.v1",
-        "name": { "_type": "DV_TEXT", "value": name }
-    })
-}
-
 #[tokio::test]
 async fn ehr_composition_lifecycle_end_to_end() {
     let db = testkit::db().await.expect("testkit database");
@@ -826,18 +749,6 @@ async fn ehr_status_subject_type_is_enforced_end_to_end() {
     svc.create_ehr(Some(typed(&anonymous)))
         .await
         .expect("an anonymous PARTY_SELF EHR_STATUS is accepted");
-}
-
-/// A `DV_CODED_TEXT` audit `change_type` (openEHR audit change-type group).
-fn change_type(code: &str, value: &str) -> Value {
-    json!({
-        "_type": "DV_CODED_TEXT", "value": value,
-        "defining_code": {
-            "_type": "CODE_PHRASE",
-            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" },
-            "code_string": code
-        }
-    })
 }
 
 #[tokio::test]

--- a/app/ferroehr/tests/it/service_events.rs
+++ b/app/ferroehr/tests/it/service_events.rs
@@ -30,80 +30,22 @@ use async_trait::async_trait;
 use serde_json::{Value, json};
 use sqlx::{PgPool, Row};
 
+use crate::fixtures::{committer, composition_by, uv};
 use crate::typed_body::typed;
 use ferroehr::extensions::events::config::EventsConfig;
 use ferroehr::extensions::events::publisher::start_with_publisher;
 use ferroehr::service::FerroEhrService;
-use ferroehr::service::version_update::{change_type_coded, lifecycle_state_coded};
 use ferroehr_ext::events::{EventError, EventPublisher};
-use openehr_its::rest::generated::common::{UpdateAudit, UpdateAuditData, UpdateVersion};
-use openehr_rm::prelude::PartyProxy;
 
 // ── fixtures ─────────────────────────────────────────────────────────────────
 
-fn committer(name: &str) -> Value {
-    json!({ "_type": "PARTY_IDENTIFIED", "name": name })
-}
-
-/// An SM `UPDATE_VERSION` wrapping bare-RM `data`.
-fn uv<T: serde::de::DeserializeOwned>(data: &Value, change_code: &str) -> UpdateVersion<T> {
-    UpdateVersion {
-        preceding_version_uid: None,
-        lifecycle_state: lifecycle_state_coded("532"),
-        attestations: None,
-        data: openehr_its::json::from_canonical_value(data)
-            .expect("the fixture commit body decodes as its RM type"),
-        commit_audit: UpdateAudit::UpdateAudit(UpdateAuditData {
-            _type: None,
-            system_id: None,
-            change_type: change_type_coded(change_code),
-            description: None,
-            committer: openehr_its::json::from_canonical_value::<PartyProxy>(&committer(
-                "event tester",
-            ))
-            .expect("committer"),
-        }),
-        signature: None,
-    }
-}
-
-/// A minimal valid bare-RM COMPOSITION (no template). Clinical-ish keys
-/// (`composer`, `archetype_node_id`, `territory`, …) let the PHI-free assertion
-/// prove none of them leak into the event envelope.
+/// A minimal valid bare-RM COMPOSITION whose `composer` is the PHI probe.
+///
+/// The name is load-bearing: [`assert_phi_free`] asserts that exact string
+/// never reaches an event envelope, so this suite cannot share the default
+/// composer.
 fn composition(name: &str) -> Value {
-    json!({
-        "_type": "COMPOSITION",
-        "archetype_node_id": "openEHR-EHR-COMPOSITION.encounter.v1",
-        "archetype_details": {
-            "_type": "ARCHETYPED",
-            "archetype_id": {
-                "_type": "ARCHETYPE_ID",
-                "value": "openEHR-EHR-COMPOSITION.encounter.v1"
-            },
-            "rm_version": "1.2.0"
-        },
-        "name": { "_type": "DV_TEXT", "value": name },
-        "language": {
-            "_type": "CODE_PHRASE",
-            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_639-1" },
-            "code_string": "en"
-        },
-        "territory": {
-            "_type": "CODE_PHRASE",
-            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_3166-1" },
-            "code_string": "NL"
-        },
-        "category": {
-            "_type": "DV_CODED_TEXT",
-            "value": "event",
-            "defining_code": {
-                "_type": "CODE_PHRASE",
-                "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" },
-                "code_string": "433"
-            }
-        },
-        "composer": { "_type": "PARTY_IDENTIFIED", "name": "secret clinician name" }
-    })
+    composition_by(name, "secret clinician name")
 }
 
 // ── outbox helpers ───────────────────────────────────────────────────────────
@@ -214,7 +156,7 @@ async fn composition_and_contribution_commits_each_write_one_phi_free_outbox_row
     assert_eq!(after_ehr, 1, "EHR creation writes one outbox row");
 
     // (a) A direct composition commit writes exactly one more row.
-    svc.create_composition(ehr, uv(&composition("v1"), "249"))
+    svc.create_composition(ehr, uv(&composition("v1"), "249", None))
         .await
         .expect("create_composition");
     assert_eq!(
@@ -280,7 +222,7 @@ async fn outbox_disabled_writes_no_rows() {
     let ehr = create_ehr(&svc).await;
     assert_eq!(total_count(&pool).await, 0, "EHR creation writes none");
 
-    svc.create_composition(ehr, uv(&composition("v1"), "249"))
+    svc.create_composition(ehr, uv(&composition("v1"), "249", None))
         .await
         .expect("create_composition");
     assert_eq!(
@@ -424,10 +366,10 @@ async fn drainer_holds_pending_while_broker_down_then_drains_without_loss() {
 
     // Commit some work: an EHR + two compositions ⇒ three outbox rows.
     let ehr = create_ehr(&svc).await;
-    svc.create_composition(ehr, uv(&composition("v1"), "249"))
+    svc.create_composition(ehr, uv(&composition("v1"), "249", None))
         .await
         .expect("comp 1");
-    svc.create_composition(ehr, uv(&composition("v2"), "249"))
+    svc.create_composition(ehr, uv(&composition("v2"), "249", None))
         .await
         .expect("comp 2");
     let committed = total_count(&pool).await;
@@ -533,7 +475,7 @@ async fn import_writes_one_phi_free_outbox_row() {
     status.as_object_mut().unwrap().remove("uid");
     status["is_modifiable"] = json!(false);
     source
-        .replace_ehr_status(ehr, uv_precede(&status, "251", &ovid))
+        .replace_ehr_status(ehr, uv(&status, "251", Some(&ovid)))
         .await
         .expect("status update");
 
@@ -562,15 +504,4 @@ async fn import_writes_one_phi_free_outbox_row() {
         kinds.contains(&"EHR_STATUS"),
         "import envelope must announce the EHR_STATUS versions, got {kinds:?}"
     );
-}
-
-/// An `UpdateVersion` with a preceding-version uid (for updates).
-fn uv_precede<T: serde::de::DeserializeOwned>(
-    data: &Value,
-    change_code: &str,
-    preceding: &str,
-) -> UpdateVersion<T> {
-    let mut v = uv(data, change_code);
-    v.preceding_version_uid = Some(preceding.parse().expect("OBJECT_VERSION_ID"));
-    v
 }

--- a/app/ferroehr/tests/it/service_import.rs
+++ b/app/ferroehr/tests/it/service_import.rs
@@ -48,7 +48,6 @@ use std::sync::Arc;
 
 use serde_json::{Value, json};
 
-use openehr_rm::prelude::PartyProxy;
 use openehr_rm::v1_2::ehr_extract::common::extract::Extract;
 use openehr_rm::v1_2::ehr_extract::common::extract_spec::ExtractSpec;
 
@@ -56,36 +55,10 @@ use ferroehr::service::FerroEhrService;
 use ferroehr::service::ehr_index::types::SubjectRef;
 use ferroehr::service::status::CallStatusType;
 
+use crate::fixtures::{composition, uv};
 use crate::typed_body::typed;
-use ferroehr::service::version_update::{change_type_coded, lifecycle_state_coded};
 use ferroehr::versioning::signature::config::{Mode, SigningConfig, VerifyOnRead};
 use ferroehr::versioning::signature::signer::Signer;
-use openehr_its::rest::generated::common::{UpdateAudit, UpdateAuditData, UpdateVersion};
-
-fn uv<T: serde::de::DeserializeOwned>(
-    data: &Value,
-    change_code: &str,
-    preceding: Option<&str>,
-) -> UpdateVersion<T> {
-    UpdateVersion {
-        preceding_version_uid: preceding.map(|p| p.parse().expect("OBJECT_VERSION_ID")),
-        lifecycle_state: lifecycle_state_coded("532"),
-        attestations: None,
-        data: openehr_its::json::from_canonical_value(data)
-            .expect("the fixture commit body decodes as its RM type"),
-        commit_audit: UpdateAudit::UpdateAudit(UpdateAuditData {
-            _type: None,
-            system_id: None,
-            change_type: change_type_coded(change_code),
-            description: None,
-            committer: openehr_its::json::from_canonical_value::<PartyProxy>(
-                &json!({ "_type": "PARTY_IDENTIFIED", "name": "conformance tester" }),
-            )
-            .expect("committer"),
-        }),
-        signature: None,
-    }
-}
 
 /// Seed an EHR with an `EHR_STATUS` (create → update = two versions), a directory
 /// `FOLDER`, and the auto-created `EHR_ACCESS` — the same shape the export tests
@@ -130,44 +103,6 @@ async fn export_one(svc: &FerroEhrService, ehr: ferroehr::ids::EhrId) -> Extract
     assert_eq!(extracts.len(), 1, "one EHR id → one EXTRACT");
     openehr_its::json::from_canonical_value(&extracts.remove(0))
         .expect("EXTRACT deserializes into the typed RM model")
-}
-
-/// A minimal *valid* RM COMPOSITION: `language`, `territory`, `category` and
-/// `composer` are all `1..1` (RM ehr, COMPOSITION class).
-fn minimal_composition(name: &str) -> Value {
-    json!({
-        "_type": "COMPOSITION",
-        "archetype_node_id": "openEHR-EHR-COMPOSITION.encounter.v1",
-        "archetype_details": {
-            "_type": "ARCHETYPED",
-            "archetype_id": {
-                "_type": "ARCHETYPE_ID",
-                "value": "openEHR-EHR-COMPOSITION.encounter.v1"
-            },
-            "rm_version": "1.2.0"
-        },
-        "name": { "_type": "DV_TEXT", "value": name },
-        "language": {
-            "_type": "CODE_PHRASE",
-            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_639-1" },
-            "code_string": "en"
-        },
-        "territory": {
-            "_type": "CODE_PHRASE",
-            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_3166-1" },
-            "code_string": "NL"
-        },
-        "category": {
-            "_type": "DV_CODED_TEXT",
-            "value": "event",
-            "defining_code": {
-                "_type": "CODE_PHRASE",
-                "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" },
-                "code_string": "433"
-            }
-        },
-        "composer": { "_type": "PARTY_IDENTIFIED", "name": "conformance tester" }
-    })
 }
 
 /// The content item of an extract whose wrapped object has the given
@@ -993,7 +928,7 @@ async fn an_as_of_read_before_the_import_does_not_see_the_imported_version() {
     // A plain modifiable source EHR (the seeded fixture ends non-modifiable).
     let ehr = source.create_ehr(None).await.expect("source ehr");
     let composition_uid = source
-        .create_composition(ehr, uv(&minimal_composition("as-of"), "249", None))
+        .create_composition(ehr, uv(&composition("as-of"), "249", None))
         .await
         .expect("source composition")
         .version_uid();

--- a/app/ferroehr/tests/it/service_signing.rs
+++ b/app/ferroehr/tests/it/service_signing.rs
@@ -28,47 +28,15 @@ use ferroehr::versioning::signature::config::{Mode, SigningConfig, VerifyOnRead}
 use ferroehr::versioning::signature::signer::Signer;
 use ferroehr::versioning::signature::verify::Verdict;
 
-use ferroehr::service::version_update::{change_type_coded, lifecycle_state_coded};
+use ferroehr::service::version_update::change_type_coded;
 use openehr_base::prelude::ObjectVersionId;
-use openehr_its::rest::generated::common::{
-    UpdateAttestation, UpdateAudit, UpdateAuditData, UpdateVersion,
-};
-use openehr_rm::prelude::{DvText, PartyProxy};
+use openehr_its::rest::generated::common::{UpdateAttestation, UpdateAudit, UpdateAuditData};
+use openehr_rm::prelude::DvText;
 use openehr_rm::v1_2::common::change_control::version_impl::canonical_form_of_json;
 use serde_json::{Value, json};
 use sqlx::{PgPool, Row};
 
-fn uid(v: &Value) -> &str {
-    v["uid"]["value"].as_str().expect("uid.value")
-}
-
-fn committer(name: &str) -> PartyProxy {
-    openehr_its::json::from_canonical_value(&json!({ "_type": "PARTY_IDENTIFIED", "name": name }))
-        .expect("committer")
-}
-
-/// The SM `UPDATE_VERSION` commit envelope for a bare-RM write.
-fn uv<T: serde::de::DeserializeOwned>(
-    data: &Value,
-    change_code: &str,
-    preceding: Option<&str>,
-) -> UpdateVersion<T> {
-    UpdateVersion {
-        preceding_version_uid: preceding.map(|p| p.parse().expect("OBJECT_VERSION_ID")),
-        lifecycle_state: lifecycle_state_coded("532"),
-        attestations: None,
-        data: openehr_its::json::from_canonical_value(data)
-            .expect("the fixture commit body decodes as its RM type"),
-        commit_audit: UpdateAudit::UpdateAudit(UpdateAuditData {
-            _type: None,
-            system_id: None,
-            change_type: change_type_coded(change_code),
-            description: None,
-            committer: committer("conformance tester"),
-        }),
-        signature: None,
-    }
-}
+use crate::fixtures::{change_type, committer_proxy, composition, uid, uv};
 
 /// A wire `UPDATE_ATTESTATION` partial for an attestation committed WITH the
 /// version (`UPDATE_VERSION.attestations`; SM
@@ -80,7 +48,7 @@ fn update_attestation(reason: &str) -> UpdateAttestation {
         system_id: None,
         change_type: change_type_coded("666"),
         description: None,
-        committer: committer("witness"),
+        committer: committer_proxy("witness"),
         attested_view: None,
         proof: None,
         items: None,
@@ -99,7 +67,7 @@ fn contribution_audit(change_code: &str, committer_name: &str) -> UpdateAudit {
         system_id: None,
         change_type: change_type_coded(change_code),
         description: None,
-        committer: committer(committer_name),
+        committer: committer_proxy(committer_name),
     })
 }
 
@@ -107,56 +75,6 @@ fn contribution_audit(change_code: &str, committer_name: &str) -> UpdateAudit {
 fn version_components(ovid: &str) -> (ferroehr::ids::VoId, String) {
     let parts: Vec<&str> = ovid.split("::").collect();
     (parts[0].parse().expect("vo uuid"), parts[2].to_owned())
-}
-
-/// A minimal *valid* RM COMPOSITION: `language`, `territory`, `category`, and
-/// `composer` are all `1..1` (RM ehr, COMPOSITION class), so the typed RM
-/// validation rejects a fixture without them.
-fn composition(name: &str) -> Value {
-    json!({
-        "_type": "COMPOSITION",
-        "archetype_node_id": "openEHR-EHR-COMPOSITION.encounter.v1",
-        "archetype_details": {
-            "_type": "ARCHETYPED",
-            "archetype_id": {
-                "_type": "ARCHETYPE_ID",
-                "value": "openEHR-EHR-COMPOSITION.encounter.v1"
-            },
-            "rm_version": "1.2.0"
-        },
-        "name": { "_type": "DV_TEXT", "value": name },
-        "language": {
-            "_type": "CODE_PHRASE",
-            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_639-1" },
-            "code_string": "en"
-        },
-        "territory": {
-            "_type": "CODE_PHRASE",
-            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_3166-1" },
-            "code_string": "NL"
-        },
-        "category": {
-            "_type": "DV_CODED_TEXT",
-            "value": "event",
-            "defining_code": {
-                "_type": "CODE_PHRASE",
-                "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" },
-                "code_string": "433"
-            }
-        },
-        "composer": { "_type": "PARTY_IDENTIFIED", "name": "conformance tester" }
-    })
-}
-
-fn change_type(code: &str, value: &str) -> Value {
-    json!({
-        "_type": "DV_CODED_TEXT", "value": value,
-        "defining_code": {
-            "_type": "CODE_PHRASE",
-            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" },
-            "code_string": code
-        }
-    })
 }
 
 /// Assert a served `ORIGINAL_VERSION` carries a server digest signature that

--- a/app/ferroehr/tests/it/service_sm3.rs
+++ b/app/ferroehr/tests/it/service_sm3.rs
@@ -20,7 +20,8 @@ use serde_json::{Value, json};
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use crate::admin_fixture::{uid, uv, vo_of};
+use crate::fixtures::uv;
+use crate::fixtures::{uid, vo_of};
 use crate::typed_body::typed;
 use ferroehr::service::FerroEhrService;
 use ferroehr::service::ehr_index::types::{

--- a/app/ferroehr/tests/it/service_spec_profile.rs
+++ b/app/ferroehr/tests/it/service_spec_profile.rs
@@ -35,46 +35,18 @@ use ferroehr::service::FerroEhrService;
 use ferroehr::service::admin::types::ExportSpec;
 use ferroehr::service::query::request::AqlQueryRequest;
 use ferroehr::service::status::{CallStatusType, SmError};
-use ferroehr::service::version_update::{change_type_coded, lifecycle_state_coded};
-use openehr_its::rest::generated::common::{UpdateAudit, UpdateAuditData, UpdateVersion};
-use openehr_rm::prelude::{Composition, PartyProxy};
 
-/// A minimal valid RM COMPOSITION carrying the given `content` list.
+use crate::fixtures::uv;
+
+/// The shared minimal valid RM COMPOSITION, carrying the given `content` list.
+///
+/// The generation delta these tests probe lives entirely in `content`, so the
+/// suite adds it to the shared fixture rather than restating the mandatory
+/// attributes.
 fn composition(name: &str, content: &Value) -> Value {
-    json!({
-        "_type": "COMPOSITION",
-        "archetype_node_id": "openEHR-EHR-COMPOSITION.encounter.v1",
-        "archetype_details": {
-            "_type": "ARCHETYPED",
-            "archetype_id": {
-                "_type": "ARCHETYPE_ID",
-                "value": "openEHR-EHR-COMPOSITION.encounter.v1"
-            },
-            "rm_version": "1.2.0"
-        },
-        "name": { "_type": "DV_TEXT", "value": name },
-        "language": {
-            "_type": "CODE_PHRASE",
-            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_639-1" },
-            "code_string": "en"
-        },
-        "territory": {
-            "_type": "CODE_PHRASE",
-            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_3166-1" },
-            "code_string": "NL"
-        },
-        "category": {
-            "_type": "DV_CODED_TEXT",
-            "value": "event",
-            "defining_code": {
-                "_type": "CODE_PHRASE",
-                "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" },
-                "code_string": "433"
-            }
-        },
-        "composer": { "_type": "PARTY_IDENTIFIED", "name": "conformance tester" },
-        "content": content
-    })
+    let mut composition = crate::fixtures::composition(name);
+    composition["content"] = content.clone();
+    composition
 }
 
 /// A COMPOSITION whose content both generation sets express.
@@ -113,28 +85,6 @@ fn development_only_composition() -> Value {
     )
 }
 
-/// The SM `UPDATE_VERSION` commit envelope for a bare-RM COMPOSITION create.
-fn create_version(data: &Value) -> UpdateVersion<Composition> {
-    UpdateVersion {
-        preceding_version_uid: None,
-        lifecycle_state: lifecycle_state_coded("532"),
-        attestations: None,
-        data: openehr_its::json::from_canonical_value(data)
-            .expect("the fixture commit body decodes as its RM type"),
-        commit_audit: UpdateAudit::UpdateAudit(UpdateAuditData {
-            _type: None,
-            system_id: None,
-            change_type: change_type_coded("249"),
-            description: None,
-            committer: openehr_its::json::from_canonical_value::<PartyProxy>(
-                &json!({ "_type": "PARTY_IDENTIFIED", "name": "conformance tester" }),
-            )
-            .expect("committer"),
-        }),
-        signature: None,
-    }
-}
-
 /// The stored `vo_version.stable_compatible` of an object's only version.
 async fn stamp(pool: &sqlx::PgPool, vo_id: VoId) -> Option<bool> {
     sqlx::query_scalar::<_, Option<bool>>(
@@ -155,7 +105,7 @@ fn stable_service(pool: sqlx::PgPool) -> FerroEhrService {
 async fn commit(svc: &FerroEhrService, body: &Value) -> (EhrId, VoId) {
     let ehr_id = svc.create_ehr(None).await.expect("ehr_create");
     let committed = svc
-        .create_composition(ehr_id, create_version(body))
+        .create_composition(ehr_id, uv(body, "249", None))
         .await
         .expect("composition create");
     (ehr_id, committed.vo_id)
@@ -703,7 +653,7 @@ async fn the_fhir_read_facade_is_gated_by_the_spec_profile() {
         .await
         .expect("the inbound ingest commits the clean composition");
     let planted = svc
-        .create_composition(ehr_id, create_version(&development_only_under_template()))
+        .create_composition(ehr_id, uv(&development_only_under_template(), "249", None))
         .await
         .expect("the development profile commits the development-only body");
     assert_eq!(

--- a/app/ferroehr/tests/it/service_system_id.rs
+++ b/app/ferroehr/tests/it/service_system_id.rs
@@ -33,74 +33,9 @@
 )]
 
 use ferroehr::ids::EhrId;
-use ferroehr::service::version_update::{change_type_coded, lifecycle_state_coded};
 use ferroehr::service::{DEFAULT_SYSTEM_ID, FerroEhrService};
-use openehr_its::rest::generated::common::{UpdateAudit, UpdateAuditData, UpdateVersion};
-use openehr_rm::prelude::PartyProxy;
-use serde_json::{Value, json};
 
-fn committer(name: &str) -> PartyProxy {
-    openehr_its::json::from_canonical_value(&json!({ "_type": "PARTY_IDENTIFIED", "name": name }))
-        .expect("committer")
-}
-
-/// A minimal *valid* RM COMPOSITION: `language`, `territory`, `category`, and
-/// `composer` are all `1..1` (RM ehr, COMPOSITION class).
-fn composition(name: &str) -> Value {
-    json!({
-        "_type": "COMPOSITION",
-        "archetype_node_id": "openEHR-EHR-COMPOSITION.encounter.v1",
-        "archetype_details": {
-            "_type": "ARCHETYPED",
-            "archetype_id": {
-                "_type": "ARCHETYPE_ID",
-                "value": "openEHR-EHR-COMPOSITION.encounter.v1"
-            },
-            "rm_version": "1.2.0"
-        },
-        "name": { "_type": "DV_TEXT", "value": name },
-        "language": {
-            "_type": "CODE_PHRASE",
-            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_639-1" },
-            "code_string": "en"
-        },
-        "territory": {
-            "_type": "CODE_PHRASE",
-            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_3166-1" },
-            "code_string": "NL"
-        },
-        "category": {
-            "_type": "DV_CODED_TEXT",
-            "value": "event",
-            "defining_code": {
-                "_type": "CODE_PHRASE",
-                "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" },
-                "code_string": "433"
-            }
-        },
-        "composer": { "_type": "PARTY_IDENTIFIED", "name": "conformance tester" }
-    })
-}
-
-/// The SM `UPDATE_VERSION` commit envelope with **no** client-supplied
-/// `system_id` — the case in which the server MUST supply its own.
-fn uv<T: serde::de::DeserializeOwned>(data: &Value) -> UpdateVersion<T> {
-    UpdateVersion {
-        preceding_version_uid: None,
-        lifecycle_state: lifecycle_state_coded("532"),
-        attestations: None,
-        data: openehr_its::json::from_canonical_value(data)
-            .expect("the fixture commit body decodes as its RM type"),
-        commit_audit: UpdateAudit::UpdateAudit(UpdateAuditData {
-            _type: None,
-            system_id: None,
-            change_type: change_type_coded("249"),
-            description: None,
-            committer: committer("conformance tester"),
-        }),
-        signature: None,
-    }
-}
+use crate::fixtures::{composition, uv};
 
 /// Create an EHR + one composition on `svc` and return
 /// `(EHR.system_id, OBJECT_VERSION_ID, AUDIT_DETAILS.system_id)`.
@@ -109,7 +44,7 @@ async fn stamped_identities(svc: &FerroEhrService) -> (String, String, String) {
     let summary = svc.get_ehr(ehr_id).await.expect("get_ehr");
 
     let ovid = svc
-        .create_composition(ehr_id, uv(&composition("system id")))
+        .create_composition(ehr_id, uv(&composition("system id"), "249", None))
         .await
         .expect("create_composition")
         .version_uid();

--- a/app/ferroehr/tests/it/storage_parity.rs
+++ b/app/ferroehr/tests/it/storage_parity.rs
@@ -22,92 +22,16 @@
               Rust Book ch11)"
 )]
 
-use serde_json::{Value, json};
 use sqlx::PgPool;
 use uuid::Uuid;
-
-use openehr_its::rest::generated::common::{UpdateAudit, UpdateAuditData, UpdateVersion};
-use openehr_rm::prelude::PartyProxy;
 
 use ferroehr::ids::EhrId;
 use ferroehr::service::FerroEhrService;
 use ferroehr::service::admin::integrity::StorageParityDefect;
-use ferroehr::service::version_update::{change_type_coded, lifecycle_state_coded};
 
-/// The SM `UPDATE_VERSION` commit envelope for a bare-RM write.
-fn uv<T: serde::de::DeserializeOwned>(
-    data: &Value,
-    change_code: &str,
-    preceding: Option<&str>,
-) -> UpdateVersion<T> {
-    UpdateVersion {
-        preceding_version_uid: preceding.map(|p| p.parse().expect("OBJECT_VERSION_ID")),
-        lifecycle_state: lifecycle_state_coded("532"),
-        attestations: None,
-        data: openehr_its::json::from_canonical_value(data)
-            .expect("the fixture commit body decodes as its RM type"),
-        commit_audit: UpdateAudit::UpdateAudit(UpdateAuditData {
-            _type: None,
-            system_id: None,
-            change_type: change_type_coded(change_code),
-            description: None,
-            committer: openehr_its::json::from_canonical_value::<PartyProxy>(
-                &json!({ "_type": "PARTY_IDENTIFIED", "name": "conformance tester" }),
-            )
-            .expect("committer"),
-        }),
-        signature: None,
-    }
-}
-
-/// A minimal *valid* RM COMPOSITION: `language`, `territory`, `category` and
-/// `composer` are all `1..1` (RM ehr, COMPOSITION class), so the typed RM
-/// validation rejects a fixture without them.
-fn composition(name: &str) -> Value {
-    json!({
-        "_type": "COMPOSITION",
-        "archetype_node_id": "openEHR-EHR-COMPOSITION.encounter.v1",
-        "archetype_details": {
-            "_type": "ARCHETYPED",
-            "archetype_id": {
-                "_type": "ARCHETYPE_ID",
-                "value": "openEHR-EHR-COMPOSITION.encounter.v1"
-            },
-            "rm_version": "1.2.0"
-        },
-        "name": { "_type": "DV_TEXT", "value": name },
-        "language": {
-            "_type": "CODE_PHRASE",
-            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_639-1" },
-            "code_string": "en"
-        },
-        "territory": {
-            "_type": "CODE_PHRASE",
-            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_3166-1" },
-            "code_string": "NL"
-        },
-        "category": {
-            "_type": "DV_CODED_TEXT",
-            "value": "event",
-            "defining_code": {
-                "_type": "CODE_PHRASE",
-                "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" },
-                "code_string": "433"
-            }
-        },
-        "composer": { "_type": "PARTY_IDENTIFIED", "name": "conformance tester" }
-    })
-}
+use crate::fixtures::{composition, folder, uv};
 
 /// A minimal *valid* root FOLDER (a folder-hierarchy root).
-fn folder(name: &str) -> Value {
-    json!({
-        "_type": "FOLDER",
-        "archetype_node_id": "openEHR-EHR-FOLDER.generic.v1",
-        "name": { "_type": "DV_TEXT", "value": name }
-    })
-}
-
 /// An EHR carrying one committed COMPOSITION — three content versions in all
 /// (`EHR_STATUS`, `EHR_ACCESS`, the COMPOSITION), every one of which the sweep
 /// reads.

--- a/app/ferroehr/tests/it/telemetry_metrics.rs
+++ b/app/ferroehr/tests/it/telemetry_metrics.rs
@@ -24,13 +24,12 @@
 use std::sync::OnceLock;
 
 use ferroehr::service::FerroEhrService;
-use ferroehr::service::version_update::{change_type_coded, lifecycle_state_coded};
 use ferroehr::telemetry::build_info::BuildInfo;
 use ferroehr::telemetry::metrics;
 use openehr_base::prelude::ObjectVersionId;
-use openehr_its::rest::generated::common::{UpdateAudit, UpdateAuditData, UpdateVersion};
-use openehr_rm::prelude::PartyProxy;
-use serde_json::{Value, json};
+use serde_json::json;
+
+use crate::fixtures::{change_type, committer, composition, uv, vo_of};
 
 /// The process-wide meter provider + its Prometheus registry, built through the
 /// real entry point so the instruments and their bucket views are the shipped
@@ -61,89 +60,6 @@ fn committed(registry: &prometheus::Registry, change_type: &str) -> u64 {
         .filter(|l| l.starts_with("compositions_committed_total{") && l.contains(&needle))
         .find_map(|l| l.rsplit(' ').next().and_then(|v| v.parse::<u64>().ok()))
         .unwrap_or(0)
-}
-
-fn committer(name: &str) -> Value {
-    json!({ "_type": "PARTY_IDENTIFIED", "name": name })
-}
-
-/// The wire `change_type` `DV_CODED_TEXT` of a CONTRIBUTION version item.
-fn change_type(code: &str, value: &str) -> Value {
-    json!({
-        "_type": "DV_CODED_TEXT", "value": value,
-        "defining_code": {
-            "_type": "CODE_PHRASE",
-            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" },
-            "code_string": code
-        }
-    })
-}
-
-/// The SM `UPDATE_VERSION` commit envelope for a bare-RM composition write.
-fn uv<T: serde::de::DeserializeOwned>(
-    data: &Value,
-    change_code: &str,
-    preceding: Option<&str>,
-) -> UpdateVersion<T> {
-    UpdateVersion {
-        preceding_version_uid: preceding.map(|p| p.parse().expect("OBJECT_VERSION_ID")),
-        lifecycle_state: lifecycle_state_coded("532"),
-        attestations: None,
-        data: openehr_its::json::from_canonical_value(data)
-            .expect("the fixture commit body decodes as its RM type"),
-        commit_audit: UpdateAudit::UpdateAudit(UpdateAuditData {
-            _type: None,
-            system_id: None,
-            change_type: change_type_coded(change_code),
-            description: None,
-            committer: openehr_its::json::from_canonical_value::<PartyProxy>(&committer(
-                "metrics tester",
-            ))
-            .expect("committer"),
-        }),
-        signature: None,
-    }
-}
-
-/// A minimal *valid* RM COMPOSITION.
-fn composition(name: &str) -> Value {
-    json!({
-        "_type": "COMPOSITION",
-        "archetype_node_id": "openEHR-EHR-COMPOSITION.encounter.v1",
-        "archetype_details": {
-            "_type": "ARCHETYPED",
-            "archetype_id": {
-                "_type": "ARCHETYPE_ID",
-                "value": "openEHR-EHR-COMPOSITION.encounter.v1"
-            },
-            "rm_version": "1.2.0"
-        },
-        "name": { "_type": "DV_TEXT", "value": name },
-        "language": {
-            "_type": "CODE_PHRASE",
-            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_639-1" },
-            "code_string": "en"
-        },
-        "territory": {
-            "_type": "CODE_PHRASE",
-            "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "ISO_3166-1" },
-            "code_string": "NL"
-        },
-        "category": {
-            "_type": "DV_CODED_TEXT",
-            "value": "event",
-            "defining_code": {
-                "_type": "CODE_PHRASE",
-                "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "openehr" },
-                "code_string": "433"
-            }
-        },
-        "composer": { "_type": "PARTY_IDENTIFIED", "name": "metrics tester" }
-    })
-}
-
-fn vo_of(ovid: &str) -> &str {
-    ovid.split("::").next().expect("object id part")
 }
 
 /// One test drives every phase in a single process, so the counter deltas are

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -87,6 +87,7 @@ full = [
 [dev-dependencies]
 serde_json.workspace = true
 insta.workspace = true   # canonical-output determinism snapshots (the contract gate)
+testkit = { path = "../../tools/testkit" }   # the shared canonical-json-literals gate scanner (path-only: stripped at packaging)
 sha2.workspace = true    # corpus manifest hashing for the determinism gate
 # The `flat` module's async WebTemplate cache tests (`flat::cache`) run under a
 # tokio runtime.

--- a/crates/openehr-its/tests/it/canonical_json_literals.rs
+++ b/crates/openehr-its/tests/it/canonical_json_literals.rs
@@ -6,26 +6,13 @@
 //! `openehr-*` types, never hand-written as `json!` literals.
 //!
 //! A `json!` literal carrying a `"_type"` key is, by definition, a hand-rolled
-//! canonical openEHR fragment: `_type` is the canonical-JSON discriminator the
-//! native codec emits (`openehr-its`, `emit-json`), so nothing else has any
-//! business writing it. Hand-written shapes drift from the model — wrong
-//! attribute order, a missing mandatory attribute, a stale spelling after a
-//! spec-pin bump — and none of that is caught by a compiler. Building the
-//! generated type and serializing it through
-//! `openehr_its::json::to_canonical_value` makes every one of those a build
-//! error instead (issue #1686; extended to this crate by #2444).
-//!
-//! This gate scans **this crate's own** `src/`. Unit-test fixtures inside
-//! `#[cfg(test)]` modules are deliberately out of scope: a test fixture is an
-//! input to assert against, not a served wire shape, and pinning literals
-//! there is exactly how a codec regression gets caught.
-//!
-//! To add a site, classify it and put it in [`ALLOWLIST`] with a one-line
-//! reason — every entry must name why that file's literals are NOT a
+//! canonical openEHR fragment — the scanner mechanics live in
+//! [`testkit::json_literals`] (shared by every crate's gate); this file owns
+//! ONLY this crate's adjudications (issue #1686; extended to this crate by
+//! #2444). To add a site, classify it and put it in [`ALLOWLIST`] with a
+//! one-line reason — every entry must name why that file's literals are NOT a
 //! synthesized canonical shape. A stale entry (allowlisted file with no
 //! remaining literals) fails too, so the list cannot rot.
-
-use std::path::{Path, PathBuf};
 
 /// Files whose `_type`-carrying `json!` literals are classified as something
 /// other than a synthesized canonical shape, each with the reason.
@@ -76,135 +63,17 @@ const ALLOWLIST: &[(&str, &str)] = &[
     ),
 ];
 
-/// Every `json!` invocation in `src` whose body carries a `"_type"` key,
-/// as `(crate-relative path, 1-based line)`.
-///
-/// # Errors
-/// Any I/O failure walking or reading the crate's own `src/` tree.
-fn offending_sites() -> std::io::Result<Vec<(String, usize)>> {
-    let src = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
-    let mut out = Vec::new();
-    collect(&src, "", &mut out)?;
-    out.sort();
-    Ok(out)
-}
-
-/// Recursively walk `dir` (reached at crate-relative `prefix`), appending each
-/// offending site to `out`.
-fn collect(dir: &Path, prefix: &str, out: &mut Vec<(String, usize)>) -> std::io::Result<()> {
-    for entry in std::fs::read_dir(dir)? {
-        let entry = entry?;
-        let name = entry.file_name().to_string_lossy().into_owned();
-        let relative = if prefix.is_empty() {
-            name
-        } else {
-            format!("{prefix}/{name}")
-        };
-        let path = entry.path();
-        if path.is_dir() {
-            collect(&path, &relative, out)?;
-            continue;
-        }
-        if path.extension().is_none_or(|e| e != "rs") {
-            continue;
-        }
-        let text = std::fs::read_to_string(&path)?;
-        // Unit tests live in a trailing `#[cfg(test)] mod tests` (the repo's
-        // test-placement rule), so everything from the first line-initial
-        // `#[cfg(test)]` on is fixture territory and out of scope.
-        let production = match text.find("\n#[cfg(test)]") {
-            Some(at) => text.get(..at).unwrap_or(&text),
-            None => &text,
-        };
-        for start in json_macro_bodies(production) {
-            let line = production
-                .get(..start)
-                .map_or(1, |before| before.matches('\n').count() + 1);
-            out.push((relative.clone(), line));
-        }
-    }
-    Ok(())
-}
-
-/// Byte offsets of every `json!` invocation in `src` whose delimited body
-/// contains a `"_type"` key.
-fn json_macro_bodies(src: &str) -> Vec<usize> {
-    let bytes = src.as_bytes();
-    let mut hits = Vec::new();
-    let mut from = 0;
-    while let Some(rel) = src.get(from..).and_then(|rest| rest.find("json!")) {
-        let at = from + rel;
-        from = at + "json!".len();
-        // `serde_json::json!` is the same macro; `foojson!` is not.
-        let preceded_by_ident = at
-            .checked_sub(1)
-            .and_then(|i| bytes.get(i))
-            .is_some_and(|c| c.is_ascii_alphanumeric() || *c == b'_');
-        if preceded_by_ident {
-            continue;
-        }
-        let Some(open) = src
-            .get(from..)
-            .and_then(|rest| rest.find(|c: char| !c.is_whitespace()).map(|i| from + i))
-        else {
-            continue;
-        };
-        if !matches!(bytes.get(open), Some(b'(' | b'{' | b'[')) {
-            continue;
-        }
-        if let Some(end) = matching_delimiter(bytes, open)
-            && src.get(open..=end).is_some_and(|b| b.contains("\"_type\""))
-        {
-            hits.push(at);
-        }
-    }
-    hits
-}
-
-/// The index of the delimiter closing the one at `open`, skipping over string
-/// literals so a brace inside a JSON string cannot unbalance the scan.
-fn matching_delimiter(bytes: &[u8], open: usize) -> Option<usize> {
-    let mut depth = 0_i32;
-    let mut in_string = false;
-    let mut escaped = false;
-    for (i, byte) in bytes.iter().enumerate().skip(open) {
-        if in_string {
-            match byte {
-                _ if escaped => escaped = false,
-                b'\\' => escaped = true,
-                b'"' => in_string = false,
-                _ => {}
-            }
-            continue;
-        }
-        match byte {
-            b'"' => in_string = true,
-            b'(' | b'{' | b'[' => depth += 1,
-            b')' | b'}' | b']' => {
-                depth -= 1;
-                if depth == 0 {
-                    return Some(i);
-                }
-            }
-            _ => {}
-        }
-    }
-    None
-}
-
 /// No production `json!` literal outside the classified allowlist synthesizes a
 /// canonical openEHR shape.
 #[test]
 fn canonical_shapes_are_built_from_the_generated_types() {
-    let sites = offending_sites().expect("the crate's src/ tree should be readable");
-    let unlisted: Vec<&(String, usize)> = sites
-        .iter()
-        .filter(|(file, _)| !ALLOWLIST.iter().any(|(listed, _)| listed == file))
-        .collect();
+    let sites = testkit::json_literals::offending_sites(env!("CARGO_MANIFEST_DIR"))
+        .expect("the crate's src/ tree should be readable");
+    let unlisted = testkit::json_literals::unlisted(&sites, ALLOWLIST);
 
     assert!(
         unlisted.is_empty(),
-        "issue #2444: {} `json!` literal(s) in ferroehr/src synthesize a \
+        "issue #2444: {} `json!` literal(s) in openehr-its/src synthesize a \
          canonical openEHR shape (they carry a `\"_type\"` key). Build the \
          generated `openehr-rm`/`openehr-base` type and serialize it with \
          `openehr_its::json::to_canonical_value` instead — that is what keeps \
@@ -225,12 +94,9 @@ fn canonical_shapes_are_built_from_the_generated_types() {
 /// silent licence to reintroduce hand-written canonical JSON.
 #[test]
 fn the_allowlist_carries_no_stale_entries() {
-    let sites = offending_sites().expect("the crate's src/ tree should be readable");
-    let stale: Vec<&str> = ALLOWLIST
-        .iter()
-        .filter(|(listed, _)| !sites.iter().any(|(file, _)| file == listed))
-        .map(|(listed, _)| *listed)
-        .collect();
+    let sites = testkit::json_literals::offending_sites(env!("CARGO_MANIFEST_DIR"))
+        .expect("the crate's src/ tree should be readable");
+    let stale = testkit::json_literals::stale_entries(&sites, ALLOWLIST);
 
     assert!(
         stale.is_empty(),

--- a/crates/openehr-its/tests/it/common.rs
+++ b/crates/openehr-its/tests/it/common.rs
@@ -257,3 +257,95 @@ pub(crate) fn excluded(name: &str) -> Option<&'static str> {
         _ => None,
     }
 }
+
+// ── Simplified-formats corpus pairing (flat.rs / structured.rs / webtemplate.rs) ──
+
+/// The canonical-JSON composition corpus vendored in this crate.
+pub(crate) fn composition_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/vendor/openehr_sdk/composition/canonical_json")
+}
+
+/// All directories that hold `.opt` operational templates for pairing.
+pub(crate) fn opt_dirs() -> Vec<PathBuf> {
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+    vec![
+        manifest.join("tests/fixtures/sdk"),
+        manifest.join("tests/fixtures/better"),
+        manifest.join("../../app/ferroehr/tests/resources/service"),
+    ]
+}
+
+/// Every `.opt` under `dir`, recursively, sorted for determinism.
+pub(crate) fn opt_files(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let Ok(entries) = fs::read_dir(dir) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            out.extend(opt_files(&path));
+        } else if path.extension().is_some_and(|e| e == "opt") {
+            out.push(path);
+        }
+    }
+    out.sort();
+    out
+}
+
+/// Build `templateId → WebTemplate` for every OPT the `opt14` parser can read.
+pub(crate) fn web_templates()
+-> std::collections::BTreeMap<String, openehr_its::flat::webtemplate::model::WebTemplate> {
+    let mut out = std::collections::BTreeMap::new();
+    for dir in opt_dirs() {
+        for path in opt_files(&dir) {
+            let Ok(xml) = fs::read_to_string(&path) else {
+                continue;
+            };
+            let Ok(opt) = openehr_its::opt14::from_xml(&xml) else {
+                continue;
+            };
+            if let Ok(wt) = openehr_its::flat::webtemplate::builder::build_web_template(&opt) {
+                out.entry(wt.template_id.clone()).or_insert(wt);
+            }
+        }
+    }
+    out
+}
+
+/// Load every canonical COMPOSITION (with its file name + template id) from
+/// the corpus, through the adjudicated-twin substitution.
+pub(crate) fn compositions() -> Vec<(String, String, serde_json::Value)> {
+    let mut out = Vec::new();
+    let Ok(entries) = fs::read_dir(composition_dir()) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_none_or(|e| e != "json") {
+            continue;
+        }
+        let Ok(text) = fs::read_to_string(twinned(&path)) else {
+            continue;
+        };
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) else {
+            continue;
+        };
+        if value.get("_type").and_then(serde_json::Value::as_str) != Some("COMPOSITION") {
+            continue;
+        }
+        let Some(tid) = value
+            .pointer("/archetype_details/template_id/value")
+            .and_then(serde_json::Value::as_str)
+        else {
+            continue;
+        };
+        let Some(name) = path.file_name().map(|n| n.to_string_lossy().into_owned()) else {
+            continue;
+        };
+        out.push((name, tid.to_owned(), value));
+    }
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+    out
+}

--- a/crates/openehr-its/tests/it/flat.rs
+++ b/crates/openehr-its/tests/it/flat.rs
@@ -33,7 +33,6 @@
 )]
 
 use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
 
 use openehr_its::flat::convert::{composition_from_flat, composition_to_flat};
 use openehr_its::flat::webtemplate::builder::build_web_template;
@@ -44,94 +43,6 @@ use serde_json::Value;
 /// Fixed `ctx/time` default for the FLAT build direction (ITS-REST
 /// simplified_formats master04 §Context) so round-trips are deterministic.
 const NOW: &str = "2024-01-01T00:00:00Z";
-
-fn manifest_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-}
-
-/// The canonical-JSON composition corpus vendored in `openehr-its`.
-fn composition_dir() -> PathBuf {
-    manifest_dir().join("../openehr-its/tests/vendor/openehr_sdk/composition/canonical_json")
-}
-
-/// All directories that hold `.opt` operational templates for pairing.
-fn opt_dirs() -> Vec<PathBuf> {
-    vec![
-        manifest_dir().join("tests/fixtures/sdk"),
-        manifest_dir().join("tests/fixtures/better"),
-        manifest_dir().join("../../app/ferroehr/tests/resources/service"),
-    ]
-}
-
-fn opt_files(dir: &Path) -> Vec<PathBuf> {
-    let mut out = Vec::new();
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return out;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            out.extend(opt_files(&path));
-        } else if path.extension().is_some_and(|e| e == "opt") {
-            out.push(path);
-        }
-    }
-    out
-}
-
-/// Build `templateId → WebTemplate` for every OPT the `opt14` parser can read.
-fn web_templates() -> BTreeMap<String, WebTemplate> {
-    let mut out = BTreeMap::new();
-    for dir in opt_dirs() {
-        for path in opt_files(&dir) {
-            let Ok(xml) = std::fs::read_to_string(&path) else {
-                continue;
-            };
-            let Ok(opt) = opt14::from_xml(&xml) else {
-                continue;
-            };
-            if let Ok(wt) = build_web_template(&opt) {
-                out.entry(wt.template_id.clone()).or_insert(wt);
-            }
-        }
-    }
-    out
-}
-
-/// Load every canonical COMPOSITION (with its template id) from the corpus.
-fn compositions() -> Vec<(String, String, Value)> {
-    let mut out = Vec::new();
-    let Ok(entries) = std::fs::read_dir(composition_dir()) else {
-        return out;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.extension().is_none_or(|e| e != "json") {
-            continue;
-        }
-        let Ok(text) = std::fs::read_to_string(crate::common::twinned(&path)) else {
-            continue;
-        };
-        let Ok(value) = serde_json::from_str::<Value>(&text) else {
-            continue;
-        };
-        if value.get("_type").and_then(Value::as_str) != Some("COMPOSITION") {
-            continue;
-        }
-        let Some(tid) = value
-            .pointer("/archetype_details/template_id/value")
-            .and_then(Value::as_str)
-        else {
-            continue;
-        };
-        let Some(name) = path.file_name().map(|n| n.to_string_lossy().into_owned()) else {
-            continue;
-        };
-        out.push((name, tid.to_owned(), value));
-    }
-    out.sort_by(|a, b| a.0.cmp(&b.0));
-    out
-}
 
 fn sorted(m: &serde_json::Map<String, Value>) -> BTreeMap<String, Value> {
     m.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
@@ -252,8 +163,8 @@ fn eprint_diagnostics(label: &str, lines: &[String]) {
 
 #[test]
 fn flat_roundtrip_stable() {
-    let wts = web_templates();
-    let comps = compositions();
+    let wts = crate::common::web_templates();
+    let comps = crate::common::compositions();
     assert!(!wts.is_empty(), "no web templates built");
     assert!(!comps.is_empty(), "no canonical compositions found");
 
@@ -294,12 +205,14 @@ fn flat_roundtrip_stable() {
 // ── insta goldens ───────────────────────────────────────────────────────────────
 
 fn golden_flat(comp_file: &str, template_id: &str, snap: &str) {
-    let wts = web_templates();
+    let wts = crate::common::web_templates();
     let wt = wts
         .get(template_id)
         .unwrap_or_else(|| panic!("no web template for {template_id:?}"));
-    let text = std::fs::read_to_string(crate::common::twinned(&composition_dir().join(comp_file)))
-        .unwrap_or_else(|e| panic!("read {comp_file}: {e}"));
+    let text = std::fs::read_to_string(crate::common::twinned(
+        &crate::common::composition_dir().join(comp_file),
+    ))
+    .unwrap_or_else(|e| panic!("read {comp_file}: {e}"));
     let comp: Value =
         serde_json::from_str(&text).unwrap_or_else(|e| panic!("parse {comp_file}: {e}"));
     let flat =
@@ -326,10 +239,10 @@ fn golden_minimal_observation_flat() {
 
 #[test]
 fn demo_vitals_flat_key_shape() {
-    let wts = web_templates();
+    let wts = crate::common::web_templates();
     let wt = wts.get("Demo Vitals").expect("Demo Vitals web template");
     let text = std::fs::read_to_string(crate::common::twinned(
-        &composition_dir().join("demo_vitals_352.json"),
+        &crate::common::composition_dir().join("demo_vitals_352.json"),
     ))
     .unwrap();
     let comp: Value = serde_json::from_str(&text).unwrap();
@@ -363,8 +276,10 @@ fn demo_vitals_flat_key_shape() {
 // ── closed-gap assertions ─────────────────────────────────────────────────────
 
 fn load(comp_file: &str) -> Value {
-    let text = std::fs::read_to_string(crate::common::twinned(&composition_dir().join(comp_file)))
-        .unwrap_or_else(|e| panic!("read {comp_file}: {e}"));
+    let text = std::fs::read_to_string(crate::common::twinned(
+        &crate::common::composition_dir().join(comp_file),
+    ))
+    .unwrap_or_else(|e| panic!("read {comp_file}: {e}"));
     serde_json::from_str(&text).unwrap_or_else(|e| panic!("parse {comp_file}: {e}"))
 }
 
@@ -378,7 +293,7 @@ fn is_valid_rm(rm: &Value) -> bool {
 /// with the mandatory `ACTIVITY.action_archetype_id`.
 #[test]
 fn instruction_activity_from_flat_is_valid_rm() {
-    let wts = web_templates();
+    let wts = crate::common::web_templates();
     let wt = wts
         .get("minimal_instruction.en.v1")
         .expect("minimal_instruction web template");
@@ -403,7 +318,7 @@ fn ctx_participation_shortcuts_round_trip() {
     // (`context/_participation:i|…`); the master06 ctx/ shortcuts remain
     // accepted on input (they are lossy — no scheme key — so they are not
     // the emission form).
-    let wts = web_templates();
+    let wts = crate::common::web_templates();
     let wt = wts
         .get("minimal_observation.en.v1")
         .expect("minimal_observation web template");
@@ -460,7 +375,7 @@ fn ctx_health_care_facility_round_trips() {
     // Output uses the lossless master05 §EVENT_CONTEXT path row
     // (`context/_health_care_facility|…` — it carries |id_scheme, which the
     // master06 ctx shortcut cannot); the ctx/ shortcut stays input-only.
-    let wts = web_templates();
+    let wts = crate::common::web_templates();
     let Some(wt) = wts.get("cardinality_of_section") else {
         return; // template not present in this checkout
     };
@@ -516,7 +431,7 @@ fn ctx_health_care_facility_round_trips() {
 /// valid RM (the previously-broken `all_types` fixtures).
 #[test]
 fn multimedia_and_parsable_leaves_are_valid_rm() {
-    let wts = web_templates();
+    let wts = crate::common::web_templates();
     let wt = wts
         .get("minimal_action_3.en.v1")
         .expect("a web template with a DV_MULTIMEDIA leaf");
@@ -542,7 +457,7 @@ fn terse_coded_text_string_is_rejected() {
     // |code/|value/|terminology suffixes (+ |other, master04 §Open
     // Value-Sets). A bare string on a closed coded leaf is rejected, never
     // silently coerced.
-    let wts = web_templates();
+    let wts = crate::common::web_templates();
     let wt = wts
         .get("Corona_Anamnese")
         .expect("Corona_Anamnese web template");
@@ -953,7 +868,7 @@ fn dv_leaf_count(v: &Value) -> usize {
 /// were lost that way). master05 §§ACTION `/ism_transition`, ISM_TRANSITION.
 #[test]
 fn action_careflow_ism_transition_wins_over_direct_path() {
-    let wts = web_templates();
+    let wts = crate::common::web_templates();
     let Some(wt) = wts.get("International Patient Summary") else {
         return; // ips.v0 OPT not present in this checkout
     };

--- a/crates/openehr-its/tests/it/structured.rs
+++ b/crates/openehr-its/tests/it/structured.rs
@@ -32,104 +32,17 @@
 )]
 
 use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
 
 use openehr_its::flat::convert::{
     composition_from_structured, composition_to_flat, composition_to_structured,
     flat_to_structured, structured_to_flat,
 };
-use openehr_its::flat::webtemplate::builder::build_web_template;
 use openehr_its::flat::webtemplate::model::WebTemplate;
-use openehr_its::opt14;
 use serde_json::Value;
 
 /// Fixed `ctx/time` default for the STRUCTURED build direction (ITS-REST
 /// simplified_formats master04 §Context) so round-trips are deterministic.
 const NOW: &str = "2024-01-01T00:00:00Z";
-
-fn manifest_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-}
-
-fn composition_dir() -> PathBuf {
-    manifest_dir().join("../openehr-its/tests/vendor/openehr_sdk/composition/canonical_json")
-}
-
-fn opt_dirs() -> Vec<PathBuf> {
-    vec![
-        manifest_dir().join("tests/fixtures/sdk"),
-        manifest_dir().join("tests/fixtures/better"),
-        manifest_dir().join("../../app/ferroehr/tests/resources/service"),
-    ]
-}
-
-fn opt_files(dir: &Path) -> Vec<PathBuf> {
-    let mut out = Vec::new();
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return out;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            out.extend(opt_files(&path));
-        } else if path.extension().is_some_and(|e| e == "opt") {
-            out.push(path);
-        }
-    }
-    out
-}
-
-fn web_templates() -> BTreeMap<String, WebTemplate> {
-    let mut out = BTreeMap::new();
-    for dir in opt_dirs() {
-        for path in opt_files(&dir) {
-            let Ok(xml) = std::fs::read_to_string(&path) else {
-                continue;
-            };
-            let Ok(opt) = opt14::from_xml(&xml) else {
-                continue;
-            };
-            if let Ok(wt) = build_web_template(&opt) {
-                out.entry(wt.template_id.clone()).or_insert(wt);
-            }
-        }
-    }
-    out
-}
-
-fn compositions() -> Vec<(String, String, Value)> {
-    let mut out = Vec::new();
-    let Ok(entries) = std::fs::read_dir(composition_dir()) else {
-        return out;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.extension().is_none_or(|e| e != "json") {
-            continue;
-        }
-        let Ok(text) = std::fs::read_to_string(crate::common::twinned(&path)) else {
-            continue;
-        };
-        let Ok(value) = serde_json::from_str::<Value>(&text) else {
-            continue;
-        };
-        if value.get("_type").and_then(Value::as_str) != Some("COMPOSITION") {
-            continue;
-        }
-        let Some(tid) = value
-            .pointer("/archetype_details/template_id/value")
-            .and_then(Value::as_str)
-        else {
-            continue;
-        };
-        let Some(name) = path.file_name().map(|n| n.to_string_lossy().into_owned()) else {
-            continue;
-        };
-        out.push((name, tid.to_owned(), value));
-    }
-    out.sort_by(|a, b| a.0.cmp(&b.0));
-    out
-}
 
 /// Drop every `:index` from a flat key, leaving path + `|suffix`.
 fn strip_indices(key: &str) -> String {
@@ -185,8 +98,8 @@ fn structured_round_trip(
 
 #[test]
 fn structured_roundtrip_and_rm_validation() {
-    let wts = web_templates();
-    let comps = compositions();
+    let wts = crate::common::web_templates();
+    let comps = crate::common::compositions();
     assert!(!wts.is_empty(), "no web templates built");
     assert!(!comps.is_empty(), "no canonical compositions found");
 
@@ -248,8 +161,8 @@ fn structured_roundtrip_and_rm_validation() {
 
 #[test]
 fn flat_structured_exact_inverses() {
-    let wts = web_templates();
-    let comps = compositions();
+    let wts = crate::common::web_templates();
+    let comps = crate::common::compositions();
     let mut paired = 0usize;
     let mut structured_exact = 0usize;
     let mut flat_exact = 0usize;
@@ -290,8 +203,8 @@ fn flat_structured_exact_inverses() {
 
 #[test]
 fn structured_and_flat_carry_identical_leaves() {
-    let wts = web_templates();
-    let comps = compositions();
+    let wts = crate::common::web_templates();
+    let comps = crate::common::compositions();
     let mut checked = 0usize;
 
     for (name, tid, comp) in &comps {
@@ -320,12 +233,14 @@ fn structured_and_flat_carry_identical_leaves() {
 // ── insta goldens ─────────────────────────────────────────────────────────────
 
 fn golden_structured(comp_file: &str, template_id: &str, snap: &str) {
-    let wts = web_templates();
+    let wts = crate::common::web_templates();
     let wt = wts
         .get(template_id)
         .unwrap_or_else(|| panic!("no web template for {template_id:?}"));
-    let text = std::fs::read_to_string(crate::common::twinned(&composition_dir().join(comp_file)))
-        .unwrap_or_else(|e| panic!("read {comp_file}: {e}"));
+    let text = std::fs::read_to_string(crate::common::twinned(
+        &crate::common::composition_dir().join(comp_file),
+    ))
+    .unwrap_or_else(|e| panic!("read {comp_file}: {e}"));
     let comp: Value =
         serde_json::from_str(&text).unwrap_or_else(|e| panic!("parse {comp_file}: {e}"));
     let structured =

--- a/crates/openehr-its/tests/it/webtemplate.rs
+++ b/crates/openehr-its/tests/it/webtemplate.rs
@@ -29,34 +29,12 @@ use openehr_its::flat::webtemplate::builder::build_web_template;
 use openehr_its::flat::webtemplate::model::{WebTemplateInputType, WebTemplateNode};
 use openehr_its::opt14;
 
-fn manifest_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-}
-
 fn corpus_dir() -> PathBuf {
-    manifest_dir().join("../../app/ferroehr/tests/resources/service")
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../app/ferroehr/tests/resources/service")
 }
 
 fn better_fixtures_dir() -> PathBuf {
-    manifest_dir().join("tests/fixtures/better")
-}
-
-/// Recursively collect every `*.opt` under `dir`.
-fn opt_files(dir: &Path) -> Vec<PathBuf> {
-    let mut out = Vec::new();
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return out;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            out.extend(opt_files(&path));
-        } else if path.extension().is_some_and(|e| e == "opt") {
-            out.push(path);
-        }
-    }
-    out.sort();
-    out
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/better")
 }
 
 /// Parse an `OPT` and build a `WebTemplate`, returning any error as a string.
@@ -108,8 +86,8 @@ fn assert_unique_sibling_ids(node: &WebTemplateNode) {
 
 #[test]
 fn every_opt_builds_a_web_template() {
-    let corpus = opt_files(&corpus_dir());
-    let vendored = opt_files(&better_fixtures_dir());
+    let corpus = crate::common::opt_files(&corpus_dir());
+    let vendored = crate::common::opt_files(&better_fixtures_dir());
     let corpus_count = corpus.len();
     let vendored_count = vendored.len();
 
@@ -600,8 +578,8 @@ fn party_related_narrowing_is_a_party_leaf_with_a_relationship_child() {
 fn no_party_node_is_inputless() {
     let mut checked = 0_usize;
     let mut offenders: Vec<String> = Vec::new();
-    let mut files: Vec<PathBuf> = opt_files(&better_fixtures_dir());
-    files.extend(opt_files(&corpus_dir()));
+    let mut files: Vec<PathBuf> = crate::common::opt_files(&better_fixtures_dir());
+    files.extend(crate::common::opt_files(&corpus_dir()));
     for path in files {
         let Ok(wt) = build_from_file(&path) else {
             continue; // parser gaps are reported by the smoke gate, not here
@@ -644,7 +622,7 @@ fn unenforceable_constraints_are_reported_not_dropped() {
     use openehr_its::flat::validation::{UnenforceableReason, unenforceable_existence_constraints};
 
     let mut seen: Vec<String> = Vec::new();
-    for path in opt_files(Path::new("tests/fixtures")) {
+    for path in crate::common::opt_files(Path::new("tests/fixtures")) {
         let Ok(wt) = build_from_file(&path) else {
             continue;
         };

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -46,6 +46,13 @@ sonar.coverage.exclusions=\
 #   - The codegen decision maps and generation-twin templates: the plan
 #     override map is a declarative spec-cited table, and the per-generation
 #     template copies are near-identical BY the #1964 design.
+#   - Two pinned expectation TABLES (adjudicated on #2915, the same class as
+#     the decision maps): vendor_bmm_schema.rs is the per-fixture
+#     adjudication register over all 43 vendored BMM schemas (one Case row
+#     per file, each carrying its decided outcome + citation), and
+#     model_query.rs pins the model-query report row-for-row — every
+#     "duplicated" run is a decided record, and compressing the rows hides
+#     the adjudication the file exists to carry.
 sonar.cpd.exclusions=\
   app/ferroehr-rest/src/api/*/openapi_routes.rs,\
   app/ferroehr-rest/src/api/demographic/relationship.rs,\
@@ -57,7 +64,9 @@ sonar.cpd.exclusions=\
   app/ferroehr-rest/src/extensions/event_subscription.rs,\
   app/ferroehr-rest/src/extensions/tenant_routes.rs,\
   tools/openehr-codegen/src/plan/overrides.rs,\
-  tools/openehr-codegen/templates/**
+  tools/openehr-codegen/templates/**,\
+  crates/openehr-lang/tests/it/vendor_bmm_schema.rs,\
+  tools/openehr-codegen/tests/it/model_query.rs
 
 # SQL is excluded as a language: every .sql here is PostgreSQL (migrations,
 # fixtures), and Sonar's PLSQL analyzer assumes Oracle — its Data Dictionary

--- a/tools/openehr-codegen/src/render/emit_validate.rs
+++ b/tools/openehr-codegen/src/render/emit_validate.rs
@@ -117,6 +117,22 @@ fn realization_register(own_schema: &BmmSchema) -> String {
          //! (or adjudicated) outside this file, and are listed so the emitted\n\
          //! bucket is accounted for in full rather than assumed.\n",
     );
+    b.push_str(&render_register_rows(
+        &rows,
+        "UNACCOUNTED (classified emittable, no register row)",
+    ));
+    b.push_str(&complex_register(own_schema));
+    b
+}
+
+/// Renders one accounted-invariant row set: the venue-grouped sections plus
+/// the explicit unaccounted heading — the ONE rendering both registers share,
+/// so the emitted and complex buckets can never drift apart in shape.
+fn render_register_rows(
+    rows: &[crate::plan::overrides::AccountedInvariant],
+    unaccounted_heading: &str,
+) -> String {
+    let mut b = String::new();
     for venue in [
         InvariantVenue::Core,
         InvariantVenue::Impl,
@@ -151,16 +167,11 @@ fn realization_register(own_schema: &BmmSchema) -> String {
     }
     let unaccounted: Vec<_> = rows.iter().filter(|r| r.realization.is_none()).collect();
     if !unaccounted.is_empty() {
-        b.push_str(
-            "//!\n\
-             //! ## UNACCOUNTED (classified emittable, no register row)\n\
-             //!\n",
-        );
+        b.push_str(&format!("//!\n//! ## {unaccounted_heading}\n//!\n"));
         for r in unaccounted {
             b.push_str(&format!("//! - `{}.{}`.\n", r.class, r.name));
         }
     }
-    b.push_str(&complex_register(own_schema));
     b
 }
 
@@ -188,49 +199,10 @@ fn complex_register(own_schema: &BmmSchema) -> String {
          //! adjudication that excludes it — the complex bucket is accounted for\n\
          //! in full, exactly like the emitted bucket above.\n",
     );
-    for venue in [
-        InvariantVenue::Core,
-        InvariantVenue::Impl,
-        InvariantVenue::Wire,
-        InvariantVenue::App,
-        InvariantVenue::Excluded,
-        InvariantVenue::Unrealized,
-    ] {
-        let group: Vec<_> = rows
-            .iter()
-            .filter_map(|r| r.realization.filter(|reg| reg.venue == venue))
-            .collect();
-        if group.is_empty() {
-            continue;
-        }
-        b.push_str(&format!("//!\n//! ## {}\n//!\n", venue.heading()));
-        for reg in group {
-            let site = if reg.site.is_empty() {
-                String::new()
-            } else {
-                format!(" — `{}`", reg.site)
-            };
-            b.push_str(&format!(
-                "//! - `{}.{}`{site}: {} ({}/{} §Invariants).\n",
-                reg.class,
-                reg.name,
-                reg.reason,
-                crate::plan::overrides::class_doc_dir(reg.spec_file),
-                reg.spec_file,
-            ));
-        }
-    }
-    let unaccounted: Vec<_> = rows.iter().filter(|r| r.realization.is_none()).collect();
-    if !unaccounted.is_empty() {
-        b.push_str(
-            "//!\n\
-             //! ## UNACCOUNTED-COMPLEX (classified complex, no register row)\n\
-             //!\n",
-        );
-        for r in unaccounted {
-            b.push_str(&format!("//! - `{}.{}`.\n", r.class, r.name));
-        }
-    }
+    b.push_str(&render_register_rows(
+        &rows,
+        "UNACCOUNTED-COMPLEX (classified complex, no register row)",
+    ));
     b
 }
 

--- a/tools/testkit/src/json_literals.rs
+++ b/tools/testkit/src/json_literals.rs
@@ -1,0 +1,154 @@
+// SPDX-FileCopyrightText: FerroEHR contributors
+// SPDX-License-Identifier: MIT
+
+//! The shared scanner behind each crate's `canonical_json_literals` gate:
+//! every production `json!` invocation whose body carries a `"_type"` key,
+//! found by walking the calling crate's own `src/` tree.
+//!
+//! A `json!` literal carrying `"_type"` is a hand-rolled canonical openEHR
+//! fragment — `_type` is the canonical-JSON discriminator the native codec
+//! emits, so nothing else has any business writing it (issue #1686). The
+//! per-crate gates own their ALLOWLIST adjudications and assertion messages;
+//! this module owns only the mechanics, so the three gates can never drift
+//! apart on WHAT counts as an offending site.
+
+use std::path::{Path, PathBuf};
+
+/// Every `json!` invocation under `<manifest_dir>/src` whose body carries a
+/// `"_type"` key, as `(crate-relative path, 1-based line)`, sorted.
+///
+/// Unit-test fixtures are out of scope: everything from a file's first
+/// line-initial `#[cfg(test)]` on is fixture territory (the repo's
+/// test-placement rule keeps unit tests in a trailing module).
+///
+/// # Errors
+/// Any I/O failure walking or reading the crate's `src/` tree.
+pub fn offending_sites(manifest_dir: &str) -> std::io::Result<Vec<(String, usize)>> {
+    let src = PathBuf::from(manifest_dir).join("src");
+    let mut out = Vec::new();
+    collect(&src, "", &mut out)?;
+    out.sort();
+    Ok(out)
+}
+
+/// Recursively walk `dir` (reached at crate-relative `prefix`), appending each
+/// offending site to `out`.
+fn collect(dir: &Path, prefix: &str, out: &mut Vec<(String, usize)>) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let relative = if prefix.is_empty() {
+            name
+        } else {
+            format!("{prefix}/{name}")
+        };
+        let path = entry.path();
+        if path.is_dir() {
+            collect(&path, &relative, out)?;
+            continue;
+        }
+        if path.extension().is_none_or(|e| e != "rs") {
+            continue;
+        }
+        let text = std::fs::read_to_string(&path)?;
+        let production = match text.find("\n#[cfg(test)]") {
+            Some(at) => text.get(..at).unwrap_or(&text),
+            None => &text,
+        };
+        for start in json_macro_bodies(production) {
+            let line = production
+                .get(..start)
+                .map_or(1, |before| before.matches('\n').count() + 1);
+            out.push((relative.clone(), line));
+        }
+    }
+    Ok(())
+}
+
+/// Byte offsets of every `json!` invocation in `src` whose delimited body
+/// contains a `"_type"` key.
+fn json_macro_bodies(src: &str) -> Vec<usize> {
+    let bytes = src.as_bytes();
+    let mut hits = Vec::new();
+    let mut from = 0;
+    while let Some(rel) = src.get(from..).and_then(|rest| rest.find("json!")) {
+        let at = from + rel;
+        from = at + "json!".len();
+        // `serde_json::json!` is the same macro; `foojson!` is not.
+        let preceded_by_ident = at
+            .checked_sub(1)
+            .and_then(|i| bytes.get(i))
+            .is_some_and(|c| c.is_ascii_alphanumeric() || *c == b'_');
+        if preceded_by_ident {
+            continue;
+        }
+        let Some(open) = src
+            .get(from..)
+            .and_then(|rest| rest.find(|c: char| !c.is_whitespace()).map(|i| from + i))
+        else {
+            continue;
+        };
+        if !matches!(bytes.get(open), Some(b'(' | b'{' | b'[')) {
+            continue;
+        }
+        if let Some(end) = matching_delimiter(bytes, open)
+            && src.get(open..=end).is_some_and(|b| b.contains("\"_type\""))
+        {
+            hits.push(at);
+        }
+    }
+    hits
+}
+
+/// The index of the delimiter closing the one at `open`, skipping over string
+/// literals so a brace inside a JSON string cannot unbalance the scan.
+fn matching_delimiter(bytes: &[u8], open: usize) -> Option<usize> {
+    let mut depth = 0_i32;
+    let mut in_string = false;
+    let mut escaped = false;
+    for (i, byte) in bytes.iter().enumerate().skip(open) {
+        if in_string {
+            match byte {
+                _ if escaped => escaped = false,
+                b'\\' => escaped = true,
+                b'"' => in_string = false,
+                _ => {}
+            }
+            continue;
+        }
+        match byte {
+            b'"' => in_string = true,
+            b'(' | b'{' | b'[' => depth += 1,
+            b')' | b'}' | b']' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// The sites in `sites` not covered by `allowlist` — the gate's failing set.
+#[must_use]
+pub fn unlisted<'a>(
+    sites: &'a [(String, usize)],
+    allowlist: &[(&str, &str)],
+) -> Vec<&'a (String, usize)> {
+    sites
+        .iter()
+        .filter(|(file, _)| !allowlist.iter().any(|(listed, _)| listed == file))
+        .collect()
+}
+
+/// The `allowlist` entries matching no site — stale licences the gate refuses.
+#[must_use]
+pub fn stale_entries<'a>(sites: &[(String, usize)], allowlist: &'a [(&str, &str)]) -> Vec<&'a str> {
+    allowlist
+        .iter()
+        .filter(|(listed, _)| !sites.iter().any(|(file, _)| file == listed))
+        .map(|(listed, _)| *listed)
+        .collect()
+}

--- a/tools/testkit/src/lib.rs
+++ b/tools/testkit/src/lib.rs
@@ -41,6 +41,8 @@
 // Doctests are copy-paste templates: they must use `?`, never unwrap
 // (C-QUESTION-MARK, https://rust-lang.github.io/api-guidelines/documentation.html#c-question-mark).
 #![doc(test(attr(deny(warnings))))]
+pub mod json_literals;
+
 use std::time::{Duration, Instant};
 
 use sqlx::{Connection, PgConnection, PgPool};


### PR DESCRIPTION
Closes #2915.

The measured program record (baselines, per-cluster dispositions, and the coverage explanation register) lands as the issue's closing comment; this PR is the code half:

**Extractions (one home each, zero behaviour change):**
- `testkit::json_literals` — the canonical-json-literals gate scanner, shared by the three per-crate gates (each keeps only its ALLOWLIST adjudications + messages). The cross-crate testkit home is the fix #2862 named.
- `app/ferroehr/tests/it/fixtures.rs` — the SM-commit fixture family (`composition`, `uv`, `committer`, `change_type`, plus `uid`/`vo_of`/`folder`) extracted from twelve topic modules (net −729 lines from that family alone); semantically load-bearing variants stayed parameterized (`composition_by` for the PHI-leak suite) and every assertion is unchanged.
- `openehr-its tests/it/common.rs` — the simplified-formats corpus pairing (`composition_dir`/`opt_dirs`/`opt_files`/`web_templates`/`compositions`) shared by flat.rs / structured.rs / webtemplate.rs; `opt_files` is now sorted everywhere (determinism webtemplate.rs already had).
- `emit_validate.rs` — the emitted/complex realization registers render through one `render_register_rows` (regenerated output verified byte-identical).
- `dump_load.rs` — the EHR-export version loop calls the existing `version_record_of`; `AttestationRow::from_row` / `ItemTagRow::from_row` replace the per-path mapping loops.

**Metric-scope cases (recorded in ai-code-review.md §Metric-scope adjudications):** `sonar.cpd.exclusions` gains the two pinned expectation TABLES — `vendor_bmm_schema.rs` (the per-fixture adjudication register over the 43 vendored BMM schemas) and `model_query.rs` (the model-query report pinned row-for-row) — on the decision-map argument.

Zero tests weakened/skipped/deleted. `no-crate-bump`: the only `crates/*` manifest change is a PATH-ONLY dev-dependency on `tools/testkit` in `openehr-its`, which cargo strips from the packaged manifest (path-only dev-deps are removed at `cargo package`), so packaged bytes are unchanged; the test-file edits are not packaged (`tests/` is outside the include list). `no-changelog`: test/tooling/metric-scope only — no user-visible behaviour.
