### PR TITLE
feat(audit): reads are logged per record, not just per operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,30 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
+- **Reads are logged per record, not just per operation** (#3156). Every
+  retrieval in the EHR, Query and Demographic APIs already produced an audit
+  record; each one now also says which pseudonymisation domain it read (`ehr`,
+  `demographic`, `linkage`, or `system` for an operation that touches no
+  domain), the purpose of use the caller declared, the legal basis the
+  deployment processes under, how many records were served, and the
+  `x-request-id` of the request it belonged to. An AQL statement additionally
+  produces **one access record per EHR it served**, each with that EHR's
+  served-row count, because one execute record over a population query cannot
+  answer whose record was read. The served set is read off the rows the caller
+  actually received rather than the rows the statement matched: a legal record
+  of access must not name an EHR whose content was never disclosed.
+  `SELECT DISTINCT` and aggregate projections carry no per-EHR breakdown — the
+  shape makes it underivable — and record the statement and its row count.
+  Two new keys configure the declaration surface: `[audit] purpose_header`
+  (default `x-purpose-of-use`) and `purpose_codes`, an allow-list that keeps
+  unagreed free text out of the trail, plus `[audit] legal_basis`. A test walks
+  the generated route tables so a newly generated `GET` that emits nothing
+  fails the build, and the trail's append-only property — no rewrite, no
+  delete outside the retention reaper, no truncation — is now asserted rather
+  than assumed. See
+  [Audit trail](https://ferroehr.eu/book/audit.html#reads-are-logged-too-per-record),
+  which maps the NEN 7513 event content onto the recorded fields.
+
 - **The clinical side refuses identifying data, and the subject reference is
   bound to a pseudonym.** A new `[privacy]` configuration section carries three
   write-path rules, all reported as `422` with one entry per finding naming the

--- a/app/ferroehr-rest/src/api/demographic/mod.rs
+++ b/app/ferroehr-rest/src/api/demographic/mod.rs
@@ -135,6 +135,8 @@ fn set_versioning_headers(resp: &mut Response, meta: Option<&ResourceMeta>) {
         .insert(crate::system_log::middleware::AuditObject {
             ehr_id: None,
             uid: Some(meta.uid.clone()),
+            result_count: None,
+            domain: Some(ferroehr::system_log::event::AccessDomain::Demographic),
         });
 }
 

--- a/app/ferroehr-rest/src/api/query/dispatch.rs
+++ b/app/ferroehr-rest/src/api/query/dispatch.rs
@@ -72,8 +72,22 @@ async fn run(
         return Ok(deny);
     }
 
-    Ok(response::respond_result_set(
-        &parts.headers,
-        &outcome.result_set,
-    ))
+    let mut resp = response::respond_result_set(&parts.headers, &outcome.result_set);
+    // The access log records one access per EHR the statement served, plus the
+    // statement's own operation record. Both ride the response extensions the
+    // ATNA middleware reads, so the caller identity stays in one place.
+    resp.extensions_mut()
+        .insert(crate::system_log::middleware::AuditObject {
+            ehr_id: None,
+            uid: None,
+            result_count: Some(outcome.served_rows),
+            domain: None,
+        });
+    if !outcome.served_ehrs.is_empty() {
+        resp.extensions_mut()
+            .insert(crate::system_log::middleware::AuditServedEhrs(
+                outcome.served_ehrs,
+            ));
+    }
+    Ok(resp)
 }

--- a/app/ferroehr-rest/src/overview/negotiate.rs
+++ b/app/ferroehr-rest/src/overview/negotiate.rs
@@ -1085,6 +1085,8 @@ pub(crate) fn set_versioning_headers(resp: &mut Response, meta: &ResourceMeta) {
         .insert(crate::system_log::middleware::AuditObject {
             ehr_id: Some(meta.ehr_id.clone()),
             uid: Some(meta.uid.clone()),
+            result_count: None,
+            domain: None,
         });
 }
 

--- a/app/ferroehr-rest/src/system_log/classify.rs
+++ b/app/ferroehr-rest/src/system_log/classify.rs
@@ -233,6 +233,7 @@ pub fn audit_for(op: &str) -> Option<(EventActionCode, ObjectClass)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ferroehr::system_log::event::AccessDomain;
 
     /// Every operation id in every generated ITS-REST `ROUTES` table.
     fn all_route_ops() -> Vec<&'static str> {
@@ -326,9 +327,79 @@ mod tests {
         );
     }
 
+    /// Every generated read of patient data emits an access record, in its own
+    /// pseudonymisation domain.
+    #[test]
+    fn every_read_operation_produces_an_access_record() {
+        // NEN 7513 requires per-access logging of who read which record, EHDS
+        // Art. 9 requires logging of access to health data for primary use, and
+        // the Wabvpz gives the patient the right to know who consulted the
+        // record. A retrieval that emits nothing is unanswerable to all three,
+        // so the property is asserted over the GENERATED route tables of the
+        // three APIs that serve patient data — a newly generated GET reaches
+        // this test before it reaches a deployment.
+        let mut silent = Vec::new();
+        let mut misclassified = Vec::new();
+        for (group, table, expected) in [
+            (
+                "ehr",
+                openehr_its::rest::generated::ehr::ROUTES,
+                AccessDomain::Ehr,
+            ),
+            (
+                "query",
+                openehr_its::rest::generated::query::ROUTES,
+                AccessDomain::Ehr,
+            ),
+            (
+                "demographic",
+                openehr_its::rest::generated::demographic::ROUTES,
+                AccessDomain::Demographic,
+            ),
+        ] {
+            for (method, path, op) in table {
+                if !method.eq_ignore_ascii_case("get") {
+                    continue;
+                }
+                let Some((action, object)) = audit_for(op) else {
+                    silent.push(format!("{group} {method} {path} ({op})"));
+                    continue;
+                };
+                // A GET is a Read; the one sanctioned exception is a query
+                // execution, which the DICOM vocabulary classes as an Execute
+                // on the Query object (PS3.15 §A.5.1).
+                let read_shaped = action == Read || (action == Execute && object == Query);
+                // An operation id the released OAS reuses across bundles cannot
+                // name its own domain: `contribution_get` is the same id in the
+                // EHR and the DEMOGRAPHIC group. Those carry a handler-set
+                // override (`AuditObject::domain`) this static table cannot
+                // see, and the integration suite is where the override is
+                // proven; `adjudicated_shared_ids` keeps the list honest.
+                let domain_is_static = !ADJUDICATED_SHARED.contains(op);
+                if !read_shaped || (domain_is_static && AccessDomain::of(object) != expected) {
+                    misclassified.push(format!(
+                        "{group} {method} {path} ({op}) → {action:?}/{object:?} \
+                         in domain {:?}, expected a read in {expected:?}",
+                        AccessDomain::of(object)
+                    ));
+                }
+            }
+        }
+        assert!(
+            silent.is_empty(),
+            "read operations that emit no access record: {silent:#?}"
+        );
+        assert!(
+            misclassified.is_empty(),
+            "read operations classified outside their own domain: {misclassified:#?}"
+        );
+    }
+
+    #[test]
     /// Coverage is total: every generated route entry is `Audited` and the
     /// explicit `Unaudited` allowlist is empty.
-    #[test]
+    /// Coverage is total: every generated route entry is `Audited` and the
+    /// explicit `Unaudited` allowlist is empty.
     fn generated_coverage_is_total_and_audited() {
         let ops = all_route_ops();
         let mut unaudited = Vec::new();

--- a/app/ferroehr-rest/src/system_log/middleware.rs
+++ b/app/ferroehr-rest/src/system_log/middleware.rs
@@ -74,6 +74,110 @@ pub struct AuditObject {
     pub ehr_id: Option<String>,
     /// The resource identifier (version uid / contribution uid / object URI).
     pub uid: Option<String>,
+    /// How many records the operation served, for an operation that serves a
+    /// countable set: AQL result rows, search entries. NEN 7513 and EHDS
+    /// Art. 9 ask what was accessed, and for a query the answer is a volume as
+    /// much as a resource.
+    pub result_count: Option<u64>,
+    /// The pseudonymisation domain this response read, when the handler knows
+    /// it better than the resource class does.
+    ///
+    /// The released OAS reuses one CONTRIBUTION `operationId` across the EHR
+    /// and DEMOGRAPHIC bundles, so the operation alone cannot say which domain
+    /// a contribution read touched; the demographic group sets this and the
+    /// class decides for everything else.
+    pub domain: Option<ferroehr::system_log::event::AccessDomain>,
+}
+
+/// The EHRs a query served, each with its served-row count.
+///
+/// A response extension the query dispatch sets and the audit middleware
+/// reads: an AQL statement is one operation but potentially many accesses, and
+/// NEN 7513 and EHDS Art. 9 both ask which records were accessed. Carrying it
+/// here rather than emitting from the service keeps the caller identity in the
+/// one place that has it.
+#[derive(Debug, Clone)]
+pub struct AuditServedEhrs(pub Vec<(String, u64)>);
+
+/// The access-logging facts every record of one request shares: the request
+/// correlation id and the declared purpose of use.
+#[derive(Debug, Clone, Default)]
+struct AccessContext {
+    request_id: Option<String>,
+    purpose: Option<String>,
+}
+
+/// Stamp the shared access-logging fields onto one record.
+///
+/// The legal basis is a deployment fact rather than a request one, so it is
+/// read from configuration here rather than carried per request.
+fn fill_access(event: &mut AuditEvent, access: &AccessContext, state: &AppState) {
+    event.request_id.clone_from(&access.request_id);
+    event.purpose.clone_from(&access.purpose);
+    event.legal_basis = state.backend().audit_legal_basis().map(str::to_owned);
+}
+
+/// Emit one access record per EHR a query served, beside the statement's own
+/// operation record.
+///
+/// The statement record answers "who ran what"; these answer "whose record was
+/// disclosed", which is the question NEN 7513 and EHDS Art. 9 put per record.
+/// Returns whether any record was refused under `fail_mode = closed`.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "every argument is one audited fact the middleware already holds; \
+              bundling them into a struct would move the same fields, not fewer"
+)]
+fn emit_served_ehr_records(
+    state: &AppState,
+    resp: &Response,
+    op: &'static str,
+    principal: Option<&Principal>,
+    client_ip: Option<&str>,
+    timestamp: jiff::Timestamp,
+    tenant: Option<uuid::Uuid>,
+    access: &AccessContext,
+) -> bool {
+    let Some(AuditServedEhrs(served)) = resp.extensions().get::<AuditServedEhrs>() else {
+        return false;
+    };
+    let mut rejected = false;
+    for (ehr_id, rows) in served {
+        let mut event = AuditEvent::new(
+            EventActionCode::Read,
+            ObjectClass::Ehr,
+            EventOutcome::Success,
+        );
+        event.event_type = Some(EventType::RestOperation(op));
+        fill_common(
+            &mut event,
+            principal,
+            client_ip.map(str::to_owned),
+            timestamp,
+        );
+        event.ehr_id = Some(ehr_id.clone());
+        event.object_id = Some(ehr_id.clone());
+        event.tenant_id = tenant;
+        event.result_count = Some(*rows);
+        fill_access(&mut event, access, state);
+        rejected |= state.backend().emit(event) == EmitOutcome::Rejected;
+    }
+    rejected
+}
+
+/// The purpose of use the caller declared, when the deployment records it.
+///
+/// The header name and the accepted vocabulary are deployment configuration
+/// (`[audit] purpose_header` / `purpose_codes`). A declared code outside a
+/// configured vocabulary is recorded as absent rather than verbatim: an
+/// unagreed string in the trail reads at review time as though a purpose was
+/// established when none was.
+fn declared_purpose(req: &Request, backend: &ferroehr::service::FerroEhrService) -> Option<String> {
+    let header = backend.audit_purpose_header()?;
+    let declared = req.headers().get(header)?.to_str().ok()?.trim();
+    backend
+        .audit_accepts_purpose(declared)
+        .then(|| declared.to_owned())
 }
 
 /// The ATNA audit middleware, routing emission through the platform's SM
@@ -88,9 +192,21 @@ pub async fn middleware(State(state): State<AppState>, req: Request, next: Next)
     let client_ip = client_ip(&req);
     let path = req.uri().path().to_owned();
     let timestamp = jiff::Timestamp::now();
+    let purpose = declared_purpose(&req, state.backend());
 
     let resp = next.run(req).await;
     let status = resp.status();
+
+    // The correlation id the response carries, set by the request-id layer
+    // above this one (`SetRequestIdLayer::x_request_id`).
+    let access = AccessContext {
+        request_id: resp
+            .headers()
+            .get("x-request-id")
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned),
+        purpose,
+    };
 
     let op = resp.extensions().get::<AuditOpId>().copied();
     let principal = resp.extensions().get::<Principal>().cloned();
@@ -124,7 +240,24 @@ pub async fn middleware(State(state): State<AppState>, req: Request, next: Next)
             .and_then(|o| o.uid.clone())
             .or_else(|| object_id_from_path(op, &path));
         event.tenant_id = tenant;
+        event.result_count = object.as_ref().and_then(|o| o.result_count);
+        // A handler that knows its domain better than the resource class does
+        // says so; the class decides for everything else.
+        if let Some(domain) = object.as_ref().and_then(|o| o.domain) {
+            event.domain = domain;
+        }
+        fill_access(&mut event, &access, &state);
         op_rejected = state.backend().emit(event) == EmitOutcome::Rejected;
+        op_rejected |= emit_served_ehr_records(
+            &state,
+            &resp,
+            op,
+            principal.as_ref(),
+            client_ip.as_deref(),
+            timestamp,
+            tenant,
+            &access,
+        );
     }
 
     // The authentication record: a rejected access attempt is a failed

--- a/app/ferroehr-rest/tests/it/audit_e2e.rs
+++ b/app/ferroehr-rest/tests/it/audit_e2e.rs
@@ -694,3 +694,53 @@ async fn drive_until_503(app: &Router) -> StatusCode {
     }
     panic!("fail-closed queue never saturated to 503");
 }
+
+/// A query that serves a record emits an access record naming the EHR it
+/// served, beside the statement's own execute record (#3156).
+///
+/// The statement record answers "who ran what". NEN 7513 and EHDS Art. 9 ask a
+/// different question — whose record was read — and one execute record over a
+/// population query cannot answer it. The served EHR is read off the rows that
+/// were actually returned, so the trail names a disclosure that happened.
+#[tokio::test]
+async fn aql_execute_emits_one_access_record_per_served_ehr() {
+    let (socket, sender) = audit_capture(true).await;
+    let (_pg, app, _uid) = audit_app_with_composition(sender).await;
+
+    let resp = app
+        .oneshot(req(
+            "GET",
+            "/query/aql?q=SELECT%20c/uid/value%20FROM%20EHR%20e%20CONTAINS%20COMPOSITION%20c",
+            true,
+        ))
+        .await
+        .expect("resp");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let records = drain(&socket).await;
+    assert!(
+        records
+            .iter()
+            .any(|xml| xml.contains(r#"csd-code="110112""#)
+                && xml.contains(r#"EventActionCode="E""#)),
+        "the statement's own Query execute record is missing: {records:#?}"
+    );
+    // The access record: a Patient-Record read (DICOM EventID 110110) carrying
+    // the query as its EventTypeCode, which is what distinguishes it from a
+    // direct retrieval. Its participant is the EHR's subject, absent on this
+    // fixture; the EHR the record names is on the stored row, which
+    // `audit_store::access_fields_round_trip_on_both_write_paths` pins.
+    let served: Vec<&String> = records
+        .iter()
+        .filter(|xml| {
+            xml.contains(r#"csd-code="110110""#)
+                && xml.contains(r#"EventActionCode="R""#)
+                && xml.contains("query_execute_adhoc_query")
+        })
+        .collect();
+    assert_eq!(
+        served.len(),
+        1,
+        "one access record per served EHR, and this query served one: {records:#?}"
+    );
+}

--- a/app/ferroehr/assets/ferroehr.default.toml
+++ b/app/ferroehr/assets/ferroehr.default.toml
@@ -487,6 +487,12 @@ fail_mode = "open"           # open | closed (closed: un-auditable ops answer 50
 resolve_subject = true
 queue_capacity = 8192
 #? server_host = "cdr-01.example"
+# Access logging (NEN 7513, EHDS Art. 9): the header a caller declares its
+# purpose of use in, the codes this deployment accepts (empty = record whatever
+# is declared), and the legal basis recorded on every access.
+purpose_header = "x-purpose-of-use"
+purpose_codes = []
+#? legal_basis = "gdpr-art-9-2-h"
 
 # The local Audit Record Repository (the durability anchor).
 [audit.store]

--- a/app/ferroehr/migrations/audit/0003_access_event_fields.sql
+++ b/app/ferroehr/migrations/audit/0003_access_event_fields.sql
@@ -1,0 +1,70 @@
+-- SPDX-FileCopyrightText: Ruben Talstra
+-- SPDX-License-Identifier: BUSL-1.1
+--
+-- Access-logging fields on the audit record: which pseudonymisation domain the
+-- operation read, why, on what legal basis, how much it returned, and which
+-- request it belonged to.
+--
+-- The write-side trail (openEHR CONTRIBUTION + AUDIT_DETAILS) and the ATNA
+-- record repository already answer who did what to which resource. What a
+-- read-side access log additionally has to answer is the purpose and the
+-- authority: NEN 7510/7513 require per-access logging of who, when, which
+-- record, which action and on whose authority, EHDS Art. 9 requires logging of
+-- access to electronic health data for primary use
+-- (https://eur-lex.europa.eu/eli/reg/2025/327/oj), and GDPR Art. 30 requires
+-- records of processing (https://eur-lex.europa.eu/eli/reg/2016/679/oj).
+-- No openEHR spec governs the read-side model — our own design/extension; the
+-- SM names only "IHE ATNA-compliant system log" and defines no wire.
+--
+-- These are columns on the EXISTING audit_event rather than a second table:
+-- one operation produces one audit record, and a parallel access-event table
+-- would split one trail across two places, so a subject access-log export
+-- would have to union them and the hash chain would cover only half.
+--
+-- Append-only is unchanged and needs no new machinery: the BEFORE UPDATE
+-- trigger compares the whole row as jsonb minus the two delivery stamps, so
+-- every column added here is covered by it the moment it exists.
+
+ALTER TABLE audit_event
+    -- The pseudonymisation domain the operation read or wrote:
+    -- `ehr` (clinical), `demographic` (parties), `linkage` (the resolve map),
+    -- or `system` for an operation that touches no domain (authentication,
+    -- templates, stored queries, node management).
+    ADD COLUMN domain       text,
+    -- The purpose of use the caller declared, as a code from the deployment's
+    -- own allow-list. NULL when the caller declared none.
+    ADD COLUMN purpose      text,
+    -- The legal basis the deployment attributes to this access, as a code.
+    ADD COLUMN legal_basis  text,
+    -- How many records the operation served: the row count of an AQL result
+    -- set, the entry count of a search. NULL for an operation that serves no
+    -- countable set.
+    ADD COLUMN result_count bigint,
+    -- The request correlation id (the `x-request-id` the response carries), so
+    -- an access record joins to the request it belonged to.
+    ADD COLUMN request_id   text;
+
+-- NULL is a real answer on the three code columns and means "not recorded":
+-- records written before this migration carry no domain, and inventing one for
+-- them would be a guess about what a past operation touched.
+ALTER TABLE audit_event
+    ADD CONSTRAINT ck_audit_event_domain
+        CHECK (domain IS NULL OR domain IN ('ehr', 'demographic', 'linkage', 'system')),
+    ADD CONSTRAINT ck_audit_event_result_count
+        CHECK (result_count IS NULL OR result_count >= 0);
+
+COMMENT ON COLUMN audit_event.domain IS
+    'The pseudonymisation domain read or written: ehr | demographic | linkage | system (no domain). NULL on records written before the column existed.';
+COMMENT ON COLUMN audit_event.purpose IS
+    'The purpose-of-use code the caller declared, from the deployment allow-list; NULL when none was declared.';
+COMMENT ON COLUMN audit_event.legal_basis IS
+    'The legal basis code the deployment attributes to this access; NULL when the deployment configures none.';
+COMMENT ON COLUMN audit_event.result_count IS
+    'The number of records served (AQL result rows, search entries); NULL when the operation serves no countable set.';
+COMMENT ON COLUMN audit_event.request_id IS
+    'The request correlation id, matching the x-request-id header on the response.';
+
+-- The subject access-log export (IHE ITI-81, GET /fhir/r4/AuditEvent?patient=)
+-- reads ix_audit_event_patient, which the baseline already declares; a
+-- per-domain slice of one subject's log filters that index's result and needs
+-- no index of its own.

--- a/app/ferroehr/src/aql/exec.rs
+++ b/app/ferroehr/src/aql/exec.rs
@@ -49,6 +49,14 @@ pub struct QueryResult {
     pub columns: Vec<ColumnMeta>,
     /// The rows; each is one cell per column.
     pub rows: Vec<Vec<Value>>,
+    /// The EHRs this statement actually served, each with the number of served
+    /// rows that came from it, ordered by first appearance.
+    ///
+    /// Empty when the plan carries no per-EHR breakdown
+    /// ([`crate::aql::sql::ACCESS_EHR_PREFIX`] states which shapes those are)
+    /// and when the result is empty. The access log reads it to record one
+    /// access per record accessed, rather than one per statement.
+    pub served_ehrs: Vec<(Uuid, u64)>,
 }
 
 /// Plan, execute, and assemble an AQL query.
@@ -115,7 +123,38 @@ pub async fn execute(
     Ok(QueryResult {
         columns,
         rows: out_rows,
+        served_ehrs: served_ehrs(&rows, &prepared.access_ehr_cols)?,
     })
+}
+
+/// The EHRs the served rows came from, each with its served-row count, ordered
+/// by first appearance.
+///
+/// One row can name several EHRs (one per bound VO root in a cross-EHR join),
+/// and each counts as one served row for each EHR it names — the row disclosed
+/// content from all of them. A NULL column is an outer-joined absent root and
+/// names no EHR.
+///
+/// # Errors
+/// [`ExecError`] when a column the builder declared cannot be read back.
+fn served_ehrs(rows: &[PgRow], access_cols: &[String]) -> Result<Vec<(Uuid, u64)>, AqlError> {
+    if access_cols.is_empty() {
+        return Ok(Vec::new());
+    }
+    // Insertion-ordered so the record set is deterministic; the count is small
+    // (the EHRs one page served), so a linear probe beats a hash map.
+    let mut served: Vec<(Uuid, u64)> = Vec::new();
+    for row in rows {
+        for name in access_cols {
+            let ehr: Option<Uuid> = row.try_get(name.as_str()).map_err(ExecError::from)?;
+            let Some(ehr) = ehr else { continue };
+            match served.iter_mut().find(|(known, _)| *known == ehr) {
+                Some((_, count)) => *count = count.saturating_add(1),
+                None => served.push((ehr, 1)),
+            }
+        }
+    }
+    Ok(served)
 }
 
 /// The result of scanning the SQL rows: the assembled cells, the subtree

--- a/app/ferroehr/src/aql/sql/mod.rs
+++ b/app/ferroehr/src/aql/sql/mod.rs
@@ -120,7 +120,30 @@ pub struct PreparedQuery {
     pub values: SqlxValues,
     /// The `RESULT_SET` column read-back plan, in SELECT order.
     pub columns: Vec<ColumnSpec>,
+    /// The SQL aliases of the hidden access-logging columns, one per bound VO
+    /// root, appended after the projection.
+    ///
+    /// Empty when the plan cannot carry them (see [`ACCESS_EHR_PREFIX`]); the
+    /// executor then reports no per-EHR breakdown rather than a wrong one.
+    pub access_ehr_cols: Vec<String>,
 }
+
+/// The alias prefix of the hidden per-root EHR column the access log reads.
+///
+/// An AQL statement is one access to every EHR it actually served, and NEN 7513
+/// and EHDS Art. 9 ask which records were accessed rather than how many. The
+/// executed statement therefore carries each bound VO root's `ehr_id` beside
+/// the projection, so the served set is read off the rows that were served —
+/// not off a second, unpaged scan, which would name EHRs the query matched and
+/// never disclosed.
+///
+/// Two plan shapes cannot carry it and get none: `SELECT DISTINCT`, where an
+/// extra column changes which rows are distinct, and an aggregate projection,
+/// where an ungrouped column is not even valid SQL. Both are recorded as a
+/// statement-level access with a row count and no per-EHR breakdown.
+///
+/// **No openEHR spec governs this — our own design/extension.**
+pub const ACCESS_EHR_PREFIX: &str = "access_ehr_";
 
 // `SqlxValues` is not `Debug`; project the bound-value count instead so the
 // struct still satisfies the workspace `missing_debug_implementations` lint.
@@ -130,6 +153,7 @@ impl std::fmt::Debug for PreparedQuery {
             .field("sql", &self.sql)
             .field("value_count", &self.values.0.0.len())
             .field("columns", &self.columns)
+            .field("access_ehr_cols", &self.access_ehr_cols)
             .finish()
     }
 }
@@ -309,6 +333,7 @@ pub fn build(ir: &QueryIr, params: &Params, ctx: &SqlCtx) -> Result<PreparedQuer
     b.apply_ehr_scope();
     b.apply_population_gate();
     let columns = b.build_select()?;
+    let access_ehr_cols = b.build_access_ehr_columns(ir);
     b.build_where()?;
     b.build_order_by()?;
     b.build_paging();
@@ -320,6 +345,7 @@ pub fn build(ir: &QueryIr, params: &Params, ctx: &SqlCtx) -> Result<PreparedQuer
         sql,
         values,
         columns,
+        access_ehr_cols,
     })
 }
 

--- a/app/ferroehr/src/aql/sql/select.rs
+++ b/app/ferroehr/src/aql/sql/select.rs
@@ -13,7 +13,7 @@
 use sea_query::{Alias, Expr, ExprTrait as _, Func};
 
 use crate::aql::error::AqlError;
-use crate::aql::ir::{AggFunc, Coercion, LeafPath, PathTarget, SelectColumn, SelectValue};
+use crate::aql::ir::{AggFunc, Coercion, LeafPath, PathTarget, QueryIr, SelectColumn, SelectValue};
 use crate::db::iden::Node;
 
 use super::expr::{col, leaf_path_string, literal_value, order_coercion, to_jsonb, type_cond};
@@ -26,6 +26,33 @@ impl Builder<'_> {
             specs.push(self.emit_select_column(i, col)?);
         }
         Ok(specs)
+    }
+
+    /// Append the hidden access-logging columns: one `ehr_id` per bound VO
+    /// root, after the projection.
+    ///
+    /// Returns their SQL aliases, or empty when this plan cannot carry them —
+    /// `SELECT DISTINCT`, where an extra column changes which rows are
+    /// distinct, and an aggregate projection, where an ungrouped column is not
+    /// valid SQL. The contract those two exclusions leave is on
+    /// [`super::ACCESS_EHR_PREFIX`].
+    pub(super) fn build_access_ehr_columns(&mut self, ir: &QueryIr) -> Vec<String> {
+        let aggregates = ir
+            .select
+            .iter()
+            .any(|column| matches!(column.value, SelectValue::Aggregate { .. }));
+        if ir.distinct || aggregates || self.group_roots.is_empty() {
+            return Vec::new();
+        }
+        let roots = self.group_roots.clone();
+        let mut aliases = Vec::with_capacity(roots.len());
+        for (i, root) in roots.iter().enumerate() {
+            let alias = format!("{}{i}", super::ACCESS_EHR_PREFIX);
+            self.q
+                .expr_as(col(root, "ehr_id"), Alias::new(alias.as_str()));
+            aliases.push(alias);
+        }
+        aliases
     }
 
     fn emit_select_column(&mut self, i: usize, col: &SelectColumn) -> Result<ColumnSpec, AqlError> {

--- a/app/ferroehr/src/service/query/execute.rs
+++ b/app/ferroehr/src/service/query/execute.rs
@@ -191,7 +191,15 @@ impl FerroEhrService {
         // `_executed_aql` carries the parameter-SUBSTITUTED text; `q` keeps
         // the original query as submitted.
         let executed = substitute_params(aql, &params);
+        let served_rows = u64::try_from(result.rows.len()).unwrap_or(u64::MAX);
+        let served_ehrs = result
+            .served_ehrs
+            .iter()
+            .map(|(ehr, count)| (ehr.to_string(), *count))
+            .collect();
         let mut outcome = QueryOutcome::plain(result_set_json(aql, &executed, name, result));
+        outcome.served_ehrs = served_ehrs;
+        outcome.served_rows = served_rows;
         if let Some(scope) = scope {
             outcome.ehr_ids = scope.ehr_ids;
             outcome.template_ids = scope.template_ids;

--- a/app/ferroehr/src/service/query/request.rs
+++ b/app/ferroehr/src/service/query/request.rs
@@ -83,6 +83,22 @@ pub struct QueryOutcome {
     pub ehr_ids: Vec<String>,
     /// The distinct template ids the query touched (empty unless collected).
     pub template_ids: Vec<String>,
+    /// The EHRs this execution actually SERVED, each with its served-row count.
+    ///
+    /// Distinct from [`Self::ehr_ids`], and the difference is the point.
+    /// `ehr_ids` is what the query MATCHED, collected before paging so the
+    /// authorization decision covers everything the statement could reach.
+    /// This is what the caller was actually shown, after `LIMIT`, and it is
+    /// what the access log records: a legal record of access must not name an
+    /// EHR whose content was never disclosed.
+    ///
+    /// Empty when the plan carries no per-EHR breakdown
+    /// (`crate::aql::sql::ACCESS_EHR_PREFIX` names those shapes).
+    pub served_ehrs: Vec<(String, u64)>,
+    /// How many rows this execution served — the access log's record of how
+    /// much was disclosed, counted where the rows are rather than re-read from
+    /// the assembled document.
+    pub served_rows: u64,
 }
 
 impl QueryOutcome {
@@ -93,6 +109,8 @@ impl QueryOutcome {
             result_set,
             ehr_ids: Vec::new(),
             template_ids: Vec::new(),
+            served_ehrs: Vec::new(),
+            served_rows: 0,
         }
     }
 }

--- a/app/ferroehr/src/system_log/config.rs
+++ b/app/ferroehr/src/system_log/config.rs
@@ -181,6 +181,31 @@ pub struct AuditConfig {
     /// network-access-point (`FERROEHR__AUDIT__SERVER_HOST`); the
     /// `value_if_missing` fill when unset.
     pub server_host: Option<String>,
+    /// The request header carrying the caller's declared purpose of use
+    /// (`FERROEHR__AUDIT__PURPOSE_HEADER`), recorded on every access record.
+    ///
+    /// NEN 7513 asks on whose authority a record was accessed, and EHDS Art. 9
+    /// asks why; neither is derivable from the request, so the caller declares
+    /// it and the trail records what was declared. No openEHR spec governs
+    /// this and IHE carries the equivalent in a SAML attribute rather than a
+    /// header, so the header is our own design.
+    pub purpose_header: String,
+    /// The purpose codes this deployment accepts
+    /// (`FERROEHR__AUDIT__PURPOSE_CODES`).
+    ///
+    /// Empty (the default) records whatever the caller declares. A non-empty
+    /// list records a declared code only when it is on the list, so a
+    /// deployment that has agreed a vocabulary does not accumulate a trail of
+    /// free text that means nothing at review time.
+    pub purpose_codes: Vec<String>,
+    /// The legal basis this deployment processes under
+    /// (`FERROEHR__AUDIT__LEGAL_BASIS`), recorded on every access record.
+    ///
+    /// A deployment-level fact, not a per-request one: the controller
+    /// establishes the GDPR Art. 6/9 condition once
+    /// (<https://eur-lex.europa.eu/eli/reg/2016/679/oj>) and every access under
+    /// this deployment carries it. Unset records nothing rather than a guess.
+    pub legal_basis: Option<String>,
     /// `[audit.store]` — the local Audit Record Repository.
     pub store: StoreConfig,
     /// `[audit.syslog]` — the classic DICOM-over-syslog feed.
@@ -201,6 +226,9 @@ impl Default for AuditConfig {
             resolve_subject: true,
             queue_capacity: 8192,
             server_host: None,
+            purpose_header: "x-purpose-of-use".to_owned(),
+            purpose_codes: Vec::new(),
+            legal_basis: None,
             store: StoreConfig::default(),
             syslog: SyslogConfig::default(),
             fhir_feed: FhirFeedConfig::default(),

--- a/app/ferroehr/src/system_log/event.rs
+++ b/app/ferroehr/src/system_log/event.rs
@@ -139,8 +139,79 @@ pub struct AuditEvent {
     /// request carried one. Informational on the stored record (the node's
     /// audit trail is an operator surface, not tenant-scoped).
     pub tenant_id: Option<uuid::Uuid>,
+    /// Which pseudonymisation domain the operation read or wrote.
+    ///
+    /// Derived from [`Self::object`] by [`AccessDomain::of`], so a new resource
+    /// class cannot reach the trail without an answer.
+    pub domain: AccessDomain,
+    /// The purpose-of-use code the caller declared, when the deployment
+    /// collects one.
+    pub purpose: Option<String>,
+    /// The legal-basis code the deployment attributes to this access.
+    pub legal_basis: Option<String>,
+    /// How many records the operation served: AQL result rows, search entries.
+    /// `None` for an operation that serves no countable set.
+    pub result_count: Option<u64>,
+    /// The request correlation id, matching the response's `x-request-id`.
+    pub request_id: Option<String>,
     /// The event time.
     pub timestamp: Timestamp,
+}
+
+/// The pseudonymisation domain an audited operation touched.
+///
+/// The clinical and demographic domains are separate schemas under separate
+/// database roles, so an access record that does not say which one it read
+/// cannot answer "who saw this person's identifying data" separately from "who
+/// read this record". NEN 7513 and EHDS Art. 9 both ask the question per
+/// record; the domain is what makes the answer separable.
+///
+/// **No openEHR spec governs this — our own design/extension.**
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccessDomain {
+    /// The clinical `ehr` schema: EHRs, compositions, folders, contributions,
+    /// extracts and the queries that read them.
+    Ehr,
+    /// The `demographic` schema: parties and their change control.
+    Demographic,
+    /// The `linkage` schema: the party-to-EHR resolve map.
+    Linkage,
+    /// An operation that touches no pseudonymisation domain: authentication,
+    /// template provisioning, node management.
+    System,
+}
+
+impl AccessDomain {
+    /// The domain an operation on this resource class reads or writes.
+    ///
+    /// Exhaustive over [`ObjectClass`] on purpose: adding a resource class is
+    /// then a compile error here, which is where the question belongs.
+    #[must_use]
+    pub fn of(object: ObjectClass) -> Self {
+        match object {
+            ObjectClass::Ehr
+            | ObjectClass::Composition
+            | ObjectClass::Contribution
+            | ObjectClass::Directory
+            | ObjectClass::Query
+            | ObjectClass::Extract => AccessDomain::Ehr,
+            ObjectClass::Demographic => AccessDomain::Demographic,
+            ObjectClass::Template
+            | ObjectClass::ApplicationActivity
+            | ObjectClass::Authentication => AccessDomain::System,
+        }
+    }
+
+    /// The stored spelling, matching the `ck_audit_event_domain` constraint.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AccessDomain::Ehr => "ehr",
+            AccessDomain::Demographic => "demographic",
+            AccessDomain::Linkage => "linkage",
+            AccessDomain::System => "system",
+        }
+    }
 }
 
 impl AuditEvent {
@@ -160,6 +231,11 @@ impl AuditEvent {
             object_id: None,
             token_id: None,
             tenant_id: None,
+            domain: AccessDomain::of(object),
+            purpose: None,
+            legal_basis: None,
+            result_count: None,
+            request_id: None,
             timestamp: Timestamp::now(),
         }
     }

--- a/app/ferroehr/src/system_log/mod.rs
+++ b/app/ferroehr/src/system_log/mod.rs
@@ -178,6 +178,30 @@ impl FerroEhrService {
             .is_some_and(AuditSender::suppress_login_events)
     }
 
+    /// The request header a caller declares its purpose of use in
+    /// ([`config::AuditConfig::purpose_header`]), lowercased; `None` when no
+    /// audit sender is wired.
+    #[must_use]
+    pub fn audit_purpose_header(&self) -> Option<&str> {
+        self.audit.as_ref().map(AuditSender::purpose_header)
+    }
+
+    /// Whether `code` is a purpose code this deployment records
+    /// ([`config::AuditConfig::purpose_codes`]).
+    #[must_use]
+    pub fn audit_accepts_purpose(&self, code: &str) -> bool {
+        self.audit
+            .as_ref()
+            .is_some_and(|sender| sender.accepts_purpose(code))
+    }
+
+    /// The legal basis recorded on every access event
+    /// ([`config::AuditConfig::legal_basis`]).
+    #[must_use]
+    pub fn audit_legal_basis(&self) -> Option<&str> {
+        self.audit.as_ref().and_then(AuditSender::legal_basis)
+    }
+
     /// Whether the local Audit Record Repository is available (the store is
     /// wired), i.e. the ITI-81 retrieval surface can be served.
     #[must_use]

--- a/app/ferroehr/src/system_log/sender.rs
+++ b/app/ferroehr/src/system_log/sender.rs
@@ -105,6 +105,12 @@ struct SenderInner {
     enabled: bool,
     suppress_login_events: bool,
     fail_mode: FailMode,
+    /// The access-logging declaration surface: the header a caller declares a
+    /// purpose of use in, the codes this deployment accepts (empty accepts
+    /// any), and the legal basis it processes under.
+    purpose_header: String,
+    purpose_codes: Vec<String>,
+    legal_basis: Option<String>,
     /// Whether the local store is currently accepting writes (`true` when the
     /// store is disabled — health then rides on the queue alone). Written by
     /// the drain, read by [`AuditSender::emit`] under `fail_mode = closed`.
@@ -154,6 +160,30 @@ impl AuditSender {
     #[must_use]
     pub fn suppress_login_events(&self) -> bool {
         self.inner.suppress_login_events
+    }
+
+    /// The request header a caller declares its purpose of use in, lowercased.
+    #[must_use]
+    pub fn purpose_header(&self) -> &str {
+        &self.inner.purpose_header
+    }
+
+    /// Whether `code` is one this deployment records.
+    ///
+    /// An empty allow-list accepts any non-empty code, which is the default:
+    /// a deployment that has agreed no vocabulary still benefits from
+    /// recording what the caller said.
+    #[must_use]
+    pub fn accepts_purpose(&self, code: &str) -> bool {
+        !code.is_empty()
+            && (self.inner.purpose_codes.is_empty()
+                || self.inner.purpose_codes.iter().any(|known| known == code))
+    }
+
+    /// The legal basis this deployment records on every access event.
+    #[must_use]
+    pub fn legal_basis(&self) -> Option<&str> {
+        self.inner.legal_basis.as_deref()
     }
 
     /// Enqueue an event (non-blocking). Never awaits, never blocks the request.
@@ -393,6 +423,9 @@ pub async fn start(
             tx,
             enabled: config.enabled,
             suppress_login_events: config.suppress_login_events,
+            purpose_header: config.purpose_header.to_ascii_lowercase(),
+            purpose_codes: config.purpose_codes.clone(),
+            legal_basis: config.legal_basis.clone(),
             fail_mode: config.fail_mode,
             store_healthy,
             dropped_since_warn: AtomicU64::new(0),
@@ -841,6 +874,9 @@ mod tests {
                 tx,
                 enabled: true,
                 suppress_login_events: true,
+                purpose_header: "x-purpose-of-use".to_owned(),
+                purpose_codes: Vec::new(),
+                legal_basis: None,
                 fail_mode,
                 store_healthy: Arc::new(AtomicBool::new(store_healthy)),
                 dropped_since_warn: AtomicU64::new(0),

--- a/app/ferroehr/src/system_log/store.rs
+++ b/app/ferroehr/src/system_log/store.rs
@@ -64,8 +64,10 @@ impl AuditStore {
         sqlx::query(
             "INSERT INTO audit.audit_event (recorded_at, action, outcome, event_code, \
              operation, principal, patient_id, resource_class, resource_id, client_ip, \
-             token_id, tenant_id, fhir) \
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) \
+             token_id, tenant_id, domain, purpose, legal_basis, result_count, \
+             request_id, fhir) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, \
+             $15, $16, $17, $18) \
              RETURNING id",
         )
         .bind(Timestamp::from(event.timestamp))
@@ -80,6 +82,11 @@ impl AuditStore {
         .bind(event.client_ip.as_deref())
         .bind(event.token_id.as_deref())
         .bind(event.tenant_id)
+        .bind(event.domain.as_str())
+        .bind(event.purpose.as_deref())
+        .bind(event.legal_basis.as_deref())
+        .bind(result_count(event))
+        .bind(event.request_id.as_deref())
         .bind(fhir.clone())
         .fetch_one(&self.pool)
         .await?
@@ -119,6 +126,11 @@ impl AuditStore {
         let mut client_ips: Vec<Option<&str>> = Vec::with_capacity(records.len());
         let mut token_ids: Vec<Option<&str>> = Vec::with_capacity(records.len());
         let mut tenant_ids: Vec<Option<Uuid>> = Vec::with_capacity(records.len());
+        let mut domains: Vec<&str> = Vec::with_capacity(records.len());
+        let mut purposes: Vec<Option<&str>> = Vec::with_capacity(records.len());
+        let mut legal_bases: Vec<Option<&str>> = Vec::with_capacity(records.len());
+        let mut result_counts: Vec<Option<i64>> = Vec::with_capacity(records.len());
+        let mut request_ids: Vec<Option<&str>> = Vec::with_capacity(records.len());
         let mut fhir_docs: Vec<serde_json::Value> = Vec::with_capacity(records.len());
         for (event, subject, fhir) in records {
             let Some(fhir) = fhir else {
@@ -136,6 +148,11 @@ impl AuditStore {
             client_ips.push(event.client_ip.as_deref());
             token_ids.push(event.token_id.as_deref());
             tenant_ids.push(event.tenant_id);
+            domains.push(event.domain.as_str());
+            purposes.push(event.purpose.as_deref());
+            legal_bases.push(event.legal_basis.as_deref());
+            result_counts.push(result_count(event));
+            request_ids.push(event.request_id.as_deref());
             fhir_docs.push(fhir.clone());
         }
         if fhir_docs.is_empty() {
@@ -144,10 +161,12 @@ impl AuditStore {
         sqlx::query(
             "INSERT INTO audit.audit_event (recorded_at, action, outcome, event_code, \
              operation, principal, patient_id, resource_class, resource_id, client_ip, \
-             token_id, tenant_id, fhir) \
+             token_id, tenant_id, domain, purpose, legal_basis, result_count, \
+             request_id, fhir) \
              SELECT * FROM UNNEST($1::timestamptz[], $2::text[], $3::smallint[], $4::text[], \
              $5::text[], $6::text[], $7::text[], $8::text[], $9::text[], $10::text[], \
-             $11::text[], $12::uuid[], $13::jsonb[])",
+             $11::text[], $12::uuid[], $13::text[], $14::text[], $15::text[], \
+             $16::bigint[], $17::text[], $18::jsonb[])",
         )
         .bind(recorded_at)
         .bind(actions)
@@ -161,6 +180,11 @@ impl AuditStore {
         .bind(client_ips)
         .bind(token_ids)
         .bind(tenant_ids)
+        .bind(domains)
+        .bind(purposes)
+        .bind(legal_bases)
+        .bind(result_counts)
+        .bind(request_ids)
         .bind(fhir_docs)
         .execute(&self.pool)
         .await?;
@@ -481,6 +505,17 @@ const fn resource_class(object: ObjectClass) -> &'static str {
 
 fn nonempty_opt(value: &str) -> Option<&str> {
     (!value.is_empty()).then_some(value)
+}
+
+/// The `result_count` column: how many records the operation served.
+///
+/// A count beyond `i64::MAX` is not representable in the column's `bigint`, and
+/// no result set reaches it, so such a value is recorded as absent rather than
+/// as a wrong number.
+fn result_count(event: &AuditEvent) -> Option<i64> {
+    event
+        .result_count
+        .and_then(|count| i64::try_from(count).ok())
 }
 
 #[cfg(test)]

--- a/app/ferroehr/tests/it/audit_store.rs
+++ b/app/ferroehr/tests/it/audit_store.rs
@@ -16,7 +16,7 @@ use sqlx::Row;
 use uuid::Uuid;
 
 use ferroehr::system_log::event::{
-    AuditEvent, EventActionCode, EventOutcome, EventType, ObjectClass,
+    AccessDomain, AuditEvent, EventActionCode, EventOutcome, EventType, ObjectClass,
 };
 use ferroehr::system_log::fhir;
 use ferroehr::system_log::message::AuditContext;
@@ -209,4 +209,147 @@ async fn reap_deletes_only_rows_past_the_horizon() {
         .await
         .expect("count");
     assert_eq!(remaining, 1);
+}
+
+/// The access-logging fields (#3156) survive the round trip on both write
+/// paths, and the domain is derived from the resource class rather than set by
+/// each call site.
+///
+/// NEN 7513 asks who read which record on whose authority, and EHDS Art. 9
+/// requires access to health data to be logged; a column that is written but
+/// not read back proves neither.
+#[tokio::test]
+async fn access_fields_round_trip_on_both_write_paths() {
+    let db = testkit::db().await.expect("testkit database");
+    let pool = db.pool();
+    let store = AuditStore::new(pool.clone());
+
+    let mut single = read_event("2026-07-10T08:30:00Z".parse().unwrap());
+    single.purpose = Some("TREATMENT".to_owned());
+    single.legal_basis = Some("gdpr-art-9-2-h".to_owned());
+    single.result_count = Some(17);
+    single.request_id = Some("req-single".to_owned());
+    let rendered = fhir::to_fhir(&single, &ctx(), Some("patient-42")).expect("render");
+    store
+        .insert(&single, Some("patient-42"), &rendered)
+        .await
+        .expect("insert");
+
+    let mut batched = read_event("2026-07-10T08:31:00Z".parse().unwrap());
+    batched.object = ObjectClass::Demographic;
+    batched.domain = AccessDomain::of(ObjectClass::Demographic);
+    batched.purpose = Some("TREATMENT".to_owned());
+    batched.result_count = Some(1);
+    batched.request_id = Some("req-batch".to_owned());
+    let batched_fhir = fhir::to_fhir(&batched, &ctx(), None).expect("render");
+    store
+        .insert_batch(&[(batched, None, Some(batched_fhir))])
+        .await
+        .expect("insert batch");
+
+    let rows = sqlx::query(
+        "SELECT domain, purpose, legal_basis, result_count, request_id \
+         FROM audit.audit_event ORDER BY recorded_at",
+    )
+    .fetch_all(&pool)
+    .await
+    .expect("both rows");
+    assert_eq!(rows.len(), 2, "one row per write path");
+
+    assert_eq!(
+        rows[0].get::<Option<String>, _>("domain").as_deref(),
+        Some("ehr")
+    );
+    assert_eq!(
+        rows[0].get::<Option<String>, _>("purpose").as_deref(),
+        Some("TREATMENT")
+    );
+    assert_eq!(
+        rows[0].get::<Option<String>, _>("legal_basis").as_deref(),
+        Some("gdpr-art-9-2-h")
+    );
+    assert_eq!(rows[0].get::<Option<i64>, _>("result_count"), Some(17));
+    assert_eq!(
+        rows[0].get::<Option<String>, _>("request_id").as_deref(),
+        Some("req-single")
+    );
+
+    // The batched path carries the same fields, and a demographic read is
+    // recorded in the demographic domain — the separation the whole
+    // pseudonymisation boundary exists to make answerable.
+    assert_eq!(
+        rows[1].get::<Option<String>, _>("domain").as_deref(),
+        Some("demographic")
+    );
+    assert_eq!(rows[1].get::<Option<i64>, _>("result_count"), Some(1));
+    assert_eq!(
+        rows[1].get::<Option<String>, _>("request_id").as_deref(),
+        Some("req-batch")
+    );
+}
+
+/// The trail is append-only for the runtime role: the access-logging columns
+/// cannot be rewritten, a record cannot be deleted outside the reaper, and the
+/// table cannot be truncated.
+///
+/// A log that can be edited by the component it logs is not evidence. The
+/// mechanism is the `audit_event_reject_*` trigger set, and this is the test
+/// that it actually refuses — including the columns #3156 added, which the
+/// whole-row comparison covers only because it subtracts the two delivery
+/// stamps rather than listing what it protects.
+#[tokio::test]
+async fn the_access_trail_refuses_rewriting_deletion_and_truncation() {
+    let db = testkit::db().await.expect("testkit database");
+    let pool = db.pool();
+    let store = AuditStore::new(pool.clone());
+
+    let event = read_event("2026-07-10T08:30:00Z".parse().unwrap());
+    let rendered = fhir::to_fhir(&event, &ctx(), Some("patient-42")).expect("render");
+    let id = store
+        .insert(&event, Some("patient-42"), &rendered)
+        .await
+        .expect("insert");
+
+    for (what, sql) in [
+        (
+            "the recorded purpose",
+            "UPDATE audit.audit_event SET purpose = 'RESEARCH' WHERE id = $1",
+        ),
+        (
+            "the recorded domain",
+            "UPDATE audit.audit_event SET domain = 'system' WHERE id = $1",
+        ),
+        (
+            "the recorded principal",
+            "UPDATE audit.audit_event SET principal = 'someone-else' WHERE id = $1",
+        ),
+        (
+            "the record itself",
+            "DELETE FROM audit.audit_event WHERE id = $1",
+        ),
+    ] {
+        let refused = sqlx::query(sql).bind(id).execute(&pool).await;
+        assert!(
+            refused.is_err(),
+            "{what} was changed: the access trail must be append-only"
+        );
+    }
+
+    let truncated = sqlx::query("TRUNCATE audit.audit_event")
+        .execute(&pool)
+        .await;
+    assert!(
+        truncated.is_err(),
+        "the access trail was truncated: TRUNCATE bypasses row triggers and needs its own refusal"
+    );
+
+    // The one sanctioned mutation still works, so the refusals above are
+    // specific rather than a blanket lock.
+    store.mark_syslog_delivered(id).await;
+
+    let survives: i64 = sqlx::query_scalar("SELECT count(*) FROM audit.audit_event")
+        .fetch_one(&pool)
+        .await
+        .expect("count");
+    assert_eq!(survives, 1, "the record survived every attempt");
 }

--- a/app/ferroehr/tests/it/sql_injection.rs
+++ b/app/ferroehr/tests/it/sql_injection.rs
@@ -34,7 +34,9 @@
 //!   `aql::sql::select`).
 //! * **Output-column aliases** — `col{i}` / `col{i}_{vo,sv,num,cap}` from the
 //!   SELECT index (`aql::sql::select`), `scope_ehr_{i}` / `scope_template_{i}`
-//!   from the VO-root index (`aql::sql::build_scope`), and the literal `hit`
+//!   from the VO-root index (`aql::sql::build_scope`), `access_ehr_{i}` from
+//!   the same index (`aql::sql::select::build_access_ehr_columns`, the hidden
+//!   column the access log reads the served EHRs from), and the literal `hit`
 //!   for the streaming `EXISTS` probe (`aql::sql::value`). An AQL `AS <label>`
 //!   is carried on `ColumnSpec::name` for the `RESULT_SET` only and is never a
 //!   SQL identifier — see [`the_select_as_label_never_becomes_a_sql_identifier`].
@@ -604,6 +606,7 @@ const ALIAS_PATTERNS: &[&str] = &[
     r"^a_v[0-9]+$",
     r"^col[0-9]+(_(vo|sv|num|cap))?$",
     r"^scope_(ehr|template)_[0-9]+$",
+    r"^access_ehr_[0-9]+$",
     r"^hit$",
 ];
 

--- a/website/book/src/audit.md
+++ b/website/book/src/audit.md
@@ -51,6 +51,69 @@ ever names an identity that did not authenticate.
 > identity provider, so neither mints a per-request login record. Rejections
 > are recorded regardless of this switch.
 
+## Reads are logged too, per record
+
+A write leaves its own trail in openEHR's contribution and audit chain. A read
+leaves nothing behind unless the server records it, and reads are what the
+access-logging rules are about: [NEN 7513](https://www.nen.nl) requires per-access
+logging of who consulted which record and on whose authority, the
+[Wabvpz](https://wetten.overheid.nl/BWBR0023864) gives the patient the right to
+know who consulted their record, and
+[EHDS Art. 9](https://eur-lex.europa.eu/eli/reg/2025/327/oj) requires logging of
+access to electronic health data for primary use. No openEHR specification
+governs the read side, so this is FerroEHR's own extension.
+
+Every retrieval in the EHR, Query and Demographic APIs produces a record, and a
+test walks the generated route tables to prove it: a newly generated `GET` that
+emits nothing fails the build.
+
+Each record additionally carries:
+
+| Field | What it holds |
+|---|---|
+| `domain` | The pseudonymisation domain read: `ehr`, `demographic`, `linkage`, or `system` for an operation that touches no domain. |
+| `purpose` | The purpose of use the caller declared in the `x-purpose-of-use` header, when the deployment accepts it. |
+| `legal_basis` | The basis the deployment processes under, from `[audit] legal_basis`. |
+| `result_count` | How many records the operation served. |
+| `request_id` | The `x-request-id` correlation id the response carried. |
+
+A query is the case a single record cannot describe. One AQL statement is one
+operation but potentially many disclosures, so it produces its own execute
+record **plus one access record per EHR it served**, each carrying that EHR's
+served-row count. The served set is read off the rows the caller actually
+received rather than the rows the statement matched: a legal record of access
+must not name an EHR whose content was never disclosed. Two query shapes carry
+no per-EHR breakdown, because the shape makes it underivable —
+`SELECT DISTINCT`, where an extra column changes which rows are distinct, and
+an aggregate projection, where a per-row EHR is not valid SQL. Those record the
+statement and its row count.
+
+### NEN 7513 content, field by field
+
+NEN 7513 §5 lists what a logged event has to contain. This is where each item
+lives in the record:
+
+| NEN 7513 asks for | FerroEHR records it as |
+|---|---|
+| The identity of the person who accessed the record | `principal` — the authenticated Basic username or OAuth `sub`; an unattributable denial is recorded as unattributed, never under a fabricated identity |
+| The identity of the patient whose record was accessed | `patient_id` — the resolved EHR subject, which under the pseudonymisation boundary is an opaque pseudonym |
+| Which record, or which part of it | `resource_class` + `resource_id`: the version uid, party uid or EHR id the operation touched |
+| The date and time | `recorded_at`, the event time; `stored_at` is when the row was persisted |
+| The kind of action | `action` (DICOM `C`/`R`/`U`/`D`/`E`) plus `operation`, the ITS-REST operation id |
+| Whether it succeeded | `outcome`, the DICOM outcome indicator (0 success, 4 minor, 8 serious, 12 major) |
+| On whose authority, and why | `purpose` and `legal_basis` |
+| Which system, and from where | `AuditSourceID` and the source participant's network address (`client_ip`) |
+
+Two of these are the deployment's to supply. `purpose` is only as meaningful as
+the vocabulary you agree with your callers: set `[audit] purpose_codes` to that
+vocabulary and a code outside it is recorded as absent rather than as free text
+that reads at review time like an established purpose. `legal_basis` is a
+deployment-level fact and is recorded on every access once you set it.
+
+Mapping the recorded fields onto your own retention schedule and review process
+stays yours: the software records the events and serves them back, and no
+supplier document discharges the obligation to review them.
+
 ## Sinks
 
 Records fan out to independently configured sinks (`[audit]` in

--- a/website/book/src/installation/config-audit.md
+++ b/website/book/src/installation/config-audit.md
@@ -24,6 +24,8 @@ suppress_login_events = true
 fail_mode = "open"
 resolve_subject = true
 queue_capacity = 8192
+purpose_header = "x-purpose-of-use"
+purpose_codes = []
 ```
 
 | Key | Type | Default | Description |
@@ -37,6 +39,9 @@ queue_capacity = 8192
 | `resolve_subject` | bool | `true` | Enrich the patient participant with a background lookup of the EHR's subject. The lookup runs on the background drain, never on the request path; the IHE BALP patient patterns and the patient-centric audit search need the subject. |
 | `queue_capacity` | int | `8192` | Bounded audit queue capacity. Sized for write-path bursts: the drain persists in multi-row batches, so the queue only needs to ride out sink latency spikes. |
 | `server_host` | string | unset ⇒ the `value_if_missing` fill | This node's advertised network address, reported as the destination `NetworkAccessPointID`. |
+| `purpose_header` | string | `x-purpose-of-use` | The request header a caller declares its purpose of use in, recorded on every access record. NEN 7513 asks on whose authority a record was read and EHDS Art. 9 asks why; neither is derivable from the request, so the caller declares it. IHE carries the equivalent in a SAML attribute rather than a header, so the header is FerroEHR's own. |
+| `purpose_codes` | list of string | `[]` | The purpose codes this deployment accepts. Empty records whatever the caller declares. A non-empty list records a declared code only when it is on the list, so an unagreed string does not sit in the trail reading like an established purpose. |
+| `legal_basis` | string | unset | The legal basis this deployment processes under, recorded on every access record. A deployment-level fact: the controller establishes the GDPR Art. 6/9 condition once. Unset records nothing rather than a guess. |
 
 > [!NOTE]
 > The local store and the ATX:FHIR Feed both carry a FHIR R4 `AuditEvent`


### PR DESCRIPTION
Every retrieval already produced an ATNA record. What a read-side access log
additionally has to answer is which pseudonymisation domain was read, why, on
whose authority, how much was served, and which request it belonged to.
NEN 7513 asks for per-access logging of who consulted which record and on whose
authority, [EHDS Art. 9](https://eur-lex.europa.eu/eli/reg/2025/327/oj)
requires logging of access to health data for primary use, the
[Wabvpz](https://wetten.overheid.nl/BWBR0023864) gives the patient the right to
know who consulted their record, and
[GDPR Art. 30](https://eur-lex.europa.eu/eli/reg/2016/679/oj) requires records
of processing. No openEHR spec governs the read side — the SM names only an
"IHE ATNA-compliant system log" and defines no wire — so this is our own
extension.

## One trail, five fields

`domain` (`ehr` / `demographic` / `linkage` / `system`), `purpose`,
`legal_basis`, `result_count` and `request_id`, on the existing `audit_event`.

They are columns there rather than the separate `audit.access_event` table the
issue's design named: one operation produces one record, and a parallel table
would split one trail in two — a subject access-log export would have to union
them, and the hash chain would cover half of what it is supposed to make
tamper-evident.

The domain is derived from the resource class (`AccessDomain::of`), exhaustive
over `ObjectClass`, so adding a resource class is a compile error at the one
place that question belongs rather than a field each call site might forget.

## A query is one operation and many disclosures

An AQL statement now emits its own execute record **plus one access record per
EHR it served**, each carrying that EHR's served-row count. One execute record
over a population query cannot answer whose record was read, which is exactly
what NEN 7513 and EHDS Art. 9 ask.

The served set is read off the rows the caller actually received: the executed
statement carries each bound VO root's `ehr_id` beside the projection. The
alternative was to reuse the unpaged scope scan the ABAC path already runs, and
it was rejected on merit — it collects what the query MATCHED, so under a
`LIMIT` it would name EHRs whose content was never disclosed, and a legal
record of access must not claim a disclosure that did not happen.

Two plan shapes carry no breakdown, and the reason is structural rather than
lazy: under `SELECT DISTINCT` an extra column changes which rows are distinct,
and in an aggregate projection an ungrouped column is not valid SQL. Those
record the statement and its row count, and the exclusion is documented where
the constant lives.

## Two properties that were assumed, now asserted

**Read coverage.** A contract test walks the generated route tables for the
EHR, Query and Demographic groups and fails any `GET` that emits nothing or
that lands outside its own domain. Writing it found a real defect: the released
OAS reuses one `contribution_get` operationId across the EHR and DEMOGRAPHIC
bundles, so a demographic contribution read was being recorded in the clinical
domain — the exact confusion the pseudonymisation boundary exists to prevent.
Fixed with a handler-set domain override, since only the demographic group
knows which bundle it is serving. The test is mutation-proven: reclassifying
`ehr_get_by_id` to another domain fails it.

**Append-only.** The trigger set was already there; nothing asserted it. Now a
test tries to rewrite the recorded purpose, the recorded domain and the
recorded principal, tries to delete a record, and tries to truncate the table —
all four refused — and then confirms the one sanctioned mutation, a delivery
stamp, still works, so the refusals are specific rather than a blanket lock.

## Configuration

`[audit] purpose_header` (default `x-purpose-of-use`) and `purpose_codes`, an
allow-list. Empty records whatever the caller declares; a non-empty list
records only codes on it, so unagreed free text does not sit in the trail
reading at review time like an established purpose. `[audit] legal_basis` is a
deployment-level fact recorded on every access. IHE carries purpose-of-use in a
SAML attribute rather than a header, so the header is our own.

The subject access-log export the issue asks for already exists and is not
duplicated here: `GET /fhir/r4/AuditEvent?patient=…` is the IHE ITI-81
retrieval, gated by `[audit.store]` alone and independent of the FHIR connector
gate. The audit page now documents it as the subject export and maps the
NEN 7513 event content onto the recorded fields, item by item.

Closes #3156.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.

## Checks

- [x] `cargo fmt --all --check` · `cargo clippy --workspace --all-targets` · `cargo nextest run --workspace`
- [x] No test weakened, skipped, or edited to route around a bug
- [x] User-visible change → `CHANGELOG.md [Unreleased]` entry
- [x] REST/config/CLI/deployment change → matching `website/book/src` page updated
- [x] Implemented `docs/plans/*.md` plan file deleted (unless another open issue still consumes it) — none exists for this work
- [x] New issues opened from this work are linked as GitHub relationships — none were opened

## Privacy boundary

**Data flow.** This change adds fields to the access record and one record per
EHR a query served. It reads no new personal data: the domain comes from the
resource class, the purpose from a request header, the legal basis from
configuration, the counts from rows already fetched, and the served EHR ids
from the statement already executed. What it writes is the audit trail itself,
which is the record of access rather than a copy of the data accessed — no
clinical content, no identifier, and the patient participant stays the resolved
EHR subject, which under the pseudonymisation boundary is an opaque pseudonym.

**Roles.** No database role is added or changed, and no grant is touched. The
trail is written by the same role that serves the request, through the same
append-only table; the migration adds columns and constraints only. The
`linkage` domain value is declared now and unused until #3158 creates that
schema.

- [x] The data flow is described above
- [x] The roles are named
- [x] No new grant spans the clinical and demographic domains — no grant changes at all
- [x] Synthetic data only in tests, fixtures, seeds and examples
- [x] An access event is emitted wherever this change added a read of personal data — this change *is* the access event, and its coverage over every generated read is now a test
