### PR TITLE
docs(query): drop the hand-typed measurements from the book

### DIFF
--- a/website/book/src/operations-admin-apis.md
+++ b/website/book/src/operations-admin-apis.md
@@ -202,8 +202,8 @@ Two optional query parameters narrow the scan, and they compose:
 
 Use them. Verifying one record after a support incident, or everything written
 since a known point, costs a fraction of a full repository scan, and the whole
-sweep still has to answer inside the server's 30-second request timeout: a
-measured run over 98 000 stored versions took 11 seconds.
+sweep still has to answer inside the server's 30-second request timeout. On a
+large repository, scope it.
 
 ```json
 {

--- a/website/book/src/querying-aql.md
+++ b/website/book/src/querying-aql.md
@@ -326,28 +326,19 @@ row order. Two requests for consecutive pages can then repeat a row or miss one
 entirely, and nothing in the response says so. Give any query you page an
 `ORDER BY` on something unique, such as `c/uid/value`.
 
-Ordering also changes what paging costs, in the direction that helps you.
-Measured against 131 000 stored compositions on one machine:
-
-| Query | Offset 0 | Offset 10 000 | Offset 100 000 |
-|---|---|---|---|
-| with `ORDER BY` | 110 ms | 222 ms | 275 ms |
-| without | 2 ms | 14 ms | 84 ms |
-
-An ordered query sorts the whole matched set to answer any page, so the first
-page already pays most of the cost and a deep page costs little more.
-An unordered one skips rows one at a time, so its cost grows with the offset,
-from nothing on page one. Either way, the number that dominates is how much your
-`FROM`/`CONTAINS` matched, not how deep you paged: narrow the query and both
-columns shrink.
+Ordering also changes what paging costs, in the direction that helps you. An
+ordered query sorts the whole matched set to answer any page, so the first page
+already pays most of the work and a deep page costs little more than a shallow
+one. An unordered query skips rows one at a time, so its cost grows with the
+offset, from almost nothing on page one. Either way what dominates is how much
+your `FROM`/`CONTAINS` matched, not how deep you paged.
 
 One more reason to order a paged query, if the deployment runs attribute-based
 authorization: the authorization decision is made over every EHR and template
 the query would touch, not over the page it served, so that set is collected
 whatever the page size. An ordered query pays nothing extra for it, because it
-was producing the whole matched set anyway. An unordered `LIMIT 10` that would
-have answered in 2 ms took 136 ms on the same 131 000-composition store. Narrow
-the query, and order it.
+was producing the whole matched set anyway. An unordered page that looks cheap
+carries the whole collection on top of it. Narrow the query, and order it.
 
 > [!TIP]
 > The more specific your `FROM`/`CONTAINS` (name the archetype, scope by


### PR DESCRIPTION
Main is red on `Docs / build`. The stale-numbers gate found hand-typed performance figures in the book, which #3121 and #3124 put there. Mine, and the gate is right.

```text
website/book/src/querying-aql.md:334:| with `ORDER BY` | 110 ms | 222 ms | 275 ms |
website/book/src/querying-aql.md:335:| without | 2 ms | 14 ms | 84 ms |
website/book/src/querying-aql.md:349:have answered in 2 ms took 136 ms on the same 131 000-composition store.
```

The website derives conformance claims from `docs/conformance/ferroehr/` and performance claims from the committed measurement records, precisely so a published number cannot outlive the run that produced it. My figures came from ad-hoc probes on one machine and are not committed records, so they would have sat on the public site going quietly stale. I also removed the sweep figure on the admin page, which the gate's pattern happened not to catch but which is the same hazard.

**The guidance survives intact, because none of it needed the numbers.** Order any query you page, or its pages have no defined row order and can silently repeat or miss rows. An ordered query pays its sort on page one, so depth adds little. An unordered one grows with the offset. The authorization scope is collected over the match rather than the page, so an unordered page that looks cheap carries the whole collection. And a repository-wide parity sweep should be scoped on a large store.

The measurements stay where measurements belong: on #3095, #3096 and #3110, with the plans and the conditions they were taken under.

`scripts/checks/conformance-numbers.sh` and `scripts/checks/docs-claims.sh` both pass.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.