### PR TITLE
fix(its): resolve an element's position only when a refusal names it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,17 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **A large operational template uploads in milliseconds again** (#3114). The
+  XML reader resolved every closing element's line and column by scanning the
+  document from byte zero, which made a parse quadratic in document size: the
+  International Patient Summary template, 1.9 MB, took 10.08 s, and the largest
+  form the CKM publishes was on track for about 59 s. A template upload holds
+  that CPU on the request, and large uploads were answering
+  `408 Request Timeout`.
+  The position and the element path are now resolved when a refusal is raised
+  rather than on every close, so a refused document names exactly what it named
+  before. The same two templates parse in 10.2 ms and 25.1 ms.
+
 - **An explicit `fetch` or AQL `LIMIT` can no longer ask for a page larger than
   `query.max_result_rows`** (#3092). The ceiling used to apply only to a query
   that carried neither bound, so `fetch=10000000` materialised the whole

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5433,7 +5433,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.60"
+version = "0.0.61"
 dependencies = [
  "indexmap 2.14.0",
  "openehr-am",
@@ -5449,7 +5449,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.60"
+version = "0.0.61"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -5459,7 +5459,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.60"
+version = "0.0.61"
 dependencies = [
  "serde",
  "serde_json",
@@ -5478,7 +5478,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.60"
+version = "0.0.61"
 dependencies = [
  "async-trait",
  "axum",
@@ -5508,7 +5508,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.60"
+version = "0.0.61"
 dependencies = [
  "assert_fs",
  "chumsky",
@@ -5522,7 +5522,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.60"
+version = "0.0.61"
 dependencies = [
  "chumsky",
  "logos",
@@ -5531,7 +5531,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.60"
+version = "0.0.61"
 dependencies = [
  "insta",
  "jsonschema",
@@ -5549,7 +5549,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.60"
+version = "0.0.61"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/app/ferroehr/benches/validation.rs
+++ b/app/ferroehr/benches/validation.rs
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: Ruben Talstra
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Criterion benches over the inline commit-validation passes, with per-bench
-//! CPU flamegraphs.
+//! Criterion benches over the CPU a write path spends inline on its worker,
+//! with per-bench flamegraphs: the commit-validation passes, and the operational
+//! template ingestion a template upload runs before either of them can.
 //!
 //! `FerroEhrService::validate_composition_for_commit` runs two CPU-bound passes
 //! on the tokio worker before a composition reaches storage: the RM +
@@ -112,6 +113,30 @@ fn commit_validation(c: &mut Criterion) {
     }
 }
 
+/// Operational template ingestion: the XML parse and the WebTemplate build a
+/// template upload runs, and the composition path runs on a cache miss.
+fn template_ingestion(c: &mut Criterion) {
+    let dir = corpus_dir();
+    for stem in [
+        "medicines-list",
+        "international-patient-summary",
+        "congenital-syphilis-case-investigation",
+    ] {
+        let xml = std::fs::read_to_string(dir.join(format!("{stem}.opt")))
+            .expect("the corpus operational template must be readable");
+        c.bench_function(&format!("opt_parse/{stem}"), |b| {
+            b.iter(|| openehr_its::opt14::from_xml(black_box(&xml)).expect("the OPT must parse"));
+        });
+        let opt = openehr_its::opt14::from_xml(&xml).expect("the OPT must parse");
+        c.bench_function(&format!("web_template_build/{stem}"), |b| {
+            b.iter(|| {
+                openehr_its::flat::webtemplate::builder::build_web_template(black_box(&opt))
+                    .expect("the OPT must build into a WebTemplate")
+            });
+        });
+    }
+}
+
 /// Criterion `Profiler` glue over the `pprof` sampler: start a guard when
 /// criterion enters profile mode, render `flamegraph.svg` into the bench's
 /// profile directory when it leaves.
@@ -181,6 +206,6 @@ impl Profiler for FlamegraphProfiler {
 criterion_group! {
     name = benches;
     config = Criterion::default().with_profiler(FlamegraphProfiler::new(999));
-    targets = commit_validation
+    targets = commit_validation, template_ingestion
 }
 criterion_main!(benches);

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-adl"
-version = "0.0.60"
+version = "0.0.61"
 description = "openEHR ADL 2.4.0: hand-written ADL2/cADL/ODIN parser, AOM2 validation catalogue, specialisation flattener, OPT2 generator, and ADL 1.4→2 conversion over the generated openehr_am::v2_4::aom2 model"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,11 +16,11 @@ include = ["src/**", "README.md", "LICENSE"]
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)
-openehr-base = { path = "../openehr-base", version = "0.0.60" }   # VersionStatus for the parsed HRID
-openehr-am = { path = "../openehr-am", version = "0.0.60" }       # v2_4 ArchetypeHrid (the identification target type)
-openehr-rm = { path = "../openehr-rm", version = "0.0.60" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
-openehr-lang = { path = "../openehr-lang", version = "0.0.60" }   # openehr_lang::odin — the ODIN section parser
-openehr-term = { path = "../openehr-term", version = "0.0.60" }   # the languages code set for the RM resource-meta rows
+openehr-base = { path = "../openehr-base", version = "0.0.61" }   # VersionStatus for the parsed HRID
+openehr-am = { path = "../openehr-am", version = "0.0.61" }       # v2_4 ArchetypeHrid (the identification target type)
+openehr-rm = { path = "../openehr-rm", version = "0.0.61" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
+openehr-lang = { path = "../openehr-lang", version = "0.0.61" }   # openehr_lang::odin — the ODIN section parser
+openehr-term = { path = "../openehr-term", version = "0.0.61" }   # the languages code set for the RM resource-meta rows
 uuid.workspace = true        # meta uid/build_uid (AUTHORED_ARCHETYPE.uid: Uuid)
 indexmap.workspace = true    # OdinValue::Object body (insertion-ordered map)
 

--- a/crates/openehr-am/Cargo.toml
+++ b/crates/openehr-am/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-am"
-version = "0.0.60"
+version = "0.0.61"
 description = "openEHR AM Archetype Model, generated from BMM: generations v1_4 (AM 1.4.0, ADL 1.4) and v2_4 (AM 2.4.0, ADL 2; current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,8 +13,8 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.60" }
-openehr-lang = { path = "../openehr-lang", version = "0.0.60" }
+openehr-base = { path = "../openehr-base", version = "0.0.61" }
+openehr-lang = { path = "../openehr-lang", version = "0.0.61" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also carries the untyped `Value` fields the generator

--- a/crates/openehr-base/Cargo.toml
+++ b/crates/openehr-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-base"
-version = "0.0.60"
+version = "0.0.61"
 description = "openEHR BASE foundation + base types, generated from BMM: generations v1_2 (BASE 1.2.0) and v1_3 (BASE 1.3.0, current)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-its"
-version = "0.0.60"
+version = "0.0.61"
 description = "openEHR ITS (Implementation Technology Specifications): canonical JSON + canonical XML serialization of the RM, the generated ITS-REST 1.1.0 API contract, OPT 1.4 and AOM2 archetype XML codecs, and the Simplified Formats (FLAT / STRUCTURED / Web Template)"
 edition.workspace = true
 rust-version.workspace = true
@@ -41,14 +41,14 @@ regex = { workspace = true, optional = true }
 fancy-regex = { workspace = true, optional = true }
 # The generated XML (de)serializers impl the crate's ToXml/FromXml traits for the
 # RM/BASE spec types, so these are real (non-dev) deps.
-openehr-base = { path = "../openehr-base", version = "0.0.60", optional = true }
-openehr-rm = { path = "../openehr-rm", version = "0.0.60", optional = true }
+openehr-base = { path = "../openehr-base", version = "0.0.61", optional = true }
+openehr-rm = { path = "../openehr-rm", version = "0.0.61", optional = true }
 # The native canonical-JSON codec (`json_codec/generated`, emit-json) implements
 # `ToJson` for EVERY generated spec type the `OpenEhrType` derive covers, so it
 # spans all five spec crates (not just the RM/BASE the XML codec needs).
-openehr-lang = { path = "../openehr-lang", version = "0.0.60", optional = true }
-openehr-am = { path = "../openehr-am", version = "0.0.60", optional = true }
-openehr-term = { path = "../openehr-term", version = "0.0.60", optional = true }
+openehr-lang = { path = "../openehr-lang", version = "0.0.61", optional = true }
+openehr-am = { path = "../openehr-am", version = "0.0.61", optional = true }
+openehr-term = { path = "../openehr-term", version = "0.0.61", optional = true }
 
 # `full` — every ITS surface (canonical JSON/XML, the generated ITS-REST
 # contract, `opt14`, Simplified Formats). ON BY DEFAULT, so every consumer sees

--- a/crates/openehr-its/src/xml/runtime.rs
+++ b/crates/openehr-its/src/xml/runtime.rs
@@ -681,6 +681,25 @@ struct Frame {
     children_seen: std::collections::BTreeMap<String, u32>,
 }
 
+/// The element the reader closed most recently, kept as the facts a
+/// [`Location`] is derived from rather than as the `Location` itself.
+///
+/// The line, column and root path are computed in [`XmlReader::located`],
+/// because a refusal aborts the parse: at most one location is ever read, and
+/// resolving a byte offset to a line number costs a scan from the start of the
+/// document. Doing that on every close made a large document quadratic — a
+/// 1.9 MB operational template took 10 s to parse.
+struct ClosedElement {
+    element: String,
+    xsi_type: Option<String>,
+    offset: usize,
+    ordinal: u32,
+    /// How many frames were still open when this element closed, so
+    /// [`XmlReader::located`] reads its ancestors and not any element opened
+    /// afterwards.
+    ancestors: usize,
+}
+
 /// Reads canonical openEHR XML, yielding owned [`XmlEvent`]s. Empty elements are
 /// expanded to Start+End so callers only handle those four cases.
 ///
@@ -692,7 +711,7 @@ pub struct XmlReader<'a> {
     r: Reader<&'a [u8]>,
     src: &'a str,
     frames: Vec<Frame>,
-    last_closed: Option<Location>,
+    last_closed: Option<ClosedElement>,
     /// Current element nesting depth, so a document cannot recurse the reader's
     /// consumers off the stack. See [`MAX_DEPTH`].
     depth: u32,
@@ -766,8 +785,35 @@ impl<'a> XmlReader<'a> {
     /// Pop the frame of the element just closed, remembering it as the element
     /// a following construction failure describes.
     fn close(&mut self) {
+        if let Some(frame) = self.frames.pop() {
+            self.last_closed = Some(ClosedElement {
+                element: frame.element,
+                xsi_type: frame.xsi_type,
+                offset: frame.offset,
+                ordinal: frame.ordinal,
+                ancestors: self.frames.len(),
+            });
+        }
+    }
+
+    /// The element a construction failure describes: the one closed most
+    /// recently, because a `FromXml` impl builds its value right after it has
+    /// consumed its own end tag. Before any element closed, the document.
+    ///
+    /// This is where the closed element's line, column and root path are
+    /// resolved, on the one path that reads them.
+    fn located(&self) -> Location {
+        let Some(closed) = &self.last_closed else {
+            return Location {
+                element: "document".to_owned(),
+                xsi_type: None,
+                line: 1,
+                column: 1,
+                path: "/".to_owned(),
+            };
+        };
         let mut path = String::new();
-        for (i, frame) in self.frames.iter().enumerate() {
+        for (i, frame) in self.frames.iter().take(closed.ancestors).enumerate() {
             path.push('/');
             path.push_str(&frame.element);
             if i > 0 {
@@ -776,29 +822,21 @@ impl<'a> XmlReader<'a> {
                 path.push(']');
             }
         }
-        if let Some(frame) = self.frames.pop() {
-            let (line, column) = line_col(self.src, frame.offset);
-            self.last_closed = Some(Location {
-                element: frame.element,
-                xsi_type: frame.xsi_type,
-                line,
-                column,
-                path,
-            });
+        path.push('/');
+        path.push_str(&closed.element);
+        if closed.ancestors > 0 {
+            path.push('[');
+            path.push_str(&closed.ordinal.to_string());
+            path.push(']');
         }
-    }
-
-    /// The element a construction failure describes: the one closed most
-    /// recently, because a `FromXml` impl builds its value right after it has
-    /// consumed its own end tag. Before any element closed, the document.
-    fn located(&self) -> Location {
-        self.last_closed.clone().unwrap_or_else(|| Location {
-            element: "document".to_owned(),
-            xsi_type: None,
-            line: 1,
-            column: 1,
-            path: "/".to_owned(),
-        })
+        let (line, column) = line_col(self.src, closed.offset);
+        Location {
+            element: closed.element.clone(),
+            xsi_type: closed.xsi_type.clone(),
+            line,
+            column,
+            path,
+        }
     }
 
     /// The refusal for a mandatory `child` element absent from the element just

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-lang"
-version = "0.0.60"
+version = "0.0.61"
 description = "openEHR LANG BMM/P_BMM object model, generated from BMM: generations v1_0 (LANG 1.0.0) and v1_1 (LANG 1.1.0, current; the stable BMM v2.x unit beside the paused BMM3 unit), plus hand-written ODIN/BEL/EL readers"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["parser-implementations", "data-structures"]
 include = ["src/**", "README.md", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.60" }
+openehr-base = { path = "../openehr-base", version = "0.0.61" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the
 # generated types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) —
 # never a derive. `serde_json` also carries the untyped `Value` fields the

--- a/crates/openehr-query/Cargo.toml
+++ b/crates/openehr-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-query"
-version = "0.0.60"
+version = "0.0.61"
 description = "openEHR QUERY (AQL 1.1.0): hand-written lexer, parser, typed AST and canonical printer from the official grammar (no ANTLR runtime)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-rm"
-version = "0.0.60"
+version = "0.0.61"
 description = "openEHR RM Reference Model, generated from BMM: generations v1_1 (RM 1.1.0) and v1_2 (RM 1.2.0, current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,11 +13,11 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.60" }
+openehr-base = { path = "../openehr-base", version = "0.0.61" }
 # The terminology-backed RM class invariants (`validate::terminology`) resolve
 # openEHR terminology groups + code sets against the vendored TERM 3.1.0 bundle.
 # `openehr-term` itself depends only on `openehr-base`, so this is acyclic.
-openehr-term = { path = "../openehr-term", version = "0.0.60" }
+openehr-term = { path = "../openehr-term", version = "0.0.61" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also backs the untyped `Value` RM representation used by

--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-term"
-version = "0.0.60"
+version = "0.0.61"
 description = "openEHR TERM terminology data model, generated from BMM (generation v3_1 = TERM 3.1.0), plus the embedded official terminology XML bundle"
 edition.workspace = true
 rust-version.workspace = true
@@ -34,7 +34,7 @@ include = [
 ]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.60" }
+openehr-base = { path = "../openehr-base", version = "0.0.61" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1276,7 +1276,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.60"
+version = "0.0.61"
 dependencies = [
  "indexmap",
  "openehr-am",
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.60"
+version = "0.0.61"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.60"
+version = "0.0.61"
 dependencies = [
  "serde",
  "serde_json",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.60"
+version = "0.0.61"
 dependencies = [
  "async-trait",
  "axum",
@@ -1337,7 +1337,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.60"
+version = "0.0.61"
 dependencies = [
  "chumsky",
  "indexmap",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.60"
+version = "0.0.61"
 dependencies = [
  "chumsky",
  "logos",
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.60"
+version = "0.0.61"
 dependencies = [
  "openehr-base",
  "openehr-term",
@@ -1374,7 +1374,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.60"
+version = "0.0.61"
 dependencies = [
  "openehr-base",
  "roxmltree",


### PR DESCRIPTION
Closes #3114

Closes #3116

The XML reader resolved every closing element's line and column by scanning the document from byte zero, and rebuilt its whole root path by walking the frame stack, on every close. Both fill a `Location` that only an error message reads, and an error aborts the parse, so at most one of them is ever used. The scan is what made a parse quadratic in document size.

This is a regression from #3104, which merged earlier today: `line_col`, `open` and `close` do not exist in the file before `aa468e943`. The diagnostics that change added are worth keeping; computing them eagerly was not.

## Measurement

The `template_ingestion` group added to `app/ferroehr/benches/validation.rs` measures the parse over the vendored CKM corpus. Criterion point estimates, Apple M2, release profile.

| Operational template | Bytes | Before | After |
|---|---|---|---|
| `medicines-list` | 10.7 kB | 513 µs | 68.7 µs |
| `international-patient-summary` | 1.92 MB | 10.08 s | 10.20 ms |
| `congenital-syphilis-case-investigation` | 5.44 MB | about 58.6 s | 25.07 ms |

The third "before" figure is criterion's projection from its warm-up iteration, 585.7 s for the ten-sample window it refused to complete. The parse is linear again: 5.3 ms per MB and 4.6 ms per MB across the two large templates.

## What changed

`close` is now constant time. It records the closed element's name, `xsi:type`, start offset and sibling ordinal, plus how many frames were still open when it closed, so `located` can read that element's ancestors and none opened afterwards. The line, column and root path are resolved in `located`, on the one path that reads them.

The refusal diagnostics are unchanged: a refused document names the same element, position, path and class attribute it named before, and the `openehr-its` suite that asserts those passes untouched.

The eight `openehr-*` crates step to 0.0.61 in lockstep, with both lockfiles.

## Gates

`cargo fmt`, the workspace clippy lane, the rustdoc lane, `comment-style`, `typed-status`, `default-style` and the changelog structure check are green. `cargo nextest run -p openehr-its` runs 615 tests, all passing.

A full `cargo nextest run --workspace --exclude ferroehr-viewer` runs 4612 tests, all passing, in 232 s. Before this fix that run could not finish: the `openehr-its` corpus sweeps were still going past 1320 s each, which is what #3116 was filed for. `ckm_full_pack` now takes 12.58 s and `coded_names` 4.15 s.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.
