### PR TITLE
feat(admin): stream the storage-parity sweep so a whole repository fits in one pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Added
+
+- **A whole large repository can now be checked for storage damage in one pass**
+  (#3122). `POST /admin/integrity/verify` computed its whole report before
+  answering, so it had to finish inside the server's 30-second request timeout
+  and a large enough repository lost the report to a `408`. Sending
+  `Accept: application/x-ndjson` streams the same sweep instead: one JSON object
+  per line, a `mismatch` as each is found, a `progress` tick per page read, and
+  a closing `summary` with the counts. Nothing bounds that response, and the
+  stream carries every mismatch rather than the first thousand. The status code
+  is committed before the work is, so a sweep that fails part-way ends with an
+  `error` line instead of a `summary` — read to the end to tell the two apart.
+  A request that does not name the media type, `*/*` included, keeps the
+  aggregated document exactly as before.
+
 ### Changed
 
 - **A refused operational template lists every violation, not the first one**

--- a/app/ferroehr-rest/Cargo.toml
+++ b/app/ferroehr-rest/Cargo.toml
@@ -49,6 +49,10 @@ uuid = { workspace = true }
 
 # Async runtime.
 tokio = { workspace = true }
+# The streamed storage-parity sweep turns its channel receiver into the
+# response body (`stream::poll_fn` over `Receiver::poll_recv`); the
+# overload-shedding tests park a handler on `stream::pending`.
+futures = { workspace = true }
 
 # Serialization & data structures.
 serde = { workspace = true }
@@ -118,9 +122,6 @@ testcontainers-modules.workspace = true
 tokio = { workspace = true }
 tower = { workspace = true }
 axum = { workspace = true }
-# Overload-shedding tests hold an API permit by parking a handler on a
-# never-ending request body (`futures::stream::pending`).
-futures = { workspace = true }
 http = { workspace = true }
 http-body-util = { workspace = true }
 serde_json = { workspace = true }

--- a/app/ferroehr-rest/src/api/admin/integrity.rs
+++ b/app/ferroehr-rest/src/api/admin/integrity.rs
@@ -41,14 +41,17 @@
 
 use axum::extract::State;
 use axum::response::{IntoResponse, Response};
-use http::StatusCode;
+use bytes::Bytes;
+use http::{HeaderValue, StatusCode, header};
 use serde_json::{Value, json};
 use utoipa_axum::router::OpenApiRouter;
 use utoipa_axum::routes;
 
 use openehr_its::rest::runtime::ApiError;
 
-use ferroehr::service::admin::integrity::{StorageParityReport, StorageParityScope};
+use ferroehr::service::admin::integrity::{
+    StorageParityEvent, StorageParityReport, StorageParityScope,
+};
 
 use crate::api::{BoxResponse, RequestParts, guarded_dispatch};
 use crate::overview::error::RestError;
@@ -81,6 +84,15 @@ pub(crate) fn integrity_routes() -> OpenApiRouter<AppState> {
          description = "Cover only versions whose validity begins at or after \
                         this RFC 3339 instant, for verifying what changed since \
                         an incident."),
+        ("Accept" = Option<String>, Header,
+         description = "`application/x-ndjson` streams the sweep as it runs, \
+                        which is how a whole large repository is verified in \
+                        one pass: the aggregated form computes its report \
+                        before the response exists and is bounded by the \
+                        server's 30 s request timeout. The stream must be \
+                        asked for by name — a wildcard, or no `Accept` at all, \
+                        keeps the aggregated document. Our own extension; no \
+                        openEHR spec governs this media type."),
     ),
     responses(
         (status = 200, description = "The sweep ran. The body is the report: \
@@ -94,22 +106,43 @@ pub(crate) fn integrity_routes() -> OpenApiRouter<AppState> {
                                       `warn` whatever the cap does). A finding \
                                       is NOT a request failure — the sweep \
                                       succeeded and is reporting what it saw, \
-                                      so the status stays `200`.",
-         body = serde_json::Value,
-         example = json!({
-             "versions_checked": 128,
-             "versions_with_body": 126,
-             "versions_without_body": 2,
-             "mismatch_count": 1,
-             "mismatches": [{
-                 "vo_id": "8849182c-82ad-4088-a07f-48ead4180515",
-                 "sys_version": 2,
-                 "kind": "COMPOSITION",
-                 "defect": "content_differs"
-             }],
-             "truncated": false,
-             "elapsed_ms": 431
-         })),
+                                      so the status stays `200`. Under \
+                                      `Accept: application/x-ndjson` the same \
+                                      sweep is streamed instead: one JSON \
+                                      object per line, each carrying a `type` \
+                                      — a `mismatch` as it is found, a \
+                                      `progress` tick per enumerated page, and \
+                                      one closing `summary` with the same \
+                                      counts. A sweep that fails after the \
+                                      response began cannot change the status \
+                                      code, so it ends with an `error` line \
+                                      instead of a `summary`: read to the end \
+                                      to tell a finished sweep from an aborted \
+                                      one.",
+         content(
+             (serde_json::Value = "application/json", example = json!({
+                 "versions_checked": 128,
+                 "versions_with_body": 126,
+                 "versions_without_body": 2,
+                 "mismatch_count": 1,
+                 "mismatches": [{
+                     "vo_id": "8849182c-82ad-4088-a07f-48ead4180515",
+                     "sys_version": 2,
+                     "kind": "COMPOSITION",
+                     "defect": "content_differs"
+                 }],
+                 "truncated": false,
+                 "elapsed_ms": 431
+             })),
+             (String = "application/x-ndjson", example = json!(
+                 "{\"type\":\"mismatch\",\"vo_id\":\"8849182c-82ad-4088-a07f-48ead4180515\",\
+                   \"sys_version\":2,\"kind\":\"COMPOSITION\",\"defect\":\"content_differs\"}\n\
+                  {\"type\":\"progress\",\"versions_checked\":500,\"versions_with_body\":498,\
+                   \"versions_without_body\":2,\"mismatch_count\":1}\n\
+                  {\"type\":\"summary\",\"versions_checked\":128,\"versions_with_body\":126,\
+                   \"versions_without_body\":2,\"mismatch_count\":1,\"elapsed_ms\":431}\n"
+             )),
+         )),
         (status = 401, description = "Unauthenticated (auth enabled, no valid \
                                       principal). Our own authorization design \
                                       — the released admin operations carry \
@@ -159,6 +192,9 @@ async fn run(
     match op {
         "admin_verify_storage_parity" => {
             let scope = parity_scope(parts.query.as_deref())?;
+            if negotiate::accepts_ndjson(&parts.headers) {
+                return Ok(stream_parity(&state, scope));
+            }
             let report = state.backend().verify_storage_parity(scope).await?;
             Ok(negotiate::respond(
                 &parts.headers,
@@ -201,6 +237,116 @@ fn parity_scope(query: Option<&str>) -> Result<StorageParityScope, RestError> {
         ehr_id,
         committed_since,
     })
+}
+
+/// How many rendered lines the streamed sweep may run ahead of the client.
+///
+/// The channel IS the flow control: a client that reads slowly stops the sweep
+/// at its next batch, and a client that disconnects drops the receiver, which
+/// ends the sweep at its next send rather than letting it read the repository
+/// for nobody.
+const STREAM_BUFFER: usize = 64;
+
+/// Answer the sweep as a line-delimited JSON stream.
+///
+/// The aggregated form computes the whole report before the response exists, so
+/// it is bounded by the router's `REQUEST_TIMEOUT` and a large enough
+/// repository outruns it. `tower_http`'s `TimeoutLayer` races only the inner
+/// service's response FUTURE (its `ResponseFuture` polls the inner future
+/// against one `Sleep`); once the head is produced the layer is out of the way,
+/// and the separate body deadlines — `ResponseBodyTimeoutLayer` /
+/// `ResponseBodyDeadlineLayer`, `tower_http::timeout` §"Body timeouts" — are
+/// not applied by `crate::router`. So a response whose head returns at once and
+/// whose body is written as the sweep proceeds has no such ceiling.
+///
+/// The cost is that the status code is committed before the work is: a fault
+/// after the head can only be reported as the final line.
+///
+/// NOTE: no openEHR spec governs storage mechanics or this media type — our own
+/// design/extension.
+fn stream_parity(state: &AppState, scope: StorageParityScope) -> Response {
+    let service = state.backend_handle();
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<Bytes>(STREAM_BUFFER);
+    drop(tokio::spawn(async move {
+        let mut sweep = service.storage_parity_sweep(scope);
+        loop {
+            let batch = match sweep.next_batch().await {
+                Ok(Some(batch)) => batch,
+                Ok(None) => return,
+                Err(e) => {
+                    tracing::error!(
+                        error = %e,
+                        "storage parity stream: the sweep failed after the response began"
+                    );
+                    // The diagnostic stays in the log: the wire line says the
+                    // sweep did not finish, which is what a client can act on.
+                    drop(
+                        tx.send(parity_line(&json!({
+                            "type": "error",
+                            "message": "the sweep failed before it completed; see the server log",
+                        })))
+                        .await,
+                    );
+                    return;
+                }
+            };
+            for event in batch {
+                if tx.send(parity_line(&parity_event(&event))).await.is_err() {
+                    return;
+                }
+            }
+        }
+    }));
+    let stream = futures::stream::poll_fn(move |cx| {
+        rx.poll_recv(cx)
+            .map(|line| line.map(Ok::<Bytes, std::convert::Infallible>))
+    });
+    let mut response = axum::body::Body::from_stream(stream).into_response();
+    *response.status_mut() = StatusCode::OK;
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static(negotiate::APPLICATION_NDJSON),
+    );
+    response
+}
+
+/// One line of the stream: the rendered object plus its terminator.
+fn parity_line(value: &Value) -> Bytes {
+    let mut line = value.to_string();
+    line.push('\n');
+    Bytes::from(line)
+}
+
+/// Render one sweep event as its wire object.
+///
+/// Written out explicitly, like [`parity_report`]: the wire contract is this
+/// function, not a serde attribute on a service type. Every object carries a
+/// `type` so a reader dispatches on one key.
+fn parity_event(event: &StorageParityEvent) -> Value {
+    match event {
+        StorageParityEvent::Mismatch(mismatch) => json!({
+            "type": "mismatch",
+            "vo_id": mismatch.vo_id.to_string(),
+            "sys_version": mismatch.sys_version,
+            "kind": mismatch.kind,
+            "defect": mismatch.defect.as_str(),
+        }),
+        StorageParityEvent::Progress { counts } => json!({
+            "type": "progress",
+            "versions_checked": counts.versions_checked,
+            "versions_with_body": counts.versions_with_body,
+            "versions_without_body": counts.versions_without_body,
+            "mismatch_count": counts.mismatch_count,
+        }),
+        StorageParityEvent::Summary { counts, elapsed_ms } => json!({
+            "type": "summary",
+            "versions_checked": counts.versions_checked,
+            "versions_with_body": counts.versions_with_body,
+            "versions_without_body": counts.versions_without_body,
+            "mismatch_count": counts.mismatch_count,
+            "elapsed_ms": elapsed_ms,
+        }),
+    }
 }
 
 /// Render the storage-parity report as the response body.

--- a/app/ferroehr-rest/src/overview/negotiate.rs
+++ b/app/ferroehr-rest/src/overview/negotiate.rs
@@ -104,6 +104,10 @@ const APPLICATION_WT_FLAT_JSON: &str = "application/openehr.wt.flat+json";
 /// Simplified STRUCTURED (structSDT) media type.
 const APPLICATION_WT_STRUCTURED_JSON: &str = "application/openehr.wt.structured+json";
 
+/// Line-delimited JSON, the media type our own long-running operational routes
+/// stream their findings as. Not a [`WireFormat`] — see [`accepts_ndjson`].
+pub(crate) const APPLICATION_NDJSON: &str = "application/x-ndjson";
+
 /// The canonical-only allowed set (`Accept_LOCATABLE` minus the simplified
 /// types) — the negotiation set for every canonical RM object endpoint.
 pub(crate) const CANONICAL: &[WireFormat] = &[WireFormat::CanonicalJson, WireFormat::CanonicalXml];
@@ -376,6 +380,26 @@ pub(crate) fn accept_xml_namespace(headers: &HeaderMap) -> Option<Namespace> {
         XmlLineage::Selected(ns) => Some(ns),
         XmlLineage::Unrecognized => None,
     }
+}
+
+/// Whether the request explicitly asks for a line-delimited JSON stream.
+///
+/// Line-delimited JSON is not a [`WireFormat`]: no openEHR spec defines it, no
+/// RM resource is served that way, and no ITS-REST operation offers it. It is
+/// the response SHAPE two of our own operational routes can take when the work
+/// behind them runs longer than one response may take to produce. It is
+/// therefore asked for BY NAME and never matched by a wildcard — a client
+/// sending `*/*`, or no `Accept` at all, keeps the aggregated document, which
+/// is what stops the shape changing under an existing caller.
+///
+/// NOTE: no openEHR spec governs this media type — our own design/extension.
+pub(crate) fn accepts_ndjson(headers: &HeaderMap) -> bool {
+    let Some(accept) = header_str(headers, header::ACCEPT) else {
+        return false;
+    };
+    accept.split(',').any(|range| {
+        media_token(range).eq_ignore_ascii_case(APPLICATION_NDJSON) && quality_of(range) > 0.0
+    })
 }
 
 /// Refuse a request whose `Content-Type` declares canonical XML in a lineage

--- a/app/ferroehr-rest/src/state.rs
+++ b/app/ferroehr-rest/src/state.rs
@@ -93,6 +93,16 @@ impl AppState {
         &self.inner.backend
     }
 
+    /// An owned handle on the service, for work that outlives the handler.
+    ///
+    /// A handler that answers with a STREAM returns its response head while
+    /// the work behind the body is still running, so that work cannot borrow
+    /// the state it was called with. Every other dispatcher takes
+    /// [`Self::backend`] instead.
+    pub(crate) fn backend_handle(&self) -> Arc<FerroEhrService> {
+        Arc::clone(&self.inner.backend)
+    }
+
     /// The authorization handle (RBAC gate), if access control is wired.
     pub(crate) fn authz(&self) -> Option<Arc<AuthzHandle>> {
         self.inner.authz.clone()

--- a/app/ferroehr-rest/tests/it/admin_integrity_http.rs
+++ b/app/ferroehr-rest/tests/it/admin_integrity_http.rs
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: Ruben Talstra
+// SPDX-License-Identifier: BUSL-1.1
+
+//! End-to-end HTTP tests for the ADMIN storage-integrity route
+//! (`POST /admin/integrity/verify`) — **our own extension**; no ITS-REST
+//! operation and no SM interface governs it.
+//!
+//! What the streaming half proves is a property of the MIDDLEWARE, so it is
+//! asserted against the middleware rather than argued: `tower_http`'s
+//! `TimeoutLayer` races the inner service's response FUTURE, so a handler that
+//! computes its whole answer before returning is bounded by it and a handler
+//! that returns a head immediately is not. Each test therefore wraps the
+//! assembled router in a `TimeoutLayer` whose budget is deliberately far too
+//! short, which is the same layer production applies at 30 s.
+#![expect(
+    clippy::expect_used,
+    reason = "clippy's in-test lint scoping (clippy.toml `allow-*-in-tests`) only \
+              reaches `#[test]`-annotated functions, so it misses this integration \
+              module's helpers and async bodies; a panicking assertion is the \
+              intended shape here (the Rust Book ch11)"
+)]
+
+use std::time::Duration;
+
+use axum::body::Body;
+use axum::response::Response;
+use http::{Request, StatusCode, header};
+use serde_json::Value;
+use tower::ServiceExt;
+use tower::util::BoxCloneService;
+use tower_http::timeout::TimeoutLayer;
+
+use crate::common;
+use crate::common::BASE;
+
+/// A budget no sweep can meet: the aggregated form needs several sequential
+/// round trips to a real database before it can answer at all.
+const IMPOSSIBLE: Duration = Duration::from_millis(1);
+
+/// The route under test.
+fn verify(accept: Option<&str>) -> Request<Body> {
+    let mut req = Request::builder()
+        .method("POST")
+        .uri(format!("{BASE}/admin/integrity/verify"));
+    if let Some(accept) = accept {
+        req = req.header(header::ACCEPT, accept);
+    }
+    req.body(Body::empty()).expect("request")
+}
+
+/// The assembled router behind a deliberately impossible timeout, plus a seeded
+/// repository for the sweep to read.
+async fn app_with_impossible_timeout() -> (
+    testkit::TestDb,
+    BoxCloneService<Request<Body>, Response, std::convert::Infallible>,
+) {
+    let (pg, service) = common::test_service().await;
+    service.create_ehr(None).await.expect("seed an EHR");
+    let router = common::router_with(common::api_config(true), service);
+    let stack = tower::ServiceBuilder::new()
+        .layer(TimeoutLayer::with_status_code(
+            StatusCode::REQUEST_TIMEOUT,
+            IMPOSSIBLE,
+        ))
+        .service(router);
+    (pg, BoxCloneService::new(stack))
+}
+
+#[tokio::test]
+async fn the_aggregated_sweep_is_bounded_by_the_request_timeout() {
+    let (_pg, app) = app_with_impossible_timeout().await;
+
+    let response = app.oneshot(verify(None)).await.expect("response");
+
+    assert_eq!(
+        response.status(),
+        StatusCode::REQUEST_TIMEOUT,
+        "the aggregated form computes its whole report before the response \
+         exists, so the timeout applies to it — this is the ceiling the \
+         streamed form exists to escape"
+    );
+}
+
+#[tokio::test]
+async fn the_streamed_sweep_completes_under_a_timeout_the_aggregated_one_cannot_meet() {
+    let (_pg, app) = app_with_impossible_timeout().await;
+
+    let response = app
+        .oneshot(verify(Some("application/x-ndjson")))
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok()),
+        Some("application/x-ndjson")
+    );
+
+    // Draining the body happens entirely outside the timeout, which is the
+    // whole claim: the sweep ran to its summary under a 1 ms budget.
+    let bytes = axum::body::to_bytes(response.into_body(), 1 << 20)
+        .await
+        .expect("drain the stream");
+    let body = String::from_utf8(bytes.to_vec()).expect("utf-8 lines");
+    let lines: Vec<Value> = body
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str(line).expect("every line is one JSON object"))
+        .collect();
+
+    assert!(!lines.is_empty(), "the stream carried no lines: {body:?}");
+    let last = lines.last().expect("a non-empty stream has a last line");
+    assert_eq!(
+        last["type"], "summary",
+        "a completed sweep ends with its summary, not an error line: {body:?}"
+    );
+    assert!(
+        last["versions_checked"].as_u64().unwrap_or(0) >= 2,
+        "an EHR create stores at least its EHR_STATUS and EHR_ACCESS: {body:?}"
+    );
+    assert_eq!(last["mismatch_count"], 0, "{body:?}");
+    assert!(
+        lines.iter().any(|line| line["type"] == "progress"),
+        "a sweep that read a page says so while it runs: {body:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_wildcard_accept_keeps_the_aggregated_document() {
+    let (_pg, service) = common::test_service().await;
+    let app = common::router_with(common::api_config(true), service);
+
+    let (status, body) = common::send_body(&app, verify(Some("*/*"))).await;
+
+    assert_eq!(status, StatusCode::OK);
+    let report: Value = serde_json::from_str(&body).expect("one JSON document");
+    assert!(
+        report.get("mismatches").is_some(),
+        "a wildcard must not switch an existing caller onto the stream: {body}"
+    );
+}

--- a/app/ferroehr-rest/tests/it/main.rs
+++ b/app/ferroehr-rest/tests/it/main.rs
@@ -29,6 +29,7 @@ mod common;
 mod abac_e2e;
 mod admin_extension_http;
 mod admin_http;
+mod admin_integrity_http;
 mod audit_e2e;
 mod audit_iti81;
 mod authz_cedar_engine;

--- a/app/ferroehr/src/service/admin/integrity.rs
+++ b/app/ferroehr/src/service/admin/integrity.rs
@@ -107,6 +107,47 @@ pub struct StorageParityMismatch {
     pub defect: StorageParityDefect,
 }
 
+/// What a sweep has read so far, or in total.
+///
+/// NOTE: no openEHR spec governs storage mechanics — our own design/extension.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct StorageParityCounts {
+    /// How many stored versions were read, across both storage tiers.
+    pub versions_checked: u64,
+    /// How many of them carry a materialized body (a content version).
+    pub versions_with_body: u64,
+    /// How many of them carry no body (a logical delete).
+    pub versions_without_body: u64,
+    /// How many mismatches were found.
+    pub mismatch_count: u64,
+}
+
+/// One event of a running storage-parity sweep.
+///
+/// A sweep reads every byte of what it covers, so a whole-repository pass can
+/// run far longer than any one request may take to answer. Reporting it as a
+/// sequence of events is what lets a caller consume the findings while the
+/// sweep is still running.
+///
+/// NOTE: no openEHR spec governs storage mechanics — our own design/extension.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StorageParityEvent {
+    /// One stored version whose two content copies disagree.
+    Mismatch(StorageParityMismatch),
+    /// The counts so far, emitted once per enumerated page.
+    Progress {
+        /// What has been read up to this point.
+        counts: StorageParityCounts,
+    },
+    /// The final counts, emitted once, after the last page.
+    Summary {
+        /// What the whole sweep read.
+        counts: StorageParityCounts,
+        /// Wall-clock duration of the sweep, in milliseconds.
+        elapsed_ms: u64,
+    },
+}
+
 /// The outcome of one storage-parity sweep.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StorageParityReport {
@@ -182,15 +223,39 @@ impl FerroEhrService {
         &self,
         scope: StorageParityScope,
     ) -> Result<StorageParityReport, SmError> {
-        Ok(self.sweep_storage_parity(scope).await?)
+        Ok(self.collect_storage_parity(scope).await?)
     }
 
-    /// The sweep itself, over the storage error domain.
-    async fn sweep_storage_parity(
+    /// Starts a sweep the caller advances itself, one batch of events at a
+    /// time.
+    ///
+    /// This is the sweep; [`Self::verify_storage_parity`] is one way of
+    /// consuming it. A caller that must report findings while the sweep is
+    /// still running — a response written as a stream of lines — drives this
+    /// instead, and gets exactly the same reads, counts and log lines.
+    ///
+    /// NOTE: no openEHR spec governs storage mechanics — our own
+    /// design/extension.
+    #[must_use]
+    pub fn storage_parity_sweep(&self, scope: StorageParityScope) -> StorageParitySweep<'_> {
+        StorageParitySweep {
+            service: self,
+            scope,
+            cursor: None,
+            page: Vec::new().into_iter(),
+            counts: StorageParityCounts::default(),
+            started: Instant::now(),
+            page_finished: false,
+            done: false,
+        }
+    }
+
+    /// Drain a sweep into the aggregated report.
+    async fn collect_storage_parity(
         &self,
         scope: StorageParityScope,
     ) -> Result<StorageParityReport, ServiceError> {
-        let started = Instant::now();
+        let mut sweep = self.storage_parity_sweep(scope);
         let mut report = StorageParityReport {
             versions_checked: 0,
             versions_with_body: 0,
@@ -200,29 +265,29 @@ impl FerroEhrService {
             truncated: false,
             elapsed_ms: 0,
         };
-        let mut cursor: Option<(Uuid, i32)> = None;
-
-        loop {
-            let page = self.parity_page(cursor, scope).await?;
-            let Some(last) = page.last() else { break };
-            cursor = Some((last.vo_id, last.sys_version));
-
-            for chunk in page.chunks(CONTENT_CHUNK) {
-                for (key, defect) in self.chunk_parity_defects(chunk).await? {
-                    report.versions_checked += 1;
-                    if key.has_body {
-                        report.versions_with_body += 1;
-                    } else {
-                        report.versions_without_body += 1;
+        while let Some(events) = sweep.next_batch().await? {
+            for event in events {
+                match event {
+                    StorageParityEvent::Mismatch(mismatch) => {
+                        if report.mismatches.len() < MAX_REPORTED_MISMATCHES {
+                            report.mismatches.push(mismatch);
+                        } else {
+                            report.truncated = true;
+                        }
                     }
-                    if let Some(defect) = defect {
-                        record(&mut report, key, defect);
+                    // The aggregated form answers once, at the end, so a
+                    // running count has nobody to tell.
+                    StorageParityEvent::Progress { .. } => {}
+                    StorageParityEvent::Summary { counts, elapsed_ms } => {
+                        report.versions_checked = counts.versions_checked;
+                        report.versions_with_body = counts.versions_with_body;
+                        report.versions_without_body = counts.versions_without_body;
+                        report.mismatch_count = counts.mismatch_count;
+                        report.elapsed_ms = elapsed_ms;
                     }
                 }
             }
         }
-
-        report.elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
         Ok(report)
     }
 
@@ -339,29 +404,118 @@ impl FerroEhrService {
     }
 }
 
-/// Count a mismatch, log it by identifier, and record it while the report has
-/// room.
+/// A storage-parity sweep in progress, advanced one batch of events at a time.
 ///
-/// The log line carries identifiers and the defect token only: a body fragment
-/// would put clinical content into an operational log.
-fn record(report: &mut StorageParityReport, key: &VersionKey, defect: StorageParityDefect) {
-    report.mismatch_count += 1;
-    tracing::warn!(
-        vo_id = %key.vo_id,
-        sys_version = key.sys_version,
-        kind = %key.kind,
-        defect = defect.as_str(),
-        "storage parity sweep: the node rows and the materialized body of a stored version disagree"
-    );
-    if report.mismatches.len() < MAX_REPORTED_MISMATCHES {
-        report.mismatches.push(StorageParityMismatch {
-            vo_id: key.vo_id,
-            sys_version: key.sys_version,
-            kind: key.kind.clone(),
-            defect,
-        });
-    } else {
-        report.truncated = true;
+/// The sweep is a cursor rather than one call so both response shapes share ONE
+/// implementation: the aggregated report drains it, and a streamed response
+/// writes each event as a line as it arrives. Advancing only when the caller
+/// asks is also what gives a stream its backpressure and its cancellation —
+/// dropping the sweep stops the reads at the next batch boundary.
+///
+/// NOTE: no openEHR spec governs storage mechanics — our own design/extension.
+pub struct StorageParitySweep<'a> {
+    service: &'a FerroEhrService,
+    scope: StorageParityScope,
+    cursor: Option<(Uuid, i32)>,
+    page: std::vec::IntoIter<VersionKey>,
+    counts: StorageParityCounts,
+    started: Instant,
+    page_finished: bool,
+    done: bool,
+}
+
+impl std::fmt::Debug for StorageParitySweep<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StorageParitySweep")
+            .field("scope", &self.scope)
+            .field("cursor", &self.cursor)
+            .field("counts", &self.counts)
+            .field("done", &self.done)
+            .finish_non_exhaustive()
+    }
+}
+
+impl StorageParitySweep<'_> {
+    /// Advances the sweep, returning the next batch of events, or `None` once
+    /// the summary has been handed over.
+    ///
+    /// A batch is what one chunk of versions produced, so it is empty whenever
+    /// those versions agreed — which is the common case. The last batch before
+    /// `None` carries the [`StorageParityEvent::Summary`].
+    ///
+    /// # Errors
+    /// - `exception` — a database fault while enumerating or reading versions.
+    ///   A version whose node rows are unreadable is a REPORTED mismatch, not
+    ///   an error: one damaged record must not abort the sweep that found it.
+    pub async fn next_batch(&mut self) -> Result<Option<Vec<StorageParityEvent>>, ServiceError> {
+        loop {
+            let chunk: Vec<VersionKey> = self.page.by_ref().take(CONTENT_CHUNK).collect();
+            if !chunk.is_empty() {
+                return Ok(Some(self.check_chunk(&chunk).await?));
+            }
+            if self.done {
+                return Ok(None);
+            }
+            // A whole page has been read. The tick both tells a consumer the
+            // sweep is advancing and keeps a streamed response writing bytes,
+            // which is what stops an intermediary closing a long clean sweep.
+            if self.page_finished {
+                self.page_finished = false;
+                return Ok(Some(vec![StorageParityEvent::Progress {
+                    counts: self.counts,
+                }]));
+            }
+            let page = self.service.parity_page(self.cursor, self.scope).await?;
+            let Some(last) = page.last() else {
+                self.done = true;
+                let elapsed_ms =
+                    u64::try_from(self.started.elapsed().as_millis()).unwrap_or(u64::MAX);
+                return Ok(Some(vec![StorageParityEvent::Summary {
+                    counts: self.counts,
+                    elapsed_ms,
+                }]));
+            };
+            self.cursor = Some((last.vo_id, last.sys_version));
+            self.page = page.into_iter();
+            self.page_finished = true;
+        }
+    }
+
+    /// Compare one chunk, count what it read, and turn its defects into events.
+    async fn check_chunk(
+        &mut self,
+        chunk: &[VersionKey],
+    ) -> Result<Vec<StorageParityEvent>, ServiceError> {
+        let mut events = Vec::new();
+        for (key, defect) in self.service.chunk_parity_defects(chunk).await? {
+            self.counts.versions_checked += 1;
+            if key.has_body {
+                self.counts.versions_with_body += 1;
+            } else {
+                self.counts.versions_without_body += 1;
+            }
+            if let Some(defect) = defect {
+                self.counts.mismatch_count += 1;
+                // The log line carries identifiers and the defect token only: a
+                // body fragment would put clinical content into an operational
+                // log. It is emitted here, in the one sweep, so a finding is
+                // logged whichever response shape asked for it.
+                tracing::warn!(
+                    vo_id = %key.vo_id,
+                    sys_version = key.sys_version,
+                    kind = %key.kind,
+                    defect = defect.as_str(),
+                    "storage parity sweep: the node rows and the materialized body of a stored version disagree"
+                );
+                events.push(StorageParityEvent::Mismatch(StorageParityMismatch {
+                    vo_id: key.vo_id,
+                    sys_version: key.sys_version,
+                    kind: key.kind.clone(),
+                    defect,
+                }));
+            }
+        }
+        Ok(events)
     }
 }
 

--- a/app/ferroehr/tests/it/storage_parity.rs
+++ b/app/ferroehr/tests/it/storage_parity.rs
@@ -27,7 +27,9 @@ use uuid::Uuid;
 
 use ferroehr::ids::EhrId;
 use ferroehr::service::FerroEhrService;
-use ferroehr::service::admin::integrity::{StorageParityDefect, StorageParityScope};
+use ferroehr::service::admin::integrity::{
+    StorageParityDefect, StorageParityEvent, StorageParityScope,
+};
 
 use crate::fixtures::{composition, folder, uv};
 
@@ -381,4 +383,83 @@ async fn a_committed_since_bound_excludes_earlier_versions() {
         later.versions_checked < whole.versions_checked,
         "the bound still excludes the versions written before it: {later:?} vs {whole:?}"
     );
+}
+
+#[tokio::test]
+async fn the_streamed_sweep_reports_the_same_findings_as_the_aggregated_one() {
+    let db = testkit::db().await.expect("testkit database");
+    let pool = db.pool();
+    let svc = FerroEhrService::new(pool.clone());
+    let ehr_id = seed_ehr_with_composition(&svc).await;
+    let (vo_id, sys_version) = one_version(&pool, ehr_id, "COMPOSITION").await;
+    tamper(
+        &pool,
+        "UPDATE node SET data = jsonb_set(data, '{archetype_node_id}', '\"tampered\"') \
+         WHERE vo_id = $1 AND sys_version = $2 AND num = 0",
+        vo_id,
+        sys_version,
+    )
+    .await;
+
+    let mut sweep = svc.storage_parity_sweep(StorageParityScope::default());
+    let mut mismatches = Vec::new();
+    let mut summary = None;
+    let mut progress_ticks = 0_u32;
+    while let Some(batch) = sweep.next_batch().await.expect("advance the sweep") {
+        for event in batch {
+            match event {
+                StorageParityEvent::Mismatch(found) => mismatches.push(found),
+                StorageParityEvent::Progress { .. } => progress_ticks += 1,
+                StorageParityEvent::Summary { counts, .. } => {
+                    assert!(summary.is_none(), "the summary is emitted exactly once");
+                    summary = Some(counts);
+                }
+            }
+        }
+    }
+
+    let counts = summary.expect("the sweep ends with a summary");
+    assert!(
+        progress_ticks > 0,
+        "a sweep that read a page reports that it is advancing"
+    );
+    assert_eq!(mismatches.len(), 1, "{mismatches:?}");
+    assert_eq!(mismatches[0].vo_id, vo_id);
+    assert_eq!(mismatches[0].sys_version, sys_version);
+    assert_eq!(mismatches[0].defect, StorageParityDefect::ContentDiffers);
+
+    // The two shapes are one sweep, so their numbers cannot drift apart.
+    let report = svc
+        .verify_storage_parity(StorageParityScope::default())
+        .await
+        .expect("aggregated sweep");
+    assert_eq!(counts.versions_checked, report.versions_checked);
+    assert_eq!(counts.versions_with_body, report.versions_with_body);
+    assert_eq!(counts.versions_without_body, report.versions_without_body);
+    assert_eq!(counts.mismatch_count, report.mismatch_count);
+    assert_eq!(mismatches, report.mismatches);
+}
+
+#[tokio::test]
+async fn a_dropped_stream_stops_the_sweep_where_it_stood() {
+    let db = testkit::db().await.expect("testkit database");
+    let svc = FerroEhrService::new(db.pool());
+    seed_ehr_with_composition(&svc).await;
+
+    // One batch, then drop. Nothing may panic and nothing may run on: the
+    // sweep holds no transaction and no lock, so abandoning it is the whole
+    // cancellation story a disconnected client gets.
+    let mut sweep = svc.storage_parity_sweep(StorageParityScope::default());
+    let first = sweep.next_batch().await.expect("the first batch");
+    assert!(
+        first.is_some(),
+        "a seeded repository yields at least one batch"
+    );
+    drop(sweep);
+
+    let report = svc
+        .verify_storage_parity(StorageParityScope::default())
+        .await
+        .expect("a later sweep is unaffected");
+    assert!(report.versions_checked >= 3, "{report:?}");
 }

--- a/website/book/src/operations-admin-apis.md
+++ b/website/book/src/operations-admin-apis.md
@@ -201,9 +201,39 @@ Two optional query parameters narrow the scan, and they compose:
 | `committed_since` | cover only versions whose validity begins at or after that RFC 3339 instant |
 
 Use them. Verifying one record after a support incident, or everything written
-since a known point, costs a fraction of a full repository scan, and the whole
-sweep still has to answer inside the server's 30-second request timeout. On a
-large repository, scope it.
+since a known point, costs a fraction of a full repository scan.
+
+### Verifying a whole large repository
+
+By default the route computes the whole report before it answers, so it has to
+finish inside the server's 30-second request timeout. Send
+`Accept: application/x-ndjson` and it streams the same sweep instead, writing
+each finding as it is made. Nothing bounds that response, so this is how you
+verify a repository too large to scope:
+
+```bash
+curl -sN -X POST \
+  -H 'Accept: application/x-ndjson' \
+  "$BASE/admin/integrity/verify"
+```
+
+The body is one JSON object per line, each carrying a `type`:
+
+| `type` | When | Carries |
+|---|---|---|
+| `mismatch` | as each disagreement is found | the same four fields the report's `mismatches` entries carry |
+| `progress` | once per page of versions read | the counts so far |
+| `summary` | once, at the end | the final counts and `elapsed_ms` |
+| `error` | instead of `summary`, if the sweep failed part-way | a short message; the detail is in the server log |
+
+Two consequences are worth planning around. The status code is sent before the
+work is done, so a sweep that fails half-way still answered `200`: read to the
+end and check that the last line is a `summary`, not an `error`. And the stream
+carries no reporting cap, so every mismatch reaches you rather than the first
+thousand.
+
+The stream has to be asked for by name. A request sending `*/*`, or no `Accept`
+at all, gets the aggregated document below, unchanged.
 
 ```json
 {


### PR DESCRIPTION
`POST /admin/integrity/verify` computed its whole report before the response existed, so the router's 30 s `REQUEST_TIMEOUT` was its ceiling: a large enough repository answered `408` and the report was lost. #3110 cut the per-version cost and #3121 added scoping, but neither changed the execution shape, which is what this closes.

## The shape, and why the other one was rejected

Two options were on the issue: a streamed response, or a background job with a resumable cursor, a status route and a stored result. The stream wins.

The claim it rests on was verified against the pinned `tower-http` 0.7 source rather than taken on trust. `TimeoutLayer` builds a `ResponseFuture` that races the inner service's future against one `Sleep` (`src/timeout/service.rs`); once that future resolves the layer is out of the picture and the body drains untimed. Body deadlines are separate opt-in layers — `ResponseBodyTimeoutLayer` / `ResponseBodyDeadlineLayer` (`src/timeout/mod.rs` §"Body timeouts") — and `router.rs` applies neither.

The background job buys exactly one property the stream does not have, surviving a restart mid-sweep, and pays for it with a cursor, a job table, a status route and a result lifecycle with its own retention question. Nobody has asked for that property; the live defect is the timeout, and the stream removes it. The reasoning is recorded on #3122 so it does not have to be re-derived.

## What changed

The sweep is now `StorageParitySweep`, a cursor the caller advances a batch at a time. **Both response shapes drive that one implementation** — `verify_storage_parity` drains it into the aggregated report — so the two cannot report different numbers and a mismatch is logged once whichever shape asked for it. A test asserts that equality directly rather than trusting it.

`Accept: application/x-ndjson` selects the stream: one JSON object per line, each carrying a `type`. A `mismatch` as it is found, a `progress` tick per enumerated page, one closing `summary`.

The progress tick was not in the issue's shape and is not decoration. A clean whole-repository sweep would otherwise send no bytes for minutes, and an idle connection that long is closed by intermediaries — the shape does not work without it. It doubles as the operator's "it is still advancing" signal.

Backpressure and cancellation come from the channel rather than new machinery: a slow reader stops the sweep at its next batch, and a disconnected client drops the receiver, which ends the sweep at its next send instead of reading the repository for nobody.

## Measurement

On the testkit harness, a store of **655 360 versions / 655 360 node rows**:

| | |
|---|---|
| Aggregated | **164.9 s**, 655 360 checked, 0 mismatches |
| Streamed | **first line at 129 ms**, 1 312 lines, complete summary, 125.7 s total |

164.9 s is five and a half times the 30 s ceiling, so through the route that store is a `408` with the report lost. 129 ms against 125.7 s is the property that matters: the head is produced before any meaningful work.

Two honest caveats. The store carries one node row per version where a production store carries many, so the version count is a **lower bound** on a real repository of that size — the same caveat #3121 attached to its 98 304-version figure. And the streamed run is **not** 39 s faster than the aggregated one in any meaningful sense: it ran second, on warm caches, on a machine that was not idle. The two numbers establish which shape survives the timeout, not throughput. The harness that built the store was scratch and is not committed; the method is recorded on the issue.

## Compatibility

The stream is asked for **by name**. `*/*`, or no `Accept` at all, keeps the aggregated document byte for byte, which is what stops an existing caller's shape changing under it. A test pins the wildcard case.

The one real cost is stated in the changelog and the book: the status code is committed before the work is, so a sweep that fails after the head ends with an `error` line instead of a `summary`. A client reads to the end to tell the two apart.

Line-delimited JSON is deliberately **not** a `WireFormat`. No openEHR spec defines it, no RM resource is served that way, and no ITS-REST operation offers it; adding a variant to that enum would have rippled a non-RM shape through every match on it. It lives beside the existing purpose-built `Accept` scan in `negotiate`, so the crate still has one Accept parser.

## Tests

Three router-level tests wrap the assembled router in the **same `TimeoutLayer` production applies**, at a deliberately impossible 1 ms: the aggregated form answers `408`, the streamed form answers `200` and drains to a complete summary, and a wildcard `Accept` keeps the aggregated document. Four consecutive runs, no flake. Two service-level tests pin that the two shapes report identical findings and counts, and that dropping a sweep mid-flight stops it cleanly.

## Gates

`cargo fmt`, clippy on `ferroehr` and `ferroehr-rest`, `docs-claims`, `comment-style`, `typed-status`, `default-style` green. `cargo nextest run -p ferroehr -p ferroehr-rest`: **1814 tests, all passing**.

One en-route finding is filed rather than folded in here: `service_import::an_imported_container_reports_the_local_chronology` failed once under full-suite load and passes in isolation, for the #3119 reason — a process instant compared against a database-stamped one. That is #3138, unrelated to this change, and lands in its own PR.

Closes #3122

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.
