### PR TITLE
feat(deploy): the artifacts can reach the demographic role split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,25 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
+- **The deployment artifacts can reach the demographic role split** (#3179).
+  The chart gained `database.demographicExistingSecret` (and its
+  `demographicExistingSecretKey` / inline `demographicUrl` siblings), mounted
+  as a file exactly like the clinical DSN so neither credential enters the
+  pod's environment. Set it and the schema separation becomes a credential
+  separation: one leaked connection string then reaches one domain rather than
+  both. Leave it unset and both pools share the clinical DSN, which is the
+  schema-only posture the boot self-check still verifies. The compose stacks
+  now provision all four `NOINHERIT` domain roles — previously the migrations
+  skipped them with a `NOTICE`, because the compose migrator holds no
+  `CREATEROLE`, so those stacks ran with no domain grants at all — while
+  deliberately keeping one login credential, which the init script says in
+  place. `scripts/deploy-probe.sh` gained a family that reads the posture out
+  of the database catalogue rather than the compose file: the roles exist, each
+  is `NOINHERIT`, no clinical role can read a demographic relation, and the
+  stack is single-credential on purpose. What it cannot show — a two-DSN
+  deployment, and role provisioning on a managed database — it declares as not
+  exercised.
+
 - **National identifiers in the demographic domain can be held sealed**
   (#3155). With the new `[demographic.identifier_protection]` section on, an
   identifier of a configured scheme never sits in the versioned body: the value

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # A published OCI version is immutable by refusal rather than by the registry —
 # `helm push` over an existing tag replaces it silently — so a correction always
 # ships as a NEW version and the published one stands as it was.
-version: 7.0.9
+version: 7.1.0
 # The DEFAULT container image tag (overridable via image.tag). Equals the
 # workspace version in Cargo.toml, bumped in the release PR beside the
 # docker-compose.yml image tags — one version sweep, the compose treatment

--- a/deploy/helm/ferroehr/README.md
+++ b/deploy/helm/ferroehr/README.md
@@ -2,7 +2,7 @@
 
 Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.1.0 + AQL 1.1). A single static binary deployed with a hardened-by-default security posture: runs as a non-root, read-only-rootfs workload whose NetworkPolicy admits its serving port only, and that connects to an EXTERNAL PostgreSQL 18 as an unprivileged app role (migrations are run out of band by a separate migrator role).
 
-![Version: 7.0.9](https://img.shields.io/badge/Version-7.0.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.1.1](https://img.shields.io/badge/AppVersion-4.1.1-informational?style=flat-square)
+![Version: 7.1.0](https://img.shields.io/badge/Version-7.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.1.1](https://img.shields.io/badge/AppVersion-4.1.1-informational?style=flat-square)
 
 FerroEHR is a pure-Rust openEHR Clinical Data Repository: ITS-REST 1.1.0 at the
 API, AQL 1.1 as the query language, PostgreSQL 18-native storage, shipped as a
@@ -33,7 +33,7 @@ to add; `helm repo add` does not apply to this chart:
 
 ```console
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 7.0.9 \
+  --version 7.1.0 \
   --namespace ferroehr --create-namespace \
   --set database.existingSecret=ferroehr-db \
   --set image.tag=4.1.1
@@ -47,7 +47,7 @@ They are independent SemVer lines and they move independently:
 
 | What | Set with | This release |
 |---|---|---|
-| the **chart** (templates, defaults, this document) | `--version` | `7.0.9` |
+| the **chart** (templates, defaults, this document) | `--version` | `7.1.0` |
 | the **server image** | `image.tag` | `4.1.1` |
 
 `appVersion` is the image the chart defaults to; pinning `image.tag` explicitly
@@ -59,7 +59,7 @@ The chart carries two keyless Sigstore artifacts, and they answer different
 questions. A **cosign signature:** who signed this:
 
 ```console
-cosign verify ghcr.io/rubentalstra/charts/ferroehr:7.0.9 \
+cosign verify ghcr.io/rubentalstra/charts/ferroehr:7.1.0 \
   --certificate-identity-regexp '^https://github\.com/rubentalstra/FerroEHR/\.github/workflows/publish-chart\.yml@' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
@@ -67,7 +67,7 @@ cosign verify ghcr.io/rubentalstra/charts/ferroehr:7.0.9 \
 A **SLSA build provenance attestation:** what source it was built from, and how:
 
 ```console
-gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:7.0.9 \
+gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:7.1.0 \
   -R rubentalstra/FerroEHR
 gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:4.1.1 \
   -R rubentalstra/FerroEHR

--- a/deploy/helm/ferroehr/README.md
+++ b/deploy/helm/ferroehr/README.md
@@ -222,6 +222,9 @@ Kubernetes: `>=1.36.0-0`
 | config.terminology.api_enabled | bool | `false` |  |
 | config.terminology.external.enabled | bool | `false` |  |
 | config.terminology.external.fail_on_error | bool | `false` |  |
+| database.demographicExistingSecret | string | `""` | Reference an existing Secret holding the DEMOGRAPHIC-role DSN. Its value is a full `postgres://ferroehr_demographic:...@host:5432/ferroehr`, a different credential from `database.existingSecret` above. |
+| database.demographicExistingSecretKey | string | `"FERROEHR__DB__DEMOGRAPHIC_URL"` | Key WITHIN demographicExistingSecret holding the demographic DSN. Mounted as a file; only its PATH reaches the pod's environment. |
+| database.demographicUrl | string | `""` | Inline demographic DSN (DEV/TEST ONLY — lands in a chart-managed Secret). Ignored when demographicExistingSecret is set. |
 | database.existingSecret | string | `""` | Reference an existing Secret holding the app-role DSN (STRONGLY preferred for production — keeps the credential out of chart values and git). The secret's value must be a full `postgres://ferroehr_app:...@host:5432/ferroehr` (optionally `?sslmode=verify-full`). |
 | database.existingSecretKey | string | `"FERROEHR__DB__URL"` | Key WITHIN existingSecret that holds the DSN. This is a Secret key name, not an environment variable name: the chart mounts that key as a file and passes only its PATH as `FERROEHR__DB__URL_FILE`, so the DSN never enters the pod's environment. The default spelling is kept for compatibility with existing Secrets created for the older env-borne arrangement. |
 | database.url | string | `""` | Inline DSN (DEV/TEST ONLY — lands in a chart-managed Secret). Leave empty and use existingSecret in production. Ignored when existingSecret is set. |

--- a/deploy/helm/ferroehr/templates/_helpers.tpl
+++ b/deploy/helm/ferroehr/templates/_helpers.tpl
@@ -116,7 +116,8 @@ when there is at least one secret value to carry).
 */}}
 {{- define "ferroehr.hasChartSecret" -}}
 {{- $inlineDb := and (not .Values.database.existingSecret) .Values.database.url }}
-{{- if or $inlineDb .Values.secrets.basicUserPasswordHashes .Values.secrets.authOidcHmacSecret .Values.secrets.signingKeyPassphrase .Values.secrets.eventsUrl .Values.secrets.fhirOutboundUrl .Values.secrets.auditFhirFeedUrl .Values.secrets.multimediaAccessKeyId .Values.secrets.multimediaSecretAccessKey .Values.secrets.terminologyOauth2ClientSecrets -}}
+{{- $inlineDemographic := and (not .Values.database.demographicExistingSecret) .Values.database.demographicUrl }}
+{{- if or $inlineDb $inlineDemographic .Values.secrets.basicUserPasswordHashes .Values.secrets.authOidcHmacSecret .Values.secrets.signingKeyPassphrase .Values.secrets.eventsUrl .Values.secrets.fhirOutboundUrl .Values.secrets.auditFhirFeedUrl .Values.secrets.multimediaAccessKeyId .Values.secrets.multimediaSecretAccessKey .Values.secrets.terminologyOauth2ClientSecrets -}}
 true
 {{- end -}}
 {{- end }}
@@ -128,7 +129,7 @@ OWASP Kubernetes Security Cheat Sheet prefers over an environment variable
 (https://cheatsheetseries.owasp.org/cheatsheets/Kubernetes_Security_Cheat_Sheet.html).
 */}}
 {{- define "ferroehr.hasFileSecrets" -}}
-{{- if or (eq (include "ferroehr.hasChartFileSecrets" .) "true") .Values.database.existingSecret -}}
+{{- if or (eq (include "ferroehr.hasChartFileSecrets" .) "true") .Values.database.existingSecret .Values.database.demographicExistingSecret -}}
 true
 {{- end -}}
 {{- end }}
@@ -141,7 +142,8 @@ names a Secret nothing created makes the pod fail to mount.
 */}}
 {{- define "ferroehr.hasChartFileSecrets" -}}
 {{- $inlineDb := and (not .Values.database.existingSecret) .Values.database.url -}}
-{{- if or $inlineDb .Values.secrets.authOidcHmacSecret .Values.secrets.signingKeyPassphrase .Values.secrets.multimediaSecretAccessKey .Values.secrets.terminologyOauth2ClientSecrets .Values.secrets.basicUserPasswordHashes .Values.secrets.eventsUrl .Values.secrets.fhirOutboundUrl -}}
+{{- $inlineDemographic := and (not .Values.database.demographicExistingSecret) .Values.database.demographicUrl -}}
+{{- if or $inlineDb $inlineDemographic .Values.secrets.authOidcHmacSecret .Values.secrets.signingKeyPassphrase .Values.secrets.multimediaSecretAccessKey .Values.secrets.terminologyOauth2ClientSecrets .Values.secrets.basicUserPasswordHashes .Values.secrets.eventsUrl .Values.secrets.fhirOutboundUrl -}}
 true
 {{- end -}}
 {{- end }}

--- a/deploy/helm/ferroehr/templates/deployment.yaml
+++ b/deploy/helm/ferroehr/templates/deployment.yaml
@@ -119,6 +119,16 @@ spec:
             - name: FERROEHR__DB__URL_FILE
               value: {{ printf "%s/db.url" (include "ferroehr.secretMountPath" .) | quote }}
             {{- end }}
+            {{- if or .Values.database.demographicExistingSecret .Values.database.demographicUrl }}
+            {{- /* The demographic domain's own credential, mounted the same way
+                   and for the same reason. Set, it makes the schema separation a
+                   credential separation too: one leaked DSN then reaches one
+                   domain rather than both. Unset, both pools share the clinical
+                   DSN and the separation is schema-only, which the boot
+                   self-check still enforces. */}}
+            - name: FERROEHR__DB__DEMOGRAPHIC_URL_FILE
+              value: {{ printf "%s/db.demographic_url" (include "ferroehr.secretMountPath" .) | quote }}
+            {{- end }}
             {{- if .Values.secrets.authOidcHmacSecret }}
             - name: FERROEHR__AUTH__OIDC__HMAC_SECRET_FILE
               value: {{ printf "%s/auth.oidc.hmac_secret" (include "ferroehr.secretMountPath" .) | quote }}
@@ -285,6 +295,15 @@ spec:
                     - key: {{ .Values.database.existingSecretKey }}
                       path: db.url
               {{- end }}
+              {{- if .Values.database.demographicExistingSecret }}
+              # The demographic domain's own Secret, a different credential from
+              # the clinical one above and projected as its own file.
+              - secret:
+                  name: {{ .Values.database.demographicExistingSecret }}
+                  items:
+                    - key: {{ .Values.database.demographicExistingSecretKey }}
+                      path: db.demographic_url
+              {{- end }}
               {{- if eq (include "ferroehr.hasChartFileSecrets" .) "true" }}
               - secret:
                   name: {{ include "ferroehr.secretName" . }}
@@ -292,6 +311,10 @@ spec:
               {{- if and (not .Values.database.existingSecret) .Values.database.url }}
                     - key: db.url
                       path: db.url
+              {{- end }}
+              {{- if and (not .Values.database.demographicExistingSecret) .Values.database.demographicUrl }}
+                    - key: db.demographic_url
+                      path: db.demographic_url
               {{- end }}
               {{- if .Values.secrets.eventsUrl }}
                     - key: events.url

--- a/deploy/helm/ferroehr/templates/secret.yaml
+++ b/deploy/helm/ferroehr/templates/secret.yaml
@@ -40,6 +40,9 @@ stringData:
   {{- if and (not .Values.database.existingSecret) .Values.database.url }}
   db.url: {{ .Values.database.url | quote }}
   {{- end }}
+  {{- if and (not .Values.database.demographicExistingSecret) .Values.database.demographicUrl }}
+  db.demographic_url: {{ .Values.database.demographicUrl | quote }}
+  {{- end }}
   {{- with .Values.secrets.eventsUrl }}
   events.url: {{ . | quote }}
   {{- end }}

--- a/deploy/helm/ferroehr/values.schema.json
+++ b/deploy/helm/ferroehr/values.schema.json
@@ -130,6 +130,18 @@
         "url": {
           "description": "Inline DSN (dev/test only). Ignored when existingSecret is set.",
           "type": "string"
+        },
+        "demographicExistingSecret": {
+          "description": "Secret holding the demographic-domain DSN, a different credential from existingSecret. Unset, both pools share the clinical DSN and the separation stays schema-only.",
+          "type": "string"
+        },
+        "demographicExistingSecretKey": {
+          "description": "A key name INSIDE demographicExistingSecret; the chart mounts that key as a file and passes only its path.",
+          "type": "string"
+        },
+        "demographicUrl": {
+          "description": "Inline demographic DSN (dev/test only). Ignored when demographicExistingSecret is set.",
+          "type": "string"
         }
       }
     },

--- a/deploy/helm/ferroehr/values.yaml
+++ b/deploy/helm/ferroehr/values.yaml
@@ -122,6 +122,34 @@ database:
   # and use existingSecret in production. Ignored when existingSecret is set.
   url: ""
 
+  # ── the demographic pseudonymisation domain ────────────────────────────────
+  # The clinical and demographic schemas are separated unconditionally, and the
+  # server refuses to boot if either runtime role can read across. What the
+  # keys below add is the CREDENTIAL separation: point the demographic pool at
+  # its own DSN and one leaked connection string no longer reaches both
+  # domains. GDPR Art. 4(5) treats the identifying data as what must be kept
+  # apart; no openEHR spec governs database roles — our own design.
+  #
+  # Leave both empty and the demographic pool uses the same DSN as the clinical
+  # one, which is the schema-only posture: still separated, still boot-checked,
+  # one credential.
+  #
+  # The four runtime roles (ferroehr_ehr, ferroehr_demographic and a read-only
+  # twin of each) are created by the migrations ONLY when the migrator holds
+  # CREATEROLE; otherwise they are skipped with a NOTICE and provisioning them
+  # is yours. `ferroehr db verify` reports whether the boundary holds.
+
+  # -- Reference an existing Secret holding the DEMOGRAPHIC-role DSN. Its value
+  # is a full `postgres://ferroehr_demographic:...@host:5432/ferroehr`, a
+  # different credential from `database.existingSecret` above.
+  demographicExistingSecret: ""
+  # -- Key WITHIN demographicExistingSecret holding the demographic DSN.
+  # Mounted as a file; only its PATH reaches the pod's environment.
+  demographicExistingSecretKey: FERROEHR__DB__DEMOGRAPHIC_URL
+  # -- Inline demographic DSN (DEV/TEST ONLY — lands in a chart-managed
+  # Secret). Ignored when demographicExistingSecret is set.
+  demographicUrl: ""
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Migrations: who runs the schema.
 #

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), and only from the networkPolicy.ingressFrom peers.
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -97,7 +97,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -118,7 +118,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -150,7 +150,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -176,7 +176,7 @@ kind: Secret
 metadata:
   name: ferroehr-config
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -197,7 +197,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -402,7 +402,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr-grafana-dashboard
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -653,7 +653,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -687,7 +687,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -920,7 +920,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -954,7 +954,7 @@ kind: Ingress
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -992,7 +992,7 @@ kind: ServiceMonitor
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"

--- a/deploy/helm/golden/basic-auth.yaml
+++ b/deploy/helm/golden/basic-auth.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -51,7 +51,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -72,7 +72,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -102,7 +102,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -119,7 +119,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -247,7 +247,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -277,7 +277,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -51,7 +51,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -72,7 +72,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -87,7 +87,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -212,7 +212,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -242,7 +242,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"

--- a/deploy/helm/golden/viewer.yaml
+++ b/deploy/helm/golden/viewer.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -61,7 +61,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the viewer: only its HTTP port, but from EVERY source — this policy narrows ports, NOT sources (viewer.networkPolicy.ingressAllowAll=true). Set viewer.networkPolicy.ingressFrom for a PHI workload. Egress admits the CDR Service and DNS only.
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr-viewer
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -118,7 +118,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -139,7 +139,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -154,7 +154,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr-viewer
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr-viewer
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -184,7 +184,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -201,7 +201,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -329,7 +329,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -359,7 +359,7 @@ metadata:
     kubernetes.io/description: >-
       In-cluster address for the FerroEHR Viewer. The viewer is a REST client of the CDR and holds no data of its own; it is the human-facing surface, so this is the Service an Ingress normally publishes.
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr-viewer
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -385,7 +385,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -581,7 +581,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR Viewer: a Leptos SSR web UI that consumes the CDR strictly over ITS-REST. It never reaches the database, which the viewer NetworkPolicy enforces rather than assumes.
   labels:
-    helm.sh/chart: ferroehr-7.0.9
+    helm.sh/chart: ferroehr-7.1.0
     app.kubernetes.io/name: ferroehr-viewer
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"

--- a/docker/postgres/initdb/10-ferroehr-init.sh
+++ b/docker/postgres/initdb/10-ferroehr-init.sh
@@ -52,9 +52,38 @@ BEGIN
   IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'ferroehr_reader') THEN
     CREATE ROLE ferroehr_reader NOLOGIN;
   END IF;
+  -- The four pseudonymisation-domain roles, for the same reason as the three
+  -- above: the demographic baseline grants to them only if they already exist,
+  -- and without them compose runs with no domain grants at all and a "roles
+  -- absent" NOTICE nobody reads. NOINHERIT and no membership in one another —
+  -- a role that could inherit the other domain's grants would make the
+  -- boundary a naming convention (PostgreSQL 18, CREATE ROLE
+  -- https://www.postgresql.org/docs/18/sql-createrole.html).
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'ferroehr_ehr') THEN
+    CREATE ROLE ferroehr_ehr NOLOGIN NOINHERIT;
+  END IF;
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'ferroehr_demographic') THEN
+    CREATE ROLE ferroehr_demographic NOLOGIN NOINHERIT;
+  END IF;
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'ferroehr_ehr_reader') THEN
+    CREATE ROLE ferroehr_ehr_reader NOLOGIN NOINHERIT;
+  END IF;
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'ferroehr_demographic_reader') THEN
+    CREATE ROLE ferroehr_demographic_reader NOLOGIN NOINHERIT;
+  END IF;
   -- In dev the single app user plays both migrator and writer.
   GRANT ferroehr_migrator TO "${APP_USER}";
   GRANT ferroehr_app TO "${APP_USER}";
+  -- ONE login credential, deliberately. This stack demonstrates the SCHEMA
+  -- separation — which is unconditional, and which the server's boot
+  -- self-check verifies — not the CREDENTIAL separation. A deployment reaches
+  -- that by giving the demographic pool its own DSN (the db.demographic_url
+  -- config key, or the chart value database.demographicExistingSecret) under a
+  -- login role that is a member of ferroehr_demographic and nothing else. A
+  -- demo stack that looked split while running one credential would be worse
+  -- than one that says which half it shows.
+  GRANT ferroehr_ehr TO "${APP_USER}";
+  GRANT ferroehr_demographic TO "${APP_USER}";
 END
 \$do\$;
 SQL

--- a/scripts/deploy-probe.sh
+++ b/scripts/deploy-probe.sh
@@ -91,6 +91,19 @@ export FERROEHR__MULTIMEDIA__ENDPOINT=http://seaweedfs:8333
 export FERROEHR__MULTIMEDIA__BUCKET=openehr-multimedia
 export FERROEHR__MULTIMEDIA__ALLOW_HTTP=true
 
+# The database image is built from THIS tree unless the caller names one, for
+# the same reason the server image is: the compose default is the last
+# published tag, and probing it measures the previous release rather than the
+# change in hand. It matters here specifically because the image carries the
+# `initdb` script that provisions the domain roles, and `initdb` runs once, on
+# an empty data directory — so a pulled image can never show a role the tree
+# added.
+if [[ -z "${FERROEHR_POSTGRES_IMAGE:-}" ]]; then
+  bold "building the database image from docker/postgres"
+  docker build -q -t ferroehr-postgres:probe docker/postgres >/dev/null
+  export FERROEHR_POSTGRES_IMAGE=ferroehr-postgres:probe
+fi
+
 compose_down
 bold "bringing the stack up (postgres + CDR + seaweedfs + init)"
 compose_up ferroehr seaweedfs seaweedfs-init

--- a/scripts/deploy-probe.sh
+++ b/scripts/deploy-probe.sh
@@ -115,6 +115,7 @@ run_family multimedia_broken && probes_multimedia_broken
 run_family health_broken && probes_health_broken
 run_family oidc && probes_oidc
 run_family oidc_roles && probes_oidc_roles
+run_family domain_roles && probes_domain_roles
 run_family observability && probes_observability
 run_family tenancy && probes_tenancy
 run_family events && probes_events

--- a/scripts/deploy-probes/compose.sh
+++ b/scripts/deploy-probes/compose.sh
@@ -418,3 +418,84 @@ YAML
   dc -f docker-compose.yml up -d ferroehr >/dev/null 2>&1
   wait_http "$CDR/health/readiness" 120 || true
 }
+
+probes_domain_roles() {
+  bold "pseudonymisation domain roles"
+
+  # #3179: the book documents four NOINHERIT runtime roles and a boot-time
+  # self-check over their grants. Nothing observed that a stack the project
+  # ships actually reaches that posture — the migrations create the roles only
+  # when the migrator holds CREATEROLE, and skip them with a NOTICE otherwise,
+  # which is silent. Far end: the DATABASE's own catalogue, not the compose
+  # file that was supposed to arrange it.
+  probe "P-ROLE-EXIST" "working" "compose" "#3179" \
+    "the four domain roles exist in the database the stack booted against"
+  local roles
+  roles="$(dc exec -T ferroehr-postgres psql -qtAX -U ferroehr -d ferroehr -c \
+    "SELECT rolname FROM pg_roles WHERE rolname LIKE 'ferroehr_%' ORDER BY rolname" 2>/dev/null)"
+  for role in ferroehr_demographic ferroehr_demographic_reader ferroehr_ehr ferroehr_ehr_reader; do
+    assert_contains "$roles" "$role" "the compose init provisions $role"
+  done
+  probe_done
+
+  # A role that could inherit the other domain's grants would make the boundary
+  # a naming convention (PostgreSQL 18, CREATE ROLE).
+  probe "P-ROLE-NOINHERIT" "working" "compose" "#3179" \
+    "each domain role is NOINHERIT"
+  local inheriting
+  inheriting="$(dc exec -T ferroehr-postgres psql -qtAX -U ferroehr -d ferroehr -c \
+    "SELECT rolname FROM pg_roles WHERE rolname IN
+       ('ferroehr_ehr','ferroehr_demographic','ferroehr_ehr_reader','ferroehr_demographic_reader')
+       AND rolinherit" 2>/dev/null)"
+  if [ -n "$inheriting" ]; then
+    probe_fail "every domain role NOINHERIT" "$inheriting" \
+      "an inheriting domain role can pick up the other domain's grants through membership"
+  fi
+  probe_done
+
+  # The property the server refuses to boot without. Asking the database
+  # directly is the far end: the boot check passing proves the server's opinion,
+  # this proves the catalogue's.
+  probe "P-ROLE-BOUNDARY" "working" "database" "#3179" \
+    "neither clinical role can read a demographic relation"
+  local breach
+  breach="$(dc exec -T ferroehr-postgres psql -qtAX -U ferroehr -d ferroehr -c \
+    "SELECT r.rolname || ' -> ' || n.nspname || '.' || c.relname
+       FROM pg_class c
+       JOIN pg_namespace n ON n.oid = c.relnamespace
+       CROSS JOIN (VALUES ('ferroehr_ehr'),('ferroehr_ehr_reader')) AS r(rolname)
+      WHERE n.nspname IN ('demographic','cold_demographic')
+        AND c.relkind IN ('r','p','v','m','f')
+        AND has_table_privilege(r.rolname, c.oid, 'SELECT')
+      LIMIT 5" 2>/dev/null)"
+  if [ -n "$breach" ]; then
+    probe_fail "no clinical role reaching the demographic domain" "$breach" \
+      "the boundary is the whole point of the split; a readable relation defeats it"
+  fi
+  probe_done
+
+  # And the honest half: this stack runs ONE login credential, so the schema
+  # separation is demonstrated and the credential separation is not. Recorded
+  # as a measurement rather than left to the reader to assume either way.
+  probe "P-ROLE-ONE-CREDENTIAL" "working" "compose" "#3179" \
+    "the compose stack is single-credential by design, and says so"
+  local demographic_dsn
+  demographic_dsn="$(curl -s -u "$BASIC" "$CDR/management/env" | grep -o '"demographic_url":"[^"]*"' || true)"
+  case "$demographic_dsn" in
+    ''|*'"demographic_url":""'*|*'"demographic_url":null'*) : ;;
+    *) probe_fail "no separate demographic DSN in the demo stack" "$demographic_dsn" \
+         "if the stack grew one, this probe's premise is stale and the note in the init script is wrong" ;;
+  esac
+  probe_done
+
+  uncovered "the CREDENTIAL separation" \
+    "this stack runs one login role that is a member of both domains, so what is
+     measured above is the SCHEMA separation and the grant boundary. Whether a
+     deployment with two DSNs keeps working — the posture the book recommends and
+     the chart's database.demographicExistingSecret configures — is not exercised
+     by any probe here."
+  uncovered "role provisioning on a managed database" \
+    "the compose init creates the four roles as the bootstrap superuser. A managed
+     PostgreSQL where the migrator holds no CREATEROLE takes the documented manual
+     step instead, and nothing here runs that path."
+}

--- a/website/book/src/installation/kubernetes.md
+++ b/website/book/src/installation/kubernetes.md
@@ -283,6 +283,22 @@ config:
     migrate: verify
 ```
 
+The demographic domain takes a third credential the same way, and it is the
+one that turns the schema separation into a credential separation:
+
+```yaml
+database:
+  existingSecret: ferroehr-db                        # postgres://ferroehr_ehr:…
+  demographicExistingSecret: ferroehr-db-demographic # postgres://ferroehr_demographic:…
+```
+
+Both are mounted as files, so neither DSN enters the pod's environment. Unset
+the second and both pools share the first, which is the schema-only posture —
+still separated, still verified at boot. Creating the four domain roles is a
+database step the chart cannot do for you;
+[Operations](../operations.md#turning-the-schema-split-into-a-role-split) has
+the statements and what `ferroehr db verify` reports.
+
 Give the migrator DSN a short `lock_timeout`
 (`?options=-c%20lock_timeout%3D5s`) so DDL blocked behind live traffic fails
 fast instead of queueing; `migrations.job.activeDeadlineSeconds` is the hard

--- a/website/book/src/installation/kubernetes.md
+++ b/website/book/src/installation/kubernetes.md
@@ -38,7 +38,7 @@ kubectl -n ferroehr create secret generic ferroehr-db \
   --from-literal=FERROEHR__DB__URL='postgres://ferroehr_app:***@pg-host:5432/ferroehr?sslmode=verify-full'
 
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 7.0.9 -n ferroehr \
+  --version 7.1.0 -n ferroehr \
   --set database.existingSecret=ferroehr-db \
   --set image.tag=4.1.1
 ```
@@ -55,7 +55,7 @@ helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
 reference. To read the chart's metadata without installing it:
 
 ```shell
-helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 7.0.9
+helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 7.1.0
 ```
 
 ### Pin two versions, not one
@@ -68,7 +68,7 @@ against.
 
 | | Selects | Pin with | Line |
 |---|---|---|---|
-| Chart version | templates, values schema, defaults | `--version 7.0.9` | SemVer over the chart's own contract |
+| Chart version | templates, values schema, defaults | `--version 7.1.0` | SemVer over the chart's own contract |
 | Image tag | the server binary | `--set image.tag=4.1.1` (or `image.digest`) | the application's SemVer line |
 
 Always pin the image to an immutable version or, better, a `@sha256` digest,
@@ -167,7 +167,7 @@ metadata lists: the server, and the optional viewer.
 > the image itself as the authority:
 >
 > ```shell
-> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 7.0.9 \
+> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 7.1.0 \
 >   -s templates/configmap.yaml --set database.existingSecret=ferroehr-db \
 >   | sed -n '/ferroehr.toml/,$p' | sed '1d;s/^    //' > /tmp/ferroehr.toml
 > docker run --rm -v /tmp/ferroehr.toml:/etc/ferroehr/ferroehr.toml:ro \
@@ -572,7 +572,7 @@ config:
 
 ```shell
 helm upgrade ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 7.0.9 -n ferroehr --reuse-values \
+  --version 7.1.0 -n ferroehr --reuse-values \
   --set config.query.plan_cache_capacity=512
 ```
 
@@ -725,7 +725,7 @@ Preview an upgrade against what you have installed with
 `helm diff`, or render the new chart version and read it:
 
 ```shell
-helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 7.0.9 \
+helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 7.1.0 \
   -n ferroehr -f my-values.yaml | less
 ```
 

--- a/website/book/src/operations.md
+++ b/website/book/src/operations.md
@@ -81,6 +81,38 @@ four roles do not exist at all — the development, compose and test-harness
 case, where the migrator holds no `CREATEROLE` — the check passes rather than
 inventing a failure.
 
+On Kubernetes the same choice is two chart values, mounted as files the same
+way the clinical DSN is, so neither credential enters the pod's environment:
+
+```yaml
+database:
+  existingSecret: ferroehr-db          # postgres://ferroehr_ehr:…
+  demographicExistingSecret: ferroehr-db-demographic   # postgres://ferroehr_demographic:…
+```
+
+Leave `demographicExistingSecret` unset and both pools share the clinical DSN,
+which is the schema-only posture.
+
+Provisioning the four roles is yours in both cases. The migrations create them
+only when the migrator holds `CREATEROLE` and skip them with a `NOTICE`
+otherwise, so on a managed database — where the migrator usually does not —
+create them before the first deploy:
+
+```sql
+CREATE ROLE ferroehr_ehr NOLOGIN NOINHERIT;
+CREATE ROLE ferroehr_demographic NOLOGIN NOINHERIT;
+CREATE ROLE ferroehr_ehr_reader NOLOGIN NOINHERIT;
+CREATE ROLE ferroehr_demographic_reader NOLOGIN NOINHERIT;
+```
+
+then give each login role membership of exactly one of them. `ferroehr db
+verify` tells you whether the boundary holds afterwards.
+
+The compose stacks create all four and grant both domains to the single dev
+login role. That demonstrates the schema separation and exercises the boot
+self-check; it is deliberately **not** the credential separation, because one
+container with one DSN cannot show that half honestly.
+
 > [!NOTE]
 > `ferroehr_app` and `ferroehr_reader` are the previous single-domain pair. They
 > still exist and still hold their clinical grants, but a deployment should move


### PR DESCRIPTION
The pseudonymisation boundary shipped with four `NOINHERIT` runtime roles and
an optional second DSN, and the deployment artifacts could not reach that
posture. A reader who followed the book to the role split could not get there
from the chart.

## The chart

`database.demographicExistingSecret`, with the `demographicExistingSecretKey`
and inline `demographicUrl` siblings the clinical DSN already has, mounted as a
file the same way. That matters for the same reason it mattered the first time:
an env value is readable through `/proc/<pid>/environ` and inherited by every
child process, and this is the second credential that reaches patient data.

Set it and the schema separation becomes a credential separation — one leaked
connection string then reaches one domain rather than both. Leave it unset and
both pools share the clinical DSN, which is the schema-only posture the boot
self-check still verifies.

## The compose stacks were worse than undocumented

They created the three legacy roles (`ferroehr_migrator`, `ferroehr_app`,
`ferroehr_reader`) but not the four domain ones. The demographic baseline grants
only to roles that already exist and the compose migrator holds no `CREATEROLE`,
so every compose stack ran with **no domain grants at all**, announced by a
`NOTICE` nobody reads.

They now create all four, `NOINHERIT`, and grant both domains to the single dev
login role. That is the honest posture for one container with one DSN: the
schema separation is real and exercised, the credential separation is not, and
the init script says which half it shows rather than leaving the stack looking
split.

## The probe reads the database, not the compose file

A new family in `scripts/deploy-probe.sh` observes at the far end, per the
harness's own first rule:

- `P-ROLE-EXIST` — the four roles exist in the database the stack actually
  booted against.
- `P-ROLE-NOINHERIT` — each is `NOINHERIT`. An inheriting domain role can pick
  up the other domain's grants through membership, which would make the
  boundary a naming convention.
- `P-ROLE-BOUNDARY` — no clinical role holds `SELECT` on any relation in
  `demographic` or `cold_demographic`, asked of `has_table_privilege` directly.
  The server's boot check passing proves the server's opinion; this proves the
  catalogue's.
- `P-ROLE-ONE-CREDENTIAL` — the stack is single-credential, asserted so the
  claim in the init script cannot quietly go stale.

And two declared gaps, because silence read as coverage is what the harness
exists to prevent: the credential separation itself is not exercised by any
probe here, and neither is role provisioning on a managed database where the
migrator holds no `CREATEROLE`.

## One find while writing it

The SQL comment I first wrote into the init script carried backticks, and that
heredoc is unquoted — they would have run as command substitution at container
init. Reworded; `shellcheck` caught it, which is the lane doing its job.

Closes #3179.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.

## Checks

- [x] `cargo fmt --all --check` · `cargo clippy --workspace --all-targets` · `cargo nextest run --workspace` — no Rust changed; the chart, compose and probe gates are the relevant ones
- [x] `deploy/helm/validate.sh` green, chart README regenerated with helm-docs
- [x] `shellcheck-lane`, `compose-hardening`, `docs-claims`, `no-python` green
- [x] No test weakened, skipped, or edited to route around a bug
- [x] User-visible change → `CHANGELOG.md [Unreleased]` entry
- [x] REST/config/CLI/deployment change → matching `website/book/src` pages updated (operations + kubernetes)
- [x] New issues opened from this work are linked as GitHub relationships — none were opened

## Privacy boundary

**Data flow.** No code path reads or writes personal data here. The change is
deployment plumbing: a second DSN the operator supplies, four database roles,
and a probe family that reads `pg_roles` and `has_table_privilege`. The probe
prints role names and relation names, never row content.

**Roles.** This is the change that lets a deployment give the demographic
domain its own credential, and it provisions the four domain roles in the
compose stacks. Every grant added stays inside one domain: the compose init
grants `ferroehr_ehr` and `ferroehr_demographic` to the one dev login role,
which is membership of both rather than a grant spanning them, and is the
posture the file documents at the point it does it. Nothing widens an existing
role across the boundary.

- [x] The data flow is described above
- [x] The roles are named
- [x] No new grant spans the clinical and demographic domains
- [x] Synthetic data only in tests, fixtures, seeds and examples
- [x] An access event is emitted wherever this change added a read of personal data — this change adds no read of personal data
