### PR TITLE
fix(query): an explicit fetch or AQL LIMIT above the result ceiling is refused, never served

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **An explicit `fetch` or AQL `LIMIT` can no longer ask for a page larger than
+  `query.max_result_rows`** (#3092). The ceiling used to apply only to a query
+  that carried neither bound, so `fetch=10000000` materialised the whole
+  matched set into one `RESULT_SET`. A page above the ceiling is now refused
+  with `400` naming the requested size and the ceiling; the effective page
+  (the smaller of `LIMIT` and `fetch`) is what is checked, and a page at or
+  below the ceiling is served as written. The page is refused rather than
+  shortened because a client paging with its own `fetch` as the stride would
+  silently skip rows.
+
 ## [4.0.18] - 2026-09-03
 
 ### Changed

--- a/app/ferroehr/src/service/query/config.rs
+++ b/app/ferroehr/src/service/query/config.rs
@@ -33,20 +33,22 @@ pub struct QueryConfig {
     /// overrun surfaces as this engine's typed refusal rather than a driver
     /// error.
     pub timeout_ms: u64,
-    /// The largest number of rows a query may return when neither the AQL nor
-    /// the request bounds it; `0` means unbounded.
+    /// The largest page of rows one query execution serves; `0` means
+    /// unbounded.
     ///
-    /// Without this a query carrying no `LIMIT`, called with no `fetch`,
+    /// A query that neither the AQL nor the request bounds takes it as its
+    /// page: without that, a query carrying no `LIMIT`, called with no `fetch`,
     /// generates SQL with no `LIMIT` and materialises every matching row before
     /// the `RESULT_SET` is built — so a one-line request is an unbounded,
     /// caller-chosen allocation (the OWASP Denial of Service Cheat Sheet's
-    /// "input-based resource allocation control").
+    /// "input-based resource allocation control"). A page asked for explicitly,
+    /// by AQL `LIMIT` or the `fetch` parameter, is served as written up to the
+    /// ceiling and refused above it with a `400` naming the ceiling, never
+    /// silently shortened.
     ///
-    /// ITS-REST leaves the `fetch` default to the implementation — query
-    /// `Request.md` §Common Headers and Query Parameters: "the default depends
-    /// on the implementation" — so a default ceiling is spec-permitted. It
-    /// applies ONLY where nothing else bounds the query: an explicit AQL `LIMIT`
-    /// or a `fetch` parameter is honoured as written, up to this ceiling.
+    /// ITS-REST leaves both the `fetch` default and its maximum to the
+    /// implementation — query `Request.md` §Common Headers and Query
+    /// Parameters: "the default depends on the implementation".
     pub max_result_rows: i64,
 }
 

--- a/app/ferroehr/src/service/query/execute.rs
+++ b/app/ferroehr/src/service/query/execute.rs
@@ -143,17 +143,7 @@ impl FerroEhrService {
         record_phase("plan", plan_start);
 
         let (limit, offset) = compose_paging(ir.limit, ir.offset, ir.limit_is_top, request)?;
-        // The ceiling applies ONLY where nothing else bounds the query. An AQL
-        // `LIMIT` or a `fetch` parameter is honoured as written; a query with
-        // neither would otherwise generate SQL with no `LIMIT` and materialise
-        // every matching row before the RESULT_SET is built, which makes one
-        // request an unbounded caller-chosen allocation. ITS-REST leaves the
-        // `fetch` default to the implementation (query `Request.md` §Common
-        // Headers and Query Parameters), so a default ceiling is spec-permitted.
-        let limit = match (limit, self.query_result_ceiling) {
-            (None, Some(ceiling)) => Some(ceiling),
-            (bounded, _) => bounded,
-        };
+        let limit = apply_result_ceiling(limit, self.query_result_ceiling)?;
         // Multi-EHR scoping (`ehr_ids: List<UUID>`): a malformed id is a
         // client precondition (`400`); a well-formed but absent id raises
         // `ehr_id_does_not_exist` (`i_query_service.adoc`).
@@ -405,6 +395,34 @@ fn compose_paging(
         }
     };
     Ok((limit, offset))
+}
+
+/// Apply the configured result-row ceiling to the composed page `limit`.
+///
+/// A query nothing else bounds takes the ceiling as its `LIMIT`: without it
+/// the SQL would carry no `LIMIT` and materialise every matching row before
+/// the `RESULT_SET` is built, one request an unbounded caller-chosen
+/// allocation. A page asked for explicitly, by AQL `LIMIT` or the `fetch`
+/// parameter, is served as written up to the ceiling and REFUSED above it:
+/// a silent clamp would hand a client paging with its own `fetch` as the
+/// stride a shorter page, and the rows between the clamped page and the next
+/// `offset` would vanish with nothing in the `RESULT_SET` to say so. ITS-REST
+/// leaves both the `fetch` default and its maximum to the implementation
+/// (query `Request.md` §Common Headers and Query Parameters), and a refused
+/// page is the released `400` branch ("invalid input … at least one of the
+/// parameters has an invalid syntax", `400_Query`).
+fn apply_result_ceiling(limit: Option<i64>, ceiling: Option<i64>) -> Result<Option<i64>, Failure> {
+    match (limit, ceiling) {
+        (None, Some(ceiling)) => Ok(Some(ceiling)),
+        (Some(asked), Some(ceiling)) if asked > ceiling => {
+            Err(Failure::analysis(SmError::precondition(format!(
+                "the requested page of {asked} rows exceeds the largest page this server \
+                 serves ({ceiling} rows, `query.max_result_rows`); page with `offset` and \
+                 a `fetch` at or below it"
+            ))))
+        }
+        (bounded, _) => Ok(bounded),
+    }
 }
 
 /// The `aql_queries_total{outcome}` label for an [`AqlError`] (spec-silent

--- a/app/ferroehr/tests/it/service_aql.rs
+++ b/app/ferroehr/tests/it/service_aql.rs
@@ -51,6 +51,7 @@ use openehr_rm::prelude::PartyProxy;
 use uuid::Uuid;
 
 use ferroehr::service::FerroEhrService;
+use ferroehr::service::query::config::QueryConfig;
 use ferroehr::service::query::request::AqlQueryRequest;
 use ferroehr::service::status::{CallStatusType, SmError};
 
@@ -2533,5 +2534,81 @@ async fn folder_contains_folder_reaches_items_referenced_versioned_folders() {
         childless,
         vec!["plan-week-1".to_owned()],
         "every non-leaf folder has a union-edge child, so only the leaf survives the anti-join"
+    );
+}
+
+/// `query.max_result_rows` is the largest page one execution serves: a query
+/// nothing bounds takes it as its page, an explicit `fetch` or AQL `LIMIT` at
+/// or below it is served as written, and a page above it is refused as a
+/// precondition (`400`) rather than silently shortened (#3092). ITS-REST leaves
+/// the `fetch` default and maximum to the implementation (query `Request.md`
+/// §Common Headers and Query Parameters).
+#[tokio::test]
+async fn an_explicit_page_above_the_result_ceiling_is_refused() {
+    let db = testkit::db().await.expect("testkit database");
+    let svc = FerroEhrService::new(db.pool()).with_query_config(&QueryConfig {
+        max_result_rows: 2,
+        ..QueryConfig::default()
+    });
+    let ehr_id = create_ehr(&svc).await;
+    for magnitude in [80.0, 90.0, 100.0, 110.0] {
+        create_comp(&svc, &ehr_id, "BP", magnitude).await;
+    }
+    let aql = "SELECT c/uid/value FROM EHR e CONTAINS COMPOSITION c";
+    let scoped = |fetch: Option<i64>| AqlQueryRequest {
+        fetch,
+        ..ehr_scope(&ehr_id)
+    };
+    let refused = |aql: &str, request: AqlQueryRequest| {
+        let aql = aql.to_owned();
+        let svc = &svc;
+        async move {
+            let err = svc
+                .execute_ad_hoc_query(aql, request)
+                .await
+                .expect_err("a page above the ceiling is refused");
+            assert!(
+                matches!(
+                    &err,
+                    SmError {
+                        status: CallStatusType::PreconditionViolation,
+                        message,
+                        ..
+                    } if message.contains("exceeds the largest page") && message.contains("2 rows")
+                ),
+                "got {err:?}"
+            );
+        }
+    };
+
+    // Nothing bounds the query: the ceiling is the page.
+    assert_eq!(rows(&run_aql(&svc, aql, scoped(None)).await).len(), 2);
+    // `fetch` at the ceiling is served as written; above it is refused.
+    assert_eq!(rows(&run_aql(&svc, aql, scoped(Some(2))).await).len(), 2);
+    refused(aql, scoped(Some(3))).await;
+    // AQL `LIMIT` alone: the same rule.
+    assert_eq!(
+        rows(&run_aql(&svc, &format!("{aql} LIMIT 2"), scoped(None)).await).len(),
+        2
+    );
+    refused(&format!("{aql} LIMIT 3"), scoped(None)).await;
+    // `LIMIT` + `fetch`: the effective page (the smaller) is what is checked.
+    assert_eq!(
+        rows(&run_aql(&svc, &format!("{aql} LIMIT 4"), scoped(Some(2))).await).len(),
+        2
+    );
+    assert_eq!(
+        rows(&run_aql(&svc, &format!("{aql} LIMIT 2"), scoped(Some(4))).await).len(),
+        2
+    );
+    refused(&format!("{aql} LIMIT 4"), scoped(Some(3))).await;
+    // `0` means unbounded: the same page is then served whole.
+    let unbounded = FerroEhrService::new(db.pool()).with_query_config(&QueryConfig {
+        max_result_rows: 0,
+        ..QueryConfig::default()
+    });
+    assert_eq!(
+        rows(&run_aql(&unbounded, aql, scoped(Some(1_000))).await).len(),
+        4
     );
 }

--- a/website/book/src/installation/config-integrations.md
+++ b/website/book/src/installation/config-integrations.md
@@ -23,7 +23,7 @@ max_result_rows = 10000
 |---|---|---|---|
 | `plan_cache_capacity` | int | `256` | Maximum distinct cached query plans; `0` disables the cache and every lookup runs the full parse-and-lower path. Cache activity is reported by the `aql_plan_cache_events` counter. |
 | `timeout_ms` | int | `30000` | Per-query database execution budget; `0` disables it. Overrun is refused `408`. |
-| `max_result_rows` | int | `10000` | The result-row ceiling for a query that neither the AQL nor the request bounds; `0` means unbounded. |
+| `max_result_rows` | int | `10000` | The largest page one query execution serves: the page of a query nothing else bounds, and the maximum an explicit `LIMIT` or `fetch` may ask for (a larger page is refused `400`); `0` means unbounded. |
 
 **`timeout_ms` is on by default, and deliberately tighter than
 [`db.statement_timeout_ms`](config-server.md#db).** The HTTP request timeout
@@ -33,12 +33,17 @@ holding pooled connections after their callers had been given up on. Keeping
 this budget the tighter of the two means an overrun surfaces as the engine's own
 typed `408` rather than a driver error.
 
-**`max_result_rows` bounds only the case where nothing else does.** Without it,
+**`max_result_rows` is the largest page one execution serves.** Without it,
 `SELECT c FROM COMPOSITION c` with no `fetch` generates SQL with no `LIMIT` and
-materialises every matching row: one request, unbounded allocation. An explicit
-AQL `LIMIT` or a `fetch` parameter is honoured as written. ITS-REST leaves the
-`fetch` default to the implementation, so a default ceiling is spec-permitted; a
-bulk consumer asks for more explicitly, which is the point.
+materialises every matching row: one request, unbounded allocation. A query that
+nothing else bounds takes the ceiling as its page. An explicit AQL `LIMIT` or a
+`fetch` parameter is honoured as written up to the ceiling; a page larger than the
+ceiling is refused with `400` naming the ceiling. The refusal is deliberate: a
+silently shortened page would let a client that pages with its own `fetch` as the
+stride skip the rows between the shortened page and its next `offset`, and the
+`RESULT_SET` has nothing to say so. ITS-REST leaves both the `fetch` default and
+its maximum to the implementation. A bulk consumer pages with `offset` and a
+`fetch` at or below the ceiling, or the operator raises the ceiling deliberately.
 
 ## `[events]`
 

--- a/website/book/src/querying-aql.md
+++ b/website/book/src/querying-aql.md
@@ -307,13 +307,17 @@ which one you hit:
 | Bound | Where it comes from | Effect |
 |---|---|---|
 | `LIMIT`/`OFFSET`, or `fetch`/`offset` | your query or request | Exactly the window you asked for. |
-| [`query.max_result_rows`](installation/config-integrations.md#query) | server config, default `10000` | The ceiling applied when neither the AQL nor the request bounds the result. `0` means unbounded. |
+| [`query.max_result_rows`](installation/config-integrations.md#query) | server config, default `10000` | The largest page one execution serves: the page of a query nothing else bounds, and the maximum a `LIMIT` or `fetch` may ask for. `0` means unbounded. |
 | [`query.timeout_ms`](installation/config-integrations.md#query) | server config, default `30000` | Per-query database execution budget. **On by default**; `0` disables it. |
 
 A query that exceeds the time budget returns **408 Request Timeout**; narrow it
 (add archetype constraints, an `ehr_id` scope, or a `WHERE` filter) rather than
-retrying it unchanged. A result truncated by the row ceiling is a signal to page
-explicitly with `offset`/`fetch` instead of relying on the default.
+retrying it unchanged. A `LIMIT` or `fetch` larger than the row ceiling returns
+**400 Bad Request** naming the ceiling; the page is never silently shortened,
+because a client paging with its own `fetch` as the stride would skip rows
+without noticing. Page with `offset` and a `fetch` at or below the ceiling. A
+result that stops at the ceiling without either bound set is the default page:
+page explicitly to read past it.
 
 > [!TIP]
 > The more specific your `FROM`/`CONTAINS` (name the archetype, scope by


### PR DESCRIPTION
Closes #3092

## What changed

`query.max_result_rows` used to bound only a query that carried neither an AQL `LIMIT` nor a `fetch` parameter; an explicit page of any size was honoured as written (`app/ferroehr/src/service/query/execute.rs`, the ceiling match after `compose_paging`). The ceiling is now the largest page one execution serves:

- a query nothing bounds still takes the ceiling as its page (unchanged);
- an explicit `fetch` or AQL `LIMIT` at or below the ceiling is served as written;
- a page above the ceiling is refused with `400` (an SM precondition violation) naming the requested size and the ceiling, and pointing at `offset` paging;
- the effective page, the smaller of `LIMIT` and `fetch` after `compose_paging`, is what is checked, so `LIMIT 100000` with `fetch=100` is served;
- `0` keeps its meaning (unbounded).

## The decision: refuse, do not clamp

The issue left the refusal shape open. A silent clamp is a data-loss shape: a client paging with `fetch=N` and `offset=k*N` would receive a shorter page, and the rows between the clamped page and the next `offset` would vanish with nothing in the `RESULT_SET` to say so. The refusal is the released `400` branch (`400_Query`: "invalid input … at least one of the parameters has an invalid syntax"). ITS-REST leaves both the `fetch` default and its maximum to the implementation (query `Request.md` §Common Headers and Query Parameters). No openEHR spec fixes the shape; this is our own design, now pinned.

## Tests

`service_aql::an_explicit_page_above_the_result_ceiling_is_refused` (DB-backed, ceiling of 2 over 4 compositions): the default page, `fetch` at and above, `LIMIT` at and above, `LIMIT` + `fetch` in both orders including the refused combination, and `0` as unbounded.

## Docs

The `max_result_rows` reference row and paragraph (`installation/config-integrations.md`) and the paging section of `querying-aql.md` state the new semantics; the config field's doc comment matches. `CHANGELOG.md` carries the entry.

## Gates

`cargo fmt`, `cargo clippy -p ferroehr --all-targets --all-features -D warnings`, the full `service_aql` suite (29 tests) and the query config unit tests, comment-style, docs-claims: green locally.

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.
