### PR TITLE
chore(conformance): re-record the baseline after the party storage move

### DIFF
--- a/docs/conformance/COMPARISON.md
+++ b/docs/conformance/COMPARISON.md
@@ -19,8 +19,8 @@
 
 | | ferroehr | EHRbase |
 |---|---|---|
-| Product | ferroehr 4.0.16 | ehrbase 2.34.0 |
-| Run date | 2026-09-02 | 2026-08-14 |
+| Product | ferroehr 4.1.1 | ehrbase 2.34.0 |
+| Run date | 2026-09-09 | 2026-08-14 |
 | Party statement | committed with the runner (declares ITS-REST pin, signing, terminology posture) | committed with the runner |
 | Stack | the project's own compose stack, built from the current sources | a dedicated compose stack of the official EHRbase images |
 
@@ -58,7 +58,7 @@ claimed. The verdict-bearing comparison below is therefore each party's
 
 ## In-scope outcomes
 
-Runs compared: **ferroehr** (run of 2026-09-02) vs **EHRbase
+Runs compared: **ferroehr** (run of 2026-09-09) vs **EHRbase
 2.34.0** (run of 2026-08-14) — the SAME catalogue through the same
 runner, each with its own committed party statement. Per the presentation
 rule, the headline is each party's VERDICT SCOPE (the cases its own

--- a/docs/conformance/ferroehr/CONFORMANCE_CERTIFICATE.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_CERTIFICATE.md
@@ -4,7 +4,7 @@
 
 | Field | Value |
 | --- | --- |
-| Solution | ferroehr 4.0.16 |
+| Solution | ferroehr 4.1.1 |
 | Vendor | Ruben Talstra |
 | Runner | veredictum 0.1.5 |
 | Infrastructure | ixit.json#/environment |

--- a/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
+++ b/docs/conformance/ferroehr/CONFORMANCE_REPORT.md
@@ -1,6 +1,6 @@
 # Conformance Report
 
-SUT: FerroEHR 4.0.16 (sut `ferroehr`) · schedule cnf-2.0-w2 · ITS its-rest
+SUT: FerroEHR 4.1.1 (sut `ferroehr`) · schedule cnf-2.0-w2 · ITS its-rest
 Runner: veredictum 0.1.5 · verification pack: passed
 
 ## Summary

--- a/docs/conformance/ferroehr/results.json
+++ b/docs/conformance/ferroehr/results.json
@@ -1,7 +1,7 @@
 {
   "sut": {
     "name": "ferroehr",
-    "version": "4.0.16"
+    "version": "4.1.1"
   },
   "runner": {
     "name": "veredictum",
@@ -20,7 +20,7 @@
     "source": "declared"
   },
   "ixit_digest": "60ab312f3d083668",
-  "statement_digest": "61b6c37faa191436",
+  "statement_digest": "8a5db4ea19e71990",
   "selection_basis": "statement",
   "restapi_specs_version": "1.1.0",
   "outcomes": [

--- a/website/book/src/conformance-assets/conformance-chapter-bars.svg
+++ b/website/book/src/conformance-assets/conformance-chapter-bars.svg
@@ -71,7 +71,7 @@ text { fill: #c3c2b7; }
 <line x1="3" y1="0" x2="3" y2="6" class="na-line"/>
 </pattern>
 </defs>
-<text x="24" y="28" class="title">Schedule outcomes by chapter — ferroehr 4.0.16</text>
+<text x="24" y="28" class="title">Schedule outcomes by chapter — ferroehr 4.1.1</text>
 <rect x="24" y="38" width="14" height="14" rx="3" class="bar-passed"/><text x="31" y="49" class="seg-label" text-anchor="middle">✓</text><text x="44" y="49" class="muted">passed</text><rect x="103.2" y="38" width="14" height="14" rx="3" class="bar-failed"/><text x="110.2" y="49" class="seg-label" text-anchor="middle">✕</text><text x="123.2" y="49" class="muted">FAILED</text><rect x="182.4" y="38" width="14" height="14" rx="3" class="bar-errored"/><text x="189.4" y="49" class="seg-label-dim" text-anchor="middle">?</text><text x="202.4" y="49" class="muted">errored</text><rect x="268.8" y="38" width="14" height="14" rx="3" fill="url(#na-hatch)"/><text x="275.8" y="49" class="seg-label-dim" text-anchor="middle">○</text><text x="288.8" y="49" class="muted">cited N/A (not executed)</text><text x="884" y="49" class="muted" text-anchor="end">this chart's scale: 145 cases = full bar</text>
 <rect x="24" y="66" width="860" height="20" rx="4" class="chap-row"/><text x="34" y="80.5" class="chap-name">EHR</text><text x="700" y="80.5" class="muted" text-anchor="end">506 cases</text>
 <text x="752" y="80.5" class="count count-passed count-strong" text-anchor="end">✓ 488</text><text x="878" y="80.5" class="count count-na count-strong" text-anchor="end">○ 18</text>

--- a/website/book/src/conformance-assets/conformance-heat-grid.svg
+++ b/website/book/src/conformance-assets/conformance-heat-grid.svg
@@ -41,7 +41,7 @@ text { fill: #c3c2b7; }
 }
 </style>
 
-<text x="24" y="28" class="title">Capability conformance — ferroehr 4.0.16</text>
+<text x="24" y="28" class="title">Capability conformance — ferroehr 4.1.1</text>
 <rect x="24" y="38" width="14" height="14" rx="3" class="ev-passed"/><text x="31" y="49" class="cell-label" text-anchor="middle" font-size="10">✓</text><text x="42" y="49" class="muted">passed</text><rect x="103.2" y="38" width="14" height="14" rx="3" class="ev-failed"/><text x="110.2" y="49" class="cell-label" text-anchor="middle" font-size="10">✕</text><text x="121.2" y="49" class="muted">FAILED</text><rect x="182.4" y="38" width="14" height="14" rx="3" class="ev-inconclusive"/><text x="189.4" y="49" class="cell-label-dim" text-anchor="middle" font-size="10">?</text><text x="200.4" y="49" class="muted">INCONCLUSIVE</text><rect x="304.8" y="38" width="14" height="14" rx="3" class="ev-not-evidenced"/><text x="311.8" y="49" class="cell-label-dim" text-anchor="middle" font-size="10">○</text><text x="322.8" y="49" class="muted">not evidenced</text><rect x="434.4" y="38" width="14" height="14" rx="3" class="ev-not-claimed"/><text x="441.4" y="49" class="cell-label-dim" text-anchor="middle" font-size="10">–</text><text x="452.4" y="49" class="muted">not claimed</text><text x="998" y="49" class="muted" text-anchor="end">solid border = required in tier · dashed = optional</text>
 <text x="24" y="82" class="title" font-size="12">CORE</text>
 <rect x="24" y="90" width="190" height="26" rx="5" class="ev-passed cell-optional"/><text x="37" y="107" class="cell-label" text-anchor="middle">✓</text><text x="50" y="107" class="cell-label sm">Adl14ArchetypeProvisioning</text>


### PR DESCRIPTION
The demographic pseudonymisation domain (#3153) moved every party's physical storage into its own schema, reached through its own pool and its own database role. The wire is unchanged by construction, but a storage-affecting merge gets re-measured rather than reasoned about: the catalogue is the acceptance instrument precisely so the reasoning does not have to be trusted.

## Result: zero drift

```
1145 case-records: 1104 passed / 0 failed / 0 errored / 41 n-a
43 capability verdicts · 0 review findings · interpreter coverage 96.3%
```

Not one verdict, case outcome or capability moved. The only change in the committed artefacts is the version the run was measured against and the statement digest that hashes it:

| | before | after |
|---|---|---|
| Solution / SUT | ferroehr 4.0.16 | ferroehr 4.1.1 |
| `statement_digest` | `61b6c37faa191436` | `8a5db4ea19e71990` |

Recording that is the point of committing these files: the baseline now says which build produced it, rather than continuing to claim a measurement from 4.0.16.

## What this actually establishes

Parties now live in a different schema, are reached through a different connection pool, and are written by a different database role, with a database constraint refusing them on the clinical side. The routing sweep in #3182 had to follow every path that touches them — the contribution writer, dump and load, archive and restore, physical delete, the statistics counts, EHR-Extract export and import, the cold-tier helpers. A miss on any CNF-exercised path would show here as a failed or errored case.

None did. That is the evidence the sweep was complete for everything the catalogue drives, which is a stronger statement than the unit and integration suites make on their own.

`bash scripts/conformance.sh`, on fresh volumes, against the composed stack built from `50c91b686`.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.

## Privacy boundary

- [x] Data flow described: none changed; this records a measurement.
- [x] Roles named: none added or widened.
- [x] No cross-domain grant.
- [x] Synthetic data only: the catalogue's own corpus.
- [x] Access event emitted where a read was added: no read was added.

## Checks

- [x] No code changed; the conformance pipeline is the check
- [x] No test weakened, skipped, or edited to route around a bug
- [ ] `CHANGELOG.md [Unreleased]` entry — not applicable, no user-visible behaviour changed (needs the `no-changelog` label)
- [x] No REST, config, CLI or deployment change, so no book page to update
- [x] No implemented plan file to delete
- [x] No new issues opened from this work