### PR TITLE
fix(rest): derive the RESULT_SET ETag from SHA-256 instead of DefaultHasher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Fixed
+
+- The `ETag` served with a query `RESULT_SET` now derives from SHA-256, a
+  pinned published algorithm, instead of the standard library's default
+  hasher, whose algorithm may change between Rust releases. Query ETags are
+  now stable across server builds; every served query ETag changes value once
+  at this upgrade.
+
 ## [4.0.15] - 2026-09-01
 
 This release carries everything prepared for 4.0.14, which was tagged but

--- a/app/ferroehr-rest/src/api/query/response.rs
+++ b/app/ferroehr-rest/src/api/query/response.rs
@@ -21,9 +21,6 @@
               negotiate seam produced once (stored-content serving / commit interior)"
 )]
 
-use std::collections::hash_map::DefaultHasher;
-use std::hash::Hasher;
-
 use axum::response::Response;
 use http::{HeaderMap, HeaderValue, StatusCode, header};
 use uuid::Uuid;
@@ -187,15 +184,19 @@ fn result_set_etag(result_set: &serde_json::Value) -> String {
     format!("W/\"{}\"", stable_uuid(&bytes))
 }
 
-/// Returns a deterministic UUID from a byte digest: two fixed-seed
-/// [`DefaultHasher`] passes, the second salted, fill the 128-bit value.
+/// Returns a deterministic UUID from a byte digest: the first 128 bits of the
+/// input's SHA-256 digest.
+///
+/// SHA-256 (the pinned `sha2` crate) is a fixed, published algorithm, so the
+/// derived value is stable across program runs, Rust toolchains, and server
+/// versions — a served `ETag` must never change for an unchanged `RESULT_SET`.
 fn stable_uuid(bytes: &[u8]) -> Uuid {
-    let mut high = DefaultHasher::new();
-    high.write(bytes);
-    let mut low = DefaultHasher::new();
-    low.write_u8(0x5b);
-    low.write(bytes);
-    Uuid::from_u64_pair(high.finish(), low.finish())
+    use sha2::Digest as _;
+    let digest: [u8; 32] = sha2::Sha256::digest(bytes).into();
+    let (half, _) = digest.split_at(16);
+    let mut arr = [0u8; 16];
+    arr.copy_from_slice(half);
+    Uuid::from_bytes(arr)
 }
 
 /// Merges a paging value carried in the POST body with the same-named URL query
@@ -291,6 +292,22 @@ mod tests {
     fn stable_uuid_is_deterministic_and_content_sensitive() {
         assert_eq!(stable_uuid(b"abc"), stable_uuid(b"abc"));
         assert_ne!(stable_uuid(b"abc"), stable_uuid(b"abd"));
+    }
+
+    /// Pins a known `RESULT_SET` to its exact served `ETag` so a change to the
+    /// digest algorithm (or the identity-document shape it hashes) fails
+    /// loudly: a served `ETag` must never change for an unchanged `RESULT_SET`
+    /// ("It changes as soon as the resource changes",
+    /// `Requests_and_responses.md` §`ETag` and Last-Modified). The expected
+    /// value is the first 128 bits of the SHA-256 digest of the identity
+    /// document, computed independently with `openssl dgst -sha256`.
+    #[test]
+    fn result_set_etag_is_pinned_to_a_known_vector() {
+        let rs = serde_json::json!({"rows": [["x"]]});
+        assert_eq!(
+            result_set_etag(&rs),
+            "W/\"e9a0328f-52cf-352e-db43-ff1abe1de874\""
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #2980.

`stable_uuid` in `app/ferroehr-rest/src/api/query/response.rs` built the query `RESULT_SET` `ETag` from two `std::collections::hash_map::DefaultHasher` passes while its doc asserted stability. The std docs guarantee `DefaultHasher::new` instances agree only within one program: the algorithm is explicitly not pinned across Rust releases, so a toolchain bump could silently change every served query ETag — a cache-busting wire change nothing would catch.

The tag now takes the first 128 bits of a SHA-256 digest (`sha2`, already in the workspace table and this crate) over the unchanged identity document (`name`, `q`, `meta._executed_aql`, `columns`, `rows`), rendered as the same weak `W/"{uuid}"` form. The doc now states the actual stability property (fixed published algorithm, stable across runs/toolchains/versions), and a new test pins a known input to the exact served ETag — the expected value computed independently with `openssl dgst -sha256` — so an algorithm or identity-shape change fails loudly instead of drifting.

Wire note: every served query ETag changes value once at this upgrade (changelog entry included). The weak form, placement, and identity semantics (`Requests_and_responses.md` §ETag and Last-Modified) are unchanged and stay pinned by the existing header tests.

Gates: `cargo clippy -p ferroehr-rest --all-targets` clean; `cargo nextest run -p ferroehr-rest` ETag/header suite green (31 tests incl. the new pinned vector); fmt clean.
