### PR TITLE
fix(message): record the EHR-Extract import verbatim-replay adjudication in the module doc

### DIFF
--- a/app/ferroehr/src/service/message/import.rs
+++ b/app/ferroehr/src/service/message/import.rs
@@ -36,6 +36,14 @@
 //! target through the DEFINITION API (master06 §Copying, the rule the admin
 //! dump/load path follows too).
 //!
+//! Re-validation on import is nowhere required (adjudicated on #2988):
+//! master06 §The Copy Operation keeps the wrapped original "a faithful copy of
+//! its original", `commit_imported_version` is the only `VERSIONED_OBJECT`
+//! commit function with no `Pre` clause, SM `i_ehr_extract_service.adoc`
+//! declares the import operations without preconditions, and BASE
+//! `master10-archetypes.adoc` §Validation during Data Capture makes archetype
+//! validation in an import service a "can", never a must.
+//!
 //! An imported EHR is a full local EHR: the promoted `ehr` columns are re-derived
 //! from the landed `EHR_STATUS`
 //! ([`crate::service::FerroEhrService::resync_promoted_columns`]), so the clone


### PR DESCRIPTION
Closes #2988.

The adjudication (recorded in full on the issue) lands as the module doc's ground in `app/ferroehr/src/service/message/import.rs` — no behaviour change:

- RM common `master06-change_control_package.adoc` §The Copy Operation: the wrapped `ORIGINAL_VERSION` "remains a faithful copy of its original".
- `org.openehr.rm.common.versioned_object.adoc` §Functions: `commit_imported_version` is the only commit function with no `Pre` clause (verified against the vendored table; `commit_original_version`, `commit_original_merged_version`, `commit_attestation` all carry one).
- SM `i_ehr_extract_service.adoc`: `import_ehr` / `import_ehr_extract` declared with zero preconditions.
- BASE `master10-archetypes.adoc` §Validation during Data Capture: archetype validation in a data import service is a "can", never a must.

The verbatim-replay posture already implemented is exactly what the released text supports; inventing a refusal the spec does not contain would be the same defect class as leniency (strictness cuts both ways).

Gates: `cargo fmt --check`, `cargo clippy -p ferroehr --all-targets`, rustdoc (`-D warnings`, private items) all green. Doc-only diff — `no-changelog`.