### PR TITLE
fix(admin): the storage-parity sweep reads a page per round trip, and can be scoped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,18 @@ workflow refuses a tag that has no matching section here.
 
 ### Changed
 
+- **The storage-parity sweep reads a page of versions per round trip instead of
+  one, and can be scoped** (#3110). `POST /admin/integrity/verify` compared each
+  stored version's node rows with its materialized body using two sequential
+  statements per version, so a store of 60 000 versions cost about 120 000 round
+  trips and the request died at the 30 s timeout with the report lost. Content
+  is now read 32 versions at a time, two statements per chunk: the same store
+  costs under 4 000 round trips. Two optional query parameters narrow what a
+  sweep covers, `ehr_id` and `committed_since`, so verifying one record or
+  everything committed since an incident no longer means reading the whole
+  repository. The report, its defect vocabulary and its status codes are
+  unchanged.
+
 - **A composition commit checks out one pooled connection instead of three**
   (#3097). The EHR-writability gate, the persistent-duplicate gate and the
   commit each took their own connection from the pool. With multi-tenancy on

--- a/app/ferroehr-rest/src/api/admin/integrity.rs
+++ b/app/ferroehr-rest/src/api/admin/integrity.rs
@@ -48,12 +48,12 @@ use utoipa_axum::routes;
 
 use openehr_its::rest::runtime::ApiError;
 
-use ferroehr::service::admin::integrity::StorageParityReport;
+use ferroehr::service::admin::integrity::{StorageParityReport, StorageParityScope};
 
 use crate::api::{BoxResponse, RequestParts, guarded_dispatch};
-use crate::negotiate;
 use crate::overview::error::RestError;
 use crate::state::AppState;
+use crate::{negotiate, params};
 
 /// The storage-integrity extension route as a native `utoipa-axum` router —
 /// **no ITS-REST contract** (see the module docs). Group-relative path (nested
@@ -72,6 +72,16 @@ pub(crate) fn integrity_routes() -> OpenApiRouter<AppState> {
 /// materialized body; the response is the resulting report.
 #[utoipa::path(
     post, path = "/admin/integrity/verify", tag = "admin-integrity",
+    params(
+        ("ehr_id" = Option<String>, Query,
+         description = "Cover only versions belonging to this EHR. A sweep reads \
+                        every byte of what it covers, so this is how an operator \
+                        verifies one record without reading the repository."),
+        ("committed_since" = Option<String>, Query,
+         description = "Cover only versions whose validity begins at or after \
+                        this RFC 3339 instant, for verifying what changed since \
+                        an incident."),
+    ),
     responses(
         (status = 200, description = "The sweep ran. The body is the report: \
                                       how many stored versions were read, how \
@@ -148,7 +158,8 @@ async fn run(
     }
     match op {
         "admin_verify_storage_parity" => {
-            let report = state.backend().verify_storage_parity().await?;
+            let scope = parity_scope(parts.query.as_deref())?;
+            let report = state.backend().verify_storage_parity(scope).await?;
             Ok(negotiate::respond(
                 &parts.headers,
                 StatusCode::OK,
@@ -159,6 +170,37 @@ async fn run(
             "unrouted admin integrity operation: {other}"
         )))),
     }
+}
+
+/// The optional bounds narrowing which stored versions the sweep covers.
+///
+/// A sweep reads every byte of what it covers, so an operator verifying one
+/// record, or everything committed since an incident, should not have to read
+/// the whole repository. Both parameters are optional and compose.
+///
+/// Our own extension — no ITS-REST operation governs this route at all.
+fn parity_scope(query: Option<&str>) -> Result<StorageParityScope, RestError> {
+    let ehr_id = match params::query_param(query, "ehr_id") {
+        Some(raw) => Some(raw.parse::<uuid::Uuid>().map_err(|e| {
+            RestError(ApiError::BadRequest(format!(
+                "query parameter `ehr_id` must be a UUID, got {raw:?}: {e}"
+            )))
+        })?),
+        None => None,
+    };
+    let committed_since = match params::query_param(query, "committed_since") {
+        Some(raw) => Some(raw.parse::<jiff::Timestamp>().map_err(|e| {
+            RestError(ApiError::BadRequest(format!(
+                "query parameter `committed_since` must be an RFC 3339 timestamp, got \
+                 {raw:?}: {e}"
+            )))
+        })?),
+        None => None,
+    };
+    Ok(StorageParityScope {
+        ehr_id,
+        committed_since,
+    })
 }
 
 /// Render the storage-parity report as the response body.

--- a/app/ferroehr/src/service/admin/integrity.rs
+++ b/app/ferroehr/src/service/admin/integrity.rs
@@ -27,6 +27,7 @@
               round-trip drops forward-compatible keys (the openEHR release strategy: minors are compatible supersets)"
 )]
 
+use std::collections::HashMap;
 use std::time::Instant;
 
 use serde_json::Value;
@@ -36,14 +37,23 @@ use crate::ids::VoId;
 use crate::service::FerroEhrService;
 use crate::service::error::ServiceError;
 use crate::service::status::SmError;
-use crate::storage::node_repo::read_version_canonical_all;
+use crate::storage::codec::reassemble;
+use crate::storage::node_repo::read_version_rows_all;
 
 /// How many version rows one page of the sweep's cursor query returns.
 ///
 /// The page carries identifiers only (no content), so it stays small whatever
-/// the documents weigh; each version's body and node rows are then read one
-/// version at a time, which bounds the sweep's memory to a single document.
+/// the documents weigh; content is then read a [`CONTENT_CHUNK`] at a time.
 const PAGE_SIZE: i64 = 500;
+
+/// How many versions' contents are read per round trip.
+///
+/// The sweep needs both copies of every version, so its cost is two statements
+/// per chunk rather than two per version: a 60 000-version store goes from
+/// about 120 000 round trips to under 4 000. The chunk is what bounds memory —
+/// the reassembled tree and the stored body of 32 documents at once, not of a
+/// whole 500-row page, and not one version at a time either.
+const CONTENT_CHUNK: usize = 32;
 
 /// How many mismatches the returned report carries in full.
 ///
@@ -124,6 +134,22 @@ impl StorageParityReport {
     }
 }
 
+/// Which stored versions a sweep covers.
+///
+/// A sweep reads every byte of the versions it covers, so an operator
+/// verifying one record, or everything committed since an incident, should not
+/// have to read the whole repository to do it. Both bounds are optional and
+/// compose; the default covers everything.
+///
+/// No openEHR spec governs storage mechanics — our own design/extension.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct StorageParityScope {
+    /// Cover only versions belonging to this EHR.
+    pub ehr_id: Option<Uuid>,
+    /// Cover only versions whose validity begins at or after this instant.
+    pub committed_since: Option<jiff::Timestamp>,
+}
+
 /// One page row of the sweep cursor: the identifiers of a stored version plus
 /// whether it carries a body. No content is fetched here.
 struct VersionKey {
@@ -152,12 +178,18 @@ impl FerroEhrService {
     /// - `exception` — a database fault while enumerating or reading versions.
     ///   A version whose node rows are unreadable is a REPORTED mismatch, not
     ///   an error: one damaged record must not abort the sweep that found it.
-    pub async fn verify_storage_parity(&self) -> Result<StorageParityReport, SmError> {
-        Ok(self.sweep_storage_parity().await?)
+    pub async fn verify_storage_parity(
+        &self,
+        scope: StorageParityScope,
+    ) -> Result<StorageParityReport, SmError> {
+        Ok(self.sweep_storage_parity(scope).await?)
     }
 
     /// The sweep itself, over the storage error domain.
-    async fn sweep_storage_parity(&self) -> Result<StorageParityReport, ServiceError> {
+    async fn sweep_storage_parity(
+        &self,
+        scope: StorageParityScope,
+    ) -> Result<StorageParityReport, ServiceError> {
         let started = Instant::now();
         let mut report = StorageParityReport {
             versions_checked: 0,
@@ -171,19 +203,21 @@ impl FerroEhrService {
         let mut cursor: Option<(Uuid, i32)> = None;
 
         loop {
-            let page = self.parity_page(cursor).await?;
+            let page = self.parity_page(cursor, scope).await?;
             let Some(last) = page.last() else { break };
             cursor = Some((last.vo_id, last.sys_version));
 
-            for key in &page {
-                report.versions_checked += 1;
-                if key.has_body {
-                    report.versions_with_body += 1;
-                } else {
-                    report.versions_without_body += 1;
-                }
-                if let Some(defect) = self.version_parity_defect(key).await? {
-                    record(&mut report, key, defect);
+            for chunk in page.chunks(CONTENT_CHUNK) {
+                for (key, defect) in self.chunk_parity_defects(chunk).await? {
+                    report.versions_checked += 1;
+                    if key.has_body {
+                        report.versions_with_body += 1;
+                    } else {
+                        report.versions_without_body += 1;
+                    }
+                    if let Some(defect) = defect {
+                        record(&mut report, key, defect);
+                    }
                 }
             }
         }
@@ -192,12 +226,86 @@ impl FerroEhrService {
         Ok(report)
     }
 
+    /// Compare one chunk of versions in two round trips: the reassembled node
+    /// content of all of them, then their stored bodies.
+    ///
+    /// Returns one verdict per input key, in input order, so the caller's
+    /// counters follow the enumeration rather than the map's iteration.
+    async fn chunk_parity_defects<'k>(
+        &self,
+        chunk: &'k [VersionKey],
+    ) -> Result<Vec<(&'k VersionKey, Option<StorageParityDefect>)>, ServiceError> {
+        let keys: Vec<(VoId, i32)> = chunk
+            .iter()
+            .map(|key| (VoId(key.vo_id), key.sys_version))
+            .collect();
+        let rows = read_version_rows_all(&self.pool, &keys).await?;
+        let bodies = self.chunk_bodies(&keys).await?;
+
+        Ok(chunk
+            .iter()
+            .map(|key| {
+                let id = (VoId(key.vo_id), key.sys_version);
+                // A set of rows that does not form one tree is a verdict, never
+                // a propagated error: the sweep exists to find damaged records,
+                // so it reports them and keeps going.
+                let nodes = rows.get(&id).map(|rows| reassemble(rows));
+                let defect = match (key.has_body, bodies.get(&id), nodes) {
+                    // A logical delete (RM common master06 §Logical Deletion)
+                    // stores no body, so any node row for it is unexpected.
+                    (false, _, Some(_)) => Some(StorageParityDefect::UnexpectedNodes),
+                    // Nothing to compare: a logical delete with no node rows is
+                    // correct, and a version with no body left the primary tier
+                    // or the repository between the page read and this one.
+                    (false, _, None) | (true, None, _) => None,
+                    (true, Some(_), None) => Some(StorageParityDefect::NodesMissing),
+                    (true, Some(_), Some(Err(_))) => Some(StorageParityDefect::NodesUnreadable),
+                    (true, Some(body), Some(Ok(value))) => {
+                        (&value != body).then_some(StorageParityDefect::ContentDiffers)
+                    }
+                };
+                (key, defect)
+            })
+            .collect())
+    }
+
+    /// The materialized bodies of one chunk of versions, in one statement.
+    ///
+    /// A version with a `NULL` body, or one that left the repository between
+    /// the page read and this one, is absent from the map.
+    async fn chunk_bodies(
+        &self,
+        keys: &[(VoId, i32)],
+    ) -> Result<HashMap<(VoId, i32), Value>, ServiceError> {
+        let vo_ids: Vec<Uuid> = keys.iter().map(|(vo_id, _)| vo_id.0).collect();
+        let sys_versions: Vec<i32> = keys.iter().map(|(_, version)| *version).collect();
+        let rows: Vec<(Uuid, i32, String)> = sqlx::query_as(
+            "SELECT v.vo_id, v.sys_version, v.body \
+             FROM unnest($1::uuid[], $2::int[]) AS k(vo_id, sys_version) \
+             JOIN vo_version_all v \
+               ON v.vo_id = k.vo_id AND v.sys_version = k.sys_version \
+             WHERE v.body IS NOT NULL",
+        )
+        .bind(&vo_ids)
+        .bind(&sys_versions)
+        .fetch_all(&self.pool)
+        .await?;
+        let mut out = HashMap::with_capacity(rows.len());
+        for (vo_id, sys_version, text) in rows {
+            let body = serde_json::from_str(&text)
+                .map_err(|e| ServiceError::internal("parse the stored canonical body", e))?;
+            out.insert((VoId(vo_id), sys_version), body);
+        }
+        Ok(out)
+    }
+
     /// One page of stored-version identifiers after `cursor`, in
     /// `(vo_id, sys_version)` order — a keyset walk, so a long sweep never
     /// pays a growing `OFFSET`.
     async fn parity_page(
         &self,
         cursor: Option<(Uuid, i32)>,
+        scope: StorageParityScope,
     ) -> Result<Vec<VersionKey>, ServiceError> {
         let (after_vo, after_version) = match cursor {
             Some((vo_id, sys_version)) => (Some(vo_id), Some(sys_version)),
@@ -207,12 +315,16 @@ impl FerroEhrService {
             "SELECT vo_id, sys_version, kind, body IS NOT NULL \
              FROM vo_version_all \
              WHERE ($1::uuid IS NULL OR (vo_id, sys_version) > ($1::uuid, $2::int)) \
+               AND ($4::uuid IS NULL OR ehr_id = $4::uuid) \
+               AND ($5::timestamptz IS NULL OR lower(sys_period) >= $5::timestamptz) \
              ORDER BY vo_id, sys_version \
              LIMIT $3",
         )
         .bind(after_vo)
         .bind(after_version)
         .bind(PAGE_SIZE)
+        .bind(scope.ehr_id)
+        .bind(scope.committed_since.map(jiff_sqlx::Timestamp::from))
         .fetch_all(&self.pool)
         .await?;
         Ok(rows
@@ -224,54 +336,6 @@ impl FerroEhrService {
                 has_body,
             })
             .collect())
-    }
-
-    /// How one stored version's two copies disagree, or `None` when they
-    /// agree.
-    ///
-    /// A reassembly failure is a verdict, never a propagated error: the sweep
-    /// exists to find damaged records, so it reports them and keeps going.
-    async fn version_parity_defect(
-        &self,
-        key: &VersionKey,
-    ) -> Result<Option<StorageParityDefect>, ServiceError> {
-        let reassembled =
-            read_version_canonical_all(&self.pool, VoId(key.vo_id), key.sys_version).await;
-        if !key.has_body {
-            return Ok(match reassembled {
-                Ok(Value::Null) => None,
-                Ok(_) | Err(_) => Some(StorageParityDefect::UnexpectedNodes),
-            });
-        }
-        let Some(body) = self.stored_body(key).await? else {
-            // The version left the primary tier (an archive move) or the
-            // repository (a physical delete) between the page read and this
-            // one; there is nothing left to compare, and no defect to claim.
-            return Ok(None);
-        };
-        Ok(match reassembled {
-            Ok(Value::Null) => Some(StorageParityDefect::NodesMissing),
-            Ok(value) if value == body => None,
-            Ok(_) => Some(StorageParityDefect::ContentDiffers),
-            Err(_) => Some(StorageParityDefect::NodesUnreadable),
-        })
-    }
-
-    /// The materialized body of one stored version, read one version at a time
-    /// so the sweep holds a single document in memory.
-    async fn stored_body(&self, key: &VersionKey) -> Result<Option<Value>, ServiceError> {
-        let row: Option<(Option<String>,)> =
-            sqlx::query_as("SELECT body FROM vo_version_all WHERE vo_id = $1 AND sys_version = $2")
-                .bind(key.vo_id)
-                .bind(key.sys_version)
-                .fetch_optional(&self.pool)
-                .await?;
-        row.and_then(|(body,)| body)
-            .map(|text| {
-                serde_json::from_str(&text)
-                    .map_err(|e| ServiceError::internal("parse the stored canonical body", e))
-            })
-            .transpose()
     }
 }
 

--- a/app/ferroehr/src/storage/node_repo.rs
+++ b/app/ferroehr/src/storage/node_repo.rs
@@ -351,6 +351,66 @@ pub async fn read_version_canonical_all(
     reassemble(&rows)
 }
 
+/// Fetch the read rows of whole stored versions in **one** statement, keyed by
+/// `(vo_id, sys_version)` and ordered by `num` within each version.
+///
+/// This is the row half of [`read_version_canonical_all`] for a page of
+/// versions: the same tier-inclusive rows, one round trip instead of one per
+/// version. A version with no stored nodes (a logical delete, RM common
+/// master06 §Logical Deletion) is absent from the map.
+///
+/// It returns rows rather than reassembled values on purpose. Its caller is the
+/// storage-parity sweep, for which a set of rows that does not form a tree is a
+/// REPORTED defect rather than a failure: reassembling here would turn one
+/// damaged record into an error that aborts the sweep that found it. For the
+/// same reason it never shortcuts to the materialized `vo_version.body` the way
+/// [`read_subtrees_canonical`] does for a root anchor — the sweep exists to
+/// compare the node rows against that body.
+///
+/// No openEHR spec governs the `node` store — our own decomposed design.
+///
+/// # Errors
+/// Returns [`StorageError`] on a driver failure or an undecodable row.
+pub async fn read_version_rows_all(
+    pool: &PgPool,
+    keys: &[(VoId, i32)],
+) -> Result<BTreeMap<(VoId, i32), Vec<ReadRow>>, StorageError> {
+    if keys.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+    let vo_ids: Vec<Uuid> = keys.iter().map(|(vo_id, _)| vo_id.0).collect();
+    let sys_versions: Vec<i32> = keys.iter().map(|(_, sys_version)| *sys_version).collect();
+
+    let db_rows = sqlx::query(
+        "SELECT n.vo_id, n.sys_version, n.num, n.num_cap, n.parent_num, n.path, n.data \
+         FROM unnest($1::uuid[], $2::int[]) AS k(vo_id, sys_version) \
+         JOIN node_all n ON n.vo_id = k.vo_id AND n.sys_version = k.sys_version",
+    )
+    .bind(&vo_ids)
+    .bind(&sys_versions)
+    .fetch_all(pool)
+    .await?;
+
+    let mut grouped: BTreeMap<(VoId, i32), Vec<ReadRow>> = BTreeMap::new();
+    for row in db_rows {
+        let key = (VoId(row.try_get("vo_id")?), row.try_get("sys_version")?);
+        grouped.entry(key).or_default().push(ReadRow {
+            num: row.try_get("num")?,
+            num_cap: row.try_get("num_cap")?,
+            parent_num: row.try_get("parent_num")?,
+            path: row.try_get("path")?,
+            data: row.try_get("data")?,
+        });
+    }
+
+    for rows in grouped.values_mut() {
+        // `read_rows` orders by `num` in SQL; the join above cannot, because one
+        // statement carries every version's rows interleaved.
+        rows.sort_by_key(|row| row.num);
+    }
+    Ok(grouped)
+}
+
 /// One whole-object cell's subtree locator: the `[num, num_cap]` interval of
 /// a stored version.
 ///

--- a/app/ferroehr/tests/it/storage_parity.rs
+++ b/app/ferroehr/tests/it/storage_parity.rs
@@ -27,7 +27,7 @@ use uuid::Uuid;
 
 use ferroehr::ids::EhrId;
 use ferroehr::service::FerroEhrService;
-use ferroehr::service::admin::integrity::StorageParityDefect;
+use ferroehr::service::admin::integrity::{StorageParityDefect, StorageParityScope};
 
 use crate::fixtures::{composition, folder, uv};
 
@@ -78,7 +78,10 @@ async fn a_committed_composition_sweeps_clean() {
     let svc = FerroEhrService::new(db.pool());
     seed_ehr_with_composition(&svc).await;
 
-    let report = svc.verify_storage_parity().await.expect("sweep");
+    let report = svc
+        .verify_storage_parity(StorageParityScope::default())
+        .await
+        .expect("sweep");
 
     assert!(
         report.is_clean(),
@@ -114,7 +117,10 @@ async fn a_tampered_node_row_is_reported_as_content_differs() {
     )
     .await;
 
-    let report = svc.verify_storage_parity().await.expect("sweep");
+    let report = svc
+        .verify_storage_parity(StorageParityScope::default())
+        .await
+        .expect("sweep");
 
     assert_eq!(
         report.mismatch_count, 1,
@@ -146,7 +152,10 @@ async fn a_tampered_version_body_is_reported_as_content_differs() {
     )
     .await;
 
-    let report = svc.verify_storage_parity().await.expect("sweep");
+    let report = svc
+        .verify_storage_parity(StorageParityScope::default())
+        .await
+        .expect("sweep");
 
     assert_eq!(report.mismatch_count, 1, "{report:?}");
     let found = &report.mismatches[0];
@@ -171,7 +180,10 @@ async fn a_version_whose_node_rows_are_gone_is_reported_as_nodes_missing() {
     )
     .await;
 
-    let report = svc.verify_storage_parity().await.expect("sweep");
+    let report = svc
+        .verify_storage_parity(StorageParityScope::default())
+        .await
+        .expect("sweep");
 
     assert_eq!(report.mismatch_count, 1, "{report:?}");
     let found = &report.mismatches[0];
@@ -205,7 +217,10 @@ async fn a_logically_deleted_version_sweeps_clean() {
     .expect("count");
     assert_eq!(bodiless, 1, "the delete must store one bodiless version");
 
-    let report = svc.verify_storage_parity().await.expect("sweep");
+    let report = svc
+        .verify_storage_parity(StorageParityScope::default())
+        .await
+        .expect("sweep");
 
     assert!(report.is_clean(), "{report:?}");
     assert_eq!(report.versions_without_body, 1);
@@ -243,11 +258,127 @@ async fn node_rows_under_a_bodiless_version_are_reported_as_unexpected_nodes() {
     .rows_affected();
     assert!(inserted > 0, "the fixture must actually insert stray rows");
 
-    let report = svc.verify_storage_parity().await.expect("sweep");
+    let report = svc
+        .verify_storage_parity(StorageParityScope::default())
+        .await
+        .expect("sweep");
 
     assert_eq!(report.mismatch_count, 1, "{report:?}");
     let found = &report.mismatches[0];
     assert_eq!(found.vo_id, vo_id);
     assert_eq!(found.sys_version, sys_version);
     assert_eq!(found.defect, StorageParityDefect::UnexpectedNodes);
+}
+
+/// A scoped sweep reads only what its bounds cover, which is how an operator
+/// verifies one record without reading the whole repository (#3110).
+///
+/// The tamper lives in one EHR; a sweep scoped to the other reports clean and
+/// never even counts the damaged version, while the unscoped sweep finds it.
+#[tokio::test]
+async fn a_scoped_sweep_covers_only_its_own_ehr() {
+    let db = testkit::db().await.expect("testkit database");
+    let pool = db.pool();
+    let svc = FerroEhrService::new(pool.clone());
+
+    let damaged = seed_ehr_with_composition(&svc).await;
+    let intact = seed_ehr_with_composition(&svc).await;
+    let (vo_id, sys_version) = one_version(&pool, damaged, "COMPOSITION").await;
+    tamper(
+        &pool,
+        "UPDATE vo_version SET body = '{\"_type\":\"COMPOSITION\"}' \
+         WHERE vo_id = $1 AND sys_version = $2",
+        vo_id,
+        sys_version,
+    )
+    .await;
+
+    let clean = svc
+        .verify_storage_parity(StorageParityScope {
+            ehr_id: Some(intact.0),
+            committed_since: None,
+        })
+        .await
+        .expect("scoped sweep");
+    assert!(clean.is_clean(), "the intact EHR sweeps clean: {clean:?}");
+    assert!(
+        clean.versions_checked > 0,
+        "the scoped sweep still read that EHR's own versions: {clean:?}"
+    );
+
+    let scoped = svc
+        .verify_storage_parity(StorageParityScope {
+            ehr_id: Some(damaged.0),
+            committed_since: None,
+        })
+        .await
+        .expect("scoped sweep");
+    assert_eq!(scoped.mismatch_count, 1, "the tamper is in this EHR");
+
+    let whole = svc
+        .verify_storage_parity(StorageParityScope::default())
+        .await
+        .expect("unscoped sweep");
+    assert_eq!(whole.mismatch_count, 1);
+    assert!(
+        whole.versions_checked > scoped.versions_checked,
+        "the unscoped sweep reads more than one EHR's versions: {whole:?} vs {scoped:?}"
+    );
+}
+
+/// A `committed_since` bound covers only versions written at or after it, so
+/// an operator can verify what changed since an incident (#3110).
+#[tokio::test]
+async fn a_committed_since_bound_excludes_earlier_versions() {
+    let db = testkit::db().await.expect("testkit database");
+    let pool = db.pool();
+    let svc = FerroEhrService::new(pool.clone());
+
+    seed_ehr_with_composition(&svc).await;
+    let before = svc
+        .verify_storage_parity(StorageParityScope::default())
+        .await
+        .expect("unscoped sweep");
+    assert!(before.versions_checked > 0);
+
+    // The cutoff is read from the database, not the process: `sys_period` is
+    // stamped by PostgreSQL's own clock, and a container's clock need not agree
+    // with this process's to the millisecond.
+    let cutoff: jiff_sqlx::Timestamp = sqlx::query_scalar("SELECT now()")
+        .fetch_one(&pool)
+        .await
+        .expect("the database's own clock");
+    let cutoff = cutoff.to_jiff();
+
+    // Everything seeded so far is older than the cutoff, so it covers nothing;
+    // the sweep succeeds and reports an empty count rather than failing or
+    // silently falling back to the whole store.
+    let after = svc
+        .verify_storage_parity(StorageParityScope {
+            ehr_id: None,
+            committed_since: Some(cutoff),
+        })
+        .await
+        .expect("bounded sweep");
+    assert_eq!(after.versions_checked, 0, "{after:?}");
+
+    // A version committed after the cutoff is covered.
+    seed_ehr_with_composition(&svc).await;
+    let later = svc
+        .verify_storage_parity(StorageParityScope {
+            ehr_id: None,
+            committed_since: Some(cutoff),
+        })
+        .await
+        .expect("bounded sweep");
+    assert!(later.versions_checked > 0, "{later:?}");
+
+    let whole = svc
+        .verify_storage_parity(StorageParityScope::default())
+        .await
+        .expect("unscoped sweep");
+    assert!(
+        later.versions_checked < whole.versions_checked,
+        "the bound still excludes the versions written before it: {later:?} vs {whole:?}"
+    );
 }

--- a/website/book/src/operations-admin-apis.md
+++ b/website/book/src/operations-admin-apis.md
@@ -190,9 +190,20 @@ breaks that agreement.
 The sweep re-derives every stored version from its decomposed rows and compares
 the result with the stored document. It reads the archived tier as well, takes
 no lock, and runs outside the request path of any clinical call, so it is safe
-to run on a live server. It is also a full scan of the repository: expect it to
-take minutes on a large one, and schedule it rather than calling it per
-request.
+to run on a live server. It is also a full scan of what it covers, so schedule
+it rather than calling it per request.
+
+Two optional query parameters narrow the scan, and they compose:
+
+| Parameter | Effect |
+|---|---|
+| `ehr_id` | cover only versions belonging to that EHR |
+| `committed_since` | cover only versions whose validity begins at or after that RFC 3339 instant |
+
+Use them. Verifying one record after a support incident, or everything written
+since a known point, costs a fraction of a full repository scan, and the whole
+sweep still has to answer inside the server's 30-second request timeout: a
+measured run over 98 000 stored versions took 11 seconds.
 
 ```json
 {


### PR DESCRIPTION
Closes #3110

The sweep compared each stored version's node rows with its materialized body using two sequential statements per version, so a store of 60 000 versions cost about 120 000 round trips and the request died at the 30 s timeout with the report lost. The dedicated suite seeds three versions and could not see it.

## The cost

Content is now read a chunk of 32 versions at a time, two statements per chunk: one `unnest` join over `node_all` for their rows, one over `vo_version_all` for their bodies. The same 60 000-version store costs under 4 000 statements.

The chunk is what bounds memory. The old code read one version at a time deliberately, so batching a whole 500-row page would have traded a latency problem for a memory one; 32 documents at a time keeps both bounded.

`read_version_rows_all` returns rows rather than reassembled values on purpose. A set of rows that does not form a tree is a REPORTED defect (`nodes_unreadable`), so reassembling inside the storage function would turn one damaged record into an error that aborts the sweep that found it. It also never shortcuts a whole version to the materialized body the way `read_subtrees_canonical` does for a root anchor, because that body is exactly what the sweep exists to compare against.

## Scoping

Two optional query parameters narrow what a sweep covers, and they compose:

| Parameter | Effect |
|---|---|
| `ehr_id` | cover only versions belonging to that EHR |
| `committed_since` | cover only versions whose validity begins at or after that RFC 3339 instant |

A sweep reads every byte of what it covers, so verifying one record after a support incident, or everything written since a known point, no longer means reading the whole repository.

## Measurement

On the testkit database, a store grown to 98 304 stored versions sweeps in 11.2 s and reports every version. The store's shape is worth stating: it carries one node row per version, where a production store carries more, so the figure is a lower bound on a repository of that version count.

What this does NOT do is make the sweep independent of the 30 s request timeout, which the issue offered as the alternative to a streamed or backgrounded response. A repository large enough still exceeds it, and the honest position is that this change moves the ceiling a long way rather than removing it. The execution shape is filed separately as #3122, with these numbers.

## Tests

Two new DB-backed tests: a sweep scoped to one EHR reports clean while an unscoped sweep over the same store finds the tamper in the other EHR, and a `committed_since` bound covers a version written after it while excluding the ones written before. The six existing parity tests, including the four defect classes, pass untouched. Its cutoff is read from the database rather than the process, because `sys_period` is stamped by PostgreSQL's clock and a container's need not agree with this process's.

## Gates

`cargo fmt`, the workspace clippy lane, the rustdoc lane, `comment-style`, `typed-status`, `default-style`, `docs-claims` and the changelog structure check are green. `cargo nextest run -p ferroehr -p ferroehr-rest` runs 1802 tests, all passing.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.
