### PR TITLE
feat(config): a validated configurable REST base path that keeps the leading /ferroehr segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,34 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Added
+
+- `server.base_path` (`FERROEHR__SERVER__BASE_PATH`) is a supported, validated
+  knob: a deployment behind a path-prefixed reverse proxy can shorten the REST
+  base path to as little as `/ferroehr/v1` instead of stacking the proxy prefix
+  on top of the full default. The API nest, `Location` headers, the System
+  Options manifest, the served OpenAPI documents, the Swagger UI, the status
+  document and SMART discovery all follow the configured value; the health
+  family stays at the process root. The default is unchanged.
+- The FerroEHR Viewer gained the mirror key `cdr.base_path`
+  (`FERROEHR_VIEWER__CDR__BASE_PATH`, default `/ferroehr/rest/openehr/v1`), so a
+  viewer can drive a CDR that shortened its base path.
+
+### Changed
+
+- `server.base_path` is now checked at boot, and a value that breaks a rule
+  stops the server with an error naming the key and every rule it broke. The
+  first segment must be `ferroehr`, the last must be the openEHR API version
+  segment `v1`, and the value must carry no trailing slash, no empty segment,
+  and only unreserved URL characters. Values that previously booted and served a
+  broken surface are now refused: a trailing slash, a missing `/ferroehr`
+  segment, a path not ending in `v1`. The default value is unaffected.
+- `ferroehr healthcheck` no longer hard-codes the default REST root: with no
+  `--url`/`FERROEHR_HEALTHCHECK_URL` it loads the same configuration as the
+  server and probes `http://127.0.0.1:<server.bind port><REST root>/status`, so
+  the container health check keeps working when `server.base_path` is
+  shortened. The URL it probes under the defaults is unchanged.
+
 ### Fixed
 
 - The hosted-sandbox CDR no longer crashloops when the box's `.env` carries a

--- a/app/ferroehr-rest/src/extensions/openapi.rs
+++ b/app/ferroehr-rest/src/extensions/openapi.rs
@@ -189,13 +189,9 @@ pub fn extensions_document(cfg: &AppConfig) -> utoipa::openapi::OpenApi {
     // Public (no lock). The health family is mounted at the process root and is
     // base-path-independent, so it needs no re-homing.
     doc.merge(health::openapi());
-    let rest_root = cfg
-        .server
-        .base_path
-        .strip_suffix("/openehr/v1")
-        .unwrap_or(&cfg.server.base_path);
-    doc.merge(status::openapi(rest_root));
-    doc.merge(crate::smart::discovery::openapi(cfg, rest_root));
+    let rest_root = cfg.server.rest_root();
+    doc.merge(status::openapi(&rest_root));
+    doc.merge(crate::smart::discovery::openapi(cfg, &rest_root));
     // The System API's OPTIONS operation is a closure route mounted outside
     // `OpenApiRouter` (above CORS), documented via its twin.
     doc.merge(crate::api::system::options::openapi(&cfg.server.base_path));

--- a/app/ferroehr-rest/src/router.rs
+++ b/app/ferroehr-rest/src/router.rs
@@ -80,12 +80,7 @@ pub fn router(state: AppState, authenticator: Arc<Authenticator>) -> Router {
     let cfg = state.config().clone();
     let mgmt_rbac = management_rbac(&state);
     let observability = state.observability().clone();
-    let rest_root = cfg
-        .server
-        .base_path
-        .strip_suffix("/openehr/v1")
-        .unwrap_or(&cfg.server.base_path)
-        .to_owned();
+    let rest_root = cfg.server.rest_root();
 
     // A known path called with a method it does not serve renders `405` with the
     // openEHR body (overview §HTTP Methods); axum supplies the mandatory `Allow`

--- a/app/ferroehr-rest/tests/it/base_path_http.rs
+++ b/app/ferroehr-rest/tests/it/base_path_http.rs
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: FerroEHR contributors
+// SPDX-License-Identifier: MIT
+
+//! The whole served surface at a NON-default `server.base_path`.
+//!
+//! ITS-REST locates the API at a deployment-chosen base followed by the
+//! version segment (`docs/specs/openehr/ITS-REST/specifications/docs/overview/
+//! Resources.md` §Resource identification), so a deployment may shorten the
+//! base path — for instance behind a path-prefixed reverse proxy, where the
+//! proxy's own prefix stacks on top of it. This module drives the assembled
+//! router at `/ferroehr/v1` and asserts that everything moved with it: the API
+//! nest, the `Location` header a commit returns, the System Options manifest,
+//! the product-root status document, and the served `OpenAPI` document, whose
+//! every declared path must be one this deployment actually serves.
+//!
+//! No openEHR spec governs where the non-API surfaces root — our own
+//! design/extension.
+
+use axum::Router;
+use ferroehr::config::FerroEhrConfig;
+use ferroehr_rest::config::AppConfig;
+use http::{StatusCode, header};
+use serde_json::Value;
+
+use crate::common;
+
+/// The shortened base path this module runs the whole server at.
+const SHORT_BASE: &str = "/ferroehr/v1";
+
+/// The product root that base path derives, where `/status`, the `OpenAPI`
+/// documents and the SMART discovery document hang.
+const SHORT_ROOT: &str = "/ferroehr";
+
+/// The assembled router at [`SHORT_BASE`], with the Swagger surface on so the
+/// served documents are reachable.
+async fn short_base_router() -> (testkit::TestDb, Router) {
+    // `api_config` supplies the unauthenticated baseline; only the base path
+    // and the Swagger surface differ from it here.
+    let config = AppConfig {
+        server: ferroehr::config::server::ServerConfig {
+            bind: "127.0.0.1:0".to_owned(),
+            base_path: SHORT_BASE.to_owned(),
+            max_in_flight: 1024,
+            swagger_ui: true,
+            cors_permissive: false,
+            ..Default::default()
+        },
+        ..common::api_config(false)
+    };
+    let (db, service) = common::test_service().await;
+    (db, common::router_with(config, service))
+}
+
+/// The shortened base path is a value boot validation ACCEPTS — the wire
+/// behaviour below only matters for a configuration a server would start on.
+#[test]
+fn the_shortened_base_path_passes_boot_validation() {
+    let mut cfg = FerroEhrConfig::default();
+    cfg.server.base_path = SHORT_BASE.to_owned();
+    assert!(cfg.validate().is_ok());
+    assert_eq!(cfg.server.rest_root(), SHORT_ROOT);
+}
+
+/// The API answers under the configured base path, the `Location` it returns
+/// points back into it, and the default path is gone.
+#[tokio::test]
+async fn the_api_moves_with_the_base_path() {
+    let (_pg, app) = short_base_router().await;
+
+    let (status, headers, _body) =
+        common::send(&app, common::request("POST", &format!("{SHORT_BASE}/ehr"))).await;
+    assert_eq!(status, StatusCode::CREATED);
+    let location = headers
+        .get(header::LOCATION)
+        .and_then(|v| v.to_str().ok())
+        .expect("Location on a created EHR");
+    assert!(
+        location.starts_with(&format!("{SHORT_BASE}/ehr/")),
+        "Location {location} must point into the configured base path"
+    );
+
+    // The created EHR is readable at the Location the server just handed out.
+    assert_eq!(
+        common::send_status(&app, common::get(location)).await,
+        StatusCode::OK
+    );
+
+    // Nothing answers at the default base path any more.
+    assert_eq!(
+        common::send_status(&app, common::get(&format!("{}/ehr", common::BASE))).await,
+        StatusCode::NOT_FOUND
+    );
+}
+
+/// The System Options manifest stays at the API base-path root itself
+/// (ITS-REST System API), and the product-root status document follows the
+/// derived REST root rather than the default `/ferroehr/rest`.
+#[tokio::test]
+async fn the_root_surfaces_follow_the_derived_rest_root() {
+    let (_pg, app) = short_base_router().await;
+
+    let (status, _headers, body) = common::send(&app, common::request("OPTIONS", SHORT_BASE)).await;
+    assert_eq!(status, StatusCode::OK);
+    let manifest: Value = serde_json::from_str(&body).expect("Options manifest is JSON");
+    assert_eq!(
+        manifest.get("solution").and_then(Value::as_str),
+        Some("FerroEHR")
+    );
+
+    assert_eq!(
+        common::send_status(&app, common::get(&format!("{SHORT_ROOT}/status"))).await,
+        StatusCode::OK
+    );
+    assert_eq!(
+        common::send_status(&app, common::get("/ferroehr/rest/status")).await,
+        StatusCode::NOT_FOUND
+    );
+    // The health family is mounted at the process root and never moves.
+    assert_eq!(
+        common::send_status(&app, common::get("/health")).await,
+        StatusCode::OK
+    );
+}
+
+/// Every path in the served document is one this deployment actually mounts:
+/// the API under the configured base path, the operational surfaces under the
+/// derived product root, the health family at the process root.
+#[tokio::test]
+async fn the_served_openapi_declares_only_paths_this_deployment_serves() {
+    let (_pg, app) = short_base_router().await;
+
+    let (status, _headers, body) = common::send(
+        &app,
+        common::get(&format!("{SHORT_ROOT}/api-docs/openapi.json")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let doc: Value = serde_json::from_str(&body).expect("served openapi json");
+    let paths = doc
+        .get("paths")
+        .and_then(Value::as_object)
+        .expect("the served document declares paths");
+    assert!(!paths.is_empty());
+
+    let allowed = [
+        SHORT_BASE.to_owned(),
+        format!("{SHORT_ROOT}/status"),
+        format!("{SHORT_ROOT}/api-docs"),
+        format!("{SHORT_ROOT}/swagger-ui"),
+        format!("{SHORT_ROOT}/.well-known"),
+        "/health".to_owned(),
+        "/management".to_owned(),
+    ];
+    for path in paths.keys() {
+        assert!(
+            allowed.iter().any(|prefix| path.starts_with(prefix)),
+            "served path {path} is outside this deployment's mounted surfaces"
+        );
+        assert!(
+            !path.starts_with(common::BASE),
+            "served path {path} still spells the default base path"
+        );
+    }
+
+    // The Swagger UI moved with the root too.
+    assert_eq!(
+        common::send_status(&app, common::get(&format!("{SHORT_ROOT}/swagger-ui"))).await,
+        StatusCode::TEMPORARY_REDIRECT
+    );
+}

--- a/app/ferroehr-rest/tests/it/main.rs
+++ b/app/ferroehr-rest/tests/it/main.rs
@@ -34,6 +34,7 @@ mod audit_iti81;
 mod authz_cedar_engine;
 mod authz_remote_pdp;
 mod authz_route_matrix;
+mod base_path_http;
 mod composition_validation_http;
 mod connection_bounds;
 mod definition_adl2_http;

--- a/app/ferroehr-server/src/lib.rs
+++ b/app/ferroehr-server/src/lib.rs
@@ -67,13 +67,11 @@ pub struct Cli {
 pub enum Command {
     /// Probe the running server's status endpoint; exit 0 on 2xx, 1 otherwise.
     Healthcheck {
-        /// The status URL to probe.
-        #[arg(
-            long,
-            env = "FERROEHR_HEALTHCHECK_URL",
-            default_value = "http://127.0.0.1:8080/ferroehr/rest/status"
-        )]
-        url: String,
+        /// The status URL to probe. Unset, it is derived from the effective
+        /// configuration: `http://127.0.0.1:<server.bind port><REST root>/status`,
+        /// so a shortened `server.base_path` moves the probe with it.
+        #[arg(long, env = "FERROEHR_HEALTHCHECK_URL")]
+        url: Option<String>,
     },
     /// Configuration utilities (validate / print the annotated default).
     Config {
@@ -129,7 +127,13 @@ fn parse_override(raw: &str) -> Result<(String, String), String> {
 /// subcommand; the process exit code follows from `main` returning it.
 pub async fn run(cli: Cli) -> anyhow::Result<()> {
     match cli.command {
-        Some(Command::Healthcheck { url }) => healthcheck(&url).await,
+        Some(Command::Healthcheck { url }) => {
+            let url = match url {
+                Some(url) => url,
+                None => healthcheck_url(cli.config.as_deref(), &cli.set)?,
+            };
+            healthcheck(&url).await
+        }
         Some(Command::Config { cmd }) => run_config(&cmd, cli.config.as_deref(), &cli.set),
         Some(Command::Db { cmd }) => run_db(&cmd, cli.config.as_deref(), &cli.set).await,
         None => serve(cli.config.as_deref(), &cli.set).await,
@@ -205,6 +209,33 @@ fn run_config(
             Ok(())
         }
     }
+}
+
+/// The default healthcheck URL, derived from the effective configuration.
+///
+/// The probe runs inside the container beside the server, so it reads the same
+/// configuration the server booted with: the port of `server.bind` and the REST
+/// root `server.base_path` derives. Loopback is fixed; the bind address is
+/// whatever the listener accepts from, which is not necessarily dialable.
+///
+/// # Errors
+/// The configuration fails to load, or `server.bind` carries no port.
+pub fn healthcheck_url(
+    config_path: Option<&Path>,
+    overrides: &[(String, String)],
+) -> anyhow::Result<String> {
+    let config =
+        ferroehr::config::load(config_path, overrides).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let port = config
+        .server
+        .bind
+        .rsplit_once(':')
+        .map(|(_, port)| port)
+        .with_context(|| format!("server.bind `{}` carries no port", config.server.bind))?;
+    Ok(format!(
+        "http://127.0.0.1:{port}{}/status",
+        config.server.rest_root()
+    ))
 }
 
 /// Probe `url`; `Ok(())` iff the response status is 2xx.

--- a/app/ferroehr-server/tests/it/wiring.rs
+++ b/app/ferroehr-server/tests/it/wiring.rs
@@ -128,10 +128,11 @@ fn config_without_a_utility_is_rejected() {
     );
 }
 
-/// `healthcheck` takes an explicit URL and otherwise defaults to the local
-/// status endpoint.
+/// `healthcheck` takes an explicit URL and otherwise derives the local status
+/// endpoint from the effective configuration, so the probe follows a
+/// shortened `server.base_path` and a moved `server.bind` port.
 #[test]
-fn healthcheck_url_is_optional_with_a_default() -> Result<(), clap::Error> {
+fn healthcheck_url_is_optional_with_a_derived_default() -> Result<(), clap::Error> {
     let explicit = Cli::try_parse_from(["ferroehr", "healthcheck", "--url", "http://h:8080/x"])?;
     assert!(
         format!("{explicit:?}").contains("http://h:8080/x"),
@@ -139,9 +140,20 @@ fn healthcheck_url_is_optional_with_a_default() -> Result<(), clap::Error> {
     );
     let defaulted = Cli::try_parse_from(["ferroehr", "healthcheck"])?;
     assert!(
-        format!("{defaulted:?}").contains("/ferroehr/rest/status"),
-        "default URL missing: {defaulted:?}"
+        format!("{defaulted:?}").contains("url: None"),
+        "an absent URL must stay absent at parse time: {defaulted:?}"
     );
+    let default_url = ferroehr_server::healthcheck_url(None, &[]).expect("default config loads");
+    assert_eq!(default_url, "http://127.0.0.1:8080/ferroehr/rest/status");
+    let shortened = ferroehr_server::healthcheck_url(
+        None,
+        &[
+            ("server.base_path".to_owned(), "/ferroehr/v1".to_owned()),
+            ("server.bind".to_owned(), "0.0.0.0:9090".to_owned()),
+        ],
+    )
+    .expect("overridden config loads");
+    assert_eq!(shortened, "http://127.0.0.1:9090/ferroehr/status");
     Ok(())
 }
 

--- a/app/ferroehr-viewer/src/auth.rs
+++ b/app/ferroehr-viewer/src/auth.rs
@@ -165,8 +165,8 @@ pub async fn fetch_login_screen() -> Result<LoginScreen, ViewerError> {
     })
 }
 
-/// The CDR `/ferroehr/rest/status` document (public endpoint), raw JSON — the
-/// shell's health pill and the system panel both read it.
+/// The CDR status document (`{rest root}/status`, a public endpoint), raw
+/// JSON: the shell's health pill and the system panel both read it.
 ///
 /// # Errors
 /// [`ViewerError::Unauthenticated`] without a session (the shell only
@@ -175,7 +175,7 @@ pub async fn fetch_login_screen() -> Result<LoginScreen, ViewerError> {
 pub async fn fetch_status() -> Result<String, ViewerError> {
     crate::session::require_session().await?;
     let state: crate::state::AppState = leptos::prelude::expect_context();
-    let url = state.cdr.origin_url("ferroehr/rest/status");
+    let url = state.cdr.rest_root_url("status");
     let response = state.cdr.get_public(&url, "application/json").await?;
     Ok(crate::cdr::CdrClient::expect_success(response)?.body)
 }

--- a/app/ferroehr-viewer/src/cdr.rs
+++ b/app/ferroehr-viewer/src/cdr.rs
@@ -131,6 +131,13 @@ pub struct CdrClient {
     http: reqwest::Client,
     /// scheme://host:port — no trailing slash.
     origin: String,
+    /// The CDR's ITS-REST base path — leading slash, no trailing slash
+    /// ([`CdrConfig::rest_base_path`](crate::config::CdrConfig::rest_base_path)).
+    base_path: String,
+    /// The CDR's product root, where `/status`, `/api-docs/…` and the SMART
+    /// discovery document live
+    /// ([`CdrConfig::rest_root`](crate::config::CdrConfig::rest_root)).
+    rest_root: String,
     /// The management surface's base URL including its base path — no trailing
     /// slash. Derived from the configuration
     /// ([`CdrConfig::management_base`](crate::config::CdrConfig::management_base)),
@@ -153,18 +160,22 @@ impl CdrClient {
         Ok(Self {
             http,
             origin: cfg.base_url.trim_end_matches('/').to_owned(),
+            base_path: cfg.rest_base_path().to_owned(),
+            rest_root: cfg.rest_root().to_owned(),
             management_base: cfg.management_base(),
         })
     }
 
-    /// The ITS-REST v1 base (`{origin}/ferroehr/rest/openehr/v1`). Endpoint
-    /// paths appended to this come from the generated `openehr-its` REST
-    /// contract; the served `openapi.json` is the cross-check.
+    /// The ITS-REST v1 base (`{origin}{base_path}`, default
+    /// `/ferroehr/rest/openehr/v1`). Endpoint paths appended to this come from
+    /// the generated `openehr-its` REST contract; the served `openapi.json` is
+    /// the cross-check.
     #[must_use]
     pub fn rest_v1(&self, path: &str) -> String {
         format!(
-            "{}/ferroehr/rest/openehr/v1/{}",
+            "{}{}/{}",
             self.origin,
+            self.base_path,
             path.trim_start_matches('/')
         )
     }
@@ -175,11 +186,24 @@ impl CdrClient {
     /// so the trailing slash `rest_v1("")` would add must not be sent.
     #[must_use]
     pub fn rest_v1_root(&self) -> String {
-        format!("{}/ferroehr/rest/openehr/v1", self.origin)
+        format!("{}{}", self.origin, self.base_path)
     }
 
-    /// A URL directly under the CDR origin (`/ferroehr/rest/status`,
-    /// `/.well-known/smart-configuration`, the served `openapi.json`).
+    /// A URL under the CDR's product root — the surfaces that sit beside the
+    /// openEHR API rather than inside it (`status`, `api-docs/openapi.json`,
+    /// `.well-known/smart-configuration`).
+    #[must_use]
+    pub fn rest_root_url(&self, path: &str) -> String {
+        format!(
+            "{}{}/{}",
+            self.origin,
+            self.rest_root,
+            path.trim_start_matches('/')
+        )
+    }
+
+    /// A URL directly under the CDR origin (the always-on health family, and
+    /// anything else the server mounts at the process root).
     #[must_use]
     pub fn origin_url(&self, path: &str) -> String {
         format!("{}/{}", self.origin, path.trim_start_matches('/'))
@@ -613,6 +637,46 @@ mod tests {
             r#"{"message":"Validation failed","validationErrors":[]}"#,
         );
         assert_eq!(diagnostic_of(&plain), "Validation failed");
+    }
+
+    /// The viewer mirrors the CDR's own base-path rule: the API hangs off
+    /// `cdr.base_path`, and the product root drops the trailing `v1` segment
+    /// plus an `openehr` segment directly before it. Restated here because the
+    /// viewer reaches the CDR strictly over ITS-REST and never links against
+    /// its crates.
+    #[test]
+    fn every_url_family_follows_the_configured_base_path() {
+        for (base_path, expected_root) in [
+            ("/ferroehr/rest/openehr/v1", "/ferroehr/rest"),
+            ("/ferroehr/v1", "/ferroehr"),
+            ("/ferroehr/openehr/v1", "/ferroehr"),
+            ("/ferroehr/cdr/v1", "/ferroehr/cdr"),
+            // A trailing slash is normalized away rather than doubling a
+            // separator into every derived URL.
+            ("/ferroehr/v1/", "/ferroehr"),
+        ] {
+            let client = CdrClient::new(&crate::config::CdrConfig {
+                base_url: "http://cdr:8080".to_owned(),
+                base_path: base_path.to_owned(),
+                ..crate::config::CdrConfig::default()
+            })
+            .expect("client");
+            let base = base_path.trim_end_matches('/');
+            assert_eq!(
+                client.rest_v1("query/aql"),
+                format!("http://cdr:8080{base}/query/aql")
+            );
+            assert_eq!(client.rest_v1_root(), format!("http://cdr:8080{base}"));
+            assert_eq!(
+                client.rest_root_url("status"),
+                format!("http://cdr:8080{expected_root}/status")
+            );
+            // A leading slash on the path is not a second separator.
+            assert_eq!(
+                client.rest_root_url("/api-docs/openapi.json"),
+                format!("http://cdr:8080{expected_root}/api-docs/openapi.json")
+            );
+        }
     }
 
     #[test]

--- a/app/ferroehr-viewer/src/config.rs
+++ b/app/ferroehr-viewer/src/config.rs
@@ -31,9 +31,17 @@ pub struct ViewerConfig {
 #[serde(default, deny_unknown_fields)]
 pub struct CdrConfig {
     /// Base URL of the CDR (scheme://host:port, no trailing path) — the
-    /// ITS-REST base path `/ferroehr/rest/openehr/v1` is appended by the
-    /// client.
+    /// ITS-REST base path ([`Self::base_path`]) is appended by the client.
     pub base_url: String,
+    /// The CDR's ITS-REST base path, the mirror of its own `server.base_path`
+    /// (default `/ferroehr/rest/openehr/v1`).
+    ///
+    /// A deployment that shortens the CDR's base path sets the same value here,
+    /// or the viewer calls paths the CDR does not serve. The CDR validates the
+    /// shape at its own boot (first segment `ferroehr`, last segment `v1`); the
+    /// viewer only normalizes a trailing slash away. No openEHR spec governs
+    /// where a server roots its API — our own design/extension.
+    pub base_path: String,
     /// Base URL of the CDR's management surface **including its base path**
     /// (e.g. `http://cdr.internal:9464/management`). Empty = derive it from
     /// [`Self::base_url`] with the CDR's default `/management` base path.
@@ -53,6 +61,7 @@ impl Default for CdrConfig {
     fn default() -> Self {
         Self {
             base_url: "http://localhost:8080".to_owned(),
+            base_path: "/ferroehr/rest/openehr/v1".to_owned(),
             management_base_url: String::new(),
             request_timeout_secs: 30,
         }
@@ -60,6 +69,32 @@ impl Default for CdrConfig {
 }
 
 impl CdrConfig {
+    /// The configured ITS-REST base path with no trailing slash.
+    #[must_use]
+    pub fn rest_base_path(&self) -> &str {
+        self.base_path.trim_end_matches('/')
+    }
+
+    /// The CDR's product root: the base path with the segments that name the
+    /// openEHR API removed.
+    ///
+    /// The rule mirrors the CDR's own `server.base_path` → REST-root
+    /// derivation, restated here because the viewer talks to the CDR strictly
+    /// over ITS-REST and never links against its crates: the trailing `v1`
+    /// API-version segment comes off, and an `openehr` segment directly before
+    /// it when the deployment spells one. So `/ferroehr/rest/openehr/v1` roots
+    /// at `/ferroehr/rest` and `/ferroehr/v1` at `/ferroehr`. That root is
+    /// where the CDR serves `/status`, `/api-docs/…` and
+    /// `/.well-known/smart-configuration`.
+    #[must_use]
+    pub fn rest_root(&self) -> &str {
+        let base = self.rest_base_path();
+        let without_version = base.strip_suffix("/v1").unwrap_or(base);
+        without_version
+            .strip_suffix("/openehr")
+            .unwrap_or(without_version)
+    }
+
     /// The management-surface base URL with no trailing slash: the configured
     /// value, or `{base_url}/management` (the CDR's default base path) when it
     /// is empty.
@@ -262,6 +297,32 @@ pub fn load() -> Result<ViewerConfig, ConfigError> {
 #[cfg(test)]
 mod tests {
     use super::{CdrConfig, ViewerConfig};
+
+    /// The base path defaults to the CDR's own default, and the product root
+    /// derives from it by the CDR's rule: drop the trailing `v1` segment, and
+    /// an `openehr` segment directly before it when the deployment spells one.
+    #[test]
+    fn the_rest_root_derives_from_the_configured_base_path() {
+        assert_eq!(
+            CdrConfig::default().base_path,
+            "/ferroehr/rest/openehr/v1",
+            "the viewer default must mirror the CDR default"
+        );
+        for (base_path, expected) in [
+            ("/ferroehr/rest/openehr/v1", "/ferroehr/rest"),
+            ("/ferroehr/v1", "/ferroehr"),
+            ("/ferroehr/openehr/v1", "/ferroehr"),
+            ("/ferroehr/cdr/v1", "/ferroehr/cdr"),
+            ("/ferroehr/v1/", "/ferroehr"),
+        ] {
+            let cfg = CdrConfig {
+                base_path: base_path.to_owned(),
+                ..CdrConfig::default()
+            };
+            assert_eq!(cfg.rest_root(), expected, "base_path {base_path}");
+            assert_eq!(cfg.rest_base_path(), base_path.trim_end_matches('/'));
+        }
+    }
 
     #[test]
     fn management_base_defaults_to_the_cdr_origin() {

--- a/app/ferroehr-viewer/src/management.rs
+++ b/app/ferroehr-viewer/src/management.rs
@@ -14,7 +14,7 @@
 //! metrics, config or logging resource at all.
 //!
 //! **Two health readers would be one too many.** The application shell's status
-//! pill polls the product status document (`/ferroehr/rest/status`); this module
+//! pill polls the product status document (`{rest root}/status`); this module
 //! reads the *other* health contract, `/health/readiness` — the dependency
 //! indicators — and nothing else re-reads either claim.
 //!

--- a/app/ferroehr-viewer/src/pages/operations.rs
+++ b/app/ferroehr-viewer/src/pages/operations.rs
@@ -13,7 +13,7 @@
 //! reader per claim:
 //!
 //! * *Health.* The application shell's topbar pill polls the product status
-//!   document (`/ferroehr/rest/status`: is the API answering, at which version).
+//!   document (`{rest root}/status`: is the API answering, at which version).
 //!   The health card here reads the OTHER contract — the public
 //!   `/health/readiness` indicators (database ping, migrations applied,
 //!   component flags) — and the card says so on screen, so the two are never

--- a/app/ferroehr-viewer/src/pages/shell.rs
+++ b/app/ferroehr-viewer/src/pages/shell.rs
@@ -44,7 +44,7 @@ use crate::components::brand::Wordmark;
 use crate::components::scope_grants::{ScopePreviewer, capability_note, fact_row, grant_cards};
 use crate::scopes::{grants_of, policy_source};
 
-/// How often (ms) the topbar re-polls the CDR `/ferroehr/rest/status` health endpoint.
+/// How often (ms) the topbar re-polls the CDR `{rest root}/status` health endpoint.
 const HEALTH_POLL_MS: u64 = 30_000;
 
 /// The browser `localStorage` key the dark-mode preference persists under.

--- a/app/ferroehr-viewer/src/pages/system.rs
+++ b/app/ferroehr-viewer/src/pages/system.rs
@@ -42,15 +42,18 @@ use crate::components::page_header::PageHeader;
 use crate::components::surface::titled_card;
 use crate::error::ViewerError;
 
-/// Where the CDR serves its SMART service-discovery document.
+/// Where the CDR serves its SMART service-discovery document, relative to the
+/// CDR's product root.
 ///
-/// Relative to the PLATFORM base URL, which this platform gives a path
-/// segment: ITS-REST `smart_app_launch/master04-service_discovery.adoc`
+/// The document hangs off the PLATFORM base URL, which this platform gives a
+/// path segment: ITS-REST `smart_app_launch/master04-service_discovery.adoc`
 /// §"the configuration endpoint" — "If the base URL includes a path segment
 /// as `https://platform.example.com/gateway/v1`, then the configuration
 /// should be accessible at
 /// `https://platform.example.com/gateway/v1/.well-known/smart-configuration`".
-const SMART_DISCOVERY_PATH: &str = "ferroehr/rest/.well-known/smart-configuration";
+/// That segment is deployment-configured (`cdr.base_path`), so the absolute
+/// path is derived per deployment rather than spelled here.
+const SMART_DISCOVERY_PATH: &str = ".well-known/smart-configuration";
 
 /// The CDR's SMART service-discovery document, or `None` when the CDR
 /// advertises none (a `404` is a first-class "SMART disabled" state, not an
@@ -64,7 +67,7 @@ const SMART_DISCOVERY_PATH: &str = "ferroehr/rest/.well-known/smart-configuratio
 pub async fn fetch_smart_config() -> Result<Option<String>, ViewerError> {
     crate::session::require_session().await?;
     let state: crate::state::AppState = expect_context();
-    let url = state.cdr.origin_url(SMART_DISCOVERY_PATH);
+    let url = state.cdr.rest_root_url(SMART_DISCOVERY_PATH);
     let response = state.cdr.get_public(&url, "application/json").await?;
     if response.is(http::StatusCode::NOT_FOUND) {
         return Ok(None);
@@ -133,21 +136,21 @@ pub async fn fetch_openapi(
         )));
     }
     // NOTE: no openEHR spec governs an OAS-serving endpoint — our own design;
-    // the CDR serves only its own natively generated documents under this
-    // default directory ("/ferroehr/rest/api-docs/", configurable CDR-side).
+    // the CDR serves only its own natively generated documents, under the
+    // `api-docs/` directory of its product root.
     let url = if family.is_empty() {
-        state.cdr.origin_url("ferroehr/rest/api-docs/openapi.json")
+        state.cdr.rest_root_url("api-docs/openapi.json")
     } else {
-        state.cdr.origin_url(&format!(
-            "ferroehr/rest/api-docs/ferroehr-{family}.openapi.json"
-        ))
+        state
+            .cdr
+            .rest_root_url(&format!("api-docs/ferroehr-{family}.openapi.json"))
     };
     let response = state.cdr.get_public(&url, "application/json").await?;
     // Public surface; if a deployment happens to gate it, retry with the
     // session credential before giving up.
     // NOTE: the credential's audience is exactly the configured CDR origin —
-    // `url` is built by `origin_url`, so the retry can only ever re-send it to
-    // the same host the session authenticated against.
+    // `url` is built by `rest_root_url`, so the retry can only ever re-send it
+    // to the same host the session authenticated against.
     let response = if response.is(http::StatusCode::UNAUTHORIZED) {
         state
             .cdr
@@ -608,7 +611,7 @@ fn card_error(error: &ViewerError) -> AnyView {
     .into_any()
 }
 
-/// Render the parsed `/ferroehr/rest/status` document: an UP/DOWN pill plus every
+/// Render the parsed `{rest root}/status` document: an UP/DOWN pill plus every
 /// scalar field as a definition list.
 ///
 /// # Errors
@@ -1044,13 +1047,12 @@ mod tests {
     /// PLATFORM base URL, which carries a path segment here (ITS-REST
     /// `smart_app_launch/master04-service_discovery.adoc` §"the configuration
     /// endpoint"). The origin-level path is a different resource, and on a
-    /// single-origin deployment it is not the CDR's at all.
+    /// single-origin deployment it is not the CDR's at all. The constant is
+    /// therefore root-relative, and `CdrClient::rest_root_url` supplies that
+    /// segment from `cdr.base_path`.
     #[test]
     fn discovery_is_probed_under_the_platform_base_path() {
-        assert_eq!(
-            SMART_DISCOVERY_PATH,
-            "ferroehr/rest/.well-known/smart-configuration"
-        );
+        assert_eq!(SMART_DISCOVERY_PATH, ".well-known/smart-configuration");
     }
 
     /// No failure branch echoes a bare status back at the reader; each names

--- a/app/ferroehr/assets/ferroehr.default.toml
+++ b/app/ferroehr/assets/ferroehr.default.toml
@@ -31,6 +31,8 @@ spec_profile = "development"
 # ── [server] — HTTP listener + REST surface ──────────────────────────────────
 [server]
 bind = "0.0.0.0:8080"
+# Shortening is supported (e.g. "/ferroehr/v1" behind a path-prefixed proxy);
+# the first segment must be /ferroehr and the last must be v1.
 base_path = "/ferroehr/rest/openehr/v1"
 max_in_flight = 256          # concurrent-request admission cap; 0 disables shedding
 swagger_ui = true            # PROD: consider false

--- a/app/ferroehr/src/config/mod.rs
+++ b/app/ferroehr/src/config/mod.rs
@@ -106,6 +106,7 @@ impl FerroEhrConfig {
     pub fn validate(&self) -> Result<(), ConfigErrors> {
         let mut errors = Vec::new();
         self.validate_system_id(&mut errors);
+        self.validate_base_path(&mut errors);
         self.validate_mechanisms(&mut errors);
         self.validate_signing(&mut errors);
         self.validate_key_sources(&mut errors);
@@ -148,6 +149,68 @@ impl FerroEhrConfig {
                  OBJECT_VERSION_ID",
                 self.server.system_id
             )));
+        }
+    }
+
+    /// `server.base_path` names this deployment's API root, and every rule it
+    /// breaks is reported at once.
+    ///
+    /// The last segment is the ITS-REST API version `v1`: the overview locates
+    /// the API at a deployment-chosen base followed by that segment
+    /// (`ITS-REST/specifications/docs/overview/Resources.md` §Resource
+    /// identification — "the request is made to an openEHR API (of version
+    /// `v1`), located at `https://openEHRSys.example.com`"), and the REST
+    /// policy is single-version. The first segment is `ferroehr`, which is our
+    /// own rule and not configurable away. In between, any segment of RFC 3986
+    /// unreserved characters is free, with no trailing slash and no empty
+    /// segment.
+    fn validate_base_path(&self, errors: &mut Vec<ConfigError>) {
+        let path = self.server.base_path.as_str();
+        let mut refuse = |rule: &str| {
+            errors.push(ConfigError::semantic(format!(
+                "server.base_path {path:?} {rule}"
+            )));
+        };
+
+        if !path.starts_with('/') {
+            refuse("must start with `/`");
+        }
+        let trailing_slash = path.len() > 1 && path.ends_with('/');
+        if trailing_slash {
+            refuse("must not end with `/`");
+        }
+
+        let body = path.strip_prefix('/').unwrap_or(path);
+        let body = if trailing_slash {
+            body.strip_suffix('/').unwrap_or(body)
+        } else {
+            body
+        };
+        let segments: Vec<&str> = body.split('/').collect();
+
+        if segments.first() != Some(&"ferroehr") {
+            refuse(
+                "must begin with the `/ferroehr` segment (the product root is not configurable \
+                 away)",
+            );
+        }
+        if segments.last() != Some(&"v1") {
+            refuse(
+                "must end with the ITS-REST API version segment `v1` (overview Resources.md \
+                 §Resource identification)",
+            );
+        }
+        if segments.iter().any(|segment| segment.is_empty()) {
+            refuse("must not contain an empty path segment (`//`)");
+        }
+        for segment in segments
+            .iter()
+            .filter(|segment| !segment.is_empty() && !segment.chars().all(is_unreserved))
+        {
+            refuse(&format!(
+                "segment {segment:?} must use only RFC 3986 unreserved characters \
+                 (A-Z a-z 0-9 - . _ ~)"
+            ));
         }
     }
 
@@ -298,6 +361,12 @@ impl FerroEhrConfig {
         serde_json::to_value(self)
             .map_err(|e| ConfigError::semantic(format!("rendering config as JSON: {e}")))
     }
+}
+
+/// Whether `c` is an RFC 3986 §2.3 unreserved character, the set a path
+/// segment may carry without percent-encoding.
+const fn is_unreserved(c: char) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, '-' | '.' | '_' | '~')
 }
 
 /// The port component of a `host:port` bind string, if parseable.
@@ -1517,6 +1586,74 @@ mod tests {
         assert!(c.validate().is_err());
         c.management.port = Some(9100);
         assert!(c.validate().is_ok());
+    }
+
+    /// The default base path and every shortened shape an operator may reach
+    /// for satisfy the rules.
+    #[test]
+    fn validate_accepts_the_default_and_shortened_base_paths() {
+        for base_path in [
+            "/ferroehr/rest/openehr/v1",
+            "/ferroehr/v1",
+            "/ferroehr/openehr/v1",
+            "/ferroehr/cdr/v1",
+            "/ferroehr/rest-api/openehr-1.2.0/v1",
+        ] {
+            let mut c = FerroEhrConfig::default();
+            c.server.base_path = base_path.to_owned();
+            assert!(c.validate().is_ok(), "{base_path} must be accepted");
+        }
+    }
+
+    /// Each rule refuses on its own, naming the key and the rule it broke.
+    #[test]
+    fn validate_refuses_a_malformed_base_path() {
+        for (base_path, expected) in [
+            ("ferroehr/rest/openehr/v1", "must start with `/`"),
+            ("/ferroehrx/v1", "must begin with the `/ferroehr` segment"),
+            ("/x/ferroehr/v1", "must begin with the `/ferroehr` segment"),
+            (
+                "/ferroehr",
+                "must end with the ITS-REST API version segment",
+            ),
+            (
+                "/ferroehr/v2",
+                "must end with the ITS-REST API version segment",
+            ),
+            ("/ferroehr/v1/", "must not end with `/`"),
+            ("/ferroehr//v1", "must not contain an empty path segment"),
+            ("/ferroehr/re st/v1", "RFC 3986 unreserved characters"),
+        ] {
+            let mut c = FerroEhrConfig::default();
+            c.server.base_path = base_path.to_owned();
+            let err = c
+                .validate()
+                .expect_err("a malformed base path must be refused")
+                .to_string();
+            assert!(err.contains("server.base_path"), "{base_path}: {err}");
+            assert!(err.contains(expected), "{base_path}: {err}");
+        }
+    }
+
+    /// Validation is aggregated: a value breaking several rules reports them
+    /// all in one boot error, so an operator fixes the key in one iteration.
+    #[test]
+    fn validate_reports_every_broken_base_path_rule_at_once() {
+        let mut c = FerroEhrConfig::default();
+        c.server.base_path = "cdr//api/".to_owned();
+        let err = c
+            .validate()
+            .expect_err("a multiply-malformed base path must be refused")
+            .to_string();
+        for expected in [
+            "must start with `/`",
+            "must not end with `/`",
+            "must begin with the `/ferroehr` segment",
+            "must end with the ITS-REST API version segment",
+            "must not contain an empty path segment",
+        ] {
+            assert!(err.contains(expected), "{expected} missing from: {err}");
+        }
     }
 
     /// `server.system_id` is judged by the openEHR `uid` grammar itself.

--- a/app/ferroehr/src/config/server.rs
+++ b/app/ferroehr/src/config/server.rs
@@ -398,12 +398,29 @@ impl ServerConfig {
         format!("{}/api-docs/openapi.json", self.rest_root())
     }
 
-    /// The `/ferroehr/rest` root (the base path with the trailing `/openehr/v1`
-    /// removed), where status/health/docs live.
-    fn rest_root(&self) -> String {
-        self.base_path
-            .strip_suffix("/openehr/v1")
-            .unwrap_or(&self.base_path)
+    /// The deployment's product root, where the non-openEHR surfaces live
+    /// (`/status`, `/swagger-ui`, `/api-docs/openapi.json`,
+    /// `/.well-known/smart-configuration`).
+    ///
+    /// The rule is the base path with the segments that name the openEHR API
+    /// removed: the trailing `v1` API-version segment, which
+    /// [`crate::config::FerroEhrConfig::validate`] guarantees is present, and an
+    /// `openehr` segment immediately before it when the deployment spells one.
+    /// So the default `/ferroehr/rest/openehr/v1` roots at `/ferroehr/rest`,
+    /// `/ferroehr/openehr/v1` and `/ferroehr/v1` both root at `/ferroehr`, and
+    /// `/ferroehr/cdr/v1` roots at `/ferroehr/cdr`. The result is always a
+    /// strict parent of the base path, so a root-hosted route can never collide
+    /// with the API nest. No openEHR spec governs where a server roots its
+    /// non-API surfaces — our own design/extension.
+    #[must_use]
+    pub fn rest_root(&self) -> String {
+        let without_version = self
+            .base_path
+            .strip_suffix("/v1")
+            .unwrap_or(&self.base_path);
+        without_version
+            .strip_suffix("/openehr")
+            .unwrap_or(without_version)
             .to_owned()
     }
 }
@@ -492,6 +509,38 @@ impl Default for SystemOptionsConfig {
             vendor: "FerroEHR project".to_owned(),
             restapi_specs_version: crate::telemetry::provenance::ITS_REST.to_owned(),
             conformance_profile: crate::telemetry::provenance::CONFORMANCE_PROFILE.to_owned(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::server::ServerConfig;
+
+    /// The REST root drops the openEHR API segments and nothing else, for every
+    /// base-path shape `FerroEhrConfig::validate` admits.
+    #[test]
+    fn rest_root_drops_the_openehr_api_segments() {
+        for (base_path, expected) in [
+            ("/ferroehr/rest/openehr/v1", "/ferroehr/rest"),
+            ("/ferroehr/v1", "/ferroehr"),
+            ("/ferroehr/openehr/v1", "/ferroehr"),
+            ("/ferroehr/cdr/v1", "/ferroehr/cdr"),
+            (
+                "/ferroehr/rest/openehr/v1/openehr/v1",
+                "/ferroehr/rest/openehr/v1",
+            ),
+        ] {
+            let cfg = ServerConfig {
+                base_path: base_path.to_owned(),
+                ..ServerConfig::default()
+            };
+            assert_eq!(cfg.rest_root(), expected, "base_path {base_path}");
+            assert_eq!(cfg.swagger_ui_path(), format!("{expected}/swagger-ui"));
+            assert_eq!(
+                cfg.openapi_json_path(),
+                format!("{expected}/api-docs/openapi.json")
+            );
         }
     }
 }

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # A published OCI version is immutable by refusal rather than by the registry —
 # `helm push` over an existing tag replaces it silently — so a correction always
 # ships as a NEW version and the published one stands as it was.
-version: 7.0.2
+version: 7.0.3
 # The DEFAULT container image tag (overridable via image.tag). Equals the
 # workspace version in Cargo.toml, bumped in the release PR beside the
 # docker-compose.yml image tags — one version sweep, the compose treatment

--- a/deploy/helm/ferroehr/README.md
+++ b/deploy/helm/ferroehr/README.md
@@ -2,7 +2,7 @@
 
 Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.1.0 + AQL 1.1). A single static binary deployed with a hardened-by-default security posture: runs as a non-root, read-only-rootfs workload whose NetworkPolicy admits its serving port only, and that connects to an EXTERNAL PostgreSQL 18 as an unprivileged app role (migrations are run out of band by a separate migrator role).
 
-![Version: 7.0.2](https://img.shields.io/badge/Version-7.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.16](https://img.shields.io/badge/AppVersion-4.0.16-informational?style=flat-square)
+![Version: 7.0.3](https://img.shields.io/badge/Version-7.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.16](https://img.shields.io/badge/AppVersion-4.0.16-informational?style=flat-square)
 
 FerroEHR is a pure-Rust openEHR Clinical Data Repository: ITS-REST 1.1.0 at the
 API, AQL 1.1 as the query language, PostgreSQL 18-native storage, shipped as a
@@ -33,7 +33,7 @@ to add; `helm repo add` does not apply to this chart:
 
 ```console
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 7.0.2 \
+  --version 7.0.3 \
   --namespace ferroehr --create-namespace \
   --set database.existingSecret=ferroehr-db \
   --set image.tag=4.0.16
@@ -47,7 +47,7 @@ They are independent SemVer lines and they move independently:
 
 | What | Set with | This release |
 |---|---|---|
-| the **chart** (templates, defaults, this document) | `--version` | `7.0.2` |
+| the **chart** (templates, defaults, this document) | `--version` | `7.0.3` |
 | the **server image** | `image.tag` | `4.0.16` |
 
 `appVersion` is the image the chart defaults to; pinning `image.tag` explicitly
@@ -59,7 +59,7 @@ The chart carries two keyless Sigstore artifacts, and they answer different
 questions. A **cosign signature:** who signed this:
 
 ```console
-cosign verify ghcr.io/rubentalstra/charts/ferroehr:7.0.2 \
+cosign verify ghcr.io/rubentalstra/charts/ferroehr:7.0.3 \
   --certificate-identity-regexp '^https://github\.com/rubentalstra/FerroEHR/\.github/workflows/publish-chart\.yml@' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
@@ -67,7 +67,7 @@ cosign verify ghcr.io/rubentalstra/charts/ferroehr:7.0.2 \
 A **SLSA build provenance attestation:** what source it was built from, and how:
 
 ```console
-gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:7.0.2 \
+gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:7.0.3 \
   -R rubentalstra/FerroEHR
 gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:4.0.16 \
   -R rubentalstra/FerroEHR

--- a/deploy/helm/ferroehr/templates/viewer.yaml
+++ b/deploy/helm/ferroehr/templates/viewer.yaml
@@ -95,6 +95,12 @@ spec:
             # talks to the database, and the egress policy below enforces that.
             - name: FERROEHR_VIEWER__CDR__BASE_URL
               value: {{ printf "http://%s:%v" (include "ferroehr.fullname" .) .Values.service.port | quote }}
+            {{- with (dig "server" "base_path" "" (.Values.config | default dict)) }}
+            # The viewer's base path mirrors the CDR's own, so shortening
+            # config.server.base_path cannot leave the two disagreeing.
+            - name: FERROEHR_VIEWER__CDR__BASE_PATH
+              value: {{ . | quote }}
+            {{- end }}
             {{- if .Values.viewer.auth.oidc.enabled }}
             - name: FERROEHR_VIEWER__AUTH__OIDC__ENABLED
               value: "true"

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), and only from the networkPolicy.ingressFrom peers.
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -97,7 +97,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -118,7 +118,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -150,7 +150,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -176,7 +176,7 @@ kind: Secret
 metadata:
   name: ferroehr-config
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -197,7 +197,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -401,7 +401,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr-grafana-dashboard
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -652,7 +652,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -686,7 +686,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -919,7 +919,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -953,7 +953,7 @@ kind: Ingress
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -991,7 +991,7 @@ kind: ServiceMonitor
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"

--- a/deploy/helm/golden/basic-auth.yaml
+++ b/deploy/helm/golden/basic-auth.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -51,7 +51,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -72,7 +72,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -102,7 +102,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -119,7 +119,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -247,7 +247,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -277,7 +277,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -51,7 +51,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -72,7 +72,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -87,7 +87,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -212,7 +212,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -242,7 +242,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"

--- a/deploy/helm/golden/viewer.yaml
+++ b/deploy/helm/golden/viewer.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -61,7 +61,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the viewer: only its HTTP port, but from EVERY source — this policy narrows ports, NOT sources (viewer.networkPolicy.ingressAllowAll=true). Set viewer.networkPolicy.ingressFrom for a PHI workload. Egress admits the CDR Service and DNS only.
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr-viewer
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -118,7 +118,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -139,7 +139,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -154,7 +154,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr-viewer
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr-viewer
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -184,7 +184,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -201,7 +201,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -329,7 +329,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -359,7 +359,7 @@ metadata:
     kubernetes.io/description: >-
       In-cluster address for the FerroEHR Viewer. The viewer is a REST client of the CDR and holds no data of its own; it is the human-facing surface, so this is the Service an Ingress normally publishes.
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr-viewer
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -385,7 +385,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"
@@ -581,7 +581,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR Viewer: a Leptos SSR web UI that consumes the CDR strictly over ITS-REST. It never reaches the database, which the viewer NetworkPolicy enforces rather than assumes.
   labels:
-    helm.sh/chart: ferroehr-7.0.2
+    helm.sh/chart: ferroehr-7.0.3
     app.kubernetes.io/name: ferroehr-viewer
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.16"

--- a/deploy/helm/golden/viewer.yaml
+++ b/deploy/helm/golden/viewer.yaml
@@ -642,6 +642,10 @@ spec:
             # talks to the database, and the egress policy below enforces that.
             - name: FERROEHR_VIEWER__CDR__BASE_URL
               value: "http://ferroehr:8080"
+            # The viewer's base path mirrors the CDR's own, so shortening
+            # config.server.base_path cannot leave the two disagreeing.
+            - name: FERROEHR_VIEWER__CDR__BASE_PATH
+              value: "/ferroehr/rest/openehr/v1"
           livenessProbe:
             httpGet:
               path: /

--- a/website/book/src/installation/config-cli.md
+++ b/website/book/src/installation/config-cli.md
@@ -57,7 +57,7 @@ the container `HEALTHCHECK` and the Kubernetes exec-probe fallback.
 
 | Variable | Type | Default | Description |
 |---|---|---|---|
-| `FERROEHR_HEALTHCHECK_URL` | URL | `http://127.0.0.1:8080/ferroehr/rest/status` | The URL the subcommand probes; also settable as `--url`. Not part of `ferroehr.toml`. |
+| `FERROEHR_HEALTHCHECK_URL` | URL | derived: `http://127.0.0.1:<server.bind port><REST root>/status` (`http://127.0.0.1:8080/ferroehr/rest/status` with the defaults) | The URL the subcommand probes; also settable as `--url`. Not part of `ferroehr.toml`. Unset, the subcommand loads the same configuration as the server (file, environment, `--set`) and follows `server.bind` and `server.base_path`, so a shortened base path moves the probe with it. |
 
 ## Zero-config boot and the production checklist
 

--- a/website/book/src/installation/config-server.md
+++ b/website/book/src/installation/config-server.md
@@ -24,7 +24,7 @@ system_id = "ferroehr.local"
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `bind` | string | `0.0.0.0:8080` | Socket address the API listener binds. |
-| `base_path` | string | `/ferroehr/rest/openehr/v1` | ITS-REST base path all API routes hang off. The status, health and documentation routes hang off its parent (`/ferroehr/rest` by default), and the served OpenAPI document describes whatever paths this setting produces, never the defaults. |
+| `base_path` | string | `/ferroehr/rest/openehr/v1` | ITS-REST base path all API routes hang off. Shortening it is supported; see [below](#base_path-shortening-the-rest-base-path). The served OpenAPI document describes whatever paths this setting produces, never the defaults. |
 | `max_in_flight` | int | `256` | Concurrent-request admission cap (not a rate). Requests beyond it are shed immediately with `503` + `Retry-After`, never queued, so offered load beyond capacity cannot exhaust memory. `0` installs no shedding layer at all. |
 | `swagger_ui` | bool | `true` | Serve Swagger UI + the OpenAPI JSON under the REST root. Consider `false` in production. |
 | `cors_permissive` | bool | `false` | Permissive (development) CORS. Left on, any origin may read API responses, so the server warns loudly at boot. Production configures explicit origins at the edge. |
@@ -33,6 +33,75 @@ system_id = "ferroehr.local"
 The shed sits on the clinical API subtree only, as its outermost layer: a shed
 request never reaches authentication, auditing, or the request body, and the
 always-on status, health, discovery and management routes are never shed.
+
+### `base_path`: shortening the REST base path
+
+ITS-REST leaves the API base to the deployment and fixes only the version
+segment at its end, so you may shorten `base_path`. The shape is checked at
+boot, and a value that breaks a rule stops the server with an error naming the
+key and every rule it broke:
+
+- The first segment is `ferroehr`. `/ferroehrx/v1` and `/x/ferroehr/v1` are
+  refused. This segment is not configurable away.
+- The last segment is `v1`, the openEHR API version this server implements.
+  The shortest accepted value is therefore `/ferroehr/v1`.
+- No trailing slash, no empty segment (`//`), and every segment uses only the
+  unreserved URL characters `A-Z a-z 0-9 - . _ ~`.
+
+The status and documentation routes hang off the **REST root**, which the server
+derives from `base_path` by dropping the segments that name the openEHR API: the
+trailing `v1`, plus an `openehr` segment directly before it when you spell one.
+
+| `base_path` | REST root | Status document |
+|---|---|---|
+| `/ferroehr/rest/openehr/v1` (default) | `/ferroehr/rest` | `/ferroehr/rest/status` |
+| `/ferroehr/openehr/v1` | `/ferroehr` | `/ferroehr/status` |
+| `/ferroehr/v1` | `/ferroehr` | `/ferroehr/status` |
+| `/ferroehr/cdr/v1` | `/ferroehr/cdr` | `/ferroehr/cdr/status` |
+
+The Swagger UI (`{rest root}/swagger-ui`), the OpenAPI documents
+(`{rest root}/api-docs/…`) and the SMART discovery document
+(`{rest root}/.well-known/smart-configuration`) move with it. The health family
+stays at the process root: `/health`, `/health/liveness`, `/health/readiness`.
+
+Set it from the environment with:
+
+```bash
+FERROEHR__SERVER__BASE_PATH=/ferroehr/v1
+```
+
+> [!NOTE]
+> The `ferroehr healthcheck` subcommand, which the published container images
+> run as their Docker health check, derives its default URL from the effective
+> configuration (`http://127.0.0.1:<port><REST root>/status`), so it follows a
+> shortened base path on its own. An explicit `FERROEHR_HEALTHCHECK_URL` still
+> wins, for example to probe `/health/readiness`, which no base path affects.
+
+### Behind a path-prefixed reverse proxy
+
+A proxy that mounts the CDR under a prefix stacks that prefix on top of
+`base_path`. A proxy serving the server at `/cdr` with the default base path
+gives clients URLs like:
+
+```text
+https://cdr.example.org/cdr/ferroehr/rest/openehr/v1/definition/template/adl1.4
+```
+
+Two ways to shorten that. Strip the prefix at the proxy, so the server sees the
+path it serves (nginx `proxy_pass http://cdr:8080/;` with the trailing slash,
+Caddy `handle_path`, Traefik `StripPrefix`). Or shorten the base path:
+
+```bash
+FERROEHR__SERVER__BASE_PATH=/ferroehr/v1
+```
+
+which gives `https://cdr.example.org/cdr/ferroehr/v1/definition/template/adl1.4`.
+
+Whichever you choose, tell every client. The server builds its `Location`
+headers, its served OpenAPI paths and its SMART discovery document from its own
+`base_path`, and it cannot see a prefix the proxy adds. The
+[FerroEHR Viewer](../viewer/index.md) has its own mirror key, `cdr.base_path`,
+which must match.
 
 ### `[server.limits]`: request-body sizes
 

--- a/website/book/src/installation/kubernetes.md
+++ b/website/book/src/installation/kubernetes.md
@@ -38,7 +38,7 @@ kubectl -n ferroehr create secret generic ferroehr-db \
   --from-literal=FERROEHR__DB__URL='postgres://ferroehr_app:***@pg-host:5432/ferroehr?sslmode=verify-full'
 
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 7.0.2 -n ferroehr \
+  --version 7.0.3 -n ferroehr \
   --set database.existingSecret=ferroehr-db \
   --set image.tag=4.0.16
 ```
@@ -55,7 +55,7 @@ helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
 reference. To read the chart's metadata without installing it:
 
 ```shell
-helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 7.0.2
+helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 7.0.3
 ```
 
 ### Pin two versions, not one
@@ -68,7 +68,7 @@ against.
 
 | | Selects | Pin with | Line |
 |---|---|---|---|
-| Chart version | templates, values schema, defaults | `--version 7.0.2` | SemVer over the chart's own contract |
+| Chart version | templates, values schema, defaults | `--version 7.0.3` | SemVer over the chart's own contract |
 | Image tag | the server binary | `--set image.tag=4.0.16` (or `image.digest`) | the application's SemVer line |
 
 Always pin the image to an immutable version or, better, a `@sha256` digest,
@@ -167,7 +167,7 @@ metadata lists: the server, and the optional viewer.
 > the image itself as the authority:
 >
 > ```shell
-> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 7.0.2 \
+> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 7.0.3 \
 >   -s templates/configmap.yaml --set database.existingSecret=ferroehr-db \
 >   | sed -n '/ferroehr.toml/,$p' | sed '1d;s/^    //' > /tmp/ferroehr.toml
 > docker run --rm -v /tmp/ferroehr.toml:/etc/ferroehr/ferroehr.toml:ro \
@@ -556,7 +556,7 @@ config:
 
 ```shell
 helm upgrade ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 7.0.2 -n ferroehr --reuse-values \
+  --version 7.0.3 -n ferroehr --reuse-values \
   --set config.query.plan_cache_capacity=512
 ```
 
@@ -709,7 +709,7 @@ Preview an upgrade against what you have installed with
 `helm diff`, or render the new chart version and read it:
 
 ```shell
-helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 7.0.2 \
+helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 7.0.3 \
   -n ferroehr -f my-values.yaml | less
 ```
 

--- a/website/book/src/using-the-api/index.md
+++ b/website/book/src/using-the-api/index.md
@@ -25,15 +25,18 @@ All clinical API routes hang off a configurable base path, which defaults to:
 
 Every path in these chapters is relative to that base. So "`POST /ehr`" means
 `POST http://your-host:8080/ferroehr/rest/openehr/v1/ehr`. The base path is set
-with `FERROEHR__SERVER__BASE_PATH` (see
-[Server, database & telemetry](../installation/config-server.md#server)).
+with `FERROEHR__SERVER__BASE_PATH`, and it may be shortened as far as
+`/ferroehr/v1` (see
+[Shortening the REST base path](../installation/config-server.md#base_path-shortening-the-rest-base-path)).
 
-The status, health and documentation routes hang off the base path's **parent**
-(`/ferroehr/rest` by default), not off the base path itself: the public,
-unauthenticated status probe is at `/ferroehr/rest/status`, and interactive docs
-at `/ferroehr/rest/swagger-ui` when `swagger_ui` is on. Every deployment serves
-that UI from its own routes, so your own server always documents its own
-surface.
+The status and documentation routes hang off the **REST root**, which the server
+derives from the base path by dropping the segments that name the openEHR API:
+`/ferroehr/rest` by default. The public, unauthenticated status probe is at
+`/ferroehr/rest/status` and interactive docs at `/ferroehr/rest/swagger-ui` when
+`swagger_ui` is on. Every deployment serves that UI from its own routes, so your
+own server always documents its own surface. The health probes stay at the
+process root whatever the base path is: `/health`, `/health/liveness`,
+`/health/readiness`.
 
 ## Capability discovery
 

--- a/website/book/src/viewer/index.md
+++ b/website/book/src/viewer/index.md
@@ -126,7 +126,8 @@ overrides. Unknown keys are refused at startup, exactly as on the CDR:
 
 | Key | Default | Meaning |
 |---|---|---|
-| `cdr.base_url` | `http://localhost:8080` | The CDR origin (the ITS-REST base path is appended). |
+| `cdr.base_url` | `http://localhost:8080` | The CDR origin (`cdr.base_path` is appended). |
+| `cdr.base_path` | `/ferroehr/rest/openehr/v1` | The CDR's ITS-REST base path. Mirror of the CDR's own `server.base_path`: set the same value here when a deployment [shortens it](../installation/config-server.md#base_path-shortening-the-rest-base-path), or the viewer calls paths the CDR does not serve. The status document, the OpenAPI documents and the SMART discovery document are derived from it by the same rule the CDR uses. |
 | `cdr.request_timeout_secs` | `30` | Per-request timeout toward the CDR. |
 | `cdr.management_base_url` | derived from `cdr.base_url` | The CDR's management surface, base path included; set it when the CDR serves management on its own internal listener (`management.port`) or under a renamed base path. Drives the [Operations panel](operations.md). |
 | `auth.basic_enabled` | `true` | Offer the username/password form (validated against the CDR; held server-side). |


### PR DESCRIPTION
Closes #3050

## What

`server.base_path` (`FERROEHR__SERVER__BASE_PATH`) is now a supported, validated knob, so a deployment behind a path-prefixed reverse proxy can shorten the REST base path to as little as `/ferroehr/v1` instead of stacking the proxy prefix on the full default.

**Validation** (`FerroEhrConfig::validate_base_path`, aggregated with the other boot errors, each naming `server.base_path` and the rule): first segment exactly `ferroehr`; last segment exactly `v1`; no trailing `/`, no empty segment, RFC 3986 unreserved characters only. The `v1` rule is grounded in the ITS-REST URL structure (`overview/Resources.md` §Resource identification: the API of version `v1` sits at a deployment-chosen base; every vendored OAS file: `servers: url: https://{baseUrl}/v1`). Because the path always ends in `v1`, the REST root is always a strict parent of the base path, so the root-hosted routes can never collide with the API nest. Bare `/ferroehr` is refused; `/ferroehr/v1` is the shortest valid value.

**REST root** is one public rule, `ServerConfig::rest_root`: the base path minus the segments naming the openEHR API (the trailing `v1`, and an `openehr` segment directly before it when present). `/ferroehr/rest/openehr/v1` → `/ferroehr/rest` (default unchanged), `/ferroehr/v1` → `/ferroehr`, `/ferroehr/openehr/v1` → `/ferroehr`, `/ferroehr/cdr/v1` → `/ferroehr/cdr`. The two `strip_suffix("/openehr/v1")` copies in the router and the OpenAPI composer are gone. The health family stays at the site root.

**End to end** at `/ferroehr/v1` (`app/ferroehr-rest/tests/it/base_path_http.rs`): the API nest and `Location`, the System Options manifest, `/ferroehr/status`, the served OpenAPI paths and the Swagger UI redirect, and 404s on the old default paths.

**Viewer**: mirror key `cdr.base_path` (`FERROEHR_VIEWER__CDR__BASE_PATH`) with the same root derivation replacing the hard-coded `/ferroehr/rest/openehr/v1` and `/ferroehr/rest/...` literals (status, SMART discovery, api-docs). The Helm chart passes it from `config.server.base_path` (golden regenerated). Zero visual change, hence the label; the one user-facing string that moved is the SMART probe failure copy, which now names the root-relative `/.well-known/smart-configuration` instead of spelling the default root.

**Healthcheck**: `ferroehr healthcheck` with no `--url`/`FERROEHR_HEALTHCHECK_URL` derives `http://127.0.0.1:<server.bind port><REST root>/status` from the effective configuration, so the published images' Docker health check follows a shortened base path (found en route: the literal default would have left such a container permanently unhealthy).

**Docs**: `ferroehr.default.toml` comment, `config-server.md` (the rules, the REST-root table, a "Behind a path-prefixed reverse proxy" section), `config-cli.md`, `using-the-api/index.md`, `viewer/index.md`; changelog `Added` + `Changed`.

## Gates

fmt, leptosfmt, clippy (workspace lane + both viewer targets), nextest (`ferroehr`, `ferroehr-rest`, `ferroehr-viewer`, `ferroehr-server`), rustdoc with private items, comment-style / default-style / typed-status / docs-claims, Helm render checks, book link check: all green locally. The conformance run against the committed baseline is scheduled on `main` before the v4.0.17 cut (the default path is byte-identical; the only new default-path code is a boot check the default passes) and will be recorded on the issue.
