### PR TITLE
fix(sandbox): the console checks follow the landing redirect

### DIFF
--- a/.github/actions/hosted-deploy/action.yml
+++ b/.github/actions/hosted-deploy/action.yml
@@ -198,7 +198,7 @@ runs:
       run: |
         set -euo pipefail
         deadline=$(( $(date +%s) + 300 ))
-        until body=$(curl -fsS -m 30 "$BASE/" 2>/dev/null) && printf '%s' "$body" | grep -q "FerroEHR"; do
+        until body=$(curl -fsSL -m 30 "$BASE/" 2>/dev/null) && printf '%s' "$body" | grep -q "FerroEHR"; do
           if [ "$(date +%s)" -ge "$deadline" ]; then
             echo "::error::the console did not serve its sign-in surface within 5 minutes of the deploy." >&2
             exit 1

--- a/.github/workflows/hosted-watch.yml
+++ b/.github/workflows/hosted-watch.yml
@@ -58,8 +58,11 @@ jobs:
             | jq -r '.server_version // empty' 2>/dev/null || true)"
 
           # The console is the landing surface; a dead console with a live CDR
-          # is still a broken sandbox.
-          console="$(curl -sS -m 30 "${HOSTED_BASE}/" | grep -c "FerroEHR" || true)"
+          # is still a broken sandbox. -L: the landing page 302-redirects to
+          # /login, and an unfollowed redirect is an empty body that reads as
+          # a dead console (measured — the watch held its issue open against
+          # a healthy box).
+          console="$(curl -sSL -m 30 "${HOSTED_BASE}/" | grep -c "FerroEHR" || true)"
 
           # What it SHOULD serve: the release pointer's own version label.
           tok=$(curl -fsS "https://ghcr.io/token?scope=repository:${IMAGE#ghcr.io/}:pull" | sed -nE 's/.*"token":"([^"]+)".*/\1/p')


### PR DESCRIPTION
The hosted watch held #2977 open against a healthy sandbox: its 19:47 run reports `verdict=degraded served=4.0.13 expected=4.0.13` — health 200, version right — because the console check curls `/` without following the 302 redirect to `/login`, so the body is empty and the grep for the console markup finds nothing. The deploy action's console-serving poll has the identical flaw and would loop its five minutes out on any deploy.

`-L` on both curls. Once merged, the next scheduled watch run reads the console through the redirect, verdicts `ok`, and closes #2977 itself — the issue's own recovery path, exercised rather than hand-closed.