### PR TITLE
test(ext): ferroehr-ext behaviour tests, and a wrong FHIR resource stops reading as an empty answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
+- **A terminology server that answers with the wrong FHIR resource is refused
+  by name** (#3099). The R4B `Parameters` resource has no mandatory member, so
+  any JSON object decoded as an empty view: a `$validate-code` answered with a
+  `ValueSet` or an `OperationOutcome` read as "no result" instead of the wrong
+  answer it was. The decoders now check the `resourceType` first and report
+  `unexpected FHIR resource: expected Parameters, got OperationOutcome`, which
+  `terminology.external.fail_on_error` then decides on like any other upstream
+  fault.
+
 - **A refused OPT or canonical-XML document says where the defect is** (#3067).
   A mandatory element or attribute that is absent used to be reported as
   `xml parse error: missing element id`, with no position and a token that

--- a/app/ferroehr-ext/CLAUDE.md
+++ b/app/ferroehr-ext/CLAUDE.md
@@ -37,6 +37,16 @@ integrations out.
   gated glue maps config → params.
 - Features are additive — no `compile_error!` pairs; the `--all-features`
   workspace lanes stay valid.
+- **One integration-test binary, one module per integration**
+  (`tests/it/main.rs` + `terminology_decode` / `events_contract` /
+  `multimedia_engine`), each `#[cfg(feature)]`-gated so `--all-features` runs
+  everything and the slim build compiles none of it. They drive this crate's
+  PUBLIC seams with no broker and no network: the typed FHIR decoders over
+  fixture bodies, the `EventPublisher` contract (a recording double plus the
+  AMQP publisher's pre-broker behaviour), the multimedia engine over the
+  in-memory `object_store`. The broker-backed and wiremock-backed journeys
+  stay in `app/ferroehr/tests/it` where the platform wires the integrations
+  in — never duplicated here.
 - Gates: `cargo clippy -p ferroehr-ext --all-targets --all-features` +
   `cargo nextest run -p ferroehr-ext --all-features`, plus a
   `--no-default-features` check lane (the slim build).

--- a/app/ferroehr-ext/Cargo.toml
+++ b/app/ferroehr-ext/Cargo.toml
@@ -70,3 +70,10 @@ url = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true }
+# The behaviour tests over the public seams (tests/it): a test double for the
+# EventPublisher trait, fixture bodies for the terminology decoders, and the
+# in-memory object_store backend standing in for S3.
+async-trait = { workspace = true }
+base64 = { workspace = true }
+object_store = { workspace = true }
+serde_json = { workspace = true }

--- a/app/ferroehr-ext/src/fhir/terminology.rs
+++ b/app/ferroehr-ext/src/fhir/terminology.rs
@@ -27,6 +27,36 @@ pub enum TerminologyDecodeError {
     /// The body is not a valid R4B resource of the expected type.
     #[error("malformed FHIR response: {0}")]
     Malformed(#[from] serde_json::Error),
+    /// The body is a well-formed resource of another type. The concrete R4B
+    /// structs carry no `resourceType` discriminator of their own (only the
+    /// `Resource` enum does), and `Parameters` has no mandatory member, so
+    /// without this check any JSON object would read as an empty `Parameters`.
+    #[error("unexpected FHIR resource: expected {expected}, got {found}")]
+    WrongResource {
+        /// The resource type the operation answers with.
+        expected: &'static str,
+        /// The `resourceType` the body declares (`(none)` when it declares none).
+        found: String,
+    },
+}
+
+/// The `resourceType` a body declares, checked before the typed decode.
+#[derive(serde::Deserialize)]
+struct ResourceHeader {
+    #[serde(rename = "resourceType")]
+    resource_type: Option<String>,
+}
+
+/// Refuses a body whose `resourceType` is not `expected`.
+fn expect_resource(body: &[u8], expected: &'static str) -> Result<(), TerminologyDecodeError> {
+    let header: ResourceHeader = serde_json::from_slice(body)?;
+    match header.resource_type {
+        Some(found) if found == expected => Ok(()),
+        found => Err(TerminologyDecodeError::WrongResource {
+            expected,
+            found: found.unwrap_or_else(|| "(none)".to_owned()),
+        }),
+    }
 }
 
 /// The named scalar values a `Parameters` response carries, by parameter name.
@@ -72,9 +102,11 @@ pub struct ExpansionMember {
 ///
 /// # Errors
 ///
-/// [`TerminologyDecodeError::Malformed`] when the body is not a valid R4B
-/// `Parameters` resource.
+/// [`TerminologyDecodeError::WrongResource`] when the body declares another
+/// `resourceType`; [`TerminologyDecodeError::Malformed`] when it is not a
+/// valid R4B `Parameters` resource.
 pub fn decode_parameters(body: &[u8]) -> Result<ParametersView, TerminologyDecodeError> {
+    expect_resource(body, "Parameters")?;
     let parameters: Parameters = serde_json::from_slice(body)?;
     let mut view = ParametersView::default();
     for parameter in parameters.parameter.iter().flatten() {
@@ -122,9 +154,11 @@ fn translate_match(parameter: &fhir_model::r4b::resources::ParametersParameter) 
 ///
 /// # Errors
 ///
-/// [`TerminologyDecodeError::Malformed`] when the body is not a valid R4B
-/// `ValueSet` resource.
+/// [`TerminologyDecodeError::WrongResource`] when the body declares another
+/// `resourceType`; [`TerminologyDecodeError::Malformed`] when it is not a
+/// valid R4B `ValueSet` resource.
 pub fn decode_expansion(body: &[u8]) -> Result<Vec<ExpansionMember>, TerminologyDecodeError> {
+    expect_resource(body, "ValueSet")?;
     let value_set: ValueSet = serde_json::from_slice(body)?;
     Ok(value_set
         .expansion

--- a/app/ferroehr-ext/tests/it/events_contract.rs
+++ b/app/ferroehr-ext/tests/it/events_contract.rs
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: Ruben Talstra
+// SPDX-License-Identifier: BUSL-1.1
+
+//! The `EventPublisher` contract (`ferroehr_ext::events`): what a publisher
+//! must provide, what the trait provides for it, and how the AMQP publisher
+//! behaves BEFORE and WITHOUT a broker. The at-least-once delivery over a real
+//! `RabbitMQ` is `app/ferroehr/tests/it/events_amqp.rs`; nothing here needs a
+//! broker, which is what lets these run in every lane.
+//!
+//! No openEHR spec governs eventing — our own design/extension.
+
+use std::sync::Mutex;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use ferroehr_ext::events::amqp::AmqpPublisher;
+use ferroehr_ext::events::{EventError, EventPublisher, routing_key, subscription_binding_key};
+
+/// A publisher that records what it was asked to publish: the shape a
+/// non-AMQP implementation (or a test double in the platform) takes.
+#[derive(Default)]
+struct Recording {
+    published: Mutex<Vec<(String, Vec<u8>)>>,
+}
+
+#[async_trait]
+impl EventPublisher for Recording {
+    async fn publish(&self, routing_key: &str, payload: &[u8]) -> Result<(), EventError> {
+        self.published
+            .lock()
+            .expect("recording lock")
+            .push((routing_key.to_owned(), payload.to_vec()));
+        Ok(())
+    }
+}
+
+/// The trait's defaults let a publisher with its own topology model implement
+/// `publish` alone: declaring a subscription is a no-op that succeeds, and the
+/// topology epoch never moves, so the drainer never re-declares against it.
+#[tokio::test]
+async fn the_trait_defaults_make_publish_the_only_obligation() {
+    let publisher = Recording::default();
+    publisher
+        .declare_subscription("q", "COMPOSITION.*.*")
+        .await
+        .expect("the default declaration is a successful no-op");
+    assert_eq!(publisher.topology_epoch(), 0);
+    publisher
+        .publish(&routing_key("COMPOSITION", "249", Some("vitals.v2")), b"{}")
+        .await
+        .expect("publish");
+    assert_eq!(
+        publisher.topology_epoch(),
+        0,
+        "publishing never moves the default epoch"
+    );
+    let recorded = publisher.published.lock().expect("recording lock");
+    assert_eq!(recorded.len(), 1);
+    assert_eq!(recorded[0].0, "COMPOSITION.249.vitals_v2");
+}
+
+/// A routing key and the binding key a subscription derives for the same
+/// facts agree word for word, so a topic match is exact on every declared
+/// predicate and the `*` wildcard stands only where the subscription left a
+/// predicate NULL. The `-` an absent template renders in a routing key is a
+/// literal word, never a wildcard: a subscription filtering on a template does
+/// not receive template-less versions.
+#[test]
+fn routing_and_binding_keys_agree_on_their_three_words() {
+    let key = routing_key(
+        "COMPOSITION",
+        "249",
+        Some("openEHR-EHR-COMPOSITION.encounter.v1"),
+    );
+    let exact = subscription_binding_key(
+        Some("COMPOSITION"),
+        Some("249"),
+        Some("openEHR-EHR-COMPOSITION.encounter.v1"),
+    );
+    assert_eq!(
+        key, exact,
+        "a fully specified subscription binds the exact routing key"
+    );
+    assert_eq!(
+        key.split('.').count(),
+        3,
+        "a dotted template id stays one word"
+    );
+
+    let no_template = routing_key("EHR_STATUS", "251", None);
+    assert_eq!(no_template, "EHR_STATUS.251.-");
+    assert_eq!(subscription_binding_key(None, None, None), "*.*.*");
+    assert_ne!(
+        subscription_binding_key(None, None, Some("-")),
+        "*.*.*",
+        "a literal `-` predicate is a word of its own, not a wildcard"
+    );
+}
+
+/// Construction performs no I/O: a publisher over an unreachable broker is
+/// built, reports the initial epoch, and fails on FIRST use with the typed
+/// transport error, leaving the caller's outbox row pending. Nothing panics,
+/// and the failure comes back quickly enough to be retried on the next poll.
+#[tokio::test]
+async fn an_unreachable_broker_is_a_typed_transport_error_on_first_use() {
+    // Port 1 is never a broker; the connection is refused at once.
+    let publisher = AmqpPublisher::new("amqp://127.0.0.1:1/%2f", "ferroehr.events");
+    assert_eq!(
+        publisher.topology_epoch(),
+        0,
+        "no connection was attempted yet"
+    );
+
+    let outcome = tokio::time::timeout(
+        Duration::from_secs(20),
+        publisher.publish(&routing_key("COMPOSITION", "249", None), b"{}"),
+    )
+    .await
+    .expect("a refused connection fails within the retry budget");
+    let err = outcome.expect_err("no broker answers on port 1");
+    assert!(matches!(err, EventError::Amqp(_)), "got {err:?}");
+    assert!(err.to_string().starts_with("amqp transport: "), "{err}");
+    assert_eq!(
+        publisher.topology_epoch(),
+        0,
+        "a connection that never came up is not a fresh topology"
+    );
+
+    // Declaring a subscription takes the same path and fails the same way.
+    let err = tokio::time::timeout(
+        Duration::from_secs(20),
+        publisher.declare_subscription("q", "*.*.*"),
+    )
+    .await
+    .expect("within budget")
+    .expect_err("no broker");
+    assert!(matches!(err, EventError::Amqp(_)), "got {err:?}");
+}

--- a/app/ferroehr-ext/tests/it/main.rs
+++ b/app/ferroehr-ext/tests/it/main.rs
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Ruben Talstra
+// SPDX-License-Identifier: BUSL-1.1
+
+//! The one integration-test binary of `ferroehr-ext`: one module per
+//! feature-gated integration, each compiled only under its feature, so
+//! `--all-features` runs everything and a slim build compiles nothing here.
+//!
+//! These are behaviour tests over the crate's public seams — the typed
+//! terminology decoders, the `EventPublisher` contract, the multimedia engine
+//! over a real (in-memory) object store. The broker-backed and wiremock-backed
+//! journeys stay in `app/ferroehr/tests/it`, where the platform wires the
+//! integrations in; nothing here repeats them.
+
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic,
+    reason = "integration-test assertions and fixture plumbing outside #[test] fns, which the clippy.toml allow-*-in-tests scoping does not reach"
+)]
+#![expect(
+    clippy::disallowed_types,
+    reason = "test fixtures and wire assertions are raw JSON by the testing rule (.claude/rules/testing.md §Test-fixture construction): a FHIR response body and a canonical composition are bytes a server or a client sends, and building them through a typed model would test the model instead of the decoder"
+)]
+
+#[cfg(feature = "events")]
+mod events_contract;
+#[cfg(feature = "multimedia")]
+mod multimedia_engine;
+#[cfg(feature = "fhir")]
+mod terminology_decode;

--- a/app/ferroehr-ext/tests/it/multimedia_engine.rs
+++ b/app/ferroehr-ext/tests/it/multimedia_engine.rs
@@ -1,0 +1,195 @@
+// SPDX-FileCopyrightText: Ruben Talstra
+// SPDX-License-Identifier: BUSL-1.1
+
+//! The multimedia engine (`ferroehr_ext::multimedia`) end to end over a real
+//! object store: a `DV_MULTIMEDIA` above the threshold is offloaded, its bytes
+//! land in the store once, the canonical value keeps the invariants RM data
+//! types demand of an externalised value, and expanding it restores the inline
+//! bytes. The in-memory `object_store` backend stands in for S3; the S3-backed
+//! journey is `app/ferroehr/tests/it/multimedia_s3.rs`. The planner's own
+//! arithmetic (thresholds, thumbnails, integrity) is unit-tested beside it in
+//! `src/multimedia/offload.rs`; this module drives the engine's public seam.
+//!
+//! No openEHR spec governs blob externalisation — our own design/extension;
+//! the value shape is RM data types `DV_MULTIMEDIA`
+//! (`docs/specs/openehr/RM/docs/data_types/master09-encapsulated_package.adoc`).
+
+use std::sync::Arc;
+
+use base64::Engine;
+use ferroehr_ext::multimedia::store::BlobStore;
+use ferroehr_ext::multimedia::{MultimediaEngine, MultimediaError, references_external_blob};
+use serde_json::{Value, json};
+
+const THRESHOLD: usize = 256;
+
+fn engine() -> MultimediaEngine {
+    MultimediaEngine::from_parts(
+        BlobStore::from_parts(
+            Arc::new(object_store::memory::InMemory::new()),
+            "media".to_owned(),
+        ),
+        THRESHOLD,
+    )
+}
+
+fn b64(bytes: &[u8]) -> String {
+    base64::engine::general_purpose::STANDARD.encode(bytes)
+}
+
+/// A composition carrying one `DV_MULTIMEDIA` of `n` bytes inline.
+fn composition_with_media(n: usize) -> (Value, Vec<u8>) {
+    let payload: Vec<u8> = (0..n)
+        .map(|i| u8::try_from(i % 251).expect("< 256"))
+        .collect();
+    let composition = json!({
+        "_type": "COMPOSITION",
+        "content": [{
+            "_type": "ELEMENT",
+            "value": {
+                "_type": "DV_MULTIMEDIA",
+                "media_type": {
+                    "_type": "CODE_PHRASE",
+                    "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "IANA_media-types" },
+                    "code_string": "application/octet-stream"
+                },
+                "size": n,
+                "data": b64(&payload)
+            }
+        }]
+    });
+    (composition, payload)
+}
+
+#[tokio::test]
+async fn a_large_value_round_trips_through_the_store() {
+    let engine = engine();
+    let (mut composition, payload) = composition_with_media(4 * THRESHOLD);
+    let inline = composition.clone();
+
+    engine.offload(&mut composition).await.expect("offload");
+    let node = composition
+        .pointer("/content/0/value")
+        .expect("the multimedia node");
+    assert!(node.get("data").is_none(), "the bytes left the document");
+    let uri = node
+        .pointer("/uri/value")
+        .and_then(Value::as_str)
+        .expect("an external uri")
+        .to_owned();
+    assert!(uri.starts_with("s3://media/"), "{uri}");
+    assert_eq!(
+        node.get("size"),
+        Some(&json!(4 * THRESHOLD)),
+        "size stays the decoded length"
+    );
+    assert!(
+        node.get("integrity_check").is_some(),
+        "the digest travels with the reference"
+    );
+    assert!(references_external_blob(&composition));
+
+    // The bytes are in the store under the key the uri names, verbatim.
+    let keys = engine.referenced_keys(&composition);
+    assert_eq!(keys.len(), 1);
+    let stored = engine.store().get(&keys[0]).await.expect("stored bytes");
+    assert_eq!(stored.as_ref(), payload.as_slice());
+    assert_eq!(engine.store().key_from_uri(&uri), Some(keys[0].as_str()));
+
+    // Expanding restores the inline document exactly.
+    engine.expand(&mut composition).await.expect("expand");
+    let restored = composition
+        .pointer("/content/0/value/data")
+        .and_then(Value::as_str)
+        .expect("inline data again");
+    assert_eq!(restored, b64(&payload));
+    // The reference stays beside the restored bytes: a value that is both
+    // inline and external is spec-legal, and a later offload finds the same key.
+    assert_eq!(
+        composition
+            .pointer("/content/0/value/uri/value")
+            .and_then(Value::as_str),
+        Some(uri.as_str())
+    );
+    assert_eq!(
+        composition.pointer("/content/0/value/size"),
+        inline.pointer("/content/0/value/size")
+    );
+}
+
+#[tokio::test]
+async fn a_small_value_and_a_disabled_engine_leave_the_document_untouched() {
+    let engine = engine();
+    let (mut small, _) = composition_with_media(THRESHOLD - 1);
+    let before = small.clone();
+    engine.offload(&mut small).await.expect("offload");
+    assert_eq!(small, before, "below the threshold nothing moves");
+    assert!(engine.referenced_keys(&small).is_empty());
+
+    let disabled = engine.with_offload_enabled(false);
+    assert!(!disabled.offload_enabled());
+    let (mut large, _) = composition_with_media(4 * THRESHOLD);
+    let before = large.clone();
+    disabled.offload(&mut large).await.expect("offload");
+    assert_eq!(
+        large, before,
+        "a disabled engine offloads nothing, whatever the size"
+    );
+}
+
+#[tokio::test]
+async fn the_same_bytes_are_stored_once_and_expand_is_idempotent() {
+    let engine = engine();
+    let (mut first, payload) = composition_with_media(3 * THRESHOLD);
+    let (mut second, _) = composition_with_media(3 * THRESHOLD);
+    engine.offload(&mut first).await.expect("offload first");
+    engine.offload(&mut second).await.expect("offload second");
+    let k1 = engine.referenced_keys(&first);
+    let k2 = engine.referenced_keys(&second);
+    assert_eq!(k1, k2, "content addressing: identical bytes share one key");
+    assert_eq!(
+        engine.store().get(&k1[0]).await.expect("bytes").as_ref(),
+        payload.as_slice()
+    );
+
+    engine.expand(&mut first).await.expect("expand");
+    let once = first.clone();
+    engine.expand(&mut first).await.expect("expand again");
+    assert_eq!(
+        first, once,
+        "expanding an already inline document changes nothing"
+    );
+}
+
+#[tokio::test]
+async fn a_reference_whose_bytes_are_missing_is_a_typed_refusal() {
+    let engine = engine();
+    let mut composition = json!({
+        "_type": "COMPOSITION",
+        "content": [{
+            "_type": "ELEMENT",
+            "value": {
+                "_type": "DV_MULTIMEDIA",
+                "media_type": {
+                    "_type": "CODE_PHRASE",
+                    "terminology_id": { "_type": "TERMINOLOGY_ID", "value": "IANA_media-types" },
+                    "code_string": "application/octet-stream"
+                },
+                "size": 3,
+                "uri": { "_type": "DV_URI", "value": engine.store().uri_for("00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff") }
+            }
+        }]
+    });
+    let err = engine
+        .expand(&mut composition)
+        .await
+        .expect_err("a reference into our store with no object behind it cannot be expanded");
+    assert!(
+        !matches!(err, MultimediaError::Malformed(_)),
+        "a missing object is a store failure, got {err:?}"
+    );
+    assert!(
+        composition.pointer("/content/0/value/data").is_none(),
+        "nothing was invented for the missing bytes"
+    );
+}

--- a/app/ferroehr-ext/tests/it/terminology_decode.rs
+++ b/app/ferroehr-ext/tests/it/terminology_decode.rs
@@ -1,0 +1,243 @@
+// SPDX-FileCopyrightText: Ruben Talstra
+// SPDX-License-Identifier: BUSL-1.1
+
+//! The typed FHIR R4B terminology decoders
+//! (`ferroehr_ext::fhir::terminology`): what the platform's terminology
+//! provider gets back from a server's `Parameters` or `ValueSet` body, and
+//! what it refuses. The wire, the routing and the SM error mapping are the
+//! platform's and are exercised by `app/ferroehr/tests/it/terminology_*.rs`
+//! against wiremock; this module drives the decoders directly with bodies,
+//! valid and malformed, that those journeys never send.
+//!
+//! No openEHR spec governs FHIR resource representation — our own
+//! design/extension; the shapes are HL7 FHIR R4B
+//! (<https://hl7.org/fhir/R4B/parameters.html>,
+//! <https://hl7.org/fhir/R4B/valueset.html>).
+
+use ferroehr_ext::fhir::terminology::{
+    ExpansionMember, TerminologyDecodeError, TranslateMatch, decode_expansion, decode_parameters,
+};
+use serde_json::json;
+
+fn bytes(value: &serde_json::Value) -> Vec<u8> {
+    serde_json::to_vec(value).expect("fixture serializes")
+}
+
+#[test]
+fn parameters_scalars_are_read_by_name_and_kind() {
+    let body = bytes(&json!({
+        "resourceType": "Parameters",
+        "parameter": [
+            {"name": "result", "valueBoolean": true},
+            {"name": "outcome", "valueCode": "subsumes"},
+            {"name": "display", "valueString": "Buccal"},
+            {"name": "message", "valueString": "matched"},
+            // A kind the view does not carry is ignored, never an error.
+            {"name": "version", "valueInteger": 3}
+        ]
+    }));
+    let view = decode_parameters(&body).expect("a valid Parameters body decodes");
+    assert_eq!(view.booleans.get("result"), Some(&true));
+    assert_eq!(
+        view.codes.get("outcome").map(String::as_str),
+        Some("subsumes")
+    );
+    assert_eq!(
+        view.strings.get("display").map(String::as_str),
+        Some("Buccal")
+    );
+    assert_eq!(
+        view.strings.get("message").map(String::as_str),
+        Some("matched")
+    );
+    assert!(view.matches.is_empty());
+    assert_eq!(
+        view.booleans.len() + view.codes.len() + view.strings.len(),
+        4
+    );
+}
+
+#[test]
+fn an_empty_parameters_body_is_an_empty_view_not_a_refusal() {
+    let body = bytes(&json!({"resourceType": "Parameters"}));
+    let view = decode_parameters(&body).expect("a Parameters without parameters is valid");
+    assert!(view.booleans.is_empty() && view.codes.is_empty() && view.strings.is_empty());
+    assert!(view.matches.is_empty());
+}
+
+#[test]
+fn translate_matches_keep_their_order_and_their_concepts() {
+    let body = bytes(&json!({
+        "resourceType": "Parameters",
+        "parameter": [
+            {"name": "result", "valueBoolean": true},
+            {"name": "match", "part": [
+                {"name": "equivalence", "valueCode": "equivalent"},
+                {"name": "concept", "valueCoding": {
+                    "system": "http://snomed.info/sct", "code": "271649006",
+                    "display": "Systolic blood pressure"
+                }}
+            ]},
+            {"name": "match", "part": [
+                {"name": "equivalence", "valueCode": "wider"},
+                {"name": "concept", "valueCoding": {"system": "http://loinc.org", "code": "8480-6"}}
+            ]},
+            // A match with no recognisable parts is still a match, all fields absent.
+            {"name": "match", "part": [{"name": "source", "valueUri": "http://example.org/map"}]}
+        ]
+    }));
+    let view = decode_parameters(&body).expect("a $translate response decodes");
+    assert_eq!(view.matches.len(), 3);
+    assert_eq!(view.matches[0].equivalence.as_deref(), Some("equivalent"));
+    assert_eq!(
+        view.matches[0].system.as_deref(),
+        Some("http://snomed.info/sct")
+    );
+    assert_eq!(view.matches[0].code.as_deref(), Some("271649006"));
+    assert_eq!(
+        view.matches[0].display.as_deref(),
+        Some("Systolic blood pressure")
+    );
+    assert_eq!(view.matches[1].equivalence.as_deref(), Some("wider"));
+    assert_eq!(view.matches[1].code.as_deref(), Some("8480-6"));
+    assert_eq!(view.matches[1].display, None);
+    assert_eq!(view.matches[2], TranslateMatch::default());
+    // The `result` beside the matches is still read.
+    assert_eq!(view.booleans.get("result"), Some(&true));
+}
+
+/// A `Parameters` has no mandatory member, so without the `resourceType`
+/// check any JSON object would read as an empty view — a `$validate-code`
+/// answered with a `ValueSet` (or an `OperationOutcome`) would look like
+/// "no result" instead of the wrong answer it is.
+#[test]
+fn a_body_of_another_resource_type_is_refused_by_name() {
+    for (body, found) in [
+        (
+            bytes(&json!({"resourceType": "ValueSet", "status": "active"})),
+            "ValueSet",
+        ),
+        (
+            bytes(&json!({"resourceType": "OperationOutcome", "issue": []})),
+            "OperationOutcome",
+        ),
+        (bytes(&json!({"parameter": []})), "(none)"),
+    ] {
+        let err = decode_parameters(&body).expect_err("another resource is refused");
+        match &err {
+            TerminologyDecodeError::WrongResource {
+                expected,
+                found: got,
+            } => {
+                assert_eq!(*expected, "Parameters");
+                assert_eq!(got, found);
+            }
+            TerminologyDecodeError::Malformed(other) => {
+                panic!("expected a wrong-resource refusal, got a malformed-body one: {other}")
+            }
+        }
+        assert_eq!(
+            err.to_string(),
+            format!("unexpected FHIR resource: expected Parameters, got {found}")
+        );
+    }
+}
+
+#[test]
+fn a_body_that_is_not_a_parameters_resource_is_refused_not_partially_read() {
+    for body in [
+        // Not JSON at all.
+        b"<Parameters/>".to_vec(),
+        // A parameter without its mandatory name.
+        bytes(&json!({"resourceType": "Parameters", "parameter": [{"valueBoolean": true}]})),
+        b"".to_vec(),
+    ] {
+        let err = decode_parameters(&body).expect_err("a malformed Parameters body is refused");
+        assert!(
+            matches!(err, TerminologyDecodeError::Malformed(_)),
+            "got {err:?}"
+        );
+        assert!(
+            err.to_string().starts_with("malformed FHIR response: "),
+            "{err}"
+        );
+    }
+}
+
+#[test]
+fn an_expansion_is_read_with_its_nesting() {
+    let body = bytes(&json!({
+        "resourceType": "ValueSet",
+        "status": "active",
+        "expansion": {
+            "timestamp": "2026-01-01T00:00:00Z",
+            "contains": [
+                {"system": "http://example.org/surface", "code": "B", "display": "Buccal"},
+                {"system": "http://example.org/surface", "code": "L", "display": "Lingual",
+                 "contains": [
+                    {"system": "http://example.org/surface", "code": "LD", "display": "Lingual distal"}
+                 ]},
+                // An abstract grouper carries no code; it still holds its members.
+                {"abstract": true, "display": "Occlusal group", "contains": [
+                    {"system": "http://example.org/surface", "code": "O"}
+                ]}
+            ]
+        }
+    }));
+    let members = decode_expansion(&body).expect("a valid ValueSet expansion decodes");
+    assert_eq!(members.len(), 3);
+    assert_eq!(
+        members[0],
+        ExpansionMember {
+            code: Some("B".to_owned()),
+            display: Some("Buccal".to_owned()),
+            children: Vec::new(),
+        }
+    );
+    assert_eq!(members[1].children.len(), 1);
+    assert_eq!(members[1].children[0].code.as_deref(), Some("LD"));
+    assert_eq!(members[2].code, None);
+    assert_eq!(members[2].children[0].code.as_deref(), Some("O"));
+    assert_eq!(members[2].children[0].display, None);
+}
+
+#[test]
+fn a_value_set_without_an_expansion_has_no_members() {
+    let body = bytes(&json!({"resourceType": "ValueSet", "status": "active"}));
+    assert!(decode_expansion(&body).expect("valid").is_empty());
+    let body = bytes(&json!({
+        "resourceType": "ValueSet", "status": "active",
+        "expansion": {"timestamp": "2026-01-01T00:00:00Z"}
+    }));
+    assert!(decode_expansion(&body).expect("valid").is_empty());
+}
+
+#[test]
+fn a_value_set_the_r4b_model_rejects_is_refused() {
+    for body in [
+        // `status` is mandatory on ValueSet.
+        bytes(
+            &json!({"resourceType": "ValueSet", "expansion": {"timestamp": "2026-01-01T00:00:00Z"}}),
+        ),
+        // `expansion.timestamp` is mandatory.
+        bytes(
+            &json!({"resourceType": "ValueSet", "status": "active", "expansion": {"contains": []}}),
+        ),
+    ] {
+        let err = decode_expansion(&body).expect_err("a malformed ValueSet body is refused");
+        assert!(
+            matches!(err, TerminologyDecodeError::Malformed(_)),
+            "got {err:?}"
+        );
+    }
+    // The wrong resource is named, not read as a ValueSet with no expansion.
+    let err = decode_expansion(&bytes(&json!({"resourceType": "Parameters"})))
+        .expect_err("a Parameters body is not an expansion");
+    assert!(
+        matches!(
+            &err,
+            TerminologyDecodeError::WrongResource { expected: "ValueSet", found } if found == "Parameters"
+        ),
+        "got {err:?}"
+    );
+}


### PR DESCRIPTION
Closes #3099

## The tests

`app/ferroehr-ext/tests/it` is one binary with one `#[cfg(feature)]`-gated module per integration, so `--all-features` runs everything and the slim build compiles none of it. They drive the crate's public seams with no broker and no network:

- **`terminology_decode`** — the typed R4B decoders over fixture bodies: named scalars read by kind (an unmodelled kind ignored, never an error), `$translate` matches in response order with their `equivalence` and target concept, an empty `Parameters` as an empty view, and every malformed shape refused (not JSON, a parameter without its mandatory name, a `ValueSet` missing `status` or `expansion.timestamp`).
- **`events_contract`** — what the `EventPublisher` trait obliges an implementation to provide (`publish`) and what it provides for free (`declare_subscription` as a successful no-op, a constant topology epoch); that a routing key and the binding key a subscription derives for the same facts agree word for word, with `-` staying a literal word and `*` only where a predicate is NULL; and that `AmqpPublisher` performs no I/O at construction, fails on first use against an unreachable broker with the typed transport error, and does not count a connection that never came up as a fresh topology.
- **`multimedia_engine`** — the engine over a real in-memory `object_store`: a value above the threshold offloads, its bytes land under the content-addressed key verbatim, the externalised value keeps its decoded `size` and integrity check, expanding restores the inline bytes with the reference beside them, a small value and a disabled engine change nothing, identical bytes share one key, expanding twice is idempotent, and a reference with no object behind it is a typed refusal that invents nothing.

Nothing duplicates `app/ferroehr/tests/it/events_amqp.rs` (real RabbitMQ) or the wiremock-backed `terminology_*.rs` suites, and nothing was added for `src/fhir/{mapping,reverse,feeder_audit}.rs`, which leave with #3080.

## The defect they found

`decode_parameters` accepted **any** JSON object. R4B `Parameters` has no mandatory member, so a `$validate-code` answered with a `ValueSet`, an `OperationOutcome`, or a bare `{"parameter": []}` decoded to an empty `ParametersView` — indistinguishable from a legitimate "no result". `decode_expansion` had the mirror hole. Both now read the `resourceType` first and refuse a mismatch as `TerminologyDecodeError::WrongResource { expected, found }`:

```
unexpected FHIR resource: expected Parameters, got OperationOutcome
```

The platform maps it through the existing `#[from]`, so `terminology.external.fail_on_error` decides on it like any other upstream fault. `CHANGELOG.md` carries the entry.

## Gates

`cargo nextest run -p ferroehr-ext --all-features` (57 tests) and each feature alone (`fhir` 31, `events` 9, `multimedia` 17); `cargo check -p ferroehr-ext --no-default-features` (the slim lane); `cargo clippy -p ferroehr-ext --all-targets --all-features -D warnings`; the platform's `terminology_fhir` + `terminology_multi_provider` suites (25 tests) against the changed decoder; comment-style, spdx-headers, changelog-structure.

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.
