### PR TITLE
fix(server): the healthcheck default-URL test derives from a config value, not the process environment

### DIFF
--- a/app/ferroehr-server/src/lib.rs
+++ b/app/ferroehr-server/src/lib.rs
@@ -128,9 +128,12 @@ fn parse_override(raw: &str) -> Result<(String, String), String> {
 pub async fn run(cli: Cli) -> anyhow::Result<()> {
     match cli.command {
         Some(Command::Healthcheck { url }) => {
-            let url = match url {
-                Some(url) => url,
-                None => healthcheck_url(cli.config.as_deref(), &cli.set)?,
+            let url = if let Some(url) = url {
+                url
+            } else {
+                let config = ferroehr::config::load(cli.config.as_deref(), &cli.set)
+                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+                healthcheck_url(&config)?
             };
             healthcheck(&url).await
         }
@@ -213,19 +216,15 @@ fn run_config(
 
 /// The default healthcheck URL, derived from the effective configuration.
 ///
-/// The probe runs inside the container beside the server, so it reads the same
-/// configuration the server booted with: the port of `server.bind` and the REST
-/// root `server.base_path` derives. Loopback is fixed; the bind address is
-/// whatever the listener accepts from, which is not necessarily dialable.
+/// The probe runs inside the container beside the server, so the caller hands
+/// it the configuration the server booted with: the port of `server.bind` and
+/// the REST root `server.base_path` derives. Loopback is fixed; the bind
+/// address is whatever the listener accepts from, which is not necessarily
+/// dialable.
 ///
 /// # Errors
-/// The configuration fails to load, or `server.bind` carries no port.
-pub fn healthcheck_url(
-    config_path: Option<&Path>,
-    overrides: &[(String, String)],
-) -> anyhow::Result<String> {
-    let config =
-        ferroehr::config::load(config_path, overrides).map_err(|e| anyhow::anyhow!("{e}"))?;
+/// `server.bind` carries no port.
+pub fn healthcheck_url(config: &ferroehr::config::FerroEhrConfig) -> anyhow::Result<String> {
     let port = config
         .server
         .bind

--- a/app/ferroehr-server/tests/it/wiring.rs
+++ b/app/ferroehr-server/tests/it/wiring.rs
@@ -143,17 +143,21 @@ fn healthcheck_url_is_optional_with_a_derived_default() -> Result<(), clap::Erro
         format!("{defaulted:?}").contains("url: None"),
         "an absent URL must stay absent at parse time: {defaulted:?}"
     );
-    let default_url = ferroehr_server::healthcheck_url(None, &[]).expect("default config loads");
+    // Built directly rather than loaded: the loader snapshots the process
+    // environment, and a test runner's own `FERROEHR_*` variables are not
+    // this test's subject.
+    let mut config = ferroehr::config::FerroEhrConfig::default();
+    let default_url = ferroehr_server::healthcheck_url(&config).expect("a port is configured");
     assert_eq!(default_url, "http://127.0.0.1:8080/ferroehr/rest/status");
-    let shortened = ferroehr_server::healthcheck_url(
-        None,
-        &[
-            ("server.base_path".to_owned(), "/ferroehr/v1".to_owned()),
-            ("server.bind".to_owned(), "0.0.0.0:9090".to_owned()),
-        ],
-    )
-    .expect("overridden config loads");
+    config.server.base_path = "/ferroehr/v1".to_owned();
+    config.server.bind = "0.0.0.0:9090".to_owned();
+    let shortened = ferroehr_server::healthcheck_url(&config).expect("a port is configured");
     assert_eq!(shortened, "http://127.0.0.1:9090/ferroehr/status");
+    config.server.bind = "no-port".to_owned();
+    assert!(
+        ferroehr_server::healthcheck_url(&config).is_err(),
+        "a bind address without a port must be refused, not probed"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
Repairs the red `build & test (pg18)` lane on main after #3052: the new `healthcheck_url_is_optional_with_a_derived_default` test loaded the configuration through `ferroehr::config::load`, which snapshots the process environment, and CI exports the testkit's `FERROEHR_TEST_PG_URL`, which the strict `FERROEHR_` sweep refuses as an unknown variable.

`healthcheck_url` now takes the loaded `FerroEhrConfig` as a value (the subcommand loads it first, exactly as before), and the test builds that value directly. The test also gains the refusal case for a `server.bind` without a port. No behaviour change for operators, hence `no-changelog`.

Gates: fmt, clippy (`-D warnings`), nextest with `FERROEHR_TEST_PG_URL` exported as CI does, rustdoc with private items, comment-style.