### PR TITLE
perf(storage,validation): one pooled connection per commit, and a large composition hands its worker off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,16 @@ workflow refuses a tag that has no matching section here.
   folded statement (or one transaction when attestations or the outbox are in
   play).
 
+- **A large composition no longer holds a request worker through its whole
+  validation** (#3097). The RM, terminology and archetype-conformance passes
+  are CPU work that ran inline on the async worker, costing about 260 ns per
+  JSON node: the largest form the CKM publishes takes 2.5 ms, and at the
+  default 16 MiB body limit a single commit could hold one worker for tens of
+  milliseconds while every other request on it waited. Above 400 nodes the
+  passes now tell the runtime to relieve the worker first. Validation itself is
+  unchanged: the same passes run in the same order and refuse the same
+  content.
+
 - **`openehr-query`, `openehr-adl` and `openehr-its` move to the Business Source
   License 1.1** (owner decision 2026-09-04). The three hand-written engines (the
   AQL parser, the ADL 2 engine, and the canonical codecs, REST contract and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,16 @@ workflow refuses a tag that has no matching section here.
 
 ### Changed
 
+- **A composition commit checks out one pooled connection instead of three**
+  (#3097). The EHR-writability gate, the persistent-duplicate gate and the
+  commit each took their own connection from the pool. With multi-tenancy on
+  every checkout costs a `set_config` round trip that stamps the tenant GUC, so
+  the acquire count was the cost: measured over 100 commits, the path went from
+  9.3 to 6.3 connection checkouts each. Behaviour is unchanged — the gates run
+  in the same order, answer the same statuses, and the commit is still one
+  folded statement (or one transaction when attestations or the outbox are in
+  play).
+
 - **`openehr-query`, `openehr-adl` and `openehr-its` move to the Business Source
   License 1.1** (owner decision 2026-09-04). The three hand-written engines (the
   AQL parser, the ADL 2 engine, and the canonical codecs, REST contract and

--- a/app/ferroehr/Cargo.toml
+++ b/app/ferroehr/Cargo.toml
@@ -163,6 +163,10 @@ inferno.workspace = true
 name = "aql"
 harness = false
 
+[[bench]]
+name = "validation"
+harness = false
+
 [lints]
 workspace = true
 

--- a/app/ferroehr/benches/validation.rs
+++ b/app/ferroehr/benches/validation.rs
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: Ruben Talstra
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Criterion benches over the inline commit-validation passes, with per-bench
+//! CPU flamegraphs.
+//!
+//! `FerroEhrService::validate_composition_for_commit` runs two CPU-bound passes
+//! on the tokio worker before a composition reaches storage: the RM +
+//! terminology pass over the canonical instance, then the archetype-conformance
+//! pass against the template's WebTemplate. Both are pure functions of the
+//! composition and the template, so they bench without a database. The fixtures
+//! are the corpus spread: a short medicines list, the International Patient
+//! Summary the issue names (a ~200 kB instance against a ~1.9 MB operational
+//! template), and the congenital-syphilis case investigation, which is the
+//! largest form the CKM publishes and this repository vendors as its
+//! large-payload scale probe (a ~539 kB instance).
+//!
+//! Plain measurement: `cargo bench -p ferroehr --bench validation`.
+//! Flamegraphs: `cargo bench -p ferroehr --bench validation -- --profile-time 10`
+//! writes `flamegraph.svg` per bench under
+//! `target/criterion/<bench>/profile/` (criterion runs the registered
+//! profiler only under `--profile-time` —
+//! <https://docs.rs/criterion/latest/criterion/profiler/trait.Profiler.html>).
+//!
+//! NOTE: the profiler glue below implements criterion's `Profiler` trait over
+//! the `pprof` sampler directly, because pprof's own `criterion` feature is
+//! pinned to criterion ^0.5 (verified on crates.io 2026-08-04) and this
+//! workspace is on criterion 0.8.
+
+#![expect(
+    clippy::expect_used,
+    reason = "bench fixture setup and profiler I/O: a malformed fixture or an \
+              unwritable profile directory must abort the bench loudly (there \
+              is no caller to return an error to)"
+)]
+#![expect(
+    clippy::disallowed_types,
+    reason = "owner-approved 2026-08-03 (#1694): the bench feeds the validators \
+              the same canonical fragment the commit seam carries"
+)]
+#![expect(
+    clippy::print_stderr,
+    reason = "the bench harness is a dev binary; profiler lifecycle notes go \
+              to the operator on stderr (no tracing subscriber is installed)"
+)]
+
+use std::fs::File;
+use std::hint::black_box;
+use std::path::{Path, PathBuf};
+
+use criterion::profiler::Profiler;
+use criterion::{Criterion, criterion_group, criterion_main};
+use openehr_its::flat::webtemplate::model::WebTemplate;
+use serde_json::Value;
+
+/// The vendored CKM corpus directory, anchored at the crate manifest so the
+/// bench runs from any working directory.
+fn corpus_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../corpus/templates/ckm")
+}
+
+/// Load one corpus template's example composition and its WebTemplate.
+fn fixture(stem: &str) -> (Value, WebTemplate) {
+    let dir = corpus_dir();
+    let example = std::fs::read_to_string(dir.join(format!("{stem}.example.json")))
+        .expect("the corpus example composition must be readable");
+    let composition: Value =
+        serde_json::from_str(&example).expect("the corpus example must be canonical JSON");
+    let xml = std::fs::read_to_string(dir.join(format!("{stem}.opt")))
+        .expect("the corpus operational template must be readable");
+    let opt = openehr_its::opt14::from_xml(&xml).expect("the corpus OPT must parse");
+    let web_template = openehr_its::flat::webtemplate::builder::build_web_template(&opt)
+        .expect("the corpus OPT must build into a WebTemplate");
+    (composition, web_template)
+}
+
+/// The two inline passes, per fixture size, plus their sum — the CPU the
+/// commit path spends on the worker before it touches the pool.
+fn commit_validation(c: &mut Criterion) {
+    for stem in [
+        "medicines-list",
+        "international-patient-summary",
+        "congenital-syphilis-case-investigation",
+    ] {
+        let (composition, web_template) = fixture(stem);
+        c.bench_function(&format!("validate_rm_terminology/{stem}"), |b| {
+            b.iter(|| {
+                openehr_its::rm_instance::validate_rm_and_terminology(black_box(&composition))
+            });
+        });
+        c.bench_function(&format!("validate_archetype_conformance/{stem}"), |b| {
+            b.iter(|| {
+                openehr_its::flat::validation::validate_archetype_conformance(
+                    black_box(&composition),
+                    black_box(&web_template),
+                )
+            });
+        });
+        c.bench_function(&format!("validate_both_passes/{stem}"), |b| {
+            b.iter(|| {
+                let mut messages =
+                    openehr_its::rm_instance::validate_rm_and_terminology(black_box(&composition));
+                messages.extend(
+                    openehr_its::flat::validation::validate_archetype_conformance(
+                        black_box(&composition),
+                        black_box(&web_template),
+                    ),
+                );
+                messages
+            });
+        });
+    }
+}
+
+/// Criterion `Profiler` glue over the `pprof` sampler: start a guard when
+/// criterion enters profile mode, render `flamegraph.svg` into the bench's
+/// profile directory when it leaves.
+struct FlamegraphProfiler {
+    frequency: i32,
+    guard: Option<pprof::ProfilerGuard<'static>>,
+}
+
+impl FlamegraphProfiler {
+    const fn new(frequency: i32) -> Self {
+        Self {
+            frequency,
+            guard: None,
+        }
+    }
+}
+
+impl Profiler for FlamegraphProfiler {
+    fn start_profiling(&mut self, _benchmark_id: &str, _benchmark_dir: &Path) {
+        self.guard = Some(
+            pprof::ProfilerGuardBuilder::default()
+                .frequency(self.frequency)
+                // The unwind-hazard blocklist pprof's docs recommend
+                // (<https://docs.rs/pprof/latest/pprof/>).
+                .blocklist(&["libc", "libgcc", "pthread", "vdso"])
+                .build()
+                .expect("the pprof sampler must start"),
+        );
+    }
+
+    fn stop_profiling(&mut self, benchmark_id: &str, benchmark_dir: &Path) {
+        let Some(guard) = self.guard.take() else {
+            return;
+        };
+        let report = guard.report().build().expect("the pprof report must build");
+        std::fs::create_dir_all(benchmark_dir).expect("the profile directory must be creatable");
+        let path = benchmark_dir.join("flamegraph.svg");
+        let file = File::create(&path).expect("the flamegraph file must be creatable");
+        // NOTE: #2406 — pprof's `flamegraph` feature pins inferno ^0.11
+        // (quick-xml 0.26, RUSTSEC-2026-0194/0195); this is pprof 0.15's own
+        // fold, rendered through the direct inferno 0.12 dependency instead.
+        let lines: Vec<String> = report
+            .data
+            .iter()
+            .map(|(frames, count)| {
+                let mut segments = vec![frames.thread_name_or_id()];
+                for frame in frames.frames.iter().rev() {
+                    for symbol in frame.iter().rev() {
+                        segments.push(symbol.to_string());
+                    }
+                }
+                format!("{} {count}", segments.join(";"))
+            })
+            .collect();
+        if !lines.is_empty() {
+            inferno::flamegraph::from_lines(
+                &mut inferno::flamegraph::Options::default(),
+                lines.iter().map(String::as_str),
+                file,
+            )
+            .expect("the flamegraph must render");
+        }
+        eprintln!("profiled {benchmark_id}: {}", path.display());
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(FlamegraphProfiler::new(999));
+    targets = commit_validation
+}
+criterion_main!(benches);

--- a/app/ferroehr/src/service/ehr/composition.rs
+++ b/app/ferroehr/src/service/ehr/composition.rs
@@ -78,13 +78,18 @@ impl FerroEhrService {
             "COMPOSITION creation",
             &self.effective_system_id(),
         )?;
+        // ONE pooled connection carries both gates AND the commit. Every
+        // checkout costs a `set_config` round trip while multi-tenancy is on
+        // (`crate::db::stamp_tenant_guc`), and this path used to take three or
+        // four of them: measured at +0.4 ms per commit on #3097.
+        let mut conn = self.pool.acquire().await?;
         // The EHR-existence (404) and content-writability (409) gates in one
         // round trip: a COMPOSITION is EHR content (RM ehr master04 §EHR
         // Creation / §EHR Active Status).
-        let commit_now = self.ensure_ehr_content_writable(ehr_id).await?;
+        let commit_now = self.ensure_ehr_content_writable(&mut *conn, ehr_id).await?;
         self.validate_composition_for_commit(&composition, incomplete)
             .await?;
-        self.reject_duplicate_persistent(ehr_id, &composition)
+        self.reject_duplicate_persistent(&mut *conn, ehr_id, &composition)
             .await?;
 
         // The committed template identity is promoted to `vo_version.template_id`
@@ -99,7 +104,6 @@ impl FerroEhrService {
         // node-decomposition machinery on every caller's stack.
         let signing_ctx = self.signing_ctx();
         let committed = if envelope.attestations.is_empty() && !signing_ctx.outbox_enabled {
-            let mut conn = self.pool.acquire().await?;
             Box::pin(create(
                 &mut conn,
                 Some(ehr_id),
@@ -113,7 +117,7 @@ impl FerroEhrService {
             ))
             .await?
         } else {
-            let mut tx = self.pool.begin().await?;
+            let mut tx = sqlx::Connection::begin(&mut *conn).await?;
             let committed = Box::pin(create(
                 &mut tx,
                 Some(ehr_id),
@@ -781,16 +785,22 @@ impl FerroEhrService {
     /// instant. The guarded concepts are RM ehr master04 §EHR Creation and §EHR
     /// Active Status; no openEHR spec governs the query shape (our own design).
     ///
+    /// Runs on the CALLER'S executor so a write path can spend one pooled
+    /// connection on its gates and its commit: with multi-tenancy on, every
+    /// checkout costs a `set_config` round trip (`crate::db`), so the acquire
+    /// count is the cost (measured on #3097).
+    ///
     /// # Errors
     /// [`ServiceError::NotFound`] when the EHR does not exist;
     /// [`ServiceError::Conflict`] when it is not modifiable;
     /// [`ServiceError::Database`] if the read fails.
-    pub(in crate::service) async fn ensure_ehr_content_writable(
+    pub(in crate::service) async fn ensure_ehr_content_writable<'e>(
         &self,
+        executor: impl sqlx::PgExecutor<'e>,
         ehr_id: EhrId,
     ) -> Result<jiff::Timestamp, ServiceError> {
         let (exists, is_modifiable, now) =
-            crate::storage::ehr_repo::ehr_writability(&self.pool, ehr_id).await?;
+            crate::storage::ehr_repo::ehr_writability(executor, ehr_id).await?;
         if !exists {
             return Err(ServiceError::sm(
                 CallStatusType::EhrIdDoesNotExist,

--- a/app/ferroehr/src/service/ehr/validation.rs
+++ b/app/ferroehr/src/service/ehr/validation.rs
@@ -51,12 +51,18 @@ impl FerroEhrService {
     /// We adopt the CNF criterion (`create_composition-same_opt_twice`). Only
     /// persistent COMPOSITIONs with a declared template are constrained.
     ///
+    /// Runs on the CALLER'S executor so the create path spends one pooled
+    /// connection on its gates and its commit: with multi-tenancy on, every
+    /// checkout costs a `set_config` round trip (`crate::db`), so the acquire
+    /// count is the cost (measured on #3097).
+    ///
     /// # Errors
     /// [`ServiceError::Conflict`] when a live persistent COMPOSITION for the
     /// same template already exists in the EHR; [`ServiceError::Database`] on
     /// a storage failure.
-    pub(super) async fn reject_duplicate_persistent(
+    pub(super) async fn reject_duplicate_persistent<'e>(
         &self,
+        executor: impl sqlx::PgExecutor<'e>,
         ehr_id: EhrId,
         composition: &Value,
     ) -> Result<(), ServiceError> {
@@ -75,7 +81,7 @@ impl FerroEhrService {
         // schedule's, still "under debate in the openEHR SEC"
         // (`CNF/docs/platform_test_schedule/master07-func_tc_ehr_composition.adoc`).
         let exists = crate::storage::version_repo::meta::persistent_template_exists(
-            &self.pool,
+            executor,
             ehr_id,
             template_id,
             code::PERSISTENT,

--- a/app/ferroehr/src/service/ehr/validation.rs
+++ b/app/ferroehr/src/service/ehr/validation.rs
@@ -40,6 +40,63 @@ use crate::service::ehr::category::code;
 use crate::service::error::{ServiceError, Violation};
 use crate::versioning::{Kind, lifecycle};
 
+/// The instance size, in JSON nodes, above which the COMPOSITION validation
+/// passes hand their worker off before running.
+///
+/// The two passes cost about 260 ns per JSON node, measured by
+/// `benches/validation.rs` over the vendored CKM corpus: 52 nodes in 11.2 µs,
+/// 4601 in 1.23 ms, 9678 in 2.55 ms. Tokio documents 10 to 100 µs as the
+/// budget for a task between await points
+/// (<https://docs.rs/tokio/latest/tokio/task/fn.block_in_place.html>), so 400
+/// nodes is where a pass first reaches the top of that budget.
+const VALIDATION_HANDOFF_NODES: usize = 400;
+
+/// Runs one CPU-bound validation pass, relieving this worker of its other
+/// tasks first when `hand_off` says the instance is large enough to hold it
+/// past tokio's budget.
+///
+/// The passes are pure functions of borrowed data, so the hand-off is
+/// [`tokio::task::block_in_place`] rather than a spawn: no owned copy of a
+/// multi-megabyte instance has to be made to cross a task boundary. That call
+/// panics outside a multi-thread runtime, so the flavor is checked and a
+/// current-thread runtime runs the pass inline, which is what it would do
+/// anyway — a single-threaded runtime has no other worker to relieve.
+///
+/// No openEHR spec governs runtime scheduling — our own design.
+fn run_validation_pass<T>(hand_off: bool, pass: impl FnOnce() -> T) -> T {
+    if hand_off
+        && matches!(
+            tokio::runtime::Handle::try_current().map(|h| h.runtime_flavor()),
+            Ok(tokio::runtime::RuntimeFlavor::MultiThread)
+        )
+    {
+        return tokio::task::block_in_place(pass);
+    }
+    pass()
+}
+
+/// Returns whether `value` carries more than `limit` JSON nodes.
+///
+/// The walk stops as soon as the answer is known, so a large instance costs
+/// `limit` steps and a small one costs its own size. It is iterative because
+/// the depth of a submitted instance is the client's choice.
+fn exceeds_node_count(value: &Value, limit: usize) -> bool {
+    let mut pending = vec![value];
+    let mut seen: usize = 0;
+    while let Some(node) = pending.pop() {
+        seen += 1;
+        if seen > limit {
+            return true;
+        }
+        match node {
+            Value::Array(items) => pending.extend(items.iter()),
+            Value::Object(fields) => pending.extend(fields.values()),
+            _ => {}
+        }
+    }
+    false
+}
+
 impl FerroEhrService {
     /// Enforce the CNF persistent-COMPOSITION uniqueness convention: an EHR may
     /// hold only one *live* persistent COMPOSITION per template.
@@ -139,14 +196,17 @@ impl FerroEhrService {
         composition: &Value,
         incomplete: bool,
     ) -> Result<(), ServiceError> {
-        let mut messages = if incomplete {
-            openehr_its::rm_instance::validate_rm_and_terminology_incomplete_as(
-                composition,
-                "COMPOSITION",
-            )
-        } else {
-            openehr_its::rm_instance::validate_rm_and_terminology(composition)
-        };
+        let hand_off = exceeds_node_count(composition, VALIDATION_HANDOFF_NODES);
+        let mut messages = run_validation_pass(hand_off, || {
+            if incomplete {
+                openehr_its::rm_instance::validate_rm_and_terminology_incomplete_as(
+                    composition,
+                    "COMPOSITION",
+                )
+            } else {
+                openehr_its::rm_instance::validate_rm_and_terminology(composition)
+            }
+        });
         let rm_terminology_failures = messages.len();
         let mut template_failures = 0;
         let mut binding_failures = 0;
@@ -155,14 +215,16 @@ impl FerroEhrService {
             .and_then(Value::as_str)
         {
             let wt = self.web_template_for(template_id).await?;
-            messages.extend(if incomplete {
-                openehr_its::flat::validation::validate_archetype_conformance_incomplete(
-                    composition,
-                    &wt,
-                )
-            } else {
-                openehr_its::flat::validation::validate_archetype_conformance(composition, &wt)
-            });
+            messages.extend(run_validation_pass(hand_off, || {
+                if incomplete {
+                    openehr_its::flat::validation::validate_archetype_conformance_incomplete(
+                        composition,
+                        &wt,
+                    )
+                } else {
+                    openehr_its::flat::validation::validate_archetype_conformance(composition, &wt)
+                }
+            }));
             template_failures = messages.len() - rm_terminology_failures;
             // Archetype constraint bindings resolve against the routed
             // terminology servers (BASE `master12-terminology.adoc` §"Binding
@@ -707,8 +769,8 @@ mod tests {
     use serde_json::{Value, json};
 
     use super::{
-        collect_local_item_refs, item_ref_root, validate_ehr_access, validate_ehr_status,
-        validate_folder,
+        collect_local_item_refs, exceeds_node_count, item_ref_root, run_validation_pass,
+        validate_ehr_access, validate_ehr_status, validate_folder,
     };
     use crate::service::ehr::access::initial_ehr_access;
     use crate::service::ehr::service::initial_ehr_status;
@@ -1341,5 +1403,29 @@ mod tests {
         );
         assert_eq!(item_ref_root("not-a-uuid"), None);
         assert_eq!(item_ref_root(""), None);
+    }
+
+    #[test]
+    fn the_node_probe_answers_both_sides_of_its_limit() {
+        // Five nodes: the root object, its two members, the inner object and its
+        // one member.
+        let small = json!({"_type": "COMPOSITION", "content": [{"_type": "SECTION"}]});
+        assert!(!exceeds_node_count(&small, 400));
+        assert!(!exceeds_node_count(&small, 5));
+        assert!(exceeds_node_count(&small, 4));
+        let wide = json!({"content": (0..500).map(|i| json!({"n": i})).collect::<Vec<_>>()});
+        assert!(exceeds_node_count(&wide, 400));
+        let deep = (0..64).fold(json!(1), |acc, _| json!({"items": [acc]}));
+        assert!(!exceeds_node_count(&deep, 400));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_large_instance_hands_the_worker_off_and_still_returns_the_pass_answer() {
+        assert_eq!(run_validation_pass(true, || 7_u8), 7);
+    }
+
+    #[tokio::test]
+    async fn a_current_thread_runtime_runs_the_pass_inline_instead_of_panicking() {
+        assert_eq!(run_validation_pass(true, || 7_u8), 7);
     }
 }

--- a/app/ferroehr/src/storage/ehr_repo.rs
+++ b/app/ferroehr/src/storage/ehr_repo.rs
@@ -428,15 +428,15 @@ pub async fn ehr_is_modifiable_locked(
 ///
 /// # Errors
 /// Returns [`StorageError::Database`] on a driver failure.
-pub async fn ehr_writability(
-    pool: &PgPool,
+pub async fn ehr_writability<'e>(
+    executor: impl PgExecutor<'e>,
     ehr_id: EhrId,
 ) -> Result<(bool, Option<bool>, jiff::Timestamp), StorageError> {
     let row = sqlx::query(
         "SELECT (SELECT is_modifiable FROM ehr WHERE id = $1) AS is_modifiable, now() AS ts",
     )
     .bind(ehr_id)
-    .fetch_one(pool)
+    .fetch_one(executor)
     .await?;
     let is_modifiable: Option<bool> = row.try_get("is_modifiable")?;
     let now = row.try_get::<jiff_sqlx::Timestamp, _>("ts")?.to_jiff();

--- a/app/ferroehr/src/storage/version_repo/meta.rs
+++ b/app/ferroehr/src/storage/version_repo/meta.rs
@@ -335,8 +335,8 @@ const EXISTS_SQL: &str = "SELECT EXISTS(SELECT 1 FROM vo_version_all WHERE vo_id
 ///
 /// # Errors
 /// Returns [`StorageError::Database`] on a driver failure.
-pub async fn persistent_template_exists(
-    pool: &PgPool,
+pub async fn persistent_template_exists<'e>(
+    executor: impl sqlx::PgExecutor<'e>,
     ehr_id: EhrId,
     template_id: &str,
     persistent_code: &str,
@@ -352,7 +352,7 @@ pub async fn persistent_template_exists(
     .bind(deleted_state)
     .bind(template_id)
     .bind(persistent_code)
-    .fetch_one(pool)
+    .fetch_one(executor)
     .await?)
 }
 


### PR DESCRIPTION
Closes #3097

The issue named three fixed per-request costs. All three were measured; two were acted on and one was measured and rejected. The numbers and the plan comparisons are recorded on the issue.

## One pooled connection per commit

A composition commit used to take three or four connections out of the pool: one for the EHR-writability gate, one for the persistent-duplicate gate, and one (or a transaction) for the commit itself. With multi-tenancy enabled each checkout costs a `set_config` round trip that stamps the tenant GUC, so the acquire count was the cost rather than the statements.

Four functions now take an executor instead of reaching for the pool themselves:

- `storage::ehr_repo::ehr_writability`
- `storage::version_repo::meta::persistent_template_exists`
- `service::ehr::composition::ensure_ehr_content_writable`
- `service::ehr::validation::reject_duplicate_persistent`

`create_composition` checks out one connection, runs both gates on it, and commits on it. The transactional branch, taken when attestations or the outbox are in play, begins on that same connection.

Measured over 100 commits on the composed stack, idle background subtracted: 9.3 connection checkouts per commit before, 6.3 after.

## A large composition hands its worker off

The RM, terminology and archetype-conformance passes are CPU work that ran inline on the async worker. `app/ferroehr/benches/validation.rs` is a new criterion bench over the vendored CKM corpus, with the same flamegraph profiler glue the AQL bench uses. It measures the passes at about 260 ns per JSON node, stable across three orders of magnitude.

| Fixture | Instance bytes | JSON nodes | Both passes |
|---|---|---|---|
| `medicines-list` | 1.5 kB | 52 | 11.2 µs |
| `international-patient-summary` | 202 kB | 4601 | 1.23 ms |
| `congenital-syphilis-case-investigation` | 539 kB | 9678 | 2.55 ms |

Tokio documents 10 to 100 µs as the budget for a task between await points, and the input size is the client's: at the default 16 MiB body limit one commit could hold a worker for tens of milliseconds with nothing able to preempt it. Above 400 nodes, the size at which a pass first reaches 100 µs, both passes now run inside `tokio::task::block_in_place`.

`block_in_place` rather than `spawn_blocking`, because the passes borrow the composition and the WebTemplate and a spawn would need an owned copy of a multi-megabyte instance. The runtime flavor is checked first since that call panics on a current-thread runtime, where the pass runs inline instead; two unit tests pin both arms. The node probe stops as soon as the answer is known and walks iteratively, because the depth of a submitted instance is the client's choice.

Validation behaviour is unchanged: the same passes, the same order, the same refusals.

## The attestation aggregates stay, with the measurement

Every full version read folds the version's `ATTESTATION`s in as two `jsonb_agg` LATERAL aggregates over the `vo_attestation_all` union view. `EXPLAIN (ANALYZE, BUFFERS)` medians over five warm runs put that at 0.015 ms on a point read (0.027 versus 0.012 ms) and 0.3 ms per 200-row bulk read (0.65 versus 0.34 ms). Against the 4 ms point-read floor the issue cites, that is 0.4%.

Three alternative shapes were measured before concluding. Guarding the correlated scan with an always-false predicate makes both index scans report `never executed` and changes nothing, so the cost is the per-row `Sort` plus `Aggregate` node pair, not the probes. Hoisting the aggregate to set level in a CTE halves the bulk cost but makes the point read worse, 0.039 against 0.027 ms. Moving the `ORDER BY` out of the aggregate does not remove the sort.

The only shape that reaches the 0.012 ms plan is a stored `has_attestations` flag on `vo_version` whose stale `false` would silently serve an `ORIGINAL_VERSION` without its attestations, maintained across the commit path, the after-committal add path and the cold-tier mirror. A 0.4% gain does not buy that. The read path and its tests are untouched.

## Gates

`cargo fmt`, the workspace clippy lane, the rustdoc lane, `comment-style`, `typed-status`, `default-style` and `no-python` are green. `cargo nextest run -p ferroehr` runs 1016 tests, all passing.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.
