### PR TITLE
fix(adl): bound every recursive walk of the ADL 2 engine with a typed refusal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,20 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **An ADL 2 upload can no longer take the server down through unbounded
+  recursion** (#3062). The ADL engine now carries one nesting bound of 512
+  levels: the cADL, ODIN and rule-expression readers refuse an artefact nested
+  past it with a `400` that names the bound (the `SUNK` syntax bucket), the
+  flattener refuses a specialisation lineage longer than the bound or a flat
+  form that composes deeper than it, and the operational-template transform
+  refuses fillers that reference each other in a cycle (naming the cycle) or
+  inline past the bound, as a `422`. Every remaining engine call, including
+  compiling a stored template to its operational form and loading the stored
+  repository, runs on the dedicated engine thread. Published archetypes and
+  templates stay far below the bound.
+
 ## [4.0.18] - 2026-09-03
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2763,6 +2763,7 @@ dependencies = [
  "moka",
  "openehr-base",
  "openehr-its",
+ "openehr-lang",
  "openehr-rm",
  "openidconnect",
  "opentelemetry",
@@ -5432,7 +5433,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.58"
+version = "0.0.59"
 dependencies = [
  "indexmap 2.14.0",
  "openehr-am",
@@ -5448,7 +5449,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.58"
+version = "0.0.59"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -5458,7 +5459,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.58"
+version = "0.0.59"
 dependencies = [
  "serde",
  "serde_json",
@@ -5477,7 +5478,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.58"
+version = "0.0.59"
 dependencies = [
  "async-trait",
  "axum",
@@ -5507,7 +5508,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.58"
+version = "0.0.59"
 dependencies = [
  "assert_fs",
  "chumsky",
@@ -5521,7 +5522,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.58"
+version = "0.0.59"
 dependencies = [
  "chumsky",
  "logos",
@@ -5530,7 +5531,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.58"
+version = "0.0.59"
 dependencies = [
  "insta",
  "jsonschema",
@@ -5548,7 +5549,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.58"
+version = "0.0.59"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/app/ferroehr-rest/Cargo.toml
+++ b/app/ferroehr-rest/Cargo.toml
@@ -106,6 +106,7 @@ utoipa-axum = { workspace = true }
 utoipa-swagger-ui = { workspace = true }
 
 [dev-dependencies]
+openehr-lang = { path = "../../crates/openehr-lang" }
 testkit = { path = "../../tools/testkit" }
 sqlx.workspace = true
 testcontainers.workspace = true

--- a/app/ferroehr-rest/tests/it/definition_adl2_http.rs
+++ b/app/ferroehr-rest/tests/it/definition_adl2_http.rs
@@ -29,6 +29,7 @@ use axum::body::Body;
 use http::{Request, StatusCode, header};
 use http_body_util::BodyExt;
 use serde_json::Value;
+use std::fmt::Write;
 use tower::ServiceExt;
 
 use ferroehr::config::auth::AuthConfig;
@@ -687,5 +688,53 @@ async fn upload_with_absent_parent_is_422_with_vasid() {
     assert!(
         body.contains("VASID") && body.contains("openEHR-EHR-CLUSTER.orphan.v1.0.0"),
         "the 422 names VASID and the missing parent: {body}"
+    );
+}
+
+/// An upload nested past the engine's bound (`openehr_lang::nesting`) is a
+/// syntactic `400` naming the bound: the parser refuses at the bound instead
+/// of recursing until the thread's stack ends, which no layer could catch
+/// (#3062). The ITS-REST `400` branch covers "syntactically invalid …
+/// content" (`docs/specs/openehr/ITS-REST/specifications/responses/400.yaml`).
+#[tokio::test]
+async fn upload_nested_past_the_engine_bound_is_a_400_naming_the_bound() {
+    let (_pg, app) = app().await;
+    let levels = openehr_lang::nesting::MAX_NESTING_DEPTH + 2;
+    let mut open = String::new();
+    for k in 0..levels {
+        write!(open, "CLUSTER[id{}] matches {{ items matches {{ ", k + 1).expect("a String write");
+    }
+    let close = " } }".repeat(levels);
+    let definition = format!("{open}ELEMENT[id99999] matches {{*}}{close}");
+    let hrid = "openEHR-EHR-CLUSTER.too_deep.v1.0.0";
+    let body = format!(
+        "archetype (adl_version=2.0.6; rm_release=1.1.0)\n    {hrid}\n\n\
+         language\n    original_language = <[ISO_639-1::en]>\n\n\
+         description\n    lifecycle_state = <\"published\">\n    details = <\n        \
+         [\"en\"] = <\n            language = <[ISO_639-1::en]>\n        >\n    >\n\n\
+         definition\n    {definition}\n\n\
+         terminology\n    term_definitions = <\n        [\"en\"] = <\n            \
+         [\"id1\"] = <text = <\"Root\"> description = <\"Root.\">>\n        >\n    >\n"
+    );
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("{BASE}/definition/template/adl2"))
+        .header(header::CONTENT_TYPE, "text/plain")
+        .body(Body::from(body))
+        .unwrap();
+    let (status, _, text) = send(&app, req).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "body: {text}");
+    let json: Value = serde_json::from_str(&text).expect("an error document");
+    let message = json["message"].as_str().expect("message");
+    assert!(
+        message.contains("SUNK"),
+        "the S-code bucket is named: {message}"
+    );
+    assert!(
+        message.contains(&format!(
+            "exceeds the limit of {} levels",
+            openehr_lang::nesting::MAX_NESTING_DEPTH
+        )),
+        "the bound is named: {message}"
     );
 }

--- a/app/ferroehr/src/service/definition/adl2.rs
+++ b/app/ferroehr/src/service/definition/adl2.rs
@@ -289,13 +289,16 @@ impl FerroEhrService {
         let sources: Vec<String> = sqlx::query_scalar("SELECT adl FROM adl2_artefact")
             .fetch_all(&self.pool)
             .await?;
-        let mut repo = ArchetypeRepository::new();
-        for src in &sources {
-            if let Ok(archetype) = parse_artefact(src, Dialect::Adl2) {
-                repo.insert(archetype);
+        on_engine_stack(move || {
+            let mut repo = ArchetypeRepository::new();
+            for src in &sources {
+                if let Ok(archetype) = parse_artefact(src, Dialect::Adl2) {
+                    repo.insert(archetype);
+                }
             }
-        }
-        Ok(repo)
+            repo
+        })
+        .await
     }
 
     /// Validate one uploaded ADL2 source with the `openehr-adl` engine and return
@@ -538,23 +541,7 @@ impl FerroEhrService {
     /// - The OPT cannot be compiled (an unresolved constituent reference) →
     ///   `Unprocessable` (`422`).
     pub(super) async fn adl2_opt_json(&self, source: &str) -> Result<String, ServiceError> {
-        let archetype = parse_artefact(source, Dialect::Adl2).map_err(|errs| {
-            ServiceError::exception(format!(
-                "stored ADL2 source no longer parses: {}",
-                join_syntax_errors(&errs)
-            ))
-        })?;
-        if let Archetype::AuthoredArchetype(a) = &archetype
-            && let AuthoredArchetype::OperationalTemplate(opt) = a.as_ref()
-        {
-            return Ok(openehr_its::json::to_canonical_json(opt.as_ref()));
-        }
-        let repo = self.adl2_repository().await?;
-        let opt = create_opt(&archetype, &repo).map_err(|e| {
-            ServiceError::content_invalid(
-                Violation::new(format!("cannot project OperationalTemplateV2: {e}")).with_source(e),
-            )
-        })?;
+        let opt = self.adl2_operational_template(source).await?;
         Ok(openehr_its::json::to_canonical_json(&opt))
     }
 
@@ -702,28 +689,43 @@ impl FerroEhrService {
 
     /// Compile stored ADL2 `source` to its operational template: a stored
     /// `operational_template` is parsed as-is; any other kind is flattened +
-    /// compiled via `create_opt` (OPT2 master03).
+    /// compiled via `create_opt` (OPT2 master03). Both steps run on the
+    /// engine stack ([`on_engine_stack`]).
+    ///
+    /// # Errors
+    ///
+    /// - The stored source no longer parses → `Internal` (`500`; a stored source
+    ///   was engine-valid at upload, so this is a server fault).
+    /// - The OPT cannot be compiled (an unresolved or cyclic constituent
+    ///   reference, a lineage or nesting past the engine bound) →
+    ///   `Unprocessable` (`422`).
     async fn adl2_operational_template(
         &self,
         source: &str,
     ) -> Result<OperationalTemplate, ServiceError> {
-        let archetype = parse_artefact(source, Dialect::Adl2).map_err(|errs| {
-            ServiceError::exception(format!(
-                "stored ADL2 source no longer parses: {}",
-                join_syntax_errors(&errs)
-            ))
-        })?;
+        let owned = source.to_owned();
+        let archetype = on_engine_stack(move || parse_artefact(&owned, Dialect::Adl2))
+            .await?
+            .map_err(|errs| {
+                ServiceError::exception(format!(
+                    "stored ADL2 source no longer parses: {}",
+                    join_syntax_errors(&errs)
+                ))
+            })?;
         if let Archetype::AuthoredArchetype(a) = &archetype
             && let AuthoredArchetype::OperationalTemplate(opt) = a.as_ref()
         {
             return Ok(opt.as_ref().clone());
         }
         let repo = self.adl2_repository().await?;
-        create_opt(&archetype, &repo).map_err(|e| {
-            ServiceError::content_invalid(
-                Violation::new(format!("cannot compile operational template: {e}")).with_source(e),
-            )
-        })
+        on_engine_stack(move || create_opt(&archetype, &repo))
+            .await?
+            .map_err(|e| {
+                ServiceError::content_invalid(
+                    Violation::new(format!("cannot compile operational template: {e}"))
+                        .with_source(e),
+                )
+            })
     }
 
     /// The ADL2 source of the artefact with `ARCHETYPE_HRID` `an_id`; absent

--- a/crates/openehr-adl/CLAUDE.md
+++ b/crates/openehr-adl/CLAUDE.md
@@ -21,6 +21,7 @@ else; each helper has exactly ONE home.
 | `aom/access` | the 13-arm `C_OBJECT` field accessors + `AomType` |
 | `aom/build` | the AOM2 constructors |
 | `aom/interval` | `Bounds` / multiplicity + `INTERVAL<T>` maths |
+| `aom/nesting` | the engine nesting bound over a constraint tree (`check_definition_nesting`, over `openehr_lang::nesting`) — every producer of a COMPOSED tree (flattener, OPT transform) re-checks its result |
 | `artefact` | `ArchetypeView`/`view` + `ArchetypeRepository`/`FlatParent` |
 
 **Front end — source text → AOM2.**

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-adl"
-version = "0.0.58"
+version = "0.0.59"
 description = "openEHR ADL 2.4.0: hand-written ADL2/cADL/ODIN parser, AOM2 validation catalogue, specialisation flattener, OPT2 generator, and ADL 1.4→2 conversion over the generated openehr_am::v2_4::aom2 model"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,11 +16,11 @@ include = ["src/**", "README.md", "LICENSE-APACHE-2.0"]
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)
-openehr-base = { path = "../openehr-base", version = "0.0.58" }   # VersionStatus for the parsed HRID
-openehr-am = { path = "../openehr-am", version = "0.0.58" }       # v2_4 ArchetypeHrid (the identification target type)
-openehr-rm = { path = "../openehr-rm", version = "0.0.58" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
-openehr-lang = { path = "../openehr-lang", version = "0.0.58" }   # openehr_lang::odin — the ODIN section parser
-openehr-term = { path = "../openehr-term", version = "0.0.58" }   # the languages code set for the RM resource-meta rows
+openehr-base = { path = "../openehr-base", version = "0.0.59" }   # VersionStatus for the parsed HRID
+openehr-am = { path = "../openehr-am", version = "0.0.59" }       # v2_4 ArchetypeHrid (the identification target type)
+openehr-rm = { path = "../openehr-rm", version = "0.0.59" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
+openehr-lang = { path = "../openehr-lang", version = "0.0.59" }   # openehr_lang::odin — the ODIN section parser
+openehr-term = { path = "../openehr-term", version = "0.0.59" }   # the languages code set for the RM resource-meta rows
 uuid.workspace = true        # meta uid/build_uid (AUTHORED_ARCHETYPE.uid: Uuid)
 indexmap.workspace = true    # OdinValue::Object body (insertion-ordered map)
 

--- a/crates/openehr-adl/src/aom/mod.rs
+++ b/crates/openehr-adl/src/aom/mod.rs
@@ -19,3 +19,4 @@
 pub mod access;
 pub mod build;
 pub mod interval;
+pub mod nesting;

--- a/crates/openehr-adl/src/aom/nesting.rs
+++ b/crates/openehr-adl/src/aom/nesting.rs
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: Ruben Talstra
+// SPDX-License-Identifier: Apache-2.0
+
+//! The nesting bound over a constraint-model tree.
+//!
+//! The parser bounds what it reads, but a flat form composes structure: a
+//! specialisation's differential paths and an OPT's inlined fillers each
+//! place nodes below what any single parsed artefact carries, so every
+//! producer of a composed tree re-checks the result against the engine's one
+//! bound, [`openehr_lang::nesting::MAX_NESTING_DEPTH`], before handing it to
+//! the recursive walkers downstream.
+
+use openehr_am::v2_4::aom2::constraint_model::c_complex_object::CComplexObject;
+use openehr_am::v2_4::aom2::constraint_model::c_object::CObject;
+use openehr_lang::nesting::{Nesting, NestingExceeded};
+
+use crate::aom::access::complex_attributes;
+
+/// Check that no object in the tree under `root` sits deeper than the engine
+/// bound; the root itself is level zero.
+///
+/// The walk descends with the same budget it checks, so it cannot itself
+/// exceed the bound.
+///
+/// # Errors
+/// [`NestingExceeded`] at the first object below the bound.
+pub fn check_definition_nesting(root: &CComplexObject) -> Result<(), NestingExceeded> {
+    check_complex(root, Nesting::ROOT)
+}
+
+fn check_complex(cco: &CComplexObject, level: Nesting) -> Result<(), NestingExceeded> {
+    for attr in complex_attributes(cco) {
+        for child in attr.children.iter().flatten() {
+            if let CObject::CComplexObject(inner) = child {
+                check_complex(inner, level.descend()?)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use openehr_lang::nesting::MAX_NESTING_DEPTH;
+
+    use super::*;
+    use crate::aom::build::complex_object;
+    use openehr_am::v2_4::aom2::constraint_model::c_attribute::CAttribute;
+
+    /// A single-attribute chain `levels` objects deep below the root.
+    fn chain(levels: usize) -> CComplexObject {
+        let mut node = complex_object(
+            "CLUSTER".to_owned(),
+            "id2".to_owned(),
+            Vec::new(),
+            Vec::new(),
+            None,
+        );
+        for _ in 0..levels {
+            let attr = CAttribute {
+                parent: None,
+                soc_parent: None,
+                rm_attribute_name: "items".to_owned(),
+                existence: None,
+                children: openehr_base::containers::present(vec![node]),
+                differential_path: None,
+                cardinality: None,
+                is_multiple: true,
+            };
+            node = complex_object(
+                "CLUSTER".to_owned(),
+                "id1".to_owned(),
+                vec![attr],
+                Vec::new(),
+                None,
+            );
+        }
+        match node {
+            CObject::CComplexObject(cco) => cco,
+            other => panic!("complex_object builds a complex object, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_tree_at_the_bound_passes_and_one_level_more_is_refused() {
+        assert_eq!(check_definition_nesting(&chain(MAX_NESTING_DEPTH)), Ok(()));
+        assert_eq!(
+            check_definition_nesting(&chain(MAX_NESTING_DEPTH + 1)),
+            Err(NestingExceeded {
+                limit: MAX_NESTING_DEPTH
+            })
+        );
+    }
+}

--- a/crates/openehr-adl/src/flatten.rs
+++ b/crates/openehr-adl/src/flatten.rs
@@ -45,11 +45,13 @@ use openehr_am::v2_4::aom2::constraint_model::c_object::CObject;
 use openehr_am::v2_4::aom2::constraint_model::sibling_order::SiblingOrder;
 use openehr_am::v2_4::aom2::terminology::archetype_terminology::ArchetypeTerminology;
 use openehr_base::prelude::MultiplicityInterval;
+use openehr_lang::nesting::MAX_NESTING_DEPTH;
 
 use crate::aom::access::{
     child_occurrences, complex_attributes, complex_node_id, object_node_id, sibling_order,
     strip_sibling_order,
 };
+use crate::aom::nesting::check_definition_nesting;
 use crate::artefact::{ArchetypeRepository, view};
 use crate::paths::{PathSegment, parse_path};
 use crate::validate::conformance::tuple_member_names;
@@ -68,6 +70,23 @@ pub enum FlattenError {
     /// A differential path in the child does not resolve in the flat parent.
     #[error("differential path {0:?} does not resolve in the flat parent")]
     UnresolvedDifferentialPath(String),
+    /// The specialisation lineage is longer than the engine bound
+    /// ([`openehr_lang::nesting::MAX_NESTING_DEPTH`] parents) — an
+    /// implementation limit, not a spec rule.
+    #[error("specialisation lineage exceeds the limit of {limit} levels")]
+    LineageTooDeep {
+        /// The bound that was crossed.
+        limit: usize,
+    },
+    /// The flat form composes objects deeper than the engine bound
+    /// ([`openehr_lang::nesting::MAX_NESTING_DEPTH`]): each artefact parses
+    /// within it, but the differential paths place nodes below the parent's
+    /// own depth — an implementation limit, not a spec rule.
+    #[error("the flat form nests deeper than the limit of {limit} levels")]
+    NestingTooDeep {
+        /// The bound that was crossed.
+        limit: usize,
+    },
 }
 
 /// Flatten `child` (a differential specialised archetype) against its already-
@@ -79,7 +98,9 @@ pub enum FlattenError {
 ///
 /// # Errors
 /// [`FlattenError::UnresolvedDifferentialPath`] if a child differential path
-/// cannot be located in the flat parent structure.
+/// cannot be located in the flat parent structure;
+/// [`FlattenError::NestingTooDeep`] if the composed flat definition nests
+/// past the engine bound.
 pub fn flatten(
     child: &Archetype,
     flat_parent: &Archetype,
@@ -94,6 +115,8 @@ pub fn flatten(
     let mut flat_def = pv.definition.clone();
     set_complex_node_id(&mut flat_def, complex_node_id(cv.definition).to_owned());
     overlay_root(&mut flat_def, cv.definition, child_level)?;
+    check_definition_nesting(&flat_def)
+        .map_err(|e| FlattenError::NestingTooDeep { limit: e.limit })?;
 
     // Terminology (master09.09 term_definitions accumulate / value_sets replace;
     // master09.10 bindings override).
@@ -112,8 +135,9 @@ pub fn flatten(
 ///
 /// # Errors
 /// [`FlattenError::ParentNotFound`] if a lineage parent is absent from `repo`,
-/// [`FlattenError::CyclicLineage`] on a lineage cycle, or a differential-path
-/// error from [`flatten`].
+/// [`FlattenError::CyclicLineage`] on a lineage cycle,
+/// [`FlattenError::LineageTooDeep`] past the engine bound on lineage length,
+/// or a differential-path or nesting error from [`flatten`].
 pub fn flat_form(
     archetype: &Archetype,
     repo: &ArchetypeRepository,
@@ -137,6 +161,11 @@ fn flat_form_memo(
     let key = parent_id.to_owned();
     if stack.contains(&key) {
         return Err(FlattenError::CyclicLineage(key));
+    }
+    if stack.len() >= MAX_NESTING_DEPTH {
+        return Err(FlattenError::LineageTooDeep {
+            limit: MAX_NESTING_DEPTH,
+        });
     }
     if let Some(cached) = memo.get(&key) {
         let cached = cached.clone();

--- a/crates/openehr-adl/src/opt.rs
+++ b/crates/openehr-adl/src/opt.rs
@@ -67,6 +67,7 @@ use crate::flatten::{FlattenError, flat_form};
 use crate::hrid::hrid_to_string;
 use crate::odin::nil_uuid;
 use crate::paths::parse_path;
+use openehr_lang::nesting::Nesting;
 
 /// A failure while generating or profiling an operational template.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -93,6 +94,20 @@ pub enum OptError {
     /// remains".
     #[error("language filtering would remove every language (at least one must remain)")]
     NoLanguagesLeft,
+    /// A filler inlines an archetype that is already being inlined above it —
+    /// the constituents reference each other in a cycle, which no finite OPT
+    /// can flatten (master03 §Flattening inlines every filler). Carries the
+    /// chain of archetype references from the outermost to the repeated one.
+    #[error("archetype references form a cycle: {}", .0.join(" -> "))]
+    CyclicReference(Vec<String>),
+    /// Inlining fillers and `use_node` targets composes objects deeper than
+    /// the engine bound ([`openehr_lang::nesting::MAX_NESTING_DEPTH`]) — an
+    /// implementation limit, not a spec rule.
+    #[error("the operational template nests deeper than the limit of {limit} levels")]
+    NestingTooDeep {
+        /// The bound that was crossed.
+        limit: usize,
+    },
 }
 
 /// Generate the raw operational template from a source `root` template (or
@@ -107,7 +122,9 @@ pub enum OptError {
 /// # Errors
 /// [`OptError::Flatten`] if the lineage cannot be flattened,
 /// [`OptError::UnresolvedReference`] if a filler / external reference is absent
-/// from `repo`.
+/// from `repo`, [`OptError::CyclicReference`] if the fillers reference each
+/// other in a cycle, [`OptError::NestingTooDeep`] if inlining composes a tree
+/// past the engine bound.
 pub fn create_opt(
     root: &Archetype,
     repo: &ArchetypeRepository,
@@ -129,8 +146,14 @@ pub fn create_opt(
 
     // Apply the OPT-specific transform to the flat definition, gathering the
     // constituent terminologies as fillers are inlined.
-    let mut components: BTreeMap<String, ArchetypeTerminology> = BTreeMap::new();
-    let opt_def = opt_complex(parts.definition.clone(), &work, &mut components, &root_id)?;
+    let mut transform = Transform {
+        work: &work,
+        components: BTreeMap::new(),
+        root_id: &root_id,
+        inlining: vec![root_id.clone()],
+    };
+    let opt_def = transform.complex(parts.definition.clone(), Nesting::ROOT)?;
+    let components = transform.components;
 
     Ok(OperationalTemplate {
         // A top-level standalone artefact — no specialisation parent
@@ -161,187 +184,210 @@ pub fn create_opt(
 
 // ── the OPT flattening transform (master03 §Flattening) ────────────────────
 
-/// OPT-transform a `C_COMPLEX_OBJECT` (or `C_ARCHETYPE_ROOT`) root: strip
-/// sibling markers and rewrite its attribute list. `proxy_root` is the enclosing
-/// flat artefact against which `use_node` target paths resolve.
-fn opt_complex(
-    def: CComplexObject,
-    work: &ArchetypeRepository,
-    components: &mut BTreeMap<String, ArchetypeTerminology>,
-    root_id: &str,
-) -> Result<CComplexObject, OptError> {
-    let proxy_root = def.clone();
-    match def {
-        CComplexObject::CComplexObject(mut d) => {
-            d.sibling_order = None;
-            d.attributes = openehr_base::containers::present(opt_attributes(
-                d.attributes.unwrap_or_default(),
-                &proxy_root,
-                work,
-                components,
-                root_id,
-            )?);
-            Ok(CComplexObject::CComplexObject(d))
-        }
-        CComplexObject::CArchetypeRoot(mut r) => {
-            r.sibling_order = None;
-            r.attributes = openehr_base::containers::present(opt_attributes(
-                r.attributes.unwrap_or_default(),
-                &proxy_root,
-                work,
-                components,
-                root_id,
-            )?);
-            Ok(CComplexObject::CArchetypeRoot(r))
-        }
-    }
+/// The state one OPT transform carries down the tree: the constituent
+/// repository, the terminologies gathered as fillers are inlined, the root
+/// template's id (whose terminology is not a component), and the chain of
+/// archetypes currently being inlined, which detects reference cycles.
+struct Transform<'a> {
+    work: &'a ArchetypeRepository,
+    components: BTreeMap<String, ArchetypeTerminology>,
+    root_id: &'a str,
+    inlining: Vec<String>,
 }
 
-/// OPT-transform an attribute list: drop `existence matches {0}` attributes
-/// (master03 §Flattening — deleted attributes removed), and rewrite each
-/// attribute's children through [`opt_object`].
-fn opt_attributes(
-    attrs: Vec<CAttribute>,
-    proxy_root: &CComplexObject,
-    work: &ArchetypeRepository,
-    components: &mut BTreeMap<String, ArchetypeTerminology>,
-    root_id: &str,
-) -> Result<Vec<CAttribute>, OptError> {
-    let mut out = Vec::new();
-    for mut attr in attrs {
-        // `existence matches {0}` — a logically-removed attribute (master03
-        // §Flattening: "attribute nodes that have `existence matches {0}` … are
-        // removed").
-        if attr
-            .existence
-            .as_ref()
-            .is_some_and(MultiplicityInterval::is_prohibited)
-        {
-            continue;
-        }
-        let mut kept = Vec::new();
-        for child in std::mem::take(&mut attr.children).into_iter().flatten() {
-            if let Some(node) = opt_object(child, proxy_root, work, components, root_id)? {
-                kept.push(node);
+impl Transform<'_> {
+    /// OPT-transform a `C_COMPLEX_OBJECT` (or `C_ARCHETYPE_ROOT`) root at
+    /// `level`: strip sibling markers and rewrite its attribute list. The
+    /// object is its own proxy root — the flat artefact against which its
+    /// `use_node` target paths resolve.
+    fn complex(&mut self, def: CComplexObject, level: Nesting) -> Result<CComplexObject, OptError> {
+        let proxy_root = def.clone();
+        match def {
+            CComplexObject::CComplexObject(mut d) => {
+                d.sibling_order = None;
+                d.attributes = openehr_base::containers::present(self.attributes(
+                    d.attributes.unwrap_or_default(),
+                    &proxy_root,
+                    level,
+                )?);
+                Ok(CComplexObject::CComplexObject(d))
+            }
+            CComplexObject::CArchetypeRoot(mut r) => {
+                r.sibling_order = None;
+                r.attributes = openehr_base::containers::present(self.attributes(
+                    r.attributes.unwrap_or_default(),
+                    &proxy_root,
+                    level,
+                )?);
+                Ok(CComplexObject::CArchetypeRoot(r))
             }
         }
-        attr.children = openehr_base::containers::present(kept);
-        // Differential paths do not survive into a flat/OPT form.
-        attr.differential_path = None;
-        out.push(attr);
     }
-    Ok(out)
-}
 
-/// OPT-transform a single object node. Returns `None` when the node is removed
-/// (`occurrences matches {0}` object or a `closed` slot; master03 §Flattening).
-fn opt_object(
-    obj: CObject,
-    proxy_root: &CComplexObject,
-    work: &ArchetypeRepository,
-    components: &mut BTreeMap<String, ArchetypeTerminology>,
-    root_id: &str,
-) -> Result<Option<CObject>, OptError> {
-    // `occurrences matches {0}` — a logically-removed object (master03
-    // §Flattening: "object … nodes with `occurrences matches {0}` [are
-    // removed]").
-    if child_occurrences(&obj).is_some_and(MultiplicityInterval::is_prohibited) {
-        return Ok(None);
-    }
-    match obj {
-        // A `closed` slot is removed; an open slot is a valid runtime extension
-        // point and is kept (master03 §Flattening: "all `closed` slots are
-        // removed").
-        CObject::ArchetypeSlot(mut s) => {
-            if s.is_closed {
-                return Ok(None);
+    /// OPT-transform an attribute list: drop `existence matches {0}` attributes
+    /// (master03 §Flattening — deleted attributes removed), and rewrite each
+    /// attribute's children one level deeper through [`Self::object`].
+    fn attributes(
+        &mut self,
+        attrs: Vec<CAttribute>,
+        proxy_root: &CComplexObject,
+        level: Nesting,
+    ) -> Result<Vec<CAttribute>, OptError> {
+        let child_level = level
+            .descend()
+            .map_err(|e| OptError::NestingTooDeep { limit: e.limit })?;
+        let mut out = Vec::new();
+        for mut attr in attrs {
+            // `existence matches {0}` — a logically-removed attribute (master03
+            // §Flattening: "attribute nodes that have `existence matches {0}` … are
+            // removed").
+            if attr
+                .existence
+                .as_ref()
+                .is_some_and(MultiplicityInterval::is_prohibited)
+            {
+                continue;
             }
-            s.sibling_order = None;
-            Ok(Some(CObject::ArchetypeSlot(s)))
+            let mut kept = Vec::new();
+            for child in std::mem::take(&mut attr.children).into_iter().flatten() {
+                if let Some(node) = self.object(child, proxy_root, child_level)? {
+                    kept.push(node);
+                }
+            }
+            attr.children = openehr_base::containers::present(kept);
+            // Differential paths do not survive into a flat/OPT form.
+            attr.differential_path = None;
+            out.push(attr);
         }
-        // A `use_node` proxy is replaced by an inline copy of its target
-        // (master03 §Flattening: "`use_node` internal references are replaced by
-        // an inline copy of the target structure").
-        CObject::CComplexObjectProxy(p) => {
-            let inlined = inline_proxy(&p, proxy_root)?;
-            opt_object(inlined, proxy_root, work, components, root_id)
-        }
-        CObject::CComplexObject(CComplexObject::CArchetypeRoot(r)) => {
-            let node = inline_filler(*r, work, components, root_id)?;
-            Ok(Some(node))
-        }
-        CObject::CComplexObject(CComplexObject::CComplexObject(mut d)) => {
-            d.sibling_order = None;
-            d.attributes = openehr_base::containers::present(opt_attributes(
-                d.attributes.unwrap_or_default(),
-                proxy_root,
-                work,
-                components,
-                root_id,
-            )?);
-            Ok(Some(CObject::CComplexObject(
-                CComplexObject::CComplexObject(d),
-            )))
-        }
-        // Primitive leaves survive as-is; strip any sibling marker.
-        mut other => {
-            strip_sibling_order(&mut other);
-            Ok(Some(other))
-        }
-    }
-}
-
-/// Inline a `C_ARCHETYPE_ROOT` slot-filler / external reference: resolve its
-/// `archetype_ref` to a constituent, flatten that constituent, and populate the
-/// root with the constituent's flattened structure and full-version id
-/// (master03 §Archetype References + §Flattening). The constituent's flat
-/// terminology is gathered under `components` (master03 §Terminology).
-fn inline_filler(
-    mut r: CArchetypeRoot,
-    work: &ArchetypeRepository,
-    components: &mut BTreeMap<String, ArchetypeTerminology>,
-    root_id: &str,
-) -> Result<CObject, OptError> {
-    let Some(constituent) = work.get(&r.archetype_ref) else {
-        return Err(OptError::UnresolvedReference(r.archetype_ref.clone()));
-    };
-    let full_id = hrid_to_string(view(constituent).archetype_id);
-    let flat = flat_form(constituent, work)?;
-    let flat_view = view(&flat);
-
-    // Gather the constituent's flat terminology (master03 §Terminology: the flat
-    // terminology of every constituent except the root template). The
-    // `component_terminologies` ODIN block carries only the term/binding/value-set
-    // maps keyed by archetype id (master10), not the within-archetype
-    // `concept_code`, so it is normalised away for serialisation fidelity.
-    if full_id != root_id {
-        components.entry(full_id.clone()).or_insert_with(|| {
-            let mut term = flat_view.terminology.clone();
-            term.concept_code = String::new();
-            term
-        });
+        Ok(out)
     }
 
-    // The filler's structure (recursively OPT-transformed, so nested fillers /
-    // proxies / deletions inside the constituent are handled too).
-    let opt_def = opt_complex(flat_view.definition.clone(), work, components, root_id)?;
-    let (rm_type, attributes, attribute_tuples) = match opt_def {
-        CComplexObject::CComplexObject(d) => (d.rm_type_name, d.attributes, d.attribute_tuples),
-        CComplexObject::CArchetypeRoot(cr) => (cr.rm_type_name, cr.attributes, cr.attribute_tuples),
-    };
-
-    // The filler keeps the slot node id it was placed at; the RM type falls back
-    // to the constituent's root type where the reference did not carry one.
-    if r.rm_type_name.is_empty() {
-        r.rm_type_name = rm_type;
+    /// OPT-transform a single object node. Returns `None` when the node is
+    /// removed (`occurrences matches {0}` object or a `closed` slot; master03
+    /// §Flattening).
+    fn object(
+        &mut self,
+        obj: CObject,
+        proxy_root: &CComplexObject,
+        level: Nesting,
+    ) -> Result<Option<CObject>, OptError> {
+        // `occurrences matches {0}` — a logically-removed object (master03
+        // §Flattening: "object … nodes with `occurrences matches {0}` [are
+        // removed]").
+        if child_occurrences(&obj).is_some_and(MultiplicityInterval::is_prohibited) {
+            return Ok(None);
+        }
+        match obj {
+            // A `closed` slot is removed; an open slot is a valid runtime extension
+            // point and is kept (master03 §Flattening: "all `closed` slots are
+            // removed").
+            CObject::ArchetypeSlot(mut s) => {
+                if s.is_closed {
+                    return Ok(None);
+                }
+                s.sibling_order = None;
+                Ok(Some(CObject::ArchetypeSlot(s)))
+            }
+            // A `use_node` proxy is replaced by an inline copy of its target
+            // (master03 §Flattening: "`use_node` internal references are replaced by
+            // an inline copy of the target structure"). The copy re-enters one
+            // level deeper: a target that contains the proxy itself would
+            // otherwise re-inline without end, and the bound turns that into a
+            // refusal.
+            CObject::CComplexObjectProxy(p) => {
+                let inlined = inline_proxy(&p, proxy_root)?;
+                let deeper = level
+                    .descend()
+                    .map_err(|e| OptError::NestingTooDeep { limit: e.limit })?;
+                self.object(inlined, proxy_root, deeper)
+            }
+            CObject::CComplexObject(CComplexObject::CArchetypeRoot(r)) => {
+                let node = self.inline_filler(*r, level)?;
+                Ok(Some(node))
+            }
+            CObject::CComplexObject(CComplexObject::CComplexObject(mut d)) => {
+                d.sibling_order = None;
+                d.attributes = openehr_base::containers::present(self.attributes(
+                    d.attributes.unwrap_or_default(),
+                    proxy_root,
+                    level,
+                )?);
+                Ok(Some(CObject::CComplexObject(
+                    CComplexObject::CComplexObject(d),
+                )))
+            }
+            // Primitive leaves survive as-is; strip any sibling marker.
+            mut other => {
+                strip_sibling_order(&mut other);
+                Ok(Some(other))
+            }
+        }
     }
-    r.archetype_ref = full_id;
-    r.sibling_order = None;
-    r.attributes = attributes;
-    r.attribute_tuples = attribute_tuples;
-    Ok(CObject::CComplexObject(CComplexObject::CArchetypeRoot(
-        Box::new(r),
-    )))
+
+    /// Inline a `C_ARCHETYPE_ROOT` slot-filler / external reference: resolve its
+    /// `archetype_ref` to a constituent, flatten that constituent, and populate
+    /// the root with the constituent's flattened structure and full-version id
+    /// (master03 §Archetype References + §Flattening). The constituent's flat
+    /// terminology is gathered under `components` (master03 §Terminology).
+    ///
+    /// The constituent joins the inlining chain for the duration of its own
+    /// transform: meeting it again below itself is a reference cycle.
+    fn inline_filler(
+        &mut self,
+        mut r: CArchetypeRoot,
+        level: Nesting,
+    ) -> Result<CObject, OptError> {
+        let Some(constituent) = self.work.get(&r.archetype_ref) else {
+            return Err(OptError::UnresolvedReference(r.archetype_ref.clone()));
+        };
+        let full_id = hrid_to_string(view(constituent).archetype_id);
+        if self.inlining.contains(&full_id) {
+            let mut chain = self.inlining.clone();
+            chain.push(full_id);
+            return Err(OptError::CyclicReference(chain));
+        }
+        let flat = flat_form(constituent, self.work)?;
+        let flat_view = view(&flat);
+
+        // Gather the constituent's flat terminology (master03 §Terminology: the flat
+        // terminology of every constituent except the root template). The
+        // `component_terminologies` ODIN block carries only the term/binding/value-set
+        // maps keyed by archetype id (master10), not the within-archetype
+        // `concept_code`, so it is normalised away for serialisation fidelity.
+        if full_id != self.root_id {
+            self.components.entry(full_id.clone()).or_insert_with(|| {
+                let mut term = flat_view.terminology.clone();
+                term.concept_code = String::new();
+                term
+            });
+        }
+
+        // The filler's structure (recursively OPT-transformed, so nested fillers /
+        // proxies / deletions inside the constituent are handled too), at the
+        // level of the slot it fills.
+        self.inlining.push(full_id.clone());
+        let opt_def = self.complex(flat_view.definition.clone(), level);
+        self.inlining.pop();
+        let (rm_type, attributes, attribute_tuples) = match opt_def? {
+            CComplexObject::CComplexObject(d) => (d.rm_type_name, d.attributes, d.attribute_tuples),
+            CComplexObject::CArchetypeRoot(cr) => {
+                (cr.rm_type_name, cr.attributes, cr.attribute_tuples)
+            }
+        };
+
+        // The filler keeps the slot node id it was placed at; the RM type falls back
+        // to the constituent's root type where the reference did not carry one.
+        if r.rm_type_name.is_empty() {
+            r.rm_type_name = rm_type;
+        }
+        r.archetype_ref = full_id;
+        r.sibling_order = None;
+        r.attributes = attributes;
+        r.attribute_tuples = attribute_tuples;
+        Ok(CObject::CComplexObject(CComplexObject::CArchetypeRoot(
+            Box::new(r),
+        )))
+    }
 }
 
 /// Inline a `use_node` proxy: copy the object at `proxy.target_path` in

--- a/crates/openehr-adl/src/parse/mod.rs
+++ b/crates/openehr-adl/src/parse/mod.rs
@@ -44,6 +44,7 @@ use openehr_am::v2_4::aom2::constraint_model::primitive::c_string::CString;
 use crate::aom::build::{cobject_to_primitive, cstring_regex};
 use crate::error::{SyntaxError, SyntaxErrorCode};
 use crate::odin::regex_inner;
+use openehr_lang::nesting::Nesting;
 use openehr_lang::v1_1::lexer::{Spanned, Token};
 
 /// Internal parse result: `Err(())` signals a bail-out; the concrete
@@ -111,6 +112,7 @@ pub fn parse_definition_body(
         pos: 0,
         errors: Vec::new(),
         dialect,
+        nesting: Nesting::ROOT,
     };
     let root = parser.parse_root();
     match root {
@@ -148,6 +150,7 @@ pub(crate) struct Parser<'a> {
     pub(crate) pos: usize,
     pub(crate) errors: Vec<SyntaxError>,
     pub(crate) dialect: Dialect,
+    pub(crate) nesting: Nesting,
 }
 
 // ── cursor + error helpers ────────────────────────────────────────────────
@@ -192,6 +195,30 @@ impl Parser<'_> {
         let span = self.cur_span();
         self.push(code, msg, span);
         Err(())
+    }
+
+    /// Run `production` one object-nesting level deeper, refusing past the
+    /// engine bound.
+    ///
+    /// Every nested object enters through here, so the recursive descent is
+    /// bounded by [`Nesting`]. The refusal is raised as `SUNK` — the
+    /// catalogue's "Syntax error (unknown cause)" bucket (`ADL2/master04.6`
+    /// §Syntax Validity Rules), because the bound is an implementation limit
+    /// no `S*` code describes — with the limit named in the message.
+    pub(crate) fn nested<T>(
+        &mut self,
+        production: impl FnOnce(&mut Self) -> PResult<T>,
+    ) -> PResult<T> {
+        let outer = self.nesting;
+        match outer.descend() {
+            Ok(inner) => self.nesting = inner,
+            Err(exceeded) => {
+                return self.err(SyntaxErrorCode::Sunk, format!("constraint {exceeded}"));
+            }
+        }
+        let result = production(self);
+        self.nesting = outer;
+        result
     }
 
     /// Take a decoded string/character literal, or report its escape defect at
@@ -338,6 +365,7 @@ pub(crate) fn parse_inline_primitive_text(raw: &str) -> Result<CPrimitiveObject,
         pos: 0,
         errors: Vec::new(),
         dialect: Dialect::Adl2,
+        nesting: Nesting::ROOT,
     };
     let parsed: PResult<CObject> = (|| {
         parser.expect(

--- a/crates/openehr-adl/src/parse/parser.rs
+++ b/crates/openehr-adl/src/parse/parser.rs
@@ -926,6 +926,11 @@ impl Parser<'_> {
     /// negated-regex semantics from defective prose would be a silent wrong
     /// answer.
     fn parse_c_regular_object(&mut self) -> PResult<CObject> {
+        self.nested(Self::parse_c_regular_object_at_level)
+    }
+
+    /// [`Self::parse_c_regular_object`] at the level the caller entered.
+    fn parse_c_regular_object_at_level(&mut self) -> PResult<CObject> {
         if self.at_regex_match_operator() {
             return self.err(
                 SyntaxErrorCode::Sccog,

--- a/crates/openehr-adl/src/rules.rs
+++ b/crates/openehr-adl/src/rules.rs
@@ -361,6 +361,13 @@ fn bel_to_syntax(err: &BelError, offset: usize, src: &str) -> SyntaxError {
             (code, *at, format!("illegal rule expression: {message}"))
         }
         BelError::Unsupported { at, message } => (SyntaxErrorCode::Sinvs, *at, message.clone()),
+        // The engine's nesting bound is an implementation limit no `S*` code
+        // describes; `SUNK` is the catalogue's own unclassified bucket.
+        BelError::NestingTooDeep { at, limit } => (
+            SyntaxErrorCode::Sunk,
+            *at,
+            format!("rule expression nesting exceeds the limit of {limit} levels"),
+        ),
     };
     SyntaxError::at(code, message, (at + offset)..(at + offset), src)
 }

--- a/crates/openehr-adl/tests/it/main.rs
+++ b/crates/openehr-adl/tests/it/main.rs
@@ -39,6 +39,7 @@ mod corpus_validity_rm;
 mod default_value_intervals;
 mod flattener_spec;
 mod legacy14_corpus;
+mod nesting_bounds;
 mod opt_spec;
 mod rules_parse;
 mod templates_corpus;

--- a/crates/openehr-adl/tests/it/nesting_bounds.rs
+++ b/crates/openehr-adl/tests/it/nesting_bounds.rs
@@ -1,0 +1,251 @@
+// SPDX-FileCopyrightText: Ruben Talstra
+// SPDX-License-Identifier: Apache-2.0
+
+//! The engine's nesting bound as a typed refusal at every recursive seam:
+//! the cADL parser, the flattener (lineage length and composed depth) and
+//! the OPT transform (inlined depth and filler cycles). Native recursion past
+//! a thread's stack aborts the process, which no caller can catch; each of
+//! these walks refuses instead.
+
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic,
+    reason = "integration-test assertions, diagnostics and fixture plumbing outside #[test] fns, which the clippy.toml allow-*-in-tests scoping does not reach"
+)]
+
+use openehr_adl::artefact::ArchetypeRepository;
+use openehr_adl::assemble::parse_artefact;
+use openehr_adl::error::SyntaxErrorCode;
+use openehr_adl::flatten::{FlattenError, flat_form};
+use openehr_adl::opt::{OptError, create_opt};
+use openehr_adl::parse::{Dialect, parse_definition_body};
+use openehr_am::v2_4::aom2::archetype::archetype::Archetype;
+use openehr_lang::nesting::MAX_NESTING_DEPTH;
+use std::fmt::Write;
+
+/// Run `f` on a thread whose stack fits a walk at the bound: the bound is set
+/// for the engine's 256 MiB thread, not the 2 MiB test thread.
+fn on_big_stack<T: Send + 'static>(f: impl FnOnce() -> T + Send + 'static) -> T {
+    std::thread::Builder::new()
+        .stack_size(256 << 20)
+        .spawn(f)
+        .expect("spawn")
+        .join()
+        .expect("join")
+}
+
+/// A `CLUSTER` chain `levels` objects deep under `root_id`, each level one
+/// `items` attribute below the last, ending in `innermost` (a leaf object).
+/// Node ids run `id{first_id}`, `id{first_id + 1}`, … down the chain.
+fn cluster_chain(root_id: &str, levels: usize, first_id: usize, innermost: &str) -> String {
+    let mut open = String::new();
+    for k in 0..levels {
+        let nid = if k == 0 {
+            root_id.to_owned()
+        } else {
+            format!("id{}", first_id + k - 1)
+        };
+        write!(open, "CLUSTER[{nid}] matches {{ items matches {{ ").expect("a String write");
+    }
+    let close = " } }".repeat(levels);
+    format!("{open}{innermost}{close}")
+}
+
+/// A minimal ADL 2 archetype around `definition`.
+fn archetype_source(hrid: &str, specialize: Option<&str>, definition: &str) -> String {
+    let spec = specialize.map_or(String::new(), |p| format!("\nspecialize\n    {p}\n"));
+    format!(
+        "archetype (adl_version=2.0.6; rm_release=1.1.0)\n    {hrid}\n{spec}\n\
+         language\n    original_language = <[ISO_639-1::en]>\n\n\
+         description\n    lifecycle_state = <\"published\">\n    details = <\n        \
+         [\"en\"] = <\n            language = <[ISO_639-1::en]>\n        >\n    >\n\n\
+         definition\n    {definition}\n\n\
+         terminology\n    term_definitions = <\n        [\"en\"] = <\n            \
+         [\"id1\"] = <text = <\"Root\"> description = <\"Root.\">>\n        >\n    >\n"
+    )
+}
+
+fn parse(src: &str) -> Archetype {
+    parse_artefact(src, Dialect::Adl2).unwrap_or_else(|errs| panic!("fixture parses: {errs:?}"))
+}
+
+fn cluster_hrid(concept: &str) -> String {
+    format!("openEHR-EHR-CLUSTER.{concept}.v1.0.0")
+}
+
+// ── the cADL parser ───────────────────────────────────────────────────────
+
+#[test]
+fn a_definition_nested_past_the_bound_is_refused_as_sunk() {
+    // The parser recurses up to the bound before refusing, so the refusal too
+    // needs the stack the bound is sized for.
+    let errs = on_big_stack(|| {
+        let body = cluster_chain(
+            "id1",
+            MAX_NESTING_DEPTH + 2,
+            2,
+            "ELEMENT[id9999] matches {*}",
+        );
+        parse_definition_body(&body, Dialect::Adl2)
+            .expect_err("a definition nested past the bound is refused, never recursed into")
+    });
+    let first = errs.first().expect("one refusal");
+    assert_eq!(first.code, SyntaxErrorCode::Sunk);
+    assert!(
+        first
+            .message
+            .contains(&format!("exceeds the limit of {MAX_NESTING_DEPTH} levels")),
+        "the refusal names the bound: {}",
+        first.message
+    );
+}
+
+#[test]
+fn a_definition_well_within_the_bound_parses() {
+    on_big_stack(|| {
+        let body = cluster_chain(
+            "id1",
+            MAX_NESTING_DEPTH.div_ceil(2),
+            2,
+            "ELEMENT[id9999] matches {*}",
+        );
+        parse_definition_body(&body, Dialect::Adl2).expect("a deep but bounded definition parses");
+    });
+}
+
+// ── the flattener ─────────────────────────────────────────────────────────
+
+#[test]
+fn a_specialisation_lineage_longer_than_the_bound_is_refused() {
+    let length = MAX_NESTING_DEPTH + 2;
+    let mut repo = ArchetypeRepository::new();
+    let mut leaf = None;
+    for k in 0..length {
+        let hrid = cluster_hrid(&format!("chain{k}"));
+        let parent = (k > 0).then(|| cluster_hrid(&format!("chain{}", k - 1)));
+        let root_id = format!("id1{}", ".1".repeat(k));
+        let src = archetype_source(
+            &hrid,
+            parent.as_deref(),
+            &format!("CLUSTER[{root_id}] matches {{*}}"),
+        );
+        let archetype = parse(&src);
+        if k + 1 == length {
+            leaf = Some(archetype);
+        } else {
+            repo.insert(archetype);
+        }
+    }
+    let err = flat_form(&leaf.expect("the deepest child"), &repo)
+        .expect_err("a lineage past the bound is refused before the walk reaches its root");
+    assert!(
+        matches!(err, FlattenError::LineageTooDeep { limit } if limit == MAX_NESTING_DEPTH),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn a_flat_form_composed_past_the_bound_is_refused() {
+    // Each artefact parses within the bound, but the child's differential
+    // path hangs its own chain under the parent's deepest node, so the flat
+    // form is deeper than either.
+    let half = MAX_NESTING_DEPTH.div_ceil(2) + 8;
+    let parent_hrid = cluster_hrid("deep_parent");
+    let parent_src = archetype_source(
+        &parent_hrid,
+        None,
+        &cluster_chain("id1", half, 2, "ELEMENT[id9999] matches {*}"),
+    );
+    // The differential path to the parent's deepest `items` attribute:
+    // `/items[id2]/items[id3]/…/items[id{half}]/items`.
+    let mut path = String::new();
+    for k in 2..=half {
+        write!(path, "/items[id{k}]").expect("a String write");
+    }
+    path.push_str("/items");
+    let child_chain = cluster_chain("id0.1", half, 20_000, "ELEMENT[id0.9999] matches {*}");
+    let child_src = archetype_source(
+        &cluster_hrid("deep_child"),
+        Some(&parent_hrid),
+        &format!("CLUSTER[id1.1] matches {{ {path} matches {{ {child_chain} }} }}"),
+    );
+    on_big_stack(move || {
+        let mut repo = ArchetypeRepository::new();
+        repo.insert(parse(&parent_src));
+        let child = parse(&child_src);
+        let err =
+            flat_form(&child, &repo).expect_err("a flat form composed past the bound is refused");
+        assert!(
+            matches!(err, FlattenError::NestingTooDeep { limit } if limit == MAX_NESTING_DEPTH),
+            "got {err:?}"
+        );
+    });
+}
+
+// ── the OPT transform ─────────────────────────────────────────────────────
+
+#[test]
+fn fillers_referencing_each_other_are_a_typed_refusal() {
+    let a = cluster_hrid("filler_a");
+    let b = cluster_hrid("filler_b");
+    let a_src = archetype_source(
+        &a,
+        None,
+        &format!("CLUSTER[id1] matches {{ items matches {{ use_archetype CLUSTER[id2, {b}] }} }}"),
+    );
+    let b_src = archetype_source(
+        &b,
+        None,
+        &format!("CLUSTER[id1] matches {{ items matches {{ use_archetype CLUSTER[id2, {a}] }} }}"),
+    );
+    let mut repo = ArchetypeRepository::new();
+    repo.insert(parse(&b_src));
+    let root = parse(&a_src);
+    repo.insert(root.clone());
+    let err =
+        create_opt(&root, &repo).expect_err("a filler cycle can never be inlined to a finite OPT");
+    match err {
+        OptError::CyclicReference(chain) => {
+            assert_eq!(
+                chain,
+                vec![a.clone(), b, a],
+                "the chain names the cycle outermost-first"
+            );
+        }
+        other => panic!("expected a cyclic-reference refusal, got {other:?}"),
+    }
+}
+
+#[test]
+fn fillers_inlined_past_the_bound_are_a_typed_refusal() {
+    // Two artefacts each within the bound whose inlining composes past it.
+    let half = MAX_NESTING_DEPTH.div_ceil(2) + 8;
+    let filler_hrid = cluster_hrid("deep_filler");
+    let filler_src = archetype_source(
+        &filler_hrid,
+        None,
+        &cluster_chain("id1", half, 2, "ELEMENT[id9999] matches {*}"),
+    );
+    let root_src = archetype_source(
+        &cluster_hrid("deep_root"),
+        None,
+        &cluster_chain(
+            "id1",
+            half,
+            2,
+            &format!("use_archetype CLUSTER[id9998, {filler_hrid}]"),
+        ),
+    );
+    on_big_stack(move || {
+        let mut repo = ArchetypeRepository::new();
+        repo.insert(parse(&filler_src));
+        let root = parse(&root_src);
+        repo.insert(root.clone());
+        let err = create_opt(&root, &repo).expect_err("an OPT composed past the bound is refused");
+        assert!(
+            matches!(err, OptError::NestingTooDeep { limit } if limit == MAX_NESTING_DEPTH),
+            "got {err:?}"
+        );
+    });
+}

--- a/crates/openehr-am/Cargo.toml
+++ b/crates/openehr-am/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-am"
-version = "0.0.58"
+version = "0.0.59"
 description = "openEHR AM Archetype Model, generated from BMM: generations v1_4 (AM 1.4.0, ADL 1.4) and v2_4 (AM 2.4.0, ADL 2; current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,8 +13,8 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.58" }
-openehr-lang = { path = "../openehr-lang", version = "0.0.58" }
+openehr-base = { path = "../openehr-base", version = "0.0.59" }
+openehr-lang = { path = "../openehr-lang", version = "0.0.59" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also carries the untyped `Value` fields the generator

--- a/crates/openehr-base/Cargo.toml
+++ b/crates/openehr-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-base"
-version = "0.0.58"
+version = "0.0.59"
 description = "openEHR BASE foundation + base types, generated from BMM: generations v1_2 (BASE 1.2.0) and v1_3 (BASE 1.3.0, current)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-its"
-version = "0.0.58"
+version = "0.0.59"
 description = "openEHR ITS (Implementation Technology Specifications): canonical JSON + canonical XML serialization of the RM, the generated ITS-REST 1.1.0 API contract, OPT 1.4 and AOM2 archetype XML codecs, and the Simplified Formats (FLAT / STRUCTURED / Web Template)"
 edition.workspace = true
 rust-version.workspace = true
@@ -41,14 +41,14 @@ regex = { workspace = true, optional = true }
 fancy-regex = { workspace = true, optional = true }
 # The generated XML (de)serializers impl the crate's ToXml/FromXml traits for the
 # RM/BASE spec types, so these are real (non-dev) deps.
-openehr-base = { path = "../openehr-base", version = "0.0.58", optional = true }
-openehr-rm = { path = "../openehr-rm", version = "0.0.58", optional = true }
+openehr-base = { path = "../openehr-base", version = "0.0.59", optional = true }
+openehr-rm = { path = "../openehr-rm", version = "0.0.59", optional = true }
 # The native canonical-JSON codec (`json_codec/generated`, emit-json) implements
 # `ToJson` for EVERY generated spec type the `OpenEhrType` derive covers, so it
 # spans all five spec crates (not just the RM/BASE the XML codec needs).
-openehr-lang = { path = "../openehr-lang", version = "0.0.58", optional = true }
-openehr-am = { path = "../openehr-am", version = "0.0.58", optional = true }
-openehr-term = { path = "../openehr-term", version = "0.0.58", optional = true }
+openehr-lang = { path = "../openehr-lang", version = "0.0.59", optional = true }
+openehr-am = { path = "../openehr-am", version = "0.0.59", optional = true }
+openehr-term = { path = "../openehr-term", version = "0.0.59", optional = true }
 
 # `full` — every ITS surface (canonical JSON/XML, the generated ITS-REST
 # contract, `opt14`, Simplified Formats). ON BY DEFAULT, so every consumer sees

--- a/crates/openehr-lang/CLAUDE.md
+++ b/crates/openehr-lang/CLAUDE.md
@@ -26,6 +26,16 @@ line, the prelude) and `v1_0` (the released LANG 1.0.0).
   path heads. Never "sync" the two generations — a 1.0.0 behaviour changes
   only on a re-derivation against the release text.
 
+- **`src/nesting.rs` is the ONE nesting bound for the whole language stack**
+  (`MAX_NESTING_DEPTH` = 512, the `Nesting` counter, `check_bracket_nesting`):
+  the ODIN readers of BOTH generations pre-scan their token stream against it
+  (a combinator parser has no per-level seam), the BEL parser threads it
+  through its self-recursive productions, and `openehr-adl` imports the same
+  constant for its cADL parser, flattener and OPT transform. Crossing it is a
+  typed refusal (`OdinErrorKind::NestingTooDeep`, `BelError::NestingTooDeep`),
+  never an abort. A walk reaches the bound before refusing, so a caller
+  provides a stack sized for it (the CDR: a 256 MiB engine thread); tests
+  that walk to the bound spawn such a thread. No openEHR spec bounds nesting.
 - **This crate is upstream of everything generated.** A change to the BMM
   loader can silently change what `openehr-codegen` emits across five
   crates — after ANY loader/model change, run `/regen-codegen` and inspect

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-lang"
-version = "0.0.58"
+version = "0.0.59"
 description = "openEHR LANG BMM/P_BMM object model, generated from BMM: generations v1_0 (LANG 1.0.0) and v1_1 (LANG 1.1.0, current; the stable BMM v2.x unit beside the paused BMM3 unit), plus hand-written ODIN/BEL/EL readers"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["parser-implementations", "data-structures"]
 include = ["src/**", "README.md", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.58" }
+openehr-base = { path = "../openehr-base", version = "0.0.59" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the
 # generated types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) —
 # never a derive. `serde_json` also carries the untyped `Value` fields the

--- a/crates/openehr-lang/src/lib.rs
+++ b/crates/openehr-lang/src/lib.rs
@@ -111,5 +111,8 @@ impl std::str::FromStr for Generation {
     }
 }
 
+// hand-written modules (spec behaviour), auto-declared:
+pub mod nesting;
+
 // canonical-JSON `serde` impls (openehr-codegen -- emit-json), auto-declared:
 mod json_serde;

--- a/crates/openehr-lang/src/nesting.rs
+++ b/crates/openehr-lang/src/nesting.rs
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: Ruben Talstra
+// SPDX-License-Identifier: Apache-2.0
+
+//! The nesting bound every recursive reader and walker in the openEHR
+//! language stack honours.
+//!
+//! The ODIN and BEL readers here, and the cADL parser, flattener and OPT
+//! transform built on them in `openehr-adl`, recurse over the structure they
+//! read. Native recursion has no typed failure mode: past the thread's stack
+//! it aborts the process, which no caller can catch. [`MAX_NESTING_DEPTH`] is
+//! the one bound they all share, and [`Nesting`] is the counter a recursive
+//! walk threads through itself so that crossing the bound is a typed refusal
+//! ([`NestingExceeded`]) instead. No openEHR spec bounds nesting — this is an
+//! implementation limit, set far above any published artefact.
+
+/// The deepest nesting any reader or walker in this stack accepts.
+///
+/// The published openEHR archetypes and templates stay well under a hundred
+/// levels; the bound is a refusal threshold for defective or hostile input,
+/// not a design envelope. A walk reaches the bound before it refuses, so the
+/// caller provides a stack sized for it: the CDR runs the engine on a
+/// dedicated 256 MiB thread, and a debug build on a default 2 MiB thread
+/// overflows first.
+pub const MAX_NESTING_DEPTH: usize = 512;
+
+/// A nesting level in a recursive walk, refusing to descend past
+/// [`MAX_NESTING_DEPTH`].
+///
+/// Value semantics: [`Nesting::descend`] returns the deeper level for the
+/// recursive call and leaves the caller's own level untouched, so unwinding
+/// needs no bookkeeping.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Nesting(usize);
+
+impl Nesting {
+    /// The outermost level.
+    pub const ROOT: Self = Self(0);
+
+    /// The current level, `0` at the root.
+    #[must_use]
+    pub const fn level(self) -> usize {
+        self.0
+    }
+
+    /// The level one deeper.
+    ///
+    /// # Errors
+    /// [`NestingExceeded`] when the deeper level would pass
+    /// [`MAX_NESTING_DEPTH`].
+    pub const fn descend(self) -> Result<Self, NestingExceeded> {
+        if self.0 >= MAX_NESTING_DEPTH {
+            return Err(NestingExceeded {
+                limit: MAX_NESTING_DEPTH,
+            });
+        }
+        Ok(Self(self.0 + 1))
+    }
+
+    /// The level one shallower, for walkers that keep one counter and unwind
+    /// it by hand; saturates at the root.
+    #[must_use]
+    pub const fn ascend(self) -> Self {
+        Self(self.0.saturating_sub(1))
+    }
+}
+
+/// A structure nests deeper than [`MAX_NESTING_DEPTH`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("nesting exceeds the limit of {limit} levels")]
+pub struct NestingExceeded {
+    /// The bound that was crossed.
+    pub limit: usize,
+}
+
+/// The deepest bracket nesting in a token stream, counted by `opens` and
+/// `closes`, refused when it passes [`MAX_NESTING_DEPTH`].
+///
+/// A combinator parser has no seam for a per-level counter, so its recursion
+/// is bounded up front by the bracket structure that drives it: every
+/// recursive production opens a bracket, so the bracket depth bounds the
+/// recursion depth. Returns the index of the first token that crosses the
+/// bound.
+///
+/// # Errors
+/// [`NestingExceeded`] with the offending token's index attached by the
+/// caller, when the nesting passes the bound.
+pub fn check_bracket_nesting<T>(
+    tokens: &[T],
+    opens: impl Fn(&T) -> bool,
+    closes: impl Fn(&T) -> bool,
+) -> Result<(), (usize, NestingExceeded)> {
+    let mut level = Nesting::ROOT;
+    for (index, token) in tokens.iter().enumerate() {
+        if opens(token) {
+            level = level.descend().map_err(|e| (index, e))?;
+        } else if closes(token) {
+            level = level.ascend();
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn descend_stops_exactly_at_the_bound() {
+        let mut level = Nesting::ROOT;
+        for _ in 0..MAX_NESTING_DEPTH {
+            level = level.descend().expect("within the bound");
+        }
+        assert_eq!(level.level(), MAX_NESTING_DEPTH);
+        assert_eq!(
+            level.descend(),
+            Err(NestingExceeded {
+                limit: MAX_NESTING_DEPTH
+            })
+        );
+        assert_eq!(level.ascend().level(), MAX_NESTING_DEPTH - 1);
+        assert_eq!(Nesting::ROOT.ascend(), Nesting::ROOT);
+    }
+
+    #[test]
+    fn bracket_nesting_reports_the_first_crossing_token() {
+        let opens = |c: &char| *c == '(';
+        let closes = |c: &char| *c == ')';
+        let balanced: Vec<char> = "(()())".chars().collect();
+        assert_eq!(check_bracket_nesting(&balanced, opens, closes), Ok(()));
+
+        let mut deep: Vec<char> = std::iter::repeat_n('(', MAX_NESTING_DEPTH).collect();
+        deep.extend(std::iter::repeat_n(')', MAX_NESTING_DEPTH));
+        assert_eq!(check_bracket_nesting(&deep, opens, closes), Ok(()));
+
+        deep.insert(MAX_NESTING_DEPTH, '(');
+        assert_eq!(
+            check_bracket_nesting(&deep, opens, closes),
+            Err((
+                MAX_NESTING_DEPTH,
+                NestingExceeded {
+                    limit: MAX_NESTING_DEPTH
+                }
+            ))
+        );
+    }
+}

--- a/crates/openehr-lang/src/nesting.rs
+++ b/crates/openehr-lang/src/nesting.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: Ruben Talstra
+// SPDX-FileCopyrightText: openEHR Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! The nesting bound every recursive reader and walker in the openEHR

--- a/crates/openehr-lang/src/v1_0/odin/mod.rs
+++ b/crates/openehr-lang/src/v1_0/odin/mod.rs
@@ -29,6 +29,7 @@ mod parser;
 
 use indexmap::IndexMap;
 
+use crate::v1_0::lexer::Token;
 use crate::v1_0::position::line_col;
 
 /// A parsed ODIN value.
@@ -295,6 +296,11 @@ pub enum OdinErrorKind {
     /// their typed values, so `[01]` duplicates `[1]`. Carries the repeated
     /// key in its path-predicate rendering.
     DuplicateKey(String),
+    /// Object blocks (or generic type parameters) nest deeper than
+    /// [`crate::nesting::MAX_NESTING_DEPTH`] — an implementation bound, not
+    /// a spec rule; the reader refuses rather than recursing without limit.
+    /// Carries the bound.
+    NestingTooDeep(usize),
 }
 
 /// An ODIN parse or lex failure, with a 1-based line/column and a byte span.
@@ -375,6 +381,21 @@ pub fn parse_document(src: &str) -> Result<OdinDocument, OdinError> {
             span: failure.span,
         }
     })?;
+    if let Err((index, exceeded)) = crate::nesting::check_bracket_nesting(
+        &spanned,
+        |t| t.token == Token::SymLt,
+        |t| t.token == Token::SymGt,
+    ) {
+        let offset = spanned.get(index).map_or(src.len(), |t| t.span.start);
+        let (line, column) = line_col(src, offset);
+        return Err(OdinError {
+            kind: OdinErrorKind::NestingTooDeep(exceeded.limit),
+            message: exceeded.to_string(),
+            line,
+            column,
+            span: offset..offset,
+        });
+    }
     parser::parse_tokens(&spanned).map_err(|located| {
         let (line, column) = line_col(src, located.offset);
         let (kind, message) = match located.failure {

--- a/crates/openehr-lang/src/v1_1/bel/mod.rs
+++ b/crates/openehr-lang/src/v1_1/bel/mod.rs
@@ -83,6 +83,16 @@ pub enum BelError {
         /// Why the builder rejected it.
         message: String,
     },
+    /// Expressions nest deeper than [`crate::nesting::MAX_NESTING_DEPTH`] —
+    /// an implementation bound, not a spec rule; the parser refuses rather
+    /// than recursing without limit.
+    #[error("BEL parse error at byte {at}: expression nesting exceeds the limit of {limit} levels")]
+    NestingTooDeep {
+        /// Byte offset of the token that crossed the bound.
+        at: usize,
+        /// The bound that was crossed.
+        limit: usize,
+    },
 }
 
 /// A manifest literal recognised by the BEL lexer, handed to

--- a/crates/openehr-lang/src/v1_1/bel/parser.rs
+++ b/crates/openehr-lang/src/v1_1/bel/parser.rs
@@ -17,6 +17,7 @@
 //! grammar); a future EL parser must take its precedence from the EL tables,
 //! never from this ordering.
 
+use crate::nesting::Nesting;
 use crate::v1_1::bel::{BelBuilder, BelError, BelLiteral};
 use crate::v1_1::beom::core::operator_kind::OperatorKind;
 use crate::v1_1::lexer::{Spanned, Token};
@@ -27,6 +28,7 @@ pub(crate) struct Parser<'a, 'b, B: BelBuilder> {
     toks: &'a [Spanned],
     pos: usize,
     builder: &'b mut B,
+    nesting: Nesting,
 }
 
 impl<'a, 'b, B: BelBuilder> Parser<'a, 'b, B> {
@@ -36,7 +38,27 @@ impl<'a, 'b, B: BelBuilder> Parser<'a, 'b, B> {
             toks,
             pos: 0,
             builder,
+            nesting: Nesting::ROOT,
         }
+    }
+
+    /// Run `production` one nesting level deeper, refusing past the bound.
+    ///
+    /// Every self-recursive production (a parenthesised or quantified
+    /// sub-expression, a `not` or sign chain) enters through here, so the
+    /// parser's native recursion is bounded by [`Nesting`].
+    fn nested<T>(
+        &mut self,
+        production: impl FnOnce(&mut Self) -> Result<T, BelError>,
+    ) -> Result<T, BelError> {
+        let outer = self.nesting;
+        self.nesting = outer.descend().map_err(|e| BelError::NestingTooDeep {
+            at: self.at(),
+            limit: e.limit,
+        })?;
+        let result = production(self);
+        self.nesting = outer;
+        result
     }
 
     // ── cursor helpers ────────────────────────────────────────────────────
@@ -284,12 +306,14 @@ impl<'a, 'b, B: BelBuilder> Parser<'a, 'b, B> {
     // ── expressions (precedence climbing) ─────────────────────────────────
     /// `expression`/`boolean_expr` entry: lowest-precedence `implies`.
     fn parse_expr(&mut self) -> Result<B::Expr, BelError> {
-        let mut left = self.parse_or()?;
-        while self.eat(&Token::SymImplies) {
-            let right = self.parse_or()?;
-            left = self.builder.binary(kind("implies"), "implies", left, right);
-        }
-        Ok(left)
+        self.nested(|p| {
+            let mut left = p.parse_or()?;
+            while p.eat(&Token::SymImplies) {
+                let right = p.parse_or()?;
+                left = p.builder.binary(kind("implies"), "implies", left, right);
+            }
+            Ok(left)
+        })
     }
 
     fn parse_or(&mut self) -> Result<B::Expr, BelError> {
@@ -321,7 +345,7 @@ impl<'a, 'b, B: BelBuilder> Parser<'a, 'b, B> {
 
     fn parse_not(&mut self) -> Result<B::Expr, BelError> {
         if self.eat(&Token::SymNot) {
-            let operand = self.parse_not()?;
+            let operand = self.nested(Self::parse_not)?;
             return Ok(self.builder.unary(kind("not"), "not", operand));
         }
         self.parse_comparison()
@@ -387,11 +411,11 @@ impl<'a, 'b, B: BelBuilder> Parser<'a, 'b, B> {
 
     fn parse_unary(&mut self) -> Result<B::Expr, BelError> {
         if self.eat(&Token::SymMinus) {
-            let operand = self.parse_unary()?;
+            let operand = self.nested(Self::parse_unary)?;
             return Ok(self.builder.unary(kind("minus"), "-", operand));
         }
         if self.eat(&Token::SymPlus) {
-            return self.parse_unary();
+            return self.nested(Self::parse_unary);
         }
         self.parse_primary()
     }

--- a/crates/openehr-lang/src/v1_1/odin/mod.rs
+++ b/crates/openehr-lang/src/v1_1/odin/mod.rs
@@ -23,6 +23,7 @@ mod parser;
 
 use indexmap::IndexMap;
 
+use crate::v1_1::lexer::Token;
 use crate::v1_1::position::line_col;
 
 /// A parsed ODIN value.
@@ -223,6 +224,11 @@ pub enum OdinErrorKind {
     /// their typed values, so `[01]` duplicates `[1]`. Carries the repeated
     /// key in its path-predicate rendering.
     DuplicateKey(String),
+    /// Object blocks (or generic type parameters) nest deeper than
+    /// [`crate::nesting::MAX_NESTING_DEPTH`] — an implementation bound, not
+    /// a spec rule; the reader refuses rather than recursing without limit.
+    /// Carries the bound.
+    NestingTooDeep(usize),
 }
 
 /// An ODIN parse or lex failure, with a 1-based line/column and a byte span.
@@ -301,6 +307,21 @@ pub fn parse_document(src: &str) -> Result<OdinDocument, OdinError> {
             span: failure.span,
         }
     })?;
+    if let Err((index, exceeded)) = crate::nesting::check_bracket_nesting(
+        &spanned,
+        |t| t.token == Token::SymLt,
+        |t| t.token == Token::SymGt,
+    ) {
+        let offset = spanned.get(index).map_or(src.len(), |t| t.span.start);
+        let (line, column) = line_col(src, offset);
+        return Err(OdinError {
+            kind: OdinErrorKind::NestingTooDeep(exceeded.limit),
+            message: exceeded.to_string(),
+            line,
+            column,
+            span: offset..offset,
+        });
+    }
     parser::parse_tokens(&spanned).map_err(|located| {
         let (line, column) = line_col(src, located.offset);
         let (kind, message) = match located.failure {

--- a/crates/openehr-lang/tests/it/bel_parse.rs
+++ b/crates/openehr-lang/tests/it/bel_parse.rs
@@ -238,3 +238,60 @@ fn terminology_code_literals_and_container_literal_boundary() {
         );
     }
 }
+
+// ── the nesting bound ─────────────────────────────────────────────────────
+
+/// Run `f` on a thread whose stack fits a walk at the bound: the bound is
+/// set for the engine's 256 MiB thread, not the 2 MiB test thread.
+fn on_big_stack<T: Send + 'static>(f: impl FnOnce() -> T + Send + 'static) -> T {
+    std::thread::Builder::new()
+        .stack_size(256 << 20)
+        .spawn(f)
+        .unwrap()
+        .join()
+        .unwrap()
+}
+
+fn parenthesised(levels: usize) -> String {
+    format!("{}1{} > 0", "(".repeat(levels), ")".repeat(levels))
+}
+
+#[test]
+fn expression_nesting_past_the_bound_is_a_typed_refusal() {
+    // The parser recurses up to the bound before refusing, so the refusal
+    // too needs the stack the bound is sized for.
+    let err = on_big_stack(|| {
+        parse_statements(&parenthesised(openehr_lang::nesting::MAX_NESTING_DEPTH + 1))
+            .expect_err("an expression nested past the bound is refused, never recursed into")
+    });
+    assert!(
+        matches!(err, BelError::NestingTooDeep { limit, .. }
+            if limit == openehr_lang::nesting::MAX_NESTING_DEPTH),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn expression_nesting_well_within_the_bound_parses() {
+    on_big_stack(|| {
+        let e = one_assertion(&parenthesised(
+            openehr_lang::nesting::MAX_NESTING_DEPTH.div_ceil(2),
+        ));
+        let (op, l, r) = binary(&e);
+        assert_eq!(op, "gt");
+        assert!(is_int(l, 1) && is_int(r, 0));
+    });
+}
+
+#[test]
+fn a_not_chain_past_the_bound_is_a_typed_refusal() {
+    let src = format!(
+        "{}$flag",
+        "not ".repeat(openehr_lang::nesting::MAX_NESTING_DEPTH + 1)
+    );
+    let err = parse_statements(&src).expect_err("a unary chain recurses per operator");
+    assert!(
+        matches!(err, BelError::NestingTooDeep { .. }),
+        "got {err:?}"
+    );
+}

--- a/crates/openehr-lang/tests/it/odin_spec_examples.rs
+++ b/crates/openehr-lang/tests/it/odin_spec_examples.rs
@@ -748,3 +748,53 @@ fn ch9_plug_in_blocks_parse() {
     assert!(parse("a = <# no tag #>").is_err());
     assert!(parse("a = (cadl) <# never closed").is_err());
 }
+
+// ── the nesting bound ─────────────────────────────────────────────────────
+
+fn nested_object(levels: usize) -> String {
+    format!("{}\"leaf\"{}", "a = <".repeat(levels), ">".repeat(levels))
+}
+
+#[test]
+fn object_nesting_past_the_bound_is_refused_before_the_parser_recurses() {
+    let err = parse(&nested_object(openehr_lang::nesting::MAX_NESTING_DEPTH + 1))
+        .expect_err("a document nested past the bound is refused, never recursed into");
+    assert_eq!(
+        err.kind,
+        OdinErrorKind::NestingTooDeep(openehr_lang::nesting::MAX_NESTING_DEPTH)
+    );
+    // The refusal points at the block that crossed the bound.
+    assert_eq!(err.line, 1);
+    let err_v1_0 = openehr_lang::v1_0::odin::parse(&nested_object(
+        openehr_lang::nesting::MAX_NESTING_DEPTH + 1,
+    ))
+    .expect_err("the 1.0.0 reader carries the same implementation bound");
+    assert_eq!(
+        err_v1_0.kind,
+        openehr_lang::v1_0::odin::OdinErrorKind::NestingTooDeep(
+            openehr_lang::nesting::MAX_NESTING_DEPTH
+        )
+    );
+}
+
+#[test]
+fn object_nesting_at_the_bound_parses() {
+    // The bound is set for the engine's 256 MiB thread, not the 2 MiB test
+    // thread, so the walk at the bound runs on a thread sized like the engine's.
+    std::thread::Builder::new()
+        .stack_size(256 << 20)
+        .spawn(|| {
+            let doc = parse(&nested_object(openehr_lang::nesting::MAX_NESTING_DEPTH))
+                .expect("a document at the bound parses");
+            let mut depth = 0usize;
+            let mut cur = &doc;
+            while let OdinValue::Object(map) = cur {
+                depth += 1;
+                cur = map.get("a").expect("the single attribute");
+            }
+            assert_eq!(depth, openehr_lang::nesting::MAX_NESTING_DEPTH);
+        })
+        .expect("spawn")
+        .join()
+        .expect("join");
+}

--- a/crates/openehr-query/Cargo.toml
+++ b/crates/openehr-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-query"
-version = "0.0.58"
+version = "0.0.59"
 description = "openEHR QUERY (AQL 1.1.0): hand-written lexer, parser, typed AST and canonical printer from the official grammar (no ANTLR runtime)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-rm"
-version = "0.0.58"
+version = "0.0.59"
 description = "openEHR RM Reference Model, generated from BMM: generations v1_1 (RM 1.1.0) and v1_2 (RM 1.2.0, current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,11 +13,11 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.58" }
+openehr-base = { path = "../openehr-base", version = "0.0.59" }
 # The terminology-backed RM class invariants (`validate::terminology`) resolve
 # openEHR terminology groups + code sets against the vendored TERM 3.1.0 bundle.
 # `openehr-term` itself depends only on `openehr-base`, so this is acyclic.
-openehr-term = { path = "../openehr-term", version = "0.0.58" }
+openehr-term = { path = "../openehr-term", version = "0.0.59" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also backs the untyped `Value` RM representation used by

--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-term"
-version = "0.0.58"
+version = "0.0.59"
 description = "openEHR TERM terminology data model, generated from BMM (generation v3_1 = TERM 3.1.0), plus the embedded official terminology XML bundle"
 edition.workspace = true
 rust-version.workspace = true
@@ -34,7 +34,7 @@ include = [
 ]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.58" }
+openehr-base = { path = "../openehr-base", version = "0.0.59" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -526,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "fraction"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33fee0259ffdc3d7bd64438b6b08437884d4df5700f9cb8a23b079c3958ae578"
+checksum = "e246562084dde8ebbcc943b261c406ce4f68e5032ec28029a251a47d6a295500"
 dependencies = [
  "num",
  "num-bigint",
@@ -1004,9 +1004,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.51.0"
+version = "0.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "152999731bfbe0bb82d561550be73b0c31a9827d6ebe3fe96ad47563703b5328"
+checksum = "93e842fa72fd1e50ca4676a527641c13f5ee0d423ac699bfe1cd2afa3a4fdbac"
 dependencies = [
  "ahash 0.8.12",
  "bytecount",
@@ -1035,18 +1035,18 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.51.0"
+version = "0.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb2e614e1c610e31e947d53156e877340c718e053cfce0dfe9b9ce7beff4d31"
+checksum = "f5d90ea83fa606c96f0b4737ecedf1fa6b624272022edc42039565f8d8af0b78"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "jsonschema-value"
-version = "0.51.0"
+version = "0.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24373bc85409cb935a46af0ffb41294c5372c08cf9b0709913d908154cd10582"
+checksum = "da4ab4cbe58181a117d8c3582844ce20b07184319b51ba6d756596c1c451aebc"
 dependencies = [
  "ahash 0.8.12",
  "bytecount",
@@ -1054,6 +1054,7 @@ dependencies = [
  "num-cmp",
  "num-traits",
  "serde_json",
+ "zmij",
 ]
 
 [[package]]
@@ -1275,7 +1276,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.58"
+version = "0.0.59"
 dependencies = [
  "indexmap",
  "openehr-am",
@@ -1291,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.58"
+version = "0.0.59"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -1301,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.58"
+version = "0.0.59"
 dependencies = [
  "serde",
  "serde_json",
@@ -1311,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.58"
+version = "0.0.59"
 dependencies = [
  "async-trait",
  "axum",
@@ -1336,7 +1337,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.58"
+version = "0.0.59"
 dependencies = [
  "chumsky",
  "indexmap",
@@ -1349,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.58"
+version = "0.0.59"
 dependencies = [
  "chumsky",
  "logos",
@@ -1358,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.58"
+version = "0.0.59"
 dependencies = [
  "openehr-base",
  "openehr-term",
@@ -1373,7 +1374,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.58"
+version = "0.0.59"
 dependencies = [
  "openehr-base",
  "roxmltree",
@@ -1627,9 +1628,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.51.0"
+version = "0.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aff997fc7eecb671a947b0f73f5ce4bcb4ad3534fd5bff2dd752718a8107525"
+checksum = "d38a014525040cdc9893361b7419bcf1f43b7ba7055eabaf6d91d6b75caa8b3f"
 dependencies = [
  "ahash 0.8.12",
  "fluent-uri",


### PR DESCRIPTION
Closes #3062

## What changed

The remaining criterion of #3062 after #3063: a bounded recursion with a typed refusal for a too-deep artefact, so that no ADL 2 upload can abort the process. #3063 moved parsing and validation onto a 256 MiB engine thread, which raised the bar; this PR removes it.

One nesting bound now lives in `openehr_lang::nesting` (`MAX_NESTING_DEPTH` = 512, the `Nesting` counter, a bracket pre-scan for combinator parsers) and every recursive walk in the engine honours it:

- **ODIN readers (both generations):** the token stream is pre-scanned for `<` nesting before the chumsky parser recurses. Refusal: `OdinErrorKind::NestingTooDeep(limit)`.
- **BEL parser:** the counter is threaded through the self-recursive productions (parenthesised and quantified sub-expressions, `not` and sign chains). Refusal: `BelError::NestingTooDeep { at, limit }`, mapped to `SUNK` by the rules parser.
- **cADL parser:** every object enters through one nesting guard. Refusal: `SUNK`, the catalogue's "Syntax error (unknown cause)" bucket (`ADL2/master04.6` §Syntax Validity Rules), with the bound named in the message. No `S*` code describes an implementation bound and the catalogue is a verbatim mirror, so no code was invented.
- **Flattener:** a specialisation lineage longer than the bound is refused before the walk reaches its root (`FlattenError::LineageTooDeep`), and every composed flat form is re-checked (`FlattenError::NestingTooDeep`): each artefact parses within the bound, but a child's differential paths hang its subtree under the parent's deepest node, so the composition can exceed what either artefact carries.
- **OPT transform:** rewritten around a `Transform` context that tracks the inlined depth (a filler continues from the level of the slot it fills; a `use_node` copy re-enters one level deeper) and keeps the chain of archetypes being inlined. Fillers that reference each other were an unguarded infinite recursion; they are now `OptError::CyclicReference(chain)` naming the cycle outermost-first. Depth past the bound is `OptError::NestingTooDeep`.
- **Server:** the three engine calls that still ran on a tokio worker (loading the stored repository, compiling a stored template to its OPT for the two projection routes) now run on the engine thread through `on_engine_stack`; the two OPT projections share one compile path.

## Wire behaviour

- A nested-past-the-bound upload is a `400` naming `SUNK` and the bound (the released `400` branch: "syntactically invalid … content", `ITS-REST/specifications/responses/400.yaml`).
- An OPT projection over a cyclic or over-deep constituent set is a `422` naming the cycle or the bound.

## Tests

- `openehr-lang`: unit tests for the counter and the bracket scan; ODIN refusal at the bound for both generations plus acceptance at exactly the bound; BEL refusal for parentheses and for a `not` chain plus acceptance well within.
- `openehr-adl` (`tests/it/nesting_bounds.rs`): parser refusal as `SUNK`, lineage refusal, composed-flat-form refusal, filler-cycle refusal with the chain asserted, inlined-depth refusal.
- `ferroehr-rest`: the wire `400` for a deep upload, asserting the S-code and the bound in the message.

Tests that walk to the bound spawn a 256 MiB thread: a walk reaches the bound before it refuses, so the caller provides the stack the bound is sized for (documented on the constant; the CDR's engine thread is that stack, a debug build on a default 2 MiB thread overflows first).

## Crates

The eight `openehr-*` crates step to 0.0.59 (lockstep; `fuzz/Cargo.lock` refreshed). `openehr-lang` gains the top-level `nesting` module (auto-declared by the regenerated crate root).

## Gates

`cargo fmt`, the exact workspace clippy lane, the viewer ssr clippy lane, the rustdoc gate, `nextest` for `openehr-lang` + `openehr-adl` (660 tests) and the server's definition suites, the ADL2 HTTP suite (20 tests), comment-style: all green locally. The CNF run follows on this branch before merge.

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.
