### PR TITLE
test(import): two import tests read their probe instant from the database

### DIFF
--- a/app/ferroehr/tests/it/service_import.rs
+++ b/app/ferroehr/tests/it/service_import.rs
@@ -60,6 +60,25 @@ use crate::typed_body::typed;
 use ferroehr::versioning::signature::config::{Mode, SigningConfig, VerifyOnRead};
 use ferroehr::versioning::signature::signer::Signer;
 
+/// The database's own current instant, for a probe an assertion compares
+/// against a stored one.
+///
+/// Committal instants are stamped by PostgreSQL, not by this process:
+/// `audit.time_committed` defaults to `now()`, because RM common
+/// `master06-change_control_package.adoc` §Committal and Audits requires the
+/// committal instant to be computed on the server. Taking the probe from
+/// `jiff::Timestamp::now()` would therefore compare a host clock against a
+/// container clock, and the two are free to disagree (#3138). Every database
+/// here comes from the one testkit server, so a probe read from any pool shares
+/// its clock with every instant under test.
+async fn db_now(pool: &sqlx::PgPool) -> jiff::Timestamp {
+    let now: jiff_sqlx::Timestamp = sqlx::query_scalar("SELECT now()")
+        .fetch_one(pool)
+        .await
+        .expect("the database's current instant");
+    now.to_jiff()
+}
+
 /// Seed an EHR with an `EHR_STATUS` (create → update = two versions), a directory
 /// `FOLDER`, and the auto-created `EHR_ACCESS` — the same shape the export tests
 /// seed. Returns the EHR id.
@@ -682,7 +701,7 @@ async fn an_imported_container_reports_the_local_chronology() {
         .parse::<jiff::Timestamp>()
         .expect("ISO 8601 instant");
 
-    let before_import = jiff::Timestamp::now();
+    let before_import = db_now(&target_db.pool()).await;
     target
         .import_ehr(None, export_one(&source, ehr).await)
         .await
@@ -947,7 +966,7 @@ async fn an_as_of_read_before_the_import_does_not_see_the_imported_version() {
         .to_owned();
 
     // Everything the source did is now in the past; the import has not run.
-    let before_import = jiff::Timestamp::now().to_string();
+    let before_import = db_now(&target_db.pool()).await.to_string();
 
     target
         .import_ehr(None, export_one(&source, ehr).await)


### PR DESCRIPTION
`service_import::an_imported_container_reports_the_local_chronology` failed during a full `cargo nextest run -p ferroehr -p ferroehr-rest` and passed on its own; a second full run passed it. Load-dependent, not deterministic.

## The cause

The test compared an instant taken from THIS PROCESS against one stamped by PostgreSQL:

```rust
let before_import = jiff::Timestamp::now();
target.import_ehr(…).await.expect("import_ehr");
assert!(time_created >= before_import, …);
```

`time_created` is not a process value. `versioning::wire::versioned_object` takes it from `version_repo::meta::commit_bounds`, which is `min(a.time_committed)` over the `audit` rows, and `audit.time_committed` is `timestamptz NOT NULL DEFAULT now()` — the database stamps it deliberately, because RM common `master06-change_control_package.adoc` §Committal and Audits requires the committal instant to be computed on the server. The testkit database runs in a container whose clock is independent of the host's, so the assertion held only while the two happened to agree.

A second site in the same file carried the same defect in two more assertions, and there it is load-bearing in a way that could hide a real regression rather than only produce noise: a host instant was used as an as-of cutoff against database-stamped validity, then compared against a database-stamped commit instant. A host clock running behind the container's turns "the as-of read must not see the imported version" into a false pass.

This is the class #3119 fixed for `demographic_http.rs` and `directory_http.rs`, in a file #3119 did not reach.

## The fix

One `db_now` helper, and both sites read their probe from the database the assertions compare against. Every database in this suite comes from the one testkit PostgreSQL server, so the probe shares its clock with every instant under test.

The assertions keep their exact bounds — `>=`, `>`, `<` all unchanged. This is a fixture correction, not a loosened test, and nothing is skipped.

## Verification

`cargo nextest run -p ferroehr --test it -E 'test(service_import)'`: 19 tests, all passing. Full `cargo nextest run -p ferroehr -p ferroehr-rest` green. `cargo fmt`, clippy on `ferroehr`, and `comment-style` green. No `jiff::Timestamp::now()` remains in the file.

Closes #3138

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.
