### PR TITLE
release: v4.0.11

### DIFF
--- a/.claude/memory/no-ai-tells-in-prose.md
+++ b/.claude/memory/no-ai-tells-in-prose.md
@@ -1,14 +1,14 @@
 ---
 name: no-ai-tells-in-prose
-description: "Owner ban on AI writing tells in ALL prose Claude drafts (comments, replies, docs, PR text) — especially em dashes"
+description: "Owner ban on AI writing tells in ALL prose Claude drafts (comments, replies, docs, PR text) — and drafted replies must match the owner's own plain forum register, not just avoid banned tokens"
 metadata: 
   node_type: memory
   type: feedback
   originSessionId: 7cc03c10-781f-4577-82fe-2a7d7546a44c
-  modified: 2026-08-26T10:24:14.099Z
+  modified: 2026-08-29T17:58:12.937Z
 ---
 
-Owner directive 2026-08-26, given angrily after a drafted GitHub reply used em dashes: never write with AI tells in any prose meant for humans (issue/PR comments, reply drafts, docs, commit bodies). Banned specifically:
+Owner directive 2026-08-26, given angrily after a drafted GitHub reply used em dashes; reinforced angrily 2026-08-29 ("the text sounds so much like AI what the fuck") after a Discourse reply draft avoided every banned token yet still read as AI. Never write with AI tells in any prose meant for humans (issue/PR comments, reply drafts, docs, commit bodies). Banned specifically:
 
 - Em dashes used to attach explanatory clauses. Use a period, comma, or parentheses instead.
 - "Not X, but Y" contrast framing.
@@ -16,6 +16,8 @@ Owner directive 2026-08-26, given angrily after a drafted GitHub reply used em d
 - Buzzwords: delve, robust, elevate, testament, landscape.
 - Vague corporate transitions ("In today's fast-paced world", "inflection point").
 
+**The 2026-08-29 lesson: token-avoidance is not enough.** The rejected draft had no banned token but still had composed-essay rhythm: parallel paragraph structure, aphoristic closers ("That is a normal review cost, and I would rather name it than have someone discover it"), abstract framing sentences ("The number that matters is therefore not the page count"). The accepted rewrite imitated the owner's OWN prior forum posts: short factual sentences, concrete numbers up front, informal direct asks ("What I need from the SEC is: which channel, what pace"), no rhetorical shaping.
+
 **Why:** drafted external replies represent the owner personally; AI-sounding text is embarrassing and defeats the point of [[public-comments-one-and-short]].
 
-**How to apply:** before handing over any drafted prose, sweep for em dashes and the tells above and rewrite in plain sentences. Repo docs rule `writing-style.md` covers the website; this applies everywhere.
+**How to apply:** before handing over any drafted prose, (1) sweep for em dashes and the tells above, (2) find a real post the owner wrote (Discourse/GitHub history is in most threads being replied to) and match ITS register, sentence length and informality, (3) delete any sentence that sounds quotable — if it would work as a slide caption, the owner would not have written it.

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -5,7 +5,7 @@
   "title": "FerroEHR",
   "description": "<p>A pure-Rust, openEHR-specification-conformant clinical data repository (CDR): ITS-REST 1.1.0 REST API, AQL 1.1 query language, and the openEHR RM 1.2.0 reference model on PostgreSQL-18-native storage. The openEHR specification layer is generated from the official machine-readable specifications, and conformance is machine-verified per release by a built-in CNF conformance runner.</p>",
   "publication_date": "2026-08-29",
-  "version": "4.0.10",
+  "version": "4.0.11",
   "creators": [
     {
       "name": "Talstra, Ruben",
@@ -39,7 +39,7 @@
       "resource_type": "publication-softwaredocumentation"
     },
     {
-      "identifier": "https://github.com/rubentalstra/FerroEHR/tree/v4.0.10",
+      "identifier": "https://github.com/rubentalstra/FerroEHR/tree/v4.0.11",
       "relation": "isSupplementTo",
       "resource_type": "software"
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+## [4.0.11] - 2026-08-29
+
 ### Added
 
 - Validation enforces the one testable rule of `DV_TEXT.formatting`: a value
@@ -7819,7 +7821,8 @@ but has not yet run in production.
   seccomp, default-deny NetworkPolicy) and golden-render validation.
 
 
-[unreleased]: https://github.com/rubentalstra/FerroEHR/compare/v4.0.10...HEAD
+[unreleased]: https://github.com/rubentalstra/FerroEHR/compare/v4.0.11...HEAD
+[4.0.11]: https://github.com/rubentalstra/FerroEHR/compare/v4.0.10...v4.0.11
 [4.0.10]: https://github.com/rubentalstra/FerroEHR/compare/v4.0.9...v4.0.10
 [4.0.9]: https://github.com/rubentalstra/FerroEHR/compare/v4.0.8...v4.0.9
 [4.0.8]: https://github.com/rubentalstra/FerroEHR/compare/v4.0.7...v4.0.8

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -37,5 +37,5 @@ keywords:
   - ITS-REST
   - Rust
   - PostgreSQL
-version: 4.0.10
+version: 4.0.11
 date-released: 2026-08-29

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2311,7 +2311,7 @@ dependencies = [
 
 [[package]]
 name = "docs-meta"
-version = "4.0.10"
+version = "4.0.11"
 
 [[package]]
 name = "dotenvy"
@@ -2636,7 +2636,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ferroehr"
-version = "4.0.10"
+version = "4.0.11"
 dependencies = [
  "argon2",
  "assert_fs",
@@ -2710,7 +2710,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-admin-ui"
-version = "4.0.10"
+version = "4.0.11"
 dependencies = [
  "anyhow",
  "axum",
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-ext"
-version = "4.0.10"
+version = "4.0.11"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2777,7 +2777,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-rest"
-version = "4.0.10"
+version = "4.0.11"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -2837,7 +2837,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-server"
-version = "4.0.10"
+version = "4.0.11"
 dependencies = [
  "anyhow",
  "clap",
@@ -5462,7 +5462,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-codegen"
-version = "4.0.10"
+version = "4.0.11"
 dependencies = [
  "roxmltree",
  "serde_json",
@@ -8655,7 +8655,7 @@ dependencies = [
 
 [[package]]
 name = "testkit"
-version = "4.0.10"
+version = "4.0.11"
 dependencies = [
  "ferroehr",
  "jiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "3"
 members = ["crates/*", "app/*", "tools/*"]
 
 [workspace.package]
-version = "4.0.10"
+version = "4.0.11"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT"

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # A published OCI version is immutable by refusal rather than by the registry —
 # `helm push` over an existing tag replaces it silently — so a correction always
 # ships as a NEW version and the published one stands as it was.
-version: 6.0.28
+version: 6.0.29
 # The DEFAULT container image tag (overridable via image.tag). Equals the
 # workspace version in Cargo.toml, bumped in the release PR beside the
 # docker-compose.yml image tags — one version sweep, the compose treatment
@@ -38,7 +38,7 @@ version: 6.0.28
 # defaults: values track development between releases, so the publish lane
 # re-checks the pairing against an image, and the `chart-boot` CI job replays it
 # against the image built from the tree.
-appVersion: "4.0.10"
+appVersion: "4.0.11"
 
 # A COMPATIBILITY floor, and a real one: 1.36 is the release where the newest
 # field this chart renders became stable.
@@ -152,7 +152,7 @@ annotations:
   # scan while leaving the false claim in place, so it is deliberately not used.
   artifacthub.io/images: |
     - name: ferroehr
-      image: ghcr.io/rubentalstra/ferroehr:4.0.10
+      image: ghcr.io/rubentalstra/ferroehr:4.0.11
       platforms:
         - linux/amd64
         - linux/arm64
@@ -161,7 +161,7 @@ annotations:
     # visible to anyone considering it. See #2193: this chart cannot deploy it
     # yet, so today the entry advertises intent rather than chart behaviour.
     - name: ferroehr-admin-ui
-      image: ghcr.io/rubentalstra/ferroehr-admin-ui:4.0.10
+      image: ghcr.io/rubentalstra/ferroehr-admin-ui:4.0.11
       platforms:
         - linux/amd64
         - linux/arm64

--- a/deploy/helm/ferroehr/README.md
+++ b/deploy/helm/ferroehr/README.md
@@ -2,7 +2,7 @@
 
 Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.1.0 + AQL 1.1). A single static binary deployed with a hardened-by-default security posture: runs as a non-root, read-only-rootfs workload whose NetworkPolicy admits its serving port only, and that connects to an EXTERNAL PostgreSQL 18 as an unprivileged app role (migrations are run out of band by a separate migrator role).
 
-![Version: 6.0.28](https://img.shields.io/badge/Version-6.0.28-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.10](https://img.shields.io/badge/AppVersion-4.0.10-informational?style=flat-square)
+![Version: 6.0.29](https://img.shields.io/badge/Version-6.0.29-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.11](https://img.shields.io/badge/AppVersion-4.0.11-informational?style=flat-square)
 
 FerroEHR is a pure-Rust openEHR Clinical Data Repository: ITS-REST 1.1.0 at the
 API, AQL 1.1 as the query language, PostgreSQL 18-native storage, shipped as a
@@ -33,10 +33,10 @@ to add; `helm repo add` does not apply to this chart:
 
 ```console
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 6.0.28 \
+  --version 6.0.29 \
   --namespace ferroehr --create-namespace \
   --set database.existingSecret=ferroehr-db \
-  --set image.tag=4.0.10
+  --set image.tag=4.0.11
 ```
 
 OCI registries require Helm 3.8 or newer.
@@ -47,8 +47,8 @@ They are independent SemVer lines and they move independently:
 
 | What | Set with | This release |
 |---|---|---|
-| the **chart** (templates, defaults, this document) | `--version` | `6.0.28` |
-| the **server image** | `image.tag` | `4.0.10` |
+| the **chart** (templates, defaults, this document) | `--version` | `6.0.29` |
+| the **server image** | `image.tag` | `4.0.11` |
 
 `appVersion` is the image the chart defaults to; pinning `image.tag` explicitly
 is what keeps an upgrade of one from silently moving the other.
@@ -59,7 +59,7 @@ The chart carries two keyless Sigstore artifacts, and they answer different
 questions. A **cosign signature:** who signed this:
 
 ```console
-cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.28 \
+cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.29 \
   --certificate-identity-regexp '^https://github\.com/rubentalstra/FerroEHR/\.github/workflows/publish-chart\.yml@' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
@@ -67,9 +67,9 @@ cosign verify ghcr.io/rubentalstra/charts/ferroehr:6.0.28 \
 A **SLSA build provenance attestation:** what source it was built from, and how:
 
 ```console
-gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:6.0.28 \
+gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:6.0.29 \
   -R rubentalstra/FerroEHR
-gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:4.0.10 \
+gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:4.0.11 \
   -R rubentalstra/FerroEHR
 ```
 

--- a/deploy/helm/golden/admin-ui.yaml
+++ b/deploy/helm/golden/admin-ui.yaml
@@ -18,10 +18,10 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the admin console: only its HTTP port, but from EVERY source — this policy narrows ports, NOT sources (adminUi.networkPolicy.ingressAllowAll=true). Set adminUi.networkPolicy.ingressFrom for a PHI workload. Egress admits the CDR Service and DNS only.
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -90,10 +90,10 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -118,10 +118,10 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -139,10 +139,10 @@ kind: ServiceAccount
 metadata:
   name: ferroehr-admin-ui
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -154,10 +154,10 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 automountServiceAccountToken: false
@@ -184,10 +184,10 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -201,10 +201,10 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -332,10 +332,10 @@ metadata:
     kubernetes.io/description: >-
       In-cluster address for the FerroEHR admin console. The console is a REST client of the CDR and holds no data of its own; it is the human-facing surface, so this is the Service an Ingress normally publishes.
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -355,10 +355,10 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -385,10 +385,10 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR admin console: a Leptos SSR web UI that consumes the CDR strictly over ITS-REST. It never reaches the database, which the console NetworkPolicy enforces rather than assumes.
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr-admin-ui
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: admin-ui
@@ -424,7 +424,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: admin-ui
-          image: "ghcr.io/rubentalstra/ferroehr-admin-ui:4.0.10"
+          image: "ghcr.io/rubentalstra/ferroehr-admin-ui:4.0.11"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -492,10 +492,10 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -543,7 +543,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:4.0.10"
+          image: "ghcr.io/rubentalstra/ferroehr:4.0.11"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -23,10 +23,10 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), and only from the networkPolicy.ingressFrom peers.
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -97,10 +97,10 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -118,10 +118,10 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -150,10 +150,10 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -176,10 +176,10 @@ kind: Secret
 metadata:
   name: ferroehr-config
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -197,10 +197,10 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -401,10 +401,10 @@ kind: ConfigMap
 metadata:
   name: ferroehr-grafana-dashboard
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     grafana_dashboard: "1"
@@ -652,10 +652,10 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -686,10 +686,10 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -739,7 +739,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:4.0.10"
+          image: "ghcr.io/rubentalstra/ferroehr:4.0.11"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -919,10 +919,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -953,10 +953,10 @@ kind: Ingress
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -991,10 +991,10 @@ kind: ServiceMonitor
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     release: kube-prometheus-stack

--- a/deploy/helm/golden/basic-auth.yaml
+++ b/deploy/helm/golden/basic-auth.yaml
@@ -23,10 +23,10 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -51,10 +51,10 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -72,10 +72,10 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 automountServiceAccountToken: false
@@ -102,10 +102,10 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -119,10 +119,10 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -247,10 +247,10 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -277,10 +277,10 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -328,7 +328,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:4.0.10"
+          image: "ghcr.io/rubentalstra/ferroehr:4.0.11"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -23,10 +23,10 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -51,10 +51,10 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -72,10 +72,10 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 automountServiceAccountToken: false
@@ -87,10 +87,10 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -212,10 +212,10 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -242,10 +242,10 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-6.0.28
+    helm.sh/chart: ferroehr-6.0.29
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.0.10"
+    app.kubernetes.io/version: "4.0.11"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -293,7 +293,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:4.0.10"
+          image: "ghcr.io/rubentalstra/ferroehr:4.0.11"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@
 
 services:
   ferroehr-postgres:
-    image: ${FERROEHR_POSTGRES_IMAGE:-ghcr.io/rubentalstra/ferroehr-postgres:4.0.10}
+    image: ${FERROEHR_POSTGRES_IMAGE:-ghcr.io/rubentalstra/ferroehr-postgres:4.0.11}
     # Docker's default 64MB /dev/shm starves PostgreSQL's dynamic shared
     # memory under load (parallel workers error `could not resize shared
     # memory segment … No space left on device`); measured runs share this
@@ -177,7 +177,7 @@ services:
       start_period: 10s
 
   ferroehr:
-    image: ${FERROEHR_IMAGE:-ghcr.io/rubentalstra/ferroehr:4.0.10}
+    image: ${FERROEHR_IMAGE:-ghcr.io/rubentalstra/ferroehr:4.0.11}
     depends_on:
       ferroehr-postgres:
         condition: service_healthy
@@ -288,7 +288,7 @@ services:
   # FERROEHR_ADMIN__AUTH__OIDC__* variables at your identity provider.
   ferroehr-admin-ui:
     profiles: [admin-ui]
-    image: ${FERROEHR_ADMIN_UI_IMAGE:-ghcr.io/rubentalstra/ferroehr-admin-ui:4.0.10}
+    image: ${FERROEHR_ADMIN_UI_IMAGE:-ghcr.io/rubentalstra/ferroehr-admin-ui:4.0.11}
     depends_on:
       ferroehr:
         condition: service_healthy

--- a/docs/conformance/ferroehr/CONFORMANCE_STATEMENT.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_STATEMENT.md
@@ -1,6 +1,6 @@
 # Conformance Statement (SDoC)
 
-Product: FerroEHR 4.0.10 — Ruben Talstra (urn:rubentalstra:ferroehr)
+Product: FerroEHR 4.0.11 — Ruben Talstra (urn:rubentalstra:ferroehr)
 Schedule release: cnf-2.0-w2
 
 ## Declared spec versions

--- a/docs/conformance/party/ferroehr/statement.json
+++ b/docs/conformance/party/ferroehr/statement.json
@@ -1,7 +1,7 @@
 {
   "product": {
     "name": "FerroEHR",
-    "version": "4.0.10",
+    "version": "4.0.11",
     "vendor": "Ruben Talstra",
     "identifier": "urn:rubentalstra:ferroehr"
   },

--- a/website/book/src/conformance-assets/conformance-chapter-bars.svg
+++ b/website/book/src/conformance-assets/conformance-chapter-bars.svg
@@ -71,7 +71,7 @@ text { fill: #c3c2b7; }
 <line x1="3" y1="0" x2="3" y2="6" class="na-line"/>
 </pattern>
 </defs>
-<text x="24" y="28" class="title">Schedule outcomes by chapter — ferroehr 4.0.9</text>
+<text x="24" y="28" class="title">Schedule outcomes by chapter — ferroehr 4.0.10</text>
 <rect x="24" y="38" width="14" height="14" rx="3" class="bar-passed"/><text x="31" y="49" class="seg-label" text-anchor="middle">✓</text><text x="44" y="49" class="muted">passed</text><rect x="103.2" y="38" width="14" height="14" rx="3" class="bar-failed"/><text x="110.2" y="49" class="seg-label" text-anchor="middle">✕</text><text x="123.2" y="49" class="muted">FAILED</text><rect x="182.4" y="38" width="14" height="14" rx="3" class="bar-errored"/><text x="189.4" y="49" class="seg-label-dim" text-anchor="middle">?</text><text x="202.4" y="49" class="muted">errored</text><rect x="268.8" y="38" width="14" height="14" rx="3" fill="url(#na-hatch)"/><text x="275.8" y="49" class="seg-label-dim" text-anchor="middle">○</text><text x="288.8" y="49" class="muted">cited N/A (not executed)</text><text x="884" y="49" class="muted" text-anchor="end">this chart's scale: 142 cases = full bar</text>
 <rect x="24" y="66" width="860" height="20" rx="4" class="chap-row"/><text x="34" y="80.5" class="chap-name">EHR</text><text x="700" y="80.5" class="muted" text-anchor="end">492 cases</text>
 <text x="752" y="80.5" class="count count-passed count-strong" text-anchor="end">✓ 474</text><text x="878" y="80.5" class="count count-na count-strong" text-anchor="end">○ 18</text>

--- a/website/book/src/conformance-assets/conformance-heat-grid.svg
+++ b/website/book/src/conformance-assets/conformance-heat-grid.svg
@@ -41,7 +41,7 @@ text { fill: #c3c2b7; }
 }
 </style>
 
-<text x="24" y="28" class="title">Capability conformance — ferroehr 4.0.9</text>
+<text x="24" y="28" class="title">Capability conformance — ferroehr 4.0.10</text>
 <rect x="24" y="38" width="14" height="14" rx="3" class="ev-passed"/><text x="31" y="49" class="cell-label" text-anchor="middle" font-size="10">✓</text><text x="42" y="49" class="muted">passed</text><rect x="103.2" y="38" width="14" height="14" rx="3" class="ev-failed"/><text x="110.2" y="49" class="cell-label" text-anchor="middle" font-size="10">✕</text><text x="121.2" y="49" class="muted">FAILED</text><rect x="182.4" y="38" width="14" height="14" rx="3" class="ev-inconclusive"/><text x="189.4" y="49" class="cell-label-dim" text-anchor="middle" font-size="10">?</text><text x="200.4" y="49" class="muted">INCONCLUSIVE</text><rect x="304.8" y="38" width="14" height="14" rx="3" class="ev-not-evidenced"/><text x="311.8" y="49" class="cell-label-dim" text-anchor="middle" font-size="10">○</text><text x="322.8" y="49" class="muted">not evidenced</text><rect x="434.4" y="38" width="14" height="14" rx="3" class="ev-not-claimed"/><text x="441.4" y="49" class="cell-label-dim" text-anchor="middle" font-size="10">–</text><text x="452.4" y="49" class="muted">not claimed</text><text x="998" y="49" class="muted" text-anchor="end">solid border = required in tier · dashed = optional</text>
 <text x="24" y="82" class="title" font-size="12">CORE</text>
 <rect x="24" y="90" width="190" height="26" rx="5" class="ev-passed cell-optional"/><text x="37" y="107" class="cell-label" text-anchor="middle">✓</text><text x="50" y="107" class="cell-label sm">Adl14ArchetypeProvisioning</text>

--- a/website/book/src/installation/kubernetes.md
+++ b/website/book/src/installation/kubernetes.md
@@ -38,9 +38,9 @@ kubectl -n ferroehr create secret generic ferroehr-db \
   --from-literal=FERROEHR__DB__URL='postgres://ferroehr_app:***@pg-host:5432/ferroehr?sslmode=verify-full'
 
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 6.0.28 -n ferroehr \
+  --version 6.0.29 -n ferroehr \
   --set database.existingSecret=ferroehr-db \
-  --set image.tag=4.0.10
+  --set image.tag=4.0.11
 ```
 
 > [!IMPORTANT]
@@ -55,7 +55,7 @@ helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
 reference. To read the chart's metadata without installing it:
 
 ```shell
-helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.28
+helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.29
 ```
 
 ### Pin two versions, not one
@@ -68,8 +68,8 @@ against.
 
 | | Selects | Pin with | Line |
 |---|---|---|---|
-| Chart version | templates, values schema, defaults | `--version 6.0.28` | SemVer over the chart's own contract |
-| Image tag | the server binary | `--set image.tag=4.0.10` (or `image.digest`) | the application's SemVer line |
+| Chart version | templates, values schema, defaults | `--version 6.0.29` | SemVer over the chart's own contract |
+| Image tag | the server binary | `--set image.tag=4.0.11` (or `image.digest`) | the application's SemVer line |
 
 Always pin the image to an immutable version or, better, a `@sha256` digest,
 never `latest`. Pin the two deliberately: the `config` tree is passed through to
@@ -167,7 +167,7 @@ metadata lists: the server, and the optional admin console.
 > the image itself as the authority:
 >
 > ```shell
-> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.28 \
+> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.29 \
 >   -s templates/configmap.yaml --set database.existingSecret=ferroehr-db \
 >   | sed -n '/ferroehr.toml/,$p' | sed '1d;s/^    //' > /tmp/ferroehr.toml
 > docker run --rm -v /tmp/ferroehr.toml:/etc/ferroehr/ferroehr.toml:ro \
@@ -556,7 +556,7 @@ config:
 
 ```shell
 helm upgrade ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 6.0.28 -n ferroehr --reuse-values \
+  --version 6.0.29 -n ferroehr --reuse-values \
   --set config.query.plan_cache_capacity=512
 ```
 
@@ -709,7 +709,7 @@ Preview an upgrade against what you have installed with
 `helm diff`, or render the new chart version and read it:
 
 ```shell
-helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.28 \
+helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 6.0.29 \
   -n ferroehr -f my-values.yaml | less
 ```
 
@@ -734,7 +734,7 @@ The check that closes that gap runs the image against your rendered
 configuration:
 
 ```shell
-FERROEHR_IMAGE=ghcr.io/rubentalstra/ferroehr:4.0.10 \
+FERROEHR_IMAGE=ghcr.io/rubentalstra/ferroehr:4.0.11 \
   deploy/helm/ci/boot-check.sh my-values.yaml
 ```
 

--- a/website/book/src/verifying-releases.md
+++ b/website/book/src/verifying-releases.md
@@ -17,7 +17,7 @@ signer identity is one you can pin to a single hardened workflow.
 ## What a release publishes
 
 Substitute the release tag you downloaded for `<tag>` (for example
-`v4.0.10`) and the architecture for `<arch>` (`x86_64` or `aarch64`) throughout
+`v4.0.11`) and the architecture for `<arch>` (`x86_64` or `aarch64`) throughout
 this page. Linux is the only published target.
 
 | Asset | What it is |
@@ -175,7 +175,7 @@ carry a Sigstore-signed SLSA provenance attestation, plus the SPDX SBOM and
 provenance the builder writes onto the image index itself.
 
 ```bash
-gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:4.0.10 \
+gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:4.0.11 \
   -R rubentalstra/FerroEHR
 ```
 
@@ -199,7 +199,7 @@ tag once and verify the digest it resolved — otherwise the bytes verified and
 the bytes pulled can differ:
 
 ```bash
-digest=$(docker buildx imagetools inspect ghcr.io/rubentalstra/ferroehr:4.0.10 \
+digest=$(docker buildx imagetools inspect ghcr.io/rubentalstra/ferroehr:4.0.11 \
   | awk '/^Digest:/{print $2}')
 gh attestation verify "oci://ghcr.io/rubentalstra/ferroehr@${digest}" \
   -R rubentalstra/FerroEHR


### PR DESCRIPTION
The v4.0.11 cut: changelog section, workspace 4.0.11 (+ lock), CITATION.cff + regenerated .zenodo.json, the party statement + regenerated conformance documents and capability SVGs (the 4.0.10 restamp the Docs drift gates caught), compose fallback tags, chart 6.0.29 / appVersion 4.0.11 with regenerated goldens + README, and the book's chart/image/release-tag pins. Gates run locally: chart-appversion, compose tags, statement-version, docs-claims, helm goldens.

Milestone v4.0.11 closed at zero open issues; the acceptance baseline is the zero-drift run on the released veredictum 0.1.0 committed in #2938.