### PR TITLE
chore(guards): the crate-bump guards see workspace-table changes to crates-consumed dependencies

### DIFF
--- a/.claude/hooks/crate_version_bump_guard.sh
+++ b/.claude/hooks/crate_version_bump_guard.sh
@@ -36,10 +36,30 @@ base="$(git merge-base HEAD origin/main 2>/dev/null || true)"
 [ -n "$base" ] || exit 0
 
 changed="$(git diff --name-only "$base" HEAD 2>/dev/null || true)"
-if ! printf '%s\n' "$changed" |
+packaged_change=0
+if printf '%s\n' "$changed" |
   grep -qE '^crates/openehr-[a-z]+/(src/|assets/|schemas/json/|README\.md|LICENSE-|Cargo\.toml)'; then
-  exit 0
+  packaged_change=1
 fi
+
+# A ROOT [workspace.dependencies] version change alters the PACKAGED manifest
+# of every crates/* member that consumes the entry with `workspace = true` —
+# `cargo package` renders the concrete requirement — without touching any
+# crates/* file, which is how PR #3021 slipped past the path scope (#3036).
+if [ "$packaged_change" -eq 0 ] && printf '%s\n' "$changed" | grep -qx 'Cargo.toml'; then
+  table_names="$(awk '/^\[workspace\.dependencies\]/{f=1;next} /^\[/{f=0} f && /^[A-Za-z0-9_-]+[. =]/{print $1}' Cargo.toml | sed 's/\.workspace$//' | sort -u)"
+  diff_names="$(git diff "$base" HEAD -- Cargo.toml | grep -E '^[+-][A-Za-z0-9_-]+(\.workspace)?[[:space:]]*=' | sed -E 's/^[+-]//; s/[[:space:]]*=.*//; s/\.workspace$//' | sort -u)"
+  for name in $diff_names; do
+    printf '%s\n' "$table_names" | grep -qx "$name" || continue
+    if grep -lE "^${name}(\.workspace)?[[:space:]]*=" crates/openehr-*/Cargo.toml >/dev/null 2>&1; then
+      packaged_change=1
+      echo "crate-bump-guard: workspace dependency '$name' changed and crates/* members consume it — packaged requirements move." >&2
+      break
+    fi
+  done
+fi
+
+[ "$packaged_change" -eq 1 ] || exit 0
 
 old_ver="$(git show "$base:crates/openehr-base/Cargo.toml" 2>/dev/null | grep -m1 '^version = ' || true)"
 new_ver="$(grep -m1 '^version = ' crates/openehr-base/Cargo.toml 2>/dev/null || true)"

--- a/.claude/rules/crates-publishing.md
+++ b/.claude/rules/crates-publishing.md
@@ -17,7 +17,12 @@ by the `crate-version-guard` CI job.
   `include` list ships: `src/**`, `assets/**` (term), the embedded ITS-JSON
   schema (its), `README.md`, the `LICENSE-*` texts, and `Cargo.toml` itself.
   Tests, fixtures, vendored codegen inputs, and `CLAUDE.md` are NOT packaged
-  and need no bump.
+  and need no bump. **The root `[workspace.dependencies]` table is part of
+  this rule too** (#3036): changing an entry a `crates/*` member consumes
+  with `workspace = true` changes that member's PACKAGED manifest —
+  `cargo package` renders the concrete requirement — so a workspace-table
+  version bump of a crates-consumed dependency needs the lockstep step even
+  though no `crates/*` file moves; both guard halves detect it.
 - **Bumps are lockstep across all eight** (`0.0.x` — cargo treats every
   `0.0.x` as its own compatibility set, so the internal `version =`
   requirements must move together): bump every crate's `version` AND every

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1788,7 +1788,28 @@ jobs:
             echo "no-crate-bump label set — guard skipped."; exit 0
           fi
           changed=$(git diff --name-only "$BASE" "$HEAD")
-          if ! echo "$changed" | grep -qE '^crates/openehr-[a-z]+/(src/|assets/|schemas/json/|README\.md|LICENSE-|Cargo\.toml)'; then
+          packaged=0
+          if echo "$changed" | grep -qE '^crates/openehr-[a-z]+/(src/|assets/|schemas/json/|README\.md|LICENSE-|Cargo\.toml)'; then
+            packaged=1
+          fi
+          # A ROOT [workspace.dependencies] version change alters the PACKAGED
+          # manifest of every crates/* member consuming the entry with
+          # `workspace = true` (cargo package renders the concrete
+          # requirement) without touching any crates/* file — the path scope
+          # alone let PR #3021 through (#3036).
+          if [ "$packaged" -eq 0 ] && echo "$changed" | grep -qx 'Cargo.toml'; then
+            table=$(git show "$HEAD:Cargo.toml" | awk '/^\[workspace\.dependencies\]/{f=1;next} /^\[/{f=0} f && /^[A-Za-z0-9_-]+[. =]/{print $1}' | sed 's/\.workspace$//' | sort -u)
+            names=$(git diff "$BASE" "$HEAD" -- Cargo.toml | grep -E '^[+-][A-Za-z0-9_-]+(\.workspace)?[[:space:]]*=' | sed -E 's/^[+-]//; s/[[:space:]]*=.*//; s/\.workspace$//' | sort -u)
+            for name in $names; do
+              echo "$table" | grep -qx "$name" || continue
+              if git grep -lE "^${name}(\.workspace)?[[:space:]]*=" "$HEAD" -- 'crates/openehr-*/Cargo.toml' >/dev/null 2>&1; then
+                echo "workspace dependency '$name' changed and crates/* members consume it — packaged requirements move."
+                packaged=1
+                break
+              fi
+            done
+          fi
+          if [ "$packaged" -eq 0 ]; then
             echo "No packaged crate content touched — guard not required."; exit 0
           fi
           old=$(git show "$BASE:crates/openehr-base/Cargo.toml" | grep -m1 '^version = ')


### PR DESCRIPTION
Closes #3036.

Measured live on #3021: a root `[workspace.dependencies]` version edit changes the PACKAGED manifest of every `crates/*` member consuming the entry (`cargo package` renders the concrete requirement), and both guard halves scoped to `crates/*` paths — so the jsonschema bump merged with no lockstep step and no label. No publish-integrity damage (crates publish only at cuts; #3020's 0.0.53 precedes the next publish), but the rule's letter went unenforced invisibly.

Both halves gain the same detection: when the root manifest is in the diff, the changed `[workspace.dependencies]` names (diff ∩ table membership) are checked for a `crates/openehr-*` consumer (`workspace = true` in either spelling); a hit makes the diff packaged-content-changing, demanding the bump or the `no-crate-bump` label, with the offending dependency named in the message. `crates-publishing.md` states the workspace-table path in the bump rule.

Mutation-proven, exits asserted unpiped: a `jsonschema` version edit (crates-consumed) blocks the push hook with exit 2 naming the dependency; a `leptos` edit (viewer-only) passes with exit 0. The CI half is the same logic over `git show`/`git grep` at the PR's own shas. Gates: shellcheck lane, actionlint (CI options), ci-conclusion-complete — green. Guard/CI-only diff — `no-changelog`.