### PR TITLE
fix(viewer): the session backstop re-reads the session instead of trusting a detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,16 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **Signing in again no longer lands back on the login card** (#3066). After the
+  viewer signed a user out, an answer to a request issued under the old session
+  could still arrive while they were signing back in. The transport reads every
+  such answer, and the shell treated one as proof the session was over, so a
+  freshly signed-in user was sent straight back to the login screen and only a
+  full page reload got them past it. The shell now re-reads the session instead
+  of trusting the detection, because a detection names no session, so a late
+  answer to a dead one is ignored and a real expiry still signs out. The visible
+  behaviour on a genuine expiry is unchanged.
+
 - **A large operational template uploads in milliseconds again** (#3114). The
   XML reader resolved every closing element's line and column by scanning the
   document from byte zero, which made a parse quadratic in document size: the

--- a/app/ferroehr-viewer/src/pages/shell.rs
+++ b/app/ferroehr-viewer/src/pages/shell.rs
@@ -216,18 +216,19 @@ pub fn AppShell() -> impl IntoView {
         }
     });
 
-    // Browser-only: the transport backstop. Every server fn runs through
-    // `SessionAwareClient`, which bumps the session-ended counter when one of
-    // them answers `Unauthenticated` or `CdrUnauthorized` — including a CDR
-    // revocation the viewer's own cookie knows nothing about. The baseline is
-    // read here, at setup, so a shell mounted after a fresh sign-in never acts
-    // on an older detection and no reset write is needed.
-    let navigate = leptos_router::hooks::use_navigate();
+    // Browser-only: the transport backstop. `SessionAwareClient` bumps the
+    // session-ended counter when a server fn answers `Unauthenticated` or
+    // `CdrUnauthorized`, including a CDR revocation this viewer's own cookie
+    // knows nothing about. It RE-READS the session rather than signing out on
+    // that alone (#3066): a detection names no session, so an answer to a
+    // request issued under the previous cookie can land after a new sign-in.
+    // The session is the only authority on whether it is over, and the gate
+    // below already acts on its answer.
     let session_ended = session_ended_signal();
     let session_ended_baseline = session_ended_epoch();
     Effect::new(move |_| {
         if session_ended.get() != session_ended_baseline {
-            navigate(&signed_out(), leptos_router::NavigateOptions::default());
+            session.refetch();
         }
     });
 


### PR DESCRIPTION
Closes #3066

## The mechanism

`SessionAwareClient` bumps a process-global counter whenever a server fn answers `Unauthenticated`, `CdrUnauthorized` or a bare `401`. The shell read that counter once at mount and signed out whenever it moved past that baseline. **The counter carries no evidence of which session a detection belonged to**, and the comment on it says so in the form of the assumption it rests on: that comparing against a mount-time baseline is enough.

It is enough for a detection that has already landed. It is not enough for one still in flight:

1. The shell is mounted and polling. `session.refetch()` runs on a timer, and `status`, `management`, `tenants`, `fhir` and `subscriptions` are all live over the same transport.
2. The cookie is revoked. One answer comes back `401`, the counter moves, the shell signs out and unmounts.
3. **Requests already sent keep completing.** The transport inspects them, not a resource, so an answer arriving after the shell is gone still bumps the counter. Disposing the shell disposes its resources; it does not cancel a fetch already in the browser's queue.
4. The user signs in. A new shell mounts and reads its baseline from the counter at that instant.
5. A straggler from step 2 lands. The counter passes the new baseline, and the fresh shell navigates back to the signed-out URL, which reads the current path — so the user is on the login card again.

That accounts for every symptom in the report. Intermittent, because it needs one request to outlive the sign-in. Only on a second sign-in in the same runtime, because a first has no prior detections in flight and a reload discards them, which is exactly why a hard reload "fixes" it. Address bar on `/login`, because the navigation is real. Console clean, because nothing failed.

## The fix

The backstop refetches the session rather than navigating. A straggler becomes a no-op, because the fresh session resolves; a genuine revocation still signs out one round trip later, through the gate in the `Suspense` that already handles exactly that case.

The direct `navigate` is removed rather than guarded, which is the point: signing out now has ONE path instead of two, and it is the one that consults the only authority on whether a session is over. The expiry poll already worked this way — `use_timeout_fn` refetches and lets the gate decide — so this makes the backstop agree with the mechanism beside it.

The destination is unchanged: the gate's `Ok(None) if seen_session` arm redirects to the same `signed_out()` URL, carrying `expired=1` and the screen the user was on.

## On the regression guard

The four journeys in `e2e_session_expiry.rs` from #3109 stay and still pass. None of them can pin this specific race: reproducing it means holding a request open across a sign-in, and the harness has no way to do that.

What replaces a journey here is structural. The shell can no longer navigate on a detection at all, so the path from an unattributable answer to a signed-out screen does not exist to regress. A future change that reintroduces a direct `navigate` would have to delete the comment explaining why it is not there.

## Evidence

The issue carries a first-hand reproduction on the composed stack, recorded before this change: `signing_in_from_the_unattended_expired_card_renders_the_dashboard_again` failed after 178 s with the card still on screen, both fields filled, and the address bar on `/login?expired=1&next=%2F`. That journey sat 8 s on the card before signing in, which is the widest window a straggler could ask for. The mechanism above was then derived from the code and posted before this fix.

## Gates

`cargo clippy -p ferroehr-viewer --all-targets --features ssr` and the wasm32 `hydrate` lane are both green with `-D warnings`. `cargo nextest run -p ferroehr-viewer --features ssr` runs 551 tests, all passing. `leptosfmt` checked 104 files, `cargo fmt`, `comment-style` and the changelog structure check are clean.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.