### PR TITLE
docs(licensing): the commercial-licence boundary, answerable at a glance

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ ITS-REST 1.1.0 &nbsp;·&nbsp; AQL 1.1 &nbsp;·&nbsp; RM 1.2.0 **+ 1.1.0** &nbsp;
 [![CNF performance](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Frubentalstra%2Fferroehr%2Fmain%2Fdocs%2Fconformance%2Fferroehr%2Fbadge-performance.json)](docs/conformance/ferroehr/CONFORMANCE_CERTIFICATE.md)
 [![SLSA Build L3](https://slsa.dev/images/gh-badge-level3.svg)](https://ferroehr.eu/docs/latest/verifying-releases.html#what-slsa-level-each-artifact-reaches)
 
-[**Live sandbox**](https://sandbox.ferroehr.eu) · [**Documentation**](https://ferroehr.eu/) · [Why this exists](#why-this-project-exists) · [Quick start](#quick-start) · [Features](#features) · [Spec versions](#choose-your-openehr-specification-generation) · [Rust crates](#the-openehr-specification-layer-as-rust-crates) · [Architecture](#architecture) · [Conformance](#conformance-measured) · [Deployment](#deployment) · [Roadmap](https://github.com/users/rubentalstra/projects/4) · [Contributing](#contributing-and-security)
+[**Live sandbox**](https://sandbox.ferroehr.eu) · [**Documentation**](https://ferroehr.eu/) · [Why this exists](#why-this-project-exists) · [**Do you need a commercial licence?**](#do-you-need-a-commercial-licence) · [Quick start](#quick-start) · [Features](#features) · [Spec versions](#choose-your-openehr-specification-generation) · [Rust crates](#the-openehr-specification-layer-as-rust-crates) · [Architecture](#architecture) · [Conformance](#conformance-measured) · [Deployment](#deployment) · [Roadmap](https://github.com/users/rubentalstra/projects/4) · [Contributing](#contributing-and-security)
 
 </div>
 
@@ -62,31 +62,11 @@ measured against the specification itself. That is what FerroEHR is for.
 The whole thing is source-available under the Business Source License 1.1,
 with no open-core tier. Multi-tenancy, RBAC/ABAC, ATNA audit, signatures,
 FHIR, events and the viewer are all in this repository under the same
-licence, and nothing is held back to be sold back to you.
-
-The licence lets you read, build, modify and redistribute the source without
-a fee and without asking anyone, and it covers every non-production use:
-development, testing, evaluation and prototyping. Production use is free for
-Non-Commercial Purposes, which the licence defines as personal use, academic
-or scientific research, teaching, and use by a non-profit organisation or
-public body that is not in the course of a business, does not deliver a
-service for payment, and is not for commercial advantage. Any other
-production use needs a commercial licence from the Licensor, including the
-delivery of health care or any other service for payment. A hospital, clinic
-or care provider running FerroEHR for its patients needs one, and so does a
-vendor, integrator or any company running it in production. Hosting FerroEHR,
-or a work derived from it, for third parties as a hosted, managed or embedded
-service, and selling, sublicensing or otherwise distributing it for a fee on
-its own or inside another product, need a commercial licence in every case.
-Each version becomes Apache License 2.0 four years after that version is
-published. The five generated `openehr-*` model crates are outside all of this:
-they are Apache-2.0 on crates.io, so any Rust project can use them without a
-licence conversation; the three hand-written engines (`openehr-query`,
-`openehr-adl`, `openehr-its`) carry the same Business Source License as the
-application. Companies and care providers building on FerroEHR are wanted here,
-and the commercial licence is the normal path for them. It starts with a
-short conversation with the maintainer named in
-[MAINTAINERS.md](MAINTAINERS.md).
+licence, and nothing is held back to be sold back to you. Reading, building,
+modifying and redistributing the source is free, and so is every
+non-production use. Production use is free for Non-Commercial Purposes and
+needs a commercial licence otherwise:
+[the table below says which applies to you](#do-you-need-a-commercial-licence).
 
 What we ask in return, and cannot require, is that improvements come back.
 A private fork inherits the entire maintenance surface (spec releases,
@@ -631,6 +611,41 @@ Two of those are worth reading before a procurement decision rather than
 after: the project has **one maintainer**, and **only the newest release
 receives security fixes**. Both are stated plainly in the documents above
 rather than left to be discovered.
+
+## Do you need a commercial licence?
+
+FerroEHR is source-available under the Business Source License 1.1, which is
+not an OSI-approved open-source licence. [`LICENSE`](LICENSE) is the authority
+and names the Licensor, the Licensed Work, the Additional Use Grant and the
+Change Date; this table is the same boundary in the order people ask about it.
+
+| What you are doing | What you need | Why |
+|---|---|---|
+| Reading, building, modifying or redistributing the source | Free | The licence grants it without a fee and without asking anyone. |
+| Development, testing, evaluation, prototyping | Free | All non-production use is granted. |
+| Production use for Non-Commercial Purposes | Free | Personal use, academic or scientific research, teaching, and use by a non-profit organisation or public body that is not in the course of a business, does not deliver a service for payment, and is not for commercial advantage. |
+| A hospital, clinic or care provider running it for its patients | Commercial licence | Delivering health care, or any other service for payment, is production use outside the grant. |
+| A vendor or integrator, or any company running it in production | Commercial licence | Production use in the course of a business is outside the grant. |
+| Offering it, or a work derived from it, to third parties as a hosted, managed or embedded service | Commercial licence | Excluded from the grant in every case, whoever you are. |
+| Selling, sublicensing or otherwise distributing it for a fee | Commercial licence | Excluded from the grant in every case, whoever you are. |
+
+The last two rows hold whatever else you are: they need a commercial licence
+even for an organisation the rows above would otherwise leave free.
+
+**Each version becomes Apache License 2.0 four years after that version is
+published.** Companies and care providers building on FerroEHR are wanted
+here, and the commercial licence is the normal path for them. It starts with
+a short conversation with the maintainer named in
+[MAINTAINERS.md](MAINTAINERS.md).
+
+The eight `openehr-*` crates on crates.io are a separate question. The five
+generated model crates (`openehr-base`, `openehr-rm`, `openehr-am`,
+`openehr-lang`, `openehr-term`) are Apache-2.0, so any Rust project can use
+them without a licence conversation; the three hand-written engines
+(`openehr-query`, `openehr-adl`, `openehr-its`) carry the same Business
+Source License as the application. The full picture, including every vendored
+third-party tree, is on the documentation site's
+[Licensing & legal](https://ferroehr.eu/docs/latest/licensing.html) page.
 
 ## Acknowledgments and license
 

--- a/website/book/src/licensing.md
+++ b/website/book/src/licensing.md
@@ -7,6 +7,40 @@ summary for evaluators and deployers, not legal advice.
 
 <!-- toc -->
 
+## Do you need a commercial licence?
+
+FerroEHR is source-available under the Business Source License 1.1, which is
+not an OSI-approved open-source licence.
+[`LICENSE`](https://github.com/rubentalstra/FerroEHR/blob/main/LICENSE) is the
+authority and names the Licensor, the Licensed Work, the Additional Use Grant
+and the Change Date; this table is the same boundary in the order people ask
+about it, and the sections below give the full text of each rule.
+
+| What you are doing | What you need | Why |
+|---|---|---|
+| Reading, building, modifying or redistributing the source | Free | The licence grants it without a fee and without asking anyone. |
+| Development, testing, evaluation, prototyping | Free | All non-production use is granted. |
+| Production use for Non-Commercial Purposes | Free | Personal use, academic or scientific research, teaching, and use by a non-profit organisation or public body that is not in the course of a business, does not deliver a service for payment, and is not for commercial advantage. |
+| A hospital, clinic or care provider running it for its patients | Commercial licence | Delivering health care, or any other service for payment, is production use outside the grant. |
+| A vendor or integrator, or any company running it in production | Commercial licence | Production use in the course of a business is outside the grant. |
+| Offering it, or a work derived from it, to third parties as a hosted, managed or embedded service | Commercial licence | Excluded from the grant in every case, whoever you are. |
+| Selling, sublicensing or otherwise distributing it for a fee | Commercial licence | Excluded from the grant in every case, whoever you are. |
+
+The last two rows hold whatever else you are: they need a commercial licence
+even for an organisation the rows above would otherwise leave free.
+
+Each version becomes Apache License 2.0 four years after that version is
+published. A commercial licence starts with a short conversation with the
+maintainer named in
+[`MAINTAINERS.md`](https://github.com/rubentalstra/FerroEHR/blob/main/MAINTAINERS.md).
+
+The eight `openehr-*` crates on crates.io are a separate question. The five
+generated model crates are Apache-2.0, so any Rust project can use them without
+a licence conversation; the three hand-written engines carry the same Business
+Source License as the application. Full detail is under
+[FerroEHR's own code](#ferroehrs-own-code-the-business-source-license-11)
+below.
+
 ## FerroEHR's own code: the Business Source License 1.1
 
 Everything written for this project (the server and application crates, the

--- a/website/book/src/why-ferroehr.md
+++ b/website/book/src/why-ferroehr.md
@@ -67,27 +67,25 @@ and published*.
 
 ## Running FerroEHR commercially
 
-FerroEHR is source-available under the Business Source License 1.1:
+FerroEHR is source-available under the Business Source License 1.1, which is
+not an OSI-approved open-source licence. One licence covers the whole
+repository, and no feature is held back for a paid tier.
 
-- Read it, build it, modify it and redistribute it without a fee. One licence
-  covers the whole repository, and no feature is held back for a paid tier.
-- All non-production use is free: development, testing, evaluation and
-  prototyping.
-- Production use is free for Non-Commercial Purposes, which the licence
-  defines as personal use, academic or scientific research, teaching, and use
-  by a non-profit organisation or public body that is not in the course of a
-  business, does not deliver a service for payment, and is not for commercial
-  advantage.
-- Any other production use needs a commercial licence from the Licensor,
-  including the delivery of health care or any other service for payment. A
-  hospital, clinic or care provider running FerroEHR for its patients needs
-  one, and so does a vendor, integrator or any company running it in
-  production. Hosting FerroEHR, or a work derived from it, for third parties
-  as a hosted, managed or embedded service, and selling, sublicensing or
-  otherwise distributing it for a fee on its own or inside another product,
-  need one in every case.
-- Each version becomes Apache 2.0 four years after it is published, so what
-  ships today opens up on a published schedule.
+| What you are doing | What you need | Why |
+|---|---|---|
+| Reading, building, modifying or redistributing the source | Free | The licence grants it without a fee and without asking anyone. |
+| Development, testing, evaluation, prototyping | Free | All non-production use is granted. |
+| Production use for Non-Commercial Purposes | Free | Personal use, academic or scientific research, teaching, and use by a non-profit organisation or public body that is not in the course of a business, does not deliver a service for payment, and is not for commercial advantage. |
+| A hospital, clinic or care provider running it for its patients | Commercial licence | Delivering health care, or any other service for payment, is production use outside the grant. |
+| A vendor or integrator, or any company running it in production | Commercial licence | Production use in the course of a business is outside the grant. |
+| Offering it, or a work derived from it, to third parties as a hosted, managed or embedded service | Commercial licence | Excluded from the grant in every case, whoever you are. |
+| Selling, sublicensing or otherwise distributing it for a fee | Commercial licence | Excluded from the grant in every case, whoever you are. |
+
+The last two rows hold whatever else you are: they need a commercial licence
+even for an organisation the rows above would otherwise leave free. Each
+version becomes Apache 2.0 four years after it is published, so what ships
+today opens up on a published schedule. [Licensing & legal](licensing.md)
+carries the full picture, including every vendored third-party tree.
 
 Building products on FerroEHR is welcome, and it is how standards reach
 patients. Companies and care providers running FerroEHR are wanted here, and

--- a/website/landing/index.html
+++ b/website/landing/index.html
@@ -92,7 +92,7 @@
         "url": "https://ferroehr.eu/",
         "codeRepository": "https://github.com/rubentalstra/FerroEHR",
         "programmingLanguage": "Rust",
-        "license": "https://mariadb.com/bsl11/",
+        "license": "https://github.com/rubentalstra/FerroEHR/blob/main/LICENSE",
         "applicationCategory": "HealthApplication",
         "runtimePlatform": "PostgreSQL 18",
         "isBasedOn": "https://specifications.openehr.org/",
@@ -155,7 +155,7 @@
           <article class="card">
             <div class="ico" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19V6a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v13"/><path d="M4 19a2 2 0 0 0 2 2h14"/><path d="M8 8h8M8 12h5"/></svg></div>
             <h3>One licence, no open-core tier</h3>
-            <p>The whole application is source-available under the Business Source License 1.1, with every capability in one repository and nothing held back for a paid tier. Free for non-commercial production; every other production use needs a commercial licence. Each version becomes Apache 2.0 four years after it is published.</p>
+            <p>The whole application is source-available under the Business Source License 1.1, with every capability in one repository and nothing held back for a paid tier. Reading, building, modifying and redistributing the source is free, and so is every non-production use. Production use is free for personal use, research, teaching and a non-profit or public body outside the course of a business. Treating patients, any other production use by a company, hosting it for third parties, and distributing it for a fee need a commercial licence. Each version becomes Apache 2.0 four years after it is published. <a href="./docs/latest/licensing.html">A table says whether you need one</a>.</p>
           </article>
 
           <article class="card">
@@ -327,7 +327,10 @@
             <span>Ferro<span class="tld">EHR</span></span>
           </a>
           <p>A pure-Rust openEHR® Clinical Data Repository. Code licensed under
-            <a href="https://github.com/rubentalstra/FerroEHR/blob/main/LICENSE" rel="noopener">BUSL-1.1</a>;
+            <a href="https://github.com/rubentalstra/FerroEHR/blob/main/LICENSE" rel="noopener">BUSL-1.1</a>, free
+            outside production and for non-commercial production use, a commercial licence for
+            other production use, Apache 2.0 four years after each version
+            (<a href="./docs/latest/licensing.html">whether you need one</a>);
             vendored openEHR material keeps its upstream
             <a href="https://github.com/rubentalstra/FerroEHR/blob/main/LICENSE-APACHE-2.0" rel="noopener">Apache-2.0</a>,
             <a href="https://github.com/rubentalstra/FerroEHR/blob/main/LICENSE-CC-BY-SA-3.0" rel="noopener">CC-BY-SA 3.0</a>


### PR DESCRIPTION
People keep asking whether they may run FerroEHR in production. The terms were already stated correctly, and in four places at once: a long paragraph inside "Why this project exists" in the README, a bullet list on the book's "Why FerroEHR" page, a prose section on "Licensing & legal", and two sentences on the landing page. A reader had to work through prose to reach the one answer they came for.

**The substance does not change. `LICENSE` stays the authority and is not edited.** This states the same boundary where people land, once, in one shape.

## What lands

- **A "Do you need a commercial licence?" section in the README**, reachable from the top-of-file navigation. The paragraph that used to carry the terms now states the short form and points at it.
- **The same table on both book pages.** "Licensing & legal" gains it above the prose that already spelled out each rule; "Why FerroEHR" §Running FerroEHR commercially replaces its bullet list with it.
- **The landing page states the terms.** The licence card and the footer said which licence applied and linked the file; they now say what is free, what is not, and when it changes, and point at the table.
- **The JSON-LD licence is corrected.** `SoftwareSourceCode.license` pointed at `https://mariadb.com/bsl11/`, the BUSL-1.1 boilerplate, which carries none of this project's parameters. It now names the repository's own `LICENSE`. That is the same defect filed against the umbrella site as rubentalstra/FerroHEALTH#5.

## The framing matches ferrohealth.eu

The umbrella site already publishes this table, and it is live, so its shape is the one everything else adopts: the heading "Do you need a commercial licence?" and the columns `What you are doing | What you need | Why`, with the values `Free` and `Commercial licence`.

The `Why` column is the part worth having. Each row names the clause of `LICENSE` that produces it, so a reader can check the table against the licence rather than trust it. rubentalstra/FerroTERM#429 tracks aligning the table that landed there, which used a different heading and column set.

## The boundary, as the table states it

Free: reading, building, modifying and redistributing the source; every non-production use; and production use for Non-Commercial Purposes, which the licence defines as personal use, academic or scientific research, teaching, and use by a non-profit organisation or public body that is not in the course of a business, does not deliver a service for payment, and is not for commercial advantage.

Commercial licence: a hospital, clinic or care provider running it for its patients; a vendor or integrator, or any company running it in production; offering it to third parties as a hosted, managed or embedded service; and selling, sublicensing or otherwise distributing it for a fee.

## One subtlety a plain table would flatten

The Additional Use Grant reads "production use of the Licensed Work for Non-Commercial Purposes **only, provided that you do not**" host it for third parties or distribute it for a fee. Those two are carve-outs from the non-commercial grant itself, so they need a commercial licence even for an organisation the free rows would otherwise cover. Every copy of the table says so in a sentence directly beneath it, rather than leaving a reader to infer it from row order.

## Checked against `LICENSE` clause by clause

Every row traces to the parameters: the free rows to "copy, modify, create derivative works, redistribute, and make non-production use" plus the `Non-Commercial Purposes` definition verbatim; the paid rows to "Any other production use, including the delivery of health care or any other service for payment" and to carve-outs (a) and (b). The Change Date and the route to a commercial licence are stated everywhere the table is, so neither needs `LICENSE` opened to find.

The eight `openehr-*` crates keep their own answer where a Rust consumer looks for it: the five generated model crates are Apache-2.0, the three hand-written engines carry BUSL-1.1. That split was already stated in each crate's README and on the Rust crates page; the new sections point at it rather than restating it a fifth time.

## Filed for the siblings

rubentalstra/FerroTERM#426 (landed as its PR #428) and #429, rubentalstra/FerroBRIDGE#111, and rubentalstra/FerroHEALTH#5.

## Gates

`scripts/checks/docs-claims.sh` (67 pages), `mdbook-lint lint website/book/src`, `scripts/site/build.sh --dev-only`, and `lychee --offline` over the built site: 9368 links OK, 0 errors. `scripts/checks/licensing-declarations.sh`, `copyright-holder.sh` and `first-party-license-text.sh` green. No em dash added to any new prose, and every bullet that defines a term uses a colon inside the bold. No Rust changes, so no crate-line bump.

Closes #3144.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.

## Checks

- [x] No Rust changed; docs gates run instead
- [x] No test weakened, skipped, or edited to route around a bug
- [ ] `CHANGELOG.md [Unreleased]` entry — not applicable, no user-visible behaviour changed (needs the `no-changelog` label)
- [x] Matching `website/book/src` pages updated
- [x] No implemented plan file to delete
- [x] New issues opened from this work are filed in the repositories they belong to and cross-referenced
