### PR TITLE
chore(memory): FerroCKM joins the sibling-products note

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -1,7 +1,7 @@
 # Memory index
 
 - [Licence is BUSL 1.1](license-busl.md) — application+tooling are Business Source License 1.1 since 2026-09-03 (non-commercial production only), the eight openehr-* crates stay Apache-2.0, holder Ruben Talstra, source-available never "open source"; grant text is owner legal text; stale-MIT guard in licensing-declarations.sh
-- [Sibling products](sibling-products.md) — ferroehr / FerroTERM (was notio) / FerroBRIDGE (Apache-2.0, the FHIR (FHIRconnect) + OMOP (OMOCL) bridge; FerroEHR #2646 + #2652 moved there); never edit a sibling from here
+- [Sibling products](sibling-products.md) — ferroehr / FerroTERM (was notio) / FerroBRIDGE / FerroCKM (BUSL, the CKM; shares the app layer) (Apache-2.0, the FHIR (FHIRconnect) + OMOP (OMOCL) bridge; FerroEHR #2646 + #2652 moved there); never edit a sibling from here
 - [Owner work style](owner-work-style.md) — defer nothing; no quick fixes (proper rewrites welcome); orchestrator codes context-heavy work itself; big-bang rewrites converge once at the end (no intermediate stubs); specs re-read first-hand; never copy a number forward; rerun `scripts/conformance.sh` after runner/validation merges
 - [Autonomous phase flow](autonomous-phase-flow.md) — standing: PR+merge each phase, checkout main, start the next without asking; never branch while finished work sits unmerged
 - [Merge on local gates](merge-on-local-gates.md) — local gates green (fmt+clippy+nextest+CNF validate) → merge the PR immediately; CI is a post-merge backstop

--- a/.claude/memory/sibling-products.md
+++ b/.claude/memory/sibling-products.md
@@ -5,7 +5,7 @@ metadata:
   type: project
 ---
 
-Three products, three repositories: FerroEHR (this repo, the CDR), FerroTERM (`../FerroTERM`, the FHIR terminology server; the local checkout was `../notio` until 2026-09-03 and the harness memory link was moved with it) and FerroBRIDGE (`../FerroBRIDGE`, the bridge from openEHR to HL7 FHIR (FHIRconnect spec, openFHIR as prior art) and to the OMOP CDM (OMOCL spec, Eos as prior art), created 2026-09-03, Apache-2.0 by owner choice while FerroEHR and FerroTERM are BUSL-1.1). FerroEHR issues #2646 and #2652 were transferred there (FerroBRIDGE #1 and #2).
+Four products, four repositories: FerroEHR (this repo, the CDR), FerroCKM (`../FerroCKM`, the Clinical Knowledge Manager, created 2026-09-03, BUSL-1.1 with FerroEHR's grant so the two share the application layer; research on its #1), FerroTERM (`../FerroTERM`, the FHIR terminology server; the local checkout was `../notio` until 2026-09-03 and the harness memory link was moved with it) and FerroBRIDGE (`../FerroBRIDGE`, the bridge from openEHR to HL7 FHIR (FHIRconnect spec, openFHIR as prior art) and to the OMOP CDM (OMOCL spec, Eos as prior art), created 2026-09-03, Apache-2.0 by owner choice while FerroEHR and FerroTERM are BUSL-1.1). FerroEHR issues #2646 and #2652 were transferred there (FerroBRIDGE #1 and #2).
 
 **Why:** the owner treats each as a separate product with its own licence story; the bridge is meant to be adopted widely, so it stays open source.
 


### PR DESCRIPTION
The agent memory's sibling-products note records the fourth Ferro repository, FerroCKM (the Clinical Knowledge Manager, created 2026-09-03, BUSL-1.1 with FerroEHR's grant so the two share the application layer; its research runs on rubentalstra/FerroCKM#1), and the MEMORY.md index line follows.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.

## Checks

- [x] Memory note only: `no-changelog`