### PR TITLE
fix(sandbox): the console binds $PORT=80 — Vercel's forward port is the platform default

### DIFF
--- a/deploy/vercel/console/Dockerfile.vercel
+++ b/deploy/vercel/console/Dockerfile.vercel
@@ -31,6 +31,10 @@ USER 65532:65532
 # The sandbox posture: the public CDR base URL and the TLS-edge cookie flag.
 COPY ferroehr-admin-ui.sandbox.toml /etc/ferroehr/admin-ui.toml
 ENV FERROEHR_ADMIN_CONFIG=/etc/ferroehr/admin-ui.toml
-# Vercel routes to the port the image declares; the console serves on 3000
-# (the base image's LEPTOS_SITE_ADDR).
-ENV PORT=3000
+# Vercel forwards to $PORT and its default is 80 — an image-level PORT does
+# not change what the platform expects (measured live: "could not connect to
+# $PORT=80 … detected ports your server listened on: 3000"). The console
+# reads its bind address from LEPTOS_SITE_ADDR at startup, so it is rebound
+# to 80 here, the same port the CDR service binds.
+ENV LEPTOS_SITE_ADDR=0.0.0.0:80
+ENV PORT=80


### PR DESCRIPTION
The release-leg redeploy proved the 4.0.12 console image accepts the `[login]` posture (the unknown-field error is gone from the logs) and surfaced the last defect: Vercel forwards requests to `$PORT`, whose default is 80 as a platform/project setting — the image-level `ENV PORT=3000` does not change what the platform expects. Measured live on the current deployment: `Error: could not connect to $PORT=80 … Detected ports your server listened on: 3000.`

The console reads its bind address from `LEPTOS_SITE_ADDR` at startup (leptos_config env override), so the sandbox Dockerfile rebinds it to `0.0.0.0:80`, the same port the CDR service already binds. Merging this fires the posture redeploy that brings the console up.

Gates: `compose-image-tags.sh` green; single-file posture change.