### PR TITLE
fix(adl2): adjudicate the vendored ADL 2 corpus, refuse a child without its stored parent, and keep the engine off the worker stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ workflow refuses a tag that has no matching section here.
   shortened. The URL it probes under the defaults is unchanged.
 - The hosted sandbox (sandbox.ferroehr.eu) now holds a complete demo dataset
   instead of four templates in three EHRs. Each nightly reset loads 16 ADL 1.4
-  operational templates from the openEHR CKM pack, 228 ADL 2 archetypes and 5
+  operational templates from the openEHR CKM pack, 235 ADL 2 archetypes and 5
   ADL 2 templates (two of them source templates the server flattens against
   that archetype library), 8 EHRs carrying 182 compositions with mixed
   records, 6 compositions with more than one version and 2 EHRs with a second
@@ -53,11 +53,29 @@ workflow refuses a tag that has no matching section here.
   stored AQL queries under `eu.ferroehr.sandbox` that all return rows. The
   seeder (`scripts/sandbox/reseed.sh`) still drives only the public REST API
   and is now a walker over `scripts/sandbox/seed/manifest.json`, so adding
-  demo content is editing data. A run takes 39–45 s against a local stack and
+  demo content is editing data. The ADL 2 corpus is uploaded parents before
+  children, and the split it pins (233 stored, 89 refused by AOM2 validation)
+  is the one the corpus gate in `openehr-adl` adjudicates file by file. A run takes 39–45 s against a local stack and
   leaves a 24 MB database; a repeat run detects the marker EHR it wrote and
   exits without changing anything.
 
 ### Fixed
+
+- An ADL 2 upload can no longer take the server down. The AOM engine's
+  validation now runs on a dedicated thread with a stack sized for its
+  recursive walks over the stored repository, and every runtime thread starts
+  with a larger stack; previously a deep enough artefact overflowed a worker's
+  2 MiB stack and the process aborted with every in-flight request.
+- ADL 2 validation no longer reports VCATU (duplicate sibling attribute) for a
+  specialised archetype whose root-level differential paths end in the same
+  attribute name (`/items` beside `/items[id9]/items`): the two address
+  different nodes of the flat parent. Twenty-nine archetypes of the vendored
+  2013 CKM export were refused on that false positive.
+- An ADL 2 upload whose `specialise` clause names a parent that is not in the
+  repository is refused with `422` carrying VASID and the missing parent's id,
+  on both validation paths. Previously the parent-conformance checks were
+  skipped and the archetype was stored as valid, so a child uploaded before its
+  parent was never checked against it.
 
 - The FerroEHR Viewer no longer leaves an interactive shell over a session that
   has ended. When a session expires or is revoked, the viewer moves the whole UI

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5431,7 +5431,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "indexmap 2.14.0",
  "openehr-am",
@@ -5447,7 +5447,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -5457,7 +5457,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "serde",
  "serde_json",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "async-trait",
  "axum",
@@ -5506,7 +5506,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "assert_fs",
  "chumsky",
@@ -5520,7 +5520,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "chumsky",
  "logos",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "insta",
  "jsonschema",
@@ -5547,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/app/ferroehr-rest/tests/it/definition_adl2_http.rs
+++ b/app/ferroehr-rest/tests/it/definition_adl2_http.rs
@@ -658,3 +658,34 @@ async fn upload_empty_source_is_400() {
          content (responses/400.yaml): {body}"
     );
 }
+
+/// A specialised upload whose `specialise` clause names a parent the repository
+/// does not hold is refused as `422` carrying VASID: without the flat parent
+/// the archetype cannot validate (AOM2 master03 VASID, master08 §Phase 2; SM
+/// `upload_artefact` "The artefact must validate"), and storing it unchecked
+/// would let a child uploaded before its parent skip conformance for good.
+#[tokio::test]
+async fn upload_with_absent_parent_is_422_with_vasid() {
+    let (_db, app) = app().await;
+    let src = "archetype (adl_version=2.0.6; rm_release=1.1.0)\n    \
+         openEHR-EHR-CLUSTER.orphan-child.v1.0.0\n\n\
+         specialise\n    openEHR-EHR-CLUSTER.orphan.v1.0.0\n\n\
+         language\n    original_language = <[ISO_639-1::en]>\n\n\
+         description\n    lifecycle_state = <\"published\">\n    details = <\n        \
+         [\"en\"] = <\n            language = <[ISO_639-1::en]>\n        >\n    >\n\n\
+         definition\n    CLUSTER[id1.1] matches { *}\n\n\
+         terminology\n    term_definitions = <\n        [\"en\"] = <\n            \
+         [\"id1.1\"] = <text = <\"Child\"> description = <\"Child.\">>\n        >\n    >\n";
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("{BASE}/definition/template/adl2"))
+        .header(header::CONTENT_TYPE, "text/plain")
+        .body(Body::from(src))
+        .unwrap();
+    let (status, _h, body) = send(&app, req).await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "{body}");
+    assert!(
+        body.contains("VASID") && body.contains("openEHR-EHR-CLUSTER.orphan.v1.0.0"),
+        "the 422 names VASID and the missing parent: {body}"
+    );
+}

--- a/app/ferroehr-server/src/main.rs
+++ b/app/ferroehr-server/src/main.rs
@@ -8,7 +8,17 @@
 
 use clap::Parser;
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    ferroehr_server::run(ferroehr_server::Cli::parse()).await
+/// The stack of every runtime thread, workers and the blocking pool alike.
+///
+/// Tokio's default is 2 MiB, which the AOM engine's recursive walks over a
+/// well-stocked archetype repository crossed in a debug build (#3062). The
+/// reservation is virtual: pages are committed only as a stack actually grows.
+const RUNTIME_THREAD_STACK_BYTES: usize = 16 * 1024 * 1024;
+
+fn main() -> anyhow::Result<()> {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_stack_size(RUNTIME_THREAD_STACK_BYTES)
+        .build()?;
+    runtime.block_on(ferroehr_server::run(ferroehr_server::Cli::parse()))
 }

--- a/app/ferroehr/src/service/definition/adl2.rs
+++ b/app/ferroehr/src/service/definition/adl2.rs
@@ -313,18 +313,26 @@ impl FerroEhrService {
     /// bindings are verified through the terminology-service resolver (VETDF,
     /// `master03` §Validity Rules; see [`Self::adl2_terminology_resolver`]).
     async fn adl2_validate(&self, source: &str) -> Result<ArtefactSummary, ServiceError> {
-        let archetype =
-            parse_artefact(source, Dialect::Adl2).map_err(|errs| syntax_bad_request(&errs))?;
+        let owned = source.to_owned();
+        let archetype = on_engine_stack(move || parse_artefact(&owned, Dialect::Adl2))
+            .await?
+            .map_err(|errs| syntax_bad_request(&errs))?;
         let repo = self.adl2_repository().await?;
-        let issues = if production_model_governs(&archetype) {
-            // VETDF: external term bindings are verified against the terminology
-            // service, pre-resolved here into the synchronous validator seam
-            // (`master03` §Validity Rules; see [`AdlTerminologyResolver`]).
-            let resolver = self.adl2_terminology_resolver(&archetype).await;
-            validate_source(source, Some(&repo), &ProductionRmModel, &resolver)
+        let governed = production_model_governs(&archetype);
+        // VETDF: external term bindings are verified against the terminology
+        // service, pre-resolved here into the synchronous validator seam
+        // (`master03` §Validity Rules; see [`AdlTerminologyResolver`]).
+        let resolver = if governed {
+            Some(self.adl2_terminology_resolver(&archetype).await)
         } else {
-            validate_source_integrity(source, Dialect::Adl2, Some(&repo))
-        }
+            None
+        };
+        let owned = source.to_owned();
+        let issues = on_engine_stack(move || match resolver {
+            Some(resolver) => validate_source(&owned, Some(&repo), &ProductionRmModel, &resolver),
+            None => validate_source_integrity(&owned, Dialect::Adl2, Some(&repo)),
+        })
+        .await?
         .map_err(|errs| syntax_bad_request(&errs))?;
 
         let errors: Vec<InvariantViolation> = issues
@@ -963,6 +971,40 @@ fn version_prefix_matches(full: &str, prefix: &str) -> bool {
 fn cmp_version(a: &str, b: &str) -> std::cmp::Ordering {
     let parse = |v: &str| -> Vec<u64> { v.split('.').map(|p| p.parse().unwrap_or(0)).collect() };
     parse(a).cmp(&parse(b))
+}
+
+/// The stack the AOM engine runs on.
+///
+/// Parsing, flattening and validating an archetype recurse over the artefact
+/// and over the stored repository (slot fillers, specialisation parents), and
+/// a well-stocked store crossed a tokio worker's 2 MiB stack (#3062). The
+/// reservation is virtual: pages are committed only as the stack grows.
+const ENGINE_STACK_BYTES: usize = 256 * 1024 * 1024;
+
+/// Run `f` on a dedicated thread with [`ENGINE_STACK_BYTES`] of stack and await
+/// its result without blocking the runtime.
+///
+/// # Errors
+/// [`ServiceError::Internal`] when the thread cannot be spawned or ends without
+/// delivering a result (a panic inside `f` surfaces as that, never as an abort
+/// of the process).
+async fn on_engine_stack<T, F>(f: F) -> Result<T, ServiceError>
+where
+    T: Send + 'static,
+    F: FnOnce() -> T + Send + 'static,
+{
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    std::thread::Builder::new()
+        .name("adl2-engine".to_owned())
+        .stack_size(ENGINE_STACK_BYTES)
+        .spawn(move || {
+            // The receiver is gone only when the request was cancelled, in
+            // which case the result has no reader left.
+            drop(tx.send(f()));
+        })
+        .map_err(|e| ServiceError::internal("spawning the ADL2 engine thread", e))?;
+    rx.await
+        .map_err(|e| ServiceError::internal("the ADL2 engine thread ended without a result", e))
 }
 
 #[cfg(test)]

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-adl"
-version = "0.0.55"
+version = "0.0.56"
 description = "openEHR ADL 2.4.0: hand-written ADL2/cADL/ODIN parser, AOM2 validation catalogue, specialisation flattener, OPT2 generator, and ADL 1.4→2 conversion over the generated openehr_am::v2_4::aom2 model"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,11 +16,11 @@ include = ["src/**", "README.md", "LICENSE-MIT"]
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)
-openehr-base = { path = "../openehr-base", version = "0.0.55" }   # VersionStatus for the parsed HRID
-openehr-am = { path = "../openehr-am", version = "0.0.55" }       # v2_4 ArchetypeHrid (the identification target type)
-openehr-rm = { path = "../openehr-rm", version = "0.0.55" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
-openehr-lang = { path = "../openehr-lang", version = "0.0.55" }   # openehr_lang::odin — the ODIN section parser
-openehr-term = { path = "../openehr-term", version = "0.0.55" }   # the languages code set for the RM resource-meta rows
+openehr-base = { path = "../openehr-base", version = "0.0.56" }   # VersionStatus for the parsed HRID
+openehr-am = { path = "../openehr-am", version = "0.0.56" }       # v2_4 ArchetypeHrid (the identification target type)
+openehr-rm = { path = "../openehr-rm", version = "0.0.56" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
+openehr-lang = { path = "../openehr-lang", version = "0.0.56" }   # openehr_lang::odin — the ODIN section parser
+openehr-term = { path = "../openehr-term", version = "0.0.56" }   # the languages code set for the RM resource-meta rows
 uuid.workspace = true        # meta uid/build_uid (AUTHORED_ARCHETYPE.uid: Uuid)
 indexmap.workspace = true    # OdinValue::Object body (insertion-ordered map)
 

--- a/crates/openehr-adl/src/validate/catalogue.rs
+++ b/crates/openehr-adl/src/validate/catalogue.rs
@@ -173,7 +173,8 @@ pub enum ValidationCode {
     /// VARD — description specified (`master03` §Validity Rules).
     Vard,
     /// VASID — specialisation parent identifier validity (`master03` §Validity
-    /// Rules; fires only when the parent is supplied).
+    /// Rules; needs a repository: a stated parent that is absent from it, or
+    /// that is not the immediate parent, both fail).
     Vasid,
     /// VALC — archetype language conformance (`master03` §Validity Rules; fires
     /// only when the parent is supplied).

--- a/crates/openehr-adl/src/validate/mod.rs
+++ b/crates/openehr-adl/src/validate/mod.rs
@@ -403,6 +403,8 @@ fn run_parent_conformance(
                 ));
             }
         }
+        // NOTE: a stated parent absent from the repository is VASID, raised by
+        // the identification pass (`specialisation::check_specialisation_depth`).
         FlatParent::NotSpecialised | FlatParent::NotFound => {}
     }
 }

--- a/crates/openehr-adl/src/validate/specialisation.rs
+++ b/crates/openehr-adl/src/validate/specialisation.rs
@@ -925,8 +925,28 @@ pub(super) fn check_specialisation_depth(
         ));
     }
 
-    let Some(parent) = repo.and_then(|r| r.get(parent_id)) else {
-        return; // parent unresolved (missing parent is a separate concern)
+    let Some(repo) = repo else {
+        return; // standalone validation: the parent-dependent half needs a repository
+    };
+    let Some(parent) = repo.get(parent_id) else {
+        // An operational template is already the flat form (master08 §Phase 3):
+        // its `specialise` clause records lineage, and no phase-2 conformance
+        // against a parent applies to it.
+        if v.kind == crate::source::ArtefactKind::OperationalTemplate {
+            return;
+        }
+        // The stated id resolves to nothing, so it is not "the identifier of the
+        // immediate specialisation parent archetype" (master03 VASID), and
+        // phase 2 (master08 §Validation of Specialised Archetype Against Flat
+        // Parent) cannot run: the archetype has not validated.
+        out.push(ValidationIssue::new(
+            ValidationCode::Vasid,
+            format!(
+                "stated parent archetype {parent_id:?} is not in the repository, so the \
+                 specialised archetype cannot be validated against its flat parent"
+            ),
+        ));
+        return;
     };
     let parent_view = view(parent);
     let parent_level = parent_view.specialisation_level();

--- a/crates/openehr-adl/src/validate/structure.rs
+++ b/crates/openehr-adl/src/validate/structure.rs
@@ -143,15 +143,25 @@ impl StructureScan<'_> {
         }
 
         // VCATU: sibling attributes uniquely named (master04.5 §`C_COMPLEX_OBJECT`).
+        // In a differential archetype a root-level attribute is identified by
+        // its whole differential path: `/items` and `/items[id9]/items` end in
+        // the same RM attribute name yet address different nodes of the flat
+        // parent (ADL2 master09.02 §Differential Paths).
         let mut seen_attrs = BTreeSet::new();
         for attr in complex_attributes(cco) {
-            if !seen_attrs.insert(attr.rm_attribute_name.as_str()) {
+            let key = (
+                attr.differential_path.as_deref(),
+                attr.rm_attribute_name.as_str(),
+            );
+            if !seen_attrs.insert(key) {
                 push_issue(
                     &mut self.issues,
                     ValidationCode::Vcatu,
                     format!(
                         "attribute {:?} is defined more than once",
-                        attr.rm_attribute_name
+                        attr.differential_path
+                            .as_deref()
+                            .unwrap_or(&attr.rm_attribute_name)
                     ),
                     path,
                 );

--- a/crates/openehr-adl/tests/it/ckm_archetype_packs.rs
+++ b/crates/openehr-adl/tests/it/ckm_archetype_packs.rs
@@ -37,9 +37,14 @@
 
 use std::path::{Path, PathBuf};
 
+use openehr_adl::artefact::ArchetypeRepository;
 use openehr_adl::assemble::parse_artefact;
 use openehr_adl::error::SyntaxErrorCode;
 use openehr_adl::parse::Dialect;
+use openehr_adl::validate::bindings::NoTerminologyResolver;
+use openehr_adl::validate::catalogue::{Severity, ValidationCode};
+use openehr_adl::validate::rm::{ProductionRmModel, production_model_governs};
+use openehr_adl::validate::{validate_source, validate_source_integrity};
 
 /// Archetypes the conformant reader MUST refuse, with the syntax code the
 /// refusal must carry and the adjudication behind it.
@@ -312,15 +317,13 @@ fn ckm_adl14_pack_is_resource_meta_clean() {
     let mut offenders = Vec::new();
     for path in &files {
         let src = std::fs::read_to_string(path).expect("archetype is readable");
-        let Ok(issues) = openehr_adl::validate::validate_adl14_source(
-            &src,
-            &openehr_adl::validate::rm::ProductionRmModel,
-        ) else {
+        let Ok(issues) = openehr_adl::validate::validate_adl14_source(&src, &ProductionRmModel)
+        else {
             continue; // adjudicated parse refusals are ckm_adl14_pack_parses' claim
         };
         for issue in issues
             .iter()
-            .filter(|i| i.severity == openehr_adl::validate::catalogue::Severity::Error)
+            .filter(|i| i.severity == Severity::Error)
             .filter(|i| resource_codes.contains(&i.code.mnemonic()))
         {
             offenders.push(format!(
@@ -335,5 +338,605 @@ fn ckm_adl14_pack_is_resource_meta_clean() {
         offenders.is_empty(),
         "CKM archetypes refused by the resource-meta pass (adjudicate, never silence):\n{}",
         offenders.join("\n")
+    );
+}
+
+/// A vendored ADL 2 archetype the AOM2 validator MUST refuse, with the
+/// validity code the refusal must carry and the adjudication behind it.
+///
+/// The validation-level twin of [`Refusal`]: these files parse, and the CDR's
+/// own upload path (`POST /definition/template/adl2`) refuses them with `422`
+/// on exactly these codes, so the sandbox seed's pinned accepted/refused split
+/// has this table as its authority.
+type ValidityRefusal = (&'static str, ValidationCode, &'static str);
+
+/// The adjudicated validity refusals over the 2013 CKM ADL 2 export.
+const ADJUDICATED_ADL2_VALIDITY: &[ValidityRefusal] = &[
+    (
+        "openEHR-DEMOGRAPHIC-PARTY_IDENTITY.person_name-individual_provider.v1.0.0.adls",
+        ValidationCode::Vacdf,
+        "constraint codes used in the definition are undefined in the terminology (master03 VACDF)",
+    ),
+    (
+        "openEHR-DEMOGRAPHIC-PERSON.person-patient.v1.0.0.adls",
+        ValidationCode::Vacdf,
+        "constraint codes used in the definition are undefined in the terminology (master03 VACDF)",
+    ),
+    (
+        "openEHR-EHR-CLUSTER.ambient_oxygen.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY (undefined in RM 1.2.0) and the RM function(s) `is_integral`, which VCARM admits but the vendored BMM does not declare (#3061)",
+    ),
+    (
+        "openEHR-EHR-CLUSTER.anatomical_location-precise.v1.0.0.adls",
+        ValidationCode::Vasid,
+        "its parent openEHR-EHR-CLUSTER.anatomical_location.v1.0.0 is refused above, so no flat parent exists to validate against (master03 VASID)",
+    ),
+    (
+        "openEHR-EHR-CLUSTER.anatomical_location.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-CLUSTER.auscultation-chest.v1.0.0.adls",
+        ValidationCode::Vpov,
+        "a redefined value-set member is not in the parent value set (master03 VPOV)",
+    ),
+    (
+        "openEHR-EHR-CLUSTER.dimensions.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-CLUSTER.environmental_conditions.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-CLUSTER.exam-abdomen.v1.0.0.adls",
+        ValidationCode::Vdssm,
+        "a specialised slot restates the parent slot constraints instead of narrowing them (master03 VDSSM)",
+    ),
+    (
+        "openEHR-EHR-CLUSTER.exam-uterine_cervix.v1.0.0.adls",
+        ValidationCode::Valc,
+        "declares language(s) es-cl absent from the flat parent (master03 VALC)",
+    ),
+    (
+        "openEHR-EHR-CLUSTER.exam_pupils.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-CLUSTER.fluid.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-CLUSTER.health_event-poisoning.v1.0.0.adls",
+        ValidationCode::Valc,
+        "declares language(s) ar-sy, es-ar absent from the flat parent (master03 VALC)",
+    ),
+    (
+        "openEHR-EHR-CLUSTER.inspection-skin-wound.v1.0.0.adls",
+        ValidationCode::Vcosu,
+        "an object node id recurs in the flat form (master04.5 VCOSU)",
+    ),
+    (
+        "openEHR-EHR-CLUSTER.level_of_exertion.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-CLUSTER.lymph_node_metastases.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-CLUSTER.macroscopy_colorectal_carcinoma.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-CLUSTER.medication_amount.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-CLUSTER.menstrual_cycle.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-CLUSTER.microscopy_colorectal_carcinoma.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-CLUSTER.microscopy_melanoma.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY (undefined in RM 1.2.0) and the RM function(s) `is_integral`, which VCARM admits but the vendored BMM does not declare (#3061)",
+    ),
+    (
+        "openEHR-EHR-CLUSTER.microscopy_prostate_carcinoma.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains the RM function(s) `is_integral`; VCARM admits computed attributes, but the vendored BMM declares no functions (#3061)",
+    ),
+    (
+        "openEHR-EHR-CLUSTER.move-joint.v1.0.0.adls",
+        ValidationCode::Vasid,
+        "its parent openEHR-EHR-CLUSTER.move.v1.0.0 is refused above, so no flat parent exists to validate against (master03 VASID)",
+    ),
+    (
+        "openEHR-EHR-CLUSTER.move-spine.v1.0.0.adls",
+        ValidationCode::Vasid,
+        "its parent openEHR-EHR-CLUSTER.move.v1.0.0 is refused above, so no flat parent exists to validate against (master03 VASID)",
+    ),
+    (
+        "openEHR-EHR-CLUSTER.move.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-CLUSTER.physical_properties.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-CLUSTER.refraction_details.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-CLUSTER.specimen.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-CLUSTER.specimen_preparation.v1.0.0.adls",
+        ValidationCode::Vcaca,
+        "cardinality {0..1} narrows below the RM cardinality {1..*} of CLUSTER.items (master04.5 VCACA)",
+    ),
+    (
+        "openEHR-EHR-CLUSTER.symptom-pain.v1.0.0.adls",
+        ValidationCode::Valc,
+        "declares language(s) es absent from the flat parent (master03 VALC)",
+    ),
+    (
+        "openEHR-EHR-CLUSTER.timing.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-CLUSTER.tumour_resection_margins.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-CLUSTER.waveform.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-EVALUATION.goal.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-EVALUATION.pregnancy.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-EVALUATION.problem_diagnosis.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-INSTRUCTION.request-procedure.v1.0.0.adls",
+        ValidationCode::Vdifp,
+        "a differential path names an attribute the flat parent does not have (master08 VDIFP)",
+    ),
+    (
+        "openEHR-EHR-INSTRUCTION.transfusion.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-ITEM_TREE.gas_administration.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-ITEM_TREE.intravenous_fluids.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.apgar.v1.0.0.adls",
+        ValidationCode::Vttbk,
+        "term binding keys name paths that do not exist in the archetype (master03 VTTBK)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.blood_pressure.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.bodily_output-defaecation.v1.0.0.adls",
+        ValidationCode::Vdssid,
+        "a specialised slot is renumbered instead of keeping the parent slot id (master03 VDSSID)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.bodily_output-urination.v1.0.0.adls",
+        ValidationCode::Vdssid,
+        "a specialised slot is renumbered instead of keeping the parent slot id (master03 VDSSID)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.body_mass_index.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.body_surface_area.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.body_temperature.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.body_weight-adjusted.v1.0.0.adls",
+        ValidationCode::Vasid,
+        "its parent openEHR-EHR-OBSERVATION.body_weight.v1.0.0 is refused above, so no flat parent exists to validate against (master03 VASID)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.body_weight-birth.v1.0.0.adls",
+        ValidationCode::Vasid,
+        "its parent openEHR-EHR-OBSERVATION.body_weight.v1.0.0 is refused above, so no flat parent exists to validate against (master03 VASID)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.body_weight.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.chest_expansion.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.demo.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY (undefined in RM 1.2.0) and the RM function(s) `is_integral`, `offset`, which VCARM admits but the vendored BMM does not declare (#3061)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.distraction_hearing_test.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.ecg.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.electroacoustic_hearing_test.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.faeces.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.fetal_heart-monitoring.v1.0.0.adls",
+        ValidationCode::Vasid,
+        "its parent openEHR-EHR-OBSERVATION.fetal_heart.v1.0.0 is refused above, so no flat parent exists to validate against (master03 VASID)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.fetal_heart.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.hearing_screening.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.height.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.indirect_oximetry.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY (undefined in RM 1.2.0) and the RM function(s) `is_integral`, which VCARM admits but the vendored BMM does not declare (#3061)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.infant_feeding.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.intraocular_pressure.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.intravascular_pressure-cvp.v1.0.0.adls",
+        ValidationCode::Vasid,
+        "its parent openEHR-EHR-OBSERVATION.intravascular_pressure.v1.0.0 is refused above, so no flat parent exists to validate against (master03 VASID)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.intravascular_pressure-jvp.v1.0.0.adls",
+        ValidationCode::Vasid,
+        "its parent openEHR-EHR-OBSERVATION.intravascular_pressure.v1.0.0 is refused above, so no flat parent exists to validate against (master03 VASID)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.intravascular_pressure.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.lab_test-blood_gases.v1.0.0.adls",
+        ValidationCode::Valc,
+        "declares language(s) es-ar absent from the flat parent (master03 VALC)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.lab_test-full_blood_count.v1.0.0.adls",
+        ValidationCode::Vsonin,
+        "new object node ids are not valid new ids at this specialisation level (master03 VSONIN)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.mantoux.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.menstruation.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.msfc_score.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.oral_fluid_intake.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.pathology_test-blood_glucose.v1.0.0.adls",
+        ValidationCode::Vdifp,
+        "a differential path names an attribute the flat parent does not have (master08 VDIFP)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.pathology_test-lipids.v1.0.0.adls",
+        ValidationCode::Vdifp,
+        "a differential path names an attribute the flat parent does not have (master08 VDIFP)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.pulmonary_function.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.pulse.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.respiration.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.substance_use-alcohol.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.substance_use-caffeine.v1.0.0.adls",
+        ValidationCode::Vcosu,
+        "an object node id recurs in the flat form (master04.5 VCOSU)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.temperature.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.tympanogram_226hz.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.tympanogram_hf.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY (undefined in RM 1.2.0) and the RM function(s) `is_integral`, which VCARM admits but the vendored BMM does not declare (#3061)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.urine_output.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.uterine_contractions.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.visual_acuity.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY (undefined in RM 1.2.0) and the RM function(s) `is_integral`, which VCARM admits but the vendored BMM does not declare (#3061)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.visual_field_measurement.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY (undefined in RM 1.2.0) and the RM function(s) `is_integral`, which VCARM admits but the vendored BMM does not declare (#3061)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.waist_hip.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.warble_tones_hearing_test.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+    (
+        "openEHR-EHR-OBSERVATION.word_list_hearing_test.v1.0.0.adls",
+        ValidationCode::Vcarm,
+        "constrains `property` on DV_QUANTITY, which RM 1.2.0 does not define (the 2013 converter carried ADL 1.4 C_DV_QUANTITY.property into an attribute position)",
+    ),
+];
+
+/// The outcome of validating a whole pack the way the CDR validates an upload.
+struct ValidityOutcome {
+    /// Files refused with no adjudication covering them (`name: CODE message`).
+    failures: Vec<String>,
+    /// Adjudications that no longer describe reality.
+    broken_adjudications: Vec<String>,
+    /// Files validating with no error-severity issue.
+    clean: usize,
+    /// Adjudicated refusals that carried exactly the expected code.
+    refused: usize,
+}
+
+/// The specialisation depth an ADL 2 id states in its concept segment
+/// (`CLUSTER.exam-abdomen` specialises `CLUSTER.exam`: one `-`, depth 1).
+fn id_depth(name: &str) -> usize {
+    name.split('.')
+        .nth(1)
+        .map_or(0, |concept| concept.matches('-').count())
+}
+
+/// The pack in upload order: parents before children (depth, then name) — the
+/// order the sandbox seed uses, so a child always meets its stored parent.
+fn parents_first(files: &[PathBuf]) -> Vec<PathBuf> {
+    let mut ordered: Vec<PathBuf> = files.to_vec();
+    ordered.sort_by_cached_key(|p| {
+        let name = file_name(p);
+        (id_depth(&name), name)
+    });
+    ordered
+}
+
+/// Validate every parseable `.adls` of the pack exactly as the CDR does on
+/// upload, in upload order: the full AOM2 catalogue against the production RM
+/// for an openEHR RM archetype, the integrity pass alone otherwise, each over a
+/// repository holding only the archetypes ACCEPTED so far — a refused parent is
+/// never a flat parent, and a child whose parent is absent is VASID.
+fn validate_all(files: &[PathBuf], adjudicated: &[ValidityRefusal]) -> ValidityOutcome {
+    let mut repo = ArchetypeRepository::new();
+    let mut out = ValidityOutcome {
+        failures: Vec::new(),
+        broken_adjudications: Vec::new(),
+        clean: 0,
+        refused: 0,
+    };
+    for path in parents_first(files) {
+        let name = file_name(&path);
+        let src = std::fs::read_to_string(&path).expect("read archetype source");
+        let Ok(archetype) = parse_artefact(&src, Dialect::Adl2) else {
+            // Parse refusals are the parse-level table's business.
+            continue;
+        };
+        let issues = if production_model_governs(&archetype) {
+            validate_source(
+                &src,
+                Some(&repo),
+                &ProductionRmModel,
+                &NoTerminologyResolver,
+            )
+        } else {
+            validate_source_integrity(&src, Dialect::Adl2, Some(&repo))
+        }
+        .expect("a parsed source validates without syntax errors");
+        let errors: Vec<_> = issues
+            .iter()
+            .filter(|i| i.severity == Severity::Error)
+            .collect();
+        let expected = adjudicated
+            .iter()
+            .find(|(file, _, _)| *file == name)
+            .map(|(_, code, reason)| (*code, *reason));
+        match (errors.is_empty(), expected) {
+            (true, None) => {
+                out.clean += 1;
+                repo.insert(archetype);
+            }
+            (true, Some((code, reason))) => out.broken_adjudications.push(format!(
+                "{name}: expected refusal {code} ({reason}) but the file now VALIDATES — \
+                 remove the adjudication if that is a genuine fix, or investigate a \
+                 loosened validator"
+            )),
+            (false, None) => out.failures.push(format!(
+                "{name}: {}",
+                errors
+                    .iter()
+                    .map(|i| {
+                        let at = i
+                            .path
+                            .as_ref()
+                            .map_or(String::new(), |p| format!(" (at {p})"));
+                        format!("{} {}{at}", i.code, i.message)
+                    })
+                    .collect::<Vec<_>>()
+                    .join(" | ")
+            )),
+            (false, Some((code, reason))) => {
+                if errors.iter().any(|i| i.code == code) {
+                    out.refused += 1;
+                } else {
+                    out.broken_adjudications.push(format!(
+                        "{name}: expected refusal {code} ({reason}) but got {:?}",
+                        errors.iter().map(|i| i.code).collect::<Vec<_>>()
+                    ));
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Every parseable archetype of the 2013 CKM ADL 2 export validates as the CDR
+/// validates an upload, or is refused on an adjudicated validity code.
+#[test]
+fn upstream_adl2_pack_validates_or_is_adjudicated() {
+    let dir = artifacts_root().join("adl2/ckm-2013-12-09");
+    let files = files_with_extension(&dir, "adls");
+    assert!(!files.is_empty(), "no .adls files under {}", dir.display());
+    let out = validate_all(&files, ADJUDICATED_ADL2_VALIDITY);
+    assert!(
+        out.broken_adjudications.is_empty(),
+        "adl2 validity: adjudications that no longer describe reality:\n{}",
+        out.broken_adjudications.join("\n")
+    );
+    assert!(
+        out.failures.is_empty(),
+        "adl2 validity: {} files are refused and not adjudicated:\n{}",
+        out.failures.len(),
+        out.failures.join("\n")
+    );
+    assert_eq!(
+        out.refused,
+        ADJUDICATED_ADL2_VALIDITY.len(),
+        "adl2 validity: {} of {} adjudicated refusals were exercised",
+        out.refused,
+        ADJUDICATED_ADL2_VALIDITY.len()
+    );
+    assert_eq!(
+        out.clean + out.refused,
+        files.len() - expected_refusals(&files, ADJUDICATED_PAIRS),
+        "adl2 validity: accounting mismatch over the parseable pack"
     );
 }

--- a/crates/openehr-adl/tests/it/validation_integrity_cases.rs
+++ b/crates/openehr-adl/tests/it/validation_integrity_cases.rs
@@ -136,6 +136,98 @@ fn vcatu_duplicate_sibling_attribute() {
     assert_raises(&issues, ValidationCode::Vcatu);
 }
 
+/// A minimal specialisation of [`BASE`] whose two root-level differential paths
+/// end in the same RM attribute name (`element_attr`) yet address different
+/// parent nodes.
+const CHILD_WITH_DIFFERENTIAL_PATHS: &str = r#"archetype (adl_version=2.0.5; rm_release=1.0.2)
+    openEHR-EHR-ENTRY.integrity_base-child.v1.0.0
+
+specialise
+    openEHR-EHR-ENTRY.integrity_base.v1.0.0
+
+language
+    original_language = <[ISO_639-1::en]>
+
+description
+    lifecycle_state = <"draft">
+
+definition
+    ENTRY[id1.1] matches {
+        /element_attr matches {
+            ELEMENT[id0.1]
+        }
+        /element_attr[id2]/element_attr matches {
+            ELEMENT[id0.2]
+        }
+    }
+
+terminology
+    term_definitions = <
+        ["en"] = <
+            ["id1.1"] = < text = <"child"> description = <"child"> >
+            ["id0.1"] = < text = <"new"> description = <"new"> >
+            ["id0.2"] = < text = <"nested"> description = <"nested"> >
+        >
+    >
+"#;
+
+#[test]
+fn vcatu_differential_paths_sharing_a_leading_segment_are_distinct() {
+    // master04.5 §C_COMPLEX_OBJECT — VCATU judges sibling attributes; in a
+    // differential archetype `/element_attr` and `/element_attr[id2]/element_attr`
+    // are different attributes of the flat parent (ADL2 master09.02
+    // §Differential Paths), not a duplicate.
+    let issues =
+        validate_source_integrity(CHILD_WITH_DIFFERENTIAL_PATHS, Dialect::Adl2, None).unwrap();
+    assert!(
+        !mnemonics(&issues).contains(&"VCATU"),
+        "differential paths must not be read as duplicate siblings: {issues:?}"
+    );
+}
+
+#[test]
+fn vasid_stated_parent_absent_from_the_repository() {
+    // master03 §Validity Rules — VASID: the stated parent must be the identifier
+    // of the immediate parent archetype; an id the repository cannot resolve is
+    // not that, and phase 2 (master08) cannot run without the flat parent.
+    let empty = ArchetypeRepository::new();
+    let issues =
+        validate_source_integrity(CHILD_WITH_DIFFERENTIAL_PATHS, Dialect::Adl2, Some(&empty))
+            .unwrap();
+    assert_raises(&issues, ValidationCode::Vasid);
+
+    let mut with_parent = ArchetypeRepository::new();
+    with_parent.insert(parse(BASE));
+    let issues = validate_source_integrity(
+        CHILD_WITH_DIFFERENTIAL_PATHS,
+        Dialect::Adl2,
+        Some(&with_parent),
+    )
+    .unwrap();
+    assert!(
+        !mnemonics(&issues).contains(&"VASID"),
+        "a resolvable parent satisfies VASID: {issues:?}"
+    );
+}
+
+#[test]
+fn vasid_absent_parent_is_not_raised_for_an_operational_template() {
+    // master08 §Phase 3 — an operational template is the flat form itself, so
+    // its `specialise` clause records lineage and needs no stored parent.
+    let src = CHILD_WITH_DIFFERENTIAL_PATHS
+        .replacen("archetype (adl_version", "operational_template (adl_version", 1)
+        .replace(
+            "        /element_attr matches {\n            ELEMENT[id0.1]\n        }\n        /element_attr[id2]/element_attr matches {\n            ELEMENT[id0.2]\n        }\n",
+            "        element_attr matches {\n            ELEMENT[id0.1]\n            ELEMENT[id0.2]\n        }\n",
+        );
+    let empty = ArchetypeRepository::new();
+    let issues = validate_source_integrity(&src, Dialect::Adl2, Some(&empty)).unwrap();
+    assert!(
+        !mnemonics(&issues).contains(&"VASID"),
+        "an operational template validates without its parent: {issues:?}"
+    );
+}
+
 #[test]
 fn vcosu_duplicate_node_id() {
     // master04.5 §C_OBJECT — VCOSU: object node ids must be unique within the

--- a/crates/openehr-am/Cargo.toml
+++ b/crates/openehr-am/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-am"
-version = "0.0.55"
+version = "0.0.56"
 description = "openEHR AM Archetype Model, generated from BMM: generations v1_4 (AM 1.4.0, ADL 1.4) and v2_4 (AM 2.4.0, ADL 2; current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,8 +13,8 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.55" }
-openehr-lang = { path = "../openehr-lang", version = "0.0.55" }
+openehr-base = { path = "../openehr-base", version = "0.0.56" }
+openehr-lang = { path = "../openehr-lang", version = "0.0.56" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also carries the untyped `Value` fields the generator

--- a/crates/openehr-base/Cargo.toml
+++ b/crates/openehr-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-base"
-version = "0.0.55"
+version = "0.0.56"
 description = "openEHR BASE foundation + base types, generated from BMM: generations v1_2 (BASE 1.2.0) and v1_3 (BASE 1.3.0, current)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-its"
-version = "0.0.55"
+version = "0.0.56"
 description = "openEHR ITS (Implementation Technology Specifications): canonical JSON + canonical XML serialization of the RM, the generated ITS-REST 1.1.0 API contract, OPT 1.4 and AOM2 archetype XML codecs, and the Simplified Formats (FLAT / STRUCTURED / Web Template)"
 edition.workspace = true
 rust-version.workspace = true
@@ -41,14 +41,14 @@ regex = { workspace = true, optional = true }
 fancy-regex = { workspace = true, optional = true }
 # The generated XML (de)serializers impl the crate's ToXml/FromXml traits for the
 # RM/BASE spec types, so these are real (non-dev) deps.
-openehr-base = { path = "../openehr-base", version = "0.0.55", optional = true }
-openehr-rm = { path = "../openehr-rm", version = "0.0.55", optional = true }
+openehr-base = { path = "../openehr-base", version = "0.0.56", optional = true }
+openehr-rm = { path = "../openehr-rm", version = "0.0.56", optional = true }
 # The native canonical-JSON codec (`json_codec/generated`, emit-json) implements
 # `ToJson` for EVERY generated spec type the `OpenEhrType` derive covers, so it
 # spans all five spec crates (not just the RM/BASE the XML codec needs).
-openehr-lang = { path = "../openehr-lang", version = "0.0.55", optional = true }
-openehr-am = { path = "../openehr-am", version = "0.0.55", optional = true }
-openehr-term = { path = "../openehr-term", version = "0.0.55", optional = true }
+openehr-lang = { path = "../openehr-lang", version = "0.0.56", optional = true }
+openehr-am = { path = "../openehr-am", version = "0.0.56", optional = true }
+openehr-term = { path = "../openehr-term", version = "0.0.56", optional = true }
 
 # `full` — every ITS surface (canonical JSON/XML, the generated ITS-REST
 # contract, `opt14`, Simplified Formats). ON BY DEFAULT, so every consumer sees

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-lang"
-version = "0.0.55"
+version = "0.0.56"
 description = "openEHR LANG BMM/P_BMM object model, generated from BMM: generations v1_0 (LANG 1.0.0) and v1_1 (LANG 1.1.0, current; the stable BMM v2.x unit beside the paused BMM3 unit), plus hand-written ODIN/BEL/EL readers"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["parser-implementations", "data-structures"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.55" }
+openehr-base = { path = "../openehr-base", version = "0.0.56" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the
 # generated types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) —
 # never a derive. `serde_json` also carries the untyped `Value` fields the

--- a/crates/openehr-query/Cargo.toml
+++ b/crates/openehr-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-query"
-version = "0.0.55"
+version = "0.0.56"
 description = "openEHR QUERY (AQL 1.1.0): hand-written lexer, parser, typed AST and canonical printer from the official grammar (no ANTLR runtime)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-rm"
-version = "0.0.55"
+version = "0.0.56"
 description = "openEHR RM Reference Model, generated from BMM: generations v1_1 (RM 1.1.0) and v1_2 (RM 1.2.0, current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,11 +13,11 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.55" }
+openehr-base = { path = "../openehr-base", version = "0.0.56" }
 # The terminology-backed RM class invariants (`validate::terminology`) resolve
 # openEHR terminology groups + code sets against the vendored TERM 3.1.0 bundle.
 # `openehr-term` itself depends only on `openehr-base`, so this is acyclic.
-openehr-term = { path = "../openehr-term", version = "0.0.55" }
+openehr-term = { path = "../openehr-term", version = "0.0.56" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also backs the untyped `Value` RM representation used by

--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-term"
-version = "0.0.55"
+version = "0.0.56"
 description = "openEHR TERM terminology data model, generated from BMM (generation v3_1 = TERM 3.1.0), plus the embedded official terminology XML bundle"
 edition.workspace = true
 rust-version.workspace = true
@@ -34,7 +34,7 @@ include = [
 ]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.55" }
+openehr-base = { path = "../openehr-base", version = "0.0.56" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive.

--- a/deploy/hosted/README.md
+++ b/deploy/hosted/README.md
@@ -117,7 +117,7 @@ One run loads, in about 590 requests:
 | What | How much |
 |---|---|
 | ADL 1.4 operational templates | 16 (the curated CKM pack, `corpus/templates/ckm/`) |
-| ADL 2 archetypes | 228 — 225 from the vendored 2013 CKM corpus plus 3 of our own |
+| ADL 2 archetypes | 235 — 232 from the vendored 2013 CKM corpus plus 3 of our own |
 | ADL 2 templates | 5 (4 of our own plus one carried by the corpus); two of ours are SOURCE templates the CDR flattens against that archetype library |
 | EHRs | 8, each with a distinct subject and a mixed record |
 | Compositions | 182 (166 ADL 1.4, 16 from CDR-generated ADL 2 examples) |
@@ -126,11 +126,16 @@ One run loads, in about 590 requests:
 | Directories | one FOLDER tree per EHR, its items real composition references |
 | Stored AQL queries | 5, under the `eu.ferroehr.sandbox` namespace |
 
-The ADL 2 archetype step offers the whole 322-file corpus and pins both
-outcomes in the manifest: 226 artefacts stored, 96 refused with a `422` because
-the 2013 conversions carry reference-model attributes the pinned RM no longer
-declares (`DV_QUANTITY.property` and its neighbours). A change in either count
-fails the run instead of passing quietly. Two of the eight EHRs end the run with
+The ADL 2 archetype step offers the whole 322-file corpus, parents before
+children, and pins both outcomes in the manifest: 233 artefacts stored, 89
+refused with a `422`. The refusals are AOM2 validity findings on the 2013
+conversions: constraints on attributes the RM does not declare
+(`DV_QUANTITY.property`, and the RM functions `is_integral` and `offset` the
+machine-readable RM omits), languages, slots and node ids that do not conform
+to the flat parent, and eight children of refused parents that therefore have
+no flat parent to validate against. Every refused file is adjudicated by name
+in the corpus gate (`crates/openehr-adl/tests/it/ckm_archetype_packs.rs`), and
+a change in either count fails the run instead of passing quietly. Two of the eight EHRs end the run with
 a second `EHR_STATUS` version: one not queryable, one not modifiable, so both
 flags are visible on live data.
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1275,7 +1275,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "indexmap",
  "openehr-am",
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -1301,7 +1301,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "serde",
  "serde_json",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "async-trait",
  "axum",
@@ -1336,7 +1336,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "chumsky",
  "indexmap",
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "chumsky",
  "logos",
@@ -1358,7 +1358,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "openehr-base",
  "openehr-term",
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/scripts/sandbox/reseed.sh
+++ b/scripts/sandbox/reseed.sh
@@ -154,11 +154,27 @@ echo "==> $adl14_count ADL 1.4 operational templates"
 
 # ── 3. the ADL 2 archetype library ───────────────────────────────────────────
 #
-# The whole vendored corpus is offered and both outcomes are pinned in the
-# manifest: an artefact the CDR stores, and one its AOM2 validation refuses
-# because the 2013 CKM conversion carries reference-model attributes the pinned
-# RM no longer declares (DV_QUANTITY.property and its neighbours). A change in
-# either count fails the run rather than passing quietly.
+# The whole vendored corpus is offered, parents before children, and both
+# outcomes are pinned in the manifest: an artefact the CDR stores, and one its
+# AOM2 validation refuses (the 2013 conversions constrain attributes the RM
+# does not declare, restate or renumber parent slots, or specialise a refused
+# parent). The per-file adjudication is the corpus gate in
+# crates/openehr-adl/tests/it/ckm_archetype_packs.rs; a change in either count
+# fails the run rather than passing quietly.
+
+# Parents before children: a specialised archetype validates against its flat
+# parent, and the CDR refuses one whose parent is not stored yet (VASID). The
+# specialisation depth is the number of `-` in the id's concept segment
+# (`CLUSTER.exam-abdomen` specialises `CLUSTER.exam`), so the list is ordered
+# by that depth first and by name second; plain `LC_ALL=C sort` put `exam-…`
+# before `exam.` because `-` sorts before `.`.
+adls_parents_first() {
+  find "$1" -name '*.adls' | while read -r f; do
+    concept="$(basename "$f" | cut -d. -f2)"
+    depth="${concept//[^-]/}"
+    printf '%d\t%s\n' "${#depth}" "$f"
+  done | LC_ALL=C sort -k1,1n -k2,2 | cut -f2-
+}
 
 lib_root="$ROOT_DIR/$(mf '.adl2.archetype_library.root')"
 want_accepted="$(mf '.adl2.archetype_library.accepted')"
@@ -173,7 +189,7 @@ while read -r adls; do
     422) refused=$((refused + 1)) ;;
     *) expect "archetype $(basename "$adls")" "$code" 201 409 422 ;;
   esac
-done < <(find "$lib_root" -name '*.adls' | LC_ALL=C sort)
+done < <(adls_parents_first "$lib_root")
 
 if [[ "$accepted" != "$want_accepted" ]] || [[ "$refused" != "$want_refused" ]]; then
   echo "::error::the ADL 2 archetype library loaded $accepted accepted / $refused refused; the manifest pins $want_accepted / $want_refused. Re-check the corpus and the manifest together." >&2

--- a/scripts/sandbox/seed/manifest.json
+++ b/scripts/sandbox/seed/manifest.json
@@ -6,7 +6,7 @@
     "editing this file plus a body under scripts/sandbox/seed/, never the walker.",
     "",
     "What one run loads, in about 590 requests: 16 ADL 1.4 operational templates",
-    "(the curated CKM pack), 226 artefacts out of the 322-file vendored ADL 2",
+    "(the curated CKM pack), 233 artefacts out of the 322-file vendored ADL 2",
     "archetype corpus, 8 ADL 2 artefacts of this repository's own, 8 EHRs carrying",
     "166 ADL 1.4 + 16 ADL 2 compositions, 6 further COMPOSITION versions, 2",
     "further EHR_STATUS versions, 11 demographic parties, a directory in every",
@@ -72,8 +72,8 @@
   "adl2": {
     "archetype_library": {
       "root": "corpus/archetypes/adl2/ckm-2013-12-09",
-      "accepted": 226,
-      "refused": 96
+      "accepted": 233,
+      "refused": 89
     },
     "artefacts": [
       "corpus/fixtures/adl2/archetype/minimal.adls",

--- a/website/book/src/getting-started.md
+++ b/website/book/src/getting-started.md
@@ -79,7 +79,7 @@ with something to look at:
   International Patient Summary, and several statutory case-report forms. Six
   compositions have more than one version, so `LATEST_VERSION` and
   `ALL_VERSIONS` differ on real data.
-- **228 ADL 2 archetypes and 5 ADL 2 templates**, browsable under
+- **235 ADL 2 archetypes and 5 ADL 2 templates**, browsable under
   `definition/archetype/adl2` and `definition/template/adl2`. Two of the
   templates are ADL 2 source templates whose slots the server flattens against
   that archetype library, and the compositions committed from them came out of


### PR DESCRIPTION
Closes #3055
Closes #3060
Closes #3061
Refs #3062 (the crash is fixed here; the recursion-depth bound in its acceptance criteria is still open)

## What

**The corpus gate** (`crates/openehr-adl/tests/it/ckm_archetype_packs.rs`) gains `upstream_adl2_pack_validates_or_is_adjudicated`, the validation-level twin of the parse table: every parseable `.adls` of the 2013 CKM export is validated exactly as the CDR validates an upload (full AOM2 catalogue against the production RM for openEHR archetypes, the integrity pass otherwise), in upload order (specialisation depth, then name) over a repository holding only the files accepted so far. Each of the 89 refusals is adjudicated by file name and validity code in `ADJUDICATED_ADL2_VALIDITY`, grouped by family: 63 VCARM (`property` on `DV_QUANTITY`, which RM 1.2.0 does not define, and the RM functions `is_integral`/`offset`), 8 VASID (children of refused parents), 4 VALC, 3 VDIFP, 2 each VCOSU/VACDF/VDSSID, 1 each VPOV/VDSSM/VTTBK/VSONIN/VCACA. A file that starts validating, or refuses on another code, fails the gate.

**Two validator defects the gate exposed, fixed in `openehr-adl`:**
- VCATU keyed sibling attributes on the bare RM attribute name, so a specialised archetype whose root-level differential paths end in the same name (`/items` beside `/items[id9]/items`, ADL2 master09.02 §Differential Paths) was refused as a duplicate. 29 corpus files were refused on that false positive; the key now includes the differential path.
- A specialised archetype whose stated parent was absent from the repository skipped every parent-conformance check and validated. It is now VASID on both validation paths (master03 VASID: the stated id must be "the identifier of the immediate specialisation parent archetype"; master08 §Phase 2 cannot run without the flat parent), naming the missing parent. An operational template, already the flat form, is exempt. Unit tests for both, plus a REST test pinning the `422` (`upload_with_absent_parent_is_422_with_vasid`).

**The seed** (`scripts/sandbox/reseed.sh`) uploads the corpus parents before children (`LC_ALL=C sort` put `exam-abdomen` before `exam`, so nine children had been stored unchecked), and the manifest's pinned split moves from 226/96 to 233/89, the gate's numbers. Run against a clean database on a locally built server: exit 0, 121 s (debug build), 16 ADL 1.4 templates, 233 + 3 ADL 2 archetypes and 5 templates (API: 235 archetypes, 5 templates), 8 EHRs, 182 compositions, 6 further versions, 8 directories, 2 further `EHR_STATUS` versions, 11 parties, 5 stored queries each above its pinned minimum row count; a repeat run is a no-op on the marker.

**The crash** (#3062): uploading `SECTION.medication_order_list` with about a hundred archetypes stored overflowed a tokio worker's 2 MiB stack in the debug build and aborted the process, an availability defect of the public upload surface. The AOM engine now parses and validates on a dedicated thread with a 256 MiB stack (`on_engine_stack`, virtual until touched; a panic inside surfaces as a typed internal error, never an abort), and `ferroehr-server` builds its runtime with 16 MiB thread stacks. The recursion-depth bound in that issue's second criterion is not in this PR; the issue stays open for it.

**Upstream report** #3061: VCARM admits computed attributes, but the published RM BMM declares no functions, so a BMM-driven validator cannot honour the rule for `is_integral`/`offset`. Verified first-hand against every vendored RM BMM generation; the refusals are pinned in the gate with that reason and the report closes as the standing record.

**Crates**: lockstep bump `0.0.55 → 0.0.56` (packaged `openehr-adl` source changed), `fuzz/Cargo.lock` refreshed. Docs: `deploy/hosted/README.md` and `website/book/src/getting-started.md` carry the new counts and the refusal families; changelog `Fixed` entries for the false positive, the missing-parent refusal and the crash, and the seed entry updated.

## Gates

fmt; clippy workspace lane (`--workspace --exclude ferroehr-viewer --all-targets --all-features -D warnings`) and `openehr-adl --all-targets`; nextest `openehr-adl` (306 passed), `ferroehr` + `ferroehr-rest` ADL2/definition suites (96 passed against the testkit PG18), `ferroehr` AQL suites; rustdoc with private items on `openehr-adl`, `ferroehr`, `ferroehr-server`; shellcheck-lane, comment-style, default-style, docs-claims, changelog-structure. Clean-database seed run as above.
