### PR TITLE
fix(admin): the storage-integrity sweep covers both pseudonymisation domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,16 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **The storage-integrity sweep and its repair cover both pseudonymisation
+  domains** (#3178). Moving the parties into their own schema left the sweep
+  reading only the clinical one, so damage to the copy no read-path check
+  recomputes went undetected on the domain that holds the identifying data.
+  A sweep with no scope now walks both in one pass, and every mismatch,
+  every streamed line and every rebuild record names the `domain` it came
+  from, so a report cannot describe half the store while looking like it
+  described all of it. The repair reaches the damaged version through that
+  same domain.
+
 - **A FLAT or STRUCTURED read no longer drops the content of a template-named
   event** (#3142). An operational template can fix the name of a node the
   simplified formats collapse away, such as the single event of a `HISTORY`.

--- a/app/ferroehr-rest/src/api/admin/integrity.rs
+++ b/app/ferroehr-rest/src/api/admin/integrity.rs
@@ -459,6 +459,7 @@ fn parity_event(event: &StorageParityEvent) -> Value {
     match event {
         StorageParityEvent::Mismatch(mismatch) => json!({
             "type": "mismatch",
+            "domain": mismatch.domain.as_str(),
             "vo_id": mismatch.vo_id.to_string(),
             "sys_version": mismatch.sys_version,
             "kind": mismatch.kind,
@@ -497,6 +498,7 @@ fn parity_report(report: &StorageParityReport) -> Value {
             .mismatches
             .iter()
             .map(|m| json!({
+                "domain": m.domain.as_str(),
                 "vo_id": m.vo_id.to_string(),
                 "sys_version": m.sys_version,
                 "kind": m.kind,
@@ -525,6 +527,7 @@ fn rebuild_report(report: &NodeRebuildReport) -> Value {
             .iter()
             .map(|record| {
                 let mut object = json!({
+                    "domain": record.domain.as_str(),
                     "vo_id": record.vo_id.to_string(),
                     "sys_version": record.sys_version,
                     "kind": record.kind,

--- a/app/ferroehr/src/service/admin/integrity/mod.rs
+++ b/app/ferroehr/src/service/admin/integrity/mod.rs
@@ -83,9 +83,6 @@ pub enum StorageDomain {
 }
 
 impl StorageDomain {
-    /// Every domain a sweep covers when the caller names none.
-    pub const ALL: [Self; 2] = [Self::Clinical, Self::Demographic];
-
     /// Returns the stable wire token for this domain.
     #[must_use]
     pub fn as_str(self) -> &'static str {
@@ -495,6 +492,8 @@ pub struct StorageParitySweep<'a> {
 impl std::fmt::Debug for StorageParitySweep<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("StorageParitySweep")
+            .field("domain", &self.domain)
+            .field("remaining", &self.remaining)
             .field("scope", &self.scope)
             .field("cursor", &self.cursor)
             .field("counts", &self.counts)
@@ -605,6 +604,12 @@ impl StorageParitySweep<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn domain_tokens_are_the_documented_wire_values() {
+        assert_eq!(StorageDomain::Clinical.as_str(), "clinical");
+        assert_eq!(StorageDomain::Demographic.as_str(), "demographic");
+    }
 
     #[test]
     fn defect_tokens_are_the_documented_wire_values() {

--- a/app/ferroehr/src/service/admin/integrity/mod.rs
+++ b/app/ferroehr/src/service/admin/integrity/mod.rs
@@ -64,6 +64,38 @@ const CONTENT_CHUNK: usize = 32;
 /// all and says it was truncated.
 const MAX_REPORTED_MISMATCHES: usize = 1000;
 
+/// Which pseudonymisation domain a sweep is reading.
+///
+/// The storage was one schema until the demographic domain split out (#3153),
+/// and the sweep quietly kept reading only the clinical one. A domain is
+/// therefore carried on every finding and every count rather than assumed:
+/// an operator asking whether their storage is intact means the whole store,
+/// and a report that covered half of it must never be able to look like a
+/// report that covered all of it.
+///
+/// NOTE: no openEHR spec governs storage layout — our own design/extension.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum StorageDomain {
+    /// The clinical schema: compositions, `EHR_STATUS`, folders.
+    Clinical,
+    /// The demographic schema: PARTY versioned objects.
+    Demographic,
+}
+
+impl StorageDomain {
+    /// Every domain a sweep covers when the caller names none.
+    pub const ALL: [Self; 2] = [Self::Clinical, Self::Demographic];
+
+    /// Returns the stable wire token for this domain.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Clinical => "clinical",
+            Self::Demographic => "demographic",
+        }
+    }
+}
+
 /// The way one stored version's two content copies disagree.
 ///
 /// NOTE: no openEHR spec governs storage mechanics — our own design/extension.
@@ -98,6 +130,8 @@ impl StorageParityDefect {
 /// One stored version whose two content copies disagree.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StorageParityMismatch {
+    /// Which domain's storage the version lives in.
+    pub domain: StorageDomain,
     /// The versioned object the version belongs to.
     pub vo_id: Uuid,
     /// The per-object storage commit ordinal of the version.
@@ -248,6 +282,8 @@ impl FerroEhrService {
     pub fn storage_parity_sweep(&self, scope: StorageParityScope) -> StorageParitySweep<'_> {
         StorageParitySweep {
             service: self,
+            remaining: vec![StorageDomain::Demographic],
+            domain: StorageDomain::Clinical,
             scope,
             cursor: None,
             page: Vec::new().into_iter(),
@@ -299,6 +335,18 @@ impl FerroEhrService {
         Ok(report)
     }
 
+    /// The pool that reaches one domain's storage.
+    ///
+    /// Both domains carry relations of the same names, distinguished only by
+    /// the pool's `search_path`, which is exactly what lets one sweep read
+    /// both with one set of statements.
+    fn domain_pool(&self, domain: StorageDomain) -> &sqlx::PgPool {
+        match domain {
+            StorageDomain::Clinical => &self.pool,
+            StorageDomain::Demographic => &self.demographic_pool,
+        }
+    }
+
     /// Compare one chunk of versions in two round trips: the reassembled node
     /// content of all of them, then their stored bodies.
     ///
@@ -306,14 +354,15 @@ impl FerroEhrService {
     /// counters follow the enumeration rather than the map's iteration.
     async fn chunk_parity_defects<'k>(
         &self,
+        domain: StorageDomain,
         chunk: &'k [VersionKey],
     ) -> Result<Vec<(&'k VersionKey, Option<StorageParityDefect>)>, ServiceError> {
         let keys: Vec<(VoId, i32)> = chunk
             .iter()
             .map(|key| (VoId(key.vo_id), key.sys_version))
             .collect();
-        let rows = read_version_rows_all(&self.pool, &keys).await?;
-        let bodies = self.chunk_bodies(&keys).await?;
+        let rows = read_version_rows_all(self.domain_pool(domain), &keys).await?;
+        let bodies = self.chunk_bodies(domain, &keys).await?;
 
         Ok(chunk
             .iter()
@@ -348,6 +397,7 @@ impl FerroEhrService {
     /// the page read and this one, is absent from the map.
     async fn chunk_bodies(
         &self,
+        domain: StorageDomain,
         keys: &[(VoId, i32)],
     ) -> Result<HashMap<(VoId, i32), Value>, ServiceError> {
         let vo_ids: Vec<Uuid> = keys.iter().map(|(vo_id, _)| vo_id.0).collect();
@@ -361,7 +411,7 @@ impl FerroEhrService {
         )
         .bind(&vo_ids)
         .bind(&sys_versions)
-        .fetch_all(&self.pool)
+        .fetch_all(self.domain_pool(domain))
         .await?;
         let mut out = HashMap::with_capacity(rows.len());
         for (vo_id, sys_version, text) in rows {
@@ -377,6 +427,7 @@ impl FerroEhrService {
     /// pays a growing `OFFSET`.
     async fn parity_page(
         &self,
+        domain: StorageDomain,
         cursor: Option<(Uuid, i32)>,
         scope: StorageParityScope,
     ) -> Result<Vec<VersionKey>, ServiceError> {
@@ -402,7 +453,7 @@ impl FerroEhrService {
         .bind(scope.committed_since.map(jiff_sqlx::Timestamp::from))
         .bind(scope.vo_id)
         .bind(scope.sys_version)
-        .fetch_all(&self.pool)
+        .fetch_all(self.domain_pool(domain))
         .await?;
         Ok(rows
             .into_iter()
@@ -427,6 +478,11 @@ impl FerroEhrService {
 /// NOTE: no openEHR spec governs storage mechanics — our own design/extension.
 pub struct StorageParitySweep<'a> {
     service: &'a FerroEhrService,
+    /// The domains still to read, most recent first; the cursor pops one when
+    /// its pages run out, so a single sweep walks the whole store.
+    remaining: Vec<StorageDomain>,
+    /// The domain currently being read.
+    domain: StorageDomain,
     scope: StorageParityScope,
     cursor: Option<(Uuid, i32)>,
     page: std::vec::IntoIter<VersionKey>,
@@ -463,7 +519,8 @@ impl StorageParitySweep<'_> {
         loop {
             let chunk: Vec<VersionKey> = self.page.by_ref().take(CONTENT_CHUNK).collect();
             if !chunk.is_empty() {
-                return Ok(Some(self.check_chunk(&chunk).await?));
+                let domain = self.domain;
+                return Ok(Some(self.check_chunk(domain, &chunk).await?));
             }
             if self.done {
                 return Ok(None);
@@ -477,8 +534,19 @@ impl StorageParitySweep<'_> {
                     counts: self.counts,
                 }]));
             }
-            let page = self.service.parity_page(self.cursor, self.scope).await?;
+            let page = self
+                .service
+                .parity_page(self.domain, self.cursor, self.scope)
+                .await?;
             let Some(last) = page.last() else {
+                // This domain is read. Move to the next before finishing: a
+                // sweep that stopped at the first exhausted domain would
+                // report a clean whole-store result having read half of it.
+                if let Some(next) = self.remaining.pop() {
+                    self.domain = next;
+                    self.cursor = None;
+                    continue;
+                }
                 self.done = true;
                 let elapsed_ms =
                     u64::try_from(self.started.elapsed().as_millis()).unwrap_or(u64::MAX);
@@ -496,10 +564,11 @@ impl StorageParitySweep<'_> {
     /// Compare one chunk, count what it read, and turn its defects into events.
     async fn check_chunk(
         &mut self,
+        domain: StorageDomain,
         chunk: &[VersionKey],
     ) -> Result<Vec<StorageParityEvent>, ServiceError> {
         let mut events = Vec::new();
-        for (key, defect) in self.service.chunk_parity_defects(chunk).await? {
+        for (key, defect) in self.service.chunk_parity_defects(domain, chunk).await? {
             self.counts.versions_checked += 1;
             if key.has_body {
                 self.counts.versions_with_body += 1;
@@ -513,6 +582,7 @@ impl StorageParitySweep<'_> {
                 // log. It is emitted here, in the one sweep, so a finding is
                 // logged whichever response shape asked for it.
                 tracing::warn!(
+                    domain = domain.as_str(),
                     vo_id = %key.vo_id,
                     sys_version = key.sys_version,
                     kind = %key.kind,
@@ -520,6 +590,7 @@ impl StorageParitySweep<'_> {
                     "storage parity sweep: the node rows and the materialized body of a stored version disagree"
                 );
                 events.push(StorageParityEvent::Mismatch(StorageParityMismatch {
+                    domain,
                     vo_id: key.vo_id,
                     sys_version: key.sys_version,
                     kind: key.kind.clone(),

--- a/app/ferroehr/src/service/admin/integrity/rebuild.rs
+++ b/app/ferroehr/src/service/admin/integrity/rebuild.rs
@@ -38,7 +38,7 @@ use uuid::Uuid;
 use crate::ids::{EhrId, VoId};
 use crate::service::FerroEhrService;
 use crate::service::admin::integrity::{
-    StorageParityDefect, StorageParityEvent, StorageParityScope,
+    StorageDomain, StorageParityDefect, StorageParityEvent, StorageParityScope,
 };
 use crate::service::error::ServiceError;
 use crate::service::status::SmError;
@@ -88,6 +88,8 @@ impl NodeRebuildOutcome {
 /// One damaged version the rebuild reached, and what happened to it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NodeRebuildRecord {
+    /// Which domain's storage the version lives in.
+    pub domain: StorageDomain,
     /// The versioned object the version belongs to.
     pub vo_id: Uuid,
     /// The per-object storage commit ordinal of the version.
@@ -199,7 +201,11 @@ impl FerroEhrService {
                 match event {
                     StorageParityEvent::Mismatch(mismatch) => {
                         let outcome = self
-                            .rebuild_one_version(VoId(mismatch.vo_id), mismatch.sys_version)
+                            .rebuild_one_version(
+                                mismatch.domain,
+                                VoId(mismatch.vo_id),
+                                mismatch.sys_version,
+                            )
                             .await?;
                         report.versions_damaged += 1;
                         match outcome {
@@ -210,6 +216,7 @@ impl FerroEhrService {
                         // body fragment would put clinical content into an
                         // operational log.
                         tracing::info!(
+                            domain = mismatch.domain.as_str(),
                             vo_id = %mismatch.vo_id,
                             sys_version = mismatch.sys_version,
                             kind = %mismatch.kind,
@@ -219,6 +226,7 @@ impl FerroEhrService {
                         );
                         if report.records.len() < MAX_REPORTED_RECORDS {
                             report.records.push(NodeRebuildRecord {
+                                domain: mismatch.domain,
                                 vo_id: mismatch.vo_id,
                                 sys_version: mismatch.sys_version,
                                 kind: mismatch.kind,
@@ -243,10 +251,18 @@ impl FerroEhrService {
     /// Repair one version in one transaction, or leave it untouched.
     async fn rebuild_one_version(
         &self,
+        domain: StorageDomain,
         vo_id: VoId,
         sys_version: i32,
     ) -> Result<NodeRebuildOutcome, ServiceError> {
-        let mut tx = self.pool.begin().await?;
+        // The repair runs in the domain that holds the damage: both schemas
+        // carry relations of the same names, and the pool's search path is
+        // what decides which one this transaction reaches.
+        let pool = match domain {
+            StorageDomain::Clinical => &self.pool,
+            StorageDomain::Demographic => &self.demographic_pool,
+        };
+        let mut tx = pool.begin().await?;
 
         // The tier's own rule: a write always thaws first, so a versioned
         // object is never split across tiers. The marker is captured before

--- a/app/ferroehr/tests/it/persistence.rs
+++ b/app/ferroehr/tests/it/persistence.rs
@@ -480,7 +480,15 @@ async fn an_as_of_read_resolves_along_the_trunk() {
     insert_version_verbatim(&mut conn, &branch_row(VoId(vo), 2))
         .await
         .expect("branch beside the trunk");
-    let at = jiff::Timestamp::now();
+    // The server clock, not the test process's: `sys_period` is stamped by the
+    // database, and a client/DB skew under parallel load races the at-time read
+    // against the validity interval it is probing. Same reasoning as
+    // `service_demographic::db_now`.
+    let at: jiff::Timestamp = sqlx::query_scalar::<_, jiff_sqlx::Timestamp>("SELECT now()")
+        .fetch_one(&pool)
+        .await
+        .expect("db now()")
+        .to_jiff();
     let read = version_at(&pool, VoId(vo), at)
         .await
         .expect("as-of read")

--- a/app/ferroehr/tests/it/pseudonymisation_boundary.rs
+++ b/app/ferroehr/tests/it/pseudonymisation_boundary.rs
@@ -593,7 +593,7 @@ async fn the_boot_self_check_refuses_a_cross_domain_grant() {
 /// A minimal valid PERSON body, authored as canonical JSON exactly as a client
 /// would post it (`.claude/rules/testing.md` §Test-fixture construction,
 /// class 2).
-fn a_person() -> serde_json::Value {
+pub(crate) fn a_person() -> serde_json::Value {
     serde_json::json!({
         "_type": "PERSON",
         "archetype_node_id": "openEHR-DEMOGRAPHIC-PERSON.person.v1",

--- a/app/ferroehr/tests/it/storage_parity.rs
+++ b/app/ferroehr/tests/it/storage_parity.rs
@@ -28,6 +28,7 @@ use uuid::Uuid;
 
 use ferroehr::ids::EhrId;
 use ferroehr::service::FerroEhrService;
+use ferroehr::service::admin::integrity::StorageDomain;
 use ferroehr::service::admin::integrity::rebuild::NodeRebuildOutcome;
 use ferroehr::service::admin::integrity::{
     StorageParityDefect, StorageParityEvent, StorageParityScope,
@@ -874,4 +875,140 @@ async fn a_scoped_rebuild_repairs_only_its_own_ehr() {
         remaining.mismatches[0].vo_id,
         one_version(&pool, left_alone, "COMPOSITION").await.0
     );
+}
+
+// ── both pseudonymisation domains (#3178) ────────────────────────────────────
+//
+// Parties left the clinical schema in #3153, and the sweep kept reading only
+// the schema it always had. Damage to the copy nobody recomputes went
+// undetected on the domain holding the identifying data, which is the one
+// place a silent integrity gap is least acceptable. These cases pin the
+// coverage so a future change cannot narrow it back without failing.
+
+/// A committed party, and the `(vo_id, sys_version)` of the version holding it.
+async fn seed_party(svc: &FerroEhrService, pool: &PgPool) -> (Uuid, i32) {
+    svc.party_create(
+        ferroehr::service::demographic::types::PartyKind::Person,
+        crate::typed_body::typed(&crate::pseudonymisation_boundary::a_person()),
+        None,
+    )
+    .await
+    .expect("create a person through the service seam");
+    sqlx::query_as(
+        "SELECT vo_id, sys_version FROM demographic.vo_version \
+         ORDER BY sys_version DESC LIMIT 1",
+    )
+    .fetch_one(pool)
+    .await
+    .expect("the stored party version")
+}
+
+#[tokio::test]
+async fn a_damaged_party_is_reported_by_a_sweep_with_no_scope() {
+    let db = testkit::db().await.expect("testkit database");
+    let pool = db.pool();
+    let svc = FerroEhrService::new(pool.clone());
+    let (vo_id, sys_version) = seed_party(&svc, &pool).await;
+
+    tamper(
+        &pool,
+        "UPDATE demographic.node SET data = jsonb_set(data, '{name,value}', '\"tampered\"') \
+         WHERE vo_id = $1 AND sys_version = $2 AND num = 0",
+        vo_id,
+        sys_version,
+    )
+    .await;
+
+    let report = svc
+        .verify_storage_parity(StorageParityScope::default())
+        .await
+        .expect("sweep");
+
+    assert_eq!(
+        report.mismatch_count, 1,
+        "an unscoped sweep reads the demographic domain too: {report:?}"
+    );
+    let found = &report.mismatches[0];
+    assert_eq!(found.vo_id, vo_id);
+    assert_eq!(
+        found.domain,
+        StorageDomain::Demographic,
+        "and says which domain the damage is in"
+    );
+    assert_eq!(found.defect, StorageParityDefect::ContentDiffers);
+}
+
+#[tokio::test]
+async fn a_sweep_with_no_scope_counts_versions_from_both_domains() {
+    let db = testkit::db().await.expect("testkit database");
+    let pool = db.pool();
+    let svc = FerroEhrService::new(pool.clone());
+    seed_ehr_with_composition(&svc).await;
+
+    let clinical_only = svc
+        .verify_storage_parity(StorageParityScope::default())
+        .await
+        .expect("sweep")
+        .versions_checked;
+
+    seed_party(&svc, &pool).await;
+    let both = svc
+        .verify_storage_parity(StorageParityScope::default())
+        .await
+        .expect("sweep")
+        .versions_checked;
+
+    assert!(
+        both > clinical_only,
+        "committing a party raises the unscoped count, so the demographic \
+         domain is actually read rather than skipped: {clinical_only} then {both}"
+    );
+}
+
+#[tokio::test]
+async fn a_damaged_party_is_rebuilt_and_reads_correctly_afterwards() {
+    let db = testkit::db().await.expect("testkit database");
+    let pool = db.pool();
+    let svc = FerroEhrService::new(pool.clone());
+    let (vo_id, sys_version) = seed_party(&svc, &pool).await;
+
+    tamper(
+        &pool,
+        "UPDATE demographic.node SET data = jsonb_set(data, '{name,value}', '\"tampered\"') \
+         WHERE vo_id = $1 AND sys_version = $2 AND num = 0",
+        vo_id,
+        sys_version,
+    )
+    .await;
+
+    let report = svc
+        .rebuild_version_nodes(StorageParityScope::default())
+        .await
+        .expect("rebuild");
+
+    assert_eq!(report.versions_rebuilt, 1, "{report:?}");
+    assert_eq!(
+        report.records[0].domain,
+        StorageDomain::Demographic,
+        "the record names the domain it repaired"
+    );
+
+    let after = svc
+        .verify_storage_parity(StorageParityScope::default())
+        .await
+        .expect("sweep");
+    assert!(after.is_clean(), "the sweep is clean afterwards: {after:?}");
+
+    // The node rows are what a decomposed read serves, so this is the reader
+    // that would still have seen the damage.
+    let name: String = sqlx::query_scalar(
+        "SELECT data #>> '{name,value}' FROM demographic.node \
+         WHERE vo_id = $1 AND sys_version = $2 AND num = 0",
+    )
+    .bind(vo_id)
+    .bind(sys_version)
+    .fetch_one(&pool)
+    .await
+    .expect("read the rebuilt name");
+    assert_ne!(name, "tampered", "the corrupted value is gone");
 }

--- a/website/book/src/operations-admin-apis.md
+++ b/website/book/src/operations-admin-apis.md
@@ -188,8 +188,11 @@ breaks that agreement.
 | `POST {base}/admin/integrity/verify` | the sweep report |
 | `POST {base}/admin/integrity/rebuild-nodes` | the rebuild report |
 
-The sweep re-derives every stored version from its decomposed rows and compares
-the result with the stored document. It reads the archived tier as well, takes
+The sweep covers **both pseudonymisation domains**, clinical and demographic,
+in one pass. Every finding names the domain it came from, so a report can never
+describe half the store while looking like it described all of it. It re-derives
+every stored version from its decomposed rows and compares the result with the
+stored document. It reads the archived tier as well, takes
 no lock, and runs outside the request path of any clinical call, so it is safe
 to run on a live server. It is also a full scan of what it covers, so schedule
 it rather than calling it per request.
@@ -225,7 +228,7 @@ The body is one JSON object per line, each carrying a `type`:
 
 | `type` | When | Carries |
 |---|---|---|
-| `mismatch` | as each disagreement is found | the same four fields the report's `mismatches` entries carry |
+| `mismatch` | as each disagreement is found | the same five fields the report's `mismatches` entries carry, `domain` included |
 | `progress` | once per page of versions read | the counts so far |
 | `summary` | once, at the end | the final counts and `elapsed_ms` |
 | `error` | instead of `summary`, if the sweep failed part-way | a short message; the detail is in the server log |
@@ -247,6 +250,7 @@ at all, gets the aggregated document below, unchanged.
   "mismatch_count": 1,
   "mismatches": [
     {
+      "domain": "clinical",
       "vo_id": "8849182c-82ad-4088-a07f-48ead4180515",
       "sys_version": 2,
       "kind": "COMPOSITION",
@@ -257,6 +261,9 @@ at all, gets the aggregated document below, unchanged.
   "elapsed_ms": 431
 }
 ```
+
+`domain` is `clinical` or `demographic`, naming the schema the damaged version
+lives in. It is also what the repair below uses to reach it.
 
 `defect` is one of four values:
 
@@ -330,6 +337,7 @@ which is the repair for `unexpected_nodes`.
   "versions_refused": 1,
   "records": [
     {
+      "domain": "clinical",
       "vo_id": "8849182c-82ad-4088-a07f-48ead4180515",
       "sys_version": 2,
       "kind": "COMPOSITION",
@@ -338,9 +346,10 @@ which is the repair for `unexpected_nodes`.
       "node_rows": 41
     },
     {
+      "domain": "demographic",
       "vo_id": "1f0b7d64-6b2a-4a1f-9f0e-6b1d2a3c4d5e",
       "sys_version": 1,
-      "kind": "COMPOSITION",
+      "kind": "PERSON",
       "defect": "content_differs",
       "outcome": "refused",
       "reason": "the stored body does not decompose: ..."


### PR DESCRIPTION
Moving the parties into their own schema left the sweep reading only the schema it always had.

Closes #3178.

## The gap

`service::admin::integrity` paged `vo_version_all` on the clinical pool. After #3153 that is half the store. Damage to the decomposed copy — the one no read-path check recomputes, which is the entire reason the sweep exists — went undetected and unrepairable on the domain that holds the identifying data.

Nothing corrupted. The instrument that would have told you simply stopped looking there, which is the worse failure of the two because it is silent.

## What lands

A sweep with no scope walks both domains in one pass. The cursor carries the domain it is reading and advances to the next when a domain's pages run out, rather than finishing at the first exhausted one — that would report a clean whole-store result having read half of it.

`domain` (`clinical` / `demographic`) rides on every mismatch, every NDJSON line, every rebuild record and every log line, so a report cannot describe part of the store while looking like it described all of it. The repair reaches the damaged version through that domain's own pool.

No SQL changed. Both schemas carry relations of the same names and are distinguished only by the pool's `search_path`, so one set of statements serves both — the same property that made the routing sweep in #3182 possible.

I chose per-domain coverage over a scope parameter because an operator asking whether their storage is intact means the whole store. The issue left that open and asked only that a partial run must never look total.

## Mutation-proven

| Mutation | Result |
|---|---|
| Cursor's remaining-domain list emptied | `a_damaged_party_is_reported_by_a_sweep_with_no_scope` FAILS |
| Same | `a_damaged_party_is_rebuilt_and_reads_correctly_afterwards` FAILS |

So a future change cannot quietly narrow the coverage back. Three new tests: a damaged party is reported with its domain named, an unscoped sweep's version count rises when a party is committed (proving the second domain is read rather than skipped), and a damaged party is repaired with the node rows — the copy that would still have held the damage — verified afterwards.

## One en-route fix

`persistence::an_as_of_read_resolves_along_the_trunk` failed once in a full run and passed alone. It took its probe instant from the **test process's** wall clock while `sys_period` is stamped by the **database**, so under parallel load the at-time read raced the validity interval it was probing. Machine-dependent, not caused by this change.

It now reads the instant from the server. That is the fix #3140 applied to the two import tests, and the reasoning is already written down in `service_demographic::db_now` — this test had simply never been converted. Fixed at its cause rather than retried, per `.claude/rules/testing.md`.

## Gates

`cargo nextest run -p ferroehr -p ferroehr-rest`: **1838 passed** (one unrelated flake in the S3 container suite, passed on retry). `cargo clippy -p ferroehr -p ferroehr-rest --all-targets --all-features -D warnings`, `cargo fmt`, `comment-style --all` (2486 files), `migration-immutability`, `changelog-structure`, `docs-claims` (70 pages), `mdbook-lint`. Admin API book page and `CHANGELOG.md` updated. No migration, no `crates/*` change.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.

## Privacy boundary

- [x] Data flow described: an admin diagnostic now reads the demographic domain as well as the clinical one; no data leaves either.
- [x] Roles named: none added or widened. The sweep uses each domain's existing pool.
- [x] No cross-domain grant: the two pools stay separate; nothing joins the domains.
- [x] Synthetic data only: the party fixture is invented.
- [x] Access event emitted where a read was added: the sweep reports by identifier and defect class only and never logs content, unchanged. Per-domain access logging is #3156.

## Checks

- [x] `cargo fmt --all --check` · `cargo clippy --workspace --all-targets` · `cargo nextest run`
- [x] No test weakened, skipped, or edited to route around a bug — the one test changed was fixed at its cause
- [x] `CHANGELOG.md [Unreleased]` entry present
- [x] Matching `website/book/src` page updated
- [x] No implemented plan file to delete
- [x] No new issues opened from this work