### PR TITLE
fix(admin-ui): the SMART card probes the served path and says what it found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@ workflow refuses a tag that has no matching section here.
   listing. A refusal keeps the dialog open with the server's diagnostic beside
   the source, and a successful upload closes it and refreshes the list.
 
+### Fixed
+
+- The admin console's System screen reports SMART correctly. It probed the
+  discovery document at the origin instead of under the platform base path
+  the CDR serves it from, and rendered whatever came back as a raw status
+  echo (`CDR answered 302: HTTP 302` on the hosted sandbox, where the origin
+  path belongs to the console itself). It now probes
+  `/ferroehr/rest/.well-known/smart-configuration`, states plainly that SMART
+  is not enabled when the CDR serves no document, and gives an unexpected
+  answer actionable copy that never claims SMART is disabled when the probe
+  could not tell.
+
 ## [4.0.13] - 2026-08-30
 
 ### Fixed

--- a/app/ferroehr-admin-ui/src/pages/system.rs
+++ b/app/ferroehr-admin-ui/src/pages/system.rs
@@ -44,9 +44,19 @@ use crate::components::page_header::PageHeader;
 use crate::components::surface::titled_card;
 use crate::error::AdminUiError;
 
+/// Where the CDR serves its SMART service-discovery document.
+///
+/// Relative to the PLATFORM base URL, which this platform gives a path
+/// segment: ITS-REST `smart_app_launch/master04-service_discovery.adoc`
+/// §"the configuration endpoint" — "If the base URL includes a path segment
+/// as `https://platform.example.com/gateway/v1`, then the configuration
+/// should be accessible at
+/// `https://platform.example.com/gateway/v1/.well-known/smart-configuration`".
+const SMART_DISCOVERY_PATH: &str = "ferroehr/rest/.well-known/smart-configuration";
+
 /// The CDR's SMART service-discovery document, or `None` when the CDR
-/// advertises none (a `404` from `/.well-known/smart-configuration` is a
-/// first-class "SMART disabled" state, not an error).
+/// advertises none (a `404` is a first-class "SMART disabled" state, not an
+/// error).
 ///
 /// # Errors
 /// [`AdminUiError::Unauthenticated`] without a console session; CDR transport
@@ -56,9 +66,7 @@ use crate::error::AdminUiError;
 pub async fn fetch_smart_config() -> Result<Option<String>, AdminUiError> {
     crate::session::require_session().await?;
     let state: crate::state::AppState = expect_context();
-    // Served relative to the platform base URL, not the ITS-REST base
-    // (master04-service_discovery.adoc §"the configuration endpoint").
-    let url = state.cdr.origin_url(".well-known/smart-configuration");
+    let url = state.cdr.origin_url(SMART_DISCOVERY_PATH);
     let response = state.cdr.get_public(&url, "application/json").await?;
     if response.is(http::StatusCode::NOT_FOUND) {
         return Ok(None);
@@ -645,6 +653,9 @@ fn status_body(body: &str) -> Result<AnyView, AdminUiError> {
 
 /// SMART card: `fetch_smart_config` → a "disabled" state, or the advertised
 /// endpoints (out-links) plus capability chips.
+///
+/// A failed probe renders [`smart_probe_failure_copy`] rather than the raw
+/// error: "the CDR answered 302" tells a reader nothing they can act on.
 fn smart_card() -> AnyView {
     let resource = Resource::new(|| (), |()| async move { fetch_smart_config().await });
     let body = view! {
@@ -652,13 +663,67 @@ fn smart_card() -> AnyView {
             {move || Suspend::new(async move {
                 match resource.await {
                     Ok(config) => smart_body(config),
-                    Err(e) => card_error(&e),
+                    Err(e) => {
+                        view! {
+                            <thaw::MessageBar intent=thaw::MessageBarIntent::Warning>
+                                <thaw::MessageBarBody>
+                                    {smart_probe_failure_copy(&e)}
+                                </thaw::MessageBarBody>
+                            </thaw::MessageBar>
+                        }
+                            .into_any()
+                    }
                 }
             })}
         </Suspense>
     }
     .into_any();
     titled_card("SMART", false, body)
+}
+
+/// What to say when the SMART discovery probe could not be read.
+///
+/// Component-free and unit-tested (the console's failure-copy convention —
+/// `crate::feedback::write_failure_copy`): every branch names what was asked
+/// for and what to do next, and none of them echoes a bare status code back
+/// at the reader.
+#[must_use]
+pub fn smart_probe_failure_copy(error: &AdminUiError) -> String {
+    let endpoint = format!("/{SMART_DISCOVERY_PATH}");
+    match error {
+        AdminUiError::CdrUnreachable(detail) => format!(
+            "SMART discovery could not be read: the CDR is unreachable ({detail}). This says \
+             nothing about whether SMART is enabled — check the CDR is up, then reload."
+        ),
+        AdminUiError::CdrUnauthorized(_) | AdminUiError::Unauthenticated => format!(
+            "SMART discovery could not be read: the CDR refused this session at {endpoint}. Sign \
+             in again, then reload."
+        ),
+        AdminUiError::Forbidden(_) => format!(
+            "SMART discovery could not be read: this session may not read {endpoint}. It needs an \
+             account the CDR allows there."
+        ),
+        _ => {
+            // A CDR body that only restates its own status ("HTTP 302") adds
+            // nothing, so it is dropped rather than printed beside the code it
+            // repeats — the doubled echo this card used to show (#2954).
+            let detail = match error {
+                AdminUiError::Cdr { status, message } => {
+                    let restatement = format!("HTTP {status}");
+                    if message.trim().is_empty() || message.trim() == restatement {
+                        format!("the CDR answered {status} there")
+                    } else {
+                        format!("the CDR answered {status} there: {message}")
+                    }
+                }
+                other => other.to_string(),
+            };
+            format!(
+                "SMART discovery could not be read from {endpoint} — {detail}. Whether SMART is \
+                 enabled is therefore unknown; check that the CDR serves that path."
+            )
+        }
+    }
 }
 
 /// Render the SMART discovery document. `None` is the neutral disabled state;
@@ -670,7 +735,7 @@ fn smart_body(config: Option<String>) -> AnyView {
         return view! {
             <thaw::MessageBar intent=thaw::MessageBarIntent::Info>
                 <thaw::MessageBarBody>
-                    "SMART: disabled — the CDR advertises no service-discovery document."
+                    "SMART is not enabled on this CDR: it serves no service-discovery document."
                 </thaw::MessageBarBody>
             </thaw::MessageBar>
         }
@@ -972,7 +1037,66 @@ fn group_openapi_paths(doc: &serde_json::Value) -> Vec<(String, Vec<(String, Str
 
 #[cfg(test)]
 mod tests {
-    use super::{OPENAPI_FAMILIES, group_openapi_paths, openapi_family_slug, scalar_rows};
+    use super::{
+        OPENAPI_FAMILIES, SMART_DISCOVERY_PATH, group_openapi_paths, openapi_family_slug,
+        scalar_rows, smart_probe_failure_copy,
+    };
+    use crate::error::AdminUiError;
+
+    /// The probe asks for the path the CDR actually serves: relative to the
+    /// PLATFORM base URL, which carries a path segment here (ITS-REST
+    /// `smart_app_launch/master04-service_discovery.adoc` §"the configuration
+    /// endpoint"). The origin-level path is a different resource, and on a
+    /// single-origin deployment it is not the CDR's at all.
+    #[test]
+    fn discovery_is_probed_under_the_platform_base_path() {
+        assert_eq!(
+            SMART_DISCOVERY_PATH,
+            "ferroehr/rest/.well-known/smart-configuration"
+        );
+    }
+
+    /// No failure branch echoes a bare status back at the reader; each names
+    /// what was probed (or why that is moot) and what to do next.
+    #[test]
+    fn a_failed_probe_reads_as_actionable_copy_never_a_status_echo() {
+        let cases = [
+            AdminUiError::CdrUnreachable("connection refused".to_owned()),
+            AdminUiError::CdrUnauthorized("expired".to_owned()),
+            AdminUiError::Forbidden("missing role".to_owned()),
+            AdminUiError::Unauthenticated,
+            AdminUiError::Cdr {
+                status: 302,
+                message: "HTTP 302".to_owned(),
+            },
+        ];
+        for error in cases {
+            let copy = smart_probe_failure_copy(&error);
+            assert!(
+                copy.starts_with("SMART discovery could not be read"),
+                "{copy}"
+            );
+            assert!(!copy.contains("CDR answered 302: HTTP 302"), "{copy}");
+            // Either the endpoint is named, or the branch explains why naming
+            // it would not help (the CDR was never reached).
+            assert!(
+                copy.contains(SMART_DISCOVERY_PATH) || copy.contains("unreachable"),
+                "{copy}"
+            );
+        }
+    }
+
+    /// An unexpected answer states that "enabled" is UNKNOWN — the one thing
+    /// the card must not do is imply SMART is off when it could not tell.
+    #[test]
+    fn an_unexpected_answer_does_not_claim_smart_is_disabled() {
+        let copy = smart_probe_failure_copy(&AdminUiError::Cdr {
+            status: 302,
+            message: "HTTP 302".to_owned(),
+        });
+        assert!(copy.contains("unknown"), "{copy}");
+        assert!(!copy.contains("not enabled"), "{copy}");
+    }
 
     #[cfg(feature = "ssr")]
     #[test]

--- a/deploy/vercel/README.md
+++ b/deploy/vercel/README.md
@@ -6,9 +6,11 @@ demo posture baked on top, and it resets to known demo data every night:
 
 - **`api`** — the CDR (`Dockerfile.vercel`, `FROM ghcr.io/rubentalstra/ferroehr:latest`).
   Owns the path families the server itself serves: `/ferroehr/*` (the REST
-  API and its Swagger UI), `/health*`, and `/management*` (disabled in the
+  API and its Swagger UI), `/health*`, `/management*` (disabled in the
   sandbox posture, so those answer the CDR's own 404 — which is what lets
-  the console's probe-and-hide read the truth).
+  the console's probe-and-hide read the truth), and `/.well-known/*`, so a
+  machine client probing the origin for a discovery document gets the CDR's
+  own answer rather than the console's sign-in redirect (#2954).
 - **`console`** — the admin console (`deploy/vercel/console/Dockerfile.vercel`,
   `FROM ghcr.io/rubentalstra/ferroehr-admin-ui:latest`), the LANDING surface
   (#2941): every other path routes here, so sandbox.ferroehr.eu opens on the

--- a/vercel.json
+++ b/vercel.json
@@ -31,6 +31,7 @@
         { "source": "/health/(.*)", "destination": { "service": "api" } },
         { "source": "/management", "destination": { "service": "api" } },
         { "source": "/management/(.*)", "destination": { "service": "api" } },
+        { "source": "/.well-known/(.*)", "destination": { "service": "api" } },
         { "source": "/(.*)", "destination": { "service": "console" } }
     ]
 }


### PR DESCRIPTION
Closes #2954. The `/system` SMART card read `CDR answered 302: HTTP 302` on the sandbox. Two defects stacked, and the spec settles which side was wrong.

## The path

ITS-REST `smart_app_launch/master04-service_discovery.adoc` §"the configuration endpoint" places the document relative to the **Platform** base URL, and covers the path-segment case in as many words: given `https://platform.example.com/gateway/v1`, discovery lives at `https://platform.example.com/gateway/v1/.well-known/smart-configuration`. FerroEHR's platform base is `/ferroehr/rest`, so the CDR's mount is right and the **console was probing the wrong resource** — the origin.

On a single-origin deployment that mistake was invisible: the origin-level miss returned the CDR's own 404 and the card read "disabled" by luck. On the sandbox, where `vercel.json` routes non-CDR paths to the console, the probe hit the console's own login guard and got its `302`. The console now asks for the served path.

## The copy

Any non-404 answer fell into a generic arm that printed the error's `Display`. Failures now render `smart_probe_failure_copy` — component-free and unit-tested, in the `write_failure_copy` house style: each branch names what was probed and the next action, and an unexpected answer states that whether SMART is enabled is **unknown**, rather than implying it is off when the probe could not tell. A CDR message that only restates its own status (`HTTP 302`) is dropped instead of printed beside the code it repeats.

Worth recording: the test asserting "never a status echo" **failed against my own first version** of that fallback, which interpolated `{error}` and reproduced `CDR answered 302: HTTP 302` inside a longer sentence. The copy was fixed, not the assertion.

## Sandbox routing

`/.well-known/*` now routes to the `api` service, so a machine client probing the origin for a discovery document gets the CDR's own answer instead of the console's sign-in redirect. The console does not rely on it — it asks for the served path directly — so the fix stands on its own.

## Gates

clippy clean on native + wasm32 · 528/528 nextest (3 new tests: the probed path, the no-status-echo property across five error shapes, and the unknown-not-disabled property) · leptosfmt + fmt · comment-style · docs-claims. `no-ui-visual-change` is deliberately NOT claimed: the card's text changes, so this rides the screenshot set refreshed in #2956 — merge that first and this needs no capture of its own.
