### PR TITLE
docs(website): the "Why we built it" section states the licence once

### DIFF
--- a/website/landing/index.html
+++ b/website/landing/index.html
@@ -154,14 +154,8 @@
 
           <article class="card">
             <div class="ico" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19V6a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v13"/><path d="M4 19a2 2 0 0 0 2 2h14"/><path d="M8 8h8M8 12h5"/></svg></div>
-            <h3>One licence for the whole application</h3>
-            <p>The application is source-available under the Business Source License 1.1, with no open-core tier: multi-tenancy, RBAC/ABAC, ATNA audit, signatures, FHIR, events and the viewer are in the same repository under the same licence, and nothing is held back to be sold back to you. The openEHR spec crates underneath are Apache 2.0 on crates.io.</p>
-          </article>
-
-          <article class="card">
-            <div class="ico" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9h18l-1.5 10.5a2 2 0 0 1-2 1.5H6.5a2 2 0 0 1-2-1.5z"/><path d="M8.5 9V6.5a3.5 3.5 0 0 1 7 0V9"/></svg></div>
-            <h3>Free for non-commercial use</h3>
-            <p>Read it, build it, modify it and redistribute it without a fee, and use it for development, testing, evaluation and prototyping. Production use is free for non-commercial purposes: personal use, academic or scientific research, teaching, and use by a non-profit organisation or public body that is not in the course of a business, does not deliver a service for payment and is not for commercial advantage. Any other production use needs a commercial licence from the Licensor, including delivering care or any other service for payment, hosting FerroEHR for third parties, and selling it for a fee. That licence is the normal path for a company or a care provider and starts with a short conversation. Each version becomes Apache 2.0 four years after it is published.</p>
+            <h3>One licence, no open-core tier</h3>
+            <p>The whole application is source-available under the Business Source License 1.1, with every capability in one repository and nothing held back for a paid tier. Free for non-commercial production; every other production use needs a commercial licence. Each version becomes Apache 2.0 four years after it is published.</p>
           </article>
 
           <article class="card">


### PR DESCRIPTION
The `#why` section on the landing page carried three cards, and two of them told the licence story from opposite ends: "One licence for the whole application" said the application is BUSL-1.1 with no open-core tier, and "Free for non-commercial use" re-derived the same licence as what is free and what is not. A reader got the licence twice and the reason FerroEHR exists once.

Measured on the page before this change, the three card paragraphs ran 347, 775 and 254 characters. The middle one was three times the length of its neighbours, so it was also the only card a reader had to work through, and the row stopped reading as three peers.

Two cards now. The licence card states it once, and "Send the improvements back" is untouched. The enumerated non-profit qualifiers, the list of commercial triggers and the four-year Apache conversion already live on `website/book/src/why-ferroehr.md`, which the section links at its foot as "Read the full statement", so nothing is lost from the site. Every surviving claim is still true against `LICENSE`: source-available, one licence for the whole application, free for non-commercial production, a commercial licence for everything else, Apache 2.0 four years after publication.

The grid is `repeat(auto-fit, minmax(250px, 1fr))`, so two cards fill the row as halves without a CSS change. `docs-claims` is green.

Closes #3135

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.
