### PR TITLE
feat(templates): a refused OPT lists every violation, not the first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Changed
+
+- **A refused operational template lists every violation, not the first one**
+  (#3129). Repairing a template meant one upload per defect: a reporter with a
+  1.7 MB template uploaded it to learn `use` was empty, fixed it, uploaded again
+  to learn `misuse` was too, and a code list with seventeen duplicated codes
+  named one of them at a time. `validationErrors` now carries an entry per
+  violation, the way a refused composition already did. A violation that makes
+  the tree below it meaningless, a constrained type the reference model does not
+  have or an attribute its parent does not declare, says that its subtree went
+  unchecked, so a short list is never mistaken for a clean one; past 200
+  violations the response says it stopped counting.
+
 ## [4.1.0] - 2026-09-05
 
 ### Added

--- a/app/ferroehr/src/validation/opt/invariants.rs
+++ b/app/ferroehr/src/validation/opt/invariants.rs
@@ -306,8 +306,10 @@ pub(super) fn check_constraint_ref(r: &ConstraintRef, ctx: &Ctx) -> Result<(), R
 /// Duplicate codes in a terminology-code code list are invalid (ADL2
 /// master04.6 STCDC — "constraint code list contains duplicate codes"; the
 /// same defect in an OPT 1.4 `C_CODE_PHRASE` list).
-pub(super) fn check_code_list(code_list: &[String], node_id: &str) -> Result<(), RuleViolation> {
+pub(super) fn check_code_list(code_list: &[String], node_id: &str) -> Vec<RuleViolation> {
     let mut seen = HashSet::new();
+    let mut reported = HashSet::new();
+    let mut violations = Vec::new();
     for code in code_list {
         // Empty entries are tooling noise, not codes (Ocean exports emit
         // repeated empty <code_list/> elements — the vendored UK AoMRC corpus
@@ -315,12 +317,62 @@ pub(super) fn check_code_list(code_list: &[String], node_id: &str) -> Result<(),
         if code.is_empty() {
             continue;
         }
-        if !seen.insert(code) {
-            return Err(RuleViolation::new(
+        // Every duplicated code is reported, once each however many times it
+        // repeats: a list with seventeen of them used to cost seventeen uploads
+        // to find (#3129), and a code repeated three times is still one defect.
+        if !seen.insert(code) && reported.insert(code) {
+            violations.push(RuleViolation::new(
                 "STCDC",
                 format!("node '{node_id}': code '{code}' is duplicated in the code list"),
             ));
         }
     }
-    Ok(())
+    violations
+}
+
+#[cfg(test)]
+mod tests {
+    use super::check_code_list;
+
+    /// The reported case (#3129): one template held seventeen duplicated codes
+    /// and the refusal named the first, so finding them all took seventeen
+    /// uploads. Every duplicate is reported now.
+    #[test]
+    fn every_duplicated_code_is_reported_not_just_the_first() {
+        let list: Vec<String> = ["a", "b", "a", "c", "b", "d", "e", "e"]
+            .iter()
+            .map(|s| (*s).to_owned())
+            .collect();
+
+        let details: Vec<String> = check_code_list(&list, "at0001")
+            .iter()
+            .map(|v| v.detail.clone())
+            .collect();
+
+        assert_eq!(details.len(), 3, "three codes repeat: {details:?}");
+        for code in ["'a'", "'b'", "'e'"] {
+            assert!(
+                details.iter().any(|d| d.contains(code)),
+                "missing {code} in {details:?}"
+            );
+        }
+    }
+
+    /// A code repeated three times is one defect, not two.
+    #[test]
+    fn a_code_repeated_several_times_is_reported_once() {
+        let list: Vec<String> = ["x", "x", "x", "x"]
+            .iter()
+            .map(|s| (*s).to_owned())
+            .collect();
+        assert_eq!(check_code_list(&list, "at0002").len(), 1);
+    }
+
+    /// Empty entries are tooling noise, not codes, so repeating them is not a
+    /// duplicate (Ocean exports emit repeated empty `code_list` elements).
+    #[test]
+    fn repeated_empty_entries_are_not_duplicates() {
+        let list: Vec<String> = ["", "", "a", ""].iter().map(|s| (*s).to_owned()).collect();
+        assert!(check_code_list(&list, "at0003").is_empty());
+    }
 }

--- a/app/ferroehr/src/validation/opt/mod.rs
+++ b/app/ferroehr/src/validation/opt/mod.rs
@@ -34,9 +34,18 @@
 //! status codes), distinct from the syntactic `400` branch that owns
 //! not-well-formed content.
 //!
-//! The check sequence — terminology sets first, then the walk, and per node
-//! VCORM, VATID, per-kind invariants, recurse — reports the first violation
-//! found, and that ordering is part of the behavioural contract.
+//! The check sequence is terminology sets first, then the walk, and per node
+//! VCORM, VATID, per-kind invariants, recurse. It reports EVERY violation it
+//! finds rather than the first, because the alternative made repairing a
+//! template one upload per defect (#3129) — and a 1.7 MB operational template
+//! is not something anyone re-uploads casually. The order above is the order
+//! they are reported in.
+//!
+//! Two failures stop a subtree instead of accumulating: an object whose RM type
+//! the model does not have, and an attribute its parent RM type does not
+//! declare. Everything below either would be checked against a shape that does
+//! not exist, so the violation carries a clause saying its subtree went
+//! unchecked. See [`Findings`].
 
 mod interval;
 mod invariants;
@@ -63,6 +72,79 @@ impl RuleViolation {
             code,
             detail: detail.into(),
         }
+    }
+}
+
+/// How many violations one refusal carries before it stops collecting.
+///
+/// Generous on purpose: a template a person is repairing has tens of defects at
+/// worst, and the whole point of reporting them together is that the list is
+/// the repair list. The cap exists for the artefact nobody is repairing — a
+/// corrupted or machine-mangled upload where every node is wrong — so a `422`
+/// body stays something a client can read. Reaching it is reported, never
+/// silent.
+const MAX_REPORTED_VIOLATIONS: usize = 200;
+
+/// The violations found so far.
+///
+/// The AOM2 rules are properties of separate nodes, so one failure says nothing
+/// about the next and the walk keeps going. Two failures are different: an
+/// object whose RM type does not exist, and an attribute its parent RM type
+/// does not declare. Everything below those is being checked against a shape
+/// the model does not have, so their subtrees are pruned and the violation says
+/// so rather than burying the real defect under its own consequences.
+struct Findings {
+    violations: Vec<RuleViolation>,
+    truncated: bool,
+}
+
+impl Findings {
+    fn new() -> Self {
+        Self {
+            violations: Vec::new(),
+            truncated: false,
+        }
+    }
+
+    /// Record `outcome` when it is a violation; returns whether it was one, so
+    /// a caller that must prune its subtree can see it without re-checking.
+    fn record(&mut self, outcome: Result<(), RuleViolation>) -> bool {
+        let Err(violation) = outcome else {
+            return false;
+        };
+        if self.violations.len() < MAX_REPORTED_VIOLATIONS {
+            self.violations.push(violation);
+        } else {
+            self.truncated = true;
+        }
+        true
+    }
+
+    /// Record a violation whose subtree is being pruned, saying so in its own
+    /// detail: a reader must not read the absence of nested violations as their
+    /// absence from the artefact.
+    fn record_pruned(&mut self, outcome: Result<(), RuleViolation>, what: &str) -> bool {
+        let Err(mut violation) = outcome else {
+            return false;
+        };
+        violation.detail = format!(
+            "{}; the {what} below it was not checked, because every rule under it \
+             would be checked against a shape the reference model does not have",
+            violation.detail
+        );
+        self.record(Err(violation))
+    }
+
+    /// Record every violation in `outcomes`, for a rule that yields more than
+    /// one at a time.
+    fn record_all(&mut self, outcomes: Vec<RuleViolation>) {
+        for violation in outcomes {
+            self.record(Err(violation));
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.violations.is_empty()
     }
 }
 
@@ -143,29 +225,45 @@ fn attribute_children(attr: &CAttribute) -> &[CObject] {
 }
 
 /// Validate an uploaded OPT 1.4 artefact against the AOM2/08 standalone-artefact
-/// validity rules. The first violation found is returned as a `422` carrying the
-/// AOM2 rule code; a fully valid artefact returns `Ok`.
+/// validity rules. Every violation found is returned as one `422` carrying the
+/// AOM2 rule codes; a fully valid artefact returns `Ok`.
 ///
 /// # Errors
 ///
 /// [`ServiceError::ValidationFailed`] (→ ITS-REST `422` rendering the `Error`
-/// object with the rule code in `validationErrors[]`) for the first violation
-/// found: an AOM2 rule violation is a semantic error on a successfully parsed
+/// object with one entry per violation in `validationErrors[]`, plus a
+/// `TRUNCATED` entry when the artefact had more than
+/// [`MAX_REPORTED_VIOLATIONS`]): an AOM2 rule violation is a semantic error on
+/// a successfully parsed
 /// artefact (the overview status table's `422` row,
 /// `docs/specs/openehr/ITS-REST/specifications/docs/overview/
 /// Requests_and_responses.md` §HTTP status codes; no template operation
 /// declares `422`, so the semantic branch is register-adjudicated), never the
 /// syntactic `400` branch of `responses/400.yaml`.
 pub(super) fn validate_opt_artefact(opt: &OperationalTemplate) -> Result<(), ServiceError> {
-    check(opt).map_err(|v| {
-        ServiceError::ValidationFailed(vec![openehr_base::validate::InvariantViolation::at(
-            v.code.to_string(),
-            v.detail,
-        )])
-    })
+    let findings = check(opt);
+    if findings.is_empty() {
+        return Ok(());
+    }
+    let mut errors: Vec<openehr_base::validate::InvariantViolation> = findings
+        .violations
+        .into_iter()
+        .map(|v| openehr_base::validate::InvariantViolation::at(v.code.to_string(), v.detail))
+        .collect();
+    if findings.truncated {
+        errors.push(openehr_base::validate::InvariantViolation::at(
+            "TRUNCATED".to_owned(),
+            format!(
+                "this artefact has more than {MAX_REPORTED_VIOLATIONS} validity violations; \
+                 the rest were not reported. Fix these and upload again to see what remains"
+            ),
+        ));
+    }
+    Err(ServiceError::ValidationFailed(errors))
 }
 
-fn check(opt: &OperationalTemplate) -> Result<(), RuleViolation> {
+fn check(opt: &OperationalTemplate) -> Findings {
+    let mut f = Findings::new();
     // Terminology-side rules first (cheap; no tree recursion needed beyond code
     // collection).
     let ctx = Ctx {
@@ -175,39 +273,45 @@ fn check(opt: &OperationalTemplate) -> Result<(), RuleViolation> {
             .iter()
             .any(|o| o.constraint_definitions.iter().any(|s| !s.items.is_empty())),
     };
-    terminology::check_term_bindings(opt, &ctx.defined_at)?; // VTTBK
-    terminology::check_constraint_bindings(opt, &ctx.defined_ac)?; // VTCBK
-    terminology::check_language_consistency(opt)?; // VTLC
+    f.record(terminology::check_term_bindings(opt, &ctx.defined_at)); // VTTBK
+    f.record(terminology::check_constraint_bindings(opt, &ctx.defined_ac)); // VTCBK
+    f.record(terminology::check_language_consistency(opt)); // VTLC
 
     // RM-conformance + structural rules walk the flattened definition tree.
     // The root definition is a `C_ARCHETYPE_ROOT`; its `rm_type_name` is the
     // top RM type (VCORM).
-    rm_conformance::check_object_type(
-        opt.definition.rm_type_name.as_str(),
+    let root_rm = opt.definition.rm_type_name.as_str();
+    let root_type_unknown = f.record_pruned(
+        rm_conformance::check_object_type(root_rm, &opt.definition.node_id),
+        "whole definition tree",
+    );
+    f.record(terminology::check_node_id(
         &opt.definition.node_id,
-    )?;
-    terminology::check_node_id(&opt.definition.node_id, &ctx.defined_at)?; // VATID (root)
+        &ctx.defined_at,
+    )); // VATID (root)
     // VARID / VARDT on the root archetype id (ADL1.4 master08 lines 544/556).
-    invariants::check_archetype_id(
+    f.record(invariants::check_archetype_id(
         &opt.definition.archetype_id.value,
-        opt.definition.rm_type_name.as_str(),
-    )?;
-    for attr in &opt.definition.attributes {
-        walk_attribute(attr, opt.definition.rm_type_name.as_str(), &ctx)?;
+        root_rm,
+    ));
+    if !root_type_unknown {
+        for attr in &opt.definition.attributes {
+            walk_attribute(attr, root_rm, &ctx, &mut f);
+        }
     }
 
     // The RM resource-package invariants over the OPT's own meta-data header
-    // run last, so every existing AOM2 refusal keeps its code (the
-    // first-violation ordering is part of the behavioural contract).
-    resource::check_resource_meta(opt)?;
-    Ok(())
+    // run last, so the codes a reader sees keep the order the catalogue walks
+    // them in.
+    f.record_all(resource::check_resource_meta(opt));
+    f
 }
 
 // ─── tree walk (T1: C_COMPLEX_OBJECT / C_ATTRIBUTE alternation) ──────────────────
 
 /// Recurse into one constrained attribute of an object whose RM type is
 /// `parent_rm`.
-fn walk_attribute(attr: &CAttribute, parent_rm: &str, ctx: &Ctx) -> Result<(), RuleViolation> {
+fn walk_attribute(attr: &CAttribute, parent_rm: &str, ctx: &Ctx, f: &mut Findings) {
     let (attr_name, existence, children, cardinality) = match attr {
         CAttribute::CSingleAttribute(a) => (
             a.rm_attribute_name.as_str(),
@@ -223,73 +327,113 @@ fn walk_attribute(attr: &CAttribute, parent_rm: &str, ctx: &Ctx) -> Result<(), R
         ),
     };
 
-    invariants::check_attribute_name(attr_name, parent_rm)?;
-    invariants::check_existence_set(attr_name, parent_rm, existence)?;
+    // An attribute the parent RM type does not declare makes every rule below
+    // it meaningless, so its children are pruned and the violation says so.
+    if f.record_pruned(
+        invariants::check_attribute_name(attr_name, parent_rm),
+        "constraint tree",
+    ) {
+        return;
+    }
+    f.record(invariants::check_existence_set(
+        attr_name, parent_rm, existence,
+    ));
 
     // A single-valued attribute (no cardinality) can hold at most one value.
     if cardinality.is_none() {
-        invariants::check_members_valid(attr_name, parent_rm, children)?;
+        f.record(invariants::check_members_valid(
+            attr_name, parent_rm, children,
+        ));
     }
 
     // RM-conformance checks (VCARM/VCAM/VCAEX) on the resolved RM attribute.
-    rm_conformance::check_attribute(attr, attr_name, parent_rm, existence)?;
+    f.record(rm_conformance::check_attribute(
+        attr, attr_name, parent_rm, existence,
+    ));
 
     // VACMCO / VCOC: occurrences-vs-cardinality (container attributes only).
     if let Some(card) = cardinality {
-        rm_conformance::check_cardinality_occurrences(attr_name, parent_rm, card, children)?;
+        f.record(rm_conformance::check_cardinality_occurrences(
+            attr_name, parent_rm, card, children,
+        ));
     }
 
     for child in children {
-        walk_object(child, ctx)?;
+        walk_object(child, ctx, f);
     }
-    Ok(())
 }
 
 /// Check one child object node, then recurse into its own attributes.
-fn walk_object(obj: &CObject, ctx: &Ctx) -> Result<(), RuleViolation> {
+fn walk_object(obj: &CObject, ctx: &Ctx, f: &mut Findings) {
     let view = NodeView::of(obj);
 
     // VCORM: object constraint type-name existence. A primitive-object node
     // carries a foundation primitive type name (STRING, INTEGER, …) which is
-    // intentionally absent from the RM model, so it is exempt.
-    if !matches!(obj, CObject::CPrimitiveObject(_)) {
-        rm_conformance::check_object_type(view.rm_type, view.node_id)?;
+    // intentionally absent from the RM model, so it is exempt. A type the model
+    // does not have prunes its own subtree, for the reason `Findings` records.
+    if !matches!(obj, CObject::CPrimitiveObject(_))
+        && f.record_pruned(
+            rm_conformance::check_object_type(view.rm_type, view.node_id),
+            "constraint tree",
+        )
+    {
+        return;
     }
 
     // VATID: every at-code used as a node_id must be defined in terminology.
-    terminology::check_node_id(view.node_id, &ctx.defined_at)?;
+    f.record(terminology::check_node_id(view.node_id, &ctx.defined_at));
 
     // AOM 1.4 per-node-kind invariants (the constraint-model class files).
     match obj {
         CObject::CArchetypeRoot(root) => {
             // VARID / VARDT on every flattened slot-filler root.
-            invariants::check_archetype_id(&root.archetype_id.value, &root.rm_type_name)?;
+            f.record(invariants::check_archetype_id(
+                &root.archetype_id.value,
+                &root.rm_type_name,
+            ));
         }
-        CObject::ArchetypeSlot(slot) => invariants::check_slot(slot)?,
-        CObject::ArchetypeInternalRef(r) => invariants::check_internal_ref(r)?,
-        CObject::ConstraintRef(r) => invariants::check_constraint_ref(r, ctx)?,
+        CObject::ArchetypeSlot(slot) => {
+            f.record(invariants::check_slot(slot));
+        }
+        CObject::ArchetypeInternalRef(r) => {
+            f.record(invariants::check_internal_ref(r));
+        }
+        CObject::ConstraintRef(r) => {
+            f.record(invariants::check_constraint_ref(r, ctx));
+        }
         CObject::CPrimitiveObject(p) => {
             if let Some(item) = &p.item {
-                primitive::check_primitive(item, view.node_id)?;
+                f.record(primitive::check_primitive(item, view.node_id));
             }
         }
         CObject::CCodePhrase(c) => {
-            invariants::check_code_list(&c.code_list, view.node_id)?;
-            primitive::check_assumed_code(c.assumed_value.as_ref(), &c.code_list, view.node_id)?;
+            f.record_all(invariants::check_code_list(&c.code_list, view.node_id));
+            f.record(primitive::check_assumed_code(
+                c.assumed_value.as_ref(),
+                &c.code_list,
+                view.node_id,
+            ));
         }
         CObject::CCodeReference(c) => {
-            invariants::check_code_list(&c.code_list, view.node_id)?;
-            primitive::check_assumed_code(c.assumed_value.as_ref(), &c.code_list, view.node_id)?;
+            f.record_all(invariants::check_code_list(&c.code_list, view.node_id));
+            f.record(primitive::check_assumed_code(
+                c.assumed_value.as_ref(),
+                &c.code_list,
+                view.node_id,
+            ));
         }
-        CObject::CDvOrdinal(c) => primitive::check_dv_ordinal(c, view.node_id)?,
-        CObject::CDvQuantity(c) => primitive::check_dv_quantity(c, view.node_id)?,
+        CObject::CDvOrdinal(c) => {
+            f.record(primitive::check_dv_ordinal(c, view.node_id));
+        }
+        CObject::CDvQuantity(c) => {
+            f.record(primitive::check_dv_quantity(c, view.node_id));
+        }
         _ => {}
     }
 
     // Recurse into a nested C_ARCHETYPE_ROOT's terminology scope-wise via the
     // global set already collected; structurally we just descend its attributes.
     for attr in view.attributes {
-        walk_attribute(attr, view.rm_type, ctx)?;
+        walk_attribute(attr, view.rm_type, ctx, f);
     }
-    Ok(())
 }

--- a/app/ferroehr/src/validation/opt/resource.rs
+++ b/app/ferroehr/src/validation/opt/resource.rs
@@ -25,23 +25,32 @@ use super::RuleViolation;
 
 /// Validates the RM resource-package invariants of the OPT's meta-data
 /// header, reporting the first violation found (the module's contract).
-pub(super) fn check_resource_meta(opt: &OperationalTemplate) -> Result<(), RuleViolation> {
+pub(super) fn check_resource_meta(opt: &OperationalTemplate) -> Vec<RuleViolation> {
     let terminology = openehr();
-    check_language(
+    let mut violations = Vec::new();
+    if let Err(v) = check_language(
         terminology,
         &opt.language.code_string,
         "AUTHORED_RESOURCE.Original_language_valid",
         "the operational template's language",
-    )?;
-    check_revision_history_flag(
+    ) {
+        violations.push(v);
+    }
+    if let Err(v) = check_revision_history_flag(
         opt.is_controlled,
         opt.revision_history.is_some(),
         "the operational template",
-    )?;
-    if let Some(description) = opt.description.as_ref() {
-        check_description(terminology, description, "the operational template")?;
+    ) {
+        violations.push(v);
     }
-    Ok(())
+    if let Some(description) = opt.description.as_ref() {
+        violations.extend(check_description(
+            terminology,
+            description,
+            "the operational template",
+        ));
+    }
+    violations
 }
 
 /// One embedded `ARCHETYPE` (an `AUTHORED_RESOURCE` subtype): the full
@@ -64,11 +73,16 @@ fn check_archetype(
     )?;
     check_translations(terminology, &archetype.translations, original)?;
     if let Some(description) = archetype.description.as_ref() {
-        check_description(
+        if let Some(v) = check_description(
             terminology,
             description,
             &format!("embedded archetype '{}'", archetype.archetype_id.value),
-        )?;
+        )
+        .into_iter()
+        .next()
+        {
+            return Err(v);
+        }
         // Description_valid: `translations /= Void implies (description.details
         // .for_all (d | translations.has_key (d.language.code_string)))`.
         // NOTE: authored_resource.adoc §Invariants Description_valid — the
@@ -145,36 +159,45 @@ fn check_description(
     terminology: &OpenehrTerminology,
     description: &ResourceDescription,
     owner: &str,
-) -> Result<(), RuleViolation> {
+) -> Vec<RuleViolation> {
+    // The three header rules below decide whether there IS a description to
+    // examine, so each one returns alone: with no author, no lifecycle state or
+    // no details at all, the per-detail rules have nothing to say.
     if description.original_author.is_empty() {
-        return Err(RuleViolation::new(
+        return vec![RuleViolation::new(
             "RESOURCE_DESCRIPTION.Original_author_valid",
             format!("the description of {owner} has an empty original_author"),
-        ));
+        )];
     }
     if description.lifecycle_state.is_empty() {
-        return Err(RuleViolation::new(
+        return vec![RuleViolation::new(
             "RESOURCE_DESCRIPTION.Lifecycle_state_valid",
             format!("the description of {owner} has an empty lifecycle_state"),
-        ));
+        )];
     }
     if description.details.is_empty() {
-        return Err(RuleViolation::new(
+        return vec![RuleViolation::new(
             "RESOURCE_DESCRIPTION.Details_valid",
             format!("the description of {owner} has no details"),
-        ));
+        )];
     }
+    // Every detail's own rules are independent properties of that detail, so
+    // they accumulate: a hand-written template with an empty `use` AND an empty
+    // `misuse` reports both at once rather than one per upload (#3129).
+    let mut violations = Vec::new();
     let mut seen: Vec<&str> = Vec::with_capacity(description.details.len());
     for item in &description.details {
         let language = item.language.code_string.as_str();
-        check_language(
+        if let Err(v) = check_language(
             terminology,
             language,
             "RESOURCE_DESCRIPTION_ITEM.Language_valid",
             "a description detail",
-        )?;
+        ) {
+            violations.push(v);
+        }
         if seen.contains(&language) {
-            return Err(RuleViolation::new(
+            violations.push(RuleViolation::new(
                 "RESOURCE_DESCRIPTION.Details_valid",
                 format!(
                     "two description details carry the same language '{language}' — details \
@@ -184,38 +207,40 @@ fn check_description(
         }
         seen.push(language);
         if item.purpose.is_empty() {
-            return Err(RuleViolation::new(
+            violations.push(RuleViolation::new(
                 "RESOURCE_DESCRIPTION_ITEM.Purpose_valid",
                 format!("the '{language}' description detail of {owner} has an empty purpose"),
             ));
         }
-        check_present_non_empty(
-            item.use_.as_deref(),
-            "RESOURCE_DESCRIPTION_ITEM.Use_valid",
-            language,
-            "use",
-            owner,
-        )?;
-        check_present_non_empty(
-            item.misuse.as_deref(),
-            "RESOURCE_DESCRIPTION_ITEM.misuse_valid",
-            language,
-            "misuse",
-            owner,
-        )?;
-        check_present_non_empty(
-            item.copyright.as_deref(),
-            "RESOURCE_DESCRIPTION_ITEM.copyright_valid",
-            language,
-            "copyright",
-            owner,
-        )?;
+        for (value, code, field) in [
+            (
+                item.use_.as_deref(),
+                "RESOURCE_DESCRIPTION_ITEM.Use_valid",
+                "use",
+            ),
+            (
+                item.misuse.as_deref(),
+                "RESOURCE_DESCRIPTION_ITEM.misuse_valid",
+                "misuse",
+            ),
+            (
+                item.copyright.as_deref(),
+                "RESOURCE_DESCRIPTION_ITEM.copyright_valid",
+                "copyright",
+            ),
+        ] {
+            if let Err(v) = check_present_non_empty(value, code, language, field, owner) {
+                violations.push(v);
+            }
+        }
     }
     if let Some(parent) = description.parent_resource.as_deref() {
         let AuthoredResource::Archetype(archetype) = parent;
-        check_archetype(terminology, archetype)?;
+        if let Err(v) = check_archetype(terminology, archetype) {
+            violations.push(v);
+        }
     }
-    Ok(())
+    violations
 }
 
 /// The `x /= Void implies not x.is_empty` rows of a description item.
@@ -326,10 +351,71 @@ mod tests {
         }
     }
 
+    /// The reported case (#3129): a hand-written OPT that left `use` and
+    /// `misuse` empty took two uploads of a 1.7 MB file to find both, because
+    /// the check returned at the first. Both come back together now.
+    #[test]
+    fn an_empty_use_and_an_empty_misuse_are_reported_together() {
+        let mut detail = item("en", "testing");
+        detail.use_ = Some(String::new());
+        detail.misuse = Some(String::new());
+
+        let codes: Vec<&str> = check_description(openehr(), &description(vec![detail]), "t")
+            .iter()
+            .map(|v| v.code)
+            .collect();
+
+        assert!(
+            codes.contains(&"RESOURCE_DESCRIPTION_ITEM.Use_valid")
+                && codes.contains(&"RESOURCE_DESCRIPTION_ITEM.misuse_valid"),
+            "both empty fields must be reported in one response, got: {codes:?}"
+        );
+    }
+
+    /// Every defect of a detail comes back at once, not just the first: an
+    /// upload cycle per rule is what #3129 removed.
+    #[test]
+    fn every_defect_of_one_description_detail_is_reported_at_once() {
+        let mut detail = item("en", "");
+        detail.use_ = Some(String::new());
+        detail.misuse = Some(String::new());
+        detail.copyright = Some(String::new());
+
+        let codes: Vec<&str> = check_description(openehr(), &description(vec![detail]), "t")
+            .iter()
+            .map(|v| v.code)
+            .collect();
+
+        for expected in [
+            "RESOURCE_DESCRIPTION_ITEM.Purpose_valid",
+            "RESOURCE_DESCRIPTION_ITEM.Use_valid",
+            "RESOURCE_DESCRIPTION_ITEM.misuse_valid",
+            "RESOURCE_DESCRIPTION_ITEM.copyright_valid",
+        ] {
+            assert!(codes.contains(&expected), "missing {expected} in {codes:?}");
+        }
+    }
+
+    /// The one violation a single-defect fixture is expected to produce.
+    ///
+    /// `check_description` reports every violation it finds (#3129), so these
+    /// tests assert the code of a fixture built to carry exactly one; a fixture
+    /// that grew a second defect fails here rather than passing quietly on the
+    /// first.
+    fn only(violations: Vec<RuleViolation>) -> RuleViolation {
+        assert_eq!(
+            violations.len(),
+            1,
+            "fixture must carry exactly one defect, got: {:?}",
+            violations.iter().map(|v| v.code).collect::<Vec<_>>()
+        );
+        violations.into_iter().next().expect("one violation")
+    }
+
     #[test]
     fn a_valid_description_passes() {
         assert!(
-            check_description(openehr(), &description(vec![item("en", "testing")]), "t").is_ok()
+            check_description(openehr(), &description(vec![item("en", "testing")]), "t").is_empty()
         );
     }
 
@@ -337,7 +423,7 @@ mod tests {
     fn empty_original_author_is_refused() {
         let mut d = description(vec![item("en", "testing")]);
         d.original_author.clear();
-        let v = check_description(openehr(), &d, "t").unwrap_err();
+        let v = only(check_description(openehr(), &d, "t"));
         assert_eq!(v.code, "RESOURCE_DESCRIPTION.Original_author_valid");
     }
 
@@ -345,39 +431,43 @@ mod tests {
     fn empty_lifecycle_state_is_refused() {
         let mut d = description(vec![item("en", "testing")]);
         d.lifecycle_state.clear();
-        let v = check_description(openehr(), &d, "t").unwrap_err();
+        let v = only(check_description(openehr(), &d, "t"));
         assert_eq!(v.code, "RESOURCE_DESCRIPTION.Lifecycle_state_valid");
     }
 
     #[test]
     fn detail_less_description_is_refused() {
-        let v = check_description(openehr(), &description(Vec::new()), "t").unwrap_err();
+        let v = only(check_description(openehr(), &description(Vec::new()), "t"));
         assert_eq!(v.code, "RESOURCE_DESCRIPTION.Details_valid");
     }
 
     #[test]
     fn duplicate_detail_language_is_refused() {
         let d = description(vec![item("en", "testing"), item("en", "again")]);
-        let v = check_description(openehr(), &d, "t").unwrap_err();
+        let v = only(check_description(openehr(), &d, "t"));
         assert_eq!(v.code, "RESOURCE_DESCRIPTION.Details_valid");
     }
 
     #[test]
     fn empty_purpose_and_empty_optionals_are_refused() {
         let d = description(vec![item("en", "")]);
-        let v = check_description(openehr(), &d, "t").unwrap_err();
+        let v = only(check_description(openehr(), &d, "t"));
         assert_eq!(v.code, "RESOURCE_DESCRIPTION_ITEM.Purpose_valid");
 
         let mut with_use = item("en", "testing");
         with_use.use_ = Some(String::new());
-        let v = check_description(openehr(), &description(vec![with_use]), "t").unwrap_err();
+        let v = only(check_description(
+            openehr(),
+            &description(vec![with_use]),
+            "t",
+        ));
         assert_eq!(v.code, "RESOURCE_DESCRIPTION_ITEM.Use_valid");
     }
 
     #[test]
     fn a_detail_language_outside_the_code_set_is_refused() {
         let d = description(vec![item("xx-not-a-language", "testing")]);
-        let v = check_description(openehr(), &d, "t").unwrap_err();
+        let v = only(check_description(openehr(), &d, "t"));
         assert_eq!(v.code, "RESOURCE_DESCRIPTION_ITEM.Language_valid");
     }
 

--- a/website/book/src/templates-validation.md
+++ b/website/book/src/templates-validation.md
@@ -75,6 +75,19 @@ archetype source uploads enforce the same family; there, an empty
 refused, because the empty string is how real-world 1.4 authoring spells
 absence.
 
+**A refusal lists everything it found, not the first thing.** `validationErrors`
+carries one entry per violation, so a template with an empty `use` and an empty
+`misuse` reports both, and a code list with several duplicated codes names each
+one. Fix the list, upload once. Two things are worth knowing about the shape of
+that list:
+
+- A constrained type the reference model does not have, or an attribute its
+  parent type does not declare, makes every rule below it meaningless. Those
+  violations say that the tree under them went unchecked, so a short list is
+  never a claim that nothing else is wrong. Fix them and upload again.
+- A template with more than 200 violations reports the first 200 and a final
+  `TRUNCATED` entry saying so.
+
 ## Uploading ADL 2 artefacts
 
 ADL 2 artefacts (archetypes, templates and operational templates) are accepted


### PR DESCRIPTION
Closes #3129

From [Igor Schoonbrood's report](https://discourse.openehr.org/t/ferroehr-a-new-rust-based-openehr-cdr-looking-for-testers/17230/22) after migrating a real library onto FerroEHR:

> Repairing a single OPT meant: upload (1.7 MB), get `Use_valid`, fix, upload, get `misuse_valid`, fix, upload. Same with the code lists — the message named the first duplicate out of seventeen. It is a small change, and I suspect it decides whether someone perseveres or gives up on the second error.

## Three layers each stopped at the first violation

The walk in `check` reached every rule with `?`. Below it, `check_description` returned between `Use_valid` and `misuse_valid`, which is exactly the sequence he hit, and `check_code_list` returned on the first repeat. Fixing only the top layer would have left both of his cases untouched, since each lives inside a single leaf call.

All three now collect. `validationErrors` carries one entry per violation, which is the shape a refused composition already had: `validate_composition_for_commit` has always gathered across the RM, terminology, archetype-conformance and constraint-binding passes. The same server was answering the same kind of question two different ways.

## What still stops

Two failures prune their subtree instead of accumulating: an object whose RM type the reference model does not have, and an attribute its parent RM type does not declare. Everything below either would be checked against a shape that does not exist, so continuing would bury the real defect under its own consequences.

Those violations carry a clause saying the tree below them went unchecked. That is the part worth being careful about: a short list must never read as a clean bill of health.

## The cap, and a correction to the issue

The list is capped at 200 with a final `TRUNCATED` entry when it is reached. It is a bound for the artefact nobody is repairing, a corrupted upload where every node is wrong, rather than for the one someone is: the worst real case in the report was seventeen.

I wrote on the issue that the composition path already caps and that this should match it. That was wrong, and I checked: the composition path has no cap. Unifying the two is separate work, and this change does not silently create a second inconsistency, it creates a bounded response where there was an unbounded one.

## Tests

The seven single-defect unit tests in `resource.rs` now go through a helper that asserts the fixture produced **exactly one** violation before checking its code. That makes them stricter than before: a fixture that grows a second defect now fails instead of passing on the first. The integration helper `expect_code` already asserted presence rather than uniqueness, so it needed no change.

Four new tests pin the reported cases:

- an empty `use` and an empty `misuse` reported together, which is his exact sequence
- every defect of one description detail at once, purpose and use and misuse and copyright
- every duplicated code in a list, not just the first
- a code repeated three times counted as one defect

## Gates

`cargo clippy -p ferroehr --all-targets --all-features`, the rustdoc lane, `comment-style`, `default-style`, `docs-claims`, `conformance-numbers` and the changelog structure check are green. `cargo nextest run -p ferroehr` runs 1024 tests, all passing; one container test was flaky and passed on retry.

The templates page now says a refusal lists everything it found, what a pruned subtree means, and what the cap does.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.