### PR TITLE
fix(corpus): the ADL 2 provenance says what the files say

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,24 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **The ADL 2 corpus provenance claimed a licence the files do not state**
+  (#3150). `corpus/archetypes/adl2/PROVENANCE.md` said the archetypes were
+  "predominantly CC-BY-SA 3.0 where stated" and pointed at the root CC-BY-SA
+  3.0 reference copy. Measured over the vendored tree: of 652 archetypes
+  exactly one states a licence, and it states CC-BY 4.0. The other 651 carry
+  an openEHR Foundation copyright and no grant, and upstream carries no
+  `LICENSE` file at the pinned commit either. The record now says that, the
+  subtree is declared `LicenseRef-openEHR-unstated` in `REUSE.toml` with its
+  own text in `LICENSES/`, and the licensing chapter carries the same
+  statement. The vendor script that generates the provenance file was
+  repeating the claim and is corrected too, so re-running it cannot restore
+  the old wording. The `openehr-adl` regression library from the same
+  upstream measured differently and is declared separately: 111 of 302 state
+  a licence, predominantly CC-BY-SA 3.0, with CC-BY 4.0 and CC-BY 3.0 present
+  and CC-BY-SA 4.0 absent — which the previous glob had asserted over it.
+  Whether material whose terms are unstated may stay committed is a decision,
+  tracked separately.
+
 - **The storage-integrity sweep and its repair cover both pseudonymisation
   domains** (#3178). Moving the parties into their own schema left the sweep
   reading only the clinical one, so damage to the copy no read-path check

--- a/LICENSES/CC-BY-3.0.txt
+++ b/LICENSES/CC-BY-3.0.txt
@@ -1,0 +1,319 @@
+Creative Commons Legal Code
+
+Attribution 3.0 Unported
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS LICENSE DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE INFORMATION PROVIDED, AND DISCLAIMS LIABILITY FOR
+    DAMAGES RESULTING FROM ITS USE.
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS CREATIVE
+COMMONS PUBLIC LICENSE ("CCPL" OR "LICENSE"). THE WORK IS PROTECTED BY
+COPYRIGHT AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS
+AUTHORIZED UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HERE, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. TO THE EXTENT THIS LICENSE MAY
+BE CONSIDERED TO BE A CONTRACT, THE LICENSOR GRANTS YOU THE RIGHTS
+CONTAINED HERE IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS.
+
+1. Definitions
+
+ a. "Adaptation" means a work based upon the Work, or upon the Work and
+    other pre-existing works, such as a translation, adaptation,
+    derivative work, arrangement of music or other alterations of a
+    literary or artistic work, or phonogram or performance and includes
+    cinematographic adaptations or any other form in which the Work may be
+    recast, transformed, or adapted including in any form recognizably
+    derived from the original, except that a work that constitutes a
+    Collection will not be considered an Adaptation for the purpose of
+    this License. For the avoidance of doubt, where the Work is a musical
+    work, performance or phonogram, the synchronization of the Work in
+    timed-relation with a moving image ("synching") will be considered an
+    Adaptation for the purpose of this License.
+ b. "Collection" means a collection of literary or artistic works, such as
+    encyclopedias and anthologies, or performances, phonograms or
+    broadcasts, or other works or subject matter other than works listed
+    in Section 1(f) below, which, by reason of the selection and
+    arrangement of their contents, constitute intellectual creations, in
+    which the Work is included in its entirety in unmodified form along
+    with one or more other contributions, each constituting separate and
+    independent works in themselves, which together are assembled into a
+    collective whole. A work that constitutes a Collection will not be
+    considered an Adaptation (as defined above) for the purposes of this
+    License.
+ c. "Distribute" means to make available to the public the original and
+    copies of the Work or Adaptation, as appropriate, through sale or
+    other transfer of ownership.
+ d. "Licensor" means the individual, individuals, entity or entities that
+    offer(s) the Work under the terms of this License.
+ e. "Original Author" means, in the case of a literary or artistic work,
+    the individual, individuals, entity or entities who created the Work
+    or if no individual or entity can be identified, the publisher; and in
+    addition (i) in the case of a performance the actors, singers,
+    musicians, dancers, and other persons who act, sing, deliver, declaim,
+    play in, interpret or otherwise perform literary or artistic works or
+    expressions of folklore; (ii) in the case of a phonogram the producer
+    being the person or legal entity who first fixes the sounds of a
+    performance or other sounds; and, (iii) in the case of broadcasts, the
+    organization that transmits the broadcast.
+ f. "Work" means the literary and/or artistic work offered under the terms
+    of this License including without limitation any production in the
+    literary, scientific and artistic domain, whatever may be the mode or
+    form of its expression including digital form, such as a book,
+    pamphlet and other writing; a lecture, address, sermon or other work
+    of the same nature; a dramatic or dramatico-musical work; a
+    choreographic work or entertainment in dumb show; a musical
+    composition with or without words; a cinematographic work to which are
+    assimilated works expressed by a process analogous to cinematography;
+    a work of drawing, painting, architecture, sculpture, engraving or
+    lithography; a photographic work to which are assimilated works
+    expressed by a process analogous to photography; a work of applied
+    art; an illustration, map, plan, sketch or three-dimensional work
+    relative to geography, topography, architecture or science; a
+    performance; a broadcast; a phonogram; a compilation of data to the
+    extent it is protected as a copyrightable work; or a work performed by
+    a variety or circus performer to the extent it is not otherwise
+    considered a literary or artistic work.
+ g. "You" means an individual or entity exercising rights under this
+    License who has not previously violated the terms of this License with
+    respect to the Work, or who has received express permission from the
+    Licensor to exercise rights under this License despite a previous
+    violation.
+ h. "Publicly Perform" means to perform public recitations of the Work and
+    to communicate to the public those public recitations, by any means or
+    process, including by wire or wireless means or public digital
+    performances; to make available to the public Works in such a way that
+    members of the public may access these Works from a place and at a
+    place individually chosen by them; to perform the Work to the public
+    by any means or process and the communication to the public of the
+    performances of the Work, including by public digital performance; to
+    broadcast and rebroadcast the Work by any means including signs,
+    sounds or images.
+ i. "Reproduce" means to make copies of the Work by any means including
+    without limitation by sound or visual recordings and the right of
+    fixation and reproducing fixations of the Work, including storage of a
+    protected performance or phonogram in digital form or other electronic
+    medium.
+
+2. Fair Dealing Rights. Nothing in this License is intended to reduce,
+limit, or restrict any uses free from copyright or rights arising from
+limitations or exceptions that are provided for in connection with the
+copyright protection under copyright law or other applicable laws.
+
+3. License Grant. Subject to the terms and conditions of this License,
+Licensor hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license to
+exercise the rights in the Work as stated below:
+
+ a. to Reproduce the Work, to incorporate the Work into one or more
+    Collections, and to Reproduce the Work as incorporated in the
+    Collections;
+ b. to create and Reproduce Adaptations provided that any such Adaptation,
+    including any translation in any medium, takes reasonable steps to
+    clearly label, demarcate or otherwise identify that changes were made
+    to the original Work. For example, a translation could be marked "The
+    original work was translated from English to Spanish," or a
+    modification could indicate "The original work has been modified.";
+ c. to Distribute and Publicly Perform the Work including as incorporated
+    in Collections; and,
+ d. to Distribute and Publicly Perform Adaptations.
+ e. For the avoidance of doubt:
+
+     i. Non-waivable Compulsory License Schemes. In those jurisdictions in
+        which the right to collect royalties through any statutory or
+        compulsory licensing scheme cannot be waived, the Licensor
+        reserves the exclusive right to collect such royalties for any
+        exercise by You of the rights granted under this License;
+    ii. Waivable Compulsory License Schemes. In those jurisdictions in
+        which the right to collect royalties through any statutory or
+        compulsory licensing scheme can be waived, the Licensor waives the
+        exclusive right to collect such royalties for any exercise by You
+        of the rights granted under this License; and,
+   iii. Voluntary License Schemes. The Licensor waives the right to
+        collect royalties, whether individually or, in the event that the
+        Licensor is a member of a collecting society that administers
+        voluntary licensing schemes, via that society, from any exercise
+        by You of the rights granted under this License.
+
+The above rights may be exercised in all media and formats whether now
+known or hereafter devised. The above rights include the right to make
+such modifications as are technically necessary to exercise the rights in
+other media and formats. Subject to Section 8(f), all rights not expressly
+granted by Licensor are hereby reserved.
+
+4. Restrictions. The license granted in Section 3 above is expressly made
+subject to and limited by the following restrictions:
+
+ a. You may Distribute or Publicly Perform the Work only under the terms
+    of this License. You must include a copy of, or the Uniform Resource
+    Identifier (URI) for, this License with every copy of the Work You
+    Distribute or Publicly Perform. You may not offer or impose any terms
+    on the Work that restrict the terms of this License or the ability of
+    the recipient of the Work to exercise the rights granted to that
+    recipient under the terms of the License. You may not sublicense the
+    Work. You must keep intact all notices that refer to this License and
+    to the disclaimer of warranties with every copy of the Work You
+    Distribute or Publicly Perform. When You Distribute or Publicly
+    Perform the Work, You may not impose any effective technological
+    measures on the Work that restrict the ability of a recipient of the
+    Work from You to exercise the rights granted to that recipient under
+    the terms of the License. This Section 4(a) applies to the Work as
+    incorporated in a Collection, but this does not require the Collection
+    apart from the Work itself to be made subject to the terms of this
+    License. If You create a Collection, upon notice from any Licensor You
+    must, to the extent practicable, remove from the Collection any credit
+    as required by Section 4(b), as requested. If You create an
+    Adaptation, upon notice from any Licensor You must, to the extent
+    practicable, remove from the Adaptation any credit as required by
+    Section 4(b), as requested.
+ b. If You Distribute, or Publicly Perform the Work or any Adaptations or
+    Collections, You must, unless a request has been made pursuant to
+    Section 4(a), keep intact all copyright notices for the Work and
+    provide, reasonable to the medium or means You are utilizing: (i) the
+    name of the Original Author (or pseudonym, if applicable) if supplied,
+    and/or if the Original Author and/or Licensor designate another party
+    or parties (e.g., a sponsor institute, publishing entity, journal) for
+    attribution ("Attribution Parties") in Licensor's copyright notice,
+    terms of service or by other reasonable means, the name of such party
+    or parties; (ii) the title of the Work if supplied; (iii) to the
+    extent reasonably practicable, the URI, if any, that Licensor
+    specifies to be associated with the Work, unless such URI does not
+    refer to the copyright notice or licensing information for the Work;
+    and (iv) , consistent with Section 3(b), in the case of an Adaptation,
+    a credit identifying the use of the Work in the Adaptation (e.g.,
+    "French translation of the Work by Original Author," or "Screenplay
+    based on original Work by Original Author"). The credit required by
+    this Section 4 (b) may be implemented in any reasonable manner;
+    provided, however, that in the case of a Adaptation or Collection, at
+    a minimum such credit will appear, if a credit for all contributing
+    authors of the Adaptation or Collection appears, then as part of these
+    credits and in a manner at least as prominent as the credits for the
+    other contributing authors. For the avoidance of doubt, You may only
+    use the credit required by this Section for the purpose of attribution
+    in the manner set out above and, by exercising Your rights under this
+    License, You may not implicitly or explicitly assert or imply any
+    connection with, sponsorship or endorsement by the Original Author,
+    Licensor and/or Attribution Parties, as appropriate, of You or Your
+    use of the Work, without the separate, express prior written
+    permission of the Original Author, Licensor and/or Attribution
+    Parties.
+ c. Except as otherwise agreed in writing by the Licensor or as may be
+    otherwise permitted by applicable law, if You Reproduce, Distribute or
+    Publicly Perform the Work either by itself or as part of any
+    Adaptations or Collections, You must not distort, mutilate, modify or
+    take other derogatory action in relation to the Work which would be
+    prejudicial to the Original Author's honor or reputation. Licensor
+    agrees that in those jurisdictions (e.g. Japan), in which any exercise
+    of the right granted in Section 3(b) of this License (the right to
+    make Adaptations) would be deemed to be a distortion, mutilation,
+    modification or other derogatory action prejudicial to the Original
+    Author's honor and reputation, the Licensor will waive or not assert,
+    as appropriate, this Section, to the fullest extent permitted by the
+    applicable national law, to enable You to reasonably exercise Your
+    right under Section 3(b) of this License (right to make Adaptations)
+    but not otherwise.
+
+5. Representations, Warranties and Disclaimer
+
+UNLESS OTHERWISE MUTUALLY AGREED TO BY THE PARTIES IN WRITING, LICENSOR
+OFFERS THE WORK AS-IS AND MAKES NO REPRESENTATIONS OR WARRANTIES OF ANY
+KIND CONCERNING THE WORK, EXPRESS, IMPLIED, STATUTORY OR OTHERWISE,
+INCLUDING, WITHOUT LIMITATION, WARRANTIES OF TITLE, MERCHANTIBILITY,
+FITNESS FOR A PARTICULAR PURPOSE, NONINFRINGEMENT, OR THE ABSENCE OF
+LATENT OR OTHER DEFECTS, ACCURACY, OR THE PRESENCE OF ABSENCE OF ERRORS,
+WHETHER OR NOT DISCOVERABLE. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION
+OF IMPLIED WARRANTIES, SO SUCH EXCLUSION MAY NOT APPLY TO YOU.
+
+6. Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE
+LAW, IN NO EVENT WILL LICENSOR BE LIABLE TO YOU ON ANY LEGAL THEORY FOR
+ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY DAMAGES
+ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK, EVEN IF LICENSOR HAS
+BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+7. Termination
+
+ a. This License and the rights granted hereunder will terminate
+    automatically upon any breach by You of the terms of this License.
+    Individuals or entities who have received Adaptations or Collections
+    from You under this License, however, will not have their licenses
+    terminated provided such individuals or entities remain in full
+    compliance with those licenses. Sections 1, 2, 5, 6, 7, and 8 will
+    survive any termination of this License.
+ b. Subject to the above terms and conditions, the license granted here is
+    perpetual (for the duration of the applicable copyright in the Work).
+    Notwithstanding the above, Licensor reserves the right to release the
+    Work under different license terms or to stop distributing the Work at
+    any time; provided, however that any such election will not serve to
+    withdraw this License (or any other license that has been, or is
+    required to be, granted under the terms of this License), and this
+    License will continue in full force and effect unless terminated as
+    stated above.
+
+8. Miscellaneous
+
+ a. Each time You Distribute or Publicly Perform the Work or a Collection,
+    the Licensor offers to the recipient a license to the Work on the same
+    terms and conditions as the license granted to You under this License.
+ b. Each time You Distribute or Publicly Perform an Adaptation, Licensor
+    offers to the recipient a license to the original Work on the same
+    terms and conditions as the license granted to You under this License.
+ c. If any provision of this License is invalid or unenforceable under
+    applicable law, it shall not affect the validity or enforceability of
+    the remainder of the terms of this License, and without further action
+    by the parties to this agreement, such provision shall be reformed to
+    the minimum extent necessary to make such provision valid and
+    enforceable.
+ d. No term or provision of this License shall be deemed waived and no
+    breach consented to unless such waiver or consent shall be in writing
+    and signed by the party to be charged with such waiver or consent.
+ e. This License constitutes the entire agreement between the parties with
+    respect to the Work licensed here. There are no understandings,
+    agreements or representations with respect to the Work not specified
+    here. Licensor shall not be bound by any additional provisions that
+    may appear in any communication from You. This License may not be
+    modified without the mutual written agreement of the Licensor and You.
+ f. The rights granted under, and the subject matter referenced, in this
+    License were drafted utilizing the terminology of the Berne Convention
+    for the Protection of Literary and Artistic Works (as amended on
+    September 28, 1979), the Rome Convention of 1961, the WIPO Copyright
+    Treaty of 1996, the WIPO Performances and Phonograms Treaty of 1996
+    and the Universal Copyright Convention (as revised on July 24, 1971).
+    These rights and subject matter take effect in the relevant
+    jurisdiction in which the License terms are sought to be enforced
+    according to the corresponding provisions of the implementation of
+    those treaty provisions in the applicable national law. If the
+    standard suite of rights granted under applicable copyright law
+    includes additional rights not granted under this License, such
+    additional rights are deemed to be included in the License; this
+    License is not intended to restrict the license of any rights under
+    applicable law.
+
+
+Creative Commons Notice
+
+    Creative Commons is not a party to this License, and makes no warranty
+    whatsoever in connection with the Work. Creative Commons will not be
+    liable to You or any party on any legal theory for any damages
+    whatsoever, including without limitation any general, special,
+    incidental or consequential damages arising in connection to this
+    license. Notwithstanding the foregoing two (2) sentences, if Creative
+    Commons has expressly identified itself as the Licensor hereunder, it
+    shall have all rights and obligations of Licensor.
+
+    Except for the limited purpose of indicating to the public that the
+    Work is licensed under the CCPL, Creative Commons does not authorize
+    the use by either party of the trademark "Creative Commons" or any
+    related trademark or logo of Creative Commons without the prior
+    written consent of Creative Commons. Any permitted use will be in
+    compliance with Creative Commons' then-current trademark usage
+    guidelines, as may be published on its website or otherwise made
+    available upon request from time to time. For the avoidance of doubt,
+    this trademark restriction does not form part of this License.
+
+    Creative Commons may be contacted at https://creativecommons.org/.

--- a/LICENSES/LicenseRef-openEHR-unstated.txt
+++ b/LICENSES/LicenseRef-openEHR-unstated.txt
@@ -1,0 +1,41 @@
+openEHR Foundation material with no stated licence
+==================================================
+
+This identifier covers vendored third-party material that carries an openEHR
+Foundation copyright notice and NO licence statement of any kind. It is not a
+licence. It is a machine-readable way of saying that the terms are unknown, so
+that a glob elsewhere in REUSE.toml cannot quietly assert a grant the files
+never made.
+
+What the files say
+------------------
+
+The material this covers is `corpus/archetypes/adl2/`, vendored from
+`https://github.com/openEHR/adl-archetypes` (`Reference/CKM_2013_12_09/`) at
+commit `093c77ea003742b9540e3dd377d615e2b26f2996`.
+
+Measured over that tree on 2026-09-10, searching every `*.adls` and `*.adl`
+for `licence` and `license` in any case and any position:
+
+  * 652 archetypes in total (322 ADL 2, 330 ADL 1.4 twins);
+  * ONE states a licence, and it states `Creative Commons CC-BY 4.0 unported`;
+  * the other 651 carry `copyright = <"© openEHR Foundation">` in their
+    description block and no licence key at all.
+
+Upstream states nothing either. At the pinned commit the repository has no
+`LICENSE`, `LICENSE.md`, `LICENSE.txt` or `COPYING`, and its `README.md` is
+four lines describing the contents with no licensing statement.
+
+What that means for a redistributor
+-----------------------------------
+
+An unstated licence is not a permissive one. Copyright is asserted by the
+files; no grant accompanies it. Anyone redistributing this tree, or lifting a
+file out of it, is doing so without a stated permission from the copyright
+holder and should reach their own conclusion about that rather than relying on
+this repository having vendored it.
+
+The subtree's own `PROVENANCE.md` carries the same measurement, the pin, and
+the reason the material is here (an independent ADL 1.4 / ADL 2 reference pair
+for the conversion path, which cannot be produced by running this project's
+own converter without validating it against its own output).

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -182,11 +182,11 @@ SPDX-FileCopyrightText = "the respective model authors"
 SPDX-License-Identifier = "MPL-1.1"
 
 # ── Clinical models (archetypes, templates) ─────────────────────────────────
-# The ADL2 archetype library and the CKM-derived clinical models. These carry
-# their licence INSIDE themselves — every archetype's own `description` block
-# has a `licence` field — so for this material licensing already survives
-# copying, and these declarations exist to make the same fact machine-readable
-# at the tree level.
+# The CKM-derived clinical models. Most of this material carries its licence
+# INSIDE itself — the archetype's own `description` block has a `licence`
+# field — so for those files licensing already survives copying, and these
+# declarations exist to make the same fact machine-readable at the tree level.
+# The ADL2 library is the exception and is declared separately below.
 #
 # The corpora are MIXED at file level and the SPDX expression says so rather
 # than picking a winner: a first-hand count over the CKM corpus finds both
@@ -202,6 +202,41 @@ path = [
 precedence = "override"
 SPDX-FileCopyrightText = ["openEHR Foundation", "the respective archetype authors"]
 SPDX-License-Identifier = "CC-BY-SA-3.0 AND CC-BY-SA-4.0"
+
+# The ADL2 archetype library states NO licence, and this declaration says so
+# rather than inheriting the CC-BY-SA expression above (#3150). Measured over
+# the vendored tree: of 652 archetypes, ONE carries a `licence` field and it
+# reads CC-BY 4.0 unported; the other 651 carry `copyright = <"© openEHR
+# Foundation">` and nothing else. Upstream states nothing either — no LICENSE
+# file at the pinned commit, and a four-line README.
+#
+# `LicenseRef-openEHR-unstated` is the REUSE-sanctioned way to say this — a
+# LicenseRef with its own text in LICENSES/, which spells out what was
+# measured. It is NOT a licence. Declaring CC-BY-SA over a tree whose files
+# never mention it would manufacture a grant out of a glob; the copyright
+# holder is named because that IS what the files say. The subtree's own
+# PROVENANCE.md carries the same measurement and its date.
+[[annotations]]
+path = "corpus/archetypes/adl2/**"
+precedence = "override"
+SPDX-FileCopyrightText = "openEHR Foundation"
+SPDX-License-Identifier = "LicenseRef-openEHR-unstated"
+
+# The ADL2 regression library inside the openehr-adl corpus is the same
+# upstream repository as the tree above but a different subtree, and it was
+# measured separately (#3150): of 302 archetypes, 111 state a licence and 191
+# state none. Where one IS stated it is predominantly CC-BY-SA 3.0 (100 of the
+# 111 — 93 by URL, 5 in prose, 2 spelled `CC-SA-BY`), with 10 CC-BY 4.0 and 1
+# CC-BY 3.0. No file in it states CC-BY-SA 4.0, which the broad clinical-model
+# glob above would otherwise have asserted over the whole tree.
+#
+# The expression names every obligation a redistributor of this subtree takes
+# on, and `LicenseRef-openEHR-unstated` names the majority that grant nothing.
+[[annotations]]
+path = "crates/openehr-adl/tests/corpus/adl2-reference/**"
+precedence = "override"
+SPDX-FileCopyrightText = ["openEHR Foundation", "the respective archetype authors"]
+SPDX-License-Identifier = "LicenseRef-openEHR-unstated AND CC-BY-SA-3.0 AND CC-BY-4.0 AND CC-BY-3.0"
 
 # The BMM reference-model subtree inside the ADL2 corpus is code-adjacent
 # material under different terms, so the two tables above are re-applied after

--- a/corpus/archetypes/adl2/PROVENANCE.md
+++ b/corpus/archetypes/adl2/PROVENANCE.md
@@ -21,11 +21,39 @@ would then be validated against its own output.
 
 ## Licensing
 
-The upstream repository carries no top-level LICENSE file; individual
-archetypes carry their own `licence` metadata (predominantly CC-BY-SA
-3.0 where stated — see the individual file). openEHR Foundation
-test/reference material, vendored verbatim with metadata retained;
-root reference copy: `LICENSE-CC-BY-SA-3.0`.
+**These files state no licence.** Measured over this vendored tree on
+2026-09-10, searching every `*.adls` and `*.adl` for `licence` and
+`license` in any case and any position:
+
+| dialect | files | state a licence |
+|---|---|---|
+| `*.adls` (ADL 2) | 322 | 1 |
+| `*.adl` (ADL 1.4 twins) | 330 | 0 |
+
+The single exception is
+`ckm-2013-12-09/composition/openEHR-EHR-COMPOSITION.t_encounter_opt_test.v1.0.0.adls`,
+and what it states is `Creative Commons CC-BY 4.0 unported` — not
+CC-BY-SA 3.0. The other 651 carry `copyright = <"© openEHR Foundation">`
+in their description block and no `licence` key at all.
+
+Upstream states nothing either: at the pinned commit the repository has no
+`LICENSE`, `LICENSE.md`, `LICENSE.txt` or `COPYING`, and its `README.md` is
+four lines describing the contents ("ADL test, reference and example
+archetypes") with no licensing statement.
+
+So the position for this tree is: **openEHR Foundation copyright, terms
+unstated.** An unstated licence is not a permissive one, and this record says
+so rather than inferring a grant from the material being published for
+testing. `REUSE.toml` declares the subtree `NOASSERTION` for the same reason.
+
+This record previously claimed the archetypes were "predominantly CC-BY-SA
+3.0 where stated" and pointed at the root `LICENSE-CC-BY-SA-3.0`. That was
+wrong on both counts and is corrected here (#3150). The wording appears to
+have been inherited from the CKM template pack, where a mixed CC-BY-SA
+population genuinely is what the files say.
+
+Whether a tree whose terms are unstated may stay committed is a separate
+decision, tracked on issue 3194; nothing here asserts that it may.
 
 ## Contents
 

--- a/crates/openehr-adl/tests/corpus/PROVENANCE.md
+++ b/crates/openehr-adl/tests/corpus/PROVENANCE.md
@@ -16,11 +16,17 @@
   `FAIL_`/`W…` prefix; this is the validator-conformance oracle keyed by
   rule code.
 - Licensing: the repository carries no top-level LICENSE file (verified
-  2026-08-04); the content is openEHR Foundation test/reference material,
-  and individual archetype descriptions carry their own `licence` field
-  (predominantly CC-BY-SA 3.0 where stated; root reference copy
-  `LICENSE-CC-BY-SA-3.0`). Recorded as-is — test-fixture use with
-  provenance retained.
+  2026-08-04, re-verified 2026-09-10, when the counts below were measured
+  over this tree). **Most of these files state no licence.** Of 302
+  archetypes, 111 carry a `licence` field and 191 carry none; where one is
+  stated it is predominantly CC-BY-SA 3.0 (100 of the 111 — 93 by URL, 5 in
+  prose, 2 spelled `CC-SA-BY`), with 10 CC-BY 4.0 and 1 CC-BY 3.0. The rest
+  carry an openEHR Foundation copyright and no grant, so `REUSE.toml`
+  declares those obligations as a disjunction and the unstated majority as
+  `LicenseRef-openEHR-unstated`. Root reference copies:
+  `LICENSE-CC-BY-SA-3.0`, `LICENSE-CC-BY-4.0`. Recorded as-is —
+  test-fixture use with provenance retained; whether unstated material may
+  stay committed is tracked on issue 3194.
 
 ## `flattener/`
 

--- a/scripts/vendor/adl2-archetypes.sh
+++ b/scripts/vendor/adl2-archetypes.sh
@@ -35,10 +35,11 @@
 #     grounds the ADL 2 wire cases of the DEFINITION API and gives the 1.4->2
 #     conversion an INDEPENDENT reference (upstream's conversion, not ours).
 #
-# Licensing: the repository carries no top-level LICENSE file (verified
-# 2026-08-04); the content is openEHR Foundation test/reference material, and
-# individual archetypes carry their own `licence` field (predominantly
-# CC-BY-SA 3.0 where stated). Recorded as-is, provenance retained.
+# Licensing: NOTHING here states one. The repository carries no top-level
+# LICENSE file (verified 2026-08-04, re-verified 2026-09-10), and of the 652
+# archetypes exactly ONE carries a `licence` field — reading CC-BY 4.0, not
+# CC-BY-SA. The rest carry an openEHR Foundation copyright and no grant.
+# Recorded as-is, provenance retained; see LICENSES/LicenseRef-openEHR-unstated.txt.
 #
 # Usage:
 #   scripts/vendor/adl2-archetypes.sh            # vendor at the pin below
@@ -133,11 +134,21 @@ would then be validated against its own output.
 
 ## Licensing
 
-The upstream repository carries no top-level LICENSE file; individual
-archetypes carry their own `licence` metadata (predominantly CC-BY-SA
-3.0 where stated — see the individual file). openEHR Foundation
-test/reference material, vendored verbatim with metadata retained;
-root reference copy: `LICENSE-CC-BY-SA-3.0`.
+**These files state no licence.** Of the archetypes vendored here, ONE
+carries a `licence` field and it reads `Creative Commons CC-BY 4.0
+unported`; every other one carries `copyright = <"© openEHR Foundation">`
+in its description block and no licence key at all. Upstream states
+nothing either: no `LICENSE`, `LICENSE.md`, `LICENSE.txt` or `COPYING` at
+the pinned commit, and a four-line `README.md`.
+
+So the position is: openEHR Foundation copyright, terms unstated. An
+unstated licence is not a permissive one, and this record says so rather
+than inferring a grant. `REUSE.toml` declares the subtree
+`LicenseRef-openEHR-unstated`, whose text in `LICENSES/` carries the
+measurement.
+
+Whether a tree whose terms are unstated may stay committed is a separate
+decision, tracked on issue 3194; nothing here asserts that it may.
 
 ## Contents
 

--- a/website/book/src/licensing.md
+++ b/website/book/src/licensing.md
@@ -135,7 +135,9 @@ used as test corpora. Each family keeps its upstream license:
 | The normative ADL, cADL, ODIN, BEL and Expression-Language ANTLR grammars | `openEHR/adl-antlr`, `openEHR/openEHR-antlr4` | [Apache-2.0](https://github.com/rubentalstra/FerroEHR/blob/main/LICENSES/Apache-2.0.txt) |
 | openEHR specification text (the conformance reference) | the openEHR `specifications-*` repositories | [CC-BY-SA 3.0](https://github.com/rubentalstra/FerroEHR/blob/main/LICENSES/CC-BY-SA-3.0.txt) |
 | The AQL grammar and the computable terminology assets (the terminology XML the server embeds, and its schemas) | `specifications-QUERY`, `specifications-TERM` | [CC-BY-SA 3.0](https://github.com/rubentalstra/FerroEHR/blob/main/LICENSES/CC-BY-SA-3.0.txt) |
-| Clinical models (archetypes and templates) from the openEHR Clinical Knowledge Manager and the openEHR ADL archetype library | ckm.openehr.org, `openEHR/adl-archetypes` | per-file `licence` metadata — a **mix** of [CC-BY-SA 4.0](https://github.com/rubentalstra/FerroEHR/blob/main/LICENSES/CC-BY-SA-4.0.txt) and [CC-BY-SA 3.0](https://github.com/rubentalstra/FerroEHR/blob/main/LICENSES/CC-BY-SA-3.0.txt) |
+| Clinical models (archetypes and templates) from the openEHR Clinical Knowledge Manager | ckm.openehr.org | per-file `licence` metadata — a **mix** of [CC-BY-SA 4.0](https://github.com/rubentalstra/FerroEHR/blob/main/LICENSES/CC-BY-SA-4.0.txt) and [CC-BY-SA 3.0](https://github.com/rubentalstra/FerroEHR/blob/main/LICENSES/CC-BY-SA-3.0.txt) |
+| The ADL 2 archetype library, with its ADL 1.4 twins (the shared corpus) | `openEHR/adl-archetypes` | **no stated licence** — see below |
+| The ADL 2 validator-regression library (the `openehr-adl` corpus) | `openEHR/adl-archetypes`, a different subtree | mixed: mostly **unstated**, else [CC-BY-SA 3.0](https://github.com/rubentalstra/FerroEHR/blob/main/LICENSES/CC-BY-SA-3.0.txt), [CC-BY 4.0](https://github.com/rubentalstra/FerroEHR/blob/main/LICENSES/CC-BY-4.0.txt) or [CC-BY 3.0](https://github.com/rubentalstra/FerroEHR/blob/main/LICENSES/CC-BY-3.0.txt) |
 | Test corpora (archie fixtures and reference models, Better `web-template-tests`, EHRbase SDK canonical-JSON data) | Nedap, Better Ltd, vitasystems | Apache-2.0 |
 | Three ISO 13606 / rejected-extract BMM reference models inside the archie corpus | offered by their authors under MPL 1.1 / GPL 2.0 / LGPL 2.1 | taken under [MPL 1.1](https://github.com/rubentalstra/FerroEHR/blob/main/LICENSES/MPL-1.1.txt) — see the election below |
 | One terminology schema file, `PropertyUnitData.xsd` | ADL Designer / ADL2-tools, via the openEHR TERM assets | [AGPL-3.0-only](https://github.com/rubentalstra/FerroEHR/blob/main/LICENSES/AGPL-3.0-only.txt) — see the contradiction below |
@@ -150,13 +152,37 @@ all of them. The fuzzing seed corpus is a copy of several of those trees, so it
 is declared under the union of their licenses rather than guessing each seed's
 origin from its filename.
 
-**The clinical-model corpora are mixed, and the table says so on purpose.** A
+**The CKM clinical-model corpus is mixed, and the table says so on purpose.** A
 first-hand count over the vendored CKM material finds both CC-BY-SA 4.0 (the
 majority) and CC-BY-SA 3.0 (several hundred files), so no single version is a
-true statement about the tree. Each archetype carries its own `licence` field
-inside its `description` block, and that per-file metadata is the authority for
-any individual file, which also means licensing for this material already
-survives being copied out of the repository.
+true statement about the tree. Each of those archetypes carries its own
+`licence` field inside its `description` block, and that per-file metadata is
+the authority for any individual file, which also means licensing for this
+material already survives being copied out of the repository.
+
+**The ADL 2 archetype library states no licence at all**, and this is the one
+tree here that carries no grant. Measured on 2026-09-10 over the vendored copy
+(`openEHR/adl-archetypes` at the pinned commit): of 652 archetypes, exactly one
+states a licence — and it states CC-BY 4.0, not CC-BY-SA — while the other 651
+carry `copyright = <"© openEHR Foundation">` and nothing more. Upstream states
+nothing either: no `LICENSE` file at that commit, and a four-line `README.md`.
+
+The validator-regression library from the same upstream repository is a
+different subtree and measures differently: of its 302 archetypes, 111 state a
+licence and 191 state none, and where one is stated it is predominantly
+CC-BY-SA 3.0 (100 of the 111), with 10 CC-BY 4.0 and 1 CC-BY 3.0. **No file in
+it states CC-BY-SA 4.0**, which is why its declaration names what is actually
+there rather than inheriting the CKM expression.
+
+An unstated licence is not a permissive one, so this material is declared
+`LicenseRef-openEHR-unstated`, whose text in `LICENSES/` records the
+measurement and says plainly that it is not a licence. If you lift a file out
+of that tree, you are doing so without a stated permission from the copyright
+holder, and that is your call to make rather than one this repository has made
+for you. The tree is here because it is the only independent source of paired
+ADL 1.4 and ADL 2 forms of the same archetype: generating the pairs with this
+project's own converter would validate that converter against its own output.
+Whether it stays committed is tracked on the issue this correction came from.
 
 **Two positions worth stating explicitly**, because both are the kind of thing a
 compliance review finds and a summary table hides:
@@ -192,7 +218,9 @@ So licensing is **also** published in the machine-readable form the
 - **[`LICENSES/`](https://github.com/rubentalstra/FerroEHR/tree/main/LICENSES)**
   holds the full text of every license any file in the tree is offered under,
   named by SPDX identifier: `BUSL-1.1`, `MIT`, `Apache-2.0`, `CC-BY-SA-3.0`,
-  `CC-BY-SA-4.0`, `CC-BY-4.0`, `MPL-1.1`, `AGPL-3.0-only`.
+  `CC-BY-SA-4.0`, `CC-BY-4.0`, `CC-BY-3.0`, `MPL-1.1`, `AGPL-3.0-only` — plus
+  `LicenseRef-openEHR-unstated`, which is not a licence but the record that
+  one tree carries none.
 - **[`REUSE.toml`](https://github.com/rubentalstra/FerroEHR/blob/main/REUSE.toml)**
   declares, by glob, which files are offered under which, including the two
   positions above, represented rather than flattened.


### PR DESCRIPTION
The provenance record said the ADL 2 archetypes were "predominantly CC-BY-SA
3.0 where stated" and pointed at the root CC-BY-SA 3.0 reference copy. That is
not what the files say.

## What they say

Measured over the vendored tree, searching every `*.adls` and `*.adl` for
`licence` and `license` in any case and any position — a wider search than the
issue's, which looked for two specific ODIN shapes:

| dialect | files | state a licence |
|---|---|---|
| `*.adls` (ADL 2) | 322 | 1 |
| `*.adl` (ADL 1.4 twins) | 330 | 0 |

The one exception states `Creative Commons CC-BY 4.0 unported` — not CC-BY-SA,
and not 3.0. The other 651 carry `copyright = <"© openEHR Foundation">` and no
licence key.

Upstream states nothing either. At the pinned commit
(`093c77ea003742b9540e3dd377d615e2b26f2996`) the repository has no `LICENSE`,
`LICENSE.md`, `LICENSE.txt` or `COPYING`, and its `README.md` is four lines
describing the contents.

So the position is: openEHR Foundation copyright, terms unstated. An unstated
licence is not a permissive one, and the records now say so instead of
inferring a grant.

## How it is declared now

`LicenseRef-openEHR-unstated`, a REUSE LicenseRef whose text in `LICENSES/`
carries the measurement and states plainly that it is **not** a licence.
`NOASSERTION` was the first choice and the REUSE lint rejects it (it wants a
corresponding text), so the LicenseRef is the spec-sanctioned way to say this.

## Three things the issue did not ask for

Each because leaving it would leave a false statement standing somewhere else.

**The vendor script generates that provenance file**, and it carried the same
claim in two places. A re-run would have restored the wording this PR removes.

**The licensing chapter** lumped this tree together with the CKM pack in one
row. They are now separate rows, because they measure differently.

**The `openehr-adl` regression library** is a different subtree of the same
upstream and was swept up by the same `CC-BY-SA-3.0 AND CC-BY-SA-4.0` glob. It
measures: 111 of 302 state a licence — 100 CC-BY-SA 3.0 (93 by URL, 5 in prose,
2 spelled `CC-SA-BY`), 10 CC-BY 4.0, 1 CC-BY 3.0 — and 191 state none. **No
file in it states CC-BY-SA 4.0**, which the glob had been asserting over the
whole tree. It now has its own declaration naming what is there, which needed
the canonical CC-BY-3.0 text (fetched with `reuse download`, not hand-written).

## What is not decided here

Whether a tree whose terms are unstated may stay committed. That has
consequences for the Licensor rather than being a measurement, so it is filed
as #3194 with the three options and a recommendation, and the provenance points
at it. Nothing in this PR asserts that the tree may stay.

Gates: `reuse lint` compliant (12454/12454 files), `licensing-declarations`
green at 10 licences declared, texted and documented, `docs-claims`,
`changelog-structure`, `shellcheck-lane`, `spdx-headers` and
`first-party-license-text` all green.

Closes #3150.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.

## Checks

- [x] `cargo fmt --all --check` · `cargo clippy --workspace --all-targets` · `cargo nextest run --workspace` — no Rust changed; the licensing and docs gates are the relevant ones
- [x] No test weakened, skipped, or edited to route around a bug
- [x] User-visible change → `CHANGELOG.md [Unreleased]` entry
- [x] REST/config/CLI/deployment change → matching `website/book/src` page updated (licensing chapter)
- [x] New issues opened from this work are linked as GitHub relationships — #3194 is linked `blocked-by` this issue
