### PR TITLE
chore(memory): record the PR contribution-licensing ruling

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -5,6 +5,7 @@
 - [Owner work style](owner-work-style.md) — defer nothing; no quick fixes (proper rewrites welcome); orchestrator codes context-heavy work itself; big-bang rewrites converge once at the end (no intermediate stubs); specs re-read first-hand; never copy a number forward; rerun `scripts/conformance.sh` after runner/validation merges
 - [Autonomous phase flow](autonomous-phase-flow.md) — standing: PR+merge each phase, checkout main, start the next without asking; never branch while finished work sits unmerged
 - [Merge on local gates](merge-on-local-gates.md) — local gates green (fmt+clippy+nextest+CNF validate) → merge the PR immediately; CI is a post-merge backstop
+- [Tick the PR licensing box](tick-pr-licensing-box.md) — every PR body I open carries the ticked contribution-licensing line; leaving it turns the PR red on a formality
 - [Max 2 concurrent workers](max-two-concurrent-workers.md) — implementation subagents run in pairs, never wider
 - [One worker per phase, hard fences](one-worker-per-phase-hard-fences.md) — within a refactor phase run ONE worker with explicit file fences; reverts are orchestrator-only; back up before any reset
 - [Concurrent sessions share this tree](concurrent-sessions-shared-tree.md) — explicit-pathspec commits, scoped gates, worktree-isolate parallel agents; ONE `./target` for everything incl. the IDE; `cargo clean` above ~30 GB

--- a/.claude/memory/tick-pr-licensing-box.md
+++ b/.claude/memory/tick-pr-licensing-box.md
@@ -1,0 +1,15 @@
+---
+name: tick-pr-licensing-box
+description: "Standing instruction to tick the contribution-licensing checkbox in every PR body I open, rather than leaving it for the owner"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 41ab4b7d-4974-4bc0-9a89-c1d7691c6eb6
+  modified: 2026-09-06T18:42:19.565Z
+---
+
+Tick the PR template's `- [ ] I accept the terms in [CONTRIBUTING.md § Licensing of contributions]` box on every PR I open (owner ruling 2026-09-06). Do not leave it unticked "for the owner to sign".
+
+**Why:** the `contribution-licence-guard` CI job fails on an unticked or missing line, so leaving it turns every PR red on a formality. The owner is the sole copyright holder AND the Licensor named in `LICENSE`, so the attestation is true by construction; a body edit unticks it if they ever disagree.
+
+**How to apply:** include the full `## Licensing of contributions` section with `- [x]` in the PR body at creation time. The guard reads the PR event payload, so a body edit re-runs it. See [[merge-on-local-gates]] and [[autonomous-phase-flow]].


### PR DESCRIPTION
The agent memory lives in-repo at `.claude/memory/` precisely so it is visible and versioned, with the harness directory under `~/.claude/projects/` symlinked to it. A memory written during a session and never committed is the one way that arrangement fails silently: it looks recorded, and it is gone with the checkout.

This commits the entry written while landing #3142, #3143 and #3144, plus its index line.

## The ruling it records

Owner ruling 2026-09-06: a pull request opened on the owner's behalf carries the `## Licensing of contributions` line already ticked.

I had been leaving it unticked, on the reasoning that "I have the right to submit this work, I license it under the project licence, and I grant the Licensor the relicensing right" is an attestation rather than a build step. In this repository that reasoning does not hold up: the owner is both the sole copyright holder and the Licensor named in `LICENSE`, so the statement is true by construction, and leaving the box empty turns every pull request red on `contribution-licence-guard` for a formality. Editing the body unticks it if that ever changes, and the guard re-runs on the edit.

## Gates

`scripts/checks/spdx-headers.sh` (2492 files), `scripts/checks/licensing-declarations.sh`, and `reuse lint` (12429/12429, REUSE 3.3 compliant). The symlink from the harness memory directory into this tree is intact and untouched. Markdown only, so no Rust gates and no crate-line bump.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.

## Checks

- [x] No Rust changed; the licence and REUSE gates run instead
- [x] No test weakened, skipped, or edited to route around a bug
- [ ] `CHANGELOG.md [Unreleased]` entry — not applicable, no user-visible behaviour changed (needs the `no-changelog` label)
- [x] No REST, config, CLI or deployment change, so no book page to update
- [x] No implemented plan file to delete
- [x] No new issues opened from this work