### PR TITLE
fix(admin-ui): sessions are a sealed cookie — any instance serves any signed-in visitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Fixed
+
+- Console sessions survive multi-instance deployments. The session moved
+  from an in-process store to a sealed cookie (AES-256-GCM): any replica
+  holding the configured `session.secret` (base64, at least 64 bytes; new,
+  with `session.secret_file`) can serve any signed-in visitor — on
+  serverless platforms the in-process store made every request that landed
+  on another instance fail as 500 and the console report the CDR as down.
+  With no secret configured the console behaves as before (one replica,
+  ephemeral key) and says so at startup. The cookie is encrypted and
+  authenticated, HttpOnly, SameSite=Lax, `Secure` per configuration; idle
+  expiry is unchanged and rides inside the sealed payload.
+
 ## [4.0.12] - 2026-08-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1618,7 +1618,11 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
+ "aes-gcm",
+ "base64 0.22.1",
  "percent-encoding",
+ "rand 0.8.7",
+ "subtle",
  "time",
  "version_check",
 ]
@@ -2714,8 +2718,10 @@ version = "4.0.12"
 dependencies = [
  "anyhow",
  "axum",
+ "base64 0.23.1",
  "config",
  "console_error_panic_hook",
+ "cookie",
  "csv",
  "futures",
  "http",
@@ -2743,7 +2749,6 @@ dependencies = [
  "tokio",
  "tower",
  "tower-http 0.7.0",
- "tower-sessions",
  "tracing",
  "tracing-subscriber",
  "urlencoding",
@@ -9106,22 +9111,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-cookies"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "151b5a3e3c45df17466454bb74e9ecedecc955269bdedbf4d150dfa393b55a36"
-dependencies = [
- "axum-core",
- "cookie",
- "futures-util",
- "http",
- "parking_lot",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "tower-http"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9184,57 +9173,6 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
-
-[[package]]
-name = "tower-sessions"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518dca34b74a17cadfcee06e616a09d2bd0c3984eff1769e1e76d58df978fc78"
-dependencies = [
- "async-trait",
- "http",
- "time",
- "tokio",
- "tower-cookies",
- "tower-layer",
- "tower-service",
- "tower-sessions-core",
- "tower-sessions-memory-store",
- "tracing",
-]
-
-[[package]]
-name = "tower-sessions-core"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568531ec3dfcf3ffe493de1958ae5662a0284ac5d767476ecdb6a34ff8c6b06c"
-dependencies = [
- "async-trait",
- "axum-core",
- "base64 0.22.1",
- "futures",
- "http",
- "parking_lot",
- "rand 0.9.5",
- "serde",
- "serde_json",
- "thiserror 2.0.20",
- "time",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "tower-sessions-memory-store"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713fabf882b6560a831e2bbed6204048b35bdd60e50bbb722902c74f8df33460"
-dependencies = [
- "async-trait",
- "time",
- "tokio",
- "tower-sessions-core",
-]
 
 [[package]]
 name = "tower_governor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,7 +219,7 @@ jsonwebtoken = { version = "11.0.0", features = ["aws_lc_rs"] }   # JWT encode/d
 oauth2 = { version = "5", default-features = false } # OAuth2 client (HTTP-client agnostic: we supply the pinned reqwest)
 openidconnect = "4"                 # OIDC / Keycloak          (verify latest 4.x)
 argon2 = "0.5"                      # password hashing (Argon2id); its `password-hash` feature re-exports the PHC string traits
-tower-sessions = "0.15.0"            # session middleware        (verify latest)
+cookie = { version = "0.18", features = ["private"] } # sealed session cookies: AES-256-GCM private jar (the console's multi-instance session, #2949)
 secrecy = "0.10"                   # wrap secrets, avoid logging
 # RBAC/ABAC policy engine for the Stage 2 access-control restoration (pick one at S2):
 cedar-policy = "4"                  # alternative policy engine (verify latest)

--- a/app/ferroehr-admin-ui/CLAUDE.md
+++ b/app/ferroehr-admin-ui/CLAUDE.md
@@ -120,8 +120,7 @@ extension); the wire it consumes IS spec-bound (`docs/specs/openehr/ITS-REST/`
 ## No console-local domain state (owner ruling, 2026-07-25)
 
 - **The console stores NOTHING of its own** — no database, no JSON store beside
-  the binary, no state directory. Its only state is the in-process session
-  store. Every fact a screen shows is read from the CDR over ITS-REST, so it is
+  the binary, no state directory. Its only state is the sealed session cookie. Every fact a screen shows is read from the CDR over ITS-REST, so it is
   visible to other clients, survives a restart, is covered by the CDR's backups,
   and is identical across replicas. The two former stores (`groups.rs` →
   `admin-ui-groups.json`, `folder_templates.rs` →

--- a/app/ferroehr-admin-ui/Cargo.toml
+++ b/app/ferroehr-admin-ui/Cargo.toml
@@ -89,7 +89,11 @@ tracing-subscriber = { workspace = true, optional = true }
 anyhow = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
 config = { workspace = true, optional = true }
-tower-sessions = { workspace = true, optional = true, features = ["memory-store"] }
+# The sealed session cookie (AES-256-GCM private jar, #2949): the whole
+# session rides one encrypted cookie so every instance can read it — the
+# console runs multi-instance on serverless platforms and keeps no store.
+cookie = { workspace = true, optional = true }
+base64 = { workspace = true, optional = true }
 # The browser security-header layer (`SetResponseHeaderLayer`). Server-only:
 # headers are a response property, so the hydrate target never needs it.
 tower-http = { workspace = true, optional = true }
@@ -150,7 +154,8 @@ ssr = [
     "dep:reqwest",
     "dep:futures",
     "dep:config",
-    "dep:tower-sessions",
+    "dep:cookie",
+    "dep:base64",
     "dep:csv",
     "dep:openidconnect",
     # The full ITS surface BFF-side (OPT parsing + WebTemplate building); the

--- a/app/ferroehr-admin-ui/src/auth.rs
+++ b/app/ferroehr-admin-ui/src/auth.rs
@@ -89,18 +89,16 @@ pub async fn login_basic(
         });
     }
 
-    let session = crate::session::http_session().await?;
-    session
-        .insert(
-            crate::session::SESSION_KEY,
-            crate::session::AdminSession {
-                identity: username,
-                credential,
-                scopes: Vec::new(),
-            },
-        )
-        .await
-        .map_err(|e| AdminUiError::Internal(format!("session store: {e}")))?;
+    let mut session = crate::session::http_session().await?;
+    session.insert(
+        crate::session::SESSION_KEY,
+        &crate::session::AdminSession {
+            identity: username,
+            credential,
+            scopes: Vec::new(),
+        },
+    )?;
+    crate::session::commit(&session)?;
 
     leptos_axum::redirect(next.as_deref().unwrap_or("/"));
     Ok(())
@@ -113,14 +111,14 @@ pub async fn login_basic(
 /// unauthenticated call is a harmless no-op redirect.
 ///
 /// # Errors
-/// [`AdminUiError::Internal`] on a session-store failure.
+/// [`AdminUiError::Internal`] outside a request or on a sealing failure.
 #[server]
 pub async fn logout() -> Result<(), AdminUiError> {
-    let session = crate::session::http_session().await?;
-    session
-        .flush()
-        .await
-        .map_err(|e| AdminUiError::Internal(format!("session store: {e}")))?;
+    // The extraction is the in-request proof (it fails outside one); its
+    // decoded content is irrelevant — sign-out overwrites the cookie.
+    crate::session::http_session().await?;
+    // Committing the EMPTY session sets the removal cookie.
+    crate::session::commit(&crate::session::ConsoleSession::default())?;
     leptos_axum::redirect("/login");
     Ok(())
 }
@@ -129,14 +127,11 @@ pub async fn logout() -> Result<(), AdminUiError> {
 /// scope panel. Deliberately NOT guarded: "no session" is a valid answer.
 ///
 /// # Errors
-/// [`AdminUiError::Internal`] on a session-store failure.
+/// [`AdminUiError::Internal`] when called outside a request (a bug).
 #[server]
 pub async fn current_session() -> Result<Option<SessionInfo>, AdminUiError> {
     let session = crate::session::http_session().await?;
-    let admin = session
-        .get::<crate::session::AdminSession>(crate::session::SESSION_KEY)
-        .await
-        .map_err(|e| AdminUiError::Internal(format!("session store: {e}")))?;
+    let admin = session.get::<crate::session::AdminSession>(crate::session::SESSION_KEY);
     Ok(admin.map(|s| SessionInfo {
         identity: s.identity,
         method: match s.credential {

--- a/app/ferroehr-admin-ui/src/config.rs
+++ b/app/ferroehr-admin-ui/src/config.rs
@@ -6,7 +6,7 @@
 //! one-file/strict/env-grammar convention.
 //!
 //! No openEHR spec governs configuration — our own design. The console is
-//! stateless bar its in-process session store: no database, and no local store
+//! stateless: sessions ride a sealed cookie, and there is no database or local store
 //! of domain state either — every fact it shows lives in the CDR and is read
 //! over ITS-REST.
 
@@ -133,7 +133,7 @@ pub struct OidcConfig {
     pub scopes: Vec<String>,
 }
 
-/// Session behaviour (in-process store; single-instance deployment).
+/// Session behaviour (a sealed cookie — no server-side store).
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct SessionConfig {
@@ -141,6 +141,14 @@ pub struct SessionConfig {
     pub idle_minutes: u64,
     /// Set the `Secure` cookie flag (turn on behind TLS).
     pub cookie_secure: bool,
+    /// The cookie-sealing secret, base64 of at least 64 bytes. Every
+    /// instance of a scaled deployment must hold the same value — the
+    /// session is an encrypted cookie any instance can open. Empty = an
+    /// ephemeral per-instance key (single-replica only), with a startup
+    /// warning.
+    pub secret: String,
+    /// Path to a file holding the sealing secret; wins over `secret`.
+    pub secret_file: String,
 }
 
 impl Default for SessionConfig {
@@ -148,6 +156,8 @@ impl Default for SessionConfig {
         Self {
             idle_minutes: 60,
             cookie_secure: false,
+            secret: String::new(),
+            secret_file: String::new(),
         }
     }
 }
@@ -214,6 +224,16 @@ pub fn load() -> Result<AdminUiConfig, ConfigError> {
             ))
         })?;
         secret.trim().clone_into(&mut cfg.auth.oidc.client_secret);
+    }
+
+    if !cfg.session.secret_file.is_empty() {
+        let secret = std::fs::read_to_string(&cfg.session.secret_file).map_err(|e| {
+            ConfigError(format!(
+                "session.secret_file `{}`: {e}",
+                cfg.session.secret_file
+            ))
+        })?;
+        secret.trim().clone_into(&mut cfg.session.secret);
     }
 
     if cfg.auth.oidc.enabled {

--- a/app/ferroehr-admin-ui/src/export.rs
+++ b/app/ferroehr-admin-ui/src/export.rs
@@ -22,7 +22,7 @@
               (#1694)"
 )]
 
-use axum::http::{HeaderValue, StatusCode, header};
+use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
 use axum::response::{IntoResponse, Response};
 
 use crate::error::AdminUiError;
@@ -43,27 +43,23 @@ pub struct ExportForm {
 ///
 /// Callers without a console session are redirected to `/login` (the form is
 /// a full-page navigation, so a redirect is the correct UX and the correct
-/// security answer) — both when no session exists and when the session store
-/// refuses it. A CDR-side refusal of the session's credential instead
+/// security answer) — a missing, tampered or idle-expired cookie all read as
+/// no session. A CDR-side refusal of the session's credential instead
 /// answers the error branch below (the download never navigates away on a
 /// mid-flight CDR 401).
 pub async fn export_aql(
     axum::Extension(state): axum::Extension<crate::state::AppState>,
-    session: tower_sessions::Session,
+    headers: HeaderMap,
     axum::Form(form): axum::Form<ExportForm>,
 ) -> Response {
-    let admin = match session
-        .get::<crate::session::AdminSession>(crate::session::SESSION_KEY)
-        .await
-    {
-        Ok(Some(admin)) => admin,
-        Ok(None) => return axum::response::Redirect::to("/login").into_response(),
-        Err(e) => {
-            return plain(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &format!("session store: {e}"),
-            );
-        }
+    let session = crate::session::unseal(
+        &state.session_keys,
+        &headers,
+        state.config.session.idle_minutes,
+    );
+    let Some(admin) = session.get::<crate::session::AdminSession>(crate::session::SESSION_KEY)
+    else {
+        return axum::response::Redirect::to("/login").into_response();
     };
     match run(&state, &admin, &form).await {
         Ok(response) => response,

--- a/app/ferroehr-admin-ui/src/main.rs
+++ b/app/ferroehr-admin-ui/src/main.rs
@@ -54,10 +54,13 @@ async fn main() -> anyhow::Result<()> {
     } else {
         None
     };
+    let session_keys = ferroehr_admin_ui::session::SessionKeys::from_secret(&config.session.secret)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
     let app_state = ferroehr_admin_ui::state::AppState {
         config: std::sync::Arc::clone(&config),
         cdr,
         oidc,
+        session_keys,
     };
 
     let conf = leptos::config::get_configuration(None)?;

--- a/app/ferroehr-admin-ui/src/oidc.rs
+++ b/app/ferroehr-admin-ui/src/oidc.rs
@@ -94,11 +94,11 @@ fn error_page(status: StatusCode, message: &str) -> Response {
     (status, format!("OIDC login failed: {message}")).into_response()
 }
 
-/// `GET /auth/oidc/login` — park PKCE/CSRF/nonce in the session and
-/// redirect to the authorization endpoint.
+/// `GET /auth/oidc/login` — park PKCE/CSRF/nonce in the sealed session
+/// cookie and redirect to the authorization endpoint.
 pub async fn login(
     axum::Extension(state): axum::Extension<crate::state::AppState>,
-    session: tower_sessions::Session,
+    headers: http::HeaderMap,
 ) -> Response {
     let Some(oidc) = state.oidc.as_ref() else {
         return error_page(StatusCode::NOT_FOUND, "OIDC is not enabled");
@@ -125,10 +125,37 @@ pub async fn login(
         csrf: csrf.secret().clone(),
         nonce: nonce.secret().clone(),
     };
-    if let Err(e) = session.insert(FLOW_KEY, flow).await {
+    let mut session = crate::session::unseal(
+        &state.session_keys,
+        &headers,
+        state.config.session.idle_minutes,
+    );
+    if let Err(e) = session.insert(FLOW_KEY, &flow) {
         return error_page(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string());
     }
-    Redirect::to(auth_url.as_str()).into_response()
+    with_session_cookie(&state, &session, Redirect::to(auth_url.as_str()))
+}
+
+/// Attach the sealed session cookie to a handler's response.
+fn with_session_cookie(
+    state: &crate::state::AppState,
+    session: &crate::session::ConsoleSession,
+    response: impl IntoResponse,
+) -> Response {
+    let sealed = match crate::session::set_cookie(
+        &state.session_keys,
+        session,
+        state.config.session.cookie_secure,
+        state.config.session.idle_minutes,
+    ) {
+        Ok(sealed) => sealed,
+        Err(e) => return error_page(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+    };
+    let mut response = response.into_response();
+    response
+        .headers_mut()
+        .append(http::header::SET_COOKIE, sealed);
+    response
 }
 
 /// The callback's query parameters (only the success pair; a provider
@@ -145,7 +172,7 @@ pub struct CallbackParams {
 /// token nonce, store the session, land on `/`.
 pub async fn callback(
     axum::Extension(state): axum::Extension<crate::state::AppState>,
-    session: tower_sessions::Session,
+    headers: http::HeaderMap,
     axum::extract::Query(params): axum::extract::Query<CallbackParams>,
 ) -> Response {
     let Some(oidc) = state.oidc.as_ref() else {
@@ -158,10 +185,13 @@ pub async fn callback(
     let (Some(code), Some(state_param)) = (params.code, params.state) else {
         return error_page(StatusCode::BAD_REQUEST, "missing code/state");
     };
-    let flow: FlowState = match session.remove(FLOW_KEY).await {
-        Ok(Some(flow)) => flow,
-        Ok(None) => return error_page(StatusCode::BAD_REQUEST, "no login in progress"),
-        Err(e) => return error_page(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+    let mut session = crate::session::unseal(
+        &state.session_keys,
+        &headers,
+        state.config.session.idle_minutes,
+    );
+    let Some(flow): Option<FlowState> = session.remove(FLOW_KEY) else {
+        return error_page(StatusCode::BAD_REQUEST, "no login in progress");
     };
     if flow.csrf != state_param {
         return error_page(StatusCode::BAD_REQUEST, "state mismatch");
@@ -206,8 +236,8 @@ pub async fn callback(
         },
         scopes,
     };
-    if let Err(e) = session.insert(crate::session::SESSION_KEY, admin).await {
+    if let Err(e) = session.insert(crate::session::SESSION_KEY, &admin) {
         return error_page(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string());
     }
-    Redirect::to("/").into_response()
+    with_session_cookie(&state, &session, Redirect::to("/"))
 }

--- a/app/ferroehr-admin-ui/src/server.rs
+++ b/app/ferroehr-admin-ui/src/server.rs
@@ -19,24 +19,11 @@ use crate::state::AppState;
 /// Assembles the console's full axum service.
 ///
 /// OIDC routes, the export POST, the Leptos routes with the per-request
-/// context, the static-file fallback, and the layer stack (session → state →
-/// session guard → security headers).
+/// context, the static-file fallback, and the layer stack (state → session
+/// guard → security headers). Sessions are a sealed cookie
+/// ([`crate::session`]) — no session-store layer exists, so no state is
+/// bound to any one instance.
 pub fn router(app_state: AppState, leptos_options: LeptosOptions) -> axum::Router {
-    let session_layer =
-        tower_sessions::SessionManagerLayer::new(tower_sessions::MemoryStore::default())
-            .with_secure(app_state.config.session.cookie_secure)
-            // Lax, not the Strict default: the OIDC callback arrives as a
-            // top-level cross-site redirect from the identity provider, and
-            // Strict would withhold the session cookie holding the PKCE/state
-            // — the flow would always fail "no login in progress". CSRF on
-            // the callback is covered by the state + PKCE checks.
-            .with_same_site(tower_sessions::cookie::SameSite::Lax)
-            .with_expiry(tower_sessions::Expiry::OnInactivity(
-                tower_sessions::cookie::time::Duration::minutes(
-                    i64::try_from(app_state.config.session.idle_minutes).unwrap_or(60),
-                ),
-            ));
-
     let routes = leptos_axum::generate_route_list(crate::app::App);
 
     let context_state = app_state.clone();
@@ -66,11 +53,11 @@ pub fn router(app_state: AppState, leptos_options: LeptosOptions) -> axum::Route
             provide_console_context,
             crate::app::shell,
         ))
-        // Inside the session layer, ahead of every render: a document request
-        // without a session never reaches Leptos.
+        // Ahead of every render: a document request without a session never
+        // reaches Leptos, and an authenticated response leaves with a
+        // refreshed sliding-expiry cookie.
         .layer(axum::middleware::from_fn(login_guard))
-        .layer(Extension(app_state))
-        .layer(session_layer);
+        .layer(Extension(app_state));
     with_security_headers(service).with_state(leptos_options)
 }
 
@@ -91,36 +78,65 @@ pub fn router(app_state: AppState, leptos_options: LeptosOptions) -> axum::Route
 /// (`is_public_path`). Server-function calls (`/api/…`) keep their own
 /// typed refusals; the export POST enforces its own session.
 ///
-/// Fail-closed: a request that reaches this layer without session machinery
-/// redirects rather than renders.
+/// Fail-closed: a request that reaches this layer without the app state
+/// redirects rather than renders. This layer is also the sliding-expiry
+/// writer: every response to an authenticated request leaves with a
+/// re-sealed cookie carrying a fresh idle anchor — unless the handler
+/// already set our cookie itself (login and logout do).
 pub async fn login_guard(
     request: axum::extract::Request,
     next: axum::middleware::Next,
 ) -> axum::response::Response {
+    let state = request.extensions().get::<AppState>().cloned();
+    let session = state.as_ref().map(|s| {
+        crate::session::unseal(
+            &s.session_keys,
+            request.headers(),
+            s.config.session.idle_minutes,
+        )
+    });
+    let authenticated = session
+        .as_ref()
+        .is_some_and(|s| s.get::<AdminSession>(SESSION_KEY).is_some());
+
     let method = request.method();
     let guarded = (method == http::Method::GET || method == http::Method::HEAD)
         && !is_public_path(request.uri().path());
-    if guarded {
-        let authenticated = match request.extensions().get::<tower_sessions::Session>() {
-            Some(session) => session
-                .get::<AdminSession>(SESSION_KEY)
-                .await
-                .ok()
-                .flatten()
-                .is_some(),
-            None => false,
-        };
-        if !authenticated {
-            let mut response = axum::response::Response::new(axum::body::Body::empty());
-            *response.status_mut() = http::StatusCode::FOUND;
-            response.headers_mut().insert(
-                http::header::LOCATION,
-                http::HeaderValue::from_static("/login"),
-            );
-            return response;
-        }
+    if guarded && !authenticated {
+        let mut response = axum::response::Response::new(axum::body::Body::empty());
+        *response.status_mut() = http::StatusCode::FOUND;
+        response.headers_mut().insert(
+            http::header::LOCATION,
+            http::HeaderValue::from_static("/login"),
+        );
+        return response;
     }
-    next.run(request).await
+
+    let mut response = next.run(request).await;
+    if authenticated
+        && !sets_session_cookie(response.headers())
+        && let (Some(state), Some(session)) = (state, session)
+        && let Ok(refreshed) = crate::session::set_cookie(
+            &state.session_keys,
+            &session,
+            state.config.session.cookie_secure,
+            state.config.session.idle_minutes,
+        )
+    {
+        response
+            .headers_mut()
+            .append(http::header::SET_COOKIE, refreshed);
+    }
+    response
+}
+
+/// Whether a response already sets our session cookie (the handler wrote the
+/// session itself — its value wins over the guard's sliding refresh).
+fn sets_session_cookie(headers: &http::HeaderMap) -> bool {
+    headers.get_all(http::header::SET_COOKIE).iter().any(|v| {
+        v.to_str()
+            .is_ok_and(|s| s.starts_with(crate::session::SESSION_COOKIE))
+    })
 }
 
 /// Whether a path is served without a console session: the sign-in screen,

--- a/app/ferroehr-admin-ui/src/session.rs
+++ b/app/ferroehr-admin-ui/src/session.rs
@@ -1,19 +1,83 @@
 // SPDX-FileCopyrightText: FerroEHR contributors
 // SPDX-License-Identifier: MIT
 
-//! Server-side session state and the auth guard every `#[server]` fn calls
-//! (the Leptos book's `server/25` security rule.
+//! Sealed-cookie session state and the auth guard every `#[server]` fn calls.
 //!
-//! Server functions are a public HTTP API — "only my UI calls this" is never
-//! assumed). CDR credentials live ONLY here, server-side; they never reach a
-//! signal, prop, or serialized resource.
+//! Server functions are a public HTTP API (the Leptos book's `server/25`
+//! security rule) — "only my UI calls this" is never assumed.
+//!
+//! The whole session lives in ONE encrypted, authenticated cookie
+//! (AES-256-GCM via the `cookie` crate's private jar), so any console
+//! instance holding the same key can read it — the console runs
+//! multi-instance on serverless platforms, keeps no database by mandate,
+//! and gets no sticky sessions there (#2949). The browser stores ciphertext
+//! only: CDR credentials never reach a signal, prop, serialized resource,
+//! or readable cookie. Idle expiry is a timestamp INSIDE the sealed payload,
+//! refreshed by the guard middleware on activity, so a stolen clock-limited
+//! cookie cannot be revived by editing its attributes.
 
+use std::collections::BTreeMap;
+
+use base64::Engine;
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
 use crate::error::AdminUiError;
 
 /// The session-store key for the one [`AdminSession`] record.
 pub const SESSION_KEY: &str = "admin_session";
+
+/// The sealed session cookie's name.
+pub const SESSION_COOKIE: &str = "ferroehr_admin_session";
+
+/// The sealing key pair (signing + encryption halves of one 64-byte secret).
+///
+/// `Debug` is manual and redacting: key material must never appear in logs.
+#[derive(Clone)]
+pub struct SessionKeys {
+    key: cookie::Key,
+}
+
+impl std::fmt::Debug for SessionKeys {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SessionKeys").finish_non_exhaustive()
+    }
+}
+
+impl SessionKeys {
+    /// Build the sealing key from the configured secret.
+    ///
+    /// An empty secret yields an ephemeral random key with a WARN: sessions
+    /// then bind to one instance and one process lifetime — fine for the
+    /// single-replica deployments (compose, the chart's default), wrong for
+    /// anything multi-instance. A configured secret must be base64 decoding
+    /// to at least 64 bytes.
+    ///
+    /// # Errors
+    /// [`AdminUiError::Internal`] when the configured secret is not valid
+    /// base64 or decodes to fewer than 64 bytes (a boot-time refusal).
+    pub fn from_secret(secret: &str) -> Result<Self, AdminUiError> {
+        if secret.trim().is_empty() {
+            tracing::warn!(
+                "session.secret is empty: using an ephemeral per-instance key — sessions will not \
+                 survive a restart and will NOT work across multiple instances; configure \
+                 session.secret (base64, at least 64 bytes) for any scaled deployment"
+            );
+            return Ok(Self {
+                key: cookie::Key::generate(),
+            });
+        }
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(secret.trim())
+            .map_err(|e| AdminUiError::Internal(format!("session.secret is not base64: {e}")))?;
+        let key = cookie::Key::try_from(bytes.as_slice()).map_err(|e| {
+            AdminUiError::Internal(format!(
+                "session.secret must decode to at least 64 bytes: {e}"
+            ))
+        })?;
+        Ok(Self { key })
+    }
+}
 
 /// The credential the BFF attaches to outbound CDR calls.
 ///
@@ -25,12 +89,12 @@ pub enum Credential {
     Basic {
         /// The CDR username.
         username: String,
-        /// The CDR password (server-side only).
+        /// The CDR password (sealed cookie only, never plaintext client-side).
         password: String,
     },
     /// A bearer token from the console's OIDC login.
     Bearer {
-        /// The access token (server-side only).
+        /// The access token (sealed cookie only, never plaintext client-side).
         access_token: String,
     },
 }
@@ -63,29 +127,346 @@ pub struct AdminSession {
     pub scopes: Vec<String>,
 }
 
-/// Extract the current `tower_sessions` session from the request context.
+/// The sealed payload: keyed entries plus the sliding idle anchor.
+#[derive(Debug, Serialize, Deserialize)]
+struct Envelope {
+    touched: i64,
+    // Each entry is its own JSON text — values decode straight to their
+    // types, so no untyped-carrier seam exists here (#1694).
+    entries: BTreeMap<String, String>,
+}
+
+/// One request's decoded session view — mutate it, then [`commit`] (or
+/// attach [`set_cookie`] on a plain axum response) to persist the change.
+#[derive(Debug, Default)]
+pub struct ConsoleSession {
+    entries: BTreeMap<String, String>,
+}
+
+impl ConsoleSession {
+    /// Read one typed entry (`None` when absent or of a different shape).
+    #[must_use]
+    pub fn get<T: DeserializeOwned>(&self, key: &str) -> Option<T> {
+        self.entries
+            .get(key)
+            .and_then(|value| serde_json::from_str(value).ok())
+    }
+
+    /// Insert one typed entry.
+    ///
+    /// # Errors
+    /// [`AdminUiError::Internal`] when the value does not serialize (a bug).
+    pub fn insert<T: Serialize>(&mut self, key: &str, value: &T) -> Result<(), AdminUiError> {
+        let value = serde_json::to_string(value)
+            .map_err(|e| AdminUiError::Internal(format!("session serialization: {e}")))?;
+        self.entries.insert(key.to_owned(), value);
+        Ok(())
+    }
+
+    /// Remove one entry, returning it typed when it was present.
+    pub fn remove<T: DeserializeOwned>(&mut self, key: &str) -> Option<T> {
+        self.entries
+            .remove(key)
+            .and_then(|value| serde_json::from_str(&value).ok())
+    }
+
+    /// Whether the session carries no entries at all.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+/// Current wall-clock seconds (jiff is the one time library).
+fn now_seconds() -> i64 {
+    jiff::Timestamp::now().as_second()
+}
+
+/// Decode the session from a request's headers.
+///
+/// Absent, unparsable, tampered, wrong-key and idle-expired cookies all
+/// decode to the empty session: on this seam every defect means the same
+/// thing — no authenticated caller — and the guard turns that into a
+/// redirect or a typed `Unauthenticated`, never a 500.
+#[must_use]
+pub fn unseal(keys: &SessionKeys, headers: &http::HeaderMap, idle_minutes: u64) -> ConsoleSession {
+    let Some(sealed) = cookie_value(headers) else {
+        return ConsoleSession::default();
+    };
+    let mut jar = cookie::CookieJar::new();
+    jar.add_original(cookie::Cookie::new(SESSION_COOKIE, sealed));
+    let Some(open) = jar.private(&keys.key).get(SESSION_COOKIE) else {
+        return ConsoleSession::default();
+    };
+    let Ok(envelope) = serde_json::from_str::<Envelope>(open.value()) else {
+        return ConsoleSession::default();
+    };
+    // Inclusive, so a zero-minute idle window admits no session at all.
+    let idle = i64::try_from(idle_minutes.saturating_mul(60)).unwrap_or(i64::MAX);
+    if now_seconds().saturating_sub(envelope.touched) >= idle {
+        return ConsoleSession::default();
+    }
+    ConsoleSession {
+        entries: envelope.entries,
+    }
+}
+
+/// The raw sealed value of our cookie from a `Cookie` request header.
+fn cookie_value(headers: &http::HeaderMap) -> Option<String> {
+    headers.get_all(http::header::COOKIE).iter().find_map(|h| {
+        let raw = h.to_str().ok()?;
+        cookie::Cookie::split_parse(raw.to_owned())
+            .filter_map(Result::ok)
+            .find(|c| c.name() == SESSION_COOKIE)
+            .map(|c| c.value().to_owned())
+    })
+}
+
+/// Seal a session into a `Set-Cookie` value (fresh idle anchor).
+///
+/// An empty session seals to the REMOVAL cookie (`Max-Age=0`), so "save an
+/// emptied session" and "sign out" are the same operation.
+///
+/// # Errors
+/// [`AdminUiError::Internal`] when the payload does not serialize or the
+/// sealed value is not a valid header (both bugs, surfaced loudly).
+pub fn set_cookie(
+    keys: &SessionKeys,
+    session: &ConsoleSession,
+    cookie_secure: bool,
+    idle_minutes: u64,
+) -> Result<http::HeaderValue, AdminUiError> {
+    let cookie = if session.is_empty() {
+        removal_cookie(cookie_secure)
+    } else {
+        let envelope = Envelope {
+            touched: now_seconds(),
+            entries: session.entries.clone(),
+        };
+        let payload = serde_json::to_string(&envelope)
+            .map_err(|e| AdminUiError::Internal(format!("session serialization: {e}")))?;
+        let mut jar = cookie::CookieJar::new();
+        jar.private_mut(&keys.key)
+            .add(base_cookie(payload, cookie_secure, Some(idle_minutes)));
+        let Some(sealed) = jar.get(SESSION_COOKIE) else {
+            return Err(AdminUiError::Internal(
+                "session sealing produced no cookie".to_owned(),
+            ));
+        };
+        sealed.clone()
+    };
+    // Rendered unencoded: the sealed value is base64, whose alphabet is
+    // entirely within RFC 6265's cookie-octet set.
+    http::HeaderValue::from_str(&cookie.to_string())
+        .map_err(|e| AdminUiError::Internal(format!("session cookie header: {e}")))
+    // NOTE: no openEHR spec governs an admin UI session — our own design;
+    // flags per the OWASP Session Management Cheat Sheet (HttpOnly, Lax for
+    // the OIDC top-level callback redirect, Secure behind TLS).
+}
+
+/// The attribute set every variant of our cookie carries.
+fn base_cookie(
+    value: String,
+    cookie_secure: bool,
+    max_age_minutes: Option<u64>,
+) -> cookie::Cookie<'static> {
+    let mut builder = cookie::Cookie::build((SESSION_COOKIE, value))
+        .path("/")
+        .http_only(true)
+        .secure(cookie_secure)
+        .same_site(cookie::SameSite::Lax);
+    if let Some(minutes) = max_age_minutes {
+        builder = builder.max_age(cookie::time::Duration::seconds(
+            i64::try_from(minutes.saturating_mul(60)).unwrap_or(i64::MAX),
+        ));
+    }
+    builder.build()
+}
+
+/// The sign-out cookie: same attributes, empty value, `Max-Age=0`.
+fn removal_cookie(cookie_secure: bool) -> cookie::Cookie<'static> {
+    let mut cookie = base_cookie(String::new(), cookie_secure, None);
+    cookie.set_max_age(cookie::time::Duration::ZERO);
+    cookie
+}
+
+/// Extract the current request's session inside a `#[server]` fn.
 ///
 /// # Errors
 /// [`AdminUiError::Internal`] when called outside a request (a bug).
-pub async fn http_session() -> Result<tower_sessions::Session, AdminUiError> {
-    leptos_axum::extract::<tower_sessions::Session>()
+pub async fn http_session() -> Result<ConsoleSession, AdminUiError> {
+    let (keys, idle) = context_keys()?;
+    let headers: http::HeaderMap = leptos_axum::extract()
         .await
-        .map_err(|e| AdminUiError::Internal(format!("session extraction: {e}")))
+        .map_err(|e| AdminUiError::Internal(format!("header extraction: {e}")))?;
+    Ok(unseal(&keys, &headers, idle))
+}
+
+/// Persist a mutated session from a `#[server]` fn: appends the sealed
+/// `Set-Cookie` to this request's response.
+///
+/// # Errors
+/// [`AdminUiError::Internal`] outside a request or on a sealing failure.
+pub fn commit(session: &ConsoleSession) -> Result<(), AdminUiError> {
+    let state = app_state()?;
+    let header = set_cookie(
+        &state.session_keys,
+        session,
+        state.config.session.cookie_secure,
+        state.config.session.idle_minutes,
+    )?;
+    let response: leptos_axum::ResponseOptions = leptos::prelude::use_context()
+        .ok_or_else(|| AdminUiError::Internal("no response context".to_owned()))?;
+    response.append_header(http::header::SET_COOKIE, header);
+    Ok(())
 }
 
 /// The guard: return the authenticated session or `Unauthenticated`.
 ///
 /// Every `#[server]` fn that touches the CDR or session state calls this
-/// first.
+/// first. A missing, tampered or idle-expired cookie is the same answer:
+/// [`AdminUiError::Unauthenticated`].
 ///
 /// # Errors
 /// [`AdminUiError::Unauthenticated`] without a live session;
-/// [`AdminUiError::Internal`] on a session-store failure.
+/// [`AdminUiError::Internal`] outside a request (a bug).
 pub async fn require_session() -> Result<AdminSession, AdminUiError> {
-    let session = http_session().await?;
-    session
+    http_session()
+        .await?
         .get::<AdminSession>(SESSION_KEY)
-        .await
-        .map_err(|e| AdminUiError::Internal(format!("session store: {e}")))?
         .ok_or(AdminUiError::Unauthenticated)
+}
+
+/// The `AppState` from the Leptos request context.
+fn app_state() -> Result<crate::state::AppState, AdminUiError> {
+    leptos::prelude::use_context::<crate::state::AppState>()
+        .ok_or_else(|| AdminUiError::Internal("no app state in context".to_owned()))
+}
+
+/// The sealing key + idle window from the Leptos request context.
+fn context_keys() -> Result<(SessionKeys, u64), AdminUiError> {
+    let state = app_state()?;
+    Ok((
+        state.session_keys.clone(),
+        state.config.session.idle_minutes,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        reason = "test assertions/fixtures"
+    )]
+
+    use super::{
+        AdminSession, ConsoleSession, Credential, SESSION_COOKIE, SESSION_KEY, SessionKeys,
+        set_cookie, unseal,
+    };
+
+    fn keys() -> SessionKeys {
+        // 96 zero bytes, base64 — a fixed key so tests are deterministic.
+        SessionKeys::from_secret(&base64_of(&[0u8; 96])).unwrap()
+    }
+
+    fn base64_of(bytes: &[u8]) -> String {
+        use base64::Engine;
+        base64::engine::general_purpose::STANDARD.encode(bytes)
+    }
+
+    fn headers_with(set_cookie_value: &http::HeaderValue) -> http::HeaderMap {
+        // Reuse the Set-Cookie's `name=value` prefix as the request Cookie.
+        let full = set_cookie_value.to_str().unwrap();
+        let pair = full.split(';').next().unwrap();
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            http::header::COOKIE,
+            http::HeaderValue::from_str(pair).unwrap(),
+        );
+        headers
+    }
+
+    fn session_with_admin() -> ConsoleSession {
+        let mut session = ConsoleSession::default();
+        session
+            .insert(
+                SESSION_KEY,
+                &AdminSession {
+                    identity: "demo".to_owned(),
+                    credential: Credential::Basic {
+                        username: "demo".to_owned(),
+                        password: "hunter2".to_owned(),
+                    },
+                    scopes: vec![],
+                },
+            )
+            .unwrap();
+        session
+    }
+
+    #[test]
+    fn seals_and_unseals_across_instances_sharing_the_key() {
+        let sealing = keys();
+        let header = set_cookie(&sealing, &session_with_admin(), true, 60).unwrap();
+        // A DIFFERENT SessionKeys value from the same secret — the
+        // multi-instance property under test.
+        let other_instance = SessionKeys::from_secret(&base64_of(&[0u8; 96])).unwrap();
+        let restored = unseal(&other_instance, &headers_with(&header), 60);
+        let admin: AdminSession = restored.get(SESSION_KEY).unwrap();
+        assert_eq!(admin.identity, "demo");
+    }
+
+    #[test]
+    fn the_cookie_is_ciphertext_with_the_hardening_attributes() {
+        let header = set_cookie(&keys(), &session_with_admin(), true, 60).unwrap();
+        let text = header.to_str().unwrap();
+        assert!(!text.contains("hunter2"), "credential visible: {text}");
+        assert!(!text.contains("demo"), "identity visible: {text}");
+        assert!(text.contains("HttpOnly"));
+        assert!(text.contains("SameSite=Lax"));
+        assert!(text.contains("Secure"));
+        assert!(text.contains("Max-Age=3600"));
+    }
+
+    #[test]
+    fn a_wrong_key_and_a_tampered_value_both_read_as_no_session() {
+        let header = set_cookie(&keys(), &session_with_admin(), false, 60).unwrap();
+        let stranger = SessionKeys::from_secret(&base64_of(&[7u8; 96])).unwrap();
+        assert!(unseal(&stranger, &headers_with(&header), 60).is_empty());
+
+        let mut headers = headers_with(&header);
+        let tampered = headers[http::header::COOKIE]
+            .to_str()
+            .unwrap()
+            .replace('=', "=X");
+        headers.insert(
+            http::header::COOKIE,
+            http::HeaderValue::from_str(&tampered).unwrap(),
+        );
+        assert!(unseal(&keys(), &headers, 60).is_empty());
+    }
+
+    #[test]
+    fn an_idle_expired_payload_reads_as_no_session() {
+        let sealing = keys();
+        let header = set_cookie(&sealing, &session_with_admin(), false, 60).unwrap();
+        // idle_minutes = 0 makes any positive age expired.
+        assert!(unseal(&sealing, &headers_with(&header), 0).is_empty());
+    }
+
+    #[test]
+    fn an_emptied_session_seals_to_the_removal_cookie() {
+        let header = set_cookie(&keys(), &ConsoleSession::default(), true, 60).unwrap();
+        let text = header.to_str().unwrap();
+        assert!(text.contains("Max-Age=0"), "not a removal cookie: {text}");
+        assert!(text.starts_with(&format!("{SESSION_COOKIE}=;")));
+    }
+
+    #[test]
+    fn a_short_or_malformed_secret_is_refused_and_empty_is_ephemeral() {
+        assert!(SessionKeys::from_secret(&base64_of(&[1u8; 32])).is_err());
+        assert!(SessionKeys::from_secret("not base64!!").is_err());
+        assert!(SessionKeys::from_secret("  ").is_ok());
+    }
 }

--- a/app/ferroehr-admin-ui/src/state.rs
+++ b/app/ferroehr-admin-ui/src/state.rs
@@ -16,4 +16,6 @@ pub struct AppState {
     pub cdr: crate::cdr::CdrClient,
     /// OIDC discovery result (present when `auth.oidc.enabled`).
     pub oidc: Option<Arc<crate::oidc::OidcState>>,
+    /// The session-cookie sealing key (from `session.secret`, or ephemeral).
+    pub session_keys: crate::session::SessionKeys,
 }

--- a/app/ferroehr-admin-ui/tests/it/ssr_pages.rs
+++ b/app/ferroehr-admin-ui/tests/it/ssr_pages.rs
@@ -109,6 +109,8 @@ fn app_state() -> ferroehr_admin_ui::state::AppState {
             .expect("the CDR client should build from a well-formed base URL"),
         config: std::sync::Arc::new(config),
         oidc: None,
+        session_keys: ferroehr_admin_ui::session::SessionKeys::from_secret("")
+            .expect("an empty secret always yields an ephemeral key"),
     }
 }
 

--- a/app/ferroehr-admin-ui/tests/it/ssr_shell.rs
+++ b/app/ferroehr-admin-ui/tests/it/ssr_shell.rs
@@ -133,6 +133,8 @@ fn app_state() -> ferroehr_admin_ui::state::AppState {
             .expect("the CDR client should build from a well-formed base URL"),
         config: std::sync::Arc::new(config),
         oidc: None,
+        session_keys: ferroehr_admin_ui::session::SessionKeys::from_secret("")
+            .expect("an empty secret always yields an ephemeral key"),
     }
 }
 

--- a/deploy/vercel/README.md
+++ b/deploy/vercel/README.md
@@ -14,8 +14,9 @@ demo posture baked on top, and it resets to known demo data every night:
   (#2941): every other path routes here, so sandbox.ferroehr.eu opens on the
   console's sign-in screen. It drives the CDR strictly over the public REST
   base (`https://sandbox.ferroehr.eu`) as the same demo user the API takes,
-  and it holds no state of its own (in-process sessions only — a serverless
-  scale-in signs visitors out, which the demo accepts).
+  and it holds no state of its own: sessions are a sealed cookie keyed by
+  the posture's deliberately public `session.secret` (#2949 — the demo's
+  only credential is itself public), so any instance serves any visitor.
 
 Routing lives in `vercel.json` `rewrites` (evaluated in order, first match
 wins — the Vercel Services model); Swagger stays reachable at

--- a/deploy/vercel/console/ferroehr-admin-ui.sandbox.toml
+++ b/deploy/vercel/console/ferroehr-admin-ui.sandbox.toml
@@ -18,6 +18,11 @@ base_url = "https://sandbox.ferroehr.eu"
 [session]
 # TLS terminates at the Vercel edge.
 cookie_secure = true
+# The cookie-sealing key, DELIBERATELY public (owner call, #2949): the
+# sandbox is a demo whose only credential is itself public, so a forgeable
+# demo session protects nothing — and a committed key keeps the deployment
+# zero-secret. Every real deployment generates its own and keeps it secret.
+secret = "QbcUgnEXEpoyarA0YLvc0Lw1BsTGigAEcFgQQu0Kb8ym1eTJc2ehU96CIQv1YrP0I1J9KjOnSwKaFaTRG89+e/svrxGYsbd4WM2JlgB6WMugNWWUBLPOIyXwkLs1zROR"
 
 # The sign-in card states what a visitor needs (#2941): the demo credentials
 # and the free-tier expectations, with the API reference linked underneath.

--- a/website/book/src/admin-ui/index.md
+++ b/website/book/src/admin-ui/index.md
@@ -64,9 +64,11 @@ and a Secret holding its client secret. **To turn the console off**, set
 CDR is untouched.
 
 > [!NOTE]
-> The console keeps its sessions **in process**, so the chart deploys one
-> replica deliberately. Scaling it out needs sticky sessions at the ingress, or
-> users get logged out whenever a request lands on the other pod.
+> To scale the console past one replica, set the same `session.secret` on
+> every replica: the session is a sealed cookie any key-holding replica can
+> serve. Without a configured secret each replica seals with its own
+> ephemeral key, and visitors get signed out whenever a request lands on
+> another pod.
 
 ## Signing in
 
@@ -133,17 +135,22 @@ overrides. Unknown keys are refused at startup, exactly as on the CDR:
 | `auth.oidc.resolve` | — | A `host=ip:port` override for the issuer host, for split-horizon DNS: the console reaches an issuer whose canonical name only resolves inside the container network, while browsers and tokens keep the canonical URL. |
 | `login.notice` | empty | Informational text on the sign-in card, line breaks preserved. A demo or evaluation deployment states its public credentials and usage expectations here. |
 | `login.links` | empty | Links under the sign-in card, each `{ label, href }` — an API reference, a documentation page. |
-| `session.idle_minutes` | `60` | Session idle expiry. |
+| `session.idle_minutes` | `60` | Session idle expiry (sliding; carried inside the sealed cookie). |
 | `session.cookie_secure` | `false` | Set behind TLS. |
+| `session.secret` | empty | The session-cookie sealing key: base64 of at least 64 bytes (`openssl rand -base64 64`). Every replica of a scaled deployment must hold the same value. Empty = an ephemeral per-instance key, fine for exactly one replica. |
+| `session.secret_file` | — | Path to a file holding the sealing key; wins over `session.secret`. |
 
-The console is **stateless apart from its in-process session store**: it has
-no database and keeps no local files of its own. Everything it shows,
-including how stored queries are grouped, which is derived from the namespace
-in each query's qualified name, lives in the CDR and is read over ITS-REST,
-so nothing here needs backing up and every replica shows the same repository.
+The console is **stateless**: it has no database and keeps no local files of
+its own. Everything it shows, including how stored queries are grouped,
+which is derived from the namespace in each query's qualified name, lives in
+the CDR and is read over ITS-REST, so nothing here needs backing up and
+every replica shows the same repository. Sessions are a **sealed cookie**
+(AES-256-GCM, keyed by `session.secret`), so any replica holding the key can
+serve any signed-in visitor.
 
-Login and sessions live in the console's backend; CDR credentials and
-bearer tokens never reach the browser.
+Login and sessions live in the console's backend; the browser stores only
+the encrypted session cookie — CDR credentials and bearer tokens never reach
+it in readable form.
 
 ![Login](img/login/login.png)
 


### PR DESCRIPTION
Closes #2949. Observed live after the sandbox rework: sign-in worked, then the dashboard's parallel server-fn fan-out failed in 500 bursts and the health pill read "CDR DOWN" — `tower_sessions_core: record not found in store`, several instances booting within seconds. The in-process MemoryStore binds a session to the instance that created it; Vercel routes the burst across instances, and the documented workarounds (one replica, sticky sessions) don't exist there.

**The fix:** the whole session rides one encrypted, authenticated cookie (AES-256-GCM, the `cookie` crate's private jar) keyed by the new `session.secret` (base64 ≥ 64 bytes, `session.secret_file` wins). Any key-holding instance opens it; there is no store. HttpOnly, SameSite=Lax (the OIDC callback arrives as a top-level cross-site redirect), `Secure` per config, `Max-Age` = the idle window; the sliding idle anchor lives INSIDE the sealed payload and the login guard refreshes it on authenticated responses (skipping responses whose handler already set the cookie — login, logout). The OIDC PKCE flow state rides the same envelope. Empty secret = today's behavior (ephemeral key, one replica) with a startup WARN; malformed/short secret refuses boot. `tower-sessions` leaves the workspace (the console was its only consumer).

**Mandates check:** no database, CDR reached only over ITS-REST — unchanged. "Credentials never reach the browser" holds in the sense that matters: the browser stores ciphertext it cannot read; the key never leaves the server. The sandbox posture commits its key openly (owner call, on the record in the TOML comment): the demo's only credential is public, so a forgeable demo session protects nothing, and the deployment stays zero-secret.

**Docs:** book config table (+ the Kubernetes multi-replica note now says "same secret on every replica" instead of "one replica or sticky sessions"), sandbox README, crate CLAUDE.md, changelog.

**Gates:** clippy native+wasm clean, 525/525 nextest (new suite: cross-instance unseal, ciphertext/attribute assertions, tamper/wrong-key/expiry read as no-session, removal-cookie logout, secret validation), leptosfmt+fmt, cargo-leptos build, comment-style. `no-ui-visual-change`: server-side session mechanics only.

Merging this + the next release cut brings the sandbox console fully alive under real fan-out.