### PR TITLE
feat(config): refuse tenancy.header at boot when authentication is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Added
+
+- **`tenancy.header` is refused at boot when authentication is enabled**
+  (#3093). The header override lets a request name its own tenant and wins
+  over the JWT claim, so on a deployment with real users any authenticated
+  caller could read and write any tenant. The server now refuses to start on
+  that pair, naming the key and the remedy, unless the new
+  `tenancy.insecure_header_override = true` accepts it explicitly for a
+  development deployment. With authentication off, or tenancy off, nothing
+  changes.
+
 ## [4.0.18] - 2026-09-03
 
 ### Changed

--- a/app/ferroehr/assets/ferroehr.default.toml
+++ b/app/ferroehr/assets/ferroehr.default.toml
@@ -264,6 +264,7 @@ enabled = false
 enabled = false
 claim = "tenant"
 #? header = "X-FerroEHR-Tenant"   # dev-only override; never in production
+insecure_header_override = false   # accept `header` with auth.enabled = true (development only)
 
 # ── [smart] — SMART App Launch ────────────────────────────────────────────────
 [smart]

--- a/app/ferroehr/src/config/mod.rs
+++ b/app/ferroehr/src/config/mod.rs
@@ -108,6 +108,7 @@ impl FerroEhrConfig {
         self.validate_system_id(&mut errors);
         self.validate_base_path(&mut errors);
         self.validate_mechanisms(&mut errors);
+        self.validate_tenancy(&mut errors);
         self.validate_signing(&mut errors);
         self.validate_key_sources(&mut errors);
         errors.extend(multimedia_endpoint_errors(&self.multimedia));
@@ -125,6 +126,27 @@ impl FerroEhrConfig {
             Ok(())
         } else {
             Err(ConfigErrors(errors))
+        }
+    }
+
+    /// `tenancy.header` lets a request name its own tenant, and the header wins
+    /// over the JWT claim. With an authentication scheme enabled that is every
+    /// authenticated caller reading and writing every tenant, so the pair is a
+    /// boot error unless `tenancy.insecure_header_override` accepts it by name.
+    /// The rest of the access layer is boot-validated the same way. No openEHR
+    /// spec governs multi-tenancy — our own design.
+    fn validate_tenancy(&self, errors: &mut Vec<ConfigError>) {
+        if self.tenancy.enabled
+            && self.auth.enabled
+            && !self.tenancy.insecure_header_override
+            && let Some(header) = self.tenancy.header.as_deref()
+        {
+            errors.push(ConfigError::semantic(format!(
+                "tenancy.header = {header:?} with auth.enabled = true lets any authenticated \
+                 caller select any tenant by naming it in that request header; unset \
+                 tenancy.header, or set tenancy.insecure_header_override = true on a \
+                 development deployment that accepts exactly that"
+            )));
         }
     }
 
@@ -1528,6 +1550,48 @@ mod tests {
             .validate()
             .expect_err("SMART without [auth.oidc] must refuse");
         assert!(format!("{err:?}").contains("auth.oidc"), "{err:?}");
+    }
+
+    /// `tenancy.header` with authentication on lets any authenticated caller
+    /// select any tenant, so the pair is refused at boot unless the loudly named
+    /// opt-in accepts it; with authentication off, or tenancy off, the header is
+    /// the development convenience it documents.
+    #[test]
+    fn a_tenant_header_with_authentication_is_refused_unless_opted_in() {
+        let tree = |tenancy_on: bool, auth_on: bool, opt_in: bool| FerroEhrConfig {
+            tenancy: server::TenancyConfig {
+                enabled: tenancy_on,
+                header: Some("X-FerroEHR-Tenant".to_owned()),
+                insecure_header_override: opt_in,
+                ..server::TenancyConfig::default()
+            },
+            auth: auth::AuthConfig {
+                enabled: auth_on,
+                ..auth::AuthConfig::default()
+            },
+            ..FerroEhrConfig::default()
+        };
+
+        let err = tree(true, true, false)
+            .validate()
+            .expect_err("a tenant header with authentication on must be refused");
+        let text = format!("{err:?}");
+        assert!(text.contains("tenancy.header"), "{text}");
+        assert!(text.contains("X-FerroEHR-Tenant"), "{text}");
+        assert!(text.contains("tenancy.insecure_header_override"), "{text}");
+
+        assert!(
+            tree(true, true, true).validate().is_ok(),
+            "the opt-in accepts the pair"
+        );
+        assert!(
+            tree(true, false, false).validate().is_ok(),
+            "no authentication: a dev header"
+        );
+        assert!(
+            tree(false, true, false).validate().is_ok(),
+            "tenancy off: the header is inert"
+        );
     }
 
     #[test]

--- a/app/ferroehr/src/config/server.rs
+++ b/app/ferroehr/src/config/server.rs
@@ -441,10 +441,19 @@ pub struct TenancyConfig {
     /// The JWT-claim path carrying the tenant key (a tenant name or uuid). A
     /// dotted path (e.g. `realm_access.tenant`) walks nested claim objects.
     pub claim: String,
-    /// Optional dev-only request-header override for the tenant key. When set
-    /// and present on the request it wins over the JWT claim. Leave unset in
-    /// production (a client-supplied header must not select a tenant).
+    /// Optional development-only request-header override for the tenant key.
+    /// When set and present on the request it wins over the JWT claim, so any
+    /// caller selects any tenant: with authentication enabled, boot refuses it
+    /// unless [`Self::insecure_header_override`] accepts that explicitly.
     pub header: Option<String>,
+    /// Accept `header` together with an enabled authentication scheme.
+    ///
+    /// Off by default. The name says what it grants: on a deployment with real
+    /// users, an authenticated caller can read and write every tenant by naming
+    /// it in a request header, because row-level security follows the tenant
+    /// GUC and the GUC follows this header. Set it only on a development
+    /// deployment that accepts exactly that.
+    pub insecure_header_override: bool,
 }
 
 impl Default for TenancyConfig {
@@ -453,6 +462,7 @@ impl Default for TenancyConfig {
             enabled: false,
             claim: "tenant".to_owned(),
             header: None,
+            insecure_header_override: false,
         }
     }
 }

--- a/deploy/helm/ci/all-features-values.yaml
+++ b/deploy/helm/ci/all-features-values.yaml
@@ -81,6 +81,9 @@ config:
     enabled: true
     claim: realm_access.tenant
     header: X-FerroEHR-Tenant
+    # The all-features fixture turns authentication on too; the server refuses
+    # that pair at boot without this explicit acceptance.
+    insecure_header_override: true
   smart:
     enabled: true
     # Required whenever SMART is on: the launch context's service URLs are

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -362,6 +362,7 @@ data:
       claim = "realm_access.tenant"
       enabled = true
       header = "X-FerroEHR-Tenant"
+      insecure_header_override = true
     
     [terminology]
       api_enabled = true
@@ -710,7 +711,7 @@ spec:
         # secret values. Hashing the ConfigMap template alone missed the last two,
         # so a rotated passphrase or an edited Cedar policy propagated into the
         # volume while every pod kept running on the value it read at startup.
-        checksum/config: f18b54059cda549b283c3597ca0fc1262d7c4a081b9456bc0f5c92562a4958e1
+        checksum/config: 32e6a6263f321cf9c91faca2dab0e819c018923bb8a9ef743407192638db1269
         prometheus.io/scrape: "true"
         prometheus.io/port: "9100"
         prometheus.io/path: "/management/prometheus"

--- a/website/book/src/installation/config-auth.md
+++ b/website/book/src/installation/config-auth.md
@@ -207,7 +207,8 @@ single-tenant deployment is unchanged.
 |---|---|---|---|
 | `enabled` | bool | `false` | Activate the tenant middleware and row-level scoping. |
 | `claim` | string | `tenant` | JWT-claim path carrying the tenant key (a tenant name or uuid). A dotted path walks nested claim objects. |
-| `header` | string | unset | Development-only request-header tenant override; when set and present on the request it wins over the JWT claim. Leave unset in production: a client-supplied header must not select a tenant. |
+| `header` | string | unset | Development-only request-header tenant override; when set and present on the request it wins over the JWT claim. With `auth.enabled = true` the server refuses to boot on this key unless `insecure_header_override` is set: a client-supplied header must not select a tenant on a deployment with real users. |
+| `insecure_header_override` | bool | `false` | Accept `header` together with an enabled authentication scheme. The name says what it grants: any authenticated caller then reads and writes any tenant by naming it in the header. Development deployments only. |
 
 ## `[smart]`
 


### PR DESCRIPTION
Closes #3093

## What changed

`tenancy.header` lets a request name its own tenant, and the header value wins over the JWT claim (`ferroehr-rest::extensions::access::tenant`, the override branch). The key was documented as development-only and nothing refused it at boot. On a deployment with real users any authenticated caller could read and write any tenant, because row-level security follows the tenant GUC and the GUC follows this value.

- **Boot refusal.** `FerroEhrConfig::validate` gains `validate_tenancy`: `tenancy.enabled` + `tenancy.header` + `auth.enabled = true` is a semantic config error naming the key, the header value, and the two remedies (unset the header, or the opt-in). The rest of the access layer is boot-validated the same way rather than degraded at the first request.
- **The loudly named opt-in.** `tenancy.insecure_header_override = true` (default `false`) accepts the pair for a development deployment. The name says what it grants.
- **Unchanged.** Authentication off, or tenancy off, keeps the header as the development convenience it documents. The middleware itself is untouched: the combination can no longer exist at runtime.

No openEHR spec governs multi-tenancy; this is our own design.

## Surfaces

- Config: the field, its `Default`, the annotated template `ferroehr.default.toml`.
- Book: `installation/config-auth.md` `[tenancy]` rows (`header` and the new key).
- Chart: the all-features CI fixture (`deploy/helm/ci/all-features-values.yaml`) turns authentication on and sets the header, so it carries the opt-in with a comment saying why; its golden render is regenerated (`deploy/helm/validate.sh --update`, all render checks pass). `values.yaml` defaults are unchanged, so the generated chart README is unchanged.
- `CHANGELOG.md`.

## Tests

`config::tests::a_tenant_header_with_authentication_is_refused_unless_opted_in`: the refused pair (asserting the key, the header value and the opt-in name appear in the error), the opt-in accepting it, authentication off accepting it, tenancy off accepting it. The template-sync test covers the new key.

## Gates

`cargo fmt`, `cargo clippy -p ferroehr --all-targets --all-features -D warnings`, the config test module (75 tests), comment-style, docs-claims, `deploy/helm/validate.sh`: green locally.

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.
