### PR TITLE
fix(ci): the release pipeline dies at startup — the reseed call-job grants its nested jobs no permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -997,9 +997,17 @@ jobs:
   # heals at deploy time instead of at the next midnight. Environment secrets
   # reach the called workflow's own environment-naming jobs here (measured:
   # the v4.0.13 release's reseed succeeded through two call hops).
+  #
+  # The permissions block is load-bearing: a called workflow's jobs can never
+  # exceed the caller JOB's grant, and under the workflow-level
+  # `permissions: {}` an ungranted call-job allows nothing — the reseed's own
+  # jobs request `contents: read`, so omitting this fails the ENTIRE pipeline
+  # at startup, before any job runs (#2991, the v4.0.14 first cut).
   sandbox-reseed:
     name: sandbox reseed
     needs: sandbox
+    permissions:
+      contents: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: ./.github/workflows/sandbox-reseed.yml
 


### PR DESCRIPTION
The v4.0.14 tag push failed the entire Release pipeline with `startup_failure` (run 33470691699, zero jobs). GitHub refused the workflow at validation time:

> Error calling workflow '…/sandbox-reseed.yml@2009d323…'. The nested job 'restart' is requesting 'contents: read', but is only allowed 'contents: none'.

(same for the `seed` job). The #2976 hosted-sandbox rewrite replaced the old `sandbox` reusable-workflow call — which carried `permissions: contents: read` — with an ordinary deploy job plus a new direct `sandbox-reseed` call, and the new call-job got no `permissions:` block. Under the workflow-level `permissions: {}` that grants nothing, and a called workflow's jobs can never exceed the caller job's grant, so the whole run is refused before any job starts — nothing was published.

The fix grants the call-job exactly what the reseed's two jobs request (`contents: read`), with a comment pinning why the block is load-bearing. actionlint and zizmor stay green.

Recovery after merge: re-point the v4.0.14 tag at the fixed main head (nothing shipped from the failed run — no GitHub release, no image, no chart — so no immutability applies) and let the tag push re-trigger the pipeline.

Closes #2991