### PR TITLE
chore(memory): the docs-dist worktree trap and the PR-body licensing line

### DIFF
--- a/.claude/memory/no-worktrees-single-checkout.md
+++ b/.claude/memory/no-worktrees-single-checkout.md
@@ -27,3 +27,10 @@ split into a second tree.
 
 See also [[concurrent-sessions-shared-tree]] for the ONE `./target` rule,
 which has the same motivation: one tree, one build.
+
+**The `docs-dist` trap (2026-09-04):** a stale `git worktree` at
+`./docs-dist` (the frozen-docs branch, gitignored so `git status` stays
+clean) sat inside the checkout for weeks and made the IDE show two active
+branches; the owner found it very annoying. `docs-dist` is a remote-only
+branch the docs pipeline writes; never check it out locally, and run
+`git worktree list` when the IDE shows a second branch.

--- a/.claude/memory/session-workflow-gotchas.md
+++ b/.claude/memory/session-workflow-gotchas.md
@@ -263,3 +263,8 @@ commit-message wording. Late labels: since #2777 applying a label raises a fresh
     and the 10-minute foreground tool limit kills it — run cold gates as
     `nohup caffeinate -i bash -c '…' > log &` with a background `until grep`
     waiter.
+  - `gh pr create --body` bypasses the PR template, and the
+    `contribution-licence-guard` CI job then fails on the missing ticked
+    line. Every PR body must carry, verbatim and ticked:
+    `- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): …`
+    (PR #3090 merged red on exactly this).


### PR DESCRIPTION
Two session gotchas recorded in the in-repo memory: a stale `docs-dist` worktree inside the checkout showed two active branches in the IDE (removed today; never check that branch out locally), and `gh pr create --body` bypasses the PR template so the licensing acceptance line must be written by hand (PR #3090 merged with that guard red).

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.