### PR TITLE
chore(quality): harden the comment guard against the #2942 sweep's hand-found shapes

### DIFF
--- a/.claude/rules/comments.md
+++ b/.claude/rules/comments.md
@@ -81,9 +81,13 @@ history carries it. A comment describes the code as it IS.
 ## Enforcement register
 
 - `scripts/checks/comment-style.sh` — block comments, TODO(#N) form, banned
-  marker vocabulary, NOTE ≤ 3 lines, `//` runs ≤ 8 lines. Runs per-edit (the
-  `rust_fmt_clippy.sh` PostToolUse hook) and on PRs (the `comment-style` CI
-  job, running `--all` over the whole tree — the legacy sweep (#1870) is done).
+  marker vocabulary, NOTE ≤ 3 lines (≤ 8 in doc comments), `//` runs ≤ 8
+  lines, punctuation-only comment lines (sweep residue), backtick-quoted
+  markers used AS markers on doc lines (leading/bullet/parenthetical — a
+  mid-sentence description stays legal), and empty `# Errors`/`# Panics`
+  doc sections (#2981). Runs per-edit (the `rust_fmt_clippy.sh` PostToolUse
+  hook) and on PRs (the `comment-style` CI job, running `--all` over the
+  whole tree — the legacy sweep (#1870) is done).
 - `clippy::too_long_first_doc_paragraph` (nursery cherry-pick, CI
   `-D warnings`) — the RFC 1574 summary line.
 - Already-active doc lints: `doc_markdown`, `missing_errors_doc`,
@@ -92,4 +96,8 @@ history carries it. A comment describes the code as it IS.
   job.
 - Review-enforced (no tool can judge them): change-narration, prose
   deferrals, third-person summary phrasing, essays relocated into doc
-  comments to dodge the `//` budget.
+  comments to dodge the `//` budget, and module-doc (`//!`) block LENGTH —
+  adjudicated on #2981: the tree's longest module docs are governing-section
+  maps and matching-rule contracts, longer than any essay the #2942 sweep
+  condensed, so a numeric cap either catches nothing or forces condensing
+  legitimate reference docs; essay-vs-reference is judgment.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5431,7 +5431,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "indexmap 2.14.0",
  "openehr-am",
@@ -5447,7 +5447,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -5457,7 +5457,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "serde",
  "serde_json",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "async-trait",
  "axum",
@@ -5506,7 +5506,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "assert_fs",
  "chumsky",
@@ -5520,7 +5520,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "chumsky",
  "logos",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "insta",
  "jsonschema",
@@ -5547,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/app/ferroehr-rest/tests/it/headers.rs
+++ b/app/ferroehr-rest/tests/it/headers.rs
@@ -1490,10 +1490,9 @@ async fn an_undecodable_header_value_is_refused_not_dropped() {
 /// wrapper-header value is the release's "remove all `ITEM_TAG`s" REQUEST
 /// instruction (overview `Requests_and_responses.md` §"openehr-item-tag and
 /// openehr-version-item-tag": "Providing an empty value for this header will
-/// effectively remove all `ITEM_TAG`s"), so a response echoing one would hand a
-/// mirroring client the destructive form as if it were state (#1837 — the EHR
-/// echo path emitted it; the guard now lives in `emit_item_tag_header` for
-/// both echo paths).
+/// effectively remove all `ITEM_TAG`s"), so a response echoing one would hand
+/// a mirroring client the destructive form as if it were state. The guard is
+/// `params::emit_item_tag_header`, shared by both echo paths.
 #[tokio::test]
 async fn an_emptied_item_tag_collection_echoes_no_header_not_an_empty_one() {
     let (_pg, app) = app().await;

--- a/app/ferroehr/src/service/definition/query.rs
+++ b/app/ferroehr/src/service/definition/query.rs
@@ -591,8 +591,7 @@ impl FerroEhrService {
     /// (`definition_query_list.yaml`: the name is a **prefix** — a bare
     /// `org.openehr` prefix "will list all versions of all queries with names
     /// starting with `org.openehr`"; empty ⇒ wildcard). All stored versions of
-    /// every matching name are returned. The prefix match is case-insensitive
-    ///.
+    /// every matching name are returned. The prefix match is case-insensitive.
     pub(super) async fn list_stored_queries(
         &self,
         name_pattern: &str,

--- a/app/ferroehr/src/service/ehr/status.rs
+++ b/app/ferroehr/src/service/ehr/status.rs
@@ -84,8 +84,7 @@ impl FerroEhrService {
     }
 
     /// The **bare** `EHR_STATUS` at a specific version (not the
-    /// `ORIGINAL_VERSION` wrapper) — `GET …/ehr_status/{version_uid}`
-    ///.
+    /// `ORIGINAL_VERSION` wrapper) — `GET …/ehr_status/{version_uid}`.
     ///
     /// # Errors
     /// [`ServiceError::NotFound`] when the version does not exist or belongs to

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-adl"
-version = "0.0.53"
+version = "0.0.54"
 description = "openEHR ADL 2.4.0: hand-written ADL2/cADL/ODIN parser, AOM2 validation catalogue, specialisation flattener, OPT2 generator, and ADL 1.4→2 conversion over the generated openehr_am::v2_4::aom2 model"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,11 +16,11 @@ include = ["src/**", "README.md", "LICENSE-MIT"]
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)
-openehr-base = { path = "../openehr-base", version = "0.0.53" }   # VersionStatus for the parsed HRID
-openehr-am = { path = "../openehr-am", version = "0.0.53" }       # v2_4 ArchetypeHrid (the identification target type)
-openehr-rm = { path = "../openehr-rm", version = "0.0.53" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
-openehr-lang = { path = "../openehr-lang", version = "0.0.53" }   # openehr_lang::odin — the ODIN section parser
-openehr-term = { path = "../openehr-term", version = "0.0.53" }   # the languages code set for the RM resource-meta rows
+openehr-base = { path = "../openehr-base", version = "0.0.54" }   # VersionStatus for the parsed HRID
+openehr-am = { path = "../openehr-am", version = "0.0.54" }       # v2_4 ArchetypeHrid (the identification target type)
+openehr-rm = { path = "../openehr-rm", version = "0.0.54" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
+openehr-lang = { path = "../openehr-lang", version = "0.0.54" }   # openehr_lang::odin — the ODIN section parser
+openehr-term = { path = "../openehr-term", version = "0.0.54" }   # the languages code set for the RM resource-meta rows
 uuid.workspace = true        # meta uid/build_uid (AUTHORED_ARCHETYPE.uid: Uuid)
 indexmap.workspace = true    # OdinValue::Object body (insertion-ordered map)
 

--- a/crates/openehr-am/Cargo.toml
+++ b/crates/openehr-am/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-am"
-version = "0.0.53"
+version = "0.0.54"
 description = "openEHR AM Archetype Model, generated from BMM: generations v1_4 (AM 1.4.0, ADL 1.4) and v2_4 (AM 2.4.0, ADL 2; current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,8 +13,8 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.53" }
-openehr-lang = { path = "../openehr-lang", version = "0.0.53" }
+openehr-base = { path = "../openehr-base", version = "0.0.54" }
+openehr-lang = { path = "../openehr-lang", version = "0.0.54" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also carries the untyped `Value` fields the generator

--- a/crates/openehr-base/Cargo.toml
+++ b/crates/openehr-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-base"
-version = "0.0.53"
+version = "0.0.54"
 description = "openEHR BASE foundation + base types, generated from BMM: generations v1_2 (BASE 1.2.0) and v1_3 (BASE 1.3.0, current)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-base/src/validate.rs
+++ b/crates/openehr-base/src/validate.rs
@@ -15,8 +15,8 @@
 //! page and invariant name it enforces. What the specifications leave
 //! underdetermined is the *algorithm* — openEHR's AOM2 `validation` spec covers
 //! ARCHETYPE validation, not RM-instance validation — so the traversal,
-//! violation shape and sub-path reporting below are our own design; the
-//! `// NOTE:` markers in the impls flag each such choice.
+//! violation shape and sub-path reporting below are our own design; a NOTE
+//! comment in the impls flags each such choice.
 
 /// An RM class-invariant violation: a human-readable message plus the RM
 /// sub-path (relative to the value being checked) it applies to.

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-its"
-version = "0.0.53"
+version = "0.0.54"
 description = "openEHR ITS (Implementation Technology Specifications): canonical JSON + canonical XML serialization of the RM, the generated ITS-REST 1.1.0 API contract, OPT 1.4 and AOM2 archetype XML codecs, and the Simplified Formats (FLAT / STRUCTURED / Web Template)"
 edition.workspace = true
 rust-version.workspace = true
@@ -41,14 +41,14 @@ regex = { workspace = true, optional = true }
 fancy-regex = { workspace = true, optional = true }
 # The generated XML (de)serializers impl the crate's ToXml/FromXml traits for the
 # RM/BASE spec types, so these are real (non-dev) deps.
-openehr-base = { path = "../openehr-base", version = "0.0.53", optional = true }
-openehr-rm = { path = "../openehr-rm", version = "0.0.53", optional = true }
+openehr-base = { path = "../openehr-base", version = "0.0.54", optional = true }
+openehr-rm = { path = "../openehr-rm", version = "0.0.54", optional = true }
 # The native canonical-JSON codec (`json_codec/generated`, emit-json) implements
 # `ToJson` for EVERY generated spec type the `OpenEhrType` derive covers, so it
 # spans all five spec crates (not just the RM/BASE the XML codec needs).
-openehr-lang = { path = "../openehr-lang", version = "0.0.53", optional = true }
-openehr-am = { path = "../openehr-am", version = "0.0.53", optional = true }
-openehr-term = { path = "../openehr-term", version = "0.0.53", optional = true }
+openehr-lang = { path = "../openehr-lang", version = "0.0.54", optional = true }
+openehr-am = { path = "../openehr-am", version = "0.0.54", optional = true }
+openehr-term = { path = "../openehr-term", version = "0.0.54", optional = true }
 
 # `full` — every ITS surface (canonical JSON/XML, the generated ITS-REST
 # contract, `opt14`, Simplified Formats). ON BY DEFAULT, so every consumer sees

--- a/crates/openehr-its/src/flat/validation/leaf.rs
+++ b/crates/openehr-its/src/flat/validation/leaf.rs
@@ -9,10 +9,12 @@
 //! For each input we validate the corresponding datum of the instance value,
 //! keyed by the input `suffix` / `type`: coded-value membership (unless the list
 //! is open or the code is from an external terminology), numeric range (honoring
-//! `minOp`/`maxOp`), and string patterns. Temporal ranges and decimal precision
-//! are intentionally not checked here (`// NOTE:` — RM well-formedness of
-//! date/time/duration values is covered by the RM-invariant pass; precise
-//! temporal-range and precision semantics are deferred).
+//! `minOp`/`maxOp`), and string patterns. RM well-formedness of
+//! date/time/duration VALUES is covered by the RM-invariant pass; a leaf's
+//! declared temporal RANGE and decimal PRECISION constraints are not yet
+//! enforced here.
+// TODO(#3027): enforce (or record the adjudicated boundary for) WebTemplate
+// temporal-range and decimal-precision leaf constraints.
 
 #![expect(
     clippy::disallowed_types,

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-lang"
-version = "0.0.53"
+version = "0.0.54"
 description = "openEHR LANG BMM/P_BMM object model, generated from BMM: generations v1_0 (LANG 1.0.0) and v1_1 (LANG 1.1.0, current; the stable BMM v2.x unit beside the paused BMM3 unit), plus hand-written ODIN/BEL/EL readers"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["parser-implementations", "data-structures"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.53" }
+openehr-base = { path = "../openehr-base", version = "0.0.54" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the
 # generated types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) —
 # never a derive. `serde_json` also carries the untyped `Value` fields the

--- a/crates/openehr-lang/src/v1_0/lexer/reclassify.rs
+++ b/crates/openehr-lang/src/v1_0/lexer/reclassify.rs
@@ -279,7 +279,7 @@ fn leader_budget(src: &str, start: usize) -> usize {
 /// `raw` after the first (see [`leader_budget`]). Single-line strings are
 /// returned untouched.
 ///
-/// `// NOTE:` The stripping runs AFTER the shared lexer has validated the raw
+/// NOTE: The stripping runs AFTER the shared lexer has validated the raw
 /// literal's `master03` escapes, and cannot change that verdict: the removed
 /// run always begins immediately after a newline, so the character preceding
 /// it is never a backslash and no escape sequence can be created or destroyed.

--- a/crates/openehr-lang/src/v1_1/lexer/reclassify.rs
+++ b/crates/openehr-lang/src/v1_1/lexer/reclassify.rs
@@ -476,7 +476,7 @@ fn iso_date_time(language: Language, text: &str) -> Option<Token> {
 /// (`ADL1.4/master05-cadl.adoc` §Symbols L1422, with the literal-field,
 /// ASCII-timezone and `[T ]`-separator widenings the chapter grants).
 ///
-/// `// NOTE:` This is the LEXICAL shape only — the token's regex, needed here
+/// NOTE: This is the LEXICAL shape only — the token's regex, needed here
 /// because the space-separated ODIN date-time widening overlaps it and the
 /// cADL reading must recover the pattern token at the same span. It is not a
 /// second home for pattern VALIDITY: the `master04.5` valid-pattern tables
@@ -714,7 +714,7 @@ fn leader_budget(src: &str, start: usize) -> usize {
 /// `raw` after the first (see [`leader_budget`]). Single-line strings are
 /// returned untouched.
 ///
-/// `// NOTE:` The stripping runs AFTER the shared lexer has validated the raw
+/// NOTE: The stripping runs AFTER the shared lexer has validated the raw
 /// literal's `master03` escapes, and cannot change that verdict: the removed
 /// run always begins immediately after a newline, so the character preceding
 /// it is never a backslash and no escape sequence can be created or destroyed.

--- a/crates/openehr-lang/src/v1_1/lexer/token.rs
+++ b/crates/openehr-lang/src/v1_1/lexer/token.rs
@@ -12,7 +12,7 @@
 //! decided by [`super::reclassify()`], not here — see the module docs of
 //! [`super`] for the two-stage contract.
 //!
-//! `// NOTE:` The Expression Language (`LANG/docs/EL/`) is deliberately NOT
+//! NOTE: The Expression Language (`LANG/docs/EL/`) is deliberately NOT
 //! part of the union: it uses `#`-prefixed codes, a different bracket algebra
 //! and `|`-delimited comments, all of which would change the reading of text
 //! in the four languages above. EL is DEVELOPMENT status with no vendored

--- a/crates/openehr-query/Cargo.toml
+++ b/crates/openehr-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-query"
-version = "0.0.53"
+version = "0.0.54"
 description = "openEHR QUERY (AQL 1.1.0): hand-written lexer, parser, typed AST and canonical printer from the official grammar (no ANTLR runtime)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-rm"
-version = "0.0.53"
+version = "0.0.54"
 description = "openEHR RM Reference Model, generated from BMM: generations v1_1 (RM 1.1.0) and v1_2 (RM 1.2.0, current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,11 +13,11 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.53" }
+openehr-base = { path = "../openehr-base", version = "0.0.54" }
 # The terminology-backed RM class invariants (`validate::terminology`) resolve
 # openEHR terminology groups + code sets against the vendored TERM 3.1.0 bundle.
 # `openehr-term` itself depends only on `openehr-base`, so this is acyclic.
-openehr-term = { path = "../openehr-term", version = "0.0.53" }
+openehr-term = { path = "../openehr-term", version = "0.0.54" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also backs the untyped `Value` RM representation used by

--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-term"
-version = "0.0.53"
+version = "0.0.54"
 description = "openEHR TERM terminology data model, generated from BMM (generation v3_1 = TERM 3.1.0), plus the embedded official terminology XML bundle"
 edition.workspace = true
 rust-version.workspace = true
@@ -34,7 +34,7 @@ include = [
 ]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.53" }
+openehr-base = { path = "../openehr-base", version = "0.0.54" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -526,12 +526,12 @@ dependencies = [
 
 [[package]]
 name = "fraction"
-version = "0.15.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+checksum = "33fee0259ffdc3d7bd64438b6b08437884d4df5700f9cb8a23b079c3958ae578"
 dependencies = [
- "lazy_static",
  "num",
+ "num-bigint",
 ]
 
 [[package]]
@@ -1004,9 +1004,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.49.9"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ec8a241beed129f06114aa68007e905ca350e7baeb6e17a7631bb7978d91b2"
+checksum = "152999731bfbe0bb82d561550be73b0c31a9827d6ebe3fe96ad47563703b5328"
 dependencies = [
  "ahash 0.8.12",
  "bytecount",
@@ -1035,18 +1035,18 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.49.9"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91994f45017ed5e66aa8e59b8415f4cb033a6380d7200387b7cf117595fbdf85"
+checksum = "8cb2e614e1c610e31e947d53156e877340c718e053cfce0dfe9b9ce7beff4d31"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "jsonschema-value"
-version = "0.49.9"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec7637f83e510868ae6ed625f7ebfbbde4554ee8ce49854caa5126a8b9b9ecb"
+checksum = "24373bc85409cb935a46af0ffb41294c5372c08cf9b0709913d908154cd10582"
 dependencies = [
  "ahash 0.8.12",
  "bytecount",
@@ -1055,12 +1055,6 @@ dependencies = [
  "num-traits",
  "serde_json",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -1281,7 +1275,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "indexmap",
  "openehr-am",
@@ -1297,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -1307,7 +1301,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "serde",
  "serde_json",
@@ -1317,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "async-trait",
  "axum",
@@ -1342,7 +1336,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "chumsky",
  "indexmap",
@@ -1355,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "chumsky",
  "logos",
@@ -1364,7 +1358,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "openehr-base",
  "openehr-term",
@@ -1379,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "openehr-base",
  "roxmltree",
@@ -1633,9 +1627,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.49.9"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6efa2154ea6f5ce0fdecdd2a8d18f2fa1a39a8fbba91564f555a592e4dce8278"
+checksum = "0aff997fc7eecb671a947b0f73f5ce4bcb4ad3534fd5bff2dd752718a8107525"
 dependencies = [
  "ahash 0.8.12",
  "fluent-uri",

--- a/scripts/checks/comment-style.sh
+++ b/scripts/checks/comment-style.sh
@@ -15,6 +15,22 @@
 #   5. essay budget        a plain `//` comment run is at most $RUN_MAX lines;
 #                          longer prose belongs in doc comments, the PR
 #                          description, or the tracker — not in code.
+#   6. orphaned lines      a comment whose whole content is punctuation
+#                          (`//.`, `///:` …) is sweep residue, not prose.
+#   7. quoted markers      a doc line carrying a backtick-quoted marker
+#                          (`` `// NOTE:` `` …) reads as a marker to a human
+#                          and is invisible to checks 2-4 — describe the
+#                          marker in words instead.
+#   8. empty sections      a bare `/// # Errors` / `# Panics` heading with no
+#                          body satisfies the doc lints and tells a caller
+#                          nothing.
+#
+# NOT machine-checked, deliberately (#2981): module-doc (`//!`) block LENGTH.
+# The tree's longest module docs are governing-section maps and matching-rule
+# contracts, longer than any essay the #2942 sweep condensed — a cap loose
+# enough to keep them catches nothing, and a cap tight enough to catch
+# essays would force condensing legitimate reference docs. Essay-vs-reference
+# is judgment; review carries it (comments.md §Enforcement register).
 #
 # Usage:
 #   scripts/checks/comment-style.sh --all               # whole tree
@@ -93,6 +109,11 @@ for f in "${files[@]}"; do
         printf ":%d: NOTE paragraph in a doc comment is %d lines (max %d) — an adjudication essay lives on the PR/issue, not in rustdoc\n", doc_note_start, doc_note_len, RUN_MAX
       doc_note_len = 0
     }
+    function flush_sec() {
+      if (sec_start)
+        printf ":%d: `# %s` doc section has no body — it satisfies the doc lint and tells a caller nothing; write the contract or drop the heading\n", sec_start, sec_name
+      sec_start = 0
+    }
     {
       line = $0
       sub(/^[[:space:]]+/, "", line)
@@ -121,6 +142,20 @@ for f in "${files[@]}"; do
           printf ":%d: unsanctioned comment marker — the only forms are TODO(#NNNN): / NOTE: / SAFETY:\n", NR
       }
 
+      # 6. orphaned punctuation-only comment lines — residue an earlier
+      # rewriting sweep left behind (`//.`, `///:`, `//!,` …).
+      if ((is_doc || is_line) && line ~ /^\/\/[\/!]?[[:space:]]*[.;:,)]+[[:space:]]*$/)
+        printf ":%d: comment line carries punctuation only — sweep residue; delete it\n", NR
+
+      # 7. a backtick-quoted marker USED AS a marker — leading the doc
+      # line, leading a bullet, or opening a parenthetical — reads as a
+      # marker to a human and is invisible to checks 2-4 (#2981). A
+      # mid-sentence DESCRIPTION ("the emitter writes a `// NOTE:` …")
+      # stays legal: precision over recall keeps the guard trusted.
+      if (is_doc && (line ~ /^\/\/[\/!][[:space:]]*([-*][[:space:]]+)?`\/\/[[:space:]]?(NOTE|TODO|SAFETY)/ \
+          || line ~ /\(`\/\/[[:space:]]?(NOTE|TODO|SAFETY)/))
+        printf ":%d: doc line uses a backtick-quoted comment marker as a marker — invisible to the marker checks; write a real NOTE/TODO or plain prose\n", NR
+
       # 4 + 5. NOTE / plain-run budgets
       if (is_line) {
         if (line ~ /^\/\/[[:space:]]*NOTE/) {
@@ -134,7 +169,7 @@ for f in "${files[@]}"; do
         }
         next
       }
-      # 6. the NOTE budget inside doc comments (`/// NOTE:` / `//! NOTE:`) —
+      # The NOTE budget inside doc comments (`/// NOTE:` / `//! NOTE:`) —
       # a doc-relocated essay is the same essay (#2441). The paragraph ends
       # at a blank doc line, per rustdoc paragraph semantics.
       if (is_doc) {
@@ -151,12 +186,25 @@ for f in "${files[@]}"; do
             flush_doc_note()
           else doc_note_len++
         }
+        # 8. a lint-required section heading must carry a body: a bare
+        # `# Errors` / `# Panics` satisfies missing_errors_doc /
+        # missing_panics_doc while documenting nothing. Pending state
+        # clears on the first non-blank, non-heading doc line and trips on
+        # another heading or the end of the doc block.
+        if (line ~ /^\/\/[\/!][[:space:]]*#[[:space:]]*(Errors|Panics)[[:space:]]*$/) {
+          flush_sec()
+          sec_start = NR
+          sec_name = (line ~ /Errors/) ? "Errors" : "Panics"
+        } else if (sec_start) {
+          if (line ~ /^\/\/[\/!][[:space:]]*#/) flush_sec()
+          else if (line !~ /^\/\/[\/!][[:space:]]*$/) sec_start = 0
+        }
         flush_note(); flush_run()
         next
       }
-      flush_note(); flush_run(); flush_doc_note()
+      flush_note(); flush_run(); flush_doc_note(); flush_sec()
     }
-    END { flush_note(); flush_run(); flush_doc_note() }
+    END { flush_note(); flush_run(); flush_doc_note(); flush_sec() }
   ' "$f")"
   if [[ -n "$out" ]]; then
     printf '%s\n' "$out" | sed "s|^|$f|"


### PR DESCRIPTION
Closes #2981.

Three of the four shapes gain failing checks in `comment-style.sh`, each mutation-proven both ways (planted violations fail naming the line; the clean twin passes; the whole tree stays green at 2471 files):

1. **Punctuation-only comment lines** (`//.`, `///:`, `//!,` — sweep residue) fail as such.
2. **Backtick-quoted markers used AS markers** on doc lines fail — leading the line, leading a bullet, or opening a parenthetical. A mid-sentence DESCRIPTION ("the emitter writes a `NOTE` comment…") stays legal: precision over recall keeps the guard trusted, and the two legitimate descriptive sites in the codegen decision maps stay untouched.
3. **Empty lint-required doc sections**: a bare `# Errors`/`# Panics` heading with no body before the block ends or another heading starts fails — it satisfies `missing_errors_doc` while documenting nothing.

The fourth shape, **module-doc (`//!`) block length, is adjudicated review-enforced** and recorded in `comments.md`'s register with the measured reason: the tree's longest module docs are governing-section maps and matching-rule contracts, longer than any essay the #2942 sweep condensed — a numeric cap either catches nothing or forces condensing legitimate reference docs, and essay-vs-reference is judgment (the #1733 honest-no-guard precedent).

The tree-wide run surfaced live instances the narrowed checks still see, fixed here: four quoted-marker paragraphs become real NOTE paragraphs (the `openehr-lang` lexer pair edited in twin lockstep), the flat leaf-validation deferral became `TODO(#3027)` with its tracker issue (whose implementation is already queued and supersedes the TODO), two orphaned punctuation lines fold into their sentences, one wrap-artifact mention reworded, and `headers.rs`'s empty-collection test drops its bare `#1837` citation and change-narration for the current-contract statement (the issue thread's addendum).

Packaged `openehr-lang`/`openehr-base`/`openehr-its` doc bytes change → lockstep step to **0.0.54** with the fuzz lock refreshed (the push hook itself vetoed a first attempt whose bump had no-op'd against a stale base — the guard working as designed). Gates: `comment-style --all` (2471 files), scoped clippy over the three crates + the two app crates, rustdoc, fmt, shellcheck — green.