### PR TITLE
fix(hosted): the sandbox CDR receives only DATABASE_URL, never the whole .env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Fixed
+
+- The hosted-sandbox CDR no longer crashloops when the box's `.env` carries a
+  `FERROEHR_`-prefixed Compose image variable the server does not recognise.
+  The CDR service in `deploy/hosted/docker-compose.yml` stops loading the whole
+  `.env` into the container and now receives only `DATABASE_URL` (interpolated,
+  and a boot error if unset) plus its config-file path. Compose image variables
+  stay substitution-only and never reach the server's strict configuration
+  check, so a renamed or stale image variable in the operator's `.env` cannot
+  stop the server from starting.
+
 ## [4.0.16] - 2026-09-02
 
 ### Changed

--- a/deploy/hosted/docker-compose.yml
+++ b/deploy/hosted/docker-compose.yml
@@ -42,11 +42,17 @@ services:
           memory: 4096m
     environment:
       FERROEHR_CONFIG: /etc/ferroehr/ferroehr.toml
-    env_file:
-      # DATABASE_URL (the DB box's private-network string) and the image
-      # references. The operator's file, readable by the service user alone;
-      # no automation writes it and CI never holds the connection string.
-      - .env
+      # The DB box's private-network string, interpolated from `.env` (Compose
+      # reads `.env` for ${...} substitution regardless), so the ONLY thing the
+      # container's environment gains from `.env` is this one key — the config
+      # alias layer maps DATABASE_URL to db.url (app/ferroehr/src/config/alias.rs).
+      # Not `env_file: .env`: that injected EVERY operator var, including the
+      # compose-only FERROEHR_*_IMAGE substitution names, and the CDR's strict
+      # boot sweep (app/ferroehr/src/config/strict.rs) rejects any FERROEHR_ name
+      # it does not allowlist — so a stale image var in `.env` crashlooped the
+      # CDR (a renamed image var and its allowlist entry drifting apart). An
+      # explicit key list cannot drift with the operator's file.
+      DATABASE_URL: ${DATABASE_URL:?DATABASE_URL must be set in /opt/ferroehr-sandbox/.env}
     volumes:
       - ./ferroehr.sandbox.toml:/etc/ferroehr/ferroehr.toml:ro
     expose:

--- a/deploy/hosted/env.example
+++ b/deploy/hosted/env.example
@@ -15,6 +15,9 @@ DATABASE_URL=postgres://ferroehr:CHANGE_ME@10.0.0.2:5432/ferroehr
 # The exact image references the compose file runs. `:latest` is the release
 # pointer the image lane moves on real release tags; naming a version here
 # instead is how a rollback pins an older one. The deploy script reads
-# FERROEHR_IMAGE to know which image carries the posture it installs.
+# FERROEHR_IMAGE to know which image carries the posture it installs. These are
+# Compose SUBSTITUTION variables (${...} in docker-compose.yml) only — no
+# container receives them in its environment, so an extra or renamed image var
+# here can never reach the CDR's strict config sweep. Add image vars freely.
 FERROEHR_IMAGE=ghcr.io/rubentalstra/ferroehr:latest
 FERROEHR_VIEWER_IMAGE=ghcr.io/rubentalstra/ferroehr-viewer:latest


### PR DESCRIPTION
Closes #3048

The hosted-sandbox CDR crashloops on deploy whenever the box's `.env` carries a `FERROEHR_`-prefixed image variable the server does not allowlist. It happened at v4.0.15 (`FERROEHR_VIEWER_IMAGE`) and again at v4.0.16 (`FERROEHR_ADMIN_UI_IMAGE`, a leftover from the viewer rename):

```
Error: unknown configuration environment variable `FERROEHR_ADMIN_UI_IMAGE` — did you mean `FERROEHR__ADMIN__UI_IMAGE`?
```

**Cause.** The `ferroehr` service used `env_file: - .env`, injecting every operator variable — including the compose-only `FERROEHR_*_IMAGE` substitution names — into the container. The CDR's strict boot sweep (`app/ferroehr/src/config/strict.rs`) rejects any `FERROEHR_` name that is neither a config key nor allowlisted (`config/alias.rs`). An image var's allowlist entry moves on a rename; the operator's hand-maintained `.env` does not — so the two drift and a stale var refuses the boot. The viewer service never had this because it passes only its config path and takes its image via `${...}` substitution.

**Fix.** The CDR now matches the viewer: no `env_file`, and `DATABASE_URL: ${DATABASE_URL:?...}` interpolated from `.env` (Compose reads `.env` for substitution regardless). The container's environment is a closed explicit set (`DATABASE_URL` + `FERROEHR_CONFIG`); no compose image var can reach the config sweep, present, renamed or stale. `env.example` documents that image vars are substitution-only.

Verified with `docker compose config`: the CDR container env is exactly `{DATABASE_URL, FERROEHR_CONFIG}`, and an unset `DATABASE_URL` fails loudly (`required variable DATABASE_URL is missing a value: DATABASE_URL must be set in /opt/ferroehr-sandbox/.env`).

The live box was already remediated (stale line removed, CDR recreated); `sandbox.ferroehr.eu/ferroehr/rest/status` serves `server_version: 4.0.16`, UP. This durable fix reaches the box with the next release image, since the compose file is installed from the image at deploy time.