### PR TITLE
chore(images): follow the upstream postgres:18.6 respin — new base digest at every pin site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1064,7 +1064,7 @@ jobs:
       contents: read
     services:
       postgres:
-        image: postgres:18.6@sha256:06cad38a5d9f5d24b4d83d86def30795d5e4b757fedbf5281172b576dedcd941
+        image: postgres:18.6@sha256:4ef4dbc939d61acea57712655ddb4b4ab27419c913f94cca0cd57cb3ea3c2280
         env:
           POSTGRES_USER: openehr
           POSTGRES_PASSWORD: openehr

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -466,7 +466,7 @@ jobs:
         org.opencontainers.image.authors=Ruben Talstra <https://github.com/rubentalstra>
         org.opencontainers.image.licenses=MIT AND PostgreSQL
         org.opencontainers.image.base.name=postgres:18.6
-        org.opencontainers.image.base.digest=sha256:06cad38a5d9f5d24b4d83d86def30795d5e4b757fedbf5281172b576dedcd941
+        org.opencontainers.image.base.digest=sha256:4ef4dbc939d61acea57712655ddb4b4ab27419c913f94cca0cd57cb3ea3c2280
 
   # ── Scan the pushed digests, then make them referencable ────────────────────
   # Both halves live in the reusable scan-and-tag.yml (#2776), which the release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -776,7 +776,7 @@ jobs:
         org.opencontainers.image.authors=Ruben Talstra <https://github.com/rubentalstra>
         org.opencontainers.image.licenses=MIT AND PostgreSQL
         org.opencontainers.image.base.name=postgres:18.6
-        org.opencontainers.image.base.digest=sha256:06cad38a5d9f5d24b4d83d86def30795d5e4b757fedbf5281172b576dedcd941
+        org.opencontainers.image.base.digest=sha256:4ef4dbc939d61acea57712655ddb4b4ab27419c913f94cca0cd57cb3ea3c2280
 
   # ── The gate that makes the pushed digests referencable ─────────────────────
   # The same reusable pair containers.yml uses, so the main lane and the

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -106,7 +106,7 @@ jobs:
     # machinery is gone with it.
     services:
       postgres:
-        image: postgres:18.6@sha256:06cad38a5d9f5d24b4d83d86def30795d5e4b757fedbf5281172b576dedcd941
+        image: postgres:18.6@sha256:4ef4dbc939d61acea57712655ddb4b4ab27419c913f94cca0cd57cb3ea3c2280
         env:
           POSTGRES_USER: openehr
           POSTGRES_PASSWORD: openehr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Security
+
+- The `ferroehr-postgres` image builds from the respun upstream `postgres:18.6`
+  base (the tag was re-pointed upstream with rebuilt base packages and bundled
+  binaries); the digest pin follows it everywhere it appears. The rebuilt
+  candidate scans clean at the published-image gate.
+
 ### Changed
 
 - The repository's commit history on `main` now starts at a single labelled

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -9,20 +9,21 @@
 # superuser. Schema CONTENT is owned by the app's sqlx migrators at boot; this
 # image bakes NO migration state (see README.md).
 #
-# Digest-pinned (resolved 2026-08-18): a mutable tag can be re-pointed, a digest
-# cannot (docs.docker.com/build/building/best-practices — "pinning to a digest
+# Digest-pinned (resolved 2026-08-31, the upstream same-version respin): a
+# mutable tag can be re-pointed, a digest cannot
+# (docs.docker.com/build/building/best-practices — "pinning to a digest
 # guarantees the same image version"). 18.6 is the latest PG 18 patch
 # (docs/VERSIONS.md; 18.5 was never released upstream); bump the tag AND the
 # digest together — the full pin-site checklist is
 # .claude/rules/image-security.md.
-FROM postgres:18.6@sha256:06cad38a5d9f5d24b4d83d86def30795d5e4b757fedbf5281172b576dedcd941
+FROM postgres:18.6@sha256:4ef4dbc939d61acea57712655ddb4b4ab27419c913f94cca0cd57cb3ea3c2280
 
 # Debian security updates, applied at OUR build time (issue #2408). The
 # upstream image rebuilds on its own cadence, so a fix already published in
-# trixie-security can sit unpulled for weeks in the pinned base — postgres:18.6
-# (built 2026-08-13) still ships the util-linux packages whose CVE-2026-53615
-# fix trixie-security carries. Plain `upgrade`, never `dist-upgrade`: packages
-# are only patched, none added or removed.
+# trixie-security can sit unpulled for weeks in the pinned base — the
+# 2026-08-13 build of postgres:18.6 shipped util-linux packages whose
+# CVE-2026-53615 fix trixie-security already carried. Plain `upgrade`, never
+# `dist-upgrade`: packages are only patched, none added or removed.
 RUN set -eux; \
     apt-get update; \
     apt-get -y upgrade; \
@@ -48,4 +49,4 @@ LABEL org.opencontainers.image.title="FerroEHR PostgreSQL" \
       org.opencontainers.image.authors="Ruben Talstra <https://github.com/rubentalstra>" \
       org.opencontainers.image.licenses="MIT AND PostgreSQL" \
       org.opencontainers.image.base.name="postgres:18.6" \
-      org.opencontainers.image.base.digest="sha256:06cad38a5d9f5d24b4d83d86def30795d5e4b757fedbf5281172b576dedcd941"
+      org.opencontainers.image.base.digest="sha256:4ef4dbc939d61acea57712655ddb4b4ab27419c913f94cca0cd57cb3ea3c2280"

--- a/scripts/security/scan-images.sh
+++ b/scripts/security/scan-images.sh
@@ -71,9 +71,10 @@ for target in "${targets[@]}"; do
   [[ -n "$platform" ]] && platform_args=(--platform "$platform")
   safe=$(printf '%s' "${ref}_${platform}" | tr '/:@' '___')
   report="$out_dir/${safe}.json"
-  echo "── scanning ${ref} ${platform:-'(as built)'}"
+  echo "── scanning ${ref} ${platform:-(as built)}"
   trivy image --skip-version-check --config trivy.yaml --scanners vuln \
-    "${platform_args[@]}" "${vex_args[@]}" -f json -o "$report" "$ref"
+    ${platform_args[@]+"${platform_args[@]}"} ${vex_args[@]+"${vex_args[@]}"} \
+    -f json -o "$report" "$ref"
   count=$(jq '[.Results[]?.Vulnerabilities // [] | .[]] | length' "$report")
   if [[ "$count" -gt 0 ]]; then
     jq -r '.Results[]? | .Target as $t | (.Vulnerabilities // [])[]

--- a/security/vex/README.md
+++ b/security/vex/README.md
@@ -29,6 +29,7 @@ re-evaluate.
 | File | Subject | Authored |
 |---|---|---|
 | `postgres-gosu.openvex.json` | Go standard-library advisories in `/usr/local/bin/gosu`, the privilege-dropping helper the upstream `postgres` image ships. Not reachable: gosu sets uid/gid and execs, opening no socket and parsing no untrusted input. | by hand |
+| `distroless-libssl.openvex.json` | CVE-2026-14456 in the `libssl3t64` the distroless base ships. Not reachable: nothing in the shipped binaries links libssl (rustls/aws-lc everywhere, no `openssl-sys` in `Cargo.lock`); goes when distroless rebuilds with openssl 3.5.7 (#2747). | by hand |
 | `rust-advisories.openvex.json` | The Rust dependency advisories: the five accepted by the advisory gate, plus the one a lock-file-reading scanner reports for a crate our feature set never compiles. Each statement additionally carries a `ferroehr:reachability` block — our own extension, since OpenVEX defines none — naming the crates the affected package is reached through. | **generated** |
 
 ## The generated document

--- a/website/book/src/verifying-releases.md
+++ b/website/book/src/verifying-releases.md
@@ -338,6 +338,7 @@ tooling at them (`trivy --vex`, and most SCA platforms take an OpenVEX feed).
 |---|---|
 | `rust-advisories.openvex.json` | the Rust dependency advisories: the ones the advisory gate accepts, plus one that only a `Cargo.lock`-reading scanner reports |
 | `postgres-gosu.openvex.json` | Go standard-library findings in the `gosu` helper the upstream `postgres` image ships |
+| `distroless-libssl.openvex.json` | an openssl finding in the `libssl3t64` library the distroless base ships but nothing in the binaries links |
 
 The Rust document is **generated** from `deny.toml` (the gate that actually
 decides whether a build passes) joined with the published reasoning, and a CI


### PR DESCRIPTION
Closes #2959.

The weekly base-image watcher found `postgres:18.6` re-pointed upstream — a same-version security respin (rebuilt base packages and bundled binaries). This follows it: the manifest-list digest (`sha256:4ef4dbc9…`, verified live via `docker buildx imagetools inspect`) replaces the old pin at all six sites the label guard keeps in step — the Dockerfile `FROM` + `base.digest` label, `containers.yml`, `release.yml`, and the `ci.yml`/`sonar.yml` service containers. Same version, so no version-text sweep applies.

Verified per `.claude/rules/image-security.md`: `scripts/security/scan-images.sh --candidate` on the rebuilt image reports **0 fixable HIGH/CRITICAL findings**. The gosu VEX adjudications were re-checked and **stay**: the respin ships the same gosu 1.19 built on go1.24.6, so all 22 adjudicated Go-stdlib advisories still fire without them (measured: removing the entries yields exactly 22 findings; restoring them, 0).

En route:
- `scripts/security/scan-images.sh` crashed on the `--candidate` path under macOS bash 3.2 (`platform_args[@]: unbound variable` — empty-array expansion under `set -u`); fixed with the `${arr[@]+…}` guard, plus the echo that printed literal quotes around `(as built)`.
- The VEX document tables in `security/vex/README.md` and the book's verifying-releases page were missing the `distroless-libssl.openvex.json` row that has existed since #2747; both now list it.