### PR TITLE
feat(admin): rebuild node rows from the stored document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,37 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Added
+
+- **The storage-parity sweep has a repair to go with it** (#3143).
+  `POST /admin/integrity/verify` reported that a version's decomposed rows and
+  its stored document disagree, and then there was nothing to run: dump and
+  load was the only re-decomposition path, and its dump side reads each version
+  through the node rows themselves, so it reproduced the damage it was asked to
+  fix. `POST /admin/integrity/rebuild-nodes` re-derives the rows of every
+  damaged version from that version's stored document, one transaction per
+  version. It runs the same sweep first and writes only what the sweep reports
+  damaged, so a run over healthy data writes nothing. Repair goes in one
+  direction only: the stored document is the canonical serialized form a point
+  read serves and a digest was taken over, the rows are an index derived from
+  it, so a version whose document is the damaged copy is refused rather than
+  having the damage copied into the index. Each version is read under a row
+  lock, decomposed, its rows replaced, and the version re-derived from the new
+  rows and compared with the document before the commit; anything that fails
+  rolls that version back untouched and the run continues. An archived object
+  is thawed and re-archived in the same transaction, marker included. A
+  logically deleted version rebuilds to no rows.
+
+### Changed
+
+- **Both storage-integrity routes can be pointed at a single version**
+  (#3143). `vo_id` and `sys_version` join `ehr_id` and `committed_since` as
+  scope parameters on `POST /admin/integrity/verify` and the new rebuild, so
+  checking or repairing one record after a support incident no longer means
+  reading the repository. The ordinal is per-object, so `sys_version` without
+  `vo_id` is a `400` rather than a filter that would match one version of every
+  object.
+
 ### Fixed
 
 - **A FLAT or STRUCTURED read no longer drops the content of a template-named

--- a/app/ferroehr-rest/src/api/admin/integrity.rs
+++ b/app/ferroehr-rest/src/api/admin/integrity.rs
@@ -49,6 +49,7 @@ use utoipa_axum::routes;
 
 use openehr_its::rest::runtime::ApiError;
 
+use ferroehr::service::admin::integrity::rebuild::{NodeRebuildOutcome, NodeRebuildReport};
 use ferroehr::service::admin::integrity::{
     StorageParityEvent, StorageParityReport, StorageParityScope,
 };
@@ -63,7 +64,9 @@ use crate::{negotiate, params};
 /// under `base_path`); the operation runs through [`guarded_dispatch`] with
 /// [`dispatch`].
 pub(crate) fn integrity_routes() -> OpenApiRouter<AppState> {
-    OpenApiRouter::new().routes(routes!(admin_verify_storage_parity))
+    OpenApiRouter::new()
+        .routes(routes!(admin_verify_storage_parity))
+        .routes(routes!(admin_rebuild_version_nodes))
 }
 
 /// Sweep the stored versions for content-copy disagreement
@@ -169,6 +172,98 @@ pub(crate) async fn admin_verify_storage_parity(
     guarded_dispatch(state, "admin_verify_storage_parity", parts, dispatch).await
 }
 
+/// Re-derive the node rows of every damaged version from its stored body
+/// (`POST /admin/integrity/rebuild-nodes`).
+///
+/// **Our own extension — no ITS-REST operation governs this, and it realizes
+/// no SM operation either** (module docs). It is the repair the storage-parity
+/// sweep had no counterpart for: the sweep reports where a version's two
+/// content copies disagree, and this replaces the derived copy from the
+/// authoritative one.
+#[utoipa::path(
+    post, path = "/admin/integrity/rebuild-nodes", tag = "admin-integrity",
+    params(
+        ("ehr_id" = Option<String>, Query,
+         description = "Cover only versions belonging to this EHR."),
+        ("vo_id" = Option<String>, Query,
+         description = "Cover only versions of this versioned object."),
+        ("sys_version" = Option<i32>, Query,
+         description = "Cover only this version of that object. The ordinal is \
+                        per-object, so it needs `vo_id`; alone it is a `400`."),
+        ("committed_since" = Option<String>, Query,
+         description = "Cover only versions whose validity begins at or after \
+                        this RFC 3339 instant, for repairing what an incident \
+                        touched."),
+    ),
+    responses(
+        (status = 200, description = "The rebuild ran. The body reports how \
+                                      many versions the underlying sweep read, \
+                                      how many it found damaged, how many were \
+                                      rebuilt, and how many were refused, plus \
+                                      one record per damaged version naming \
+                                      the defect that selected it and what \
+                                      happened to it. A refusal is NOT a \
+                                      request failure: the version's own \
+                                      stored body is the damaged copy, so \
+                                      re-deriving the index from it would \
+                                      spread the damage; the version's rows \
+                                      are left exactly as they were and the \
+                                      run continues. `records` is capped and \
+                                      `truncated` says whether the cap was \
+                                      reached; every record is also logged. A \
+                                      run over an undamaged scope writes \
+                                      nothing.",
+         content(
+             (serde_json::Value = "application/json", example = json!({
+                 "versions_checked": 128,
+                 "versions_damaged": 2,
+                 "versions_rebuilt": 1,
+                 "versions_refused": 1,
+                 "records": [{
+                     "vo_id": "8849182c-82ad-4088-a07f-48ead4180515",
+                     "sys_version": 2,
+                     "kind": "COMPOSITION",
+                     "defect": "content_differs",
+                     "outcome": "rebuilt",
+                     "node_rows": 41
+                 }, {
+                     "vo_id": "1f0b7d64-6b2a-4a1f-9f0e-6b1d2a3c4d5e",
+                     "sys_version": 1,
+                     "kind": "COMPOSITION",
+                     "defect": "content_differs",
+                     "outcome": "refused",
+                     "reason": "the stored body does not decompose: …"
+                 }],
+                 "truncated": false,
+                 "elapsed_ms": 812
+             })),
+         )),
+        (status = 400, description = "`sys_version` without `vo_id`, or a \
+                                      malformed identifier or instant.",
+         body = serde_json::Value),
+        (status = 401, description = "Unauthenticated (auth enabled, no valid \
+                                      principal). Our own authorization design.",
+         body = serde_json::Value),
+        (status = 403, description = "Authenticated but not in the Admin class \
+                                      (`OperationClass::Admin`, keyed off the \
+                                      `/admin/` path). Our own authorization \
+                                      design.",
+         body = serde_json::Value),
+        (status = 405, description = "The admin API is disabled on this server \
+                                      (`AppConfig::admin.enabled`, default \
+                                      false), answered with an empty `Allow` \
+                                      per RFC 9110 §10.2.1.",
+         body = serde_json::Value)
+    )
+)]
+pub(crate) async fn admin_rebuild_version_nodes(
+    State(state): State<AppState>,
+    request: axum::extract::Request,
+) -> Response {
+    let parts = crate::api::into_parts(request).await;
+    guarded_dispatch(state, "admin_rebuild_version_nodes", parts, dispatch).await
+}
+
 // ── dispatch ─────────────────────────────────────────────────────────────────
 
 pub(crate) fn dispatch(state: AppState, op: &'static str, parts: RequestParts) -> BoxResponse {
@@ -202,19 +297,30 @@ async fn run(
                 &parity_report(&report),
             ))
         }
+        "admin_rebuild_version_nodes" => {
+            let scope = parity_scope(parts.query.as_deref())?;
+            let report = state.backend().rebuild_version_nodes(scope).await?;
+            Ok(negotiate::respond(
+                &parts.headers,
+                StatusCode::OK,
+                &rebuild_report(&report),
+            ))
+        }
         other => Err(RestError(ApiError::Internal(format!(
             "unrouted admin integrity operation: {other}"
         )))),
     }
 }
 
-/// The optional bounds narrowing which stored versions the sweep covers.
+/// The optional bounds narrowing which stored versions a sweep, or the rebuild
+/// driven by one, covers.
 ///
 /// A sweep reads every byte of what it covers, so an operator verifying one
-/// record, or everything committed since an incident, should not have to read
-/// the whole repository. Both parameters are optional and compose.
+/// record, one object, one version, or everything committed since an incident,
+/// should not have to read the whole repository. Every parameter is optional
+/// and they compose; the default covers everything.
 ///
-/// Our own extension — no ITS-REST operation governs this route at all.
+/// Our own extension — no ITS-REST operation governs these routes at all.
 fn parity_scope(query: Option<&str>) -> Result<StorageParityScope, RestError> {
     let ehr_id = match params::query_param(query, "ehr_id") {
         Some(raw) => Some(raw.parse::<uuid::Uuid>().map_err(|e| {
@@ -233,9 +339,36 @@ fn parity_scope(query: Option<&str>) -> Result<StorageParityScope, RestError> {
         })?),
         None => None,
     };
+    let vo_id = match params::query_param(query, "vo_id") {
+        Some(raw) => Some(raw.parse::<uuid::Uuid>().map_err(|e| {
+            RestError(ApiError::BadRequest(format!(
+                "query parameter `vo_id` must be a UUID, got {raw:?}: {e}"
+            )))
+        })?),
+        None => None,
+    };
+    let sys_version = match params::query_param(query, "sys_version") {
+        Some(raw) => Some(raw.parse::<i32>().map_err(|e| {
+            RestError(ApiError::BadRequest(format!(
+                "query parameter `sys_version` must be an integer, got {raw:?}: {e}"
+            )))
+        })?),
+        None => None,
+    };
+    // The ordinal is per-object, so on its own it would name one version of
+    // every object in the scope — which is never what an operator naming a
+    // version means.
+    if sys_version.is_some() && vo_id.is_none() {
+        return Err(RestError(ApiError::BadRequest(
+            "query parameter `sys_version` names a version of one object and needs `vo_id`"
+                .to_owned(),
+        )));
+    }
     Ok(StorageParityScope {
         ehr_id,
         committed_since,
+        vo_id,
+        sys_version,
     })
 }
 
@@ -369,6 +502,47 @@ fn parity_report(report: &StorageParityReport) -> Value {
                 "kind": m.kind,
                 "defect": m.defect.as_str(),
             }))
+            .collect::<Vec<Value>>(),
+        "truncated": report.truncated,
+        "elapsed_ms": report.elapsed_ms,
+    })
+}
+
+/// Render the node-rebuild report as the response body.
+///
+/// Written out explicitly, like [`parity_report`]: the wire contract is this
+/// function, not a serde attribute on a service type. A record carries the
+/// key its outcome earns — `node_rows` for a rebuild, `reason` for a
+/// refusal — so a reader never has to interpret a placeholder.
+fn rebuild_report(report: &NodeRebuildReport) -> Value {
+    json!({
+        "versions_checked": report.versions_checked,
+        "versions_damaged": report.versions_damaged,
+        "versions_rebuilt": report.versions_rebuilt,
+        "versions_refused": report.versions_refused,
+        "records": report
+            .records
+            .iter()
+            .map(|record| {
+                let mut object = json!({
+                    "vo_id": record.vo_id.to_string(),
+                    "sys_version": record.sys_version,
+                    "kind": record.kind,
+                    "defect": record.defect.as_str(),
+                    "outcome": record.outcome.as_str(),
+                });
+                if let Some(map) = object.as_object_mut() {
+                    match &record.outcome {
+                        NodeRebuildOutcome::Rebuilt { node_rows } => {
+                            map.insert("node_rows".to_owned(), json!(node_rows));
+                        }
+                        NodeRebuildOutcome::Refused { reason } => {
+                            map.insert("reason".to_owned(), json!(reason));
+                        }
+                    }
+                }
+                object
+            })
             .collect::<Vec<Value>>(),
         "truncated": report.truncated,
         "elapsed_ms": report.elapsed_ms,

--- a/app/ferroehr-rest/tests/it/admin_integrity_http.rs
+++ b/app/ferroehr-rest/tests/it/admin_integrity_http.rs
@@ -142,3 +142,71 @@ async fn a_wildcard_accept_keeps_the_aggregated_document() {
         "a wildcard must not switch an existing caller onto the stream: {body}"
     );
 }
+
+// ── the rebuild (`POST /admin/integrity/rebuild-nodes`) ─────────────────────
+
+/// The repair route, with an optional query string.
+fn rebuild(query: &str) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri(format!("{BASE}/admin/integrity/rebuild-nodes{query}"))
+        .body(Body::empty())
+        .expect("request")
+}
+
+#[tokio::test]
+async fn the_rebuild_answers_a_report_over_an_undamaged_repository() {
+    let (_pg, service) = common::test_service().await;
+    service.create_ehr(None).await.expect("seed an EHR");
+    let app = common::router_with(common::api_config(true), service);
+
+    let (status, body) = common::send_body(&app, rebuild("")).await;
+
+    assert_eq!(status, StatusCode::OK);
+    let report: Value = serde_json::from_str(&body).expect("one JSON document");
+    assert!(
+        report["versions_checked"].as_u64().unwrap_or(0) >= 2,
+        "the sweep behind the repair still read the repository: {body}"
+    );
+    assert_eq!(report["versions_damaged"], 0, "{body}");
+    assert_eq!(report["versions_rebuilt"], 0, "{body}");
+    assert_eq!(report["versions_refused"], 0, "{body}");
+    assert_eq!(
+        report["records"].as_array().map(Vec::len),
+        Some(0),
+        "an undamaged repository produces no records: {body}"
+    );
+}
+
+#[tokio::test]
+async fn a_sys_version_without_a_vo_id_is_refused() {
+    let (_pg, service) = common::test_service().await;
+    let app = common::router_with(common::api_config(true), service);
+
+    let (status, body) = common::send_body(&app, rebuild("?sys_version=2")).await;
+
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "the ordinal is per-object, so alone it names one version of every \
+         object — never what an operator naming a version means: {body}"
+    );
+    assert!(
+        body.contains("vo_id"),
+        "the refusal names the parameter it needs: {body}"
+    );
+}
+
+#[tokio::test]
+async fn the_rebuild_is_gated_with_the_rest_of_the_admin_group() {
+    let (_pg, service) = common::test_service().await;
+    let app = common::router_with(common::api_config(false), service);
+
+    let (status, _) = common::send_body(&app, rebuild("")).await;
+
+    assert_eq!(
+        status,
+        StatusCode::METHOD_NOT_ALLOWED,
+        "the whole ADMIN group is opt-in and answers 405 with an empty Allow"
+    );
+}

--- a/app/ferroehr-rest/tests/it/authz_route_matrix.rs
+++ b/app/ferroehr-rest/tests/it/authz_route_matrix.rs
@@ -360,6 +360,10 @@ const ADMIN_WRITE: &[(&str, &str)] = &[
     ("POST", "/admin/archive/parties/restore"),
     ("POST", "/admin/dump"),
     ("POST", "/admin/load"),
+    // The repair the parity sweep is the diagnosis for. Unlike the sweep it
+    // REPLACES stored rows, so it stays out of EXTENSION_READ_ROUTES and a
+    // read-only server refuses it (#3143).
+    ("POST", "/admin/integrity/rebuild-nodes"),
     ("POST", "/admin/tenant"),
     ("PUT", "/admin/tenant/{tenant_id}"),
     ("DELETE", "/admin/tenant/{tenant_id}"),

--- a/app/ferroehr/src/service/admin/integrity/mod.rs
+++ b/app/ferroehr/src/service/admin/integrity/mod.rs
@@ -27,6 +27,8 @@
               round-trip drops forward-compatible keys (the openEHR release strategy: minors are compatible supersets)"
 )]
 
+pub mod rebuild;
+
 use std::collections::HashMap;
 use std::time::Instant;
 
@@ -178,9 +180,9 @@ impl StorageParityReport {
 /// Which stored versions a sweep covers.
 ///
 /// A sweep reads every byte of the versions it covers, so an operator
-/// verifying one record, or everything committed since an incident, should not
-/// have to read the whole repository to do it. Both bounds are optional and
-/// compose; the default covers everything.
+/// verifying one record, one object, or everything committed since an
+/// incident, should not have to read the whole repository to do it. Every
+/// bound is optional and they compose; the default covers everything.
 ///
 /// No openEHR spec governs storage mechanics — our own design/extension.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -189,6 +191,12 @@ pub struct StorageParityScope {
     pub ehr_id: Option<Uuid>,
     /// Cover only versions whose validity begins at or after this instant.
     pub committed_since: Option<jiff::Timestamp>,
+    /// Cover only versions of this versioned object.
+    pub vo_id: Option<Uuid>,
+    /// Cover only this version of it. Ignored without [`Self::vo_id`], which
+    /// is what makes a `sys_version` alone meaningless: the ordinal is
+    /// per-object, so on its own it names one version of every object.
+    pub sys_version: Option<i32>,
 }
 
 /// One page row of the sweep cursor: the identifiers of a stored version plus
@@ -382,6 +390,8 @@ impl FerroEhrService {
              WHERE ($1::uuid IS NULL OR (vo_id, sys_version) > ($1::uuid, $2::int)) \
                AND ($4::uuid IS NULL OR ehr_id = $4::uuid) \
                AND ($5::timestamptz IS NULL OR lower(sys_period) >= $5::timestamptz) \
+               AND ($6::uuid IS NULL OR vo_id = $6::uuid) \
+               AND ($6::uuid IS NULL OR $7::int IS NULL OR sys_version = $7::int) \
              ORDER BY vo_id, sys_version \
              LIMIT $3",
         )
@@ -390,6 +400,8 @@ impl FerroEhrService {
         .bind(PAGE_SIZE)
         .bind(scope.ehr_id)
         .bind(scope.committed_since.map(jiff_sqlx::Timestamp::from))
+        .bind(scope.vo_id)
+        .bind(scope.sys_version)
         .fetch_all(&self.pool)
         .await?;
         Ok(rows

--- a/app/ferroehr/src/service/admin/integrity/rebuild.rs
+++ b/app/ferroehr/src/service/admin/integrity/rebuild.rs
@@ -1,0 +1,406 @@
+// SPDX-FileCopyrightText: Ruben Talstra
+// SPDX-License-Identifier: BUSL-1.1
+
+//! The node rebuild: the repair the storage-parity sweep had no counterpart
+//! for.
+//!
+//! NOTE: no openEHR spec governs storage mechanics — our own design/extension;
+//! the storage keeps a version's content twice, as `vo_version.body` and as the
+//! decomposed `node` rows, and the sweep ([`super`]) reports where the two
+//! disagree.
+//!
+//! Which copy is authoritative is not a choice this module makes, it is a
+//! property of the storage: `body` is the version's canonical serialized form,
+//! the bytes the digital signature was taken over (RM common
+//! `master06-change_control_package.adoc` §Digital Signature) and the bytes a
+//! point read serves; the node rows are a derived index over it, produced by
+//! `crate::storage::codec::decompose`. So a disagreement is repaired in one
+//! direction only — the rows are re-derived from the body — and a version whose
+//! BODY is the damaged copy is refused rather than propagated into the index.
+//!
+//! Dump and load re-decomposes too, but cannot serve as the repair: its dump
+//! side reads each version through `node_repo::read_version_canonical`, from
+//! the node rows themselves, so it would reproduce exactly the damage it is
+//! asked to fix. It is also a whole-repository round trip.
+
+#![expect(
+    clippy::disallowed_types,
+    reason = "owner-approved 2026-08-03 (#1694 family 1): stored canonical fragments — a typed \
+              round-trip drops forward-compatible keys (the openEHR release strategy: minors are compatible supersets)"
+)]
+
+use std::time::Instant;
+
+use serde_json::Value;
+use sqlx::PgConnection;
+use uuid::Uuid;
+
+use crate::ids::{EhrId, VoId};
+use crate::service::FerroEhrService;
+use crate::service::admin::integrity::{
+    StorageParityDefect, StorageParityEvent, StorageParityScope,
+};
+use crate::service::error::ServiceError;
+use crate::service::status::SmError;
+use crate::storage::codec::decompose;
+use crate::storage::node_repo::{delete_version_nodes, read_version_canonical_tx, write_nodes};
+use crate::storage::version_repo::tier;
+
+/// How many rebuild records the returned report carries in full.
+///
+/// The same cap the sweep applies to its mismatches, for the same reason:
+/// every record is also logged, so nothing is lost when a repair of a badly
+/// damaged store passes it.
+const MAX_REPORTED_RECORDS: usize = 1000;
+
+/// What happened to one damaged version the rebuild reached.
+///
+/// NOTE: no openEHR spec governs storage mechanics — our own design/extension.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NodeRebuildOutcome {
+    /// The node rows were replaced from the body, and the version re-derived
+    /// from the new rows equals that body. The count is how many rows the
+    /// rebuild wrote, which is zero for a logical delete.
+    Rebuilt {
+        /// How many `node` rows the version now has.
+        node_rows: u32,
+    },
+    /// Nothing was written. The version's own body is the damaged copy, so
+    /// re-deriving the index from it would spread the damage rather than
+    /// repair it.
+    Refused {
+        /// What is wrong with the body, in one line.
+        reason: String,
+    },
+}
+
+impl NodeRebuildOutcome {
+    /// Returns the stable wire token for this outcome.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match *self {
+            Self::Rebuilt { .. } => "rebuilt",
+            Self::Refused { .. } => "refused",
+        }
+    }
+}
+
+/// One damaged version the rebuild reached, and what happened to it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NodeRebuildRecord {
+    /// The versioned object the version belongs to.
+    pub vo_id: Uuid,
+    /// The per-object storage commit ordinal of the version.
+    pub sys_version: i32,
+    /// The `vo_version.kind` discriminator (`COMPOSITION` / `EHR_STATUS` /
+    /// `FOLDER` / a demographic PARTY class / …).
+    pub kind: String,
+    /// The disagreement the sweep found, which is what selected this version.
+    pub defect: StorageParityDefect,
+    /// What the rebuild did about it.
+    pub outcome: NodeRebuildOutcome,
+}
+
+/// The outcome of one node rebuild.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NodeRebuildReport {
+    /// How many stored versions the underlying sweep read.
+    pub versions_checked: u64,
+    /// How many of them it found damaged, whatever `records` holds.
+    pub versions_damaged: u64,
+    /// How many were rebuilt.
+    pub versions_rebuilt: u64,
+    /// How many were refused because their body is the damaged copy.
+    pub versions_refused: u64,
+    /// The per-version records, up to the reporting cap.
+    pub records: Vec<NodeRebuildRecord>,
+    /// Whether `records` was cut short by the cap.
+    pub truncated: bool,
+    /// Wall-clock duration of the rebuild, in milliseconds.
+    pub elapsed_ms: u64,
+}
+
+impl NodeRebuildReport {
+    /// Returns `true` when the rebuild repaired everything it found.
+    ///
+    /// A run that found nothing is complete: the scope was already clean.
+    #[must_use]
+    pub fn is_complete(&self) -> bool {
+        self.versions_refused == 0
+    }
+}
+
+/// One stored version's body plus the storage context its rows carry, read
+/// under the transaction's row lock.
+struct VersionBody {
+    ehr_id: Option<EhrId>,
+    /// `None` for a logical delete (data Void, RM common
+    /// `master06-change_control_package.adoc` §Logical Deletion), which
+    /// rebuilds to zero node rows.
+    body: Option<String>,
+}
+
+impl FerroEhrService {
+    /// Re-derives the `node` rows of every damaged version in `scope` from its
+    /// `vo_version.body`, one transaction per version.
+    ///
+    /// The scope is the sweep's own ([`StorageParityScope`]): the whole
+    /// repository, one EHR, one versioned object, one version of it, or
+    /// everything committed since an instant. Whatever the scope covers, only
+    /// the versions the sweep reports damaged are written — a clean version is
+    /// read and left alone, so running this over a healthy repository writes
+    /// nothing.
+    ///
+    /// Each version is repaired in its own transaction: the body is read under
+    /// a row lock, decomposed, the old rows deleted, the new set inserted, and
+    /// the version re-derived from what was just written and compared with the
+    /// body BEFORE the commit. A body that does not decompose, or that the
+    /// rebuilt rows do not reproduce, rolls that transaction back, so the
+    /// version's rows are left exactly as they were and the refusal is
+    /// reported. One refused version never stops the rebuild that found it.
+    ///
+    /// An ARCHIVED object is thawed into the primary tier for the repair and
+    /// re-frozen with its archive marker in the same transaction, because the
+    /// tier's own rule is that a write always thaws first
+    /// (`crate::storage::version_repo::tier`) — a versioned object is never
+    /// split across tiers.
+    ///
+    /// NOTE: no openEHR spec governs storage mechanics — our own
+    /// design/extension (the module docs carry the full derivation).
+    ///
+    /// # Errors
+    /// - `exception` — a database fault while enumerating or reading versions.
+    ///   A version the rebuild refuses is a REPORTED record, not an error.
+    pub async fn rebuild_version_nodes(
+        &self,
+        scope: StorageParityScope,
+    ) -> Result<NodeRebuildReport, SmError> {
+        Ok(self.collect_node_rebuild(scope).await?)
+    }
+
+    /// Drive the sweep, repairing each version it reports.
+    async fn collect_node_rebuild(
+        &self,
+        scope: StorageParityScope,
+    ) -> Result<NodeRebuildReport, ServiceError> {
+        let started = Instant::now();
+        let mut sweep = self.storage_parity_sweep(scope);
+        let mut report = NodeRebuildReport {
+            versions_checked: 0,
+            versions_damaged: 0,
+            versions_rebuilt: 0,
+            versions_refused: 0,
+            records: Vec::new(),
+            truncated: false,
+            elapsed_ms: 0,
+        };
+        while let Some(events) = sweep.next_batch().await? {
+            for event in events {
+                match event {
+                    StorageParityEvent::Mismatch(mismatch) => {
+                        let outcome = self
+                            .rebuild_one_version(VoId(mismatch.vo_id), mismatch.sys_version)
+                            .await?;
+                        report.versions_damaged += 1;
+                        match outcome {
+                            NodeRebuildOutcome::Rebuilt { .. } => report.versions_rebuilt += 1,
+                            NodeRebuildOutcome::Refused { .. } => report.versions_refused += 1,
+                        }
+                        // The log line carries identifiers and tokens only: a
+                        // body fragment would put clinical content into an
+                        // operational log.
+                        tracing::info!(
+                            vo_id = %mismatch.vo_id,
+                            sys_version = mismatch.sys_version,
+                            kind = %mismatch.kind,
+                            defect = mismatch.defect.as_str(),
+                            outcome = outcome.as_str(),
+                            "node rebuild: a damaged stored version was re-derived from its body"
+                        );
+                        if report.records.len() < MAX_REPORTED_RECORDS {
+                            report.records.push(NodeRebuildRecord {
+                                vo_id: mismatch.vo_id,
+                                sys_version: mismatch.sys_version,
+                                kind: mismatch.kind,
+                                defect: mismatch.defect,
+                                outcome,
+                            });
+                        } else {
+                            report.truncated = true;
+                        }
+                    }
+                    StorageParityEvent::Progress { .. } => {}
+                    StorageParityEvent::Summary { counts, .. } => {
+                        report.versions_checked = counts.versions_checked;
+                    }
+                }
+            }
+        }
+        report.elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+        Ok(report)
+    }
+
+    /// Repair one version in one transaction, or leave it untouched.
+    async fn rebuild_one_version(
+        &self,
+        vo_id: VoId,
+        sys_version: i32,
+    ) -> Result<NodeRebuildOutcome, ServiceError> {
+        let mut tx = self.pool.begin().await?;
+
+        // The tier's own rule: a write always thaws first, so a versioned
+        // object is never split across tiers. The marker is captured before
+        // the thaw drops it and re-inserted before the re-freeze, so an
+        // archived object comes out of this exactly as archived as it went in.
+        let archive_reason: Option<String> =
+            sqlx::query_scalar("SELECT reason FROM vo_archive WHERE vo_id = $1 FOR UPDATE")
+                .bind(vo_id)
+                .fetch_optional(&mut *tx)
+                .await?;
+        if archive_reason.is_some() {
+            tier::thaw(&mut tx, &[vo_id]).await?;
+        }
+
+        let outcome = rebuild_in_tx(&mut tx, vo_id, sys_version).await?;
+
+        if matches!(outcome, NodeRebuildOutcome::Refused { .. }) {
+            // Nothing this transaction wrote may survive: not the rows, and
+            // not the thaw either.
+            tx.rollback().await?;
+            return Ok(outcome);
+        }
+
+        if let Some(reason) = archive_reason {
+            sqlx::query(
+                "INSERT INTO vo_archive (vo_id, reason) VALUES ($1, $2) \
+                 ON CONFLICT (vo_id) DO NOTHING",
+            )
+            .bind(vo_id)
+            .bind(reason)
+            .execute(&mut *tx)
+            .await?;
+            tier::freeze(&mut tx, &[vo_id]).await?;
+        }
+        tx.commit().await?;
+        Ok(outcome)
+    }
+}
+
+/// The repair itself, inside the caller's transaction and the primary tier.
+///
+/// Returns [`NodeRebuildOutcome::Refused`] without propagating an error for
+/// every way the BODY can be the damaged copy, because the caller answers a
+/// refusal by rolling back rather than by failing the whole run.
+async fn rebuild_in_tx(
+    tx: &mut PgConnection,
+    vo_id: VoId,
+    sys_version: i32,
+) -> Result<NodeRebuildOutcome, ServiceError> {
+    let Some(version) = locked_body(tx, vo_id, sys_version).await? else {
+        return Ok(NodeRebuildOutcome::Refused {
+            reason: "the version is no longer stored".to_owned(),
+        });
+    };
+
+    // A logical delete stores no body and must therefore have no node rows;
+    // re-deriving it from nothing is exactly the delete below.
+    let Some(text) = version.body else {
+        delete_version_nodes(tx, vo_id, sys_version).await?;
+        return Ok(NodeRebuildOutcome::Rebuilt { node_rows: 0 });
+    };
+
+    let body: Value = match serde_json::from_str(&text) {
+        Ok(body) => body,
+        Err(e) => {
+            return Ok(NodeRebuildOutcome::Refused {
+                reason: format!("the stored body is not valid JSON: {e}"),
+            });
+        }
+    };
+    let rows = match decompose(body.clone()) {
+        Ok(rows) => rows,
+        Err(e) => {
+            return Ok(NodeRebuildOutcome::Refused {
+                reason: format!("the stored body does not decompose: {e}"),
+            });
+        }
+    };
+    let node_rows = u32::try_from(rows.len()).unwrap_or(u32::MAX);
+
+    // The row set is replaced wholesale: a nested-set numbering is only
+    // meaningful as a whole (`crate::storage::codec`).
+    delete_version_nodes(tx, vo_id, sys_version).await?;
+    write_nodes(tx, vo_id, sys_version, version.ehr_id, &rows).await?;
+
+    // The parity comparison the sweep runs, over the rows just written and
+    // before they are committed. A rebuild that did not restore parity must
+    // not report success, and the read is transaction-scoped precisely so it
+    // sees this transaction's own uncommitted rows.
+    match read_version_canonical_tx(tx, vo_id, sys_version).await {
+        Ok(rebuilt) if rebuilt == body => Ok(NodeRebuildOutcome::Rebuilt { node_rows }),
+        Ok(_) => Ok(NodeRebuildOutcome::Refused {
+            reason: "the rows re-derived from the stored body do not reproduce it".to_owned(),
+        }),
+        Err(e) => Ok(NodeRebuildOutcome::Refused {
+            reason: format!("the rebuilt rows do not reassemble: {e}"),
+        }),
+    }
+}
+
+/// Read one primary-tier version's body and storage context under a row lock,
+/// so a concurrent commit on the same version cannot interleave with the
+/// replacement of its rows.
+async fn locked_body(
+    tx: &mut PgConnection,
+    vo_id: VoId,
+    sys_version: i32,
+) -> Result<Option<VersionBody>, ServiceError> {
+    let row: Option<(Option<Uuid>, Option<String>)> = sqlx::query_as(
+        "SELECT ehr_id, body FROM vo_version \
+         WHERE vo_id = $1 AND sys_version = $2 FOR UPDATE",
+    )
+    .bind(vo_id)
+    .bind(sys_version)
+    .fetch_optional(&mut *tx)
+    .await?;
+    Ok(row.map(|(ehr_id, body)| VersionBody {
+        ehr_id: ehr_id.map(EhrId),
+        body,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn outcome_tokens_are_the_documented_wire_values() {
+        assert_eq!(
+            NodeRebuildOutcome::Rebuilt { node_rows: 7 }.as_str(),
+            "rebuilt"
+        );
+        assert_eq!(
+            NodeRebuildOutcome::Refused {
+                reason: "x".to_owned()
+            }
+            .as_str(),
+            "refused"
+        );
+    }
+
+    #[test]
+    fn a_report_with_no_refusal_is_complete() {
+        let mut report = NodeRebuildReport {
+            versions_checked: 4,
+            versions_damaged: 2,
+            versions_rebuilt: 2,
+            versions_refused: 0,
+            records: Vec::new(),
+            truncated: false,
+            elapsed_ms: 1,
+        };
+        assert!(report.is_complete());
+        report.versions_refused = 1;
+        assert!(!report.is_complete());
+    }
+}

--- a/app/ferroehr/src/storage/node_repo.rs
+++ b/app/ferroehr/src/storage/node_repo.rs
@@ -279,12 +279,21 @@ const READ_ROWS_ALL_SQL: &str = "SELECT num, num_cap, parent_num, path, data \
 /// Fetch the lean read rows of one stored version, ordered by `num` —
 /// primary tier only, or both tiers through the `node_all` union view (no
 /// openEHR spec governs storage tiering — our own design).
-async fn read_rows(
-    pool: &PgPool,
+///
+/// Generic over the executor so a caller inside a transaction reads its OWN
+/// uncommitted rows through the same statement: the node rebuild
+/// (`crate::service::admin::integrity::rebuild`) re-verifies what it just
+/// wrote before it commits, and a pool-typed read would see the pre-rebuild
+/// rows from another connection.
+async fn read_rows<'e, E>(
+    executor: E,
     vo_id: VoId,
     sys_version: i32,
     both_tiers: bool,
-) -> Result<Vec<ReadRow>, StorageError> {
+) -> Result<Vec<ReadRow>, StorageError>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
     let sql = if both_tiers {
         READ_ROWS_ALL_SQL
     } else {
@@ -293,7 +302,7 @@ async fn read_rows(
     let rows = sqlx::query(sql)
         .bind(vo_id)
         .bind(sys_version)
-        .fetch_all(pool)
+        .fetch_all(executor)
         .await?;
     let mut read = Vec::with_capacity(rows.len());
     for row in rows {
@@ -349,6 +358,52 @@ pub async fn read_version_canonical_all(
         return Ok(Value::Null);
     }
     reassemble(&rows)
+}
+
+/// [`read_version_canonical`] inside a transaction, over the primary tier.
+///
+/// The rebuild writes a version's node rows and then re-derives the version
+/// from them BEFORE committing, so it must read its own uncommitted rows; a
+/// pool-typed read runs on another connection and would see the rows the
+/// rebuild is replacing.
+///
+/// # Errors
+///
+/// Returns [`StorageError`] on a DB error or if a non-empty row set does not
+/// form one tree rooted at `num = 0`.
+pub async fn read_version_canonical_tx(
+    tx: &mut PgConnection,
+    vo_id: VoId,
+    sys_version: i32,
+) -> Result<Value, StorageError> {
+    let rows = read_rows(&mut *tx, vo_id, sys_version, false).await?;
+    if rows.is_empty() {
+        return Ok(Value::Null);
+    }
+    reassemble(&rows)
+}
+
+/// Deletes every primary-tier `node` row of one stored version, returning how
+/// many were removed.
+///
+/// The rebuild's first write: the row set is replaced wholesale rather than
+/// reconciled, because a nested-set numbering is only meaningful as a whole
+/// (`crate::storage::codec`).
+///
+/// # Errors
+///
+/// Returns [`StorageError::Database`] on any driver/statement failure.
+pub async fn delete_version_nodes(
+    tx: &mut PgConnection,
+    vo_id: VoId,
+    sys_version: i32,
+) -> Result<u64, StorageError> {
+    let result = sqlx::query("DELETE FROM node WHERE vo_id = $1 AND sys_version = $2")
+        .bind(vo_id)
+        .bind(sys_version)
+        .execute(&mut *tx)
+        .await?;
+    Ok(result.rows_affected())
 }
 
 /// Fetch the read rows of whole stored versions in **one** statement, keyed by

--- a/app/ferroehr/tests/it/storage_parity.rs
+++ b/app/ferroehr/tests/it/storage_parity.rs
@@ -22,11 +22,13 @@
               Rust Book ch11)"
 )]
 
+use serde_json::Value;
 use sqlx::PgPool;
 use uuid::Uuid;
 
 use ferroehr::ids::EhrId;
 use ferroehr::service::FerroEhrService;
+use ferroehr::service::admin::integrity::rebuild::NodeRebuildOutcome;
 use ferroehr::service::admin::integrity::{
     StorageParityDefect, StorageParityEvent, StorageParityScope,
 };
@@ -298,7 +300,7 @@ async fn a_scoped_sweep_covers_only_its_own_ehr() {
     let clean = svc
         .verify_storage_parity(StorageParityScope {
             ehr_id: Some(intact.0),
-            committed_since: None,
+            ..StorageParityScope::default()
         })
         .await
         .expect("scoped sweep");
@@ -311,7 +313,7 @@ async fn a_scoped_sweep_covers_only_its_own_ehr() {
     let scoped = svc
         .verify_storage_parity(StorageParityScope {
             ehr_id: Some(damaged.0),
-            committed_since: None,
+            ..StorageParityScope::default()
         })
         .await
         .expect("scoped sweep");
@@ -357,8 +359,8 @@ async fn a_committed_since_bound_excludes_earlier_versions() {
     // silently falling back to the whole store.
     let after = svc
         .verify_storage_parity(StorageParityScope {
-            ehr_id: None,
             committed_since: Some(cutoff),
+            ..StorageParityScope::default()
         })
         .await
         .expect("bounded sweep");
@@ -368,8 +370,8 @@ async fn a_committed_since_bound_excludes_earlier_versions() {
     seed_ehr_with_composition(&svc).await;
     let later = svc
         .verify_storage_parity(StorageParityScope {
-            ehr_id: None,
             committed_since: Some(cutoff),
+            ..StorageParityScope::default()
         })
         .await
         .expect("bounded sweep");
@@ -462,4 +464,414 @@ async fn a_dropped_stream_stops_the_sweep_where_it_stood() {
         .await
         .expect("a later sweep is unaffected");
     assert!(report.versions_checked >= 3, "{report:?}");
+}
+
+// ── the rebuild: the repair the sweep is the diagnosis for (#3143) ───────────
+//
+// Every case here damages the derived copy the same way the sweep cases do,
+// with raw SQL past the service, then repairs it through the admin operation
+// and proves the repair by two independent readers: the sweep itself, and an
+// AQL query, which reads the `node` rows and nothing else.
+
+/// The `name/value` strings an AQL query over every COMPOSITION returns — a
+/// reader that touches the `node` rows and never the materialized body, so it
+/// sees the rebuild's actual output.
+async fn aql_composition_names(svc: &FerroEhrService) -> Vec<String> {
+    let result = svc
+        .execute_ad_hoc_query(
+            "SELECT c/name/value FROM COMPOSITION c".to_owned(),
+            ferroehr::service::query::request::AqlQueryRequest::default(),
+        )
+        .await
+        .expect("ad-hoc AQL")
+        .result_set;
+    result
+        .get("rows")
+        .and_then(Value::as_array)
+        .expect("rows array")
+        .iter()
+        .filter_map(|row| row.as_array()?.first()?.as_str().map(str::to_owned))
+        .collect()
+}
+
+#[tokio::test]
+async fn a_rebuild_over_an_undamaged_repository_writes_nothing() {
+    let db = testkit::db().await.expect("testkit database");
+    let pool = db.pool();
+    let svc = FerroEhrService::new(pool.clone());
+    let ehr_id = seed_ehr_with_composition(&svc).await;
+
+    let before: i64 = sqlx::query_scalar("SELECT count(*) FROM node WHERE ehr_id = $1")
+        .bind(ehr_id.0)
+        .fetch_one(&pool)
+        .await
+        .expect("node count");
+
+    let report = svc
+        .rebuild_version_nodes(StorageParityScope {
+            ehr_id: Some(ehr_id.0),
+            ..StorageParityScope::default()
+        })
+        .await
+        .expect("rebuild");
+
+    assert!(report.is_complete(), "nothing to refuse: {report:?}");
+    assert_eq!(report.versions_damaged, 0, "nothing was damaged");
+    assert_eq!(report.versions_rebuilt, 0, "so nothing was written");
+    assert!(report.records.is_empty());
+    assert!(
+        report.versions_checked >= 3,
+        "the sweep behind it still read the scope: {report:?}"
+    );
+
+    let after: i64 = sqlx::query_scalar("SELECT count(*) FROM node WHERE ehr_id = $1")
+        .bind(ehr_id.0)
+        .fetch_one(&pool)
+        .await
+        .expect("node count");
+    assert_eq!(before, after, "a clean scope is left byte for byte alone");
+}
+
+#[tokio::test]
+async fn a_tampered_node_row_is_rebuilt_and_the_sweep_goes_clean() {
+    let db = testkit::db().await.expect("testkit database");
+    let pool = db.pool();
+    let svc = FerroEhrService::new(pool.clone());
+    let ehr_id = seed_ehr_with_composition(&svc).await;
+    let (vo_id, sys_version) = one_version(&pool, ehr_id, "COMPOSITION").await;
+
+    // The AQL index copy: the composition's name, which an AQL projection of
+    // `c/name/value` reads straight out of the damaged row.
+    tamper(
+        &pool,
+        "UPDATE node SET data = jsonb_set(data, '{name,value}', '\"tampered\"') \
+         WHERE vo_id = $1 AND sys_version = $2 AND num = 0",
+        vo_id,
+        sys_version,
+    )
+    .await;
+    assert!(
+        aql_composition_names(&svc)
+            .await
+            .contains(&"tampered".to_owned()),
+        "the fixture really did corrupt what AQL reads"
+    );
+
+    let report = svc
+        .rebuild_version_nodes(StorageParityScope::default())
+        .await
+        .expect("rebuild");
+
+    assert_eq!(
+        report.versions_damaged, 1,
+        "exactly one damaged: {report:?}"
+    );
+    assert_eq!(report.versions_rebuilt, 1);
+    assert_eq!(report.versions_refused, 0);
+    let record = &report.records[0];
+    assert_eq!(record.vo_id, vo_id);
+    assert_eq!(record.sys_version, sys_version);
+    assert_eq!(record.kind, "COMPOSITION");
+    assert_eq!(record.defect, StorageParityDefect::ContentDiffers);
+    let NodeRebuildOutcome::Rebuilt { node_rows } = &record.outcome else {
+        panic!("expected a rebuild, got {:?}", record.outcome);
+    };
+    let stored: i64 =
+        sqlx::query_scalar("SELECT count(*) FROM node WHERE vo_id = $1 AND sys_version = $2")
+            .bind(vo_id)
+            .bind(sys_version)
+            .fetch_one(&pool)
+            .await
+            .expect("node count");
+    assert_eq!(
+        i64::from(*node_rows),
+        stored,
+        "the reported row count is what the version actually has"
+    );
+    assert!(stored > 0, "and the version has rows again");
+
+    let after = svc
+        .verify_storage_parity(StorageParityScope::default())
+        .await
+        .expect("sweep");
+    assert!(after.is_clean(), "the sweep is clean afterwards: {after:?}");
+
+    let names = aql_composition_names(&svc).await;
+    assert!(
+        !names.contains(&"tampered".to_owned()),
+        "AQL no longer reads the corrupted value: {names:?}"
+    );
+    assert!(
+        names.contains(&"Encounter".to_owned()),
+        "AQL reads the restored value: {names:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_version_whose_node_rows_are_gone_is_rebuilt_from_its_body() {
+    let db = testkit::db().await.expect("testkit database");
+    let pool = db.pool();
+    let svc = FerroEhrService::new(pool.clone());
+    let ehr_id = seed_ehr_with_composition(&svc).await;
+    let (vo_id, sys_version) = one_version(&pool, ehr_id, "COMPOSITION").await;
+
+    tamper(
+        &pool,
+        "DELETE FROM node WHERE vo_id = $1 AND sys_version = $2",
+        vo_id,
+        sys_version,
+    )
+    .await;
+
+    let report = svc
+        .rebuild_version_nodes(StorageParityScope {
+            vo_id: Some(vo_id),
+            sys_version: Some(sys_version),
+            ..StorageParityScope::default()
+        })
+        .await
+        .expect("rebuild");
+
+    assert_eq!(
+        report.versions_checked, 1,
+        "the version-scoped rebuild read exactly that version: {report:?}"
+    );
+    assert_eq!(report.versions_rebuilt, 1);
+    assert_eq!(
+        report.records[0].defect,
+        StorageParityDefect::NodesMissing,
+        "the sweep verdict that selected it is carried through"
+    );
+
+    let after = svc
+        .verify_storage_parity(StorageParityScope::default())
+        .await
+        .expect("sweep");
+    assert!(
+        after.is_clean(),
+        "the whole store is clean again: {after:?}"
+    );
+    assert!(
+        aql_composition_names(&svc)
+            .await
+            .contains(&"Encounter".to_owned()),
+        "and AQL reaches the composition again"
+    );
+}
+
+#[tokio::test]
+async fn node_rows_under_a_bodiless_version_rebuild_to_none() {
+    let db = testkit::db().await.expect("testkit database");
+    let pool = db.pool();
+    let svc = FerroEhrService::new(pool.clone());
+    let ehr_id = seed_ehr_with_composition(&svc).await;
+    let (vo_id, sys_version) = one_version(&pool, ehr_id, "COMPOSITION").await;
+
+    // A logical delete (RM common master06 §Logical Deletion) stores no body,
+    // so its node rows are unexpected — and rebuild to zero of them.
+    tamper(
+        &pool,
+        "UPDATE vo_version SET body = NULL WHERE vo_id = $1 AND sys_version = $2",
+        vo_id,
+        sys_version,
+    )
+    .await;
+
+    let report = svc
+        .rebuild_version_nodes(StorageParityScope::default())
+        .await
+        .expect("rebuild");
+
+    assert_eq!(report.versions_rebuilt, 1, "{report:?}");
+    assert_eq!(
+        report.records[0].defect,
+        StorageParityDefect::UnexpectedNodes
+    );
+    assert_eq!(
+        report.records[0].outcome,
+        NodeRebuildOutcome::Rebuilt { node_rows: 0 },
+        "a bodiless version rebuilds to no node rows"
+    );
+
+    let remaining: i64 =
+        sqlx::query_scalar("SELECT count(*) FROM node WHERE vo_id = $1 AND sys_version = $2")
+            .bind(vo_id)
+            .bind(sys_version)
+            .fetch_one(&pool)
+            .await
+            .expect("node count");
+    assert_eq!(remaining, 0, "the rows are gone");
+
+    let after = svc
+        .verify_storage_parity(StorageParityScope::default())
+        .await
+        .expect("sweep");
+    assert!(after.is_clean(), "the sweep is clean afterwards: {after:?}");
+}
+
+#[tokio::test]
+async fn a_body_that_does_not_decompose_is_refused_and_its_rows_are_untouched() {
+    let db = testkit::db().await.expect("testkit database");
+    let pool = db.pool();
+    let svc = FerroEhrService::new(pool.clone());
+    let ehr_id = seed_ehr_with_composition(&svc).await;
+    let (vo_id, sys_version) = one_version(&pool, ehr_id, "COMPOSITION").await;
+
+    // The body is the damaged copy here: `NOT_A_ROOT` is no versioned-object
+    // root type, so `decompose` refuses it (`StorageError::NotAStructureRoot`).
+    tamper(
+        &pool,
+        "UPDATE vo_version SET body = '{\"_type\":\"NOT_A_ROOT\"}' \
+         WHERE vo_id = $1 AND sys_version = $2",
+        vo_id,
+        sys_version,
+    )
+    .await;
+    let before: Vec<(i32, String)> = sqlx::query_as(
+        "SELECT num, path FROM node WHERE vo_id = $1 AND sys_version = $2 ORDER BY num",
+    )
+    .bind(vo_id)
+    .bind(sys_version)
+    .fetch_all(&pool)
+    .await
+    .expect("node rows");
+    assert!(!before.is_empty(), "the version has rows to preserve");
+
+    let report = svc
+        .rebuild_version_nodes(StorageParityScope::default())
+        .await
+        .expect("rebuild");
+
+    assert_eq!(report.versions_refused, 1, "{report:?}");
+    assert_eq!(report.versions_rebuilt, 0);
+    assert!(
+        !report.is_complete(),
+        "a refusal makes the run incomplete: {report:?}"
+    );
+    let NodeRebuildOutcome::Refused { reason } = &report.records[0].outcome else {
+        panic!("expected a refusal, got {:?}", report.records[0].outcome);
+    };
+    assert!(
+        reason.contains("does not decompose"),
+        "the refusal names what is wrong with the body: {reason}"
+    );
+
+    let after: Vec<(i32, String)> = sqlx::query_as(
+        "SELECT num, path FROM node WHERE vo_id = $1 AND sys_version = $2 ORDER BY num",
+    )
+    .bind(vo_id)
+    .bind(sys_version)
+    .fetch_all(&pool)
+    .await
+    .expect("node rows");
+    assert_eq!(
+        before, after,
+        "a refused version's rows are left exactly as they were, never half-written"
+    );
+}
+
+#[tokio::test]
+async fn an_archived_version_is_rebuilt_and_stays_archived() {
+    let db = testkit::db().await.expect("testkit database");
+    let pool = db.pool();
+    let svc = FerroEhrService::new(pool.clone());
+    let ehr_id = seed_ehr_with_composition(&svc).await;
+    let (vo_id, sys_version) = one_version(&pool, ehr_id, "COMPOSITION").await;
+
+    tamper(
+        &pool,
+        "UPDATE node SET data = jsonb_set(data, '{name,value}', '\"tampered\"') \
+         WHERE vo_id = $1 AND sys_version = $2 AND num = 0",
+        vo_id,
+        sys_version,
+    )
+    .await;
+    svc.archive_ehrs(vec![ehr_id.0.to_string()])
+        .await
+        .expect("archive");
+    let cold_before: i64 =
+        sqlx::query_scalar("SELECT count(*) FROM cold.node WHERE vo_id = $1 AND sys_version = $2")
+            .bind(vo_id)
+            .bind(sys_version)
+            .fetch_one(&pool)
+            .await
+            .expect("cold node count");
+    assert!(cold_before > 0, "the object really moved to the cold tier");
+
+    let report = svc
+        .rebuild_version_nodes(StorageParityScope::default())
+        .await
+        .expect("rebuild");
+    assert_eq!(report.versions_rebuilt, 1, "{report:?}");
+
+    // The tier's rule is that a write thaws first, so the repair happens in
+    // the primary tier — and the object must come back exactly as archived as
+    // it went in.
+    let still_marked: bool =
+        sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM vo_archive WHERE vo_id = $1)")
+            .bind(vo_id)
+            .fetch_one(&pool)
+            .await
+            .expect("archive marker");
+    assert!(still_marked, "the archive marker survives the repair");
+    let primary: i64 =
+        sqlx::query_scalar("SELECT count(*) FROM node WHERE vo_id = $1 AND sys_version = $2")
+            .bind(vo_id)
+            .bind(sys_version)
+            .fetch_one(&pool)
+            .await
+            .expect("primary node count");
+    assert_eq!(primary, 0, "nothing was left behind in the primary tier");
+
+    let after = svc
+        .verify_storage_parity(StorageParityScope::default())
+        .await
+        .expect("sweep");
+    assert!(
+        after.is_clean(),
+        "the sweep, which reads both tiers, is clean: {after:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_scoped_rebuild_repairs_only_its_own_ehr() {
+    let db = testkit::db().await.expect("testkit database");
+    let pool = db.pool();
+    let svc = FerroEhrService::new(pool.clone());
+    let repaired = seed_ehr_with_composition(&svc).await;
+    let left_alone = seed_ehr_with_composition(&svc).await;
+
+    for ehr_id in [repaired, left_alone] {
+        let (vo_id, sys_version) = one_version(&pool, ehr_id, "COMPOSITION").await;
+        tamper(
+            &pool,
+            "UPDATE node SET data = jsonb_set(data, '{name,value}', '\"tampered\"') \
+             WHERE vo_id = $1 AND sys_version = $2 AND num = 0",
+            vo_id,
+            sys_version,
+        )
+        .await;
+    }
+
+    let report = svc
+        .rebuild_version_nodes(StorageParityScope {
+            ehr_id: Some(repaired.0),
+            ..StorageParityScope::default()
+        })
+        .await
+        .expect("rebuild");
+    assert_eq!(report.versions_rebuilt, 1, "one EHR's damage: {report:?}");
+
+    let remaining = svc
+        .verify_storage_parity(StorageParityScope::default())
+        .await
+        .expect("sweep");
+    assert_eq!(
+        remaining.mismatch_count, 1,
+        "the other EHR's damage is untouched: {remaining:?}"
+    );
+    assert_eq!(
+        remaining.mismatches[0].vo_id,
+        one_version(&pool, left_alone, "COMPOSITION").await.0
+    );
 }

--- a/website/book/src/operations-admin-apis.md
+++ b/website/book/src/operations-admin-apis.md
@@ -186,6 +186,7 @@ breaks that agreement.
 | Route | **200** body |
 |---|---|
 | `POST {base}/admin/integrity/verify` | the sweep report |
+| `POST {base}/admin/integrity/rebuild-nodes` | the rebuild report |
 
 The sweep re-derives every stored version from its decomposed rows and compares
 the result with the stored document. It reads the archived tier as well, takes
@@ -193,11 +194,14 @@ no lock, and runs outside the request path of any clinical call, so it is safe
 to run on a live server. It is also a full scan of what it covers, so schedule
 it rather than calling it per request.
 
-Two optional query parameters narrow the scan, and they compose:
+Four optional query parameters narrow the scan, and they compose. Both routes
+take the same set:
 
 | Parameter | Effect |
 |---|---|
 | `ehr_id` | cover only versions belonging to that EHR |
+| `vo_id` | cover only versions of that versioned object |
+| `sys_version` | cover only that version of it; the ordinal is per-object, so it needs `vo_id` and is a **400** on its own |
 | `committed_since` | cover only versions whose validity begins at or after that RFC 3339 instant |
 
 Use them. Verifying one record after a support incident, or everything written
@@ -277,6 +281,87 @@ it saw, so the status stays **200** and the report is the body. Check
 > digest covers the document a point read serves; it says nothing about the
 > decomposed rows, which no read-path check recomputes. Together the two cover
 > both copies.
+
+### Repairing what the sweep found
+
+The sweep is the diagnosis. `POST {base}/admin/integrity/rebuild-nodes` is the
+repair: it re-derives the decomposed rows of every damaged version from that
+version's stored document, one transaction per version.
+
+```bash
+curl -s -X POST "$BASE/admin/integrity/rebuild-nodes?ehr_id=$EHR_ID"
+```
+
+It runs the same sweep first and writes only the versions that sweep reports
+damaged, so a run over healthy data writes nothing at all. The scope
+parameters are the same four, so a repair can be as narrow as one version:
+
+```bash
+curl -s -X POST \
+  "$BASE/admin/integrity/rebuild-nodes?vo_id=$VO_ID&sys_version=2"
+```
+
+Which copy wins is not a choice the route makes. The stored document is the
+version's canonical serialized form, the bytes a point read serves and the
+bytes a digest was taken over; the decomposed rows are an index derived from
+it. So the repair only ever runs in that direction, and a version whose
+**document** is the damaged copy is refused rather than having the damage
+copied into the index.
+
+Each version is repaired inside one transaction: the document is read under a
+row lock, decomposed, the old rows deleted, the new set inserted, and the
+version re-derived from what was just written and compared with the document
+before the commit. Anything that fails rolls that transaction back, so the
+version's rows are left exactly as they were. One refusal never stops the run
+that found it.
+
+An archived object is thawed for the repair and re-archived in the same
+transaction, marker and all, because a write to a versioned object always
+happens in the primary tier.
+
+A logically deleted version stores no document, so it rebuilds to no rows,
+which is the repair for `unexpected_nodes`.
+
+```json
+{
+  "versions_checked": 128,
+  "versions_damaged": 2,
+  "versions_rebuilt": 1,
+  "versions_refused": 1,
+  "records": [
+    {
+      "vo_id": "8849182c-82ad-4088-a07f-48ead4180515",
+      "sys_version": 2,
+      "kind": "COMPOSITION",
+      "defect": "content_differs",
+      "outcome": "rebuilt",
+      "node_rows": 41
+    },
+    {
+      "vo_id": "1f0b7d64-6b2a-4a1f-9f0e-6b1d2a3c4d5e",
+      "sys_version": 1,
+      "kind": "COMPOSITION",
+      "defect": "content_differs",
+      "outcome": "refused",
+      "reason": "the stored body does not decompose: ..."
+    }
+  ],
+  "truncated": false,
+  "elapsed_ms": 812
+}
+```
+
+`defect` is the sweep verdict that selected the version, from the four values
+above. `outcome` is `rebuilt`, carrying the `node_rows` the version now has, or
+`refused`, carrying the `reason`. `records` is capped at 1000 entries with
+`truncated` saying whether the cap was reached; every record is logged at
+`info` level with its identifiers whatever the cap does.
+
+A refusal is **not** a request failure, so the status stays **200**. Check
+`versions_refused`: anything above zero means a stored document is itself
+damaged, and that is a restore-from-backup question rather than a rebuild one.
+
+Unlike the sweep, this route writes, so a server in read-only mode refuses it.
 
 ## Dump and load
 


### PR DESCRIPTION
The storage-parity sweep found damage and then the operator had nothing to run. This is its counterpart.

## What was missing

`POST /admin/integrity/verify` reports `NodesMissing` / `ContentDiffers` / `NodesUnreadable` / `UnexpectedNodes`, and the only re-decomposition path in the server was dump and load. Its dump side reads each version through `node_repo::read_version_canonical`, from the node rows themselves, so it reproduces exactly the damage it would be asked to repair, and it is a whole-repository round trip besides. The codec half (`storage::codec::decompose` plus the `unnest` insert) already existed.

## What lands

`POST /admin/integrity/rebuild-nodes` re-derives the node rows of every damaged version from that version's `vo_version.body`, one transaction per version. It drives the sweep as its enumeration, so it writes only what the sweep reports damaged: a run over healthy data reads and writes nothing, which `a_rebuild_over_an_undamaged_repository_writes_nothing` pins by counting rows either side.

## Which copy wins, and why that is not a choice

`body` is the version's canonical serialized form: the bytes a point read serves, and the bytes the signature was taken over (RM common `master06-change_control_package.adoc` §Digital Signature). The node rows are an index derived from it by `decompose`. So the repair only ever runs in that direction, and a version whose **body** is the damaged copy is refused rather than having the damage decomposed into the index. That is a restore-from-backup question, and the report says so instead of pretending otherwise.

## Per version, atomically

The body is read under a `FOR UPDATE` row lock, decomposed, the old rows deleted, the new set inserted, and then the version is re-derived from what was just written and compared with the body **before** the commit. A body that does not parse, a body that does not decompose, and a rebuild whose rows do not reproduce it all roll that transaction back, so the version's rows are left exactly as they were. `a_body_that_does_not_decompose_is_refused_and_its_rows_are_untouched` asserts the row set is byte-identical before and after, not merely that the call reported a refusal. One refusal never stops the run that found it.

The re-verify needed `node_repo::read_rows` to become executor-generic: a pool-typed read runs on another connection and would see the rows being replaced rather than the ones just written.

## The archived tier

`storage::version_repo::tier` states the rule the whole design rests on: a write always thaws first, so a versioned object is never split across tiers. The rebuild honours it rather than inventing a cold-tier write path. An archived object is thawed, repaired in the primary tier, and re-frozen with its archive marker inside the same transaction, so a rollback undoes the thaw too. `an_archived_version_is_rebuilt_and_stays_archived` damages a composition, archives it, repairs it, and then asserts the marker survived and the primary tier is empty again.

## Logical deletes

A logically deleted version (RM common master06 §Logical Deletion) stores no body, so it rebuilds to zero node rows. That is exactly the repair for `unexpected_nodes`, and it falls out of the same code path rather than being special-cased.

## Scope

`StorageParityScope` gains `vo_id` and `sys_version`, so **both** integrity routes can be pointed at one object or one version instead of reading the repository. The ordinal is per-object, so `sys_version` without `vo_id` is a `400` rather than a filter that would quietly match one version of every object.

## Authorization

The route writes, so it stays out of `EXTENSION_READ_ROUTES` and a read-only server refuses it; `admin_rebuild_version_nodes` classifies as a write through the existing `admin_` prefix rule. The sweep beside it keeps its read classification (#2692). `authz_route_matrix` caught the unclassified route before I did, which is what it is for.

## Proven by two independent readers

Every repair case is verified twice: by the sweep itself, and by an AQL query, which reads the `node` rows and nothing else. `a_tampered_node_row_is_rebuilt_and_the_sweep_goes_clean` first asserts the fixture really corrupted what AQL returns, then asserts AQL reads the restored value afterwards — so a repair that only satisfied the sweep could not pass it.

Seven new DB-backed tests (`storage_parity.rs`) plus three HTTP tests (`admin_integrity_http.rs`). Every tamper reaches past the service with raw SQL and asserts its statement matched a row, per that module's existing rule.

## Gates

`cargo nextest run --workspace`: 5015 passed, 0 failed. `cargo clippy --workspace --exclude ferroehr-viewer --all-targets --all-features -D warnings`, `cargo fmt`, `RUSTDOCFLAGS=-D warnings cargo doc --document-private-items`, and the guards: `comment-style` (2484 files), `typed-status`, `default-style`, `error-source-chain`, `sql-string-building`, `spdx-headers` (2491 files), `docs-claims` (67 pages), `shellcheck`. Admin API book page and `CHANGELOG.md` updated. No `crates/*` content changed, so no crate-line bump.

Closes #3143.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.

## Checks

- [x] `cargo fmt --all --check` · `cargo clippy --workspace --all-targets` · `cargo nextest run --workspace`
- [x] No test weakened, skipped, or edited to route around a bug
- [x] User-visible change → `CHANGELOG.md [Unreleased]` entry
- [x] REST change → `website/book/src/operations-admin-apis.md` updated
- [x] No implemented plan file to delete
- [x] No new issues opened from this work