### PR TITLE
ci(license): a pull request records acceptance of the contribution licensing terms

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,10 @@
 
 Closes #<!-- tracker issue number — the merge into main auto-closes it -->
 
+## Licensing of contributions
+
+- [ ] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.
+
 ## Checks
 
 - [ ] `cargo fmt --all --check` · `cargo clippy --workspace --all-targets` · `cargo nextest run --workspace`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ on:
   # three runs — the concurrency group below collapses them, because PR runs
   # supersede within the pull request.
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
   # Declared before any merge queue exists, because a queue reports its checks
   # on this event alone: "you need to update the workflows to include the
   # merge_group event as an additional trigger. Otherwise, status checks will
@@ -1992,6 +1992,27 @@ jobs:
   # already gated on the pull request. The structure half is a whole-file
   # check, but it is not worth splitting into a second job for a queue that
   # cannot change the file between the pull request and the merge.
+  # A person's pull request records acceptance of the contribution licensing
+  # terms (CONTRIBUTING.md § Licensing of contributions) through the template's
+  # checkbox; this gate is what makes the checkbox binding. Bot authors are
+  # skipped: a bot cannot accept terms and its bumps carry no expression of its
+  # own. `edited` is in the pull_request trigger so ticking the box re-runs it.
+  contribution-licence:
+    name: contribution-licence-guard
+    if: github.event_name == 'pull_request' && github.event.pull_request.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: The pull request body accepts the contribution licensing terms
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: bash scripts/checks/contribution-licence.sh
+
   changelog:
     name: changelog-guard
     if: github.event_name == 'pull_request'
@@ -2171,6 +2192,7 @@ jobs:
       - deploy-probe
       - server-image-from-source
       - ui-screenshot-guard
+      - contribution-licence
       - changelog
       - citation
       - compose-version-guard

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ FerroEHR's own code is licensed under the Business Source License 1.1 ([`LICENSE
 2. license it under the Business Source License 1.1 as applied to the version it lands in, including that version's Change License, so it becomes Apache 2.0 with the rest of that version. A contribution to one of the `crates/openehr-*` crates is licensed under that crate's Apache License 2.0 instead; and
 3. grant the Licensor named in `LICENSE` a perpetual, irrevocable, worldwide, royalty-free, transferable right to use, reproduce, modify, distribute, sublicense and relicense the contribution as part of the Licensed Work under any terms, including commercial licences.
 
-You keep your copyright. Point 3 is what lets the Licensed Work stay one work with one licensor: a commercial licence, a change of the licence parameters, or a transfer of the project can then cover every line, not only the maintainer's own. There is no separate agreement to sign; opening the pull request is the acceptance.
+You keep your copyright. Point 3 is what lets the Licensed Work stay one work with one licensor: a commercial licence, a change of the licence parameters, or a transfer of the project can then cover every line, not only the maintainer's own. There is no separate agreement to sign: the pull request template carries a checkbox recording your acceptance of these terms, and a pull request from a person does not merge without it (the `contribution-licence-guard` CI job).
 
 ## Reporting issues
 

--- a/scripts/checks/contribution-licence.sh
+++ b/scripts/checks/contribution-licence.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Ruben Talstra
+# SPDX-License-Identifier: BUSL-1.1
+# Every pull request from a person records acceptance of the contribution
+# licensing terms (CONTRIBUTING.md § Licensing of contributions).
+#
+# The terms turn a contribution into part of one Licensed Work under one
+# Licensor; a merge without a recorded acceptance is a line whose relicensing
+# right was never granted. A checkbox in the pull request template is the
+# record, and this gate is what makes it binding: a body without the ticked
+# line fails, whether the box was left empty or the section deleted.
+#
+# Bots cannot accept terms, and their changes carry no copyrightable expression
+# of their own (dependency and pin bumps); the workflow skips them by author
+# type before this script runs.
+#
+# Usage: PR_BODY="$body" scripts/checks/contribution-licence.sh
+set -euo pipefail
+
+readonly ACCEPTED='^[[:space:]]*[-*] \[[xX]\] I accept the terms in \[CONTRIBUTING\.md § Licensing of contributions\]'
+readonly UNTICKED='^[[:space:]]*[-*] \[ \] I accept the terms in \[CONTRIBUTING\.md § Licensing of contributions\]'
+
+body="${PR_BODY:-}"
+if printf '%s\n' "$body" | grep -qE "$ACCEPTED"; then
+  echo "ok: the contribution licensing terms are accepted in the pull request body"
+  exit 0
+fi
+if printf '%s\n' "$body" | grep -qE "$UNTICKED"; then
+  echo "error: the licensing checkbox in the pull request body is not ticked" >&2
+else
+  echo "error: the pull request body carries no licensing acceptance line" >&2
+  echo "       (the pull request template's 'Licensing of contributions' section was removed)" >&2
+fi
+echo >&2
+echo "Tick the box under 'Licensing of contributions' in the pull request" >&2
+echo "description (edit the description; the check re-runs on the edit). The" >&2
+echo "terms are CONTRIBUTING.md § Licensing of contributions." >&2
+exit 1


### PR DESCRIPTION
## What this changes

Closes nothing on the tracker; a follow-up to #3069 at the owner's request.

CONTRIBUTING.md § Licensing of contributions said acceptance happens by opening the pull request. That leaves no record a contributor can be held to, and nothing stopped a merge without it. Now:

- `.github/PULL_REQUEST_TEMPLATE.md` carries a checkbox under **Licensing of contributions** (right to submit, licence under the project licence of the landing version, the relicensing grant).
- `scripts/checks/contribution-licence.sh`, run by the new `contribution-licence-guard` CI job, fails a pull request whose body lacks the ticked line, with a distinct message for an unticked box and for a removed section. The job skips bot authors (a bot cannot accept terms; dependabot bumps carry no expression of their own) and gates through `conclusion`.
- `edited` joins the `pull_request` trigger types, so ticking the box in the description re-runs the check without a new push.
- CONTRIBUTING.md names the checkbox as the acceptance record.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.

## Checks

- [x] shellcheck (style), comment-style, spdx-headers-text, ci-conclusion-complete, zizmor on ci.yml; the script tested on a ticked body, an unticked body and a body without the section
- [x] No test weakened
- [x] CI/template change with no user-visible effect: `no-changelog`