### PR TITLE
feat(sandbox): the Admin API is served — the conformance statement's claims are exercisable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,6 @@ workflow refuses a tag that has no matching section here.
   spec's own terms, and the conformance statement's AdminApi claims become
   exercisable against it. The public demo credential reaches the whole admin
   group, bulk delete included — it wipes what the nightly reset wipes anyway.
-
-### Changed
-
 - The repository's commit history on `main` now starts at a single labelled
   import commit holding the tree FerroEHR was forked from, followed only by
   this project's own commits. The 4864 inherited upstream commits and their

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ workflow refuses a tag that has no matching section here.
 
 ### Changed
 
+- The hosted sandbox (sandbox.ferroehr.eu) now serves the Admin API: the
+  nightly-reset demo is a development/testing deployment in the released
+  spec's own terms, and the conformance statement's AdminApi claims become
+  exercisable against it. The public demo credential reaches the whole admin
+  group, bulk delete included — it wipes what the nightly reset wipes anyway.
+
+### Changed
+
 - The repository's commit history on `main` now starts at a single labelled
   import commit holding the tree FerroEHR was forked from, followed only by
   this project's own commits. The 4864 inherited upstream commits and their

--- a/deploy/vercel/ferroehr.sandbox.toml
+++ b/deploy/vercel/ferroehr.sandbox.toml
@@ -3,11 +3,15 @@
 #
 # The hosted-sandbox posture (#2710, sandbox.ferroehr.eu), baked into the
 # Vercel image by Dockerfile.vercel. It differs from the compose quickstart
-# where a PUBLIC endpoint demands it: the admin API and the management
-# introspection stay OFF (defaults), so the public demo credentials can read
-# and write clinical data and nothing else. The database DSN comes from the
-# environment, never from this file — the Neon integration's injected
-# DATABASE_URL(_UNPOOLED), mapped to db.url by the config aliases (#2716).
+# where a PUBLIC endpoint demands it: the management introspection stays OFF
+# (default). The admin API is ON (owner ruling, #2965): the sandbox resets
+# nightly, so it is disposable by design — the development/testing posture the
+# released admin operations describe — and the conformance statement's
+# AdminApi claims become exercisable against this deployment. The public bulk
+# delete is accepted: it wipes what the nightly reset wipes anyway. The
+# database DSN comes from the environment, never from this file — the Neon
+# integration's injected DATABASE_URL(_UNPOOLED), mapped to db.url by the
+# config aliases (#2716).
 
 [server]
 # Vercel's default container port; the PORT environment convention lands on
@@ -19,6 +23,11 @@ cors_permissive = true
 [auth]
 enabled = true
 
+# The whole admin group behind the demo credential — no partial enablement,
+# no separate admin user (owner ruling, #2965).
+[admin]
+enabled = true
+
 # The demo user: ferroehr / ferroehr (the hash is Argon2id of "ferroehr").
 # Public by design; the sandbox holds demo data only and is wiped on a
 # schedule.
@@ -27,7 +36,7 @@ username = "ferroehr"
 password_hash = "$argon2id$v=19$m=19456,t=2,p=1$ZmVycm9laHJEZXZTYWx0$be5nPwWjfUl1qvSrvkvqvdMOuCgM0VFcN/VN4MFLjT8"
 roles = ["USER"]
 
-# Authentication only, no role gate — one demo user, no admin surface exists
-# to separate (admin + management stay disabled above by default).
+# Authentication only, no role gate — the one demo user deliberately reaches
+# every enabled surface, the admin group included (#2965).
 [authz.rbac]
 enabled = false


### PR DESCRIPTION
Closes #2965.

The sandbox answered `405 Method Not Allowed` on every admin route — specification-legal, but the committed conformance statement claims `AdminApi` plus four admin extensions, and a claim the driven deployment cannot exercise is unevidenced. Owner ruling on the issue: enable the whole Admin API, no separate credential, no partial enablement — the sandbox resets nightly, so it is disposable by design, and a public wipe of a database that is wiped nightly costs nothing worth protecting.

The change is one section in `deploy/vercel/ferroehr.sandbox.toml` (`[admin] enabled = true`) plus the posture comments, which claimed admin stays off. With `authz.rbac.enabled = false` the demo user reaches the admin class — verified in `app/ferroehr-rest/src/extensions/access/authz/roles.rs` (`rbac.enabled = false` allows every operation class; pinned by `rbac_disabled_allows_everything`). Vercel rebuilds from `Dockerfile.vercel` on the merge, which bakes this file.

Run-integrity note recorded on the issue: a conformance run must not straddle the nightly reset — a wipe mid-run invalidates the run, which is scheduling, not security.