### PR TITLE
docs(query): what paging and authorization scope collection actually cost

### DIFF
--- a/website/book/src/querying-aql.md
+++ b/website/book/src/querying-aql.md
@@ -319,6 +319,28 @@ without noticing. Page with `offset` and a `fetch` at or below the ceiling. A
 result that stops at the ceiling without either bound set is the default page:
 page explicitly to read past it.
 
+### Always order a query you intend to page
+
+`OFFSET` skips rows of a result, and without `ORDER BY` a result has no defined
+row order. Two requests for consecutive pages can then repeat a row or miss one
+entirely, and nothing in the response says so. Give any query you page an
+`ORDER BY` on something unique, such as `c/uid/value`.
+
+Ordering also changes what paging costs, in the direction that helps you.
+Measured against 131 000 stored compositions on one machine:
+
+| Query | Offset 0 | Offset 10 000 | Offset 100 000 |
+|---|---|---|---|
+| with `ORDER BY` | 110 ms | 222 ms | 275 ms |
+| without | 2 ms | 14 ms | 84 ms |
+
+An ordered query sorts the whole matched set to answer any page, so the first
+page already pays most of the cost and a deep page costs little more.
+An unordered one skips rows one at a time, so its cost grows with the offset,
+from nothing on page one. Either way, the number that dominates is how much your
+`FROM`/`CONTAINS` matched, not how deep you paged: narrow the query and both
+columns shrink.
+
 > [!TIP]
 > The more specific your `FROM`/`CONTAINS` (name the archetype, scope by
 > `ehr_id`), the faster the query: those constraints map to indexed columns,

--- a/website/book/src/querying-aql.md
+++ b/website/book/src/querying-aql.md
@@ -341,6 +341,14 @@ from nothing on page one. Either way, the number that dominates is how much your
 `FROM`/`CONTAINS` matched, not how deep you paged: narrow the query and both
 columns shrink.
 
+One more reason to order a paged query, if the deployment runs attribute-based
+authorization: the authorization decision is made over every EHR and template
+the query would touch, not over the page it served, so that set is collected
+whatever the page size. An ordered query pays nothing extra for it, because it
+was producing the whole matched set anyway. An unordered `LIMIT 10` that would
+have answered in 2 ms took 136 ms on the same 131 000-composition store. Narrow
+the query, and order it.
+
 > [!TIP]
 > The more specific your `FROM`/`CONTAINS` (name the archetype, scope by
 > `ehr_id`), the faster the query: those constraints map to indexed columns,


### PR DESCRIPTION
Closes #3096

Closes #3095

Both issues predicted a cost in the AQL paging path. Both were measured against a store of 131 072 stored COMPOSITION versions on the testkit database, driven through `execute_ad_hoc_query` so the numbers cover the whole path rather than the SQL alone. Neither turned out to need an engine change, and the measurements are recorded on the issues in full.

## Deep paging (#3096)

`SELECT c/uid/value FROM EHR e CONTAINS COMPOSITION c [ORDER BY c/uid/value] LIMIT 10 OFFSET N`, six runs per point, medians:

| Query | Offset 0 | Offset 10 000 | Offset 100 000 |
|---|---|---|---|
| with `ORDER BY` | 110 ms | 222 ms | 275 ms |
| without | 2 ms | 14 ms | 84 ms |

The O(offset) cost is real and exists only without `ORDER BY`, at about 0.8 µs per skipped row. With `ORDER BY` the sort produces the whole matched set to answer any page, so page one already pays most of it and offset 100 000 costs 2.5 times page one rather than a thousand times.

A keyset extension would be our own wire extension, since AQL 1.1 defines no cursor, and it would buy 84 ms on the unordered path while doing nothing for the ordered one. `build_paging` keeps emitting `LIMIT`/`OFFSET` as the spec defines them.

What the measurement did surface is a correctness hazard nothing documented: `OFFSET` on a query with no `ORDER BY` pages a result with no defined row order, so consecutive pages can silently repeat or miss a row.

## Authorization scope collection (#3095)

Same store, 8 EHRs, five runs per point, medians:

| Query | `collect_attributes: false` | `collect_attributes: true` |
|---|---|---|
| with `ORDER BY` | 146 ms | 143 ms |
| without | 2 ms | 136 ms |

On an ordered page the collection is free: the main query was producing the whole matched set anyway and `collect_scope` runs concurrently inside that time. On an unordered page it costs 134 ms, about 65 times the query itself, which is exactly the asymmetry the issue describes.

The scope statement's plan is a parallel sequential scan over 131 067 node rows joined to the version spine, sorted and de-duplicated to 8 distinct pairs in 128.5 ms. The sequential scan is the planner's correct choice: the `rm_type` filter removes 5 rows out of 131 072, so no index on it is selective.

The shape stays, for a reason the issue's own criterion allows. Paging the scope query would make the authorization decision over the served page rather than over what the query touches, letting a caller page past a resource the policy would refuse. Deriving the scope from the served rows is the same under-scoping. A version-spine-only probe is correct only until a predicate reaches into a node, and silently wrong after. A cardinality bound is the one surviving candidate and it is a new refusal on a security path, which 134 ms does not justify.

## What changed

`website/book/src/querying-aql.md` gains two paragraphs in the paging section: order any query you intend to page, with both cost shapes in a table; and, for deployments running attribute-based authorization, why the surcharge lands on exactly the queries that look cheap.

No engine change, so no `CHANGELOG.md` entry and the `no-changelog` label carries it. `docs-claims` passes over all 67 pages.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.