### PR TITLE
chore(conformance): veredictum 0.1.0 + pin watcher; the pre-cut CI green-up

### DIFF
--- a/.github/workflows/veredictum-pin-watcher.yml
+++ b/.github/workflows/veredictum-pin-watcher.yml
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+
+# Scheduled Veredictum pin watcher.
+#
+# The acceptance instrument is pinned in exactly one place
+# (scripts/lib/veredictum.sh, VEREDICTUM_VERSION — docs/VERSIONS.md
+# §Conformance instrument), and nothing used to notice when upstream released
+# past it: the pin sat at 0.1.0-alpha.6 while 0.1.0 shipped with eleven new
+# query cases, and the staleness surfaced only because a coverage-mining pass
+# happened to diff against the live tree (2026-08-29). A stale instrument
+# grades every acceptance run against yesterday's catalogue — worse than a
+# red row, because it looks green.
+#
+# This lane is the missing check: compare the pin against the newest
+# non-yanked version on crates.io and file/refresh ONE tracking issue when
+# they differ. It deliberately files an ISSUE rather than opening a bump PR:
+# a pin bump is only honest together with a fresh full acceptance run and the
+# committed baseline that run produces (scripts/conformance.sh), which no
+# unattended lane can provide.
+#
+# NOTE: GitHub disables scheduled workflows after 60 days without repository
+# activity — re-enable from the Actions tab if that ever happens.
+name: Veredictum pin watcher
+
+on:
+  schedule:
+    # Mon + Thu 09:13 UTC — off the hour, in a slot of its own (read the
+    # estate's slots with `grep -rE '^ +- cron:' .github/workflows/`).
+    - cron: "13 9 * * 1,4"
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  compare:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write # file/update the one tracking issue below
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Compare the pin against crates.io
+        id: probe
+        run: |
+          set -euo pipefail
+          pin=$(sed -nE 's/^VEREDICTUM_VERSION="([^"]+)"$/\1/p' scripts/lib/veredictum.sh)
+          [ -n "$pin" ] || { echo "::error::VEREDICTUM_VERSION not found in scripts/lib/veredictum.sh"; exit 1; }
+          latest=$(curl -fsS --retry 3 -H "User-Agent: ferroehr-pin-watcher (github.com/rubentalstra/FerroEHR)" \
+              https://crates.io/api/v1/crates/veredictum \
+            | jq -r '[.versions[] | select(.yanked | not)][0].num')
+          [ -n "$latest" ] && [ "$latest" != "null" ] || { echo "::error::crates.io returned no version list"; exit 1; }
+          echo "pin=$pin latest=$latest"
+          if [ "$pin" = "$latest" ]; then
+            echo "stale=0" >> "$GITHUB_OUTPUT"
+            echo "The pin ($pin) is the newest published version." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          echo "stale=1" >> "$GITHUB_OUTPUT"
+          # shellcheck disable=SC2016 # the backticked names are literal markdown, never expansions
+          {
+            printf 'The acceptance instrument is pinned at `%s` while crates.io serves `%s`.\n\n' "$pin" "$latest"
+            printf 'A stale instrument grades every acceptance run against an old catalogue, which\n'
+            printf 'looks green while missing the newest cases. The bump is one line in\n'
+            printf '`scripts/lib/veredictum.sh` (`VEREDICTUM_VERSION`) plus a fresh\n'
+            printf '`bash scripts/conformance.sh` acceptance run whose artifacts become the new\n'
+            printf 'committed baseline (`docs/VERSIONS.md` §Conformance instrument). A red row on\n'
+            printf 'the new cases goes through spec-first triage (`.claude/rules/cnf-triage.md`)\n'
+            printf 'before any fix.\n'
+          } > body.md
+          cat body.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: File or update the tracking issue
+        if: steps.probe.outputs.stale == '1'
+        uses: ./.github/actions/file-watcher-issue
+        with:
+          title: "chore(conformance): the Veredictum pin is behind the published instrument"
+          body-file: body.md
+          labels: chore,P1
+          on-existing: update

--- a/docs/conformance/COMPARISON.md
+++ b/docs/conformance/COMPARISON.md
@@ -19,7 +19,7 @@
 
 | | ferroehr | EHRbase |
 |---|---|---|
-| Product | ferroehr 4.0.9 | ehrbase 2.34.0 |
+| Product | ferroehr 4.0.10 | ehrbase 2.34.0 |
 | Run date | 2026-08-29 | 2026-08-14 |
 | Party statement | committed with the runner (declares ITS-REST pin, signing, terminology posture) | committed with the runner |
 | Stack | the project's own compose stack, built from the current sources | a dedicated compose stack of the official EHRbase images |

--- a/docs/conformance/ferroehr/CONFORMANCE_CERTIFICATE.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_CERTIFICATE.md
@@ -6,7 +6,7 @@
 | --- | --- |
 | Solution | ferroehr 4.0.10 |
 | Vendor | Ruben Talstra |
-| Runner | veredictum 0.1.0-alpha.6 |
+| Runner | veredictum 0.1.0 |
 | Infrastructure | ixit.json#/environment |
 
 ## Scope of Test

--- a/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
@@ -1,7 +1,7 @@
 # Conformance Report
 
 SUT: FerroEHR 4.0.10 (sut `ferroehr`) · schedule cnf-2.0-w2 · ITS its-rest
-Runner: veredictum 0.1.0-alpha.6 · verification pack: passed
+Runner: veredictum 0.1.0 · verification pack: passed
 
 ## Summary
 

--- a/docs/conformance/ferroehr/results.json
+++ b/docs/conformance/ferroehr/results.json
@@ -5,7 +5,7 @@
   },
   "runner": {
     "name": "veredictum",
-    "version": "0.1.0-alpha.6",
+    "version": "0.1.0",
     "verification_pack_status": "passed"
   },
   "schedule_release": "cnf-2.0-w2",

--- a/scripts/deploy-probes/signing.sh
+++ b/scripts/deploy-probes/signing.sh
@@ -58,11 +58,11 @@ probes_signing() {
   local before after rows
   before="$(http_code -u "$BASIC" "$API/ehr/$ehr/versioned_ehr_status/version")"
   rows="$(probe_psql "UPDATE ehr.vo_version
-                         SET body = jsonb_set(body, '{name,value}', '\"tampered\"')
+                         SET body = (jsonb_set((body)::jsonb, '{name,value}', '\"tampered\"'))::text
                        WHERE ehr_id = '$ehr'::uuid AND kind = 'EHR_STATUS';" \
           && probe_psql "SELECT count(*) FROM ehr.vo_version
                           WHERE ehr_id = '$ehr'::uuid
-                            AND body #>> '{name,value}' = 'tampered';")"
+                            AND (body)::jsonb #>> '{name,value}' = 'tampered';")"
   if [[ "${rows:-0}" = "0" ]]; then
     probe_fail "a tampered stored row" "the UPDATE matched nothing" \
       "the probe could not reach the stored content, so detection was never tested"

--- a/scripts/deploy-probes/signing_pgp.sh
+++ b/scripts/deploy-probes/signing_pgp.sh
@@ -122,11 +122,11 @@ probes_signing_pgp() {
     "a tampered pgp-signed version is REFUSED on read"
   local matched after
   probe_psql "UPDATE ehr.vo_version
-                 SET body = jsonb_set(body, '{name,value}', '\"tampered\"')
+                 SET body = (jsonb_set((body)::jsonb, '{name,value}', '\"tampered\"'))::text
                WHERE ehr_id = '$ehr'::uuid AND kind = 'EHR_STATUS';" >/dev/null
   matched="$(probe_psql "SELECT count(*) FROM ehr.vo_version
                           WHERE ehr_id = '$ehr'::uuid
-                            AND body #>> '{name,value}' = 'tampered';")"
+                            AND (body)::jsonb #>> '{name,value}' = 'tampered';")"
   if [[ "${matched:-0}" = "0" ]]; then
     probe_fail "a tampered stored row" "the UPDATE matched nothing" \
       "detection was never tested — the probe could not reach the stored content"
@@ -232,11 +232,11 @@ probes_signing_rotation() {
     "a tampered version still fails after rotation — the keyring is not permissive"
   local matched after
   probe_psql "UPDATE ehr.vo_version
-                 SET body = jsonb_set(body, '{name,value}', '\"tampered\"')
+                 SET body = (jsonb_set((body)::jsonb, '{name,value}', '\"tampered\"'))::text
                WHERE ehr_id = '$ehr_a'::uuid AND kind = 'EHR_STATUS';" >/dev/null
   matched="$(probe_psql "SELECT count(*) FROM ehr.vo_version
                           WHERE ehr_id = '$ehr_a'::uuid
-                            AND body #>> '{name,value}' = 'tampered';")"
+                            AND (body)::jsonb #>> '{name,value}' = 'tampered';")"
   if [[ "${matched:-0}" = "0" ]]; then
     probe_fail "a tampered stored row" "the UPDATE matched nothing" \
       "permissiveness was never tested — the probe could not reach the stored content"

--- a/scripts/lib/veredictum.sh
+++ b/scripts/lib/veredictum.sh
@@ -38,7 +38,7 @@
 # `scripts/conformance.sh` run against the committed baseline. Machine-enforced
 # by the `veredictum-pin` CI job (#2867): the bumping PR refreshes
 # docs/conformance/ferroehr/ or carries the `no-conformance-run` deferral label.
-VEREDICTUM_VERSION="0.1.0-alpha.6"
+VEREDICTUM_VERSION="0.1.0"
 VEREDICTUM_REPO="https://github.com/rubentalstra/Veredictum"
 
 veredictum_cache_root() {

--- a/security/vex/rust-advisories.openvex.json
+++ b/security/vex/rust-advisories.openvex.json
@@ -14,12 +14,16 @@
         "workspace_roots": [
           "ferroehr",
           "ferroehr-admin-ui",
+          "ferroehr-ext",
           "ferroehr-rest",
           "ferroehr-server",
+          "openehr-adl",
+          "openehr-its",
+          "openehr-rm",
           "testkit"
         ]
       },
-      "impact_statement": "The Marvin timing sidechannel leaks information about an RSA PRIVATE key through the timing of private-key operations, so what matters is whether a FerroEHR process performs one. Two paths reach the crate. Through `openidconnect`, in the OIDC authentication path, the sole RSA operation is verifying an RS256 signature on an ID token with the identity provider's PUBLIC key: there is no secret in that computation for a timing observation to recover. Through `pgp`, in VERSION signing, an RSA operation would be a private-key one — but only in `[signing] mode = \"pgp\"`, which is not the default: the shipped default is `digest` mode (SHA-256 over the canonical form), which uses no asymmetric key at all, so the default artifact performs no RSA private-key operation. A deployment that does enable `pgp` mode chooses its own OpenPGP key, and an ECC/EdDSA signing key keeps `rsa` off the signing path entirely; a deployment that enables `pgp` mode with an RSA key is outside this statement and should rotate to an ECC key. No upstream fix exists — `rsa` has no patched release — so this is not a deferred upgrade. Re-evaluate if a release beyond rsa 0.9 ships, or if the default signing mode changes.",
+      "impact_statement": "The Marvin timing sidechannel leaks information about an RSA PRIVATE key through the timing of private-key operations, so what matters is whether a FerroEHR process performs one. Two paths reach the crate. Through `openidconnect`, in the OIDC authentication path, the sole RSA operation is verifying an RS256 signature on an ID token with the identity provider's PUBLIC key: there is no secret in that computation for a timing observation to recover. Through `pgp`, in VERSION signing, an RSA operation would be a private-key one — but only in `[signing] mode = \"pgp\"`, which is not the default: the shipped default is `digest` mode (SHA-256 over the canonical form), which uses no asymmetric key at all, so the default artifact performs no RSA private-key operation. A deployment that does enable `pgp` mode chooses its own OpenPGP key, and an ECC/EdDSA signing key keeps `rsa` off the signing path entirely; a deployment that enables `pgp` mode with an RSA key is outside this statement and should rotate to an ECC key. `ferroehr-ext` reaches the crate through the same two carriers as the platform library it extends, so the same argument covers it. The spec crates (`openehr-rm`, `openehr-its`, `openehr-adl`) reach `rsa` only through their path-only dev-dependency on the `testkit` harness (which depends on the platform library): a test-only edge cargo strips at packaging, so no published crate ships the code at all. No upstream fix exists — `rsa` has no patched release — so this is not a deferred upgrade. Re-evaluate if a release beyond rsa 0.9 ships, or if the default signing mode changes.",
       "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
       "products": [
         {

--- a/security/vex/rust-advisories.toml
+++ b/security/vex/rust-advisories.toml
@@ -83,8 +83,12 @@ carriers = ["openidconnect", "pgp"]
 workspace_roots = [
   "ferroehr",
   "ferroehr-admin-ui",
+  "ferroehr-ext",
   "ferroehr-rest",
   "ferroehr-server",
+  "openehr-adl",
+  "openehr-its",
+  "openehr-rm",
   "testkit",
 ]
 status = "not_affected"
@@ -103,9 +107,15 @@ form), which uses no asymmetric key at all, so the default artifact performs no 
 RSA private-key operation. A deployment that does enable `pgp` mode chooses its \
 own OpenPGP key, and an ECC/EdDSA signing key keeps `rsa` off the signing path \
 entirely; a deployment that enables `pgp` mode with an RSA key is outside this \
-statement and should rotate to an ECC key. No upstream fix exists — `rsa` has \
-no patched release — so this is not a deferred upgrade. Re-evaluate if a \
-release beyond rsa 0.9 ships, or if the default signing mode changes.\
+statement and should rotate to an ECC key. `ferroehr-ext` reaches the crate \
+through the same two carriers as the platform library it extends, so the same \
+argument covers it. The spec crates (`openehr-rm`, `openehr-its`, \
+`openehr-adl`) reach `rsa` only through their path-only dev-dependency on the \
+`testkit` harness (which depends on the platform library): a test-only edge \
+cargo strips at packaging, so no published crate ships the code at all. No \
+upstream fix exists — `rsa` has no patched release — so this is not a deferred \
+upgrade. Re-evaluate if a release beyond rsa 0.9 ships, or if the default \
+signing mode changes.\
 """
 
 [[accepted]]


### PR DESCRIPTION
The pre-cut green-up, four fixes in one branch:

**The instrument pin moves to the released veredictum 0.1.0** (from 0.1.0-alpha.6), with the full acceptance run on it recorded here: **1102 case-records, 1064 passed / 0 failed / 0 errored / 38 n-a — zero drift**, baseline committed. (The eleven newest query cases the live tree carries sit past the v0.1.0 tag and arrive with the next upstream release.)

**The new scheduled pin watcher** (`veredictum-pin-watcher.yml`) compares `VEREDICTUM_VERSION` against crates.io twice a week and files/refreshes one P1 tracking issue when behind — the staleness class that let alpha.6 linger while 0.1.0 shipped cannot stay silent past a Monday/Thursday tick again. It deliberately files an issue rather than a bump PR: an honest bump needs the acceptance run and its baseline, which no unattended lane can produce. actionlint + zizmor clean.

**Deploy-probe repair (the CI red):** the three signing tamper probes still treated `vo_version.body` as jsonb; post-#2913 their UPDATEs matched nothing and "detection was never tested". Their SQL now casts (`jsonb_set((body)::jsonb, …)::text`, `(body)::jsonb #>>`), mirroring the in-repo storage-parity fix.

**cargo-deny repair (the CI red):** the RUSTSEC-2023-0071 VEX statement names the four workspace roots the testkit dev-dependency chain added (`ferroehr-ext`, `openehr-adl`, `openehr-its`, `openehr-rm`) with the path argument in the prose — a path-only test-harness edge cargo strips at packaging, so no published crate ships the code. OpenVEX regenerated; both VEX gates green locally.

**Docs repair (the CI red):** COMPARISON.md re-rendered (it still said ferroehr 4.0.9; the drift gate compares regenerated against committed).

No user-visible behaviour change (`no-changelog`): instrument/CI/probe plumbing and regenerated records.
