### PR TITLE
chore(sandbox+admin-ui): deploy over IPv4, immutable bundle caching, console hygiene

### DIFF
--- a/.github/actions/hosted-deploy/action.yml
+++ b/.github/actions/hosted-deploy/action.yml
@@ -62,9 +62,14 @@ inputs:
     required: false
     default: ghcr.io/rubentalstra/ferroehr
   host:
-    description: The box the deploy key opens.
+    description: >-
+      The box the deploy key opens — the IPv4 address, not the DNS name:
+      GitHub-hosted runners have no IPv6 route, and the name's AAAA record
+      makes ssh fail with "Network is unreachable" (measured, run
+      33426489417). HOSTED_KNOWN_HOSTS is keyed to this address. The public
+      verification below keeps the DNS name; curl falls back to IPv4 itself.
     required: false
-    default: sandbox.ferroehr.eu
+    default: "167.233.172.220"
   verify-base:
     description: The public base URL the deploy's own verification fetches.
     required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,12 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- The admin console's two template Example panes report a failed example read
+  the same way: an inline error in the pane, in both template families. The
+  ADL 1.4 pane used to render the whole-screen error with a back link even
+  though the template itself had loaded.
+- The hosted sandbox serves the console's content-hashed script and wasm
+  bundle with immutable caching, so a repeat visit stops re-downloading it.
 - A template example request with a present but empty `detail_level` or
   `type` query value is refused with `400`. The declared defaults apply only
   to an absent parameter; an empty or whitespace-padded value is outside the

--- a/app/ferroehr-admin-ui/src/pages/fhir.rs
+++ b/app/ferroehr-admin-ui/src/pages/fhir.rs
@@ -586,10 +586,10 @@ fn create_card(draft: Draft, create: CreateAction) -> AnyView {
         <section id="fhir-create" class=format!("{CARD_PAD} mb-4")>
             <h2 class=CARD_TITLE>"Store a mapping"</h2>
             <p class="mb-3 text-xs text-ink-muted">
-                "The definition is the mapping document itself — the resource type it binds, the
-                 profile URL it matches, the openEHR template it builds under, the subject binding
-                 and the field entries. It is sent verbatim; the CDR validates it and its rejection
-                 is shown here in full. The name is the deployable identity and cannot be changed
+                "The definition is the mapping document itself — the resource type it binds, the \
+                 profile URL it matches, the openEHR template it builds under, the subject binding \
+                 and the field entries. It is sent verbatim; the CDR validates it and its rejection \
+                 is shown here in full. The name is the deployable identity and cannot be changed \
                  afterwards."
             </p>
             <div class="flex flex-col gap-3">
@@ -966,8 +966,8 @@ fn read_viewer(
         <section id="fhir-read" class=format!("{CARD_PAD} mb-4")>
             <h2 class=CARD_TITLE>"Read path"</h2>
             <p class="mb-3 text-xs text-ink-muted">
-                "Ask the connector what a stored mapping produces on READ for one patient. The
-                 facade serves only this explicit scope — a resource type and a patient — never a
+                "Ask the connector what a stored mapping produces on READ for one patient. The \
+                 facade serves only this explicit scope — a resource type and a patient — never a \
                  general FHIR search, and it reads committed data without changing anything."
             </p>
             <leptos_router::components::Form method="GET" action="/fhir" attr:class="mb-3">
@@ -1043,12 +1043,12 @@ fn dry_run_panel(form: DryRunForm, dry_run: DryRunAction) -> AnyView {
         <section id="fhir-dry-run" class=CARD_PAD>
             <h2 class=CARD_TITLE>"Dry run (validate only)"</h2>
             <p class="mb-3 text-xs text-ink-muted">
-                "Runs the resource through its stored mapping and the full commit validation, then
+                "Runs the resource through its stored mapping and the full commit validation, then \
                  reports the verdict. "
                 <span class="font-medium text-ink">
                     "Nothing is committed — no EHR, no COMPOSITION, no version."
                 </span>
-                " Sending a resource for real is the connector's integration door, and the console
+                " Sending a resource for real is the connector's integration door, and the console \
                  deliberately offers no path to it."
             </p>
             <div class="flex flex-col gap-3">

--- a/app/ferroehr-admin-ui/src/pages/subscriptions.rs
+++ b/app/ferroehr-admin-ui/src/pages/subscriptions.rs
@@ -332,8 +332,8 @@ fn create_card(name: RwSignal<String>, draft: Draft, create: CreateAction) -> An
                 </button>
             </div>
             <p class="mt-2 text-xs text-ink-muted">
-                "The name is unique on the CDR and cannot be changed afterwards — it may hold only
-                 letters, digits, and “_”, “.” or “-”. Every predicate left empty matches anything,
+                "The name is unique on the CDR and cannot be changed afterwards — it may hold only \
+                 letters, digits, and “_”, “.” or “-”. Every predicate left empty matches anything, \
                  so a subscription with none of them set receives every committed version."
             </p>
             {failure}

--- a/app/ferroehr-admin-ui/src/pages/template_adl2.rs
+++ b/app/ferroehr-admin-ui/src/pages/template_adl2.rs
@@ -592,7 +592,7 @@ fn catalog_tab(
             <section class=CARD_PAD>
                 <h2 class=CARD_TITLE>"Path catalog (WT tree)"</h2>
                 <p class="mb-2 text-xs text-ink-muted">
-                    "Built by the console from the served OperationalTemplateV2: the ADL2 resource
+                    "Built by the console from the served OperationalTemplateV2: the ADL2 resource \
                      serves no Web Template representation of its own."
                 </p>
                 <div class="overflow-auto max-h-[70vh]">
@@ -705,8 +705,8 @@ fn example_tab(
     view! {
         <div class="space-y-3">
             <p class="text-sm text-ink-muted">
-                "The example is generated from the artefact this route names — the Definition API
-                 declares no versioned example resource, so the version bar above does not change
+                "The example is generated from the artefact this route names — the Definition API \
+                 declares no versioned example resource, so the version bar above does not change \
                  it."
             </p>
             <crate::components::example_controls::ExampleControls

--- a/app/ferroehr-admin-ui/src/pages/template_detail.rs
+++ b/app/ferroehr-admin-ui/src/pages/template_detail.rs
@@ -854,7 +854,7 @@ fn example_tab(
                             view! { <crate::components::format_view::DocumentPane body=pretty /> }
                                 .into_any()
                         }
-                        Err(e) => catalog_error_view(&e, "/templates"),
+                        Err(e) => crate::components::notice::inline_error(&e),
                     }
                 })}
             </Transition>

--- a/app/ferroehr-admin-ui/src/pages/tenants.rs
+++ b/app/ferroehr-admin-ui/src/pages/tenants.rs
@@ -284,8 +284,8 @@ fn context_card(current: Resource<Result<Option<CurrentTenant>, AdminUiError>>) 
                 })}
             </Transition>
             <p class="mt-2 text-xs text-ink-muted">
-                "Tenancy is derived from the credential the request carries. The console displays
-                 the resolved tenant and never selects one: signing in with a different credential
+                "Tenancy is derived from the credential the request carries. The console displays \
+                 the resolved tenant and never selects one: signing in with a different credential \
                  is the only way to work in another tenant."
             </p>
         </section>
@@ -335,8 +335,8 @@ fn create_card(
                 </button>
             </div>
             <p class="mt-2 text-xs text-ink-muted">
-                "The name is unique across the registry and is what a credential's tenant claim
-                 resolves by; the system_id is the openEHR system identifier the tenant's data is
+                "The name is unique across the registry and is what a credential's tenant claim \
+                 resolves by; the system_id is the openEHR system identifier the tenant's data is \
                  committed under."
             </p>
             {failure}

--- a/deploy/hosted/Caddyfile
+++ b/deploy/hosted/Caddyfile
@@ -21,6 +21,13 @@ sandbox.ferroehr.eu {
 
 	redir /favicon.ico /ferroehr/rest/swagger-ui/favicon-32x32.png
 
+	# The hydration bundle is served under content-hashed names
+	# (LEPTOS_HASH_FILES; docker/admin-ui/Dockerfile), so a changed build is a
+	# changed URL and the bytes behind one URL never change — the RFC 9111
+	# immutable case. Repeat visits skip re-downloading the wasm entirely.
+	@bundle path /pkg/*
+	header @bundle Cache-Control "public, max-age=31536000, immutable"
+
 	@cdr path /ferroehr/* /health /health/* /management /management/* /.well-known/*
 	handle @cdr {
 		reverse_proxy ferroehr:8080


### PR DESCRIPTION
Closes #2970. Closes #2971.

Three sandbox follow-ups from the live cutover (#2974) plus the two console hygiene issues:

- **The deploy action SSHes the box's IPv4 address, not the DNS name.** GitHub-hosted runners have no IPv6 route, and once the sandbox's AAAA record propagated, ssh resolved it first and failed with `Network is unreachable` (measured twice on run 33426489417 — the reseed's restart leg). `HOSTED_KNOWN_HOSTS` is already keyed to the address; the public HTTPS verification keeps the DNS name, where curl falls back to IPv4 by itself.
- **The hashed hydration bundle is cached immutable** (Caddyfile): `/pkg/*` names are content-hashed (`LEPTOS_HASH_FILES`), so a changed build is a changed URL — the RFC 9111 immutable case. Repeat visits skip re-downloading the wasm. Already applied to the box by hand and verified live (`cache-control: public, max-age=31536000, immutable`).
- **#2970** — nine multi-line view literals across `pages/{fhir,subscriptions,template_adl2,tenants}.rs` leaked their source indentation into the rendered strings; each interior newline is now a `\` continuation, so the string carries single spaces. Found by a literal-level scan of the whole console crate; raw-string test fixtures (where whitespace is irrelevant) were left alone.
- **#2971** — the ADL 1.4 Example pane rendered a failed read with `catalog_error_view` (the whole-screen shape with a back link) while the ADL 2 pane used `notice::inline_error`. A failed example read is a section-level read failure — the template itself resolved — so both panes now take the crate's one inline-error shape. The WT/OPT tabs keep `catalog_error_view`: there the route's own subject failed to resolve and the back link is the remedy.

Gates: both-target clippy clean, 360 nextest, leptosfmt + fmt clean, comment-style OK on the touched files, the deploy action parses, the Caddyfile change verified serving on the box.