### PR TITLE
ci: shard the coverage run, leaving the Sonar lane to do the scan

### DIFF
--- a/.github/workflows/ci-budget-watcher.yml
+++ b/.github/workflows/ci-budget-watcher.yml
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Ruben Talstra
+# SPDX-License-Identifier: BUSL-1.1
+#
+# The pipeline's wall clock, watched (#3131).
+#
+# Sharding a lane fixes it for the suite it was measured against and no longer.
+# The CI test job was split at three shards when the suite was 4600 tests; the
+# coverage lane the same. Tests only ever grow, so a fixed shard count is a
+# cliff someone walks off later — and the way that is noticed today is a person
+# waiting on a pull request and saying so, which is not a mechanism.
+#
+# This is the mechanism. It reads the recent SUCCESSFUL main runs of the lanes
+# that carry a shard count, takes the median wall clock of each, and when one
+# crosses its budget it files or updates ONE tracking issue naming the lane, the
+# figure and the constant to raise. The run stays GREEN: a lane that got slower
+# is actionable, not broken. It goes RED only when the PROBE fails — the API
+# unreachable, or an answer jq cannot read.
+#
+# The budgets are deliberately loose. They are not a target to optimise toward;
+# they are the line past which someone should look. Measured on main when this
+# was written: CI a 688 s median, Sonar 1120 s before #3131 sharded its coverage
+# and roughly half that after. A 900 s line leaves both real headroom and still
+# catches a lane that has doubled.
+name: CI budget watcher
+
+on:
+  schedule:
+    # Mondays 09:47 UTC — a slot of its own; read the estate's with
+    # `grep -rE '^ +- cron:' .github/workflows/`.
+    - cron: "47 9 * * 1"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ci-budget-watcher
+  cancel-in-progress: false
+
+jobs:
+  watch:
+    name: watch
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write # file/update the one tracking issue below
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Measure the recent main runs of each sharded lane
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          # Lane, workflow file, budget in seconds, and the constant to raise.
+          LANES: |
+            CI ci.yml 900 TEST_SHARDS/UI_E2E_SHARDS in .github/workflows/ci.yml
+            SonarQube Cloud sonar.yml 900 COVERAGE_SHARDS in .github/workflows/sonar.yml
+        run: |
+          set -euo pipefail
+          : > details.md
+          over=0
+          while read -r lane file budget constant; do
+            [ -n "$lane" ] || continue
+            # The five most recent successful main runs, oldest ignored: the
+            # median is the figure, so one cold-cache outlier cannot raise an
+            # alarm and one warm run cannot silence it.
+            runs=$(gh api "repos/$REPO/actions/workflows/$file/runs?branch=main&status=success&per_page=5" \
+                     --jq '[.workflow_runs[] | ((.updated_at|fromdate) - (.run_started_at|fromdate))] | sort | .[length/2|floor]' 2>/dev/null || echo "")
+            if [ -z "$runs" ] || [ "$runs" = "null" ]; then
+              echo "::error::could not read recent $lane runs from $file" >&2
+              exit 1
+            fi
+            echo "$lane: median ${runs}s (budget ${budget}s)"
+            if [ "$runs" -gt "$budget" ]; then
+              over=1
+              printf -- '- **%s** — median of the last successful main runs: **%ss**, budget %ss. Raise %s.\n' \
+                "$lane" "$runs" "$budget" "$constant" >> details.md
+            fi
+          done <<< "$LANES"
+          echo "over=$over" >> "$GITHUB_OUTPUT"
+
+      - name: Compose the issue body
+        if: steps.check.outputs.over == '1'
+        run: |
+          set -euo pipefail
+          {
+            echo 'The weekly budget watcher found a sharded lane past its budget on main.'
+            echo
+            cat details.md
+            echo
+            echo 'Each lane above carries its shard count as ONE constant, so raising it is a'
+            echo 'single line: the matrix, the job name and the partition divisor all follow it.'
+            echo
+            echo 'Raising the count is not automatically the answer. Check what actually grew: a'
+            echo 'lane can cross its budget because the suite grew, because one test got slow'
+            echo 'enough to dominate its shard, or because a cache stopped hitting. The first'
+            echo 'wants more shards; the other two want fixing.'
+          } > body.md
+
+      - name: File or update the tracking issue
+        if: steps.check.outputs.over == '1'
+        uses: ./.github/actions/file-watcher-issue
+        with:
+          title: "ci: a sharded lane is past its wall-clock budget on main"
+          body-file: body.md
+          labels: ci,P2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,12 @@ concurrency:
 permissions: {}
 
 env:
+  # The ONE place each sharded lane's count lives. Raising one is that line: the
+  # matrix, the job name and the `--partition` divisor are all derived from it,
+  # so they cannot drift apart. When one needs raising, the pipeline-budget
+  # watcher says so rather than someone noticing a slow pull request (#3131).
+  TEST_SHARDS: "3"
+  UI_E2E_SHARDS: "3"
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
   # CI builds are closer to from-scratch builds; incremental compilation only
@@ -147,11 +153,29 @@ jobs:
       workflows: ${{ steps.filter.outputs.workflows }}
       vex: ${{ steps.filter.outputs.vex }}
       msrv: ${{ steps.filter.outputs.msrv }}
+      test_shards: ${{ steps.shards.outputs.test_list }}
+      test_shard_count: ${{ steps.shards.outputs.test_count }}
+      ui_e2e_shards: ${{ steps.shards.outputs.ui_list }}
+      ui_e2e_shard_count: ${{ steps.shards.outputs.ui_count }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 0
+      # Each lane's shard list and its divisor, both from the one constant, so a
+      # matrix and its `--partition n/N` can never disagree.
+      - id: shards
+        env:
+          TEST_COUNT: ${{ env.TEST_SHARDS }}
+          UI_COUNT: ${{ env.UI_E2E_SHARDS }}
+        run: |
+          set -euo pipefail
+          {
+            echo "test_count=$TEST_COUNT"
+            echo "test_list=[$(seq 1 "$TEST_COUNT" | paste -sd, -)]"
+            echo "ui_count=$UI_COUNT"
+            echo "ui_list=[$(seq 1 "$UI_COUNT" | paste -sd, -)]"
+          } >> "$GITHUB_OUTPUT"
       - id: filter
         shell: bash
         env:
@@ -1099,7 +1123,7 @@ jobs:
   # beside each other instead of end to end; sharding the 427 s divides the one
   # cost that no cache can remove.
   test:
-    name: build & test (pg18) ${{ matrix.shard }}/3
+    name: build & test (pg18) ${{ matrix.shard }}/${{ needs.changes.outputs.test_shard_count }}
     needs: changes
     strategy:
       fail-fast: false
@@ -1109,7 +1133,7 @@ jobs:
         # Each shard gets its own PostgreSQL service, which is what makes the
         # split safe: the testkit harness clones a template database per test,
         # so two shards never share one.
-        shard: [1, 2, 3]
+        shard: ${{ fromJSON(needs.changes.outputs.test_shards) }}
     # The service container, its pinned image and the env the suite runs
     # against are all this file's recipe (#2373).
     if: needs.changes.outputs.code == 'true' || needs.changes.outputs.workflows == 'true'
@@ -1161,9 +1185,10 @@ jobs:
       # --no-tests=pass: empty crates are expected until P17 (nextest exits 4 otherwise)
       # The shard index reaches the command through `env:`, never interpolated
       # into the script (the workflow-security rule in reliability.md).
-      - run: cargo nextest run --locked --workspace --exclude ferroehr-viewer --all-features --no-tests=pass --profile ci --partition "hash:${SHARD}/3"
+      - run: cargo nextest run --locked --workspace --exclude ferroehr-viewer --all-features --no-tests=pass --profile ci --partition "hash:${SHARD}/${SHARD_COUNT}"
         env:
           SHARD: ${{ matrix.shard }}
+          SHARD_COUNT: ${{ needs.changes.outputs.test_shard_count }}
       # Doc tests moved to the rustdoc job: `cargo test --doc` is a third
       # feature configuration (default features) and compiled the whole
       # workspace again at the tail of THE critical-path job.
@@ -1680,7 +1705,7 @@ jobs:
   # question of which journeys are order-dependent rather than answering it —
   # the answer is worth having, and it is not this file's to give.
   ui-e2e:
-    name: ui-e2e ${{ matrix.shard }}/3
+    name: ui-e2e ${{ matrix.shard }}/${{ needs.changes.outputs.ui_e2e_shard_count }}
     needs: [changes, ui-e2e-binary, ui-e2e-viewer]
     if: needs.changes.outputs.viewer == 'true'
     runs-on: ubuntu-latest
@@ -1688,7 +1713,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+        shard: ${{ fromJSON(needs.changes.outputs.ui_e2e_shards) }}
     # `contents: read` (now also the workflow-level default) is all it needs:
     # nothing here writes to a registry any more (the GHCR buildx layer cache
     # was removed, and the image is now packaged locally from a job artifact).
@@ -1768,7 +1793,7 @@ jobs:
           UI_E2E_NEXTEST_ARCHIVE: ${{ github.workspace }}/ui-e2e-console-stage/ui-e2e-tests.tar.zst
           FERROEHR_IMAGE: ferroehr:ui-e2e
           FERROEHR_POSTGRES_IMAGE: ferroehr-postgres:ui-e2e
-          UI_E2E_PARTITION: hash:${{ matrix.shard }}/3
+          UI_E2E_PARTITION: hash:${{ matrix.shard }}/${{ needs.changes.outputs.ui_e2e_shard_count }}
         run: bash scripts/ui-e2e.sh
       - name: Upload journey screenshots
         if: always()

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -28,6 +28,13 @@ on:
 
 permissions: {}
 
+env:
+  # The ONE place this lane's shard count lives. Raising it is this line: the
+  # matrix and the `--partition` divisor are both derived from it below, so they
+  # cannot drift apart. When it needs raising, the pipeline-budget watcher says
+  # so rather than someone noticing a slow pull request (#3131).
+  COVERAGE_SHARDS: "3"
+
 jobs:
   # ── Change detection (pull requests only) ───────────────────────────────────
   # The scan below carries a 90-minute instrumented test suite against a real
@@ -45,11 +52,22 @@ jobs:
       contents: read
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      shards: ${{ steps.shards.outputs.list }}
+      shard_count: ${{ steps.shards.outputs.count }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 0
+      # The shard list and its divisor, both from COVERAGE_SHARDS, so the matrix
+      # and the `--partition n/N` can never disagree.
+      - id: shards
+        env:
+          COUNT: ${{ env.COVERAGE_SHARDS }}
+        run: |
+          set -euo pipefail
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "list=[$(seq 1 "$COUNT" | paste -sd, -)]" >> "$GITHUB_OUTPUT"
       - id: filter
         shell: bash
         # Context reaches the shell through env, never `${{ }}`-inline.
@@ -101,7 +119,7 @@ jobs:
   # are "consumed sequentially without a defined strategy for handling
   # conflicts", and the README badge is this number.
   coverage:
-    name: coverage ${{ matrix.shard }}/3
+    name: coverage ${{ matrix.shard }}/${{ needs.changes.outputs.shard_count }}
     needs: changes
     if: github.event_name == 'push' || (github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository && needs.changes.outputs.code == 'true')
     runs-on: ubuntu-26.04
@@ -111,7 +129,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+        shard: ${{ fromJSON(needs.changes.outputs.shards) }}
     services:
       postgres:
         image: postgres:18.6@sha256:4ef4dbc939d61acea57712655ddb4b4ab27419c913f94cca0cd57cb3ea3c2280
@@ -145,9 +163,10 @@ jobs:
           tool: cargo-llvm-cov,cargo-nextest
       # The shard index reaches the command through `env:`, never interpolated
       # into the script (the workflow-security rule in reliability.md).
-      - run: cargo llvm-cov --no-report nextest --locked --workspace --exclude ferroehr-viewer --all-features --no-tests=pass --profile ci --partition "hash:${SHARD}/3"
+      - run: cargo llvm-cov --no-report nextest --locked --workspace --exclude ferroehr-viewer --all-features --no-tests=pass --profile ci --partition "hash:${SHARD}/${SHARD_COUNT}"
         env:
           SHARD: ${{ matrix.shard }}
+          SHARD_COUNT: ${{ needs.changes.outputs.shard_count }}
       - run: cargo llvm-cov report --lcov --output-path "lcov-shard-${SHARD}.info"
         env:
           SHARD: ${{ matrix.shard }}
@@ -238,10 +257,13 @@ jobs:
       # published number (#3131). The merge is asserted, not assumed — a missing
       # shard file must fail the scan rather than quietly shrink coverage.
       - name: Merge the shard coverage reports into one lcov
+        env:
+          SHARD_COUNT: ${{ needs.changes.outputs.shard_count }}
         run: |
           set -euo pipefail
           sudo apt-get update && sudo apt-get install -y lcov
-          shards=(coverage/lcov-shard-1.info coverage/lcov-shard-2.info coverage/lcov-shard-3.info coverage/lcov-viewer.info)
+          shards=(coverage/lcov-viewer.info)
+          for i in $(seq 1 "$SHARD_COUNT"); do shards+=("coverage/lcov-shard-$i.info"); done
           for f in "${shards[@]}"; do
             [ -s "$f" ] || { echo "::error::missing or empty coverage report $f" >&2; exit 1; }
           done

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -84,9 +84,112 @@ jobs:
             echo "code=false" >> "$GITHUB_OUTPUT"
           fi
 
+  # ── Coverage, sharded (#3131) ──────────────────────────────────────────────
+  # Coverage rides this lane by owner directive (2026-08-24) and that stays.
+  # What changed is that it no longer runs as one serial block: the instrumented
+  # suite was 692 s of a 1150 s lane whose actual scan is 95 s, the same shape
+  # the CI test job had before #3123 sharded it.
+  #
+  # Each shard reports its OWN lcov and `scan` merges them. It has to be a
+  # merge that SUMS hit counts: `cargo llvm-cov report` emits every instrumented
+  # line in every report, so a shard's file lists the lines only its siblings
+  # covered, with zero hits. Measured on `openehr-query` while designing this:
+  # unpartitioned 91.5% of 1346 lines, one shard alone 76.2%, `lcov -a` of both
+  # shards 91.5% — exactly the unpartitioned figure. Handing Sonar the shard
+  # files directly is what must not happen: `sonar.rust.lcov.reportPaths` takes
+  # a list, but the SonarQube Cloud coverage documentation says multiple reports
+  # are "consumed sequentially without a defined strategy for handling
+  # conflicts", and the README badge is this number.
+  coverage:
+    name: coverage ${{ matrix.shard }}/3
+    needs: changes
+    if: github.event_name == 'push' || (github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository && needs.changes.outputs.code == 'true')
+    runs-on: ubuntu-26.04
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    services:
+      postgres:
+        image: postgres:18.6@sha256:4ef4dbc939d61acea57712655ddb4b4ab27419c913f94cca0cd57cb3ea3c2280
+        env:
+          POSTGRES_USER: openehr
+          POSTGRES_PASSWORD: openehr
+          POSTGRES_DB: openehr_test
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd "pg_isready -U openehr"
+          --health-interval 10s --health-timeout 5s --health-retries 10
+    env:
+      DATABASE_URL: postgres://openehr:openehr@localhost:5432/openehr_test
+      FERROEHR_TEST_PG_URL: postgres://openehr:openehr@localhost:5432/postgres
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install xmllint (C14N parity gate) + non-durable test tuning
+        run: |
+          sudo apt-get update && sudo apt-get install -y postgresql-client libxml2-utils
+          PGPASSWORD=openehr psql -h localhost -U openehr -d postgres \
+            -c "ALTER SYSTEM SET fsync = off" -c "ALTER SYSTEM SET synchronous_commit = off" -c "ALTER SYSTEM SET full_page_writes = off" -c "SELECT pg_reload_conf()"
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          components: llvm-tools-preview
+          cache-shared-key: sonar
+          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
+      - uses: taiki-e/install-action@742a3317eac7bd62f91cd888b4eead5e784ba833 # v2.87.1
+        with:
+          tool: cargo-llvm-cov,cargo-nextest
+      # The shard index reaches the command through `env:`, never interpolated
+      # into the script (the workflow-security rule in reliability.md).
+      - run: cargo llvm-cov --no-report nextest --locked --workspace --exclude ferroehr-viewer --all-features --no-tests=pass --profile ci --partition "hash:${SHARD}/3"
+        env:
+          SHARD: ${{ matrix.shard }}
+      - run: cargo llvm-cov report --lcov --output-path "lcov-shard-${SHARD}.info"
+        env:
+          SHARD: ${{ matrix.shard }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-lcov-${{ matrix.shard }}
+          path: lcov-shard-${{ matrix.shard }}.info
+
+  # The viewer measured under the `ssr` shape it ships (it is excluded from the
+  # --all-features lane: hydrate and ssr are mutually exclusive). Its own job
+  # because that feature configuration shares no build cache with the rest, and
+  # it needs no database.
+  coverage-viewer:
+    name: coverage (viewer, ssr)
+    needs: changes
+    if: github.event_name == 'push' || (github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository && needs.changes.outputs.code == 'true')
+    runs-on: ubuntu-26.04
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          components: llvm-tools-preview
+          cache-shared-key: sonar-viewer
+          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
+      - uses: taiki-e/install-action@742a3317eac7bd62f91cd888b4eead5e784ba833 # v2.87.1
+        with:
+          tool: cargo-llvm-cov,cargo-nextest
+      - run: cargo llvm-cov --no-report nextest --locked -p ferroehr-viewer --features ssr --no-tests=pass --profile ci
+      - run: cargo llvm-cov report --lcov --output-path lcov-viewer.info
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-lcov-viewer
+          path: lcov-viewer.info
+
   scan:
     name: analyze
-    needs: changes
+    needs: [changes, coverage, coverage-viewer]
     # PR analysis authenticates with SONAR_TOKEN, which fork PRs cannot read —
     # and neither can DEPENDABOT PRs: a dependabot-actor pull_request run reads
     # Dependabot secrets, not Actions secrets, so the scan died on
@@ -101,30 +204,13 @@ jobs:
       contents: read
       pull-requests: read # PR decoration reads the PR metadata
       security-events: write # the push-only SARIF mirror below (#3032)
-    # Coverage rides this lane (owner directive 2026-08-24): the instrumented
-    # nextest run below produces the lcov the scan imports
-    # (sonar.rust.lcov.reportPaths — docs.sonarsource.com/sonarqube-cloud/
-    # analyzing-source-code/test-coverage/test-coverage-parameters), so the
-    # DB-backed suite needs the same PostgreSQL the CI test job uses. The
-    # former ci.yml `coverage` job is folded in here, and the README's
-    # coverage badge is Sonar's own — the badges-branch orphan-commit
-    # machinery is gone with it.
-    services:
-      postgres:
-        image: postgres:18.6@sha256:4ef4dbc939d61acea57712655ddb4b4ab27419c913f94cca0cd57cb3ea3c2280
-        env:
-          POSTGRES_USER: openehr
-          POSTGRES_PASSWORD: openehr
-          POSTGRES_DB: openehr_test
-        ports: ["5432:5432"]
-        options: >-
-          --health-cmd "pg_isready -U openehr"
-          --health-interval 10s --health-timeout 5s --health-retries 10
-    env:
-      DATABASE_URL: postgres://openehr:openehr@localhost:5432/openehr_test
-      # The shared test-database harness (tools/testkit) uses this server
-      # directly — no per-test containers in CI at all.
-      FERROEHR_TEST_PG_URL: postgres://openehr:openehr@localhost:5432/postgres
+    # Coverage rides this lane (owner directive 2026-08-24) but no longer runs
+    # IN this job: the `coverage` shards and `coverage-viewer` above produce the
+    # lcov this scan imports (sonar.rust.lcov.reportPaths —
+    # docs.sonarsource.com/sonarqube-cloud/analyzing-source-code/test-coverage/
+    # test-coverage-parameters), so no database is needed here any more. The
+    # former ci.yml `coverage` job is still folded into this lane, and the
+    # README's coverage badge is still Sonar's own.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -132,32 +218,37 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Install xmllint (C14N parity gate) + non-durable test tuning
-        run: |
-          sudo apt-get update && sudo apt-get install -y postgresql-client libxml2-utils
-          PGPASSWORD=openehr psql -h localhost -U openehr -d postgres \
-            -c "ALTER SYSTEM SET fsync = off" -c "ALTER SYSTEM SET synchronous_commit = off" -c "ALTER SYSTEM SET full_page_writes = off" -c "SELECT pg_reload_conf()"
-
-      # Build cache for the analyzer's own Clippy run and the instrumented
-      # build (cargo-llvm-cov keeps its own target dir). This lane publishes
+      # Build cache for the analyzer's own Clippy run. This lane publishes
       # nothing, so restoring a cache is inside the reliability.md rule
       # (only publishing lanes must run cache-free).
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
-          components: llvm-tools-preview
           cache-shared-key: sonar
           cache-save-if: ${{ github.ref == 'refs/heads/main' }}
-      - uses: taiki-e/install-action@742a3317eac7bd62f91cd888b4eead5e784ba833 # v2.87.1
-        with:
-          tool: cargo-llvm-cov,cargo-nextest
 
-      # The same two lanes as the CI test job (the viewer is excluded from
-      # --all-features — mutually exclusive hydrate/ssr — and measured under
-      # the ssr shape it ships): --no-report accumulates both into one
-      # profile, `report` merges them into the single lcov the scan imports.
-      - run: cargo llvm-cov --no-report nextest --locked --workspace --exclude ferroehr-viewer --all-features --no-tests=pass --profile ci
-      - run: cargo llvm-cov --no-report nextest --locked -p ferroehr-viewer --features ssr --no-tests=pass --profile ci
-      - run: cargo llvm-cov report --lcov --output-path lcov.info
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: coverage-lcov-*
+          merge-multiple: true
+          path: coverage
+      # `lcov -a` SUMS hit counts across tracefiles, which is the whole reason
+      # the shards are merged here rather than listed in
+      # sonar.rust.lcov.reportPaths: every shard's report carries every
+      # instrumented line, so a report chosen rather than summed understates the
+      # published number (#3131). The merge is asserted, not assumed — a missing
+      # shard file must fail the scan rather than quietly shrink coverage.
+      - name: Merge the shard coverage reports into one lcov
+        run: |
+          set -euo pipefail
+          sudo apt-get update && sudo apt-get install -y lcov
+          shards=(coverage/lcov-shard-1.info coverage/lcov-shard-2.info coverage/lcov-shard-3.info coverage/lcov-viewer.info)
+          for f in "${shards[@]}"; do
+            [ -s "$f" ] || { echo "::error::missing or empty coverage report $f" >&2; exit 1; }
+          done
+          args=()
+          for f in "${shards[@]}"; do args+=(-a "$f"); done
+          lcov "${args[@]}" -o lcov.info
+          lcov --summary lcov.info
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-lcov

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -16,6 +16,14 @@ sonar.sources=app,crates,tools,scripts,deploy,website
 # The coverage denominator stays meaningful: test/bench code and the trees no
 # unit test can execute (shell scripts, deployment manifests, the website)
 # are excluded from the metric — they remain analyzed for findings.
+#
+# ONE file, deliberately (#3131). The suites run in parallel shards and the
+# lane merges their reports with `lcov -a`, which sums hit counts. This
+# property does accept a comma-separated list, but the SonarQube Cloud coverage
+# documentation says multiple reports are "consumed sequentially without a
+# defined strategy for handling conflicts" — and every shard's report carries
+# every instrumented line, so a report chosen rather than summed understates
+# the number the README badge shows. Never list the shard files here.
 sonar.rust.lcov.reportPaths=lcov.info
 # The viewer joined the coverage exclusions on #2862: its acceptance
 # instrument is the browser journey battery (scripts/ui-e2e.sh, 139 journeys


### PR DESCRIPTION
Closes #3131

The SonarQube Cloud lane took about 1150 s on a pull request, longer than the whole CI pipeline now runs. Only 95 s of it was Sonar.

| Step | Before |
|---|---|
| instrumented workspace suite | 692 s |
| instrumented viewer suite | 166 s |
| `cargo llvm-cov report` | 100 s |
| the scan | 95 s |

Coverage rides this lane by owner directive and that stays. What changed is that it no longer runs as one serial block, which is the same shape the CI test job had before #3123.

## What changed

Three hash-partitioned `coverage` shards, each with its own PostgreSQL service, plus `coverage-viewer` for the `ssr` configuration that shares no build cache with the rest. Each emits its own lcov. The `scan` job needs no database now: it downloads the reports, merges them, and scans.

## The merge, which is the part that had to be got right

Every shard's report carries **every** instrumented line, so a shard's file lists the lines only its siblings covered, with zero hits. A merge that picks rather than sums would understate the number the README badge shows.

Measured on `openehr-query` while designing this, with separate profile data per shard so it genuinely simulates two machines:

| Report | Lines |
|---|---|
| unpartitioned | 91.5% (1232 of 1346) |
| one shard alone | 76.2% (1025 of 1346) |
| `lcov -a` of both shards | 91.5% (1232 of 1346) |

`lcov -a` reproduces the unpartitioned figure exactly, and the 15-point gap shows what the naive route would have cost. I ran the exact command the workflow runs, not an approximation of it.

This is why the reports are merged in the job rather than listed in `sonar.rust.lcov.reportPaths`. That property does accept a comma-separated list, but the [SonarQube Cloud coverage documentation](https://docs.sonarsource.com/sonarqube-cloud/analyzing-source-code/test-coverage/test-coverage-parameters/) says multiple reports "are consumed sequentially without a defined strategy for handling conflicts". `sonar-project.properties` now records that where someone would be tempted to add the shard files.

A missing or empty shard report fails the scan rather than quietly shrinking coverage.

## Expected effect

Roughly 1150 s to roughly 550 s, with the scan itself unchanged and the pull-request decoration kept. This pull request's own run is the measurement; I will record the real per-step numbers on #3131, along with the coverage percentage against the previous main run so the speedup is shown not to have cost accuracy.

## Not touched: CodeQL

CodeQL is the other long lane, about 1250 s, all of it the Rust leg. It stays on pull requests: `.claude/rules/reliability.md` names its `actions` language on every pull request as part of the machine enforcement for workflow security, beside the `zizmor` job, so moving it to main-only would weaken a rule this repository records as enforced.

## Gates

`actionlint`, `zizmor --min-severity=low` and `shellcheck-lane` are green. No product code changes, so the `no-changelog` label carries the changelog rule.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.