### PR TITLE
chore(lang): record why the lexer/ODIN generation siblings are not template twins

### DIFF
--- a/tools/openehr-codegen/tests/it/emitter_invariants.rs
+++ b/tools/openehr-codegen/tests/it/emitter_invariants.rs
@@ -1468,6 +1468,19 @@ fn unrealized_bmm_functions_match_the_ratchet() {
 /// be a template (`tools/openehr-codegen/templates/<crate>/…`) — one source,
 /// per-generation copies stamped by `emit` — so twins can never silently
 /// diverge. A non-empty list here names the families to convert.
+///
+/// The `openehr-lang` `v1_0`/`v1_1` sibling pairs (`lexer/mod.rs`,
+/// `lexer/token.rs`, `lexer/reclassify.rs`, `odin/parser.rs`) are NOT covered,
+/// and that is the adjudicated outcome (#2984), not a gap: measured on
+/// 2026-09-01 they diverge by 117–892 diff lines per pair, because `v1_0` is
+/// the faithful Release-1.0.0 generation — an ODIN-only lexer over the
+/// release's own grammar set, no EL/BEL (`docs/VERSIONS.md` §LANG; the #1946
+/// faithful-emission decision) — while `v1_1` carries the development
+/// generation's larger token and reclassification surface. Whole-file-verbatim
+/// overrides cannot express an eighty-percent-shared file, so conversion would
+/// re-house the divergence without removing the duplication. The identity
+/// check below stays the machine half: if a pair ever converges to
+/// identical-modulo-tokens, it appears in this list and MUST convert then.
 #[test]
 fn hand_written_twins_are_templates() {
     for key in ["base", "rm", "am", "term", "lang"] {


### PR DESCRIPTION
Closes #2984.

The issue asked: convert the `openehr-lang` `v1_0`/`v1_1` sibling pairs (`lexer/mod.rs`, `lexer/token.rs`, `lexer/reclassify.rs`, `odin/parser.rs`) to #1964 templates, or record why the `hand_written_twins_are_templates` invariant excludes them.

Measured first-hand (2026-09-01): the pairs are not near-identical —

| pair | lines (v1_0 vs v1_1) | diff lines |
|---|---|---|
| `lexer/mod.rs` | 591 vs 891 | 892 |
| `lexer/token.rs` | 598 vs 593 | 117 |
| `lexer/reclassify.rs` | 305 vs 740 | 687 |
| `odin/parser.rs` | 829 vs 767 | 260 |

The divergence is spec-mandated, not accidental duplication: `v1_0` is the faithful Release-1.0.0 generation (ODIN-only lexer over the release's own grammar set, no EL/BEL — the #1946 faithful-emission decision, `docs/VERSIONS.md` §LANG), while `v1_1` carries the development generation's larger token/reclassification surface. The #1964 template mechanism stamps identical-modulo-generation-tokens files and takes per-generation overrides only as whole verbatim files, so converting an eighty-percent-shared pair would re-house the divergence without removing the duplication.

The adjudication is recorded on the invariant test itself, which stays the machine half: `identical_hand_written_twins` computes twin-ness from the tree, so if any of these pairs ever converges to identity, the invariant fails and forces the conversion — no exclusion list exists to rot.

Doc-comment-only diff; the invariant test itself passes unchanged. Gates: nextest (the invariant), clippy, fmt, comment-style — green.