### PR TITLE
fix(its): enforce the constrained precision interval on DV_QUANTITY and DV_PROPORTION leaves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,12 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- Composition validation now enforces a template's decimal-precision
+  constraint on `DV_QUANTITY` and `DV_PROPORTION` leaves: an instance whose
+  optional `precision` attribute falls outside the constrained interval is
+  refused (422) instead of silently accepted. Temporal-range constraints
+  were already enforced; the module documentation claiming otherwise was
+  stale and now states the real contract.
 - The FerroEHR Viewer's session cookie sets `Secure` by default
   (`session.cookie_secure` now defaults to `true`, fail closed): a TLS-fronted
   deployment needs nothing, and plain-HTTP contexts (the compose quickstart on

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5431,7 +5431,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "indexmap 2.14.0",
  "openehr-am",
@@ -5447,7 +5447,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -5457,7 +5457,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "serde",
  "serde_json",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "async-trait",
  "axum",
@@ -5506,7 +5506,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "assert_fs",
  "chumsky",
@@ -5520,7 +5520,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "chumsky",
  "logos",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "insta",
  "jsonschema",
@@ -5547,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-adl"
-version = "0.0.54"
+version = "0.0.55"
 description = "openEHR ADL 2.4.0: hand-written ADL2/cADL/ODIN parser, AOM2 validation catalogue, specialisation flattener, OPT2 generator, and ADL 1.4→2 conversion over the generated openehr_am::v2_4::aom2 model"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,11 +16,11 @@ include = ["src/**", "README.md", "LICENSE-MIT"]
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)
-openehr-base = { path = "../openehr-base", version = "0.0.54" }   # VersionStatus for the parsed HRID
-openehr-am = { path = "../openehr-am", version = "0.0.54" }       # v2_4 ArchetypeHrid (the identification target type)
-openehr-rm = { path = "../openehr-rm", version = "0.0.54" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
-openehr-lang = { path = "../openehr-lang", version = "0.0.54" }   # openehr_lang::odin — the ODIN section parser
-openehr-term = { path = "../openehr-term", version = "0.0.54" }   # the languages code set for the RM resource-meta rows
+openehr-base = { path = "../openehr-base", version = "0.0.55" }   # VersionStatus for the parsed HRID
+openehr-am = { path = "../openehr-am", version = "0.0.55" }       # v2_4 ArchetypeHrid (the identification target type)
+openehr-rm = { path = "../openehr-rm", version = "0.0.55" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
+openehr-lang = { path = "../openehr-lang", version = "0.0.55" }   # openehr_lang::odin — the ODIN section parser
+openehr-term = { path = "../openehr-term", version = "0.0.55" }   # the languages code set for the RM resource-meta rows
 uuid.workspace = true        # meta uid/build_uid (AUTHORED_ARCHETYPE.uid: Uuid)
 indexmap.workspace = true    # OdinValue::Object body (insertion-ordered map)
 

--- a/crates/openehr-am/Cargo.toml
+++ b/crates/openehr-am/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-am"
-version = "0.0.54"
+version = "0.0.55"
 description = "openEHR AM Archetype Model, generated from BMM: generations v1_4 (AM 1.4.0, ADL 1.4) and v2_4 (AM 2.4.0, ADL 2; current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,8 +13,8 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.54" }
-openehr-lang = { path = "../openehr-lang", version = "0.0.54" }
+openehr-base = { path = "../openehr-base", version = "0.0.55" }
+openehr-lang = { path = "../openehr-lang", version = "0.0.55" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also carries the untyped `Value` fields the generator

--- a/crates/openehr-base/Cargo.toml
+++ b/crates/openehr-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-base"
-version = "0.0.54"
+version = "0.0.55"
 description = "openEHR BASE foundation + base types, generated from BMM: generations v1_2 (BASE 1.2.0) and v1_3 (BASE 1.3.0, current)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-its"
-version = "0.0.54"
+version = "0.0.55"
 description = "openEHR ITS (Implementation Technology Specifications): canonical JSON + canonical XML serialization of the RM, the generated ITS-REST 1.1.0 API contract, OPT 1.4 and AOM2 archetype XML codecs, and the Simplified Formats (FLAT / STRUCTURED / Web Template)"
 edition.workspace = true
 rust-version.workspace = true
@@ -41,14 +41,14 @@ regex = { workspace = true, optional = true }
 fancy-regex = { workspace = true, optional = true }
 # The generated XML (de)serializers impl the crate's ToXml/FromXml traits for the
 # RM/BASE spec types, so these are real (non-dev) deps.
-openehr-base = { path = "../openehr-base", version = "0.0.54", optional = true }
-openehr-rm = { path = "../openehr-rm", version = "0.0.54", optional = true }
+openehr-base = { path = "../openehr-base", version = "0.0.55", optional = true }
+openehr-rm = { path = "../openehr-rm", version = "0.0.55", optional = true }
 # The native canonical-JSON codec (`json_codec/generated`, emit-json) implements
 # `ToJson` for EVERY generated spec type the `OpenEhrType` derive covers, so it
 # spans all five spec crates (not just the RM/BASE the XML codec needs).
-openehr-lang = { path = "../openehr-lang", version = "0.0.54", optional = true }
-openehr-am = { path = "../openehr-am", version = "0.0.54", optional = true }
-openehr-term = { path = "../openehr-term", version = "0.0.54", optional = true }
+openehr-lang = { path = "../openehr-lang", version = "0.0.55", optional = true }
+openehr-am = { path = "../openehr-am", version = "0.0.55", optional = true }
+openehr-term = { path = "../openehr-term", version = "0.0.55", optional = true }
 
 # `full` — every ITS surface (canonical JSON/XML, the generated ITS-REST
 # contract, `opt14`, Simplified Formats). ON BY DEFAULT, so every consumer sees

--- a/crates/openehr-its/src/flat/validation/leaf.rs
+++ b/crates/openehr-its/src/flat/validation/leaf.rs
@@ -8,13 +8,11 @@
 //!
 //! For each input we validate the corresponding datum of the instance value,
 //! keyed by the input `suffix` / `type`: coded-value membership (unless the list
-//! is open or the code is from an external terminology), numeric range (honoring
-//! `minOp`/`maxOp`), and string patterns. RM well-formedness of
-//! date/time/duration VALUES is covered by the RM-invariant pass; a leaf's
-//! declared temporal RANGE and decimal PRECISION constraints are not yet
-//! enforced here.
-// TODO(#3027): enforce (or record the adjudicated boundary for) WebTemplate
-// temporal-range and decimal-precision leaf constraints.
+//! is open or the code is from an external terminology), numeric and temporal
+//! ranges (honoring `minOp`/`maxOp`), decimal-precision intervals on
+//! `DV_QUANTITY`/`DV_PROPORTION` (#3027), string patterns, duration
+//! field/range constraints, and timezone validity. RM well-formedness of
+//! date/time/duration VALUES stays with the RM-invariant pass.
 
 #![expect(
     clippy::disallowed_types,
@@ -395,6 +393,27 @@ fn check_quantity(v: &mut Validator, instance: &Value, wt: &WebTemplateNode) {
             );
         }
     }
+
+    // DV_QUANTITY.precision against the constrained precision interval
+    // (`OpenehrProfile.xsd` `C_QUANTITY_ITEM.precision : IntervalOfInteger`;
+    // the Web Template surfaces it as `inputs[].validation.precision` — the
+    // ITS-REST `simplified_formats` `master04` model). The RM attribute is
+    // 0..1, so an instance that omits it violates nothing (#3027).
+    if let Some(prec) = instance.get("precision").and_then(as_f64) {
+        let range = input_with_suffix(wt, "magnitude")
+            .and_then(|i| i.validation.as_ref())
+            .and_then(|val| val.precision.as_ref())
+            .or_else(|| unit_scoped_precision(unit_input, unit));
+        if let Some(range) = range
+            && !in_range(prec, range)
+        {
+            v.push(
+                &wt.aql_path,
+                format!("precision {prec} is outside the constrained precision range"),
+                ValidationKind::RangeError,
+            );
+        }
+    }
 }
 
 fn unit_scoped_range<'a>(
@@ -407,6 +426,21 @@ fn unit_scoped_range<'a>(
         .find(|cv| cv.value == u)
         .and_then(|cv| cv.validation.as_ref())
         .and_then(|val| val.range.as_ref())
+}
+
+/// The precision interval scoped to the instance's unit, when the constraint
+/// carries per-unit validation (the `master04` example model attaches both
+/// `range` and `precision` to each coded unit value).
+fn unit_scoped_precision<'a>(
+    unit_input: Option<&'a WebTemplateInput>,
+    unit: Option<&str>,
+) -> Option<&'a WebTemplateRange> {
+    let (ui, u) = (unit_input?, unit?);
+    ui.list
+        .iter()
+        .find(|cv| cv.value == u)
+        .and_then(|cv| cv.validation.as_ref())
+        .and_then(|val| val.precision.as_ref())
 }
 
 fn check_count(v: &mut Validator, instance: &Value, wt: &WebTemplateNode) {
@@ -449,6 +483,22 @@ fn check_proportion(v: &mut Validator, instance: &Value, wt: &WebTemplateNode) {
                 ValidationKind::CodedValue,
             );
         }
+    }
+    // DV_PROPORTION.precision against the constrained interval, the same
+    // contract as DV_QUANTITY (the `|precision` suffix in `master05`'s
+    // DV_PROPORTION table; RM attribute 0..1, absent violates nothing).
+    if let Some(prec) = instance.get("precision").and_then(as_f64)
+        && let Some(range) = wt
+            .inputs
+            .iter()
+            .find_map(|i| i.validation.as_ref().and_then(|val| val.precision.as_ref()))
+        && !in_range(prec, range)
+    {
+        v.push(
+            &wt.aql_path,
+            format!("precision {prec} is outside the constrained precision range"),
+            ValidationKind::RangeError,
+        );
     }
     for part in ["numerator", "denominator"] {
         let Some(value) = instance.get(part).and_then(as_f64) else {

--- a/crates/openehr-its/src/flat/validation/mod.rs
+++ b/crates/openehr-its/src/flat/validation/mod.rs
@@ -2031,6 +2031,69 @@ mod tests {
         assert!(walk_only(&good, &prop).is_empty());
     }
 
+    /// `C_QUANTITY_ITEM.precision` (`OpenehrProfile.xsd`, surfaced as
+    /// `inputs[].validation.precision`): the instance's `DV_QUANTITY.precision`
+    /// must lie in the interval; an absent instance precision violates
+    /// nothing (#3027).
+    #[test]
+    fn quantity_precision_interval() {
+        let mut q = node("DV_QUANTITY", "/q");
+        let mut input = WebTemplateInput::new(WebTemplateInputType::Decimal, Some("magnitude"));
+        input.validation = Some(WebTemplateValidation {
+            pattern: None,
+            range: None,
+            precision: Some(WebTemplateRange {
+                min_op: Some(">=".to_owned()),
+                min: Some(json!(0)),
+                max_op: Some("<=".to_owned()),
+                max: Some(json!(1)),
+            }),
+        });
+        q.inputs = vec![input];
+
+        let over =
+            json!({"_type": "DV_QUANTITY", "magnitude": 5.25, "units": "kg", "precision": 3});
+        assert!(
+            kinds(&walk_only(&over, &q)).contains(&ValidationKind::RangeError),
+            "precision 3 violates [0, 1]"
+        );
+        let ok = json!({"_type": "DV_QUANTITY", "magnitude": 5.2, "units": "kg", "precision": 1});
+        assert!(walk_only(&ok, &q).is_empty());
+        let absent = json!({"_type": "DV_QUANTITY", "magnitude": 5.2, "units": "kg"});
+        assert!(
+            walk_only(&absent, &q).is_empty(),
+            "an absent optional precision violates nothing"
+        );
+    }
+
+    /// `DV_PROPORTION.precision` under the same interval contract as
+    /// `DV_QUANTITY` (the `|precision` suffix in the `master05` table; #3027).
+    #[test]
+    fn proportion_precision_interval() {
+        let mut prop = node("DV_PROPORTION", "/p");
+        let mut input = WebTemplateInput::new(WebTemplateInputType::Decimal, Some("numerator"));
+        input.validation = Some(WebTemplateValidation {
+            pattern: None,
+            range: None,
+            precision: Some(WebTemplateRange {
+                min_op: Some(">=".to_owned()),
+                min: Some(json!(0)),
+                max_op: Some("<=".to_owned()),
+                max: Some(json!(0)),
+            }),
+        });
+        prop.inputs = vec![input];
+        let bad = json!({"_type": "DV_PROPORTION", "numerator": 42.0, "denominator": 100.0,
+            "type": 2, "precision": 2});
+        assert!(
+            kinds(&walk_only(&bad, &prop)).contains(&ValidationKind::RangeError),
+            "precision 2 violates [0, 0]"
+        );
+        let ok = json!({"_type": "DV_PROPORTION", "numerator": 42.0, "denominator": 100.0,
+            "type": 2, "precision": 0});
+        assert!(walk_only(&ok, &prop).is_empty());
+    }
+
     /// `C_DATE` pattern + range (master17.4 CONT-DV_DATE-validate_constraint/-range).
     #[test]
     fn temporal_pattern_and_range() {

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-lang"
-version = "0.0.54"
+version = "0.0.55"
 description = "openEHR LANG BMM/P_BMM object model, generated from BMM: generations v1_0 (LANG 1.0.0) and v1_1 (LANG 1.1.0, current; the stable BMM v2.x unit beside the paused BMM3 unit), plus hand-written ODIN/BEL/EL readers"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["parser-implementations", "data-structures"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.54" }
+openehr-base = { path = "../openehr-base", version = "0.0.55" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the
 # generated types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) —
 # never a derive. `serde_json` also carries the untyped `Value` fields the

--- a/crates/openehr-query/Cargo.toml
+++ b/crates/openehr-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-query"
-version = "0.0.54"
+version = "0.0.55"
 description = "openEHR QUERY (AQL 1.1.0): hand-written lexer, parser, typed AST and canonical printer from the official grammar (no ANTLR runtime)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-rm"
-version = "0.0.54"
+version = "0.0.55"
 description = "openEHR RM Reference Model, generated from BMM: generations v1_1 (RM 1.1.0) and v1_2 (RM 1.2.0, current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,11 +13,11 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.54" }
+openehr-base = { path = "../openehr-base", version = "0.0.55" }
 # The terminology-backed RM class invariants (`validate::terminology`) resolve
 # openEHR terminology groups + code sets against the vendored TERM 3.1.0 bundle.
 # `openehr-term` itself depends only on `openehr-base`, so this is acyclic.
-openehr-term = { path = "../openehr-term", version = "0.0.54" }
+openehr-term = { path = "../openehr-term", version = "0.0.55" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also backs the untyped `Value` RM representation used by

--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-term"
-version = "0.0.54"
+version = "0.0.55"
 description = "openEHR TERM terminology data model, generated from BMM (generation v3_1 = TERM 3.1.0), plus the embedded official terminology XML bundle"
 edition.workspace = true
 rust-version.workspace = true
@@ -34,7 +34,7 @@ include = [
 ]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.54" }
+openehr-base = { path = "../openehr-base", version = "0.0.55" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1275,7 +1275,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "indexmap",
  "openehr-am",
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -1301,7 +1301,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "serde",
  "serde_json",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "async-trait",
  "axum",
@@ -1336,7 +1336,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "chumsky",
  "indexmap",
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "chumsky",
  "logos",
@@ -1358,7 +1358,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "openehr-base",
  "openehr-term",
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "openehr-base",
  "roxmltree",


### PR DESCRIPTION
Closes #3027.

The adjudication (recorded on the issue with first-hand citations): the published OPT profile schema declares `C_QUANTITY_ITEM.precision : IntervalOfInteger` beside `magnitude` (`OpenehrProfile.xsd`, the vendored `its-xml-1.0.2` bundle — the AM UML page omits it, a docs-vs-XSD divergence flagged for the #2522 upstream-report bar), and the STABLE Simplified Formats `master04` model surfaces it per input and per coded unit value as `validation.precision`. The leaf pass silently ignored it.

- `DV_QUANTITY`: the instance's optional `precision` attribute validates against the magnitude input's interval, with the unit-scoped fallback mirroring the magnitude range's; absent violates nothing (RM 0..1).
- `DV_PROPORTION`: the same contract through its `|precision` suffix (`master05` table).
- Valid and refusal twins pinned for both types (`quantity_precision_interval`, `proportion_precision_interval`).

Measurement during the fix also caught the module doc lying in the OTHER direction: temporal ranges WERE already enforced (`check_temporal` → `temporal_in_range`), so the stale "intentionally not checked" deferral is replaced by the real contract statement and the #2981-era `TODO(#3027)` retires with the implementation.

Changelog entry under `### Fixed` (new 422 refusal class). Packaged `openehr-its` content changes → lockstep **0.0.55**, fuzz lock refreshed. Gates: full `openehr-its` suite 613/613 pre-rebase and the precision/temporal battery post-rebase, clippy, fmt, comment-style `--all`, changelog-structure — green. The cycle-closing conformance zero-drift run covers this together with the TDD and quick-xml wire changes and starts now on this exact content.