### PR TITLE
fix(its): TDD import carries compacted-wrapper instance data instead of defaulting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,13 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- TDD import no longer discards instance data a TDD spells out on wrappers
+  the WebTemplate compacted: `HISTORY.origin`, an event's `time` and `name`,
+  and the other LOCATABLE metadata (`uid`, `links`, `feeder_audit`) now land
+  on the re-materialised nodes instead of RM-mandatory defaults, each value
+  parsed as its model-declared type. Spelled-out wrapper data that cannot
+  legally sit on the corresponding node is refused with a named error rather
+  than silently dropped.
 - The platform validity checker (`definitions_valid`) now checks archetype
   identifiers, not just template identifiers, per the SM clause it realizes:
   every `archetype_details` declaration in the checked content contributes its

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5431,7 +5431,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.51"
+version = "0.0.52"
 dependencies = [
  "indexmap 2.14.0",
  "openehr-am",
@@ -5447,7 +5447,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.51"
+version = "0.0.52"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -5457,7 +5457,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.51"
+version = "0.0.52"
 dependencies = [
  "serde",
  "serde_json",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.51"
+version = "0.0.52"
 dependencies = [
  "async-trait",
  "axum",
@@ -5506,7 +5506,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.51"
+version = "0.0.52"
 dependencies = [
  "assert_fs",
  "chumsky",
@@ -5520,7 +5520,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.51"
+version = "0.0.52"
 dependencies = [
  "chumsky",
  "logos",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.51"
+version = "0.0.52"
 dependencies = [
  "insta",
  "jsonschema",
@@ -5547,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.51"
+version = "0.0.52"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-adl"
-version = "0.0.51"
+version = "0.0.52"
 description = "openEHR ADL 2.4.0: hand-written ADL2/cADL/ODIN parser, AOM2 validation catalogue, specialisation flattener, OPT2 generator, and ADL 1.4→2 conversion over the generated openehr_am::v2_4::aom2 model"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,11 +16,11 @@ include = ["src/**", "README.md", "LICENSE-MIT"]
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)
-openehr-base = { path = "../openehr-base", version = "0.0.51" }   # VersionStatus for the parsed HRID
-openehr-am = { path = "../openehr-am", version = "0.0.51" }       # v2_4 ArchetypeHrid (the identification target type)
-openehr-rm = { path = "../openehr-rm", version = "0.0.51" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
-openehr-lang = { path = "../openehr-lang", version = "0.0.51" }   # openehr_lang::odin — the ODIN section parser
-openehr-term = { path = "../openehr-term", version = "0.0.51" }   # the languages code set for the RM resource-meta rows
+openehr-base = { path = "../openehr-base", version = "0.0.52" }   # VersionStatus for the parsed HRID
+openehr-am = { path = "../openehr-am", version = "0.0.52" }       # v2_4 ArchetypeHrid (the identification target type)
+openehr-rm = { path = "../openehr-rm", version = "0.0.52" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
+openehr-lang = { path = "../openehr-lang", version = "0.0.52" }   # openehr_lang::odin — the ODIN section parser
+openehr-term = { path = "../openehr-term", version = "0.0.52" }   # the languages code set for the RM resource-meta rows
 uuid.workspace = true        # meta uid/build_uid (AUTHORED_ARCHETYPE.uid: Uuid)
 indexmap.workspace = true    # OdinValue::Object body (insertion-ordered map)
 

--- a/crates/openehr-am/Cargo.toml
+++ b/crates/openehr-am/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-am"
-version = "0.0.51"
+version = "0.0.52"
 description = "openEHR AM Archetype Model, generated from BMM: generations v1_4 (AM 1.4.0, ADL 1.4) and v2_4 (AM 2.4.0, ADL 2; current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,8 +13,8 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.51" }
-openehr-lang = { path = "../openehr-lang", version = "0.0.51" }
+openehr-base = { path = "../openehr-base", version = "0.0.52" }
+openehr-lang = { path = "../openehr-lang", version = "0.0.52" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also carries the untyped `Value` fields the generator

--- a/crates/openehr-base/Cargo.toml
+++ b/crates/openehr-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-base"
-version = "0.0.51"
+version = "0.0.52"
 description = "openEHR BASE foundation + base types, generated from BMM: generations v1_2 (BASE 1.2.0) and v1_3 (BASE 1.3.0, current)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-its"
-version = "0.0.51"
+version = "0.0.52"
 description = "openEHR ITS (Implementation Technology Specifications): canonical JSON + canonical XML serialization of the RM, the generated ITS-REST 1.1.0 API contract, OPT 1.4 and AOM2 archetype XML codecs, and the Simplified Formats (FLAT / STRUCTURED / Web Template)"
 edition.workspace = true
 rust-version.workspace = true
@@ -41,14 +41,14 @@ regex = { workspace = true, optional = true }
 fancy-regex = { workspace = true, optional = true }
 # The generated XML (de)serializers impl the crate's ToXml/FromXml traits for the
 # RM/BASE spec types, so these are real (non-dev) deps.
-openehr-base = { path = "../openehr-base", version = "0.0.51", optional = true }
-openehr-rm = { path = "../openehr-rm", version = "0.0.51", optional = true }
+openehr-base = { path = "../openehr-base", version = "0.0.52", optional = true }
+openehr-rm = { path = "../openehr-rm", version = "0.0.52", optional = true }
 # The native canonical-JSON codec (`json_codec/generated`, emit-json) implements
 # `ToJson` for EVERY generated spec type the `OpenEhrType` derive covers, so it
 # spans all five spec crates (not just the RM/BASE the XML codec needs).
-openehr-lang = { path = "../openehr-lang", version = "0.0.51", optional = true }
-openehr-am = { path = "../openehr-am", version = "0.0.51", optional = true }
-openehr-term = { path = "../openehr-term", version = "0.0.51", optional = true }
+openehr-lang = { path = "../openehr-lang", version = "0.0.52", optional = true }
+openehr-am = { path = "../openehr-am", version = "0.0.52", optional = true }
+openehr-term = { path = "../openehr-term", version = "0.0.52", optional = true }
 
 # `full` — every ITS surface (canonical JSON/XML, the generated ITS-REST
 # contract, `opt14`, Simplified Formats). ON BY DEFAULT, so every consumer sees

--- a/crates/openehr-its/src/flat/tdd.rs
+++ b/crates/openehr-its/src/flat/tdd.rs
@@ -54,7 +54,7 @@
 //! match are kept, and when a re-materialised node corresponds to one (its
 //! element name matches the RM attribute, its Ocean `…_as_<ConcreteType>`
 //! suffix names the node's type, or its metadata keys discriminate the node —
-//! `origin`/`time`), that element's [`WRAPPER_METADATA`] children
+//! `origin`/`time`), that element's `WRAPPER_METADATA` children
 //! (`HISTORY.origin`, `EVENT.time`, `name`, `uid`, `links`, `feeder_audit`)
 //! are parsed as their model-declared types and placed on the node. The
 //! RM-mandatory temporal defaults apply only when the TDD carries no value; a

--- a/crates/openehr-its/src/flat/tdd.rs
+++ b/crates/openehr-its/src/flat/tdd.rs
@@ -49,10 +49,17 @@
 //!   web-template-declared concrete type as `xsi:type` and parsed as an
 //!   [`openehr_rm::prelude::DataValue`].
 //!
-//! Where the TDD spells out a wrapper the `WebTemplate` compacted
-//! (`HISTORY.origin`, `EVENT.time`), the re-materialised node takes the
-//! RM-mandatory default, as in the FLAT reverse converter; the leaf data values
-//! and the composition/entry context are faithful.
+//! Where the TDD spells out a wrapper the `WebTemplate` compacted, the
+//! wrapper's own instance data travels: the skipped elements on the path to a
+//! match are kept, and when a re-materialised node corresponds to one (its
+//! element name matches the RM attribute, its Ocean `…_as_<ConcreteType>`
+//! suffix names the node's type, or its metadata keys discriminate the node —
+//! `origin`/`time`), that element's [`WRAPPER_METADATA`] children
+//! (`HISTORY.origin`, `EVENT.time`, `name`, `uid`, `links`, `feeder_audit`)
+//! are parsed as their model-declared types and placed on the node. The
+//! RM-mandatory temporal defaults apply only when the TDD carries no value; a
+//! spelled-out wrapper whose metadata cannot legally sit on the corresponding
+//! node is refused, never silently dropped.
 //!
 //! The multi-valued RM-attribute set used to re-materialise arrays comes from
 //! the generated BMM RM attribute model, never a hard-coded list. A construct
@@ -66,7 +73,7 @@
               (#1694)"
 )]
 
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 use std::sync::LazyLock;
 
 use openehr_rm::v1_2::paths::{PathSegment, is_archetype_root_node_id};
@@ -85,9 +92,10 @@ pub const TDD_TEMPLATE_NS: &str = "http://schemas.oceanehr.com/templates";
 /// converter's `RM_VERSION`.
 const RM_VERSION: &str = "1.2.0";
 
-/// RM-mandatory temporal default for wrapper nodes whose instance value the TDD
-/// leaves in a compacted wrapper this wave does not carry (see the module
-/// `NOTE`). Matches the FLAT converter's `DEFAULT_TIME`.
+/// RM-mandatory temporal default for re-materialised wrapper nodes whose
+/// instance value the TDD does not carry at all (a fully compacted chain —
+/// a spelled-out wrapper's own value wins over this, see the module doc).
+/// Matches the FLAT converter's `DEFAULT_TIME`.
 const DEFAULT_TIME: &str = "1970-01-01T00:00:00Z";
 
 // ── generic XML tree ─────────────────────────────────────────────────────────
@@ -279,11 +287,12 @@ fn xml_escape(s: &str) -> String {
 /// content, which is what the `400`/`422` body must show the caller.
 fn parse_typed(el: &El, type_name: &str) -> Result<Value, FlatError> {
     use crate::xml::from_canonical_xml as fx;
+    use openehr_base::prelude::UidBasedId;
     use openehr_rm::prelude::{
         CodePhrase, DataValue, DvBoolean, DvCodedText, DvCount, DvDate, DvDateTime, DvDuration,
         DvEhrUri, DvIdentifier, DvMultimedia, DvOrdinal, DvParagraph, DvParsable, DvProportion,
-        DvQuantity, DvScale, DvState, DvText, DvTime, DvUri, EventContext, IsmTransition, Link,
-        Participation, PartyProxy,
+        DvQuantity, DvScale, DvState, DvText, DvTime, DvUri, EventContext, FeederAudit,
+        IsmTransition, Link, Participation, PartyProxy,
     };
 
     let resolved = el.xsi_type().unwrap_or(type_name);
@@ -321,6 +330,10 @@ fn parse_typed(el: &El, type_name: &str) -> Result<Value, FlatError> {
         "EVENT_CONTEXT" => p!(EventContext),
         "LINK" => p!(Link),
         "ISM_TRANSITION" => p!(IsmTransition),
+        "FEEDER_AUDIT" => p!(FeederAudit),
+        // A LOCATABLE `uid` on a spelled-out wrapper: the closed UID_BASED_ID
+        // set, dispatched on the element's own `xsi:type`.
+        "UID_BASED_ID" | "HIER_OBJECT_ID" | "OBJECT_VERSION_ID" => p!(UidBasedId),
         // Any DV slot with an unknown/absent concrete hint dispatches through the
         // DATA_VALUE enum on the element's own xsi:type.
         _ => p!(DataValue),
@@ -436,11 +449,12 @@ pub fn from_tdd(tdd_xml: &str, wt: &WebTemplate) -> Result<Value, FlatError> {
 /// at least one match (the compaction rule in the module doc). Anything else
 /// is content the template-derived TDS does not define — a conversion error
 /// naming the offending element, so the refusal localizes.
-/// Compacted-wrapper instance metadata (the module doc's documented limit): a
-/// TDD may spell out RM fields of a wrapper the `WebTemplate` compacted
-/// (`HISTORY.origin`, `EVENT.time`/`name`) plus universal LOCATABLE metadata —
-/// RM attribute names, never template content, deliberately not carried by
-/// the build. Everything else is content the TDS does not define.
+/// Compacted-wrapper instance metadata: the RM fields a TDD may spell out on
+/// a wrapper the `WebTemplate` compacted (`HISTORY.origin`, `EVENT.time`,
+/// plus the universal LOCATABLE metadata) — RM attribute names, never
+/// template content. Conformance tolerates them here; the build carries them
+/// onto the re-materialised node via [`WrapperMeta`]. Everything else is
+/// content the TDS does not define.
 const WRAPPER_METADATA: [&str; 6] = ["name", "uid", "links", "feeder_audit", "origin", "time"];
 
 fn check_conformance(el: &El, wt: &WebTemplateNode, rm_type: &str) -> Result<(), FlatError> {
@@ -633,7 +647,7 @@ fn build_content_children(
         {
             continue;
         }
-        for cel in find_matches(el, node_display(wc)) {
+        for (wrappers, cel) in find_matches_with_wrappers(el, node_display(wc)) {
             let child_value = if wc.has_input() {
                 // A leaf: the ELEMENT wrapper is materialised by `place`; the
                 // datum is the leaf element's `<value>` fragment.
@@ -641,7 +655,17 @@ fn build_content_children(
             } else {
                 build_node(cel, wc, concrete_type(&wc.rm_type), &wc.aql_path, false)?
             };
-            place(obj, &rel, child_value, wc);
+            let mut metas = WrapperMeta::carriers(&wrappers);
+            place(obj, &rel, child_value, wc, &mut metas)?;
+            if let Some(unused) = metas.front() {
+                return Err(FlatError::Conversion(format!(
+                    "TDD wrapper <{}> carries instance data ({}) that corresponds to no \
+                     re-materialised node on the path to {:?}",
+                    unused.el.name,
+                    unused.keys.join(", "),
+                    wc.id
+                )));
+            }
         }
     }
     Ok(())
@@ -724,20 +748,169 @@ pub(crate) fn is_multiple_attr(attr: &str) -> bool {
     MULTIVALUED_ATTRS.contains(attr)
 }
 
+/// A spelled-out wrapper element carrying instance data for a compacted RM
+/// node: the element plus the [`WRAPPER_METADATA`] child names present on it.
+///
+/// Queued in document order along the scoped search's skip chain and consumed
+/// positionally as [`place`] re-materialises the compacted chain: the front
+/// wrapper attaches to the first node it corresponds to, and is never consumed
+/// out of order — a front that corresponds to nothing at the current node
+/// simply waits for a deeper one.
+struct WrapperMeta<'a> {
+    el: &'a El,
+    keys: Vec<&'a str>,
+}
+
+impl<'a> WrapperMeta<'a> {
+    /// The metadata carriers among `wrappers` (skip-chain order kept; a
+    /// wrapper with no [`WRAPPER_METADATA`] children carries nothing and is
+    /// not queued).
+    fn carriers(wrappers: &[&'a El]) -> VecDeque<WrapperMeta<'a>> {
+        wrappers
+            .iter()
+            .filter_map(|w| {
+                let mut keys: Vec<&str> = w
+                    .children
+                    .iter()
+                    .map(|c| c.name.as_str())
+                    .filter(|n| WRAPPER_METADATA.contains(n))
+                    .collect();
+                keys.dedup();
+                if keys.is_empty() {
+                    None
+                } else {
+                    Some(WrapperMeta { el: w, keys })
+                }
+            })
+            .collect()
+    }
+
+    /// Whether this wrapper is the spelled-out form of the node materialised
+    /// at `attribute`/`rm_type`: its element name matches the RM attribute,
+    /// its Ocean `…_as_<ConcreteType>` suffix names the node's type, or — for
+    /// a wrapper whose keys discriminate the node kind (`origin`/`time`) —
+    /// every key it carries is an attribute of the node.
+    fn corresponds(&self, attribute: &str, rm_type: &str) -> bool {
+        if name_matches(&self.el.name, attribute) {
+            return true;
+        }
+        if let Some((_, suffix)) = self.el.name.rsplit_once("_as_")
+            && suffix.eq_ignore_ascii_case(rm_type)
+        {
+            return true;
+        }
+        (self.keys.contains(&"origin") || self.keys.contains(&"time")) && self.fits(rm_type)
+    }
+
+    /// Whether every metadata key this wrapper carries is an RM attribute of
+    /// `rm_type`, inherited attributes included.
+    fn fits(&self, rm_type: &str) -> bool {
+        self.keys
+            .iter()
+            .all(|k| carried_attribute(rm_type, k).is_some())
+    }
+
+    /// Parse this wrapper's metadata children as their model-declared types
+    /// and set them on the re-materialised node (a spelled-out value replaces
+    /// the RM-mandatory default; a multi-valued attribute collects every
+    /// same-named child).
+    ///
+    /// # Errors
+    /// [`FlatError::Conversion`] when a key is not an attribute of `rm_type`
+    /// (spelled-out instance data is never silently dropped) or a fragment
+    /// does not parse as the declared type.
+    fn apply(&self, rm_type: &str, obj: &mut Map<String, Value>) -> Result<(), FlatError> {
+        for key in &self.keys {
+            let Some(attr) = carried_attribute(rm_type, key) else {
+                return Err(FlatError::Conversion(format!(
+                    "TDD wrapper <{}> spells out `{key}`, which is not an attribute of the \
+                     re-materialised {rm_type}",
+                    self.el.name
+                )));
+            };
+            let children = self.el.children.iter().filter(|c| c.name == **key);
+            if attr.container == openehr_rm::v1_2::model::Container::None {
+                if let Some(c) = children.into_iter().next() {
+                    obj.insert((*key).to_owned(), parse_typed(c, attr.declared_type)?);
+                }
+            } else {
+                let mut arr = Vec::new();
+                for c in children {
+                    arr.push(parse_typed(c, attr.declared_type)?);
+                }
+                obj.insert((*key).to_owned(), Value::Array(arr));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// The model attribute `rm_type` carries under `attr` — declared on the class
+/// itself or inherited from an ancestor (the generated model records each
+/// attribute on its declaring class).
+fn carried_attribute(
+    rm_type: &str,
+    attr: &str,
+) -> Option<&'static openehr_rm::v1_2::model::RmAttribute> {
+    openehr_rm::v1_2::model::attribute(rm_type, attr).or_else(|| {
+        openehr_rm::v1_2::model::ancestors(rm_type)
+            .iter()
+            .find_map(|a| openehr_rm::v1_2::model::attribute(a, attr))
+    })
+}
+
+/// Pop the front wrapper when it corresponds to the node at `attribute`/
+/// `rm_type` (creation and revisit paths both consume, so a second match under
+/// the same spelled-out wrapper does not re-apply what creation already set).
+fn take_corresponding<'a>(
+    attribute: &str,
+    rm_type: &str,
+    metas: &mut VecDeque<WrapperMeta<'a>>,
+) -> Option<WrapperMeta<'a>> {
+    if metas
+        .front()
+        .is_some_and(|m| m.corresponds(attribute, rm_type))
+    {
+        metas.pop_front()
+    } else {
+        None
+    }
+}
+
+/// Consume (and discard) the front wrapper against an EXISTING node — the
+/// values were applied when the node was created from the same wrapper.
+fn discard_corresponding(
+    existing: Option<&Value>,
+    attribute: &str,
+    metas: &mut VecDeque<WrapperMeta<'_>>,
+) {
+    if let Some(ty) = existing
+        .and_then(|v| v.get("_type"))
+        .and_then(Value::as_str)
+    {
+        let _consumed = take_corresponding(attribute, ty, metas);
+    }
+}
+
 /// Insert `child_value` into `parent` at relative path `rel`, materialising the
 /// compacted RM structural nodes it passes through (mirrors the FLAT builder's
-/// `place`).
+/// `place`) and attaching queued spelled-out wrapper instance data
+/// ([`WrapperMeta`]) to the nodes it corresponds to.
+///
+/// # Errors
+/// [`FlatError::Conversion`] from [`WrapperMeta::apply`].
 fn place(
     parent: &mut Map<String, Value>,
     rel: &[PathSegment],
     child_value: Value,
     wc: &WebTemplateNode,
-) {
+    metas: &mut VecDeque<WrapperMeta<'_>>,
+) -> Result<(), FlatError> {
     if rel.is_empty() {
-        return;
+        return Ok(());
     }
     let id_idx = rel.iter().rposition(|s| is_multiple(&s.attribute));
-    place_rec(parent, rel, 0, id_idx, child_value, wc);
+    place_rec(parent, rel, 0, id_idx, child_value, wc, metas)
 }
 
 #[expect(
@@ -751,70 +924,98 @@ fn place_rec(
     id_idx: Option<usize>,
     child_value: Value,
     wc: &WebTemplateNode,
-) {
+    metas: &mut VecDeque<WrapperMeta<'_>>,
+) -> Result<(), FlatError> {
     let seg = &rel[i];
     let node_id = seg.predicate.archetype_node_id.as_deref();
     let last = i + 1 == rel.len();
 
     if Some(i) == id_idx {
-        let Some(arr) = cur
+        let mut entry = if last {
+            let mut el = child_value;
+            set_node_id(&mut el, node_id);
+            el
+        } else {
+            let mut el = new_struct(seg, rel.get(i + 1), wc.name.as_deref(), metas)?;
+            if let Value::Object(m) = &mut el {
+                place(m, &rel[i + 1..], child_value, wc, metas)?;
+            }
+            el
+        };
+        if let Some(arr) = cur
             .entry(seg.attribute.clone())
             .or_insert_with(|| json!([]))
             .as_array_mut()
-        else {
-            return;
-        };
-        if last {
-            let mut el = child_value;
-            set_node_id(&mut el, node_id);
-            arr.push(el);
-        } else {
-            let mut el = new_struct(seg, rel.get(i + 1), wc.name.as_deref());
-            if let Value::Object(m) = &mut el {
-                place(m, &rel[i + 1..], child_value, wc);
-            }
-            arr.push(el);
+        {
+            arr.push(std::mem::take(&mut entry));
         }
-        return;
+        return Ok(());
     }
 
     if is_multiple(&seg.attribute) {
-        let Some(arr) = cur
-            .entry(seg.attribute.clone())
-            .or_insert_with(|| json!([]))
-            .as_array_mut()
-        else {
-            return;
+        let created = {
+            let Some(arr) = cur
+                .entry(seg.attribute.clone())
+                .or_insert_with(|| json!([]))
+                .as_array_mut()
+            else {
+                return Ok(());
+            };
+            arr.iter()
+                .position(|e| e.get("archetype_node_id").and_then(Value::as_str) == node_id)
         };
-        let pos = arr
-            .iter()
-            .position(|e| e.get("archetype_node_id").and_then(Value::as_str) == node_id);
-        let idx = pos.unwrap_or_else(|| {
-            arr.push(new_struct(seg, rel.get(i + 1), None));
+        let idx = if let Some(pos) = created {
+            pos
+        } else {
+            let fresh = new_struct(seg, rel.get(i + 1), None, metas)?;
+            let Some(arr) = cur.get_mut(&seg.attribute).and_then(Value::as_array_mut) else {
+                return Ok(());
+            };
+            arr.push(fresh);
             arr.len() - 1
-        });
-        if let Some(Value::Object(m)) = arr.get_mut(idx) {
-            place_rec(m, rel, i + 1, id_idx, child_value, wc);
+        };
+        let Some(arr) = cur.get_mut(&seg.attribute).and_then(Value::as_array_mut) else {
+            return Ok(());
+        };
+        if created.is_some() {
+            discard_corresponding(arr.get(idx), &seg.attribute, metas);
         }
-        return;
+        if let Some(Value::Object(m)) = arr.get_mut(idx) {
+            place_rec(m, rel, i + 1, id_idx, child_value, wc, metas)?;
+        }
+        return Ok(());
     }
 
     if last {
         cur.insert(seg.attribute.clone(), child_value);
-        return;
+        return Ok(());
     }
-    if !cur.contains_key(&seg.attribute) {
-        cur.insert(seg.attribute.clone(), new_struct(seg, rel.get(i + 1), None));
+    if cur.contains_key(&seg.attribute) {
+        discard_corresponding(cur.get(&seg.attribute), &seg.attribute, metas);
+    } else {
+        let fresh = new_struct(seg, rel.get(i + 1), None, metas)?;
+        cur.insert(seg.attribute.clone(), fresh);
     }
     if let Some(Value::Object(m)) = cur.get_mut(&seg.attribute) {
-        place_rec(m, rel, i + 1, id_idx, child_value, wc);
+        place_rec(m, rel, i + 1, id_idx, child_value, wc, metas)?;
     }
+    Ok(())
 }
 
 /// Create a compacted structural RM node for `seg` with its RM-mandatory fields
 /// filled (mirrors the FLAT builder's `new_struct`, plus `archetype_details` for an
-/// archetyped wrapper root the TDD omitted, e.g. an `ITEM_TREE` `description`).
-fn new_struct(seg: &PathSegment, next: Option<&PathSegment>, name: Option<&str>) -> Value {
+/// archetyped wrapper root the TDD omitted, e.g. an `ITEM_TREE` `description`),
+/// then overlay the instance data of the corresponding spelled-out wrapper, if
+/// the TDD carries one ([`WrapperMeta`]).
+///
+/// # Errors
+/// [`FlatError::Conversion`] from [`WrapperMeta::apply`].
+fn new_struct(
+    seg: &PathSegment,
+    next: Option<&PathSegment>,
+    name: Option<&str>,
+    metas: &mut VecDeque<WrapperMeta<'_>>,
+) -> Result<Value, FlatError> {
     let rm_type = infer_type(&seg.attribute, next.map(|s| s.attribute.as_str()));
     let node_id = seg.predicate.archetype_node_id.as_deref();
     let mut o = Map::new();
@@ -846,7 +1047,10 @@ fn new_struct(seg: &PathSegment, next: Option<&PathSegment>, name: Option<&str>)
         }
         _ => {}
     }
-    Value::Object(o)
+    if let Some(meta) = take_corresponding(&seg.attribute, rm_type, metas) {
+        meta.apply(rm_type, &mut o)?;
+    }
+    Ok(Value::Object(o))
 }
 
 fn infer_type(attr: &str, next: Option<&str>) -> &'static str {
@@ -1004,14 +1208,34 @@ fn normalise(s: &str) -> String {
 /// each match, so a match's own subtree is not searched). Scoped so the TDD's
 /// explicit wrapper elements between a parent and its template child are skipped.
 fn find_matches<'a>(parent: &'a El, display: &str) -> Vec<&'a El> {
-    let mut out = Vec::new();
-    for c in &parent.children {
-        if name_matches(&c.name, display) {
-            out.push(c);
-        } else {
-            out.extend(find_matches(c, display));
+    find_matches_with_wrappers(parent, display)
+        .into_iter()
+        .map(|(_, el)| el)
+        .collect()
+}
+
+/// [`find_matches`] plus, per match, the skipped wrapper elements on the path
+/// from `parent` to it (outermost first, both endpoints excluded) — the
+/// carriers of compacted-wrapper instance data ([`WrapperMeta`]).
+fn find_matches_with_wrappers<'a>(parent: &'a El, display: &str) -> Vec<(Vec<&'a El>, &'a El)> {
+    fn walk<'a>(
+        parent: &'a El,
+        display: &str,
+        chain: &mut Vec<&'a El>,
+        out: &mut Vec<(Vec<&'a El>, &'a El)>,
+    ) {
+        for c in &parent.children {
+            if name_matches(&c.name, display) {
+                out.push((chain.clone(), c));
+            } else {
+                chain.push(c);
+                walk(c, display, chain, out);
+                chain.pop();
+            }
         }
     }
+    let mut out = Vec::new();
+    walk(parent, display, &mut Vec::new(), &mut out);
     out
 }
 

--- a/crates/openehr-its/tests/it/tdd.rs
+++ b/crates/openehr-its/tests/it/tdd.rs
@@ -109,9 +109,18 @@ fn persistent_minimal_converts_and_validates() {
     let history = &obs["data"];
     assert_eq!(history["_type"], "HISTORY");
     assert_eq!(history["archetype_node_id"], "at0001");
+    // The TDD spells the compacted HISTORY out as a <data> wrapper carrying
+    // its own <origin>: the instance value travels, never the RM-mandatory
+    // 1970 default (#2982).
+    assert_eq!(history["origin"]["value"], "2021-05-20T16:47:47.044+03:00");
     let event = &history["events"][0];
     assert_eq!(event["_type"], "POINT_EVENT");
     assert_eq!(event["archetype_node_id"], "at0002");
+    // Same for the spelled-out event wrapper (<Cualquier_evento_as_Point_Event>,
+    // corresponding to the POINT_EVENT via its Ocean `_as_` suffix): its <time>
+    // and <name> instance data land on the re-materialised node.
+    assert_eq!(event["time"]["value"], "2021-05-20T16:47:47.044+03:00");
+    assert_eq!(event["name"]["value"], "Cualquier evento");
     let item_tree = &event["data"];
     assert_eq!(item_tree["_type"], "ITEM_TREE");
     assert_eq!(item_tree["archetype_node_id"], "at0003");
@@ -189,6 +198,31 @@ fn nested_converts_and_validates() {
     assert_eq!(nested2["items"][0]["value"]["value"], false);
     assert_eq!(nested2["items"][1]["value"]["_type"], "DV_COUNT");
     assert_eq!(nested2["items"][1]["value"]["magnitude"], 99265);
+}
+
+/// The refusal twin of the wrapper-instance-data recovery (#2982): a
+/// spelled-out wrapper whose metadata cannot legally sit on the node it
+/// corresponds to is a typed conversion error, never silently dropped —
+/// here a `<time>` on the `<data>` wrapper, which re-materialises as a
+/// HISTORY, and HISTORY carries no `time` attribute.
+#[test]
+fn ill_fitting_wrapper_metadata_is_refused_not_dropped() {
+    let opt = format!("{CORPUS}/valid_templates/minimal_persistent/persistent_minimal.opt");
+    let wt = wt_from(&opt);
+    let tdd = std::fs::read_to_string(format!(
+        "{CORPUS}/compositions/TDD/persistent_minimal.en.v1__full.xml"
+    ))
+    .expect("read corpus TDD");
+    let mutated = tdd.replace(
+        "<origin>",
+        "<time><rm:value>2021-01-01T00:00:00Z</rm:value></time><origin>",
+    );
+    assert_ne!(mutated, tdd, "the fixture must carry the mutation");
+    let err = from_tdd(&mutated, &wt).expect_err("time on a HISTORY wrapper must refuse");
+    assert!(
+        err.to_string().contains("not an attribute"),
+        "the refusal names the illegal key: {err}"
+    );
 }
 
 /// A payload whose root does not match the template root is a typed conversion

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-lang"
-version = "0.0.51"
+version = "0.0.52"
 description = "openEHR LANG BMM/P_BMM object model, generated from BMM: generations v1_0 (LANG 1.0.0) and v1_1 (LANG 1.1.0, current; the stable BMM v2.x unit beside the paused BMM3 unit), plus hand-written ODIN/BEL/EL readers"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["parser-implementations", "data-structures"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.51" }
+openehr-base = { path = "../openehr-base", version = "0.0.52" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the
 # generated types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) —
 # never a derive. `serde_json` also carries the untyped `Value` fields the

--- a/crates/openehr-query/Cargo.toml
+++ b/crates/openehr-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-query"
-version = "0.0.51"
+version = "0.0.52"
 description = "openEHR QUERY (AQL 1.1.0): hand-written lexer, parser, typed AST and canonical printer from the official grammar (no ANTLR runtime)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-rm"
-version = "0.0.51"
+version = "0.0.52"
 description = "openEHR RM Reference Model, generated from BMM: generations v1_1 (RM 1.1.0) and v1_2 (RM 1.2.0, current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,11 +13,11 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.51" }
+openehr-base = { path = "../openehr-base", version = "0.0.52" }
 # The terminology-backed RM class invariants (`validate::terminology`) resolve
 # openEHR terminology groups + code sets against the vendored TERM 3.1.0 bundle.
 # `openehr-term` itself depends only on `openehr-base`, so this is acyclic.
-openehr-term = { path = "../openehr-term", version = "0.0.51" }
+openehr-term = { path = "../openehr-term", version = "0.0.52" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also backs the untyped `Value` RM representation used by

--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-term"
-version = "0.0.51"
+version = "0.0.52"
 description = "openEHR TERM terminology data model, generated from BMM (generation v3_1 = TERM 3.1.0), plus the embedded official terminology XML bundle"
 edition.workspace = true
 rust-version.workspace = true
@@ -34,7 +34,7 @@ include = [
 ]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.51" }
+openehr-base = { path = "../openehr-base", version = "0.0.52" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1281,7 +1281,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.51"
+version = "0.0.52"
 dependencies = [
  "indexmap",
  "openehr-am",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.51"
+version = "0.0.52"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.51"
+version = "0.0.52"
 dependencies = [
  "serde",
  "serde_json",
@@ -1317,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.51"
+version = "0.0.52"
 dependencies = [
  "async-trait",
  "axum",
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.51"
+version = "0.0.52"
 dependencies = [
  "chumsky",
  "indexmap",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.51"
+version = "0.0.52"
 dependencies = [
  "chumsky",
  "logos",
@@ -1364,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.51"
+version = "0.0.52"
 dependencies = [
  "openehr-base",
  "openehr-term",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.51"
+version = "0.0.52"
 dependencies = [
  "openehr-base",
  "roxmltree",


### PR DESCRIPTION
Closes #2982.

**The gap, characterized on the corpus itself:** the vendored `persistent_minimal.en.v1__full.xml` TDD spells out the compacted wrappers WITH instance data — a `<data>` wrapper carrying `HISTORY.origin`, and a named event (`<Cualquier_evento_as_Point_Event>`) carrying its `<time>` and `<name>` — and the converter re-materialised those nodes with the RM-mandatory 1970 defaults, silently discarding the values. Exactly the drop the removed prose deferral described.

**The recovery (our own design/extension — the module doc's NOTE stands: the historical TDS account fixes no mapping back to canonical form):**

- the scoped search keeps the skipped wrapper elements per match (`find_matches_with_wrappers`), and placement consumes them positionally as it re-materialises the compacted chain
- a wrapper corresponds to a node by element name matching the RM attribute, by its Ocean `…_as_<ConcreteType>` suffix naming the node's type, or — for the type-discriminating keys `origin`/`time` — by every carried key fitting the node
- each `WRAPPER_METADATA` child (`origin`, `time`, `name`, `uid`, `links`, `feeder_audit`) parses as its **model-declared attribute type**, inherited attributes included, via the generated RM attribute model — no hard-coded type table, the same discipline the file's multi-valued-attribute set already follows; `parse_typed` gains `FEEDER_AUDIT` and the closed `UID_BASED_ID` set
- strict in both directions: a spelled-out wrapper whose metadata cannot legally sit on the corresponding node, or that corresponds to no re-materialised node, refuses with a named error — never a silent drop

**Tests:** the corpus test now pins the recovered origin, event time and event name verbatim (previously unasserted, and unrecoverable); the refusal twin is pinned (`ill_fitting_wrapper_metadata_is_refused_not_dropped` — a `<time>` on the HISTORY wrapper). Full `openehr-its` suite 611/611; `ferroehr` service TDD suite 7/7; fmt, clippy, comment-style green. Packaged `openehr-its` content changes, so the eight crates take their lockstep step to 0.0.52.