### PR TITLE
chore(codegen): re-ground the container-shape adjudication on the vendored spec facts

### DIFF
--- a/tools/openehr-codegen/src/render/emit.rs
+++ b/tools/openehr-codegen/src/render/emit.rs
@@ -1230,8 +1230,33 @@ fn single_field_type(
 /// like other broader-than-a-crate openEHR types; its optionality follows the
 /// property.
 ///
-/// NOTE: every other container's shape follows its BMM existence and
-/// cardinality.
+/// Every other container's shape follows its BMM existence and cardinality:
+///
+/// - mandatory with cardinality `0..*` is `Vec<T>` (the model genuinely
+///   admits zero members);
+/// - mandatory `1..*` is `NonEmptyVec<T>` — the declared lower bound is a
+///   structural statement about the model, so the type carries it and the
+///   strict readers refuse `[]` at parse;
+/// - optional with no non-empty rule is `Option<Vec<T>>`, because the RM
+///   distinguishes Void from empty on a `0..1` container — `FOLDER.items` /
+///   `FOLDER.folders` are both `0..1` with no non-empty invariant
+///   (`org.openehr.rm.common.folder.adoc` §Attributes), so "absent" and
+///   "present-but-empty" are two legitimate model states;
+/// - optional under an invariant of the `x /= Void implies not x.is_empty`
+///   family is `Option<NonEmptyVec<T>>` — no valid instance can carry
+///   present-but-empty, so it stops being representable
+///   (`LOCATABLE.Links_valid`, `org.openehr.rm.common.locatable.adoc`
+///   §Invariants).
+///
+/// The `1..*` source is the BMM minus
+/// [`crate::plan::overrides::cardinality_contradicted`] (a class whose own
+/// invariants contradict its declared lower bound). The write direction is
+/// unaffected either way: the canonical-JSON writer omits an empty list
+/// whether it is `None` or `Some(vec![])` (ITS-REST overview `Resources.md`
+/// §JSON Format — "attributes (even required ones) that are `Null` or an
+/// empty list (array) SHOULD be absent when serialized"); the reader is the
+/// direction that gains (`absent` → `None`, `[]` → `Some(vec![])`, or a
+/// refusal where the type is `NonEmptyVec`).
 #[expect(
     clippy::too_many_arguments,
     reason = "the field-shape decision threads the same resolution tables `field_type` takes; bundling them would hide which each renderer reads"


### PR DESCRIPTION
Closes #2983.

`container_field_type`'s NOTE pointed at "the emission table in this crate's CLAUDE.md §Container shapes" until the internal-markdown citation scrub removed it, leaving the container-shape decision with no in-code ground. The doc comment now carries the adjudication in place, on citations the rules allow:

- mandatory `0..*` → `Vec<T>`; mandatory `1..*` → `NonEmptyVec<T>` (the declared bound is structural, refused at parse)
- optional with no non-empty rule → `Option<Vec<T>>` — the RM distinguishes Void from empty on `0..1` containers (`FOLDER.items`/`folders`, `org.openehr.rm.common.folder.adoc` §Attributes)
- optional under the `x /= Void implies not x.is_empty` family → `Option<NonEmptyVec<T>>` (`LOCATABLE.Links_valid`, `org.openehr.rm.common.locatable.adoc` §Invariants)
- the `1..*` source is the BMM minus `plan::overrides::cardinality_contradicted`; the write wire is unaffected either way (ITS-REST overview `Resources.md` §JSON Format omits empty lists)

Doc-comment-only change to the hand-written emitter — no generated output moves, so no regeneration and no drift. Gates: `cargo clippy -p openehr-codegen --all-targets`, rustdoc `-D warnings` with private items, `cargo fmt --check` — green.