### PR TITLE
docs: the fork lineage is recorded in the import root, not in an inherited history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ workflow refuses a tag that has no matching section here.
 
 ### Changed
 
+- The repository's commit history on `main` now starts at a single labelled
+  import commit holding the tree FerroEHR was forked from, followed only by
+  this project's own commits. The 4864 inherited upstream commits and their
+  authors are no longer part of `main`. Nothing published changed: all release
+  tags still point at the commits they were cut from, release assets, Sigstore
+  bundles, image attestations and archived deposits verify exactly as before,
+  and the pre-rewrite lineage stays reachable in this repository through those
+  tags. Existing clones must be re-cloned rather than pulled, and comparisons
+  spanning the rewrite (for example `git describe` against `main`, or a tag
+  range that crosses it) no longer share ancestry.
 - The admin console's Template Manager uploads both template families the same
   way: one button in the page header (**Upload OPT** / **Upload ADL2**) opens a
   dialog offering a file picker and a paste area for either family, so ADL 1.4

--- a/README.md
+++ b/README.md
@@ -612,8 +612,9 @@ rather than left to be discovered.
 - **[EHRbase](https://github.com/ehrbase/ehrbase):** FerroEHR began as a
   fork of EHRbase, developed by
   [vitasystems GmbH](https://www.vitagroup.ag/) and the
-  [Peter L. Reichertz Institute](https://www.plri.de/), and keeps that
-  lineage in its git history. It is not affiliated with or endorsed by the
+  [Peter L. Reichertz Institute](https://www.plri.de/), and records that
+  lineage in the labelled import commit at the root of this repository's
+  history. It is not affiliated with or endorsed by the
   EHRbase project; EHRbase itself remains Apache-2.0, and no code from it
   is present in this tree.
 - **[openEHR Foundation](https://www.openehr.org/):** publishes the openEHR

--- a/docs/VERSIONS.md
+++ b/docs/VERSIONS.md
@@ -259,12 +259,21 @@ This is a fork; its import point is recorded so provenance is unambiguous:
 | Original reasoning authored against | EHRbase v2.31.0 |
 | Tree actually imported at (Phase 0) | EHRbase v2.33.0 |
 | Enterprise-capability prior art | upstream EHRbase tag v0.32.0 (last pre-v2) |
+| How the import is recorded | the root commit of `main`, `Import: EHRbase as the fork point` |
 
 The original design reasoning was authored against v2.31.0. By the time this
 fork's Phase 0 reorganization ran, upstream had advanced to v2.33.0, and that
 is the tree actually imported into the Cargo workspace. EHRbase v2.33.0 is the
 *prior-art* reference, consulted via its upstream repo — never an in-tree copy
 and never a parity oracle (acceptance is the openEHR CNF suite).
+
+The inherited commit history is not part of `main`. `main` begins at a single
+labelled import commit carrying the imported tree, and every commit after it is
+this project's own work (history rewritten 2026-08-31, issue #2962). The
+upstream commit history that produced the imported tree stays reachable in this
+repository through the release tags `v3.0.0` and later, whose ancestry predates
+that rewrite, so the provenance remains checkable first-hand rather than only
+asserted here.
 
 Work on enterprise capabilities not yet built (the plugin system and peers)
 may consult the upstream EHRbase v0.32.0 tag — the last release before the

--- a/website/book/src/introduction.md
+++ b/website/book/src/introduction.md
@@ -85,7 +85,8 @@ user terms; if you are new to openEHR itself, start with the
 
 > [!NOTE]
 > FerroEHR began as a fork of **EHRbase** (by vitasystems and the Peter L.
-> Reichertz Institute) and keeps that lineage in its git history, but it is an
+> Reichertz Institute) and records that lineage in the labelled import commit
+> at the root of its history, but it is an
 > independent, from-scratch Rust implementation with no EHRbase code in this
 > tree, and it is not affiliated with or endorsed by the EHRbase project.
 > FerroEHR's own code is MIT-licensed; vendored openEHR material keeps its

--- a/website/book/src/licensing.md
+++ b/website/book/src/licensing.md
@@ -181,8 +181,9 @@ no merge; `cargo deny` is the gate.
   endorsed by** the openEHR Foundation.
 - FerroEHR began as a fork of **EHRbase**, developed by
   [vitasystems GmbH](https://www.vitagroup.ag/) and the
-  [Peter L. Reichertz Institute](https://www.plri.de/), and keeps that lineage in
-  its git history. EHRbase itself remains Apache-2.0; no code from it is present
+  [Peter L. Reichertz Institute](https://www.plri.de/), and records that lineage
+  in the labelled import commit at the root of its history. EHRbase itself
+  remains Apache-2.0; no code from it is present
   in this tree, and it is consulted as prior art only. FerroEHR is not affiliated
   with or endorsed by the EHRbase project. The measured
   [comparison](comparison.md) between the two is published in both directions.

--- a/website/book/src/why-ferroehr.md
+++ b/website/book/src/why-ferroehr.md
@@ -134,7 +134,8 @@ products built on open foundations are a perfectly good outcome, and we would
 rather your product succeed with FerroEHR inside it than not exist at all.
 
 It is also not a claim to be the only good openEHR CDR. FerroEHR began as a
-fork of EHRbase and keeps that lineage in its git history; today it is an
+fork of EHRbase and records that lineage in the labelled import commit at the
+root of its history; today it is an
 independent Rust implementation with none of that code left in the tree, and
 we measure ourselves against EHRbase with the same instrument, publishing both
 directions of the result. FerroEHR is an independent implementation of the


### PR DESCRIPTION
`main` was rewritten on 2026-08-31 (issue #2962): it now begins at a single labelled import commit holding the tree FerroEHR was forked from, followed only by this project's own commits. Four prose sites told the reader the EHRbase lineage lives in this repository's commit history, which stopped being true at that push. They now point at the import commit instead.

`docs/VERSIONS.md` gains the same record beside its existing import-point table, plus where the pre-rewrite lineage stays reachable: the release tags `v3.0.0` and later, whose ancestry predates the rewrite. The provenance stays checkable in the repository rather than asserted only in prose.

The changelog entry states what a user of the repository has to know: nothing published changed, existing clones are re-cloned rather than pulled, and comparisons spanning the rewrite no longer share ancestry.

Guards run locally: `docs-claims`, `changelog-structure`, `licensing-declarations`, `packaged-attribution`, `copyright-holder`, all green.

Closes #2962
