### PR TITLE
chore(conformance): the v4.0.17 acceptance run on the release commit

### DIFF
--- a/docs/conformance/ferroehr/CONFORMANCE_CERTIFICATE.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_CERTIFICATE.md
@@ -4,7 +4,7 @@
 
 | Field | Value |
 | --- | --- |
-| Solution | ferroehr 4.0.15 |
+| Solution | ferroehr 4.0.16 |
 | Vendor | Ruben Talstra |
 | Runner | veredictum 0.1.5 |
 | Infrastructure | ixit.json#/environment |

--- a/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
@@ -1,6 +1,6 @@
 # Conformance Report
 
-SUT: FerroEHR 4.0.15 (sut `ferroehr`) · schedule cnf-2.0-w2 · ITS its-rest
+SUT: FerroEHR 4.0.16 (sut `ferroehr`) · schedule cnf-2.0-w2 · ITS its-rest
 Runner: veredictum 0.1.5 · verification pack: passed
 
 ## Summary

--- a/docs/conformance/ferroehr/results.json
+++ b/docs/conformance/ferroehr/results.json
@@ -1,7 +1,7 @@
 {
   "sut": {
     "name": "ferroehr",
-    "version": "4.0.15"
+    "version": "4.0.16"
   },
   "runner": {
     "name": "veredictum",
@@ -20,7 +20,7 @@
     "source": "declared"
   },
   "ixit_digest": "60ab312f3d083668",
-  "statement_digest": "94161899de2835be",
+  "statement_digest": "61b6c37faa191436",
   "selection_basis": "statement",
   "restapi_specs_version": "1.1.0",
   "outcomes": [


### PR DESCRIPTION
A fresh `bash scripts/conformance.sh` (cold image build after the 0.0.56 crate bump, `CARGO_BUILD_JOBS=1`) against main at the v4.0.17 merge commit: 1145 case-records, 1104 passed / 0 failed / 0 errored / 41 n-a; interpreter coverage 96.3%; 43 capability verdicts, 0 review findings. Zero drift against the committed baseline from #3042: only the run's timestamps and identifiers move in the three artifact files. Artifacts only, hence `no-changelog`.