### PR TITLE
chore(hosted): dedicated CX33 postgres box — committed posture, on-box wipe verb, Neon retired

### DIFF
--- a/.github/actions/hosted-deploy/action.yml
+++ b/.github/actions/hosted-deploy/action.yml
@@ -36,8 +36,10 @@ inputs:
   verb:
     description: >-
       What the restricted key is asked to run: `deploy` (pull + install the
-      posture + recreate) or `restart` (recreate the CDR so a fresh boot
-      re-runs the migrations — the reseed's step after its wipe).
+      posture + recreate), `restart` (recreate the CDR so a fresh boot
+      re-runs the migrations — the reseed's step after its wipe), or `wipe`
+      (drop the CDR's schemas on the private database box, using the DSN the
+      app box already holds — the reseed's first step; #3015).
     required: false
     default: deploy
   expected-version:
@@ -216,3 +218,16 @@ runs:
         ssh-key: ${{ inputs.ssh-key }}
         known-hosts: ${{ inputs.known-hosts }}
         remote-command: restart
+
+    # The wipe runs on the app box, which reaches the database box over the
+    # private network with the DSN in its own .env — no runner ever opens a
+    # SQL connection and CI holds no database credential (#3015).
+    - name: Wipe the sandbox schemas (on the box, over the private network)
+      if: inputs.verb == 'wipe'
+      uses: rubentalstra/hetzner-deploy-action@23e875e1249a2fe2a27107291a638ab40da0172b # v1.0.1
+      with:
+        host: ${{ inputs.host }}
+        user: deploy
+        ssh-key: ${{ inputs.ssh-key }}
+        known-hosts: ${{ inputs.known-hosts }}
+        remote-command: wipe

--- a/.github/workflows/sandbox-reseed.yml
+++ b/.github/workflows/sandbox-reseed.yml
@@ -1,30 +1,30 @@
 # SPDX-FileCopyrightText: FerroEHR contributors
 # SPDX-License-Identifier: MIT
 #
-# The sandbox reset (#2710, rewritten for the Hetzner posture in #2974): wipe
-# the standalone Neon database's schemas, restart the CDR container so a fresh
-# boot re-runs the migrations, then seed demo data through the PUBLIC API
-# (scripts/sandbox/reseed.sh). Visitors can create, change and delete
+# The sandbox reset (#2710; Hetzner posture #2974; dedicated database box
+# #3015): wipe the sandbox database's schemas, restart the CDR container so a
+# fresh boot re-runs the migrations, then seed demo data through the PUBLIC
+# API (scripts/sandbox/reseed.sh). Visitors can create, change and delete
 # anything; every night the demo returns to a known state.
+#
+# Both the wipe and the restart run through the SAME restricted deploy key
+# (SSH_ORIGINAL_COMMAND verbs `wipe` and `restart`;
+# deploy/hosted/cloud-init.yaml): the database is a dedicated box on the
+# Hetzner private network with no public port, so no runner can open a SQL
+# connection to it, and CI holds no database credential at all. The verb
+# reads the DSN from the app box's own .env, which bounds what it can wipe
+# to the database the sandbox actually runs on — the structural replacement
+# for the old runner-side psql and its Neon-endpoint fence.
 #
 # The restart replaces the Vercel-era "promote a fresh deployment" dance
 # (#2941/#2948): the server runs its migrations only at boot, and on one box
-# a fresh boot is one `docker compose restart ferroehr` away — issued through
-# the same restricted deploy key the deploy lane uses (SSH_ORIGINAL_COMMAND
-# verb `restart`; deploy/hosted/cloud-init.yaml).
+# a fresh boot is one `docker compose restart ferroehr` away.
 #
-# The wipe is direct SQL from the runner because the sandbox's bulk-delete
-# surface is not the reset instrument. Safety fence: the job refuses to run
-# against any host that is not a Neon endpoint, so a mispasted secret can
-# never wipe a real deployment.
-#
-# Secrets: SANDBOX_DATABASE_URL — the standalone Neon project's DIRECT
-# (non-pooled) connection string, in the sandbox-reseed environment.
-# HOSTED_SSH_KEY / HOSTED_KNOWN_HOSTS — the deploy key, in the hosted
-# environment. An empty secret is a hard failure, never a skip (#2755).
-# Environment secrets demonstrably reach these jobs on the workflow_call path
-# in this repository (the v4.0.13 release's reseed succeeded through two
-# call hops).
+# Secrets: HOSTED_SSH_KEY / HOSTED_KNOWN_HOSTS — the deploy key, in the
+# hosted environment. An empty secret is a hard failure, never a skip
+# (#2755). Environment secrets demonstrably reach these jobs on the
+# workflow_call path in this repository (the v4.0.13 release's reseed
+# succeeded through two call hops).
 
 name: Sandbox reseed
 
@@ -45,30 +45,40 @@ concurrency:
 
 jobs:
   wipe:
-    name: wipe the sandbox schemas
+    name: wipe the sandbox schemas (on the box)
     if: github.repository == 'rubentalstra/FerroEHR'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
-    environment: sandbox-reseed
+    timeout-minutes: 15
+    environment: hosted
+    permissions:
+      contents: read
     steps:
-      - name: Wipe the sandbox schemas
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: The deploy key exists
         env:
-          SANDBOX_DATABASE_URL: ${{ secrets.SANDBOX_DATABASE_URL }}
+          KEY: ${{ secrets.HOSTED_SSH_KEY }}
         run: |
           set -euo pipefail
-          case "$SANDBOX_DATABASE_URL" in
-            *neon.tech*) ;;
-            *)
-              echo "::error::SANDBOX_DATABASE_URL does not point at a Neon endpoint — refusing to wipe." >&2
-              exit 1
-              ;;
-          esac
-          psql "$SANDBOX_DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL'
-          DROP SCHEMA IF EXISTS ehr CASCADE;
-          DROP SCHEMA IF EXISTS audit CASCADE;
-          DROP SCHEMA IF EXISTS ext CASCADE;
-          DROP SCHEMA IF EXISTS cold CASCADE;
-          SQL
+          if [ -z "$KEY" ]; then
+            echo "::error::HOSTED_SSH_KEY is empty in the hosted environment — the reset needs it to run the wipe verb on the box." >&2
+            exit 1
+          fi
+
+      # The wipe runs ON the app box (the deploy script's `wipe` verb,
+      # deploy/hosted/cloud-init.yaml): the database is a dedicated box on the
+      # private network with no public port, and CI holds no database
+      # credential — the DSN is the box's own .env, so the verb can only ever
+      # wipe the database the sandbox actually runs on. That structural bound
+      # replaces the old runner-side psql and its Neon-endpoint fence.
+      - name: Wipe the sandbox schemas
+        uses: ./.github/actions/hosted-deploy
+        with:
+          verb: wipe
+          ssh-key: ${{ secrets.HOSTED_SSH_KEY }}
+          known-hosts: ${{ secrets.HOSTED_KNOWN_HOSTS }}
 
   restart:
     name: restart the CDR (fresh boot re-runs the migrations)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ workflow refuses a tag that has no matching section here.
   compose memory limits that ship inside the server image move with it: the
   CDR container to 4096m and the FerroEHR Viewer container to 1536m, so the
   services actually use the larger box.
+- The sandbox database moved from Neon to a second, dedicated CX33 running
+  the published `ferroehr-postgres` image (PostgreSQL 18), reachable only
+  over a Hetzner private network — no public database port exists. The
+  committed posture gains `deploy/hosted/cloud-init-postgres.yaml`; the
+  nightly reseed's schema wipe now runs on the app box through the deploy
+  script's new `wipe` verb instead of a `psql` from the CI runner, so CI no
+  longer holds any database credential (the `SANDBOX_DATABASE_URL` secret is
+  retired).
 - The admin console is now **FerroEHR Viewer**, and every name it carries
   changes with it. Deployments must switch their references: the OCI image is
   `ghcr.io/rubentalstra/ferroehr-viewer` (was `ferroehr-admin-ui`), the Compose

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ knows what it runs on and what it costs:
 |---|---|
 | Server | one Hetzner Cloud CX33 — 4 shared vCPU, 8 GB RAM, 80 GB NVMe SSD — at €8.49/month net |
 | Location | Nuremberg, Germany (`eu-central`), dual-stack, behind a Caddy proxy terminating TLS |
-| Database | Neon serverless PostgreSQL 18, Frankfurt, on its direct (non-pooled) endpoint |
+| Database | a second CX33 running the project's own `ferroehr-postgres` image (PostgreSQL 18), reachable only over a Hetzner private network |
 
 The whole posture is committed at [`deploy/hosted/`](deploy/hosted/). One step up,
 [open a GitHub Codespace](https://codespaces.new/rubentalstra/FerroEHR)

--- a/deploy/hosted/README.md
+++ b/deploy/hosted/README.md
@@ -16,23 +16,44 @@ does not stop. The cost of that choice is ownership: the firewall, the
 certificate, the deploy path and the answer to "is it up" are all things this
 directory states.
 
-## The machine
+## The machines
 
-A Hetzner **CX33** — 4 shared vCPU, 8 GB RAM, 80 GB NVMe SSD, 20 TB included
-traffic; €8.49/month net (€0.0136/h, DE list price since 15 June 2026,
+Two Hetzner **CX33** servers — 4 shared vCPU, 8 GB RAM, 80 GB NVMe SSD, 20 TB
+included traffic each; €8.49/month net apiece (€0.0136/h, DE list price since
+15 June 2026,
 <https://docs.hetzner.com/general/infrastructure-and-availability/price-adjustment/>) —
-in Nuremberg (`eu-central`), dual-stack (167.233.172.220 /
-2a01:4f8:1c16:5d4::/64), provisioned once from `cloud-init.yaml` and resized
-in place from the original CPX22 on 2026-09-01. The compose memory limits are
-sized for this box; on a resize they move with it, and neither is a code
-change.
+in Nuremberg (`eu-central`), joined by a private network
+(`ferroehr-sandbox-net`, 10.0.0.0/24) and a spread placement group (different
+physical hosts, so one host failure never takes both):
 
-The database is NOT on the box: a standalone Neon project (PostgreSQL 18,
-Frankfurt) consumed over its **direct** (non-pooled) endpoint — Neon's pooler
-is PgBouncer in transaction mode, which breaks the session GUCs and the
-boot-time migrations (https://neon.com/docs/connect/connection-pooling). The
-connection string lives in the box's `.env` and nowhere else; CI never holds
-it.
+- **The app box** (`ferroehr`, 167.233.172.220 / 2a01:4f8:1c16:5d4::/64,
+  private 10.0.0.3): the CDR, the viewer and Caddy — provisioned once from
+  `cloud-init.yaml`, resized in place from the original CPX22 on 2026-09-01.
+  The compose memory limits are sized for this box; on a resize they move
+  with it, and neither is a code change.
+- **The database box** (`ferroehr-sandbox-postgres`, 2.28.64.110 /
+  2a01:4f8:1c16:c964::/64, private 10.0.0.2): the published
+  `ferroehr-postgres` image (PostgreSQL 18), provisioned once from
+  `cloud-init-postgres.yaml` on 2026-09-01 (#3015). PostgreSQL binds to the
+  private address alone; the public side carries key-only SSH and nothing
+  else. `postgres.ferroehr.eu` names the PUBLIC address for SSH and
+  operations — its 5432 never answers, by design.
+
+The connection string lives in the app box's `.env` and nowhere else; CI
+never holds it. The release deploy lane touches the APP box only — the
+database box has no deploy lane, and its image moves by hand
+(`docker compose pull && docker compose up -d` in `/opt/ferroehr-postgres`).
+
+Two operational lessons, learned live at the cutover and load-bearing:
+
+- **A `DATABASE_URL` change needs `docker compose up -d` (a recreate), never
+  `docker compose restart`** — restart reuses the container's original
+  environment, so the CDR keeps talking to the old database while readiness
+  honestly reports UP about the wrong server.
+- **The app box's `.env` is fed into the CDR container wholesale**, and the
+  CDR's strict boot sweep refuses any `FERROEHR_*` name its release does not
+  know — an `.env` line staged for a FUTURE release keeps the CURRENT one
+  from booting. Stage such lines commented out.
 
 ## What is in this directory
 
@@ -43,7 +64,8 @@ it.
 | `Caddyfile` | Automatic TLS, and the routing table (the CDR owns `/ferroehr/*`, `/health*`, `/management*`, `/.well-known/*`; the console is everything else) | the same way; a change to it restarts Caddy |
 | `ferroehr.sandbox.toml` | The CDR's sandbox posture (demo user, admin API on per #2965, management off) | the same way |
 | `ferroehr-viewer.sandbox.toml` | The console's sandbox posture | the same way |
-| `env.example` | A copy-to-`.env` template: the Neon direct DSN and the image references | never. `.env` is the operator's file, written by hand on the box |
+| `env.example` | A copy-to-`.env` template: the DB box's private-network DSN and the image references | never. `.env` is the operator's file, written by hand on the box |
+| `cloud-init-postgres.yaml` | The DATABASE box, fresh to serving state: the `deploy` user, key-only SSH, both firewalls, Docker, and the `ferroehr-postgres` compose posture bound to the private address | the DB server's user data at creation, once |
 
 The box holds **no checkout of this repository** and fetches nothing from it
 over the network: the posture travels inside the published ferroehr image, so
@@ -62,12 +84,13 @@ every step. Three callers:
    The `sandbox-reseed` leg then wipes, restarts and reseeds.
 2. **A manual `workflow_dispatch`** of `.github/workflows/hosted-deploy.yml`.
 3. **The reseed** (`sandbox-reseed.yml`, nightly + after every release
-   deploy) — verb `restart` only: recreate the CDR so a fresh boot re-runs
-   the migrations against the wiped database.
+   deploy) — verbs `wipe` (drop the schemas on the private database box,
+   with the DSN this box already holds) and `restart` (recreate the CDR so
+   a fresh boot re-runs the migrations against the wiped database).
 
 The deploy key is restricted on the box to `deploy.sh` (`command=` in
 `cloud-init.yaml`), which reads `SSH_ORIGINAL_COMMAND` and accepts exactly
-`deploy` and `restart`. The lane builds nothing; it asserts by digest that
+`deploy`, `restart` and `wipe`. The lane builds nothing; it asserts by digest that
 `:latest` is the tagged image, refuses an image that does not declare
 `eu.ferroehr.image.carries-sandbox-posture=true`, deploys through
 [`rubentalstra/hetzner-deploy-action`](https://github.com/rubentalstra/hetzner-deploy-action),
@@ -103,6 +126,6 @@ box that fills its disk fails in a way that looks like nothing at all.
 
 Nothing durable and nothing secret beyond the one `.env`: the containers are
 rebuilt from published images, the data is wiped nightly by design
-(`sandbox-reseed.yml` — the wipe runs from CI against Neon directly, never
-through the box), and no signing key, token or credential beyond the database
-DSN exists on the host. **No backups**, deliberately.
+(`sandbox-reseed.yml` — the wipe runs ON this box through the deploy
+script's `wipe` verb, over the private network), and no signing key, token
+or credential beyond the database DSN exists on the host. **No backups**, deliberately.

--- a/deploy/hosted/cloud-init-postgres.yaml
+++ b/deploy/hosted/cloud-init-postgres.yaml
@@ -1,0 +1,138 @@
+#cloud-config
+# The sandbox DATABASE box (ferroehr-sandbox-postgres): a dedicated CX33
+# running the project's own ferroehr-postgres image (PG 18 with uuid-ossp,
+# pgcrypto and pg_trgm), reachable ONLY over the Hetzner private network
+# (ferroehr-sandbox-net, 10.0.0.0/24). Pass this as the server's user data at
+# creation; provisioned 2026-09-01 (#3015).
+#
+# Committed rather than remembered, like the app box's cloud-init.yaml: a
+# host built by hand is a host nobody can rebuild. Unlike the app box, this
+# box's posture is owned by THIS file — no deploy lane touches it, the
+# release pipeline never connects to it, and the database image moves only by
+# hand (docker compose pull + up -d in /opt/ferroehr-postgres).
+#
+# The network posture, layer by layer: PostgreSQL binds to the box's PRIVATE
+# address only (the compose ports entry — Docker's published ports bypass
+# ufw, so the bind address is the real gate); ufw admits 5432 solely from the
+# private subnet as the belt; the Hetzner Cloud Firewall on the public side
+# admits SSH alone (cloud firewalls do not filter private-network traffic).
+# postgres.ferroehr.eu names the PUBLIC address for SSH and operations only —
+# its 5432 must never answer.
+
+users:
+  - name: deploy
+    lock_passwd: true
+    shell: /bin/bash
+    # The key is REAL and that is deliberate: a public key is not a secret,
+    # and a cloud-init carrying placeholders cannot rebuild the box. No CI
+    # key here — nothing deploys to this box.
+    ssh_authorized_keys:
+      # A person, for logging in and looking around (same key as the app box).
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGFOMcuGIZKPwC0aHkleBo7MNO1jEz3wyNSUKTNpQSBJ RubenTalstra1211@outlook.com
+
+ssh_pwauth: false
+disable_root: true
+
+package_update: true
+package_upgrade: true
+packages:
+  - ca-certificates
+  - curl
+  - ufw
+  - unattended-upgrades
+
+write_files:
+  # A box nobody logs into still takes security updates.
+  - path: /etc/apt/apt.conf.d/20auto-upgrades
+    content: |
+      APT::Periodic::Update-Package-Lists "1";
+      APT::Periodic::Unattended-Upgrade "1";
+
+  # Container logs are the likeliest thing to fill a small disk, and a full
+  # disk fails in a way that looks like nothing at all.
+  - path: /etc/docker/daemon.json
+    content: |
+      {
+        "log-driver": "json-file",
+        "log-opts": { "max-size": "10m", "max-file": "3" },
+        "live-restore": true
+      }
+
+  # What runs here. The operator's .env beside it carries POSTGRES_PASSWORD
+  # (the bootstrap superuser), PG_INIT_PASSWORD (the ferroehr app role the
+  # image's init script creates — the password in the app box's
+  # DATABASE_URL), and PG_BIND_IP (this box's private 10.0.0.x address).
+  - path: /opt/ferroehr-postgres/docker-compose.yml
+    owner: deploy:deploy
+    # Deferred to the final stage: `write-files` runs BEFORE `users-groups`
+    # in the default module order, so an owner naming this user cannot be
+    # applied any earlier.
+    defer: true
+    content: |
+      services:
+        postgres:
+          image: ${FERROEHR_POSTGRES_IMAGE:-ghcr.io/rubentalstra/ferroehr-postgres:latest}
+          container_name: ferroehr-sandbox-postgres
+          restart: unless-stopped
+          # Docker's default 64MB /dev/shm starves PostgreSQL's dynamic
+          # shared memory (parallel workers fail with "could not resize
+          # shared memory segment") — same floor the quickstart compose sets.
+          shm_size: 1gb
+          environment:
+            POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?write .env first}
+            PG_INIT_USER: ferroehr
+            PG_INIT_PASSWORD: ${PG_INIT_PASSWORD:?write .env first}
+            PG_INIT_DB: ferroehr
+          # Sized for the box (a CX33: 4 vCPU, 8 GB) — the one resident.
+          command:
+            - postgres
+            - -c
+            - shared_buffers=2GB
+            - -c
+            - max_wal_size=4GB
+          # Bound to the PRIVATE IP only: Docker's published ports bypass
+          # ufw, so the bind address is the real gate — the public interface
+          # never carries 5432.
+          ports:
+            - "${PG_BIND_IP:?write .env first}:5432:5432"
+          healthcheck:
+            test: ["CMD-SHELL", "pg_isready -U postgres"]
+            interval: 30s
+            timeout: 5s
+            retries: 3
+            start_period: 30s
+          # The PG 18 image expects its volume at /var/lib/postgresql (data
+          # lands in a subdirectory, which is what lets pg_upgrade --link
+          # work across majors); mounting the old …/data path crash-loops.
+          # Learned live at provisioning — do not "correct" this back.
+          volumes:
+            - pgdata:/var/lib/postgresql
+          env_file:
+            - .env
+      volumes:
+        pgdata:
+
+runcmd:
+  # Two firewalls that agree. The Hetzner Cloud Firewall keeps public traffic
+  # off the NIC (SSH alone); this is what the box itself says — including
+  # about the private network, which the cloud firewall cannot see.
+  - [ufw, default, deny, incoming]
+  - [ufw, default, allow, outgoing]
+  - [ufw, allow, "22/tcp"]
+  # Belt beside the bind-address gate: 5432 only from the private subnet.
+  - [ufw, allow, from, "10.0.0.0/24", to, any, port, "5432", proto, tcp]
+  - [ufw, --force, enable]
+  - [sh, -c, "curl -fsSL https://get.docker.com | sh"]
+  - [systemctl, enable, --now, docker]
+  - [install, -d, -o, deploy, -g, deploy, /opt/ferroehr-postgres]
+  # The group exists now, so the deploy user can join it. A group change
+  # takes effect at the next login.
+  - [usermod, -aG, docker, deploy]
+  - [systemctl, enable, --now, unattended-upgrades]
+
+final_message: >-
+  the postgres box is up after $UPTIME seconds. Write
+  /opt/ferroehr-postgres/.env (POSTGRES_PASSWORD, PG_INIT_PASSWORD, and
+  PG_BIND_IP = this box's private 10.0.0.x address), chmod 600 it, then run
+  `docker compose up -d` in /opt/ferroehr-postgres and point the app box's
+  DATABASE_URL at ferroehr@<PG_BIND_IP>:5432/ferroehr.

--- a/deploy/hosted/cloud-init.yaml
+++ b/deploy/hosted/cloud-init.yaml
@@ -65,10 +65,13 @@ write_files:
       }
 
   # The ONE command the CI key may run. It reads SSH_ORIGINAL_COMMAND and
-  # accepts exactly two verbs: `deploy` (the default — pull, extract the
-  # posture out of the pulled image, recreate) and `restart` (recreate the CDR
+  # accepts exactly three verbs: `deploy` (the default — pull, extract the
+  # posture out of the pulled image, recreate), `restart` (recreate the CDR
   # so a fresh boot re-runs the migrations — what the reseed needs after its
-  # wipe). Nothing is built here, and nothing is fetched from the repository.
+  # wipe), and `wipe` (drop the CDR's schemas on the private database, using
+  # the DSN this box already holds — the database has no public port and CI
+  # holds no database credential). Nothing is built here, and nothing is
+  # fetched from the repository.
   - path: /opt/ferroehr-sandbox/deploy.sh
     permissions: "0755"
     owner: deploy:deploy
@@ -80,7 +83,7 @@ write_files:
       #!/usr/bin/env bash
       # SSH runs this whatever the client asked for — that is the point of the
       # command= restriction on the key — and the client's request arrives in
-      # SSH_ORIGINAL_COMMAND, which selects one of two verbs below.
+      # SSH_ORIGINAL_COMMAND, which selects one of the verbs below.
       #
       # The posture this box runs — docker-compose.yml, the Caddyfile and the
       # two sandbox configuration files — travels INSIDE the published
@@ -96,12 +99,34 @@ write_files:
 
       verb="${SSH_ORIGINAL_COMMAND:-deploy}"
       case "$verb" in
-        deploy|restart) ;;
+        deploy|restart|wipe) ;;
         *)
-          echo "deploy: unknown verb '$verb' (this key runs 'deploy' or 'restart')" >&2
+          echo "deploy: unknown verb '$verb' (this key runs 'deploy', 'restart' or 'wipe')" >&2
           exit 1
           ;;
       esac
+
+      # `wipe` is the nightly reset's schema drop (sandbox-reseed.yml),
+      # executed HERE because the database lives on the private network with
+      # no public port, and CI holds no database credential: the DSN is the
+      # same .env value the CDR runs with, so this can only ever wipe the
+      # database this box is configured against. psql comes from the
+      # ferroehr-postgres image (the CDR image is distroless).
+      if [[ "$verb" == "wipe" ]]; then
+        dsn="$(sed -n 's/^DATABASE_URL=//p' .env | tail -n 1)"
+        if [[ -z "$dsn" ]]; then
+          echo "wipe: .env names no DATABASE_URL, so there is nothing to wipe" >&2
+          exit 1
+        fi
+        docker run --rm --entrypoint psql \
+          ghcr.io/rubentalstra/ferroehr-postgres:latest "$dsn" \
+          -v ON_ERROR_STOP=1 \
+          -c 'DROP SCHEMA IF EXISTS ehr CASCADE' \
+          -c 'DROP SCHEMA IF EXISTS audit CASCADE' \
+          -c 'DROP SCHEMA IF EXISTS ext CASCADE' \
+          -c 'DROP SCHEMA IF EXISTS cold CASCADE'
+        exit 0
+      fi
 
       # `restart` exists for the reseed: after the schema wipe the CDR must
       # boot fresh to re-run its migrations, and `docker compose up -d` alone
@@ -212,6 +237,7 @@ runcmd:
 
 final_message: >-
   the box is up after $UPTIME seconds. Write /opt/ferroehr-sandbox/.env (the
-  Neon DIRECT connection string as DATABASE_URL, and FERROEHR_IMAGE), then run
+  DB box's private-network connection string as DATABASE_URL, plus the
+  image references), then run
   the hosted deploy lane: it installs the compose file, the Caddyfile and the
   sandbox configuration out of the image it pulls.

--- a/deploy/hosted/docker-compose.yml
+++ b/deploy/hosted/docker-compose.yml
@@ -10,11 +10,12 @@
 # out of the image it just pulled. So an edit here reaches the box with the
 # release that carries it, and never before one.
 #
-# The database is a standalone Neon project: `.env` carries its DIRECT
-# (non-pooled) connection string as DATABASE_URL, which the config alias layer
-# maps to db.url (app/ferroehr/src/config/alias.rs). The pooled `-pooler`
-# endpoint is unsuitable — transaction-mode PgBouncer breaks the session GUCs
-# and the boot migrations (https://neon.com/docs/connect/connection-pooling).
+# The database is the dedicated DB box (ferroehr-sandbox-postgres, a second
+# CX33 provisioned by deploy/hosted/cloud-init-postgres.yaml): `.env` carries
+# its private-network connection string as DATABASE_URL, which the config
+# alias layer maps to db.url (app/ferroehr/src/config/alias.rs). The database
+# has no public port; the app reaches it over the Hetzner private network
+# (10.0.0.0/24) alone.
 
 services:
   ferroehr:
@@ -42,9 +43,9 @@ services:
     environment:
       FERROEHR_CONFIG: /etc/ferroehr/ferroehr.toml
     env_file:
-      # DATABASE_URL (the Neon direct string) and FERROEHR_IMAGE. The
-      # operator's file, readable by the service user alone; no automation
-      # writes it and CI never holds the connection string.
+      # DATABASE_URL (the DB box's private-network string) and the image
+      # references. The operator's file, readable by the service user alone;
+      # no automation writes it and CI never holds the connection string.
       - .env
     volumes:
       - ./ferroehr.sandbox.toml:/etc/ferroehr/ferroehr.toml:ro

--- a/deploy/hosted/env.example
+++ b/deploy/hosted/env.example
@@ -2,15 +2,15 @@
 #
 # Copy to `.env` on the box and fill in the connection string. The operator's
 # file: no automation writes it, and CI never holds the database credential —
-# the deploy key can only run the one deploy script.
+# the deploy key can only run the deploy script's three verbs.
 
-# The standalone Neon project's DIRECT (non-pooled) connection string — the
-# endpoint hostname WITHOUT the `-pooler` suffix. The config alias layer maps
-# it to db.url (app/ferroehr/src/config/alias.rs). The pooled endpoint is
-# unsuitable: Neon's PgBouncer runs in transaction mode, which breaks the
-# session GUCs and the boot migrations
-# (https://neon.com/docs/connect/connection-pooling).
-DATABASE_URL=
+# The dedicated database box (ferroehr-sandbox-postgres, a second CX33 in the
+# same project) over the Hetzner PRIVATE network — the server binds 5432 to
+# its private address only, so this hostname is always the 10.0.0.x address,
+# never the public IP and never postgres.ferroehr.eu (an SSH/ops name whose
+# public 5432 is firewalled shut by design). The password is PG_INIT_PASSWORD
+# from that box's /opt/ferroehr-postgres/.env.
+DATABASE_URL=postgres://ferroehr:CHANGE_ME@10.0.0.2:5432/ferroehr
 
 # The exact image references the compose file runs. `:latest` is the release
 # pointer the image lane moves on real release tags; naming a version here

--- a/deploy/hosted/ferroehr.sandbox.toml
+++ b/deploy/hosted/ferroehr.sandbox.toml
@@ -11,7 +11,7 @@
 # conformance statement's AdminApi claims are exercisable against this
 # deployment. The public bulk delete is accepted: it wipes what the nightly
 # reset wipes anyway. The database DSN comes from the box's `.env`, never from
-# this file — the standalone Neon project's DIRECT connection string as
+# this file — the DB box's private-network connection string as
 # DATABASE_URL, mapped to db.url by the config aliases (#2716).
 
 [server]

--- a/website/book/src/installation/codespaces.md
+++ b/website/book/src/installation/codespaces.md
@@ -56,7 +56,7 @@ what it runs on and what to expect from it:
 | | |
 |---|---|
 | Compute | one dedicated Hetzner Cloud CX33 (4 shared vCPU, 8 GB RAM, 80 GB NVMe SSD; Nuremberg, `eu-central`; €8.49/month net), running the published container images behind a Caddy proxy that terminates TLS |
-| Database | Neon serverless PostgreSQL 18, region Frankfurt, over its direct (non-pooled) endpoint |
+| Database | a second, dedicated CX33 running the published `ferroehr-postgres` image (PostgreSQL 18), reachable only over a Hetzner private network — no public database port |
 | Data durability | none by design: **every night around midnight UTC the whole store is wiped and fresh demo data is seeded** |
 
 The server does not scale to zero, so there is no cold start; it is still a


### PR DESCRIPTION
Closes #3015.

The repo half of the database move (the boxes are already live and verified — the full runbook, live test battery and cutover record are on the issue):

- **`deploy/hosted/cloud-init-postgres.yaml`** (new): the DB box's posture as provisioned — deploy user, key-only SSH, both firewalls (5432 admitted only from the private subnet, and bound to the private address, which is the real gate since Docker bypasses ufw), the `ferroehr-postgres` compose with the PG 18 volume layout learned live (`pgdata:/var/lib/postgresql`; the classic `…/data` path crash-loops on this image).
- **The `wipe` verb** joins `deploy`/`restart` in the app box's restricted deploy script: it drops the four schemas through a one-off `ferroehr-postgres` container using the DSN in the box's own `.env`, over the private network. `sandbox-reseed.yml`'s wipe job becomes a call of that verb through `.github/actions/hosted-deploy`; the runner-side `psql`, the Neon-endpoint fence and the `SANDBOX_DATABASE_URL` requirement are gone — the structural bound (the verb can only wipe the database the box runs on) replaces the string fence. **CI now holds no database credential.**
- Neon commentary scrubbed from the hosted compose, `env.example`, `ferroehr.sandbox.toml`, the final_message, the hosted README, the root README table and the book's environment table; the hosted README's §The machines records the two-box topology (private network, spread placement group, per-box firewalls) and the two cutover lessons (DSN change ⇒ compose recreate, never restart; staged future `FERROEHR_*` env lines refuse the current release's strict boot sweep).

Already done outside the tree, recorded on #3015: both boxes live and verified (SSH, closed public 5432, private-net auth, readiness UP on the new DB, 8 migrations, seeded 24 compositions/3 EHRs through the public API), the updated `deploy.sh` installed on the box byte-identical to the committed one (sha `a60a74f5…` both sides), DNS records at Vimexx.

Gates: `hosted-deploy-script` (extracts + shellchecks the embedded script), `compose-hardening`, `compose-image-tags`, `changelog-structure`, `docs-claims --all`, `actionlint` — all green; the embedded postgres compose parses under `docker compose config`.

**After this merges:** dispatch `sandbox-reseed.yml` once — a green wipe→restart→seed is the end-to-end acceptance — then the owner deletes the `SANDBOX_DATABASE_URL` secret and the Neon project, in that order.