### PR TITLE
feat(sandbox): rewrite the seed into a manifest-driven, representative demo dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,20 @@ workflow refuses a tag that has no matching section here.
   server and probes `http://127.0.0.1:<server.bind port><REST root>/status`, so
   the container health check keeps working when `server.base_path` is
   shortened. The URL it probes under the defaults is unchanged.
+- The hosted sandbox (sandbox.ferroehr.eu) now holds a complete demo dataset
+  instead of four templates in three EHRs. Each nightly reset loads 16 ADL 1.4
+  operational templates from the openEHR CKM pack, 228 ADL 2 archetypes and 5
+  ADL 2 templates (two of them source templates the server flattens against
+  that archetype library), 8 EHRs carrying 182 compositions with mixed
+  records, 6 compositions with more than one version and 2 EHRs with a second
+  `EHR_STATUS` version (one not queryable, one not modifiable), 11 demographic
+  parties, a FOLDER directory per EHR referencing real compositions, and 5
+  stored AQL queries under `eu.ferroehr.sandbox` that all return rows. The
+  seeder (`scripts/sandbox/reseed.sh`) still drives only the public REST API
+  and is now a walker over `scripts/sandbox/seed/manifest.json`, so adding
+  demo content is editing data. A run takes 39–45 s against a local stack and
+  leaves a 24 MB database; a repeat run detects the marker EHR it wrote and
+  exits without changing anything.
 
 ### Fixed
 

--- a/app/ferroehr/src/service/definition/adl2.rs
+++ b/app/ferroehr/src/service/definition/adl2.rs
@@ -125,10 +125,13 @@ impl FerroEhrService {
     }
 
     /// `upload_artefact` (Pre `valid_artefact`, Post `has_artefact`) — validate a
-    /// full ADL2 artefact through the `openehr-adl` engine and store it,
-    /// replacing any existing one with the same `ARCHETYPE_HRID` ("If an
-    /// artefact with the same physical identifier and namespace exists, replace
-    /// it" — `i_definition_adl2.adoc`).
+    /// full ADL2 artefact through the `openehr-adl` engine and store it.
+    ///
+    /// An existing artefact with the same `ARCHETYPE_HRID` is a conflict, never
+    /// replaced: the released REST API answers `409` (ITS-REST definition OAS,
+    /// `POST /definition/template/adl2` → `409_template_already_exists`), and
+    /// the wire is the API oracle where the SM's `i_definition_adl2.adoc`
+    /// wording ("replace it") differs.
     ///
     /// # Errors
     ///

--- a/deploy/hosted/README.md
+++ b/deploy/hosted/README.md
@@ -103,6 +103,56 @@ deployment being replaced answers 200 too.
 No Hetzner API token exists in CI at all — the deploy talks to the host and
 nothing else, so a leaked key cannot destroy the server.
 
+## The demo dataset
+
+`scripts/sandbox/reseed.sh` fills the wiped sandbox, driving only the public
+REST API: the seed is the same surface a visitor uses, so a green seed run is
+itself evidence that the deployment serves what it claims. The script is a
+walker over `scripts/sandbox/seed/manifest.json`, and the bodies live as files
+beside it, so **adding content is editing data**: a template slug, an EHR
+subject, an AQL file, a party. The walker itself never changes.
+
+One run loads, in about 590 requests:
+
+| What | How much |
+|---|---|
+| ADL 1.4 operational templates | 16 (the curated CKM pack, `corpus/templates/ckm/`) |
+| ADL 2 archetypes | 228 — 225 from the vendored 2013 CKM corpus plus 3 of our own |
+| ADL 2 templates | 5 (4 of our own plus one carried by the corpus); two of ours are SOURCE templates the CDR flattens against that archetype library |
+| EHRs | 8, each with a distinct subject and a mixed record |
+| Compositions | 182 (166 ADL 1.4, 16 from CDR-generated ADL 2 examples) |
+| Further versions | 6 COMPOSITION, 2 EHR_STATUS |
+| Demographic parties | 6 persons, 3 roles, 2 party relationships |
+| Directories | one FOLDER tree per EHR, its items real composition references |
+| Stored AQL queries | 5, under the `eu.ferroehr.sandbox` namespace |
+
+The ADL 2 archetype step offers the whole 322-file corpus and pins both
+outcomes in the manifest: 226 artefacts stored, 96 refused with a `422` because
+the 2013 conversions carry reference-model attributes the pinned RM no longer
+declares (`DV_QUANTITY.property` and its neighbours). A change in either count
+fails the run instead of passing quietly. Two of the eight EHRs end the run with
+a second `EHR_STATUS` version: one not queryable, one not modifiable, so both
+flags are visible on live data.
+
+Measured on 2026-09-02 against the composed quickstart stack on an 8-CPU/8 GB
+Docker VM: **39–45 s** from an empty schema, under a second on a repeat run.
+The data is ~9 MB of canonical composition JSON and leaves a **24 MB**
+database. Against the box, the ~590 sequential HTTPS round trips dominate the
+wall clock, and the `seed` job's `timeout-minutes: 20` covers that with room
+for the 12 × 15 s retry budget.
+
+Repeats are safe. The definition surfaces answer `409` when the artefact is
+already there and the walker accepts that; the EHRs resolve by subject before
+being created; and a marker EHR (`sandbox-seed-complete`) written last records
+completion, so a second run reports "already seeded" and touches nothing.
+
+The terminology seed under `docker/terminology/seed/` belongs to the
+conformance lane and stays out of this deployment. Its two synthetic code
+systems live under `cnf.example.test`, and no example in the CKM pack
+references them; the coded text those examples do carry (`openehr`, ISO 639-1,
+ISO 3166-1, plus external SNOMED CT references) resolves against the server's
+own in-process terminology bundle.
+
 ## Bootstrap and recovery
 
 The first posture on a fresh box (or recovery from a broken one) is manual by

--- a/scripts/sandbox/reseed.sh
+++ b/scripts/sandbox/reseed.sh
@@ -2,17 +2,22 @@
 # SPDX-FileCopyrightText: FerroEHR contributors
 # SPDX-License-Identifier: MIT
 #
-# Seed the hosted sandbox (#2710) with demo data through the PUBLIC API —
-# the same surface visitors use, so the seed itself proves the deployment.
-# Uploads a small slice of the vendored CKM operational templates and
-# commits each one's committed example composition into a handful of fresh
-# EHRs.
+# Seed the hosted sandbox (#2710, dataset #3045) with demo data through the
+# PUBLIC API — the same surface visitors use, so the seed itself proves the
+# deployment. This file is a WALKER: what gets loaded is
+# scripts/sandbox/seed/manifest.json plus the bodies beside it, so adding
+# content is editing data. The manifest's `notes` describe the dataset, its
+# measured runtime and the placeholder tokens substituted below.
 #
-# Every request retries: right after the nightly wipe, serverless instances
-# booted BEFORE the wipe keep serving until they idle out, and the platform
-# load-balances across old and fresh instances — a request landing on a
-# stale one answers 5xx until it recycles (observed live, #2710). Retrying
-# for a few minutes rides that window out.
+# Every request retries: right after the nightly wipe, instances booted BEFORE
+# the wipe can keep serving until they recycle, and a request landing on one
+# answers 5xx (observed live, #2710). Retrying for a few minutes rides that
+# window out. Anything else is fatal: a wrong status prints ::error:: and the
+# run exits non-zero.
+#
+# Re-runs: the definition surfaces are 409-tolerant and the EHRs resolve by
+# subject, so the seed is safe to repeat. A marker EHR written last records
+# completion, and a second run sees it and exits without touching anything.
 #
 # Environment: SANDBOX_BASE (default https://sandbox.ferroehr.eu),
 # SANDBOX_USER / SANDBOX_PASS (default the public demo credentials).
@@ -21,31 +26,45 @@ set -Eeuo pipefail
 BASE="${SANDBOX_BASE:-https://sandbox.ferroehr.eu}/ferroehr/rest/openehr/v1"
 AUTH="${SANDBOX_USER:-ferroehr}:${SANDBOX_PASS:-ferroehr}"
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SEED_DIR="$ROOT_DIR/scripts/sandbox/seed"
+MANIFEST="$SEED_DIR/manifest.json"
 TPL_DIR="$ROOT_DIR/corpus/templates/ckm"
-
-# A small, stable slice of the curated CKM pack: recognizable clinical
-# content without inflating the free-tier storage. Each slug names an
-# `<slug>.opt` + `<slug>.example.json` pair in the pack.
-TEMPLATES=(
-  vital-signs
-  medicines-list
-  problem-list
-  covid19-infection-report
-)
-EHRS=3
-COMPOSITIONS_PER_EXAMPLE=2
 ATTEMPTS=12
 RETRY_DELAY=15
 
-# POST with retry; prints the final status code. `$1` = a label, `$2` = the
-# URL, remaining args go to curl verbatim. Retries any 5xx/connection
-# failure; any non-5xx answer is final.
-post_retry() {
-  local label="$1" url="$2"
-  shift 2
+command -v jq > /dev/null || {
+  echo "::error::jq is required to walk $MANIFEST" >&2
+  exit 1
+}
+[[ -f "$MANIFEST" ]] || {
+  echo "::error::missing manifest $MANIFEST" >&2
+  exit 1
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+HDR="$WORK/headers"
+BODY="$WORK/body"
+
+# ── the manifest ─────────────────────────────────────────────────────────────
+
+# Read the manifest with a jq filter, raw output.
+mf() { jq -r "$1" "$MANIFEST"; }
+
+SUBJECT_NS="$(mf '.subject_namespace')"
+
+# ── the wire ─────────────────────────────────────────────────────────────────
+
+# One request, retried through stale instances. `$1` = a label, `$2` = the
+# method, `$3` = the URL; the rest go to curl verbatim. Prints the final status
+# code; the response headers land in $HDR and the body in $BODY.
+request() {
+  local label="$1" method="$2" url="$3"
+  shift 3
   local attempt code
   for attempt in $(seq 1 "$ATTEMPTS"); do
-    code=$(curl -sS -m 120 -u "$AUTH" -o /dev/null -w '%{http_code}' -X POST "$url" "$@" || echo 000)
+    code=$(curl -sS -m 300 -u "$AUTH" -D "$HDR" -o "$BODY" -w '%{http_code}' \
+      -X "$method" "$url" "$@" || echo 000)
     case "$code" in
       5?? | 000)
         echo "  $label answered $code (attempt $attempt/$ATTEMPTS); a stale instance may still be serving — retrying" >&2
@@ -60,56 +79,382 @@ post_retry() {
   printf '%s' "$code"
 }
 
-echo "==> seeding $BASE"
-
-# The demo EHRs, shared across every template so each carries a mixed record.
-ehrs=()
-for _e in $(seq 1 "$EHRS"); do
-  ehr=""
-  for attempt in $(seq 1 "$ATTEMPTS"); do
-    ehr=$(curl -sS -m 60 -u "$AUTH" -X POST "$BASE/ehr" -H 'Prefer: return=minimal' \
-      -D- -o /dev/null 2>/dev/null | tr -d '\r' | awk -F'/ehr/' 'tolower($0) ~ /^location/{print $2}' | tr -d ' ') || true
-    [[ -n "$ehr" ]] && break
-    echo "  EHR creation returned no Location (attempt $attempt/$ATTEMPTS); retrying" >&2
-    sleep "$RETRY_DELAY"
+# Fail loud unless `$2` is one of the accepted codes in `$3…`.
+expect() {
+  local label="$1" code="$2" want
+  shift 2
+  for want in "$@"; do
+    [[ "$code" == "$want" ]] && return 0
   done
-  if [[ -z "$ehr" ]]; then
-    echo "::error::EHR creation kept failing after $ATTEMPTS attempts — the sandbox is not serving writes." >&2
-    exit 1
-  fi
-  ehrs+=("$ehr")
-done
+  echo "::error::$label answered $code (accepted: $*)" >&2
+  head -c 600 "$BODY" >&2
+  echo >&2
+  exit 1
+}
 
-seeded=0
-for slug in "${TEMPLATES[@]}"; do
+# The last value of response header `$1`, case-insensitively.
+header_value() {
+  tr -d '\r' < "$HDR" | awk -v want="$1" '
+    BEGIN { want = tolower(want) ":" }
+    tolower($1) == want { sub(/^[^:]*:[ ]*/, ""); print }
+  ' | tail -1
+}
+
+# The identifier the weak ETag carries (`W/"<uid>"` → `<uid>`).
+etag_uid() { header_value etag | sed -e 's|^W/||' -e 's|"||g'; }
+
+# ── bodies ───────────────────────────────────────────────────────────────────
+
+# Render `$1` into `$2`, replacing each remaining `TOKEN=VALUE` pair wherever
+# TOKEN appears as a whole JSON string. The walker never writes JSON itself;
+# every body is a file under scripts/sandbox/seed/.
+render() {
+  local src="$1" dst="$2" pair token value
+  shift 2
+  cp "$src" "$dst"
+  for pair in "$@"; do
+    token="${pair%%=*}"
+    value="${pair#*=}"
+    jq --arg t "$token" --arg v "$value" \
+      'walk(if . == $t then $v else . end)' "$dst" > "$dst.next"
+    mv "$dst.next" "$dst"
+  done
+}
+
+# ── 1. completion marker ─────────────────────────────────────────────────────
+
+echo "==> seeding $BASE"
+MARKER_SUBJECT="$(mf '.marker.subject')"
+code=$(request "marker lookup" GET \
+  "$BASE/ehr?subject_id=$MARKER_SUBJECT&subject_namespace=$SUBJECT_NS")
+case "$code" in
+  200)
+    echo "==> already seeded (marker EHR $MARKER_SUBJECT present); nothing to do"
+    exit 0
+    ;;
+  404) ;;
+  *) expect "marker lookup" "$code" 200 404 ;;
+esac
+
+# ── 2. ADL 1.4 operational templates ─────────────────────────────────────────
+
+adl14_count=0
+while read -r slug; do
   opt="$TPL_DIR/$slug.opt"
-  example="$TPL_DIR/$slug.example.json"
-  [[ -f "$opt" ]] && [[ -f "$example" ]] || {
-    echo "::error::missing template pair for $slug in $TPL_DIR" >&2
+  [[ -f "$opt" ]] || {
+    echo "::error::missing operational template $opt" >&2
     exit 1
   }
-  code=$(post_retry "template $slug" "$BASE/definition/template/adl1.4" \
+  code=$(request "template $slug" POST "$BASE/definition/template/adl1.4" \
     -H 'Content-Type: application/xml' --data-binary @"$opt")
+  expect "template $slug" "$code" 201 204 409
+  adl14_count=$((adl14_count + 1))
+done < <(mf '.adl14_templates[].slug')
+echo "==> $adl14_count ADL 1.4 operational templates"
+
+# ── 3. the ADL 2 archetype library ───────────────────────────────────────────
+#
+# The whole vendored corpus is offered and both outcomes are pinned in the
+# manifest: an artefact the CDR stores, and one its AOM2 validation refuses
+# because the 2013 CKM conversion carries reference-model attributes the pinned
+# RM no longer declares (DV_QUANTITY.property and its neighbours). A change in
+# either count fails the run rather than passing quietly.
+
+lib_root="$ROOT_DIR/$(mf '.adl2.archetype_library.root')"
+want_accepted="$(mf '.adl2.archetype_library.accepted')"
+want_refused="$(mf '.adl2.archetype_library.refused')"
+accepted=0
+refused=0
+while read -r adls; do
+  code=$(request "archetype $(basename "$adls")" POST "$BASE/definition/template/adl2" \
+    -H 'Content-Type: text/plain' --data-binary @"$adls")
   case "$code" in
-    201 | 204 | 409) echo "template $slug -> $code" ;;
-    *)
-      echo "::error::template upload for $slug answered $code" >&2
-      exit 1
-      ;;
+    200 | 201 | 409) accepted=$((accepted + 1)) ;;
+    422) refused=$((refused + 1)) ;;
+    *) expect "archetype $(basename "$adls")" "$code" 201 409 422 ;;
   esac
+done < <(find "$lib_root" -name '*.adls' | LC_ALL=C sort)
 
-  for ehr in "${ehrs[@]}"; do
-    for _c in $(seq 1 "$COMPOSITIONS_PER_EXAMPLE"); do
-      code=$(post_retry "composition $slug" "$BASE/ehr/$ehr/composition" \
-        -H 'Content-Type: application/json' -H 'Prefer: return=minimal' \
-        --data-binary @"$example")
-      if [[ "$code" != "201" ]]; then
-        echo "::error::composition commit answered $code ($slug into $ehr)" >&2
-        exit 1
-      fi
-      seeded=$((seeded + 1))
-    done
+if [[ "$accepted" != "$want_accepted" ]] || [[ "$refused" != "$want_refused" ]]; then
+  echo "::error::the ADL 2 archetype library loaded $accepted accepted / $refused refused; the manifest pins $want_accepted / $want_refused. Re-check the corpus and the manifest together." >&2
+  exit 1
+fi
+echo "==> $accepted ADL 2 archetypes stored ($refused refused by AOM2 validation, as pinned)"
+
+# ── 4. this repository's own ADL 2 artefacts and templates ───────────────────
+#
+# The archetypes go first: a SOURCE template's `use_archetype` slot only
+# flattens once its filler is in the store.
+
+adl2_artefacts=0
+while read -r rel; do
+  file="$ROOT_DIR/$rel"
+  [[ -f "$file" ]] || {
+    echo "::error::missing ADL 2 artefact $file" >&2
+    exit 1
+  }
+  code=$(request "adl2 artefact $(basename "$rel")" POST "$BASE/definition/template/adl2" \
+    -H 'Content-Type: text/plain' --data-binary @"$file")
+  expect "adl2 artefact $(basename "$rel")" "$code" 201 409
+  adl2_artefacts=$((adl2_artefacts + 1))
+done < <(mf '.adl2.artefacts[]')
+
+adl2_templates=0
+while read -r rel; do
+  file="$ROOT_DIR/$rel"
+  [[ -f "$file" ]] || {
+    echo "::error::missing ADL 2 template $file" >&2
+    exit 1
+  }
+  code=$(request "adl2 template $(basename "$rel")" POST "$BASE/definition/template/adl2" \
+    -H 'Content-Type: text/plain' --data-binary @"$file")
+  expect "adl2 template $(basename "$rel")" "$code" 201 409
+  adl2_templates=$((adl2_templates + 1))
+done < <(mf '.adl2.templates[].file')
+echo "==> $adl2_artefacts ADL 2 archetypes + $adl2_templates ADL 2 templates of our own"
+
+# ── 5. the EHRs ──────────────────────────────────────────────────────────────
+#
+# Resolved by subject first: the subject of an EHR_STATUS is unique across the
+# repository, so a re-run reuses what it finds instead of failing on the
+# duplicate. Only a freshly created EHR is filled below.
+
+ehrs=()
+created=()
+reused=0
+index=0
+while read -r entry; do
+  subject=$(printf '%s' "$entry" | jq -r '.subject')
+  status_file="$SEED_DIR/$(printf '%s' "$entry" | jq -r '.status')"
+  code=$(request "ehr lookup $subject" GET \
+    "$BASE/ehr?subject_id=$subject&subject_namespace=$SUBJECT_NS")
+  case "$code" in
+    200)
+      ehrs[index]=$(jq -r '.ehr_id.value' "$BODY")
+      created[index]=no
+      reused=$((reused + 1))
+      ;;
+    404)
+      render "$status_file" "$WORK/status.json" "__SUBJECT_ID__=$subject"
+      code=$(request "ehr create $subject" POST "$BASE/ehr" \
+        -H 'Content-Type: application/json' --data-binary @"$WORK/status.json")
+      expect "ehr create $subject" "$code" 201
+      ehrs[index]=$(etag_uid)
+      created[index]=yes
+      ;;
+    *) expect "ehr lookup $subject" "$code" 200 404 ;;
+  esac
+  : > "$WORK/comps.$index"
+  index=$((index + 1))
+done < <(jq -c '.ehrs[]' "$MANIFEST")
+echo "==> ${#ehrs[@]} demo EHRs ($reused reused)"
+
+# ── 6. compositions ──────────────────────────────────────────────────────────
+
+compositions=0
+extra=0
+
+# Commit `$3` copies of the body `$2` into the EHR at index `$1`, recording each
+# new VERSIONED_OBJECT uid; then add `$4` further versions to the first of them,
+# so LATEST_VERSION and ALL_VERSIONS differ on real data.
+commit_series() {
+  local slot="$1" body="$2" copies="$3" versions="$4" label="$5"
+  local ehr="${ehrs[$slot]}" ovid vo code first=""
+  for _ in $(seq 1 "$copies"); do
+    code=$(request "$label" POST "$BASE/ehr/$ehr/composition" \
+      -H 'Content-Type: application/json' -H 'Prefer: return=minimal' \
+      --data-binary @"$body")
+    expect "$label" "$code" 201
+    ovid=$(etag_uid)
+    printf '%s\n' "${ovid%%::*}" >> "$WORK/comps.$slot"
+    [[ -n "$first" ]] || first="$ovid"
+    compositions=$((compositions + 1))
   done
-done
+  [[ "$versions" -gt 0 ]] || return 0
+  vo="${first%%::*}"
+  ovid="$first"
+  jq 'del(.uid)' "$body" > "$WORK/update.json"
+  for _ in $(seq 1 "$versions"); do
+    code=$(request "$label version" PUT "$BASE/ehr/$ehr/composition/$vo" \
+      -H 'Content-Type: application/json' -H "If-Match: \"$ovid\"" \
+      --data-binary @"$WORK/update.json")
+    expect "$label version" "$code" 200 204
+    ovid=$(etag_uid)
+    extra=$((extra + 1))
+  done
+}
 
-echo "==> seeded $seeded compositions across ${#ehrs[@]} demo EHRs"
+while read -r entry; do
+  slug=$(printf '%s' "$entry" | jq -r '.slug')
+  copies=$(printf '%s' "$entry" | jq -r '.compositions_per_ehr')
+  versions=$(printf '%s' "$entry" | jq -r '.extra_versions')
+  example="$TPL_DIR/$slug.example.json"
+  [[ -f "$example" ]] || {
+    echo "::error::missing example composition $example" >&2
+    exit 1
+  }
+  first_slot=yes
+  while read -r slot; do
+    [[ "${created[$slot]}" == yes ]] || continue
+    if [[ "$first_slot" == yes ]]; then
+      commit_series "$slot" "$example" "$copies" "$versions" "composition $slug"
+      first_slot=no
+    else
+      commit_series "$slot" "$example" "$copies" 0 "composition $slug"
+    fi
+  done < <(printf '%s' "$entry" | jq -r '.ehrs[]')
+done < <(jq -c '.adl14_templates[]' "$MANIFEST")
+
+# The ADL 2 side commits the CDR's OWN generated example for each template, so
+# that path carries real versioned content rather than definitions alone.
+while read -r entry; do
+  template=$(printf '%s' "$entry" | jq -r '.id')
+  copies=$(printf '%s' "$entry" | jq -r '.compositions_per_ehr')
+  [[ "$copies" -gt 0 ]] || continue
+  code=$(request "adl2 example $template" GET \
+    "$BASE/definition/template/adl2/$template/example" -H 'Accept: application/json')
+  expect "adl2 example $template" "$code" 200
+  cp "$BODY" "$WORK/adl2-example.json"
+  while read -r slot; do
+    [[ "${created[$slot]}" == yes ]] || continue
+    commit_series "$slot" "$WORK/adl2-example.json" "$copies" 0 "composition $template"
+  done < <(printf '%s' "$entry" | jq -r '.ehrs[]')
+done < <(jq -c '.adl2.templates[]' "$MANIFEST")
+echo "==> $compositions compositions committed, $extra further versions"
+
+# ── 7. the directory ─────────────────────────────────────────────────────────
+
+directories=0
+folder_file="$SEED_DIR/$(mf '.directory.folder')"
+while read -r slot; do
+  [[ "${created[$slot]}" == yes ]] || continue
+  ehr="${ehrs[$slot]}"
+  render "$folder_file" "$WORK/folder.json" \
+    "__COMPOSITION_1__=$(sed -n 1p "$WORK/comps.$slot")" \
+    "__COMPOSITION_2__=$(sed -n 2p "$WORK/comps.$slot")" \
+    "__COMPOSITION_3__=$(sed -n 3p "$WORK/comps.$slot")"
+  code=$(request "directory $ehr" POST "$BASE/ehr/$ehr/directory" \
+    -H 'Content-Type: application/json' --data-binary @"$WORK/folder.json")
+  expect "directory $ehr" "$code" 201 409
+  directories=$((directories + 1))
+done < <(mf '.directory.ehrs[]')
+echo "==> $directories EHR directories"
+
+# ── 8. the second EHR_STATUS version ─────────────────────────────────────────
+#
+# Applied after the per-EHR content: `is_modifiable = false` is a write guard,
+# so an EHR that ends up locked has to be filled first (RM ehr master04 §EHR
+# Active Status).
+
+statuses=0
+index=0
+while read -r entry; do
+  slot=$index
+  index=$((index + 1))
+  [[ "${created[$slot]}" == yes ]] || continue
+  final=$(printf '%s' "$entry" | jq -r '.final_status // empty')
+  [[ -n "$final" ]] || continue
+  subject=$(printf '%s' "$entry" | jq -r '.subject')
+  ehr="${ehrs[$slot]}"
+  code=$(request "ehr_status read $ehr" GET "$BASE/ehr/$ehr/ehr_status")
+  expect "ehr_status read $ehr" "$code" 200
+  current=$(etag_uid)
+  render "$SEED_DIR/$final" "$WORK/status.json" "__SUBJECT_ID__=$subject"
+  code=$(request "ehr_status update $ehr" PUT "$BASE/ehr/$ehr/ehr_status" \
+    -H 'Content-Type: application/json' -H "If-Match: \"$current\"" \
+    --data-binary @"$WORK/status.json")
+  expect "ehr_status update $ehr" "$code" 200 204
+  statuses=$((statuses + 1))
+done < <(jq -c '.ehrs[]' "$MANIFEST")
+echo "==> $statuses further EHR_STATUS versions"
+
+# ── 9. demographics ──────────────────────────────────────────────────────────
+
+persons=()
+index=0
+while read -r rel; do
+  code=$(request "person $(basename "$rel")" POST "$BASE/demographic/person" \
+    -H 'Content-Type: application/json' --data-binary @"$SEED_DIR/$rel")
+  expect "person $(basename "$rel")" "$code" 201
+  ovid=$(etag_uid)
+  persons[index]="${ovid%%::*}"
+  index=$((index + 1))
+done < <(mf '.demographics.persons[]')
+
+roles=0
+while read -r entry; do
+  file=$(printf '%s' "$entry" | jq -r '.file')
+  performer=$(printf '%s' "$entry" | jq -r '.performer')
+  render "$SEED_DIR/$file" "$WORK/role.json" "__PERFORMER__=${persons[$performer]}"
+  code=$(request "role $(basename "$file")" POST "$BASE/demographic/role" \
+    -H 'Content-Type: application/json' --data-binary @"$WORK/role.json")
+  expect "role $(basename "$file")" "$code" 201
+  roles=$((roles + 1))
+done < <(jq -c '.demographics.roles[]' "$MANIFEST")
+
+relationships=0
+while read -r entry; do
+  file=$(printf '%s' "$entry" | jq -r '.file')
+  source_index=$(printf '%s' "$entry" | jq -r '.source')
+  target_index=$(printf '%s' "$entry" | jq -r '.target')
+  render "$SEED_DIR/$file" "$WORK/relationship.json" \
+    "__SOURCE__=${persons[$source_index]}" "__TARGET__=${persons[$target_index]}"
+  code=$(request "relationship $(basename "$file")" POST \
+    "$BASE/demographic/party_relationship" \
+    -H 'Content-Type: application/json' --data-binary @"$WORK/relationship.json")
+  expect "relationship $(basename "$file")" "$code" 201
+  relationships=$((relationships + 1))
+done < <(jq -c '.demographics.relationships[]' "$MANIFEST")
+echo "==> ${#persons[@]} persons, $roles roles, $relationships party relationships"
+
+# ── 10. stored AQL queries ───────────────────────────────────────────────────
+#
+# Each one is executed after it is stored and must answer at least the row count
+# the manifest pins: a query the demo data cannot feed is a broken demo, not a
+# detail to discover from the viewer.
+
+queries=0
+while read -r entry; do
+  name=$(printf '%s' "$entry" | jq -r '.name')
+  version=$(printf '%s' "$entry" | jq -r '.version')
+  aql="$SEED_DIR/$(printf '%s' "$entry" | jq -r '.file')"
+  min_rows=$(printf '%s' "$entry" | jq -r '.min_rows')
+  [[ -f "$aql" ]] || {
+    echo "::error::missing AQL body $aql" >&2
+    exit 1
+  }
+  code=$(request "query $name" PUT "$BASE/definition/query/$name/$version" \
+    -H 'Content-Type: text/plain' --data-binary @"$aql")
+  expect "query $name" "$code" 200 201 409
+
+  parameters=$(printf '%s' "$entry" | jq -c '.parameters // empty')
+  if [[ -n "$parameters" ]]; then
+    printf '%s' "$parameters" \
+      | jq --arg e "${ehrs[0]}" '{query_parameters: walk(if . == "__EHR_0__" then $e else . end)}' \
+        > "$WORK/params.json"
+    code=$(request "query run $name" POST "$BASE/query/$name" \
+      -H 'Content-Type: application/json' --data-binary @"$WORK/params.json")
+  else
+    code=$(request "query run $name" GET "$BASE/query/$name")
+  fi
+  expect "query run $name" "$code" 200
+
+  rows=$(jq '.rows | length' "$BODY")
+  if [[ "$rows" -lt "$min_rows" ]]; then
+    echo "::error::stored query $name returned $rows rows, below the $min_rows the manifest pins — the seeded data no longer feeds it." >&2
+    exit 1
+  fi
+  echo "query $name -> $rows rows"
+  queries=$((queries + 1))
+done < <(jq -c '.stored_queries[]' "$MANIFEST")
+echo "==> $queries stored AQL queries, each answering rows"
+
+# ── 11. the completion marker ────────────────────────────────────────────────
+
+render "$SEED_DIR/$(mf '.marker.status')" "$WORK/marker.json" \
+  "__SUBJECT_ID__=$MARKER_SUBJECT"
+code=$(request "marker create" POST "$BASE/ehr" \
+  -H 'Content-Type: application/json' --data-binary @"$WORK/marker.json")
+expect "marker create" "$code" 201 409
+
+echo "==> seeded ${#ehrs[@]} EHRs, $compositions compositions (+$extra versions), $directories directories, ${#persons[@]} persons, $queries stored queries"

--- a/scripts/sandbox/seed/ehr_status/active.json
+++ b/scripts/sandbox/seed/ehr_status/active.json
@@ -1,0 +1,21 @@
+{
+  "_type": "EHR_STATUS",
+  "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": { "_type": "ARCHETYPE_ID", "value": "openEHR-EHR-EHR_STATUS.generic.v1" },
+    "rm_version": "1.2.0"
+  },
+  "name": { "_type": "DV_TEXT", "value": "EHR Status" },
+  "subject": {
+    "_type": "PARTY_SELF",
+    "external_ref": {
+      "_type": "PARTY_REF",
+      "namespace": "ferroehr-sandbox",
+      "type": "PERSON",
+      "id": { "_type": "HIER_OBJECT_ID", "value": "__SUBJECT_ID__" }
+    }
+  },
+  "is_queryable": true,
+  "is_modifiable": true
+}

--- a/scripts/sandbox/seed/ehr_status/locked.json
+++ b/scripts/sandbox/seed/ehr_status/locked.json
@@ -1,0 +1,30 @@
+{
+  "_type": "EHR_STATUS",
+  "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-EHR_STATUS.generic.v1"
+    },
+    "rm_version": "1.2.0"
+  },
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "EHR Status (locked)"
+  },
+  "subject": {
+    "_type": "PARTY_SELF",
+    "external_ref": {
+      "_type": "PARTY_REF",
+      "namespace": "ferroehr-sandbox",
+      "type": "PERSON",
+      "id": {
+        "_type": "HIER_OBJECT_ID",
+        "value": "__SUBJECT_ID__"
+      }
+    }
+  },
+  "is_queryable": true,
+  "is_modifiable": false
+}

--- a/scripts/sandbox/seed/ehr_status/marker.json
+++ b/scripts/sandbox/seed/ehr_status/marker.json
@@ -1,0 +1,30 @@
+{
+  "_type": "EHR_STATUS",
+  "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-EHR_STATUS.generic.v1"
+    },
+    "rm_version": "1.2.0"
+  },
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Sandbox seed marker"
+  },
+  "subject": {
+    "_type": "PARTY_SELF",
+    "external_ref": {
+      "_type": "PARTY_REF",
+      "namespace": "ferroehr-sandbox",
+      "type": "PERSON",
+      "id": {
+        "_type": "HIER_OBJECT_ID",
+        "value": "__SUBJECT_ID__"
+      }
+    }
+  },
+  "is_queryable": false,
+  "is_modifiable": false
+}

--- a/scripts/sandbox/seed/ehr_status/not-queryable.json
+++ b/scripts/sandbox/seed/ehr_status/not-queryable.json
@@ -1,0 +1,30 @@
+{
+  "_type": "EHR_STATUS",
+  "archetype_node_id": "openEHR-EHR-EHR_STATUS.generic.v1",
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-EHR_STATUS.generic.v1"
+    },
+    "rm_version": "1.2.0"
+  },
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "EHR Status (not queryable)"
+  },
+  "subject": {
+    "_type": "PARTY_SELF",
+    "external_ref": {
+      "_type": "PARTY_REF",
+      "namespace": "ferroehr-sandbox",
+      "type": "PERSON",
+      "id": {
+        "_type": "HIER_OBJECT_ID",
+        "value": "__SUBJECT_ID__"
+      }
+    }
+  },
+  "is_queryable": false,
+  "is_modifiable": true
+}

--- a/scripts/sandbox/seed/folders/episodes.json
+++ b/scripts/sandbox/seed/folders/episodes.json
@@ -1,0 +1,46 @@
+{
+  "_type": "FOLDER",
+  "name": { "_type": "DV_TEXT", "value": "record" },
+  "archetype_node_id": "openEHR-EHR-FOLDER.directory.v1",
+  "folders": [
+    {
+      "_type": "FOLDER",
+      "name": { "_type": "DV_TEXT", "value": "episodes" },
+      "archetype_node_id": "openEHR-EHR-FOLDER.directory.v1",
+      "folders": [
+        {
+          "_type": "FOLDER",
+          "name": { "_type": "DV_TEXT", "value": "episode-1" },
+          "archetype_node_id": "openEHR-EHR-FOLDER.directory.v1",
+          "items": [
+            {
+              "_type": "OBJECT_REF",
+              "namespace": "local",
+              "type": "VERSIONED_COMPOSITION",
+              "id": { "_type": "HIER_OBJECT_ID", "value": "__COMPOSITION_1__" }
+            },
+            {
+              "_type": "OBJECT_REF",
+              "namespace": "local",
+              "type": "VERSIONED_COMPOSITION",
+              "id": { "_type": "HIER_OBJECT_ID", "value": "__COMPOSITION_2__" }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "_type": "FOLDER",
+      "name": { "_type": "DV_TEXT", "value": "summaries" },
+      "archetype_node_id": "openEHR-EHR-FOLDER.directory.v1",
+      "items": [
+        {
+          "_type": "OBJECT_REF",
+          "namespace": "local",
+          "type": "VERSIONED_COMPOSITION",
+          "id": { "_type": "HIER_OBJECT_ID", "value": "__COMPOSITION_3__" }
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/sandbox/seed/manifest.json
+++ b/scripts/sandbox/seed/manifest.json
@@ -1,0 +1,175 @@
+{
+  "notes": [
+    "The hosted sandbox demo dataset (issue #3045). scripts/sandbox/reseed.sh walks",
+    "this file and drives the PUBLIC REST API only, so a green seed run is itself",
+    "evidence that the deployment serves what it claims. Adding content means",
+    "editing this file plus a body under scripts/sandbox/seed/, never the walker.",
+    "",
+    "What one run loads, in about 590 requests: 16 ADL 1.4 operational templates",
+    "(the curated CKM pack), 226 artefacts out of the 322-file vendored ADL 2",
+    "archetype corpus, 8 ADL 2 artefacts of this repository's own, 8 EHRs carrying",
+    "166 ADL 1.4 + 16 ADL 2 compositions, 6 further COMPOSITION versions, 2",
+    "further EHR_STATUS versions, 11 demographic parties, a directory in every",
+    "EHR, and 5 stored AQL queries. One marker EHR records completion, so a second",
+    "run exits immediately and the instance data is never doubled.",
+    "",
+    "Measured 2026-09-02 against the composed quickstart stack on an 8-CPU/8 GB",
+    "Docker VM: 39-45 s from an empty schema, under a second on a second run. The",
+    "loaded data is ~9 MB of canonical composition JSON and leaves a 24 MB",
+    "database (17 373 node rows, 227 versions).",
+    "",
+    "Placeholders in the body files are substituted by the walker: __SUBJECT_ID__",
+    "(an EHR subject), __PERFORMER__ / __SOURCE__ / __TARGET__ (a seeded party's",
+    "VERSIONED_OBJECT uid), __COMPOSITION_n__ (the n-th composition committed into",
+    "the EHR the folder is written to), and __EHR_n__ (the n-th seeded EHR id) in",
+    "stored-query verification parameters."
+  ],
+
+  "subject_namespace": "ferroehr-sandbox",
+  "marker": {
+    "subject": "sandbox-seed-complete",
+    "status": "ehr_status/marker.json"
+  },
+
+  "ehrs": [
+    { "subject": "sandbox-patient-01", "status": "ehr_status/active.json" },
+    { "subject": "sandbox-patient-02", "status": "ehr_status/active.json" },
+    { "subject": "sandbox-patient-03", "status": "ehr_status/active.json" },
+    { "subject": "sandbox-patient-04", "status": "ehr_status/active.json" },
+    { "subject": "sandbox-patient-05", "status": "ehr_status/active.json" },
+    { "subject": "sandbox-patient-06", "status": "ehr_status/active.json" },
+    {
+      "subject": "sandbox-patient-07",
+      "status": "ehr_status/active.json",
+      "final_status": "ehr_status/not-queryable.json"
+    },
+    {
+      "subject": "sandbox-patient-08",
+      "status": "ehr_status/active.json",
+      "final_status": "ehr_status/locked.json"
+    }
+  ],
+
+  "adl14_templates": [
+    { "slug": "vital-signs", "ehrs": [0, 1, 2, 3, 4, 5, 6, 7], "compositions_per_ehr": 4, "extra_versions": 2 },
+    { "slug": "problem-list", "ehrs": [0, 1, 2, 3, 4, 5, 6, 7], "compositions_per_ehr": 3, "extra_versions": 2 },
+    { "slug": "medicines-list", "ehrs": [0, 1, 2, 3, 4, 5, 6, 7], "compositions_per_ehr": 3, "extra_versions": 2 },
+    { "slug": "generic-lab-test-result", "ehrs": [0, 1, 2, 3, 4, 5, 6, 7], "compositions_per_ehr": 3, "extra_versions": 0 },
+    { "slug": "international-patient-summary", "ehrs": [0, 1, 2, 3, 4, 5, 6, 7], "compositions_per_ehr": 1, "extra_versions": 0 },
+    { "slug": "eprescription-fhir", "ehrs": [0, 1, 2, 3, 4, 5], "compositions_per_ehr": 2, "extra_versions": 0 },
+    { "slug": "gp-data-set", "ehrs": [0, 1, 2, 3, 4, 5], "compositions_per_ehr": 1, "extra_versions": 0 },
+    { "slug": "ereferral", "ehrs": [0, 1, 2, 3, 4, 5], "compositions_per_ehr": 1, "extra_versions": 0 },
+    { "slug": "ccta-report", "ehrs": [0, 2, 4, 6], "compositions_per_ehr": 1, "extra_versions": 0 },
+    { "slug": "bc-breast-cancer-report", "ehrs": [1, 3, 5, 7], "compositions_per_ehr": 1, "extra_versions": 0 },
+    { "slug": "treat-registry-report", "ehrs": [0, 3, 4, 7], "compositions_per_ehr": 1, "extra_versions": 0 },
+    { "slug": "covid19-infection-report", "ehrs": [0, 1, 4, 5], "compositions_per_ehr": 2, "extra_versions": 0 },
+    { "slug": "sars-event-notification", "ehrs": [2, 3, 6, 7], "compositions_per_ehr": 1, "extra_versions": 0 },
+    { "slug": "diphtheria-case-investigation", "ehrs": [1, 5], "compositions_per_ehr": 1, "extra_versions": 0 },
+    { "slug": "poisoning-case-investigation", "ehrs": [2, 6], "compositions_per_ehr": 1, "extra_versions": 0 },
+    { "slug": "congenital-syphilis-case-investigation", "ehrs": [3, 7], "compositions_per_ehr": 1, "extra_versions": 0 }
+  ],
+
+  "adl2": {
+    "archetype_library": {
+      "root": "corpus/archetypes/adl2/ckm-2013-12-09",
+      "accepted": 226,
+      "refused": 96
+    },
+    "artefacts": [
+      "corpus/fixtures/adl2/archetype/minimal.adls",
+      "corpus/fixtures/adl2/archetype/cnf_count_a.adls",
+      "corpus/fixtures/adl2/archetype/cnf_count_b.adls"
+    ],
+    "templates": [
+      {
+        "file": "corpus/fixtures/adl2/opt/vitals.adls",
+        "id": "openEHR-EHR-COMPOSITION.cnf_vitals.v1.0.0",
+        "ehrs": [0, 1, 2, 3, 4, 5, 6, 7],
+        "compositions_per_ehr": 1
+      },
+      {
+        "file": "corpus/fixtures/adl2/opt/versioned.v1_0_0.adls",
+        "id": "openEHR-EHR-COMPOSITION.cnf_adl2_versioned.v1.0.0",
+        "ehrs": [],
+        "compositions_per_ehr": 0
+      },
+      {
+        "file": "corpus/fixtures/adl2/opt/versioned.v1_1_0.adls",
+        "id": "openEHR-EHR-COMPOSITION.cnf_adl2_versioned.v1.1.0",
+        "ehrs": [0, 1, 2, 3],
+        "compositions_per_ehr": 1
+      },
+      {
+        "file": "corpus/fixtures/adl2/opt/flat_parity_a.adls",
+        "id": "openEHR-EHR-COMPOSITION.cnf_adl2_flat_a.v1.0.0",
+        "ehrs": [0, 1],
+        "compositions_per_ehr": 1
+      },
+      {
+        "file": "corpus/fixtures/adl2/opt/flat_parity_b.adls",
+        "id": "openEHR-EHR-COMPOSITION.cnf_adl2_flat_b.v1.0.0",
+        "ehrs": [2, 3],
+        "compositions_per_ehr": 1
+      }
+    ]
+  },
+
+  "demographics": {
+    "persons": [
+      "parties/person-01.json",
+      "parties/person-02.json",
+      "parties/person-03.json",
+      "parties/person-04.json",
+      "parties/person-05.json",
+      "parties/person-06.json"
+    ],
+    "roles": [
+      { "file": "parties/role-general-practitioner.json", "performer": 0 },
+      { "file": "parties/role-specialist-nurse.json", "performer": 1 },
+      { "file": "parties/role-consultant-cardiologist.json", "performer": 2 }
+    ],
+    "relationships": [
+      { "file": "parties/relationship-registered-with.json", "source": 3, "target": 0 },
+      { "file": "parties/relationship-next-of-kin.json", "source": 4, "target": 5 }
+    ]
+  },
+
+  "directory": {
+    "folder": "folders/episodes.json",
+    "ehrs": [0, 1, 2, 3, 4, 5, 6, 7]
+  },
+
+  "stored_queries": [
+    {
+      "name": "eu.ferroehr.sandbox::composition_index",
+      "version": "1.0.0",
+      "file": "queries/composition_index.aql",
+      "min_rows": 150
+    },
+    {
+      "name": "eu.ferroehr.sandbox::blood_pressure",
+      "version": "1.0.0",
+      "file": "queries/blood_pressure.aql",
+      "min_rows": 30
+    },
+    {
+      "name": "eu.ferroehr.sandbox::case_reports",
+      "version": "1.0.0",
+      "file": "queries/case_reports.aql",
+      "min_rows": 40
+    },
+    {
+      "name": "eu.ferroehr.sandbox::composition_versions",
+      "version": "1.0.0",
+      "file": "queries/composition_versions.aql",
+      "min_rows": 160
+    },
+    {
+      "name": "eu.ferroehr.sandbox::patient_record",
+      "version": "1.0.0",
+      "file": "queries/patient_record.aql",
+      "min_rows": 20,
+      "parameters": { "ehr_id": "__EHR_0__" }
+    }
+  ]
+}

--- a/scripts/sandbox/seed/parties/person-01.json
+++ b/scripts/sandbox/seed/parties/person-01.json
@@ -1,0 +1,36 @@
+{
+  "_type": "PERSON",
+  "archetype_node_id": "openEHR-DEMOGRAPHIC-PERSON.person.v1",
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": { "_type": "ARCHETYPE_ID", "value": "openEHR-DEMOGRAPHIC-PERSON.person.v1" },
+    "rm_version": "1.2.0"
+  },
+  "name": { "_type": "DV_TEXT", "value": "Alice Bloom" },
+  "identities": [
+    {
+      "_type": "PARTY_IDENTITY",
+      "archetype_node_id": "at0001",
+      "name": { "_type": "DV_TEXT", "value": "legal name" },
+      "details": {
+        "_type": "ITEM_TREE",
+        "archetype_node_id": "at0002",
+        "name": { "_type": "DV_TEXT", "value": "structure" },
+        "items": [
+          {
+            "_type": "ELEMENT",
+            "archetype_node_id": "at0003",
+            "name": { "_type": "DV_TEXT", "value": "given name" },
+            "value": { "_type": "DV_TEXT", "value": "Alice" }
+          },
+          {
+            "_type": "ELEMENT",
+            "archetype_node_id": "at0004",
+            "name": { "_type": "DV_TEXT", "value": "family name" },
+            "value": { "_type": "DV_TEXT", "value": "Bloom" }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/scripts/sandbox/seed/parties/person-02.json
+++ b/scripts/sandbox/seed/parties/person-02.json
@@ -1,0 +1,36 @@
+{
+  "_type": "PERSON",
+  "archetype_node_id": "openEHR-DEMOGRAPHIC-PERSON.person.v1",
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": { "_type": "ARCHETYPE_ID", "value": "openEHR-DEMOGRAPHIC-PERSON.person.v1" },
+    "rm_version": "1.2.0"
+  },
+  "name": { "_type": "DV_TEXT", "value": "Bilal Farouk" },
+  "identities": [
+    {
+      "_type": "PARTY_IDENTITY",
+      "archetype_node_id": "at0001",
+      "name": { "_type": "DV_TEXT", "value": "legal name" },
+      "details": {
+        "_type": "ITEM_TREE",
+        "archetype_node_id": "at0002",
+        "name": { "_type": "DV_TEXT", "value": "structure" },
+        "items": [
+          {
+            "_type": "ELEMENT",
+            "archetype_node_id": "at0003",
+            "name": { "_type": "DV_TEXT", "value": "given name" },
+            "value": { "_type": "DV_TEXT", "value": "Bilal" }
+          },
+          {
+            "_type": "ELEMENT",
+            "archetype_node_id": "at0004",
+            "name": { "_type": "DV_TEXT", "value": "family name" },
+            "value": { "_type": "DV_TEXT", "value": "Farouk" }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/scripts/sandbox/seed/parties/person-03.json
+++ b/scripts/sandbox/seed/parties/person-03.json
@@ -1,0 +1,36 @@
+{
+  "_type": "PERSON",
+  "archetype_node_id": "openEHR-DEMOGRAPHIC-PERSON.person.v1",
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": { "_type": "ARCHETYPE_ID", "value": "openEHR-DEMOGRAPHIC-PERSON.person.v1" },
+    "rm_version": "1.2.0"
+  },
+  "name": { "_type": "DV_TEXT", "value": "Chen Wei" },
+  "identities": [
+    {
+      "_type": "PARTY_IDENTITY",
+      "archetype_node_id": "at0001",
+      "name": { "_type": "DV_TEXT", "value": "legal name" },
+      "details": {
+        "_type": "ITEM_TREE",
+        "archetype_node_id": "at0002",
+        "name": { "_type": "DV_TEXT", "value": "structure" },
+        "items": [
+          {
+            "_type": "ELEMENT",
+            "archetype_node_id": "at0003",
+            "name": { "_type": "DV_TEXT", "value": "given name" },
+            "value": { "_type": "DV_TEXT", "value": "Chen" }
+          },
+          {
+            "_type": "ELEMENT",
+            "archetype_node_id": "at0004",
+            "name": { "_type": "DV_TEXT", "value": "family name" },
+            "value": { "_type": "DV_TEXT", "value": "Wei" }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/scripts/sandbox/seed/parties/person-04.json
+++ b/scripts/sandbox/seed/parties/person-04.json
@@ -1,0 +1,36 @@
+{
+  "_type": "PERSON",
+  "archetype_node_id": "openEHR-DEMOGRAPHIC-PERSON.person.v1",
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": { "_type": "ARCHETYPE_ID", "value": "openEHR-DEMOGRAPHIC-PERSON.person.v1" },
+    "rm_version": "1.2.0"
+  },
+  "name": { "_type": "DV_TEXT", "value": "Dara Nowak" },
+  "identities": [
+    {
+      "_type": "PARTY_IDENTITY",
+      "archetype_node_id": "at0001",
+      "name": { "_type": "DV_TEXT", "value": "legal name" },
+      "details": {
+        "_type": "ITEM_TREE",
+        "archetype_node_id": "at0002",
+        "name": { "_type": "DV_TEXT", "value": "structure" },
+        "items": [
+          {
+            "_type": "ELEMENT",
+            "archetype_node_id": "at0003",
+            "name": { "_type": "DV_TEXT", "value": "given name" },
+            "value": { "_type": "DV_TEXT", "value": "Dara" }
+          },
+          {
+            "_type": "ELEMENT",
+            "archetype_node_id": "at0004",
+            "name": { "_type": "DV_TEXT", "value": "family name" },
+            "value": { "_type": "DV_TEXT", "value": "Nowak" }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/scripts/sandbox/seed/parties/person-05.json
+++ b/scripts/sandbox/seed/parties/person-05.json
@@ -1,0 +1,36 @@
+{
+  "_type": "PERSON",
+  "archetype_node_id": "openEHR-DEMOGRAPHIC-PERSON.person.v1",
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": { "_type": "ARCHETYPE_ID", "value": "openEHR-DEMOGRAPHIC-PERSON.person.v1" },
+    "rm_version": "1.2.0"
+  },
+  "name": { "_type": "DV_TEXT", "value": "Elena Rossi" },
+  "identities": [
+    {
+      "_type": "PARTY_IDENTITY",
+      "archetype_node_id": "at0001",
+      "name": { "_type": "DV_TEXT", "value": "legal name" },
+      "details": {
+        "_type": "ITEM_TREE",
+        "archetype_node_id": "at0002",
+        "name": { "_type": "DV_TEXT", "value": "structure" },
+        "items": [
+          {
+            "_type": "ELEMENT",
+            "archetype_node_id": "at0003",
+            "name": { "_type": "DV_TEXT", "value": "given name" },
+            "value": { "_type": "DV_TEXT", "value": "Elena" }
+          },
+          {
+            "_type": "ELEMENT",
+            "archetype_node_id": "at0004",
+            "name": { "_type": "DV_TEXT", "value": "family name" },
+            "value": { "_type": "DV_TEXT", "value": "Rossi" }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/scripts/sandbox/seed/parties/person-06.json
+++ b/scripts/sandbox/seed/parties/person-06.json
@@ -1,0 +1,36 @@
+{
+  "_type": "PERSON",
+  "archetype_node_id": "openEHR-DEMOGRAPHIC-PERSON.person.v1",
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": { "_type": "ARCHETYPE_ID", "value": "openEHR-DEMOGRAPHIC-PERSON.person.v1" },
+    "rm_version": "1.2.0"
+  },
+  "name": { "_type": "DV_TEXT", "value": "Femi Adeyemi" },
+  "identities": [
+    {
+      "_type": "PARTY_IDENTITY",
+      "archetype_node_id": "at0001",
+      "name": { "_type": "DV_TEXT", "value": "legal name" },
+      "details": {
+        "_type": "ITEM_TREE",
+        "archetype_node_id": "at0002",
+        "name": { "_type": "DV_TEXT", "value": "structure" },
+        "items": [
+          {
+            "_type": "ELEMENT",
+            "archetype_node_id": "at0003",
+            "name": { "_type": "DV_TEXT", "value": "given name" },
+            "value": { "_type": "DV_TEXT", "value": "Femi" }
+          },
+          {
+            "_type": "ELEMENT",
+            "archetype_node_id": "at0004",
+            "name": { "_type": "DV_TEXT", "value": "family name" },
+            "value": { "_type": "DV_TEXT", "value": "Adeyemi" }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/scripts/sandbox/seed/parties/relationship-next-of-kin.json
+++ b/scripts/sandbox/seed/parties/relationship-next-of-kin.json
@@ -1,0 +1,17 @@
+{
+  "_type": "PARTY_RELATIONSHIP",
+  "archetype_node_id": "openEHR-DEMOGRAPHIC-PARTY_RELATIONSHIP.relationship.v1",
+  "name": { "_type": "DV_TEXT", "value": "next of kin of" },
+  "source": {
+    "_type": "PARTY_REF",
+    "namespace": "demographic",
+    "type": "PERSON",
+    "id": { "_type": "HIER_OBJECT_ID", "value": "__SOURCE__" }
+  },
+  "target": {
+    "_type": "PARTY_REF",
+    "namespace": "demographic",
+    "type": "PERSON",
+    "id": { "_type": "HIER_OBJECT_ID", "value": "__TARGET__" }
+  }
+}

--- a/scripts/sandbox/seed/parties/relationship-registered-with.json
+++ b/scripts/sandbox/seed/parties/relationship-registered-with.json
@@ -1,0 +1,17 @@
+{
+  "_type": "PARTY_RELATIONSHIP",
+  "archetype_node_id": "openEHR-DEMOGRAPHIC-PARTY_RELATIONSHIP.relationship.v1",
+  "name": { "_type": "DV_TEXT", "value": "registered with" },
+  "source": {
+    "_type": "PARTY_REF",
+    "namespace": "demographic",
+    "type": "PERSON",
+    "id": { "_type": "HIER_OBJECT_ID", "value": "__SOURCE__" }
+  },
+  "target": {
+    "_type": "PARTY_REF",
+    "namespace": "demographic",
+    "type": "PERSON",
+    "id": { "_type": "HIER_OBJECT_ID", "value": "__TARGET__" }
+  }
+}

--- a/scripts/sandbox/seed/parties/role-consultant-cardiologist.json
+++ b/scripts/sandbox/seed/parties/role-consultant-cardiologist.json
@@ -1,0 +1,36 @@
+{
+  "_type": "ROLE",
+  "archetype_node_id": "openEHR-DEMOGRAPHIC-ROLE.role.v1",
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": { "_type": "ARCHETYPE_ID", "value": "openEHR-DEMOGRAPHIC-ROLE.role.v1" },
+    "rm_version": "1.2.0"
+  },
+  "name": { "_type": "DV_TEXT", "value": "consultant cardiologist" },
+  "identities": [
+    {
+      "_type": "PARTY_IDENTITY",
+      "archetype_node_id": "at0001",
+      "name": { "_type": "DV_TEXT", "value": "role name" },
+      "details": {
+        "_type": "ITEM_TREE",
+        "archetype_node_id": "at0002",
+        "name": { "_type": "DV_TEXT", "value": "structure" },
+        "items": [
+          {
+            "_type": "ELEMENT",
+            "archetype_node_id": "at0003",
+            "name": { "_type": "DV_TEXT", "value": "role" },
+            "value": { "_type": "DV_TEXT", "value": "consultant cardiologist" }
+          }
+        ]
+      }
+    }
+  ],
+  "performer": {
+    "_type": "PARTY_REF",
+    "namespace": "demographic",
+    "type": "PERSON",
+    "id": { "_type": "HIER_OBJECT_ID", "value": "__PERFORMER__" }
+  }
+}

--- a/scripts/sandbox/seed/parties/role-general-practitioner.json
+++ b/scripts/sandbox/seed/parties/role-general-practitioner.json
@@ -1,0 +1,36 @@
+{
+  "_type": "ROLE",
+  "archetype_node_id": "openEHR-DEMOGRAPHIC-ROLE.role.v1",
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": { "_type": "ARCHETYPE_ID", "value": "openEHR-DEMOGRAPHIC-ROLE.role.v1" },
+    "rm_version": "1.2.0"
+  },
+  "name": { "_type": "DV_TEXT", "value": "general practitioner" },
+  "identities": [
+    {
+      "_type": "PARTY_IDENTITY",
+      "archetype_node_id": "at0001",
+      "name": { "_type": "DV_TEXT", "value": "role name" },
+      "details": {
+        "_type": "ITEM_TREE",
+        "archetype_node_id": "at0002",
+        "name": { "_type": "DV_TEXT", "value": "structure" },
+        "items": [
+          {
+            "_type": "ELEMENT",
+            "archetype_node_id": "at0003",
+            "name": { "_type": "DV_TEXT", "value": "role" },
+            "value": { "_type": "DV_TEXT", "value": "general practitioner" }
+          }
+        ]
+      }
+    }
+  ],
+  "performer": {
+    "_type": "PARTY_REF",
+    "namespace": "demographic",
+    "type": "PERSON",
+    "id": { "_type": "HIER_OBJECT_ID", "value": "__PERFORMER__" }
+  }
+}

--- a/scripts/sandbox/seed/parties/role-specialist-nurse.json
+++ b/scripts/sandbox/seed/parties/role-specialist-nurse.json
@@ -1,0 +1,36 @@
+{
+  "_type": "ROLE",
+  "archetype_node_id": "openEHR-DEMOGRAPHIC-ROLE.role.v1",
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": { "_type": "ARCHETYPE_ID", "value": "openEHR-DEMOGRAPHIC-ROLE.role.v1" },
+    "rm_version": "1.2.0"
+  },
+  "name": { "_type": "DV_TEXT", "value": "specialist nurse" },
+  "identities": [
+    {
+      "_type": "PARTY_IDENTITY",
+      "archetype_node_id": "at0001",
+      "name": { "_type": "DV_TEXT", "value": "role name" },
+      "details": {
+        "_type": "ITEM_TREE",
+        "archetype_node_id": "at0002",
+        "name": { "_type": "DV_TEXT", "value": "structure" },
+        "items": [
+          {
+            "_type": "ELEMENT",
+            "archetype_node_id": "at0003",
+            "name": { "_type": "DV_TEXT", "value": "role" },
+            "value": { "_type": "DV_TEXT", "value": "specialist nurse" }
+          }
+        ]
+      }
+    }
+  ],
+  "performer": {
+    "_type": "PARTY_REF",
+    "namespace": "demographic",
+    "type": "PERSON",
+    "id": { "_type": "HIER_OBJECT_ID", "value": "__PERFORMER__" }
+  }
+}

--- a/scripts/sandbox/seed/queries/blood_pressure.aql
+++ b/scripts/sandbox/seed/queries/blood_pressure.aql
@@ -1,0 +1,11 @@
+SELECT
+    e/ehr_id/value AS ehr_id,
+    o/data[at0001]/events[at0006]/time/value AS measured_at,
+    o/data[at0001]/events[at0006]/data[at0003]/items[at0004]/value/magnitude AS systolic,
+    o/data[at0001]/events[at0006]/data[at0003]/items[at0005]/value/magnitude AS diastolic,
+    o/data[at0001]/events[at0006]/data[at0003]/items[at0004]/value/units AS units
+FROM EHR e
+    CONTAINS COMPOSITION c
+        CONTAINS OBSERVATION o[openEHR-EHR-OBSERVATION.blood_pressure.v2]
+ORDER BY e/ehr_id/value ASC
+LIMIT 100

--- a/scripts/sandbox/seed/queries/case_reports.aql
+++ b/scripts/sandbox/seed/queries/case_reports.aql
@@ -1,0 +1,9 @@
+SELECT
+    e/ehr_id/value AS ehr_id,
+    c/name/value AS title,
+    c/archetype_details/template_id/value AS template_id,
+    c/context/start_time/value AS start_time
+FROM EHR e
+    CONTAINS COMPOSITION c[openEHR-EHR-COMPOSITION.report.v1]
+ORDER BY c/archetype_details/template_id/value ASC, e/ehr_id/value ASC
+LIMIT 100

--- a/scripts/sandbox/seed/queries/composition_index.aql
+++ b/scripts/sandbox/seed/queries/composition_index.aql
@@ -1,0 +1,10 @@
+SELECT
+    e/ehr_id/value AS ehr_id,
+    c/archetype_details/template_id/value AS template_id,
+    c/name/value AS title,
+    c/context/start_time/value AS start_time,
+    c/uid/value AS version_uid
+FROM EHR e
+    CONTAINS COMPOSITION c
+ORDER BY c/archetype_details/template_id/value ASC, c/uid/value ASC
+LIMIT 200

--- a/scripts/sandbox/seed/queries/composition_versions.aql
+++ b/scripts/sandbox/seed/queries/composition_versions.aql
@@ -1,0 +1,11 @@
+SELECT
+    e/ehr_id/value AS ehr_id,
+    v/uid/value AS version_uid,
+    v/commit_audit/time_committed/value AS committed_at,
+    v/commit_audit/change_type/value AS change_type,
+    c/name/value AS title
+FROM EHR e
+    CONTAINS VERSION v[ALL_VERSIONS]
+        CONTAINS COMPOSITION c
+ORDER BY v/uid/value ASC
+LIMIT 200

--- a/scripts/sandbox/seed/queries/patient_record.aql
+++ b/scripts/sandbox/seed/queries/patient_record.aql
@@ -1,0 +1,8 @@
+SELECT
+    c/archetype_details/template_id/value AS template_id,
+    c/name/value AS title,
+    c/context/start_time/value AS start_time,
+    c/uid/value AS version_uid
+FROM EHR e[ehr_id/value=$ehr_id]
+    CONTAINS COMPOSITION c
+ORDER BY c/archetype_details/template_id/value ASC, c/uid/value ASC

--- a/website/book/src/getting-started.md
+++ b/website/book/src/getting-started.md
@@ -59,8 +59,39 @@ served at <http://localhost:8080/ferroehr/rest/swagger-ui>. If you have no
 server yet, use the hosted sandbox: <https://sandbox.ferroehr.eu> opens the
 viewer over a live CDR, and the same server's Swagger UI is at
 <https://sandbox.ferroehr.eu/ferroehr/rest/swagger-ui>. Both take the public
-demo credentials `ferroehr` / `ferroehr`. The sandbox runs on best-effort
-free compute and resets nightly: expect it to slow down under heavy use.
+demo credentials `ferroehr` / `ferroehr`. The sandbox is a shared demo server
+that resets every night, so treat anything you write there as temporary and
+expect it to slow down under heavy use.
+
+### What is already in the sandbox
+
+The nightly reset reloads a fixed demo dataset, so the server always answers
+with something to look at:
+
+- **8 EHRs**, each with a mixed record and its own subject id
+  (`sandbox-patient-01` … `-08` in the `ferroehr-sandbox` namespace, so
+  `GET /ehr?subject_id=sandbox-patient-01&subject_namespace=ferroehr-sandbox`
+  finds one). Two of them carry a second `EHR_STATUS` version: patient 07 is
+  not queryable and so never appears in AQL results, patient 08 is not
+  modifiable and refuses writes with a `409`.
+- **182 compositions** across **16 ADL 1.4 templates** from the openEHR CKM —
+  vital signs, problem and medicines lists, lab results, referrals, an
+  International Patient Summary, and several statutory case-report forms. Six
+  compositions have more than one version, so `LATEST_VERSION` and
+  `ALL_VERSIONS` differ on real data.
+- **228 ADL 2 archetypes and 5 ADL 2 templates**, browsable under
+  `definition/archetype/adl2` and `definition/template/adl2`. Two of the
+  templates are ADL 2 source templates whose slots the server flattens against
+  that archetype library, and the compositions committed from them came out of
+  the server's own `…/example` generator.
+- **11 demographic parties** (persons, roles, party relationships) and a
+  **FOLDER directory** in every EHR whose items reference real compositions.
+- **5 stored AQL queries** under `eu.ferroehr.sandbox`, all of which return
+  rows: `composition_index`, `blood_pressure`, `case_reports`,
+  `composition_versions`, and `patient_record` (takes an `$ehr_id` parameter).
+  Run one with
+  `GET /query/eu.ferroehr.sandbox::composition_index`, or open the viewer's
+  query screen.
 
 There are also three always-on, unauthenticated health endpoints: `/health`,
 `/health/liveness` and `/health/readiness`; the last one reports each


### PR DESCRIPTION
Closes #3045

## What

`scripts/sandbox/reseed.sh` is now a walker over `scripts/sandbox/seed/manifest.json` plus body files beside it (`queries/*.aql`, `parties/*.json`, `ehr_status/*.json`, `folders/*.json`); adding demo content is editing data, never the script. It still drives only the public REST API (the seed proving the deployment is the point), keeps the retry-through-stale-instances budget (12 × 15 s) on every request kind, and stays fail-loud: any status outside the accepted set for a step prints `::error::` and exits non-zero. Bash 3.2-safe, `jq` for reading the manifest and substituting the placeholder tokens (`__SUBJECT_ID__`, `__PERFORMER__`, `__COMPOSITION_n__`, `__EHR_n__`), never JSON written from bash.

**What one run loads** (measured against a composed `ghcr.io/rubentalstra/ferroehr:4.0.16` stack, ~590 requests):

| | |
|---|---|
| ADL 1.4 operational templates | 16 (the whole curated CKM pack; every example committed 201) |
| ADL 2 artefacts | 234 stored: 226 of the 322 vendored corpus files + 8 of this repository's own fixtures; 96 corpus files refused `422` by the AOM2 validator, the counts pinned so a change fails the run |
| ADL 2 templates | 5 listed, 4 carrying compositions committed from the server's own `GET …/example` (two are source templates flattened against the uploaded archetypes) |
| EHRs | 8 with mixed records (+ 1 marker EHR), one made not-queryable and one locked after filling, each with a second `EHR_STATUS` version |
| Compositions | 182 (166 ADL 1.4, 16 ADL 2); 6 objects with 2 further versions |
| Demographics | 6 persons, 3 roles, 2 relationships |
| Directory | one FOLDER tree per EHR with 3 real composition `OBJECT_REF`s (`namespace: local`) |
| Stored AQL | 5 under `eu.ferroehr.sandbox`, each verified to return rows after the seed (164 / 38 / 45 / 170 / 25) |

Runtime from an empty schema: 39–45 s locally; footprint 24 MB (17 373 node rows, 227 versions). A repeat run finds the marker EHR (`sandbox-seed-complete`) and exits 0 immediately, so the nightly `wipe` + reseed is the only re-seed path and instance data is never doubled; definitions stay 409-tolerant. The `seed` job's 20-minute budget is unchanged.

**Wire shapes** came from the repository's own tests (`demographic_http.rs`, `directory_http.rs`, `stored_query_definition_http.rs`, `headers.rs`, `service_dump_load.rs`), verified live. Two facts the walker encodes: the ADL 2 archetype store is read-only over REST, every ADL 2 artefact enters through `POST /definition/template/adl2` and is filed by AOM2 kind; and `is_modifiable = false` is a write guard, so the locked EHR is filled first.

**ADL 2 decision**: the whole vendored corpus is offered and both outcomes are pinned (226/96), chosen over a `use_archetype` closure because the closure pulls in refused files anyway and the whole-corpus form is self-checking. `minimal_h.adls` is deliberately not seeded: the viewer's ADL 2 e2e scene deletes it.

**Terminology**: `docker/terminology/seed/` was only ever wired into the conformance SUT compose file, never the hosted sandbox; the curated examples carry no code from its synthetic code systems, and the terminologies they do carry resolve through the in-process `openehr-term` bundle. Stated in the README.

**Docs**: `deploy/hosted/README.md` §The demo dataset (contents, measured runtime and footprint, repeat-run semantics), `website/book/src/getting-started.md` §What is already in the sandbox (also corrects the stale "best-effort free compute" claim; the sandbox has run on a dedicated Hetzner box since #3015). Changelog `Changed` entry.

Also in this PR: the `upload_artefact` doc comment in `app/ferroehr/src/service/definition/adl2.rs` claimed SM "replace" semantics; the released REST API answers `409_template_already_exists`, which is what the service does, so the comment now says so.

**En-route findings filed**: #3054 (an aggregate beside a non-aggregated AQL projection answers `500`, SQLSTATE 42803 leaking; no seeded query uses aggregates because of it) and #3055 (the 96 validator refusals over the vendored ADL 2 corpus have no adjudication record).

## Gates

shellcheck-lane (style), comment-style, docs-claims, changelog-structure, spdx-headers, licensing guards, hosted-deploy-script: all OK. Clippy and rustdoc on `ferroehr` for the doc-comment change. Two fresh-volume local runs plus a repeat run exit 0; the local compose project was torn down.

**Left to observe**: the hosted runtime is extrapolated from the local stack; the first nightly run on the box confirms it.
