### PR TITLE
feat(rest): server.swagger_ui is an access level, private by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,22 @@ workflow refuses a tag that has no matching section here.
   `tenancy.insecure_header_override = true` accepts it explicitly for a
   development deployment. With authentication off, or tenancy off, nothing
   changes.
+
+### Changed
+
+- **`server.swagger_ui` is an access level, and the Swagger UI needs a credential
+  by default** (#3094). The key used to be a boolean that mounted the UI and the
+  OpenAPI documents outside the authentication layer, on by default, so an
+  unauthenticated client received the complete operation surface, admin and
+  message groups included. It now takes the management vocabulary `off`,
+  `admin_only`, `private` (any authenticated principal; the new default) or
+  `public`, and the non-public levels sit behind the same access guard the
+  management endpoints use: unauthenticated is `401` with the `WWW-Authenticate`
+  challenge, so a browser prompts for the Basic credential. An existing
+  `swagger_ui = true` or `false` is a boot error naming the new spellings;
+  the hosted sandbox keeps the UI `public` explicitly. The Helm chart default
+  follows (`config.server.swagger_ui: private`).
+
 ### Fixed
 
 - **An explicit `fetch` or AQL `LIMIT` can no longer ask for a page larger than

--- a/app/ferroehr-rest/src/config.rs
+++ b/app/ferroehr-rest/src/config.rs
@@ -50,7 +50,10 @@ mod tests {
         let c = ServerConfig::default();
         assert_eq!(c.base_path, "/ferroehr/rest/openehr/v1");
         assert_eq!(c.max_in_flight, 256);
-        assert!(c.swagger_ui);
+        assert_eq!(
+            c.swagger_ui,
+            ferroehr::config::management::AccessLevel::Private
+        );
         assert!(!c.cors_permissive);
         assert_eq!(c.swagger_ui_path(), "/ferroehr/rest/swagger-ui");
         assert_eq!(

--- a/app/ferroehr-rest/src/extensions/management/mod.rs
+++ b/app/ferroehr-rest/src/extensions/management/mod.rs
@@ -538,16 +538,16 @@ fn recorder_unavailable() -> Response {
 /// The per-endpoint access guard: the shared authenticator plus the required
 /// level for one route.
 #[derive(Clone)]
-struct AccessGuard {
-    authenticator: Arc<Authenticator>,
-    rbac: RbacConfig,
-    level: AccessLevel,
+pub(crate) struct AccessGuard {
+    pub(crate) authenticator: Arc<Authenticator>,
+    pub(crate) rbac: RbacConfig,
+    pub(crate) level: AccessLevel,
 }
 
 /// The access-level middleware: enforce the guard's level, then run the route
 /// (or short-circuit with `401`/`403`/`404`). Installed per-route via the `mk`
-/// closure in [`router`].
-async fn access_middleware(
+/// closure in [`router`], and around the Swagger surface by the main router.
+pub(crate) async fn access_middleware(
     State(guard): State<AccessGuard>,
     req: axum::extract::Request,
     next: Next,

--- a/app/ferroehr-rest/src/extensions/openapi.rs
+++ b/app/ferroehr-rest/src/extensions/openapi.rs
@@ -396,7 +396,7 @@ fn meta_openapi(cfg: &AppConfig) -> utoipa::openapi::OpenApi {
     // These paths exist only when the Swagger surface is mounted, and the
     // generator's documented property is that every path it lists is one the
     // live router mounts.
-    if !cfg.server.swagger_ui {
+    if !cfg.server.swagger_ui.is_mounted() {
         return utoipa::openapi::OpenApiBuilder::new().build();
     }
 

--- a/app/ferroehr-rest/src/router.rs
+++ b/app/ferroehr-rest/src/router.rs
@@ -66,6 +66,7 @@ use crate::extensions::openapi;
 use crate::overview::{error, status};
 use crate::smart;
 use crate::state::AppState;
+use ferroehr::config::management::AccessLevel;
 
 /// Per-request timeout.
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
@@ -137,7 +138,7 @@ pub fn router(state: AppState, authenticator: Arc<Authenticator>) -> Router {
     // installs no layer.
     let api = crate::overload::shed_layer(api, cfg.server.max_in_flight);
 
-    let inner = mount_public_surface(&cfg, api, &rest_root);
+    let inner = mount_public_surface(&cfg, &state, &authenticator, api, &rest_root);
 
     let cors = if cfg.server.cors_permissive {
         CorsLayer::very_permissive()
@@ -370,8 +371,10 @@ async fn align_transport_error_body(response: Response) -> Response {
 /// Mounts the public, pre-auth surface around the API tree: the always-on health
 /// family, the REST-root status surface, the config-gated SMART
 /// `/.well-known/smart-configuration` document (SMART master04 §Service
-/// Discovery; an empty router when SMART is disabled), and the config-gated
-/// Swagger UI plus `OpenAPI` documents.
+/// Discovery; an empty router when SMART is disabled), and the Swagger UI plus
+/// `OpenAPI` documents at the access level `server.swagger_ui` names — `public`
+/// sits beside the health family, `private`/`admin_only` sit behind the same
+/// access guard the management endpoints use, `off` is not mounted.
 ///
 /// No openEHR spec governs this — our own operational surface. The health family
 /// ([`crate::extensions::health`]) is mounted unconditionally and ungated,
@@ -380,6 +383,8 @@ async fn align_transport_error_body(response: Response) -> Response {
 /// layer being able to shed the probe.
 fn mount_public_surface(
     cfg: &crate::config::AppConfig,
+    state: &AppState,
+    authenticator: &Arc<Authenticator>,
     api: Router<AppState>,
     rest_root: &str,
 ) -> Router<AppState> {
@@ -392,8 +397,19 @@ fn mount_public_surface(
         .merge(status::router(rest_root))
         .merge(discovery);
 
-    if cfg.server.swagger_ui {
-        inner = inner.merge(openapi::swagger_router(cfg));
+    match cfg.server.swagger_ui {
+        AccessLevel::Off => {}
+        AccessLevel::Public => inner = inner.merge(openapi::swagger_router(cfg)),
+        level @ (AccessLevel::Private | AccessLevel::AdminOnly) => {
+            inner = inner.merge(openapi::swagger_router(cfg).layer(from_fn_with_state(
+                management::AccessGuard {
+                    authenticator: Arc::clone(authenticator),
+                    rbac: management_rbac(state),
+                    level,
+                },
+                management::access_middleware,
+            )));
+        }
     }
     inner
 }

--- a/app/ferroehr-rest/tests/it/abac_e2e.rs
+++ b/app/ferroehr-rest/tests/it/abac_e2e.rs
@@ -120,7 +120,7 @@ impl PolicyEngine for PermitAll {
 fn rest_config() -> AppConfig {
     AppConfig {
         server: ServerConfig {
-            swagger_ui: false,
+            swagger_ui: ferroehr::config::management::AccessLevel::Off,
             ..Default::default()
         },
         auth: common::hs256_auth_config(ISSUER, AUDIENCE, HMAC_SECRET),

--- a/app/ferroehr-rest/tests/it/audit_e2e.rs
+++ b/app/ferroehr-rest/tests/it/audit_e2e.rs
@@ -129,7 +129,7 @@ fn auth_on() -> AuthConfig {
 fn rest_config() -> AppConfig {
     AppConfig {
         server: ServerConfig {
-            swagger_ui: false,
+            swagger_ui: ferroehr::config::management::AccessLevel::Off,
             ..Default::default()
         },
         auth: auth_on(),
@@ -140,7 +140,7 @@ fn rest_config() -> AppConfig {
 fn auth_off_config() -> AppConfig {
     AppConfig {
         server: ServerConfig {
-            swagger_ui: false,
+            swagger_ui: ferroehr::config::management::AccessLevel::Off,
             ..Default::default()
         },
         auth: AuthConfig {

--- a/app/ferroehr-rest/tests/it/authz_route_matrix.rs
+++ b/app/ferroehr-rest/tests/it/authz_route_matrix.rs
@@ -44,6 +44,7 @@ use std::sync::Arc;
 use axum::Router;
 use axum::body::Body;
 use ferroehr::config::authz::AuthzConfig;
+use ferroehr::config::management::AccessLevel;
 use ferroehr::config::server::{AdminConfig, ServerConfig};
 use ferroehr::config::smart::SmartConfig;
 use ferroehr_rest::config::AppConfig;
@@ -438,7 +439,7 @@ fn matrix_config() -> AppConfig {
             // ON: the PUBLIC table declares the OAS/Swagger routes, and they are
             // mounted only when this is set — with it off the coverage assertion
             // reports them as declared-but-unmounted.
-            swagger_ui: true,
+            swagger_ui: AccessLevel::Public,
             ..Default::default()
         },
         auth: common::hs256_auth_config(ISSUER, AUDIENCE, HMAC_SECRET),
@@ -738,5 +739,77 @@ async fn the_public_family_needs_no_credential_and_the_gated_surface_does() {
         gated.status,
         StatusCode::UNAUTHORIZED,
         "an unauthenticated read of a gated route must be 401"
+    );
+}
+
+/// `server.swagger_ui` is an access level over the Swagger UI and the OpenAPI
+/// documents (#3094): `private` needs a credential (`401` with the server's
+/// `WWW-Authenticate` challenge for an anonymous request, so a browser prompts),
+/// `admin_only` needs the admin role (`403` for a role-less principal), `off`
+/// mounts nothing (`404`). No openEHR spec governs the documentation surface —
+/// our own design.
+#[tokio::test]
+async fn the_swagger_surface_honours_its_access_level() {
+    async fn app_at(level: AccessLevel) -> (testkit::TestDb, Router) {
+        let (pg, pool) = common::migrated_pool().await;
+        let cfg = AppConfig {
+            server: ServerConfig {
+                swagger_ui: level,
+                ..Default::default()
+            },
+            ..matrix_config()
+        };
+        let app = ferroehr_rest::build_full(
+            cfg,
+            Arc::new(ferroehr::service::FerroEhrService::new(pool)),
+            authz(),
+            ferroehr_rest::extensions::management::Observability::default(),
+        )
+        .expect("build app");
+        (pg, app)
+    }
+    let ui = "/ferroehr/rest/swagger-ui";
+    let doc = "/ferroehr/rest/api-docs/openapi.json";
+
+    let (_pg, app) = app_at(AccessLevel::Private).await;
+    for path in [ui, doc] {
+        assert_eq!(
+            probe(&app, "GET", path, None).await.status,
+            StatusCode::UNAUTHORIZED,
+            "{path} needs a credential under `private`"
+        );
+        let authed = probe(&app, "GET", path, Some(&[])).await.status;
+        assert!(
+            authed.is_success() || authed.is_redirection(),
+            "{path} is served to any authenticated principal under `private`, got {authed}"
+        );
+    }
+    let anonymous = app
+        .clone()
+        .oneshot(Request::get(ui).body(Body::empty()).expect("request"))
+        .await
+        .expect("oneshot");
+    assert!(
+        anonymous.headers().contains_key("www-authenticate"),
+        "the refusal carries the challenge a browser answers"
+    );
+
+    let (_pg, app) = app_at(AccessLevel::AdminOnly).await;
+    assert_eq!(
+        probe(&app, "GET", ui, Some(&[])).await.status,
+        StatusCode::FORBIDDEN,
+        "a role-less principal is refused under `admin_only`"
+    );
+    assert_eq!(
+        probe(&app, "GET", ui, Some(&["ADMIN"])).await.status,
+        StatusCode::TEMPORARY_REDIRECT,
+        "the admin role reaches the UI under `admin_only`"
+    );
+
+    let (_pg, app) = app_at(AccessLevel::Off).await;
+    assert_eq!(
+        probe(&app, "GET", ui, None).await.status,
+        StatusCode::NOT_FOUND,
+        "`off` mounts nothing"
     );
 }

--- a/app/ferroehr-rest/tests/it/base_path_http.rs
+++ b/app/ferroehr-rest/tests/it/base_path_http.rs
@@ -41,7 +41,7 @@ async fn short_base_router() -> (testkit::TestDb, Router) {
             bind: "127.0.0.1:0".to_owned(),
             base_path: SHORT_BASE.to_owned(),
             max_in_flight: 1024,
-            swagger_ui: true,
+            swagger_ui: ferroehr::config::management::AccessLevel::Public,
             cors_permissive: false,
             ..Default::default()
         },

--- a/app/ferroehr-rest/tests/it/common/mod.rs
+++ b/app/ferroehr-rest/tests/it/common/mod.rs
@@ -89,7 +89,7 @@ pub(crate) fn api_config(admin_enabled: bool) -> AppConfig {
             bind: "127.0.0.1:0".to_owned(),
             base_path: BASE.to_owned(),
             max_in_flight: 1024,
-            swagger_ui: false,
+            swagger_ui: ferroehr::config::management::AccessLevel::Off,
             cors_permissive: false,
             ..Default::default()
         },

--- a/app/ferroehr-rest/tests/it/definition_adl2_http.rs
+++ b/app/ferroehr-rest/tests/it/definition_adl2_http.rs
@@ -73,7 +73,7 @@ fn config() -> AppConfig {
             bind: "127.0.0.1:0".to_owned(),
             base_path: BASE.to_owned(),
             max_in_flight: 1024,
-            swagger_ui: false,
+            swagger_ui: ferroehr::config::management::AccessLevel::Off,
             cors_permissive: false,
             ..Default::default()
         },

--- a/app/ferroehr-rest/tests/it/demographic_http.rs
+++ b/app/ferroehr-rest/tests/it/demographic_http.rs
@@ -115,7 +115,7 @@ fn config() -> AppConfig {
             bind: "127.0.0.1:0".to_owned(),
             base_path: BASE.to_owned(),
             max_in_flight: 1024,
-            swagger_ui: false,
+            swagger_ui: ferroehr::config::management::AccessLevel::Off,
             cors_permissive: false,
             ..Default::default()
         },

--- a/app/ferroehr-rest/tests/it/demographic_tags_http.rs
+++ b/app/ferroehr-rest/tests/it/demographic_tags_http.rs
@@ -70,7 +70,7 @@ fn config() -> AppConfig {
             bind: "127.0.0.1:0".to_owned(),
             base_path: BASE.to_owned(),
             max_in_flight: 1024,
-            swagger_ui: false,
+            swagger_ui: ferroehr::config::management::AccessLevel::Off,
             cors_permissive: false,
             ..Default::default()
         },

--- a/app/ferroehr-rest/tests/it/ehr_access_gate.rs
+++ b/app/ferroehr-rest/tests/it/ehr_access_gate.rs
@@ -75,7 +75,7 @@ fn user(name: &str, roles: &[&str]) -> BasicUser {
 fn rest_config(auth_enabled: bool) -> AppConfig {
     AppConfig {
         server: ServerConfig {
-            swagger_ui: false,
+            swagger_ui: ferroehr::config::management::AccessLevel::Off,
             ..Default::default()
         },
         auth: AuthConfig {

--- a/app/ferroehr-rest/tests/it/event_subscription_http.rs
+++ b/app/ferroehr-rest/tests/it/event_subscription_http.rs
@@ -43,7 +43,7 @@ fn config(enabled: bool) -> AppConfig {
             bind: "127.0.0.1:0".to_owned(),
             base_path: BASE.to_owned(),
             max_in_flight: 1024,
-            swagger_ui: false,
+            swagger_ui: ferroehr::config::management::AccessLevel::Off,
             cors_permissive: false,
             ..Default::default()
         },

--- a/app/ferroehr-rest/tests/it/example_http.rs
+++ b/app/ferroehr-rest/tests/it/example_http.rs
@@ -63,7 +63,7 @@ fn config() -> AppConfig {
             bind: "127.0.0.1:0".to_owned(),
             base_path: BASE.to_owned(),
             max_in_flight: 1024,
-            swagger_ui: false,
+            swagger_ui: ferroehr::config::management::AccessLevel::Off,
             cors_permissive: false,
             ..Default::default()
         },

--- a/app/ferroehr-rest/tests/it/extensions_openapi.rs
+++ b/app/ferroehr-rest/tests/it/extensions_openapi.rs
@@ -526,7 +526,7 @@ fn log_reload() -> LogReload {
 fn app_config() -> AppConfig {
     AppConfig {
         server: ServerConfig {
-            swagger_ui: true,
+            swagger_ui: AccessLevel::Public,
             ..Default::default()
         },
         auth: AuthConfig {

--- a/app/ferroehr-rest/tests/it/fhir_http.rs
+++ b/app/ferroehr-rest/tests/it/fhir_http.rs
@@ -56,7 +56,7 @@ fn config(enabled: bool) -> AppConfig {
             bind: "127.0.0.1:0".to_owned(),
             base_path: BASE.to_owned(),
             max_in_flight: 1024,
-            swagger_ui: false,
+            swagger_ui: ferroehr::config::management::AccessLevel::Off,
             cors_permissive: false,
             ..Default::default()
         },

--- a/app/ferroehr-rest/tests/it/fhir_inbound.rs
+++ b/app/ferroehr-rest/tests/it/fhir_inbound.rs
@@ -60,7 +60,7 @@ fn config(fhir_enabled: bool) -> AppConfig {
     AppConfig {
         server: ServerConfig {
             base_path: BASE.to_owned(),
-            swagger_ui: false,
+            swagger_ui: ferroehr::config::management::AccessLevel::Off,
             ..ServerConfig::default()
         },
         auth: AuthConfig {

--- a/app/ferroehr-rest/tests/it/flat_http.rs
+++ b/app/ferroehr-rest/tests/it/flat_http.rs
@@ -89,7 +89,7 @@ fn config() -> AppConfig {
             bind: "127.0.0.1:0".to_owned(),
             base_path: BASE.to_owned(),
             max_in_flight: 1024,
-            swagger_ui: false,
+            swagger_ui: ferroehr::config::management::AccessLevel::Off,
             cors_permissive: false,
             ..Default::default()
         },

--- a/app/ferroehr-rest/tests/it/http.rs
+++ b/app/ferroehr-rest/tests/it/http.rs
@@ -64,7 +64,7 @@ fn config(enabled: bool) -> AppConfig {
             bind: "127.0.0.1:0".to_owned(),
             base_path: BASE.to_owned(),
             max_in_flight: 1024,
-            swagger_ui: false,
+            swagger_ui: ferroehr::config::management::AccessLevel::Off,
             cors_permissive: false,
             ..Default::default()
         },
@@ -881,7 +881,7 @@ async fn every_response_carries_the_security_headers() {
 async fn app_with_swagger() -> (testkit::TestDb, Router) {
     let (pg, service) = common::test_service().await;
     let mut cfg = config(false);
-    cfg.server.swagger_ui = true;
+    cfg.server.swagger_ui = ferroehr::config::management::AccessLevel::Public;
     (pg, common::router_with(cfg, service))
 }
 
@@ -1220,7 +1220,7 @@ async fn subject_lookup_by_query_parameter_still_answers() {
 async fn the_served_document_omits_paths_whose_features_are_off() {
     let (pg, service) = common::test_service().await;
     let mut cfg = config(false);
-    cfg.server.swagger_ui = false;
+    cfg.server.swagger_ui = ferroehr::config::management::AccessLevel::Off;
     cfg.smart.enabled = false;
     let app = common::router_with(cfg, service);
     let _keep = pg;

--- a/app/ferroehr-rest/tests/it/management.rs
+++ b/app/ferroehr-rest/tests/it/management.rs
@@ -69,7 +69,7 @@ fn auth_config(roles: &[&str]) -> AuthConfig {
 fn base_config(auth: AuthConfig) -> AppConfig {
     AppConfig {
         server: ServerConfig {
-            swagger_ui: false,
+            swagger_ui: AccessLevel::Off,
             ..Default::default()
         },
         auth,

--- a/app/ferroehr-rest/tests/it/overload_http.rs
+++ b/app/ferroehr-rest/tests/it/overload_http.rs
@@ -61,7 +61,7 @@ fn config(max_in_flight: usize) -> AppConfig {
             bind: "127.0.0.1:0".to_owned(),
             base_path: BASE.to_owned(),
             max_in_flight,
-            swagger_ui: false,
+            swagger_ui: ferroehr::config::management::AccessLevel::Off,
             ..Default::default()
         },
         auth: AuthConfig {

--- a/app/ferroehr-rest/tests/it/protocol_tail.rs
+++ b/app/ferroehr-rest/tests/it/protocol_tail.rs
@@ -71,7 +71,7 @@ fn config() -> AppConfig {
             bind: "127.0.0.1:0".to_owned(),
             base_path: BASE.to_owned(),
             max_in_flight: 1024,
-            swagger_ui: false,
+            swagger_ui: ferroehr::config::management::AccessLevel::Off,
             cors_permissive: false,
             ..Default::default()
         },

--- a/app/ferroehr-rest/tests/it/query_ehr_id_header.rs
+++ b/app/ferroehr-rest/tests/it/query_ehr_id_header.rs
@@ -86,7 +86,7 @@ fn config() -> AppConfig {
             bind: "127.0.0.1:0".to_owned(),
             base_path: BASE.to_owned(),
             max_in_flight: 1024,
-            swagger_ui: false,
+            swagger_ui: ferroehr::config::management::AccessLevel::Off,
             cors_permissive: false,
             ..Default::default()
         },

--- a/app/ferroehr-rest/tests/it/rbac_e2e.rs
+++ b/app/ferroehr-rest/tests/it/rbac_e2e.rs
@@ -79,7 +79,7 @@ fn user(name: &str, roles: &[&str]) -> BasicUser {
 fn rest_config() -> AppConfig {
     AppConfig {
         server: ServerConfig {
-            swagger_ui: false,
+            swagger_ui: ferroehr::config::management::AccessLevel::Off,
             ..Default::default()
         },
         auth: AuthConfig {

--- a/app/ferroehr-rest/tests/it/smart_http.rs
+++ b/app/ferroehr-rest/tests/it/smart_http.rs
@@ -37,7 +37,7 @@ fn config(smart_enabled: bool, fail_closed: bool) -> AppConfig {
             bind: "127.0.0.1:0".to_owned(),
             base_path: BASE.to_owned(),
             max_in_flight: 1024,
-            swagger_ui: false,
+            swagger_ui: ferroehr::config::management::AccessLevel::Off,
             cors_permissive: false,
             ..Default::default()
         },

--- a/app/ferroehr-rest/tests/it/stored_query_definition_http.rs
+++ b/app/ferroehr-rest/tests/it/stored_query_definition_http.rs
@@ -39,7 +39,7 @@ fn config() -> AppConfig {
             bind: "127.0.0.1:0".to_owned(),
             base_path: BASE.to_owned(),
             max_in_flight: 1024,
-            swagger_ui: false,
+            swagger_ui: ferroehr::config::management::AccessLevel::Off,
             cors_permissive: false,
             ..Default::default()
         },

--- a/app/ferroehr-rest/tests/it/template_adl14_http.rs
+++ b/app/ferroehr-rest/tests/it/template_adl14_http.rs
@@ -60,7 +60,7 @@ fn config() -> AppConfig {
             bind: "127.0.0.1:0".to_owned(),
             base_path: BASE.to_owned(),
             max_in_flight: 1024,
-            swagger_ui: false,
+            swagger_ui: ferroehr::config::management::AccessLevel::Off,
             cors_permissive: false,
             ..Default::default()
         },

--- a/app/ferroehr-rest/tests/it/tenant_http.rs
+++ b/app/ferroehr-rest/tests/it/tenant_http.rs
@@ -44,7 +44,7 @@ fn config(enabled: bool) -> AppConfig {
     AppConfig {
         server: ServerConfig {
             base_path: BASE.to_owned(),
-            swagger_ui: false,
+            swagger_ui: ferroehr::config::management::AccessLevel::Off,
             ..Default::default()
         },
         auth: AuthConfig {

--- a/app/ferroehr-rest/tests/it/terminology_http.rs
+++ b/app/ferroehr-rest/tests/it/terminology_http.rs
@@ -54,7 +54,7 @@ fn config(terminology_enabled: bool) -> AppConfig {
             bind: "127.0.0.1:0".to_owned(),
             base_path: BASE.to_owned(),
             max_in_flight: 1024,
-            swagger_ui: false,
+            swagger_ui: ferroehr::config::management::AccessLevel::Off,
             cors_permissive: false,
             ..Default::default()
         },

--- a/app/ferroehr/assets/ferroehr.default.toml
+++ b/app/ferroehr/assets/ferroehr.default.toml
@@ -35,7 +35,7 @@ bind = "0.0.0.0:8080"
 # the first segment must be /ferroehr and the last must be v1.
 base_path = "/ferroehr/rest/openehr/v1"
 max_in_flight = 256          # concurrent-request admission cap; 0 disables shedding
-swagger_ui = true            # PROD: consider false
+swagger_ui = "private"       # off | admin_only | private | public — "public" discloses the whole operation surface anonymously
 cors_permissive = false      # PROD: keep false; configure explicit origins
 # This CDR's own openEHR system identifier: stamped into EHR.system_id, the
 # AUDIT_DETAILS.system_id server default, and every

--- a/app/ferroehr/src/config/server.rs
+++ b/app/ferroehr/src/config/server.rs
@@ -22,6 +22,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::config::management::AccessLevel;
+
 /// The `[server]` section — the HTTP listener and REST surface.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
@@ -36,9 +38,13 @@ pub struct ServerConfig {
     /// limited. No openEHR spec governs server overload — our own design
     /// (RFC 9110 §15.6.4).
     pub max_in_flight: usize,
-    /// Serve the Swagger UI + the `OpenAPI` JSON at the REST root. Consider
-    /// `false` in production.
-    pub swagger_ui: bool,
+    /// Who may read the Swagger UI and the `OpenAPI` documents at the REST
+    /// root: `off` (not mounted), `admin_only`, `private` (any authenticated
+    /// principal; the default) or `public`. The documents list the whole
+    /// enabled operation surface, admin and message groups included, so
+    /// `public` discloses it to anyone who can reach the port. The same
+    /// vocabulary the management endpoints use.
+    pub swagger_ui: AccessLevel,
     /// Permissive CORS (dev only). Production configures explicit origins.
     pub cors_permissive: bool,
     /// This CDR's own openEHR **system identifier** — the identity the
@@ -371,7 +377,7 @@ impl Default for ServerConfig {
             // in-flight clinical commits) while still permitting ~10k req/s at
             // 25 ms latency (throughput = in-flight / latency, Little's law).
             max_in_flight: 256,
-            swagger_ui: true,
+            swagger_ui: AccessLevel::Private,
             cors_permissive: false,
             // The service layer's own default, so an unset `[server] system_id`
             // boots exactly as the service does.

--- a/deploy/helm/ci/all-features-values.yaml
+++ b/deploy/helm/ci/all-features-values.yaml
@@ -33,7 +33,7 @@ config:
   server:
     bind: "0.0.0.0:8080"
     base_path: /ferroehr/rest/openehr/v1
-    swagger_ui: true
+    swagger_ui: public
     cors_permissive: false
   db:
     max_connections: 10

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # A published OCI version is immutable by refusal rather than by the registry —
 # `helm push` over an existing tag replaces it silently — so a correction always
 # ships as a NEW version and the published one stands as it was.
-version: 7.0.6
+version: 7.0.7
 # The DEFAULT container image tag (overridable via image.tag). Equals the
 # workspace version in Cargo.toml, bumped in the release PR beside the
 # docker-compose.yml image tags — one version sweep, the compose treatment

--- a/deploy/helm/ferroehr/README.md
+++ b/deploy/helm/ferroehr/README.md
@@ -212,7 +212,7 @@ Kubernetes: `>=1.36.0-0`
 | config.server.rate_limit.enabled | bool | `true` |  |
 | config.server.rate_limit.principal_burst | int | `2048` |  |
 | config.server.rate_limit.principal_per_second | int | `1024` |  |
-| config.server.swagger_ui | bool | `true` |  |
+| config.server.swagger_ui | string | `"private"` |  |
 | config.signing.enabled | bool | `true` |  |
 | config.signing.mode | string | `"digest"` |  |
 | config.signing.verify_on_read | string | `"strict"` |  |

--- a/deploy/helm/ferroehr/README.md
+++ b/deploy/helm/ferroehr/README.md
@@ -2,7 +2,7 @@
 
 Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.1.0 + AQL 1.1). A single static binary deployed with a hardened-by-default security posture: runs as a non-root, read-only-rootfs workload whose NetworkPolicy admits its serving port only, and that connects to an EXTERNAL PostgreSQL 18 as an unprivileged app role (migrations are run out of band by a separate migrator role).
 
-![Version: 7.0.6](https://img.shields.io/badge/Version-7.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.18](https://img.shields.io/badge/AppVersion-4.0.18-informational?style=flat-square)
+![Version: 7.0.7](https://img.shields.io/badge/Version-7.0.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.18](https://img.shields.io/badge/AppVersion-4.0.18-informational?style=flat-square)
 
 FerroEHR is a pure-Rust openEHR Clinical Data Repository: ITS-REST 1.1.0 at the
 API, AQL 1.1 as the query language, PostgreSQL 18-native storage, shipped as a
@@ -33,7 +33,7 @@ to add; `helm repo add` does not apply to this chart:
 
 ```console
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 7.0.6 \
+  --version 7.0.7 \
   --namespace ferroehr --create-namespace \
   --set database.existingSecret=ferroehr-db \
   --set image.tag=4.0.18
@@ -47,7 +47,7 @@ They are independent SemVer lines and they move independently:
 
 | What | Set with | This release |
 |---|---|---|
-| the **chart** (templates, defaults, this document) | `--version` | `7.0.6` |
+| the **chart** (templates, defaults, this document) | `--version` | `7.0.7` |
 | the **server image** | `image.tag` | `4.0.18` |
 
 `appVersion` is the image the chart defaults to; pinning `image.tag` explicitly
@@ -59,7 +59,7 @@ The chart carries two keyless Sigstore artifacts, and they answer different
 questions. A **cosign signature:** who signed this:
 
 ```console
-cosign verify ghcr.io/rubentalstra/charts/ferroehr:7.0.6 \
+cosign verify ghcr.io/rubentalstra/charts/ferroehr:7.0.7 \
   --certificate-identity-regexp '^https://github\.com/rubentalstra/FerroEHR/\.github/workflows/publish-chart\.yml@' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
@@ -67,7 +67,7 @@ cosign verify ghcr.io/rubentalstra/charts/ferroehr:7.0.6 \
 A **SLSA build provenance attestation:** what source it was built from, and how:
 
 ```console
-gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:7.0.6 \
+gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:7.0.7 \
   -R rubentalstra/FerroEHR
 gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:4.0.18 \
   -R rubentalstra/FerroEHR

--- a/deploy/helm/ferroehr/values.yaml
+++ b/deploy/helm/ferroehr/values.yaml
@@ -292,8 +292,10 @@ config:
   server:
     bind: "0.0.0.0:8080"
     base_path: /ferroehr/rest/openehr/v1
-    # Serve Swagger UI + the OpenAPI JSON. Consider false in production.
-    swagger_ui: true
+    # Who may read the Swagger UI + the OpenAPI JSON: off, admin_only, private
+    # (any authenticated principal) or public. The documents list the whole
+    # enabled operation surface, so public discloses it anonymously.
+    swagger_ui: private
     # Permissive CORS — DEV ONLY. Production configures explicit origins.
     cors_permissive: false
     # [server.limits] — the largest accepted request body per route family.

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -307,7 +307,7 @@ data:
       base_path = "/ferroehr/rest/openehr/v1"
       bind = "0.0.0.0:8080"
       cors_permissive = false
-      swagger_ui = true
+      swagger_ui = "public"
       [server.connection]
         header_read_timeout_secs = 10.0
         http2_keep_alive_interval_secs = 30.0
@@ -711,7 +711,7 @@ spec:
         # secret values. Hashing the ConfigMap template alone missed the last two,
         # so a rotated passphrase or an edited Cedar policy propagated into the
         # volume while every pod kept running on the value it read at startup.
-        checksum/config: 32e6a6263f321cf9c91faca2dab0e819c018923bb8a9ef743407192638db1269
+        checksum/config: 5c705d3dba9f0ba88c7bed60c774c3eaf73bd249afbb7cedc944d32fcef1e420
         prometheus.io/scrape: "true"
         prometheus.io/port: "9100"
         prometheus.io/path: "/management/prometheus"

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), and only from the networkPolicy.ingressFrom peers.
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -97,7 +97,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -118,7 +118,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -150,7 +150,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -176,7 +176,7 @@ kind: Secret
 metadata:
   name: ferroehr-config
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -197,7 +197,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -402,7 +402,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr-grafana-dashboard
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -653,7 +653,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -687,7 +687,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -920,7 +920,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -954,7 +954,7 @@ kind: Ingress
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -992,7 +992,7 @@ kind: ServiceMonitor
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"

--- a/deploy/helm/golden/basic-auth.yaml
+++ b/deploy/helm/golden/basic-auth.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -51,7 +51,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -72,7 +72,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -102,7 +102,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -119,7 +119,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -247,7 +247,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -277,7 +277,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"

--- a/deploy/helm/golden/basic-auth.yaml
+++ b/deploy/helm/golden/basic-auth.yaml
@@ -208,7 +208,7 @@ data:
       base_path = "/ferroehr/rest/openehr/v1"
       bind = "0.0.0.0:8080"
       cors_permissive = false
-      swagger_ui = true
+      swagger_ui = "private"
       [server.connection]
         header_read_timeout_secs = 10.0
         http2_keep_alive_interval_secs = 30.0
@@ -302,7 +302,7 @@ spec:
         # secret values. Hashing the ConfigMap template alone missed the last two,
         # so a rotated passphrase or an edited Cedar policy propagated into the
         # volume while every pod kept running on the value it read at startup.
-        checksum/config: 9f7825f9e384ed704dfb70f4c080135ed3f0f1711849db0e0c8dae5644089559
+        checksum/config: 8eac5e0a787f90f460619ced75c95b9757895a17eb5c75d784c5b9bbab5f4113
       labels:
         app.kubernetes.io/name: ferroehr
         app.kubernetes.io/instance: ferroehr

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -173,7 +173,7 @@ data:
       base_path = "/ferroehr/rest/openehr/v1"
       bind = "0.0.0.0:8080"
       cors_permissive = false
-      swagger_ui = true
+      swagger_ui = "private"
       [server.connection]
         header_read_timeout_secs = 10.0
         http2_keep_alive_interval_secs = 30.0
@@ -267,7 +267,7 @@ spec:
         # secret values. Hashing the ConfigMap template alone missed the last two,
         # so a rotated passphrase or an edited Cedar policy propagated into the
         # volume while every pod kept running on the value it read at startup.
-        checksum/config: bdf8127c9fca1fa72f3584043c96cc239403d54c51ee39b9782cdfcf944703c4
+        checksum/config: 46f3813ef5bf7a4507324531500c8aa64c86662467f464c00ae71f977fb5655e
       labels:
         app.kubernetes.io/name: ferroehr
         app.kubernetes.io/instance: ferroehr

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -51,7 +51,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -72,7 +72,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -87,7 +87,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -212,7 +212,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -242,7 +242,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"

--- a/deploy/helm/golden/viewer.yaml
+++ b/deploy/helm/golden/viewer.yaml
@@ -290,7 +290,7 @@ data:
       base_path = "/ferroehr/rest/openehr/v1"
       bind = "0.0.0.0:8080"
       cors_permissive = false
-      swagger_ui = true
+      swagger_ui = "private"
       [server.connection]
         header_read_timeout_secs = 10.0
         http2_keep_alive_interval_secs = 30.0
@@ -410,7 +410,7 @@ spec:
         # secret values. Hashing the ConfigMap template alone missed the last two,
         # so a rotated passphrase or an edited Cedar policy propagated into the
         # volume while every pod kept running on the value it read at startup.
-        checksum/config: 3ed2ca67998d454ccfab2d584d9977ec667edf296007f95eb35106ec324b59e4
+        checksum/config: 888bfa22d2e3938161363568881385a22e5fb55dbe200a7e42cda7731a6b2746
       labels:
         app.kubernetes.io/name: ferroehr
         app.kubernetes.io/instance: ferroehr

--- a/deploy/helm/golden/viewer.yaml
+++ b/deploy/helm/golden/viewer.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -61,7 +61,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the viewer: only its HTTP port, but from EVERY source — this policy narrows ports, NOT sources (viewer.networkPolicy.ingressAllowAll=true). Set viewer.networkPolicy.ingressFrom for a PHI workload. Egress admits the CDR Service and DNS only.
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr-viewer
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -118,7 +118,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -139,7 +139,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -154,7 +154,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr-viewer
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr-viewer
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -184,7 +184,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -201,7 +201,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -329,7 +329,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -359,7 +359,7 @@ metadata:
     kubernetes.io/description: >-
       In-cluster address for the FerroEHR Viewer. The viewer is a REST client of the CDR and holds no data of its own; it is the human-facing surface, so this is the Service an Ingress normally publishes.
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr-viewer
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -385,7 +385,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"
@@ -581,7 +581,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR Viewer: a Leptos SSR web UI that consumes the CDR strictly over ITS-REST. It never reaches the database, which the viewer NetworkPolicy enforces rather than assumes.
   labels:
-    helm.sh/chart: ferroehr-7.0.6
+    helm.sh/chart: ferroehr-7.0.7
     app.kubernetes.io/name: ferroehr-viewer
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.0.18"

--- a/deploy/hosted/ferroehr.sandbox.toml
+++ b/deploy/hosted/ferroehr.sandbox.toml
@@ -19,6 +19,9 @@
 bind = "0.0.0.0:8080"
 # Browser tinkering against the demo is the point.
 cors_permissive = true
+# The public API reference the documentation links to; the default asks for the
+# API credential.
+swagger_ui = "public"
 
 [auth]
 enabled = true

--- a/website/book/src/getting-started.md
+++ b/website/book/src/getting-started.md
@@ -55,7 +55,9 @@ curl http://localhost:8080/ferroehr/rest/status
 It answers a small JSON document: `status`, `server_version`,
 `openehr_rest_api_version` and a `timestamp`. All clinical API routes live under
 the base path `/ferroehr/rest/openehr/v1`. Interactive OpenAPI documentation is
-served at <http://localhost:8080/ferroehr/rest/swagger-ui>. If you have no
+served at <http://localhost:8080/ferroehr/rest/swagger-ui>; sign in with the
+API credential when the browser asks (the UI is served to authenticated users by
+default, see [`server.swagger_ui`](installation/config-server.md#server)). If you have no
 server yet, use the hosted sandbox: <https://sandbox.ferroehr.eu> opens the
 viewer over a live CDR, and the same server's Swagger UI is at
 <https://sandbox.ferroehr.eu/ferroehr/rest/swagger-ui>. Both take the public
@@ -203,8 +205,9 @@ feature set.
 
 ## 7. Explore the API interactively
 
-Open <http://localhost:8080/ferroehr/rest/swagger-ui> to browse and try every
-endpoint from your browser. The UI's spec selector carries one entry per API
+Open <http://localhost:8080/ferroehr/rest/swagger-ui> (signing in with the API
+credential when the browser asks) to browse and try every endpoint from your
+browser. The UI's spec selector carries one entry per API
 family: the standardised openEHR groups (EHR, Query, Definition, Demographic,
 Admin) and the server's own extensions (status & management, terminology, party
 relationships, messaging, event subscriptions, multi-tenancy, the FHIR

--- a/website/book/src/installation/compose.md
+++ b/website/book/src/installation/compose.md
@@ -94,7 +94,8 @@ This pulls and starts the two core services (no profile needed):
   because the image has no shell.
 
 The API is then at `http://localhost:8080/ferroehr/rest/openehr/v1`, with
-Swagger UI at `http://localhost:8080/ferroehr/rest/swagger-ui`.
+Swagger UI at `http://localhost:8080/ferroehr/rest/swagger-ui` (the browser asks
+for the API credential; `server.swagger_ui` chooses who may read it).
 
 > [!IMPORTANT]
 > **Every published port binds the loopback interface by default**

--- a/website/book/src/installation/config-server.md
+++ b/website/book/src/installation/config-server.md
@@ -16,7 +16,7 @@ The HTTP listener and REST surface.
 bind = "0.0.0.0:8080"
 base_path = "/ferroehr/rest/openehr/v1"
 max_in_flight = 256
-swagger_ui = true
+swagger_ui = "private"
 cors_permissive = false
 system_id = "ferroehr.local"
 ```
@@ -26,7 +26,7 @@ system_id = "ferroehr.local"
 | `bind` | string | `0.0.0.0:8080` | Socket address the API listener binds. |
 | `base_path` | string | `/ferroehr/rest/openehr/v1` | ITS-REST base path all API routes hang off. Shortening it is supported; see [below](#base_path-shortening-the-rest-base-path). The served OpenAPI document describes whatever paths this setting produces, never the defaults. |
 | `max_in_flight` | int | `256` | Concurrent-request admission cap (not a rate). Requests beyond it are shed immediately with `503` + `Retry-After`, never queued, so offered load beyond capacity cannot exhaust memory. `0` installs no shedding layer at all. |
-| `swagger_ui` | bool | `true` | Serve Swagger UI + the OpenAPI JSON under the REST root. Consider `false` in production. |
+| `swagger_ui` | enum{off,admin_only,private,public} | `private` | Who may read the Swagger UI and the OpenAPI documents under the REST root: `off` does not mount them, `admin_only` needs the admin role, `private` needs any authenticated principal (unauthenticated is `401` with the server's `WWW-Authenticate` challenge, so a browser prompts for the Basic credential), `public` needs nothing. The documents list the whole enabled operation surface, admin and message groups included, so `public` discloses it to anyone who can reach the port; the [hosted sandbox](https://sandbox.ferroehr.eu/ferroehr/rest/swagger-ui) sets it deliberately. With authentication off the guard admits everyone, as the management endpoints do. |
 | `cors_permissive` | bool | `false` | Permissive (development) CORS. Left on, any origin may read API responses, so the server warns loudly at boot. Production configures explicit origins at the edge. |
 | `system_id` | string | `ferroehr.local` | **This deployment's own openEHR system identifier**; see [below](#system_id-the-data-authoring-identity). Set a stable, deployment-unique name in production (`FERROEHR__SERVER__SYSTEM_ID`). |
 

--- a/website/book/src/using-the-api/index.md
+++ b/website/book/src/using-the-api/index.md
@@ -32,8 +32,10 @@ with `FERROEHR__SERVER__BASE_PATH`, and it may be shortened as far as
 The status and documentation routes hang off the **REST root**, which the server
 derives from the base path by dropping the segments that name the openEHR API:
 `/ferroehr/rest` by default. The public, unauthenticated status probe is at
-`/ferroehr/rest/status` and interactive docs at `/ferroehr/rest/swagger-ui` when
-`swagger_ui` is on. Every deployment serves that UI from its own routes, so your
+`/ferroehr/rest/status` and interactive docs at `/ferroehr/rest/swagger-ui` at
+the access level `swagger_ui` names (by default any authenticated principal, so
+a browser prompts for the API credential; the documents list the whole enabled
+operation surface). Every deployment serves that UI from its own routes, so your
 own server always documents its own surface. The health probes stay at the
 process root whatever the base path is: `/health`, `/health/liveness`,
 `/health/readiness`.


### PR DESCRIPTION
Closes #3094

## What changed

`mount_public_surface` merged the swagger router into the outer router beside the health and status routers, outside the authentication layer, and `server.swagger_ui` defaulted to `true`, so an unauthenticated client received the complete operation surface, admin and message groups included.

- **`server.swagger_ui` is an `AccessLevel`** (the management endpoints' vocabulary, `ferroehr::config::management::AccessLevel`): `off` (not mounted), `admin_only`, `private` (any authenticated principal) or `public`. The default is `private`.
- **The mount honours the level.** `public` sits beside the health family as before; `private` and `admin_only` wrap the swagger router in the management `AccessGuard` (`AccessGuard` + `access_middleware` are now `pub(crate)`), so an anonymous request is `401` with the server's `WWW-Authenticate` challenge (a browser prompts for the Basic credential and then loads the UI and its documents), a role-less principal under `admin_only` is `403`, and `off` is `404`. With authentication disabled the guard admits everyone, exactly as it does for the management endpoints. The extensions document lists the swagger paths only when the level mounts them (`is_mounted`).
- **Config surface.** The field, its `Default`, the annotated template (`swagger_ui = "private"`), the boot-time strict loader (a former `true`/`false` is a type error naming the key).
- **Hosted sandbox** (`deploy/hosted/ferroehr.sandbox.toml`): `swagger_ui = "public"` explicitly, since the documentation links to it as the API reference.
- **Chart:** `config.server.swagger_ui: private` in `values.yaml` (README regenerated by helm-docs), the all-features CI fixture keeps `public`, goldens regenerated (all render checks pass).
- **Book:** the `[server]` reference row and example, using-the-api, getting-started (sign in when the browser asks), compose.
- `CHANGELOG.md` under `### Changed`.

No openEHR spec governs the documentation surface; this is our own operational design.

## Tests

- `authz_route_matrix::the_swagger_surface_honours_its_access_level`: `private` is `401` anonymous (challenge header asserted) and served to a role-less principal; `admin_only` is `403` role-less and reaches the UI with `ADMIN`; `off` is `404`.
- The existing matrix, base-path, CSP, extensions-openapi and management suites keep their coverage under `public`/`off` (every test config now spells the level).
- `server_defaults_are_sane` pins the `private` default; the config template-sync tests pass.

## Gates

`cargo fmt`, `cargo clippy -p ferroehr -p ferroehr-rest --all-targets --all-features -D warnings`, the full `ferroehr-rest` suite (783 tests) and the `ferroehr` config module, comment-style, docs-claims, `deploy/helm/validate.sh`: green locally.

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.
