### PR TITLE
chore(quality): the comment-debt condensation over app/ferroehr — part 1, plain comments

### DIFF
--- a/app/ferroehr/src/aql/analyze.rs
+++ b/app/ferroehr/src/aql/analyze.rs
@@ -450,10 +450,9 @@ fn version_field_from_parts(parts: &[&str]) -> Result<VersionField, AqlError> {
     match parts {
         ["uid", ..] => Ok(VersionField::Uid),
         // The two CODED version fields are sub-path-sensitive: the stored
-        // representation is the numeric group code, the rubric renders from
-        // the openEHR terminology group, and the terminology id is the
-        // constant `openehr` — a flat mapping would compare the rubric form
-        // against the code and silently never match (#976).
+        // representation is the numeric group code, the rubric renders from the
+        // openEHR terminology group, and the terminology id is the constant
+        // `openehr` — a flat mapping would silently never match.
         ["lifecycle_state", rest @ ..] => coded_version_field(
             rest,
             parts,
@@ -474,11 +473,9 @@ fn version_field_from_parts(parts: &[&str]) -> Result<VersionField, AqlError> {
             ),
             ["committer", ..] => Ok(VersionField::Committer),
             // AUDIT_DETAILS.description is a DV_TEXT whose DV_CODED_TEXT
-            // subtype carries a defining_code (RM common
-            // UML/classes/org.openehr.rm.common.audit_details.adoc
-            // §Attributes), so each addressed representation resolves to its
-            // own extraction — a flat mapping would compare a coded
-            // description's code against its display text and never match.
+            // subtype carries a defining_code (`audit_details.adoc`
+            // §Attributes), so each addressed representation resolves to its own
+            // extraction.
             ["description", rest @ ..] => match rest {
                 [] => Ok(VersionField::Description),
                 ["value"] => Ok(VersionField::DescriptionValue),
@@ -602,14 +599,11 @@ fn apply_standard(sp: &StandardPredicate, out: &mut NodeConstraint) -> Result<()
         });
         return Ok(());
     }
-    // `archetype_node_id = <code|hrid>` — the standard-predicate form the
-    // QUERY spec declares equivalent to the archetype/node shortcut predicates
-    // (master03 §Archetype predicate: "These predicates could also be written
-    // as standard predicates"). Which of the two the operand is, is decided by
-    // the RM's own reading of `LOCATABLE.archetype_node_id`
-    // (`openehr_rm::v1_2::paths`), never a leader guess: an id in `ARCHETYPE_ID`
-    // lexical form is an archetype root, an `at`/`id` term code is an interior
-    // node, and anything else addresses no node at all.
+    // `archetype_node_id = <code|hrid>` is the standard-predicate form of the
+    // archetype/node shortcut predicates (master03 §Archetype predicate). Which
+    // of the two the operand is comes from the RM's own reading of
+    // `LOCATABLE.archetype_node_id` (`openehr_rm::v1_2::paths`), never a leader
+    // guess.
     if sp.op == CompOp::Eq
         && parts == ["archetype_node_id"]
         && let Bind::Literal(TypedLit::String(s)) = &value

--- a/app/ferroehr/src/aql/sql/from.rs
+++ b/app/ferroehr/src/aql/sql/from.rs
@@ -171,7 +171,7 @@ pub(super) fn streaming_plan(ir: &QueryIr) -> Option<StreamPlan> {
     // A FOLDER root is ineligible: the streaming shape binds the root at
     // `num = 0`, but `EHR CONTAINS FOLDER` matches every folder node
     // (containment is transitive — QUERY master03 §Containment), which only
-    // the flat shape's whole-table scan serves (#2880).
+    // the flat shape's whole-table scan serves.
     if r.rm_type.names().iter().any(|t| t == "FOLDER") {
         return None;
     }
@@ -659,11 +659,8 @@ impl Builder<'_> {
             self.q.and_where(cond);
         }
 
-        // The edge kind is classified from the RM relationship of the two
-        // operands' types (#2880). Before this, the join shape was inferred
-        // from the CHILD alone (VO root or not) — a VO-root child under a
-        // non-EHR parent silently dropped the parent edge entirely and
-        // answered a cartesian product.
+        // The edge kind is classified from the RM relationship of BOTH
+        // operands' types: the child alone does not determine the join shape.
         let edge = match vo {
             Some(parent) => Some(classify_edge(&parent.types, &r.rm_type)?),
             None => None,
@@ -697,13 +694,10 @@ impl Builder<'_> {
             self.group_vos.push(voa.clone());
             self.vo_alias.insert(sid, voa.clone());
             if let Some(e) = ehr {
-                // The EHR link binds on the version SPINE only: vo_version.
-                // ehr_id equals the node rows' by construction (one owning
-                // EHR per versioned object — RM ehr master04 §EHR), the node
-                // group already joins the spine on (vo_id, sys_version), and
-                // the spine predicate drives idx_vo_version_ehr. A node-side
-                // twin predicate bought no plan this route does not serve and
-                // cost a per-node-row index at every write (#2698).
+                // The EHR link binds on the version SPINE only: one owning EHR
+                // per versioned object (RM ehr master04 §EHR) makes the node
+                // rows' `ehr_id` equal by construction, and the spine predicate
+                // drives idx_vo_version_ehr with no per-node-row index.
                 self.q.and_where(col(&voa, "ehr_id").eq(col(e, "id")));
                 self.roots_linked_to_ehr.insert(node.clone());
             }
@@ -714,11 +708,10 @@ impl Builder<'_> {
             if let (Some(EdgeKind::FolderItems), Some(parent)) = (edge, vo) {
                 self.q.and_where(folder_items_exists(&parent.node, &node));
             }
-            // FolderChild: the union edge (#2887) — a by-value strict
-            // descendant in the parent's own tree, or any folder row of an
-            // items-referenced VERSIONED_FOLDER. The child's own version
-            // group serves both branches: in the by-value branch the child's
-            // spine row IS the parent's (same vo_id + sys_version).
+            // FolderChild is a union edge: a by-value strict descendant of the
+            // parent's own tree, or any folder row of an items-referenced
+            // VERSIONED_FOLDER. The child's version group serves both — a
+            // by-value child's spine row IS the parent's.
             if let (Some(EdgeKind::FolderChild), Some(parent)) = (edge, vo) {
                 self.q.and_where(
                     folder_by_value_child(&parent.node, &node)
@@ -805,12 +798,10 @@ impl Builder<'_> {
                         );
                     }
                     EdgeKind::FolderChild => {
-                        // The union edge (#2887): a by-value strict
-                        // descendant, or any folder row of an items-referenced
-                        // VERSIONED_FOLDER — the latter needs the child's own
-                        // version spine + scope (the FolderItems shape below;
-                        // by-value rows satisfy it too, sharing the parent's
-                        // spine row).
+                        // The union edge: an items-referenced VERSIONED_FOLDER
+                        // needs the child's own version spine + scope, which a
+                        // by-value descendant satisfies too by sharing the
+                        // parent's spine row.
                         let voa = format!("xv{}", self.next_ctr());
                         sub.from_as(VoVersion::Table, Alias::new(voa.as_str()));
                         sub.and_where(col(alias, "vo_id").eq(col(&voa, "vo_id")));
@@ -895,7 +886,6 @@ impl Builder<'_> {
         // single-`ehr_id` REST case is just the one-element set. Empty = no
         // explicit scope (the population gate takes over).
         if !self.ctx.ehr_ids.is_empty() {
-            // sea-query bind boundary: the `ehr_id` column is a plain `uuid`.
             let ids: Vec<Uuid> = self.ctx.ehr_ids.iter().map(|id| id.0).collect();
             for root in self.group_roots.clone() {
                 self.q.and_where(col(&root, "ehr_id").is_in(ids.clone()));
@@ -908,10 +898,9 @@ impl Builder<'_> {
                 self.q.and_where(col(&alias, "id").is_in(ids.clone()));
             }
         }
-        // ABAC patient scope (no openEHR spec governs this, our own
-        // access-control extension): restrict
-        // every VO root to the caller's patient EHRs. Rows outside are never
-        // fetched — regardless of the query's projection (the v1 defect-#1 fix).
+        // NOTE: the ABAC patient scope restricts every VO root to the caller's
+        // patient EHRs, so out-of-scope rows are never fetched whatever the
+        // projection (no openEHR spec governs this — our own extension).
         if let Some(subject) = self.ctx.subject_scope.clone() {
             for root in self.group_roots.clone() {
                 let mut sub = Query::select();

--- a/app/ferroehr/src/aql/sql/predicate.rs
+++ b/app/ferroehr/src/aql/sql/predicate.rs
@@ -106,13 +106,10 @@ impl Builder<'_> {
         coercion: Coercion,
         positive: bool,
     ) -> Result<Expr, AqlError> {
-        // Typed EHR-id equality: `e/ehr_id/value = <uuid>` as a uuid comparison
-        // on `ehr.id` instead of a text-cast on both sides (which blinded the
-        // btree on `ehr.id` and left the join unbounded). uuid equality is
-        // value-based — case-insensitive — which is also the
-        // identifier-equality semantics (BASE base_types master05 §Composite
-        // Identifiers and Case); a literal that is not a uuid can match no EHR
-        // (constant).
+        // `e/ehr_id/value = <uuid>` compares as uuid on `ehr.id`, keeping the
+        // btree usable where a two-sided text cast would not. uuid equality is
+        // case-insensitive, which is also the identifier-equality semantics
+        // (BASE base_types master05 §Composite Identifiers and Case).
         if let Some(expr) = self.ehr_id_typed_compare(lhs, op, rhs)? {
             return Ok(expr);
         }
@@ -448,10 +445,7 @@ impl Builder<'_> {
                 // A function operand joins the comparison in the requested
                 // coercion space like any literal: the date/time functions
                 // render ISO-8601 text (QUERY master03 §Date and time
-                // functions), so a temporal comparison casts them to
-                // timestamptz exactly as it casts a temporal literal —
-                // otherwise a promoted timestamptz column has no operator
-                // against text.
+                // functions), which a temporal comparison must cast.
                 Ok(match coercion {
                     Coercion::Temporal => cast(expr, "timestamptz"),
                     _ => expr,

--- a/app/ferroehr/src/aql/sql/value.rs
+++ b/app/ferroehr/src/aql/sql/value.rs
@@ -235,14 +235,11 @@ impl Builder<'_> {
         sub.expr(Expr::val(1));
         sub.and_where(cond(coerce_value(base, mode, leaf)));
         if self.streaming {
-            // STREAMING shape: the EXISTS must stay CORRELATED. As a bare WHERE
-            // sublink the planner may pull it up into a semi-join and
-            // DECORRELATE its inner side into a corpus-wide Materialize, which
-            // costs seconds per execution where the correlated probe runs in
-            // milliseconds. Hosting the EXISTS inside a LATERAL subquery behind
-            // the `OFFSET 0` fence pins the correlated per-row SubPlan by
-            // construction (a `LIMIT 1` inside the sublink is NOT a fence).
-            // Identical semantics: one boolean per outer row.
+            // The EXISTS must stay CORRELATED: as a bare WHERE sublink the
+            // planner may pull it up and decorrelate its inner side into a
+            // corpus-wide Materialize. Hosting it in a LATERAL behind the
+            // `OFFSET 0` fence pins the per-row SubPlan (a `LIMIT 1` inside the
+            // sublink is NOT a fence); semantics are one boolean per outer row.
             let probe = format!("p{}", self.next_ctr());
             let mut wrapper = Query::select();
             wrapper.expr_as(Expr::exists(sub), Alias::new("hit"));
@@ -344,7 +341,6 @@ impl Builder<'_> {
         {
             return None;
         }
-        // Flattened attribute path: anchor hops then fragment names.
         let path: Vec<&str> = leaf
             .anchor
             .iter()
@@ -466,13 +462,10 @@ impl Builder<'_> {
         for key in self.ir.order_by.clone() {
             let OrderKey { path, ascending } = key;
             let order = if ascending { Order::Asc } else { Order::Desc };
-            // SELECT DISTINCT: PostgreSQL requires every ORDER BY expression
-            // to appear in the select list, so a sort key that IS a selected
-            // column orders by that output column (jsonb ordering of the
-            // projected cell — numbers numeric, strings lexical), and an
-            // unselected sort key is a typed reject: QUERY master03 §DISTINCT
-            // defines no semantics for sorting a de-duplicated projection by
-            // an expression outside it.
+            // PostgreSQL requires every ORDER BY expression of a SELECT
+            // DISTINCT to appear in the select list, so a selected sort key
+            // orders by its output column and an unselected one is a typed
+            // reject — QUERY master03 §DISTINCT defines no semantics for it.
             if self.ir.distinct {
                 let selected = self.ir.select.iter().position(
                     |c| matches!(&c.value, crate::aql::ir::SelectValue::Path(p) if *p == path),
@@ -487,13 +480,11 @@ impl Builder<'_> {
                     }
                 }
             }
-            // ORDER BY `e/ehr_id[/value]` sorts by the raw `ehr.id` uuid column,
-            // not the `CAST(id AS text)` the projection reads: a UUID's canonical
-            // text form is fixed-length lowercase hex (BASE base_types master05
-            // §Basic Types — Uuid), so lexical text order and the uuid binary
-            // order coincide — the row sequence is byte-identical while the raw
-            // column is index-served instead of forcing a per-row cast. The text
-            // cast stays in the projection path.
+            // ORDER BY `e/ehr_id[/value]` sorts by the raw `ehr.id` column: a
+            // UUID's canonical text form is fixed-length lowercase hex (BASE
+            // base_types master05 §Basic Types — Uuid), so text and binary
+            // order coincide and the index serves the sort without a per-row
+            // cast. The projection path keeps the text cast.
             if let PathTarget::Ehr {
                 source,
                 field: EhrField::EhrId | EhrField::Whole,
@@ -544,7 +535,7 @@ pub(super) fn coerce_value(base: Expr, mode: ValueMode, leaf: &LeafPath) -> Expr
         ValueMode::Value(Coercion::Boolean) => cast(as_text(base), "boolean"),
         // NOTE: RM data_types master07 §Partial Date/Times admits reduced
         // precision, so the leaf reads through the total `ext.openehr_timestamp`
-        // — floor completion, NULL for garbage (the recorded semantics, #1493).
+        // — floor completion, NULL for garbage.
         ValueMode::Value(Coercion::Temporal) => call("openehr_timestamp", vec![as_text(base)]),
         ValueMode::Value(Coercion::Text | Coercion::Raw) => as_text(base),
         // a mixed-type (`Raw`) leaf being compared/matched against a
@@ -591,7 +582,7 @@ pub(super) fn coerce_rhs(value: sea_query::Value, coercion: Coercion) -> Result<
 fn is_iso_temporal(s: &str) -> bool {
     static ISO_TEMPORAL: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
         // The separator set includes the space form PostgreSQL's own parser
-        // accepts, so previously-working SQL-style literals keep working.
+        // accepts.
         let time = r"\d{2}(:\d{2}(:\d{2}([.,]\d+)?)?|\d{2}(\d{2}([.,]\d+)?)?)?";
         let offset = r"([Zz]|[+-]\d{2}(:?\d{2})?)?";
         let date = r"\d{4}(-\d{2}(-\d{2})?|\d{2}(\d{2})?)?";
@@ -667,9 +658,7 @@ pub(super) fn version_field_expr(
         VersionField::SystemId => col(&audit(), "system_id"),
         VersionField::ChangeType => col(&audit(), "change_type"),
         // The rubric renders from the openEHR terminology group at SQL-build
-        // time (the bundle is the authority, never a hardcoded rubric — the
-        // same rule as the versioning render edge); the terminology id of
-        // both coded version fields is the constant `openehr` (#976).
+        // time — the bundle is the authority, never a hardcoded rubric.
         VersionField::ChangeTypeRubric => {
             coded_rubric_case(&col(&audit(), "change_type"), "audit_change_type")
         }
@@ -708,7 +697,7 @@ pub(super) fn version_field_expr(
             coded_rubric_case(&col(voa, "lifecycle_state"), "version_lifecycle_state")
         }
         // Both coded version fields belong to the constant `openehr`
-        // terminology (#976).
+        // terminology.
         VersionField::ChangeTypeTerminology | VersionField::LifecycleStateTerminology => {
             Expr::val("openehr")
         }

--- a/app/ferroehr/src/config/loader.rs
+++ b/app/ferroehr/src/config/loader.rs
@@ -164,7 +164,7 @@ pub fn assemble<S: std::hash::BuildHasher>(
         // `serde_path_to_error` wraps the deserializer so a refusal names the
         // SECTION PATH ("auth.oidc"), which plain serde errors do not carry —
         // the ingredient that lets `enrich` attribute the right file line, or
-        // honestly say the key came from the environment (#2572).
+        // honestly say the key came from the environment.
         Ok(built) => match serde_path_to_error::deserialize::<_, FerroEhrConfig>(built) {
             Ok(config) => Some(config),
             Err(e) => {
@@ -562,9 +562,9 @@ mod tests {
 
     #[test]
     fn an_env_sourced_unknown_key_names_its_section_and_the_variable() {
-        // #2572 regression: FERROEHR__AUTH__OIDC__ENABLED built a nested
-        // auth.oidc.enabled that OidcConfig rejects — the diagnostic must name
-        // the full path and the environment spelling, never a file line.
+        // FERROEHR__AUTH__OIDC__ENABLED builds a nested auth.oidc.enabled that
+        // OidcConfig rejects: the diagnostic must name the full path and the
+        // environment spelling, never a file line.
         let env: HashMap<String, String> = [(
             "FERROEHR__AUTH__OIDC__ENABLED".to_owned(),
             "false".to_owned(),
@@ -597,7 +597,7 @@ mod tests {
             find_key_line_in_section(content, "admin", "enabled"),
             Some(2)
         );
-        // The pre-fix behaviour: the bare name from the WRONG section.
+        // The bare name from the WRONG section resolves to nothing.
         assert_eq!(
             find_key_line_in_section(content, "auth.oidc", "enabled"),
             None

--- a/app/ferroehr/src/config/mod.rs
+++ b/app/ferroehr/src/config/mod.rs
@@ -456,8 +456,8 @@ pub fn load(
     let file = loader::discover_file(cli_config, &env)?;
     let config = assemble(file.as_deref(), &env, overrides)?;
 
-    // Review condition 1: never a silent production trap — announce the dev
-    // default DSN prominently at boot.
+    // The dev default DSN is announced prominently at boot so it is never a
+    // silent production trap.
     if config.db.is_dev_default() {
         tracing::warn!(
             url = crate::db::DEFAULT_URL,
@@ -596,14 +596,12 @@ mod tests {
         // file overrides default (20).
         let c = assemble_ok(Some(file.path()), &env(&[]), &[]);
         assert_eq!(c.db.max_connections, 5);
-        // env overrides file.
         let c = assemble_ok(
             Some(file.path()),
             &env(&[("FERROEHR__DB__MAX_CONNECTIONS", "9")]),
             &[],
         );
         assert_eq!(c.db.max_connections, 9);
-        // --set overrides env.
         let c = assemble_ok(
             Some(file.path()),
             &env(&[("FERROEHR__DB__MAX_CONNECTIONS", "9")]),
@@ -614,10 +612,8 @@ mod tests {
 
     #[test]
     fn conventional_aliases_lose_to_ferroehr_forms() {
-        // DATABASE_URL alone binds db.url.
         let c = assemble_ok(None, &env(&[("DATABASE_URL", "postgres://a@h/x")]), &[]);
         assert_eq!(c.db.url.expose(), "postgres://a@h/x");
-        // FERROEHR__DB__URL wins over DATABASE_URL.
         let c = assemble_ok(
             None,
             &env(&[
@@ -649,7 +645,6 @@ mod tests {
             c.db.url.expose(),
             "postgres://demo:p%40ss%2Fw@db.example.neon.tech/ferroehr?sslmode=require"
         );
-        // DATABASE_URL wins over the assembled form.
         let c = assemble_ok(
             None,
             &env(&[
@@ -660,7 +655,6 @@ mod tests {
             &[],
         );
         assert_eq!(c.db.url.expose(), "postgres://a@h/x");
-        // FERROEHR__DB__URL wins over everything.
         let c = assemble_ok(
             None,
             &env(&[
@@ -675,8 +669,8 @@ mod tests {
 
     #[test]
     fn unpooled_endpoints_win_over_pooled_ones() {
-        // A transaction-pooled endpoint drops the session search_path (#2716),
-        // so the direct form outranks the pooled one within the alias layer.
+        // A transaction-pooled endpoint drops the session search_path, so the
+        // direct form outranks the pooled one within the alias layer.
         let c = assemble_ok(
             None,
             &env(&[
@@ -686,7 +680,6 @@ mod tests {
             &[],
         );
         assert_eq!(c.db.url.expose(), "postgres://direct@h/x");
-        // The libpq assembly prefers the direct host too.
         let c = assemble_ok(
             None,
             &env(&[
@@ -709,7 +702,6 @@ mod tests {
         // platform convention: Vercel/Cloud Run/Heroku inject only the port).
         let c = assemble_ok(None, &env(&[("PORT", "3123")]), &[]);
         assert_eq!(c.server.bind, "0.0.0.0:3123");
-        // FERROEHR__SERVER__BIND wins over PORT.
         let c = assemble_ok(
             None,
             &env(&[
@@ -721,7 +713,7 @@ mod tests {
         assert_eq!(c.server.bind, "127.0.0.1:9000");
     }
 
-    // ── 2. Mapping (the test class whose absence let the dead env form ship) ──
+    // ── 2. Mapping ────────────────────────────────────────────────────────────
 
     #[test]
     fn env_mapping_scalars_maps_and_lists() {
@@ -775,7 +767,7 @@ mod tests {
         let c = assemble_ok(
             None,
             &env(&[
-                // The key #2122's rotation keyring depends on.
+                // The key the signing rotation keyring depends on.
                 (
                     "FERROEHR__SIGNING__RETIRED_KEY_PATHS",
                     "/etc/ferroehr/retired-2025.pub.asc",
@@ -890,17 +882,14 @@ mod tests {
     /// the compatibility default, the file value, and the `FERROEHR__` env form.
     #[test]
     fn server_system_id_default_file_and_env() {
-        // Default: unchanged from the service-layer constant, so an unset key
-        // boots byte-identically to previous behaviour.
+        // Unset, the default is the service-layer constant.
         let c = assemble_ok(None, &env(&[]), &[]);
         assert_eq!(c.server.system_id, crate::service::DEFAULT_SYSTEM_ID);
 
-        // File.
         let file = toml_file("[server]\nsystem_id = \"cdr.hospital.example\"\n");
         let c = assemble_ok(Some(file.path()), &env(&[]), &[]);
         assert_eq!(c.server.system_id, "cdr.hospital.example");
 
-        // Env wins over the file (the uniform `__` grammar).
         let c = assemble_ok(
             Some(file.path()),
             &env(&[("FERROEHR__SERVER__SYSTEM_ID", "cdr.env.example")]),
@@ -926,7 +915,7 @@ mod tests {
 
     #[test]
     fn near_miss_prefix_suggests_the_uniform_spelling() {
-        // The old mixed form (single `_` after the prefix) no longer binds; the
+        // The mixed form (a single `_` after the prefix) does not bind; the
         // sweep names the exact uniform spelling.
         let err = assemble(None, &env(&[("FERROEHR_DB__URL", "postgres://x")]), &[])
             .expect_err("near-miss");
@@ -991,7 +980,6 @@ mod tests {
         let rendered = c.to_redacted_toml().expect("toml");
         assert!(!rendered.contains("topsecret"), "secret leaked: {rendered}");
         assert!(!serde_json::to_string(&c).unwrap().contains("topsecret"));
-        // *_file resolution.
         let secret = assert_fs::NamedTempFile::new("pass").expect("temp");
         secret.write_str("s3cret\n").expect("write");
         let file = toml_file(&format!(
@@ -1455,7 +1443,6 @@ mod tests {
             ..FerroEhrConfig::default()
         };
 
-        // Disagreeing issuers.
         let err = tree(
             "https://as.example/realms/ferroehr",
             Some("https://other-as.example/realms/ferroehr"),
@@ -1659,7 +1646,6 @@ mod tests {
         let err = c.validate().expect_err("a dangling route must be rejected");
         assert!(err.to_string().contains("snomed"), "got {err}");
 
-        // Pointing the route at the configured provider resolves it.
         c.terminology
             .external
             .routes
@@ -1697,8 +1683,8 @@ mod tests {
         assert!(err.to_string().contains("ts-client"), "got {err}");
 
         // A client table with none of its mandatory keys: each is named. The
-        // section reads its defaults from one `Default` impl, so serde no
-        // longer reports the missing keys and this pass owns all three.
+        // section reads its defaults from one `Default` impl, so serde reports
+        // none of them and this pass owns all three.
         c.terminology.external.oauth2_clients.insert(
             "ts-client".to_owned(),
             crate::service::terminology::config::TerminologyOauth2Config::default(),

--- a/app/ferroehr/src/config/server.rs
+++ b/app/ferroehr/src/config/server.rs
@@ -505,8 +505,7 @@ pub struct SystemOptionsConfig {
 impl Default for SystemOptionsConfig {
     fn default() -> Self {
         Self {
-            // `solution` (the product) and `vendor` (the organisation) are
-            // distinct — they were the same placeholder before the redesign.
+            // `solution` names the product, `vendor` the organisation.
             solution: "FerroEHR".to_owned(),
             solution_version: env!("CARGO_PKG_VERSION").to_owned(),
             vendor: "FerroEHR project".to_owned(),

--- a/app/ferroehr/src/config/strict.rs
+++ b/app/ferroehr/src/config/strict.rs
@@ -46,14 +46,10 @@ pub(super) fn strict_env<S: std::hash::BuildHasher>(
             }
             continue;
         }
-        // `FERROEHR_` but not `FERROEHR__`, and not allowlisted: a near-miss
-        // for the uniform grammar — a single separator where the grammar wants
-        // two is the easiest mistake to make. Repair it mechanically:
-        // (a) insert the missing prefix separator; if the first `__`-segment
-        // then names a known section, suggest that verbatim; (b) else, for a
-        // flat tail (`DB_MAX_CONNECTIONS`), match the leading word against the
-        // known sections and double that boundary too. Otherwise fall back to
-        // a section did-you-mean.
+        // `FERROEHR_` but not `FERROEHR__`, and not allowlisted: a near-miss for
+        // the uniform grammar, repaired mechanically — insert the missing prefix
+        // separator, else double the leading word's boundary too, else fall back
+        // to a section did-you-mean.
         let tail = key.strip_prefix("FERROEHR_").unwrap_or_default();
         let first = tail.split("__").next().unwrap_or_default();
         let section = first.to_ascii_lowercase();

--- a/app/ferroehr/src/db/mod.rs
+++ b/app/ferroehr/src/db/mod.rs
@@ -30,9 +30,7 @@ use sqlx::{Connection, PgConnection, PgPool};
 
 use crate::config::secret::SecretUrl;
 
-// ---------------------------------------------------------------------------
-// Settings — the `[db]` config section
-// ---------------------------------------------------------------------------
+// ── Settings — the `[db]` config section ─────────────────────────────────────
 
 /// The zero-config dev DSN (matches the compose dev stack). Production MUST
 /// override it; the boot path warns prominently when
@@ -153,9 +151,7 @@ impl DbConfig {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Error
-// ---------------------------------------------------------------------------
+// ── Error ────────────────────────────────────────────────────────────────────
 
 /// Errors produced by the persistence foundation.
 #[derive(Debug, thiserror::Error)]
@@ -248,9 +244,7 @@ pub enum SchemaMismatch {
     },
 }
 
-// ---------------------------------------------------------------------------
-// Pool
-// ---------------------------------------------------------------------------
+// ── Pool ─────────────────────────────────────────────────────────────────────
 
 /// Search path applied to every pooled connection: the application tables live
 /// in `ehr`, the AQL support functions and the `"C"`/`en_US` collations in
@@ -284,14 +278,11 @@ fn pool_options(settings: &DbConfig) -> PgPoolOptions {
             Box::pin(async move {
                 sqlx::query(SET_SEARCH_PATH_SQL).execute(&mut *conn).await?;
                 if let Some(statement_timeout) = statement_timeout {
-                    // `SET LOCAL` would last only the current transaction, so
-                    // this is a session-level SET on the physical connection —
-                    // it survives every checkout of that connection.
-                    // `AssertSqlSafe` because PostgreSQL's `SET` takes no bind
-                    // placeholder, so the value has to be rendered into the
-                    // statement. Audited: it is a `u64` from our own
-                    // configuration formatted with `{}`, never client input, so
-                    // no string can reach here that is not decimal digits.
+                    // A session-level SET on the physical connection, surviving
+                    // every checkout, where `SET LOCAL` would last one
+                    // transaction. `AssertSqlSafe` is audited: PostgreSQL's
+                    // `SET` takes no bind placeholder and the value is a `u64`
+                    // from our own configuration, never client input.
                     sqlx::query(sqlx::AssertSqlSafe(statement_timeout))
                         .execute(&mut *conn)
                         .await?;
@@ -406,9 +397,7 @@ pub async fn connect_tenant_scoped(settings: &DbConfig) -> Result<PgPool, DbErro
     Ok(pool)
 }
 
-// ---------------------------------------------------------------------------
-// Migrations
-// ---------------------------------------------------------------------------
+// ── Migrations ───────────────────────────────────────────────────────────────
 
 /// The `ext` schema: our openEHR support functions (`openehr_magnitude` and
 /// its ISO-8601 helpers). Runs before `ehr`.

--- a/app/ferroehr/src/extensions/events/publisher.rs
+++ b/app/ferroehr/src/extensions/events/publisher.rs
@@ -199,7 +199,6 @@ async fn run(
             last_prune = tokio::time::Instant::now();
         }
 
-        // Wait for the next poll tick or a shutdown signal.
         tokio::select! {
             _ = shutdown.changed() => {}
             () = tokio::time::sleep(poll_interval) => {}

--- a/app/ferroehr/src/extensions/fhir/ingest.rs
+++ b/app/ferroehr/src/extensions/fhir/ingest.rs
@@ -267,12 +267,10 @@ impl FerroEhrService {
         let scope = self.resolve_patient_scope(patient).await?;
         let mut entries: Vec<Value> = Vec::new();
         // One entry per COMPOSITION, never per mapping: two enabled mappings
-        // sharing a template would otherwise serve the same versioned object
-        // twice under one fullUrl, which HL7 FHIR R4 bundle.html `bdl-7`
-        // forbids ("FullUrl must be unique in a bundle"). Definitions iterate
-        // in the ingest disposition's own precedence (profiled first, then
-        // id — `enabled_definitions_for_type`), so the mapping that wins a
-        // composition is the one ingest would have picked.
+        // sharing a template would serve one versioned object twice under one
+        // fullUrl, which HL7 FHIR R4 bundle.html `bdl-7` forbids. Definitions
+        // iterate in the ingest disposition's own precedence, so the mapping
+        // that wins a composition is the one ingest would have picked.
         let mut seen: std::collections::HashSet<VoId> = std::collections::HashSet::new();
         for raw in self.enabled_definitions_for_type(resource_type).await? {
             let def: FhirMappingDefinition = serde_json::from_value(raw)
@@ -445,9 +443,7 @@ impl FerroEhrService {
             let definition: Value = row.try_get("definition")?;
             // A STORED mapping definition that no longer parses is a
             // server-side fault, not a client error: the caller supplied
-            // nothing wrong, so the class is `exception` (500) with the
-            // diagnostic traced — the sibling read paths already classify it
-            // that way.
+            // nothing wrong, so it is an `exception` with the diagnostic traced.
             let def: FhirMappingDefinition = serde_json::from_value(definition).map_err(|e| {
                 ServiceError::internal(
                     format!("read a stored FHIR mapping definition for {resource_type}"),
@@ -704,13 +700,10 @@ impl FerroEhrService {
         );
         ferroehr_ext::fhir::feeder_audit::inject_feeder_audit(&mut composition, feeder);
 
-        // 5. Commit through the NORMAL validated path — a resource that maps to
-        //    an invalid COMPOSITION is rejected here (content_invalid → 422),
-        //    never partially stored.
-        // The converter emits a canonical COMPOSITION fragment; re-typing it
-        // through the strict reader is what hands the commit seam a typed
-        // value (a mapping that produced something else is content-invalid,
-        // never partially stored).
+        // 5. Commit through the NORMAL validated path: the converter emits a
+        //    canonical fragment, and re-typing it through the strict reader is
+        //    what hands the commit seam a typed value. A resource that maps to
+        //    an invalid COMPOSITION is rejected, never partially stored.
         let typed: openehr_rm::prelude::Composition =
             openehr_its::json::from_canonical_value(&composition).map_err(|e| {
                 SmError::new(

--- a/app/ferroehr/src/service/admin/delete.rs
+++ b/app/ferroehr/src/service/admin/delete.rs
@@ -129,8 +129,6 @@ impl FerroEhrService {
                 format!("template {template_id}"),
             ));
         };
-        // Physical deletes never orphan clinical data (no openEHR spec
-        // governs the FK graph — our own design).
         // Counted over BOTH storage tiers: the cold archival mirror is
         // foreign-key-free, so an archived composition's reference is invisible
         // to the `template_ref` FK and would be orphaned silently.
@@ -286,9 +284,8 @@ impl FerroEhrService {
         } else {
             ehr_ids.to_vec()
         };
-        // Batched: three set statements per chunk instead of a per-EHR
-        // transaction loop; a missing id simply deletes zero rows (idempotent
-        // bulk, same semantics as before). `DELETE … RETURNING id` counts the
+        // Three set statements per chunk, not a per-EHR transaction loop; a
+        // missing id deletes zero rows, and `DELETE … RETURNING id` counts the
         // EHRs actually removed.
         let mut deleted = 0u64;
         for chunk in targets.chunks(CHUNK) {

--- a/app/ferroehr/src/service/admin/dump_load.rs
+++ b/app/ferroehr/src/service/admin/dump_load.rs
@@ -864,11 +864,9 @@ fn original_version_envelope(
     audit: &AuditRow,
     attestations: &[&AttestationRow],
 ) -> Result<Value, ServiceError> {
-    // Same discipline as the version read-back: an archived
-    // `other_input_version_uids` that does not decode is a corrupt record, not
-    // an absent merge list — restoring the version without its merge inputs
-    // would silently rewrite history (RM common master06 §Distributed
-    // Versioning).
+    // An archived `other_input_version_uids` that does not decode is a corrupt
+    // record, not an absent merge list: restoring without the merge inputs
+    // would rewrite history (RM common master06 §Distributed Versioning).
     let other_input_version_uids: Vec<String> = v
         .other_input_version_uids
         .as_ref()
@@ -2060,14 +2058,11 @@ impl FerroEhrService {
 
         load_attestations(&mut tx, &record.attestations).await?;
 
-        // The load re-decomposed the EHR_STATUS versions directly, so the
-        // promoted `ehr` columns are re-derived from the loaded current status
-        // — the EHR_STATUS content is the truth, the exported columns only its
-        // cached projection. This makes a loaded EHR visible to the subject
-        // lookup (SM `I_EHR_SERVICE.get_ehrs_for_subject`) and bound by the
-        // one-EHR-per-subject rule (RM ehr master04 §EHR Status), and keeps
-        // `is_queryable`/`is_modifiable` matching the loaded state for the AQL
-        // full-population gate and the content-write guard (§EHR Active Status).
+        // The EHR_STATUS content is the truth and the promoted `ehr` columns
+        // only its cached projection, so they are re-derived from the loaded
+        // current status — which is what makes a loaded EHR visible to the
+        // subject lookup and bound by the one-EHR-per-subject rule (RM ehr
+        // master04 §EHR Status / §EHR Active Status).
         self.resync_promoted_columns(&mut tx, ehr_id).await?;
 
         // EHR.folders membership rows, verbatim (rank fidelity — RM ehr §EHR
@@ -2089,14 +2084,11 @@ impl FerroEhrService {
         insert_item_tag_rows(&mut tx, Some(ehr_id), &record.item_tags).await?;
         insert_archive_rows(&mut tx, &record.archives).await?;
 
-        // Lineage keys mirror the removed EXCLUDE constraints exactly: trunk
-        // rows are one lineage per vo_id; branch rows are per {vo, creating
-        // system, fork point, branch number}. The archive is the ONLY path
-        // writing explicit historical `sys_period` bounds, so it carries the
-        // per-lineage temporal non-overlap invariant check the regular write
-        // path holds by construction (RM common master06: one valid version per
-        // lineage at any instant). A corrupted archive with overlapping validity
-        // fails the whole record before commit.
+        // The archive is the ONLY path writing explicit historical `sys_period`
+        // bounds, so it checks the per-lineage temporal non-overlap invariant
+        // the regular write path holds by construction (RM common master06: one
+        // valid version per lineage at any instant) — trunk rows per vo_id,
+        // branch rows per {vo, creating system, fork point, branch number}.
         let overlap: bool = sqlx::query_scalar(
             "SELECT EXISTS ( \
                  SELECT 1 FROM vo_version a \

--- a/app/ferroehr/src/service/admin/statistics.rs
+++ b/app/ferroehr/src/service/admin/statistics.rs
@@ -101,14 +101,11 @@ impl FerroEhrService {
         let Some(ehr_scoped) = contribution_ehr_scoped(a_service) else {
             return Ok(0);
         };
-        // Two static shapes, selected in Rust rather than by an in-SQL OR:
-        // the measured corpus holds ~10^6 contributions and the 2026-07-29
-        // idle-box POC window put this count's p99 at 2.9 s — the unbounded
-        // form was paying a full `audit` hash join it never filters, and the
+        // Two static shapes, selected in Rust rather than by an in-SQL OR: a
         // `($3 AND …) OR (NOT $3 AND …)` scoping predicate resists index
-        // planning. Unbounded: an index-only count over
-        // `idx_contribution_ehr_id`. Bounded: the audit join with
-        // `idx_audit_time_committed` behind it (0001_baseline.sql).
+        // planning. Unbounded takes an index-only count over
+        // `idx_contribution_ehr_id`, bounded the audit join behind
+        // `idx_audit_time_committed` (0001_baseline.sql).
         let count: i64 = if lo.is_none() && hi.is_none() {
             let sql = if ehr_scoped {
                 "SELECT count(*) FROM contribution WHERE ehr_id IS NOT NULL"
@@ -162,8 +159,7 @@ impl FerroEhrService {
         if a_service != PlatformService::Ehr {
             return Ok(0);
         }
-        // Unbounded: no reason to touch `audit` at all (the 2026-07-29
-        // measured-window finding on the sibling count).
+        // Unbounded: no reason to touch `audit` at all.
         let count: i64 = if lo.is_none() && hi.is_none() {
             sqlx::query_scalar(
                 "SELECT count(DISTINCT vo_id) FROM vo_version_all WHERE kind = 'COMPOSITION'",

--- a/app/ferroehr/src/service/definition/adl14.rs
+++ b/app/ferroehr/src/service/definition/adl14.rs
@@ -590,12 +590,10 @@ impl FerroEhrService {
     /// UUID → `400`.
     async fn opt_delete(&self, an_opt_id: &str) -> Result<(), ServiceError> {
         let id = parse_opt_uuid(an_opt_id)?;
-        // Resolve, count references, and delete in ONE transaction so the
-        // friendly 409 is consistent with the delete (mirroring the admin
-        // wire delete, `delete_template_by_id`); the `vo_version.template_id`
-        // → `template_ref` foreign key (`0001_baseline.sql`, NO ACTION)
-        // remains the underlying integrity guard even under a concurrent
-        // commit. Absent row → 404.
+        // Resolve, count references and delete in ONE transaction so the 409 is
+        // consistent with the delete; the `vo_version.template_id` →
+        // `template_ref` foreign key stays the integrity guard under a
+        // concurrent commit.
         let mut tx = self.pool.begin().await?;
         let template_id: Option<String> =
             sqlx::query_scalar("SELECT template_id FROM template_store WHERE id = $1")
@@ -608,13 +606,10 @@ impl FerroEhrService {
                 format!("OPT {an_opt_id}"),
             ));
         };
-        // Physical deletes never orphan clinical data (no openEHR spec governs
-        // the in-use refusal — our own integrity design; the SM operation
-        // defines only `Pre_has_opt`/`invalid_template`).
         // Counted over BOTH storage tiers: the cold archival mirror carries no
         // `template_ref` foreign key, so an archived composition's reference is
         // invisible to the constraint and deleting under it would make that
-        // object unrestorable.
+        // object unrestorable (no openEHR spec governs the in-use refusal).
         let refs: i64 =
             sqlx::query_scalar("SELECT count(*) FROM vo_version_all WHERE template_id = $1")
                 .bind(&template_id)
@@ -643,12 +638,9 @@ impl FerroEhrService {
         .execute(&mut *tx)
         .await?;
         tx.commit().await?;
-        // Delete is the only mutation that ends a stored template's lifetime
-        // (uploads are create-only), so this is the single cache-invalidation
-        // point. Key on the identity-canonical form so a case variant of the id
-        // is evicted too (BASE master05 §Composite Identifiers and Case). No
-        // openEHR spec governs the cache; cross-instance eviction is out of
-        // scope for this single-node optimisation — our own design.
+        // Uploads are create-only, so delete is the single cache-invalidation
+        // point. The key is the identity-canonical form, so a case variant is
+        // evicted too (BASE master05 §Composite Identifiers and Case).
         self.web_templates
             .invalidate(&crate::templates::identity::canonical_key(&template_id))
             .await;

--- a/app/ferroehr/src/service/definition/opt14_convert.rs
+++ b/app/ferroehr/src/service/definition/opt14_convert.rs
@@ -3,44 +3,20 @@
 
 //! OPT-1.4 → ADL2 conversion front end.
 //!
-//! The in-CDR 1.4 → 2 converter (`openehr_adl::adl14::convert::convert`) takes an
-//! assembled *source archetype* (`openehr_am::v2_4`), so only stored 1.4 source
-//! archetypes convert directly. A stored 1.4 **operational template** is a
-//! *specialisation-flattened* artefact whose `definition` is a single
-//! `C_ARCHETYPE_ROOT` tree with the component archetypes embedded inline as
-//! nested `C_ARCHETYPE_ROOT` nodes — each embedded root carries its own
-//! independent at-code space. Feeding that flattened tree to the converter as
-//! one archetype is impossible: the component code spaces collide (every
-//! embedded archetype re-uses `at0000`, `at0001`, …).
+//! A stored 1.4 operational template is a specialisation-flattened artefact
+//! whose `definition` embeds each component archetype as a nested
+//! `C_ARCHETYPE_ROOT` with its own independent at-code space, so it cannot be
+//! fed to `openehr_adl::adl14::convert::convert` (which takes one source
+//! archetype) as a whole: the component code spaces collide. This front end
+//! decomposes the OPT into one 1.4-shaped `openehr_am::v2_4` source archetype
+//! per embedded root, replacing each child by an `ARCHETYPE_SLOT` whose
+//! `include` assertion names it and recording the parent → child fill edge in
+//! [`OptConversion::structure`]. Anything a decomposed root cannot express is
+//! reported in `RESOURCE_DESCRIPTION.conversion_details`.
 //!
-//! This front end therefore **decomposes** the OPT into one 1.4-shaped `v2_4`
-//! source archetype per embedded `C_ARCHETYPE_ROOT` (the top root plus each
-//! nested one), each with its own scoped at-code space, and converts each
-//! through the existing converter core. At every embedded-root boundary the
-//! child is replaced in the parent by an `ARCHETYPE_SLOT` (a fresh
-//! parent-space at-code the converter renumbers) whose `include` assertion
-//! names the archetype that filled it, and the parent → child fill edge is
-//! additionally recorded in the returned [`OptConversion::structure`] so the
-//! composition structure the flattening erased is preserved. Anything a
-//! decomposed root cannot express (out-of-scope bindings, tuple assumed
-//! values, `DV_STATE` machines, unconvertible slot assertions) is reported in
-//! the converted archetype's `RESOURCE_DESCRIPTION.conversion_details`.
-//!
-//! NOTE: no openEHR spec governs 1.4 → 2 conversion — the entire `adl14` design,
-//! including this OPT front end (decomposition strategy, slot substitution, code
-//! allocation), is **our own design/extension** (the vendored ITS-REST OAS
-//! declares no conversion operation; `openehr_adl::adl14` carries the same
-//! flag). The `opt14` object model is `openehr_its::opt14` (the AOM 1.4 / OPT 1.4
-//! model); the target is `openehr_am::v2_4::aom2` in the 1.4-shaped form
-//! `openehr_adl::assemble::parse_artefact` produces from ADL 1.4 text, so
-//! the converter core is fed exactly the shape it was built for.
-//!
-//! Home: this lives in the `ferroehr` service layer (not `openehr-adl`) because
-//! the `opt14` DTOs live in `openehr-its`, and `openehr-adl`'s crate contract is
-//! "no REST" — `openehr-its` carries the ITS-REST contract, so an
-//! `openehr-adl → openehr-its` dependency would invert that boundary. The
-//! service layer already depends on both `openehr_its::opt14` and
-//! `openehr_adl::adl14`, so it is the existing meeting point.
+//! NOTE: no openEHR spec governs 1.4 → 2 conversion — the decomposition
+//! strategy, slot substitution and code allocation here are our own
+//! design/extension, as is `openehr_adl::adl14` itself.
 
 use std::collections::BTreeMap;
 
@@ -149,13 +125,6 @@ pub(crate) fn convert_opt_to_adl2(
     Ok(OptConversion { roots, structure })
 }
 
-/// The conversion core: decompose the OPT and convert each embedded root,
-/// returning the converted `v2_4` archetypes (id + object) and the recovered
-/// fill structure. [`convert_opt_to_adl2`] prints these to ADL2 text; tests
-/// validate the objects directly (the converter's `validate_integrity` oracle).
-///
-/// # Errors
-/// As [`convert_opt_to_adl2`].
 /// One decomposed source per embedded OPT root, keyed by its archetype id.
 pub(crate) type ConvertedRoots = Vec<(String, Archetype)>;
 
@@ -185,6 +154,11 @@ fn minimal_description(conversion_details: BTreeMap<String, String>) -> Resource
     }
 }
 
+/// Decomposes the OPT and converts each embedded root, returning the converted
+/// `v2_4` archetypes and the recovered fill structure.
+///
+/// # Errors
+/// As [`convert_opt_to_adl2`].
 pub(crate) fn convert_opt_to_archetypes(
     opt: &opt14::types::OperationalTemplate,
 ) -> Result<(ConvertedRoots, Vec<FillEdge>), OptConvertError> {
@@ -200,11 +174,9 @@ pub(crate) fn convert_opt_to_archetypes(
     dx.process_root(&opt.definition, "", true);
 
     let cfg = ConvertConfig {
-        // A flattened OPT inlines `-`-specialised roots standalone, where
-        // the differential lineage is unresolvable — emit them UNSPECIALISED
-        // with every dotted code collapsed into the flat space (VARCN/VACSD
-        // at depth 0; see the flag's contract). No openEHR spec governs
-        // 1.4→2 conversion — our own design.
+        // NOTE: a flattened OPT inlines `-`-specialised roots standalone with
+        // no resolvable lineage, so they emit unspecialised at depth 0 (no
+        // openEHR spec governs 1.4→2 conversion — our own design).
         collapse_specialised_codes: true,
         ..ConvertConfig::default()
     };
@@ -223,13 +195,6 @@ pub(crate) fn convert_opt_to_archetypes(
             rm_overlay: None,
             uid: None,
             original_language: term_code("ISO_639-1", &dx.language),
-            // A decomposed OPT root carries no RESOURCE_DESCRIPTION of its own,
-            // but VARD (`master03` §Validity Rules) requires one — synthesize
-            // the minimal valid description with the converter's own lifecycle
-            // mapping (`unmanaged`; see `adl14::convert::transform_description`)
-            // and this root's conversion-report entries in
-            // `conversion_details`. No openEHR spec governs 1.4→2 conversion —
-            // our own design.
             description: Some(Box::new(minimal_description(unit.notes))),
             is_controlled: None,
             annotations: None,
@@ -308,12 +273,9 @@ impl Decomposer<'_> {
     /// for the archetype's flattened terminology.
     fn process_root(&mut self, root: &opt14::types::CArchetypeRoot, path: &str, is_top: bool) {
         let archetype_id = root.archetype_id.value.clone();
-        // Slot at-codes are allocated strictly above every at-code node id used
-        // by THIS root's own retained subtree (child roots are excluded — their
-        // codes belong to the child's space), so a substituted slot never
-        // collides with a real node in the parent's code space. Minted ac codes
-        // likewise allocate above the flattened ontology's constraint
-        // definitions.
+        // Slot at-codes and minted ac codes allocate strictly above this root's
+        // own retained subtree and its flattened ontology, so a substituted slot
+        // never collides with a real node in the parent's code space.
         let ontology = self.ontology_for(&archetype_id, is_top);
         let defined_acs: std::collections::BTreeSet<String> = ontology
             .iter()
@@ -438,14 +400,10 @@ impl Decomposer<'_> {
         cx: &mut RootCx,
     ) -> CObject {
         match obj {
-            // An embedded archetype root: decompose it as its own source and
-            // leave a slot (fresh parent-space code) in this parent whose
-            // `include` assertion names the archetype that filled it — the
-            // canonical `archetype_id/value matches {/…/}` form
-            // (`org.openehr.am.aom2.archetype_slot.adoc`: "an expression of
-            // the form EXPR_ARCHETYPE_REF matches EXPR_ARCHETYPE_ID_CONSTRAINT").
-            // The fill edge is additionally recorded in the conversion
-            // structure.
+            // An embedded root becomes its own source, leaving a slot in this
+            // parent whose `include` names the archetype that filled it — the
+            // `EXPR_ARCHETYPE_REF matches EXPR_ARCHETYPE_ID_CONSTRAINT` form of
+            // `org.openehr.am.aom2.archetype_slot.adoc`.
             opt14::types::CObject::CArchetypeRoot(child) => {
                 let slot_node_id = format!("at{}", cx.slot_num);
                 cx.slot_num += 1;
@@ -509,13 +467,6 @@ impl Decomposer<'_> {
                     target_path: r.target_path.clone(),
                 })
             }
-            // A retained (unfilled) 1.4 slot: its include/exclude ASSERTION
-            // trees (AOM 1.4 `EXPR_BINARY_OPERATOR`/`EXPR_LEAF`,
-            // `AOM1.4/master05-assertion_package.adoc`) map onto the AOM2
-            // `beom` assertion form via the BEL parser — the same
-            // `archetype_id/value matches {/…/}` shape both models share. An
-            // assertion that cannot be rendered/parsed falls back to an open
-            // slot, reported in `conversion_details`.
             opt14::types::CObject::ArchetypeSlot(s) => {
                 let includes = map_slot_assertions(&s.includes, &s.node_id, "include", cx);
                 let excludes = map_slot_assertions(&s.excludes, &s.node_id, "exclude", cx);
@@ -533,8 +484,6 @@ impl Decomposer<'_> {
                     is_closed: false,
                 })
             }
-            // A coded-value constraint → the 1.4-shaped `C_TERMINOLOGY_CODE` the
-            // converter rewrites (`terminology::code[,code…][;assumed]`).
             opt14::types::CObject::CCodePhrase(c) => terminology_code(
                 &c.rm_type_name,
                 &c.node_id,
@@ -545,42 +494,10 @@ impl Decomposer<'_> {
                     c.assumed_value.as_ref().map(|a| a.code_string.as_str()),
                 ),
             ),
-            // A `C_CODE_REFERENCE` names an external reference set by URI. With
-            // no inline code list that is exactly the AOM2 ac-code term-binding
-            // pattern, whose binding URI "will designate a ref-set or value set"
-            // (`AOM2/master07-terminology_package.adoc` §Overview), so a minted
-            // ac-code + definition + binding is emitted. When an inline code
-            // list is ALSO present the list constraint wins and the URI is
-            // carried in `conversion_details` (no openEHR spec governs 1.4→2
-            // conversion — our own design).
             opt14::types::CObject::CCodeReference(c) => map_code_reference(c, cx),
-            // A `CONSTRAINT_REF` names an ac-code whose definition lives in the
-            // flattened ontology's `constraint_definitions` (AOM 1.4
-            // `constraint_ref.adoc`); ADL2 folds those into
-            // `term_definitions`/`term_bindings` (`master07.13` §Terminology
-            // section), so the ac-code constraint resolves (VACDF/VTCBK). An
-            // ac-code the ontology does NOT define would dangle — it stays an
-            // unconstrained node, reported in `conversion_details`.
             opt14::types::CObject::ConstraintRef(r) => map_constraint_ref(r, cx),
-            // DV_ORDINAL: the 1.4 domain constrainer becomes the AOM2
-            // `[value, symbol]` attribute tuple (`master04.4-cadl_second_order.adoc`
-            // §Tuple Constraints — "the tuple constraint type replaces all
-            // domain-specific constraint types defined in ADL/AOM 1.4").
             opt14::types::CObject::CDvOrdinal(c) => ordinal_tuple(c, cx),
-            // DV_QUANTITY: property → a `property` terminology-code attribute;
-            // the per-unit magnitude (and, where present, precision) lists →
-            // the `[units, magnitude(, precision)]` attribute tuple (the
-            // `master04.4` §Tuple Constraints units/magnitude matrix; the
-            // vendored `C_QUANTITY_ITEM` carries no precision — including it
-            // as a third tuple member uses the generic tuple mechanism, no
-            // vendored spec section shows it: our own design).
             opt14::types::CObject::CDvQuantity(c) => quantity_tuple(c, cx),
-            // DV_STATE: the 1.4 constrainer carries a state machine; the
-            // vendored AM defines no ADL2/AOM2 constraint form for it (the
-            // tuple mechanism covers co-varying attribute values, not state
-            // machines) — a loose domain-typed complex object is the honest
-            // valid constraint. No vendored openEHR spec governs DV_STATE
-            // conversion — our own design; recorded in `conversion_details`.
             opt14::types::CObject::CDvState(c) => dv_state_loose(c, cx),
             opt14::types::CObject::CPrimitiveObject(c) => map_primitive_object(c, cx),
         }
@@ -625,7 +542,6 @@ impl Decomposer<'_> {
             merge_ontology(ont, &mut term_definitions, &mut term_bindings);
         }
 
-        // Entries minted during the definition walk (reference-set ac codes).
         {
             let inline = term_definitions.entry(self.language.clone()).or_default();
             for t in &cx.extra_terms {
@@ -928,13 +844,6 @@ fn map_primitive_object(c: &opt14::types::CPrimitiveObject, cx: &mut RootCx) -> 
                 constraint,
             })
         }
-        // Temporal constraints: the range converts to `Interval<Iso8601_*>`
-        // and the assumed value is carried. C_DURATION carries pattern AND
-        // range together (the combined `"PWD/|P0W..P50W|"` form —
-        // `org.openehr.am.aom2.c_duration.adoc`); for date/time/date-time the
-        // ADL2 surface defines pattern XOR range (`master04.5` §Mixed Pattern
-        // and Interval is duration-only), so a 1.4 node carrying both keeps
-        // the range and reports the dropped pattern.
         opt14::types::CPrimitive::CDate(p) => CObject::CDate(CDate {
             parent: None,
             soc_parent: None,
@@ -1209,10 +1118,9 @@ fn map_code_reference(c: &opt14::types::CCodeReference, cx: &mut RootCx) -> CObj
         description: format!("External reference set {}", c.referenceSetUri),
         other_items: None,
     });
-    // The binding's terminology key: the node's terminology id when declared,
-    // else the generic "external" bucket (the 1.4 referenceSetUri carries no
-    // terminology name — no openEHR spec governs the key choice, our own
-    // design).
+    // NOTE: the 1.4 `referenceSetUri` carries no terminology name, so an
+    // undeclared one keys under a generic bucket (no openEHR spec governs the
+    // key choice — our own design).
     let term_key = c
         .terminology_id
         .as_ref()
@@ -1650,13 +1558,10 @@ fn quantity_tuple(c: &opt14::types::CDvQuantity, cx: &mut RootCx) -> CObject {
             is_multiple: false,
         });
     }
-    // Tuple members co-vary: a tuple is emitted only when EVERY item constrains
-    // the magnitude (the reference corpus renders a units-only constraint as a
-    // plain `units` attribute). A mixed set widens to the plain units list — the
-    // safe direction, since a widened constraint never rejects valid data — with
-    // the dropped per-unit ranges reported. Precision joins the tuple only when
-    // every item carries one. No openEHR spec governs 1.4→2 conversion — our own
-    // design.
+    // Tuple arity must be uniform, so a tuple is emitted only when EVERY item
+    // constrains the magnitude; a mixed set widens to the plain units list,
+    // which never rejects valid data (no openEHR spec governs 1.4→2 conversion
+    // — our own design).
     let all_magnitude = !c.list.is_empty() && c.list.iter().all(|i| i.magnitude.is_some());
     let all_precision = !c.list.is_empty() && c.list.iter().all(|i| i.precision.is_some());
     let some_dropped = c

--- a/app/ferroehr/src/service/definition/query.rs
+++ b/app/ferroehr/src/service/definition/query.rs
@@ -446,12 +446,9 @@ impl FerroEhrService {
             ));
         }
 
-        // ONE canonical key for every surface (SM master04 §Registered
-        // Queries: "If no namespace is supplied, the namespace \"misc\" is
-        // assumed") — the wire store previously keyed a bare name under
-        // ('', name) while the SM/admin/list paths keyed ('misc', name),
-        // making the same identifier resolve on one surface and 404 on the
-        // other.
+        // ONE canonical key for every surface (SM master04 §Registered Queries:
+        // "If no namespace is supplied, the namespace \"misc\" is assumed"), so
+        // the same identifier never resolves on one surface and 404s on another.
         let qualified = parse_qualified_name(qualified_name).qualified();
         let (rdn, semantic) = split_qualified(&qualified);
         let Some(v) = version else {
@@ -482,14 +479,10 @@ impl FerroEhrService {
             return Ok(DEFAULT_QUERY_VERSION.to_owned());
         };
 
-        // The versioned store requires an EXACT numeric `major.minor.patch` —
-        // ITS-REST `docs/query/Qualified_query_name.md`: "The `version`
-        // identifier is in the format specified by SEMVER style (i.e.
-        // `major.minor.patch`)". The partial-prefix form is a READ-resolution
-        // semantic stated over versions that ALREADY exist, so on a store it
-        // resolves either to an existing pair (which that operation assigns to
-        // `409`) or to nothing; accepting it verbatim would also break the
-        // surface's SEMVER ordering (`string_to_array(semver, '.')::int[]`).
+        // The versioned store requires an EXACT `major.minor.patch` (ITS-REST
+        // `docs/query/Qualified_query_name.md`): the partial-prefix form is a
+        // READ-resolution semantic over versions that already exist, and storing
+        // one verbatim would break the surface's SEMVER ordering.
         // NOTE: no released sentence completes a prefix into a version to
         // create, so the refusal status is the docs text's own generic client
         // error (`Requests_and_responses.md` §"HTTP status codes", `400`).

--- a/app/ferroehr/src/service/definition/wire.rs
+++ b/app/ferroehr/src/service/definition/wire.rs
@@ -542,9 +542,7 @@ mod tests {
     #[test]
     fn concrete_version_glob_filters_without_collapsing() {
         // The OAS's own shape (`1.*`, filter_version.yaml) against the ids'
-        // version AXES: every matching version, no collapse. The pre-fix
-        // whole-id workaround glob (`*v1.*`) belongs to the defect #2567
-        // fixed and must no longer be needed.
+        // version AXES: every matching version, no collapse.
         let out = filter_templates(
             rows(&["T.v1.0", "T.v1.5", "T.v2.0"]),
             &TemplateListFilter {
@@ -558,10 +556,10 @@ mod tests {
 
     #[test]
     fn exact_version_glob_matches_the_axis_alone() {
-        // #2567 regression: `?version=1.0` matched NOTHING while T.v1.0 was
-        // stored, because the glob was compiled anchored and evaluated
-        // against the whole template_id. The subject is the version axis
-        // ("taken from template_id" — filter_version.yaml).
+        // The glob's subject is the version AXIS ("taken from template_id" —
+        // filter_version.yaml), never the whole template_id: matching against
+        // the whole id made `?version=1.0` match nothing while T.v1.0 was
+        // stored.
         let out = filter_templates(
             rows(&["T.v1.0", "T.v1.5"]),
             &TemplateListFilter {

--- a/app/ferroehr/src/service/demographic/api.rs
+++ b/app/ferroehr/src/service/demographic/api.rs
@@ -185,11 +185,8 @@ impl FerroEhrService {
     ///   not parse (defensive; the uid is server-generated).
     pub async fn create_party(&self, a_version: UpdateVersion<Party>) -> Result<VoId, SmError> {
         let kind = party_kind_of(&a_version.data);
-        // The ONE serialization boundary of this commit, taken before any
-        // await (`crate::service::ehr::canonicalize`).
         let a_version = crate::service::ehr::canonicalize(a_version);
         let committal = envelope_committal(&a_version);
-        // Reuse the wire-seam domain logic (validation + versioned create).
         let resp = self
             .commit_new_party(kind, a_version.data, Some(&committal))
             .await?;
@@ -322,8 +319,6 @@ impl FerroEhrService {
         a_version: UpdateVersion<Party>,
     ) -> Result<String, SmError> {
         let kind = party_kind_of(&a_version.data);
-        // The ONE serialization boundary of this commit, taken before any
-        // await (`crate::service::ehr::canonicalize`).
         let a_version = crate::service::ehr::canonicalize(a_version);
         let expected = match &a_version.preceding_version_uid {
             Some(ovid) => Some(components(ovid)?.1),
@@ -383,9 +378,6 @@ impl FerroEhrService {
         body: Party,
         committal: Option<Committal>,
     ) -> Result<ServiceResponse, SmError> {
-        // The ONE serialization boundary of this commit, taken before any
-        // await so the typed RM value does not ride the whole write
-        // transaction.
         let body = openehr_its::json::to_canonical_value(&body);
         // A freshly created party has no stored ITEM_TAGs by construction, so
         // the response seam needs no tag read here; when the request carried
@@ -447,9 +439,6 @@ impl FerroEhrService {
         body: Party,
         committal: Option<Committal>,
     ) -> Result<ServiceResponse, SmError> {
-        // The ONE serialization boundary of this commit, taken before any
-        // await so the typed RM value does not ride the whole write
-        // transaction.
         let body = openehr_its::json::to_canonical_value(&body);
         let vo_id = parse_uid_based_id(&uid_based_id)?.vo_id;
         // Resolve the current version ONCE (lean, kind-checked): the same handle
@@ -532,14 +521,10 @@ impl FerroEhrService {
     ) -> Result<ServiceResponse, SmError> {
         let vo_id = parse_uid_based_id(&versioned_object_uid)?.vo_id;
         let body = self.versioned_party(vo_id).await?;
-        // The container response carries `Last-Modified` from the newest
-        // version's commit instant — ITS-REST overview §"ETag and
-        // Last-Modified": "Both ETag and Last-Modified SHOULD be included in
-        // responses for VERSION, VERSIONED_OBJECT, or other resources that
-        // have versioning", derived "from VERSION.commit_audit.
-        // time_committed.value". The container BODY exposes no commit audit,
-        // so the instant comes from the version spine (the EHR-side
-        // versioned_composition precedent), never scraped from the body.
+        // ITS-REST overview §"ETag and Last-Modified" derives `Last-Modified`
+        // from `VERSION.commit_audit.time_committed.value`, and the container
+        // body exposes no commit audit, so the instant comes from the version
+        // spine rather than the body.
         let newest = crate::storage::version_repo::meta::all_version_meta(&self.pool, vo_id)
             .await
             .map_err(ServiceError::from)?
@@ -768,8 +753,6 @@ impl FerroEhrService {
         &self,
         a_version: UpdateVersion<PartyRelationship>,
     ) -> Result<VoId, SmError> {
-        // The ONE serialization boundary of this commit, taken before any
-        // await (`crate::service::ehr::canonicalize`).
         let a_version = crate::service::ehr::canonicalize(a_version);
         let committal = envelope_committal(&a_version);
         let resp = self
@@ -881,8 +864,6 @@ impl FerroEhrService {
         a_versioned_party_rel_id: VoId,
         a_version: UpdateVersion<PartyRelationship>,
     ) -> Result<String, SmError> {
-        // The ONE serialization boundary of this commit, taken before any
-        // await (`crate::service::ehr::canonicalize`).
         let a_version = crate::service::ehr::canonicalize(a_version);
         let expected = match &a_version.preceding_version_uid {
             Some(ovid) => Some(components(ovid)?.1),
@@ -943,9 +924,6 @@ impl FerroEhrService {
         body: PartyRelationship,
         committal: Option<Committal>,
     ) -> Result<ServiceResponse, SmError> {
-        // The ONE serialization boundary of this commit, taken before any
-        // await so the typed RM value does not ride the whole write
-        // transaction.
         let body = openehr_its::json::to_canonical_value(&body);
         Ok(self.create_relationship(body, committal.as_ref()).await?)
     }
@@ -991,9 +969,6 @@ impl FerroEhrService {
         body: PartyRelationship,
         committal: Option<Committal>,
     ) -> Result<ServiceResponse, SmError> {
-        // The ONE serialization boundary of this commit, taken before any
-        // await so the typed RM value does not ride the whole write
-        // transaction.
         let body = openehr_its::json::to_canonical_value(&body);
         let vo_id = parse_uid_based_id(&uid_based_id)?.vo_id;
         let current = self.relationship_current(vo_id).await?;

--- a/app/ferroehr/src/service/demographic/tags.rs
+++ b/app/ferroehr/src/service/demographic/tags.rs
@@ -131,12 +131,9 @@ impl FerroEhrService {
         self.ensure_party_tag_target(kind, vo_id, target_version)
             .await?;
         // Validate + dedup (last wins) before touching the DB, keyed on the
-        // ITEM_TAG identity — the (key, target_path) PAIR, never the key alone
-        // (two same-key tags on different target_paths coexist). BTreeMap
-        // ordering matches the `ORDER BY key` read-back order on the leading
-        // component. The invariants and the `target_path: ""` normalization are
-        // the EHR family's, called rather than restated: one implementation of
-        // each, so the two families cannot diverge.
+        // ITEM_TAG identity — the (key, target_path) PAIR, never the key alone.
+        // The invariants and the `target_path: ""` normalization are the EHR
+        // family's, called rather than restated.
         let target = match target_version {
             Some(version) => UidBasedId::ObjectVersionId(version.clone()),
             // A bare container key is a UUID by type, so the conversion is
@@ -148,7 +145,7 @@ impl FerroEhrService {
         let mut deduped: BTreeMap<(String, Option<String>), Option<String>> = BTreeMap::new();
         for tag in tags {
             let target_path = normalized_target_path(tag.target_path.as_deref());
-            // Construction IS the invariant check (#1839).
+            // Construction IS the invariant check.
             ItemTag::new(
                 tag.key.clone(),
                 tag.value.clone(),
@@ -246,8 +243,7 @@ impl FerroEhrService {
 /// is not a well-formed BASE identifier.
 fn party_item_tag(system_id: &str, row: &tag_repo::TagRow) -> Result<ItemTag, ServiceError> {
     // A stored row that no longer constructs is storage corruption, not a
-    // client fault — fail loud (the write path validated at commit; #1839
-    // made construction the invariant check).
+    // client fault — fail loud.
     ItemTag::new(
         row.key.clone(),
         row.value.clone(),

--- a/app/ferroehr/src/service/demographic/validate.rs
+++ b/app/ferroehr/src/service/demographic/validate.rs
@@ -61,7 +61,7 @@ fn validate_party_ref(reference: &Value, context: &str) -> Result<(), ServiceErr
     let violations = typed.invariants();
     if !violations.is_empty() {
         // The class's own `InvariantViolation`s travel on as data; only the
-        // first is rendered, exactly as before.
+        // first is rendered.
         return Err(ServiceError::content_invalid(
             Violation::new("fails its BASE class invariants")
                 .with_path(context)
@@ -141,12 +141,10 @@ pub(super) fn party_invariants(
     incomplete: bool,
 ) -> Result<(), ServiceError> {
     // PARTY is unconditionally an archetype root (`demographic.party.adoc`
-    // §Invariants `Is_archetype_root: is_archetype_root` — no antecedent), so
-    // the same root-only rule the EHR_STATUS/EHR_ACCESS commits enforce applies
-    // here: `Archetyped_valid`'s "a root MUST carry ARCHETYPED" direction, the
-    // one a per-node pass cannot express. The root-identity rule
-    // (`archetype_node_id` = the stringified `archetype_details.archetype_id`)
-    // and `Links_valid` are the whole-instance pass's, run below.
+    // §Invariants `Is_archetype_root`), so `Archetyped_valid`'s "a root MUST
+    // carry ARCHETYPED" direction applies here — the one a per-node pass cannot
+    // express. Root identity and `Links_valid` belong to the whole-instance
+    // pass run below.
     if let Some(obj) = data.as_object() {
         crate::service::ehr::validation::validate_root_locatable(obj, rm_type)?;
     }
@@ -156,13 +154,10 @@ pub(super) fn party_invariants(
     // `553|incomplete|` lane skips typed construction (master06 §Incomplete).
 
     // Relationships_validity, second arm (party.adoc): every inline
-    // relationship's `source` must reference THIS party. The comparison is
-    // against the party's CONTAINER id, not the version id: RM demographic
-    // `master02-demographic_package.adoc` §Party Relationships requires
-    // "`OBJECT_REFs` containing `HIER_OBJECT_IDs` to denote the Version
-    // container of a Party", while a served party's `uid` is the three-part
-    // `OBJECT_VERSION_ID`, so the body's uid is reduced to its `object_id`
-    // (BASE `master05-identification_package.adoc` §Syntaxes).
+    // relationship's `source` must reference THIS party's CONTAINER id — RM
+    // demographic master02 §Party Relationships requires `HIER_OBJECT_ID`s
+    // there, while a served party's `uid` is the three-part
+    // `OBJECT_VERSION_ID`, so it is reduced to its `object_id`.
     if let (Some(uid), Some(relationships)) = (
         data.pointer("/uid/value").and_then(Value::as_str),
         data.get("relationships").and_then(Value::as_array),
@@ -201,13 +196,9 @@ pub(super) fn party_invariants(
         validate_party_ref(performer, "ROLE.performer")?;
     }
 
-    // The whole-instance RM class-invariant + terminology pass, rooted at the
-    // concrete party type. The checks above are root-scoped; the RM class
-    // invariants bind every node of the body (`ARCHETYPED.Rm_version_valid`,
-    // `LOCATABLE.Links_valid`, the `LINK` 1..1 attributes,
-    // `FEEDER_AUDIT_DETAILS.System_id_valid`, …), so an identity, contact or
-    // nested CLUSTER below the root is judged by the same rules a COMPOSITION's
-    // nodes are.
+    // The checks above are root-scoped, but the RM class invariants bind every
+    // node, so this whole-instance pass judges an identity, contact or nested
+    // CLUSTER below the root by the rules a COMPOSITION's nodes get.
     crate::service::ehr::validation::validate_rm_invariants_for_commit(data, rm_type, incomplete)
 }
 
@@ -223,13 +214,10 @@ pub(super) fn party_invariants(
 pub(crate) fn relationship_check(data: &Value, incomplete: bool) -> Result<(), ServiceError> {
     use openehr_base::prelude::ObjectId;
     use openehr_rm::prelude::PartyRelationship;
-    // The decode is the validating ACT, and its result is the carrier the two
-    // ref rules below are judged on — `source`/`target` are mandatory
-    // `PARTY_REF`s on the RM type, so once this succeeds their PRESENCE and
-    // SHAPE are facts of the type, not things to re-check (the Rust Book ch9.3
-    // custom-validation-type pattern). A body that does NOT construct is handed
-    // to the relaxed whole-instance pass, which enforces everything except
-    // presence.
+    // The decode is the validating ACT: `source`/`target` are mandatory
+    // `PARTY_REF`s on the RM type, so once it succeeds their presence and shape
+    // are facts of the type. A body that does NOT construct is handed to the
+    // relaxed whole-instance pass, which enforces everything except presence.
     // NOTE: on a `553|incomplete|` commit the decode is not the gate —
     // mandatory `source`/`target` may be absent (RM common master06 §Incomplete
     // Content), which is exactly what the decode refuses.

--- a/app/ferroehr/src/service/ehr/composition.rs
+++ b/app/ferroehr/src/service/ehr/composition.rs
@@ -64,9 +64,6 @@ impl FerroEhrService {
         ehr_id: EhrId,
         version: UpdateVersion<Composition>,
     ) -> Result<crate::versioning::change::Committed, ServiceError> {
-        // The ONE serialization boundary of this commit, taken before any
-        // await so the typed RM value does not ride the whole write
-        // transaction (`super::canonicalize`).
         let version = super::canonicalize(version);
         // 553|incomplete| relaxes validation strictness (master06 §Version
         // Lifecycle).
@@ -83,8 +80,7 @@ impl FerroEhrService {
         )?;
         // The EHR-existence (404) and content-writability (409) gates in one
         // round trip: a COMPOSITION is EHR content (RM ehr master04 §EHR
-        // Creation / §EHR Active Status). Same errors, same order as the
-        // separate `ensure_ehr_exists` + `ensure_content_writable` checks.
+        // Creation / §EHR Active Status).
         let commit_now = self.ensure_ehr_content_writable(ehr_id).await?;
         self.validate_composition_for_commit(&composition, incomplete)
             .await?;
@@ -97,12 +93,10 @@ impl FerroEhrService {
         // stamps it exactly like the CONTRIBUTION route.
         let template_id = composition_template_id(&composition).map(str::to_owned);
 
-        // With no accompanying attestations and no event outbox, the whole
-        // commit is the ONE folded statement — atomic on its own, so the
-        // explicit transaction's BEGIN/COMMIT round trips are skipped.
-        // Boxed: the versioned-write future is by far the widest state this
-        // call holds, and inlining it puts the whole node-decomposition
-        // machinery on every caller's stack (clippy `large_futures`).
+        // With no attestations and no event outbox the commit is ONE folded,
+        // self-atomic statement, so the explicit BEGIN/COMMIT is skipped. The
+        // versioned-write future is boxed: inlining it puts the whole
+        // node-decomposition machinery on every caller's stack.
         let signing_ctx = self.signing_ctx();
         let committed = if envelope.attestations.is_empty() && !signing_ctx.outbox_enabled {
             let mut conn = self.pool.acquire().await?;
@@ -140,8 +134,6 @@ impl FerroEhrService {
             .add(1, &[opentelemetry::KeyValue::new("outcome", "commit")]);
         crate::versioning::change::meter_committed(&committed);
 
-        // The write result is the committed version identity itself — a
-        // representation response re-reads at the protocol layer.
         Ok(committed)
     }
 
@@ -425,17 +417,12 @@ impl FerroEhrService {
         vo_id: VoId,
         version: UpdateVersion<Composition>,
     ) -> Result<crate::versioning::change::Committed, ServiceError> {
-        // The ONE serialization boundary of this commit, taken before any
-        // await so the typed RM value does not ride the whole write
-        // transaction (`super::canonicalize`).
         let version = super::canonicalize(version);
         let preceding_version_uid = version.preceding_version_uid.clone();
-        // The CPU-side envelope resolution and the content validation run
-        // BEFORE the write transaction: validation may consult the template
-        // store and the routed terminology servers, so neither the pool
-        // connection nor the per-vo advisory lock is ever held across it.
-        // Both RESULTS are held and surfaced below in the pre-check order the
-        // in-transaction gates define.
+        // Envelope resolution and content validation run BEFORE the write
+        // transaction — validation may consult the template store and the
+        // routed terminology servers, so no pool connection or advisory lock
+        // is held across it; both results surface below in pre-check order.
         let resolved = resolve_envelope(
             version,
             change_type::MODIFICATION,
@@ -487,18 +474,15 @@ impl FerroEhrService {
             ));
         }
         // is_modifiable = False forbids content writes (RM ehr master04 §EHR
-        // Active Status); the 409 outcome and its ordering (after the deleted
-        // 404, before the template 422) are unchanged.
+        // Active Status), after the deleted 404 and before the template 422.
         if pre.is_modifiable == Some(false) {
             return Err(crate::versioning::change::not_modifiable_error(ehr_id));
         }
-        // Reject an update whose body declares a *different* template than the
-        // stored composition it supersedes — a semantic 422. NOTE: no openEHR
-        // spec governs template stability across versions (RM ehr
-        // `versioned_composition.adoc` pins archetype_node_id and
-        // is_persistent across versions but not
-        // archetype_details.template_id) — our own design convention,
-        // consistent with those container invariants.
+        // An update declaring a *different* template than the version it
+        // supersedes is a semantic 422.
+        // NOTE: `versioned_composition.adoc` pins archetype_node_id and
+        // is_persistent across versions but not template_id, so this
+        // convention is our own design.
         let stored_template = pre.stored_template.as_deref();
         if let (Some(stored), Some(incoming)) =
             (stored_template, composition_template_id(&composition))
@@ -516,8 +500,6 @@ impl FerroEhrService {
             validation?;
         }
 
-        // Same template stamping as the create arm — every version row carries
-        // the template it was committed against.
         let template_id = composition_template_id(&composition).map(str::to_owned);
 
         // VERSIONED_COMPOSITION cross-version invariants (RM ehr
@@ -593,11 +575,9 @@ impl FerroEhrService {
         ehr_id: EhrId,
         vo_id: VoId,
     ) -> Result<Option<ResourceMeta>, ServiceError> {
-        // Lean `vo_version`⋈`audit` read scoped to the EHR: the
-        // `ETag`/`If-Match` compare needs only the full `OBJECT_VERSION_ID` +
-        // commit instant (RM common master06 §Version Identification /
-        // §Committal), never the reassembled document the full `read_current`
-        // pays.
+        // The `ETag`/`If-Match` compare needs only the full `OBJECT_VERSION_ID`
+        // + commit instant (RM common master06 §Version Identification /
+        // §Committal), never the document reassembly `read_current` pays.
         let Some(m) = crate::storage::version_repo::meta::current_version_meta_scoped(
             &self.pool, vo_id, ehr_id,
         )
@@ -668,11 +648,9 @@ impl FerroEhrService {
         update_audit: Option<&openehr_its::rest::generated::common::UpdateAudit>,
     ) -> Result<crate::versioning::change::Committed, ServiceError> {
         let (vo_id, expected) = components(a_version_uid)?;
-        // Lean delete pre-read: the pre-checks need only the owning EHR, the
-        // lifecycle (already-deleted → 400), and the current
-        // `VERSION_TREE_ID` (the `preceding_version_uid` conflict compare) —
-        // not a full node reassembly (the deleted version stores no nodes
-        // anyway).
+        // The delete pre-checks need only the owning EHR, the lifecycle and the
+        // current `VERSION_TREE_ID` — never a node reassembly (a deleted
+        // version stores no nodes anyway).
         let current =
             crate::storage::version_repo::meta::current_composition_meta(&self.pool, vo_id)
                 .await?
@@ -689,10 +667,8 @@ impl FerroEhrService {
             )));
         }
         // is_modifiable = False forbids content writes (RM ehr master04 §EHR
-        // Active Status) — folded from the standalone `ensure_content_writable`
-        // side-SELECT into the pre-read; the 409 outcome and its ordering
-        // (after the already-deleted 400, before the stale-precondition 409)
-        // unchanged.
+        // Active Status), after the already-deleted 400 and before the
+        // stale-precondition 409.
         if !current.is_modifiable {
             return Err(crate::versioning::change::not_modifiable_error(ehr_id));
         }
@@ -701,14 +677,11 @@ impl FerroEhrService {
             current.branch_number,
             current.branch_version,
         );
-        // The addressed preceding_version_uid must identify THE latest
-        // VERSION by its full three-part identity — object_id ::
-        // creating_system_id :: version_tree_id (ITS-REST overview
-        // Resources.md §Identifier types: the version_uid "uniquely
-        // identifies a VERSION"; RM common master06 §Distributed
-        // Versioning) — compared case-insensitively (BASE master05
-        // §Composite Identifiers and Case). Comparing the tree id alone
-        // let a fabricated creating_system_id delete the latest version.
+        // The addressed preceding_version_uid must identify THE latest VERSION
+        // by its full three-part identity (Resources.md §Identifier types; RM
+        // common master06 §Distributed Versioning), compared case-insensitively
+        // (BASE master05 §Composite Identifiers and Case): the tree id alone
+        // would let a fabricated creating_system_id delete the latest version.
         let latest_uid = crate::versioning::object_version_id::object_version_id(
             vo_id,
             &current.creating_system_id,
@@ -720,13 +693,10 @@ impl FerroEhrService {
                 a_version_uid.value()
             )));
         }
-        // A client MAY volunteer `If-Match` although this route carries the
-        // version in the path. It is evaluated HERE — after the 404/400/409
-        // pre-checks — so the RFC 9110 §13.2.1 precedence holds by
-        // construction (preconditions are ignored when the unconditioned
-        // answer would not be 2xx), and a false condition refuses the
-        // delete (ITS-REST overview Requests_and_responses §"If-Match and
-        // accidental overwrites": the method MUST NOT be performed → 412).
+        // A volunteered `If-Match` is evaluated after the 404/400/409
+        // pre-checks, so the RFC 9110 §13.2.1 precedence holds by construction;
+        // a false condition refuses the delete with 412 (ITS-REST overview
+        // Requests_and_responses §"If-Match and accidental overwrites").
         if let Some(condition) = volunteered_if_match
             && !composite_ids_equal(&latest_uid, condition.value())
         {
@@ -767,7 +737,6 @@ impl FerroEhrService {
             .db_transactions
             .add(1, &[opentelemetry::KeyValue::new("outcome", "commit")]);
         crate::versioning::change::meter_committed(&committed);
-        // 204_COMPOSITION_deleted: the (now deleted) version identity.
         Ok(committed)
     }
 
@@ -1049,12 +1018,11 @@ impl FerroEhrService {
 
 // ── ITS-REST read-response adapter (adapter-support extension) ────────────────
 //
-// The SM `I_EHR_COMPOSITION` reads above return the bare COMPOSITION, which
-// carries no commit audit — yet ITS-REST requires `Last-Modified` "derived from
-// `VERSION.commit_audit.time_committed.value`" (`Requests_and_responses.md`
-// §"`ETag` and Last-Modified"). These siblings therefore hand the adapter the
-// same read PLUS its [`ResourceMeta`] (version uid + commit instant). No
-// openEHR spec governs this envelope — our own design.
+// The SM reads above return the bare COMPOSITION, which carries no commit
+// audit, yet ITS-REST derives `Last-Modified` from
+// `VERSION.commit_audit.time_committed.value` (`Requests_and_responses.md`
+// §"`ETag` and Last-Modified"), so these siblings return the read plus its
+// [`ResourceMeta`] (no openEHR spec governs the envelope — our own design).
 
 impl FerroEhrService {
     /// [`Self::get_composition_latest`] with the version metadata the wire's
@@ -1139,11 +1107,10 @@ impl FerroEhrService {
     #[cfg(feature = "multimedia")]
     pub async fn expand_multimedia(&self, body: Value) -> Result<Value, SmError> {
         let Some(engine) = &self.multimedia else {
-            // No store is reachable. Serving the stored form is correct only
-            // when there is nothing to expand; a record that DOES reference a
-            // blob is clinical content this server externalized, and answering
-            // 200 with the compact reference would drop the caller's request
-            // on the floor without saying so.
+            // With no store reachable, serving the stored form is correct only
+            // when there is nothing to expand: answering 200 with a compact
+            // reference would silently withhold clinical content this server
+            // externalized.
             if ferroehr_ext::multimedia::references_external_blob(&body) {
                 return Err(internal_fault(
                     "expand a multimedia reference",

--- a/app/ferroehr/src/service/ehr/directory.rs
+++ b/app/ferroehr/src/service/ehr/directory.rs
@@ -62,13 +62,9 @@ impl FerroEhrService {
         ehr_id: EhrId,
         version: UpdateVersion<Folder>,
     ) -> Result<ServiceResponse, ServiceError> {
-        // The ONE serialization boundary of this commit, taken before any
-        // await so the typed RM value does not ride the whole write
-        // transaction (`super::canonicalize`).
         let version = super::canonicalize(version);
-        // 553|incomplete| relaxes the existence/cardinality lower bounds
-        // (RM common master06 §Incomplete Content), exactly as on the
-        // COMPOSITION direct route.
+        // 553|incomplete| relaxes the existence/cardinality lower bounds (RM
+        // common master06 §Incomplete Content).
         let super::CommitParts {
             audit,
             envelope,
@@ -87,12 +83,11 @@ impl FerroEhrService {
         // content (RM ehr master04 §EHR Active Status).
         self.ensure_content_writable(ehr_id).await?;
         // `POST /directory` manages the single directory slot = EHR.directory
-        // (= folders[1], RM ehr §EHR Class Directory_in_folders); it conflicts
-        // only when a LIVE hierarchy occupies that slot. NOTE: no released
-        // sentence states whether a logically DELETED directory still occupies
-        // the slot — register AMB-79 records both leans; our choice is that a
-        // deleted directory does not block a re-create, and the conflict
-        // status 409 is likewise our choice on the unbound status-table row.
+        // (= folders[1], RM ehr §EHR Class Directory_in_folders), conflicting
+        // only when a LIVE hierarchy occupies it.
+        // NOTE: no released sentence says whether a logically DELETED directory
+        // still occupies the slot — our choice is that it does not block a
+        // re-create, and 409 is likewise ours.
         if crate::storage::ehr_repo::live_directory_exists(&self.pool, ehr_id).await? {
             return Err(ServiceError::conflict(format!(
                 "EHR {ehr_id} already has a directory"
@@ -115,10 +110,8 @@ impl FerroEhrService {
         tx.commit().await?;
 
         // The write response is metadata-only: `Committed` already carries the
-        // written version identity + the commit instant (RM common master06
-        // §Committal), so the create path never re-reads the row it just wrote
-        // — a representation response re-reads at the protocol layer. This
-        // mirrors the COMPOSITION create path.
+        // version identity and commit instant (RM common master06 §Committal),
+        // so a representation response re-reads at the protocol layer instead.
         Ok(self.committed_response(ehr_id, &committed))
     }
 
@@ -137,9 +130,8 @@ impl FerroEhrService {
         path: Option<&str>,
     ) -> Result<ServiceResponse, ServiceError> {
         // The current read folds the `ehr_folder` slot resolution into the
-        // version statement (same slot choice as `directory_vo`); the as-of
-        // read keeps the two-step so the slot is still chosen by CURRENT
-        // state, exactly as before.
+        // version statement; the as-of read keeps the two-step so the slot is
+        // still chosen by CURRENT state.
         let read = match at {
             Some(at) => {
                 let vo_id = self.directory_vo(ehr_id).await?;
@@ -293,9 +285,6 @@ impl FerroEhrService {
         expected: Option<TreeId>,
         is_modifiable: bool,
     ) -> Result<ServiceResponse, ServiceError> {
-        // The ONE serialization boundary of this commit, taken before any
-        // await so the typed RM value does not ride the whole write
-        // transaction (`super::canonicalize`).
         let version = super::canonicalize(version);
         let super::CommitParts {
             audit,
@@ -310,11 +299,8 @@ impl FerroEhrService {
         )?;
         validate_folder(&folder, incomplete)?;
         check_folder_item_refs(&self.pool, ehr_id, &self.effective_system_id(), &folder).await?;
-        // is_modifiable = False forbids content writes (RM ehr master04 §EHR
-        // Active Status) — the directory is EHR content. Folded from the
-        // standalone `ensure_content_writable` side-SELECT into the merged
-        // pre-read; the 409 outcome and its ordering (after validate_folder's
-        // 422) are unchanged.
+        // is_modifiable = False forbids content writes to the directory (RM ehr
+        // master04 §EHR Active Status), after validate_folder's 422.
         if !is_modifiable {
             return Err(crate::versioning::change::not_modifiable_error(ehr_id));
         }
@@ -335,8 +321,6 @@ impl FerroEhrService {
         .await?;
         tx.commit().await?;
 
-        // Metadata-only write response from `Committed` (see
-        // `commit_new_directory`).
         Ok(self.committed_response(ehr_id, &committed))
     }
 
@@ -358,8 +342,7 @@ impl FerroEhrService {
         update_audit: Option<&openehr_its::rest::generated::common::UpdateAudit>,
     ) -> Result<ServiceResponse, ServiceError> {
         // is_modifiable = False forbids content writes (RM ehr master04 §EHR
-        // Active Status) — folded from the standalone `ensure_content_writable`
-        // side-SELECT into the merged pre-read; the 409 outcome is unchanged.
+        // Active Status).
         if !is_modifiable {
             return Err(crate::versioning::change::not_modifiable_error(ehr_id));
         }
@@ -573,11 +556,9 @@ impl FerroEhrService {
         an_ehr_id: EhrId,
         a_dir_struct: UpdateVersion<Folder>,
     ) -> Result<ResourceMeta, SmError> {
-        // Resolve the directory-slot vo_id + its current version metadata + the
-        // EHR's is_modifiable flag ONCE (the `If-Match` pre-read); a missing
-        // directory is `NotFound` (the same error the inner write's slot
-        // resolution produced). The vo_id + is_modifiable are threaded into the
-        // write so neither the slot JOIN nor the writability probe is re-run.
+        // The slot vo_id, its current version metadata and the EHR's
+        // is_modifiable flag resolve ONCE here and are threaded into the write,
+        // so neither the slot JOIN nor the writability probe runs twice.
         let Some((vo_id, is_modifiable, latest)) = self.directory_meta_with_vo(an_ehr_id).await?
         else {
             return Err(ServiceError::sm(

--- a/app/ferroehr/src/service/ehr/service.rs
+++ b/app/ferroehr/src/service/ehr/service.rs
@@ -76,13 +76,10 @@ impl FerroEhrService {
         // first status version is complete — full strictness.
         super::validation::validate_ehr_status(&status, false)?;
 
-        // The creation commit's AUDIT_DETAILS: the server default, or — when the
-        // request carried committal headers — the merge of the client's
-        // attributes over it. Built BEFORE the transaction so an illegal client
-        // `change_type` is a plain 400/422 without a storage round trip.
+        // The creation commit's AUDIT_DETAILS, built BEFORE the transaction so
+        // an illegal client `change_type` refuses without a storage round trip.
         // `from_update` constrains the code to `249|creation|`: a create commits
-        // a first version, so any other group code is a change-control mismatch
-        // (RM common master06 §Contributions).
+        // a first version (RM common master06 §Contributions).
         let audit = match committal {
             Some(c) => crate::versioning::audit::AuditInput::from_update(
                 &c.audit,
@@ -95,14 +92,11 @@ impl FerroEhrService {
 
         let mut tx = self.pool.begin().await?;
 
-        // EHR.system_id is recorded at creation, immutable thereafter (arch
-        // master06 §System Identity — a stored value, not the live config), and
-        // `time_created` (§The EHR) comes back from the INSERT. The promoted
-        // subject / is_queryable columns are set in this same INSERT, so the
-        // create path never runs the separate `sync_ehr_subject` UPDATE the
-        // update/contribution paths use. A subject already owned by another EHR
-        // is a distinct 409 (RM ehr master04 §EHR Status; ITS-REST
-        // `409_EHR.yaml`).
+        // EHR.system_id is recorded at creation and immutable thereafter (arch
+        // master06 §System Identity — a stored value, not the live config); the
+        // promoted subject / is_queryable columns ride the same INSERT, so no
+        // separate `sync_ehr_subject` UPDATE runs. A subject already owned by
+        // another EHR is a distinct 409 (RM ehr master04 §EHR Status).
         let (subject_id, subject_namespace, is_queryable, is_modifiable) =
             super::status::ehr_promoted_columns(&status);
         let time_created = match crate::storage::ehr_repo::insert_ehr(
@@ -175,9 +169,6 @@ impl FerroEhrService {
             &self.signing_ctx(),
         )
         .await?;
-        // The promoted subject / is_queryable columns were set in the initial
-        // `insert_ehr` (folded, no separate UPDATE) — one EHR per subject (RM
-        // ehr master04 §EHR Status).
         tx.commit().await?;
 
         // The EHR is created with the settings-less default EHR_ACCESS
@@ -185,14 +176,11 @@ impl FerroEhrService {
         // is a hit, not a DB miss (the access gate runs on every such request).
         self.prewarm_ehr_access_open(ehr_id).await;
 
-        // Build the RM `EHR` wire body straight from the commit results — the
-        // status/access version identities are already in `Committed`,
-        // `time_created` came back from the row INSERT, and a fresh EHR indexes
-        // no folder hierarchy — so the create path never re-reads via
-        // `ehr_summary` (its five header/version/folder reads). The body is
-        // byte-identical to `ehr_summary` for a new EHR (pinned by a test); it
-        // is stashed so `ehr_created_object` serves a
-        // `Prefer: return=representation` response without a re-read.
+        // The RM `EHR` wire body is built from the commit results rather than
+        // re-read through `ehr_summary`: the version identities are in
+        // `Committed`, `time_created` came back from the INSERT, and a fresh EHR
+        // indexes no folder hierarchy. It is stashed so a
+        // `Prefer: return=representation` response needs no re-read.
         let body = self.ehr_object_from_committed(ehr_id, time_created, &committed.versions)?;
         self.created_ehr_repr.insert(ehr_id, body.clone()).await;
         let meta = ResourceMeta::new(ehr_id.to_string(), ehr_id.to_string())
@@ -279,11 +267,10 @@ impl FerroEhrService {
         &self,
         ehr_id: EhrId,
     ) -> Result<ServiceResponse, ServiceError> {
-        // ONE statement for the whole representation (the former four serial
-        // reads — header, EHR_STATUS identity, EHR_ACCESS ref, folder
-        // hierarchies — merged; read batching is spec-silent, our own design).
-        // EHR.system_id is IMMUTABLE after creation (arch master06 §System
-        // Identity) — the stored per-EHR value, never the live config.
+        // ONE statement for the whole representation — header, EHR_STATUS
+        // identity, EHR_ACCESS ref and folder hierarchies. EHR.system_id is
+        // IMMUTABLE after creation (arch master06 §System Identity): the stored
+        // per-EHR value, never the live config.
         let read = crate::storage::ehr_repo::ehr_summary_read(&self.pool, ehr_id)
             .await?
             .ok_or_else(|| {
@@ -688,11 +675,10 @@ impl FerroEhrService {
 // ── ITS-REST create-response adapter (adapter-support extension) ──────────────
 //
 // The SM creates return only the new `ehr_id`, but ITS-REST
-// `Requests_and_responses.md` §"`ETag` and Last-Modified" mandates both headers
-// on "resources that have versioning or unique state identifiers": for an EHR
-// the `ETag` is "`EHR.ehr_id.value`" and `Last-Modified` the creating
-// CONTRIBUTION's commit time, returned in [`ResourceMeta`]. No openEHR spec
-// governs this envelope — our own design.
+// `Requests_and_responses.md` §"`ETag` and Last-Modified" mandates both headers,
+// the `ETag` being `EHR.ehr_id.value` and `Last-Modified` the creating
+// CONTRIBUTION's commit time, so these siblings also return a [`ResourceMeta`]
+// (no openEHR spec governs the envelope — our own design).
 
 impl FerroEhrService {
     /// [`Self::create_ehr`] returning the new `ehr_id` together with the
@@ -737,9 +723,6 @@ impl FerroEhrService {
         committal: Option<&crate::service::version_update::Committal>,
     ) -> Result<ResourceMeta, SmError> {
         // see `create_ehr` — `Pre_no_subject` deliberately not enforced.
-        // The ONE serialization boundary of the bootstrap commit: the caller's
-        // typed EHR_STATUS (or the server default) becomes its canonical
-        // fragment once, here.
         let status = an_ehr_status.map_or_else(initial_ehr_status, |s| {
             openehr_its::json::to_canonical_value(&s)
         });

--- a/app/ferroehr/src/service/ehr/status.rs
+++ b/app/ferroehr/src/service/ehr/status.rs
@@ -129,9 +129,6 @@ impl FerroEhrService {
         version: UpdateVersion<EhrStatus>,
         if_match: &str,
     ) -> Result<crate::versioning::change::Committed, ServiceError> {
-        // The ONE serialization boundary of this commit, taken before any
-        // await so the typed RM value does not ride the whole write
-        // transaction (`super::canonicalize`).
         let version = super::canonicalize(version);
         let super::CommitParts {
             audit,
@@ -162,7 +159,7 @@ impl FerroEhrService {
         )
         .await?;
         // Keep the promoted subject columns in sync (the subject may have
-        // changed); the is_queryable promotion (Fix B) rides this same UPDATE.
+        // changed); the is_queryable promotion rides this same UPDATE.
         self.sync_ehr_subject(&mut tx, ehr_id, &body).await?;
         tx.commit().await?;
 
@@ -218,11 +215,9 @@ impl FerroEhrService {
             .as_ref()
             .map(|m| m.uid.clone())
             .unwrap_or_default();
-        // The stored fragment decodes ONCE into the typed EHR_STATUS and the
-        // mutation operates on the typed value (#1846 — no Map round trip):
-        // a mutation that cannot produce a legal EHR_STATUS is unrepresentable
-        // (the typed fields) or refused by the closure itself (the
-        // client-supplied `other_details` decode, SM `i_ehr_status.adoc`
+        // The stored fragment decodes ONCE into the typed EHR_STATUS, so a
+        // mutation that cannot produce a legal one is either unrepresentable or
+        // refused by the closure itself (SM `i_ehr_status.adoc`
         // §update_other_details).
         let mut status: EhrStatus = openehr_its::json::from_canonical_value(&current.body)
             .map_err(|e| {
@@ -766,9 +761,8 @@ impl FerroEhrService {
         // Boxed: the typed EHR_STATUS envelope makes the mutate future large
         // enough to matter on the stack (clippy `large_futures`).
         Ok(Box::pin(self.status_mutate(an_ehr_id, move |s| {
-            // The client-supplied details decode through the strict reader —
-            // a non-ITEM_STRUCTURE refuses here, path-named (the same
-            // judgement the retired post-mutation re-decode made).
+            // The client-supplied details decode through the strict reader, so
+            // a non-ITEM_STRUCTURE refuses here, path-named.
             s.other_details = Some(openehr_its::json::from_canonical_value(&a_details).map_err(
                 |e| {
                     ServiceError::content_invalid(
@@ -850,11 +844,10 @@ impl FerroEhrService {
 // ── ITS-REST read/write-response adapter (adapter-support extension) ──────────
 //
 // The SM `I_EHR_STATUS` calls return the bare `EHR_STATUS` (or its new version
-// uid), neither of which carries the commit instant ITS-REST wants:
-// `Requests_and_responses.md` §"`ETag` and Last-Modified" derives it from
-// `VERSION.commit_audit.time_committed.value`. These siblings hand the adapter
-// the same result PLUS its [`ResourceMeta`] — no second read. No openEHR spec
-// governs this envelope — our own design.
+// uid), neither of which carries the commit instant `Requests_and_responses.md`
+// §"`ETag` and Last-Modified" wants, so these siblings return the same result
+// plus its [`ResourceMeta`] with no second read (no openEHR spec governs the
+// envelope — our own design).
 
 impl FerroEhrService {
     /// [`Self::get_ehr_status_at_time`] with the version metadata the wire's

--- a/app/ferroehr/src/service/ehr/tags.rs
+++ b/app/ferroehr/src/service/ehr/tags.rs
@@ -119,14 +119,11 @@ impl FerroEhrService {
         self.ensure_ehr_exists(ehr_id).await?;
         self.ensure_tag_target(ehr_id, target_vo_id, target_version, target_type)
             .await?;
-        // Validate every tag before writing; the storage replace dedupes the
-        // posted set on the ITEM_TAG identity — the (key, target_path) PAIR
-        // (ITS-REST Requests_and_responses.md §item-tag headers), last-wins.
-        // The judgement is the RM's own: each posted UPDATE_ITEM_TAG is turned
-        // into the ITEM_TAG the write would store — with the `target` and
-        // `owner_id` the server assigns, which is why the write schema omits
-        // them — and run through `ItemTag`'s single `Validate` impl, the same
-        // one the demographic seam uses.
+        // The storage replace dedupes the posted set on the ITEM_TAG identity —
+        // the (key, target_path) PAIR (ITS-REST Requests_and_responses.md
+        // §item-tag headers), last-wins. Each posted UPDATE_ITEM_TAG is first
+        // turned into the ITEM_TAG the write would store, with the server's own
+        // `target`/`owner_id`, and judged by `ItemTag`'s own `Validate` impl.
         let target = match target_version {
             Some(version) => UidBasedId::ObjectVersionId(version.clone()),
             None => UidBasedId::HierObjectId(HierObjectId::from(target_vo_id.0)),
@@ -136,8 +133,8 @@ impl FerroEhrService {
             Vec::with_capacity(tags.len());
         for tag in tags {
             let target_path = normalized_target_path(tag.target_path.as_deref());
-            // Construction IS the invariant check (#1839): a violating tag
-            // cannot exist as a typed ItemTag.
+            // Construction IS the invariant check: a violating tag cannot exist
+            // as a typed ItemTag.
             ItemTag::new(
                 tag.key.clone(),
                 tag.value.clone(),
@@ -285,8 +282,7 @@ impl FerroEhrService {
         row: &crate::storage::tag_repo::TagRow,
     ) -> Result<ItemTag, ServiceError> {
         // A stored row that no longer constructs is storage corruption, not a
-        // client fault — fail loud as the 500 class (the write path validated
-        // at commit; #1839 made construction the invariant check).
+        // client fault — fail loud as the 500 class.
         ItemTag::new(
             row.key.clone(),
             row.value.clone(),

--- a/app/ferroehr/src/service/ehr/uri.rs
+++ b/app/ferroehr/src/service/ehr/uri.rs
@@ -134,12 +134,10 @@ impl FerroEhrService {
         } else {
             let attribute = &locator.attribute;
             // An attribute with no id addresses the EHR's single current object
-            // of that kind (e.g. `directory`, `ehr_status`). `directory` (and a
-            // bare `folders`, whose only spec-pinned member is `folders.item(1)`
-            // = the directory — RM ehr §EHR Class `Directory_in_folders`) must
-            // resolve deterministically among multiple hierarchies, so it goes
-            // through the rank-ordered directory lookup, never a bare
-            // kind-scan.
+            // of that kind. `directory` — and a bare `folders`, whose only
+            // spec-pinned member is `folders.item(1)` (RM ehr §EHR Class
+            // `Directory_in_folders`) — must resolve deterministically among
+            // multiple hierarchies, so it takes the rank-ordered lookup.
             let vo_id = match attribute.as_str() {
                 "directory" | "folders" => {
                     self.directory_vo_opt(ehr_id).await?.ok_or_else(|| {

--- a/app/ferroehr/src/service/ehr/validation.rs
+++ b/app/ferroehr/src/service/ehr/validation.rs
@@ -162,14 +162,11 @@ impl FerroEhrService {
                 openehr_its::flat::validation::validate_archetype_conformance(composition, &wt)
             });
             template_failures = messages.len() - rm_terminology_failures;
-            // Archetype constraint bindings (ac-code → external value set)
-            // resolve against the routed terminology servers — a no-op, free of
-            // any remote call, unless `[terminology.external]` is configured
-            // (BASE `architecture_overview/master12-terminology.adoc`
-            // §"Binding Terminology Value-sets to Archetypes"). The relaxation
-            // for a `553|incomplete|` commit does not reach it: a code that IS
-            // present may not be wrong (RM common master06 §Incomplete
-            // Content). Counted as its own pass.
+            // Archetype constraint bindings resolve against the routed
+            // terminology servers (BASE `master12-terminology.adoc` §"Binding
+            // Terminology Value-sets to Archetypes"), and the `553|incomplete|`
+            // relaxation does not reach them: a code that IS present may not be
+            // wrong (RM common master06 §Incomplete Content).
             let bindings = self.constraint_binding_violations(composition, &wt).await;
             binding_failures = bindings.len();
             messages.extend(bindings);
@@ -241,11 +238,9 @@ impl FerroEhrService {
             Kind::EhrStatus => validate_ehr_status(data, incomplete),
             Kind::EhrAccess => validate_ehr_access(data, incomplete),
             Kind::Folder => validate_folder(data, incomplete),
-            // The demographic kinds arrive here from the raw-body
-            // CONTRIBUTION lane only (the `Kind` was derived from the
-            // payload's own `_type`), so they take the full check — decode
-            // included; the direct routes enter at `party_invariants`, having
-            // decoded already.
+            // The demographic kinds reach here from the raw-body CONTRIBUTION
+            // lane only, so they take the full check including the decode; the
+            // direct routes enter at `party_invariants`, already decoded.
             Kind::Agent | Kind::Group | Kind::Organisation | Kind::Person | Kind::Role => {
                 crate::service::demographic::validate::party_check(kind.as_str(), data, incomplete)
             }
@@ -575,14 +570,11 @@ pub(in crate::service) fn validate_ehr_access(
                 .to_owned(),
         ));
     }
-    // `EHR_ACCESS.settings` is the RM's one implementation-defined slot —
-    // "Instance is a subtype of the type `ACCESS_CONTROL_SETTINGS`, allowing for
-    // the use of different access control schemes"
-    // (`RM/docs/UML/classes/org.openehr.rm.ehr.ehr_access.adoc` §Attributes) —
-    // and that type is abstract with no attributes, no invariants and no
-    // RM-defined descendant, so the RM defines NOTHING inside it to judge while
-    // a pass that walked in would refuse every legal instance. `Scheme_valid`
-    // above is the whole of the RM's demand on the slot.
+    // `EHR_ACCESS.settings` is the RM's one implementation-defined slot
+    // (`org.openehr.rm.ehr.ehr_access.adoc` §Attributes) and its type is
+    // abstract with no attributes, invariants or RM-defined descendant, so a
+    // pass that walked in would refuse every legal instance; `Scheme_valid`
+    // above is the whole of the RM's demand on it.
     // NOTE: `settings` is therefore excluded from the whole-instance RM pass,
     // and only from it — the one RM-mandated OPEN slot.
     let mut without_settings = access.clone();
@@ -751,13 +743,10 @@ mod tests {
                 .insert("other_details".into(), other);
             st
         };
-        // Each subtype is spelled out at its own mandatory shape: `ITEM_SINGLE.item`
-        // is `ELEMENT [1..1]` (RM `data_structures`
-        // `org.openehr.rm.data_structures.item_single.adoc` §Attributes), while
-        // ITEM_TREE/ITEM_LIST `items` and ITEM_TABLE `rows` are 0..1. The
-        // whole-instance RM pass reaches `other_details`, so an ITEM_SINGLE
-        // without its item is refused on its own merits — the acceptance
-        // asserted here is of a *valid* instance of each subtype.
+        // Each subtype is spelled out at its own mandatory shape:
+        // `ITEM_SINGLE.item` is `ELEMENT [1..1]`
+        // (`org.openehr.rm.data_structures.item_single.adoc` §Attributes) while
+        // ITEM_TREE/ITEM_LIST `items` and ITEM_TABLE `rows` are 0..1.
         for other in [
             json!({ "_type": "ITEM_TREE", "name": { "_type": "DV_TEXT", "value": "d" },
                     "archetype_node_id": "at0001" }),
@@ -1112,8 +1101,7 @@ mod tests {
     //
     // The RM class invariants are properties of the instance, not of the
     // resource kind, so a defect BELOW the root of an EHR_STATUS / FOLDER /
-    // demographic body is a 422 exactly as it is inside a COMPOSITION. Before
-    // `validate_rm_invariants_for_commit` these arms saw only their root.
+    // demographic body is a 422 exactly as it is inside a COMPOSITION.
 
     /// `ARCHETYPED.Rm_version_valid` (`not rm_version.is_empty`, RM common
     /// `org.openehr.rm.common.archetyped.adoc` §Invariants) on an `EHR_STATUS`

--- a/app/ferroehr/src/service/error.rs
+++ b/app/ferroehr/src/service/error.rs
@@ -682,7 +682,6 @@ impl From<ServiceError> for SmError {
             // A raw `sqlx` error carries SQLSTATE/constraint detail: classify it
             // (integrity/serialization conflict → 409, pool exhaustion → 503)
             // instead of collapsing every database error to a blanket 500.
-            // The classifier emits the structured trace.
             ServiceError::Database(e) => crate::storage::error::classify_sqlx(&e),
             // A malformed payload the server was asked to read names its own
             // defect (`400`); a failure to serialize the server's own data is
@@ -726,9 +725,7 @@ impl From<ServiceError> for ApiError {
             ),
             // Storage/DB failures carry SQLSTATE/constraint detail: classify
             // them (integrity/serialization conflict → 409, pool exhaustion →
-            // 503) rather than blanket-500. A genuine fault stays 500. This
-            // path is secondary to the SM `SmError` bridge, but must stay
-            // consistent with it.
+            // 503) rather than blanket-500. A genuine fault stays 500.
             ServiceError::Storage(e) => sqlx_conflict_api_error(SmError::from(e)),
             ServiceError::Database(e) => {
                 sqlx_conflict_api_error(crate::storage::error::classify_sqlx(&e))

--- a/app/ferroehr/src/service/message/export.rs
+++ b/app/ferroehr/src/service/message/export.rs
@@ -633,14 +633,10 @@ impl FerroEhrService {
                 "item": {
                     "_type": "X_VERSIONED_PARTY",
                     "uid": { "_type": "HIER_OBJECT_ID", "value": vo_id.to_string() },
-                    // The serving system is the owner — there is no owning EHR
-                    // (RM demographic content stands alone). Same shape the
-                    // VERSIONED_PARTY container read serves: the released
-                    // `VersionedParty` example's `OBJECT_REF`
-                    // `{namespace: local, type: SYSTEM, id: HIER_OBJECT_ID}`
-                    // (vendored ITS-REST OAS
-                    // `crates/openehr-its/vendor/rest-oas/demographic-codegen.openapi.yaml`,
-                    // `components.schemas.VersionedParty.example`).
+                    // RM demographic content stands alone, so the serving system
+                    // is the owner — the shape the VERSIONED_PARTY container read
+                    // serves, per the released `VersionedParty` example's
+                    // `OBJECT_REF` in the ITS-REST demographic OAS.
                     "owner_id": {
                         "_type": "OBJECT_REF",
                         "namespace": "local",

--- a/app/ferroehr/src/service/message/import.rs
+++ b/app/ferroehr/src/service/message/import.rs
@@ -157,20 +157,15 @@ impl FerroEhrService {
             self.commit_default_ehr_access(&mut tx, ehr_id, "EHR Extract import: default access")
                 .await?;
         }
-        // The clone landed the EHR_STATUS directly (not via the service's
-        // sync_ehr_subject hook), so re-promote the `ehr` columns from the
-        // stored current status: the subject (`GET /ehr?subject_id` +
-        // one-EHR-per-subject, RM ehr master04 §EHR Status) and the
-        // `is_queryable` / `is_modifiable` flags the AQL full-population gate
-        // (SM I_QUERY_SERVICE) and the content-write guard (§EHR Active Status)
-        // read.
+        // The clone landed the EHR_STATUS directly, bypassing the service's
+        // sync hook, so the promoted `ehr` columns — subject, `is_queryable`,
+        // `is_modifiable` — are re-derived from the stored current status (RM
+        // ehr master04 §EHR Status / §EHR Active Status).
         self.resync_promoted_columns(&mut tx, ehr_id).await?;
         tx.commit().await.map_err(ServiceError::from)?;
-        // An imported EHR_ACCESS version changes the EHR's access policy — evict
-        // the cached settings the access gate consults (RM ehr master04 §EHR
-        // Access; the settings are change-controlled). A bootstrapped default
-        // carries no settings, so the clone is default-open: seed that entry
-        // instead, exactly as the create path does.
+        // An imported EHR_ACCESS version changes the EHR's access policy, so the
+        // cached settings are evicted (RM ehr master04 §EHR Access); a
+        // bootstrapped default carries none, so that entry is seeded open.
         if touches_ehr_access {
             self.invalidate_ehr_access(ehr_id).await;
         } else {
@@ -234,12 +229,9 @@ impl FerroEhrService {
         let touches_ehr_access = containers.iter().any(|c| c.kind == Kind::EhrAccess);
         commit_import(&mut tx, &signing, an_ehr_id, &audit, containers).await?;
         commit_demographic_import(&mut tx, &signing, &audit, parties).await?;
-        // An imported EHR_STATUS version can change the current status
-        // (Copying Case 3 append) — including its subject; re-promote the `ehr`
-        // columns from the stored current status so the subject lookup +
-        // one-EHR-per-subject rule (RM ehr master04 §EHR Status), the AQL
-        // full-population gate (SM I_QUERY_SERVICE) and the content-write guard
-        // (§EHR Active Status) all stay consistent with it.
+        // An imported EHR_STATUS version can change the current status, subject
+        // included (Copying Case 3 append), so the promoted `ehr` columns are
+        // re-derived from it (RM ehr master04 §EHR Status / §EHR Active Status).
         self.resync_promoted_columns(&mut tx, an_ehr_id).await?;
         tx.commit().await.map_err(ServiceError::from)?;
         // An imported EHR_ACCESS version changes the EHR's access policy — evict
@@ -571,14 +563,10 @@ fn parse_wrapped_commit_audit(ov: &Value) -> Result<Value, SmError> {
 /// `ORIGINAL_VERSION` instance is never modified"; `ehr_extract` master05
 /// `X_VERSIONED_OBJECT.versions: List<ORIGINAL_VERSION>`).
 fn parse_imported_version(ov: &Value) -> Result<(VoId, ImportVersion), SmError> {
-    // A member typed anything other than ORIGINAL_VERSION (e.g. an
-    // already-wrapped IMPORTED_VERSION) is invalid on TWO independent grounds:
-    // `X_VERSIONED_OBJECT.versions` is declared `List<ORIGINAL_VERSION<T>>` (RM
-    // ehr_extract `x_versioned_object.adoc` §Attributes), and master06 §Copying
-    // makes the ORIGINAL_VERSION the unit of copying, with each receiving system
-    // creating its OWN wrapper (§Committal and Audits). So a re-export ships the
-    // WRAPPED original, a re-import wraps that original afresh, and wrappers
-    // never nest.
+    // `X_VERSIONED_OBJECT.versions` is `List<ORIGINAL_VERSION<T>>`
+    // (`x_versioned_object.adoc` §Attributes) and master06 §Copying makes the
+    // ORIGINAL_VERSION the unit of copying, each receiving system creating its
+    // own wrapper — so wrappers never nest.
     match ov.get("_type").and_then(Value::as_str) {
         None | Some("ORIGINAL_VERSION") => {}
         Some(other) => {

--- a/app/ferroehr/src/service/query/execute.rs
+++ b/app/ferroehr/src/service/query/execute.rs
@@ -77,9 +77,8 @@ impl FerroEhrService {
         version: Option<String>,
         request: AqlQueryRequest,
     ) -> Result<QueryOutcome, SmError> {
-        // Resolve the stored AQL text (exact/partial SEMVER, or the latest)
-        // via the DEFINITION store, then execute it exactly like an ad-hoc
-        // query.
+        // The stored AQL text resolves through the DEFINITION store by
+        // exact/partial SEMVER, or the latest.
         let stored = self
             .get_stored_query(&qualified_query_name, version.as_deref())
             .await?;
@@ -139,11 +138,9 @@ impl FerroEhrService {
     ) -> Result<QueryOutcome, Failure> {
         let plan_start = Instant::now();
         let params = build_params(request);
-        // Parse + terminology-expand + lower to the typed IR, reusing a
-        // cached plan when the query text has been seen. The IR is a pure
-        // function of the query text; the parameter *values*, paging, and
-        // scope all bind downstream, so a cached plan serves every caller of
-        // the same text correctly.
+        // The IR is a pure function of the query text — parameter values,
+        // paging and scope all bind downstream — so a cached plan serves every
+        // caller of the same text correctly.
         let ir = self.plan_query(aql, &params).await?;
         record_phase("plan", plan_start);
 
@@ -177,14 +174,11 @@ impl FerroEhrService {
         };
 
         let exec_start = Instant::now();
-        // Query-level execution budget (`[query].timeout_ms`, our own
-        // operational extension — no openEHR spec governs a query timeout):
-        // when set, the DB execution is bounded so an over-long query is
-        // `408` instead of hanging to the global request timeout. The ABAC
-        // scope collection (our own access-control extension) stays a
-        // separate statement — the main query is paged, folding the sets in
-        // would scope only the served page — but runs CONCURRENTLY with it,
-        // both under the one budget.
+        // `[query].timeout_ms` bounds the DB execution so an over-long query is
+        // `408` rather than hanging to the global request timeout. The ABAC
+        // scope collection stays a separate statement — the main query is paged,
+        // so folding the sets in would scope only the served page — but runs
+        // concurrently under the same budget (our own extension).
         let run = async {
             let exec = aql::exec::execute(&self.pool, &ir, &params, &ctx, self.spec_profile);
             if request.collect_attributes {
@@ -470,14 +464,11 @@ fn map_plan_error(e: AqlError) -> SmError {
 /// ([`internal_fault`]).
 fn map_exec_error(e: AqlError) -> SmError {
     match e {
-        // A data-exception the DRIVER raises on this path is the caller's own
-        // binding failing Postgres coercion — the lowered literals are typed,
-        // so only client `query_parameters` reach text→type casts here. 22007
-        // invalid_datetime_format / 22008 datetime_field_overflow / 22P02
-        // invalid_text_representation (PostgreSQL Appendix A, errcodes) are
-        // therefore a 400 naming the defect class, never the write paths'
-        // opaque 500 (#2593: "not-a-date" against a temporal predicate
-        // answered 500).
+        // A data-exception the DRIVER raises here is the caller's own binding
+        // failing Postgres coercion: the lowered literals are typed, so only
+        // client `query_parameters` reach text→type casts. 22007 / 22008 / 22P02
+        // (PostgreSQL Appendix A, errcodes) are therefore a 400 naming the
+        // defect class, never an opaque 500.
         AqlError::Exec(ExecError::Database(db))
             if matches!(
                 db.as_database_error()

--- a/app/ferroehr/src/service/query/result_set.rs
+++ b/app/ferroehr/src/service/query/result_set.rs
@@ -160,11 +160,9 @@ pub(super) fn result_set_json(
             // and it is left absent rather than fabricated.
             _generator: None,
             _executed_aql: Some(executed.to_owned()),
-            // The OAS declares `ResultSetMetadata` `additionalProperties: true`
-            // (`crates/openehr-its/vendor/rest-oas/query-*.openapi.yaml`
-            // §`components.schemas.ResultSetMetadata`); this server publishes
-            // no metadata extension, so the map stays empty (and serializes to
-            // nothing).
+            // The OAS declares `ResultSetMetadata` `additionalProperties: true`,
+            // but this server publishes no metadata extension, so the map stays
+            // empty and serializes to nothing.
             additional_properties: std::collections::BTreeMap::new(),
         }),
         name: name.map(ToOwned::to_owned),

--- a/app/ferroehr/src/storage/codec.rs
+++ b/app/ferroehr/src/storage/codec.rs
@@ -87,13 +87,10 @@ fn walk(
         .and_then(Value::as_str)
         .unwrap_or_default()
         .to_owned();
-    // Case-folded at write: openEHR identifiers are defined "to be
-    // case-insensitive - two identifiers identical apart from case are
-    // considered to be identical" (BASE `base_types` master05
-    // §Composite Identifiers and Case), so the promoted predicate column stores the
-    // lowercase form and AQL archetype equality is plain indexed equality
-    // with honest statistics (no `LOWER()` on the column). The canonical
-    // `data` fragment keeps the original casing.
+    // openEHR identifiers are case-insensitive (BASE `base_types` master05
+    // §Composite Identifiers and Case), so the promoted predicate column stores
+    // the lowercase form and AQL archetype equality stays plain indexed equality
+    // with honest statistics. The canonical `data` fragment keeps its casing.
     let archetype = json
         .get("archetype_node_id")
         .and_then(Value::as_str)

--- a/app/ferroehr/src/storage/version_repo/attestation.rs
+++ b/app/ferroehr/src/storage/version_repo/attestation.rs
@@ -89,10 +89,8 @@ pub async fn attestation_target(
     kind: &str,
 ) -> Result<Option<AttestTargetRow>, StorageError> {
     // Attesting an archived version appends a row that references it, so the
-    // statement's leading CTEs bring the object back to the primary tier —
-    // the same merged thaw the commit path's placement read carries
-    // (`crate::storage::version_repo::placement::next_placement`); the lookup
-    // reads `vo_version` UNION ALL the thaw's own `RETURNING` rows because a
+    // leading CTEs thaw the object back to the primary tier. The lookup reads
+    // `vo_version` UNION ALL the thaw's own `RETURNING` rows, because a
     // same-statement `INSERT` is invisible to the sibling scans
     // (<https://www.postgresql.org/docs/18/queries-with.html>).
     let (t, b, v) = tree;

--- a/app/ferroehr/src/system_log/message.rs
+++ b/app/ferroehr/src/system_log/message.rs
@@ -140,7 +140,6 @@ impl AuditMessage {
         let mut w = Writer::new_with_indent(Vec::new(), b' ', 2);
         w.write_event(Event::Start(BytesStart::new("AuditMessage")))?;
 
-        // EventIdentification
         let mut ev = BytesStart::new("EventIdentification");
         ev.push_attribute(("EventActionCode", self.action.to_string().as_str()));
         ev.push_attribute(("EventDateTime", self.event_datetime.as_str()));
@@ -157,7 +156,6 @@ impl AuditMessage {
         w.write_event(Event::End(BytesEnd::new("EventOutcomeDescription")))?;
         w.write_event(Event::End(BytesEnd::new("EventIdentification")))?;
 
-        // ActiveParticipant(s)
         for p in &self.participants {
             let mut ap = BytesStart::new("ActiveParticipant");
             ap.push_attribute(("UserID", p.user_id.as_str()));
@@ -169,7 +167,6 @@ impl AuditMessage {
             w.write_event(Event::End(BytesEnd::new("ActiveParticipant")))?;
         }
 
-        // AuditSourceIdentification
         let mut src = BytesStart::new("AuditSourceIdentification");
         src.push_attribute(("AuditEnterpriseSiteID", self.enterprise_site_id.as_str()));
         src.push_attribute(("AuditSourceID", self.source_id.as_str()));
@@ -177,7 +174,6 @@ impl AuditMessage {
         write_code(&mut w, "AuditSourceTypeCode", &self.source_type)?;
         w.write_event(Event::End(BytesEnd::new("AuditSourceIdentification")))?;
 
-        // ParticipantObjectIdentification(s)
         for obj in &self.objects {
             let mut po = BytesStart::new("ParticipantObjectIdentification");
             po.push_attribute(("ParticipantObjectID", obj.id.as_str()));
@@ -235,12 +231,10 @@ fn build_objects(
     }
 
     if object_class.has_object_uri() {
-        // Patient-centric classes already carry the Patient-Number object; the
-        // URI object is added when the id is known. Non-patient classes
-        // (template / demographic) always carry the URI object, filled with
-        // `value_if_missing` when unknown (DICOM PS3.15 §A.5 mandatory-field
-        // rule — a required element is never absent) so every record
-        // identifies its participant object.
+        // Patient-centric classes already carry the Patient-Number object and
+        // add the URI object when the id is known; non-patient classes always
+        // carry it, filled with `value_if_missing` when unknown, so no required
+        // element is absent (DICOM PS3.15 §A.5).
         let id = event.object_id.clone();
         if let Some(id) = id {
             objects.push(uri_object(id, event));

--- a/app/ferroehr/src/system_log/sender.rs
+++ b/app/ferroehr/src/system_log/sender.rs
@@ -411,14 +411,13 @@ async fn drain(
     resolve_subject: bool,
     store_healthy: Arc<AtomicBool>,
 ) {
-    // Batched receive: under load one loop turn takes up to DRAIN_BATCH
-    // queued events at once, so the store sink can persist them in one
-    // multi-row INSERT instead of per-event round trips (the throughput
-    // defect behind a full queue at write-path rates).
+    // Batched receive: one loop turn takes up to DRAIN_BATCH queued events, so
+    // the store sink persists them in one multi-row INSERT rather than per-event
+    // round trips.
     let mut batch: Vec<AuditEvent> = Vec::with_capacity(DRAIN_BATCH);
     // The subject lookup memo: an EHR's subject id is immutable for audit
-    // purposes at write-path rates, and one awaited per-event lookup was the
-    // remaining drain bottleneck (a saturated queue at seeding-grade load).
+    // purposes at write-path rates, and one awaited per-event lookup is the
+    // remaining drain bottleneck.
     let subject_cache: SubjectCache = moka::future::Cache::builder()
         .max_capacity(100_000)
         .time_to_live(Duration::from_hours(1))

--- a/app/ferroehr/src/telemetry/mod.rs
+++ b/app/ferroehr/src/telemetry/mod.rs
@@ -76,7 +76,7 @@ pub enum TelemetryError {
 pub fn init(cfg: &TelemetryConfig, build: &BuildInfo) -> Result<TelemetryGuard, TelemetryError> {
     // 1) Metrics: ONE meter provider. The Prometheus reader always serves the
     //    pull surface; the OTLP periodic reader is added when the push is on,
-    //    so both surfaces carry every instrument (#2181).
+    //    so both surfaces carry every instrument.
     let mut tracer_provider = None;
     let mut tracer = None;
 

--- a/app/ferroehr/src/templates/runtime.rs
+++ b/app/ferroehr/src/templates/runtime.rs
@@ -71,26 +71,20 @@ impl FerroEhrService {
         // to the single entry for the same template.
         let key = identity::canonical_key(template_id);
 
-        // Fast path: a built WebTemplate is already resident — serve it without
-        // touching `template_store`. This is the hot commit path: composition
-        // validation calls `web_template_for` once per commit, and once a
-        // template is warm every subsequent commit is a pure in-memory hit (no
-        // per-commit OPT read). No openEHR spec governs this cache — the spec blesses
-        // a compiled near-runtime form; the caching mechanics are our own design.
+        // A resident WebTemplate is served without touching `template_store`:
+        // composition validation calls this once per commit, so a warm template
+        // makes every later commit a pure in-memory hit (no openEHR spec governs
+        // the cache — our own design).
         if let Some(wt) = self.web_templates.get(&key).await {
             note_cache_event("hit");
             return Ok(wt);
         }
         note_cache_event("miss");
 
-        // Miss: load the stored OPT XML (the one store read, amortised across
-        // every future commit for this template). When the id is not an ADL 1.4
-        // template, fall back to the ADL2/OPT2 store
-        // (`web_template_adl2_cached`), so a FLAT/STRUCTURED commit keyed to an
-        // ADL2-registered template resolves and is archetype-constraint-checked.
-        // Only after *both* stores miss is the id "operational template not
-        // known" (the commit-path 422). No openEHR spec governs the internal
-        // resolver wiring — our own design/extension.
+        // On a miss the stored OPT XML is loaded once, and an id that is not an
+        // ADL 1.4 template falls back to the ADL2/OPT2 store so a FLAT/STRUCTURED
+        // commit against an ADL2-registered template still resolves. Only after
+        // BOTH stores miss is the id unknown (the commit-path 422).
         let xml = match self.get_template_xml(template_id).await {
             Ok(xml) => xml,
             Err(ServiceError::NotFound(_)) => {

--- a/app/ferroehr/src/templates/store.rs
+++ b/app/ferroehr/src/templates/store.rs
@@ -154,13 +154,10 @@ impl FerroEhrService {
             .await?;
         tx.commit().await?;
 
-        // No `WebTemplate`-cache invalidation is needed on the create path: this
-        // insert is create-only (`ON CONFLICT DO NOTHING` never overwrites), and
-        // `web_template_for` only caches a *successful* build, so no stale or
-        // negative entry can pre-exist for a freshly stored template_id. The
-        // cache is invalidated only where a template's lifetime ends — the delete
-        // path (`service/definition/adl14.rs::opt_delete`). No openEHR spec
-        // governs the cache; this is our own design.
+        // The create path needs no `WebTemplate`-cache invalidation: the insert
+        // never overwrites and `web_template_for` caches only successful builds,
+        // so a freshly stored template_id can have no pre-existing entry. The
+        // cache is invalidated where a template's lifetime ends, in the delete.
         Self::template_json(&row)
     }
 

--- a/app/ferroehr/src/validation/opt/mod.rs
+++ b/app/ferroehr/src/validation/opt/mod.rs
@@ -242,7 +242,6 @@ fn walk_attribute(attr: &CAttribute, parent_rm: &str, ctx: &Ctx) -> Result<(), R
         rm_conformance::check_cardinality_occurrences(attr_name, parent_rm, card, children)?;
     }
 
-    // Recurse into each child object.
     for child in children {
         walk_object(child, ctx)?;
     }

--- a/app/ferroehr/src/validation/opt/rm_conformance.rs
+++ b/app/ferroehr/src/validation/opt/rm_conformance.rs
@@ -138,9 +138,8 @@ pub(super) fn check_attribute(
         return Ok(());
     }
     match model::attribute(parent_rm, attr_name) {
-        // (Prior art, named only as where the shape is OBSERVED and never as
-        // its authority: archie/openEHR-SDK-generated OPTs model every
-        // constrainable node as Locatable and emit exactly these constraints.)
+        // The shape is OBSERVED in archie/openEHR-SDK-generated OPTs, which
+        // model every constrainable node as Locatable — prior art, not authority.
         // NOTE: a LOCATABLE meta attribute constrained on a PATHABLE-only class
         // (e.g. ISM_TRANSITION) binds to a field that node's canonical
         // serialization carries, so it has a referent and is not a VCARM breach.

--- a/app/ferroehr/src/validation/opt/terminology.rs
+++ b/app/ferroehr/src/validation/opt/terminology.rs
@@ -48,13 +48,11 @@ pub(super) fn check_node_id(
     defined_at: &HashSet<String>,
 ) -> Result<(), RuleViolation> {
     if !archetype_node_id_is_term_code(node_id) {
-        // THE MALFORMED MIDDLE CLASS: a node id CARRYING the at/id leader but
-        // failing the code-body grammar (`at0abc`) is a malformed CLAIMED code,
-        // not free text — AOM2's own predicate is leader-based
-        // (`adl_code_definitions.adoc` §is_at_code: "Result =
-        // a_code.starts_with (At_code_leader)"), so the string claims code-hood
-        // and the body must then satisfy the code syntax. Refused here rather
-        // than falling between the code family and the free-text family.
+        // A node id CARRYING the at/id leader but failing the code-body grammar
+        // (`at0abc`) is a malformed CLAIMED code, not free text: AOM2's own
+        // predicate is leader-based (`adl_code_definitions.adoc` §is_at_code),
+        // so the string claims code-hood and its body must then satisfy the code
+        // syntax.
         let claims_code_leader = (node_id.starts_with("at") || node_id.starts_with("id"))
             && node_id.len() > 2
             && !openehr_rm::v1_2::paths::is_archetype_root_node_id(node_id);

--- a/app/ferroehr/src/versioning/attestation.rs
+++ b/app/ferroehr/src/versioning/attestation.rs
@@ -95,9 +95,8 @@ pub(crate) async fn attest(
     contribution_id: Uuid,
     time_committed: jiff::Timestamp,
 ) -> Result<Committed, ServiceError> {
-    // The target lookup (`version_repo::attestation::attestation_target`) yields the owning
-    // EHR (compared against the caller's), the storage ordinal the attestation
-    // keys to, and the target's `creating_system_id` (carried into the outbox).
+    // The target's owning EHR is compared against the caller's, its ordinal
+    // keys the attestation, and its `creating_system_id` rides the outbox.
     let target = crate::storage::version_repo::attestation::attestation_target(
         tx,
         vo_id,
@@ -278,14 +277,10 @@ impl AttestationParts {
                         .with_path("ATTESTATION.is_pending"),
                 )
             })?;
-        // items (0..1); Items_valid: non-empty when present.
-        //
-        // A JSON `null` is the ABSENT encoding of an optional attribute, not a
-        // present-but-invalid list — the same reading `attested_view` and `proof`
-        // below apply, and the one the native `UPDATE_VERSION` DTO emits for
-        // `Option::None`. So it is filtered out before `Items_valid` is
-        // evaluated; a present-but-EMPTY list (`[]`) still fails, which is what
-        // the invariant actually forbids.
+        // items (0..1); Items_valid: non-empty when present. A JSON `null` is
+        // the ABSENT encoding of an optional attribute (the one the native
+        // `UPDATE_VERSION` DTO emits for `Option::None`), so it is filtered out
+        // before `Items_valid`; a present-but-EMPTY list still fails.
         // NOTE: the released text's two statements of `items` SCOPE conflict
         // (master04 §Attestation vs the class table on `attestation.adoc`); the
         // class model is enforced — `Items_valid`, and NO containment check.
@@ -301,10 +296,8 @@ impl AttestationParts {
                 .filter(|v| !v.is_null())
                 .map(|v| decode(v, "ATTESTATION.attested_view", "DV_MULTIMEDIA"))
                 .transpose()?,
-            // This is NOT the VERSION `signature` mechanism, which this server
-            // does generate and verify for its own signatures (master06 §Digital
-            // Signature — `crate::versioning::integrity`); there the server owns
-            // both the canonicalisation and the key.
+            // Not the VERSION `signature` mechanism, where the server owns both
+            // the canonicalisation and the key (master06 §Digital Signature).
             // NOTE: `proof` is an OPAQUE CLIENT FACT — no released text defines a
             // canonical form to recompute against ("The exact serialisation is
             // not yet defined by openEHR", master04 §Attestation).
@@ -402,14 +395,11 @@ impl AttestationInput {
     /// `PARTY_PROXY` or `description` is neither a string nor a canonical
     /// `DV_TEXT`.
     pub(crate) fn decode(partial: &Value) -> Result<Self, ServiceError> {
-        // description: the inherited AUDIT_DETAILS.description (0..1). ITS-REST
-        // types it `UDvText` — `oneOf` [`DV_TEXT`, `DV_CODED_TEXT`]
-        // (`schemas/data_types/UDvText.yaml`) — while SM
-        // `UPDATE_AUDIT.description` is `String [0..1]` (`update_audit.adoc`),
-        // which grounds the plain-string branch. Both spellings are read, and
-        // the object spelling is decoded WHOLE: reducing a `DV_CODED_TEXT` to
-        // its `value` would permanently drop the `defining_code` of a committed
-        // attestation (RM common `audit_details.adoc` §Attributes).
+        // description: the inherited AUDIT_DETAILS.description (0..1). Both
+        // released spellings are read — the ITS-REST `UDvText` object and the SM
+        // `String [0..1]` (`update_audit.adoc`) — and the object is decoded
+        // WHOLE: reducing a `DV_CODED_TEXT` to its `value` would drop the
+        // `defining_code` of a committed attestation.
         let description = partial
             .get("description")
             .filter(|d| !d.is_null())

--- a/app/ferroehr/src/versioning/audit.rs
+++ b/app/ferroehr/src/versioning/audit.rs
@@ -245,12 +245,10 @@ impl AuditInput {
                 .map_or_else(|| fallback_system_id.to_owned(), str::to_owned),
             change_type,
             // The wire types `description` as `DV_TEXT`
-            // (`schemas/common/UpdateAudit.yaml`), whose `DV_CODED_TEXT`
-            // subtype substitutes for it — so a client-supplied description
-            // is kept WHOLE: reducing it to its `value` would drop the
-            // `defining_code` of a coded description permanently (RM common
-            // `UML/classes/org.openehr.rm.common.audit_details.adoc`
-            // §Attributes types the attribute `DV_TEXT`).
+            // (`schemas/common/UpdateAudit.yaml`), whose `DV_CODED_TEXT` subtype
+            // substitutes for it, so it is kept WHOLE: reducing it to its
+            // `value` would permanently drop a coded description's
+            // `defining_code`.
             description: Some(
                 base.description
                     .filter(|d| !crate::service::version_update::text_value(d).is_empty())
@@ -259,12 +257,10 @@ impl AuditInput {
             ),
             committer: base.committer.clone(),
             // `UPDATE_VERSION.commit_audit` is polymorphic on the released wire
-            // (`UpdateAudit.yaml` carries a `discriminator.mapping` to
-            // `UPDATE_ATTESTATION`), which is the RM's own pair: "the committing
+            // (`UpdateAudit.yaml`), which is the RM's own pair: "the committing
             // party … `AUDIT_DETAILS` … or its subtype `ATTESTATION`" (RM common
-            // master06 §Committal and Audits). The shared
-            // [`crate::versioning::attestation::AttestationInput`] decoder is
-            // the one place the subtype's invariants are evaluated.
+            // master06 §Committal and Audits). The shared decoder is the one
+            // place the subtype's invariants are evaluated.
             attestation: match update {
                 UpdateAudit::UpdateAudit(_) => None,
                 UpdateAudit::UpdateAttestation(att) => Some(Box::new(

--- a/app/ferroehr/src/versioning/change.rs
+++ b/app/ferroehr/src/versioning/change.rs
@@ -383,10 +383,9 @@ async fn next_version(
         // at the preceding version's trunk fork point (master06 §Distributed
         // Versioning); the copied version itself stays valid.
         //
-        // Consequence: a trunk whose creating system changes mid-line is
-        // unrepresentable THROUGH THIS COMMIT ENGINE, while storage and the read
-        // paths tolerate one, so a container that arrives already carrying such
-        // a lineage (an archive load, an extract import) serves correctly.
+        // A trunk whose creating system changes mid-line is unrepresentable
+        // through this engine, but storage and the read paths tolerate one, so
+        // an imported container carrying such a lineage still serves.
         // NOTE: master06 §Copying §Subsequent Local Modifications and §Moving
         // Version Containers contradict each other on the identical observable
         // state; §Copying is followed — the rule with a procedure and a wire.
@@ -521,11 +520,9 @@ fn stamp_version_uid(canonical: &mut Value, version_uid: &str) -> Result<(), Ver
             // Replacing keeps the key's existing position.
             map.insert("uid".to_owned(), value);
         } else {
-            // A fresh `uid` must land at its BMM-declared position — the RM
-            // BMM declares LOCATABLE as (name, archetype_node_id, uid, …), so
-            // in the canonical encoding it follows `archetype_node_id`. A
-            // plain insert appends at the map's end, and the stored body is
-            // now served byte-verbatim (#2913), so placement is wire-visible.
+            // The RM BMM declares LOCATABLE as (name, archetype_node_id, uid,
+            // …), and the stored body is served byte-verbatim, so a fresh uid
+            // must land after `archetype_node_id` rather than at the map's end.
             let anchor = ["archetype_node_id", "name", "_type"]
                 .iter()
                 .find_map(|k| map.keys().position(|key| key == k));
@@ -678,10 +675,9 @@ async fn apply_change(
                     .map_err(|e| ServiceError::internal("externalize multimedia", e))?;
             }
             let lifecycle = resolve_lifecycle(lifecycle_state)?;
-            // Same coupling as the create arm: a modification carries content,
-            // so it can never be the `deleted` version (master06 §Logical
-            // Deletion). Refused before the placement read, so a data-carrying
-            // `523` never reaches storage.
+            // A modification carries content, so it can never be the `deleted`
+            // version (master06 §Logical Deletion) — refused before the
+            // placement read, so a data-carrying `523` never reaches storage.
             reject_deleted_with_data(&lifecycle)?;
             let next =
                 next_version(tx, ehr_id, vo_id, kind, expected, &ctx.system_id, preplaced).await?;
@@ -794,12 +790,10 @@ async fn commit_resolved(
         ContributionCtx::Existing(cid) => cid,
     };
 
-    // The attestations committed WITH this version, completed ONCE — before the
-    // signature, because they are inside the signed canonical form (master06
-    // §Digital Signature signs "the entire Version object", `signature` alone
-    // excluded), and reused verbatim for the insert below so the signed bytes
-    // and the stored bytes are the same bytes. `r.time_committed` is the
-    // transaction timestamp every row of this transaction stamps.
+    // The accompanying attestations are completed ONCE before the signature —
+    // master06 §Digital Signature signs "the entire Version object" — and
+    // reused verbatim for the insert, so signed bytes and stored bytes are the
+    // same bytes.
     let at_committal_attestations: Vec<Value> = attestation::complete_accompanying(
         &r.attestations,
         &ctx.system_id,
@@ -862,8 +856,6 @@ async fn commit_resolved(
         }
     };
 
-    // The shared commit tail: folder membership + attestations (the node rows
-    // rode the folded statement itself, through its node CTE).
     // A newly created FOLDER hierarchy joins `EHR.folders` as a new member (RM
     // ehr master04 §Folders). Recorded only on CREATION.
     if r.is_first_folder

--- a/app/ferroehr/src/versioning/contribution.rs
+++ b/app/ferroehr/src/versioning/contribution.rs
@@ -341,14 +341,11 @@ const COMMITTABLE_MEMBER_TYPES: [&str; 2] = ["UPDATE_VERSION", "ORIGINAL_VERSION
 /// # Errors
 /// [`ServiceError::BadRequest`] naming the offending key.
 fn reject_foreign_version_identity(version: &Value, index: usize) -> Result<(), ServiceError> {
-    // THE CLOSED MEMBER READ (#1753): the released commit wire declares
-    // exactly six member properties (ITS-REST `schemas/ehr/UpdateVersion.yaml`
-    // — `preceding_version_uid`, `signature`, `lifecycle_state`,
-    // `attestations`, `data`, `commit_audit`), plus the adjudicated `_type`
-    // self-tag (overview `Resources.md` §Resource representation — the docs
-    // text outranks the OAS). Everything else is refused with the member
-    // index in the path, exactly like the strict reader everywhere else
-    // post-#1702 — the three keys below keep their richer diagnostics.
+    // Anything outside the declared set is refused with the member index in
+    // the path.
+    // NOTE: the commit wire declares exactly these six member properties
+    // (ITS-REST `schemas/ehr/UpdateVersion.yaml`) plus the `_type` self-tag
+    // (overview `Resources.md` §Resource representation).
     const DECLARED: [&str; 7] = [
         "preceding_version_uid",
         "signature",
@@ -455,13 +452,9 @@ pub(crate) async fn commit_version_set(
     let supplied_uid = parse_supplied_uid(body)?;
     let (contrib_committer, contrib_system_id) = parse_contribution_committer(cx, body)?;
 
-    // ── ONE parse pass over the version set ────────────────────────────────
-    // Each UPDATE_VERSION is read exactly once into a typed plan entry:
-    // classification (master06 §Change Type), the parsed preceding target,
-    // the merged per-version audit (m4 committer/system_id copy-down), the
-    // lifecycle/signature/attestation envelope. The modification targets are
-    // then existence/kind-checked in ONE batched statement, and the plan is
-    // resolved to [`Change`]s without re-reading any JSON.
+    // Each UPDATE_VERSION is read exactly once into a typed plan entry; the
+    // modification targets are then existence/kind-checked in ONE batched
+    // statement and resolved without re-reading any JSON.
     let mut plan: Vec<PlannedVersion> = Vec::with_capacity(versions.len());
     for (index, version) in versions.iter().enumerate() {
         plan.push(plan_version(
@@ -474,7 +467,6 @@ pub(crate) async fn commit_version_set(
 
     let target_kinds = read_target_kinds(cx, &plan).await?;
 
-    // ── Resolve the plan to changes ────────────────────────────────────────
     let mut changes: Vec<(AuditInput, Change)> = Vec::with_capacity(plan.len());
     // 666 attestations of existing versions (committing no new version).
     let mut attests: Vec<PendingAttest> = Vec::new();
@@ -497,10 +489,8 @@ pub(crate) async fn commit_version_set(
     let contribution_audit =
         parse_contribution_audit(body, &contrib_committer, &contrib_system_id)?;
 
-    // Cross-area commit hooks — the single site of truth for the CONTRIBUTION
-    // path (the direct create/update paths run the same fns inline on their own
-    // write flow). Collect the EHR_STATUS bodies before `changes` is moved into
-    // the commit engine, since the subject-sync hook runs after the commit.
+    // The subject-sync hook runs after the commit, so the EHR_STATUS bodies
+    // are collected before `changes` moves into the commit engine.
     let status_commits: Vec<Value> = changes
         .iter()
         .filter_map(|(_, c)| match c {
@@ -1281,14 +1271,10 @@ fn parse_audit(
     default_system_id: &str,
     attestable: bool,
 ) -> Result<AuditInput, ServiceError> {
-    // AUDIT_DETAILS.description is a DV_TEXT (0..1). The two released sources
-    // spell it differently and BOTH spellings are accepted: ITS-REST types it
-    // `UDvText`, `oneOf` [`DV_TEXT`, `DV_CODED_TEXT`] discriminated on `_type`
-    // (`schemas/data_types/UDvText.yaml` — an object, never a bare string),
-    // while SM `UPDATE_AUDIT.description` is `String [0..1]`
-    // (`update_audit.adoc` §Attributes), which grounds the plain-string branch.
-    // The whole fragment is kept for the object spelling: a DV_CODED_TEXT
-    // description's defining_code is part of the committed audit.
+    // Both released spellings of `description` are accepted: the ITS-REST
+    // `UDvText` object (`schemas/data_types/UDvText.yaml`) and the SM
+    // `String [0..1]` (`update_audit.adoc` §Attributes). The object spelling is
+    // kept whole — a DV_CODED_TEXT's `defining_code` is part of the audit.
     let description = audit
         .and_then(|a| a.get("description"))
         .filter(|d| !d.is_null())
@@ -1620,12 +1606,9 @@ pub(crate) async fn get_contribution(
                     format!("VERSION {vo_id}::{tree}"),
                 )
             })?;
-            // The resolved object is the VERSION the CONTRIBUTION lists
-            // (`CONTRIBUTION.versions`, master06 §Contributions: "a
-            // CONTRIBUTION object will be created, listing the affected
-            // VERSION objects"), so an imported member resolves to its
-            // IMPORTED_VERSION — the version that actually sits in the
-            // container — not to the ORIGINAL_VERSION it wraps.
+            // `CONTRIBUTION.versions` lists the affected VERSION objects
+            // (master06 §Contributions), so an imported member resolves to its
+            // IMPORTED_VERSION, not the ORIGINAL_VERSION it wraps.
             versions.push(version_envelope(&loaded, signer)?);
         } else {
             versions.push(openehr_its::json::to_canonical_value(
@@ -1967,11 +1950,8 @@ mod tests {
     fn classify_rejects_spec_invalid_combinations() {
         // A non-creation change type as the FIRST version is THE released
         // `400_CONTRIBUTION` trigger ("the modification type does not match
-        // the operation - i.e. first version of a MODIFICATION") → 400;
-        // creation WITH a preceding is its unassigned mirror → the
+        // the operation"); creation WITH a preceding is its unassigned mirror,
         // adjudicated 422.
-        // Each refusal is asserted on its DATA — the attribute path it is
-        // about, the named rule it breaks — not on a substring of the prose.
         let creation_with_preceding = classify_err(Some("249"), true, true);
         assert_eq!(creation_with_preceding.path(), Some("change_type"));
         assert_eq!(

--- a/app/ferroehr/src/versioning/import.rs
+++ b/app/ferroehr/src/versioning/import.rs
@@ -538,13 +538,9 @@ async fn import_one_version(
             lifecycle_state: &version.lifecycle_state,
             data: &served,
             // The received original's own attestations are attributes of
-            // `item`, so they ride inside the wrapper's signed form: master06
-            // §Digital Signature says of an IMPORTED_VERSION that "all
-            // attributes of the object are serialised and then used to generate
-            // a signature". They are the version's at-committal attestations for
-            // this repository — the local act of importing supplies none of its
-            // own (§Copying: "the `ORIGINAL_VERSION` instance is never
-            // modified").
+            // `item`, so they ride inside the wrapper's signed form (master06
+            // §Digital Signature). They are this repository's at-committal
+            // attestations: the local act of importing supplies none of its own.
             attestations: &version.attestations,
             signature: version.signature.as_deref(),
         },
@@ -651,14 +647,11 @@ async fn commit_import_scoped(
     containers: Vec<ImportContainer>,
     skip_existing: bool,
 ) -> Result<Uuid, ServiceError> {
-    // One instant anchors the whole import's temporal chain — the DATABASE
-    // transaction timestamp (returned by the audit insert), never the app clock:
-    // under app↔DB skew an app-clock base could close an existing open lineage
-    // at an instant before that row's lower bound. This ONE audit row is the
+    // The DATABASE transaction timestamp anchors the whole import's temporal
+    // chain, never the app clock: under skew an app-clock base could close an
+    // open lineage before that row's lower bound. This ONE audit row is the
     // local act of committal for the CONTRIBUTION and every IMPORTED_VERSION it
-    // carries: master06 §Committal and Audits requires the CONTRIBUTION audit's
-    // `system_id`, `committer` and `time_committed` to be copied into each
-    // VERSION's `commit_audit`, and an import's `change_type` is `249|creation|`.
+    // carries (master06 §Committal and Audits).
     let (contribution_audit_id, import_time) =
         crate::storage::version_repo::commit::insert_audit(tx, &import_audit.row()).await?;
     let base = import_time;

--- a/app/ferroehr/src/versioning/object_version_id.rs
+++ b/app/ferroehr/src/versioning/object_version_id.rs
@@ -252,7 +252,6 @@ pub(crate) fn parse_tree_id(raw: &str) -> Result<TreeId, VersionIdError> {
 /// into the storage key pair (`vo_id`, [`TreeId`]).
 pub(crate) fn parse_version_uid(raw: &str) -> Result<(VoId, TreeId), VersionIdError> {
     let (vo_id, _, tree) = parse_object_version_id(raw)?;
-    // The `object_id` of an `OBJECT_VERSION_ID` is a versioned-object id.
     Ok((VoId(vo_id), tree))
 }
 
@@ -299,7 +298,6 @@ fn components_of(
 /// version-id argument) into the storage key pair (`vo_id`, [`TreeId`]).
 pub(crate) fn components(ovid: &ObjectVersionId) -> Result<(VoId, TreeId), VersionIdError> {
     let (object_id, _, tree) = components_of(ovid, ovid.value())?;
-    // The `object_id` of an `OBJECT_VERSION_ID` is a versioned-object id.
     Ok((VoId(object_id), tree))
 }
 
@@ -354,17 +352,13 @@ pub fn parse_uid_based_id(raw: &str) -> Result<UidAddress, VersionIdError> {
     if raw.contains("::") {
         // ONE parse, ONE grammar: the strict `OBJECT_VERSION_ID` decode both
         // validates the wire value and yields the typed id, so the address can
-        // never carry a version id that the BASE grammar did not accept. (The
-        // struct-literal shortcut this replaced re-wrapped `raw` verbatim,
-        // bypassing the constructor; the generated field is `pub(crate)` now,
-        // so that shortcut is not expressible.)
+        // never carry a version id the BASE grammar did not accept.
         let ovid = ObjectVersionId::from_str(raw).map_err(|source| VersionIdError::Malformed {
             raw: raw.to_owned(),
             source,
         })?;
         let (object_id, _, tree) = components_of(&ovid, raw)?;
         Ok(UidAddress {
-            // The `object_id` of an `OBJECT_VERSION_ID` is a versioned-object id.
             vo_id: VoId(object_id),
             version: Some(ovid),
             tree: Some(tree),
@@ -454,7 +448,7 @@ mod tests {
         assert_eq!(vo_id, VoId(Uuid::parse_str(VO).unwrap()));
         assert_eq!(tree, TreeId::trunk(3));
 
-        // Two parts (the old `rsplit`/`nth(1)` splitters disagreed here).
+        // Two parts is not a valid lexical form.
         assert!(matches!(
             parse_version_uid(&format!("{VO}::2")),
             Err(VersionIdError::Malformed { .. })
@@ -567,7 +561,7 @@ mod tests {
         assert_eq!(expected_from_if_match("*").unwrap(), None);
         // A malformed `If-Match` is REJECTED (400), never silently discarded as
         // "no precondition" — ITS-REST overview §"If-Match and accidental
-        // overwrites" (the lost-update window fix).
+        // overwrites".
         assert!(matches!(
             expected_from_if_match("garbage"),
             Err(VersionIdError::Malformed { .. })

--- a/app/ferroehr/src/versioning/signature/key.rs
+++ b/app/ferroehr/src/versioning/signature/key.rs
@@ -146,11 +146,9 @@ impl PgpKey {
         let (secret, _headers) = SignedSecretKey::from_string(armored).map_err(KeyError::Parse)?;
         let public = secret.to_public_key();
         // The secret is exposed HERE and nowhere earlier: `pgp`'s `Password` is
-        // the one consumer that must have the plaintext, so the value stays
-        // inside its `secrecy`-backed wrapper — which zeroizes on drop — until
-        // this line. Taking it as a `&str` at the boundary would leave an
-        // ordinary copy in freed memory afterwards, which is the guarantee the
-        // crate is pinned to provide.
+        // the one consumer that needs the plaintext, so the value stays inside
+        // its `secrecy`-backed wrapper — which zeroizes on drop — until this
+        // line.
         let password = match passphrase {
             Some(secret) => Password::from(secret.expose()),
             None => Password::empty(),
@@ -209,8 +207,7 @@ impl PgpKey {
     /// # Errors
     /// [`PgpSignError`] if signing or armoring fails.
     pub fn sign(&self, data: &[u8]) -> Result<String, PgpSignError> {
-        // A certificate with no signing subkey signs with the primary key, as
-        // before — an upgrade changes nothing for a single-key deployment.
+        // A certificate with no signing subkey signs with the primary key.
         let sig = match self
             .signing_subkey
             .and_then(|index| self.secret.secret_subkeys.get(index))

--- a/app/ferroehr/src/versioning/wire.rs
+++ b/app/ferroehr/src/versioning/wire.rs
@@ -113,14 +113,10 @@ pub(crate) async fn revision_history(
         )
     })?;
     let history = RevisionHistory { items };
-    // The history resource's `Last-Modified` value (ITS-REST overview
-    // `Requests_and_responses.md` §"`ETag` and Last-Modified": derived from
-    // `VERSION.commit_audit.time_committed.value`). On a `REVISION_HISTORY` that
-    // instant is what `REVISION_HISTORY.most_recent_version_time_committed`
-    // returns (`revision_history.adoc` §Functions, `Post: Result.is_equal
-    // (items.last.audits.first.time_committed.value)`), so the header is read
-    // off the built history through that function rather than re-derived from
-    // the rows — two expressions of one rule can drift apart, one cannot.
+    // The `Last-Modified` instant is read off the built history through
+    // `REVISION_HISTORY.most_recent_version_time_committed`
+    // (`revision_history.adoc` §Functions) rather than re-derived from the rows:
+    // two expressions of one rule can drift apart, one cannot.
     let last_modified = history
         .most_recent_version_time_committed()
         .ok_or_else(|| {
@@ -290,14 +286,10 @@ pub(crate) fn version_envelope(read: &VersionRead, signer: &Signer) -> Result<Va
         read.signature.as_deref(),
         read.signature_client_supplied,
     )?;
-    // The attestations the wrapped original carried AT the act of importing are
-    // already inside `item` (built by `build_wrapped_original` above), because
-    // master06 §Digital Signature signs an `IMPORTED_VERSION` the same way as an
-    // ORIGINAL_VERSION — "all attributes of the object are serialised" — and
-    // `item` is one of those attributes, wrapped whole. Anything attested
-    // AFTERWARDS ("Attestations can be added at any time after committal",
-    // §Attestation) post-dates the wrapper's signature and is appended here,
-    // after verification.
+    // The attestations the wrapped original carried AT importing are already
+    // inside `item`, which master06 §Digital Signature includes in the wrapper's
+    // signed serialisation. Anything attested AFTERWARDS post-dates that
+    // signature and is appended here, after verification.
     if let Some(item) = iv.get_mut("item") {
         append_after_committal_attestations(item, &read.attestations_after_committal);
     }
@@ -570,11 +562,10 @@ pub(crate) fn build_original_version(
         )),
     });
     if let Value::Object(map) = &mut ov {
-        // preceding_version_uid: the STORED prior OBJECT_VERSION_ID (absent for
-        // a first version). Stored — not synthesized — because under branching
-        // and import the preceding version may carry a different
-        // creating_system_id (RM common master06 §Distributed Versioning). A
-        // branch version always carries its real preceding uid here.
+        // preceding_version_uid: the STORED prior OBJECT_VERSION_ID, never
+        // synthesized, because under branching and import it may carry a
+        // different creating_system_id (RM common master06 §Distributed
+        // Versioning).
         //
         // NOTE: `VERSION.Preceding_version_uid_validity` is enforced in its
         // TRUNK-ONLY sense — BASE's `is_first` is "trunk_version is 1" alone,


### PR DESCRIPTION
Part 1 of #2942 (the issue stays open — it covers every hand-written tree; this PR is the `app/ferroehr/src` plain-comment pass).

51 files, comment/doc text only — no code, test, or behaviour change. Plain `//` comment lines: **3892 → 3462 (−430, −11.1%)**. Every file with ≥20 comment lines got a full read-and-edit pass, and every remaining 1–2-line run in the crate was read individually; what survives is spec citations, invariant records, NOTEs and TODOs within their budgets.

| module | before | after |
|---|---|---|
| service | 1784 | 1518 |
| versioning | 570 | 503 |
| aql | 401 | 367 |
| config | 237 | 218 |
| storage | 215 | 210 |
| system_log | 173 | 166 |
| validation | 149 | 145 |
| extensions | 140 | 132 |
| templates | 73 | 64 |
| db | 49 | 38 |
| telemetry / roots | 101 | 101 |

Representative deletions: the same 3-line "ONE serialization boundary" note repeated 11 times across the commit paths (the called function's doc already states it); `// EventIdentification`-style labels above `BytesStart::new("EventIdentification")`; config-precedence labels the assertions beside them already spell; 5 lines of change-narration in `aql/sql/from.rs` reduced to the 2-line rule the code enforces. Deliberately kept: the 5–8-line spec-citation runs quoting the normative sentence (master06, ITS-REST `Requests_and_responses.md`), the temporal-non-overlap and CTE-visibility invariant records, and the `AssertSqlSafe`/`persistent(false)` audits.

One in-scope defect fixed: `service/definition/opt14_convert.rs` had the function's doc block (summary + `# Errors`) orphaned onto a type alias; moved back onto the function.

Gates: `comment-style.sh --all` OK (2468 files), `clippy -p ferroehr --all-targets -D warnings` clean, `nextest -p ferroehr` 1005/1005, fmt clean, the private-items rustdoc gate green.

Next parts recorded on #2942: the doc-comment essays (21,441 `///`/`//!` lines in this crate, module docs up to 93 lines) and the remaining hand-written trees.