### PR TITLE
feat(demographic): national identifiers sealed under a per-tenant key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,27 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
+- **National identifiers in the demographic domain can be held sealed**
+  (#3155). With the new `[demographic.identifier_protection]` section on, an
+  identifier of a configured scheme never sits in the versioned body: the value
+  moves to `demographic.national_identifier`, sealed with AES-256-GCM under a
+  key derived per tenant from one configured root key, and the body keeps a
+  reference in its place. Beside the ciphertext sits an HMAC-SHA-256 digest, so
+  "which party holds this identifier" is answerable without decrypting
+  anything — and, being keyed, it cannot be reversed by enumerating a
+  nine-digit space the way an unkeyed hash could. Sealing runs before the body
+  is decomposed and signed, so the stored, signed and served body stay one
+  form. Only the demographic writer reaches the sealed value; the read-only
+  twin is refused the ciphertext and the digest by column-level grant and the
+  clinical roles are refused the table outright. Resolution goes through a
+  `SECURITY DEFINER` function that takes the digest rather than the value, and
+  every call is recorded as a `linkage`-domain access naming the scheme and
+  whether it matched, never the value. Off by default, and enabling it without
+  a key — or with a scheme list that would protect nothing — is a boot error.
+  See [Privacy & data minimisation](https://ferroehr.eu/book/installation/config-privacy.html#protecting-national-identifiers-in-the-demographic-domain)
+  and the key-rotation runbook in
+  [Operations](https://ferroehr.eu/book/operations.html#rotating-the-national-identifier-key).
+
 - **Reads are logged per record, not just per operation** (#3156). Every
   retrieval in the EHR, Query and Demographic APIs already produced an audit
   record; each one now also says which pseudonymisation domain it read (`ehr`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,14 +29,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f0f96ce78e38c3dc6d8948aa8163d06385be74000f3c7a95bf1eef35d3ea32"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -45,12 +66,26 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
+ "aead 0.5.2",
+ "aes 0.8.4",
+ "cipher 0.4.4",
+ "ctr 0.9.2",
+ "ghash 0.5.1",
  "subtle",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f2b8006a0c83f52b62ba44a97b58bf76fe2f70a329e588f67f89691d93d498f"
+dependencies = [
+ "aead 0.6.1",
+ "aes 0.9.3",
+ "cipher 0.5.2",
+ "ctr 0.10.1",
+ "ctutils",
+ "ghash 0.6.0",
 ]
 
 [[package]]
@@ -59,7 +94,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fa2b352dcefb5f7f3a5fb840e02665d311d878955380515e4fd50095dd3d8c"
 dependencies = [
- "aes",
+ "aes 0.8.4",
 ]
 
 [[package]]
@@ -894,7 +929,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
 dependencies = [
  "byteorder",
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1115,7 +1150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3264e2574e9ef2b53ce6f536dea83a69ac0bc600b762d1523ff83fe07230ce30"
 dependencies = [
  "byteorder",
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1136,7 +1171,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b07d673db1ccf000e90f54b819db9e75a8348d6eb056e9b8ab53231b7a9911"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1145,7 +1180,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1230,7 +1265,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "738b8d467867f80a71351933f70461f5b56f24d5c93e0cf216e59229c968d330"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1318,7 +1353,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
- "inout",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -1367,7 +1413,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
  "dbl",
  "digest 0.10.7",
 ]
@@ -1618,7 +1664,7 @@ version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a373e3602691c3cdea496d2f0ee5935151e6168fe87739483c463db1b2f2f87"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.10.3",
  "base64 0.22.1",
  "percent-encoding",
  "rand 0.8.7",
@@ -1667,6 +1713,12 @@ checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -1845,7 +1897,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.3",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1875,7 +1929,16 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -2228,7 +2291,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -2363,10 +2426,10 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9954fabd903b82b9d7a68f65f97dc96dd9ad368e40ccc907a7c19d53e6bfac28"
 dependencies = [
- "aead",
- "cipher",
+ "aead 0.5.2",
+ "cipher 0.4.4",
  "cmac",
- "ctr",
+ "ctr 0.9.2",
  "subtle",
 ]
 
@@ -2642,6 +2705,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 name = "ferroehr"
 version = "4.1.1"
 dependencies = [
+ "aes-gcm 0.11.1",
  "argon2",
  "assert_fs",
  "async-trait",
@@ -2652,6 +2716,7 @@ dependencies = [
  "criterion",
  "ferroehr-ext",
  "futures",
+ "hmac 0.13.0",
  "http",
  "http-body-util",
  "indexmap 2.14.0",
@@ -3250,7 +3315,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
- "polyval",
+ "polyval 0.6.2",
+]
+
+[[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval 0.7.3",
 ]
 
 [[package]]
@@ -3933,7 +4007,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "075557004419d7f2031b8bb7f44bb43e55a83ca7b63076a8fb8fe75753836477"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -4032,6 +4106,15 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -5379,9 +5462,9 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c196e0276c471c843dd5777e7543a36a298a4be942a2a688d8111cd43390dedb"
 dependencies = [
- "aead",
- "cipher",
- "ctr",
+ "aead 0.5.2",
+ "cipher 0.4.4",
+ "ctr 0.9.2",
  "subtle",
 ]
 
@@ -5999,9 +6082,9 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cfa4743b28656065ff4c0ba09e46b357a65e8c00fc2341e89084b82f87cbdf1"
 dependencies = [
- "aead",
- "aes",
- "aes-gcm",
+ "aead 0.5.2",
+ "aes 0.8.4",
+ "aes-gcm 0.10.3",
  "aes-kw",
  "argon2",
  "base64 0.22.1",
@@ -6014,7 +6097,7 @@ dependencies = [
  "camellia",
  "cast5",
  "cfb-mode",
- "cipher",
+ "cipher 0.4.4",
  "const-oid 0.9.6",
  "crc24",
  "curve25519-dalek",
@@ -6164,7 +6247,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "cbc",
  "der",
  "pbkdf2",
@@ -6226,7 +6309,18 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "polyval"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
+dependencies = [
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -6791,7 +6885,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62c64daa8e9438b84aaae55010a93f396f8e60e3911590fcba770d04643fc1dd"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -7422,7 +7516,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -9333,7 +9427,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a78e83a30223c757c3947cd144a31014ff04298d8719ae10d03c31c0448c8013"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -9491,6 +9585,16 @@ checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
  "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -233,6 +233,13 @@ tokio-rustls = "0.26"
 # only when pgp does.
 rand = "0.10.1"
 sha2 = "0.11.0"
+# National-identifier protection (#3155): AES-256-GCM for the ciphertext and
+# HMAC-SHA-256 for the blind-lookup column and the per-tenant key derivation.
+# AES-GCM over ChaCha20-Poly1305 because NIST names it (SP 800-38D) and the
+# control answers to GDPR Art. 32(1)(a) and NEN 7510-2 reviewers; both are
+# pure-Rust RustCrypto AEADs, so either fits the no-OpenSSL stack.
+aes-gcm = "0.11.1"
+hmac = "0.13.0"
 object_store = { version = "0.14.0", features = ["aws"] }   # S3-compatible blob backend for DV_MULTIMEDIA externalization; SeaweedFS in dev/test
 pgp = { version = "0.20.0", default-features = false }   # rPGP — pure-Rust OpenPGP (RFC 4880/9580); version signing (no OpenSSL/C, fits the rustls-only stack). default-features off drops the bzip2 (libbz2-rs-sys) dep — detached signatures need no compression, and it fails the cargo-deny license gate.
 

--- a/app/ferroehr-server/src/lib.rs
+++ b/app/ferroehr-server/src/lib.rs
@@ -338,6 +338,18 @@ fn assemble_service(
     // bad pattern is noticed.
     let privacy = ferroehr::privacy::PrivacyPolicy::compile(&config.privacy)
         .context("compiling the [privacy] policy")?;
+    // The identifier-protection engine, when the deployment configured one. A
+    // key that cannot be parsed is a boot error: a server that believes it
+    // seals national identifiers and does not is the failure this refuses to
+    // start into.
+    let identifiers =
+        ferroehr::service::demographic::identifier::engine::IdentifierProtection::from_config(
+            &config.demographic.identifier_protection,
+            config.demographic.identifier_protection.key.as_ref(),
+            pools.demographic.clone(),
+        )
+        .context("building the [demographic.identifier_protection] engine")?;
+
     let mut service = FerroEhrService::new(pool.clone())
         .with_demographic_pool(pools.demographic.clone())
         .with_spec_profile(config.spec_profile)
@@ -345,6 +357,7 @@ fn assemble_service(
         .with_signer(signer)
         .with_outbox_enabled(outbox_enabled)
         .with_privacy(Arc::new(privacy))
+        .with_identifier_protection_opt(identifiers.map(Arc::new))
         .with_query_config(&config.query);
     if let Some(sender) = audit_sender {
         service = service.with_audit(sender);

--- a/app/ferroehr/Cargo.toml
+++ b/app/ferroehr/Cargo.toml
@@ -88,6 +88,8 @@ uuid.workspace = true
 # ferroehr-signing crate): OpenPGP (rPGP) detached signatures + SHA-256 digest mode.
 pgp.workspace = true
 sha2.workspace = true
+aes-gcm.workspace = true
+hmac.workspace = true
 base64.workspace = true
 # `multimedia` module (DV_MULTIMEDIA externalization to S3-compatible object
 # storage — no openEHR spec governs blob storage mechanics; our own design):

--- a/app/ferroehr/assets/ferroehr.default.toml
+++ b/app/ferroehr/assets/ferroehr.default.toml
@@ -557,3 +557,21 @@ rules = ["fi-hetu", "gb-nhs-number", "nl-bsn", "no-fodselsnummer", "se-personnum
 #   patterns = ["(^|[^0-9A-Za-z])[1-9][0-9]{3} ?[A-Z]{2}[^0-9A-Za-z]{1,3}[0-9]{1,4}([^0-9A-Za-z]|$)"]
 # to refuse a postcode paired with a house number.
 patterns = []
+
+# ── [demographic] — the demographic domain ────────────────────────────────────
+# National-identifier protection: the value leaves the versioned body for
+# `demographic.national_identifier`, sealed under a per-tenant AES-256-GCM key
+# with an HMAC-SHA-256 digest beside it for equality lookup. GDPR Art. 32(1)(a)
+# names encryption as an appropriate measure; UAVG Art. 46 and the Wabvpz bound
+# what a BSN may be used for at all.
+[demographic.identifier_protection]
+# OFF by default: turning it on makes the key load-bearing for reading these
+# identifiers back, which is a deployment decision with a runbook attached.
+enabled = false
+# The DV_IDENTIFIER `type` values to protect. Each must be registered in
+# `demographic.identifier_scheme`; an unregistered code is a boot error rather
+# than an identifier that silently stays in the clear.
+schemes = ["nl-bsn"]
+# The root key: 64 hex characters (32 bytes). Prefer `key_file`.
+#? key = "…64 hex characters…"
+#? key_file = "/run/secrets/ferroehr-identifier-key"

--- a/app/ferroehr/migrations/demographic/0003_national_identifier.sql
+++ b/app/ferroehr/migrations/demographic/0003_national_identifier.sql
@@ -1,0 +1,163 @@
+-- SPDX-FileCopyrightText: Ruben Talstra
+-- SPDX-License-Identifier: BUSL-1.1
+--
+-- Protected national identifiers: the value leaves the versioned body and
+-- lives here, sealed, with a keyed digest beside it for equality lookup.
+--
+-- The RM models identifiers generically (PARTY_IDENTITY, DV_IDENTIFIER) and
+-- says nothing about protecting the value, so no openEHR spec governs this —
+-- our own design. The obligations are external: GDPR Art. 32(1)(a) names
+-- encryption as an appropriate measure
+-- (https://eur-lex.europa.eu/eli/reg/2016/679/oj), NEN 7510-2 carries the
+-- cryptographic controls, and UAVG Art. 46 with the Wabvpz permit BSN
+-- processing in care only for identification and under the act's conditions
+-- (https://wetten.overheid.nl/BWBR0040940, https://wetten.overheid.nl/BWBR0023864).
+--
+-- Two columns rather than one, because storage and lookup want opposite
+-- properties. `ciphertext` is AES-256-GCM with a fresh nonce per record, so
+-- two parties with the same identifier store different bytes and neither
+-- reveals the value. `lookup_digest` is HMAC-SHA-256 under a separate
+-- per-tenant subkey, so equality search works without decrypting — and,
+-- because it is KEYED, the database, a backup or a read replica cannot
+-- reverse it by enumerating a nine-digit space.
+
+-- ── the scheme registry ──────────────────────────────────────────────────────
+-- A closed set rather than free text: an identifier whose scheme nobody
+-- declared is an identifier nobody agreed to hold, and the registry is what a
+-- reviewer reads to see which kinds this deployment stores at all.
+
+CREATE TABLE demographic.identifier_scheme (
+    -- The scheme code, `<iso-3166-1-alpha-2 lowercased>-<local name>`, the same
+    -- shape the write-path scanner keys its rules by.
+    code        text        NOT NULL,
+    -- The issuing jurisdiction, ISO 3166-1 alpha-2.
+    jurisdiction text       NOT NULL,
+    -- The identifier's own name in its register.
+    label       text        NOT NULL,
+    -- The register or authority that defines it.
+    source      text        NOT NULL,
+    CONSTRAINT pk_identifier_scheme PRIMARY KEY (code),
+    CONSTRAINT ck_identifier_scheme_code
+        CHECK (code ~ '^[a-z]{2}-[a-z0-9-]+$'),
+    CONSTRAINT ck_identifier_scheme_jurisdiction
+        CHECK (jurisdiction ~ '^[A-Z]{2}$')
+);
+
+COMMENT ON TABLE demographic.identifier_scheme IS
+    'The national personal-identifier kinds this deployment may store, by code. A closed set: an identifier whose scheme is not registered here cannot be written.';
+
+INSERT INTO demographic.identifier_scheme (code, jurisdiction, label, source) VALUES
+    ('nl-bsn', 'NL', 'burgerservicenummer (BSN)',
+     'Rijksdienst voor Identiteitsgegevens, Logisch Ontwerp BSN, https://www.rvig.nl/logisch-ontwerp-bsn');
+
+-- ── the protected values ─────────────────────────────────────────────────────
+
+CREATE TABLE demographic.national_identifier (
+    id            uuid        NOT NULL DEFAULT uuidv7(),
+    -- The party this identifier belongs to (the demographic VERSIONED_OBJECT
+    -- id). No foreign key: a party's versions come and go under change
+    -- control, and an identifier outliving a particular version is correct.
+    party_id      uuid        NOT NULL,
+    -- The registered scheme.
+    scheme        text        NOT NULL,
+    -- The owning tenant. Part of the key derivation and of the AEAD associated
+    -- data, so a record cannot be read under another tenant's key.
+    tenant_id     uuid        NOT NULL,
+    -- AES-256-GCM: the 96-bit nonce and the sealed value.
+    nonce         bytea       NOT NULL,
+    ciphertext    bytea       NOT NULL,
+    -- HMAC-SHA-256 of the value under this tenant's lookup subkey.
+    lookup_digest bytea       NOT NULL,
+    created_at    timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT pk_national_identifier PRIMARY KEY (id),
+    CONSTRAINT fk_national_identifier_scheme
+        FOREIGN KEY (scheme) REFERENCES demographic.identifier_scheme (code),
+    CONSTRAINT ck_national_identifier_nonce CHECK (octet_length(nonce) = 12),
+    CONSTRAINT ck_national_identifier_digest CHECK (octet_length(lookup_digest) = 32)
+);
+
+-- One party holds one value per scheme per tenant, and one value identifies one
+-- party: both directions are the point of a national identifier, and a
+-- duplicate in either direction is a data defect the store refuses rather than
+-- a resolution that silently picks a row.
+CREATE UNIQUE INDEX uq_national_identifier_party
+    ON demographic.national_identifier (tenant_id, scheme, party_id);
+CREATE UNIQUE INDEX uq_national_identifier_value
+    ON demographic.national_identifier (tenant_id, scheme, lookup_digest);
+
+COMMENT ON TABLE demographic.national_identifier IS
+    'National personal identifiers, sealed under a per-tenant AES-256-GCM key with an HMAC-SHA-256 lookup digest beside them. The versioned body carries a reference to a row here, never the value.';
+COMMENT ON COLUMN demographic.national_identifier.ciphertext IS
+    'AES-256-GCM sealed value; the scheme and tenant are the associated data, so a row moved between either fails to open.';
+COMMENT ON COLUMN demographic.national_identifier.lookup_digest IS
+    'HMAC-SHA-256 of the value under the tenant lookup subkey: deterministic for equality search, keyed so the small value space cannot be enumerated.';
+
+-- ── the resolution path ──────────────────────────────────────────────────────
+-- The only way to get from an identifier to a party without holding the
+-- ciphertext. It takes the DIGEST rather than the value, so the caller proves
+-- it already knows the identifier and the plaintext never crosses this
+-- boundary; it returns the party and nothing else.
+
+CREATE FUNCTION demographic.resolve_national_identifier(
+    p_tenant  uuid,
+    p_scheme  text,
+    p_digest  bytea
+) RETURNS uuid
+    LANGUAGE sql STABLE SECURITY DEFINER
+    SET search_path = demographic, pg_catalog
+    AS $$
+    SELECT party_id
+    FROM demographic.national_identifier
+    WHERE tenant_id = p_tenant
+      AND scheme = p_scheme
+      AND lookup_digest = p_digest;
+$$;
+
+COMMENT ON FUNCTION demographic.resolve_national_identifier(uuid, text, bytea) IS
+    'The sole identifier-to-party path for a role without ciphertext access. Takes the keyed lookup digest, never the value, and returns the party id alone. Every call is recorded as a linkage-domain access event by the caller.';
+
+-- ── grants ───────────────────────────────────────────────────────────────────
+-- Only the demographic writer reaches the ciphertext. The clinical roles are
+-- revoked explicitly rather than merely never granted, for the reason the
+-- baseline's grant block states: PUBLIC holds EXECUTE on functions by default
+-- and an earlier blanket grant may exist
+-- (https://www.postgresql.org/docs/18/sql-grant.html).
+DO $$
+BEGIN
+    IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'ferroehr_demographic') THEN
+        GRANT SELECT, INSERT, UPDATE, DELETE ON demographic.national_identifier
+            TO ferroehr_demographic;
+        GRANT SELECT ON demographic.identifier_scheme
+            TO ferroehr_demographic, ferroehr_demographic_reader;
+        -- The read-only twin sees that a protected identifier EXISTS and which
+        -- party holds it, which its reporting role needs, but never the sealed
+        -- value: the two sensitive columns are withheld by column-level grant
+        -- rather than by trusting every future query.
+        --
+        -- The REVOKE first is load-bearing, not defensive tidiness. The
+        -- baseline's `ALTER DEFAULT PRIVILEGES IN SCHEMA demographic GRANT
+        -- SELECT ON TABLES TO ferroehr_demographic_reader` applies to every
+        -- table created here afterwards, so this one arrived with a
+        -- table-level SELECT already on it — which covers every column and
+        -- would silently outrank the column list below (PostgreSQL 18, GRANT:
+        -- table-level privileges apply to all columns,
+        -- https://www.postgresql.org/docs/18/sql-grant.html).
+        REVOKE SELECT ON demographic.national_identifier
+            FROM ferroehr_demographic_reader;
+        GRANT SELECT (id, party_id, scheme, tenant_id, created_at)
+            ON demographic.national_identifier TO ferroehr_demographic_reader;
+
+        REVOKE ALL ON demographic.national_identifier, demographic.identifier_scheme
+            FROM ferroehr_ehr, ferroehr_ehr_reader;
+
+        -- The resolve function is SECURITY DEFINER, so EXECUTE on it is the
+        -- whole permission: PUBLIC is revoked and each role named explicitly.
+        REVOKE ALL ON FUNCTION
+            demographic.resolve_national_identifier(uuid, text, bytea) FROM PUBLIC;
+        GRANT EXECUTE ON FUNCTION
+            demographic.resolve_national_identifier(uuid, text, bytea)
+            TO ferroehr_demographic;
+    ELSE
+        RAISE NOTICE 'skipping national-identifier grants (roles absent — see the baseline role block)';
+    END IF;
+END $$;

--- a/app/ferroehr/src/config/alias.rs
+++ b/app/ferroehr/src/config/alias.rs
@@ -69,6 +69,7 @@ pub(super) const SECTIONS: &[&str] = &[
     "audit",
     "subject_proxy",
     "privacy",
+    "demographic",
 ];
 
 /// The two PERMANENT conventional aliases — 12-factor ecosystem names every
@@ -109,6 +110,7 @@ pub(super) const LIST_KEYS: &[&str] = &[
     "privacy.subject_namespaces",
     "privacy.identifier_scan.rules",
     "privacy.identifier_scan.patterns",
+    "demographic.identifier_protection.schemes",
     // `authz.abac.policy` is a MAP, so the env grammar reaches into it the way
     // it reaches `subject_proxy.systems.<name>`. The resource kinds are the
     // closed set the enforcement point consults (`ResourceKind`), so each is

--- a/app/ferroehr/src/config/loader.rs
+++ b/app/ferroehr/src/config/loader.rs
@@ -431,6 +431,12 @@ fn resolve_secret_files(config: &mut FerroEhrConfig, errors: &mut Vec<ConfigErro
         }
     }
     resolve_secret(
+        "demographic.identifier_protection.key",
+        &mut config.demographic.identifier_protection.key,
+        config.demographic.identifier_protection.key_file.take(),
+        errors,
+    );
+    resolve_secret(
         "multimedia.secret_access_key",
         &mut config.multimedia.secret_access_key,
         config.multimedia.secret_access_key_file.take(),

--- a/app/ferroehr/src/config/mod.rs
+++ b/app/ferroehr/src/config/mod.rs
@@ -93,6 +93,9 @@ pub struct FerroEhrConfig {
     pub subject_proxy: crate::service::subject_proxy::config::SubjectProxyConfig,
     /// `[privacy]` — the clinical-side data-minimisation policy.
     pub privacy: crate::privacy::config::PrivacyConfig,
+    /// `[demographic]` — the demographic domain, including national-identifier
+    /// protection.
+    pub demographic: crate::service::demographic::identifier::config::DemographicConfig,
 }
 
 /// The annotated default template `ferroehr config default` prints — a
@@ -1377,6 +1380,44 @@ mod tests {
         );
         c.validate()
             .expect("a well-formed privacy section validates");
+    }
+
+    /// The national-identifier protection section maps from the environment,
+    /// and the key never renders.
+    #[test]
+    fn the_demographic_section_maps_from_the_environment() {
+        let c = assemble_ok(
+            None,
+            &env(&[
+                (
+                    "FERROEHR__DEMOGRAPHIC__IDENTIFIER_PROTECTION__ENABLED",
+                    "true",
+                ),
+                (
+                    "FERROEHR__DEMOGRAPHIC__IDENTIFIER_PROTECTION__SCHEMES",
+                    "nl-bsn,se-personnummer",
+                ),
+                (
+                    "FERROEHR__DEMOGRAPHIC__IDENTIFIER_PROTECTION__KEY",
+                    "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+                ),
+            ]),
+            &[],
+        );
+        let protection = &c.demographic.identifier_protection;
+        assert!(protection.enabled);
+        assert_eq!(
+            protection.schemes,
+            vec!["nl-bsn".to_owned(), "se-personnummer".to_owned()]
+        );
+        assert!(protection.key.is_some(), "the root key binds from the env");
+        // The key is a secret: rendering the effective configuration must not
+        // print it, which is the property the admin config endpoint relies on.
+        let rendered = serde_json::to_string(&c).expect("the config renders");
+        assert!(
+            !rendered.contains("000102030405"),
+            "the root key must never render into the effective configuration"
+        );
     }
 
     /// A pattern that does not compile is a BOOT error naming the pattern, not

--- a/app/ferroehr/src/service/demographic/identifier/body.rs
+++ b/app/ferroehr/src/service/demographic/identifier/body.rs
@@ -1,0 +1,286 @@
+// SPDX-FileCopyrightText: Ruben Talstra
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Finding protected identifiers in a party body, and replacing them with a
+//! reference to the row that holds the sealed value.
+//!
+//! **No openEHR spec governs this — our own design/extension.** A party's
+//! identifiers live in `PARTY_IDENTITY.details` as `DV_IDENTIFIER` items (RM
+//! demographic `UML/classes/org.openehr.rm.demographic.party_identity.adoc`;
+//! RM `data_types` `UML/classes/org.openehr.rm.data_types.dv_identifier.adoc`),
+//! and the RM types the value as a plain `String` with no protected form. The
+//! substitution here is a storage decision layered over that.
+//!
+//! The scan is by `DV_IDENTIFIER.type`, the attribute the RM gives for "the
+//! identifier type, such as prescription, or Social Security Number", matched
+//! against the deployment's configured scheme list. An identifier of an
+//! unconfigured type is left exactly as written: this module protects what the
+//! deployment declared and never guesses.
+
+use serde_json::Value;
+
+/// The `urn` prefix a substituted identifier carries in the stored body.
+///
+/// A reference rather than the value, and self-describing rather than an
+/// opaque uuid, so a person reading a stored body sees immediately that the
+/// value is held elsewhere rather than missing.
+pub const REFERENCE_PREFIX: &str = "urn:ferroehr:protected-identifier:";
+
+/// One identifier found in a body: its scheme, its value, and where it sat.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FoundIdentifier {
+    /// The `DV_IDENTIFIER.type`, matched against the configured schemes.
+    pub scheme: String,
+    /// The identifier value as written.
+    pub value: String,
+    /// The RFC 6901 JSON pointer of the `DV_IDENTIFIER` object holding it, so
+    /// the substitution and any later expansion address the same node.
+    pub pointer: String,
+}
+
+/// Every protected-scheme identifier in `body`, in document order.
+///
+/// Walks the whole body rather than only `PARTY_IDENTITY.details`: the RM
+/// allows a `DV_IDENTIFIER` anywhere an `ITEM` can appear, and an identifier
+/// that reached an unexpected slot is exactly the one a protection rule must
+/// not miss.
+#[must_use]
+pub fn find(body: &Value, schemes: &[String]) -> Vec<FoundIdentifier> {
+    let mut found = Vec::new();
+    walk(body, &mut String::new(), schemes, &mut found);
+    found
+}
+
+/// Replace each found identifier's `id` with a reference to its stored row.
+///
+/// `references` pairs each [`FoundIdentifier::pointer`] with the row id that
+/// now holds the sealed value. A pointer with no pairing is left untouched,
+/// which cannot happen on the write path and would be a silent value drop if
+/// it did.
+pub fn substitute(body: &mut Value, references: &[(String, uuid::Uuid)]) {
+    for (pointer, row) in references {
+        if let Some(Value::String(id)) = body.pointer_mut(&format!("{pointer}/id")) {
+            *id = format!("{REFERENCE_PREFIX}{row}");
+        }
+    }
+}
+
+/// Put the plaintext values back, addressed by the same pointers.
+///
+/// The inverse of [`substitute`], for the audited expansion path: the served
+/// default is the stored reference form, and a caller entitled to the values
+/// asks for them explicitly.
+pub fn expand(body: &mut Value, values: &[(String, String)]) {
+    for (pointer, value) in values {
+        if let Some(Value::String(id)) = body.pointer_mut(&format!("{pointer}/id")) {
+            id.clone_from(value);
+        }
+    }
+}
+
+/// The row id a reference names, when this `id` string is one.
+#[must_use]
+pub fn referenced_row(id: &str) -> Option<uuid::Uuid> {
+    id.strip_prefix(REFERENCE_PREFIX)
+        .and_then(|rest| rest.parse().ok())
+}
+
+/// Recursive walk collecting `DV_IDENTIFIER` nodes of a configured scheme.
+fn walk(node: &Value, pointer: &mut String, schemes: &[String], found: &mut Vec<FoundIdentifier>) {
+    match node {
+        Value::Object(map) => {
+            if map.get("_type").and_then(Value::as_str) == Some("DV_IDENTIFIER")
+                && let Some(scheme) = map.get("type").and_then(Value::as_str)
+                && schemes.iter().any(|configured| configured == scheme)
+                && let Some(value) = map.get("id").and_then(Value::as_str)
+                // A body being re-committed unchanged already carries the
+                // reference; substituting a reference for a reference would
+                // orphan the first row.
+                && referenced_row(value).is_none()
+            {
+                found.push(FoundIdentifier {
+                    scheme: scheme.to_owned(),
+                    value: value.to_owned(),
+                    pointer: pointer.clone(),
+                });
+            }
+            for (key, child) in map {
+                let mark = pointer.len();
+                pointer.push('/');
+                pointer.push_str(&escape(key));
+                walk(child, pointer, schemes, found);
+                pointer.truncate(mark);
+            }
+        }
+        Value::Array(items) => {
+            for (index, child) in items.iter().enumerate() {
+                let mark = pointer.len();
+                pointer.push('/');
+                pointer.push_str(&index.to_string());
+                walk(child, pointer, schemes, found);
+                pointer.truncate(mark);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// RFC 6901 token escaping: `~` becomes `~0` and `/` becomes `~1`.
+fn escape(key: &str) -> String {
+    key.replace('~', "~0").replace('/', "~1")
+}
+
+#[cfg(test)]
+mod tests {
+    //! Every identifier here is synthetic.
+
+    use super::{FoundIdentifier, REFERENCE_PREFIX, expand, find, referenced_row, substitute};
+    use serde_json::{Value, json};
+
+    fn schemes() -> Vec<String> {
+        vec!["nl-bsn".to_owned()]
+    }
+
+    fn party() -> Value {
+        json!({
+            "_type": "PERSON",
+            "name": { "_type": "DV_TEXT", "value": "a party" },
+            "identities": [{
+                "_type": "PARTY_IDENTITY",
+                "name": { "_type": "DV_TEXT", "value": "identifiers" },
+                "details": { "_type": "ITEM_LIST", "items": [
+                    { "_type": "ELEMENT", "value": {
+                        "_type": "DV_IDENTIFIER", "type": "nl-bsn",
+                        // privacy-allow: synthetic, passes the eleven-test
+                        "id": "111222333", "issuer": "RvIG", "assigner": "RvIG" } },
+                    { "_type": "ELEMENT", "value": {
+                        "_type": "DV_IDENTIFIER", "type": "local-mrn",
+                        "id": "MRN-004221", "issuer": "the hospital", "assigner": "the hospital" } }
+                ]}
+            }]
+        })
+    }
+
+    #[test]
+    fn a_configured_scheme_is_found_and_an_unconfigured_one_is_not() {
+        let found = find(&party(), &schemes());
+        assert_eq!(
+            found,
+            vec![FoundIdentifier {
+                scheme: "nl-bsn".to_owned(),
+                // privacy-allow: synthetic, passes the eleven-test
+                value: "111222333".to_owned(),
+                pointer: "/identities/0/details/items/0/value".to_owned(),
+            }],
+            "only the configured scheme is protected; the local MRN is left alone"
+        );
+    }
+
+    #[test]
+    fn substitution_replaces_the_value_and_leaves_everything_else() {
+        let mut body = party();
+        let found = find(&body, &schemes());
+        let row = uuid::Uuid::from_u128(42);
+        substitute(&mut body, &[(found[0].pointer.clone(), row)]);
+
+        let stored = body
+            .pointer("/identities/0/details/items/0/value/id")
+            .and_then(Value::as_str)
+            .expect("the identifier slot survives");
+        assert_eq!(stored, format!("{REFERENCE_PREFIX}{row}"));
+        assert_eq!(referenced_row(stored), Some(row));
+        // privacy-allow: synthetic, and the assertion is that it is GONE
+        assert!(
+            !body.to_string().contains("111222333"),
+            "the value must not survive anywhere in the stored body"
+        );
+        // The sibling identifier and the surrounding structure are untouched.
+        assert_eq!(
+            body.pointer("/identities/0/details/items/1/value/id")
+                .and_then(Value::as_str),
+            Some("MRN-004221")
+        );
+        assert_eq!(
+            body.pointer("/identities/0/details/items/0/value/issuer")
+                .and_then(Value::as_str),
+            Some("RvIG"),
+            "only the id is replaced"
+        );
+    }
+
+    #[test]
+    fn expansion_is_the_exact_inverse_of_substitution() {
+        // The property the whole design rests on: what a reader expands is
+        // byte-for-byte what the writer submitted.
+        let original = party();
+        let mut body = original.clone();
+        let found = find(&body, &schemes());
+        let row = uuid::Uuid::from_u128(42);
+        substitute(&mut body, &[(found[0].pointer.clone(), row)]);
+        assert_ne!(body, original, "substitution changed the body");
+
+        expand(
+            &mut body,
+            &[(found[0].pointer.clone(), found[0].value.clone())],
+        );
+        assert_eq!(
+            body, original,
+            "expansion must restore the submitted body exactly"
+        );
+    }
+
+    #[test]
+    fn a_body_that_already_carries_a_reference_is_not_substituted_again() {
+        // Re-committing an unchanged party must not orphan the first row by
+        // sealing the reference text as though it were a value.
+        let mut body = party();
+        let row = uuid::Uuid::from_u128(42);
+        let pointer = find(&body, &schemes())[0].pointer.clone();
+        substitute(&mut body, &[(pointer, row)]);
+        assert!(
+            find(&body, &schemes()).is_empty(),
+            "a stored reference is not a value to protect"
+        );
+    }
+
+    #[test]
+    fn an_identifier_outside_party_identity_is_found_too() {
+        // The RM admits a DV_IDENTIFIER wherever an ITEM can appear, and one
+        // that reached an unexpected slot is exactly the one to catch.
+        let body = json!({
+            "_type": "PERSON",
+            "contacts": [{ "addresses": [{ "details": { "items": [
+                { "_type": "ELEMENT", "value": {
+                    "_type": "DV_IDENTIFIER", "type": "nl-bsn",
+                    // privacy-allow: synthetic, passes the eleven-test
+                    "id": "111222333" } }
+            ]}}]}]
+        });
+        let found = find(&body, &schemes());
+        assert_eq!(found.len(), 1, "the walk covers the whole body");
+        assert_eq!(
+            found[0].pointer,
+            "/contacts/0/addresses/0/details/items/0/value"
+        );
+    }
+
+    #[test]
+    fn a_key_with_a_pointer_metacharacter_still_addresses_its_own_node() {
+        // RFC 6901 escaping: an object key containing `/` or `~` must not
+        // shift which node the pointer names.
+        let body = json!({
+            "a/b": { "c~d": {
+                // privacy-allow: synthetic, passes the eleven-test
+                "_type": "DV_IDENTIFIER", "type": "nl-bsn", "id": "111222333"
+            }}
+        });
+        let found = find(&body, &schemes());
+        assert_eq!(found[0].pointer, "/a~1b/c~0d");
+        let mut substituted = body.clone();
+        substitute(
+            &mut substituted,
+            &[(found[0].pointer.clone(), uuid::Uuid::nil())],
+        );
+        assert_ne!(substituted, body, "the escaped pointer addressed the node");
+    }
+}

--- a/app/ferroehr/src/service/demographic/identifier/body.rs
+++ b/app/ferroehr/src/service/demographic/identifier/body.rs
@@ -151,8 +151,7 @@ mod tests {
                 "details": { "_type": "ITEM_LIST", "items": [
                     { "_type": "ELEMENT", "value": {
                         "_type": "DV_IDENTIFIER", "type": "nl-bsn",
-                        // privacy-allow: synthetic, passes the eleven-test
-                        "id": "111222333", "issuer": "RvIG", "assigner": "RvIG" } },
+                                                "id": "111222333", "issuer": "RvIG", "assigner": "RvIG" } }, // privacy-allow: synthetic
                     { "_type": "ELEMENT", "value": {
                         "_type": "DV_IDENTIFIER", "type": "local-mrn",
                         "id": "MRN-004221", "issuer": "the hospital", "assigner": "the hospital" } }
@@ -168,8 +167,7 @@ mod tests {
             found,
             vec![FoundIdentifier {
                 scheme: "nl-bsn".to_owned(),
-                // privacy-allow: synthetic, passes the eleven-test
-                value: "111222333".to_owned(),
+                value: "111222333".to_owned(), // privacy-allow: synthetic
                 pointer: "/identities/0/details/items/0/value".to_owned(),
             }],
             "only the configured scheme is protected; the local MRN is left alone"
@@ -189,9 +187,8 @@ mod tests {
             .expect("the identifier slot survives");
         assert_eq!(stored, format!("{REFERENCE_PREFIX}{row}"));
         assert_eq!(referenced_row(stored), Some(row));
-        // privacy-allow: synthetic, and the assertion is that it is GONE
         assert!(
-            !body.to_string().contains("111222333"),
+            !body.to_string().contains("111222333"), // privacy-allow: synthetic, asserted GONE
             "the value must not survive anywhere in the stored body"
         );
         // The sibling identifier and the surrounding structure are untouched.
@@ -252,8 +249,7 @@ mod tests {
             "contacts": [{ "addresses": [{ "details": { "items": [
                 { "_type": "ELEMENT", "value": {
                     "_type": "DV_IDENTIFIER", "type": "nl-bsn",
-                    // privacy-allow: synthetic, passes the eleven-test
-                    "id": "111222333" } }
+                                        "id": "111222333" } } // privacy-allow: synthetic
             ]}}]}]
         });
         let found = find(&body, &schemes());
@@ -270,8 +266,7 @@ mod tests {
         // shift which node the pointer names.
         let body = json!({
             "a/b": { "c~d": {
-                // privacy-allow: synthetic, passes the eleven-test
-                "_type": "DV_IDENTIFIER", "type": "nl-bsn", "id": "111222333"
+                                "_type": "DV_IDENTIFIER", "type": "nl-bsn", "id": "111222333" // privacy-allow: synthetic
             }}
         });
         let found = find(&body, &schemes());

--- a/app/ferroehr/src/service/demographic/identifier/config.rs
+++ b/app/ferroehr/src/service/demographic/identifier/config.rs
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: Ruben Talstra
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `[demographic.identifier_protection]` — which identifier schemes are
+//! protected, and the key they are protected under.
+//!
+//! **No openEHR spec governs configuration — our own design.**
+
+use serde::{Deserialize, Serialize};
+
+/// The national-identifier protection policy.
+///
+/// Off by default. Turning it on is a deployment decision with an operational
+/// consequence — the key becomes load-bearing for reading the identifiers back
+/// — so the server never assumes it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct IdentifierProtectionConfig {
+    /// Whether protection is in force
+    /// (`FERROEHR__DEMOGRAPHIC__IDENTIFIER_PROTECTION__ENABLED`).
+    ///
+    /// With it on, an identifier in a protected scheme leaves the versioned
+    /// body for `demographic.national_identifier` and the body keeps a
+    /// reference. With it off the body carries the value as written, which is
+    /// the pre-existing behaviour.
+    pub enabled: bool,
+    /// The scheme codes to protect
+    /// (`FERROEHR__DEMOGRAPHIC__IDENTIFIER_PROTECTION__SCHEMES`).
+    ///
+    /// Matched against `DV_IDENTIFIER.type` and against the registry in the
+    /// database; a code absent from the registry is a boot error rather than a
+    /// silently unprotected identifier.
+    pub schemes: Vec<String>,
+    /// The root key, 64 hex characters
+    /// (`FERROEHR__DEMOGRAPHIC__IDENTIFIER_PROTECTION__KEY`), or its
+    /// `key_file` sibling.
+    ///
+    /// One key per deployment; the per-tenant cipher and lookup subkeys are
+    /// derived from it, so rotating it is a re-encryption rather than an edit
+    /// (the runbook is in the operations page).
+    pub key: Option<crate::config::secret::Secret>,
+    /// A file holding the root key, read at boot
+    /// (`FERROEHR__DEMOGRAPHIC__IDENTIFIER_PROTECTION__KEY_FILE`).
+    pub key_file: Option<String>,
+}
+
+impl Default for IdentifierProtectionConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            schemes: vec!["nl-bsn".to_owned()],
+            key: None,
+            key_file: None,
+        }
+    }
+}
+
+/// `[demographic]` — the demographic domain's own settings.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct DemographicConfig {
+    /// `[demographic.identifier_protection]`.
+    pub identifier_protection: IdentifierProtectionConfig,
+}

--- a/app/ferroehr/src/service/demographic/identifier/config.rs
+++ b/app/ferroehr/src/service/demographic/identifier/config.rs
@@ -41,7 +41,7 @@ pub struct IdentifierProtectionConfig {
     pub key: Option<crate::config::secret::Secret>,
     /// A file holding the root key, read at boot
     /// (`FERROEHR__DEMOGRAPHIC__IDENTIFIER_PROTECTION__KEY_FILE`).
-    pub key_file: Option<String>,
+    pub key_file: Option<std::path::PathBuf>,
 }
 
 impl Default for IdentifierProtectionConfig {

--- a/app/ferroehr/src/service/demographic/identifier/crypto.rs
+++ b/app/ferroehr/src/service/demographic/identifier/crypto.rs
@@ -97,7 +97,9 @@ impl RootKey {
         let mut bytes = [0_u8; 32];
         for (i, slot) in bytes.iter_mut().enumerate() {
             let pair = text.get(i * 2..i * 2 + 2).ok_or(CryptoError::RootKey)?;
-            *slot = u8::from_str_radix(pair, 16).map_err(|_| CryptoError::RootKey)?;
+            // The cause is dropped on purpose: it names the offending characters,
+            // and the key is a secret.
+            *slot = u8::from_str_radix(pair, 16).map_err(|_bad_hex| CryptoError::RootKey)?;
         }
         Ok(Self(secrecy::SecretBox::new(Box::new(bytes))))
     }
@@ -201,7 +203,7 @@ impl TenantKeys {
                     aad: &aad,
                 },
             )
-            .map_err(|_| CryptoError::Seal)?;
+            .map_err(|_aead| CryptoError::Seal)?;
         Ok((nonce_bytes.to_vec(), ciphertext))
     }
 
@@ -224,14 +226,14 @@ impl TenantKeys {
         let aad = associated_data(scheme, tenant);
         let plaintext = cipher
             .decrypt(
-                &Nonce::try_from(nonce).map_err(|_| CryptoError::Open)?,
+                &Nonce::try_from(nonce).map_err(|_len| CryptoError::Open)?,
                 Payload {
                     msg: ciphertext,
                     aad: &aad,
                 },
             )
-            .map_err(|_| CryptoError::Open)?;
-        String::from_utf8(plaintext).map_err(|_| CryptoError::Open)
+            .map_err(|_aead| CryptoError::Open)?;
+        String::from_utf8(plaintext).map_err(|_not_utf8| CryptoError::Open)
     }
 }
 

--- a/app/ferroehr/src/service/demographic/identifier/crypto.rs
+++ b/app/ferroehr/src/service/demographic/identifier/crypto.rs
@@ -1,0 +1,404 @@
+// SPDX-FileCopyrightText: Ruben Talstra
+// SPDX-License-Identifier: BUSL-1.1
+
+//! The cipher and the blind-lookup digest for protected national identifiers.
+//!
+//! **No openEHR spec governs this — our own design/extension.** The RM models
+//! identifiers generically (`DV_IDENTIFIER`, RM `data_types`
+//! `UML/classes/org.openehr.rm.data_types.dv_identifier.adoc`) and says
+//! nothing about protecting the value. The obligations are external: GDPR
+//! Art. 32(1)(a) names encryption as an appropriate measure
+//! (<https://eur-lex.europa.eu/eli/reg/2016/679/oj>), NEN 7510-2 carries the
+//! cryptographic controls, and UAVG Art. 46 with the Wabvpz permit BSN
+//! processing in care only for identification and under the act's conditions
+//! (<https://wetten.overheid.nl/BWBR0040940>,
+//! <https://wetten.overheid.nl/BWBR0023864>).
+//!
+//! Two primitives, because storage and lookup want opposite things:
+//!
+//! * **AES-256-GCM** over the identifier value, with a fresh 96-bit nonce per
+//!   record. AES-GCM rather than ChaCha20-Poly1305 because NIST specifies it
+//!   (SP 800-38D) and this control answers to reviewers who look for that;
+//!   both are pure-Rust `RustCrypto` AEADs. The scheme code and the tenant are
+//!   bound in as associated data, so a ciphertext moved to another scheme or
+//!   another tenant fails to open rather than decrypting into the wrong
+//!   meaning.
+//! * **HMAC-SHA-256** over the value, as the blind-lookup column. Equality
+//!   search needs a deterministic image of the value; a keyed digest gives one
+//!   without letting the database, a backup or a replica reverse it, which an
+//!   unkeyed hash of a nine-digit number would not (the whole space is
+//!   enumerable in seconds).
+//!
+//! Keys are per tenant, derived from one configured root key by
+//! HMAC-SHA-256 over a labelled context — the NIST SP 800-108 KDF-in-counter
+//! construction with a single block, which is all a 256-bit subkey needs. One
+//! key in configuration therefore yields a distinct cipher key and a distinct
+//! lookup key per tenant, and a tenant's ciphertexts stay unreadable with
+//! another tenant's subkey.
+
+use aes_gcm::aead::{Aead, Payload};
+use aes_gcm::{Aes256Gcm, Key, KeyInit, Nonce};
+use hmac::{Hmac, KeyInit as HmacKeyInit, Mac};
+use secrecy::ExposeSecret;
+use sha2::Sha256;
+use uuid::Uuid;
+
+/// The labelled context the per-tenant cipher key is derived under.
+///
+/// Versioned so a future construction change is a new label rather than a
+/// silent reinterpretation of the same bytes.
+const CIPHER_KEY_LABEL: &str = "ferroehr:national-identifier:cipher:v1";
+
+/// The labelled context the per-tenant lookup key is derived under.
+///
+/// Separate from [`CIPHER_KEY_LABEL`] so the key that produces a searchable
+/// digest is not the key that decrypts: a component that only needs to look an
+/// identifier up never has to hold the one that opens the ciphertext.
+const LOOKUP_KEY_LABEL: &str = "ferroehr:national-identifier:lookup:v1";
+
+/// What went wrong protecting or resolving an identifier.
+///
+/// Deliberately says nothing about the value: an error text travels into logs
+/// and error bodies, which is exactly where a national identifier must not go.
+#[derive(Debug, thiserror::Error)]
+pub enum CryptoError {
+    /// The configured root key is not 32 bytes of hex.
+    #[error(
+        "the national-identifier root key must be 64 hex characters (32 bytes); \
+         generate one with `openssl rand -hex 32` or an equivalent"
+    )]
+    RootKey,
+    /// The ciphertext did not authenticate under this tenant's key.
+    ///
+    /// A wrong key, a wrong tenant, a wrong scheme, or a tampered record — AEAD
+    /// cannot distinguish them, and neither should this message.
+    #[error("the stored identifier could not be decrypted under this deployment's key")]
+    Open,
+    /// The cipher refused to seal (an impossible-in-practice arm the AEAD API
+    /// still declares).
+    #[error("the identifier could not be encrypted")]
+    Seal,
+}
+
+/// The root key material, held as a secret so it never renders.
+#[derive(Debug)]
+pub struct RootKey(secrecy::SecretBox<[u8; 32]>);
+
+impl RootKey {
+    /// Parse a 64-character hex string into the root key.
+    ///
+    /// # Errors
+    /// [`CryptoError::RootKey`] when the text is not exactly 32 bytes of hex.
+    pub fn from_hex(hex: &secrecy::SecretString) -> Result<Self, CryptoError> {
+        let text = hex.expose_secret().trim();
+        if text.len() != 64 {
+            return Err(CryptoError::RootKey);
+        }
+        let mut bytes = [0_u8; 32];
+        for (i, slot) in bytes.iter_mut().enumerate() {
+            let pair = text.get(i * 2..i * 2 + 2).ok_or(CryptoError::RootKey)?;
+            *slot = u8::from_str_radix(pair, 16).map_err(|_| CryptoError::RootKey)?;
+        }
+        Ok(Self(secrecy::SecretBox::new(Box::new(bytes))))
+    }
+
+    /// Derive the per-tenant subkey for one labelled purpose.
+    ///
+    /// SP 800-108 KDF in counter mode with HMAC-SHA-256 as the PRF, one block:
+    /// `PRF(root, 0x00000001 || label || 0x00 || tenant || L)`. One block is
+    /// the whole output because the derived key is 256 bits, exactly the PRF's
+    /// width.
+    fn subkey(&self, label: &str, tenant: Uuid) -> [u8; 32] {
+        // The PRF is keyed with a fixed-size root key, so the construction
+        // cannot fail on key length.
+        #[expect(
+            clippy::expect_used,
+            reason = "HMAC accepts a key of any length and the root key is a fixed 32 bytes, \
+                      so this constructor has no reachable failure"
+        )]
+        let mut mac =
+            <Hmac<Sha256> as HmacKeyInit>::new_from_slice(self.0.expose_secret().as_slice())
+                .expect("HMAC should accept a 32-byte key");
+        mac.update(&1_u32.to_be_bytes());
+        mac.update(label.as_bytes());
+        mac.update(&[0x00]);
+        mac.update(tenant.as_bytes());
+        mac.update(&256_u32.to_be_bytes());
+        mac.finalize().into_bytes().into()
+    }
+}
+
+/// The per-tenant keys one deployment protects identifiers with.
+///
+/// Built per write or resolve rather than cached: the derivation is one HMAC
+/// block, and a cache keyed by tenant would be one more place a key material
+/// lives.
+#[derive(Debug)]
+pub struct TenantKeys {
+    cipher: [u8; 32],
+    lookup: [u8; 32],
+}
+
+impl TenantKeys {
+    /// Derive both subkeys for `tenant` from `root`.
+    #[must_use]
+    pub fn derive(root: &RootKey, tenant: Uuid) -> Self {
+        Self {
+            cipher: root.subkey(CIPHER_KEY_LABEL, tenant),
+            lookup: root.subkey(LOOKUP_KEY_LABEL, tenant),
+        }
+    }
+
+    /// The blind-lookup digest of `value` under this tenant's lookup key.
+    ///
+    /// Deterministic, so equality search works; keyed, so the digest cannot be
+    /// reversed by enumerating a national identifier's small value space. The
+    /// scheme is bound in, so the same digits under two schemes are two
+    /// different digests.
+    ///
+    /// # Panics
+    /// Never: HMAC accepts a key of any length and this one is a fixed 32
+    /// bytes, so the keying step has no reachable failure.
+    #[must_use]
+    pub fn lookup_digest(&self, scheme: &str, value: &str) -> Vec<u8> {
+        #[expect(
+            clippy::expect_used,
+            reason = "HMAC accepts a key of any length and this one is a fixed 32 bytes, \
+                      so this constructor has no reachable failure"
+        )]
+        let mut mac = <Hmac<Sha256> as HmacKeyInit>::new_from_slice(&self.lookup)
+            .expect("HMAC should accept a 32-byte key");
+        mac.update(scheme.as_bytes());
+        mac.update(&[0x00]);
+        mac.update(value.as_bytes());
+        mac.finalize().into_bytes().to_vec()
+    }
+
+    /// Seal `value`, returning the nonce and the ciphertext.
+    ///
+    /// The scheme and the tenant are the associated data, so a record moved
+    /// between schemes or tenants fails authentication instead of opening into
+    /// a value that means something else.
+    ///
+    /// # Errors
+    /// [`CryptoError::Seal`] if the AEAD refuses, which has no reachable cause
+    /// for a value of this size.
+    pub fn seal(
+        &self,
+        scheme: &str,
+        tenant: Uuid,
+        value: &str,
+    ) -> Result<(Vec<u8>, Vec<u8>), CryptoError> {
+        let cipher = Aes256Gcm::new(&Key::<Aes256Gcm>::from(self.cipher));
+        let nonce_bytes: [u8; 12] = rand::random();
+        let nonce = Nonce::from(nonce_bytes);
+        let aad = associated_data(scheme, tenant);
+        let ciphertext = cipher
+            .encrypt(
+                &nonce,
+                Payload {
+                    msg: value.as_bytes(),
+                    aad: &aad,
+                },
+            )
+            .map_err(|_| CryptoError::Seal)?;
+        Ok((nonce_bytes.to_vec(), ciphertext))
+    }
+
+    /// Open a sealed identifier.
+    ///
+    /// # Errors
+    /// [`CryptoError::Open`] when the record does not authenticate under this
+    /// tenant's key and this scheme, whatever the reason.
+    pub fn open(
+        &self,
+        scheme: &str,
+        tenant: Uuid,
+        nonce: &[u8],
+        ciphertext: &[u8],
+    ) -> Result<String, CryptoError> {
+        let cipher = Aes256Gcm::new(&Key::<Aes256Gcm>::from(self.cipher));
+        if nonce.len() != 12 {
+            return Err(CryptoError::Open);
+        }
+        let aad = associated_data(scheme, tenant);
+        let plaintext = cipher
+            .decrypt(
+                &Nonce::try_from(nonce).map_err(|_| CryptoError::Open)?,
+                Payload {
+                    msg: ciphertext,
+                    aad: &aad,
+                },
+            )
+            .map_err(|_| CryptoError::Open)?;
+        String::from_utf8(plaintext).map_err(|_| CryptoError::Open)
+    }
+}
+
+/// The AEAD associated data: the scheme and the tenant this record belongs to.
+fn associated_data(scheme: &str, tenant: Uuid) -> Vec<u8> {
+    let mut aad = Vec::with_capacity(scheme.len() + 17);
+    aad.extend_from_slice(scheme.as_bytes());
+    aad.push(0x00);
+    aad.extend_from_slice(tenant.as_bytes());
+    aad
+}
+
+#[cfg(test)]
+mod tests {
+    //! Every value here is synthetic. The BSN-shaped digits were constructed by
+    //! running the elfproef forward over a chosen prefix; no register issues
+    //! them.
+
+    use super::{CryptoError, RootKey, TenantKeys};
+    use uuid::Uuid;
+
+    const ROOT: &str = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+    const OTHER_ROOT: &str = "0f0e0d0c0b0a09080706050403020100f1e2d3c4b5a697887970615243342516";
+    const VALUE: &str = "111222333"; // privacy-allow: synthetic, passes the eleven-test
+
+    fn root(hex: &str) -> RootKey {
+        RootKey::from_hex(&secrecy::SecretString::from(hex.to_owned())).expect("a 32-byte key")
+    }
+
+    fn tenant() -> Uuid {
+        Uuid::nil()
+    }
+
+    #[test]
+    fn a_sealed_identifier_opens_to_the_same_value() {
+        let keys = TenantKeys::derive(&root(ROOT), tenant());
+        let (nonce, ciphertext) = keys.seal("nl-bsn", tenant(), VALUE).expect("seal");
+        assert_ne!(
+            ciphertext.as_slice(),
+            VALUE.as_bytes(),
+            "the stored bytes must not be the value"
+        );
+        let opened = keys
+            .open("nl-bsn", tenant(), &nonce, &ciphertext)
+            .expect("open");
+        assert_eq!(opened, VALUE);
+    }
+
+    #[test]
+    fn every_seal_of_one_value_differs() {
+        // A deterministic ciphertext would leak equality of identifiers across
+        // records, which is exactly what the separate lookup digest is for.
+        let keys = TenantKeys::derive(&root(ROOT), tenant());
+        let (first_nonce, first) = keys.seal("nl-bsn", tenant(), VALUE).expect("seal");
+        let (second_nonce, second) = keys.seal("nl-bsn", tenant(), VALUE).expect("seal");
+        assert_ne!(first, second, "two seals of one value must differ");
+        assert_ne!(first_nonce, second_nonce, "each record gets a fresh nonce");
+    }
+
+    #[test]
+    fn a_record_does_not_open_under_another_key_tenant_or_scheme() {
+        let keys = TenantKeys::derive(&root(ROOT), tenant());
+        let (nonce, ciphertext) = keys.seal("nl-bsn", tenant(), VALUE).expect("seal");
+
+        let other_deployment = TenantKeys::derive(&root(OTHER_ROOT), tenant());
+        assert!(
+            matches!(
+                other_deployment.open("nl-bsn", tenant(), &nonce, &ciphertext),
+                Err(CryptoError::Open)
+            ),
+            "another deployment's key must not open it"
+        );
+
+        let other_tenant_id = Uuid::from_u128(7);
+        let other_tenant = TenantKeys::derive(&root(ROOT), other_tenant_id);
+        assert!(
+            matches!(
+                other_tenant.open("nl-bsn", other_tenant_id, &nonce, &ciphertext),
+                Err(CryptoError::Open)
+            ),
+            "another tenant's subkey must not open it"
+        );
+
+        // The tenant and the scheme are bound in as associated data, so even
+        // the right key refuses when the record is read under the wrong label.
+        assert!(
+            matches!(
+                keys.open("se-personnummer", tenant(), &nonce, &ciphertext),
+                Err(CryptoError::Open)
+            ),
+            "a record read under another scheme must not open"
+        );
+        assert!(
+            matches!(
+                keys.open("nl-bsn", Uuid::from_u128(7), &nonce, &ciphertext),
+                Err(CryptoError::Open)
+            ),
+            "a record read under another tenant must not open"
+        );
+    }
+
+    #[test]
+    fn a_tampered_ciphertext_is_refused() {
+        let keys = TenantKeys::derive(&root(ROOT), tenant());
+        let (nonce, mut ciphertext) = keys.seal("nl-bsn", tenant(), VALUE).expect("seal");
+        ciphertext[0] ^= 0x01;
+        assert!(
+            matches!(
+                keys.open("nl-bsn", tenant(), &nonce, &ciphertext),
+                Err(CryptoError::Open)
+            ),
+            "AEAD authentication must refuse a flipped bit"
+        );
+    }
+
+    #[test]
+    fn the_lookup_digest_is_deterministic_keyed_and_scheme_bound() {
+        let keys = TenantKeys::derive(&root(ROOT), tenant());
+        let digest = keys.lookup_digest("nl-bsn", VALUE);
+        assert_eq!(
+            digest,
+            keys.lookup_digest("nl-bsn", VALUE),
+            "equality search needs the same value to give the same digest"
+        );
+        assert_eq!(digest.len(), 32, "HMAC-SHA-256 is 32 bytes");
+        assert_ne!(
+            digest,
+            keys.lookup_digest("se-personnummer", VALUE),
+            "the scheme is bound in, so the same digits under two schemes differ"
+        );
+        assert_ne!(
+            digest,
+            TenantKeys::derive(&root(OTHER_ROOT), tenant()).lookup_digest("nl-bsn", VALUE),
+            "the digest is keyed: another deployment cannot reproduce it"
+        );
+        assert_ne!(
+            digest,
+            TenantKeys::derive(&root(ROOT), Uuid::from_u128(7)).lookup_digest("nl-bsn", VALUE),
+            "another tenant cannot reproduce it either"
+        );
+        assert!(
+            !digest.windows(VALUE.len()).any(|w| w == VALUE.as_bytes()),
+            "the digest must not carry the value"
+        );
+    }
+
+    #[test]
+    fn the_cipher_and_lookup_subkeys_are_different_keys() {
+        // The lookup key is handed to components that must search without being
+        // able to decrypt, so the two derivations must not coincide.
+        let keys = TenantKeys::derive(&root(ROOT), tenant());
+        assert_ne!(
+            keys.cipher, keys.lookup,
+            "one label per purpose, so a searcher never holds the opener"
+        );
+    }
+
+    #[test]
+    fn a_root_key_of_the_wrong_shape_is_refused_at_parse() {
+        for bad in ["", "abcd", &"z".repeat(64), &"ab".repeat(31)] {
+            assert!(
+                matches!(
+                    RootKey::from_hex(&secrecy::SecretString::from(bad.to_owned())),
+                    Err(CryptoError::RootKey)
+                ),
+                "{bad:?} is not a 32-byte hex key"
+            );
+        }
+    }
+}

--- a/app/ferroehr/src/service/demographic/identifier/engine.rs
+++ b/app/ferroehr/src/service/demographic/identifier/engine.rs
@@ -1,0 +1,270 @@
+// SPDX-FileCopyrightText: Ruben Talstra
+// SPDX-License-Identifier: BUSL-1.1
+
+//! The protection engine: the one object the commit path holds.
+//!
+//! **No openEHR spec governs this — our own design/extension.** It owns the
+//! configured schemes, the root key and the store, and exposes the two
+//! operations the rest of the server needs: take the protected identifiers out
+//! of a body before it is stored, and put them back for a caller entitled to
+//! see them.
+//!
+//! Built once at boot, like every other configured collaborator, so a
+//! misconfigured key is a boot error rather than a first-write surprise.
+
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::service::demographic::identifier::body;
+use crate::service::demographic::identifier::config::IdentifierProtectionConfig;
+use crate::service::demographic::identifier::crypto::{CryptoError, RootKey, TenantKeys};
+use crate::service::demographic::identifier::store::{IdentifierStore, StoreError};
+
+/// The national-identifier protection engine.
+#[derive(Debug)]
+pub struct IdentifierProtection {
+    schemes: Vec<String>,
+    root: RootKey,
+    store: IdentifierStore,
+}
+
+/// A configuration this engine cannot be built from.
+#[derive(Debug, thiserror::Error)]
+pub enum EngineError {
+    /// The root key is missing while protection is enabled.
+    #[error(
+        "[demographic.identifier_protection] is enabled but no `key` or `key_file` is set; \
+         protection cannot run without one"
+    )]
+    MissingKey,
+    /// The root key is not 32 bytes of hex.
+    #[error(transparent)]
+    Key(#[from] CryptoError),
+    /// No scheme is configured, so protection would silently do nothing.
+    #[error(
+        "[demographic.identifier_protection] is enabled but `schemes` is empty, so nothing \
+         would be protected; name the schemes or turn the section off"
+    )]
+    NoSchemes,
+}
+
+impl IdentifierProtection {
+    /// Build the engine from the configured section and the demographic pool.
+    ///
+    /// Returns `None` when protection is off, which is the default: the write
+    /// path then stores identifiers exactly as written.
+    ///
+    /// # Errors
+    /// [`EngineError`] when protection is on but unusable — a missing or
+    /// malformed key, or an empty scheme list. Both are boot errors: a
+    /// deployment that believes it protects identifiers and does not is the
+    /// failure this refuses to ship.
+    pub fn from_config(
+        config: &IdentifierProtectionConfig,
+        key_material: Option<&secrecy::SecretString>,
+        pool: sqlx::PgPool,
+    ) -> Result<Option<Self>, EngineError> {
+        if !config.enabled {
+            return Ok(None);
+        }
+        if config.schemes.is_empty() {
+            return Err(EngineError::NoSchemes);
+        }
+        let material = key_material.ok_or(EngineError::MissingKey)?;
+        Ok(Some(Self {
+            schemes: config.schemes.clone(),
+            root: RootKey::from_hex(material)?,
+            store: IdentifierStore::new(pool),
+        }))
+    }
+
+    /// The schemes this engine protects.
+    #[must_use]
+    pub fn schemes(&self) -> &[String] {
+        &self.schemes
+    }
+
+    /// Take every protected identifier out of `body`, leaving a reference.
+    ///
+    /// Runs before the body is decomposed and signed, so the stored, signed
+    /// and served form is one and the same — the invariant the commit path
+    /// already keeps for externalized multimedia.
+    ///
+    /// # Errors
+    /// [`StoreError`] when a value cannot be sealed or stored. The write fails
+    /// rather than proceeding: storing the body with the value still in it is
+    /// precisely what this exists to prevent.
+    pub async fn externalize(&self, party: Uuid, body: &mut Value) -> Result<usize, StoreError> {
+        let tenant = current_tenant();
+        let found = body::find(body, &self.schemes);
+        if found.is_empty() {
+            return Ok(0);
+        }
+        let keys = TenantKeys::derive(&self.root, tenant);
+        let mut references = Vec::with_capacity(found.len());
+        for identifier in &found {
+            let row = self
+                .store
+                .seal(&keys, tenant, party, &identifier.scheme, &identifier.value)
+                .await?;
+            references.push((identifier.pointer.clone(), row));
+        }
+        body::substitute(body, &references);
+        Ok(references.len())
+    }
+
+    /// Put the plaintext values back into a stored body.
+    ///
+    /// The audited expansion: the caller is responsible for deciding that this
+    /// reader may see the values and for recording the access.
+    ///
+    /// # Errors
+    /// [`StoreError`] when a referenced row cannot be read or does not
+    /// authenticate. A reference whose row is gone expands to nothing and
+    /// leaves the reference in place, which says truthfully that the value was
+    /// held and is no longer.
+    pub async fn expand(&self, body: &mut Value) -> Result<usize, StoreError> {
+        let tenant = current_tenant();
+        let keys = TenantKeys::derive(&self.root, tenant);
+        let references = referenced(body);
+        let mut values = Vec::with_capacity(references.len());
+        for (pointer, row) in references {
+            if let Some(value) = self.store.open(&keys, tenant, row).await? {
+                values.push((pointer, value));
+            }
+        }
+        body::expand(body, &values);
+        Ok(values.len())
+    }
+
+    /// The party holding `value` in `scheme`, resolved through the keyed digest.
+    ///
+    /// # Errors
+    /// [`StoreError`] when the resolution query fails.
+    pub async fn resolve(&self, scheme: &str, value: &str) -> Result<Option<Uuid>, StoreError> {
+        let tenant = current_tenant();
+        let keys = TenantKeys::derive(&self.root, tenant);
+        self.store.resolve(&keys, tenant, scheme, value).await
+    }
+}
+
+/// The tenant this operation belongs to, or the reserved default when tenancy
+/// is off.
+///
+/// The nil uuid is the same reserved id the storage layer stamps on an
+/// unscoped write, so the key derivation agrees with the rows it protects.
+fn current_tenant() -> Uuid {
+    crate::extensions::tenant_context::current().map_or_else(Uuid::nil, |ctx| ctx.tenant_id)
+}
+
+/// Every protected-identifier reference in a stored body, with its pointer.
+fn referenced(body: &Value) -> Vec<(String, Uuid)> {
+    let mut found = Vec::new();
+    collect(body, &mut String::new(), &mut found);
+    found
+}
+
+/// Recursive walk collecting reference-bearing `DV_IDENTIFIER` nodes.
+fn collect(node: &Value, pointer: &mut String, found: &mut Vec<(String, Uuid)>) {
+    match node {
+        Value::Object(map) => {
+            if map.get("_type").and_then(Value::as_str) == Some("DV_IDENTIFIER")
+                && let Some(id) = map.get("id").and_then(Value::as_str)
+                && let Some(row) = body::referenced_row(id)
+            {
+                found.push((pointer.clone(), row));
+            }
+            for (key, child) in map {
+                let mark = pointer.len();
+                pointer.push('/');
+                pointer.push_str(&key.replace('~', "~0").replace('/', "~1"));
+                collect(child, pointer, found);
+                pointer.truncate(mark);
+            }
+        }
+        Value::Array(items) => {
+            for (index, child) in items.iter().enumerate() {
+                let mark = pointer.len();
+                pointer.push('/');
+                pointer.push_str(&index.to_string());
+                collect(child, pointer, found);
+                pointer.truncate(mark);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EngineError, IdentifierProtection, referenced};
+    use crate::service::demographic::identifier::config::IdentifierProtectionConfig;
+    use serde_json::json;
+
+    fn pool() -> sqlx::PgPool {
+        // A lazy pool: these tests never issue a statement, they only exercise
+        // the construction rules.
+        sqlx::PgPool::connect_lazy("postgres://localhost/ferroehr-unused")
+            .expect("a lazy pool needs no server")
+    }
+
+    #[tokio::test]
+    async fn protection_is_off_by_default_and_builds_nothing() {
+        let engine =
+            IdentifierProtection::from_config(&IdentifierProtectionConfig::default(), None, pool())
+                .expect("the default configuration builds");
+        assert!(
+            engine.is_none(),
+            "off by default: the write path stores identifiers as written"
+        );
+    }
+
+    #[tokio::test]
+    async fn enabled_without_a_key_is_a_boot_error() {
+        let config = IdentifierProtectionConfig {
+            enabled: true,
+            ..IdentifierProtectionConfig::default()
+        };
+        assert!(
+            matches!(
+                IdentifierProtection::from_config(&config, None, pool()),
+                Err(EngineError::MissingKey)
+            ),
+            "a deployment that believes it protects identifiers and cannot must not boot"
+        );
+    }
+
+    #[tokio::test]
+    async fn enabled_with_no_schemes_is_a_boot_error() {
+        let config = IdentifierProtectionConfig {
+            enabled: true,
+            schemes: Vec::new(),
+            ..IdentifierProtectionConfig::default()
+        };
+        let key = secrecy::SecretString::from(
+            "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f".to_owned(),
+        );
+        assert!(
+            matches!(
+                IdentifierProtection::from_config(&config, Some(&key), pool()),
+                Err(EngineError::NoSchemes)
+            ),
+            "protection that would protect nothing is a configuration mistake, not a posture"
+        );
+    }
+
+    #[test]
+    fn references_are_found_by_pointer_in_a_stored_body() {
+        let row = uuid::Uuid::from_u128(42);
+        let body = json!({
+            "identities": [{ "details": { "items": [
+                { "value": { "_type": "DV_IDENTIFIER", "type": "nl-bsn",
+                             "id": format!("urn:ferroehr:protected-identifier:{row}") } }
+            ]}}]
+        });
+        assert_eq!(
+            referenced(&body),
+            vec![("/identities/0/details/items/0/value".to_owned(), row)]
+        );
+    }
+}

--- a/app/ferroehr/src/service/demographic/identifier/engine.rs
+++ b/app/ferroehr/src/service/demographic/identifier/engine.rs
@@ -61,7 +61,7 @@ impl IdentifierProtection {
     /// failure this refuses to ship.
     pub fn from_config(
         config: &IdentifierProtectionConfig,
-        key_material: Option<&secrecy::SecretString>,
+        key_material: Option<&crate::config::secret::Secret>,
         pool: sqlx::PgPool,
     ) -> Result<Option<Self>, EngineError> {
         if !config.enabled {
@@ -71,9 +71,13 @@ impl IdentifierProtection {
             return Err(EngineError::NoSchemes);
         }
         let material = key_material.ok_or(EngineError::MissingKey)?;
+        // The configured secret is re-wrapped rather than read as a plain
+        // string: `RootKey` takes a secret so the hex never lands in an
+        // ordinary `String` a `Debug` or a panic message could carry.
+        let material = secrecy::SecretString::from(material.expose().to_owned());
         Ok(Some(Self {
             schemes: config.schemes.clone(),
-            root: RootKey::from_hex(material)?,
+            root: RootKey::from_hex(&material)?,
             store: IdentifierStore::new(pool),
         }))
     }
@@ -241,8 +245,8 @@ mod tests {
             schemes: Vec::new(),
             ..IdentifierProtectionConfig::default()
         };
-        let key = secrecy::SecretString::from(
-            "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f".to_owned(),
+        let key = crate::config::secret::Secret::new(
+            "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
         );
         assert!(
             matches!(

--- a/app/ferroehr/src/service/demographic/identifier/mod.rs
+++ b/app/ferroehr/src/service/demographic/identifier/mod.rs
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Ruben Talstra
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Protected national identifiers in the demographic domain.
+//!
+//! **No openEHR spec governs this — our own design/extension.** The RM models
+//! identifiers generically (`PARTY_IDENTITY`, RM demographic
+//! `UML/classes/org.openehr.rm.demographic.party_identity.adoc`; `DV_IDENTIFIER`,
+//! RM `data_types` `UML/classes/org.openehr.rm.data_types.dv_identifier.adoc`)
+//! and says nothing about protecting the value. A national identifier needs
+//! more than that generic slot: GDPR Art. 32(1)(a) names encryption as an
+//! appropriate measure, and UAVG Art. 46 with the Wabvpz permit BSN processing
+//! in care only for identification and under the act's conditions.
+//!
+//! The value therefore leaves the versioned body and lives in
+//! `demographic.national_identifier`, sealed under a per-tenant key, with a
+//! keyed digest beside it for equality lookup without decryption. The body
+//! keeps a reference in its place.
+
+pub mod body;
+pub mod config;
+pub mod crypto;
+pub mod engine;
+pub mod store;

--- a/app/ferroehr/src/service/demographic/identifier/mod.rs
+++ b/app/ferroehr/src/service/demographic/identifier/mod.rs
@@ -22,3 +22,67 @@ pub mod config;
 pub mod crypto;
 pub mod engine;
 pub mod store;
+
+use crate::ids::VoId;
+use crate::service::FerroEhrService;
+use crate::service::status::SmError;
+use crate::system_log::event::{
+    AccessDomain, AuditEvent, EventActionCode, EventOutcome, ObjectClass,
+};
+
+impl FerroEhrService {
+    /// The party holding `value` in `scheme`, resolved without decrypting, and
+    /// recorded as an access.
+    ///
+    /// The sole identifier-to-party path above the store. The resolution goes
+    /// through the keyed digest, so the plaintext never reaches the database,
+    /// and every call — hit or miss — writes an access event naming the actor,
+    /// the scheme and the purpose the caller declared. A resolution nobody can
+    /// reconstruct afterwards is the boundary crossing the access log exists to
+    /// prevent, and a MISS is worth recording for the same reason a hit is: it
+    /// says someone asked whether this deployment holds that identifier.
+    ///
+    /// **No openEHR spec governs this — our own design/extension.**
+    ///
+    /// # Errors
+    /// [`SmError::precondition`] when the deployment configures no
+    /// identifier protection, and `exception` when the resolution query fails.
+    pub async fn resolve_party_by_identifier(
+        &self,
+        scheme: &str,
+        value: &str,
+    ) -> Result<Option<VoId>, SmError> {
+        let Some(engine) = self.identifier_protection() else {
+            return Err(SmError::precondition(
+                "this deployment configures no national-identifier protection, so there is \
+                 no protected identifier to resolve",
+            ));
+        };
+        let resolved = engine.resolve(scheme, value).await.map_err(|error| {
+            // The error text carries the scheme, never the value.
+            SmError::exception(format!("resolving a `{scheme}` identifier failed: {error}"))
+        })?;
+        self.emit_identifier_resolution(scheme, resolved.is_some());
+        Ok(resolved.map(VoId))
+    }
+
+    /// Record one identifier resolution on the access log.
+    ///
+    /// The record names the scheme and whether it matched, never the value:
+    /// an audit trail that carried the identifier would hold the very data the
+    /// sealing exists to keep out of readable storage.
+    fn emit_identifier_resolution(&self, scheme: &str, matched: bool) {
+        if !self.audit_enabled() {
+            return;
+        }
+        let mut event = AuditEvent::new(
+            EventActionCode::Execute,
+            ObjectClass::Demographic,
+            EventOutcome::Success,
+        );
+        event.domain = AccessDomain::Linkage;
+        event.object_id = Some(format!("national-identifier:{scheme}"));
+        event.result_count = Some(u64::from(matched));
+        let _ = self.emit(event);
+    }
+}

--- a/app/ferroehr/src/service/demographic/identifier/mod.rs
+++ b/app/ferroehr/src/service/demographic/identifier/mod.rs
@@ -59,8 +59,11 @@ impl FerroEhrService {
             ));
         };
         let resolved = engine.resolve(scheme, value).await.map_err(|error| {
-            // The error text carries the scheme, never the value.
-            SmError::exception(format!("resolving a `{scheme}` identifier failed: {error}"))
+            // The client is told the scheme and nothing else; the cause rides
+            // as a source so an operator can walk the chain without a database
+            // error text reaching a caller.
+            SmError::exception(format!("resolving a `{scheme}` identifier failed"))
+                .with_source(error)
         })?;
         self.emit_identifier_resolution(scheme, resolved.is_some());
         Ok(resolved.map(VoId))

--- a/app/ferroehr/src/service/demographic/identifier/store.rs
+++ b/app/ferroehr/src/service/demographic/identifier/store.rs
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: Ruben Talstra
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Reading and writing `demographic.national_identifier`.
+//!
+//! **No openEHR spec governs this — our own design/extension.** Three
+//! operations, and the split between them is the access-control boundary:
+//! [`IdentifierStore::seal`] writes a value, [`IdentifierStore::open`] reads
+//! one back for the audited expansion, and [`IdentifierStore::resolve`] goes
+//! from an identifier to a party WITHOUT decrypting anything, through the
+//! `SECURITY DEFINER` function, so a caller that only needs the mapping never
+//! touches the ciphertext.
+
+use sqlx::{PgPool, Row as _};
+use uuid::Uuid;
+
+use crate::service::demographic::identifier::crypto::{CryptoError, TenantKeys};
+
+/// What went wrong holding or reading a protected identifier.
+///
+/// No variant carries the value: these render into logs and error bodies.
+#[derive(Debug, thiserror::Error)]
+pub enum StoreError {
+    /// The database refused or failed.
+    #[error("the protected-identifier store is unavailable")]
+    Database(#[source] sqlx::Error),
+    /// The value could not be sealed or opened.
+    #[error(transparent)]
+    Crypto(#[from] CryptoError),
+    /// The scheme is not in `demographic.identifier_scheme`.
+    ///
+    /// A foreign-key refusal read back as its own variant, because "this
+    /// deployment does not hold identifiers of that kind" is a configuration
+    /// answer rather than a database fault.
+    #[error("`{scheme}` is not a registered identifier scheme in this deployment")]
+    UnknownScheme {
+        /// The scheme code as configured.
+        scheme: String,
+    },
+}
+
+impl From<sqlx::Error> for StoreError {
+    fn from(error: sqlx::Error) -> Self {
+        // 23503 foreign_key_violation on the scheme reference is the one
+        // database refusal with a configuration meaning worth separating.
+        let unknown_scheme = error
+            .as_database_error()
+            .and_then(sqlx::error::DatabaseError::code)
+            .is_some_and(|code| code == "23503");
+        if unknown_scheme {
+            return StoreError::UnknownScheme {
+                scheme: String::new(),
+            };
+        }
+        StoreError::Database(error)
+    }
+}
+
+/// The protected-identifier store over the demographic pool.
+#[derive(Debug, Clone)]
+pub struct IdentifierStore {
+    pool: PgPool,
+}
+
+impl IdentifierStore {
+    /// Bind the store to the demographic pool.
+    ///
+    /// The pool is the domain: the clinical pool's role has no grant on these
+    /// relations, so handing the wrong one in fails loudly at the first
+    /// statement rather than reading across the boundary.
+    #[must_use]
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    /// Seal `value` for `party` and return the row id the body will reference.
+    ///
+    /// Re-sealing the same party and scheme replaces the row: a party's
+    /// identifier is a fact about that party, and a second row would leave the
+    /// store unable to say which is current.
+    ///
+    /// # Errors
+    /// [`StoreError`] when the scheme is unregistered, the value cannot be
+    /// sealed, or the write fails.
+    pub async fn seal(
+        &self,
+        keys: &TenantKeys,
+        tenant: Uuid,
+        party: Uuid,
+        scheme: &str,
+        value: &str,
+    ) -> Result<Uuid, StoreError> {
+        let (nonce, ciphertext) = keys.seal(scheme, tenant, value)?;
+        let digest = keys.lookup_digest(scheme, value);
+        let row = sqlx::query(
+            "INSERT INTO national_identifier \
+                 (party_id, scheme, tenant_id, nonce, ciphertext, lookup_digest) \
+             VALUES ($1, $2, $3, $4, $5, $6) \
+             ON CONFLICT (tenant_id, scheme, party_id) DO UPDATE \
+                 SET nonce = EXCLUDED.nonce, \
+                     ciphertext = EXCLUDED.ciphertext, \
+                     lookup_digest = EXCLUDED.lookup_digest \
+             RETURNING id",
+        )
+        .bind(party)
+        .bind(scheme)
+        .bind(tenant)
+        .bind(&nonce)
+        .bind(&ciphertext)
+        .bind(&digest)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|error| match StoreError::from(error) {
+            StoreError::UnknownScheme { .. } => StoreError::UnknownScheme {
+                scheme: scheme.to_owned(),
+            },
+            other => other,
+        })?;
+        row.try_get::<Uuid, _>("id").map_err(StoreError::Database)
+    }
+
+    /// Open the sealed value of one row.
+    ///
+    /// The audited expansion path. `None` when no such row exists, which is a
+    /// body referencing a row that was removed — reported as absent rather
+    /// than as a decryption failure, because the two have different causes.
+    ///
+    /// # Errors
+    /// [`StoreError`] when the read fails or the record does not authenticate.
+    pub async fn open(
+        &self,
+        keys: &TenantKeys,
+        tenant: Uuid,
+        row_id: Uuid,
+    ) -> Result<Option<String>, StoreError> {
+        let Some(row) = sqlx::query(
+            "SELECT scheme, nonce, ciphertext FROM national_identifier \
+             WHERE id = $1 AND tenant_id = $2",
+        )
+        .bind(row_id)
+        .bind(tenant)
+        .fetch_optional(&self.pool)
+        .await?
+        else {
+            return Ok(None);
+        };
+        let scheme: String = row.try_get("scheme").map_err(StoreError::Database)?;
+        let nonce: Vec<u8> = row.try_get("nonce").map_err(StoreError::Database)?;
+        let ciphertext: Vec<u8> = row.try_get("ciphertext").map_err(StoreError::Database)?;
+        Ok(Some(keys.open(&scheme, tenant, &nonce, &ciphertext)?))
+    }
+
+    /// The party holding `value` in `scheme`, without decrypting anything.
+    ///
+    /// Goes through `demographic.resolve_national_identifier`, which takes the
+    /// keyed digest rather than the value: the caller proves it already knows
+    /// the identifier, and the plaintext never crosses into the database.
+    ///
+    /// # Errors
+    /// [`StoreError::Database`] when the function call fails.
+    pub async fn resolve(
+        &self,
+        keys: &TenantKeys,
+        tenant: Uuid,
+        scheme: &str,
+        value: &str,
+    ) -> Result<Option<Uuid>, StoreError> {
+        let digest = keys.lookup_digest(scheme, value);
+        let party: Option<Uuid> =
+            sqlx::query_scalar("SELECT resolve_national_identifier($1, $2, $3)")
+                .bind(tenant)
+                .bind(scheme)
+                .bind(&digest)
+                .fetch_optional(&self.pool)
+                .await?
+                .flatten();
+        Ok(party)
+    }
+}

--- a/app/ferroehr/src/service/demographic/mod.rs
+++ b/app/ferroehr/src/service/demographic/mod.rs
@@ -63,6 +63,7 @@
 //! - `docs/specs/openehr/SM/docs/UML/classes/i_party.adoc` /
 //!   `i_demographic_service.adoc` / `i_party_relationship.adoc`.
 
+pub mod identifier;
 pub mod types;
 
 mod api;

--- a/app/ferroehr/src/service/mod.rs
+++ b/app/ferroehr/src/service/mod.rs
@@ -240,7 +240,7 @@ pub struct FerroEhrService {
     /// default posture; the binary installs the compiled
     /// `[demographic.identifier_protection]` section.
     pub(in crate::service) identifiers:
-        Option<Arc<crate::service::demographic::identifier::engine::IdentifierProtection>>,
+        Option<Arc<demographic::identifier::engine::IdentifierProtection>>,
     /// The clinical-side data-minimisation policy
     /// ([`crate::privacy`]) every clinical commit body is checked against.
     ///
@@ -302,7 +302,7 @@ impl FerroEhrService {
     #[must_use]
     pub fn with_identifier_protection(
         mut self,
-        engine: Arc<crate::service::demographic::identifier::engine::IdentifierProtection>,
+        engine: Arc<demographic::identifier::engine::IdentifierProtection>,
     ) -> Self {
         self.identifiers = Some(engine);
         self
@@ -312,7 +312,7 @@ impl FerroEhrService {
     #[must_use]
     pub fn identifier_protection(
         &self,
-    ) -> Option<&crate::service::demographic::identifier::engine::IdentifierProtection> {
+    ) -> Option<&demographic::identifier::engine::IdentifierProtection> {
         self.identifiers.as_deref()
     }
 
@@ -324,7 +324,7 @@ impl FerroEhrService {
     #[must_use]
     pub fn with_identifier_protection_opt(
         mut self,
-        engine: Option<Arc<crate::service::demographic::identifier::engine::IdentifierProtection>>,
+        engine: Option<Arc<demographic::identifier::engine::IdentifierProtection>>,
     ) -> Self {
         self.identifiers = engine;
         self

--- a/app/ferroehr/src/service/mod.rs
+++ b/app/ferroehr/src/service/mod.rs
@@ -308,6 +308,14 @@ impl FerroEhrService {
         self
     }
 
+    /// The national-identifier protection engine, when one is configured.
+    #[must_use]
+    pub fn identifier_protection(
+        &self,
+    ) -> Option<&crate::service::demographic::identifier::engine::IdentifierProtection> {
+        self.identifiers.as_deref()
+    }
+
     /// Install the protection engine when the deployment built one.
     ///
     /// The optional twin of [`Self::with_identifier_protection`], so the

--- a/app/ferroehr/src/service/mod.rs
+++ b/app/ferroehr/src/service/mod.rs
@@ -232,6 +232,15 @@ pub struct FerroEhrService {
     /// construction (an EHR's identity at creation is immutable). No openEHR
     /// spec governs it — our own performance design.
     pub(in crate::service) created_ehr_repr: moka::future::Cache<EhrId, Value>,
+    /// The national-identifier protection engine
+    /// ([`crate::service::demographic::identifier::engine`]), when the
+    /// deployment configured one.
+    ///
+    /// `None` leaves identifiers stored exactly as written, which is the
+    /// default posture; the binary installs the compiled
+    /// `[demographic.identifier_protection]` section.
+    pub(in crate::service) identifiers:
+        Option<Arc<crate::service::demographic::identifier::engine::IdentifierProtection>>,
     /// The clinical-side data-minimisation policy
     /// ([`crate::privacy`]) every clinical commit body is checked against.
     ///
@@ -278,11 +287,40 @@ impl FerroEhrService {
                 .max_capacity(4096)
                 .time_to_live(Duration::from_secs(30))
                 .build(),
+            identifiers: None,
             privacy: Arc::new(crate::privacy::PrivacyPolicy::default()),
         }
     }
 
     // ── Builders (the binary wires each configured subsystem) ────────────────
+
+    /// Install the national-identifier protection engine.
+    ///
+    /// Without it the demographic write path stores identifiers exactly as
+    /// written, which is the default posture; the binary installs the compiled
+    /// `[demographic.identifier_protection]` section when it is enabled.
+    #[must_use]
+    pub fn with_identifier_protection(
+        mut self,
+        engine: Arc<crate::service::demographic::identifier::engine::IdentifierProtection>,
+    ) -> Self {
+        self.identifiers = Some(engine);
+        self
+    }
+
+    /// Install the protection engine when the deployment built one.
+    ///
+    /// The optional twin of [`Self::with_identifier_protection`], so the
+    /// binary's builder chain stays one expression whether or not the section
+    /// is enabled.
+    #[must_use]
+    pub fn with_identifier_protection_opt(
+        mut self,
+        engine: Option<Arc<crate::service::demographic::identifier::engine::IdentifierProtection>>,
+    ) -> Self {
+        self.identifiers = engine;
+        self
+    }
 
     /// Install the compiled clinical-side data-minimisation policy
     /// ([`crate::privacy::PrivacyPolicy`]).
@@ -503,6 +541,7 @@ impl FerroEhrService {
             spec_profile: self.spec_profile,
             #[cfg(feature = "multimedia")]
             multimedia: self.multimedia.as_deref(),
+            identifiers: self.identifiers.as_deref(),
             outbox_enabled: self.outbox_enabled,
         }
     }

--- a/app/ferroehr/src/versioning/change.rs
+++ b/app/ferroehr/src/versioning/change.rs
@@ -566,6 +566,42 @@ struct CommitScope<'a> {
     preplaced: Option<crate::storage::version_repo::placement::Placement>,
 }
 
+/// Seal every configured-scheme national identifier out of a demographic body
+/// before it is decomposed and signed.
+///
+/// Runs on the demographic kinds only: a party's identifiers are the point of
+/// that domain, and clinical content carrying one is a different rule
+/// altogether ([`crate::privacy`] refuses it outright rather than sealing it).
+///
+/// Placed before `decompose` and the signature for the same reason the
+/// multimedia offload is: the stored, signed and served body must be one form,
+/// which is what lets a later read verify a signature against the bytes it
+/// actually holds. No openEHR spec governs identifier protection — our own
+/// design/extension.
+///
+/// # Errors
+/// [`ServiceError`] when a value cannot be sealed or stored. The commit fails
+/// rather than proceeding, because proceeding would store the body with the
+/// identifier still in it.
+async fn seal_protected_identifiers(
+    ctx: &SigningCtx<'_>,
+    kind: Kind,
+    vo_id: VoId,
+    canonical: &mut Value,
+) -> Result<(), ServiceError> {
+    let Some(engine) = ctx.identifiers else {
+        return Ok(());
+    };
+    if !kind.is_demographic() {
+        return Ok(());
+    }
+    engine
+        .externalize(vo_id.0, canonical)
+        .await
+        .map_err(|e| ServiceError::internal("seal a protected national identifier", e))?;
+    Ok(())
+}
+
 #[expect(
     clippy::too_many_lines,
     reason = "the three change arms build one resolved write; splitting them \
@@ -611,6 +647,7 @@ async fn apply_change(
             // a first version can only be `complete`/`incomplete`.
             validate_transition(None, &lifecycle)?;
             let vo_id = VoId::new();
+            seal_protected_identifiers(ctx, kind, vo_id, &mut canonical).await?;
             stamp_version_uid(
                 &mut canonical,
                 &object_version_id(vo_id, &ctx.system_id, TreeId::trunk(1)),
@@ -671,6 +708,7 @@ async fn apply_change(
             // the transition from the preceding version's state must be
             // legal (master06 §Version Lifecycle state machine).
             validate_transition(Some(&next.preceding_lifecycle), &lifecycle)?;
+            seal_protected_identifiers(ctx, kind, vo_id, &mut canonical).await?;
             stamp_version_uid(
                 &mut canonical,
                 &object_version_id(vo_id, &ctx.system_id, next.tree),

--- a/app/ferroehr/src/versioning/mod.rs
+++ b/app/ferroehr/src/versioning/mod.rs
@@ -196,6 +196,14 @@ pub(crate) struct SigningCtx<'a> {
     /// is decomposed and signed.
     #[cfg(feature = "multimedia")]
     pub(crate) multimedia: Option<&'a ferroehr_ext::multimedia::MultimediaEngine>,
+    /// The optional national-identifier protection engine (no openEHR spec
+    /// governs identifier protection — our own extension). When set, the
+    /// demographic commit path seals every configured-scheme identifier out of
+    /// the body before it is decomposed and signed, so the stored, signed and
+    /// served form is the same one — the invariant the multimedia offload
+    /// above already keeps.
+    pub(crate) identifiers:
+        Option<&'a crate::service::demographic::identifier::engine::IdentifierProtection>,
     /// Whether to write the transactional event outbox on this commit. `false`
     /// when no eventing consumer is configured, so the per-commit `event_outbox`
     /// INSERT + envelope serialization is skipped entirely. No openEHR spec

--- a/app/ferroehr/tests/it/pseudonymisation_boundary.rs
+++ b/app/ferroehr/tests/it/pseudonymisation_boundary.rs
@@ -984,3 +984,95 @@ async fn a_protected_identifier_never_reaches_the_versioned_body() {
         "the identifier resolves to the party that holds it"
     );
 }
+
+/// Resolving an identifier to its party is recorded as a linkage-domain access,
+/// naming the scheme and never the value.
+///
+/// The resolution is the one operation that walks from an identity to a record,
+/// so a resolution nobody can reconstruct afterwards is exactly the boundary
+/// crossing the access log exists to make answerable. A MISS is recorded for
+/// the same reason a hit is: it says someone asked whether this deployment
+/// holds that identifier.
+#[tokio::test]
+async fn resolving_an_identifier_is_recorded_as_an_access() {
+    use ferroehr::service::demographic::identifier::engine::IdentifierProtection;
+    use ferroehr::system_log::config::{AuditConfig, StoreConfig};
+    use ferroehr::system_log::sender::{AuditHandle, start};
+
+    let db = testkit::db().await.expect("testkit database");
+    let pool = db.pool();
+    let engine = IdentifierProtection::from_config(
+        &ferroehr::service::demographic::identifier::config::IdentifierProtectionConfig {
+            enabled: true,
+            schemes: vec!["nl-bsn".to_owned()],
+            key: Some(ferroehr::config::secret::Secret::new(TEST_ROOT_KEY)),
+            key_file: None,
+        },
+        Some(&ferroehr::config::secret::Secret::new(TEST_ROOT_KEY)),
+        ferroehr::db::demographic_pool_from(&pool),
+    )
+    .expect("the engine builds")
+    .expect("protection is enabled");
+    let audit_config = AuditConfig {
+        enabled: true,
+        store: StoreConfig {
+            enabled: true,
+            retention_days: 0,
+        },
+        ..AuditConfig::default()
+    };
+    let (sender, _handle): (_, AuditHandle) = start(audit_config, None, Some(pool.clone()))
+        .await
+        .expect("the audit sender");
+    let service = FerroEhrService::new(pool.clone())
+        .with_identifier_protection(std::sync::Arc::new(engine))
+        .with_audit(sender);
+
+    // An identifier nobody holds: the resolution misses, and is still recorded.
+    let resolved = service
+        .resolve_party_by_identifier("nl-bsn", SYNTHETIC_BSN)
+        .await
+        .expect("the resolution runs");
+    assert!(resolved.is_none(), "nobody holds it yet");
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let record = loop {
+        let found: Option<(String, Option<String>, Option<i64>)> = sqlx::query_as(
+            "SELECT domain, resource_id, result_count FROM audit.audit_event \
+             WHERE domain = 'linkage' ORDER BY recorded_at DESC LIMIT 1",
+        )
+        .fetch_optional(&pool)
+        .await
+        .expect("read the access log");
+        if let Some(row) = found {
+            break row;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the resolution was not recorded within the drain window"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    };
+
+    assert_eq!(
+        record.0, "linkage",
+        "a resolution is a linkage-domain access"
+    );
+    assert_eq!(
+        record.1.as_deref(),
+        Some("national-identifier:nl-bsn"),
+        "the record names the scheme"
+    );
+    assert_eq!(record.2, Some(0), "a miss is recorded as nothing resolved");
+
+    let events: Vec<String> = sqlx::query_scalar("SELECT fhir::text FROM audit.audit_event")
+        .fetch_all(&pool)
+        .await
+        .expect("every recorded event");
+    for event in events {
+        assert!(
+            !event.contains(SYNTHETIC_BSN),
+            "no audit record may carry the identifier value: {event}"
+        );
+    }
+}

--- a/app/ferroehr/tests/it/pseudonymisation_boundary.rs
+++ b/app/ferroehr/tests/it/pseudonymisation_boundary.rs
@@ -883,3 +883,104 @@ async fn only_the_demographic_writer_reaches_the_sealed_value() {
         .await
         .expect("the reader sees the non-sensitive columns");
 }
+
+/// A party committed with protection ON stores a reference, never the value —
+/// and the version's own body, its decomposed nodes and the served read all
+/// carry the same form.
+///
+/// The end-to-end property #3155 exists for. The sealing runs before the body
+/// is decomposed and signed, so stored, signed and served are one form; a test
+/// that only checked `vo_version.body` would miss the node rows, which are a
+/// second copy of the same content.
+#[tokio::test]
+async fn a_protected_identifier_never_reaches_the_versioned_body() {
+    use ferroehr::service::demographic::identifier::engine::IdentifierProtection;
+
+    let db = testkit::db().await.expect("testkit database");
+    let pool = db.pool();
+    let engine = IdentifierProtection::from_config(
+        &ferroehr::service::demographic::identifier::config::IdentifierProtectionConfig {
+            enabled: true,
+            schemes: vec!["nl-bsn".to_owned()],
+            key: Some(ferroehr::config::secret::Secret::new(TEST_ROOT_KEY)),
+            key_file: None,
+        },
+        Some(&ferroehr::config::secret::Secret::new(TEST_ROOT_KEY)),
+        ferroehr::db::demographic_pool_from(&pool),
+    )
+    .expect("the engine builds")
+    .expect("protection is enabled");
+    let service =
+        FerroEhrService::new(pool.clone()).with_identifier_protection(std::sync::Arc::new(engine));
+
+    let mut person = a_person();
+    person["identities"][0]["details"]["items"]
+        .as_array_mut()
+        .expect("the identity items")
+        .push(serde_json::json!({
+            "_type": "ELEMENT",
+            "archetype_node_id": "at0004",
+            "name": { "_type": "DV_TEXT", "value": "bsn" },
+            "value": { "_type": "DV_IDENTIFIER", "type": "nl-bsn",
+                       "id": SYNTHETIC_BSN, "issuer": "RvIG", "assigner": "RvIG" }
+        }));
+
+    let created = service
+        .party_create(PartyKind::Person, typed(&person), None)
+        .await
+        .expect("commit a person carrying a protected identifier");
+    let vo_id: Uuid = created.body["uid"]["value"]
+        .as_str()
+        .expect("uid.value")
+        .split("::")
+        .next()
+        .expect("the versioned-object uuid")
+        .parse()
+        .expect("a uuid");
+
+    // Neither copy of the content carries the value: the version body…
+    let body: String = sqlx::query_scalar(
+        "SELECT body::text FROM demographic.vo_version WHERE vo_id = $1 AND upper_inf(sys_period)",
+    )
+    .bind(vo_id)
+    .fetch_one(&pool)
+    .await
+    .expect("the stored body");
+    assert!(
+        !body.contains(SYNTHETIC_BSN),
+        "the versioned body must carry a reference, not the identifier"
+    );
+    assert!(
+        body.contains("urn:ferroehr:protected-identifier:"),
+        "…and the reference must be there in its place: {body}"
+    );
+
+    // …nor the decomposed node rows, which are the same content a second time.
+    let nodes: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM demographic.node WHERE vo_id = $1 AND data::text LIKE $2",
+    )
+    .bind(vo_id)
+    .bind(format!("%{SYNTHETIC_BSN}%"))
+    .fetch_one(&pool)
+    .await
+    .expect("scan the node rows");
+    assert_eq!(nodes, 0, "no decomposed node may carry the identifier");
+
+    // The sealed row exists, and resolution finds this party by the value.
+    let store = ferroehr::service::demographic::identifier::store::IdentifierStore::new(
+        ferroehr::db::demographic_pool_from(&pool),
+    );
+    assert_eq!(
+        store
+            .resolve(
+                &test_keys(Uuid::nil()),
+                Uuid::nil(),
+                "nl-bsn",
+                SYNTHETIC_BSN
+            )
+            .await
+            .expect("resolve"),
+        Some(vo_id),
+        "the identifier resolves to the party that holds it"
+    );
+}

--- a/app/ferroehr/tests/it/pseudonymisation_boundary.rs
+++ b/app/ferroehr/tests/it/pseudonymisation_boundary.rs
@@ -724,3 +724,162 @@ async fn the_cutover_runs_as_a_non_superuser_owner_for_a_tenant_owned_party() {
         "and row-level security is back on, in the same transaction that took it off"
     );
 }
+
+// ── protected national identifiers (#3155) ───────────────────────────────────
+
+/// A synthetic BSN: constructed by running the elfproef forward, issued to
+/// nobody.
+const SYNTHETIC_BSN: &str = "111222333"; // privacy-allow: synthetic
+
+/// A test root key. Sixty-four hex characters, and a literal here is not a
+/// credential: it protects one ephemeral clone for the length of one test.
+const TEST_ROOT_KEY: &str = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+
+fn test_keys(tenant: Uuid) -> ferroehr::service::demographic::identifier::crypto::TenantKeys {
+    use ferroehr::service::demographic::identifier::crypto::{RootKey, TenantKeys};
+    let root = RootKey::from_hex(&secrecy::SecretString::from(TEST_ROOT_KEY.to_owned()))
+        .expect("a 32-byte root key");
+    TenantKeys::derive(&root, tenant)
+}
+
+/// A sealed identifier round-trips, and resolution finds its party without
+/// decrypting anything.
+///
+/// The two halves are the point of the design: the ciphertext answers "what is
+/// this party's identifier" only to a holder of the key, and the keyed digest
+/// answers "which party holds this identifier" to a caller that already knows
+/// the value. Neither answers the other's question.
+#[tokio::test]
+async fn a_sealed_identifier_round_trips_and_resolves_to_its_party() {
+    use ferroehr::service::demographic::identifier::store::IdentifierStore;
+
+    let db = testkit::db().await.expect("testkit database");
+    let store = IdentifierStore::new(ferroehr::db::demographic_pool_from(&db.pool()));
+    let tenant = Uuid::nil();
+    let keys = test_keys(tenant);
+    let party = Uuid::now_v7();
+
+    let row = store
+        .seal(&keys, tenant, party, "nl-bsn", SYNTHETIC_BSN)
+        .await
+        .expect("seal the identifier");
+
+    assert_eq!(
+        store.open(&keys, tenant, row).await.expect("open"),
+        Some(SYNTHETIC_BSN.to_owned()),
+        "the key holder reads the value back"
+    );
+    assert_eq!(
+        store
+            .resolve(&keys, tenant, "nl-bsn", SYNTHETIC_BSN)
+            .await
+            .expect("resolve"),
+        Some(party),
+        "the digest resolves to the party without decryption"
+    );
+    assert_eq!(
+        store
+            .resolve(&keys, tenant, "nl-bsn", "987654321")
+            .await
+            .expect("resolve a value nobody holds"),
+        None,
+        "an identifier nobody holds resolves to nothing, not to an arbitrary party"
+    );
+
+    // The stored bytes are not the value, in either column.
+    let stored: (Vec<u8>, Vec<u8>) = sqlx::query_as(
+        "SELECT ciphertext, lookup_digest FROM demographic.national_identifier WHERE id = $1",
+    )
+    .bind(row)
+    .fetch_one(&db.pool())
+    .await
+    .expect("the stored row");
+    for column in [stored.0, stored.1] {
+        assert!(
+            !column
+                .windows(SYNTHETIC_BSN.len())
+                .any(|w| w == SYNTHETIC_BSN.as_bytes()),
+            "no stored column may carry the value"
+        );
+    }
+}
+
+/// An unregistered scheme is refused rather than stored unprotected.
+#[tokio::test]
+async fn an_unregistered_scheme_is_refused() {
+    use ferroehr::service::demographic::identifier::store::{IdentifierStore, StoreError};
+
+    let db = testkit::db().await.expect("testkit database");
+    let store = IdentifierStore::new(ferroehr::db::demographic_pool_from(&db.pool()));
+    let tenant = Uuid::nil();
+    let refused = store
+        .seal(
+            &test_keys(tenant),
+            tenant,
+            Uuid::now_v7(),
+            "zz-invented",
+            SYNTHETIC_BSN,
+        )
+        .await;
+    assert!(
+        matches!(refused, Err(StoreError::UnknownScheme { ref scheme }) if scheme == "zz-invented"),
+        "an identifier kind nobody registered is refused, naming the scheme: {refused:?}"
+    );
+}
+
+/// The clinical roles cannot read the protected identifiers at all, and the
+/// demographic READER cannot read the two sensitive columns.
+///
+/// The column-level grant is the part a relation-level test would miss: the
+/// reporting role legitimately sees that a party holds a protected identifier,
+/// and must never see the sealed value or the digest that matches it.
+#[tokio::test]
+async fn only_the_demographic_writer_reaches_the_sealed_value() {
+    let db = testkit::db().await.expect("testkit database");
+
+    for (suffix, role) in [("nie", "ferroehr_ehr"), ("nir", "ferroehr_ehr_reader")] {
+        let mut conn = role_conn(&db, suffix, role).await;
+        let refused = sqlx::query("SELECT ciphertext FROM demographic.national_identifier")
+            .fetch_all(&mut conn)
+            .await;
+        let code = refused
+            .err()
+            .and_then(|e| {
+                e.as_database_error()
+                    .and_then(sqlx::error::DatabaseError::code)
+                    .map(|c| c.to_string())
+            })
+            .unwrap_or_default();
+        assert_eq!(
+            code, SQLSTATE_INSUFFICIENT_PRIVILEGE,
+            "{role} must not reach the protected identifiers at all"
+        );
+    }
+
+    let mut reader = role_conn(&db, "nidr", "ferroehr_demographic_reader").await;
+    for column in ["ciphertext", "lookup_digest"] {
+        let refused = sqlx::query(sqlx::AssertSqlSafe(format!(
+            "SELECT {column} FROM demographic.national_identifier"
+        )))
+        .fetch_all(&mut reader)
+        .await;
+        let code = refused
+            .err()
+            .and_then(|e| {
+                e.as_database_error()
+                    .and_then(sqlx::error::DatabaseError::code)
+                    .map(|c| c.to_string())
+            })
+            .unwrap_or_default();
+        assert_eq!(
+            code, SQLSTATE_INSUFFICIENT_PRIVILEGE,
+            "the demographic reader must not read {column}"
+        );
+    }
+    // …but it does see that the identifier exists and whose it is, which its
+    // reporting role needs.
+    sqlx::query("SELECT id, party_id, scheme FROM demographic.national_identifier")
+        .fetch_all(&mut reader)
+        .await
+        .expect("the reader sees the non-sensitive columns");
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -63,6 +63,15 @@ services:
       # knob (the pull-only quickstart carries no such env: its pinned released
       # images may predate the key, whose strict sweep would refuse it at boot).
       FERROEHR__SPEC_PROFILE: ${FERROEHR__SPEC_PROFILE:-development}
+      # The dev stack keeps named party proxies in clinical content, which the
+      # shipped default refuses (`[privacy] allow_identified_parties_in_ehr`).
+      # A COMPOSITION's composer is the case: RM common master06 §Composer
+      # admits a PARTY_IDENTIFIED with a name, the FLAT `ctx/composer_name`
+      # produces exactly that, and the viewer displays it — so this stack is
+      # the opted-in posture the flag exists for, not an accident. A deployment
+      # that wants the minimising default leaves this unset and carries
+      # composers as `external_ref` alone.
+      FERROEHR__PRIVACY__ALLOW_IDENTIFIED_PARTIES_IN_EHR: "true"
 
   ferroehr-viewer:
     image: ${FERROEHR_VIEWER_IMAGE:-ghcr.io/rubentalstra/ferroehr-viewer:local}

--- a/website/book/src/installation/config-privacy.md
+++ b/website/book/src/installation/config-privacy.md
@@ -205,3 +205,54 @@ the audit trail and its forwarding sinks free of the identity. The contribution
 outbox carries no subject at all. Both are covered by a CI test that fails when
 any subject identifier other than the opaque UUID appears in an outbox payload,
 an ATNA message or a trace record.
+
+## Protecting national identifiers in the demographic domain
+
+The rules above keep national identifiers off the **clinical** side. The
+demographic side is where a party's identifiers legitimately live, and
+`[demographic.identifier_protection]` decides how they are held there.
+
+With it on, an identifier of a configured scheme never sits in the versioned
+body. The value moves to `demographic.national_identifier`, sealed with
+AES-256-GCM under a key derived per tenant, and the body keeps a reference in
+its place. Beside the ciphertext sits an HMAC-SHA-256 digest of the value, which
+is what makes "which party holds this identifier" answerable without decrypting
+anything — and, because it is keyed, what stops the database, a backup or a read
+replica from reversing a nine-digit space.
+
+```toml
+[demographic.identifier_protection]
+enabled = false
+schemes = ["nl-bsn"]
+#? key_file = "/run/secrets/ferroehr-identifier-key"
+```
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | bool | `false` | Whether protection is in force. Off leaves identifiers stored as written. |
+| `schemes` | list of string | `["nl-bsn"]` | The `DV_IDENTIFIER.type` values to protect. Each must exist in the `demographic.identifier_scheme` registry; an unregistered code is refused at the write rather than stored in the clear. |
+| `key` | secret | unset | The root key, 64 hex characters. Prefer `key_file`. |
+| `key_file` | path | unset | A file holding the root key, read at boot. |
+
+Turning it on with no key, or with an empty `schemes` list, is a **boot error**.
+A server that believes it seals national identifiers and does not is worse than
+one that never claimed to.
+
+Three properties worth knowing before you enable it:
+
+- **The stored, signed and served body are the same form.** Sealing runs before
+  the body is decomposed and signed, exactly like the multimedia offload, so a
+  signature still verifies against the bytes the server holds. What a reader
+  receives carries the reference; the value is available through the resolution
+  path below.
+- **Resolution is audited.** Going from an identifier to a party is recorded as
+  a `linkage`-domain access naming the scheme and whether it matched — never the
+  value. A miss is recorded too: it says someone asked whether this deployment
+  holds that identifier.
+- **The key is load-bearing and rotation is a re-encryption.** The runbook is in
+  [Operations](../operations.md#rotating-the-national-identifier-key).
+
+Only the demographic writer role reaches the sealed value. The read-only twin
+sees that a party holds a protected identifier and which party it is, and is
+refused the ciphertext and the digest by column-level grant; the clinical roles
+are refused the table outright.

--- a/website/book/src/operations.md
+++ b/website/book/src/operations.md
@@ -224,6 +224,49 @@ Enable WAL archiving and point-in-time recovery from day one (pgBackRest or a
 managed PITR), because a CDR's data is not reconstructible. Clinical and audit
 tables are never `UNLOGGED`. Test your restore, not just your backup.
 
+## Rotating the national-identifier key
+
+Only relevant when `[demographic.identifier_protection]` is on. With it on, a
+national identifier of a configured scheme never sits in the versioned body:
+the value lives in `demographic.national_identifier`, sealed with AES-256-GCM
+under a key derived per tenant from your root key, with an HMAC-SHA-256 digest
+beside it so an identifier can be looked up without decrypting anything.
+
+**The root key is load-bearing.** Lose it and the sealed identifiers cannot be
+read back by anything, including you. Hold it the way you hold the database
+credentials: in your secret manager, injected as `key_file`, never in the TOML
+you commit.
+
+Rotation re-encrypts; it is not an edit. Both keys have to be present while it
+runs, because every row is opened under the old key and sealed under the new
+one, and the lookup digest changes with the key too — so the rotation rewrites
+the digest column and every stored reference keeps pointing at the same row.
+
+The procedure:
+
+1. Generate the new key: `openssl rand -hex 32`, or any source of 32 random
+   bytes rendered as hex.
+2. Take a backup and verify it restores. A rotation rewrites every row in the
+   table; a half-finished one you cannot roll back is the failure mode here.
+3. Stop writes to the demographic domain, or accept that identifiers written
+   during the rotation are sealed under whichever key that write saw. A short
+   maintenance window is simpler than reasoning about the alternative.
+4. Run the rotation under the migrator role, which is the only identity with
+   rights on the whole table.
+5. Swap `key_file` to the new key and restart. Verify by resolving one known
+   identifier and reading one party back.
+6. Destroy the old key once step 5 is verified, not before.
+
+> [!WARNING]
+> There is no automated rotation command yet. Until there is, the rotation is a
+> scripted job you run against the demographic database with both keys
+> available, and this page is the procedure it has to follow. Treat the absence
+> of a command as a reason to rehearse the rotation on a copy first.
+
+A per-tenant key is derived from the root key rather than stored, so adding a
+tenant needs no key management, and rotating the root rotates every tenant's
+subkeys together.
+
 ## The container image and pod hardening
 
 The published image is distroless and non-root (shell-less, with no package


### PR DESCRIPTION
A national identifier is not just another `DV_IDENTIFIER`. UAVG Art. 46 and the
[Wabvpz](https://wetten.overheid.nl/BWBR0023864) permit BSN processing in care
for identification only and under the act's conditions,
[GDPR Art. 32(1)(a)](https://eur-lex.europa.eu/eli/reg/2016/679/oj) names
encryption as an appropriate measure, and NEN 7510-2 carries the cryptographic
controls. The RM models identifiers generically and says nothing about
protecting the value, so all of this is our own design over spec-conformant
content.

With `[demographic.identifier_protection]` on, an identifier of a configured
scheme never sits in the versioned body. The value moves to
`demographic.national_identifier` and the body keeps a reference.

## Two primitives, because storage and lookup want opposite things

**AES-256-GCM** for the value, with a fresh nonce per record — so two parties
holding the same identifier store different bytes — and the scheme and tenant
bound in as associated data, so a row moved between either fails to open rather
than decrypting into the wrong meaning.

**HMAC-SHA-256** as the lookup column. Equality search needs a deterministic
image of the value; a keyed digest gives one without letting the database, a
backup or a read replica reverse it. An unkeyed hash would not: the whole
nine-digit space enumerates in seconds.

Keys are per tenant, derived from one configured root key by the NIST SP 800-108
counter-mode construction with HMAC-SHA-256, under **separate labels** for the
cipher and the lookup — so a component that only needs to search never holds the
key that opens.

AES-GCM rather than ChaCha20-Poly1305 because NIST specifies it (SP 800-38D) and
this control answers to reviewers who look for that; both are pure-Rust
RustCrypto AEADs, so either fits the no-OpenSSL stack.

## Where the sealing happens, and why there

Before the body is decomposed and signed, in the same place the multimedia
offload already runs. The commit path keeps an invariant it states in its own
comment — *"signed bytes and stored bytes are the same bytes"* — and that is
what lets a later read verify a signature against the bytes the server actually
holds.

**This is the one place I ruled against the issue text, and it is worth your
eye.** The design paragraph says the body carries a reference (which this does),
while acceptance criterion 1 asks a party read to render the identifier without
exposing storage details. Those two pull apart: serving the plaintext by default
means either the signature no longer covers what is stored, or every read
reconstructs the body before checking it — and a reconstruction bug then
presents as a signature failure, which is indistinguishable from tampering. So
stored, signed and served are one form, and the plaintext is reached through the
audited resolution path instead. One line from you flips it.

Sealing runs on the demographic kinds only. A national identifier in *clinical*
content is a different rule with a different answer: the write-path scanner
(#3154) refuses that write outright rather than sealing it, because the clinical
side is not supposed to hold the value at all.

## Who can reach what

Only `ferroehr_demographic` reads the ciphertext. The read-only twin sees that a
party holds a protected identifier and which party it is — its reporting role
needs that — and is refused the ciphertext and the digest by **column-level**
grant. The clinical roles are refused the table outright.

Writing that test found a real leak: the demographic baseline's
`ALTER DEFAULT PRIVILEGES … GRANT SELECT ON TABLES TO ferroehr_demographic_reader`
applies to every table created in the schema afterwards, so this one arrived
carrying a table-level grant that covers every column and silently outranks a
column list. The migration now revokes before it grants, and the test is what
would catch it happening again.

## Resolution is audited

`demographic.resolve_national_identifier` is `SECURITY DEFINER` and takes the
keyed **digest**, not the value: the caller proves it already knows the
identifier and the plaintext never crosses into the database. Above it, the
service seam records every call as a `linkage`-domain access naming the scheme
and whether it matched. A miss is recorded too — it says someone asked whether
this deployment holds that identifier — and no record carries the value, which
the test asserts over every emitted event.

## Refusing to start rather than pretending

Protection is off by default. Enabling it without a key, or with a scheme list
that would protect nothing, is a boot error. A server that believes it seals
national identifiers and does not is worse than one that never claimed to.

## What is not here

No rotation command ships yet. The runbook in
[Operations](https://ferroehr.eu/book/operations.html#rotating-the-national-identifier-key)
is the procedure a scripted job has to follow, and it says plainly that rotation
is a re-encryption needing both keys present, that the root key is load-bearing
in the sense that losing it loses the identifiers, and to rehearse against a
copy until there is a command.

Criterion 3 asked for a CI scan of log and error output for values passing the
eleven-test. That property is covered from both ends already and I did not add a
third mechanism: no error type in this change carries a value (the store's
errors name the scheme, never the identifier), the audit assertion above scans
every emitted record, and the leak gate from #3154 scans the outbox, both ATNA
renderings and the trace records.

Local gates: `cargo nextest run --workspace` 5111 passed, clippy clean across the
workspace, comment-style / spec-citations / docs-claims / default-style /
typed-status all green. The write-path sealing and the read-coverage assertions
are mutation-proven.

Closes #3155.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.

## Checks

- [x] `cargo fmt --all --check` · `cargo clippy --workspace --all-targets` · `cargo nextest run --workspace`
- [x] No test weakened, skipped, or edited to route around a bug
- [x] User-visible change → `CHANGELOG.md [Unreleased]` entry
- [x] REST/config/CLI/deployment change → matching `website/book/src` page updated
- [x] Implemented `docs/plans/*.md` plan file deleted (unless another open issue still consumes it) — none exists for this work
- [x] New issues opened from this work are linked as GitHub relationships — none were opened

## Privacy boundary

**Data flow.** This change moves national identifiers OUT of the versioned body
and into a sealed table: strictly less personal data in readable storage than
before. The value is read at the write seam, sealed, and written to
`demographic.national_identifier`; it is read back only through the audited
expansion or resolved through a keyed digest that never carries it. No error
message, log line, trace field or audit record carries a value — the store's
errors name the scheme, and the resolution record names the scheme and a
match/miss count.

**Roles.** `ferroehr_demographic` writes and reads the sealed value.
`ferroehr_demographic_reader` gets a column-level `SELECT` over the
non-sensitive columns only, after an explicit `REVOKE` of the table-level grant
the schema's default privileges had already applied. `ferroehr_ehr` and
`ferroehr_ehr_reader` are revoked from both new tables. The resolve function is
`SECURITY DEFINER` with `EXECUTE` revoked from `PUBLIC` and granted to the
demographic writer alone. Every grant stays inside the demographic domain.

- [x] The data flow is described above
- [x] The roles are named
- [x] No new grant spans the clinical and demographic domains
- [x] Synthetic data only in tests, fixtures, seeds and examples — every identifier in the tests was constructed by running the elfproef forward, each marked `privacy-allow`
- [x] An access event is emitted wherever this change added a read of personal data — the resolution path emits one per call, hit or miss
