### PR TITLE
docs(operations): a release that changes migration files means recreating the database

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -1,6 +1,7 @@
 # Memory index
 
 - [Licence is BUSL 1.1](license-busl.md) — application+tooling are Business Source License 1.1 since 2026-09-03 (non-commercial production only), the eight openehr-* crates stay Apache-2.0, holder Ruben Talstra, source-available never "open source"; grant text is owner legal text; stale-MIT guard in licensing-declarations.sh
+- [Sibling products](sibling-products.md) — ferroehr / FerroTERM (was notio) / FerroBRIDGE (Apache-2.0, the FHIR (FHIRconnect) + OMOP (OMOCL) bridge; FerroEHR #2646 + #2652 moved there); never edit a sibling from here
 - [Owner work style](owner-work-style.md) — defer nothing; no quick fixes (proper rewrites welcome); orchestrator codes context-heavy work itself; big-bang rewrites converge once at the end (no intermediate stubs); specs re-read first-hand; never copy a number forward; rerun `scripts/conformance.sh` after runner/validation merges
 - [Autonomous phase flow](autonomous-phase-flow.md) — standing: PR+merge each phase, checkout main, start the next without asking; never branch while finished work sits unmerged
 - [Merge on local gates](merge-on-local-gates.md) — local gates green (fmt+clippy+nextest+CNF validate) → merge the PR immediately; CI is a post-merge backstop

--- a/.claude/memory/sibling-products.md
+++ b/.claude/memory/sibling-products.md
@@ -1,0 +1,12 @@
+---
+name: sibling-products
+description: The Ferro family is three repos side by side under ~/RustroverProjects (ferroehr, FerroTERM, FerroBRIDGE); FerroTERM's checkout was renamed from notio on 2026-09-03; FerroBRIDGE (Apache-2.0) owns the FHIRconnect bridge and the in-tree FHIR extension is expected to move there
+metadata:
+  type: project
+---
+
+Three products, three repositories: FerroEHR (this repo, the CDR), FerroTERM (`../FerroTERM`, the FHIR terminology server; the local checkout was `../notio` until 2026-09-03 and the harness memory link was moved with it) and FerroBRIDGE (`../FerroBRIDGE`, the bridge from openEHR to HL7 FHIR (FHIRconnect spec, openFHIR as prior art) and to the OMOP CDM (OMOCL spec, Eos as prior art), created 2026-09-03, Apache-2.0 by owner choice while FerroEHR and FerroTERM are BUSL-1.1). FerroEHR issues #2646 and #2652 were transferred there (FerroBRIDGE #1 and #2).
+
+**Why:** the owner treats each as a separate product with its own licence story; the bridge is meant to be adopted widely, so it stays open source.
+
+**How to apply:** never edit a sibling repo from a FerroEHR session unless the owner asks; FerroEHR's `ferroehr-ext` FHIR feature is expected to be retired in favour of FerroBRIDGE once the bridge exists (a FerroEHR issue is filed when the bridge's first milestone is scoped); FerroBRIDGE consumes FerroEHR strictly over ITS-REST, never as a crate dependency. See [[license-busl]].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ workflow refuses a tag that has no matching section here.
   their work under the project licence, and additionally grant the Licensor the
   right to sublicense and relicense it, so the work stays one work under one
   licensor.
+- Every migration file carries a licence header, which changes its recorded
+  checksum: a database created by 4.0.17 or earlier refuses to start this
+  version with `migration 1 was previously applied but has been modified`.
+  The schema is greenfield (see the operations chapter, "Upgrades"), so the
+  remedy is to recreate the database, or drop the `ehr`, `ext`, `audit` and
+  `cold` schemas, and reload; the hosted sandbox was reset the same way.
 
 ## [4.0.17] - 2026-09-02
 

--- a/website/book/src/operations.md
+++ b/website/book/src/operations.md
@@ -250,11 +250,19 @@ why they are written as your checklist rather than as our claim.
 
 ## Upgrades
 
-- **Backward-compatible migrations.** Migrations are append-only and never
-  edited once applied. A rolling upgrade must be compatible with the
-  _previous_ schema for the window where both versions run: apply additive
-  changes first, and defer destructive changes to a later release once every
-  pod is on the new version.
+- **The schema is still greenfield: a release may change the migration
+  files, and a database created by an earlier release is then recreated, not
+  upgraded in place.** The server records the checksum of every applied
+  migration and refuses to start against a database whose recorded checksums
+  differ from the files it carries (`migration 1 was previously applied but
+  has been modified`). Until the project declares the schema stable, treat a
+  version change as "recreate the database and reload the data": drop the
+  `ehr`, `ext`, `audit` and `cold` schemas (or the database) and let the new
+  version boot. The 4.0.18 release changed every migration file this way (a
+  licence header was added to each). Once stability is declared, migrations
+  become append-only and a rolling upgrade must stay compatible with the
+  _previous_ schema for the window where both versions run: additive changes
+  first, destructive changes a release later.
 - **Bound the DDL yourself.** Every pooled connection carries the
   `db.statement_timeout_ms` value (60 seconds by default), and the migration
   step runs on that pool, so a runaway statement is cut off, but there is **no


### PR DESCRIPTION
## What this changes

The v4.0.18 sandbox leg failed because the licence header added to every migration file changed its recorded checksum, and the CDR refuses to start against a database whose `_sqlx_migrations` ledger disagrees with the files it carries. That is the greenfield policy working as designed (deployments recreate), but the operations chapter said the opposite ("migrations are append-only and never edited once applied"). The Upgrades section now states the greenfield rule, the error text an operator will see and the remedy (recreate the database or drop the `ehr`, `ext`, `audit`, `cold` schemas and reload); the 4.0.18 changelog section records the consequence; the hosted sandbox was reset through the sandbox-reseed workflow. The `.claude/memory` note on the three sibling products (FerroEHR, FerroTERM, FerroBRIDGE) lands with it.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.

## Checks

- [x] changelog-structure, docs-claims --all, mdbook-lint (no new warnings)
- [x] No test weakened
- [x] Documentation only: `no-changelog` (the changelog edit is a note inside the already-released 4.0.18 section)