### PR TITLE
fix(aql): a backslash-escaped LIKE wildcard matches the literal character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- AQL `LIKE` honors the escaped single-character wildcard: `\?` in a pattern
+  now matches a literal `?` (QUERY master03 §Operators/LIKE), symmetrically
+  with the already-correct `\*`. The string reader was consuming `\?` as a
+  string escape before the pattern layer could see it, so the escaped form
+  still matched as the wildcard.
 - Console sessions survive multi-instance deployments. The session moved
   from an in-process store to a sealed cookie (AES-256-GCM): any replica
   holding the configured `session.secret` (base64, at least 64 bytes; new,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5431,7 +5431,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.47"
+version = "0.0.48"
 dependencies = [
  "indexmap 2.14.0",
  "openehr-am",
@@ -5447,7 +5447,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.47"
+version = "0.0.48"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -5457,7 +5457,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.47"
+version = "0.0.48"
 dependencies = [
  "serde",
  "serde_json",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.47"
+version = "0.0.48"
 dependencies = [
  "async-trait",
  "axum",
@@ -5506,7 +5506,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.47"
+version = "0.0.48"
 dependencies = [
  "assert_fs",
  "chumsky",
@@ -5520,7 +5520,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.47"
+version = "0.0.48"
 dependencies = [
  "chumsky",
  "logos",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.47"
+version = "0.0.48"
 dependencies = [
  "insta",
  "jsonschema",
@@ -5547,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.47"
+version = "0.0.48"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/app/ferroehr/tests/it/service_aql.rs
+++ b/app/ferroehr/tests/it/service_aql.rs
@@ -1827,6 +1827,48 @@ async fn like_and_matches_are_any_match_on_multi_valued_paths() {
     assert_eq!(rows(&none).len(), 0, "no node satisfies: {none}");
 }
 
+/// #2940 — QUERY master03 §Operators/LIKE: a backslash-escaped wildcard
+/// (`\?`, `\*`) matches the LITERAL character. Against values containing no
+/// `?` or `*`, the escaped patterns select nothing while their unescaped
+/// twins select the row — both wildcards, symmetrically (4.0.11 honored `\*`
+/// and let `\?` keep matching as the single-character wildcard).
+#[tokio::test]
+async fn like_escaped_wildcards_match_the_literal_character() {
+    let db = testkit::db().await.expect("testkit database");
+    let svc = FerroEhrService::new(db.pool());
+    let ehr_id = create_ehr(&svc).await;
+
+    let mut c = composition("escape-target", 1.0);
+    c["content"][0]["data"]["events"][0]["data"]["items"][0]["value"] =
+        json!({ "_type": "DV_TEXT", "value": "2026-01-01T03:00:00Z" });
+    svc.create_composition(ehr_id.parse().expect("ehr_id uuid"), uv(&c, "249", None))
+        .await
+        .expect("escape-target composition");
+
+    let path = "o/data[at0001]/events[at0002]/data[at0003]/items[at0004]/value/value";
+    for (pattern, expected, claim) in [
+        (
+            r"2026-01-01T0?:00:00Z",
+            1,
+            "unescaped ? is the one-char wildcard",
+        ),
+        (r"2026-01-01T0\?:00:00Z", 0, "escaped \\? is the literal ?"),
+        (r"2026-01-01T0*", 1, "unescaped * is the any-run wildcard"),
+        (r"2026-01-01T0\*", 0, "escaped \\* is the literal *"),
+    ] {
+        let result = run_aql(
+            &svc,
+            &format!(
+                "SELECT c/uid/value FROM EHR e CONTAINS COMPOSITION c CONTAINS OBSERVATION o \
+                 WHERE {path} LIKE '{pattern}'"
+            ),
+            ehr_scope(&ehr_id),
+        )
+        .await;
+        assert_eq!(rows(&result).len(), expected, "{claim}: {result}");
+    }
+}
+
 /// A composition carrying MULTI-VALUED FRAGMENT attributes — two `links` on
 /// the root, two `context/participations`, two composer `identifiers` — where
 /// only the LAST element of each list satisfies the predicates below.

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-adl"
-version = "0.0.47"
+version = "0.0.48"
 description = "openEHR ADL 2.4.0: hand-written ADL2/cADL/ODIN parser, AOM2 validation catalogue, specialisation flattener, OPT2 generator, and ADL 1.4→2 conversion over the generated openehr_am::v2_4::aom2 model"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,11 +16,11 @@ include = ["src/**", "README.md", "LICENSE-MIT"]
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)
-openehr-base = { path = "../openehr-base", version = "0.0.47" }   # VersionStatus for the parsed HRID
-openehr-am = { path = "../openehr-am", version = "0.0.47" }       # v2_4 ArchetypeHrid (the identification target type)
-openehr-rm = { path = "../openehr-rm", version = "0.0.47" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
-openehr-lang = { path = "../openehr-lang", version = "0.0.47" }   # openehr_lang::odin — the ODIN section parser
-openehr-term = { path = "../openehr-term", version = "0.0.47" }   # the languages code set for the RM resource-meta rows
+openehr-base = { path = "../openehr-base", version = "0.0.48" }   # VersionStatus for the parsed HRID
+openehr-am = { path = "../openehr-am", version = "0.0.48" }       # v2_4 ArchetypeHrid (the identification target type)
+openehr-rm = { path = "../openehr-rm", version = "0.0.48" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
+openehr-lang = { path = "../openehr-lang", version = "0.0.48" }   # openehr_lang::odin — the ODIN section parser
+openehr-term = { path = "../openehr-term", version = "0.0.48" }   # the languages code set for the RM resource-meta rows
 uuid.workspace = true        # meta uid/build_uid (AUTHORED_ARCHETYPE.uid: Uuid)
 indexmap.workspace = true    # OdinValue::Object body (insertion-ordered map)
 

--- a/crates/openehr-am/Cargo.toml
+++ b/crates/openehr-am/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-am"
-version = "0.0.47"
+version = "0.0.48"
 description = "openEHR AM Archetype Model, generated from BMM: generations v1_4 (AM 1.4.0, ADL 1.4) and v2_4 (AM 2.4.0, ADL 2; current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,8 +13,8 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.47" }
-openehr-lang = { path = "../openehr-lang", version = "0.0.47" }
+openehr-base = { path = "../openehr-base", version = "0.0.48" }
+openehr-lang = { path = "../openehr-lang", version = "0.0.48" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also carries the untyped `Value` fields the generator

--- a/crates/openehr-base/Cargo.toml
+++ b/crates/openehr-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-base"
-version = "0.0.47"
+version = "0.0.48"
 description = "openEHR BASE foundation + base types, generated from BMM: generations v1_2 (BASE 1.2.0) and v1_3 (BASE 1.3.0, current)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-its"
-version = "0.0.47"
+version = "0.0.48"
 description = "openEHR ITS (Implementation Technology Specifications): canonical JSON + canonical XML serialization of the RM, the generated ITS-REST 1.1.0 API contract, OPT 1.4 and AOM2 archetype XML codecs, and the Simplified Formats (FLAT / STRUCTURED / Web Template)"
 edition.workspace = true
 rust-version.workspace = true
@@ -41,14 +41,14 @@ regex = { workspace = true, optional = true }
 fancy-regex = { workspace = true, optional = true }
 # The generated XML (de)serializers impl the crate's ToXml/FromXml traits for the
 # RM/BASE spec types, so these are real (non-dev) deps.
-openehr-base = { path = "../openehr-base", version = "0.0.47", optional = true }
-openehr-rm = { path = "../openehr-rm", version = "0.0.47", optional = true }
+openehr-base = { path = "../openehr-base", version = "0.0.48", optional = true }
+openehr-rm = { path = "../openehr-rm", version = "0.0.48", optional = true }
 # The native canonical-JSON codec (`json_codec/generated`, emit-json) implements
 # `ToJson` for EVERY generated spec type the `OpenEhrType` derive covers, so it
 # spans all five spec crates (not just the RM/BASE the XML codec needs).
-openehr-lang = { path = "../openehr-lang", version = "0.0.47", optional = true }
-openehr-am = { path = "../openehr-am", version = "0.0.47", optional = true }
-openehr-term = { path = "../openehr-term", version = "0.0.47", optional = true }
+openehr-lang = { path = "../openehr-lang", version = "0.0.48", optional = true }
+openehr-am = { path = "../openehr-am", version = "0.0.48", optional = true }
+openehr-term = { path = "../openehr-term", version = "0.0.48", optional = true }
 
 # `full` — every ITS surface (canonical JSON/XML, the generated ITS-REST
 # contract, `opt14`, Simplified Formats). ON BY DEFAULT, so every consumer sees

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-lang"
-version = "0.0.47"
+version = "0.0.48"
 description = "openEHR LANG BMM/P_BMM object model, generated from BMM: generations v1_0 (LANG 1.0.0) and v1_1 (LANG 1.1.0, current; the stable BMM v2.x unit beside the paused BMM3 unit), plus hand-written ODIN/BEL/EL readers"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["parser-implementations", "data-structures"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.47" }
+openehr-base = { path = "../openehr-base", version = "0.0.48" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the
 # generated types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) —
 # never a derive. `serde_json` also carries the untyped `Value` fields the

--- a/crates/openehr-query/Cargo.toml
+++ b/crates/openehr-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-query"
-version = "0.0.47"
+version = "0.0.48"
 description = "openEHR QUERY (AQL 1.1.0): hand-written lexer, parser, typed AST and canonical printer from the official grammar (no ANTLR runtime)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-query/src/parser.rs
+++ b/crates/openehr-query/src/parser.rs
@@ -158,10 +158,18 @@ fn unquote(s: &str) -> String {
     unescape(inner)
 }
 
-/// Decode AQL string escapes. `ESCAPE_SEQ: '\\' ['"?abfnrtv\\]`,
-/// `UTF8CHAR: '\\u' HEX{4}`, and `OCTAL_ESC: '\\' [0-3]?OCTAL{1,2}` (a `\`
-/// followed by 1–3 octal digits). Unknown escapes are passed through verbatim
-/// (the backslash is retained), which keeps the function total on any input.
+/// Decode AQL string escapes: quotes, `\\`, the control escapes
+/// (`abfnrtv`), `UTF8CHAR: '\\u' HEX{4}`, and `OCTAL_ESC` (a `\` followed by
+/// 1–3 octal digits). Unknown escapes are passed through verbatim (the
+/// backslash is retained), which keeps the function total on any input.
+///
+/// `\?` is deliberately NOT a string escape, although the grammar's
+/// `ESCAPE_SEQ` lists `?`: QUERY AQL master03 §Operators/LIKE requires `\?`
+/// and `\*` in a pattern to match the literal character, which is only
+/// expressible when the string layer preserves them for the pattern layer —
+/// under the grammar reading, `\?` decodes to a bare wildcard and `'\*'` is
+/// not even lexable, so the docs text wins and both escapes pass through
+/// verbatim, symmetrically.
 fn unescape(inner: &str) -> String {
     if !inner.contains('\\') {
         return inner.to_string();
@@ -178,7 +186,7 @@ fn unescape(inner: &str) -> String {
             break;
         };
         match next {
-            '\'' | '"' | '?' | '\\' => {
+            '\'' | '"' | '\\' => {
                 out.push(next);
                 chars.next();
             }
@@ -846,6 +854,31 @@ mod tests {
                 ..
             } if rm_type == "COMPOSITION" && variable.as_deref() == Some("c")
         ));
+    }
+
+    /// QUERY master03 §Operators/LIKE: `\?` and `\*` in a pattern match the
+    /// literal character, so string decoding must preserve BOTH escapes for
+    /// the pattern layer — symmetrically (the 4.0.11 defect kept `\*` and
+    /// consumed `\?` into a bare wildcard, #2940).
+    #[test]
+    fn like_pattern_escapes_survive_string_decoding() {
+        for (src, expected) in [
+            (r"'2026-01-01T0\?:00:00Z'", r"2026-01-01T0\?:00:00Z"),
+            (r"'2026-01-01T\*'", r"2026-01-01T\*"),
+        ] {
+            let q = parse_str(&format!(
+                "SELECT c FROM COMPOSITION c WHERE c/name/value LIKE {src}"
+            ))
+            .expect("parse");
+            let Some(WhereExpr::Identified(IdentifiedExpr::Like {
+                operand: LikeOperand::String(pattern),
+                ..
+            })) = q.where_
+            else {
+                panic!("not a LIKE: {:?}", q.where_);
+            };
+            assert_eq!(pattern, expected);
+        }
     }
 
     #[test]

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-rm"
-version = "0.0.47"
+version = "0.0.48"
 description = "openEHR RM Reference Model, generated from BMM: generations v1_1 (RM 1.1.0) and v1_2 (RM 1.2.0, current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,11 +13,11 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.47" }
+openehr-base = { path = "../openehr-base", version = "0.0.48" }
 # The terminology-backed RM class invariants (`validate::terminology`) resolve
 # openEHR terminology groups + code sets against the vendored TERM 3.1.0 bundle.
 # `openehr-term` itself depends only on `openehr-base`, so this is acyclic.
-openehr-term = { path = "../openehr-term", version = "0.0.47" }
+openehr-term = { path = "../openehr-term", version = "0.0.48" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also backs the untyped `Value` RM representation used by

--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-term"
-version = "0.0.47"
+version = "0.0.48"
 description = "openEHR TERM terminology data model, generated from BMM (generation v3_1 = TERM 3.1.0), plus the embedded official terminology XML bundle"
 edition.workspace = true
 rust-version.workspace = true
@@ -34,7 +34,7 @@ include = [
 ]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.47" }
+openehr-base = { path = "../openehr-base", version = "0.0.48" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1281,7 +1281,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.47"
+version = "0.0.48"
 dependencies = [
  "indexmap",
  "openehr-am",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.47"
+version = "0.0.48"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.47"
+version = "0.0.48"
 dependencies = [
  "serde",
  "serde_json",
@@ -1317,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.47"
+version = "0.0.48"
 dependencies = [
  "async-trait",
  "axum",
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.47"
+version = "0.0.48"
 dependencies = [
  "chumsky",
  "indexmap",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.47"
+version = "0.0.48"
 dependencies = [
  "chumsky",
  "logos",
@@ -1364,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.47"
+version = "0.0.48"
 dependencies = [
  "openehr-base",
  "openehr-term",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.47"
+version = "0.0.48"
 dependencies = [
  "openehr-base",
  "roxmltree",


### PR DESCRIPTION
Closes #2940. The re-verified asymmetry (`\*` literal, `\?` still a wildcard) had exactly the shape the issue's replay suggested, one seam earlier than the LIKE translation: the AQL **string reader** consumed `\?` as a string escape (per the stalled grammar's `ESCAPE_SEQ: '\\' ['\"?abfnrtv\\]`), so the pattern layer received a bare `?`; `\*` survived only because `*` was never in that escape set. The SQL pattern translator has always handled both escapes correctly.

**Adjudication (released text only):** QUERY `master03-syntax.adoc` §Operators/LIKE requires `\?`/`\*` in a pattern to match the literal character. The same release's embedded lexer grammar (master07 includes `AqlLexer.g4`) contradicts it twice over: `\?` decodes to a bare wildcard there, and `'\*'` is not even lexable (a backslash must begin a listed escape, and `*` is not one). The docs-text sentence is only expressible when the string layer preserves both escapes for the pattern layer, so that is the implemented reading — `\?` now passes through verbatim, exactly as `\*` already did. The grammar-vs-text contradiction goes upstream as its own report issue.

**Pinned at three layers:** the parser preserves both escapes into the AST (new test), `aql_like_to_sql` maps them to SQL literals (existing test), and a database-backed service test drives the four twin patterns — escaped selects nothing against wildcard-free values, unescaped selects the row — mirroring the Veredictum case `execute_ad_hoc_query-like_escaped_wildcard` including the `\*` half its runner never reached.

**Crate hygiene:** `openehr-query` packaged content changed → all eight spec crates step to 0.0.48 in lockstep, root and fuzz locks refreshed.

Gates: `openehr-query` 68/68, the LIKE service tests green against a real PG18, clippy clean on both touched crates, fmt + comment-style green.