### PR TITLE
chore(memory): FerroTERM is Apache-2.0, not BUSL-1.1

### DIFF
--- a/.claude/memory/sibling-products.md
+++ b/.claude/memory/sibling-products.md
@@ -5,7 +5,7 @@ metadata:
   type: project
 ---
 
-Four products, four repositories: FerroEHR (this repo, the CDR), FerroCKM (`../FerroCKM`, the Clinical Knowledge Manager, created 2026-09-03, BUSL-1.1 with FerroEHR's grant so the two share the application layer; research on its #1), FerroTERM (`../FerroTERM`, the FHIR terminology server; the local checkout was `../notio` until 2026-09-03 and the harness memory link was moved with it) and FerroBRIDGE (`../FerroBRIDGE`, the bridge from openEHR to HL7 FHIR (FHIRconnect spec, openFHIR as prior art) and to the OMOP CDM (OMOCL spec, Eos as prior art), created 2026-09-03, Apache-2.0 by owner choice while FerroEHR and FerroTERM are BUSL-1.1). FerroEHR issues #2646 and #2652 were transferred there (FerroBRIDGE #1 and #2).
+Four products, four repositories: FerroEHR (this repo, the CDR), FerroCKM (`../FerroCKM`, the Clinical Knowledge Manager, created 2026-09-03, BUSL-1.1 with FerroEHR's grant so the two share the application layer; research on its #1), FerroTERM (`../FerroTERM`, the FHIR terminology server; the local checkout was `../notio` until 2026-09-03 and the harness memory link was moved with it) and FerroBRIDGE (`../FerroBRIDGE`, the bridge from openEHR to HL7 FHIR (FHIRconnect spec, openFHIR as prior art) and to the OMOP CDM (OMOCL spec, Eos as prior art), created 2026-09-03, Apache-2.0 by owner choice; FerroTERM is Apache-2.0 too (its LICENSE and Cargo manifest, checked 2026-09-03), only FerroEHR and FerroCKM are BUSL-1.1). FerroEHR issues #2646 and #2652 were transferred there (FerroBRIDGE #1 and #2).
 
 **Why:** the owner treats each as a separate product with its own licence story; the bridge is meant to be adopted widely, so it stays open source.
 


### PR DESCRIPTION
The sibling-products memory note claimed FerroTERM shares the Business Source License. Its LICENSE file and Cargo manifest say Apache-2.0 (checked 2026-09-03 while filing #3085). Only FerroEHR and FerroCKM are BUSL-1.1. Memory-only change, no code.