### PR TITLE
test: two container-free tests leave the serialized containers group

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -24,8 +24,18 @@
 [test-groups.containers]
 max-threads = 1
 
+#
+# Two tests in those modules start NO container and are excluded by name
+# (#3120): `disabled_by_default_stores_inline_verbatim` asserts the posture with
+# the store switched off, and
+# `unreachable_store_refuses_expansion_instead_of_answering_silently` asserts the
+# refusal when there is no store to reach. Both take only a testkit database, so
+# serializing them against the broker suites bought nothing and the retry they
+# inherited was meaningless. The filter stays an EXCLUSION rather than a list of
+# the container tests, so a new test in these modules is serialized by default:
+# the safe direction is a container test that waits, never one that does not.
 [[profile.default.overrides]]
-filter = 'package(ferroehr) & binary(it) & test(/^(events_amqp|fhir_outbound_amqp|multimedia_s3)::/)'
+filter = 'package(ferroehr) & binary(it) & test(/^(events_amqp|fhir_outbound_amqp|multimedia_s3)::/) - test(/^multimedia_s3::(disabled_by_default_stores_inline_verbatim|unreachable_store_refuses_expansion_instead_of_answering_silently)$/)'
 test-group = 'containers'
 retries = 1
 


### PR DESCRIPTION
Closes #3120

This is the last of that issue's acceptance criteria; the pipeline work itself landed in #3123, which took the pull-request wall clock from 1332 s to 469 s.

The `containers` nextest group matches by module prefix, so every test in `events_amqp`, `fhir_outbound_amqp` and `multimedia_s3` was serialized against the others and inherited their retry. Two of them start no container at all:

| Test | Time | What it needs |
|---|---|---|
| `multimedia_s3::disabled_by_default_stores_inline_verbatim` | 1.3 s | a testkit database; the store is switched off, which is the point |
| `multimedia_s3::unreachable_store_refuses_expansion_instead_of_answering_silently` | 1.7 s | a testkit database; there is deliberately no store to reach |

They are excluded **by name**, rather than the filter being rewritten as a list of the ten tests that do start containers. An exclusion keeps a new test in those modules serialized by default, and the safe direction is a container test that waits rather than one that does not.

Three seconds of serialized time, so this is about the group meaning what its comment says rather than about the clock. The larger adjudication of these suites is recorded on #3120: each of the remaining ten keeps its container because the property under test is the integration itself, and a mock would be testing our own mock.

Coverage and assertions are untouched; only scheduling changes. `cargo nextest run -p ferroehr -E 'test(/^multimedia_s3::/)'` runs 8 tests, all passing.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.
