### PR TITLE
feat(sandbox): the public sandbox leads with the admin console — two Vercel services

### DIFF
--- a/.github/workflows/sandbox-deploy.yml
+++ b/.github/workflows/sandbox-deploy.yml
@@ -66,6 +66,7 @@ on:
     branches: [main]
     paths:
       - Dockerfile.vercel
+      - Dockerfile.admin-ui.vercel
       - vercel.json
       - deploy/vercel/**
   workflow_dispatch:
@@ -94,32 +95,34 @@ jobs:
     permissions: {}
     steps:
       # The needs-edge's guarantee, re-asserted at the point of use (#2846): a
-      # release call means `:latest` must ALREADY be the tag's image, because
-      # the Vercel build is `FROM …:latest`. A stale tag fails here, before
-      # any ping — never as a 20-minute blind poll. Anonymous registry reads:
-      # the images are public.
-      - name: The :latest tag is the release image
+      # release call means `:latest` must ALREADY be the tag's image for BOTH
+      # sandbox services (the CDR and the console, #2941), because both Vercel
+      # builds are `FROM …:latest`. A stale tag fails here, before any ping —
+      # never as a 20-minute blind poll. Anonymous registry reads: the images
+      # are public.
+      - name: The :latest tags are the release images
         if: inputs.expected-version != ''
         env:
           EXPECTED: ${{ inputs.expected-version }}
-          IMAGE: ghcr.io/rubentalstra/ferroehr
         run: |
           set -euo pipefail
-          tok=$(curl -fsS "https://ghcr.io/token?scope=repository:${IMAGE#ghcr.io/}:pull" | sed -nE 's/.*"token":"([^"]+)".*/\1/p')
-          digest_of() {
-            curl -fsS -o /dev/null -w '%{header_json}' \
-              -H "Authorization: Bearer ${tok}" \
-              -H "Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json" \
-              "https://ghcr.io/v2/${IMAGE#ghcr.io/}/manifests/$1" \
-              | sed -nE 's/.*"docker-content-digest":\["([^"]+)"\].*/\1/p'
-          }
-          latest=$(digest_of latest)
-          tagged=$(digest_of "$EXPECTED")
-          if [ -z "$latest" ] || [ -z "$tagged" ] || [ "$latest" != "$tagged" ]; then
-            echo "::error:::latest (${latest:-unreadable}) is not the ${EXPECTED} image (${tagged:-unreadable}) — the deploy would rebuild the OLD release; the tag-apply leg must land first." >&2
-            exit 1
-          fi
-          echo ":latest == ${EXPECTED} (${latest})"
+          for image in ghcr.io/rubentalstra/ferroehr ghcr.io/rubentalstra/ferroehr-admin-ui; do
+            tok=$(curl -fsS "https://ghcr.io/token?scope=repository:${image#ghcr.io/}:pull" | sed -nE 's/.*"token":"([^"]+)".*/\1/p')
+            digest_of() {
+              curl -fsS -o /dev/null -w '%{header_json}' \
+                -H "Authorization: Bearer ${tok}" \
+                -H "Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json" \
+                "https://ghcr.io/v2/${image#ghcr.io/}/manifests/$1" \
+                | sed -nE 's/.*"docker-content-digest":\["([^"]+)"\].*/\1/p'
+            }
+            latest=$(digest_of latest)
+            tagged=$(digest_of "$EXPECTED")
+            if [ -z "$latest" ] || [ -z "$tagged" ] || [ "$latest" != "$tagged" ]; then
+              echo "::error::${image}:latest (${latest:-unreadable}) is not the ${EXPECTED} image (${tagged:-unreadable}) — the deploy would rebuild the OLD release; the tag-apply leg must land first." >&2
+              exit 1
+            fi
+            echo "${image}:latest == ${EXPECTED} (${latest})"
+          done
 
       # The hook response is CAPTURED, not discarded (#2846): it carries the
       # created job's id — the only handle linking this run to the deployment
@@ -202,6 +205,30 @@ jobs:
               exit 1
             fi
             echo "sandbox serves '${served:-nothing}'; waiting for '${expected:-any}'"
+            sleep 20
+          done
+
+      # The console is the second service of the same deployment (#2941), and
+      # Vercel promotes a deployment atomically — so once the version poll
+      # above proves the new deployment serves, a 200 from the console's
+      # public sign-in path proves the console CONTAINER boots (a posture
+      # defect — a config key the release image refuses — would leave it
+      # failing while the API answers happily beside it).
+      - name: The console serves its sign-in screen
+        run: |
+          set -euo pipefail
+          deadline=$(( $(date +%s) + 600 ))
+          while :; do
+            code=$(curl -sS -m 30 -o /dev/null -w '%{http_code}' https://sandbox.ferroehr.eu/login || true)
+            if [ "$code" = "200" ]; then
+              echo "console serves /login (200)"
+              break
+            fi
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "::error::the console answers '${code:-nothing}' on /login 10 minutes after the API came up — the deployment promoted, so the suspect is the console container itself: its config posture (deploy/vercel/ferroehr-admin-ui.sandbox.toml) against the released image, or the service routing in vercel.json." >&2
+              exit 1
+            fi
+            echo "console answers '${code:-nothing}' on /login; waiting for 200"
             sleep 20
           done
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,25 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Added
+
+- The admin console's sign-in card takes a deployment-configured notice and
+  links: `login.notice` (informational text, line breaks preserved — a demo
+  states its public credentials and usage expectations there) and
+  `login.links` (label + href pairs, e.g. an API reference). Both default
+  empty and render nothing when unset.
+
+### Changed
+
+- The hosted sandbox (sandbox.ferroehr.eu) leads with the admin console: the
+  deployment now runs both published container images, the console is the
+  landing surface (a visitor gets its sign-in screen, demo credentials
+  `ferroehr` / `ferroehr`), and the CDR keeps its path families —
+  `/ferroehr/*` (including the Swagger UI, which stays the API reference),
+  `/health*`, and `/management*`. The console drives the sandbox CDR over
+  the public REST base as the same demo user; the CDR's admin and
+  management surfaces stay off.
+
 ## [4.0.11] - 2026-08-29
 
 ### Added

--- a/Dockerfile.admin-ui.vercel
+++ b/Dockerfile.admin-ui.vercel
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+#
+# The Vercel container build for the sandbox's admin console (#2941) — the
+# `console` service in vercel.json, deployed beside the CDR service
+# (Dockerfile.vercel) and the sandbox's landing surface: every path outside
+# the CDR's own families (/ferroehr, /health, /management) routes here.
+#
+# Same doctrine as Dockerfile.vercel: FROM the PUBLISHED release image, so
+# the sandbox runs the exact release bytes and Vercel's build is a pull +
+# retag. `:latest` is the release pointer the image lane moves on release
+# tags only; the only deploy trigger is sandbox-deploy.yml, which fires after
+# that lane succeeds, so this reference always resolves.
+#
+# The console is a stateless ITS-REST client of the CDR — no database, no
+# Neon integration, no injected DSN. It reaches the sandbox CDR over the
+# public REST base (deploy/vercel/ferroehr-admin-ui.sandbox.toml).
+
+FROM ghcr.io/rubentalstra/ferroehr-admin-ui:latest
+
+# The base image already runs as uid 65532 (distroless nonroot); stated
+# explicitly so the posture is a property of THIS file too (trivy DS-0002).
+USER 65532:65532
+
+# The sandbox posture: the public CDR base URL and the TLS-edge cookie flag.
+COPY deploy/vercel/ferroehr-admin-ui.sandbox.toml /etc/ferroehr/admin-ui.toml
+ENV FERROEHR_ADMIN_CONFIG=/etc/ferroehr/admin-ui.toml
+# Vercel routes to the port the image declares; the console serves on 3000
+# (the base image's LEPTOS_SITE_ADDR).
+ENV PORT=3000

--- a/app/ferroehr-admin-ui/src/auth.rs
+++ b/app/ferroehr-admin-ui/src/auth.rs
@@ -11,6 +11,33 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::AdminUiError;
 
+/// One deployment-configured link rendered under the sign-in card.
+///
+/// Doubles as the `[login.links]` configuration entry (ssr side), so the wire
+/// and the configuration cannot drift; both fields are required there.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LoginLink {
+    /// Visible link text.
+    pub label: String,
+    /// Absolute or same-origin URL the link opens.
+    pub href: String,
+}
+
+/// What the login screen offers and says: the available modes plus the
+/// deployment-configured notice and links.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LoginScreen {
+    /// Offer the Basic (username/password) form.
+    pub basic: bool,
+    /// Offer the OIDC login button.
+    pub oidc: bool,
+    /// Informational text on the sign-in card (empty = none).
+    pub notice: String,
+    /// Links rendered under the sign-in card.
+    pub links: Vec<LoginLink>,
+}
+
 /// What the UI may know about the current session (never the credential).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SessionInfo {
@@ -120,12 +147,13 @@ pub async fn current_session() -> Result<Option<SessionInfo>, AdminUiError> {
     }))
 }
 
-/// Which login modes the login screen should offer.
+/// Which login modes the login screen should offer, plus the configured
+/// notice and links it renders.
 ///
 /// # Errors
 /// None in practice; the signature is fallible per the server-fn contract.
 #[server]
-pub async fn login_modes() -> Result<(bool, bool), AdminUiError> {
+pub async fn fetch_login_screen() -> Result<LoginScreen, AdminUiError> {
     let state: crate::state::AppState = leptos::prelude::expect_context();
     // The console offers only what BOTH sides support: its own configured
     // modes intersected with the schemes the CDR advertises in its
@@ -134,10 +162,12 @@ pub async fn login_modes() -> Result<(bool, bool), AdminUiError> {
     // config alone so the login page still renders — the login attempt
     // itself then surfaces the outage.
     let (cdr_basic, cdr_bearer) = state.cdr.advertised_schemes().await.unwrap_or((true, true));
-    Ok((
-        state.config.auth.basic_enabled && cdr_basic,
-        state.config.auth.oidc.enabled && cdr_bearer,
-    ))
+    Ok(LoginScreen {
+        basic: state.config.auth.basic_enabled && cdr_basic,
+        oidc: state.config.auth.oidc.enabled && cdr_bearer,
+        notice: state.config.login.notice.clone(),
+        links: state.config.login.links.clone(),
+    })
 }
 
 /// The CDR `/ferroehr/rest/status` document (public endpoint), raw JSON — the

--- a/app/ferroehr-admin-ui/src/config.rs
+++ b/app/ferroehr-admin-ui/src/config.rs
@@ -20,6 +20,8 @@ pub struct AdminUiConfig {
     pub cdr: CdrConfig,
     /// Console login modes.
     pub auth: AuthConfig,
+    /// Login-screen presentation.
+    pub login: LoginConfig,
     /// Session behaviour.
     pub session: SessionConfig,
 }
@@ -70,6 +72,19 @@ impl CdrConfig {
             configured.to_owned()
         }
     }
+}
+
+/// Login-screen presentation: what the sign-in card says beyond the forms.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct LoginConfig {
+    /// Informational text rendered on the sign-in card (empty = none); line
+    /// breaks are preserved. A demo deployment states its public credentials
+    /// and usage expectations here.
+    pub notice: String,
+    /// Links rendered under the sign-in card — an API reference, a
+    /// documentation page. Each entry needs both `label` and `href`.
+    pub links: Vec<crate::auth::LoginLink>,
 }
 
 /// Which login modes the console offers (design: both ship in v1).
@@ -225,7 +240,7 @@ pub fn load() -> Result<AdminUiConfig, ConfigError> {
 
 #[cfg(test)]
 mod tests {
-    use super::CdrConfig;
+    use super::{AdminUiConfig, CdrConfig};
 
     #[test]
     fn management_base_defaults_to_the_cdr_origin() {
@@ -243,6 +258,39 @@ mod tests {
             ..CdrConfig::default()
         };
         assert_eq!(cfg.management_base(), "http://cdr.internal:9464/ops");
+    }
+
+    #[test]
+    fn the_login_section_parses_and_defaults_to_empty() {
+        let parsed: AdminUiConfig = config::Config::builder()
+            .add_source(config::File::from_str(
+                "[login]\nnotice = \"demo\"\n\n[[login.links]]\nlabel = \"API reference\"\nhref = \"https://example.org/swagger\"\n",
+                config::FileFormat::Toml,
+            ))
+            .build()
+            .unwrap()
+            .try_deserialize()
+            .unwrap();
+        assert_eq!(parsed.login.notice, "demo");
+        assert_eq!(parsed.login.links.len(), 1);
+        assert_eq!(parsed.login.links[0].label, "API reference");
+        assert_eq!(parsed.login.links[0].href, "https://example.org/swagger");
+
+        let defaults = AdminUiConfig::default();
+        assert!(defaults.login.notice.is_empty());
+        assert!(defaults.login.links.is_empty());
+    }
+
+    #[test]
+    fn a_login_link_without_an_href_is_refused() {
+        let assembled = config::Config::builder()
+            .add_source(config::File::from_str(
+                "[[login.links]]\nlabel = \"dangling\"\n",
+                config::FileFormat::Toml,
+            ))
+            .build()
+            .unwrap();
+        assert!(assembled.try_deserialize::<AdminUiConfig>().is_err());
     }
 
     #[test]

--- a/app/ferroehr-admin-ui/src/pages/login.rs
+++ b/app/ferroehr-admin-ui/src/pages/login.rs
@@ -8,13 +8,14 @@
 //! (progressive enhancement — the inputs are named exactly `username`,
 //! `password`, `next`, matching the server-fn arguments). The OIDC path is a
 //! plain `<a>` to the BFF's `/auth/oidc/login` axum route, styled as the
-//! secondary design-system button. Which paths appear is decided by
-//! [`crate::auth::login_modes`]. The post-login destination is carried through
-//! the `next` query parameter.
+//! secondary design-system button. Which paths appear — and the
+//! deployment-configured notice and links around them — is decided by
+//! [`crate::auth::fetch_login_screen`]. The post-login destination is carried
+//! through the `next` query parameter.
 
 use leptos::prelude::*;
 
-use crate::auth::{LoginBasic, login_modes};
+use crate::auth::{LoginBasic, fetch_login_screen};
 use crate::components::brand::Wordmark;
 use crate::components::field::{BTN_PRIMARY, BTN_SECONDARY, INPUT, LABEL};
 use crate::components::surface::CARD_PAD;
@@ -36,7 +37,7 @@ use crate::components::surface::CARD_PAD;
 #[component]
 pub fn LoginPage() -> impl IntoView {
     let action = ServerAction::<LoginBasic>::new();
-    let modes = Resource::new(|| (), |()| login_modes());
+    let screen = Resource::new(|| (), |()| fetch_login_screen());
     let pending = action.pending();
     let value = action.value();
 
@@ -75,9 +76,48 @@ pub fn LoginPage() -> impl IntoView {
         }>
             {move || {
                 Suspend::new(async move {
-                    let (basic, oidc, mode_error) = match modes.await {
-                        Ok((basic, oidc)) => (basic, oidc, None),
-                        Err(e) => (true, true, Some(e.to_string())),
+                    let (basic, oidc, notice, links, mode_error) = match screen.await {
+                        Ok(s) => (s.basic, s.oidc, s.notice, s.links, None),
+                        Err(e) => (true, true, String::new(), Vec::new(), Some(e.to_string())),
+                    };
+                    let notice_note = if notice.is_empty() {
+                        ().into_any()
+                    } else {
+                        // whitespace-pre-line: a configured notice states its
+                        // lines (credentials, expectations) deliberately.
+                        view! {
+                            <div class="rounded-control border border-accent/40 bg-accent-subtle px-3 py-2 text-xs text-accent-ink whitespace-pre-line">
+                                {notice}
+                            </div>
+                        }
+                            .into_any()
+                    };
+                    let link_row = if links.is_empty() {
+                        ().into_any()
+                    } else {
+                        view! {
+                            <div class="flex flex-wrap justify-center gap-x-4 gap-y-1 text-xs">
+                                {links
+                                    .into_iter()
+                                    .map(|link| {
+                                        // rel=external: these point at non-app
+                                        // URLs (an API reference, docs); the
+                                        // client router must not intercept a
+                                        // same-origin one.
+                                        view! {
+                                            <a
+                                                href=link.href
+                                                rel="external noopener"
+                                                class="text-accent underline underline-offset-2 hover:text-accent-hover"
+                                            >
+                                                {link.label}
+                                            </a>
+                                        }
+                                    })
+                                    .collect::<Vec<_>>()}
+                            </div>
+                        }
+                            .into_any()
                     };
                     let mode_warning = match mode_error {
                         Some(e) => {
@@ -155,7 +195,8 @@ pub fn LoginPage() -> impl IntoView {
                     };
                     view! {
                         <div class="flex flex-col gap-4">
-                            {mode_warning} {basic_form} {separator} {oidc_button} {none_available}
+                            {notice_note} {mode_warning} {basic_form} {separator} {oidc_button}
+                            {none_available} {link_row}
                         </div>
                     }
                         .into_any()

--- a/deploy/vercel/README.md
+++ b/deploy/vercel/README.md
@@ -1,8 +1,25 @@
 # The hosted sandbox — how it deploys (sandbox.ferroehr.eu)
 
 The sandbox is Vercel (container runtime) + Neon (PostgreSQL 18). It runs
-the latest published release image with a demo posture baked on top, and it
-resets to known demo data every night.
+TWO container services from the latest published release images, each with a
+demo posture baked on top, and it resets to known demo data every night:
+
+- **`api`** — the CDR (`Dockerfile.vercel`, `FROM ghcr.io/rubentalstra/ferroehr:latest`).
+  Owns the path families the server itself serves: `/ferroehr/*` (the REST
+  API and its Swagger UI), `/health*`, and `/management*` (disabled in the
+  sandbox posture, so those answer the CDR's own 404 — which is what lets
+  the console's probe-and-hide read the truth).
+- **`console`** — the admin console (`Dockerfile.admin-ui.vercel`,
+  `FROM ghcr.io/rubentalstra/ferroehr-admin-ui:latest`), the LANDING surface
+  (#2941): every other path routes here, so sandbox.ferroehr.eu opens on the
+  console's sign-in screen. It drives the CDR strictly over the public REST
+  base (`https://sandbox.ferroehr.eu`) as the same demo user the API takes,
+  and it holds no state of its own (in-process sessions only — a serverless
+  scale-in signs visitors out, which the demo accepts).
+
+Routing lives in `vercel.json` `rewrites` (evaluated in order, first match
+wins — the Vercel Services model); Swagger stays reachable at
+`/ferroehr/rest/swagger-ui` as the API reference.
 
 The Neon↔Vercel integration is LOAD-BEARING for exactly one thing: its
 injected `DATABASE_URL`/`DATABASE_URL_UNPOOLED` is the server's DSN (the
@@ -23,16 +40,19 @@ Vercel never builds on its own: git-triggered deployments are OFF
 ignore script exists. Every deploy is a POST to the project's Deploy Hook,
 and the only place that POST happens is `.github/workflows/sandbox-deploy.yml`:
 
-1. **A release publishes.** The Containers pipeline builds and pushes
-   `ghcr.io/rubentalstra/ferroehr:X.Y.Z` and moves `:latest` (release tags
-   only, never prereleases). When that pipeline SUCCEEDS for a release tag,
-   `sandbox-deploy.yml` runs (called by the release pipeline after the scanned tags apply), pings the hook, and Vercel
-   builds `Dockerfile.vercel` — `FROM ghcr.io/rubentalstra/ferroehr:latest`,
-   a pull + retag measured in seconds. The image provably exists before the
-   ping, so no ordering race exists to guard against.
+1. **A release publishes.** The Containers pipeline builds and pushes the
+   `ghcr.io/rubentalstra/ferroehr:X.Y.Z` and `…/ferroehr-admin-ui:X.Y.Z`
+   images and moves both `:latest` pointers (release tags only, never
+   prereleases). When that pipeline SUCCEEDS for a release tag,
+   `sandbox-deploy.yml` runs (called by the release pipeline after the
+   scanned tags apply), pings the hook, and Vercel builds both Dockerfiles —
+   each `FROM …:latest`, a pull + retag measured in seconds. The images
+   provably exist before the ping, so no ordering race exists to guard
+   against.
 2. **A posture change lands on main** (`Dockerfile.vercel`,
-   `vercel.json`, `deploy/vercel/**`): the same workflow fires on the push
-   and redeploys the current release image with the new posture.
+   `Dockerfile.admin-ui.vercel`, `vercel.json`, `deploy/vercel/**`): the
+   same workflow fires on the push and redeploys the current release images
+   with the new posture.
 3. **Manual**: `workflow_dispatch` on Sandbox deploy (reseed skippable).
 
 After the deploy, the workflow polls `/ferroehr/rest/status` until the new
@@ -48,13 +68,14 @@ Sandbox failures live in the two sandbox-named workflows (Sandbox deploy,
 Sandbox reseed) and nowhere else. CI, Containers, the chart and release
 lanes carry no sandbox steps, so a sandbox outage can never redden them.
 
-The deploy job verifies in two layers (#2846, after the v4.0.7 cut spent
-20 blind minutes on a Vercel-side build failure):
+The deploy job verifies in three layers (#2846, after the v4.0.7 cut spent
+20 blind minutes on a Vercel-side build failure; the console layer joined
+with #2941):
 
-1. **Precondition** (release calls): `:latest`'s digest must equal the
-   release tag's image digest on GHCR before any ping — the needs-edge's
-   guarantee, re-asserted where it is consumed, with anonymous registry
-   reads.
+1. **Precondition** (release calls): both images' `:latest` digests must
+   equal the release tag's image digests on GHCR before any ping — the
+   needs-edge's guarantee, re-asserted where it is consumed, with anonymous
+   registry reads.
 2. **The served-version poll** is the acceptance, and it is version-bound on
    EVERY path: a release run waits for the tag's version, and a push or
    dispatch run derives its expectation from the `:latest` image's own
@@ -67,6 +88,10 @@ The deploy job verifies in two layers (#2846, after the v4.0.7 cut spent
    already proven (the image side) so the remaining suspect (Vercel's own
    build/promotion — historically a flaky Neon integration step, #2846) is
    named, not guessed.
+3. **The console poll**: once the version poll proves the new deployment
+   serves (promotion is atomic across services), a 200 from `/login` proves
+   the console container boots — a posture defect (a config key the release
+   image refuses) would leave it failing while the API answers beside it.
 
 Watching the triggered deployment's own state was considered and REFUSED
 (#2846): Vercel offers no read-only tokens, so it would cost a stored
@@ -75,7 +100,8 @@ repository's no-long-lived-tokens posture.
 
 ## Two build-log warnings that are understood, not unnoticed (#2773)
 
-Every Vercel build of `Dockerfile.vercel` prints two warnings. Both were
+Every Vercel build of the sandbox Dockerfiles (both services) prints two
+warnings. Both were
 adjudicated first-hand against Vercel's own documentation (read 2026-08-27)
 and neither has a configuration that removes it, so they will keep printing —
 this section is what makes them read as understood.
@@ -116,9 +142,11 @@ this section is what makes them read as understood.
 
 | File | Role |
 |---|---|
-| `vercel.json` | routing, container service, git auto-deploys OFF |
-| `Dockerfile.vercel` | `FROM …:latest` + the baked sandbox posture |
-| `deploy/vercel/ferroehr.sandbox.toml` | the demo configuration |
+| `vercel.json` | routing (console = landing, `/ferroehr`+`/health`+`/management` = the CDR), both container services, git auto-deploys OFF |
+| `Dockerfile.vercel` | the CDR: `FROM ferroehr:latest` + the baked sandbox posture |
+| `Dockerfile.admin-ui.vercel` | the console: `FROM ferroehr-admin-ui:latest` + its posture |
+| `deploy/vercel/ferroehr.sandbox.toml` | the CDR's demo configuration |
+| `deploy/vercel/ferroehr-admin-ui.sandbox.toml` | the console's demo configuration |
 | `.github/workflows/sandbox-deploy.yml` | the ONLY deploy trigger + verify + reseed call |
 | `.github/workflows/sandbox-reseed.yml` | nightly janitor + the reusable wipe/seed |
 | `scripts/sandbox/reseed.sh` | seeds demo data through the public API |

--- a/deploy/vercel/ferroehr-admin-ui.sandbox.toml
+++ b/deploy/vercel/ferroehr-admin-ui.sandbox.toml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+#
+# The hosted-sandbox posture for the admin console (#2941,
+# sandbox.ferroehr.eu), baked into the Vercel image by
+# Dockerfile.admin-ui.vercel. The console is the sandbox's landing surface;
+# it drives the sandbox CDR strictly over the public REST base, so what it
+# shows is exactly what the public API serves. It signs in as the same demo
+# user the API takes (ferroehr / ferroehr, USER role): the CDR's admin and
+# management surfaces stay OFF, and the console's probe-and-hide keeps their
+# screens out of the navigation.
+
+[cdr]
+# The public REST base — the console's BFF calls the same origin a visitor's
+# own tooling calls, never a private channel.
+base_url = "https://sandbox.ferroehr.eu"
+
+[session]
+# TLS terminates at the Vercel edge.
+cookie_secure = true
+
+# The sign-in card states what a visitor needs (#2941): the demo credentials
+# and the free-tier expectations, with the API reference linked underneath.
+# The [login] key ships in the console image from v4.0.12 on — an older
+# :latest refuses it at boot, which the deploy workflow's console poll
+# catches.
+[login]
+notice = """
+Public demo sandbox. Sign in with ferroehr / ferroehr.
+Demo data only, wiped nightly. It runs on best-effort free compute: heavy use (a conformance run, concurrent load) will slow it down, and that is expected."""
+
+[[login.links]]
+label = "API reference (Swagger UI)"
+href = "https://sandbox.ferroehr.eu/ferroehr/rest/swagger-ui"
+
+[[login.links]]
+label = "Documentation"
+href = "https://ferroehr.eu/docs/latest/"

--- a/scripts/checks/compose-image-tags.sh
+++ b/scripts/checks/compose-image-tags.sh
@@ -16,6 +16,7 @@ set -Eeuo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
 VERCEL_FILE="$ROOT_DIR/Dockerfile.vercel"
+VERCEL_UI_FILE="$ROOT_DIR/Dockerfile.admin-ui.vercel"
 MANIFEST="$ROOT_DIR/Cargo.toml"
 
 version="$(sed -nE 's/^version = "(.*)"$/\1/p' "$MANIFEST" | head -1)"
@@ -53,6 +54,15 @@ if [[ "$vercel_ref" != "ghcr.io/rubentalstra/ferroehr:latest" ]]; then
   rc=1
 else
   echo "Dockerfile.vercel tracks the :latest release pointer."
+fi
+
+# The console service (#2941) is held to the same pointer discipline.
+vercel_ui_ref="$(grep -oE '^FROM ghcr\.io/[^ ]+' "$VERCEL_UI_FILE" | head -1 | sed 's/^FROM //')"
+if [[ "$vercel_ui_ref" != "ghcr.io/rubentalstra/ferroehr-admin-ui:latest" ]]; then
+  echo "::error::Dockerfile.admin-ui.vercel must be FROM ghcr.io/rubentalstra/ferroehr-admin-ui:latest (the release pointer, #2941); found '$vercel_ui_ref'." >&2
+  rc=1
+else
+  echo "Dockerfile.admin-ui.vercel tracks the :latest release pointer."
 fi
 
 exit "$rc"

--- a/vercel.json
+++ b/vercel.json
@@ -15,13 +15,22 @@
             "root": ".",
             "entrypoint": "Dockerfile.vercel",
             "runtime": "container"
+        },
+        "console": {
+            "root": ".",
+            "entrypoint": "Dockerfile.admin-ui.vercel",
+            "runtime": "container"
         }
     },
     "redirects": [
-        { "source": "/", "destination": "/ferroehr/rest/swagger-ui/", "permanent": false },
         { "source": "/favicon.ico", "destination": "/ferroehr/rest/swagger-ui/favicon-32x32.png", "permanent": false }
     ],
     "rewrites": [
-        { "source": "/(.*)", "destination": { "service": "api" } }
+        { "source": "/ferroehr/(.*)", "destination": { "service": "api" } },
+        { "source": "/health", "destination": { "service": "api" } },
+        { "source": "/health/(.*)", "destination": { "service": "api" } },
+        { "source": "/management", "destination": { "service": "api" } },
+        { "source": "/management/(.*)", "destination": { "service": "api" } },
+        { "source": "/(.*)", "destination": { "service": "console" } }
     ]
 }

--- a/website/book/src/admin-ui/index.md
+++ b/website/book/src/admin-ui/index.md
@@ -131,6 +131,8 @@ overrides. Unknown keys are refused at startup, exactly as on the CDR:
 | `auth.oidc.enabled` | `false` | Offer OIDC login (authorization code + PKCE). |
 | `auth.oidc.issuer` / `client_id` / `client_secret` (`_file`) / `public_base_url` / `scopes` | — | The OIDC client registration; `public_base_url` is the console's externally visible origin for the redirect URI. Enabling OIDC without issuer, client id and public base URL is a startup error. |
 | `auth.oidc.resolve` | — | A `host=ip:port` override for the issuer host, for split-horizon DNS: the console reaches an issuer whose canonical name only resolves inside the container network, while browsers and tokens keep the canonical URL. |
+| `login.notice` | empty | Informational text on the sign-in card, line breaks preserved. A demo or evaluation deployment states its public credentials and usage expectations here. |
+| `login.links` | empty | Links under the sign-in card, each `{ label, href }` — an API reference, a documentation page. |
 | `session.idle_minutes` | `60` | Session idle expiry. |
 | `session.cookie_secure` | `false` | Set behind TLS. |
 

--- a/website/book/src/getting-started.md
+++ b/website/book/src/getting-started.md
@@ -56,9 +56,11 @@ It answers a small JSON document: `status`, `server_version`,
 `openehr_rest_api_version` and a `timestamp`. All clinical API routes live under
 the base path `/ferroehr/rest/openehr/v1`. Interactive OpenAPI documentation is
 served at <http://localhost:8080/ferroehr/rest/swagger-ui>. If you have no
-server yet, the hosted sandbox serves the same UI at
-<https://sandbox.ferroehr.eu/ferroehr/rest/swagger-ui> with the public demo
-credentials `ferroehr` / `ferroehr`.
+server yet, use the hosted sandbox: <https://sandbox.ferroehr.eu> opens the
+admin console over a live CDR, and the same server's Swagger UI is at
+<https://sandbox.ferroehr.eu/ferroehr/rest/swagger-ui>. Both take the public
+demo credentials `ferroehr` / `ferroehr`. The sandbox runs on best-effort
+free compute and resets nightly: expect it to slow down under heavy use.
 
 There are also three always-on, unauthenticated health endpoints: `/health`,
 `/health/liveness` and `/health/readiness`; the last one reports each
@@ -182,7 +184,9 @@ drift from the routes it actually serves. When authentication is enabled the
 "Authorize" dialog shows the one scheme the server is configured for (HTTP
 Bearer/JWT when OIDC is set up, otherwise HTTP Basic). The hosted sandbox runs
 the same UI at <https://sandbox.ferroehr.eu/ferroehr/rest/swagger-ui> if you
-want to try it before running anything locally.
+want to try it before running anything locally — and
+<https://sandbox.ferroehr.eu> itself opens the [admin console](admin-ui/index.md)
+on that server, with the demo credentials `ferroehr` / `ferroehr`.
 
 ## Next steps
 

--- a/website/book/src/using-the-api/index.md
+++ b/website/book/src/using-the-api/index.md
@@ -11,8 +11,9 @@ schema), open the Swagger UI of the live sandbox at
 <https://sandbox.ferroehr.eu/ferroehr/rest/swagger-ui> and sign in with the
 public demo credentials `ferroehr` / `ferroehr`. That server generates the
 document from its own handlers, so it describes the running release and its
-"Try it out" buttons issue real requests. This book explains how to *use* the
-API.
+"Try it out" buttons issue real requests. The sandbox's landing surface,
+<https://sandbox.ferroehr.eu>, is the admin console over the same server and
+takes the same credentials. This book explains how to *use* the API.
 
 ## Base path
 

--- a/website/landing/index.html
+++ b/website/landing/index.html
@@ -136,7 +136,7 @@
         </p>
         <div class="hero-cta">
           <a class="btn btn-primary" href="./docs/latest/getting-started.html">Get started</a>
-          <a class="btn btn-ghost" href="https://sandbox.ferroehr.eu/ferroehr/rest/swagger-ui" rel="noopener">Try the live API</a>
+          <a class="btn btn-ghost" href="https://sandbox.ferroehr.eu" rel="noopener">Try the live demo</a>
         </div>
         <p class="note">No JVM · no language runtime · every compliance claim machine-verified.</p>
       </div>


### PR DESCRIPTION
Community feedback (Borut Jures, 2026-08-30): the Swagger UI is documentation, not UX — the sandbox should lead with the admin console. The console image already exists and drives the CDR strictly over the public openEHR REST API; the sandbox just never surfaced it.

## What this does

**The sandbox runs two Vercel services.** `vercel.json` declares `api` (`Dockerfile.vercel`, the CDR) and `console` (`Dockerfile.admin-ui.vercel`, new — `FROM ghcr.io/rubentalstra/ferroehr-admin-ui:latest`, the same release-pointer doctrine). Rewrites route `/ferroehr/*`, `/health*` and `/management*` to the CDR and everything else to the console, so sandbox.ferroehr.eu lands on the console's sign-in screen. `/management*` goes to the CDR deliberately: the sandbox posture keeps management off, and the CDR's own 404 there is what lets the console's probe-and-hide read the truth (a console-served 302 would read as "present"). Swagger stays where it was, `/ferroehr/rest/swagger-ui`, and remains the API reference.

**The console gains a configurable sign-in card notice** (`login.notice` + `login.links`, default empty, rendering nothing when unset — no visual change for existing deployments). The sandbox posture (`deploy/vercel/ferroehr-admin-ui.sandbox.toml`) states the demo credentials `ferroehr` / `ferroehr`, the free-tier expectations, and links the Swagger UI and the docs under the card. The console signs in as the same demo USER the API takes; the CDR's admin and management surfaces stay off (owner confirmation on the issue thread's contract: demo posture unchanged).

**The deploy verifies the console too.** `sandbox-deploy.yml`: the release-call precondition now pins BOTH images' `:latest` digests to the tag; after the version-bound API poll (promotion is atomic across services), a new step polls `/login` for a 200, which proves the console container boots — and is also the discriminator on this very deploy, since the previous single-service deployment 404s `/login`. `compose-image-tags.sh` holds the new Dockerfile to the `:latest` pointer rule.

**Known, accepted window (owner call, in-session):** the `[login]` key ships in the console image from v4.0.12 on. This merge's posture deploy runs it against the 4.0.11 `:latest`, whose strict config refuses the unknown key — the console poll will go red and the landing is dark until the v4.0.12 release leg (cut immediately after this merge) redeploys with the new image. Configured now rather than in a follow-up so the credentials are stated the moment the release lands; #2943 is folded in and closes here.

## Docs

`deploy/vercel/README.md` (two services, three verification layers, file table), the book's console configuration table (`login.notice`/`login.links`), getting-started + using-the-api sandbox passages (console landing, credentials, free-tier note), landing-page hero ("Try the live demo" → sandbox root), changelog entry.

## Gates

clippy native (`ssr`) + wasm32 (`hydrate`) clean, `cargo nextest run -p ferroehr-admin-ui --features ssr` 519/519, leptosfmt + fmt clean, `scripts/cargo-leptos.sh build` completes, `compose-image-tags.sh` / `docs-claims.sh` / `shellcheck-lane.sh` green, actionlint + zizmor clean on the workflow. Default-config console renders byte-identical login markup (`no-ui-visual-change`).

Closes #2941. Closes #2943.
