### PR TITLE
feat(tenancy): an unresolvable tenant key is refused, not run on the default tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,20 @@ workflow refuses a tag that has no matching section here.
 
 ### Changed
 
+- **A tenant key that names no registered tenant is refused instead of running
+  unscoped** (#3111). It used to fall through to the reserved default tenant,
+  on the argument that a cross-tenant access should look like an empty result
+  set rather than a `403` confirming another tenant exists. That argument holds
+  only while the default tenant is empty, and the default tenant owns every row
+  written while tenancy was off: on a deployment that enabled tenancy after
+  going live, a misspelled claim read and wrote the entire pre-tenancy store.
+  Such a request now gets a `403`. Set
+  `FERROEHR__TENANCY__UNKNOWN_TENANT=default_tenant` to restore the old
+  behaviour where the existence-hiding is worth more. A request carrying no
+  tenant key at all is unchanged. With tenancy enabled, boot now counts the
+  default tenant's stored versions and warns when it holds any, because both
+  paths lead there.
+
 - **A composition commit checks out one pooled connection instead of three**
   (#3097). The EHR-writability gate, the persistent-duplicate gate and the
   commit each took their own connection from the pool. With multi-tenancy on

--- a/app/ferroehr-rest/src/extensions/access/tenant.rs
+++ b/app/ferroehr-rest/src/extensions/access/tenant.rs
@@ -15,14 +15,27 @@
 //! application's tenant-scoped pool then reads that scope on every acquired
 //! connection to set `ferroehr.tenant_id` for RLS.
 //!
-//! Only installed when `tenancy.enabled` (`crate::router::router`), so single-tenant
-//! deployments pay nothing. A request that carries no tenant key, or an
-//! unknown/unresolvable one, runs **unscoped** → the reserved default tenant:
-//! cross-tenant access is an engine-level empty set, never a `403`.
+//! Only installed when `tenancy.enabled` (`crate::router::router`), so
+//! single-tenant deployments pay nothing.
+//!
+//! A request carrying NO tenant key runs **unscoped** → the reserved default
+//! tenant. A key that names no registered tenant is refused `403` under the
+//! default `tenancy.unknown_tenant = "refuse"`, because the fall-through would
+//! hand the caller that same default tenant, and it owns every row written
+//! while tenancy was off. `"default_tenant"` restores the fall-through for a
+//! deployment that prefers a cross-tenant access to look like an empty result
+//! set rather than a `403` confirming another tenant exists; that argument
+//! holds only while the default tenant is empty, which boot checks.
+//!
+//! A resolution ERROR is not an unknown tenant: an unreachable registry
+//! answers `503`, never the default tenant.
 
 use axum::extract::{Request, State};
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
+
+use ferroehr::config::server::UnknownTenant;
+use openehr_its::rest::runtime::ApiError;
 
 use crate::extensions::access::authn::current_principal;
 use crate::extensions::access::authz::roles::claim_string;
@@ -44,15 +57,21 @@ pub async fn middleware(State(state): State<AppState>, req: Request, next: Next)
         .map(str::to_owned)
         .or_else(|| current_principal().and_then(|p| claim_string(&p.claims, &cfg.claim)));
 
-    // Resolve to a context. An UNKNOWN key leaves the request unscoped
-    // (default tenant) — an engine-level empty set, not a 403 (documented
-    // policy; the resolver negative-caches the outcome). A resolution ERROR
-    // (registry unreachable ≠ unknown tenant) must NEVER silently fall
-    // through to the default tenant — it answers 503 like any other
-    // dependency failure, with the standard openEHR error body.
+    // Resolve to a context. An UNKNOWN key is refused under the default
+    // `unknown_tenant = "refuse"` and falls through to the default tenant only
+    // when the deployment asks for it (module docs). A resolution ERROR
+    // (registry unreachable ≠ unknown tenant) never falls through either — it
+    // answers 503 like any other dependency failure.
     let ctx = match key {
         Some(k) => match state.backend().tenant_resolve(&k).await {
-            Ok(ctx) => ctx,
+            Ok(Some(ctx)) => Some(ctx),
+            Ok(None) if cfg.unknown_tenant == UnknownTenant::Refuse => {
+                return crate::overview::error::RestError::from(ApiError::Forbidden(
+                    "the request's tenant is not registered".to_owned(),
+                ))
+                .into_response();
+            }
+            Ok(None) => None,
             Err(e) => {
                 return crate::overview::error::RestError::from(e).into_response();
             }

--- a/app/ferroehr-rest/tests/it/tenant_http.rs
+++ b/app/ferroehr-rest/tests/it/tenant_http.rs
@@ -112,7 +112,9 @@ fn config_with_header(enabled: bool) -> AppConfig {
 async fn current_reports_the_default_when_unscoped() {
     // GET /admin/tenant/current with no tenant key: the request runs unscoped
     // on the reserved default tenant, and the read says so rather than
-    // fabricating a record.
+    // fabricating a record. `tenancy.unknown_tenant` governs a key that does
+    // not resolve, never the absence of one, so the refusing default (#3111)
+    // leaves this path alone.
     let (_pg, app) = app(true).await;
     let (status, body) = send(app, req("GET", &format!("{GROUP}/current"), None)).await;
     assert_eq!(status, StatusCode::OK);
@@ -145,8 +147,30 @@ async fn current_reports_the_resolved_tenant_when_scoped() {
     assert_eq!(body["tenant"]["name"], "acme-current");
     assert_eq!(body["tenant"]["id"], created["id"]);
 
-    // An UNKNOWN key runs unscoped -> the default answer (the documented
-    // unknown-key policy: engine-level default scope, never a 403).
+    // An UNKNOWN key is refused: falling through would hand the caller the
+    // reserved default tenant, which owns every row written while tenancy was
+    // off (#3111).
+    let unknown = Request::builder()
+        .method("GET")
+        .uri(format!("{GROUP}/current"))
+        .header("X-Tenant", "no-such-tenant")
+        .body(Body::empty())
+        .unwrap();
+    let (status, _body) = send(app, unknown).await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+}
+
+/// The opt-in twin of the refusal above: `unknown_tenant = "default_tenant"`
+/// restores the fall-through for a deployment that prefers a cross-tenant
+/// access to look like an empty result set rather than a `403` confirming
+/// another tenant exists (#3111).
+#[tokio::test]
+async fn an_unknown_key_falls_through_to_the_default_tenant_when_the_deployment_asks() {
+    let (_pg, service) = common::test_service().await;
+    let mut cfg = config_with_header(true);
+    cfg.tenancy.unknown_tenant = ferroehr::config::server::UnknownTenant::DefaultTenant;
+    let app = ferroehr_rest::build_with(cfg, service).expect("router builds");
+
     let unknown = Request::builder()
         .method("GET")
         .uri(format!("{GROUP}/current"))

--- a/app/ferroehr-server/src/lib.rs
+++ b/app/ferroehr-server/src/lib.rs
@@ -485,7 +485,41 @@ async fn connect_pool(config: &ferroehr::config::FerroEhrConfig) -> anyhow::Resu
     db::prepare(&config.db, &pool)
         .await
         .context("preparing the database schema")?;
+    if config.tenancy.enabled {
+        warn_on_occupied_default_tenant(&pool).await?;
+    }
     Ok(pool)
+}
+
+/// Says at boot how much content the reserved default tenant holds, because a
+/// request the tenancy middleware cannot scope reads exactly that.
+///
+/// The default tenant owns every row written while tenancy was off, so on a
+/// deployment that enables tenancy over an existing store it IS the legacy
+/// repository. Two request shapes still land there: one carrying no tenant key
+/// at all, and, under `tenancy.unknown_tenant = "default_tenant"`, one whose
+/// key names no registered tenant.
+///
+/// A warning rather than a refusal: an operator enabling tenancy on a live
+/// store has no in-product way to reassign those rows yet, so refusing would
+/// strand the deployment instead of protecting it.
+///
+/// # Errors
+/// A database failure reading the count.
+async fn warn_on_occupied_default_tenant(pool: &PgPool) -> anyhow::Result<()> {
+    let versions = db::default_tenant_versions(pool)
+        .await
+        .context("counting the reserved default tenant's stored versions")?;
+    if versions > 0 {
+        tracing::warn!(
+            default_tenant_versions = versions,
+            "tenancy is enabled and the reserved default tenant owns stored versions: a request \
+             with no tenant key reads them, and so does an unresolvable key unless \
+             tenancy.unknown_tenant is \"refuse\". Move this content into a named tenant, or \
+             treat the deployment as single-tenant."
+        );
+    }
+    Ok(())
 }
 
 /// Wires the opt-in external FHIR terminology servers — ALL configured

--- a/app/ferroehr/assets/ferroehr.default.toml
+++ b/app/ferroehr/assets/ferroehr.default.toml
@@ -265,6 +265,13 @@ enabled = false
 claim = "tenant"
 #? header = "X-FerroEHR-Tenant"   # dev-only override; never in production
 insecure_header_override = false   # accept `header` with auth.enabled = true (development only)
+# What a tenant key that names no registered tenant gets: "refuse" (403) or
+# "default_tenant" (run unscoped against the reserved default tenant, so a
+# cross-tenant read is an empty set rather than a 403 confirming another
+# tenant exists). "default_tenant" is safe only while that tenant is empty —
+# it owns every row written before tenancy was enabled, and boot warns when
+# it holds any.
+unknown_tenant = "refuse"
 
 # ── [smart] — SMART App Launch ────────────────────────────────────────────────
 [smart]

--- a/app/ferroehr/src/config/server.rs
+++ b/app/ferroehr/src/config/server.rs
@@ -460,6 +460,8 @@ pub struct TenancyConfig {
     /// GUC and the GUC follows this header. Set it only on a development
     /// deployment that accepts exactly that.
     pub insecure_header_override: bool,
+    /// What a request whose tenant key names no registered tenant gets.
+    pub unknown_tenant: UnknownTenant,
 }
 
 impl Default for TenancyConfig {
@@ -469,8 +471,33 @@ impl Default for TenancyConfig {
             claim: "tenant".to_owned(),
             header: None,
             insecure_header_override: false,
+            unknown_tenant: UnknownTenant::Refuse,
         }
     }
+}
+
+/// What a request whose tenant key names no registered tenant gets.
+///
+/// No openEHR spec governs multi-tenancy — our own design/extension.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum UnknownTenant {
+    /// Refuse with `403`.
+    ///
+    /// The default, because the alternative grants the caller the reserved
+    /// default tenant, which owns every row written while tenancy was off. A
+    /// key that does not resolve is a misspelled claim, a renamed tenant or a
+    /// drifted issuer mapping, and none of those should read data.
+    #[default]
+    Refuse,
+    /// Run unscoped, against the reserved default tenant, so a cross-tenant
+    /// access is an empty result set rather than a `403` that would confirm
+    /// another tenant's existence.
+    ///
+    /// That argument holds only while the default tenant is empty. On a
+    /// deployment that enabled tenancy after going live it holds the whole
+    /// pre-tenancy store, and boot says so.
+    DefaultTenant,
 }
 
 /// Configuration of the ADMIN API group (`[admin]`; SM `I_ADMIN_SERVICE`).

--- a/app/ferroehr/src/db/mod.rs
+++ b/app/ferroehr/src/db/mod.rs
@@ -531,6 +531,33 @@ pub async fn verify_migrations(pool: &PgPool) -> Result<(), DbError> {
     Ok(())
 }
 
+/// How many stored versions the reserved default tenant owns.
+///
+/// The default tenant is the nil uuid, and `ext.current_tenant_id()` resolves
+/// an unset `ferroehr.tenant_id` GUC to it, so it owns every row written while
+/// tenancy was off. A request that reaches the tenancy middleware without a
+/// resolvable tenant runs unscoped and therefore reads exactly this content,
+/// which is why a deployment enabling tenancy over an existing store is told
+/// at boot what that tenant holds.
+///
+/// The count is taken over the primary tier only: an archived version is not
+/// reachable by a query, and the number exists to say whether the default
+/// tenant is empty, not to size the store.
+///
+/// No openEHR spec governs multi-tenancy — our own design/extension.
+///
+/// # Errors
+///
+/// [`DbError::Sqlx`] when the connection or the count fails.
+pub async fn default_tenant_versions(pool: &PgPool) -> Result<i64, DbError> {
+    let count: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM ehr.vo_version WHERE tenant_id = '00000000-0000-0000-0000-000000000000'::uuid",
+    )
+    .fetch_one(pool)
+    .await?;
+    Ok(count)
+}
+
 /// Compare one migration set's bookkeeping table against its embedded source.
 async fn verify_set(pool: &PgPool, schema: &str, migrator: &Migrator) -> Result<(), DbError> {
     // The schema name is one of the three literals in `MIGRATION_SETS`, never

--- a/app/ferroehr/tests/it/tenant_isolation.rs
+++ b/app/ferroehr/tests/it/tenant_isolation.rs
@@ -410,3 +410,40 @@ async fn scoped_pool_stamps_connections_opened_during_acquire() {
     })
     .await;
 }
+
+/// The boot check reads what the reserved default tenant holds, which is what
+/// a request the tenancy middleware cannot scope goes on to read (#3111).
+///
+/// A freshly migrated database owns nothing there; an EHR created with no
+/// tenant scope — the pre-tenancy write shape — lands in it and the count
+/// says so.
+#[tokio::test]
+async fn the_default_tenant_count_sees_content_written_without_a_tenant_scope() {
+    use ferroehr::service::FerroEhrService;
+
+    let testdb = testkit::db().await.expect("testkit database");
+    let pool = testdb.pool();
+
+    assert_eq!(
+        db::default_tenant_versions(&pool)
+            .await
+            .expect("count on a fresh database"),
+        0,
+        "a freshly migrated store leaves the reserved default tenant empty"
+    );
+
+    let service = FerroEhrService::new(pool.clone());
+    service
+        .create_ehr(None)
+        .await
+        .expect("an unscoped EHR create");
+
+    assert!(
+        db::default_tenant_versions(&pool)
+            .await
+            .expect("count after an unscoped write")
+            > 0,
+        "an unscoped write lands in the reserved default tenant, which is the \
+         content the boot warning exists to name"
+    );
+}

--- a/scripts/deploy-probes/tenancy.sh
+++ b/scripts/deploy-probes/tenancy.sh
@@ -127,10 +127,16 @@ probes_tenancy() {
 
   # An UNREGISTERED tenant key. Recorded because it is the behaviour a typo in a
   # JWT claim produces, and because a reader of this file would otherwise have to
-  # guess: the key does not resolve to alpha's data.
+  # guess: the request is refused before it reaches any tenant's data.
+  #
+  # It used to answer 404, because an unknown key ran on the reserved default
+  # tenant and alpha's record was invisible there. That is no longer the shipped
+  # default (#3111): the default tenant owns everything written before tenancy
+  # was enabled, so the fall-through was a way into the legacy store. The
+  # refusal is the stronger outcome — the read never happens at all.
   probe "P-TEN-UNKNOWN" "broken" "server" "#2178" \
-    "an unregistered tenant key cannot read a registered tenant's record"
-  assert_eq "404" "$(http_code -u "$BASIC" -H "${TENANT_HEADER}: nosuchtenant" "$API/ehr/$a")" \
+    "an unregistered tenant key is refused before it reads anything"
+  assert_eq "403" "$(http_code -u "$BASIC" -H "${TENANT_HEADER}: nosuchtenant" "$API/ehr/$a")" \
     "an unknown key must not be a way around the boundary"
   probe_done
 

--- a/website/book/src/security.md
+++ b/website/book/src/security.md
@@ -554,6 +554,7 @@ server behaves byte-for-byte as a single-tenant system.
 | `FERROEHR__TENANCY__ENABLED` | `false` | enable multi-tenancy |
 | `FERROEHR__TENANCY__CLAIM` | `tenant` | the JWT claim (a dotted path) carrying the tenant key |
 | `FERROEHR__TENANCY__HEADER` | unset | a development header override for the tenant |
+| `FERROEHR__TENANCY__UNKNOWN_TENANT` | `refuse` | what a tenant key naming no registered tenant gets: `refuse` (a `403`) or `default_tenant` (run unscoped) |
 
 A request's tenant is resolved from the configured JWT claim (a dotted path
 such as `realm_access.tenant` is walked through nested objects). Isolation is
@@ -570,10 +571,25 @@ table owner is subject to them.
 
 Isolation is otherwise fail-safe by design, and the three cases are distinct:
 
-- **No tenant key, or an unknown one:** the request runs unscoped against a
-  reserved default tenant rather than guessing, and a cross-tenant access
-  surfaces as an empty result set, never a `403` that would leak the existence
-  of another tenant's data.
+- **A tenant key naming no registered tenant:** a `403`. The alternative,
+  running the request unscoped, hands the caller the reserved default tenant,
+  and that tenant owns every row written while tenancy was off. On a deployment
+  that enabled tenancy after going live it therefore holds the entire
+  pre-tenancy store, so a misspelled claim, a renamed tenant or a drifted
+  issuer mapping would read and write all of it.
+
+  Set `FERROEHR__TENANCY__UNKNOWN_TENANT=default_tenant` to restore the
+  fall-through. It buys one thing: a cross-tenant access then surfaces as an
+  empty result set rather than a `403` confirming another tenant exists. That
+  is a real property, and it holds only while the default tenant is empty,
+  which is true on a deployment that ran with tenancy on from its first write.
+  The server counts that tenant's stored versions at boot and warns when it
+  holds any.
+
+- **No tenant key at all:** the request runs unscoped against the reserved
+  default tenant. `UNKNOWN_TENANT` governs a key that does not resolve, not the
+  absence of one, so the same boot warning applies: with tenancy on and content
+  in the default tenant, a token carrying no tenant claim reads it.
 - **A tenant registry that cannot be reached:** a `503`, like any other
   dependency failure. A resolution *error* is never quietly read as "no
   tenant", because that would fall through to the default tenant.

--- a/website/book/src/threat-model.md
+++ b/website/book/src/threat-model.md
@@ -248,10 +248,10 @@ to operator-configured endpoints.
 single-tenant. When on, the tenant is resolved from a configured JWT claim and
 applied as a PostgreSQL session setting that drives **`FORCE ROW LEVEL
 SECURITY`** policies on every tenant-scoped table, including the cold-archive
-mirrors. Isolation is fail-safe: an absent or unresolvable tenant runs against a
-reserved default rather than guessing, and a cross-tenant access is an empty
-result set rather than a `403` that would leak the existence of another tenant's
-data.
+mirrors. A tenant key that names no registered tenant is refused with a `403`,
+because the reserved default tenant it would otherwise fall through to owns
+every row written while tenancy was off. A request carrying no tenant key at
+all still runs against that default rather than guessing.
 
 A tenant *registry* that cannot be reached is a separate case and is not read as
 "no tenant": it answers `503`, like any other dependency failure, rather than
@@ -263,9 +263,12 @@ falling through to the default.
   when set it **wins over the JWT claim**. It is a development affordance and
   there is no way to make it safe in production. If it is set, tenancy is not a
   boundary. Leave it unset.
-- **A missing or unknown claim degrades quietly to the default tenant.** That is
-  the fail-safe choice, and its cost is that a misconfigured claim path looks
-  like "tenancy is doing nothing" rather than failing loudly.
+- **A missing claim still degrades quietly to the default tenant**, and so does
+  an unknown one when `FERROEHR__TENANCY__UNKNOWN_TENANT=default_tenant` is set
+  to trade the `403` for existence-hiding. On a deployment that enabled tenancy
+  after going live, that default tenant is the whole pre-tenancy store. The
+  server counts its stored versions at boot and warns when it holds any; moving
+  that content into a named tenant is a manual step today.
 - **Row-level security binds a connection, not a request.** The scoping is
   applied per connection from a shared pool; a defect in that plumbing is a
   cross-tenant read, which is why it is enforced by the database rather than by


### PR DESCRIPTION
Closes #3111

With tenancy enabled, a request whose configured claim named no registered tenant fell through to the reserved default tenant. The security page argued that as the fail-safe choice: a cross-tenant access then surfaces as an empty result set rather than a `403` confirming another tenant exists.

That argument holds only while the default tenant is empty. `ext.current_tenant_id()` coalesces an unset `ferroehr.tenant_id` GUC to the nil uuid, and the migration that introduced it says so in its own comment: the nil uuid "owns every row created while tenancy is OFF". On any deployment that enabled tenancy after going live, the default tenant is the legacy store, so a misspelled claim, a renamed tenant or a drifted issuer mapping read and wrote all of it, silently and with a `200`.

## The decision

`tenancy.unknown_tenant` pins it, and defaults to `refuse`.

- **`refuse`** (default): a key that resolves to nothing answers `403`.
- **`default_tenant`**: the old fall-through, for a deployment where the existence-hiding is worth more. That is a real property, and it is true on a store that ran tenancy from its first write.

A resolution *error* is untouched and still answers `503`: an unreachable registry is not an unknown tenant.

A request carrying no tenant key at all is also untouched. The key governs a key that does not resolve, not the absence of one, and refusing that would break a tenancy-enabled deployment running without authentication.

## The boot warning

Both the no-key path and the opted-in fall-through still lead to the default tenant, so with tenancy enabled boot counts its stored versions and warns when it holds any, naming the remedy.

A warning rather than a refusal, deliberately: an operator enabling tenancy on a live store has no in-product way to reassign those rows yet, so refusing would strand the deployment rather than protect it. The count is `db::default_tenant_versions`, over the primary tier, and exists to answer "is it empty", not to size the store.

## Tests

The tenancy test that pinned the old fall-through now asserts the `403`, and its opt-in twin sits beside it asserting the fall-through still works under `default_tenant` — the flipped-gate pattern, so coverage does not narrow. A third existing test already covers the no-key path and gains a comment saying the new key leaves it alone. A DB-backed test proves a freshly migrated store leaves the default tenant empty and that an unscoped write lands in it, which is the content the boot check counts.

## Docs

`website/book/src/security.md` gains the configuration key and replaces the "empty result set" bullet with the condition under which that argument holds. `website/book/src/threat-model.md` §B5 does the same for its control and residual-risk entries.

## Gates

`cargo fmt`, the workspace clippy lane, the rustdoc lane, `comment-style`, `typed-status`, `default-style`, `docs-claims` and the changelog structure check are green. `cargo nextest run --workspace --exclude ferroehr-viewer` runs 4614 tests with 4613 passing; the one failure is `events_amqp::subscriptions_route_by_predicate_and_wildcard_receives_all`, a RabbitMQ container test that times out under full-suite load on this machine and passes in 10 s in isolation.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.