### PR TITLE
docs(rest): correct the overview module docs' item-tag names, demographic-tags claim, and wire-oracle citation

### DIFF
--- a/app/ferroehr-rest/src/overview/mod.rs
+++ b/app/ferroehr-rest/src/overview/mod.rs
@@ -53,18 +53,17 @@
 //!   template uploads, the `ITEM_TAG` collection writes, and the
 //!   Simplified-Formats commit. A request with no `Prefer` gets the applied
 //!   default, `return=minimal`.
-//! - **Item-tag headers — DONE (EHR group).** The parse/emit helpers
-//!   (`params::parse_item_tag_header` / `params::emit_item_tag_header`) are
-//!   consumed by the EHR/COMPOSITION dispatch:
-//!   `api::ehr::apply_item_tag_headers` folds
-//!   the request wrapper headers onto the `ITEM_TAG` service on change-controlled
-//!   writes (empty value ⇒ delete all) and
-//!   `api::ehr::echo_item_tags` echoes each stored
+//! - **Item-tag headers — DONE (EHR + demographic groups).** The parse/emit
+//!   helpers (`params::parse_item_tag_header` / `params::emit_item_tag_header`)
+//!   are consumed through the one shared write-wrapper
+//!   (`crate::api::item_tags`): `pending` reads the request wrapper headers,
+//!   `persist` folds them onto the `ITEM_TAG` service on change-controlled
+//!   writes (empty value ⇒ delete all), and `echo` emits each stored
 //!   collection under ITS OWN header — `openehr-item-tag` confirms the
-//!   `VERSIONED_OBJECT`'s tags, `openehr-version-item-tag` the VERSION's, never
-//!   merged. The demographic group emits both headers from the same set by
-//!   design (its tags are `VERSIONED_OBJECT`-scoped only — see
-//!   `crate::api::demographic`).
+//!   `VERSIONED_OBJECT`'s tags, `openehr-version-item-tag` the VERSION's,
+//!   never merged. The demographic group writes and echoes the same DISTINCT
+//!   collections (pinned by `tests/it/demographic_tags_http.rs`
+//!   `wrapper_headers_write_distinct_collections_on_update`).
 //! - **Method status — DONE.** `error::method_not_allowed_handler`
 //!   (`405`) is mounted as the API router's `method_not_allowed_fallback`
 //!   (`crate::router::router`), so a known path called with a disallowed method renders
@@ -83,7 +82,7 @@
 //!   `crate::extensions::provenance::ITS_REST`) and `openehr-uri` is not emitted.
 //!
 //! All the cross-folder wiring the redesign deferred has since landed: the
-//! item-tag dispatch (the EHR group's `apply_item_tag_headers` / `echo_item_tags`),
+//! item-tag dispatch (the shared `crate::api::item_tags` write-wrapper),
 //! the `405` router-fallback mount + the `501` `ApiError` seam, the per-API
 //! identifier bodies, and the `UpdateAudit.system_id` field (set by
 //! `api::ehr::mk_update_version` and merged from the

--- a/app/ferroehr-rest/src/overview/negotiate.rs
+++ b/app/ferroehr-rest/src/overview/negotiate.rs
@@ -517,10 +517,13 @@ pub(crate) fn json_vec(
 ///
 /// The one caller family today is the `ITEM_TAG` PUT
 /// (`schemas/common/UpdateItemTag.yaml`: required `key`, optional
-/// `value`/`target_path`, `additionalProperties: false`). The oracle order puts
-/// this on the released OAS: the ITS-REST docs text is silent on the write
-/// body's member set, so the released schema grounds it
-/// (`.claude/rules/spec-adherence.md` §the ITS-REST wire-oracle order).
+/// `value`/`target_path`, `additionalProperties: false`). The ITS-REST docs
+/// text is silent on the write body's member set, and where the docs text is
+/// silent the released OAS grounds the expectation — the release presents its
+/// OAS files as its computable specification artifacts (ITS-REST overview
+/// `Specifications.md`: "Specifications can be downloaded as YAML files in
+/// OpenAPI Specification 3.0 format") — so the released schema is the ground
+/// here.
 ///
 /// # Errors
 /// [`ApiError::UnsupportedMediaType`] if the `Content-Type` is not canonical


### PR DESCRIPTION
Closes #3001.

The three passages, corrected as the issue specifies:

1. **Stale names after #2985/#3000**: the overview's item-tag bullet and the cross-folder-wiring paragraph now name the shared write-wrapper `crate::api::item_tags` (`pending` / `persist` / `echo`) instead of the retired `api::ehr::apply_item_tag_headers` / `echo_item_tags`; verified against the current `api/item_tags.rs` surface, and the `params::parse_item_tag_header` / `emit_item_tag_header` helpers it still consumes.
2. **The demographic-tags claim**: the doc now states the true behaviour — the demographic group writes and echoes DISTINCT collections — naming the pinning test (`demographic_tags_http.rs::wrapper_headers_write_distinct_collections_on_update`) instead of the false "both headers from the same set" sentence.
3. **The wire-oracle citation** in `negotiate.rs`: the internal-rule-file pointer is replaced by the substance stated in place with its spec ground — the docs text is silent on the `UpdateItemTag` write-body member set, and the released OAS grounds docs-text silence because the release presents the OAS files as its computable specification artifacts (ITS-REST overview `Specifications.md`, quoted).

Gates: `cargo clippy -p ferroehr-rest --all-targets`, rustdoc `-D warnings` with private items, fmt, comment-style on both files, spec-citations — green. Doc-prose-only diff — `no-changelog`.