### PR TITLE
test: two timing tests stop depending on the machine they run on

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2759,6 +2759,7 @@ dependencies = [
  "indexmap 2.14.0",
  "inferno",
  "jiff",
+ "jiff-sqlx",
  "jsonwebtoken",
  "moka",
  "openehr-base",

--- a/app/ferroehr-rest/Cargo.toml
+++ b/app/ferroehr-rest/Cargo.toml
@@ -109,6 +109,10 @@ utoipa-swagger-ui = { workspace = true }
 openehr-lang = { path = "../../crates/openehr-lang" }
 testkit = { path = "../../tools/testkit" }
 sqlx.workspace = true
+# The at-time version tests take their probe instant from the database rather
+# than a wall clock (#3119); sqlx has no jiff feature, so the timestamptz comes
+# back through the official wrapper.
+jiff-sqlx.workspace = true
 testcontainers.workspace = true
 testcontainers-modules.workspace = true
 tokio = { workspace = true }

--- a/app/ferroehr-rest/tests/it/demographic_http.rs
+++ b/app/ferroehr-rest/tests/it/demographic_http.rs
@@ -659,15 +659,9 @@ async fn versioned_party_reads_emit_versioning_headers() {
 /// process's system zone and the assertion is independent of what that zone is.
 #[tokio::test]
 async fn version_at_time_without_offset_resolves_in_the_local_timezone() {
-    let (_pg, app) = app().await;
+    let (pg, app) = app().await;
     let v1 = create(&app, "person", &person_body()).await;
     let vo = vo_of(&v1).to_owned();
-
-    // An instant strictly inside v1's validity window (the 150 ms margins keep
-    // it between the two commits — same clock, same host).
-    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
-    let between = jiff::Timestamp::now();
-    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
 
     let req = Request::builder()
         .method("PUT")
@@ -678,6 +672,21 @@ async fn version_at_time_without_offset_resolves_in_the_local_timezone() {
         .unwrap();
     let (status, _h, body) = send(&app, req).await;
     assert_eq!(status, StatusCode::NO_CONTENT, "second version: {body}");
+
+    // The probe instant is v1's OWN start, read back from the database rather
+    // than sampled from a clock (#3119). `sys_period` is stamped by PostgreSQL,
+    // whose container clock need not agree with this process's, and the margins
+    // this test used to sleep around were eaten under full-suite load. The
+    // range's lower bound is INCLUSIVE, so the version extant at exactly that
+    // instant is v1 by construction, with no margin to lose.
+    let between: jiff_sqlx::Timestamp = sqlx::query_scalar(
+        "SELECT lower(sys_period) FROM vo_version WHERE vo_id = $1 AND sys_version = 1",
+    )
+    .bind(vo.parse::<uuid::Uuid>().expect("the versioned object id"))
+    .fetch_one(&pg.pool())
+    .await
+    .expect("v1's stored validity start");
+    let between = between.to_jiff();
 
     // The same instant written WITHOUT an offset: its civil rendering in the
     // server's local timezone (`YYYY-MM-DDThh:mm:ss.sss`, no `Z`, no `±hh:mm`).

--- a/app/ferroehr-rest/tests/it/directory_http.rs
+++ b/app/ferroehr-rest/tests/it/directory_http.rs
@@ -788,17 +788,27 @@ async fn get_version_at_time_variants() {
 /// is independent of what that zone happens to be.
 #[tokio::test]
 async fn version_at_time_without_offset_resolves_in_the_local_timezone() {
-    let (_pg, app) = common::test_router().await;
+    let (pg, app) = common::test_router().await;
     let ehr = create_ehr(&app).await;
 
     let (_s, h, _b) = create_directory(&app, &ehr, &folder_json("dir-v1", vec![]), None).await;
     let v1 = etag_uid(&h);
 
-    // An instant strictly inside v1's validity window (the 150 ms margins keep
-    // it between the two commits — same clock, same host).
-    tokio::time::sleep(Duration::from_millis(150)).await;
-    let between = jiff::Timestamp::now();
-    tokio::time::sleep(Duration::from_millis(150)).await;
+    // The probe instant is v1's OWN start, read back from the database rather
+    // than sampled from a clock (#3119). `sys_period` is stamped by PostgreSQL,
+    // whose container clock need not agree with this process's, and the margins
+    // this test used to sleep around were eaten under full-suite load. The
+    // range's lower bound is INCLUSIVE, so the version extant at exactly that
+    // instant is v1 by construction, with no margin to lose.
+    let between: jiff_sqlx::Timestamp = sqlx::query_scalar(
+        "SELECT lower(sys_period) FROM vo_version \
+         WHERE kind = 'FOLDER' AND sys_version = 1 AND ehr_id = $1",
+    )
+    .bind(ehr.parse::<Uuid>().expect("the EHR id"))
+    .fetch_one(&pg.pool())
+    .await
+    .expect("v1's stored validity start");
+    let between = between.to_jiff();
 
     let (_s, _h, _b) = update_directory(
         &app,

--- a/app/ferroehr/tests/it/events_amqp.rs
+++ b/app/ferroehr/tests/it/events_amqp.rs
@@ -111,6 +111,36 @@ async fn pending_count(pool: &PgPool) -> i64 {
         .expect("pending count")
 }
 
+/// Wait for the outbox to drain, bounded by PROGRESS rather than by total
+/// elapsed time (#3119).
+///
+/// A loaded runner makes the whole drain slower without making it stuck, so a
+/// fixed budget fails on the machine rather than on the code — this suite's
+/// wildcard test did exactly that at 63 s against a 60 s deadline, and passed
+/// in 10 s alone minutes later. A stall budget cannot: it fires only when the
+/// pending count has not moved at all, which is what "stuck" actually means,
+/// and it fires just as fast on a real hang.
+async fn drain_outbox(pool: &PgPool) {
+    const STALL: Duration = Duration::from_secs(30);
+    let mut pending = pending_count(pool).await;
+    let mut last_progress = tokio::time::Instant::now();
+    loop {
+        let now = pending_count(pool).await;
+        if now == 0 {
+            return;
+        }
+        if now != pending {
+            pending = now;
+            last_progress = tokio::time::Instant::now();
+        }
+        assert!(
+            last_progress.elapsed() < STALL,
+            "the outbox stopped draining with {pending} row(s) pending and no progress for {STALL:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
 /// The total number of version entries across all outbox rows — the number of
 /// per-version messages the publisher emits.
 async fn version_count(pool: &PgPool) -> i64 {
@@ -351,17 +381,7 @@ async fn broker_down_then_up_delivers_without_loss() {
 
     // Broker up: a correctly-configured publisher drains every row (no loss).
     let up = start(events_config(url), pool.clone());
-    let deadline = tokio::time::Instant::now() + Duration::from_mins(1);
-    loop {
-        if pending_count(&pool).await == 0 {
-            break;
-        }
-        assert!(
-            tokio::time::Instant::now() < deadline,
-            "did not drain in time"
-        );
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
+    drain_outbox(&pool).await;
 
     // Every per-version message arrives on the catch-all queue (no loss).
     for _ in 0..expected_messages {
@@ -407,17 +427,7 @@ async fn subscriptions_route_by_predicate_and_wildcard_receives_all() {
     // Start the publisher: each cycle re-syncs (declares/binds) the subscription
     // queues *before* it publishes, so the durable queues capture the messages.
     let handle = start(events_config(url.clone()), pool.clone());
-    let deadline = tokio::time::Instant::now() + Duration::from_mins(1);
-    loop {
-        if pending_count(&pool).await == 0 {
-            break;
-        }
-        assert!(
-            tokio::time::Instant::now() < deadline,
-            "did not drain in time"
-        );
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
+    drain_outbox(&pool).await;
 
     // The wildcard queue received every per-version message (per-version fan-out).
     let (_c_all, mut all) =


### PR DESCRIPTION
Closes #3119

Both tests failed only under full-workspace load and passed alone minutes later, which is the shape that teaches people to re-run rather than read.

## The at-time version tests

`version_at_time_without_offset_resolves_in_the_local_timezone`, in both `demographic_http` and `directory_http`, sampled `jiff::Timestamp::now()` between two commits and slept 150 ms either side to keep it inside the first version's window.

Two things were wrong with that. `sys_period` is stamped by **PostgreSQL**, whose container clock need not agree with this process's, so the probe and the window came from different clocks. And 150 ms is not a margin on a machine running 4600 other tests.

They now read the version's own `lower(sys_period)` back from the database and probe at exactly that instant. The range's lower bound is inclusive, so the version extant there is the first one by construction: no margin to lose, and no sleeps at all. `jiff-sqlx` joins the dev-dependencies for that, which is the pattern the workspace manifest already documents for reading a timestamptz through sqlx.

## The events suite

`events_amqp` drained its outbox against a fixed one-minute deadline. A loaded runner makes a drain slower without making it stuck, so the budget failed on the machine rather than on the code: 63 s against 60 s in the full run, then 10 s in isolation.

The wait is now bounded by **progress**. It fires only when the pending count has not moved for 30 s, which is what stuck actually means, and it fires just as fast on a real hang. The failure message names how many rows were still pending, so a real stall says what it stalled on.

## What I left alone, and why

**The FHIR outbound cursor poll.** It waits for a single transition, so there is no progress to measure and a stall budget has nothing to read. Its 30 s already absorbs the instrumented-build slowdown its own comment records.

**A third failure mode I found while verifying this.** One run had `events_amqp::end_to_end_publish_and_consume` fail with testcontainers answering `PortNotExposed` for RabbitMQ's 5672, then pass on retry. That is the container's port mapping not being ready, not a budget this change touches, and the group's existing retry absorbs it. Worth its own look rather than being folded in here.

## Verification

`cargo nextest run --workspace --exclude ferroehr-viewer --no-fail-fast`: 4621 tests, all passing. `cargo clippy` on both crates with `-D warnings`, `comment-style` and `cargo machete` are clean.

No test is weakened: both timing tests assert exactly what they asserted before, and the drain wait still fails on a stuck outbox.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.