### PR TITLE
fix(flat): a template-named collapsed node keeps its content in FLAT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,26 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A FLAT or STRUCTURED read no longer drops the content of a template-named
+  event** (#3142). An operational template can fix the name of a node the
+  simplified formats collapse away, such as the single event of a `HISTORY`.
+  The constrained name then survives only inside the leaf's `aqlPath`, and a
+  composition written through the FLAT surface came back short: the reporter's
+  body weight and comment were present in the canonical JSON and absent from
+  `application/openehr.wt.flat+json`, with no error to say so. Two halves are
+  fixed. Building a composition named that collapsed node after its archetype
+  node id rather than the name its own template path constrains, so the node
+  did not satisfy the path it had just been created for, and every datum
+  beneath it became unaddressable. Reading now tolerates it either way: a node
+  whose runtime name differs from the template's is still reached by archetype
+  node id, exactly as the archetype-conformance validator already did. That
+  applies only where the name identifies nothing the node id does not. A
+  template that distinguishes same-node-id siblings by name keeps matching
+  strictly, so one sibling can never claim another's content. Compositions
+  already stored with the wrong name read correctly without being rewritten.
+
 ## [4.1.1] - 2026-09-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5434,7 +5434,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.61"
+version = "0.0.62"
 dependencies = [
  "indexmap 2.14.0",
  "openehr-am",
@@ -5450,7 +5450,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.61"
+version = "0.0.62"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -5460,7 +5460,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.61"
+version = "0.0.62"
 dependencies = [
  "serde",
  "serde_json",
@@ -5479,7 +5479,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.61"
+version = "0.0.62"
 dependencies = [
  "async-trait",
  "axum",
@@ -5509,7 +5509,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.61"
+version = "0.0.62"
 dependencies = [
  "assert_fs",
  "chumsky",
@@ -5523,7 +5523,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.61"
+version = "0.0.62"
 dependencies = [
  "chumsky",
  "logos",
@@ -5532,7 +5532,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.61"
+version = "0.0.62"
 dependencies = [
  "insta",
  "jsonschema",
@@ -5550,7 +5550,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.61"
+version = "0.0.62"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -155,6 +155,16 @@ precedence = "override"
 SPDX-FileCopyrightText = ["Nedap Healthcare", "Better Ltd", "vitasystems GmbH", "openEHR Foundation"]
 SPDX-License-Identifier = "Apache-2.0"
 
+# One fixture under that tree is NOT third-party: it is a repo-authored
+# derivative of an openEHR CNF Robot template (CC-BY-SA 3.0), so it carries
+# that licence and both copyright holders. Its own PROVENANCE.md records the
+# upstream commit and every edit.
+[[annotations]]
+path = "crates/openehr-its/tests/fixtures/named_event/**"
+precedence = "override"
+SPDX-FileCopyrightText = ["openEHR Foundation", "Ruben Talstra"]
+SPDX-License-Identifier = "CC-BY-SA-3.0"
+
 # Three BMM reference models inside that set are offered by their authors under
 # a Mozilla Public License 1.1 / GPL 2.0 / LGPL 2.1 TRI-LICENCE. This project
 # TAKES THEM UNDER MPL-1.1 — the election is recorded in that corpus's

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-adl"
-version = "0.0.61"
+version = "0.0.62"
 description = "openEHR ADL 2.4.0: hand-written ADL2/cADL/ODIN parser, AOM2 validation catalogue, specialisation flattener, OPT2 generator, and ADL 1.4→2 conversion over the generated openehr_am::v2_4::aom2 model"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,11 +16,11 @@ include = ["src/**", "README.md", "LICENSE"]
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)
-openehr-base = { path = "../openehr-base", version = "0.0.61" }   # VersionStatus for the parsed HRID
-openehr-am = { path = "../openehr-am", version = "0.0.61" }       # v2_4 ArchetypeHrid (the identification target type)
-openehr-rm = { path = "../openehr-rm", version = "0.0.61" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
-openehr-lang = { path = "../openehr-lang", version = "0.0.61" }   # openehr_lang::odin — the ODIN section parser
-openehr-term = { path = "../openehr-term", version = "0.0.61" }   # the languages code set for the RM resource-meta rows
+openehr-base = { path = "../openehr-base", version = "0.0.62" }   # VersionStatus for the parsed HRID
+openehr-am = { path = "../openehr-am", version = "0.0.62" }       # v2_4 ArchetypeHrid (the identification target type)
+openehr-rm = { path = "../openehr-rm", version = "0.0.62" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
+openehr-lang = { path = "../openehr-lang", version = "0.0.62" }   # openehr_lang::odin — the ODIN section parser
+openehr-term = { path = "../openehr-term", version = "0.0.62" }   # the languages code set for the RM resource-meta rows
 uuid.workspace = true        # meta uid/build_uid (AUTHORED_ARCHETYPE.uid: Uuid)
 indexmap.workspace = true    # OdinValue::Object body (insertion-ordered map)
 

--- a/crates/openehr-am/Cargo.toml
+++ b/crates/openehr-am/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-am"
-version = "0.0.61"
+version = "0.0.62"
 description = "openEHR AM Archetype Model, generated from BMM: generations v1_4 (AM 1.4.0, ADL 1.4) and v2_4 (AM 2.4.0, ADL 2; current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,8 +13,8 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.61" }
-openehr-lang = { path = "../openehr-lang", version = "0.0.61" }
+openehr-base = { path = "../openehr-base", version = "0.0.62" }
+openehr-lang = { path = "../openehr-lang", version = "0.0.62" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also carries the untyped `Value` fields the generator

--- a/crates/openehr-base/Cargo.toml
+++ b/crates/openehr-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-base"
-version = "0.0.61"
+version = "0.0.62"
 description = "openEHR BASE foundation + base types, generated from BMM: generations v1_2 (BASE 1.2.0) and v1_3 (BASE 1.3.0, current)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-its"
-version = "0.0.61"
+version = "0.0.62"
 description = "openEHR ITS (Implementation Technology Specifications): canonical JSON + canonical XML serialization of the RM, the generated ITS-REST 1.1.0 API contract, OPT 1.4 and AOM2 archetype XML codecs, and the Simplified Formats (FLAT / STRUCTURED / Web Template)"
 edition.workspace = true
 rust-version.workspace = true
@@ -41,14 +41,14 @@ regex = { workspace = true, optional = true }
 fancy-regex = { workspace = true, optional = true }
 # The generated XML (de)serializers impl the crate's ToXml/FromXml traits for the
 # RM/BASE spec types, so these are real (non-dev) deps.
-openehr-base = { path = "../openehr-base", version = "0.0.61", optional = true }
-openehr-rm = { path = "../openehr-rm", version = "0.0.61", optional = true }
+openehr-base = { path = "../openehr-base", version = "0.0.62", optional = true }
+openehr-rm = { path = "../openehr-rm", version = "0.0.62", optional = true }
 # The native canonical-JSON codec (`json_codec/generated`, emit-json) implements
 # `ToJson` for EVERY generated spec type the `OpenEhrType` derive covers, so it
 # spans all five spec crates (not just the RM/BASE the XML codec needs).
-openehr-lang = { path = "../openehr-lang", version = "0.0.61", optional = true }
-openehr-am = { path = "../openehr-am", version = "0.0.61", optional = true }
-openehr-term = { path = "../openehr-term", version = "0.0.61", optional = true }
+openehr-lang = { path = "../openehr-lang", version = "0.0.62", optional = true }
+openehr-am = { path = "../openehr-am", version = "0.0.62", optional = true }
+openehr-term = { path = "../openehr-term", version = "0.0.62", optional = true }
 
 # `full` — every ITS surface (canonical JSON/XML, the generated ITS-REST
 # contract, `opt14`, Simplified Formats). ON BY DEFAULT, so every consumer sees

--- a/crates/openehr-its/src/flat/build.rs
+++ b/crates/openehr-its/src/flat/build.rs
@@ -1180,7 +1180,21 @@ fn new_struct(
     // `UML/classes/org.openehr.rm.composition.ism_transition.adoc` §Inherit).
     // The generated RM model is the oracle rather than a hardcoded class list.
     if is_locatable(rm_type) {
-        let display = name.or(node_id).unwrap_or(rm_type);
+        // A `[atNNNN,'Name']` conjunct on the path spells the name the ARCHETYPE
+        // constrains for this node, so it outranks both the web-template child's
+        // display name and the node-id placeholder: a synthesised wrapper named
+        // anything else does not satisfy its own template path, and every datum
+        // under it becomes unaddressable (RM common
+        // `master03-archetyped_package.adoc` §"The `LOCATABLE` class"; BASE
+        // `architecture_overview/master11-paths.adoc` §"Using a Name-based
+        // Predicate").
+        let display = seg
+            .predicate
+            .name_value
+            .as_deref()
+            .or(name)
+            .or(node_id)
+            .unwrap_or(rm_type);
         o.insert("name".into(), name_value(display, coded_name));
         if let Some(nid) = node_id {
             o.insert("archetype_node_id".into(), json!(nid));

--- a/crates/openehr-its/src/flat/flatten.rs
+++ b/crates/openehr-its/src/flat/flatten.rs
@@ -29,6 +29,8 @@
               (#1694)"
 )]
 
+use std::borrow::Cow;
+
 use serde_json::Value;
 
 use crate::flat::ctx;
@@ -145,12 +147,30 @@ fn walk(node: &WebTemplateNode, rm: &Value, out: &mut SimNode) {
     // tables: `_uid`, `_link:i`, `_feeder_audit`, `_work_flow_id`, …).
     map::emit_rm_attrs(rm, base_type(&node.rm_type), out);
 
+    let names = name_fallback(node);
     for child in &node.children {
         if !covered_by_ctx(node, child) {
-            walk_child(node, child, rm, out);
+            walk_child(node, child, rm, out, &names);
         }
     }
     emit_direct_rm_paths(node, rm, out);
+}
+
+/// The per-step id-only name-fallback table for `node`'s children
+/// ([`rmpath::NameFallback`]).
+///
+/// Reuses the table the web-template builder cached on the node's walk plan so
+/// the projection and the archetype-conformance walk decide a renamed instance
+/// node by ONE rule; a hand-built node carrying no plan gets an equivalent
+/// table computed here.
+fn name_fallback(node: &WebTemplateNode) -> Cow<'_, rmpath::NameFallback> {
+    match &node.walk {
+        Some(plan) => Cow::Borrowed(&plan.name_fallback),
+        None => Cow::Owned(rmpath::name_fallback_from_paths(
+            &node.aql_path,
+            node.children.iter().map(|c| c.aql_path.as_str()),
+        )),
+    }
 }
 
 /// Emits every occurrence of one template child under its simplified slot.
@@ -160,14 +180,20 @@ fn walk(node: &WebTemplateNode, rm: &Value, out: &mut SimNode) {
 /// `_type`. That filter must apply to EVERY member of a choice group — the
 /// first alternative carries no `alt_json_id`, so sharing an `aqlPath` with a
 /// sibling is the group marker.
-fn walk_child(node: &WebTemplateNode, child: &WebTemplateNode, rm: &Value, out: &mut SimNode) {
+fn walk_child(
+    node: &WebTemplateNode,
+    child: &WebTemplateNode,
+    rm: &Value,
+    out: &mut SimNode,
+    names: &rmpath::NameFallback,
+) {
     let rel = rmpath::relative(&node.aql_path, &child.aql_path);
     let in_choice = child.alt_json_id.is_some()
         || node
             .children
             .iter()
             .any(|c| c.id != child.id && c.aql_path == child.aql_path);
-    let occurrences = occurrences_of(child, rm, &rel, in_choice);
+    let occurrences = occurrences_of(child, rm, &rel, in_choice, names);
     if occurrences.is_empty() {
         return;
     }
@@ -222,9 +248,10 @@ fn occurrences_of<'a>(
     rm: &'a Value,
     rel: &[openehr_rm::v1_2::paths::PathSegment],
     in_choice: bool,
+    names: &rmpath::NameFallback,
 ) -> Vec<Occurrence<'a>> {
-    let Some(wrappers) = value_step_owners(child, rm, rel) else {
-        return rmpath::resolve(rm, rel)
+    let Some(wrappers) = value_step_owners(child, rm, rel, names) else {
+        return rmpath::resolve_matched(rm, rel, names)
             .into_iter()
             .filter(|value| !in_choice || type_matches(value, &child.rm_type))
             .map(|value| Occurrence {
@@ -271,12 +298,13 @@ fn value_step_owners<'a>(
     child: &WebTemplateNode,
     rm: &'a Value,
     rel: &[openehr_rm::v1_2::paths::PathSegment],
+    names: &rmpath::NameFallback,
 ) -> Option<Vec<&'a Value>> {
     if !child.has_input() {
         return None;
     }
     let (last, parents) = rel.split_last()?;
-    (last.attribute == "value").then(|| rmpath::resolve(rm, parents))
+    (last.attribute == "value").then(|| rmpath::resolve_matched(rm, parents, names))
 }
 
 /// Whether the template-child walk already emitted a child that realizes RM

--- a/crates/openehr-its/src/flat/rmpath.rs
+++ b/crates/openehr-its/src/flat/rmpath.rs
@@ -122,10 +122,110 @@ pub(crate) fn select_children_excluding_names<'a>(
         .collect()
 }
 
+/// Per-parent decision table for the id-only name fallback of
+/// [`select_children_matched`], built from the template paths that share one
+/// parent node.
+///
+/// A template-derived `[atNNNN,'Name']` conjunct spells the name the ARCHETYPE
+/// constrains, while a stored instance may carry a different `LOCATABLE.name`
+/// (RM common `master03-archetyped_package.adoc` §"The `LOCATABLE` class": the
+/// runtime name distinguishes sibling nodes sharing an `archetype_node_id`).
+/// Dropping the conjunct is sound exactly when the name is REDUNDANT for
+/// identification — when every template path under the same parent spells the
+/// same name for that `(attribute, archetype_node_id)`. If two sibling paths
+/// spell different names, or one spells none, the name is a discriminator and
+/// the fallback would let one sibling claim another's instances.
+///
+/// The value is `Some(name)` for an identity every path spells identically and
+/// `None` for a discriminating identity. An identity absent from the map was
+/// never seen and takes no fallback.
+pub(crate) type NameFallback = std::collections::HashMap<(String, String), Option<String>>;
+
+/// Build the [`NameFallback`] table from every predicate-bearing segment of a
+/// parent's template paths (each already parsed relative to that parent).
+pub(crate) fn name_fallback_from_segments<'a>(
+    paths: impl Iterator<Item = &'a [PathSegment]>,
+) -> NameFallback {
+    let mut out: NameFallback = std::collections::HashMap::new();
+    for segs in paths {
+        for seg in segs {
+            let Some(id) = &seg.predicate.archetype_node_id else {
+                continue;
+            };
+            let key = (seg.attribute.clone(), id.clone());
+            let name = seg.predicate.name_value.clone();
+            match out.entry(key) {
+                std::collections::hash_map::Entry::Vacant(v) => {
+                    v.insert(name);
+                }
+                std::collections::hash_map::Entry::Occupied(mut o) => {
+                    if *o.get() != name {
+                        o.insert(None);
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Build the [`NameFallback`] table from a parent's absolute template paths,
+/// parsing each relative to `parent_aql` first.
+pub(crate) fn name_fallback_from_paths<'a>(
+    parent_aql: &str,
+    paths: impl Iterator<Item = &'a str>,
+) -> NameFallback {
+    let parsed: Vec<Vec<PathSegment>> = paths.map(|p| relative(parent_aql, p)).collect();
+    name_fallback_from_segments(parsed.iter().map(Vec::as_slice))
+}
+
+/// Whether `seg`'s name conjunct is redundant under `table` — the condition
+/// [`NameFallback`] documents.
+fn fallback_allowed(table: &NameFallback, seg: &PathSegment) -> bool {
+    let Some(id) = &seg.predicate.archetype_node_id else {
+        return false;
+    };
+    table
+        .get(&(seg.attribute.clone(), id.clone()))
+        .is_some_and(|uniform| uniform.as_ref() == seg.predicate.name_value.as_ref())
+}
+
+/// [`navigate`] with the id-only name fallback of [`select_children_matched`]
+/// enabled per step, as `table` permits.
+///
+/// This is what keeps a renamed instance node addressable: without it a step
+/// whose template name conjunct the instance does not match locates nothing,
+/// and every constraint and every datum below that step silently disappears —
+/// from the validation walk as much as from the simplified projection.
+pub(crate) fn navigate_matched<'a>(
+    roots: &[&'a Value],
+    segs: &[PathSegment],
+    table: &NameFallback,
+) -> Vec<&'a Value> {
+    let mut current: Vec<&Value> = roots.to_vec();
+    for seg in segs {
+        let allow = fallback_allowed(table, seg);
+        current = current
+            .iter()
+            .flat_map(|n| select_children_matched(n, seg, allow))
+            .collect();
+    }
+    current
+}
+
 /// Resolve the RM value(s) a full relative path reaches from `rm` (an empty
 /// segment list resolves to `rm` itself).
 pub(crate) fn resolve<'a>(rm: &'a Value, segs: &[PathSegment]) -> Vec<&'a Value> {
     navigate(&[rm], segs)
+}
+
+/// [`resolve`] with the per-step name fallback of [`navigate_matched`].
+pub(crate) fn resolve_matched<'a>(
+    rm: &'a Value,
+    segs: &[PathSegment],
+    table: &NameFallback,
+) -> Vec<&'a Value> {
+    navigate_matched(&[rm], segs, table)
 }
 
 #[cfg(test)]
@@ -202,6 +302,83 @@ mod tests {
         let found = select_children_matched(&rm, &segs[0], true);
         assert_eq!(found.len(), 1);
         assert_eq!(found[0]["tag"], 2);
+    }
+
+    #[test]
+    fn a_redundant_name_conjunct_permits_the_id_only_fallback() {
+        // One sibling path spells `events[at0002,'Point in time']` and nothing
+        // else claims `events[at0002]`, so the name identifies nothing the id
+        // does not — an instance that renamed the node is still reached.
+        let table = name_fallback_from_paths(
+            "/content[openEHR-EHR-OBSERVATION.x.v1]",
+            [
+                "/content[openEHR-EHR-OBSERVATION.x.v1]/data[at0001]/events[at0002,'Point in time']/data[at0003]/items[at0004]/value",
+                "/content[openEHR-EHR-OBSERVATION.x.v1]/language",
+            ]
+            .into_iter(),
+        );
+        let rm = serde_json::json!({
+            "data": {"archetype_node_id": "at0001", "events": [{
+                "archetype_node_id": "at0002",
+                "name": {"value": "at0002"},
+                "data": {"archetype_node_id": "at0003", "items": [{
+                    "archetype_node_id": "at0004",
+                    "value": {"_type": "DV_TEXT", "value": "hit"}
+                }]}
+            }]}
+        });
+        let segs =
+            parse("/data[at0001]/events[at0002,'Point in time']/data[at0003]/items[at0004]/value");
+        assert!(
+            resolve(&rm, &segs).is_empty(),
+            "the strict match locates nothing"
+        );
+        let found = resolve_matched(&rm, &segs, &table);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0]["value"], "hit");
+    }
+
+    #[test]
+    fn a_discriminating_name_conjunct_refuses_the_id_only_fallback() {
+        // Two sibling paths spell the same identity under different names, so
+        // dropping the name would let one sibling claim the other's instances.
+        let table = name_fallback_from_paths(
+            "",
+            [
+                "/content[openEHR-EHR-SECTION.adhoc.v1,'Reporting']/items[at0001]/value",
+                "/content[openEHR-EHR-SECTION.adhoc.v1,'Outcome']/items[at0001]/value",
+            ]
+            .into_iter(),
+        );
+        let rm = serde_json::json!({
+            "content": [{
+                "archetype_node_id": "openEHR-EHR-SECTION.adhoc.v1",
+                "name": {"value": "Neither"},
+                "items": [{"archetype_node_id": "at0001", "value": {"_type": "DV_TEXT", "value": "x"}}]
+            }]
+        });
+        let segs = parse("/content[openEHR-EHR-SECTION.adhoc.v1,'Reporting']/items[at0001]/value");
+        assert!(
+            resolve_matched(&rm, &segs, &table).is_empty(),
+            "a name-differentiated sibling never widens to the bare node id"
+        );
+    }
+
+    #[test]
+    fn an_unqualified_sibling_sharing_the_identity_refuses_the_fallback() {
+        // One path names the identity and another leaves it unconstrained; the
+        // unqualified sibling is the residual arm, so the named one must not
+        // reach past its own name.
+        let table = name_fallback_from_paths(
+            "",
+            ["/items[at0001,'Named']/value", "/items[at0001]/value"].into_iter(),
+        );
+        let segs = parse("/items[at0001,'Named']/value");
+        let rm = serde_json::json!({
+            "items": [{"archetype_node_id": "at0001", "name": {"value": "Other"},
+                       "value": {"_type": "DV_TEXT", "value": "x"}}]
+        });
+        assert!(resolve_matched(&rm, &segs, &table).is_empty());
     }
 
     #[test]

--- a/crates/openehr-its/src/flat/validation/mod.rs
+++ b/crates/openehr-its/src/flat/validation/mod.rs
@@ -425,6 +425,10 @@ pub(crate) struct NodeWalk {
     pub(crate) slot_groups: Vec<SlotGroup>,
     /// Name-based sibling routing index over the slot groups.
     pub(crate) slot_names: SiblingNameIndex,
+    /// Per-step id-only name fallback over every template path under this node
+    /// ([`rmpath::NameFallback`]), so a step whose name conjunct a renamed
+    /// instance does not match still reaches it when the name is redundant.
+    pub(crate) name_fallback: rmpath::NameFallback,
 }
 
 /// A sibling group of `WebTemplate` children sharing one `aqlPath` (a single
@@ -500,6 +504,12 @@ impl NodeWalk {
         }
         let slot_names =
             sibling_index_from_segments(slot_groups.iter().map(|g| g.segments.as_slice()));
+        let name_fallback = rmpath::name_fallback_from_segments(
+            child_groups
+                .iter()
+                .map(|g| g.segments.as_slice())
+                .chain(slot_groups.iter().map(|g| g.segments.as_slice())),
+        );
 
         let rel = |p: &str| p.strip_prefix(aql).map(rmpath::parse);
 
@@ -515,6 +525,7 @@ impl NodeWalk {
                 .collect(),
             slot_groups,
             slot_names,
+            name_fallback,
         }
     }
 }
@@ -768,7 +779,7 @@ impl Validator {
             &built
         };
         for group in &plan.child_groups {
-            self.check_group(instance, wt, group, &plan.child_names);
+            self.check_group(instance, wt, group, &plan.child_names, &plan.name_fallback);
         }
 
         self.check_cardinalities(instance, wt, plan);
@@ -800,7 +811,9 @@ impl Validator {
             let Some((last, intermediate)) = segments.split_last() else {
                 continue;
             };
-            for container in &rmpath::navigate(&[instance], intermediate) {
+            for container in
+                &rmpath::navigate_matched(&[instance], intermediate, &plan.name_fallback)
+            {
                 let slot_counts = self.match_closed_children(container, ca, &last.attribute);
                 self.check_slot_occurrences(ca, &last.attribute, &slot_counts);
             }
@@ -908,7 +921,8 @@ impl Validator {
             let Some((last, intermediate)) = sg.segments.split_last() else {
                 continue;
             };
-            let containers = rmpath::navigate(&[instance], intermediate);
+            let containers =
+                rmpath::navigate_matched(&[instance], intermediate, &plan.name_fallback);
             for container in &containers {
                 for node in select_group_children(container, last, &plan.slot_names) {
                     let Some(it) = node.get("_type").and_then(Value::as_str) else {
@@ -963,7 +977,8 @@ impl Validator {
                 continue;
             }
             // Navigate the intermediate segments to the container node(s).
-            let containers = rmpath::navigate(&[instance], intermediate);
+            let containers =
+                rmpath::navigate_matched(&[instance], intermediate, &plan.name_fallback);
             for container in &containers {
                 if attr_absent(container, &last.attribute) {
                     self.push(
@@ -993,6 +1008,7 @@ impl Validator {
         wt_parent: &WebTemplateNode,
         group: &ChildGroup,
         names: &SiblingNameIndex,
+        name_fallback: &rmpath::NameFallback,
     ) {
         // Segments were parsed once at build time; an empty slice means the child
         // path is not a strict extension of the parent's (or equals it) — the
@@ -1019,7 +1035,8 @@ impl Validator {
         let id_seg: &PathSegment = structural_id_seg.as_ref().unwrap_or(raw_id_seg);
 
         // Navigate the intermediate segments to the container node(s).
-        let containers = rmpath::navigate(&[parent], &segments[..identity_idx]);
+        let containers =
+            rmpath::navigate_matched(&[parent], &segments[..identity_idx], name_fallback);
 
         // Occurrences are an *archetype-node* constraint: only checked when the
         // matched node is identified by an archetype-node predicate (at-code /
@@ -1039,7 +1056,7 @@ impl Validator {
                 self.emit_occurrences(&first.aql_path, group_min, group_max, matched.len());
             }
             for node in matched {
-                self.walk_group_targets(node, trailing, &members);
+                self.walk_group_targets(node, trailing, &members, name_fallback);
             }
         }
     }
@@ -1053,8 +1070,9 @@ impl Validator {
         node: &Value,
         trailing: &[PathSegment],
         members: &[&WebTemplateNode],
+        name_fallback: &rmpath::NameFallback,
     ) {
-        for target in rmpath::navigate(&[node], trailing) {
+        for target in rmpath::navigate_matched(&[node], trailing, name_fallback) {
             match members {
                 [only] => self.walk(target, only),
                 _ => self.visit_choice(target, members),
@@ -1148,7 +1166,8 @@ impl Validator {
             // (the vendored Multi_list template pairs `content` cardinality 1..*
             // with existence 0..1), so an absent or null attribute is no cardinality
             // violation — and the RM list invariants forbid a present-empty `[]`.
-            let containers = rmpath::navigate(&[instance], intermediate);
+            let containers =
+                rmpath::navigate_matched(&[instance], intermediate, &plan.name_fallback);
             for container in &containers {
                 if matches!(container.get(&last.attribute), None | Some(Value::Null)) {
                     continue;

--- a/crates/openehr-its/tests/fixtures/named_event/PROVENANCE.md
+++ b/crates/openehr-its/tests/fixtures/named_event/PROVENANCE.md
@@ -1,0 +1,26 @@
+# `named_event.en.v1` — a repo-authored regression fixture
+
+Derived from the openEHR CNF Robot fixture
+`docs/specs/openehr/CNF/tests/platform/robot/_resources/test_data_sets/valid_templates/minimal_persistent/persistent_minimal.opt`
+(specifications-CNF, commit `33251d2abe5a75c042e11c9385d2e9a79aa15904`,
+CC-BY-SA 3.0 Unported), and licensed under the same terms as a derivative
+work. `LICENSE-CC-BY-SA-3.0` at the repository root is the licence text; the
+declaration is in `REUSE.toml`.
+
+## What was changed and why
+
+The carrier issue is #3142: an operational template may fix `LOCATABLE.name`
+on a node the Simplified Formats collapse away, and no template in any
+vendored corpus does that for a COLLAPSED event. Three edits to the skeleton
+produce one:
+
+- the event is narrowed from the abstract `EVENT` to `POINT_EVENT` and its
+  occurrences from `0..1` to `1..1`, so `master04 §Conditionally Collapsed
+  Wrapper Types` collapses it;
+- a `name` attribute is constrained to the `C_STRING` list `Point in time`,
+  so the collapsed node's name survives only inside the leaf's `aqlPath`;
+- the identifiers, term definitions and the composition category (`433`,
+  event) are renamed to describe the fixture rather than the skeleton.
+
+Everything else, including the template envelope and the `content` /
+`ITEM_TREE` / `ELEMENT` chain, is the upstream skeleton unchanged.

--- a/crates/openehr-its/tests/fixtures/named_event/named_event.opt
+++ b/crates/openehr-its/tests/fixtures/named_event/named_event.opt
@@ -1,0 +1,351 @@
+<?xml version="1.0" encoding="utf-8"?>
+<template xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://schemas.openehr.org/v1">
+  <language>
+    <terminology_id>
+      <value>ISO_639-1</value>
+    </terminology_id>
+    <code_string>en</code_string>
+  </language>
+  <description>
+    <original_author id="Original Author">Not Specified</original_author>
+    <lifecycle_state>Initial</lifecycle_state>
+    <other_details id="MetaDataSet:Sample Set ">Template metadata sample set </other_details>
+    <other_details id="Acknowledgements"></other_details>
+    <other_details id="Business Process Level"></other_details>
+    <other_details id="Care setting"></other_details>
+    <other_details id="Client group"></other_details>
+    <other_details id="Clinical Record Element"></other_details>
+    <other_details id="Copyright"></other_details>
+    <other_details id="Issues"></other_details>
+    <other_details id="Owner"></other_details>
+    <other_details id="Sign off"></other_details>
+    <other_details id="Speciality"></other_details>
+    <other_details id="User roles"></other_details>
+    <details>
+      <language>
+        <terminology_id>
+          <value>ISO_639-1</value>
+        </terminology_id>
+        <code_string>en</code_string>
+      </language>
+      <purpose>Not Specified</purpose>
+    </details>
+  </description>
+  <uid>
+    <value>8d0f5f1c-2c1e-4a2c-9a2b-6f2a0b9f3d41</value>
+  </uid>
+  <template_id>
+    <value>named_event.en.v1</value>
+  </template_id>
+  <concept>named event</concept>
+  <definition>
+    <rm_type_name>COMPOSITION</rm_type_name>
+    <occurrences>
+      <lower_included>true</lower_included>
+      <upper_included>true</upper_included>
+      <lower_unbounded>false</lower_unbounded>
+      <upper_unbounded>false</upper_unbounded>
+      <lower>1</lower>
+      <upper>1</upper>
+    </occurrences>
+    <node_id>at0000</node_id>
+    <attributes xsi:type="C_SINGLE_ATTRIBUTE">
+      <rm_attribute_name>category</rm_attribute_name>
+      <existence>
+        <lower_included>true</lower_included>
+        <upper_included>true</upper_included>
+        <lower_unbounded>false</lower_unbounded>
+        <upper_unbounded>false</upper_unbounded>
+        <lower>1</lower>
+        <upper>1</upper>
+      </existence>
+      <children xsi:type="C_COMPLEX_OBJECT">
+        <rm_type_name>DV_CODED_TEXT</rm_type_name>
+        <occurrences>
+          <lower_included>true</lower_included>
+          <upper_included>true</upper_included>
+          <lower_unbounded>false</lower_unbounded>
+          <upper_unbounded>false</upper_unbounded>
+          <lower>1</lower>
+          <upper>1</upper>
+        </occurrences>
+        <node_id />
+        <attributes xsi:type="C_SINGLE_ATTRIBUTE">
+          <rm_attribute_name>defining_code</rm_attribute_name>
+          <existence>
+            <lower_included>true</lower_included>
+            <upper_included>true</upper_included>
+            <lower_unbounded>false</lower_unbounded>
+            <upper_unbounded>false</upper_unbounded>
+            <lower>1</lower>
+            <upper>1</upper>
+          </existence>
+          <children xsi:type="C_CODE_PHRASE">
+            <rm_type_name>CODE_PHRASE</rm_type_name>
+            <occurrences>
+              <lower_included>true</lower_included>
+              <upper_included>true</upper_included>
+              <lower_unbounded>false</lower_unbounded>
+              <upper_unbounded>false</upper_unbounded>
+              <lower>1</lower>
+              <upper>1</upper>
+            </occurrences>
+            <node_id />
+            <terminology_id>
+              <value>openehr</value>
+            </terminology_id>
+            <code_list>433</code_list>
+          </children>
+        </attributes>
+      </children>
+    </attributes>
+    <attributes xsi:type="C_MULTIPLE_ATTRIBUTE">
+      <rm_attribute_name>content</rm_attribute_name>
+      <existence>
+        <lower_included>true</lower_included>
+        <upper_included>true</upper_included>
+        <lower_unbounded>false</lower_unbounded>
+        <upper_unbounded>false</upper_unbounded>
+        <lower>0</lower>
+        <upper>1</upper>
+      </existence>
+      <children xsi:type="C_ARCHETYPE_ROOT">
+        <rm_type_name>OBSERVATION</rm_type_name>
+        <occurrences>
+          <lower_included>true</lower_included>
+          <lower_unbounded>false</lower_unbounded>
+          <upper_unbounded>true</upper_unbounded>
+          <lower>0</lower>
+        </occurrences>
+        <node_id>at0000</node_id>
+        <attributes xsi:type="C_SINGLE_ATTRIBUTE">
+          <rm_attribute_name>data</rm_attribute_name>
+          <existence>
+            <lower_included>true</lower_included>
+            <upper_included>true</upper_included>
+            <lower_unbounded>false</lower_unbounded>
+            <upper_unbounded>false</upper_unbounded>
+            <lower>1</lower>
+            <upper>1</upper>
+          </existence>
+          <children xsi:type="C_COMPLEX_OBJECT">
+            <rm_type_name>HISTORY</rm_type_name>
+            <occurrences>
+              <lower_included>true</lower_included>
+              <upper_included>true</upper_included>
+              <lower_unbounded>false</lower_unbounded>
+              <upper_unbounded>false</upper_unbounded>
+              <lower>1</lower>
+              <upper>1</upper>
+            </occurrences>
+            <node_id>at0001</node_id>
+            <attributes xsi:type="C_MULTIPLE_ATTRIBUTE">
+              <rm_attribute_name>events</rm_attribute_name>
+              <existence>
+                <lower_included>true</lower_included>
+                <upper_included>true</upper_included>
+                <lower_unbounded>false</lower_unbounded>
+                <upper_unbounded>false</upper_unbounded>
+                <lower>0</lower>
+                <upper>1</upper>
+              </existence>
+              <children xsi:type="C_COMPLEX_OBJECT">
+                <rm_type_name>POINT_EVENT</rm_type_name>
+                <occurrences>
+                  <lower_included>true</lower_included>
+                  <upper_included>true</upper_included>
+                  <lower_unbounded>false</lower_unbounded>
+                  <upper_unbounded>false</upper_unbounded>
+                  <lower>1</lower>
+                  <upper>1</upper>
+                </occurrences>
+                <node_id>at0002</node_id>
+                <attributes xsi:type="C_SINGLE_ATTRIBUTE">
+                  <rm_attribute_name>name</rm_attribute_name>
+                  <existence>
+                    <lower_included>true</lower_included>
+                    <upper_included>true</upper_included>
+                    <lower_unbounded>false</lower_unbounded>
+                    <upper_unbounded>false</upper_unbounded>
+                    <lower>1</lower>
+                    <upper>1</upper>
+                  </existence>
+                  <children xsi:type="C_COMPLEX_OBJECT">
+                    <rm_type_name>DV_TEXT</rm_type_name>
+                    <occurrences>
+                      <lower_included>true</lower_included>
+                      <upper_included>true</upper_included>
+                      <lower_unbounded>false</lower_unbounded>
+                      <upper_unbounded>false</upper_unbounded>
+                      <lower>1</lower>
+                      <upper>1</upper>
+                    </occurrences>
+                    <node_id />
+                    <attributes xsi:type="C_SINGLE_ATTRIBUTE">
+                      <rm_attribute_name>value</rm_attribute_name>
+                      <existence>
+                        <lower_included>true</lower_included>
+                        <upper_included>true</upper_included>
+                        <lower_unbounded>false</lower_unbounded>
+                        <upper_unbounded>false</upper_unbounded>
+                        <lower>1</lower>
+                        <upper>1</upper>
+                      </existence>
+                      <children xsi:type="C_PRIMITIVE_OBJECT">
+                        <rm_type_name>STRING</rm_type_name>
+                        <occurrences>
+                          <lower_included>true</lower_included>
+                          <upper_included>true</upper_included>
+                          <lower_unbounded>false</lower_unbounded>
+                          <upper_unbounded>false</upper_unbounded>
+                          <lower>1</lower>
+                          <upper>1</upper>
+                        </occurrences>
+                        <node_id />
+                        <item xsi:type="C_STRING">
+                          <list>Point in time</list>
+                        </item>
+                      </children>
+                    </attributes>
+                  </children>
+                </attributes>
+                <attributes xsi:type="C_SINGLE_ATTRIBUTE">
+                  <rm_attribute_name>data</rm_attribute_name>
+                  <existence>
+                    <lower_included>true</lower_included>
+                    <upper_included>true</upper_included>
+                    <lower_unbounded>false</lower_unbounded>
+                    <upper_unbounded>false</upper_unbounded>
+                    <lower>1</lower>
+                    <upper>1</upper>
+                  </existence>
+                  <children xsi:type="C_COMPLEX_OBJECT">
+                    <rm_type_name>ITEM_TREE</rm_type_name>
+                    <occurrences>
+                      <lower_included>true</lower_included>
+                      <upper_included>true</upper_included>
+                      <lower_unbounded>false</lower_unbounded>
+                      <upper_unbounded>false</upper_unbounded>
+                      <lower>1</lower>
+                      <upper>1</upper>
+                    </occurrences>
+                    <node_id>at0003</node_id>
+                    <attributes xsi:type="C_MULTIPLE_ATTRIBUTE">
+                      <rm_attribute_name>items</rm_attribute_name>
+                      <existence>
+                        <lower_included>true</lower_included>
+                        <upper_included>true</upper_included>
+                        <lower_unbounded>false</lower_unbounded>
+                        <upper_unbounded>false</upper_unbounded>
+                        <lower>0</lower>
+                        <upper>1</upper>
+                      </existence>
+                      <children xsi:type="C_COMPLEX_OBJECT">
+                        <rm_type_name>ELEMENT</rm_type_name>
+                        <occurrences>
+                          <lower_included>true</lower_included>
+                          <upper_included>true</upper_included>
+                          <lower_unbounded>false</lower_unbounded>
+                          <upper_unbounded>false</upper_unbounded>
+                          <lower>0</lower>
+                          <upper>1</upper>
+                        </occurrences>
+                        <node_id>at0004</node_id>
+                        <attributes xsi:type="C_SINGLE_ATTRIBUTE">
+                          <rm_attribute_name>value</rm_attribute_name>
+                          <existence>
+                            <lower_included>true</lower_included>
+                            <upper_included>true</upper_included>
+                            <lower_unbounded>false</lower_unbounded>
+                            <upper_unbounded>false</upper_unbounded>
+                            <lower>0</lower>
+                            <upper>1</upper>
+                          </existence>
+                          <children xsi:type="C_COMPLEX_OBJECT">
+                            <rm_type_name>DV_TEXT</rm_type_name>
+                            <occurrences>
+                              <lower_included>true</lower_included>
+                              <upper_included>true</upper_included>
+                              <lower_unbounded>false</lower_unbounded>
+                              <upper_unbounded>false</upper_unbounded>
+                              <lower>1</lower>
+                              <upper>1</upper>
+                            </occurrences>
+                            <node_id />
+                          </children>
+                        </attributes>
+                      </children>
+                      <cardinality>
+                        <is_ordered>false</is_ordered>
+                        <is_unique>false</is_unique>
+                        <interval>
+                          <lower_included>true</lower_included>
+                          <lower_unbounded>false</lower_unbounded>
+                          <upper_unbounded>true</upper_unbounded>
+                          <lower>0</lower>
+                        </interval>
+                      </cardinality>
+                    </attributes>
+                  </children>
+                </attributes>
+              </children>
+              <cardinality>
+                <is_ordered>false</is_ordered>
+                <is_unique>false</is_unique>
+                <interval>
+                  <lower_included>true</lower_included>
+                  <lower_unbounded>false</lower_unbounded>
+                  <upper_unbounded>true</upper_unbounded>
+                  <lower>1</lower>
+                </interval>
+              </cardinality>
+            </attributes>
+          </children>
+        </attributes>
+        <archetype_id>
+          <value>openEHR-EHR-OBSERVATION.named_event.v1</value>
+        </archetype_id>
+        <term_definitions code="at0000">
+          <items id="description">unknown</items>
+          <items id="text">Named event observation</items>
+        </term_definitions>
+        <term_definitions code="at0001">
+          <items id="description">@ internal @</items>
+          <items id="text">Event Series</items>
+        </term_definitions>
+        <term_definitions code="at0002">
+          <items id="description">*</items>
+          <items id="text">Point in time</items>
+        </term_definitions>
+        <term_definitions code="at0003">
+          <items id="description">@ internal @</items>
+          <items id="text">Tree</items>
+        </term_definitions>
+        <term_definitions code="at0004">
+          <items id="description">*</items>
+          <items id="text">Reading</items>
+        </term_definitions>
+      </children>
+      <cardinality>
+        <is_ordered>false</is_ordered>
+        <is_unique>false</is_unique>
+        <interval>
+          <lower_included>true</lower_included>
+          <lower_unbounded>false</lower_unbounded>
+          <upper_unbounded>true</upper_unbounded>
+          <lower>0</lower>
+        </interval>
+      </cardinality>
+    </attributes>
+    <archetype_id>
+      <value>openEHR-EHR-COMPOSITION.named_event.v1</value>
+    </archetype_id>
+    <template_id>
+      <value>named_event.en.v1</value>
+    </template_id>
+    <term_definitions code="at0000">
+      <items id="description">unknown</items>
+      <items id="text">Named event</items>
+    </term_definitions>
+  </definition>
+</template>

--- a/crates/openehr-its/tests/it/flat.rs
+++ b/crates/openehr-its/tests/it/flat.rs
@@ -35,6 +35,7 @@
 use std::collections::BTreeMap;
 
 use openehr_its::flat::convert::{composition_from_flat, composition_to_flat};
+use openehr_its::flat::example::{DetailLevel, example_composition};
 use openehr_its::flat::webtemplate::builder::build_web_template;
 use openehr_its::flat::webtemplate::model::WebTemplate;
 use openehr_its::opt14;
@@ -1061,5 +1062,198 @@ fn careflow_stepped_ism_transition_flattens_to_the_generic_master05_spelling() {
         rm.pointer("/content/0/ism_transition"),
         rm2.pointer("/content/0/ism_transition"),
         "the careflow-stepped ism_transition is round-trip stable"
+    );
+}
+
+// ── a name-constrained wrapper the level removal collapses (#3142) ───────────
+//
+// An OPT may constrain `LOCATABLE.name` on a node the web template compacts
+// away: the single `EVENT` of `master04 §Conditionally Collapsed Wrapper
+// Types`. Its constrained name then survives only inside the leaf's `aqlPath`
+// (`events[at0002,'Point in time']`), so it is the one identity the RM ⇄ FLAT
+// walks cannot see in the tree and must still honour. Carrier: the
+// repo-authored `named_event.en.v1` fixture.
+
+fn named_event_wt() -> WebTemplate {
+    let opt_xml = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/named_event/named_event.opt"
+    ))
+    .unwrap_or_else(|e| panic!("read named_event OPT: {e}"));
+    let opt = opt14::from_xml(&opt_xml).unwrap_or_else(|e| panic!("parse OPT: {e}"));
+    build_web_template(&opt).unwrap_or_else(|e| panic!("build WT: {e}"))
+}
+
+/// The fixture is only a regression carrier while its event stays COLLAPSED and
+/// NAME-CONSTRAINED: a template change that retained the event, or dropped the
+/// `C_STRING`, would leave the two tests below passing vacuously.
+#[test]
+fn the_named_event_fixture_collapses_a_name_constrained_event() {
+    let wt = named_event_wt();
+    let observation = wt
+        .tree
+        .children
+        .iter()
+        .find(|c| c.rm_type == "OBSERVATION")
+        .unwrap_or_else(|| panic!("fixture has an OBSERVATION content node"));
+    assert!(
+        observation
+            .children
+            .iter()
+            .all(|c| c.rm_type != "POINT_EVENT"),
+        "the single 1..1 event is collapsed (master04 §Conditionally Collapsed Wrapper Types)"
+    );
+    let reading = observation
+        .children
+        .iter()
+        .find(|c| c.id == "reading")
+        .unwrap_or_else(|| panic!("fixture has a `reading` leaf"));
+    assert!(
+        reading
+            .aql_path
+            .contains("/events[at0002,'Point in time']/"),
+        "the collapsed event's constrained name survives in the leaf path: {}",
+        reading.aql_path
+    );
+}
+
+/// A composition whose collapsed `POINT_EVENT` carries a name OTHER than the one
+/// its template constrains still projects its content into FLAT.
+///
+/// The `[at0002,'Point in time']` conjunct is redundant for identification here —
+/// no sibling constraint claims `events[at0002]` under another name — so the step
+/// falls back to the `archetype_node_id` alone rather than locating nothing
+/// (RM common `master03-archetyped_package.adoc` §"The `LOCATABLE` class": a
+/// runtime `name` distinguishes siblings sharing an `archetype_node_id`; BASE
+/// `architecture_overview/master11-paths.adoc` §"Using a Name-based Predicate").
+/// Without the fallback the whole event subtree — every datum under it — is
+/// silently absent from the response, which is the defect reported in #3142.
+#[test]
+fn a_renamed_collapsed_event_still_yields_its_content() {
+    let wt = named_event_wt();
+    let mut flat = serde_json::Map::new();
+    flat.insert("ctx/language".to_owned(), Value::String("en".into()));
+    flat.insert("ctx/territory".to_owned(), Value::String("US".into()));
+    flat.insert(
+        "ctx/composer_name".to_owned(),
+        Value::String("Dr. Marcus Johnson".into()),
+    );
+    flat.insert(
+        "named_event/named_event_observation:0/reading".to_owned(),
+        Value::String("120 over 80".into()),
+    );
+    let mut rm = composition_from_flat(&flat, &wt, NOW).expect("from_flat");
+
+    let event_name = rm
+        .pointer_mut("/content/0/data/events/0/name/value")
+        .unwrap_or_else(|| panic!("the built composition carries the collapsed event"));
+    *event_name = Value::String("at0002".into());
+
+    let flat_again = composition_to_flat(&rm, &wt).expect("to_flat");
+    assert_eq!(
+        flat_again
+            .get("named_event/named_event_observation:0/reading")
+            .and_then(Value::as_str),
+        Some("120 over 80"),
+        "the renamed event's content is still projected: {:?}",
+        flat_again.keys().collect::<Vec<_>>()
+    );
+}
+
+/// Building a collapsed wrapper stamps the name its own template path
+/// constrains, not the `archetype_node_id` placeholder.
+///
+/// A wrapper named anything else does not satisfy the path it was created for,
+/// so every datum beneath it becomes unaddressable — the composition is written
+/// once and then reads back short, which is how #3142 was produced in the first
+/// place.
+#[test]
+fn a_built_collapsed_event_takes_the_name_its_template_constrains() {
+    let wt = named_event_wt();
+    let mut flat = serde_json::Map::new();
+    flat.insert("ctx/language".to_owned(), Value::String("en".into()));
+    flat.insert("ctx/territory".to_owned(), Value::String("US".into()));
+    flat.insert(
+        "ctx/composer_name".to_owned(),
+        Value::String("Dr. Marcus Johnson".into()),
+    );
+    flat.insert(
+        "named_event/named_event_observation:0/reading".to_owned(),
+        Value::String("120 over 80".into()),
+    );
+    let rm = composition_from_flat(&flat, &wt, NOW).expect("from_flat");
+    assert_eq!(
+        rm.pointer("/content/0/data/events/0/name/value")
+            .and_then(Value::as_str),
+        Some("Point in time"),
+        "the synthesized POINT_EVENT takes its constrained name"
+    );
+    assert_eq!(
+        rm.pointer("/content/0/data/events/0/archetype_node_id")
+            .and_then(Value::as_str),
+        Some("at0002"),
+        "and keeps its archetype node id"
+    );
+}
+
+/// The id-only fallback must NOT fire where the name is the DISCRIMINATOR.
+///
+/// The vendored COVID-19 report template fills `content` with four
+/// `openEHR-EHR-SECTION.adhoc.v1` siblings distinguished only by their
+/// constrained names ('Reporting', 'Clinical status', 'Exposure', 'Outcome').
+/// Dropping the name there would let the sibling whose section was renamed claim
+/// every section, so one section's slot would report all four sections' content
+/// — the opposite failure to #3142 and the reason the fallback is conditional
+/// rather than unconditional.
+#[test]
+fn a_name_discriminated_sibling_set_takes_no_id_only_fallback() {
+    let opt_xml =
+        std::fs::read_to_string("../../corpus/templates/ckm/covid19-infection-report.opt")
+            .unwrap_or_else(|e| panic!("read covid19 OPT: {e}"));
+    let opt = opt14::from_xml(&opt_xml).unwrap_or_else(|e| panic!("parse OPT: {e}"));
+    let wt = build_web_template(&opt).unwrap_or_else(|e| panic!("build WT: {e}"));
+    let sections: Vec<String> = wt
+        .tree
+        .children
+        .iter()
+        .filter(|c| {
+            c.aql_path
+                .starts_with("/content[openEHR-EHR-SECTION.adhoc.v1,'")
+        })
+        .map(|c| c.id.clone())
+        .collect();
+    assert!(
+        sections.len() > 1,
+        "the carrier really has name-differentiated adhoc sections: {sections:?}"
+    );
+
+    let mut composition = example_composition(&wt, DetailLevel::Medium);
+    let before = composition_to_flat(&composition, &wt).expect("to_flat");
+    assert!(
+        before.keys().any(|k| k.contains("/reporting:0/first_test")),
+        "the example really populates the Reporting section"
+    );
+
+    let renamed = composition
+        .pointer_mut("/content")
+        .and_then(Value::as_array_mut)
+        .unwrap_or_else(|| panic!("the example carries content"))
+        .iter_mut()
+        .find(|c| c.pointer("/name/value").and_then(Value::as_str) == Some("Reporting"))
+        .unwrap_or_else(|| panic!("the example carries the Reporting section"));
+    renamed["name"]["value"] = Value::String("A name no sibling constrains".into());
+
+    let after = composition_to_flat(&composition, &wt).expect("to_flat");
+    let leaked: Vec<&String> = after
+        .keys()
+        .filter(|k| k.contains("/reporting:") && !k.contains("/first_test"))
+        .collect();
+    assert!(
+        leaked.is_empty(),
+        "no sibling section's content is claimed by the renamed one: {leaked:?}"
+    );
+    assert!(
+        !after.keys().any(|k| k.contains("/reporting:")),
+        "and the renamed section is claimed by no name-differentiated sibling at all"
     );
 }

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-lang"
-version = "0.0.61"
+version = "0.0.62"
 description = "openEHR LANG BMM/P_BMM object model, generated from BMM: generations v1_0 (LANG 1.0.0) and v1_1 (LANG 1.1.0, current; the stable BMM v2.x unit beside the paused BMM3 unit), plus hand-written ODIN/BEL/EL readers"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["parser-implementations", "data-structures"]
 include = ["src/**", "README.md", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.61" }
+openehr-base = { path = "../openehr-base", version = "0.0.62" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the
 # generated types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) —
 # never a derive. `serde_json` also carries the untyped `Value` fields the

--- a/crates/openehr-query/Cargo.toml
+++ b/crates/openehr-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-query"
-version = "0.0.61"
+version = "0.0.62"
 description = "openEHR QUERY (AQL 1.1.0): hand-written lexer, parser, typed AST and canonical printer from the official grammar (no ANTLR runtime)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-rm"
-version = "0.0.61"
+version = "0.0.62"
 description = "openEHR RM Reference Model, generated from BMM: generations v1_1 (RM 1.1.0) and v1_2 (RM 1.2.0, current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,11 +13,11 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.61" }
+openehr-base = { path = "../openehr-base", version = "0.0.62" }
 # The terminology-backed RM class invariants (`validate::terminology`) resolve
 # openEHR terminology groups + code sets against the vendored TERM 3.1.0 bundle.
 # `openehr-term` itself depends only on `openehr-base`, so this is acyclic.
-openehr-term = { path = "../openehr-term", version = "0.0.61" }
+openehr-term = { path = "../openehr-term", version = "0.0.62" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also backs the untyped `Value` RM representation used by

--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-term"
-version = "0.0.61"
+version = "0.0.62"
 description = "openEHR TERM terminology data model, generated from BMM (generation v3_1 = TERM 3.1.0), plus the embedded official terminology XML bundle"
 edition.workspace = true
 rust-version.workspace = true
@@ -34,7 +34,7 @@ include = [
 ]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.61" }
+openehr-base = { path = "../openehr-base", version = "0.0.62" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1276,7 +1276,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.61"
+version = "0.0.62"
 dependencies = [
  "indexmap",
  "openehr-am",
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.61"
+version = "0.0.62"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.61"
+version = "0.0.62"
 dependencies = [
  "serde",
  "serde_json",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.61"
+version = "0.0.62"
 dependencies = [
  "async-trait",
  "axum",
@@ -1337,7 +1337,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.61"
+version = "0.0.62"
 dependencies = [
  "chumsky",
  "indexmap",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.61"
+version = "0.0.62"
 dependencies = [
  "chumsky",
  "logos",
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.61"
+version = "0.0.62"
 dependencies = [
  "openehr-base",
  "openehr-term",
@@ -1374,7 +1374,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.61"
+version = "0.0.62"
 dependencies = [
  "openehr-base",
  "roxmltree",


### PR DESCRIPTION
A composition written through the FLAT surface came back short. The reporter's body weight and comment were in the canonical JSON and absent from `application/openehr.wt.flat+json`, with no error to say so.

## What was wrong

An operational template may fix `LOCATABLE.name` on a node the Simplified Formats collapse away. The live case is the single `1..1` event of a `HISTORY`, which `simplified_formats/master04-basic_concepts.adoc` §"Conditionally Collapsed Wrapper Types" removes from the tree. Its constrained name then survives only inside the leaf's `aqlPath`, as the `events[at0002,'Point in time']` conjunct, which makes it the one identity the RM ⇄ FLAT walks cannot see in the instance and must still honour.

Neither of them did, and the two failures compounded:

- **Writing.** `build::new_struct` named a synthesised collapsed wrapper after its `archetype_node_id`, ignoring the segment's own name conjunct. The node therefore did not satisfy the path it had just been created for.
- **Reading.** `flatten` resolved each child's relative path strictly, so a step whose name the instance did not carry located nothing, and the entire subtree beneath it vanished from the response.

The archetype-conformance validator already tolerated the renamed node (`select_group_children`, the id-only fallback arm), which is why the composition committed cleanly and only the read was short.

## What lands

`new_struct` prefers the segment's name conjunct over the node-id placeholder, then the web-template child's name, then the id.

The three walks share ONE rule, `rmpath::NameFallback`: a table built per parent from its template paths, mapping each `(attribute, archetype_node_id)` to the single name every path spells for it, or to nothing when they disagree. A step falls back to the node id alone only when its name is redundant by that test. The table is computed once per node in the cached `NodeWalk` plan and read by the flattener and the validator alike.

The validator's intermediate navigation takes the same table. That closes a second hole in passing: a mandatory node under a renamed intermediate was never reached, so its `min` was never checked and its absence was accepted silently.

Compositions already stored with the wrong name read correctly without being rewritten.

## Why the fallback is conditional

Unconditional widening is the opposite defect. The vendored COVID-19 report template fills `content` with four `openEHR-EHR-SECTION.adhoc.v1` siblings distinguished only by their constrained names, and dropping the name there would let the renamed sibling claim all four sections. `a_name_discriminated_sibling_set_takes_no_id_only_fallback` pins that, over the real template, with real content in the section.

Grounds for tolerating the rename at all: RM common `master03-archetyped_package.adoc` §"The `LOCATABLE` class" (a runtime `name` distinguishes sibling nodes sharing an `archetype_node_id`) and BASE `architecture_overview/master11-paths.adoc` §"Using a Name-based Predicate". This is the rule the validator already applied; the change is that the projection now applies the same one.

## The carrier

No vendored template constrains the name of a COLLAPSED event, so `named_event.en.v1` is repo-authored: the CNF Robot `persistent_minimal` skeleton with its event narrowed to a `POINT_EVENT` occurring exactly once and named by a `C_STRING`. It is a CC-BY-SA 3.0 derivative of openEHR material and says so in its own `PROVENANCE.md` and in `REUSE.toml`; `reuse lint` is green. `the_named_event_fixture_collapses_a_name_constrained_event` guards the carrier itself, so a template edit that retained the event or dropped the constraint cannot leave the other tests passing vacuously.

## Mutation-proven

Each new test was run against a reverted fix and observed to fail:

| Test | Reverted | Result |
|---|---|---|
| `a_renamed_collapsed_event_still_yields_its_content` | tolerant resolution | FAIL |
| `a_built_collapsed_event_takes_the_name_its_template_constrains` | the build-side name | FAIL (`at0002` vs `Point in time`) |
| `a_discriminating_name_conjunct_refuses_the_id_only_fallback` | fallback forced on | FAIL |
| `an_unqualified_sibling_sharing_the_identity_refuses_the_fallback` | fallback forced on | FAIL |
| `a_name_discriminated_sibling_set_takes_no_id_only_fallback` | fallback forced on | FAIL |

## What this does not change

The event stays collapsed. The reporter's expected output showed `point_in_time:0/weight`, which is EHRbase's shape; `master04` §"Conditionally Collapsed Wrapper Types" collapses an event with `max = 1` and no sibling events, so `body_weight/body_weight/weight|magnitude` is the spec-correct key and the fixture pins it.

## Gates

`cargo nextest run --workspace`: 5003 passed, 0 failed. `cargo clippy -p openehr-its --all-targets --all-features -D warnings`, `cargo fmt`, `scripts/checks/comment-style.sh`, `reuse lint`, and the licensing/SPDX guards all green. Packaged crate content changed, so the eight `openehr-*` crates step to `0.0.62` in lockstep with their internal requirements and both lockfiles.

Closes #3142.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.

## Checks

- [x] `cargo fmt --all --check` · `cargo clippy --workspace --all-targets` · `cargo nextest run --workspace`
- [x] No test weakened, skipped, or edited to route around a bug
- [x] User-visible change → `CHANGELOG.md [Unreleased]` entry
- [ ] REST/config/CLI/deployment change → matching `website/book/src` page updated (no such change: the FLAT wire keys are unchanged, this restores keys that were being dropped)
- [x] No implemented plan file to delete
- [x] No new issues opened from this work

