### PR TITLE
docs: describe how building products on FerroEHR works under the new licence

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,8 +3,8 @@
 Thank you for your interest in contributing. This document covers the practical
 rules; the architectural ground rules live in
 [`docs/architecture.md`](docs/architecture.md) and the root `CLAUDE.md`, and
-the project's position (why it exists, and what it asks of the companies
-that build on it) is
+the project's position (why it exists, and what it offers the organisations
+that run it and build on it) is
 [Why FerroEHR exists](https://ferroehr.eu/docs/latest/why-ferroehr.html).
 
 You keep your copyright, and there is no separate agreement to sign; the terms

--- a/website/book/src/contributing.md
+++ b/website/book/src/contributing.md
@@ -10,8 +10,8 @@ separate agreement to sign; the terms a contribution lands under are set out
 in
 [CONTRIBUTING.md](https://github.com/rubentalstra/FerroEHR/blob/main/CONTRIBUTING.md)
 § Licensing of contributions.
-[Why FerroEHR exists](why-ferroehr.md) explains what the project asks
-of the companies that build on it, and why.
+[Why FerroEHR exists](why-ferroehr.md) explains what the project offers
+the organisations that run it and build on it, and what it asks in return.
 
 A bug report with a reproducing request, a
 conformance case for behaviour nothing covers yet, a specification ambiguity you

--- a/website/book/src/introduction.md
+++ b/website/book/src/introduction.md
@@ -65,8 +65,8 @@ user terms; if you are new to openEHR itself, start with the
 
 - **Wondering why this exists?** [Why FerroEHR exists](why-ferroehr.md) is the
   project's position: what openEHR is worth, what we commit to, what the
-  licence lets you do, and why companies are invited to build on it and
-  contribute back.
+  licence lets you do, how building a product on it works, and why
+  contributing back pays.
 - **Just want to try it?** [Getting started](getting-started.md) takes you from
   `docker compose up` to a stored composition and an AQL result in a few
   minutes.

--- a/website/book/src/why-ferroehr.md
+++ b/website/book/src/why-ferroehr.md
@@ -1,8 +1,8 @@
 # Why FerroEHR exists
 
 This chapter is the project's position: what makes openEHR worth implementing,
-what this implementation commits to, and what it asks of the organisations that
-build on it. Read it if you are deciding whether to depend on FerroEHR, or
+what this implementation commits to, and what it offers the organisations that
+run it and build on it. Read it if you are deciding whether to depend on FerroEHR, or
 whether to contribute to it.
 
 <!-- toc -->
@@ -75,7 +75,7 @@ FerroEHR is source-available under the Business Source License 1.1:
 - Read it, build it, modify it and redistribute it without a fee. One licence
   covers the whole repository, and no feature is held back for a paid tier.
 - Each version becomes Apache 2.0 four years after it is published, so what
-  ships today is permissively licensed on a published schedule.
+  ships today opens up on a published schedule.
 - Two uses need a commercial licence from the Licensor: offering FerroEHR, or
   a work derived from it, to third parties as a hosted, managed or embedded
   service through which anyone outside your organisation stores, manages or
@@ -84,10 +84,14 @@ FerroEHR is source-available under the Business Source License 1.1:
   The contact is the maintainer named in
   [`MAINTAINERS.md`](https://github.com/rubentalstra/FerroEHR/blob/main/MAINTAINERS.md).
 
-Commercial adoption is the goal here. Standards reach patients through
-products, and products are built by organisations that need to earn a living.
-What matters is that they can do it on a shared, conformant foundation instead
-of rebuilding one in private.
+Building products on FerroEHR is welcome, and it is how standards reach
+patients. Two kinds of use ask for a conversation first: hosting FerroEHR for
+other organisations, and shipping it inside a product you sell. A commercial
+licence covers both, on terms meant to make such products possible on a
+sustainable footing, and it is how the shared, conformant foundation gets
+maintained by the people who build on it instead of every vendor rebuilding
+one in private. Talk to the maintainer early; that conversation is usually
+short.
 
 ## What we ask in return
 
@@ -139,9 +143,10 @@ tracker.
 
 ## What this is not
 
-This is not an argument against commercial or proprietary software. Closed
-products built on open foundations are a perfectly good outcome, and we would
-rather your product succeed with FerroEHR inside it than not exist at all.
+This is not an argument against commercial or proprietary software. A product
+with FerroEHR inside it is a good outcome, and we would rather it succeed than
+not exist at all; a commercial licence is how that product and this foundation
+support each other.
 
 It is also not a claim to be the only good openEHR CDR. FerroEHR began as a
 fork of EHRbase and records that lineage in the labelled import commit at the
@@ -168,5 +173,5 @@ can verify instead of trusting it — is the repository's
 ---
 
 _Maintained by Ruben Talstra and the FerroEHR contributors. If your
-organisation is building on FerroEHR, we would like to hear about it: open
-an issue or say hello on the tracker._
+organisation runs FerroEHR, or is thinking about building a product on it, we
+would like to hear about it early: open an issue or say hello on the tracker._


### PR DESCRIPTION
Follow-up to #3069. The why-page, the README pointer, the book introduction and both contributing pages predate the move to the Business Source License 1.1 and still described the project's offer to companies in MIT terms.

They now say what the licence offers the organisations that run FerroEHR and build on it: production use for your own organisation stays free; building products on it is welcome, because that is how standards reach patients; hosting FerroEHR for other organisations, or shipping it inside a product you sell, starts with a conversation about a commercial licence, on terms meant to make such products possible on a sustainable footing.

The rest of the first-party prose, the landing page, the repository description, the board readme and the package descriptions were swept and needed no change. Gates: mdbook-lint (no new warnings), docs-claims --all OK.