### PR TITLE
fix(vendor): the CKM list endpoints page with size/offset, and ADL 2 exists only as Ocean's generated conversion

### DIFF
--- a/.claude/rules/vendored-corpora.md
+++ b/.claude/rules/vendored-corpora.md
@@ -23,16 +23,19 @@ commit the result.
 
 ## The openEHR CKM REST API — facts, verified 2026-08-01
 
-Base: `https://ckm.openehr.org/ckm/rest/v1`. There is no published OpenAPI
-document (`swagger.json`, `openapi.json`, `v3/api-docs` all 404), so these
-observations ARE the reference — re-verify with a probe before trusting a
-guess.
+Base: `https://ckm.openehr.org/ckm/rest/v1`. The API IS documented: a
+Swagger 2.0 document at `/rest/v1/swagger.json` ("CKM REST API" 1.6.0, 39
+paths) with Swagger UI at `/ckm/rest-doc/` (verified 2026-09-03; the 2026-08-01
+probe tried `openapi.json` and `v3/api-docs` and wrongly concluded none
+existed). Read it first, then re-verify on the wire before trusting a guess.
 
-- **Pagination is `?page=N&size=M` and nothing else.** `limit`, `pageSize`,
-  `maxResults`, `offset`, `count`, `rows`, `resultsPerPage`, `startIndex` are
-  all silently IGNORED and you get a **20-row first page** — which reads
-  exactly like "CKM only publishes 20 resources". This has burned time twice.
-  Every list fetch pages with page/size **and asserts the row count grew**
+- **Pagination is `?size=M&offset=N` and nothing else** (corrected
+  2026-09-03: the earlier `page` claim was wrong; `?page=0&size=10000` worked
+  only because `size` did). `page`, `limit`, `pageSize`, `maxResults`, `count`,
+  `rows`, `resultsPerPage`, `startIndex` are all silently IGNORED and you get a
+  **20-row first page** — which reads exactly like "CKM only publishes 20
+  resources". This has burned time twice. Every list fetch uses size/offset
+  **and asserts the row count grew**
   (both vendor scripts fail loud on `<= 20` rows).
 - Resource lists: `GET /templates`, `GET /archetypes`. Both return a flat JSON
   array of metadata (`cid`, `resourceType`, `resourceMainId`,
@@ -41,6 +44,13 @@ guess.
 - Exports: `GET /templates/{cid}/opt` (OPT 1.4 XML),
   `GET /archetypes/{cid}/adl` (ADL text), `GET /archetypes/{cid}/xml`
   (AM 1.4 ARCHETYPE XML). `GET /{kind}/{cid}` returns the metadata.
+- **ADL 2 exists only as Ocean's generated conversion.** `/rest/v1` has no
+  ADL 2 export, but the legacy servlet
+  `GET /ckm/retrieveArchetype?cid-archetype=<cid>&format=ADL2` returns an
+  `.adls` whose header carries `generated` (verified 2026-09-03). It is a
+  1.4->2 conversion, never an authored source, so the ADL 2 corpus stays
+  `openEHR/adl-archetypes`. Bulk: `GET /ckm/retrieveResources` with no
+  parameters ships the whole published archetype library as one zip.
 - **A 404 on an export is usually not a bug**: resources held in a private
   CKM incubator are only exportable by a signed-in account with access. Record
   them as unreachable in `PROVENANCE.md` — never silently skip, never drop the

--- a/scripts/vendor/ckm-archetypes.sh
+++ b/scripts/vendor/ckm-archetypes.sh
@@ -13,20 +13,26 @@
 #     archetype header). This is the ONLY ADL CKM publishes.
 #   * `GET /archetypes/{cid}/xml` -> the AM 1.4 ARCHETYPE XML of the same
 #     archetype (opt-in here via --with-xml; roughly +40% bytes).
-#   * There is NO ADL 2 export: `/adl2`, `/adl14`, `/adl2.4`, `/opt2` and
+#   * `/rest/v1` publishes NO ADL 2: `/adl2`, `/adl14`, `/adl2.4`, `/opt2` and
 #     `/source` all 404, and `?format=ADL2` / `?version=2` are silently
-#     ignored (byte-identical 1.4 response). The ADL 2.4 corpus therefore
-#     comes from a DIFFERENT official source —
+#     ignored (byte-identical 1.4 response). The legacy servlet
+#     `GET /ckm/retrieveArchetype?cid-archetype=<cid>&format=ADL2` DOES return
+#     an `.adls` file, but its header carries the `generated` flag: it is
+#     Ocean's own 1.4->2 conversion, not an authored ADL 2 source (verified
+#     2026-09-03). The ADL 2.4 corpus therefore comes from a DIFFERENT
+#     official source —
 #     `scripts/vendor/adl2-archetypes.sh` (openEHR/adl-archetypes).
 #     Never present a CKM export as ADL 2, and never fill the ADL 2 side by
 #     running our own 1.4->2 converter over CKM output: that would test the
 #     converter against itself.
 #
-# CKM REST PAGINATION GOTCHA: the list endpoints page with `?page=N&size=M`.
-# `limit`, `pageSize`, `maxResults`, `offset`, `count` and `rows` are all
-# silently IGNORED and you get a 20-row first page — which reads exactly like
-# "CKM only publishes 20 archetypes". Always page with page/size and assert
-# the count grew.
+# CKM REST PAGINATION GOTCHA: the list endpoints page with `?size=M&offset=N`
+# (the Swagger 2.0 document at `/rest/v1/swagger.json`, verified on the wire
+# 2026-09-03: `?size=2&offset=2` shifts the window, `?page=5&size=2` does not).
+# `page`, `limit`, `pageSize`, `maxResults`, `count` and `rows` are all silently
+# IGNORED and you get a 20-row first page — which reads exactly like "CKM only
+# publishes 20 archetypes". Always fetch with size/offset and assert the count
+# grew.
 #
 # Usage:
 #   scripts/vendor/ckm-archetypes.sh                # ADL 1.4 texts
@@ -72,8 +78,8 @@ WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
 STAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-echo "==> listing the full CKM archetype library (page/size pagination)"
-curl -fsS "$CKM/archetypes?page=0&size=10000" -H "Accept: application/json" \
+echo "==> listing the full CKM archetype library (size/offset pagination)"
+curl -fsS "$CKM/archetypes?size=10000&offset=0" -H "Accept: application/json" \
   -o "$WORK/archetypes.json"
 
 # The list is turned into two job files and a provenance TSV with jq. The
@@ -84,7 +90,7 @@ curl -fsS "$CKM/archetypes?page=0&size=10000" -H "Accept: application/json" \
 published=$(jq 'length' "$WORK/archetypes.json")
 if [[ "$published" -le 20 ]]; then
   echo "::error::the list endpoint returned only $published rows — CKM ignored the" \
-       "pagination parameters (use ?page=N&size=M)" >&2
+       "pagination parameters (use ?size=M&offset=N)" >&2
   exit 1
 fi
 
@@ -151,9 +157,9 @@ XML_EXPORTS=$(grep -cE '^(OK|BAD|FAIL) ' "$WORK/xml.log" || true)
   echo "## Dialect"
   echo
   echo "\`adl14/\` holds CKM's \`GET /archetypes/{cid}/adl\` response — **ADL 1.4**"
-  echo "text (\`adl_version=1.4\`). CKM publishes NO ADL 2 export (\`/adl2\`,"
-  echo "\`/adl14\`, \`/opt2\` 404; \`?format=ADL2\` is ignored and returns the same"
-  echo "1.4 bytes), so the **ADL 2.4 half of the corpus comes from"
+  echo "text (\`adl_version=1.4\`). \`/rest/v1\` publishes NO ADL 2 (\`/adl2\`,"
+  echo "\`/adl14\`, \`/opt2\` 404; \`?format=ADL2\` is ignored); the legacy servlet's"
+  echo "\`format=ADL2\` export is Ocean's own GENERATED 1.4->2 conversion, so the **ADL 2.4 half of the corpus comes from"
   echo "\`scripts/vendor/adl2-archetypes.sh\`** (openEHR/adl-archetypes). A CKM"
   echo "export is never labelled ADL 2, and the ADL 2 side is never produced by"
   echo "running our own 1.4->2 converter over these files — that would test the"

--- a/scripts/vendor/ckm-templates.sh
+++ b/scripts/vendor/ckm-templates.sh
@@ -21,10 +21,11 @@
 #     for breadth gates over the OPT 1.4 reader / WebTemplate builder.
 #
 # CKM REST PAGINATION GOTCHA (cost an afternoon once — do not relearn it):
-# the list endpoints page with `?page=N&size=M`. `limit`, `pageSize`,
-# `maxResults`, `offset`, `count`, `rows` are all silently IGNORED and you
+# the list endpoints page with `?size=M&offset=N` (the Swagger 2.0 document at
+# `/rest/v1/swagger.json`, verified on the wire 2026-09-03). `page`, `limit`,
+# `pageSize`, `maxResults`, `count`, `rows` are all silently IGNORED and you
 # get a 20-row first page, which reads exactly like "CKM only publishes 20
-# templates". Always page with page/size, and assert the count grew.
+# templates". Always fetch with size/offset, and assert the count grew.
 #
 # Some CKM resources live in a private incubator and 404 without an account;
 # those are recorded as unreachable in the provenance file rather than
@@ -170,17 +171,17 @@ fi
 # ── the full library ─────────────────────────────────────────────────────
 if [[ "$MODE" != curated ]]; then
   mkdir -p "$FULL"
-  echo "==> listing the full CKM template library (page/size pagination)"
-  curl -fsS "$CKM/templates?page=0&size=10000" -H "Accept: application/json" \
+  echo "==> listing the full CKM template library (size/offset pagination)"
+  curl -fsS "$CKM/templates?size=10000&offset=0" -H "Accept: application/json" \
     -o "$WORK/templates.json"
 
   # Slugs come from CKM display names, so they collide: the counter suffixes the
   # second and later occurrences of a base. The 20-row floor is the CKM paging
-  # trap — every parameter other than page/size is silently ignored and yields a
+  # trap — every parameter other than size/offset is silently ignored and yields a
   # 20-row first page that reads like the whole library.
   jq '
     if length <= 20 then
-      error("::error::the list endpoint returned only \(length) rows — CKM ignored the pagination parameters (use ?page=N&size=M)")
+      error("::error::the list endpoint returned only \(length) rows — CKM ignored the pagination parameters (use ?size=M&offset=N)")
     else . end
     | sort_by(.cid)
     | reduce .[] as $t ({ seen: {}, rows: [] };


### PR DESCRIPTION
## What this changes

Found while researching the CKM for FerroCKM. Both vendoring scripts (`scripts/vendor/ckm-archetypes.sh`, `ckm-templates.sh`) and `.claude/rules/vendored-corpora.md` stated two facts that are wrong:

1. **Pagination.** The instance publishes a Swagger 2.0 document at `/ckm/rest/v1/swagger.json` ("CKM REST API" 1.6.0, 39 paths; the 2026-08-01 probe tried `openapi.json` and `v3/api-docs` only). List endpoints page with `size` and `offset`; `page` is one of the silently ignored parameters. Verified on the wire: `?size=2&offset=2` shifts the window, `?page=5&size=2` returns the first page. `?page=0&size=10000` worked only because `size` did. The list calls now use `size=10000&offset=0` (945 rows, unchanged), and the comments, error text and rule say size/offset.
2. **ADL 2.** `/rest/v1` has no ADL 2 export, as stated, but the legacy servlet `GET /ckm/retrieveArchetype?cid-archetype=<cid>&format=ADL2` returns an `.adls` whose header carries the `generated` flag: Ocean's own 1.4 to 2 conversion. The vendoring decision is unchanged (the ADL 2 corpus stays `openEHR/adl-archetypes`; a generated conversion is never an authored source), but the claim "there is no ADL 2 export" was false and now says what is true. The rule also records the bulk zip at `GET /ckm/retrieveResources`.

No vendored bytes change; only script comments, the list-call query string, the PROVENANCE wording the script emits, and the rule.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.

## Checks

- [x] shellcheck (style), comment-style --all; the corrected list call returns 945 rows live
- [x] No test weakened
- [x] Tooling and rules only: `no-changelog`