### PR TITLE
ci: split the critical-path job three ways and shard the workspace tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,7 @@ jobs:
       deploy: ${{ steps.filter.outputs.deploy }}
       workflows: ${{ steps.filter.outputs.workflows }}
       vex: ${{ steps.filter.outputs.vex }}
+      msrv: ${{ steps.filter.outputs.msrv }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -184,6 +185,7 @@ jobs:
             {
               echo "code=true"
               echo "viewer=true"
+              echo "msrv=true"
               echo "server_dockerfile=true"
               echo "helm=true"
               echo "chart_boot=true"
@@ -209,6 +211,7 @@ jobs:
               echo "deploy=false"
               echo "workflows=false"
               echo "vex=false"
+              echo "msrv=false"
             } >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -237,6 +240,21 @@ jobs:
           else
             echo "No build-relevant paths touched — cargo jobs will be skipped."
             echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
+          # MSRV trigger: `cargo hack check --rust-version` compiles the whole
+          # workspace under every feature permutation to verify one manifest
+          # field, and it cost 556 s on every pull request (#3120). The property
+          # it checks — that no crate needs more than the declared
+          # `rust-version` — can only change when a manifest declares a
+          # different floor, a dependency arrives or moves, or the toolchain
+          # itself does. Source edits cannot change it: the compiler that
+          # accepts them is the same one either way, and a source-level MSRV
+          # violation is `clippy::incompatible_msrv`, which is deny-tier on
+          # every cargo lane.
+          if echo "$changed" | grep -qE '(^|/)Cargo\.toml$|^Cargo\.lock$|^rust-toolchain\.toml$|^clippy\.toml$|^\.github/workflows/ci\.yml$'; then
+            echo "msrv=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "msrv=false" >> "$GITHUB_OUTPUT"
           fi
           # Viewer E2E trigger: the viewer crate, its harness, the
           # composed stack it drives — AND the inputs to the CDR artifact the
@@ -1031,7 +1049,7 @@ jobs:
   msrv:
     name: msrv (cargo-hack)
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.msrv == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -1073,9 +1091,25 @@ jobs:
   # the separate Veredictum project (pinned in scripts/lib/veredictum.sh), and
   # its catalogue is validated by its own CI. The e2e CNF run stays where it
   # was: the Docker compose stack (scripts/conformance.sh) at phase gates.
+  # The critical-path job, split three ways because the single job it replaced
+  # ran 21.75 minutes and was the pipeline's whole wall clock (#3120). Measured
+  # there: 276 s linking every bin, 197 s + 164 s compiling the viewer under
+  # `ssr` to run 2.3 s of viewer tests, 186 s compiling the workspace's test
+  # targets and 427 s running 4614 of them. Splitting lets the four costs run
+  # beside each other instead of end to end; sharding the 427 s divides the one
+  # cost that no cache can remove.
   test:
-    name: build & test (pg18)
+    name: build & test (pg18) ${{ matrix.shard }}/3
     needs: changes
+    strategy:
+      fail-fast: false
+      matrix:
+        # Three shards, hash-partitioned by nextest so a slow suite cannot land
+        # them all in one shard (https://nexte.st/docs/ci-features/partitioning/).
+        # Each shard gets its own PostgreSQL service, which is what makes the
+        # split safe: the testkit harness clones a template database per test,
+        # so two shards never share one.
+        shard: [1, 2, 3]
     # The service container, its pinned image and the env the suite runs
     # against are all this file's recipe (#2373).
     if: needs.changes.outputs.code == 'true' || needs.changes.outputs.workflows == 'true'
@@ -1123,18 +1157,64 @@ jobs:
         with:
           tool: cargo-nextest
       # The viewer is excluded from --all-features lanes (mutually exclusive
-      # hydrate/ssr, compile_error!-guarded) and tested per-feature instead.
-      # The explicit `cargo build` is NOT redundant with nextest: nextest
-      # compiles test targets only, this is the one place every workspace BIN
-      # actually links (clippy type-checks but never links).
-      - run: cargo build --locked --workspace --exclude ferroehr-viewer --all-features
-      - run: cargo build --locked -p ferroehr-viewer --features ssr
+      # hydrate/ssr, compile_error!-guarded) and has its own job below.
       # --no-tests=pass: empty crates are expected until P17 (nextest exits 4 otherwise)
-      - run: cargo nextest run --locked --workspace --exclude ferroehr-viewer --all-features --no-tests=pass --profile ci
-      - run: cargo nextest run --locked -p ferroehr-viewer --features ssr --no-tests=pass --profile ci
+      # The shard index reaches the command through `env:`, never interpolated
+      # into the script (the workflow-security rule in reliability.md).
+      - run: cargo nextest run --locked --workspace --exclude ferroehr-viewer --all-features --no-tests=pass --profile ci --partition "hash:${SHARD}/3"
+        env:
+          SHARD: ${{ matrix.shard }}
       # Doc tests moved to the rustdoc job: `cargo test --doc` is a third
       # feature configuration (default features) and compiled the whole
       # workspace again at the tail of THE critical-path job.
+
+  # ── Every workspace BIN actually links here ────────────────────────────────
+  # `cargo clippy` type-checks but never links, and `nextest` compiles test
+  # targets only, so without this step a broken bin reaches main. It was the
+  # first 276 s of the old test job and needs no database, so it runs beside
+  # the shards instead of in front of them.
+  build:
+    name: build (link every bin)
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.workflows == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
+      - run: cargo build --locked --workspace --exclude ferroehr-viewer --all-features
+
+  # ── The viewer's own build + unit tests ────────────────────────────────────
+  # The viewer compiles under `ssr`, a different feature configuration from the
+  # rest of the workspace, so it shares no build cache with them. In the old
+  # test job that cost 361 s of the critical path to run 551 tests in 2.3 s.
+  # It needs no database.
+  test-viewer:
+    name: build & test (viewer, ssr)
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.workflows == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
+      - uses: taiki-e/install-action@742a3317eac7bd62f91cd888b4eead5e784ba833 # v2.87.1
+        with:
+          tool: cargo-nextest
+      - run: cargo build --locked -p ferroehr-viewer --features ssr
+      - run: cargo nextest run --locked -p ferroehr-viewer --features ssr --no-tests=pass --profile ci
 
   # ── The Helm chart's lint + golden renders (issue #2110) ────────────────────
   # deploy/helm/validate.sh is the only check in the repository that pins the
@@ -2209,7 +2289,9 @@ jobs:
       - doc
       - msrv
       - codegen-drift
+      - build
       - test
+      - test-viewer
       - helm-golden
       - unused-deps
       - ui-e2e-binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1672,12 +1672,23 @@ jobs:
   # ferroehr + Keycloak via compose, the viewer + e2e binaries prebuilt by the
   # jobs above, chromedriver journeys with the browser-console gate. Screenshots
   # upload on success AND failure (human review — no pixel-diff assertions).
+  # The pipeline's critical path (#3120): this job cannot start until the
+  # binaries it downloads exist, so the wall clock is `ui-e2e-binary` plus this.
+  # The journeys run `-j 1` because all 139 share one composed stack and one
+  # browser; sharding gives each shard its own stack, so the serialization holds
+  # inside a shard and the shards divide the wall clock. That sidesteps the
+  # question of which journeys are order-dependent rather than answering it —
+  # the answer is worth having, and it is not this file's to give.
   ui-e2e:
-    name: ui-e2e
+    name: ui-e2e ${{ matrix.shard }}/3
     needs: [changes, ui-e2e-binary, ui-e2e-viewer]
     if: needs.changes.outputs.viewer == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
     # `contents: read` (now also the workflow-level default) is all it needs:
     # nothing here writes to a registry any more (the GHCR buildx layer cache
     # was removed, and the image is now packaged locally from a job artifact).
@@ -1757,12 +1768,13 @@ jobs:
           UI_E2E_NEXTEST_ARCHIVE: ${{ github.workspace }}/ui-e2e-console-stage/ui-e2e-tests.tar.zst
           FERROEHR_IMAGE: ferroehr:ui-e2e
           FERROEHR_POSTGRES_IMAGE: ferroehr-postgres:ui-e2e
+          UI_E2E_PARTITION: hash:${{ matrix.shard }}/3
         run: bash scripts/ui-e2e.sh
       - name: Upload journey screenshots
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ui-e2e-screenshots
+          name: ui-e2e-screenshots-${{ matrix.shard }}
           path: target/ui-e2e/screenshots/
           if-no-files-found: ignore
 

--- a/scripts/ui-e2e.sh
+++ b/scripts/ui-e2e.sh
@@ -372,6 +372,14 @@ echo "── running e2e journeys"
 # than through the UI, whose own paths have their own journeys.
 NEXTEST_FILTER=(-E 'binary(it) - test(/^e2e_docs_shots::/)')
 [[ -n "$FILTER" ]] && NEXTEST_FILTER=(-E "test($FILTER)")
+# UI_E2E_PARTITION splits the battery across several runs of this script, each
+# against its OWN composed stack (#3120). The journeys run `-j 1` because they
+# share one server and one browser; a partition gives each shard a server of its
+# own, so the serialization is preserved inside a shard and the shards divide
+# the wall clock between them. Unset means the whole battery, which is what a
+# local run and a single-job CI lane both do.
+NEXTEST_PARTITION=()
+[[ -n "${UI_E2E_PARTITION:-}" ]] && NEXTEST_PARTITION=(--partition "$UI_E2E_PARTITION")
 UI_E2E_BASE_URL="$VIEWER_URL" \
 UI_E2E_WEBDRIVER_URL="http://127.0.0.1:$DRIVER_PORT" \
 UI_E2E_SHOTS_DIR="$SHOTS_DIR" \
@@ -384,7 +392,7 @@ UI_E2E_OIDC_USER="ferroehr-admin" \
 UI_E2E_OIDC_PASS="E2ePass-admin1!" \
 UI_E2E_SEEDED_EHR_ID="$SEEDED_EHR_ID" \
 UI_E2E_SEEDED_VO_ID="$SEEDED_VO_ID" \
-  cargo nextest run "${NEXTEST_TARGET[@]}" -j 1 "${NEXTEST_FILTER[@]}"
+  cargo nextest run "${NEXTEST_TARGET[@]}" -j 1 "${NEXTEST_FILTER[@]}" "${NEXTEST_PARTITION[@]}"
 fi
 
 # ── 6. The documentation-screenshot pass (opt-in) ────────────────────────────


### PR DESCRIPTION
Refs #3120

`build & test (pg18)` ran 21.75 minutes and was the pipeline's entire wall clock. Measured per step on run 33926059083:

| Step | Seconds | What it was doing |
|---|---|---|
| `cargo build --workspace --all-features` | 276 | linking every workspace bin |
| `cargo build -p ferroehr-viewer --features ssr` | 197 | compiling the viewer |
| `cargo nextest run --workspace` | 614 | 186 compiling test targets, 427 running 4614 tests |
| `cargo nextest run -p ferroehr-viewer --features ssr` | 164 | compiling the viewer again, to run 551 tests in 2.3 s |

Four costs, one after another, on one runner. 818 s of it was compilation and 429 s was actually running tests.

## What changed

**`build`** links every workspace bin. That step exists because clippy type-checks without linking and nextest compiles test targets only, so a broken bin would otherwise reach main. It needs no database, so it no longer sits in front of the tests.

**`test-viewer`** builds and tests the viewer. The viewer compiles under `ssr`, a different feature configuration from the rest of the workspace, so it shares no build cache with it and never did; 361 s of the critical path bought 2.3 s of test execution.

**`test`** keeps the database and runs the workspace suite in three hash-partitioned nextest shards, each with its own PostgreSQL service. That is safe because the testkit harness clones a template database per test, so no two shards ever share one. Hash partitioning rather than count so a slow suite cannot land entirely in one shard.

**`msrv`** gains its own change filter. `cargo hack check --rust-version` compiled the whole workspace under every feature permutation on every pull request, 556 s, to verify that no crate needs more than the declared floor. Only a manifest, the lockfile, the toolchain file or this workflow can change that answer. A source-level violation is `clippy::incompatible_msrv`, which is deny-tier on every cargo lane, so source edits are covered without this job.

## What did not change

The same tests run, under the same features, against the same pinned PostgreSQL 18.6. No test is skipped, weakened or retried to reach a number. The partition covers the whole set: verified locally on `openehr-query`, where the three shards hold 27, 22 and 19 of its 68 tests.

Only `conclusion` is a required status check on `main`, confirmed against the repository ruleset, so the shard suffix in the job name breaks no branch protection. A matrix job contributes one entry to `needs`, and `conclusion` already requires every entry to be `success` or `skipped`, so a failing shard still fails the gate.

## Expected effect

The old critical path was 1332 s. The remaining long jobs are `ui-e2e server binary` at 548 s, `clippy` at 475 s and `deploy-probe` at 338 s, and the three new jobs should each land near or below those. This pull request's own run is the measurement, and I will record the real per-job numbers on #3120 rather than claim them here.

## Gates

`actionlint`, `zizmor --min-severity=low`, `scripts/checks/ci-conclusion-complete.sh` and `scripts/checks/shellcheck-lane.sh` are green. No product code changes, so the `no-changelog` label carries the changelog rule.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.

---

## Measured result

Run 33930708941, this branch with both commits: **469 s**, against the 1332 s baseline. Every job passed, all three journey shards included, so partitioning the battery did not disturb the isolation the `-j 1` serialization protects.

| Job | Baseline | After |
|---|---|---|
| `build & test (pg18)` | 1305 | shards at 396, 411, 437 |
| `build & test (viewer, ssr)` | (inside the above) | 433 |
| `build (link every bin)` | (inside the above) | 245 |
| `ui-e2e` | ~600 in one job | shards at 294, 308, 328 |
| `msrv (cargo-hack)` | 556 | 306 |

**One caveat, because it changes how to read 469.** On that run the two binary jobs were cache hits, 27 s and 40 s. On the previous run of this branch they were cold at 656 s and 384 s, and that run totalled 1316 s. So: a pull request that touches neither the server nor the viewer restores main's binary caches and lands near 469 s; one that does still pays about 656 s for the binary stage, and the sharding takes the journey stage after it from about 600 s to about 328 s.

The next lever in the cold case is the single 602-second step that builds the viewer for two targets and archives the test binaries together. That is smaller than either change here and is left for its own change.
