### PR TITLE
ci(security): mirror Sonar and Trivy findings into code scanning; unbreak dependabot lanes

### DIFF
--- a/.claude/rules/ai-code-review.md
+++ b/.claude/rules/ai-code-review.md
@@ -95,6 +95,23 @@ upgrade would only ever cover the website's JS/TS. Re-evaluate if Sonar ships
 Rust support for it AND the plan changes; the architecture record remains
 `docs/architecture.md`, which no analyzer output outranks.
 
+## The findings mirror into GitHub code scanning (#3032)
+
+Sonar's own GitHub App uploads SECURITY-only code-scanning analyses, which
+arrive empty here — the tools page listed SonarCloud with 0 results while
+the dashboard carried the real set. A push to `main` therefore exports the
+project's OPEN and CONFIRMED findings as SARIF
+(`scripts/sonar/issues-to-sarif.sh`) and uploads them under the `sonarcloud`
+category. The dashboard stays canonical: the query excludes ACCEPTED and
+FALSE_POSITIVE, so a disposition recorded there closes its GitHub alert on
+the next push, and the two surfaces cannot disagree for longer than one
+analysis. Pull requests keep Sonar's own decoration; the mirror gates
+nothing. The App's native (empty) security uploads stay enabled — they cost
+nothing and would cover the vulnerability class if the mirror lane ever
+broke. Dependabot pull requests skip the scan entirely: a dependabot-actor
+run reads Dependabot secrets, not the Actions `SONAR_TOKEN`, and the
+post-merge main push analyzes the merged result anyway.
+
 ## It does not gate a merge, and it never writes
 
 No quality gate blocks a merge. Findings worth acting on are written by

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,12 @@ version: 2
 updates:
   - package-ecosystem: "cargo"
     directory: "/"
+    # Dependency bumps default to the changelog-guard escape (the triage
+    # discipline adds a real entry when a bump is user-visible, which also
+    # satisfies the guard with the label present).
+    labels:
+      - "dependencies"
+      - "no-changelog"
     schedule:
       interval: "weekly"
     # A delay between a release being published and this bot proposing it, so a
@@ -46,6 +52,12 @@ updates:
   # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
   - package-ecosystem: "cargo"
     directory: "/fuzz"
+    # Dependency bumps default to the changelog-guard escape (the triage
+    # discipline adds a real entry when a bump is user-visible, which also
+    # satisfies the guard with the label present).
+    labels:
+      - "dependencies"
+      - "no-changelog"
     schedule:
       interval: "weekly"
     # The same window as the root cargo entry: these dependencies execute in a
@@ -76,6 +88,12 @@ updates:
       - "/docker"
       - "/docker/postgres"
       - "/docker/viewer"
+    # Dependency bumps default to the changelog-guard escape (the triage
+    # discipline adds a real entry when a bump is user-visible, which also
+    # satisfies the guard with the label present).
+    labels:
+      - "dependencies"
+      - "no-changelog"
     schedule:
       interval: "weekly"
     # Between the cargo and actions windows. A base image ships in the product,
@@ -93,6 +111,12 @@ updates:
       prefix: "deps"
   - package-ecosystem: "github-actions"
     directory: "/"
+    # Dependency bumps default to the changelog-guard escape (the triage
+    # discipline adds a real entry when a bump is user-visible, which also
+    # satisfies the guard with the label present).
+    labels:
+      - "dependencies"
+      - "no-changelog"
     schedule:
       interval: "weekly"
     # Shorter than cargo: an action runs in CI but does not ship in the product,

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -74,6 +74,7 @@ jobs:
       contents: read
       packages: read # pull the published images
       issues: write # file/update the one tracking issue below
+      security-events: write # the per-architecture SARIF uploads (#3033)
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -145,6 +146,37 @@ jobs:
           path: "*.json"
           if-no-files-found: warn
           retention-days: 30
+
+      # The findings mirror into GitHub code scanning (#3033): the JSON
+      # reports the scan already wrote convert locally (`trivy convert` — no
+      # second registry read) and merge into one SARIF per architecture, so a
+      # CVE in a published image is an alert that closes when a later scan of
+      # a re-released image stops reporting it. Runs only after a successful
+      # scan (a failed probe uploads nothing); zero findings upload an empty
+      # run, which is what keeps the tools page listing Trivy. The mirror
+      # gates nothing — the run-colour rule above is unchanged.
+      - name: Convert the reports to one SARIF per architecture
+        run: |
+          set -euo pipefail
+          for arch in amd64 arm64; do
+            for image in ferroehr ferroehr-postgres ferroehr-viewer; do
+              trivy convert --format sarif --output "${image}.${arch}.sarif" "${image}.${arch}.json"
+            done
+            jq -s '{ "$schema": .[0]."$schema", version: .[0].version, runs: [.[].runs[]] }' \
+              ferroehr."${arch}".sarif ferroehr-postgres."${arch}".sarif ferroehr-viewer."${arch}".sarif \
+              > "trivy-${arch}.sarif"
+            jq -r --arg arch "$arch" '"trivy-\($arch): \([.runs[].results | length] | add) result(s) across \(.runs | length) run(s)"' "trivy-${arch}.sarif"
+          done
+      - name: Upload the amd64 findings to code scanning
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        with:
+          sarif_file: trivy-amd64.sarif
+          category: trivy-image/amd64
+      - name: Upload the arm64 findings to code scanning
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        with:
+          sarif_file: trivy-arm64.sarif
+          category: trivy-image/arm64
 
       # An issue with no failing check can be closed without the finding being
       # addressed, so the issue says what the remedy is and the remediation law

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -87,15 +87,20 @@ jobs:
   scan:
     name: analyze
     needs: changes
-    # PR analysis authenticates with SONAR_TOKEN, which fork PRs cannot read.
-    # A main push always scans; a pull request scans only when it touched
-    # scanned code (#2777).
-    if: github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && needs.changes.outputs.code == 'true')
+    # PR analysis authenticates with SONAR_TOKEN, which fork PRs cannot read —
+    # and neither can DEPENDABOT PRs: a dependabot-actor pull_request run reads
+    # Dependabot secrets, not Actions secrets, so the scan died on
+    # "Not authorized" for every dependency bump (#3024's red batch). A lock
+    # bump has nothing to decorate anyway, and the post-merge main push scans
+    # the merged result in full. A main push always scans; a pull request scans
+    # only when it touched scanned code (#2777).
+    if: github.event_name == 'push' || (github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository && needs.changes.outputs.code == 'true')
     runs-on: ubuntu-26.04
     timeout-minutes: 90
     permissions:
       contents: read
       pull-requests: read # PR decoration reads the PR metadata
+      security-events: write # the push-only SARIF mirror below (#3032)
     # Coverage rides this lane (owner directive 2026-08-24): the instrumented
     # nextest run below produces the lcov the scan imports
     # (sonar.rust.lcov.reportPaths — docs.sonarsource.com/sonarqube-cloud/
@@ -172,3 +177,24 @@ jobs:
       - uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      # The findings mirror into GitHub code scanning (#3032). Sonar's own
+      # GitHub App uploads SECURITY-only analyses that arrive empty here, so
+      # the tools page listed SonarCloud with 0 results while the dashboard
+      # carried the real set. Push-only: a pull request keeps Sonar's own
+      # decoration, and the alert set is main's. The script waits on this
+      # run's compute task and excludes ACCEPTED/FALSE_POSITIVE, so a
+      # disposition recorded in the dashboard closes its GitHub alert on the
+      # next push — the two surfaces cannot disagree for longer than one
+      # analysis. The mirror gates nothing (ai-code-review.md).
+      - name: Export the analysis' open findings as SARIF
+        if: github.event_name == 'push'
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: bash scripts/sonar/issues-to-sarif.sh rubentalstra_FerroEHR sonar-findings.sarif
+      - name: Upload the findings to code scanning
+        if: github.event_name == 'push'
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        with:
+          sarif_file: sonar-findings.sarif
+          category: sonarcloud

--- a/scripts/sonar/issues-to-sarif.sh
+++ b/scripts/sonar/issues-to-sarif.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: FerroEHR contributors
+# SPDX-License-Identifier: MIT
+#
+# Exports the SonarQube Cloud project's OPEN and CONFIRMED findings as SARIF
+# 2.1.0, so `sonar.yml` can upload them to GitHub code scanning (#3032).
+# SonarQube Cloud's own GitHub integration is checks and pull-request
+# decoration only — its native code-scanning uploads carry the SECURITY class
+# alone and arrive empty here, which is why the tools page showed a
+# SonarCloud entry with 0 results while the dashboard carried the real list.
+#
+# The query excludes ACCEPTED and FALSE_POSITIVE on purpose: a disposition
+# recorded in the dashboard (the ai-code-review.md law) disappears from the
+# next upload, and code scanning then closes the alert — the two surfaces
+# cannot disagree for longer than one analysis.
+#
+# Usage: issues-to-sarif.sh <project-key> <output.sarif>
+# Reads SONAR_TOKEN from the environment. When the scanner's
+# .scannerwork/report-task.txt is present, waits for that analysis' compute
+# task first, so the export reads the run's own result rather than the
+# previous one.
+
+set -euo pipefail
+
+PROJECT="${1:?usage: issues-to-sarif.sh <project-key> <output.sarif>}"
+OUT="${2:?usage: issues-to-sarif.sh <project-key> <output.sarif>}"
+: "${SONAR_TOKEN:?SONAR_TOKEN is required}"
+
+HOST="https://sonarcloud.io"
+CURL=(curl -fsS --proto '=https' --tlsv1.2 -H "Authorization: Bearer ${SONAR_TOKEN}")
+
+# The scanner writes the compute-engine task id beside its work directory.
+# Polling it is what makes "export after the scan" mean THIS scan: the web API
+# serves the last PROCESSED analysis, and processing is asynchronous.
+TASK_FILE=".scannerwork/report-task.txt"
+if [[ -f "$TASK_FILE" ]]; then
+  task_url="$(sed -n 's/^ceTaskUrl=//p' "$TASK_FILE")"
+  if [[ -n "$task_url" ]]; then
+    for _ in $(seq 1 60); do
+      status="$("${CURL[@]}" "$task_url" | jq -r '.task.status')"
+      case "$status" in
+        SUCCESS) break ;;
+        FAILED | CANCELED)
+          echo "::error::the analysis compute task ended ${status}, so there is no result to export" >&2
+          exit 1
+          ;;
+        *) sleep 5 ;;
+      esac
+    done
+    if [[ "${status:-}" != "SUCCESS" ]]; then
+      echo "::error::the analysis compute task did not finish within the wait budget" >&2
+      exit 1
+    fi
+  fi
+fi
+
+# Page through every open finding. The endpoint caps a listing at 10,000
+# results, which is two orders of magnitude above this project's worst day;
+# hitting the cap fails loud below rather than exporting a silent subset.
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+page=1
+while :; do
+  "${CURL[@]}" "${HOST}/api/issues/search?projects=${PROJECT}&issueStatuses=OPEN,CONFIRMED&ps=500&p=${page}" \
+    >"${tmp}/page-${page}.json"
+  total="$(jq -r '.paging.total' "${tmp}/page-${page}.json")"
+  if ((total > 10000)); then
+    echo "::error::${total} open findings exceed the listing cap; the export would be a silent subset" >&2
+    exit 1
+  fi
+  ((page * 500 >= total)) && break
+  page=$((page + 1))
+done
+
+# One SARIF run: every finding is a result carrying the Sonar issue key as its
+# fingerprint (stable across uploads, so an alert keeps its identity), and the
+# rule set is the distinct rules the results actually cite. Severity maps
+# BLOCKER/CRITICAL to error, MAJOR to warning, and the rest to note. A finding
+# without a text range (a project-level finding) is anchored to line 1 of the
+# file, or skipped when it names no file at all.
+jq -s --arg project "$PROJECT" --arg host "$HOST" '
+  [.[].issues[]] as $issues
+  | {
+      "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+      version: "2.1.0",
+      runs: [{
+        automationDetails: { id: "sonarcloud/" },
+        tool: { driver: {
+          name: "SonarQube Cloud",
+          informationUri: ($host + "/project/overview?id=" + $project),
+          rules: ([$issues[].rule] | unique | map({
+            id: .,
+            helpUri: ($host + "/organizations/rubentalstra/rules?open=" + . + "&rule_key=" + .)
+          }))
+        }},
+        results: [
+          $issues[]
+          | select(.component != $project)
+          | {
+              ruleId: .rule,
+              level: (if .severity == "BLOCKER" or .severity == "CRITICAL" then "error"
+                      elif .severity == "MAJOR" then "warning"
+                      else "note" end),
+              message: { text: .message },
+              partialFingerprints: { sonarIssueKey: .key },
+              locations: [{
+                physicalLocation: {
+                  artifactLocation: { uri: (.component | sub("^" + $project + ":"; "")) },
+                  region: {
+                    startLine: (.textRange.startLine // 1),
+                    endLine: (.textRange.endLine // .textRange.startLine // 1)
+                  }
+                }
+              }]
+            }
+        ]
+      }]
+    }
+' "${tmp}"/page-*.json >"$OUT"
+
+count="$(jq '.runs[0].results | length' "$OUT")"
+echo "exported ${count} finding(s) to ${OUT}"


### PR DESCRIPTION
Closes #3032.
Closes #3033.

**The Sonar mirror (#3032):** `scripts/sonar/issues-to-sarif.sh` (ported from Veredictum#544, adapted: MIT, our project key, `sonarcloud` category) waits on the scan's own compute-engine task, pages OPEN+CONFIRMED findings, and emits SARIF 2.1.0 with each Sonar issue key as the result fingerprint. `sonar.yml` uploads it push-to-main-only under `sonarcloud`; PRs keep Sonar's own decoration; the mirror gates nothing. **App-overlap decision (recorded per the acceptance):** the App's native security-only uploads stay ON — they arrive empty today, cost nothing, and would still cover the vulnerability class if this lane ever broke; `ai-code-review.md` documents the whole arrangement.

**The Trivy mirror (#3033):** `image-scan.yml` converts the per-arch JSON reports it already writes (`trivy convert`, no second registry read), merges the three images into one SARIF per architecture, and uploads under `trivy-image/amd64` + `trivy-image/arm64`. A failed probe halts the step chain so nothing uploads; zero findings upload an empty run, which keeps the tool listed. The run-colour rule (red = probe failure only) is untouched. **After merge, one `workflow_dispatch` of the lane seeds the tools page** — I will fire it.

**The dependabot batch's reds (#3024), fixed at the cause, not by rerun:**
- `analyze` failed on every dependency PR because a dependabot-actor `pull_request` run reads **Dependabot** secrets — the Actions `SONAR_TOKEN` is empty there, and the scanner died on "Not authorized". The scan job now skips dependabot PRs (a lock bump has nothing to decorate; the post-merge main push analyzes the merged result in full).
- `changelog-guard` failed because dependabot PRs carry no entry and no label: `dependabot.yml` now labels every bump `no-changelog` at birth (all four update blocks); the triage discipline still adds a real entry when a bump is user-visible — an entry satisfies the guard regardless of the label. The five currently-open invisible bumps were labeled by hand; #3020 gets its real entry (the quick-xml reader now refuses non-UTF-8 documents) on its own branch.

Security properties held: `security-events: write` scoped per job and nothing wider, all actions SHA-pinned with version comments, no context interpolation into `run:` blocks. Gates: shellcheck lane (99 programs — the new script counted), actionlint with CI's own options, zizmor offline (no findings), ci-conclusion-complete. Workflow/CI-only diff — `no-changelog`.