### PR TITLE
chore(conformance): an undeclared ixit instance parameter fails the pipeline instead of guarding cases out silently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2219,6 +2219,7 @@ jobs:
       - server-image-from-source
       - ui-screenshot-guard
       - contribution-licence
+      - ixit-declarations
       - changelog
       - citation
       - compose-version-guard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1982,6 +1982,32 @@ jobs:
           fi
           echo "pin bump carries a refreshed docs/conformance/ferroehr/ record — OK."
 
+  # Every per-instance ixit parameter the PINNED instrument defines is declared
+  # on every instance of our party set, or its absence is adjudicated in the
+  # register beside the ixit (#3041). The parameter set comes from the pinned
+  # tag's own schema, fetched here, so a pin bump that introduces one fails this
+  # job until the party declares or adjudicates it — before the pipeline would
+  # silently guard its cases out.
+  ixit-declarations:
+    name: ixit-declarations
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: The party ixit declares every instance parameter the pinned schema defines
+        run: |
+          set -euo pipefail
+          version=$(grep -m1 '^VEREDICTUM_VERSION=' scripts/lib/veredictum.sh | cut -d'"' -f2)
+          curl -fsSL --retry 3 \
+            "https://raw.githubusercontent.com/rubentalstra/Veredictum/v${version}/schemas/ixit.schema.json" \
+            -o /tmp/ixit.schema.json
+          bash scripts/checks/ixit-declarations.sh --schema /tmp/ixit.schema.json docs/conformance/party/ferroehr
+
   # Changelog guard (Keep a Changelog discipline): a PR that changes
   # user-visible surfaces must update CHANGELOG.md's [Unreleased] section in
   # the same PR. Escape hatch: the `no-changelog` label for genuinely

--- a/docs/conformance/party/ferroehr/ixit-undeclared.json
+++ b/docs/conformance/party/ferroehr/ixit-undeclared.json
@@ -1,0 +1,14 @@
+{
+  "*": {
+    "headers": "No extra request headers are needed to reach this deployment: the composed stack fronts the server directly, and every credential travels in the Authorization header the auth block mints. No case in the pinned catalogue requires a header declaration."
+  },
+  "unauthenticated": {
+    "administrative": "This instance carries no credential at all; it exists to prove the 401 branch. An administrative posture is a property of a principal, and there is none, so the role-boundary cases addressing it are not applicable by construction."
+  },
+  "smart_app": {
+    "administrative": "The SMART app principal is scoped by the SMART resource-scope grammar, not by the RBAC role set the role-boundary cases probe; its authorization is adjudicated by the SMART capability cases, so no administrative posture is claimed for it."
+  },
+  "smart_platform": {
+    "administrative": "The SMART platform principal is scoped by the SMART resource-scope grammar, not by the RBAC role set the role-boundary cases probe; its authorization is adjudicated by the SMART capability cases, so no administrative posture is claimed for it."
+  }
+}

--- a/scripts/checks/ixit-declarations.sh
+++ b/scripts/checks/ixit-declarations.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Ruben Talstra
+# SPDX-License-Identifier: BUSL-1.1
+#
+# scripts/checks/ixit-declarations.sh — every per-instance ixit parameter the
+# pinned instrument defines is DECLARED on every instance, or its absence is
+# adjudicated (#3041).
+#
+# The instrument's ixit schema is explicit that an absent instance parameter
+# is undeclared, never a default: a case whose `requires` clause names it
+# records not_applicable, and the capability that case evidences gains an
+# `unevidenced` slot. That happened silently at the 0.1.4 pin bump, when the
+# new `administrative` parameter guarded six role-boundary cases out and the
+# only trace was a diff of results.json outcome rows. This check makes the
+# cost visible before the run: a pin that introduces a parameter fails here
+# until the party either declares it on its instances or records, in a
+# register beside the ixit, why an instance leaves it undeclared.
+#
+# What counts as declared, per instance and per optional parameter:
+#   1. the instance carries the key; or
+#   2. the party carries the same top-level key AND the schema says an absent
+#      instance value inherits it ("Absent => the top-level … applies"); or
+#   3. the register `ixit-undeclared.json` beside the ixit names the instance
+#      (or `*`) and the parameter with a reason.
+# Anything else fails, naming the instance and the parameter. A register
+# entry naming a parameter the schema no longer defines, or an instance the
+# ixit no longer declares, fails too: an adjudication that has nothing to
+# adjudicate is stale.
+#
+# The parameter set is READ FROM THE PINNED SCHEMA, never hand-maintained:
+# `--schema PATH` for a caller that already has it (the pipeline, CI), else
+# the pinned catalogue checkout `scripts/lib/veredictum.sh` resolves.
+#
+# Usage: scripts/checks/ixit-declarations.sh [--schema PATH] <party-dir>...
+#   party-dir  a directory holding ixit.json (and optionally ixit-undeclared.json)
+
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+command -v jq >/dev/null || { echo "error: jq is required" >&2; exit 1; }
+
+schema=""
+parties=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --schema)
+    schema="${2:?--schema needs a path}"
+    shift 2
+    ;;
+  -h | --help)
+    sed -n '4,40p' "$0" | sed 's/^# \{0,1\}//'
+    exit 0
+    ;;
+  *)
+    parties+=("$1")
+    shift
+    ;;
+  esac
+done
+[[ ${#parties[@]} -gt 0 ]] || { echo "usage: $0 [--schema PATH] <party-dir>..." >&2; exit 2; }
+
+if [[ -z "$schema" ]]; then
+  # shellcheck source=scripts/lib/veredictum.sh
+  source scripts/lib/veredictum.sh
+  schema="$(veredictum_root)/schemas/ixit.schema.json"
+fi
+[[ -f "$schema" ]] || { echo "error: ixit schema not found: $schema" >&2; exit 1; }
+
+# The optional per-instance parameters, and which of them the schema lets an
+# instance inherit from the party level. Both come from the schema text: the
+# inheritance rule is the sentence the schema itself writes for those keys.
+optional=$(jq -r '
+  .properties.instances.additionalProperties as $inst
+  | ($inst.required // []) as $req
+  | $inst.properties | keys[] | select(. as $k | $req | index($k) | not)
+' "$schema")
+inheriting=$(jq -r '
+  .properties.instances.additionalProperties.properties
+  | to_entries[]
+  | select((.value.description // "") | test("Absent => the top-level"))
+  | .key
+' "$schema")
+
+fail=0
+note() { echo "ixit-declarations: $*" >&2; fail=1; }
+checked=0
+
+for party in "${parties[@]}"; do
+  ixit="$party/ixit.json"
+  register="$party/ixit-undeclared.json"
+  [[ -f "$ixit" ]] || { note "missing $ixit"; continue; }
+  if [[ -f "$register" ]]; then
+    jq -e 'type == "object" and all(.[]; type == "object" and all(.[]; type == "string" and length > 0))' "$register" >/dev/null \
+      || { note "$register is not an object of instance -> {parameter: reason} with non-empty reasons"; continue; }
+  fi
+  reg='{}'
+  [[ -f "$register" ]] && reg=$(cat "$register")
+
+  while read -r instance; do
+    [[ -n "$instance" ]] || continue
+    checked=$((checked + 1))
+    while read -r param; do
+      [[ -n "$param" ]] || continue
+      declared=$(jq -r --arg i "$instance" --arg p "$param" --argjson reg "$reg" --arg inherit "$inheriting" '
+        (.instances[$i] | has($p))
+        or ((has($p)) and (($inherit | split("\n")) | index($p) != null))
+        or ($reg[$i][$p]? != null)
+        or ($reg["*"][$p]? != null)
+      ' "$ixit")
+      if [[ "$declared" != "true" ]]; then
+        note "$ixit: instance '$instance' leaves '$param' undeclared — the instrument records every case that requires it not_applicable. Declare it on the instance, or record the reason in $register under \"$instance\" (or \"*\")."
+      fi
+    done <<<"$optional"
+  done < <(jq -r '.instances | keys[]' "$ixit")
+
+  # Stale adjudications: a register may only name instances the ixit declares
+  # (or `*`) and parameters the schema defines.
+  while IFS=$'\t' read -r instance param; do
+    [[ -n "$instance" ]] || continue
+    if [[ "$instance" != "*" ]] && ! jq -e --arg i "$instance" '.instances | has($i)' "$ixit" >/dev/null; then
+      note "$register adjudicates instance '$instance', which $ixit does not declare — remove the stale entry"
+    fi
+    if ! grep -qxF -- "$param" <<<"$optional"; then
+      note "$register adjudicates '$param' on '$instance', but the pinned schema defines no such optional instance parameter — remove the stale entry"
+    fi
+  done < <(jq -r 'to_entries[] | .key as $i | .value | keys[] | "\($i)\t\(.)"' <<<"$reg")
+done
+
+[[ "$fail" -eq 0 ]] || {
+  echo >&2
+  echo "An undeclared instance parameter is not a default: the pinned instrument" >&2
+  echo "guards every case that requires it out of the run, and the capability it" >&2
+  echo "evidences loses coverage silently. Declare, or adjudicate the absence." >&2
+  exit 1
+}
+echo "ixit-declarations: OK ($checked instance(s) across ${#parties[@]} party set(s), $(wc -l <<<"$optional" | tr -d ' ') optional parameter(s) from $(basename "$(dirname "$schema")")/$(basename "$schema"))"

--- a/scripts/conformance.sh
+++ b/scripts/conformance.sh
@@ -243,6 +243,16 @@ echo "==> Resolving the pinned instrument (veredictum $VEREDICTUM_VERSION)"
 VEREDICTUM="$(veredictum_bin)"
 ROOT="$(veredictum_artifacts)"
 
+# Every optional per-instance parameter the PINNED schema defines is declared
+# on every instance, or its absence is adjudicated beside the ixit — an
+# undeclared one guards its cases out of the run silently (#3041). The byo
+# rewrite above touches base URLs only, so the committed party set is what is
+# judged.
+echo "==> Checking the ixit declares every instance parameter the pinned schema defines"
+bash "$REPO_ROOT/scripts/checks/ixit-declarations.sh" \
+  --schema "$(veredictum_root)/schemas/ixit.schema.json" \
+  "$(dirname "${CONF_IXIT:-$PARTY/ixit.json}")"
+
 mkdir -p "$OUT"
 
 echo "==> Executing the catalogue (sut=$SUT_NAME filter='${FILTER}')"

--- a/website/book/src/conformance.md
+++ b/website/book/src/conformance.md
@@ -125,6 +125,19 @@ exposes, each of which switches on the cases that depend on it:
 A party that declares none of these has the dependent cases recorded
 not-applicable rather than checked against a guess.
 
+That silence has a cost, and the pipeline makes it visible before a run. The
+instrument's ixit schema also defines parameters per instance (the
+`administrative` posture of a principal, an instance's own `signing`,
+`terminology` or `spec_profile` when it differs from the party's), and an
+absent one is undeclared, never a default: every case that requires it is
+guarded out. `scripts/checks/ixit-declarations.sh` reads that parameter set
+from the pinned schema itself and refuses to run the catalogue while an
+instance leaves one undeclared, unless `ixit-undeclared.json` beside the ixit
+records why that instance leaves it so (an unauthenticated instance has no
+principal to be administrative, for example). A pin bump that introduces a
+parameter therefore fails the pipeline until the party declares or adjudicates
+it, instead of quietly losing the cases it guards.
+
 ## Running the suite yourself
 
 The suite runs against a real, deployed server (the same container image and


### PR DESCRIPTION
Closes #3041

## What changed

- **`scripts/checks/ixit-declarations.sh`** (bash + jq): reads the optional per-instance parameters from the pinned instrument's own `schemas/ixit.schema.json` (`properties.instances.additionalProperties`, minus `required`), never a hand-maintained list. For every instance in the party ixit and every such parameter it demands one of: the instance declares it; the party declares the same top-level key and the schema's own text says an absent instance value inherits it ("Absent => the top-level … applies", which is what `signing`, `terminology` and `spec_profile` say); or `ixit-undeclared.json` beside the ixit records, per instance or `*`, why the instance leaves it undeclared. Anything else fails naming the instance and the parameter. A register entry naming a parameter the schema no longer defines, or an instance the ixit no longer has, fails as stale.
- **`scripts/conformance.sh`** runs the check right after resolving the pinned instrument, before the catalogue executes, against the party set the run uses (the byo rewrite touches base URLs only).
- **CI** gains an `ixit-declarations` job on every pull request that fetches the schema at the pinned tag from the Veredictum repository and runs the check on `docs/conformance/party/ferroehr`, so a pin bump that introduces a parameter fails before any pipeline run.
- **`docs/conformance/party/ferroehr/ixit-undeclared.json`** records the current adjudications: `headers` for every instance (no extra header is needed to reach the composed stack), and `administrative` for the `unauthenticated` principal (no principal to be administrative) and the two SMART principals (scoped by the SMART resource-scope grammar, adjudicated by the SMART cases, not the RBAC role set).
- The book's conformance page describes the check beside the declarations table.

Mutation-proven locally (unpiped exits): dropping `administrative` from `sut` fails naming it; a stale register entry fails; a schema with a new `brand_new` parameter fails on every instance. The check passes on the committed party set against the v0.1.5 schema. `shellcheck-lane`, `docs-claims`: green.

The EHRbase party set is deliberately left alone here: that material moves to Veredictum (#3105).

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.
