### PR TITLE
docs(compliance): the overview and shared-responsibility pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,24 @@ workflow refuses a tag that has no matching section here.
   undeclared source stops the render and names the issue. A CI job re-renders
   and diffs, so a control that shipped since the last render fails the build
   instead of sitting on the public site as "planned".
+
+- **The documentation site has a compliance section** (#3163, #3165). Two
+  pages join the generated control matrix. The compliance overview states the
+  pseudonymisation boundary, then walks GDPR, the EDPB Guidelines 01/2025 on
+  pseudonymisation, the EHDS, the Dutch UAVG and Wabvpz, and NEN 7510, 7512 and
+  7513, saying per requirement what the product ships, what is planned and
+  under which issue, and what the deploying organisation still has to do. The
+  shared-responsibility page draws the same line obligation by obligation,
+  because most duties in these texts rest on the controller and the processor
+  and cannot be met by software. Both pages carry the wording policy of the
+  compliance programme: FerroEHR aims to be the first openly developed,
+  source-available openEHR CDR with a published, tracker-backed EU compliance
+  posture and an EHDS conformity self-assessment on its roadmap, and it claims
+  no certification, no conformity and no compliant deployment. The
+  pseudonymisation boundary is written as planned throughout, with its issue
+  numbers, because the schema split and the linkage service are not merged.
+  Every legal source is linked to its official publisher, and every openEHR
+  statement to the published specification section it comes from.
 - **The storage-parity sweep has a repair to go with it** (#3143).
   `POST /admin/integrity/verify` reported that a version's decomposed rows and
   its stored document disagree, and then there was nothing to run: dump and

--- a/website/book/src/SUMMARY.md
+++ b/website/book/src/SUMMARY.md
@@ -67,4 +67,6 @@
 - [Rust crates](crates.md)
 - [Contributing](contributing.md)
 - [Licensing & legal](licensing.md)
+  - [Compliance overview](compliance/index.md)
+  - [Shared responsibility](compliance/shared-responsibility.md)
   - [Control matrix](compliance/control-matrix.md)

--- a/website/book/src/comparison.md
+++ b/website/book/src/comparison.md
@@ -37,6 +37,17 @@ rejects any attempt to hand-type it. To reproduce either side yourself, see
 [Conformance](conformance.md#running-the-suite-yourself) and
 [Benchmarks](benchmarks.md).
 
+One difference between the two projects is not something a runner can score,
+so this page states it rather than tabling it. FerroEHR aims to be the first
+openly developed, source-available openEHR CDR with a published,
+tracker-backed EU compliance posture, and an EHDS conformity self-assessment
+is on its roadmap: the [compliance overview](compliance/index.md) names the
+legal sources, the [control matrix](compliance/control-matrix.md) is generated
+from the tracker, and the [shared-responsibility page](compliance/shared-responsibility.md)
+says which obligations the software cannot carry. None of that is a
+certification claim, and none of it is a statement about EHRbase, which
+publishes its own documentation on its own terms.
+
 <!-- toc -->
 
 ## Conformance

--- a/website/book/src/compliance/index.md
+++ b/website/book/src/compliance/index.md
@@ -1,0 +1,214 @@
+# Compliance overview
+
+FerroEHR is software. It is not a controller, not a processor and not a
+certified organisation, so nothing on this page says that a deployment
+complies with anything. What this page does say is which technical controls
+the product ships today, which are planned and tracked in public, and which
+obligations stay with the organisation that runs it.
+
+The page is written for three readers. A privacy officer wants the legal
+sources and the split of duties. A hospital CISO wants the controls and their
+status. A developer wants to know where the boundary between clinical and
+identifying data runs. Each of those three readings takes about ten minutes.
+
+<!-- toc -->
+
+## What FerroEHR claims, and what it does not
+
+FerroEHR aims to be the first openly developed, source-available openEHR CDR
+with a published, tracker-backed EU compliance posture, and an EHDS conformity
+self-assessment is on its roadmap.
+
+It holds no certification, no declaration of conformity and no third-party
+assessment. No page on this site will tell you that FerroEHR is "GDPR
+compliant", "NEN 7510 certified" or "EHDS conformant", because none of those
+statements would be true of a piece of software on its own.
+
+What the project does instead is publish the record. A shipped control has a
+feature page in this book and an issue in the tracker that delivered it. A
+planned control has an open issue and appears here as planned, with its
+number. The [control matrix](control-matrix.md) is generated from the tracker,
+so a control cannot sit on this site as "planned" after it has shipped, or as
+"shipped" before it has.
+
+> [!WARNING]
+> The legal texts linked here change, and some of them are not yet in force.
+> The EHDS obligations phase in over several years on the dates its own final
+> provisions carry, and NEN republishes its standards on its own cycle
+> (NEN 7510 was reissued in December 2024). Check each publisher directly
+> before you rely on a statement here: [EUR-Lex](https://eur-lex.europa.eu/)
+> for EU law, [wetten.overheid.nl](https://wetten.overheid.nl/) for Dutch law,
+> the [EDPB](https://www.edpb.europa.eu/) for guidelines, and
+> [NEN](https://www.nen.nl/zorg-welzijn/ict-in-de-zorg/informatiebeveiliging-in-de-zorg)
+> for the 7510 family. This page is a summary for evaluators and deployers,
+> not legal advice.
+
+## The pseudonymisation boundary
+
+A clinical record is identifying as soon as the record and the person can be
+put back together by whoever holds the database. Separating the two, and
+controlling who may rejoin them, is what
+[GDPR Art. 4(5)](https://eur-lex.europa.eu/eli/reg/2016/679/oj) calls
+pseudonymisation, and it is the control the
+[EDPB Guidelines 01/2025](https://www.edpb.europa.eu/our-work-tools/documents/public-consultations/2025/guidelines-012025-pseudonymisation_en)
+expect a supplier to describe rather than assert.
+
+openEHR anticipated this. The Reference Model's
+[PARTY_SELF and Referring to the Patient from the EHR](https://specifications.openehr.org/releases/RM/Release-1.1.0/common.html#_party_self_and_referring_to_the_patient_from_the_ehr)
+section names three schemes for pointing at the record subject, and calls the
+one that never sets `external_ref` anywhere in the EHR "the most secure
+approach", because the link between record and patient is then held outside
+the EHR. The second scheme sets it once, in
+[`EHR_STATUS.subject`](https://specifications.openehr.org/releases/RM/Release-1.1.0/ehr.html#_ehr_status_class),
+whose own class description says the association "may be done elsewhere for
+security reasons". The reference itself is a
+[`PARTY_REF`](https://specifications.openehr.org/releases/BASE/Release-1.2.0/base_types.html#_party_ref_class),
+described by the specification as an "identifier for parties in a demographic
+or identity service", so it carries a namespace, a party type and an id and no
+demographic content of its own. The specification leaves the choice of scheme
+to the implementation. Where the schemas, the database roles and the resolve
+path live is FerroEHR's own design, and no openEHR spec governs it.
+
+### What ships today
+
+Clinical content and demographic parties share one PostgreSQL schema, `ehr`,
+and one runtime database role, `ferroehr_app`. A demographic contribution is
+distinguished by carrying no owning EHR rather than by living anywhere else.
+The controls that do apply across both are the same ones: role- and
+attribute-based authorization, per-EHR access settings, tenant row-level
+security, and the audit trail. Both sides also carry openEHR's own provenance,
+because every write commits a contribution and its audit in the same
+transaction, which is the versioning discipline the
+[Change Control Package](https://specifications.openehr.org/releases/RM/Release-1.1.0/common.html#_change_control_package)
+defines.
+
+```mermaid
+flowchart LR
+    client["API client"] --> server["FerroEHR server"]
+    server -->|ferroehr_app| ehr[("ehr schema:<br/>clinical versions, nodes,<br/>demographic parties")]
+    server -->|ferroehr_app| audit[("audit schema:<br/>ATNA record repository")]
+```
+
+### What is planned
+
+The boundary splits the store into separate schemas with non-overlapping
+database roles, so no single runtime credential reaches both the clinical
+content and the identifying data, and the resolve map that rejoins them is a
+third domain with its own role and its own audit. The whole programme is
+[#3152](https://github.com/rubentalstra/FerroEHR/issues/3152).
+
+```mermaid
+flowchart LR
+    client2["API client"] --> server2["FerroEHR server"]
+    server2 -->|clinical role| ehr2[("ehr schema:<br/>clinical versions and nodes")]
+    server2 -->|demographic role| demo[("demographic schema:<br/>parties and identifiers")]
+    server2 -->|linkage role| link[("linkage schema:<br/>party to EHR resolve map")]
+```
+
+None of the following is shipped. Each row is an open issue.
+
+| Planned control | Issue |
+|---|---|
+| Demographic parties move to a `demographic` schema with their own runtime role | [#3153](https://github.com/rubentalstra/FerroEHR/issues/3153) |
+| The clinical side refuses identifying data, and the subject reference is constrained to a pseudonym namespace | [#3154](https://github.com/rubentalstra/FerroEHR/issues/3154) |
+| National identifiers stored encrypted, looked up by key, resolved under audit | [#3155](https://github.com/rubentalstra/FerroEHR/issues/3155) |
+| Per-domain access logging for reads and queries | [#3156](https://github.com/rubentalstra/FerroEHR/issues/3156) |
+| Separate encryption keys and per-schema backup handling | [#3157](https://github.com/rubentalstra/FerroEHR/issues/3157) |
+| The linkage service: the party-to-EHR resolve map as its own schema and role | [#3158](https://github.com/rubentalstra/FerroEHR/issues/3158) |
+| Cross-domain cohort queries with a demographic predicate and a clinical selection | [#3159](https://github.com/rubentalstra/FerroEHR/issues/3159) |
+| A secondary-use read model as a separate pseudonymisation domain | [#3160](https://github.com/rubentalstra/FerroEHR/issues/3160) |
+
+Until those land, treat a FerroEHR database as holding directly identifying
+data alongside clinical data, and size your access control, backup handling
+and risk assessment accordingly. The
+[threat model](../threat-model.md) states the residual risk at each boundary
+the product does defend.
+
+## GDPR
+
+[Regulation (EU) 2016/679](https://eur-lex.europa.eu/eli/reg/2016/679/oj)
+places its duties on the controller and the processor. A CDR can only supply
+the technical measures those duties are met with. These are the articles a
+repository actually touches.
+
+| What the article asks for | What FerroEHR ships | Tracker | What the deploying organisation must do |
+|---|---|---|---|
+| **Art. 4(5)** pseudonymisation: identifying data kept separately, under technical measures | Nothing yet: clinical and demographic data share one schema and one runtime role | planned, [#3152](https://github.com/rubentalstra/FerroEHR/issues/3152) | Treat the store as directly identifying; keep the separation at your own layer if you need it now |
+| **Art. 5(1)(f)** integrity and confidentiality | TLS 1.3 with optional mutual authentication, [authentication and authorization](../security.md), per-version digest [signing](../signing/index.md), a tamper-evident audit chain | shipped | Terminate TLS correctly, run the identity provider, hold the keys |
+| **Art. 5(2)** accountability: being able to demonstrate compliance | An audit trail of every access, [retrievable over ITI-81](../audit.md#retrieving-audit-records-iti-81), plus openEHR's own contribution and audit chain on every write | shipped | Keep the records, define retention, be able to produce them |
+| **Art. 9** special categories of data | Object-level [`EHR_ACCESS`](../security.md#per-ehr-access-control-ehr_access) settings, RBAC, ABAC, tenant row-level security | shipped | Establish the Art. 9(2) condition and the national derogation that permits the processing |
+| **Art. 25** data protection by design and by default | Deny-by-default authorization, an `EHR_ACCESS` default that can be set to restricted, tenancy that fails closed, audit on by default | shipped | Choose the restrictive settings. Two defaults favour compatibility instead: the per-EHR access default is `open`, and the audit fail mode is `open` |
+| **Art. 30** records of processing activities | The effective configuration as a redacted JSON tree at `GET {base}/admin/config`, and this book as a description of what the software does | shipped | Write and maintain the record itself; the software cannot know your purposes or recipients |
+| **Art. 32** security of processing | The controls listed in [Security & multi-tenancy](../security.md) and the residual risk in the [threat model](../threat-model.md) | shipped | Assess whether they are appropriate to your risk, and supply everything below the application |
+| **Art. 35** data protection impact assessment | Published control and boundary documentation to assess against | guidance planned, [#3161](https://github.com/rubentalstra/FerroEHR/issues/3161) | Run the DPIA; it is the controller's, and no supplier document replaces it |
+
+## EDPB Guidelines 01/2025 on pseudonymisation
+
+The [EDPB guidelines](https://www.edpb.europa.eu/our-work-tools/documents/public-consultations/2025/guidelines-012025-pseudonymisation_en)
+ask for something more specific than "we pseudonymise": a named
+pseudonymisation domain, a stated attacker, and additional information kept
+where that attacker cannot reach it.
+
+| What the guidelines ask for | What FerroEHR ships | Tracker | What the deploying organisation must do |
+|---|---|---|---|
+| A pseudonymisation domain stated explicitly | Nothing yet; the domain is being defined as the schema and role split | planned, [#3152](https://github.com/rubentalstra/FerroEHR/issues/3152) | State the domain for your deployment, including the parts outside FerroEHR |
+| The additional information held separately from the pseudonymised data | Nothing yet; the resolve map is planned as its own schema and role | planned, [#3158](https://github.com/rubentalstra/FerroEHR/issues/3158) | Hold your own identity mapping outside the CDR if you need the separation today |
+| A written attacker model, including the insider holding a credential | The [threat model](../threat-model.md) names actors, boundaries and the risk surviving each control | shipped | Extend it with the actors your environment adds: operators, backups, the network |
+| Resolution of a pseudonym recorded and controlled | Every access is audited today; the audited resolve path is planned with the linkage service | partly shipped, [#3155](https://github.com/rubentalstra/FerroEHR/issues/3155) | Restrict who may resolve, and review the trail |
+
+## EHDS
+
+[Regulation (EU) 2025/327](https://eur-lex.europa.eu/eli/reg/2025/327/oj)
+splits into chapters that reach a CDR differently. Chapter III is the one that
+speaks to an EHR system as a product, and its obligations apply from a date in
+the regulation's own final provisions rather than today.
+
+| Chapter | What FerroEHR ships | Tracker | What the deploying organisation must do |
+|---|---|---|---|
+| **Chapter II**, primary use, including the patient's access to their data and to a record of who accessed it | An [access trail](../audit.md) of every read, write and refusal, searchable by patient and by agent | shipped | Build the patient-facing access route; the CDR exposes the trail to an admin caller, not to the patient |
+| **Chapter III**, EHR systems: a European interoperability software component and a European logging software component, with published technical documentation | A [conformance record](../conformance.md) and an [audit model](../audit.md) to map onto those components | readiness planned, [#3168](https://github.com/rubentalstra/FerroEHR/issues/3168), [#3169](https://github.com/rubentalstra/FerroEHR/issues/3169), [#3170](https://github.com/rubentalstra/FerroEHR/issues/3170), [#3171](https://github.com/rubentalstra/FerroEHR/issues/3171) | Decide whether you are the manufacturer of the EHR system you put into service |
+| **Chapter IV**, secondary use | [AQL](../querying-aql.md) over the stored record, and a [change-event outbox](../beyond-core/amqp.md) | a separate pseudonymisation domain for secondary use is planned, [#3160](https://github.com/rubentalstra/FerroEHR/issues/3160) | Deal with the health data access body; a CDR is not a data-holder process |
+
+## Dutch law: UAVG and Wabvpz
+
+Two Dutch acts sit on top of the GDPR for a care provider. The
+[UAVG](https://wetten.overheid.nl/BWBR0040940) is the national implementation
+act; the [Wabvpz](https://wetten.overheid.nl/BWBR0023864) governs the
+burgerservicenummer in care and the patient's electronic access to their
+record.
+
+| Provision | What FerroEHR ships | Tracker | What the deploying organisation must do |
+|---|---|---|---|
+| **UAVG Art. 30**, exceptions for health data | Access control at the record and the attribute level, and an audit trail of who used it | shipped | Establish that your processing falls inside the exception, per role and per purpose |
+| **UAVG Art. 46**, processing a national identification number | Nothing specific yet; a party identifier is stored like any other in the shared schema | planned, [#3155](https://github.com/rubentalstra/FerroEHR/issues/3155) | Hold the legal authorisation before a BSN enters the store, and keep it out until then |
+| **Wabvpz Art. 4 to 9**, use and verification of the BSN by care providers | Nothing specific: FerroEHR performs no BSN verification and consults no index | not planned | Verify identity and the BSN in your own systems before data reaches the CDR |
+| **Wabvpz Art. 15d**, electronic access and copy for the patient | The full record over the openEHR REST API, and [EHR Extract export](../beyond-core/messaging.md) for a whole record | shipped | Build the patient-facing route and authenticate the patient |
+| **Wabvpz Art. 15e**, a record of who made data available and who consulted it | The ATNA trail records reads, writes and refusals with the agent, the patient, the action and the outcome, and answers a per-patient search | shipped | Turn the trail into something a patient can read, and set retention |
+
+## NEN 7510, NEN 7512 and NEN 7513
+
+The [NEN 7510 family](https://www.nen.nl/zorg-welzijn/ict-in-de-zorg/informatiebeveiliging-in-de-zorg)
+governs information security in Dutch healthcare. NEN 7510 is a
+management-system standard, which no product can be certified against.
+NEN 7512 governs what exchanging parties promise each other. NEN 7513 is the
+one that states requirements a piece of software meets directly.
+
+| Standard | What FerroEHR ships | Tracker | What the deploying organisation must do |
+|---|---|---|---|
+| **[NEN 7510-1](https://www.nen.nl/nen-7510-1-2024-nl-331311)** and **[7510-2](https://www.nen.nl/nen-7510-2-2024-nl-331314)**, the management system and its controls | Technical controls an ISMS can point at, documented per control with their residual risk | shipped | Run the ISMS and hold the [certification](https://www.nen.nl/certificatie-en-keurmerken-nen-7510); a product cannot be certified against a management-system standard |
+| **[NEN 7512](https://www.nen.nl/nen-7512-2022-nl-297137)**, the trust basis for data exchange | Mutually authenticated TLS ([IHE ITI-19](../audit.md#node-authentication-iti-19-mutual-tls)), OAuth2 and OIDC with an [enterprise identity provider](../identity-providers.md), signed and verifiable [releases](../verifying-releases.md) | shipped | Agree the trust basis with each counterparty and operate the certificate estate |
+| **[NEN 7513](https://www.nen.nl/nen-7513-2018-nl-245399)**, logging actions on electronic patient records | An IHE ATNA trail that records every operation including refusals, in FHIR `AuditEvent` and DICOM PS3.15 form, hash-chained in the database and retrievable per patient | shipped | Map the recorded fields onto the standard's own list, set retention, and review the trail |
+
+## Where to go next
+
+- **[Control matrix](control-matrix.md):** the machine-generated status of every
+  declared control, straight from the tracker.
+- **[Shared responsibility](shared-responsibility.md):** which obligation is
+  the software's and which is yours, obligation by obligation.
+- **[Security & multi-tenancy](../security.md):** how each control is
+  configured.
+- **[Threat model](../threat-model.md):** what survives each control.
+- **[Audit trail](../audit.md):** what is recorded, in which formats, and how
+  to read it back.
+- **DPIA guidance, records of processing and a go-live checklist:** planned,
+  [#3161](https://github.com/rubentalstra/FerroEHR/issues/3161).

--- a/website/book/src/compliance/shared-responsibility.md
+++ b/website/book/src/compliance/shared-responsibility.md
@@ -1,0 +1,103 @@
+# Shared responsibility
+
+Almost every obligation in EU and Dutch health-data law rests on the
+controller, and where FerroEHR is operated on that controller's behalf, on the
+processor. A repository supplies technical measures. It cannot hold a legal
+basis, sign a processing agreement, notify a supervisory authority or run a
+management system.
+
+This page draws that line obligation by obligation, so you can see at a glance
+which part of the work the software has already done and which part is still
+yours. No openEHR specification governs any of it; the division below follows
+the legal texts each row links.
+
+<!-- toc -->
+
+## How to read the tables
+
+Each row names one obligation and links its official source. The middle column
+is what FerroEHR provides, linked to the page that documents it, or to the open
+issue when the control is planned rather than shipped. The right column is the
+work that stays with the deploying organisation.
+
+"Nothing" in the middle column is a real answer and appears wherever it is
+the true one.
+
+> [!NOTE]
+> The FerroEHR project is not your processor. It publishes software; it
+> operates nothing on your behalf and holds none of your data. Where a row says
+> "the processor", it means whoever runs the deployment, which may be you.
+
+## GDPR
+
+Every row below cites
+[Regulation (EU) 2016/679](https://eur-lex.europa.eu/eli/reg/2016/679/oj). The
+duties in it belong to the controller and the processor. The middle column is
+only the technical measure FerroEHR supplies toward one of them.
+
+| Obligation | What FerroEHR provides | What the deploying organisation does |
+|---|---|---|
+| [Art. 5(1)(e)](https://eur-lex.europa.eu/eli/reg/2016/679/oj) storage limitation | Audit-trail retention as a configured period, and irreversible [physical deletion](../operations-admin-apis.md#physical-deletion) of an EHR through the admin API | Set the retention schedule and execute it; openEHR versions are append-only until you delete the record |
+| [Art. 5(2)](https://eur-lex.europa.eu/eli/reg/2016/679/oj) accountability | An [audit trail](../audit.md) of every access, openEHR's own contribution and audit chain on every write, and a published [conformance record](../conformance.md) | Retain the evidence and be able to produce it on demand |
+| [Art. 6 and Art. 9(2)](https://eur-lex.europa.eu/eli/reg/2016/679/oj) legal basis and the condition for health data | Nothing. Software cannot hold a legal basis | Establish the basis and the Art. 9(2) condition, per purpose, before data is entered |
+| [Art. 24 and Art. 25](https://eur-lex.europa.eu/eli/reg/2016/679/oj) responsibility, and protection by design and by default | Deny-by-default [authorization](../security.md#authorization), per-EHR access settings, tenancy that fails closed, audit on by default | Choose the restrictive settings, and document why the chosen configuration is appropriate |
+| [Art. 28](https://eur-lex.europa.eu/eli/reg/2016/679/oj) processor terms and sufficient guarantees | Published control documentation, a [threat model](../threat-model.md) with named residual risk, and verifiable [release artifacts](../verifying-releases.md) | Conclude the processing agreement with whoever operates the deployment, and audit them |
+| [Art. 30](https://eur-lex.europa.eu/eli/reg/2016/679/oj) records of processing activities | The effective configuration as a redacted tree at `GET {base}/admin/config`, and this book as a description of what the software does | Write and maintain the record; only you know the purposes, the recipients and the transfers |
+| [Art. 32](https://eur-lex.europa.eu/eli/reg/2016/679/oj) security of processing | TLS 1.3 with optional [mutual authentication](../audit.md#node-authentication-iti-19-mutual-tls), [authentication and access control](../security.md), per-version [signing](../signing/index.md), a tamper-evident audit chain, [tenant row-level security](../security.md#multi-tenancy) | Supply everything below the application: the database, its backups, the network, the platform. See [Cluster hardening](../installation/kubernetes-hardening.md) |
+| [Art. 32(1)(d)](https://eur-lex.europa.eu/eli/reg/2016/679/oj) regularly testing the measures | A [storage-integrity sweep and rebuild](../operations-admin-apis.md#storage-integrity), an [audit-chain verification query](../audit.md#tamper-evidence), and a [conformance suite](../conformance.md) that runs against your own server | Schedule the checks, alert on their output, and test your restore |
+| [Art. 33 and 34](https://eur-lex.europa.eu/eli/reg/2016/679/oj) breach notification | The evidence a breach assessment needs: who read what, when, and whether the trail itself is intact | Detect, assess and notify within the deadlines. No software does this for you |
+| [Art. 15 and 20](https://eur-lex.europa.eu/eli/reg/2016/679/oj) access and portability | The full record over the openEHR REST API in canonical JSON or XML, and [EHR Extract export](../beyond-core/messaging.md) for a whole record | Authenticate the data subject and build the patient-facing route |
+| [Art. 16 and 17](https://eur-lex.europa.eu/eli/reg/2016/679/oj) rectification and erasure | Versioned correction with the prior version retained, and [physical, irreversible deletion](../operations-admin-apis.md#physical-deletion) of an EHR for a legal erasure request | Decide how an erasure request interacts with the medical record-keeping duty, and record the decision |
+| [Art. 18 and 21](https://eur-lex.europa.eu/eli/reg/2016/679/oj) restriction and objection | `EHR_STATUS.is_queryable` and `is_modifiable`, both enforced by the server: a restricted record leaves population queries and refuses content writes | Decide when to set them, and record why |
+| [Art. 35](https://eur-lex.europa.eu/eli/reg/2016/679/oj) data protection impact assessment | Control and boundary documentation to assess against; DPIA guidance is planned in [#3161](https://github.com/rubentalstra/FerroEHR/issues/3161) | Run the DPIA and keep it current. It is the controller's, and no supplier document replaces it |
+| [Art. 4(5)](https://eur-lex.europa.eu/eli/reg/2016/679/oj) pseudonymisation | Nothing yet. Clinical and demographic data share one schema and one runtime role; the boundary is planned in [#3152](https://github.com/rubentalstra/FerroEHR/issues/3152) | Keep identifying data outside the CDR if you need the separation today |
+
+## EHDS
+
+[Regulation (EU) 2025/327](https://eur-lex.europa.eu/eli/reg/2025/327/oj)
+is in force, and its operative obligations apply from the dates its own final
+provisions carry. No row below claims conformity with any of them.
+
+| Obligation | What FerroEHR provides | What the deploying organisation does |
+|---|---|---|
+| [Chapter II](https://eur-lex.europa.eu/eli/reg/2025/327/oj), primary use and the patient's sight of who accessed their data | An access trail of every read, write and refusal, [searchable by patient and by agent](../audit.md#retrieving-audit-records-iti-81) | Build the patient-facing access route; the trail is exposed to an admin caller, not to the patient |
+| [Chapter III](https://eur-lex.europa.eu/eli/reg/2025/327/oj), EHR systems: the European interoperability and logging software components, and published technical documentation | Readiness work is planned in [#3168](https://github.com/rubentalstra/FerroEHR/issues/3168), [#3169](https://github.com/rubentalstra/FerroEHR/issues/3169), [#3170](https://github.com/rubentalstra/FerroEHR/issues/3170) and [#3171](https://github.com/rubentalstra/FerroEHR/issues/3171) | Decide whether you are the manufacturer of the EHR system you put into service, and carry the manufacturer's duties if so |
+| [Chapter IV](https://eur-lex.europa.eu/eli/reg/2025/327/oj), secondary use | [AQL](../querying-aql.md) over the stored record and a [change-event outbox](../beyond-core/amqp.md); a separate pseudonymisation domain for secondary use is planned in [#3160](https://github.com/rubentalstra/FerroEHR/issues/3160) | Deal with the health data access body and carry the data holder's duties |
+
+## Dutch law
+
+| Obligation | What FerroEHR provides | What the deploying organisation does |
+|---|---|---|
+| [UAVG Art. 30](https://wetten.overheid.nl/BWBR0040940), the exception for health data | Access control at the record and attribute level, with every use audited | Establish that your processing falls inside the exception, per role and per purpose |
+| [UAVG Art. 46](https://wetten.overheid.nl/BWBR0040940), processing a national identification number | Nothing specific yet; encrypted storage and audited resolution of national identifiers is planned in [#3155](https://github.com/rubentalstra/FerroEHR/issues/3155) | Hold the statutory authorisation before a BSN enters the store |
+| [Wabvpz Art. 4 to 9](https://wetten.overheid.nl/BWBR0023864), use and verification of the BSN | Nothing. FerroEHR performs no BSN verification and consults no index | Verify identity and the BSN in your own systems before data reaches the CDR |
+| [Wabvpz Art. 15d](https://wetten.overheid.nl/BWBR0023864), electronic access and copy for the patient | The full record over the REST API, and [EHR Extract export](../beyond-core/messaging.md) | Authenticate the patient and build the route; the CDR has no patient-facing interface |
+| [Wabvpz Art. 15e](https://wetten.overheid.nl/BWBR0023864), a record of who made data available and who consulted it | An [ATNA trail](../audit.md) recording the agent, the patient, the action, the outcome and the time, retrievable per patient | Render it for the patient, set retention, and review it |
+| [BW Book 7, Art. 454](https://wetten.overheid.nl/BWBR0005290), the medical treatment contract's record-keeping duty | Append-only version history, so a correction never destroys the prior version | Set the retention schedule the article requires, and reconcile it with erasure requests |
+
+## NEN
+
+The [NEN 7510 family](https://www.nen.nl/zorg-welzijn/ict-in-de-zorg/informatiebeveiliging-in-de-zorg)
+is where the split is sharpest. A management-system standard cannot be met by
+a product at all.
+
+| Obligation | What FerroEHR provides | What the deploying organisation does |
+|---|---|---|
+| [NEN 7510-1](https://www.nen.nl/nen-7510-1-2024-nl-331311), the information security management system | Technical controls an ISMS can point at, each documented with its residual risk in the [threat model](../threat-model.md) | Run the ISMS: scope, risk assessment, policy, internal audit, management review |
+| [NEN 7510-2](https://www.nen.nl/nen-7510-2-2024-nl-331314), the controls | [Access control](../security.md), [audit logging](../audit.md), cryptography in transit and for [version signatures](../signing/index.md), [supply-chain verification](../verifying-releases.md) | Everything organisational: personnel, physical security, supplier management, continuity |
+| [Certification](https://www.nen.nl/certificatie-en-keurmerken-nen-7510) against NEN 7510 | Nothing. A product cannot be certified against a management-system standard, and FerroEHR makes no such claim | Obtain and maintain the certificate for your organisation |
+| [NEN 7512](https://www.nen.nl/nen-7512-2022-nl-297137), the trust basis for data exchange | [Mutually authenticated TLS](../audit.md#node-authentication-iti-19-mutual-tls), OAuth2 and OIDC with an [enterprise identity provider](../identity-providers.md), [SMART App Launch](../smart-app-launch.md) | Agree the trust basis with each counterparty, and operate the certificate estate |
+| [NEN 7513](https://www.nen.nl/nen-7513-2018-nl-245399), logging actions on electronic patient records | An [audit trail](../audit.md) of every operation including refusals, in FHIR `AuditEvent` and DICOM PS3.15 form, hash-chained in the database | Map the recorded fields onto the standard's own list, set retention, and review the trail |
+
+## What this page does not do
+
+It does not tell you whether your deployment satisfies any of these
+obligations. That answer depends on your legal basis, your organisation, your
+infrastructure and your operating practice, none of which a supplier can see.
+
+The companion guidance is planned rather than written:
+[DPIA guidance, records of processing and a go-live checklist](https://github.com/rubentalstra/FerroEHR/issues/3161).
+Until it lands, the [compliance overview](index.md) carries the legal sources,
+the [control matrix](control-matrix.md) carries the live status of every
+declared control, and the [threat model](../threat-model.md) carries the risk
+that survives each one.

--- a/website/book/src/why-ferroehr.md
+++ b/website/book/src/why-ferroehr.md
@@ -64,6 +64,15 @@ and published*.
 - **Maintenance in the open.** Public roadmap, public issue tracker,
   changelog-driven releases, signed artifacts, and a security policy with a
   private reporting channel.
+- **A compliance posture you can read before you buy.** FerroEHR aims to be
+  the first openly developed, source-available openEHR CDR with a published,
+  tracker-backed EU compliance posture, and an EHDS conformity
+  self-assessment is on its roadmap. The
+  [compliance overview](compliance/index.md) states which controls ship
+  today, which are planned and under which issue number, and which
+  obligations stay with the organisation running the software. It claims no
+  certification and no conformity, because a product cannot hold either on
+  its own.
 
 ## Running FerroEHR commercially
 


### PR DESCRIPTION
Two pages a privacy officer, a hospital CISO and a developer can each read in ten minutes, and the line between what the software does and what the deploying organisation must do.

Closes #3163. Closes #3165.

## What lands

- **`compliance/index.md`** — the boundary in a diagram, then a per-source walk: GDPR (Art. 4(5), 5, 9, 25, 30, 32, 35), EDPB Guidelines 01/2025, EHDS chapters II/III/IV, UAVG Art. 30 and 46, Wabvpz, NEN 7510/7512/7513. Each with what FerroEHR ships, what the deployer must do, and the issue where it is still planned.
- **`compliance/shared-responsibility.md`** — a three-column table grouped by source. Most obligations rest on the controller: legal basis, DPIA, records of processing, processor terms, breach notification, data subject rights, the ISMS and its certification, the BSN authorisation, the retention schedule. A page that implies the software carries those misleads whoever relies on it.
- One paragraph each in `why-ferroehr.md` and `comparison.md`.

## The honesty properties, which are the point

**The pseudonymisation boundary is written as PLANNED throughout**, naming its issues. Only its migrations exist, on an unmerged branch, and `linkage` (#3158) does not exist at all. The overview states plainly that until those land, a FerroEHR database holds directly identifying data alongside clinical data. A compliance page claiming a boundary the database does not enforce is the one failure mode these pages cannot have.

**Everything written as shipped was verified in the code**, not inferred from an issue title: RBAC/ABAC and `EHR_ACCESS`, tenant RLS in `0004_multitenancy.sql`, the ATNA trail with its local repository and ITI-81 retrieval, digest signing, contribution and audit in one transaction, physical deletion, the integrity sweep and `rebuild-nodes`.

**No certification claim anywhere.** FerroEHR aims to be the first openly developed, source-available openEHR CDR with a published, tracker-backed EU compliance posture and an EHDS conformity self-assessment on its roadmap. It does not claim certification, conformity, or that a deployment is compliant. Both pages say legal texts change and name where to check them.

Two rows are marked honestly rather than softened: FerroEHR performs no BSN verification and consults no index, so the Wabvpz Art. 4–9 row says "Nothing"; and NEN 7510 certification is not something a product can hold.

## Three deviations from the issue text, each deliberate

- **#3163's wording policy says "first open-source openEHR CDR".** This project is source-available and `licensing.md` never says otherwise, so claiming open source on a compliance page would contradict the licence page two clicks away. Written as "openly developed, source-available".
- **#3163 places `PARTY_REF` in RM.** It is in BASE (`org.openehr.base.base_types.party_ref`). BASE is cited.
- **openEHR is cited by published URL, not vendored path.** `.claude/rules/docs-website.md` forbids linking `docs/specs/**` from the site. All four anchors were checked live: `common.html#_party_self_and_referring_to_the_patient_from_the_ehr`, `ehr.html#_ehr_status_class`, `base_types.html#_party_ref_class`, `common.html#_change_control_package`.

## What could not be verified, and how it is handled

EUR-Lex serves an empty body to automated fetches, so Regulation (EU) 2025/327 could not be read first-hand. The pages cite EHDS **chapters**, never article numbers, and name no application dates — secondary sources give 2029 and 2031, which is not good enough for a compliance page. Similarly `BW 7:454`'s retention period is cited as an article with no number of years. Notably, the pages do **not** assert "EHDS Art. 9" for logging even though #3156's title implies it: the only Article 9 substantiable in that context is GDPR's.

Every legal URL was checked to return 200. The one that did not is filed as **#3177** — the NEN 7510 link in the control-matrix registry returns 404, inherited from #3164's own issue text. It is not silently worked around here.

## Gates

`docs-claims` (68 pages), `mdbook-lint` (exit 0), `scripts/site/build.sh --dev-only`, `lychee --offline` over the built site (9884 links, 0 errors), `changelog-structure`, and `control-matrix.sh --check`. Cross-page fragments were verified by hand against the rendered HTML, since `lychee --offline` does not check them. No Rust changed, so no crate-line bump.

## Sequencing

#3153 is in flight on a sibling branch and will describe the boundary as shipped. When it lands it must flip the "planned" rows here; the exact lines are enumerated in its own pull request so neither page is left asserting something the other contradicts.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.

## Privacy boundary

- [x] Data flow described: no data flow changes; documentation only.
- [x] Roles named: none added or widened.
- [x] No cross-domain grant.
- [x] Synthetic data only: no identifiers of any kind appear.
- [x] Access event emitted where a read was added: no read was added.

## Checks

- [x] No Rust changed; the docs gates run instead
- [x] No test weakened, skipped, or edited to route around a bug
- [x] `CHANGELOG.md [Unreleased]` entry present
- [x] Matching `website/book/src` pages updated
- [x] No implemented plan file to delete
- [x] New issues opened from this work are filed and cross-referenced (#3177)