### PR TITLE
docs(website): storage-architecture and AQL-engine chapters; docs/storage.md moves into the book

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,7 +84,8 @@ regenerates everything and fails on any diff.
 Grounded in docs-verified PostgreSQL physics (JSONB has no partial detoast —
 big single documents pay whole-document decompression per leaf access; GIN
 serves no range/ordering), the storage is a **decomposed node model designed
-fresh** (the diagrammed deep-dive is `docs/storage.md`):
+fresh** (the diagrammed deep-dive is the book's Storage architecture page,
+`website/book/src/concepts/storage.md`):
 
 - **`node`** — one unified table for all versioned-object content
   (COMPOSITION / EHR_STATUS / FOLDER). One row per RM structure node with a

--- a/website/book/src/SUMMARY.md
+++ b/website/book/src/SUMMARY.md
@@ -24,6 +24,8 @@
 - [Concepts](concepts/index.md)
   - [openEHR primer](concepts/openehr-primer.md)
   - [System architecture](concepts/architecture.md)
+  - [Storage architecture](concepts/storage.md)
+  - [The AQL engine](concepts/aql-engine.md)
 - [Using the API](using-the-api/index.md)
   - [Resource walkthroughs](using-the-api/resources.md)
   - [Content negotiation & errors](using-the-api/content-negotiation.md)

--- a/website/book/src/concepts/aql-engine.md
+++ b/website/book/src/concepts/aql-engine.md
@@ -1,0 +1,140 @@
+# The AQL engine
+
+How FerroEHR turns an AQL query into SQL, and why the result is fast. This
+page is about the engine's internals; for writing queries against the API,
+see [Querying with AQL](../querying-aql.md).
+
+The language is openEHR AQL 1.1. openEHR defines the language, not its
+execution, so everything after the parse is FerroEHR's own design.
+
+<!-- toc -->
+
+## The pipeline
+
+One query passes through six stages. Each stage has a single job, a typed
+output, and a typed refusal: a construct the engine does not support is
+rejected with an error naming the QUERY specification section it comes from,
+never answered approximately.
+
+```mermaid
+flowchart LR
+    q["AQL text"] --> lex["lexer<br/>(logos)"]
+    lex --> parse["parser<br/>(chumsky)"]
+    parse --> ast["AST"]
+    ast --> an["path analysis + typing<br/>(generated RM model)"]
+    an --> ir["typed query IR<br/>(cached per query text)"]
+    ir --> sql["SQL builder<br/>(sea-query)"]
+    sql --> pg[("PostgreSQL 18")]
+    pg --> rs["RESULT_SET"]
+```
+
+### Lexer and parser
+
+The front end is a hand-written crate (`openehr-query`) with no ANTLR
+runtime: a `logos` tokenizer transcribed from the official `AqlLexer.g4`
+grammar and a `chumsky` parser that builds one AST type per `AqlParser.g4`
+rule. AQL keywords are case-insensitive; quoted temporal literals stay
+strings at this layer because the QUERY specification resolves their typing
+from the path context, not from the literal. The crate stops at the AST and
+is validated against the grammar's own example corpus.
+
+### Path analysis and typing
+
+The planner types every identified path
+(`c/content[...]/data/events[...]/...`) against a **generated RM attribute
+model**: the same code generator that produces the RM types from openEHR's
+machine-readable meta-model also emits a static table of every class's
+attributes, their declared types, containers and cardinalities, plus the
+abstract-to-concrete descendant sets. Path resolution is therefore a table
+lookup, not runtime reflection and not a hand-maintained list, and it cannot
+drift from the RM: regenerating the spec layer regenerates the oracle.
+
+This stage answers, per path step: which RM classes can this step land on,
+is it a structural hop or a data leaf, what value type does the leaf carry,
+and which archetype predicates bound it.
+
+### The typed IR
+
+Analysis and lowering produce a typed query intermediate representation. The
+IR carries no SQL and bakes in no request state: no parameter values, no
+paging window, no EHR scope. That purity is deliberate. Because the IR is a
+pure function of the query text, the query service caches lowered plans
+keyed on that text, so a stored query is planned once, not once per call;
+per-request parameter checking runs separately against the cached plan.
+
+### SQL generation
+
+The IR lowers to one `SELECT` built entirely with `sea-query`'s typed
+expression API: no string-concatenated SQL anywhere, every literal bound as
+a parameter. The shapes it emits are where the
+[storage design](storage.md) pays off:
+
+- **CONTAINS is integer arithmetic.** The node store keeps a nested-set
+  interval per RM node: "B inside A" is
+  `A.num < B.num AND B.num <= A.num_cap`. A CONTAINS chain becomes a chain
+  of integer range joins over one table. No JSON is opened to answer
+  containment.
+
+```mermaid
+flowchart LR
+    subgraph aql ["AQL"]
+        contains["COMPOSITION c<br/>CONTAINS OBSERVATION o"]
+    end
+    subgraph sql ["generated SQL (shape)"]
+        join["JOIN node o<br/>ON o.vo_id = c.vo_id<br/>AND c.num &lt; o.num<br/>AND o.num &lt;= c.num_cap<br/>WHERE o.rm_type = 'OBSERVATION'"]
+    end
+    contains --> join
+```
+
+- **Class and archetype predicates hit promoted columns.** `rm_type`, the
+  parsed archetype identifier columns and names are plain indexed columns;
+  a predicate naming a parent archetype matches specialised children through
+  an indexed prefix scan.
+- **Leaf values come out through SQL/JSON.** Data values are extracted from
+  the canonical node fragments with `jsonb_path_query_first` and jsonpath
+  item methods; `JSON_TABLE` unnests arrays; ordering on clinical magnitudes
+  uses `openehr_magnitude`, an `IMMUTABLE` helper function realizing
+  DV_ORDERED ordering semantics, usable in expression indexes.
+- **Version scope is a predicate, not a join through history tables.**
+  `LATEST_VERSION` is a partial-index predicate on the one temporal version
+  table; `ALL_VERSIONS` is the same table unfiltered.
+
+### Execution and RESULT_SET
+
+The built statement executes with bound parameters, and rows assemble into
+the ITS-REST `RESULT_SET` shape. Whole-object projections serve the
+version's stored canonical body bytes; leaf projections serve the extracted
+values.
+
+## What the engine refuses
+
+Every AQL construct outside the accepted envelope is a typed error carrying
+its QUERY specification reference. The same strictness applies inside the
+pipeline: an unknown class, an unresolvable attribute, a type mismatch, or
+an unbound `$parameter` refuses the query at plan time, before any SQL
+exists. A query never degrades into a silently wrong answer.
+
+## Why it is fast
+
+The speed is a property of the storage and planning design, not of tuning
+flags:
+
+1. **No JSON tree walking on the hot path.** The classic CDR cost is walking
+   large JSON documents to test containment and extract predicates. That
+   cost is gone by construction: containment is integer math, predicates
+   are indexed columns.
+2. **Decomposed fragments stay small.** Node fragments average a few hundred
+   bytes, so the rows a query touches decompress cheaply, and point reads
+   of whole compositions bypass reassembly entirely by serving stored
+   canonical bytes.
+3. **Plans are cached.** The IR is request-independent and cached on query
+   text; repeated and stored queries skip lexing, parsing and typing.
+4. **PostgreSQL 18 does the heavy lifting.** B-tree skip scan, `OR` to
+   `= ANY` rewriting, self-join elimination, asynchronous I/O and the
+   SQL/JSON function family are exactly the features the generated SQL
+   leans on.
+5. **Everything is measured, nothing declared.** The performance FerroEHR
+   publishes comes from committed, re-checkable measurement records under
+   the conformance instrument: see [Performance](../performance.md) and
+   [Benchmarks](../benchmarks.md). This page explains the design; those
+   pages carry the numbers.

--- a/website/book/src/concepts/index.md
+++ b/website/book/src/concepts/index.md
@@ -1,7 +1,7 @@
 # Concepts
 
-This part explains the ideas you need to use FerroEHR effectively. Two
-chapters, read in either order:
+This part explains the ideas you need to use FerroEHR effectively. Four
+chapters; the first two read in either order, the last two go deeper:
 
 - **[openEHR primer](openehr-primer.md):** the standard itself: the Reference
   Model, archetypes and templates, compositions, versioning, and AQL, with no
@@ -11,6 +11,13 @@ chapters, read in either order:
   together and where your data actually lives, so the behaviour you see through
   the API makes sense: why the specification layer is generated, how storage and
   versioning work on PostgreSQL, and how an AQL query becomes SQL.
+- **[Storage architecture](storage.md):** the deep-dive on the tables: the
+  temporal version table, the decomposed node model with its nested-set
+  index, the one-transaction write path, and the cold archival tier, each
+  with a diagram.
+- **[The AQL engine](aql-engine.md):** the query pipeline from lexer to
+  `RESULT_SET`, what each stage refuses, and the design reasons queries are
+  fast.
 
 Neither chapter is a prerequisite for [Getting started](../getting-started.md);
 you can commit a composition and run a query without them. Come back when you

--- a/website/book/src/concepts/storage.md
+++ b/website/book/src/concepts/storage.md
@@ -1,22 +1,22 @@
 # Storage architecture
 
-How FerroEHR physically stores clinical data. This is a living reference
-document beside `docs/architecture.md` (the overall design) and
-`docs/postgres-features.md` (the PostgreSQL 18 feature map); the authoritative
-definition of every column is the schema itself
-(`app/ferroehr/migrations/`), whose `COMMENT ON` lines carry the per-column
-spec citations.
+How FerroEHR physically stores clinical data. This page goes one level below
+the [system architecture](architecture.md): the tables, the write path, the
+read paths, and the reasons the layout looks the way it does. If you read the
+source, the schema itself is the authority: every column in
+`app/ferroehr/migrations/` carries a `COMMENT ON` line with its citation.
 
 One thing up front: **openEHR defines no SQL schema.** What the specs do
 define, and what this storage realizes, are the versioning and change-control
-semantics (RM common `master06-change_control_package.adoc`), canonical data
-fidelity (ITS-JSON), and the contribution/audit duties. The relational layout
-below is our own PG18-native design, and the RM explicitly sanctions that
-freedom: "Although the figure implies physical containment of Versions by a
-Versioned object, this is only one possible implementation. Other
+semantics (RM `common` change control), canonical data fidelity (ITS-JSON),
+and the contribution and audit duties. The relational layout below is
+FerroEHR's own PostgreSQL-18-native design, and the RM explicitly sanctions
+that freedom: "Although the figure implies physical containment of Versions
+by a Versioned object, this is only one possible implementation. Other
 implementations (e.g. using orthodox relational structures) might use
-references, separate compressed copies, or any other mechanism" (RM common
-master06 §Overview).
+references, separate compressed copies, or any other mechanism."
+
+<!-- toc -->
 
 ## The big picture
 
@@ -33,8 +33,8 @@ transaction:
 
 ```mermaid
 flowchart LR
-    client[REST client] --> rest["ferroehr-rest<br/>(ITS-REST adapter)"]
-    rest --> svc["FerroEhrService<br/>(validation, versioning)"]
+    client[REST client] --> rest["ITS-REST adapter"]
+    rest --> svc["service layer<br/>(validation, versioning)"]
     svc --> tx{{"one transaction<br/>per commit"}}
     tx --> audit[(audit)]
     tx --> contrib[(contribution)]
@@ -46,12 +46,12 @@ flowchart LR
 
 The database is PostgreSQL 18, split into four schemas:
 
-| Schema | Holds | Migrations |
-|---|---|---|
-| `ehr` | the CDR proper: versions, nodes, EHRs, contributions, templates, queries, tags | `app/ferroehr/migrations/ehr/` |
-| `ext` | our own `IMMUTABLE` helper functions (`openehr_magnitude`, `openehr_timestamp`) and the tenant context | `app/ferroehr/migrations/ext/` |
-| `audit` | the IHE ATNA Audit Record Repository (`audit_event`), fed by `ferroehr::system_log` | `app/ferroehr/migrations/audit/` |
-| `cold` | the archival tier: FK-free mirrors of `vo_version` / `node` / `vo_attestation` | `ehr/0007_cold_archive_tier.sql` |
+| Schema | Holds |
+|---|---|
+| `ehr` | the CDR proper: versions, nodes, EHRs, contributions, templates, queries, tags |
+| `ext` | FerroEHR's own `IMMUTABLE` helper functions (`openehr_magnitude`, `openehr_timestamp`) and the tenant context |
+| `audit` | the IHE ATNA Audit Record Repository (`audit_event`) |
+| `cold` | the archival tier: FK-free mirrors of `vo_version` / `node` / `vo_attestation` |
 
 ## Core tables and how they relate
 
@@ -101,13 +101,13 @@ erDiagram
 
 Supporting tables not drawn above: `stored_query` (stored AQL, qualified name
 plus SemVer), `archetype_store` and `adl2_artefact` (the two DEFINITION
-dialects), `ehr_index` (SM `I_EHR_INDEX`), `vo_archive` (the admin archive
-marker), and the `sp_*` family (Subject Proxy Service). The `ehr` table itself
-carries the three creation-immutable values (RM ehr master04 §Root EHR
-Object: `system_id`, `id`, `time_created`) plus promoted copies of the current
-EHR_STATUS subject reference and `is_queryable` / `is_modifiable` flags, which
-back the one-EHR-per-subject index, the AQL full-population gate, and the
-content-write guard without probing a JSON root per request.
+dialects), `ehr_index`, `vo_archive` (the admin archive marker), and the
+`sp_*` family (Subject Proxy Service). The `ehr` table itself carries the
+three creation-immutable values the RM names (`system_id`, `id`,
+`time_created`) plus promoted copies of the current EHR_STATUS subject
+reference and `is_queryable` / `is_modifiable` flags, which back the
+one-EHR-per-subject rule, the AQL full-population gate, and the content-write
+guard without probing a JSON root per request.
 
 ## Versioning: one temporal table, no history pairs
 
@@ -118,34 +118,32 @@ predicate, not a location.
 - Every version row carries `sys_period tstzrange`, the half-open validity
   interval `[committed, superseded)`. The current trunk version of an object
   is simply the row with `upper_inf(sys_period) AND branch_number = 0`, held
-  unique by a partial index (`uq_vo_version_current`), which realizes RM
-  common master06 `latest_trunk_version`.
+  unique by a partial index, which is what realizes the RM's
+  `latest_trunk_version`.
 - `ALL_VERSIONS` is the unfiltered table; `LATEST_VERSION` is that partial
   index. Time travel is a range containment test on `sys_period`.
 - The spec-facing version identity is the three-part `OBJECT_VERSION_ID`
-  `{object_id, creating_system_id, version_tree_id}` (RM common master06
-  §Distributed versioning), stored as `vo_id` + `creating_system_id` +
-  the `trunk_version`/`branch_number`/`branch_version` triple and held unique
-  by `uq_vo_version_tree`. `sys_version` is deliberately not that number: it
-  is an opaque per-object commit ordinal (1..n across trunk and branch
-  commits) used as the join key for `node` and `vo_attestation`.
+  `{object_id, creating_system_id, version_tree_id}`, stored as `vo_id` +
+  `creating_system_id` + the `trunk_version`/`branch_number`/`branch_version`
+  triple and held unique together. `sys_version` is deliberately not that
+  number: it is an opaque per-object commit ordinal (1..n across trunk and
+  branch commits) used as the join key for `node` and `vo_attestation`.
 - Version keys and generated ids use PostgreSQL 18's native `uuidv7()`, so
   keys are time-ordered and index-friendly.
-- A logical delete writes a content-less version with lifecycle state `523`
-  (RM common master06 §Logical Deletion); nothing is physically deleted.
+- A logical delete writes a content-less version with lifecycle state `523`;
+  nothing is physically deleted.
 - An import (EHR-Extract, archive load) stores the wrapped
   `ORIGINAL_VERSION`'s own provenance verbatim in `wrapped_original`, while
-  the row's own contribution/audit columns record the local act of committal
-  (master06 §Committal and Audits). `NULL` there means a locally created
-  `ORIGINAL_VERSION`; `NOT NULL` means the row is an `IMPORTED_VERSION`.
+  the row's own contribution and audit columns record the local act of
+  committal. `NULL` there means a locally created `ORIGINAL_VERSION`;
+  `NOT NULL` means the row is an `IMPORTED_VERSION`.
 
 Non-overlap per lineage (one valid version per lineage at any instant) is
 enforced by construction rather than by GiST exclusion constraints, which
 were measured to serialize concurrent inserts: at most one open row per
 lineage exists (the partial unique indexes), and every write closes the open
 row and inserts its successor at the same `now()` inside one transaction, so
-half-open ranges meet exactly. No openEHR spec governs the enforcement
-mechanism; the semantics stay master06.
+half-open ranges meet exactly.
 
 ```mermaid
 flowchart TD
@@ -163,10 +161,9 @@ flowchart TD
 
 At commit, the accepted composition is decomposed into one row per RM
 structure node. Each row stores the node's **canonical openEHR JSON fragment
-verbatim** (the `openehr-its` ITS-JSON encoding) with its structure children
-pruned out: no alias compaction, no synthetic fields, so what sits in
-`node.data` is byte-identical in shape to what the API serves. Storage equals
-wire.
+verbatim** (the ITS-JSON encoding) with its structure children pruned out: no
+alias compaction, no synthetic fields, so what sits in `node.data` is
+byte-identical in shape to what the API serves. Storage equals wire.
 
 The tree shape is captured as a **nested-set interval**: nodes are numbered
 in pre-order (`num`, root = 0), and each row records the maximum number in
@@ -191,36 +188,30 @@ Beside the interval, each row promotes the predicates AQL actually filters
 on, so hot paths never open the JSON:
 
 - `rm_type` (full RM type names, never compacted), `name`, `archetype`
-  (case-folded at write, per BASE base_types master05 §Composite Identifiers
-  and Case);
+  (case-folded at write, because openEHR identifier equality is
+  case-insensitive);
 - the archetype-subsumption columns `arch_entity` / `arch_concept` /
   `arch_major`, parsed from full archetype HRIDs so a query naming a parent
-  archetype matches specialisation children via an indexed prefix scan (BASE
-  architecture_overview master10 §Design-time Relationships; the major
-  boundary stays hard per AM master07 §Querying);
+  archetype matches specialised children through an indexed prefix scan (the
+  major-version boundary stays hard, as the AM requires);
 - `citem_num`, the nearest archetyped ancestor, for archetype-anchored path
   resolution;
 - `context_start`, the promoted `EVENT_CONTEXT.start_time` on COMPOSITION
-  roots, serving the dashboard ORDER BY from a partial index;
+  roots, serving dashboard ordering from a partial index;
 - `path`, the materialized path from the root (`COLLATE "C"`, so byte order
   equals tree order), used only for reassembly, never as an AQL predicate.
 
-The promoted-column registry lives in `app/ferroehr/src/storage/promoted.rs`.
-All of this is our own storage design; no openEHR spec governs storage
-columns.
-
 ## The write path: one transaction per commit
 
-Every write realizes the openEHR contribution rule: "a `CONTRIBUTION` object
-will be created, listing the affected `VERSION` objects, and including its
-own audit object" (RM common master06 §Contributions), and a Contribution
-commits only if every member commits (master06 §Committal and Audits). In
-storage terms, one `sqlx::Transaction` per service-level write:
+Every write realizes the openEHR contribution rule: a `CONTRIBUTION` lists
+the affected `VERSION`s and carries its own audit, and it commits only if
+every member commits. In storage terms, one transaction per service-level
+write:
 
 ```mermaid
 sequenceDiagram
-    participant R as ferroehr-rest
-    participant S as FerroEhrService
+    participant R as REST adapter
+    participant S as service layer
     participant PG as PostgreSQL 18
 
     R->>S: commit (COMPOSITION, EHR_STATUS, ...)
@@ -238,19 +229,14 @@ sequenceDiagram
 
 Details that matter:
 
-- `time_committed` is always server-computed (master06 §Committal and
-  Audits: it "should therefore be computed on the server"), never
-  client-supplied.
+- `time_committed` is always server-computed, never client-supplied; the RM
+  requires the committal time to reflect the EHR server's own clock.
 - The close-out UPDATE and the successor INSERT use the same `now()`, which
   is what makes the half-open intervals meet with no gap and no overlap.
 - The body bytes in `vo_version.body` are materialized from the accepted,
   uid-stamped value **before** decomposition, stored as `text` (not `jsonb`,
-  which would re-order keys) so a point read serves the codec's
-  `_type`-first, BMM-declared field order verbatim.
-- `vo_version.stable_compatible` (migration `0008`) stamps at commit whether
-  the released-generation reader can express the body, which is what the
-  `spec_profile` read gate consults (see `docs/VERSIONS.md` §Spec version
-  policy).
+  which would re-order keys) so a point read serves the canonical
+  `_type`-first field order verbatim.
 
 ## Read paths
 
@@ -262,14 +248,12 @@ re-aggregation, zero translation between storage and wire.
 chains become nested-set interval joins, class and archetype predicates hit
 the promoted columns and their indexes, and leaf values are extracted from
 the canonical fragments with `jsonb_path_query_first`, jsonpath item
-methods, and `ext.openehr_magnitude` (our `IMMUTABLE` helper realizing
-DV_ORDERED ordering semantics). `JSON_TABLE` (PG 17+) serves array
-unnesting. The full construct-by-construct envelope lives in
-`.claude/rules/aql-engine.md`; the AQL population gate filters the promoted
-`ehr.is_queryable` column directly (SM `i_query_service.adoc`).
+methods, and `ext.openehr_magnitude` (the `IMMUTABLE` helper realizing
+DV_ORDERED ordering semantics). `JSON_TABLE` serves array unnesting. The
+whole pipeline has [its own page](aql-engine.md).
 
-**Time travel** (VERSIONED_OBJECT version-at-time, REST `version_at_time`)
-is a `sys_period @> timestamptz` containment test on the same one table.
+**Time travel** (a version at a point in time) is a `sys_period @>
+timestamptz` containment test on the same one table.
 
 ## The cold archival tier
 
@@ -279,7 +263,7 @@ Admin-archived objects move physically out of the primary tables into the
 deliberate and visible:
 
 - point reads retry cold only on a primary miss;
-- whole-repository readers (exports, dumps) use the `*_all` union views;
+- whole-repository readers (exports, dumps) use the union views;
 - **AQL stays primary-only**: archived content leaves the queryable store
   until restored;
 - a write to an archived object thaws it back to the primary tier first.
@@ -297,27 +281,26 @@ flowchart LR
     pv -- "admin archive (transactional move)" --> cv
     cv -- "restore / thaw-on-write" --> pv
     pv -. "AQL reads primary only" .-> aql[AQL engine]
-    pv & cv -. "*_all union views" .-> dump[whole-repo readers]
+    pv & cv -. "union views" .-> dump[whole-repo readers]
 ```
 
-No openEHR spec governs archival tiers; this is our own design, recorded
-here and in the migration (`ehr/0007_cold_archive_tier.sql`).
+No openEHR spec governs archival tiers; this is FerroEHR's own design.
 
 ## Why this design
 
-The shape follows measured PostgreSQL physics rather than habit
-(`docs/postgres-features.md` has the feature map):
+The shape follows measured PostgreSQL physics rather than habit:
 
 - JSONB has no partial detoast: a big single-document design pays
-  whole-document decompression for every leaf access. Decomposed ~360 B
-  fragments stay under TOAST and each read touches only the rows it needs.
+  whole-document decompression for every leaf access. Decomposed fragments
+  average a few hundred bytes, stay under TOAST, and each read touches only
+  the rows it needs.
 - GIN indexes serve neither ranges nor ordering, so CONTAINS and ORDER BY
   ride integers and promoted btree columns instead.
-- PG 18's temporal machinery (`tstzrange`, partial unique indexes,
+- PostgreSQL 18's temporal machinery (`tstzrange`, partial unique indexes,
   `uuidv7()`, `RETURNING OLD/NEW`) makes the single temporal version table
   cheaper than current/history pairs, with `ALL_VERSIONS` a plain scan of
   one relation.
 
-Every table and column comment in the migrations either cites the vendored
-spec clause it realizes or states "our own storage design"; when this
-document and the migrations disagree, the migrations win.
+The performance this buys is measured, not asserted: see
+[Performance](../performance.md) for the earned deployment classes and the
+committed measurement records behind them.


### PR DESCRIPTION
Closes #3006.

Two new Concepts chapters, slotted after System architecture in SUMMARY.md and introduced on the Concepts index:

- **Storage architecture** (`concepts/storage.md`): adapted from `docs/storage.md` for the book audience with all five mermaid diagrams (big picture, ER model, version-tree timeline, nested-set worked example, write-path sequence, cold tier). Per the owner ruling recorded on the issue, the book chapter is now the ONE home: `docs/storage.md` is deleted and `docs/architecture.md` §Storage points at the book page, so nothing can drift.
- **The AQL engine** (`concepts/aql-engine.md`): the six-stage pipeline (logos lexer and chumsky parser over the official grammar, typing against the generated RM attribute model, the request-independent cached IR, sea-query SQL generation, RESULT_SET assembly), what each stage refuses, a CONTAINS-to-SQL shape diagram, and the why-it-is-fast section grounded in design facts with the numbers left to the Performance/Benchmarks pages (committed measurement records only — never restated).

Both pages follow the prose rule (zero em dashes, no decorative contrasts), publish nothing from `docs/specs/**` or `.claude/**`, and cross-link each other, the querying page, and Performance. Gates: `docs-claims --all` green, `mdbook build` green (mermaid renders via the book's own mdbook-mermaid preprocessor). Docs-only diff.