### PR TITLE
release: v4.1.1

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -5,7 +5,7 @@
   "title": "FerroEHR",
   "description": "<p>A pure-Rust, openEHR-specification-conformant clinical data repository (CDR): ITS-REST 1.1.0 REST API, AQL 1.1 query language, and the openEHR RM 1.2.0 reference model on PostgreSQL-18-native storage. The openEHR specification layer is generated from the official machine-readable specifications, and conformance is machine-verified per release by a built-in CNF conformance runner.</p>",
   "publication_date": "2026-09-05",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "creators": [
     {
       "name": "Talstra, Ruben",
@@ -39,7 +39,7 @@
       "resource_type": "publication-softwaredocumentation"
     },
     {
-      "identifier": "https://github.com/rubentalstra/FerroEHR/tree/v4.1.0",
+      "identifier": "https://github.com/rubentalstra/FerroEHR/tree/v4.1.1",
       "relation": "isSupplementTo",
       "resource_type": "software"
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+## [4.1.1] - 2026-09-05
+
 ### Added
 
 - **A whole large repository can now be checked for storage damage in one pass**
@@ -8351,7 +8353,8 @@ but has not yet run in production.
   seccomp, default-deny NetworkPolicy) and golden-render validation.
 
 
-[unreleased]: https://github.com/rubentalstra/FerroEHR/compare/v4.1.0...HEAD
+[unreleased]: https://github.com/rubentalstra/FerroEHR/compare/v4.1.1...HEAD
+[4.1.1]: https://github.com/rubentalstra/FerroEHR/compare/v4.1.0...v4.1.1
 [4.1.0]: https://github.com/rubentalstra/FerroEHR/compare/v4.0.18...v4.1.0
 [4.0.18]: https://github.com/rubentalstra/FerroEHR/compare/v4.0.17...v4.0.18
 [4.0.17]: https://github.com/rubentalstra/FerroEHR/compare/v4.0.16...v4.0.17

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -37,5 +37,5 @@ keywords:
   - ITS-REST
   - Rust
   - PostgreSQL
-version: 4.1.0
+version: 4.1.1
 date-released: 2026-09-05

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2315,7 +2315,7 @@ dependencies = [
 
 [[package]]
 name = "docs-meta"
-version = "4.1.0"
+version = "4.1.1"
 
 [[package]]
 name = "dotenvy"
@@ -2640,7 +2640,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ferroehr"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "argon2",
  "assert_fs",
@@ -2714,7 +2714,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-ext"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2738,7 +2738,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-rest"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-server"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2816,7 +2816,7 @@ dependencies = [
 
 [[package]]
 name = "ferroehr-viewer"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -5470,7 +5470,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-codegen"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "roxmltree",
  "serde_json",
@@ -8673,7 +8673,7 @@ dependencies = [
 
 [[package]]
 name = "testkit"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "ferroehr",
  "jiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "3"
 members = ["crates/*", "app/*", "tools/*"]
 
 [workspace.package]
-version = "4.1.0"
+version = "4.1.1"
 edition = "2024"
 rust-version = "1.96"
 license = "BUSL-1.1"

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # A published OCI version is immutable by refusal rather than by the registry —
 # `helm push` over an existing tag replaces it silently — so a correction always
 # ships as a NEW version and the published one stands as it was.
-version: 7.0.8
+version: 7.0.9
 # The DEFAULT container image tag (overridable via image.tag). Equals the
 # workspace version in Cargo.toml, bumped in the release PR beside the
 # docker-compose.yml image tags — one version sweep, the compose treatment
@@ -38,7 +38,7 @@ version: 7.0.8
 # defaults: values track development between releases, so the publish lane
 # re-checks the pairing against an image, and the `chart-boot` CI job replays it
 # against the image built from the tree.
-appVersion: "4.1.0"
+appVersion: "4.1.1"
 
 # A COMPATIBILITY floor, and a real one: 1.36 is the release where the newest
 # field this chart renders became stable.
@@ -152,7 +152,7 @@ annotations:
   # scan while leaving the false claim in place, so it is deliberately not used.
   artifacthub.io/images: |
     - name: ferroehr
-      image: ghcr.io/rubentalstra/ferroehr:4.1.0
+      image: ghcr.io/rubentalstra/ferroehr:4.1.1
       platforms:
         - linux/amd64
         - linux/arm64
@@ -162,7 +162,7 @@ annotations:
     # the entry describes a surface an operator opts into rather than one every
     # install carries, and it is listed so that surface is scanned.
     - name: ferroehr-viewer
-      image: ghcr.io/rubentalstra/ferroehr-viewer:4.1.0
+      image: ghcr.io/rubentalstra/ferroehr-viewer:4.1.1
       platforms:
         - linux/amd64
         - linux/arm64

--- a/deploy/helm/ferroehr/README.md
+++ b/deploy/helm/ferroehr/README.md
@@ -2,7 +2,7 @@
 
 Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.1.0 + AQL 1.1). A single static binary deployed with a hardened-by-default security posture: runs as a non-root, read-only-rootfs workload whose NetworkPolicy admits its serving port only, and that connects to an EXTERNAL PostgreSQL 18 as an unprivileged app role (migrations are run out of band by a separate migrator role).
 
-![Version: 7.0.8](https://img.shields.io/badge/Version-7.0.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.1.0](https://img.shields.io/badge/AppVersion-4.1.0-informational?style=flat-square)
+![Version: 7.0.9](https://img.shields.io/badge/Version-7.0.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.1.1](https://img.shields.io/badge/AppVersion-4.1.1-informational?style=flat-square)
 
 FerroEHR is a pure-Rust openEHR Clinical Data Repository: ITS-REST 1.1.0 at the
 API, AQL 1.1 as the query language, PostgreSQL 18-native storage, shipped as a
@@ -33,10 +33,10 @@ to add; `helm repo add` does not apply to this chart:
 
 ```console
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 7.0.8 \
+  --version 7.0.9 \
   --namespace ferroehr --create-namespace \
   --set database.existingSecret=ferroehr-db \
-  --set image.tag=4.1.0
+  --set image.tag=4.1.1
 ```
 
 OCI registries require Helm 3.8 or newer.
@@ -47,8 +47,8 @@ They are independent SemVer lines and they move independently:
 
 | What | Set with | This release |
 |---|---|---|
-| the **chart** (templates, defaults, this document) | `--version` | `7.0.8` |
-| the **server image** | `image.tag` | `4.1.0` |
+| the **chart** (templates, defaults, this document) | `--version` | `7.0.9` |
+| the **server image** | `image.tag` | `4.1.1` |
 
 `appVersion` is the image the chart defaults to; pinning `image.tag` explicitly
 is what keeps an upgrade of one from silently moving the other.
@@ -59,7 +59,7 @@ The chart carries two keyless Sigstore artifacts, and they answer different
 questions. A **cosign signature:** who signed this:
 
 ```console
-cosign verify ghcr.io/rubentalstra/charts/ferroehr:7.0.8 \
+cosign verify ghcr.io/rubentalstra/charts/ferroehr:7.0.9 \
   --certificate-identity-regexp '^https://github\.com/rubentalstra/FerroEHR/\.github/workflows/publish-chart\.yml@' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
@@ -67,9 +67,9 @@ cosign verify ghcr.io/rubentalstra/charts/ferroehr:7.0.8 \
 A **SLSA build provenance attestation:** what source it was built from, and how:
 
 ```console
-gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:7.0.8 \
+gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:7.0.9 \
   -R rubentalstra/FerroEHR
-gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:4.1.0 \
+gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:4.1.1 \
   -R rubentalstra/FerroEHR
 ```
 

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -23,10 +23,10 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), and only from the networkPolicy.ingressFrom peers.
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -97,10 +97,10 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -118,10 +118,10 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -150,10 +150,10 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -176,10 +176,10 @@ kind: Secret
 metadata:
   name: ferroehr-config
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -197,10 +197,10 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -402,10 +402,10 @@ kind: ConfigMap
 metadata:
   name: ferroehr-grafana-dashboard
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     grafana_dashboard: "1"
@@ -653,10 +653,10 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -687,10 +687,10 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -740,7 +740,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:4.1.0"
+          image: "ghcr.io/rubentalstra/ferroehr:4.1.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -920,10 +920,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -954,10 +954,10 @@ kind: Ingress
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -992,10 +992,10 @@ kind: ServiceMonitor
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     release: kube-prometheus-stack

--- a/deploy/helm/golden/basic-auth.yaml
+++ b/deploy/helm/golden/basic-auth.yaml
@@ -23,10 +23,10 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -51,10 +51,10 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -72,10 +72,10 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 automountServiceAccountToken: false
@@ -102,10 +102,10 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -119,10 +119,10 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -247,10 +247,10 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -277,10 +277,10 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -328,7 +328,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:4.1.0"
+          image: "ghcr.io/rubentalstra/ferroehr:4.1.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -23,10 +23,10 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -51,10 +51,10 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -72,10 +72,10 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 automountServiceAccountToken: false
@@ -87,10 +87,10 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -212,10 +212,10 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -242,10 +242,10 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -293,7 +293,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:4.1.0"
+          image: "ghcr.io/rubentalstra/ferroehr:4.1.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/helm/golden/viewer.yaml
+++ b/deploy/helm/golden/viewer.yaml
@@ -23,10 +23,10 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -61,10 +61,10 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the viewer: only its HTTP port, but from EVERY source — this policy narrows ports, NOT sources (viewer.networkPolicy.ingressAllowAll=true). Set viewer.networkPolicy.ingressFrom for a PHI workload. Egress admits the CDR Service and DNS only.
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr-viewer
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: viewer
@@ -118,10 +118,10 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -139,10 +139,10 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 automountServiceAccountToken: false
@@ -154,10 +154,10 @@ kind: ServiceAccount
 metadata:
   name: ferroehr-viewer
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr-viewer
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: viewer
@@ -184,10 +184,10 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 type: Opaque
@@ -201,10 +201,10 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 data:
@@ -329,10 +329,10 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
   annotations:
@@ -359,10 +359,10 @@ metadata:
     kubernetes.io/description: >-
       In-cluster address for the FerroEHR Viewer. The viewer is a REST client of the CDR and holds no data of its own; it is the human-facing surface, so this is the Service an Ingress normally publishes.
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr-viewer
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: viewer
@@ -385,10 +385,10 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
 spec:
@@ -436,7 +436,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: ferroehr
-          image: "ghcr.io/rubentalstra/ferroehr:4.1.0"
+          image: "ghcr.io/rubentalstra/ferroehr:4.1.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -581,10 +581,10 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR Viewer: a Leptos SSR web UI that consumes the CDR strictly over ITS-REST. It never reaches the database, which the viewer NetworkPolicy enforces rather than assumes.
   labels:
-    helm.sh/chart: ferroehr-7.0.8
+    helm.sh/chart: ferroehr-7.0.9
     app.kubernetes.io/name: ferroehr-viewer
     app.kubernetes.io/instance: ferroehr
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: ferroehr
     app.kubernetes.io/component: viewer
@@ -620,7 +620,7 @@ spec:
         supplementalGroupsPolicy: Strict
       containers:
         - name: viewer
-          image: "ghcr.io/rubentalstra/ferroehr-viewer:4.1.0"
+          image: "ghcr.io/rubentalstra/ferroehr-viewer:4.1.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@
 
 services:
   ferroehr-postgres:
-    image: ${FERROEHR_POSTGRES_IMAGE:-ghcr.io/rubentalstra/ferroehr-postgres:4.1.0}
+    image: ${FERROEHR_POSTGRES_IMAGE:-ghcr.io/rubentalstra/ferroehr-postgres:4.1.1}
     # Docker's default 64MB /dev/shm starves PostgreSQL's dynamic shared
     # memory under load (parallel workers error `could not resize shared
     # memory segment … No space left on device`); measured runs share this
@@ -177,7 +177,7 @@ services:
       start_period: 10s
 
   ferroehr:
-    image: ${FERROEHR_IMAGE:-ghcr.io/rubentalstra/ferroehr:4.1.0}
+    image: ${FERROEHR_IMAGE:-ghcr.io/rubentalstra/ferroehr:4.1.1}
     depends_on:
       ferroehr-postgres:
         condition: service_healthy
@@ -288,7 +288,7 @@ services:
   # FERROEHR_VIEWER__AUTH__OIDC__* variables at your identity provider.
   ferroehr-viewer:
     profiles: [viewer]
-    image: ${FERROEHR_VIEWER_IMAGE:-ghcr.io/rubentalstra/ferroehr-viewer:4.1.0}
+    image: ${FERROEHR_VIEWER_IMAGE:-ghcr.io/rubentalstra/ferroehr-viewer:4.1.1}
     depends_on:
       ferroehr:
         condition: service_healthy

--- a/docs/conformance/ferroehr/CONFORMANCE_STATEMENT.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_STATEMENT.md
@@ -1,6 +1,6 @@
 # Conformance Statement (SDoC)
 
-Product: FerroEHR 4.1.0 — Ruben Talstra (urn:rubentalstra:ferroehr)
+Product: FerroEHR 4.1.1 — Ruben Talstra (urn:rubentalstra:ferroehr)
 Schedule release: cnf-2.0-w2
 
 ## Declared spec versions

--- a/docs/conformance/party/ferroehr/statement.json
+++ b/docs/conformance/party/ferroehr/statement.json
@@ -1,7 +1,7 @@
 {
   "product": {
     "name": "FerroEHR",
-    "version": "4.1.0",
+    "version": "4.1.1",
     "vendor": "Ruben Talstra",
     "identifier": "urn:rubentalstra:ferroehr"
   },

--- a/website/book/src/installation/kubernetes.md
+++ b/website/book/src/installation/kubernetes.md
@@ -38,9 +38,9 @@ kubectl -n ferroehr create secret generic ferroehr-db \
   --from-literal=FERROEHR__DB__URL='postgres://ferroehr_app:***@pg-host:5432/ferroehr?sslmode=verify-full'
 
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 7.0.8 -n ferroehr \
+  --version 7.0.9 -n ferroehr \
   --set database.existingSecret=ferroehr-db \
-  --set image.tag=4.1.0
+  --set image.tag=4.1.1
 ```
 
 > [!IMPORTANT]
@@ -55,7 +55,7 @@ helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
 reference. To read the chart's metadata without installing it:
 
 ```shell
-helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 7.0.8
+helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 7.0.9
 ```
 
 ### Pin two versions, not one
@@ -68,8 +68,8 @@ against.
 
 | | Selects | Pin with | Line |
 |---|---|---|---|
-| Chart version | templates, values schema, defaults | `--version 7.0.8` | SemVer over the chart's own contract |
-| Image tag | the server binary | `--set image.tag=4.1.0` (or `image.digest`) | the application's SemVer line |
+| Chart version | templates, values schema, defaults | `--version 7.0.9` | SemVer over the chart's own contract |
+| Image tag | the server binary | `--set image.tag=4.1.1` (or `image.digest`) | the application's SemVer line |
 
 Always pin the image to an immutable version or, better, a `@sha256` digest,
 never `latest`. Pin the two deliberately: the `config` tree is passed through to
@@ -167,7 +167,7 @@ metadata lists: the server, and the optional viewer.
 > the image itself as the authority:
 >
 > ```shell
-> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 7.0.8 \
+> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 7.0.9 \
 >   -s templates/configmap.yaml --set database.existingSecret=ferroehr-db \
 >   | sed -n '/ferroehr.toml/,$p' | sed '1d;s/^    //' > /tmp/ferroehr.toml
 > docker run --rm -v /tmp/ferroehr.toml:/etc/ferroehr/ferroehr.toml:ro \
@@ -556,7 +556,7 @@ config:
 
 ```shell
 helm upgrade ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 7.0.8 -n ferroehr --reuse-values \
+  --version 7.0.9 -n ferroehr --reuse-values \
   --set config.query.plan_cache_capacity=512
 ```
 
@@ -709,7 +709,7 @@ Preview an upgrade against what you have installed with
 `helm diff`, or render the new chart version and read it:
 
 ```shell
-helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 7.0.8 \
+helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 7.0.9 \
   -n ferroehr -f my-values.yaml | less
 ```
 
@@ -734,7 +734,7 @@ The check that closes that gap runs the image against your rendered
 configuration:
 
 ```shell
-FERROEHR_IMAGE=ghcr.io/rubentalstra/ferroehr:4.1.0 \
+FERROEHR_IMAGE=ghcr.io/rubentalstra/ferroehr:4.1.1 \
   deploy/helm/ci/boot-check.sh my-values.yaml
 ```
 

--- a/website/book/src/verifying-releases.md
+++ b/website/book/src/verifying-releases.md
@@ -17,7 +17,7 @@ signer identity is one you can pin to a single hardened workflow.
 ## What a release publishes
 
 Substitute the release tag you downloaded for `<tag>` (for example
-`v4.1.0`) and the architecture for `<arch>` (`x86_64` or `aarch64`) throughout
+`v4.1.1`) and the architecture for `<arch>` (`x86_64` or `aarch64`) throughout
 this page. Linux is the only published target.
 
 | Asset | What it is |
@@ -175,7 +175,7 @@ carry a Sigstore-signed SLSA provenance attestation, plus the SPDX SBOM and
 provenance the builder writes onto the image index itself.
 
 ```bash
-gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:4.1.0 \
+gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:4.1.1 \
   -R rubentalstra/FerroEHR
 ```
 
@@ -199,7 +199,7 @@ tag once and verify the digest it resolved — otherwise the bytes verified and
 the bytes pulled can differ:
 
 ```bash
-digest=$(docker buildx imagetools inspect ghcr.io/rubentalstra/ferroehr:4.1.0 \
+digest=$(docker buildx imagetools inspect ghcr.io/rubentalstra/ferroehr:4.1.1 \
   | awk '/^Digest:/{print $2}')
 gh attestation verify "oci://ghcr.io/rubentalstra/ferroehr@${digest}" \
   -R rubentalstra/FerroEHR


### PR DESCRIPTION
Milestone [v4.1.1](https://github.com/rubentalstra/FerroEHR/milestone/52) reached zero open issues, so this cuts the release.

## What v4.1.1 ships

**A whole large repository can be checked for storage damage in one pass** (#3122). `POST /admin/integrity/verify` computed its whole report before answering, so it had to finish inside the 30-second request timeout and a large enough repository lost the report to a `408`. `Accept: application/x-ndjson` now streams the same sweep. Measured on a 655 360-version store: 164.9 s aggregated, against 129 ms to the first streamed line.

**A refused operational template lists every violation, not the first one** (#3129), from a tester's report that repairing a 1.7 MB template meant one upload per defect.

The rest of the milestone was CI and test correctness, which carry no changelog entry but are why this release exists as a patch: the coverage run was sharded and moved out of the Sonar lane (#3131), two timing tests stopped depending on the machine they run on (#3119), a `thaw` dialog backdrop stopped swallowing the next click in the browser battery (#3134), and two import tests stopped comparing a process instant against a database-stamped one (#3138).

## The cut

- `CHANGELOG.md`: `[Unreleased]` renamed to `## [4.1.1] - 2026-09-05`, a fresh empty `[Unreleased]`, new link references.
- Workspace `version` → 4.1.1, with `Cargo.lock` refreshed by `cargo check`.
- `CITATION.cff` version, and `.zenodo.json` **re-rendered** from it by `scripts/render/zenodo-json.sh` rather than hand-edited — Zenodo ignores `CITATION.cff` entirely whenever a `.zenodo.json` exists.
- The ferroehr party statement's product version, with its derived conformance documents regenerated by `scripts/render/conformance-docs.sh`.
- `docker-compose.yml` image tags (server, viewer, postgres).
- The chart: `appVersion` and the `artifacthub.io/images` tags → 4.1.1, and the chart's own SemVer line **7.0.8 → 7.0.9**. That bump is unconditional, not diff-driven: every release ships a distinct packaged chart, and an unbumped version is refused by the publish lane at the tag. Golden renders and the generated chart README regenerated with it.
- The book's pinned versions: `installation/kubernetes.md` (chart `--version`, `image.tag`) and `verifying-releases.md` (the release tag and image tags).

## Gates

`chart-appversion`, `statement-version`, `compose-image-tags` and `docs-claims` green; `deploy/helm/validate.sh` green after the README regeneration. `cargo check --workspace` clean. The full `cargo nextest run -p ferroehr -p ferroehr-rest` ran green on the last two feature branches (1814 and 1809 tests), and main's CI has been green since #3136 landed, including all three `ui-e2e` shards.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.
