### PR TITLE
fix(compliance): correct the legal-source links and say which country each applies to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,19 @@ workflow refuses a tag that has no matching section here.
   described all of it. The repair reaches the damaged version through that
   same domain.
 
+- **The compliance control matrix says which jurisdiction each legal source
+  belongs to, and its links work** (#3177). The NEN 7510 entry pointed at a
+  page that returns 404, and NEN 7513 pointed at the publisher's homepage
+  rather than the standard. Both are corrected, NEN 7512 and the EDPB
+  pseudonymisation guidelines are added, and every URL in the registry was
+  checked by hand on the day it landed, which is the only way it can be
+  checked: the site's link gate runs offline on purpose, so an external URL
+  that rots is invisible to it. The table now carries an "Applies to" column.
+  `EU` and `INT` apply to every deployment; a two-letter code is national law
+  and applies to a deployment in that country. openEHR is not a Dutch
+  standard, and a page listing Dutch law beside EU law without saying which
+  is which reads as though every deployment answers to both.
+
 - **A FLAT or STRUCTURED read no longer drops the content of a template-named
   event** (#3142). An operational template can fix the name of a node the
   simplified formats collapse away, such as the single event of a `HISTORY`.

--- a/scripts/render/control-matrix.sh
+++ b/scripts/render/control-matrix.sh
@@ -39,18 +39,34 @@ BOARD_TITLE="${FERROEHR_PROJECT_TITLE:-FerroEHR Roadmap}"
 # outgrows this number into a loud failure rather than a short page.
 FETCH_LIMIT=10000
 
-# The legal-source registry: short name, then the official publisher URL. A
-# control naming a short name that is not declared here is a hard failure, so
-# no page cell can ever carry free text where a citation belongs. Order here is
-# the order the table groups by.
+# The legal-source registry: short name, jurisdiction, then the official
+# publisher URL. A control naming a short name that is not declared here is a
+# hard failure, so no page cell can ever carry free text where a citation
+# belongs. Order here is the order the table groups by.
+#
+# The jurisdiction column is not decoration. openEHR is not a Dutch standard,
+# and FerroEHR is deployed outside the Netherlands, so a page that lists Dutch
+# law beside EU law without saying which is which reads as though every
+# deployment answers to both (#3185). EU and INT apply everywhere; a
+# two-letter code is national and applies to deployments in that country.
+#
+# Every URL here is checked BY HAND when it is added or changed, and the date
+# recorded below. Nothing in CI can do it: the link checker runs with
+# --offline deliberately, because a rate-limited publisher says nothing about
+# the change under review (#2287). That is exactly how the NEN 7510 entry sat
+# here returning 404 (#3177).
+#
+# Last checked, all 200: 2026-09-09.
 LEGAL_SOURCES=(
-  "GDPR|https://eur-lex.europa.eu/eli/reg/2016/679/oj"
-  "EHDS|https://eur-lex.europa.eu/eli/reg/2025/327/oj"
-  "UAVG|https://wetten.overheid.nl/BWBR0040940"
-  "Wabvpz|https://wetten.overheid.nl/BWBR0023864"
-  "NEN 7510|https://www.nen.nl/zorg-en-welzijn/informatiebeveiliging-in-de-zorg/nen-7510"
-  "NEN 7513|https://www.nen.nl"
-  "IHE ATNA|https://profiles.ihe.net/ITI/TF/Volume1/ch-9.html"
+  "GDPR|EU|https://eur-lex.europa.eu/eli/reg/2016/679/oj"
+  "EHDS|EU|https://eur-lex.europa.eu/eli/reg/2025/327/oj"
+  "EDPB 01/2025|EU|https://www.edpb.europa.eu/our-work-tools/documents/public-consultations/2025/guidelines-012025-pseudonymisation_en"
+  "UAVG|NL|https://wetten.overheid.nl/BWBR0040940"
+  "Wabvpz|NL|https://wetten.overheid.nl/BWBR0023864"
+  "NEN 7510|NL|https://www.nen.nl/nen-7510-1-2024-nl-331311"
+  "NEN 7512|NL|https://www.nen.nl/nen-7512-2022-nl-297137"
+  "NEN 7513|NL|https://www.nen.nl/nen-7513-2018-nl-245399"
+  "IHE ATNA|INT|https://profiles.ihe.net/ITI/TF/Volume1/ch-9.html"
 )
 
 die() {
@@ -77,7 +93,8 @@ trap 'rm -rf "$WORK"' EXIT
 
 # ── the registry, as JSON ────────────────────────────────────────────────────
 printf '%s\n' "${LEGAL_SOURCES[@]}" |
-  jq -R -s 'split("\n") | map(select(length > 0) | split("|") | {name: .[0], url: .[1]})
+  jq -R -s 'split("\n") | map(select(length > 0) | split("|")
+              | {name: .[0], jurisdiction: .[1], url: .[2]})
             | to_entries | map(.value + {rank: .key})' > "$WORK/sources.json"
 
 # ── the tracker ──────────────────────────────────────────────────────────────
@@ -117,6 +134,7 @@ jq --slurpfile sources "$WORK/sources.json" '
               rank: $src.rank,
               source: $src.name,
               source_url: $src.url,
+              jurisdiction: $src.jurisdiction,
               clause: $clause,
               title: $issue.title,
               number: $issue.number,
@@ -230,13 +248,13 @@ rows="$(jq -r --slurpfile board "$WORK/board.json" '
   def prs:
     if (.pr | length) == 0 then "—"
     else [ .pr[] | "[#\(.number)](\(.url))" ] | join(", ") end;
-  .[] | "| [\(.source)](\(.source_url)) | \(.clause | esc) | \(.title | esc) | [#\(.number)](\(.url)) | \(status) | \(prs) |"
+  .[] | "| [\(.source)](\(.source_url)) | \(.jurisdiction) | \(.clause | esc) | \(.title | esc) | [#\(.number)](\(.url)) | \(status) | \(prs) |"
 ' "$WORK/controls.json")"
 
 if [[ -n "$rows" ]]; then
   cat >> "$OUT" <<'TABLE'
-| Legal source | Article or clause | Control | Issue | Status | Closing PR |
-|---|---|---|---|---|---|
+| Legal source | Applies to | Article or clause | Control | Issue | Status | Closing PR |
+|---|---|---|---|---|---|---|
 TABLE
   printf '%s\n' "$rows" >> "$OUT"
 else
@@ -247,18 +265,29 @@ fills itself as the compliance program lands: the first issue to carry a
 EMPTY
 fi
 
-cat >> "$OUT" <<'FOOTER'
+{
+  cat <<'FOOTER'
 
 ## Legal sources
 
 The short names above resolve to these publishers. The linked text is the
 authority; nothing on this page restates it.
 
-| Short name | Source |
-|---|---|
+| Short name | Applies to | Source |
+|---|---|---|
 FOOTER
 
-jq -r '.[] | "| \(.name) | [\(.url)](\(.url)) |"' "$WORK/sources.json" >> "$OUT"
+  jq -r '.[] | "| \(.name) | \(.jurisdiction) | [\(.url)](\(.url)) |"' "$WORK/sources.json"
+
+  cat <<'SCOPE'
+
+`EU` and `INT` apply to every deployment. A two-letter country code is
+national law or a national standard, and applies to a deployment in that
+country: FerroEHR is an openEHR CDR, openEHR is not a Dutch standard, and a
+deployment elsewhere answers to its own equivalents rather than to these.
+Adding a jurisdiction is a registry entry plus the controls that cite it.
+SCOPE
+} >> "$OUT"
 
 if [[ "$CHECK" -eq 1 ]]; then
   [[ -f "$PAGE" ]] || die "$PAGE does not exist — run $SCRIPT"

--- a/website/book/src/compliance/control-matrix.md
+++ b/website/book/src/compliance/control-matrix.md
@@ -50,12 +50,20 @@ fills itself as the compliance program lands: the first issue to carry a
 The short names above resolve to these publishers. The linked text is the
 authority; nothing on this page restates it.
 
-| Short name | Source |
-|---|---|
-| GDPR | [https://eur-lex.europa.eu/eli/reg/2016/679/oj](https://eur-lex.europa.eu/eli/reg/2016/679/oj) |
-| EHDS | [https://eur-lex.europa.eu/eli/reg/2025/327/oj](https://eur-lex.europa.eu/eli/reg/2025/327/oj) |
-| UAVG | [https://wetten.overheid.nl/BWBR0040940](https://wetten.overheid.nl/BWBR0040940) |
-| Wabvpz | [https://wetten.overheid.nl/BWBR0023864](https://wetten.overheid.nl/BWBR0023864) |
-| NEN 7510 | [https://www.nen.nl/zorg-en-welzijn/informatiebeveiliging-in-de-zorg/nen-7510](https://www.nen.nl/zorg-en-welzijn/informatiebeveiliging-in-de-zorg/nen-7510) |
-| NEN 7513 | [https://www.nen.nl](https://www.nen.nl) |
-| IHE ATNA | [https://profiles.ihe.net/ITI/TF/Volume1/ch-9.html](https://profiles.ihe.net/ITI/TF/Volume1/ch-9.html) |
+| Short name | Applies to | Source |
+|---|---|---|
+| GDPR | EU | [https://eur-lex.europa.eu/eli/reg/2016/679/oj](https://eur-lex.europa.eu/eli/reg/2016/679/oj) |
+| EHDS | EU | [https://eur-lex.europa.eu/eli/reg/2025/327/oj](https://eur-lex.europa.eu/eli/reg/2025/327/oj) |
+| EDPB 01/2025 | EU | [https://www.edpb.europa.eu/our-work-tools/documents/public-consultations/2025/guidelines-012025-pseudonymisation_en](https://www.edpb.europa.eu/our-work-tools/documents/public-consultations/2025/guidelines-012025-pseudonymisation_en) |
+| UAVG | NL | [https://wetten.overheid.nl/BWBR0040940](https://wetten.overheid.nl/BWBR0040940) |
+| Wabvpz | NL | [https://wetten.overheid.nl/BWBR0023864](https://wetten.overheid.nl/BWBR0023864) |
+| NEN 7510 | NL | [https://www.nen.nl/nen-7510-1-2024-nl-331311](https://www.nen.nl/nen-7510-1-2024-nl-331311) |
+| NEN 7512 | NL | [https://www.nen.nl/nen-7512-2022-nl-297137](https://www.nen.nl/nen-7512-2022-nl-297137) |
+| NEN 7513 | NL | [https://www.nen.nl/nen-7513-2018-nl-245399](https://www.nen.nl/nen-7513-2018-nl-245399) |
+| IHE ATNA | INT | [https://profiles.ihe.net/ITI/TF/Volume1/ch-9.html](https://profiles.ihe.net/ITI/TF/Volume1/ch-9.html) |
+
+`EU` and `INT` apply to every deployment. A two-letter country code is
+national law or a national standard, and applies to a deployment in that
+country: FerroEHR is an openEHR CDR, openEHR is not a Dutch standard, and a
+deployment elsewhere answers to its own equivalents rather than to these.
+Adding a jurisdiction is a registry entry plus the controls that cite it.


### PR DESCRIPTION
Two defects in one registry, one of them the reason #3185 exists.

Closes #3177.

## The dead links

`NEN 7510` pointed at a page returning **404**; `NEN 7513` pointed at the publisher's homepage rather than the standard. Both came from the issue that specified the generator, so the source was stale rather than mistranscribed.

Nothing in CI could have caught it. The site's link gate runs `--offline` **on purpose** (#2287: a rate-limited publisher says nothing about the change under review), so an external URL that rots is invisible to it by design. The registry therefore now records that its URLs are verified by hand and the date they last were.

All nine checked individually with `curl -o /dev/null -w '%{http_code}' -L`, every one **200** on 2026-09-09. `NEN 7512` and the EDPB pseudonymisation guidelines are added — both already cited on the compliance pages, both missing from the registry that is supposed to be the single place a citation can come from.

## The larger defect

The registry listed Dutch law beside EU law with nothing distinguishing them, so the published page read as though every deployment answers to the UAVG and the NEN standards. openEHR is not a Dutch standard, and FerroEHR is deployed outside the Netherlands.

Each source now carries a jurisdiction, shown in both tables:

| Short name | Applies to | Source |
|---|---|---|
| GDPR, EHDS, EDPB 01/2025 | `EU` | EUR-Lex, EDPB |
| UAVG, Wabvpz, NEN 7510/7512/7513 | `NL` | wetten.overheid.nl, NEN |
| IHE ATNA | `INT` | IHE |

and the page states the rule rather than leaving a reader to infer it from the names: `EU` and `INT` apply to every deployment, a two-letter code is national and applies to a deployment in that country.

This is the documentation half of **#3185**. The code half matters more: an identifier scanner that knows only the BSN passes a Norwegian fødselsnummer or an NHS number onto the clinical side *while reporting the write as scanned*, which is a false assurance rather than a gap.

## En route

The three consecutive `>> "$OUT"` redirects I added tripped `SC2129`. Grouped as `{ … } >> "$OUT"`, which is what shellcheck suggests and reads better than a disable directive.

## Gates

`shellcheck-lane` (103 programs, severity=style), `no-python`, `control-matrix.sh --check` green and idempotent across two renders, `changelog-structure`, `mdbook-lint`, and `lychee --offline` over the built site (9908 links, 0 errors). No Rust changed, so no crate-line bump.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.

## Privacy boundary

- [x] Data flow described: none; a generator and its rendered page.
- [x] Roles named: none added or widened.
- [x] No cross-domain grant.
- [x] Synthetic data only: no identifiers appear.
- [x] Access event emitted where a read was added: no read of personal data was added.

## Checks

- [x] No Rust changed; the shell and docs gates run instead
- [x] No test weakened, skipped, or edited to route around a bug
- [x] `CHANGELOG.md [Unreleased]` entry present
- [x] Matching `website/book/src` page regenerated
- [x] No implemented plan file to delete
- [x] No new issues opened from this work