### PR TITLE
feat(backup): one key and one dump per pseudonymisation domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,10 @@ docs/conformance/*/perf-corpus-*.json
 # from the history, where removing them means rewriting it.
 SnomedCT_*.zip
 doc_SnomedCT*.pdf
+
+# The default targets of the opt-in `backup` compose profile
+# (`docker compose --profile backup run --rm ferroehr-backup-clinical`).
+# A dump of a real deployment carries clinical data and, from the second
+# directory, the identities of its subjects — neither belongs in a git
+# history, and the two are separate directories for exactly that reason.
+/backups/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
+- **Backups are taken per pseudonymisation domain** (#3157). A single
+  `pg_dump` of the whole database produces one file holding both the
+  pseudonymised clinical record and the identities of its subjects, and
+  whoever can read that file can re-identify every record in it. The Compose
+  stack gained an opt-in `backup` profile with one job per domain, writing to
+  two separate directories (`FERROEHR_BACKUP_CLINICAL_DIR`,
+  `FERROEHR_BACKUP_DEMOGRAPHIC_DIR`), and the operations page carries the
+  `pg_dump --schema` recipe, the restore procedure, and the two properties no
+  configuration can enforce for you: different access control on the two
+  targets, and a credential per job that reaches one domain. Point-in-time
+  recovery stays instance-wide and the page says so. `ferroehr db verify` is
+  the restore gate — it issues no DDL and refuses a database whose grants let
+  a runtime role read across the boundary, which is the same check the server
+  runs at boot.
+
 - **The deployment artifacts can reach the demographic role split** (#3179).
   The chart gained `database.demographicExistingSecret` (and its
   `demographicExistingSecretKey` / inline `demographicUrl` siblings), mounted
@@ -194,6 +209,16 @@ workflow refuses a tag that has no matching section here.
   anything. `.claude/rules/personal-data.md` carries the rules for agents.
 
 ### Changed
+
+- **A key derived for one pseudonymisation domain opens nothing in another**
+  (#3157). The per-tenant subkeys protecting national identifiers now take the
+  domain as part of their derivation context, so the clinical domain's key
+  material cannot decrypt a demographic record or reproduce its lookup digest
+  even when both derive from the same configured root key. That is what makes
+  a per-schema backup a separate artefact under a separate key rather than two
+  files under one. `[demographic.identifier_protection]` has not shipped in a
+  release yet, so no stored data is affected; a deployment that enabled it on
+  an unreleased build re-seals its identifiers.
 
 - **The Rust toolchain moves to 1.98.1 and the MSRV to 1.97.** 1.98.1 is a
   point release for a vtable-generation miscompilation, which is reason enough

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,13 @@ workflow refuses a tag that has no matching section here.
   `pg_dump --schema` recipe, the restore procedure, and the two properties no
   configuration can enforce for you: different access control on the two
   targets, and a credential per job that reaches one domain. Point-in-time
-  recovery stays instance-wide and the page says so. `ferroehr db verify` is
-  the restore gate — it issues no DDL and refuses a database whose grants let
+  recovery stays instance-wide and the page says so. A backup credential needs
+  `BYPASSRLS`: every tenant-scoped table carries `FORCE ROW LEVEL SECURITY`, so
+  `pg_dump` refuses a table it would read through a policy and the application
+  role cannot take a backup at all — and `--enable-row-security`, which makes
+  the dump succeed, quietly writes a single tenant's rows. The chart therefore
+  requires a backup Secret per domain and refuses to render without one.
+  `ferroehr db verify` is the restore gate — it issues no DDL and refuses a database whose grants let
   a runtime role read across the boundary, which is the same check the server
   runs at boot.
 

--- a/app/ferroehr/src/service/demographic/identifier/crypto.rs
+++ b/app/ferroehr/src/service/demographic/identifier/crypto.rs
@@ -29,12 +29,22 @@
 //!   unkeyed hash of a nine-digit number would not (the whole space is
 //!   enumerable in seconds).
 //!
-//! Keys are per tenant, derived from one configured root key by
+//! Keys are per DOMAIN and per tenant, derived from one configured root key by
 //! HMAC-SHA-256 over a labelled context — the NIST SP 800-108 KDF-in-counter
 //! construction with a single block, which is all a 256-bit subkey needs. One
 //! key in configuration therefore yields a distinct cipher key and a distinct
 //! lookup key per tenant, and a tenant's ciphertexts stay unreadable with
 //! another tenant's subkey.
+//!
+//! The domain is bound in for the same reason the tenant is. The clinical and
+//! demographic sides are separate pseudonymisation domains (GDPR Art. 4(5);
+//! EDPB Guidelines 01/2025 §2), and a separation that holds in the schema and
+//! in the database roles but shares one cipher key is one key disclosure away
+//! from collapsing. With [`KeyDomain`] in the derivation context, a subkey
+//! derived for the clinical domain cannot open a demographic record even when
+//! both are derived from the same configured root — which is what makes a
+//! per-schema backup a genuinely separate artefact rather than two files under
+//! one key.
 
 use aes_gcm::aead::{Aead, Payload};
 use aes_gcm::{Aes256Gcm, Key, KeyInit, Nonce};
@@ -55,6 +65,43 @@ const CIPHER_KEY_LABEL: &str = "ferroehr:national-identifier:cipher:v1";
 /// digest is not the key that decrypts: a component that only needs to look an
 /// identifier up never has to hold the one that opens the ciphertext.
 const LOOKUP_KEY_LABEL: &str = "ferroehr:national-identifier:lookup:v1";
+
+/// The pseudonymisation domain a subkey belongs to.
+///
+/// The three domains are the ones the storage layer separates: the clinical
+/// record, the identities of its subjects, and the map between them. Binding
+/// the domain into the derivation makes a subkey usable in exactly one of them,
+/// so a key that escapes with one domain's backup opens nothing in another.
+///
+/// **No openEHR spec governs this — our own design/extension.** The obligation
+/// is GDPR Art. 4(5) and Art. 32(1)(a)
+/// (<https://eur-lex.europa.eu/eli/reg/2016/679/oj>) as the EDPB reads them in
+/// Guidelines 01/2025 §2: a pseudonymisation domain is defined by who can
+/// re-identify within it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyDomain {
+    /// The clinical record (`ehr`, `cold`).
+    Ehr,
+    /// The identities of record subjects (`demographic`, `cold_demographic`).
+    Demographic,
+    /// The party-to-EHR resolve map.
+    Linkage,
+}
+
+impl KeyDomain {
+    /// The domain's stable name in a derivation context.
+    ///
+    /// These strings are key material inputs, so they never change: renaming
+    /// one silently re-derives every subkey in that domain.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            KeyDomain::Ehr => "ehr",
+            KeyDomain::Demographic => "demographic",
+            KeyDomain::Linkage => "linkage",
+        }
+    }
+}
 
 /// What went wrong protecting or resolving an identifier.
 ///
@@ -104,13 +151,13 @@ impl RootKey {
         Ok(Self(secrecy::SecretBox::new(Box::new(bytes))))
     }
 
-    /// Derive the per-tenant subkey for one labelled purpose.
+    /// Derive the per-domain, per-tenant subkey for one labelled purpose.
     ///
     /// SP 800-108 KDF in counter mode with HMAC-SHA-256 as the PRF, one block:
-    /// `PRF(root, 0x00000001 || label || 0x00 || tenant || L)`. One block is
-    /// the whole output because the derived key is 256 bits, exactly the PRF's
-    /// width.
-    fn subkey(&self, label: &str, tenant: Uuid) -> [u8; 32] {
+    /// `PRF(root, 0x00000001 || label || 0x00 || domain || 0x00 || tenant || L)`.
+    /// One block is the whole output because the derived key is 256 bits,
+    /// exactly the PRF's width.
+    fn subkey(&self, label: &str, domain: KeyDomain, tenant: Uuid) -> [u8; 32] {
         // The PRF is keyed with a fixed-size root key, so the construction
         // cannot fail on key length.
         #[expect(
@@ -123,6 +170,8 @@ impl RootKey {
                 .expect("HMAC should accept a 32-byte key");
         mac.update(&1_u32.to_be_bytes());
         mac.update(label.as_bytes());
+        mac.update(&[0x00]);
+        mac.update(domain.as_str().as_bytes());
         mac.update(&[0x00]);
         mac.update(tenant.as_bytes());
         mac.update(&256_u32.to_be_bytes());
@@ -142,12 +191,16 @@ pub struct TenantKeys {
 }
 
 impl TenantKeys {
-    /// Derive both subkeys for `tenant` from `root`.
+    /// Derive both subkeys for one domain and tenant from `root`.
+    ///
+    /// The domain is part of the derivation, so the same root key yields
+    /// unrelated subkeys in the clinical and demographic domains and neither
+    /// can read the other's records.
     #[must_use]
-    pub fn derive(root: &RootKey, tenant: Uuid) -> Self {
+    pub fn derive(root: &RootKey, domain: KeyDomain, tenant: Uuid) -> Self {
         Self {
-            cipher: root.subkey(CIPHER_KEY_LABEL, tenant),
-            lookup: root.subkey(LOOKUP_KEY_LABEL, tenant),
+            cipher: root.subkey(CIPHER_KEY_LABEL, domain, tenant),
+            lookup: root.subkey(LOOKUP_KEY_LABEL, domain, tenant),
         }
     }
 
@@ -252,7 +305,7 @@ mod tests {
     //! running the elfproef forward over a chosen prefix; no register issues
     //! them.
 
-    use super::{CryptoError, RootKey, TenantKeys};
+    use super::{CryptoError, KeyDomain, RootKey, TenantKeys};
     use uuid::Uuid;
 
     const ROOT: &str = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
@@ -269,7 +322,7 @@ mod tests {
 
     #[test]
     fn a_sealed_identifier_opens_to_the_same_value() {
-        let keys = TenantKeys::derive(&root(ROOT), tenant());
+        let keys = TenantKeys::derive(&root(ROOT), KeyDomain::Demographic, tenant());
         let (nonce, ciphertext) = keys.seal("nl-bsn", tenant(), VALUE).expect("seal");
         assert_ne!(
             ciphertext.as_slice(),
@@ -286,7 +339,7 @@ mod tests {
     fn every_seal_of_one_value_differs() {
         // A deterministic ciphertext would leak equality of identifiers across
         // records, which is exactly what the separate lookup digest is for.
-        let keys = TenantKeys::derive(&root(ROOT), tenant());
+        let keys = TenantKeys::derive(&root(ROOT), KeyDomain::Demographic, tenant());
         let (first_nonce, first) = keys.seal("nl-bsn", tenant(), VALUE).expect("seal");
         let (second_nonce, second) = keys.seal("nl-bsn", tenant(), VALUE).expect("seal");
         assert_ne!(first, second, "two seals of one value must differ");
@@ -295,10 +348,11 @@ mod tests {
 
     #[test]
     fn a_record_does_not_open_under_another_key_tenant_or_scheme() {
-        let keys = TenantKeys::derive(&root(ROOT), tenant());
+        let keys = TenantKeys::derive(&root(ROOT), KeyDomain::Demographic, tenant());
         let (nonce, ciphertext) = keys.seal("nl-bsn", tenant(), VALUE).expect("seal");
 
-        let other_deployment = TenantKeys::derive(&root(OTHER_ROOT), tenant());
+        let other_deployment =
+            TenantKeys::derive(&root(OTHER_ROOT), KeyDomain::Demographic, tenant());
         assert!(
             matches!(
                 other_deployment.open("nl-bsn", tenant(), &nonce, &ciphertext),
@@ -308,7 +362,7 @@ mod tests {
         );
 
         let other_tenant_id = Uuid::from_u128(7);
-        let other_tenant = TenantKeys::derive(&root(ROOT), other_tenant_id);
+        let other_tenant = TenantKeys::derive(&root(ROOT), KeyDomain::Demographic, other_tenant_id);
         assert!(
             matches!(
                 other_tenant.open("nl-bsn", other_tenant_id, &nonce, &ciphertext),
@@ -336,8 +390,56 @@ mod tests {
     }
 
     #[test]
+    fn the_clinical_domain_key_cannot_read_a_demographic_record() {
+        // The property #3157 asks for: even where an operator configures ONE
+        // root key, the clinical domain's key material opens nothing in the
+        // demographic domain, so a clinical backup and a demographic backup
+        // are separate artefacts under separate keys rather than two files.
+        let demographic = TenantKeys::derive(&root(ROOT), KeyDomain::Demographic, tenant());
+        let clinical = TenantKeys::derive(&root(ROOT), KeyDomain::Ehr, tenant());
+        let linkage = TenantKeys::derive(&root(ROOT), KeyDomain::Linkage, tenant());
+        let (nonce, ciphertext) = demographic.seal("nl-bsn", tenant(), VALUE).expect("seal");
+
+        for (other, domain) in [(&clinical, "clinical"), (&linkage, "linkage")] {
+            assert!(
+                matches!(
+                    other.open("nl-bsn", tenant(), &nonce, &ciphertext),
+                    Err(CryptoError::Open)
+                ),
+                "the {domain} domain's key must not open a demographic record"
+            );
+            assert_ne!(
+                other.lookup_digest("nl-bsn", VALUE),
+                demographic.lookup_digest("nl-bsn", VALUE),
+                "the {domain} domain must not be able to reproduce the lookup digest either, \
+                 which is what would let it ask whether a known identifier is present"
+            );
+        }
+
+        // And the same-root/same-domain derivation is stable, so the refusals
+        // above are the domain doing the work rather than a derivation that
+        // never reproduces anything.
+        let again = TenantKeys::derive(&root(ROOT), KeyDomain::Demographic, tenant());
+        assert_eq!(
+            again
+                .open("nl-bsn", tenant(), &nonce, &ciphertext)
+                .expect("the demographic domain's own key opens it"),
+            VALUE
+        );
+    }
+
+    #[test]
+    fn each_domain_name_is_its_own_derivation_context() {
+        // A rename would silently re-derive every subkey in that domain, so the
+        // strings are pinned here as the key-material inputs they are.
+        assert_eq!(KeyDomain::Ehr.as_str(), "ehr");
+        assert_eq!(KeyDomain::Demographic.as_str(), "demographic");
+        assert_eq!(KeyDomain::Linkage.as_str(), "linkage");
+    }
+
+    #[test]
     fn a_tampered_ciphertext_is_refused() {
-        let keys = TenantKeys::derive(&root(ROOT), tenant());
+        let keys = TenantKeys::derive(&root(ROOT), KeyDomain::Demographic, tenant());
         let (nonce, mut ciphertext) = keys.seal("nl-bsn", tenant(), VALUE).expect("seal");
         ciphertext[0] ^= 0x01;
         assert!(
@@ -351,7 +453,7 @@ mod tests {
 
     #[test]
     fn the_lookup_digest_is_deterministic_keyed_and_scheme_bound() {
-        let keys = TenantKeys::derive(&root(ROOT), tenant());
+        let keys = TenantKeys::derive(&root(ROOT), KeyDomain::Demographic, tenant());
         let digest = keys.lookup_digest("nl-bsn", VALUE);
         assert_eq!(
             digest,
@@ -366,12 +468,14 @@ mod tests {
         );
         assert_ne!(
             digest,
-            TenantKeys::derive(&root(OTHER_ROOT), tenant()).lookup_digest("nl-bsn", VALUE),
+            TenantKeys::derive(&root(OTHER_ROOT), KeyDomain::Demographic, tenant())
+                .lookup_digest("nl-bsn", VALUE),
             "the digest is keyed: another deployment cannot reproduce it"
         );
         assert_ne!(
             digest,
-            TenantKeys::derive(&root(ROOT), Uuid::from_u128(7)).lookup_digest("nl-bsn", VALUE),
+            TenantKeys::derive(&root(ROOT), KeyDomain::Demographic, Uuid::from_u128(7))
+                .lookup_digest("nl-bsn", VALUE),
             "another tenant cannot reproduce it either"
         );
         assert!(
@@ -384,7 +488,7 @@ mod tests {
     fn the_cipher_and_lookup_subkeys_are_different_keys() {
         // The lookup key is handed to components that must search without being
         // able to decrypt, so the two derivations must not coincide.
-        let keys = TenantKeys::derive(&root(ROOT), tenant());
+        let keys = TenantKeys::derive(&root(ROOT), KeyDomain::Demographic, tenant());
         assert_ne!(
             keys.cipher, keys.lookup,
             "one label per purpose, so a searcher never holds the opener"

--- a/app/ferroehr/src/service/demographic/identifier/engine.rs
+++ b/app/ferroehr/src/service/demographic/identifier/engine.rs
@@ -17,7 +17,9 @@ use uuid::Uuid;
 
 use crate::service::demographic::identifier::body;
 use crate::service::demographic::identifier::config::IdentifierProtectionConfig;
-use crate::service::demographic::identifier::crypto::{CryptoError, RootKey, TenantKeys};
+use crate::service::demographic::identifier::crypto::{
+    CryptoError, KeyDomain, RootKey, TenantKeys,
+};
 use crate::service::demographic::identifier::store::{IdentifierStore, StoreError};
 
 /// The national-identifier protection engine.
@@ -104,7 +106,7 @@ impl IdentifierProtection {
         if found.is_empty() {
             return Ok(0);
         }
-        let keys = TenantKeys::derive(&self.root, tenant);
+        let keys = TenantKeys::derive(&self.root, KeyDomain::Demographic, tenant);
         let mut references = Vec::with_capacity(found.len());
         for identifier in &found {
             let row = self
@@ -129,7 +131,7 @@ impl IdentifierProtection {
     /// held and is no longer.
     pub async fn expand(&self, body: &mut Value) -> Result<usize, StoreError> {
         let tenant = current_tenant();
-        let keys = TenantKeys::derive(&self.root, tenant);
+        let keys = TenantKeys::derive(&self.root, KeyDomain::Demographic, tenant);
         let references = referenced(body);
         let mut values = Vec::with_capacity(references.len());
         for (pointer, row) in references {
@@ -147,7 +149,7 @@ impl IdentifierProtection {
     /// [`StoreError`] when the resolution query fails.
     pub async fn resolve(&self, scheme: &str, value: &str) -> Result<Option<Uuid>, StoreError> {
         let tenant = current_tenant();
-        let keys = TenantKeys::derive(&self.root, tenant);
+        let keys = TenantKeys::derive(&self.root, KeyDomain::Demographic, tenant);
         self.store.resolve(&keys, tenant, scheme, value).await
     }
 }

--- a/app/ferroehr/tests/it/pseudonymisation_boundary.rs
+++ b/app/ferroehr/tests/it/pseudonymisation_boundary.rs
@@ -736,10 +736,10 @@ const SYNTHETIC_BSN: &str = "111222333"; // privacy-allow: synthetic
 const TEST_ROOT_KEY: &str = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
 
 fn test_keys(tenant: Uuid) -> ferroehr::service::demographic::identifier::crypto::TenantKeys {
-    use ferroehr::service::demographic::identifier::crypto::{RootKey, TenantKeys};
+    use ferroehr::service::demographic::identifier::crypto::{KeyDomain, RootKey, TenantKeys};
     let root = RootKey::from_hex(&secrecy::SecretString::from(TEST_ROOT_KEY.to_owned()))
         .expect("a 32-byte root key");
-    TenantKeys::derive(&root, tenant)
+    TenantKeys::derive(&root, KeyDomain::Demographic, tenant)
 }
 
 /// A sealed identifier round-trips, and resolution finds its party without

--- a/deploy/helm/ci/all-features-values.yaml
+++ b/deploy/helm/ci/all-features-values.yaml
@@ -4,6 +4,12 @@
 database:
   existingSecret: ferroehr-db
   existingSecretKey: FERROEHR__DB__URL
+  # The two-credential posture (#3179): the demographic pool, and the
+  # demographic backup CronJob, read a secret the clinical side never mounts.
+  # Exercised here because a branch no overlay renders is a branch no golden
+  # and no boot check ever sees.
+  demographicExistingSecret: ferroehr-db-demographic
+  demographicExistingSecretKey: FERROEHR__DB__DEMOGRAPHIC_URL
 
 secrets:
   # 40 bytes of obvious filler. RFC 8725 §3.5 puts a 32-byte floor under a
@@ -261,3 +267,14 @@ serviceAccount:
   create: true
   annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/ferroehr-s3
+
+# Per-domain logical backups, so the two CronJobs reach a golden render and the
+# restricted-profile gate — the claims are render fixtures, nothing provisions
+# them here. Two DIFFERENT claim names: one claim for both domains is refused.
+backup:
+  enabled: true
+  timeZone: Europe/Amsterdam
+  clinical:
+    persistentVolumeClaim: ferroehr-backup-clinical
+  demographic:
+    persistentVolumeClaim: ferroehr-backup-demographic

--- a/deploy/helm/ci/all-features-values.yaml
+++ b/deploy/helm/ci/all-features-values.yaml
@@ -276,5 +276,9 @@ backup:
   timeZone: Europe/Amsterdam
   clinical:
     persistentVolumeClaim: ferroehr-backup-clinical
+    # A BYPASSRLS role, read-only on the clinical schemas — not the pool's
+    # credential, which FORCE ROW LEVEL SECURITY makes pg_dump refuse.
+    existingSecret: ferroehr-backup-clinical-dsn
   demographic:
     persistentVolumeClaim: ferroehr-backup-demographic
+    existingSecret: ferroehr-backup-demographic-dsn

--- a/deploy/helm/ci/boot-check.sh
+++ b/deploy/helm/ci/boot-check.sh
@@ -239,6 +239,12 @@ boot_one() {
     [[ -e "${secdir}/${base}" ]] && continue
     case "$base" in
       db.url) printf 'postgres://ferroehr_app:pw@postgres:5432/ferroehr' > "${secdir}/${base}" ;;
+      # The demographic pool's own DSN (#3179). Without a stand-in here, no ci
+      # overlay could set database.demographicExistingSecret without failing
+      # this check, so the branch that gives the two pseudonymisation domains
+      # separate credentials would stay unexercised by construction.
+      db.demographic_url)
+        printf 'postgres://ferroehr_demographic:pw@postgres:5432/ferroehr' > "${secdir}/${base}" ;;
       *)
         red "  ${p} is referenced but no rendered Secret key supplies it"
         return 1

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # A published OCI version is immutable by refusal rather than by the registry —
 # `helm push` over an existing tag replaces it silently — so a correction always
 # ships as a NEW version and the published one stands as it was.
-version: 7.1.0
+version: 7.2.0
 # The DEFAULT container image tag (overridable via image.tag). Equals the
 # workspace version in Cargo.toml, bumped in the release PR beside the
 # docker-compose.yml image tags — one version sweep, the compose treatment
@@ -146,10 +146,11 @@ annotations:
   # ONLY images this chart actually deploys. Artifact Hub scans every entry here
   # and attributes the findings to this package, so listing an image the chart
   # never installs reports us for software no user runs. `ferroehr-postgres` was
-  # listed and removed: the chart takes an EXTERNAL DSN and provisions no
-  # database, so an upstream postgres image's CVEs were being attributed to a
-  # chart that never installs one. The `whitelisted` flag would silence such a
-  # scan while leaving the false claim in place, so it is deliberately not used.
+  # once listed for a database this chart has never provisioned, and removed for
+  # exactly that reason; it is listed again because the backup CronJobs run
+  # pg_dump FROM it when `backup.enabled` is set, which makes it an image the
+  # chart installs. The `whitelisted` flag would silence such a scan while
+  # leaving a false claim in place, so it is deliberately not used.
   artifacthub.io/images: |
     - name: ferroehr
       image: ghcr.io/rubentalstra/ferroehr:4.1.1
@@ -163,6 +164,14 @@ annotations:
     # install carries, and it is listed so that surface is scanned.
     - name: ferroehr-viewer
       image: ghcr.io/rubentalstra/ferroehr-viewer:4.1.1
+      platforms:
+        - linux/amd64
+        - linux/arm64
+    # The per-domain backup CronJobs' image, deployed only when
+    # `backup.enabled` is set: it carries pg_dump. The chart still provisions no
+    # database — this image runs as a client, on a schedule, and exits.
+    - name: ferroehr-postgres
+      image: ghcr.io/rubentalstra/ferroehr-postgres:4.1.1
       platforms:
         - linux/amd64
         - linux/arm64

--- a/deploy/helm/ferroehr/README.md
+++ b/deploy/helm/ferroehr/README.md
@@ -2,7 +2,7 @@
 
 Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.1.0 + AQL 1.1). A single static binary deployed with a hardened-by-default security posture: runs as a non-root, read-only-rootfs workload whose NetworkPolicy admits its serving port only, and that connects to an EXTERNAL PostgreSQL 18 as an unprivileged app role (migrations are run out of band by a separate migrator role).
 
-![Version: 7.1.0](https://img.shields.io/badge/Version-7.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.1.1](https://img.shields.io/badge/AppVersion-4.1.1-informational?style=flat-square)
+![Version: 7.2.0](https://img.shields.io/badge/Version-7.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.1.1](https://img.shields.io/badge/AppVersion-4.1.1-informational?style=flat-square)
 
 FerroEHR is a pure-Rust openEHR Clinical Data Repository: ITS-REST 1.1.0 at the
 API, AQL 1.1 as the query language, PostgreSQL 18-native storage, shipped as a
@@ -33,7 +33,7 @@ to add; `helm repo add` does not apply to this chart:
 
 ```console
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 7.1.0 \
+  --version 7.2.0 \
   --namespace ferroehr --create-namespace \
   --set database.existingSecret=ferroehr-db \
   --set image.tag=4.1.1
@@ -47,7 +47,7 @@ They are independent SemVer lines and they move independently:
 
 | What | Set with | This release |
 |---|---|---|
-| the **chart** (templates, defaults, this document) | `--version` | `7.1.0` |
+| the **chart** (templates, defaults, this document) | `--version` | `7.2.0` |
 | the **server image** | `image.tag` | `4.1.1` |
 
 `appVersion` is the image the chart defaults to; pinning `image.tag` explicitly
@@ -59,7 +59,7 @@ The chart carries two keyless Sigstore artifacts, and they answer different
 questions. A **cosign signature:** who signed this:
 
 ```console
-cosign verify ghcr.io/rubentalstra/charts/ferroehr:7.1.0 \
+cosign verify ghcr.io/rubentalstra/charts/ferroehr:7.2.0 \
   --certificate-identity-regexp '^https://github\.com/rubentalstra/FerroEHR/\.github/workflows/publish-chart\.yml@' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
@@ -67,7 +67,7 @@ cosign verify ghcr.io/rubentalstra/charts/ferroehr:7.1.0 \
 A **SLSA build provenance attestation:** what source it was built from, and how:
 
 ```console
-gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:7.1.0 \
+gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:7.2.0 \
   -R rubentalstra/FerroEHR
 gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:4.1.1 \
   -R rubentalstra/FerroEHR
@@ -163,6 +163,24 @@ Kubernetes: `>=1.36.0-0`
 | autoscaling.minReplicas | int | `2` | Lower bound the HPA may scale to. |
 | autoscaling.targetCPUUtilizationPercentage | int | `75` | Target average CPU. 0 removes the metric; removing BOTH metrics is refused, since an HPA with none never scales. |
 | autoscaling.targetMemoryUtilizationPercentage | int | `0` | Target average memory. 0 removes the metric. A CDR is usually CPU-bound, so this is off by default. |
+| backup.activeDeadlineSeconds | int | `7200` | Hard ceiling on one dump, so a dump blocked on the database ends rather than overlapping the next schedule. |
+| backup.backoffLimit | int | `2` | Retries before a dump is declared failed. |
+| backup.clinical.persistentVolumeClaim | string | `""` | REQUIRED when enabled: the name of an EXISTING PersistentVolumeClaim the clinical dumps are written to, mounted at /backup. The chart creates no claim — its storage class, size, retention and who may read it are yours. |
+| backup.clinical.schedule | string | `"15 1 * * *"` | Cron schedule for the clinical dump (schemas ehr, cold, ext, audit). |
+| backup.demographic.persistentVolumeClaim | string | `""` | REQUIRED when enabled: an EXISTING PersistentVolumeClaim for the demographic dumps, and a DIFFERENT one from the clinical claim (the same claim for both is refused at render). This is the volume that carries identifying data; give it the narrower audience. |
+| backup.demographic.schedule | string | `"45 1 * * *"` | Cron schedule for the demographic dump (schemas demographic, cold_demographic). Offset from the clinical one by default so the two dumps do not read the database in the same minute. |
+| backup.enabled | bool | `false` | Render the two per-domain backup CronJobs. Each domain then needs its own `persistentVolumeClaim` below, or the render is refused. |
+| backup.image.digest | string | `""` | Image digest (`sha256:…`); wins over `tag` entirely when set. |
+| backup.image.pullPolicy | string | `"IfNotPresent"` | Pull policy. |
+| backup.image.repository | string | `"ghcr.io/rubentalstra/ferroehr-postgres"` | Image carrying `pg_dump`. The project's own PostgreSQL 18 image, so the dump is taken by the same major version the server runs against. |
+| backup.image.tag | string | `""` | Image tag. Empty falls back to .Chart.appVersion, as the server's does. |
+| backup.nodeSelector | object | `{}` | Node selector for the dump pods. |
+| backup.podAnnotations | object | `{}` | Extra annotations on the dump pods. |
+| backup.resources | object | `{}` | Resource requests/limits for the dump pods. |
+| backup.startingDeadlineSeconds | int | `3600` | Seconds a dump that missed its scheduled time may still start in; past it the run is skipped and the next schedule stands (https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/). |
+| backup.timeZone | string | `""` | IANA time zone the schedules below are read in ("Europe/Amsterdam"). Empty leaves the kube-controller-manager's own zone, which is where an unqualified schedule drifts between clusters (KEP-3140, stable v1.27 — https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/). |
+| backup.tolerations | list | `[]` | Tolerations for the dump pods. |
+| backup.ttlSecondsAfterFinished | int | `86400` | How long a finished dump's pod is kept for its logs. |
 | config.admin.enabled | bool | `false` |  |
 | config.audit.enabled | bool | `true` |  |
 | config.audit.store.enabled | bool | `true` |  |

--- a/deploy/helm/ferroehr/README.md
+++ b/deploy/helm/ferroehr/README.md
@@ -165,8 +165,12 @@ Kubernetes: `>=1.36.0-0`
 | autoscaling.targetMemoryUtilizationPercentage | int | `0` | Target average memory. 0 removes the metric. A CDR is usually CPU-bound, so this is off by default. |
 | backup.activeDeadlineSeconds | int | `7200` | Hard ceiling on one dump, so a dump blocked on the database ends rather than overlapping the next schedule. |
 | backup.backoffLimit | int | `2` | Retries before a dump is declared failed. |
+| backup.clinical.existingSecret | string | `""` | REQUIRED when enabled: Secret holding the clinical BACKUP DSN — a role with BYPASSRLS, read-only on the clinical schemas. Not the pool's credential: FORCE ROW LEVEL SECURITY makes pg_dump refuse for that one. |
+| backup.clinical.existingSecretKey | string | `"FERROEHR__DB__URL"` | Key within `existingSecret` carrying that DSN. |
 | backup.clinical.persistentVolumeClaim | string | `""` | REQUIRED when enabled: the name of an EXISTING PersistentVolumeClaim the clinical dumps are written to, mounted at /backup. The chart creates no claim — its storage class, size, retention and who may read it are yours. |
 | backup.clinical.schedule | string | `"15 1 * * *"` | Cron schedule for the clinical dump (schemas ehr, cold, ext, audit). |
+| backup.demographic.existingSecret | string | `""` | REQUIRED when enabled: Secret holding the demographic BACKUP DSN — a role with BYPASSRLS, read-only on the demographic schemas, and a DIFFERENT role from the clinical one. This credential can read every tenant's identities; treat it accordingly. |
+| backup.demographic.existingSecretKey | string | `"FERROEHR__DB__DEMOGRAPHIC_URL"` | Key within `existingSecret` carrying that DSN. |
 | backup.demographic.persistentVolumeClaim | string | `""` | REQUIRED when enabled: an EXISTING PersistentVolumeClaim for the demographic dumps, and a DIFFERENT one from the clinical claim (the same claim for both is refused at render). This is the volume that carries identifying data; give it the narrower audience. |
 | backup.demographic.schedule | string | `"45 1 * * *"` | Cron schedule for the demographic dump (schemas demographic, cold_demographic). Offset from the clinical one by default so the two dumps do not read the database in the same minute. |
 | backup.enabled | bool | `false` | Render the two per-domain backup CronJobs. Each domain then needs its own `persistentVolumeClaim` below, or the render is refused. |

--- a/deploy/helm/ferroehr/templates/NOTES.txt
+++ b/deploy/helm/ferroehr/templates/NOTES.txt
@@ -94,7 +94,24 @@ role, NOT the runtime app role.
 Wrap the migration step in a short lock_timeout so DDL blocked behind live
 traffic fails fast instead of queueing, and pin the image by digest so a
 rollback cannot outrun the schema.
-
+{{ if .Values.backup.enabled -}}
+Backups: two CronJobs, one per pseudonymisation domain.
+  clinical     {{ .Values.backup.clinical.schedule }}  → claim "{{ .Values.backup.clinical.persistentVolumeClaim }}"  (ehr, cold, ext, audit)
+  demographic  {{ .Values.backup.demographic.schedule }}  → claim "{{ .Values.backup.demographic.persistentVolumeClaim }}"  (demographic, cold_demographic)
+{{ if not .Values.database.demographicExistingSecret -}}
+  ⚠  Both jobs read the CLINICAL DSN: database.demographicExistingSecret is
+     unset, so the demographic dump runs under a credential that can also read
+     the clinical schemas. Give that domain its own DSN to make the credential
+     separation real.
+{{ end -}}
+  Two claims, not one, is enforced at render. WHO MAY READ EACH is not, and it
+  is the half that matters: restrict the volume behind the demographic claim to
+  a smaller group than the clinical one. Nothing here prunes old dumps.
+{{ else -}}
+NOTE: backup.enabled=false — this release takes no logical backups. Per-domain
+      dumps (pg_dump per pseudonymisation domain, into separate claims) are
+      opt-in; point each domain at its own PersistentVolumeClaim to enable them.
+{{ end }}
 ────────────────────────────────────────────────────────────────────────────
 SECURITY POSTURE
 ────────────────────────────────────────────────────────────────────────────

--- a/deploy/helm/ferroehr/templates/_helpers.tpl
+++ b/deploy/helm/ferroehr/templates/_helpers.tpl
@@ -503,28 +503,27 @@ and only that PATH is passed to the container.
 
 Call with (dict "root" $ "domain" "clinical").
 */}}
+{{- /*
+The backup DSN is the domain's OWN backup Secret, never the pool's credential.
+Every tenant-scoped table carries FORCE ROW LEVEL SECURITY, so pg_dump refuses
+a table it would read through a policy — "query would be affected by row-level
+security policy" (PostgreSQL 18, pg_dump §Notes) — and the runtime role cannot
+take a backup at all. The dump needs a role with BYPASSRLS, read-only on its
+own domain, which is a different credential from the one the server serves
+with. Reusing the pool's DSN here would render CronJobs that fail every night.
+*/ -}}
 {{- define "ferroehr.backupDsnSecret" -}}
-{{- $database := .root.Values.database -}}
-{{- if and (eq .domain "demographic") $database.demographicExistingSecret -}}
-{{ $database.demographicExistingSecret }}
-{{- else if and (eq .domain "demographic") $database.demographicUrl -}}
-{{ include "ferroehr.secretName" .root }}
-{{- else if $database.existingSecret -}}
-{{ $database.existingSecret }}
+{{- if eq .domain "demographic" -}}
+{{ .root.Values.backup.demographic.existingSecret }}
 {{- else -}}
-{{ include "ferroehr.secretName" .root }}
+{{ .root.Values.backup.clinical.existingSecret }}
 {{- end -}}
 {{- end }}
 
 {{- define "ferroehr.backupDsnSecretKey" -}}
-{{- $database := .root.Values.database -}}
-{{- if and (eq .domain "demographic") $database.demographicExistingSecret -}}
-{{ $database.demographicExistingSecretKey }}
-{{- else if and (eq .domain "demographic") $database.demographicUrl -}}
-db.demographic_url
-{{- else if $database.existingSecret -}}
-{{ $database.existingSecretKey }}
+{{- if eq .domain "demographic" -}}
+{{ .root.Values.backup.demographic.existingSecretKey }}
 {{- else -}}
-db.url
+{{ .root.Values.backup.clinical.existingSecretKey }}
 {{- end -}}
 {{- end }}

--- a/deploy/helm/ferroehr/templates/_helpers.tpl
+++ b/deploy/helm/ferroehr/templates/_helpers.tpl
@@ -431,3 +431,100 @@ The viewer image reference — digest wins over tag, as for the server.
 {{- printf "%s:%s" .Values.viewer.image.repository (.Values.viewer.image.tag | default .Chart.AppVersion) }}
 {{- end }}
 {{- end }}
+
+{{/*
+A backup CronJob's resource name: the release fullname, `-backup-`, and the
+domain it dumps.
+
+Truncated to 52, not 63: the CronJob controller appends 11 characters to build
+each Job's name and a Job name may not exceed 63
+(https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/).
+
+Call with (dict "root" $ "domain" "clinical").
+*/}}
+{{- define "ferroehr.backupFullname" -}}
+{{- printf "%s-backup-%s" (include "ferroehr.fullname" .root) .domain | trunc 52 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Labels for a backup CronJob and its pods.
+
+Each domain carries its OWN `app.kubernetes.io/name` rather than the server's
+name plus a component, for the reason the viewer's labels carry: a Service or
+PodDisruptionBudget selector is a SUBSET match, so a dump pod labelled with the
+server's name would be selected by the server's Service while it runs
+(https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/).
+*/}}
+{{- define "ferroehr.backupLabels" -}}
+helm.sh/chart: {{ include "ferroehr.chart" .root }}
+{{ include "ferroehr.backupSelectorLabels" . }}
+{{- if .root.Chart.AppVersion }}
+app.kubernetes.io/version: {{ .root.Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .root.Release.Service }}
+app.kubernetes.io/part-of: ferroehr
+app.kubernetes.io/component: backup
+{{- end }}
+
+{{- define "ferroehr.backupSelectorLabels" -}}
+app.kubernetes.io/name: {{ printf "%s-backup-%s" (include "ferroehr.name" .root) .domain }}
+app.kubernetes.io/instance: {{ .root.Release.Name }}
+{{- end }}
+
+{{/*
+The backup image reference — digest wins over tag, as for the server.
+*/}}
+{{- define "ferroehr.backupImage" -}}
+{{- if .Values.backup.image.digest }}
+{{- $digest := .Values.backup.image.digest }}
+{{- if not (hasPrefix "sha256:" $digest) }}{{- $digest = printf "sha256:%s" $digest }}{{- end }}
+{{- printf "%s@%s" .Values.backup.image.repository $digest }}
+{{- else }}
+{{- printf "%s:%s" .Values.backup.image.repository (.Values.backup.image.tag | default .Chart.AppVersion) }}
+{{- end }}
+{{- end }}
+
+{{/*
+The fixed path a dump is written to. A path, not a value: the claim behind it is
+the operator's choice, the location inside the container is not.
+*/}}
+{{- define "ferroehr.backupMountPath" -}}
+/backup
+{{- end }}
+
+{{/*
+The Secret a backup domain's DSN comes from, and the key inside it.
+
+Resolved exactly as the Deployment resolves the two pools: the demographic
+domain uses its own credential when one is configured, and falls back to the
+clinical DSN when it is not, so a dump never reaches a domain the running server
+could not reach either. Whichever Secret it is, the key is mounted as `db.url`
+and only that PATH is passed to the container.
+
+Call with (dict "root" $ "domain" "clinical").
+*/}}
+{{- define "ferroehr.backupDsnSecret" -}}
+{{- $database := .root.Values.database -}}
+{{- if and (eq .domain "demographic") $database.demographicExistingSecret -}}
+{{ $database.demographicExistingSecret }}
+{{- else if and (eq .domain "demographic") $database.demographicUrl -}}
+{{ include "ferroehr.secretName" .root }}
+{{- else if $database.existingSecret -}}
+{{ $database.existingSecret }}
+{{- else -}}
+{{ include "ferroehr.secretName" .root }}
+{{- end -}}
+{{- end }}
+
+{{- define "ferroehr.backupDsnSecretKey" -}}
+{{- $database := .root.Values.database -}}
+{{- if and (eq .domain "demographic") $database.demographicExistingSecret -}}
+{{ $database.demographicExistingSecretKey }}
+{{- else if and (eq .domain "demographic") $database.demographicUrl -}}
+db.demographic_url
+{{- else if $database.existingSecret -}}
+{{ $database.existingSecretKey }}
+{{- else -}}
+db.url
+{{- end -}}
+{{- end }}

--- a/deploy/helm/ferroehr/templates/backup-cronjob.yaml
+++ b/deploy/helm/ferroehr/templates/backup-cronjob.yaml
@@ -1,0 +1,159 @@
+{{- if .Values.backup.enabled }}
+{{- /*
+Per-domain logical backups: one CronJob per pseudonymisation domain, each
+dumping only its own schemas, to its own claim, under its own credential.
+
+Keeping the clinical record and the identifying data in separate artefacts is
+the separation pseudonymisation rests on (GDPR Art. 4(5),
+https://eur-lex.europa.eu/eli/reg/2016/679/oj); the dumps themselves are the
+restore capability of Art. 32(1)(c). `pg_dump --schema` is the mechanism
+(https://www.postgresql.org/docs/18/app-pgdump.html). No openEHR spec governs
+backups — our own design/extension.
+
+batch/v1 CronJob is stable since v1.21 and `timeZone` since v1.27 (KEP-19 and
+KEP-3140), both below this chart's kubeVersion floor, so neither is gated.
+*/}}
+{{- if not .Values.backup.clinical.persistentVolumeClaim }}
+{{- fail "backup.enabled is true but backup.clinical.persistentVolumeClaim is empty: name an EXISTING PersistentVolumeClaim for the clinical dump (schemas ehr, cold, ext, audit). The chart provisions no storage — a dump with nowhere to write is a backup that silently does not exist." }}
+{{- end }}
+{{- if not .Values.backup.demographic.persistentVolumeClaim }}
+{{- fail "backup.enabled is true but backup.demographic.persistentVolumeClaim is empty: name an EXISTING PersistentVolumeClaim for the demographic dump (schemas demographic, cold_demographic). It must be a different volume from the clinical one — that separation is what this feature is for (GDPR Art. 4(5))." }}
+{{- end }}
+{{- if eq .Values.backup.clinical.persistentVolumeClaim .Values.backup.demographic.persistentVolumeClaim }}
+{{- fail "backup.clinical.persistentVolumeClaim and backup.demographic.persistentVolumeClaim name the same claim: one volume carrying both the clinical record and the identifying data is the state per-domain backups exist to prevent (GDPR Art. 4(5)). Give each domain its own claim, and the demographic one the narrower audience." }}
+{{- end }}
+{{- if not (or .Values.database.existingSecret .Values.database.url) }}
+{{- fail "backup.enabled is true but no clinical DSN is configured: set database.existingSecret (preferred) or database.url. The dump jobs read the same credential the server's pools read, so with neither set there is nothing for pg_dump to connect as." }}
+{{- end }}
+{{- $root := . }}
+{{- $mount := include "ferroehr.backupMountPath" . }}
+{{- $secrets := include "ferroehr.secretMountPath" . }}
+{{- $domains := list
+      (dict "name" "clinical"
+            "schedule" .Values.backup.clinical.schedule
+            "claim" .Values.backup.clinical.persistentVolumeClaim
+            "schemas" (list "ehr" "cold" "ext" "audit"))
+      (dict "name" "demographic"
+            "schedule" .Values.backup.demographic.schedule
+            "claim" .Values.backup.demographic.persistentVolumeClaim
+            "schemas" (list "demographic" "cold_demographic")) }}
+{{- range $domain := $domains }}
+{{- $args := "" }}
+{{- range $schema := $domain.schemas }}{{ $args = printf "%s --schema=%s" $args $schema }}{{ end }}
+{{- /* The DSN is read from its mounted file at call time: only the PATH is in
+       the pod spec, so the credential is never an environment variable an
+       operator can read back off the object or a child process inherits
+       (https://cheatsheetseries.owasp.org/cheatsheets/Kubernetes_Security_Cheat_Sheet.html).
+       `--format=custom` so pg_restore can choose what to restore and in what
+       order (https://www.postgresql.org/docs/18/app-pgdump.html). */}}
+{{- $command := printf "pg_dump --dbname=\"$(cat %s/db.url)\" --format=custom --no-owner%s --file=%s/%s-$(date -u +%%Y%%m%%dT%%H%%M%%SZ).dump" $secrets $args $mount $domain.name }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "ferroehr.backupFullname" (dict "root" $root "domain" $domain.name) }}
+  annotations:
+    kubernetes.io/description: >-
+      Logical backup of the {{ $domain.name }} pseudonymisation domain: pg_dump of {{ join ", " $domain.schemas }} into the {{ $domain.claim }} claim, under the DSN that domain's pool uses. Separate claim, separate credential, separate schedule from the other domain, so no one artefact carries both the clinical record and the identifying data.
+  labels:
+    {{- include "ferroehr.backupLabels" (dict "root" $root "domain" $domain.name) | nindent 4 }}
+spec:
+  schedule: {{ $domain.schedule | quote }}
+  {{- with $root.Values.backup.timeZone }}
+  timeZone: {{ . | quote }}
+  {{- end }}
+  {{- /* A second dump of one domain starting while the first still runs adds
+         database load and a half-written second artefact, and buys nothing:
+         the next schedule takes a complete dump anyway. */}}
+  concurrencyPolicy: Forbid
+  {{- with $root.Values.backup.startingDeadlineSeconds }}
+  startingDeadlineSeconds: {{ . }}
+  {{- end }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ $root.Values.backup.backoffLimit }}
+      activeDeadlineSeconds: {{ $root.Values.backup.activeDeadlineSeconds }}
+      ttlSecondsAfterFinished: {{ $root.Values.backup.ttlSecondsAfterFinished }}
+      {{- /* A pod killed by a drain or a preemption never took the dump, so it
+             must not spend one of `backoffLimit` — the same rule, for the same
+             reason, as the migration Job
+             (https://kubernetes.io/docs/tasks/job/pod-failure-policy/). */}}
+      podFailurePolicy:
+        rules:
+          - action: Ignore
+            onPodConditions:
+              - type: DisruptionTarget
+      template:
+        metadata:
+          labels:
+            {{- include "ferroehr.backupSelectorLabels" (dict "root" $root "domain" $domain.name) | nindent 12 }}
+            app.kubernetes.io/component: backup
+          {{- with $root.Values.backup.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        spec:
+          restartPolicy: Never
+          {{- with $root.Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          serviceAccountName: {{ include "ferroehr.serviceAccountName" $root }}
+          automountServiceAccountToken: {{ $root.Values.serviceAccount.automountServiceAccountToken }}
+          # pg_dump reads no Service link variable, and the release's other pods
+          # disable them, so the posture stays one posture
+          # (https://kubernetes.io/docs/concepts/services-networking/service/#environment-variables).
+          enableServiceLinks: false
+          {{- if not $root.Values.hostUsers }}
+          {{- include "ferroehr.hostUsers" $root | nindent 10 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml $root.Values.podSecurityContext | nindent 12 }}
+          containers:
+            - name: pg-dump
+              image: "{{ include "ferroehr.backupImage" $root }}"
+              imagePullPolicy: {{ $root.Values.backup.image.pullPolicy }}
+              securityContext:
+                {{- toYaml $root.Values.securityContext | nindent 16 }}
+              command:
+                - /bin/sh
+                - -ec
+              args:
+                - {{ $command | quote }}
+              volumeMounts:
+                # readOnlyRootFilesystem=true → give the process a writable scratch dir.
+                - name: tmp
+                  mountPath: /tmp
+                - name: dsn
+                  mountPath: {{ $secrets }}
+                  readOnly: true
+                - name: backup
+                  mountPath: {{ $mount }}
+              resources:
+                {{- toYaml $root.Values.backup.resources | nindent 16 }}
+          volumes:
+            - name: tmp
+              emptyDir: {}
+            # This domain's DSN, mounted as db.url whichever Secret it came from,
+            # so the command is the same for both domains and only the
+            # credential differs.
+            - name: dsn
+              secret:
+                secretName: {{ include "ferroehr.backupDsnSecret" (dict "root" $root "domain" $domain.name) }}
+                defaultMode: 0440
+                items:
+                  - key: {{ include "ferroehr.backupDsnSecretKey" (dict "root" $root "domain" $domain.name) }}
+                    path: db.url
+            - name: backup
+              persistentVolumeClaim:
+                claimName: {{ $domain.claim }}
+          {{- with $root.Values.backup.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $root.Values.backup.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/ferroehr/templates/backup-cronjob.yaml
+++ b/deploy/helm/ferroehr/templates/backup-cronjob.yaml
@@ -22,8 +22,11 @@ KEP-3140), both below this chart's kubeVersion floor, so neither is gated.
 {{- if eq .Values.backup.clinical.persistentVolumeClaim .Values.backup.demographic.persistentVolumeClaim }}
 {{- fail "backup.clinical.persistentVolumeClaim and backup.demographic.persistentVolumeClaim name the same claim: one volume carrying both the clinical record and the identifying data is the state per-domain backups exist to prevent (GDPR Art. 4(5)). Give each domain its own claim, and the demographic one the narrower audience." }}
 {{- end }}
-{{- if not (or .Values.database.existingSecret .Values.database.url) }}
-{{- fail "backup.enabled is true but no clinical DSN is configured: set database.existingSecret (preferred) or database.url. The dump jobs read the same credential the server's pools read, so with neither set there is nothing for pg_dump to connect as." }}
+{{- if not .Values.backup.clinical.existingSecret }}
+{{- fail "backup.enabled is true but backup.clinical.existingSecret is empty: name a Secret holding a BACKUP DSN for the clinical domain — a role with BYPASSRLS, read-only on ehr, cold, ext and audit. It cannot be the pool's credential: every tenant-scoped table carries FORCE ROW LEVEL SECURITY, and pg_dump refuses a table it would read through a policy, so a CronJob wired to the runtime role fails every night." }}
+{{- end }}
+{{- if not .Values.backup.demographic.existingSecret }}
+{{- fail "backup.enabled is true but backup.demographic.existingSecret is empty: name a Secret holding a BACKUP DSN for the demographic domain — a role with BYPASSRLS, read-only on demographic and cold_demographic. Give it its own role, not the clinical backup one: a single credential that dumps both domains re-joins in one identity what the split exists to separate (GDPR Art. 4(5))." }}
 {{- end }}
 {{- $root := . }}
 {{- $mount := include "ferroehr.backupMountPath" . }}

--- a/deploy/helm/ferroehr/values.schema.json
+++ b/deploy/helm/ferroehr/values.schema.json
@@ -1162,6 +1162,15 @@
         "persistentVolumeClaim": {
           "description": "The name of an EXISTING PersistentVolumeClaim. Required when backup.enabled, and a different claim per domain.",
           "type": "string"
+        },
+        "existingSecret": {
+          "type": "string",
+          "description": "Secret holding this domain's BACKUP DSN (a BYPASSRLS role, read-only on that domain's schemas)."
+        },
+        "existingSecretKey": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Key within existingSecret carrying the backup DSN."
         }
       }
     },

--- a/deploy/helm/ferroehr/values.schema.json
+++ b/deploy/helm/ferroehr/values.schema.json
@@ -203,6 +203,90 @@
         }
       }
     },
+    "backup": {
+      "description": "Per-domain logical backups: one CronJob per pseudonymisation domain. Off by default, and enabling it requires a DISTINCT existing PersistentVolumeClaim per domain \u2014 the render is refused otherwise.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "image": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "repository": {
+              "type": "string",
+              "minLength": 1
+            },
+            "pullPolicy": {
+              "type": "string",
+              "enum": [
+                "Always",
+                "IfNotPresent",
+                "Never"
+              ]
+            },
+            "tag": {
+              "description": "Empty falls back to .Chart.appVersion.",
+              "type": "string"
+            },
+            "digest": {
+              "description": "Wins over `tag` entirely when set.",
+              "type": "string",
+              "pattern": "^(sha256:[0-9a-f]{64})?$"
+            }
+          }
+        },
+        "timeZone": {
+          "description": "An IANA time zone name; empty leaves the kube-controller-manager's own zone.",
+          "type": "string"
+        },
+        "startingDeadlineSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "backoffLimit": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "activeDeadlineSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "ttlSecondsAfterFinished": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "resources": {
+          "$ref": "#/definitions/resourceRequirements"
+        },
+        "podAnnotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "nodeSelector": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "tolerations": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "clinical": {
+          "$ref": "#/definitions/backupDomain"
+        },
+        "demographic": {
+          "$ref": "#/definitions/backupDomain"
+        }
+      }
+    },
     "secrets": {
       "type": "object",
       "additionalProperties": false,
@@ -1059,6 +1143,25 @@
           "items": {
             "type": "object"
           }
+        }
+      }
+    },
+    "cronSchedule": {
+      "description": "A five-field cron expression, or one of the @macros the CronJob API accepts.",
+      "type": "string",
+      "pattern": "^(@(annually|yearly|monthly|weekly|daily|midnight|hourly)|@every +[0-9a-z]+|[^@ ]+( +[^ ]+){4})$"
+    },
+    "backupDomain": {
+      "description": "One pseudonymisation domain's backup: its own schedule and its own destination claim.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "schedule": {
+          "$ref": "#/definitions/cronSchedule"
+        },
+        "persistentVolumeClaim": {
+          "description": "The name of an EXISTING PersistentVolumeClaim. Required when backup.enabled, and a different claim per domain.",
+          "type": "string"
         }
       }
     },

--- a/deploy/helm/ferroehr/values.yaml
+++ b/deploy/helm/ferroehr/values.yaml
@@ -202,6 +202,91 @@ migrations:
     tolerations: []
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Per-domain logical backups (off by default).
+#
+# Two CronJobs, one per pseudonymisation domain, each dumping ONLY its own
+# schemas into its OWN PersistentVolumeClaim under its OWN credential. A single
+# artefact carrying the clinical record and the identifying data together undoes
+# the separation pseudonymisation rests on (GDPR Art. 4(5),
+# https://eur-lex.europa.eu/eli/reg/2016/679/oj), and the restore capability is
+# Art. 32(1)(c). The mechanism is `pg_dump --schema`
+# (https://www.postgresql.org/docs/18/app-pgdump.html): the clinical job dumps
+# ehr, cold, ext and audit, the demographic job dumps demographic and
+# cold_demographic. No openEHR spec governs backups — our own design/extension.
+#
+# Credentials follow the pools. The clinical job reads the DSN
+# `database.existingSecret`/`database.url` carries; the demographic job reads
+# `database.demographicExistingSecret` when that domain has its own, and falls
+# back to the clinical DSN when it has not. Either way the DSN arrives as a
+# mounted file, never as an environment variable.
+#
+# The chart keeps the two dumps apart; ACCESS CONTROL over them is yours. Back
+# the two claims with different volumes and give the demographic one the
+# narrower audience — one claim for both domains is refused at render, because
+# that is the state this whole section exists to prevent.
+#
+# Off by default: the destination is a claim you provision. Two further things
+# this chart does not do, said here rather than assumed: nothing prunes old
+# dumps, and no NetworkPolicy of ours selects these pods. And a logical dump is
+# not point-in-time recovery — PITR is instance-wide and stays database-side.
+# ─────────────────────────────────────────────────────────────────────────────
+backup:
+  # -- Render the two per-domain backup CronJobs. Each domain then needs its own
+  # `persistentVolumeClaim` below, or the render is refused.
+  enabled: false
+  image:
+    # -- Image carrying `pg_dump`. The project's own PostgreSQL 18 image, so the
+    # dump is taken by the same major version the server runs against.
+    repository: ghcr.io/rubentalstra/ferroehr-postgres
+    # -- Pull policy.
+    pullPolicy: IfNotPresent
+    # -- Image tag. Empty falls back to .Chart.appVersion, as the server's does.
+    tag: ""
+    # -- Image digest (`sha256:…`); wins over `tag` entirely when set.
+    digest: ""
+  # -- IANA time zone the schedules below are read in ("Europe/Amsterdam"). Empty
+  # leaves the kube-controller-manager's own zone, which is where an unqualified
+  # schedule drifts between clusters (KEP-3140, stable v1.27 —
+  # https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/).
+  timeZone: ""
+  # -- Seconds a dump that missed its scheduled time may still start in; past it
+  # the run is skipped and the next schedule stands
+  # (https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/).
+  startingDeadlineSeconds: 3600
+  # -- Retries before a dump is declared failed.
+  backoffLimit: 2
+  # -- Hard ceiling on one dump, so a dump blocked on the database ends rather
+  # than overlapping the next schedule.
+  activeDeadlineSeconds: 7200
+  # -- How long a finished dump's pod is kept for its logs.
+  ttlSecondsAfterFinished: 86400
+  # -- Resource requests/limits for the dump pods.
+  resources: {}
+  # -- Extra annotations on the dump pods.
+  podAnnotations: {}
+  # -- Node selector for the dump pods.
+  nodeSelector: {}
+  # -- Tolerations for the dump pods.
+  tolerations: []
+  clinical:
+    # -- Cron schedule for the clinical dump (schemas ehr, cold, ext, audit).
+    schedule: "15 1 * * *"
+    # -- REQUIRED when enabled: the name of an EXISTING PersistentVolumeClaim the
+    # clinical dumps are written to, mounted at /backup. The chart creates no
+    # claim — its storage class, size, retention and who may read it are yours.
+    persistentVolumeClaim: ""
+  demographic:
+    # -- Cron schedule for the demographic dump (schemas demographic,
+    # cold_demographic). Offset from the clinical one by default so the two dumps
+    # do not read the database in the same minute.
+    schedule: "45 1 * * *"
+    # -- REQUIRED when enabled: an EXISTING PersistentVolumeClaim for the
+    # demographic dumps, and a DIFFERENT one from the clinical claim (the same
+    # claim for both is refused at render). This is the volume that carries
+    # identifying data; give it the narrower audience.
+    persistentVolumeClaim: ""
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Secret values carried by a chart-managed Secret. Anything set here is rendered
 # from values (keep it out of committed values — prefer an external secret store
 # / IRSA, or set these via `helm --set`/a values overlay from your secret

--- a/deploy/helm/ferroehr/values.yaml
+++ b/deploy/helm/ferroehr/values.yaml
@@ -214,11 +214,15 @@ migrations:
 # ehr, cold, ext and audit, the demographic job dumps demographic and
 # cold_demographic. No openEHR spec governs backups — our own design/extension.
 #
-# Credentials follow the pools. The clinical job reads the DSN
-# `database.existingSecret`/`database.url` carries; the demographic job reads
-# `database.demographicExistingSecret` when that domain has its own, and falls
-# back to the clinical DSN when it has not. Either way the DSN arrives as a
-# mounted file, never as an environment variable.
+# EACH JOB NEEDS ITS OWN BACKUP CREDENTIAL, and it is not the pool's. Every
+# tenant-scoped table carries FORCE ROW LEVEL SECURITY, so the policy applies to
+# the table's owner too and pg_dump refuses a table it would read through one
+# ("query would be affected by row-level security policy" — PostgreSQL 18,
+# pg_dump §Notes). The runtime role therefore cannot take a backup at all, and
+# `--enable-row-security` is not the answer: it makes the dump succeed with one
+# tenant's rows in it. Give each job a role with BYPASSRLS, read-only on its own
+# domain, through `backup.<domain>.existingSecret`. The DSN arrives as a mounted
+# file, never as an environment variable.
 #
 # The chart keeps the two dumps apart; ACCESS CONTROL over them is yours. Back
 # the two claims with different volumes and give the demographic one the
@@ -271,6 +275,12 @@ backup:
   clinical:
     # -- Cron schedule for the clinical dump (schemas ehr, cold, ext, audit).
     schedule: "15 1 * * *"
+    # -- REQUIRED when enabled: Secret holding the clinical BACKUP DSN — a role
+    # with BYPASSRLS, read-only on the clinical schemas. Not the pool's
+    # credential: FORCE ROW LEVEL SECURITY makes pg_dump refuse for that one.
+    existingSecret: ""
+    # -- Key within `existingSecret` carrying that DSN.
+    existingSecretKey: FERROEHR__DB__URL
     # -- REQUIRED when enabled: the name of an EXISTING PersistentVolumeClaim the
     # clinical dumps are written to, mounted at /backup. The chart creates no
     # claim — its storage class, size, retention and who may read it are yours.
@@ -280,6 +290,13 @@ backup:
     # cold_demographic). Offset from the clinical one by default so the two dumps
     # do not read the database in the same minute.
     schedule: "45 1 * * *"
+    # -- REQUIRED when enabled: Secret holding the demographic BACKUP DSN — a
+    # role with BYPASSRLS, read-only on the demographic schemas, and a DIFFERENT
+    # role from the clinical one. This credential can read every tenant's
+    # identities; treat it accordingly.
+    existingSecret: ""
+    # -- Key within `existingSecret` carrying that DSN.
+    existingSecretKey: FERROEHR__DB__DEMOGRAPHIC_URL
     # -- REQUIRED when enabled: an EXISTING PersistentVolumeClaim for the
     # demographic dumps, and a DIFFERENT one from the clinical claim (the same
     # claim for both is refused at render). This is the volume that carries

--- a/deploy/helm/gates/restricted.jq
+++ b/deploy/helm/gates/restricted.jq
@@ -7,13 +7,22 @@
 [ "configMap", "csi", "downwardAPI", "emptyDir", "ephemeral",
   "persistentVolumeClaim", "projected", "secret" ] as $allowed_volumes
 | . as $docs
+# A CronJob's pod sits one level deeper, under jobTemplate. Reading only
+# .spec.template would skip it silently — and a workload this gate cannot see
+# is a workload nothing checks, which is the failure §3 of the Helm rules
+# describes.
 | [ $docs[]
     | select(.kind == "Deployment" or .kind == "StatefulSet"
-             or .kind == "DaemonSet" or .kind == "Job")
-    | select(.spec.template != null)
+             or .kind == "DaemonSet" or .kind == "Job" or .kind == "CronJob")
     | { kind: .kind, name: .metadata.name,
         replicas: .spec.replicas,
-        pod: (.spec.template.spec // {}) } ] as $workloads
+        template: (if .kind == "CronJob"
+                   then .spec.jobTemplate.spec.template
+                   else .spec.template end) }
+    | select(.template != null)
+    | { kind: .kind, name: .name,
+        replicas: .replicas,
+        pod: (.template.spec // {}) } ] as $workloads
 | ( [ $workloads[]
       | . as $w
       | ($w.pod.securityContext // {}) as $sc

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), and only from the networkPolicy.ingressFrom peers.
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -97,7 +97,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -118,7 +118,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -150,7 +150,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -176,7 +176,7 @@ kind: Secret
 metadata:
   name: ferroehr-config
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -197,7 +197,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -402,7 +402,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr-grafana-dashboard
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -653,7 +653,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -687,7 +687,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -770,6 +770,8 @@ spec:
           env:
             - name: FERROEHR__DB__URL_FILE
               value: "/etc/ferroehr-secrets/db.url"
+            - name: FERROEHR__DB__DEMOGRAPHIC_URL_FILE
+              value: "/etc/ferroehr-secrets/db.demographic_url"
             - name: FERROEHR__AUTH__OIDC__HMAC_SECRET_FILE
               value: "/etc/ferroehr-secrets/auth.oidc.hmac_secret"
             - name: FERROEHR__SIGNING__KEY_PASSPHRASE_FILE
@@ -887,6 +889,13 @@ spec:
                   items:
                     - key: FERROEHR__DB__URL
                       path: db.url
+              # The demographic domain's own Secret, a different credential from
+              # the clinical one above and projected as its own file.
+              - secret:
+                  name: ferroehr-db-demographic
+                  items:
+                    - key: FERROEHR__DB__DEMOGRAPHIC_URL
+                      path: db.demographic_url
               - secret:
                   name: ferroehr-env
                   items:
@@ -920,7 +929,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -948,13 +957,220 @@ spec:
           averageUtilization: 80
 
 ---
+# Source: ferroehr/templates/backup-cronjob.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ferroehr-backup-clinical
+  annotations:
+    kubernetes.io/description: >-
+      Logical backup of the clinical pseudonymisation domain: pg_dump of ehr, cold, ext, audit into the ferroehr-backup-clinical claim, under the DSN that domain's pool uses. Separate claim, separate credential, separate schedule from the other domain, so no one artefact carries both the clinical record and the identifying data.
+  labels:
+    helm.sh/chart: ferroehr-7.2.0
+    app.kubernetes.io/name: ferroehr-backup-clinical
+    app.kubernetes.io/instance: ferroehr
+    app.kubernetes.io/version: "4.1.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: ferroehr
+    app.kubernetes.io/component: backup
+spec:
+  schedule: "15 1 * * *"
+  timeZone: "Europe/Amsterdam"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 3600
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 7200
+      ttlSecondsAfterFinished: 86400
+      podFailurePolicy:
+        rules:
+          - action: Ignore
+            onPodConditions:
+              - type: DisruptionTarget
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: ferroehr-backup-clinical
+            app.kubernetes.io/instance: ferroehr
+            app.kubernetes.io/component: backup
+        spec:
+          restartPolicy: Never
+          serviceAccountName: ferroehr
+          automountServiceAccountToken: false
+          # pg_dump reads no Service link variable, and the release's other pods
+          # disable them, so the posture stays one posture
+          # (https://kubernetes.io/docs/concepts/services-networking/service/#environment-variables).
+          enableServiceLinks: false
+          hostUsers: false
+          securityContext:
+            fsGroup: 65532
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 65532
+            runAsNonRoot: true
+            runAsUser: 65532
+            seccompProfile:
+              type: RuntimeDefault
+            supplementalGroupsPolicy: Strict
+          containers:
+            - name: pg-dump
+              image: "ghcr.io/rubentalstra/ferroehr-postgres:4.1.1"
+              imagePullPolicy: IfNotPresent
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                  - ALL
+                privileged: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 65532
+                seccompProfile:
+                  type: RuntimeDefault
+              command:
+                - /bin/sh
+                - -ec
+              args:
+                - "pg_dump --dbname=\"$(cat /etc/ferroehr-secrets/db.url)\" --format=custom --no-owner --schema=ehr --schema=cold --schema=ext --schema=audit --file=/backup/clinical-$(date -u +%Y%m%dT%H%M%SZ).dump"
+              volumeMounts:
+                # readOnlyRootFilesystem=true → give the process a writable scratch dir.
+                - name: tmp
+                  mountPath: /tmp
+                - name: dsn
+                  mountPath: /etc/ferroehr-secrets
+                  readOnly: true
+                - name: backup
+                  mountPath: /backup
+              resources:
+                {}
+          volumes:
+            - name: tmp
+              emptyDir: {}
+            # This domain's DSN, mounted as db.url whichever Secret it came from,
+            # so the command is the same for both domains and only the
+            # credential differs.
+            - name: dsn
+              secret:
+                secretName: ferroehr-db
+                defaultMode: 0440
+                items:
+                  - key: FERROEHR__DB__URL
+                    path: db.url
+            - name: backup
+              persistentVolumeClaim:
+                claimName: ferroehr-backup-clinical
+---
+# Source: ferroehr/templates/backup-cronjob.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ferroehr-backup-demographic
+  annotations:
+    kubernetes.io/description: >-
+      Logical backup of the demographic pseudonymisation domain: pg_dump of demographic, cold_demographic into the ferroehr-backup-demographic claim, under the DSN that domain's pool uses. Separate claim, separate credential, separate schedule from the other domain, so no one artefact carries both the clinical record and the identifying data.
+  labels:
+    helm.sh/chart: ferroehr-7.2.0
+    app.kubernetes.io/name: ferroehr-backup-demographic
+    app.kubernetes.io/instance: ferroehr
+    app.kubernetes.io/version: "4.1.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: ferroehr
+    app.kubernetes.io/component: backup
+spec:
+  schedule: "45 1 * * *"
+  timeZone: "Europe/Amsterdam"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 3600
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 7200
+      ttlSecondsAfterFinished: 86400
+      podFailurePolicy:
+        rules:
+          - action: Ignore
+            onPodConditions:
+              - type: DisruptionTarget
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: ferroehr-backup-demographic
+            app.kubernetes.io/instance: ferroehr
+            app.kubernetes.io/component: backup
+        spec:
+          restartPolicy: Never
+          serviceAccountName: ferroehr
+          automountServiceAccountToken: false
+          # pg_dump reads no Service link variable, and the release's other pods
+          # disable them, so the posture stays one posture
+          # (https://kubernetes.io/docs/concepts/services-networking/service/#environment-variables).
+          enableServiceLinks: false
+          hostUsers: false
+          securityContext:
+            fsGroup: 65532
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 65532
+            runAsNonRoot: true
+            runAsUser: 65532
+            seccompProfile:
+              type: RuntimeDefault
+            supplementalGroupsPolicy: Strict
+          containers:
+            - name: pg-dump
+              image: "ghcr.io/rubentalstra/ferroehr-postgres:4.1.1"
+              imagePullPolicy: IfNotPresent
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                  - ALL
+                privileged: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 65532
+                seccompProfile:
+                  type: RuntimeDefault
+              command:
+                - /bin/sh
+                - -ec
+              args:
+                - "pg_dump --dbname=\"$(cat /etc/ferroehr-secrets/db.url)\" --format=custom --no-owner --schema=demographic --schema=cold_demographic --file=/backup/demographic-$(date -u +%Y%m%dT%H%M%SZ).dump"
+              volumeMounts:
+                # readOnlyRootFilesystem=true → give the process a writable scratch dir.
+                - name: tmp
+                  mountPath: /tmp
+                - name: dsn
+                  mountPath: /etc/ferroehr-secrets
+                  readOnly: true
+                - name: backup
+                  mountPath: /backup
+              resources:
+                {}
+          volumes:
+            - name: tmp
+              emptyDir: {}
+            # This domain's DSN, mounted as db.url whichever Secret it came from,
+            # so the command is the same for both domains and only the
+            # credential differs.
+            - name: dsn
+              secret:
+                secretName: ferroehr-db-demographic
+                defaultMode: 0440
+                items:
+                  - key: FERROEHR__DB__DEMOGRAPHIC_URL
+                    path: db.url
+            - name: backup
+              persistentVolumeClaim:
+                claimName: ferroehr-backup-demographic
+
+---
 # Source: ferroehr/templates/ingress.yaml
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -992,7 +1208,7 @@ kind: ServiceMonitor
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -1051,7 +1051,7 @@ spec:
             # credential differs.
             - name: dsn
               secret:
-                secretName: ferroehr-db
+                secretName: ferroehr-backup-clinical-dsn
                 defaultMode: 0440
                 items:
                   - key: FERROEHR__DB__URL
@@ -1154,7 +1154,7 @@ spec:
             # credential differs.
             - name: dsn
               secret:
-                secretName: ferroehr-db-demographic
+                secretName: ferroehr-backup-demographic-dsn
                 defaultMode: 0440
                 items:
                   - key: FERROEHR__DB__DEMOGRAPHIC_URL

--- a/deploy/helm/golden/basic-auth.yaml
+++ b/deploy/helm/golden/basic-auth.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -51,7 +51,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -72,7 +72,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -102,7 +102,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -119,7 +119,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -247,7 +247,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -277,7 +277,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -51,7 +51,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -72,7 +72,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -87,7 +87,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -212,7 +212,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -242,7 +242,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"

--- a/deploy/helm/golden/viewer.yaml
+++ b/deploy/helm/golden/viewer.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -61,7 +61,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the viewer: only its HTTP port, but from EVERY source — this policy narrows ports, NOT sources (viewer.networkPolicy.ingressAllowAll=true). Set viewer.networkPolicy.ingressFrom for a PHI workload. Egress admits the CDR Service and DNS only.
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr-viewer
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -118,7 +118,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -139,7 +139,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -154,7 +154,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr-viewer
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr-viewer
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -184,7 +184,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -201,7 +201,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -329,7 +329,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -359,7 +359,7 @@ metadata:
     kubernetes.io/description: >-
       In-cluster address for the FerroEHR Viewer. The viewer is a REST client of the CDR and holds no data of its own; it is the human-facing surface, so this is the Service an Ingress normally publishes.
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr-viewer
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -385,7 +385,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -581,7 +581,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR Viewer: a Leptos SSR web UI that consumes the CDR strictly over ITS-REST. It never reaches the database, which the viewer NetworkPolicy enforces rather than assumes.
   labels:
-    helm.sh/chart: ferroehr-7.1.0
+    helm.sh/chart: ferroehr-7.2.0
     app.kubernetes.io/name: ferroehr-viewer
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"

--- a/deploy/helm/validate.sh
+++ b/deploy/helm/validate.sh
@@ -418,7 +418,8 @@ refusal_registry_gate() {
     "backup-cronjob.yaml|backup.clinical.persistentVolumeClaim is empty|${base}|--set backup.enabled=true --set backup.demographic.persistentVolumeClaim=demographic-dumps|backup.clinical.persistentVolumeClaim"
     "backup-cronjob.yaml|backup.demographic.persistentVolumeClaim is empty|${base}|--set backup.enabled=true --set backup.clinical.persistentVolumeClaim=clinical-dumps|backup.demographic.persistentVolumeClaim"
     "backup-cronjob.yaml|name the same claim|${base}|--set backup.enabled=true --set backup.clinical.persistentVolumeClaim=one-claim --set backup.demographic.persistentVolumeClaim=one-claim|backup.clinical.persistentVolumeClaim;backup.demographic.persistentVolumeClaim"
-    "backup-cronjob.yaml|no clinical DSN is configured|${base}|--set backup.enabled=true --set backup.clinical.persistentVolumeClaim=clinical-dumps --set backup.demographic.persistentVolumeClaim=demographic-dumps --set database.existingSecret=null|database.existingSecret;database.url"
+    "backup-cronjob.yaml|backup.clinical.existingSecret is empty|${base}|--set backup.enabled=true --set backup.clinical.persistentVolumeClaim=clinical-dumps --set backup.demographic.persistentVolumeClaim=demographic-dumps|backup.clinical.existingSecret;BYPASSRLS"
+    "backup-cronjob.yaml|backup.demographic.existingSecret is empty|${base}|--set backup.enabled=true --set backup.clinical.persistentVolumeClaim=clinical-dumps --set backup.demographic.persistentVolumeClaim=demographic-dumps --set backup.clinical.existingSecret=clinical-backup-dsn|backup.demographic.existingSecret;BYPASSRLS"
   )
 
   local record values probe wants want out refused=0

--- a/deploy/helm/validate.sh
+++ b/deploy/helm/validate.sh
@@ -6,8 +6,9 @@
 #   1. helm lint      — default + all-features value sets (must be clean)
 #   2. helm template  — render both; assert the output is valid multi-doc YAML
 #   3. security gate   — assert the Kubernetes Pod Security Standards
-#                        "Restricted" fields are pinned in the rendered
-#                        Deployment (runAsNonRoot, seccompProfile
+#                        "Restricted" fields are pinned on EVERY container of
+#                        EVERY rendered workload — Deployment, Job and CronJob
+#                        alike (runAsNonRoot, seccompProfile
 #                        RuntimeDefault, drop ALL caps,
 #                        allowPrivilegeEscalation:false), plus our
 #                        readOnlyRootFilesystem hardening
@@ -414,6 +415,10 @@ refusal_registry_gate() {
     "networkpolicy.yaml|networkPolicy.ingressAllowAll=false with an empty|${base}|--set networkPolicy.ingressAllowAll=false|networkPolicy.ingressFrom;hardening-network-policy.md"
     "networkpolicy.yaml|with no destination for the database|${base}|--set networkPolicy.egress.enabled=true|networkPolicy.egress.database.to;hardening-network-policy.md"
     "viewer.yaml|viewer.networkPolicy.ingressAllowAll=false with an empty|${viewer}|--set viewer.networkPolicy.ingressAllowAll=false|viewer.networkPolicy.ingressFrom;hardening-network-policy.md"
+    "backup-cronjob.yaml|backup.clinical.persistentVolumeClaim is empty|${base}|--set backup.enabled=true --set backup.demographic.persistentVolumeClaim=demographic-dumps|backup.clinical.persistentVolumeClaim"
+    "backup-cronjob.yaml|backup.demographic.persistentVolumeClaim is empty|${base}|--set backup.enabled=true --set backup.clinical.persistentVolumeClaim=clinical-dumps|backup.demographic.persistentVolumeClaim"
+    "backup-cronjob.yaml|name the same claim|${base}|--set backup.enabled=true --set backup.clinical.persistentVolumeClaim=one-claim --set backup.demographic.persistentVolumeClaim=one-claim|backup.clinical.persistentVolumeClaim;backup.demographic.persistentVolumeClaim"
+    "backup-cronjob.yaml|no clinical DSN is configured|${base}|--set backup.enabled=true --set backup.clinical.persistentVolumeClaim=clinical-dumps --set backup.demographic.persistentVolumeClaim=demographic-dumps --set database.existingSecret=null|database.existingSecret;database.url"
   )
 
   local record values probe wants want out refused=0
@@ -533,6 +538,11 @@ schema_gate() {
     "metrics.serviceMonitor.interval=30|/metrics/serviceMonitor/interval"
     "networkPolicy.ingressAllowAll=maybe|/networkPolicy/ingressAllowAll"
     "viewer.networkPolicy.ingressAllowAll=maybe|/viewer/networkPolicy/ingressAllowAll"
+    "backup.clinicl.schedule=@daily|additional properties 'clinicl' not allowed"
+    "backup.enabled=maybe|/backup/enabled"
+    "backup.clinical.schedule=17|/backup/clinical/schedule"
+    "backup.demographic.schedule=daily|/backup/demographic/schedule"
+    "backup.backoffLimit=-1|/backup/backoffLimit"
   )
   local refused=0 probe want out
   for case in "${refusals[@]}"; do

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -200,6 +200,16 @@ services:
   # choose what to restore and in what order; `pg_restore` reads it.
   # Point-in-time recovery is a different instrument and stays instance-wide:
   # see the operations page in the documentation.
+  #
+  # THE DUMP CONNECTS AS THE BOOTSTRAP SUPERUSER, and that is not laziness.
+  # Every tenant-scoped table carries FORCE ROW LEVEL SECURITY, so the policy
+  # applies to the table owner too, and pg_dump refuses a table it would have
+  # to read through a policy: "query would be affected by row-level security
+  # policy" (PostgreSQL 18, pg_dump §Notes). The application role therefore
+  # CANNOT take a backup — by design, because the alternative is worse: with
+  # --enable-row-security the dump succeeds and silently contains one tenant's
+  # rows. A backup credential needs BYPASSRLS or superuser; the operations page
+  # says so for deployments that do not share this stack's single credential.
   ferroehr-backup-clinical:
     profiles: [backup]
     image: ${FERROEHR_POSTGRES_IMAGE:-ghcr.io/rubentalstra/ferroehr-postgres:4.1.1}
@@ -207,7 +217,7 @@ services:
       ferroehr-postgres:
         condition: service_healthy
     environment:
-      PGPASSWORD: ${PG_INIT_PASSWORD:-ferroehr}
+      PGPASSWORD: ${POSTGRES_PASSWORD:-postgres}
     # The target is a directory on the HOST, owned by whoever created it, so
     # the dump has to run as somebody who can write it. Two ways, and the
     # default has to work without the operator arranging anything:
@@ -225,7 +235,7 @@ services:
     entrypoint: ["/bin/sh", "-c"]
     command:
       - >-
-        pg_dump --host=ferroehr-postgres --username=${PG_INIT_USER:-ferroehr}
+        pg_dump --host=ferroehr-postgres --username=postgres
         --dbname=${PG_INIT_DB:-ferroehr} --format=custom --no-owner
         --schema=ehr --schema=cold --schema=ext --schema=audit
         --file=/backup/clinical-$$(date -u +%Y%m%dT%H%M%SZ).dump
@@ -245,18 +255,18 @@ services:
       ferroehr-postgres:
         condition: service_healthy
     # This stack runs one login credential for both domains (the init script
-    # says why). A deployment that gives the demographic domain its own DSN
-    # points this job at that one instead, and then the job that can read the
-    # identities cannot read the clinical record.
+    # says why). A deployment that gives the demographic domain its own
+    # BYPASSRLS backup role points this job at that one instead, and then the
+    # job that can read the identities cannot read the clinical record.
     environment:
-      PGPASSWORD: ${PG_INIT_PASSWORD:-ferroehr}
+      PGPASSWORD: ${POSTGRES_PASSWORD:-postgres}
     # Same reason as its clinical twin above.
     user: "${FERROEHR_BACKUP_USER:-0:0}"
     cap_add: [DAC_OVERRIDE]
     entrypoint: ["/bin/sh", "-c"]
     command:
       - >-
-        pg_dump --host=ferroehr-postgres --username=${PG_INIT_USER:-ferroehr}
+        pg_dump --host=ferroehr-postgres --username=postgres
         --dbname=${PG_INIT_DB:-ferroehr} --format=custom --no-owner
         --schema=demographic --schema=cold_demographic
         --file=/backup/demographic-$$(date -u +%Y%m%dT%H%M%SZ).dump

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -208,6 +208,14 @@ services:
         condition: service_healthy
     environment:
       PGPASSWORD: ${PG_INIT_PASSWORD:-ferroehr}
+    # The target is a directory on the HOST, so the dump has to run as a user
+    # that can write it. The image's own `postgres` user (uid 999) cannot write
+    # a directory the operator created, which is a "Permission denied" on Linux
+    # — root inside the container can write any target, and the container still
+    # holds no capabilities, cannot gain privileges and has a read-only root.
+    # For a file owned by you instead of by root, run the command with
+    # FERROEHR_BACKUP_USER="$(id -u):$(id -g)".
+    user: "${FERROEHR_BACKUP_USER:-0:0}"
     entrypoint: ["/bin/sh", "-c"]
     command:
       - >-
@@ -236,6 +244,8 @@ services:
     # identities cannot read the clinical record.
     environment:
       PGPASSWORD: ${PG_INIT_PASSWORD:-ferroehr}
+    # Same reason as its clinical twin above.
+    user: "${FERROEHR_BACKUP_USER:-0:0}"
     entrypoint: ["/bin/sh", "-c"]
     command:
       - >-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -176,6 +176,82 @@ services:
       retries: 20
       start_period: 10s
 
+  # ── Per-domain logical backups (opt-in: `--profile backup`) ────────────────
+  # Two one-shot dump jobs, one per pseudonymisation domain, writing to two
+  # SEPARATE host directories. Splitting the dump is the point: an artefact
+  # carrying the pseudonymised clinical record and the identities of its
+  # subjects together re-joins what the schema separation exists to keep apart
+  # (GDPR Art. 4(5), https://eur-lex.europa.eu/eli/reg/2016/679/oj; the EDPB
+  # reads the separation as defining the pseudonymisation domain in Guidelines
+  # 01/2025). Art. 32(1)(c) is why they exist at all. No openEHR spec governs
+  # backups — our own design/extension.
+  #
+  # Run one, or both:
+  #   docker compose --profile backup run --rm ferroehr-backup-clinical
+  #   docker compose --profile backup run --rm ferroehr-backup-demographic
+  #
+  # The two targets are ordinary directories, so they take ordinary
+  # permissions: give them different owners, ship them to different buckets,
+  # hand the demographic one to a smaller group. That is the "separately
+  # access-controlled" half, and this file cannot enforce it for you — it can
+  # only stop the two from landing in one file.
+  #
+  # `--format=custom` (PostgreSQL 18, pg_dump §Options) so the restore side can
+  # choose what to restore and in what order; `pg_restore` reads it.
+  # Point-in-time recovery is a different instrument and stays instance-wide:
+  # see the operations page in the documentation.
+  ferroehr-backup-clinical:
+    profiles: [backup]
+    image: ${FERROEHR_POSTGRES_IMAGE:-ghcr.io/rubentalstra/ferroehr-postgres:4.1.1}
+    depends_on:
+      ferroehr-postgres:
+        condition: service_healthy
+    environment:
+      PGPASSWORD: ${PG_INIT_PASSWORD:-ferroehr}
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - >-
+        pg_dump --host=ferroehr-postgres --username=${PG_INIT_USER:-ferroehr}
+        --dbname=${PG_INIT_DB:-ferroehr} --format=custom --no-owner
+        --schema=ehr --schema=cold --schema=ext --schema=audit
+        --file=/backup/clinical-$$(date -u +%Y%m%dT%H%M%SZ).dump
+    volumes:
+      - ${FERROEHR_BACKUP_CLINICAL_DIR:-./backups/clinical}:/backup
+    cap_drop: [ALL]
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp
+
+  ferroehr-backup-demographic:
+    profiles: [backup]
+    image: ${FERROEHR_POSTGRES_IMAGE:-ghcr.io/rubentalstra/ferroehr-postgres:4.1.1}
+    depends_on:
+      ferroehr-postgres:
+        condition: service_healthy
+    # This stack runs one login credential for both domains (the init script
+    # says why). A deployment that gives the demographic domain its own DSN
+    # points this job at that one instead, and then the job that can read the
+    # identities cannot read the clinical record.
+    environment:
+      PGPASSWORD: ${PG_INIT_PASSWORD:-ferroehr}
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - >-
+        pg_dump --host=ferroehr-postgres --username=${PG_INIT_USER:-ferroehr}
+        --dbname=${PG_INIT_DB:-ferroehr} --format=custom --no-owner
+        --schema=demographic --schema=cold_demographic
+        --file=/backup/demographic-$$(date -u +%Y%m%dT%H%M%SZ).dump
+    volumes:
+      - ${FERROEHR_BACKUP_DEMOGRAPHIC_DIR:-./backups/demographic}:/backup
+    cap_drop: [ALL]
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp
+
   ferroehr:
     image: ${FERROEHR_IMAGE:-ghcr.io/rubentalstra/ferroehr:4.1.1}
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -208,14 +208,20 @@ services:
         condition: service_healthy
     environment:
       PGPASSWORD: ${PG_INIT_PASSWORD:-ferroehr}
-    # The target is a directory on the HOST, so the dump has to run as a user
-    # that can write it. The image's own `postgres` user (uid 999) cannot write
-    # a directory the operator created, which is a "Permission denied" on Linux
-    # — root inside the container can write any target, and the container still
-    # holds no capabilities, cannot gain privileges and has a read-only root.
-    # For a file owned by you instead of by root, run the command with
-    # FERROEHR_BACKUP_USER="$(id -u):$(id -g)".
+    # The target is a directory on the HOST, owned by whoever created it, so
+    # the dump has to run as somebody who can write it. Two ways, and the
+    # default has to work without the operator arranging anything:
+    #
+    #   * `FERROEHR_BACKUP_USER="$(id -u):$(id -g)"` — the better posture. The
+    #     job runs as you, the file lands owned by you, and DAC_OVERRIDE below
+    #     is never used.
+    #   * unset — the job runs as root, which needs CAP_DAC_OVERRIDE to write a
+    #     directory it does not own. `cap_drop: [ALL]` takes that capability
+    #     away, and without it uid 0 is simply "other" against a mode-755
+    #     directory (capabilities(7)); root alone does NOT make the write
+    #     succeed. So the capability is added back, and only that one.
     user: "${FERROEHR_BACKUP_USER:-0:0}"
+    cap_add: [DAC_OVERRIDE]
     entrypoint: ["/bin/sh", "-c"]
     command:
       - >-
@@ -246,6 +252,7 @@ services:
       PGPASSWORD: ${PG_INIT_PASSWORD:-ferroehr}
     # Same reason as its clinical twin above.
     user: "${FERROEHR_BACKUP_USER:-0:0}"
+    cap_add: [DAC_OVERRIDE]
     entrypoint: ["/bin/sh", "-c"]
     command:
       - >-

--- a/scripts/deploy-probe.sh
+++ b/scripts/deploy-probe.sh
@@ -129,6 +129,7 @@ run_family health_broken && probes_health_broken
 run_family oidc && probes_oidc
 run_family oidc_roles && probes_oidc_roles
 run_family domain_roles && probes_domain_roles
+run_family backup_restore && probes_backup_restore
 run_family observability && probes_observability
 run_family tenancy && probes_tenancy
 run_family events && probes_events

--- a/scripts/deploy-probes/compose.sh
+++ b/scripts/deploy-probes/compose.sh
@@ -548,13 +548,17 @@ probes_backup_restore() {
     "the backup profile writes one dump per pseudonymisation domain"
   # The recipe's own output is KEPT: a dump job that fails is the finding, and
   # discarding its stderr would report the missing file without the reason.
+  # Compose's own progress and orphan-container chatter is dropped: it is
+  # longer than the diagnostic underneath it, and a truncated note that shows
+  # the chatter instead of the error is worse than no note.
   local dump_log=""
   local job
   for job in clinical demographic; do
     dump_log="$dump_log$(FERROEHR_BACKUP_CLINICAL_DIR="$dumps/clinical" \
       FERROEHR_BACKUP_DEMOGRAPHIC_DIR="$dumps/demographic" \
       dc -f docker-compose.yml --profile backup run --rm --quiet-pull \
-        "ferroehr-backup-$job" 2>&1)"
+        "ferroehr-backup-$job" 2>&1 \
+      | grep -vE '^time="|^ *Container |orphan containers' | tr '\n' ' ')"
   done
   local clinical_dump demographic_dump
   clinical_dump="$(find "$dumps/clinical" -name 'clinical-*.dump' -print -quit 2>/dev/null)"
@@ -568,7 +572,8 @@ probes_backup_restore() {
       FERROEHR_BACKUP_DEMOGRAPHIC_DIR="$dumps/demographic" \
       dc -f docker-compose.yml --profile backup run --rm --quiet-pull \
         --entrypoint /bin/sh ferroehr-backup-clinical -c \
-        'id; ls -ldn /backup; grep " /backup " /proc/mounts; touch /backup/.probe-write 2>&1' 2>&1)"
+        'id; ls -ldn /backup; grep " /backup " /proc/mounts; touch /backup/.probe-write 2>&1' 2>&1 \
+      | grep -vE '^time="|^ *Container |orphan containers' | tr '\n' ' ')"
     probe_fail "one dump file in each of the two target directories" \
       "clinical='$clinical_dump' demographic='$demographic_dump'" \
       "recipe: ${dump_log:0:300} || target from inside the job: ${target_state:0:400} \

--- a/scripts/deploy-probes/compose.sh
+++ b/scripts/deploy-probes/compose.sh
@@ -419,8 +419,37 @@ YAML
   wait_http "$CDR/health/readiness" 120 || true
 }
 
+# Whether the stack's database actually carries the demographic domain.
+#
+# A local run defaults to the PUBLISHED server image, and a release that
+# predates the domain split migrates no `demographic` schema — so every probe
+# about the boundary would answer about a database that has no second domain to
+# separate, passing vacuously. CI builds the image from source
+# (`FERROEHR_IMAGE: ferroehr:deploy-probe`); a run that does not is told what it
+# is measuring instead of being allowed to look green.
+demographic_domain_present() {
+  local tables
+  tables="$(dc exec -T ferroehr-postgres psql -qtAX -U "${PG_INIT_USER:-ferroehr}" \
+    -d "${PG_INIT_DB:-ferroehr}" -c \
+    "SELECT count(*) FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'demographic' AND c.relkind = 'r'" 2>/dev/null)"
+  [ "${tables:-0}" -gt 0 ] 2>/dev/null
+}
+
+# The one sentence every domain probe prints when it declines to measure.
+demographic_domain_absent_reason() {
+  printf '%s' "the stack's database carries no demographic schema, so this measures
+     nothing about the boundary. A local run defaults to the published server image
+     (\`FERROEHR_IMAGE\`), which predates the domain split; CI builds it from source."
+}
+
 probes_domain_roles() {
   bold "pseudonymisation domain roles"
+
+  if ! demographic_domain_present; then
+    uncovered "the pseudonymisation domain roles" "$(demographic_domain_absent_reason)"
+    return
+  fi
 
   # #3179: the book documents four NOINHERIT runtime roles and a boot-time
   # self-check over their grants. Nothing observed that a stack the project
@@ -498,4 +527,133 @@ probes_domain_roles() {
     "the compose init creates the four roles as the bootstrap superuser. A managed
      PostgreSQL where the migrator holds no CREATEROLE takes the documented manual
      step instead, and nothing here runs that path."
+}
+
+probes_backup_restore() {
+  bold "per-domain logical backups and the restore self-check"
+
+  if ! demographic_domain_present; then
+    uncovered "per-domain logical backups" "$(demographic_domain_absent_reason)"
+    return
+  fi
+
+  # #3157: the book documents per-schema dumps into separate targets and a
+  # restore that the boot self-check gates. Far end: the DUMP FILES the shipped
+  # compose profile actually writes, and the server's own verdict on a database
+  # restored from them — not the compose file that was supposed to arrange it.
+  local dumps="$PROBE_TMP/backup"
+  mkdir -p "$dumps/clinical" "$dumps/demographic"
+
+  probe "P-BACKUP-SPLIT" "working" "compose" "#3157" \
+    "the backup profile writes one dump per pseudonymisation domain"
+  # The recipe's own output is KEPT: a dump job that fails is the finding, and
+  # discarding its stderr would report the missing file without the reason.
+  local dump_log=""
+  local job
+  for job in clinical demographic; do
+    dump_log="$dump_log$(FERROEHR_BACKUP_CLINICAL_DIR="$dumps/clinical" \
+      FERROEHR_BACKUP_DEMOGRAPHIC_DIR="$dumps/demographic" \
+      dc -f docker-compose.yml --profile backup run --rm --quiet-pull \
+        "ferroehr-backup-$job" 2>&1)"
+  done
+  local clinical_dump demographic_dump
+  clinical_dump="$(find "$dumps/clinical" -name 'clinical-*.dump' -print -quit 2>/dev/null)"
+  demographic_dump="$(find "$dumps/demographic" -name 'demographic-*.dump' -print -quit 2>/dev/null)"
+  if [ -z "$clinical_dump" ] || [ -z "$demographic_dump" ]; then
+    probe_fail "one dump file in each of the two target directories" \
+      "clinical='$clinical_dump' demographic='$demographic_dump'" \
+      "the documented recipe reported: ${dump_log:0:400}"
+    probe_done
+    return
+  fi
+  probe_done
+
+  # The property the split exists for: neither artefact carries the other
+  # domain. A dump that named both would re-join what the schema separation
+  # keeps apart (GDPR Art. 4(5)), and it would do so silently.
+  probe "P-BACKUP-DISJOINT" "working" "compose" "#3157" \
+    "neither dump carries the other domain's relations"
+  local clinical_toc demographic_toc
+  clinical_toc="$(docker run --rm -v "$dumps/clinical:/backup:ro" \
+    "${FERROEHR_POSTGRES_IMAGE:-ghcr.io/rubentalstra/ferroehr-postgres:4.1.1}" \
+    pg_restore --list "/backup/$(basename "$clinical_dump")" 2>/dev/null)"
+  demographic_toc="$(docker run --rm -v "$dumps/demographic:/backup:ro" \
+    "${FERROEHR_POSTGRES_IMAGE:-ghcr.io/rubentalstra/ferroehr-postgres:4.1.1}" \
+    pg_restore --list "/backup/$(basename "$demographic_dump")" 2>/dev/null)"
+  assert_contains "$clinical_toc" "ehr vo_version" \
+    "the clinical dump must carry the clinical version table"
+  assert_not_contains "$clinical_toc" "demographic national_identifier" \
+    "a clinical backup carrying the identifier table defeats the split"
+  assert_not_contains "$clinical_toc" "demographic vo_version" \
+    "a clinical backup carrying the demographic versions defeats the split"
+  assert_contains "$demographic_toc" "demographic vo_version" \
+    "the demographic dump must carry the demographic version table; the dump job \
+reported: ${dump_log:0:300}"
+  assert_not_contains "$demographic_toc" "ehr vo_version" \
+    "a demographic backup carrying the clinical record defeats the split"
+  probe_done
+
+  # The restore, judged by the server rather than by the restore's own exit
+  # code: `ferroehr db verify` is the boot self-check (the migrations this
+  # build carries, then the domain-isolation gate over the four runtime roles).
+  probe "P-BACKUP-RESTORE" "working" "database" "#3157" \
+    "a database restored from the two dumps passes the boot self-check"
+  local restored=ferroehr_restored
+  dc exec -T ferroehr-postgres psql -qtAX -U "${PG_INIT_USER:-ferroehr}" \
+    -d "${PG_INIT_DB:-ferroehr}" -c "DROP DATABASE IF EXISTS $restored" >/dev/null 2>&1
+  dc exec -T ferroehr-postgres psql -qtAX -U "${PG_INIT_USER:-ferroehr}" \
+    -d "${PG_INIT_DB:-ferroehr}" -c "CREATE DATABASE $restored" >/dev/null 2>&1
+  # The restore runs the way an operator's would: a client container on the
+  # stack's network with the two dump directories mounted. Copying the files
+  # INTO the database container instead would restore from a path no runbook
+  # uses, and its /tmp is a tmpfs the copy does not reach.
+  local restore_log
+  restore_log="$(FERROEHR_BACKUP_CLINICAL_DIR="$dumps/clinical" \
+    FERROEHR_BACKUP_DEMOGRAPHIC_DIR="$dumps/demographic" \
+    dc -f docker-compose.yml --profile backup run --rm --quiet-pull \
+      --entrypoint /bin/sh -v "$dumps:/dumps:ro" ferroehr-backup-clinical -c \
+      "pg_restore --host=ferroehr-postgres --username=${PG_INIT_USER:-ferroehr} \
+         --dbname=$restored --no-owner /dumps/clinical/$(basename "$clinical_dump") 2>&1;
+       pg_restore --host=ferroehr-postgres --username=${PG_INIT_USER:-ferroehr} \
+         --dbname=$restored --no-owner /dumps/demographic/$(basename "$demographic_dump") 2>&1" 2>&1)"
+  local restored_dsn verify_out
+  restored_dsn="postgres://${PG_INIT_USER:-ferroehr}:${PG_INIT_PASSWORD:-ferroehr}@ferroehr-postgres:5432/$restored"
+  if verify_out="$(dc exec -T -e FERROEHR__DB__URL="$restored_dsn" -e FERROEHR__DB__MIGRATE=verify \
+      ferroehr /usr/local/bin/ferroehr db verify 2>&1)"; then
+    :
+  else
+    probe_fail "the restored database passes \`ferroehr db verify\`" \
+      "${verify_out:0:400}" \
+      "restore output: ${restore_log:0:200}"
+  fi
+  probe_done
+
+  # And the half that makes the probe above mean something: the self-check has
+  # to REFUSE a restore whose grants came back wrong. A runbook that re-applies
+  # access with a blanket GRANT is the realistic way that happens.
+  probe "P-BACKUP-GRANTS-REFUSED" "broken" "database" "#3157" \
+    "the self-check refuses a restore whose grants cross the domain boundary"
+  dc exec -T ferroehr-postgres psql -qtAX -U "${PG_INIT_USER:-ferroehr}" -d "$restored" -c \
+    "GRANT USAGE ON SCHEMA demographic TO ferroehr_ehr_reader;
+     GRANT SELECT ON ALL TABLES IN SCHEMA demographic TO ferroehr_ehr_reader" >/dev/null 2>&1
+  if dc exec -T -e FERROEHR__DB__URL="$restored_dsn" -e FERROEHR__DB__MIGRATE=verify \
+      ferroehr /usr/local/bin/ferroehr db verify >/dev/null 2>&1; then
+    probe_fail "\`ferroehr db verify\` refusing a cross-domain grant" \
+      "it accepted a database where ferroehr_ehr_reader can read demographic tables" \
+      "the boot gate is then decorative, and a careless restore ships a collapsed boundary"
+  fi
+  probe_done
+
+  dc exec -T ferroehr-postgres psql -qtAX -U "${PG_INIT_USER:-ferroehr}" \
+    -d "${PG_INIT_DB:-ferroehr}" -c "DROP DATABASE IF EXISTS $restored" >/dev/null 2>&1
+
+  uncovered "point-in-time recovery" \
+    "PITR stays instance-wide by design (the two domains share one cluster), so
+     nothing here exercises a WAL archive or a recovery target. What is measured
+     is the LOGICAL per-domain dump and the restore's grant posture."
+  uncovered "an off-host backup target" \
+    "both dumps land in a directory on the machine running the stack. Whether a
+     deployment's two targets are genuinely separately access-controlled — different
+     owners, different buckets, different credentials — is an operator property this
+     harness cannot observe."
 }

--- a/scripts/deploy-probes/compose.sh
+++ b/scripts/deploy-probes/compose.sh
@@ -551,15 +551,32 @@ probes_backup_restore() {
   # Compose's own progress and orphan-container chatter is dropped: it is
   # longer than the diagnostic underneath it, and a truncated note that shows
   # the chatter instead of the error is worse than no note.
-  local dump_log=""
-  local job
+  local dump_log="" dump_status=0
+  local job status
   for job in clinical demographic; do
-    dump_log="$dump_log$(FERROEHR_BACKUP_CLINICAL_DIR="$dumps/clinical" \
+    # The job's EXIT STATUS is the assertion, not the presence of a file:
+    # `pg_dump --file` creates its output before it connects, so a dump that
+    # dies part-way leaves an artefact behind. Checking only for a file lets a
+    # truncated archive through and throws the reason away — which is exactly
+    # what happened here (#3157), and cost several runs.
+    # The status is taken from the RUN, before any filtering: a pipeline
+    # reports its last stage, which would be the noise filter's.
+    local raw
+    raw="$(FERROEHR_BACKUP_CLINICAL_DIR="$dumps/clinical" \
       FERROEHR_BACKUP_DEMOGRAPHIC_DIR="$dumps/demographic" \
       dc -f docker-compose.yml --profile backup run --rm --quiet-pull \
-        "ferroehr-backup-$job" 2>&1 \
+        "ferroehr-backup-$job" 2>&1)"
+    status=$?
+    [ "$status" -eq 0 ] || dump_status=$status
+    dump_log="${dump_log}[$job exit=$status] $(printf '%s' "$raw" \
       | grep -vE '^time="|^ *Container |orphan containers' | tr '\n' ' ')"
   done
+  if [ "$dump_status" -ne 0 ]; then
+    probe_fail "both dump jobs exit 0" "exit $dump_status" \
+      "the recipe reported: $(printf '%s' "$dump_log" | tail -c 400)"
+    probe_done
+    return
+  fi
   local clinical_dump demographic_dump
   clinical_dump="$(find "$dumps/clinical" -name 'clinical-*.dump' -print -quit 2>/dev/null)"
   demographic_dump="$(find "$dumps/demographic" -name 'demographic-*.dump' -print -quit 2>/dev/null)"

--- a/scripts/deploy-probes/compose.sh
+++ b/scripts/deploy-probes/compose.sh
@@ -614,10 +614,16 @@ reported: ${dump_log:0:300}"
   probe "P-BACKUP-RESTORE" "working" "database" "#3157" \
     "a database restored from the two dumps passes the boot self-check"
   local restored=ferroehr_restored
-  dc exec -T ferroehr-postgres psql -qtAX -U "${PG_INIT_USER:-ferroehr}" \
-    -d "${PG_INIT_DB:-ferroehr}" -c "DROP DATABASE IF EXISTS $restored" >/dev/null 2>&1
-  dc exec -T ferroehr-postgres psql -qtAX -U "${PG_INIT_USER:-ferroehr}" \
-    -d "${PG_INIT_DB:-ferroehr}" -c "CREATE DATABASE $restored" >/dev/null 2>&1
+  # The database is created by the BOOTSTRAP superuser and owned by the
+  # application role, which is what a restore runbook does: the application
+  # role holds no CREATEDB, and a database owned by `postgres` would refuse
+  # the restore its schemas. Errors are kept — a suppressed CREATE DATABASE
+  # turns into a confusing "database does not exist" three steps later.
+  local create_log
+  create_log="$(dc exec -T ferroehr-postgres psql -qtAX -U postgres \
+    -d "${PG_INIT_DB:-ferroehr}" \
+    -c "DROP DATABASE IF EXISTS $restored" \
+    -c "CREATE DATABASE $restored OWNER ${PG_INIT_USER:-ferroehr}" 2>&1)"
   # The restore runs the way an operator's would: a client container on the
   # stack's network with the two dump directories mounted. Copying the files
   # INTO the database container instead would restore from a path no runbook
@@ -651,7 +657,8 @@ reported: ${dump_log:0:300}"
   else
     probe_fail "the restored database passes \`ferroehr db verify\`" \
       "${verify_out:0:400}" \
-      "restore output: ${restore_log:0:200}"
+      "create: ${create_log:0:150} || restore: $(printf '%s' "$restore_log" \
+        | grep -vE '^time="|^ *Container |orphan containers' | tr '\n' ' ' | tail -c 250)"
   fi
   probe_done
 
@@ -663,11 +670,20 @@ reported: ${dump_log:0:300}"
   dc exec -T ferroehr-postgres psql -qtAX -U "${PG_INIT_USER:-ferroehr}" -d "$restored" -c \
     "GRANT USAGE ON SCHEMA demographic TO ferroehr_ehr_reader;
      GRANT SELECT ON ALL TABLES IN SCHEMA demographic TO ferroehr_ehr_reader" >/dev/null 2>&1
-  if dc exec -T -e FERROEHR__DB__URL="$restored_dsn" -e FERROEHR__DB__MIGRATE=verify \
-      ferroehr /usr/local/bin/ferroehr db verify >/dev/null 2>&1; then
+  local breach_out
+  if breach_out="$(dc exec -T -e FERROEHR__DB__URL="$restored_dsn" \
+      -e FERROEHR__DB__MIGRATE=verify \
+      ferroehr /usr/local/bin/ferroehr db verify 2>&1)"; then
     probe_fail "\`ferroehr db verify\` refusing a cross-domain grant" \
       "it accepted a database where ferroehr_ehr_reader can read demographic tables" \
       "the boot gate is then decorative, and a careless restore ships a collapsed boundary"
+  else
+    # A refusal for ANY other reason would make this probe pass without
+    # measuring the gate at all — the vacuity this harness exists to avoid.
+    assert_contains "$breach_out" "ferroehr_ehr_reader" \
+      "the refusal must name the role that reached across, not merely be a refusal"
+    assert_contains "$breach_out" "demographic" \
+      "the refusal must name the domain it reached into"
   fi
   probe_done
 

--- a/scripts/deploy-probes/compose.sh
+++ b/scripts/deploy-probes/compose.sh
@@ -624,23 +624,10 @@ reported: ${dump_log:0:300}"
     -d "${PG_INIT_DB:-ferroehr}" \
     -c "DROP DATABASE IF EXISTS $restored" \
     -c "CREATE DATABASE $restored OWNER ${PG_INIT_USER:-ferroehr}" 2>&1)"
-  # The restore runs the way an operator's would: a client container on the
-  # stack's network with the two dump directories mounted. Copying the files
-  # INTO the database container instead would restore from a path no runbook
-  # uses, and its /tmp is a tmpfs the copy does not reach.
-  local restore_log
-  restore_log="$(FERROEHR_BACKUP_CLINICAL_DIR="$dumps/clinical" \
-    FERROEHR_BACKUP_DEMOGRAPHIC_DIR="$dumps/demographic" \
-    dc -f docker-compose.yml --profile backup run --rm --quiet-pull \
-      --entrypoint /bin/sh -v "$dumps:/dumps:ro" ferroehr-backup-clinical -c \
-      "pg_restore --host=ferroehr-postgres --username=${PG_INIT_USER:-ferroehr} \
-         --dbname=$restored --no-owner /dumps/clinical/$(basename "$clinical_dump") 2>&1;
-       pg_restore --host=ferroehr-postgres --username=${PG_INIT_USER:-ferroehr} \
-         --dbname=$restored --no-owner /dumps/demographic/$(basename "$demographic_dump") 2>&1" 2>&1)"
   # The DSN is taken from the SERVER CONTAINER's own environment and its
-  # database name swapped, rather than rebuilt from the compose defaults: this
-  # probe then authenticates with the credential the stack actually runs, and
-  # no credential literal lives in this harness.
+  # database name swapped, rather than rebuilt from the compose defaults: the
+  # restore and the verify then use the credential the stack actually runs,
+  # and no credential literal lives in this harness.
   local restored_dsn verify_out
   restored_dsn="$(docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' \
     "$(dc ps -q ferroehr)" 2>/dev/null | sed -n 's/^FERROEHR__DB__URL=//p')"
@@ -651,14 +638,28 @@ reported: ${dump_log:0:300}"
     return
   fi
   restored_dsn="${restored_dsn%/*}/$restored"
+  # The restore runs the way an operator's would: a client container on the
+  # stack's network with the dump directory mounted, addressed by DSN. It is
+  # the same `docker run` shape the table-of-contents read above uses, because
+  # that one demonstrably reaches these files.
+  local restore_log network
+  network="$(docker inspect \
+    --format '{{range $net, $_ := .NetworkSettings.Networks}}{{$net}}{{end}}' \
+    "$(dc ps -q ferroehr-postgres)" 2>/dev/null)"
+  restore_log="$(docker run --rm --network "$network" -v "$dumps:/dumps:ro" \
+    "${FERROEHR_POSTGRES_IMAGE:-ghcr.io/rubentalstra/ferroehr-postgres:4.1.1}" \
+    sh -c "pg_restore --dbname='$restored_dsn' --no-owner \
+             '/dumps/clinical/$(basename "$clinical_dump")';
+           pg_restore --dbname='$restored_dsn' --no-owner \
+             '/dumps/demographic/$(basename "$demographic_dump")'" 2>&1)"
   if verify_out="$(dc exec -T -e FERROEHR__DB__URL="$restored_dsn" -e FERROEHR__DB__MIGRATE=verify \
       ferroehr /usr/local/bin/ferroehr db verify 2>&1)"; then
     :
   else
     probe_fail "the restored database passes \`ferroehr db verify\`" \
       "${verify_out:0:400}" \
-      "create: ${create_log:0:150} || restore: $(printf '%s' "$restore_log" \
-        | grep -vE '^time="|^ *Container |orphan containers' | tr '\n' ' ' | tail -c 250)"
+      "create: ${create_log:0:150} || network: '${network}' || restore: $(printf '%s' \
+        "$restore_log" | tr '\n' ' ' | tail -c 250)"
   fi
   probe_done
 

--- a/scripts/deploy-probes/compose.sh
+++ b/scripts/deploy-probes/compose.sh
@@ -560,9 +560,19 @@ probes_backup_restore() {
   clinical_dump="$(find "$dumps/clinical" -name 'clinical-*.dump' -print -quit 2>/dev/null)"
   demographic_dump="$(find "$dumps/demographic" -name 'demographic-*.dump' -print -quit 2>/dev/null)"
   if [ -z "$clinical_dump" ] || [ -z "$demographic_dump" ]; then
+    # A dump that produced no file says nothing about WHY on its own, and the
+    # answer is usually about the target rather than about postgres: who the
+    # job runs as, and what the mount looks like from inside it.
+    local target_state
+    target_state="$(FERROEHR_BACKUP_CLINICAL_DIR="$dumps/clinical" \
+      FERROEHR_BACKUP_DEMOGRAPHIC_DIR="$dumps/demographic" \
+      dc -f docker-compose.yml --profile backup run --rm --quiet-pull \
+        --entrypoint /bin/sh ferroehr-backup-clinical -c \
+        'id; ls -ldn /backup; grep " /backup " /proc/mounts; touch /backup/.probe-write 2>&1' 2>&1)"
     probe_fail "one dump file in each of the two target directories" \
       "clinical='$clinical_dump' demographic='$demographic_dump'" \
-      "the documented recipe reported: ${dump_log:0:400}"
+      "recipe: ${dump_log:0:300} || target from inside the job: ${target_state:0:400} \
+|| on the host: $(ls -ldn "$dumps/clinical" 2>&1)"
     probe_done
     return
   fi

--- a/scripts/deploy-probes/compose.sh
+++ b/scripts/deploy-probes/compose.sh
@@ -648,7 +648,8 @@ reported: ${dump_log:0:300}"
     "$(dc ps -q ferroehr-postgres)" 2>/dev/null)"
   restore_log="$(docker run --rm --network "$network" -v "$dumps:/dumps:ro" \
     "${FERROEHR_POSTGRES_IMAGE:-ghcr.io/rubentalstra/ferroehr-postgres:4.1.1}" \
-    sh -c "pg_restore --dbname='$restored_dsn' --no-owner \
+    sh -c "id; ls -ln /dumps/clinical /dumps/demographic;
+           pg_restore --dbname='$restored_dsn' --no-owner \
              '/dumps/clinical/$(basename "$clinical_dump")';
            pg_restore --dbname='$restored_dsn' --no-owner \
              '/dumps/demographic/$(basename "$demographic_dump")'" 2>&1)"
@@ -659,7 +660,7 @@ reported: ${dump_log:0:300}"
     probe_fail "the restored database passes \`ferroehr db verify\`" \
       "${verify_out:0:400}" \
       "create: ${create_log:0:150} || network: '${network}' || restore: $(printf '%s' \
-        "$restore_log" | tr '\n' ' ' | tail -c 250)"
+        "$restore_log" | tr '\n' ' ' | tail -c 600)"
   fi
   probe_done
 

--- a/scripts/deploy-probes/compose.sh
+++ b/scripts/deploy-probes/compose.sh
@@ -616,8 +616,20 @@ reported: ${dump_log:0:300}"
          --dbname=$restored --no-owner /dumps/clinical/$(basename "$clinical_dump") 2>&1;
        pg_restore --host=ferroehr-postgres --username=${PG_INIT_USER:-ferroehr} \
          --dbname=$restored --no-owner /dumps/demographic/$(basename "$demographic_dump") 2>&1" 2>&1)"
+  # The DSN is taken from the SERVER CONTAINER's own environment and its
+  # database name swapped, rather than rebuilt from the compose defaults: this
+  # probe then authenticates with the credential the stack actually runs, and
+  # no credential literal lives in this harness.
   local restored_dsn verify_out
-  restored_dsn="postgres://${PG_INIT_USER:-ferroehr}:${PG_INIT_PASSWORD:-ferroehr}@ferroehr-postgres:5432/$restored"
+  restored_dsn="$(docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' \
+    "$(dc ps -q ferroehr)" 2>/dev/null | sed -n 's/^FERROEHR__DB__URL=//p')"
+  if [ -z "$restored_dsn" ]; then
+    probe_fail "the server container's FERROEHR__DB__URL" "(empty)" \
+      "without it this probe would build a DSN of its own and measure that instead"
+    probe_done
+    return
+  fi
+  restored_dsn="${restored_dsn%/*}/$restored"
   if verify_out="$(dc exec -T -e FERROEHR__DB__URL="$restored_dsn" -e FERROEHR__DB__MIGRATE=verify \
       ferroehr /usr/local/bin/ferroehr db verify 2>&1)"; then
     :

--- a/scripts/deploy-probes/lib.sh
+++ b/scripts/deploy-probes/lib.sh
@@ -61,7 +61,7 @@ probe_done() {
   PROBE_ROWS+=("$(printf '{"id":"%s","state":"%s","outcome":"%s","layer":"%s","issue":"%s","title":"%s"}' \
     "$PROBE_ID" "$PROBE_STATE" "$outcome" \
     "$([[ "$outcome" = fail ]] && printf '%s' "$PROBE_LAYER" || printf '')" \
-    "$PROBE_ISSUE" "$PROBE_TITLE")")
+    "$PROBE_ISSUE" "$(json_string "$PROBE_TITLE")")")
 }
 
 # The failure path: name the layer, quote what was actually seen.
@@ -101,9 +101,27 @@ assert_not_contains() {
   esac
 }
 
+# One JSON string value: the control characters and quoting a record must
+# escape to stay parseable.
+#
+# Every reason in this harness is written as a wrapped shell string, so it
+# carries literal newlines — interpolated raw, they made the emitted record
+# invalid JSON, which is what a record is FOR (found 2026-09-10 while adding
+# the backup family: `jq` refused both the artifact and the committed
+# docs/conformance/deployment/compose.json). Newlines and the runs of
+# indentation after them collapse to one space; quotes, backslashes and tabs
+# are escaped (RFC 8259 §7).
+json_string() {
+  printf '%s' "$1" | tr -d '\r' | awk '
+    { gsub(/\\/, "\\\\"); gsub(/"/, "\\\""); gsub(/\t/, " ");
+      sub(/^[[:space:]]+/, ""); printf "%s%s", (NR > 1 ? " " : ""), $0 }
+  '
+}
+
 # uncovered <what> <why> — the honest half of the report.
 uncovered() {
-  PROBE_UNCOVERED+=("$(printf '{"what":"%s","why":"%s"}' "$1" "$2")")
+  PROBE_UNCOVERED+=("$(printf '{"what":"%s","why":"%s"}' \
+    "$(json_string "$1")" "$(json_string "$2")")")
   PROBE_SKIP=$((PROBE_SKIP + 1))
 }
 

--- a/website/book/src/installation/kubernetes.md
+++ b/website/book/src/installation/kubernetes.md
@@ -38,7 +38,7 @@ kubectl -n ferroehr create secret generic ferroehr-db \
   --from-literal=FERROEHR__DB__URL='postgres://ferroehr_app:***@pg-host:5432/ferroehr?sslmode=verify-full'
 
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 7.1.0 -n ferroehr \
+  --version 7.2.0 -n ferroehr \
   --set database.existingSecret=ferroehr-db \
   --set image.tag=4.1.1
 ```
@@ -55,7 +55,7 @@ helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
 reference. To read the chart's metadata without installing it:
 
 ```shell
-helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 7.1.0
+helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 7.2.0
 ```
 
 ### Pin two versions, not one
@@ -68,7 +68,7 @@ against.
 
 | | Selects | Pin with | Line |
 |---|---|---|---|
-| Chart version | templates, values schema, defaults | `--version 7.1.0` | SemVer over the chart's own contract |
+| Chart version | templates, values schema, defaults | `--version 7.2.0` | SemVer over the chart's own contract |
 | Image tag | the server binary | `--set image.tag=4.1.1` (or `image.digest`) | the application's SemVer line |
 
 Always pin the image to an immutable version or, better, a `@sha256` digest,
@@ -167,7 +167,7 @@ metadata lists: the server, and the optional viewer.
 > the image itself as the authority:
 >
 > ```shell
-> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 7.1.0 \
+> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 7.2.0 \
 >   -s templates/configmap.yaml --set database.existingSecret=ferroehr-db \
 >   | sed -n '/ferroehr.toml/,$p' | sed '1d;s/^    //' > /tmp/ferroehr.toml
 > docker run --rm -v /tmp/ferroehr.toml:/etc/ferroehr/ferroehr.toml:ro \
@@ -572,7 +572,7 @@ config:
 
 ```shell
 helm upgrade ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 7.1.0 -n ferroehr --reuse-values \
+  --version 7.2.0 -n ferroehr --reuse-values \
   --set config.query.plan_cache_capacity=512
 ```
 
@@ -659,6 +659,30 @@ own record: the viewer's OIDC path, the screens behind a session, and whether a
 CNI enforces the viewer's NetworkPolicy. Its screens are documented in the
 [viewer](../viewer/index.md) chapter.
 
+### Per-domain backups (two CronJobs, off by default)
+
+`backup.enabled` renders one CronJob per pseudonymisation domain:
+`backup.clinical.schedule` dumps the clinical schemas, `backup.demographic.schedule`
+dumps the identities, and each writes to its own existing claim
+(`backup.clinical.persistentVolumeClaim`, `backup.demographic.persistentVolumeClaim`).
+The image is `backup.image.repository`, which carries `pg_dump`.
+
+The chart refuses to render rather than let the separation collapse quietly: a
+missing claim is an error naming the value, and naming the **same** claim for
+both domains is an error too, because one volume holding the clinical record
+and the identities together is the state per-domain backups exist to prevent.
+
+The credential follows the same split the pools use. The demographic job reads
+`database.demographicExistingSecret` when you set it, and falls back to the
+clinical DSN when you do not — so until you run two credentials, you have
+separated the artefacts but not the authority to produce them. Both jobs read
+their DSN from a mounted file, never an environment variable.
+
+The chart provisions no storage. Create the two claims yourself, and give them
+different access control; that part no chart can do for you. The restore
+procedure, and the `ferroehr db verify` gate that judges it, are on the
+[Operating](../operations.md) page.
+
 ## Staying available while things move
 
 Four defaults keep the API serving through the events that routinely interrupt
@@ -725,7 +749,7 @@ Preview an upgrade against what you have installed with
 `helm diff`, or render the new chart version and read it:
 
 ```shell
-helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 7.1.0 \
+helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 7.2.0 \
   -n ferroehr -f my-values.yaml | less
 ```
 

--- a/website/book/src/installation/kubernetes.md
+++ b/website/book/src/installation/kubernetes.md
@@ -672,11 +672,14 @@ missing claim is an error naming the value, and naming the **same** claim for
 both domains is an error too, because one volume holding the clinical record
 and the identities together is the state per-domain backups exist to prevent.
 
-The credential follows the same split the pools use. The demographic job reads
-`database.demographicExistingSecret` when you set it, and falls back to the
-clinical DSN when you do not — so until you run two credentials, you have
-separated the artefacts but not the authority to produce them. Both jobs read
-their DSN from a mounted file, never an environment variable.
+Each job needs **its own backup credential**, named by
+`backup.clinical.existingSecret` and `backup.demographic.existingSecret`, and
+the render is refused without them. It cannot be the pool's credential: every
+tenant-scoped table carries `FORCE ROW LEVEL SECURITY`, so `pg_dump` refuses a
+table it would read through a policy, and a CronJob wired to the runtime role
+would fail every night. Give each domain a role with `BYPASSRLS`, read-only on
+that domain's schemas. Both jobs read their DSN from a mounted file, never an
+environment variable.
 
 The chart provisions no storage. Create the two claims yourself, and give them
 different access control; that part no chart can do for you. The restore

--- a/website/book/src/operations.md
+++ b/website/book/src/operations.md
@@ -286,6 +286,10 @@ docker compose --profile backup run --rm ferroehr-backup-demographic
 
 Set `FERROEHR_BACKUP_CLINICAL_DIR` and `FERROEHR_BACKUP_DEMOGRAPHIC_DIR` to the
 two targets; they default to `./backups/clinical` and `./backups/demographic`.
+The dump runs as root inside the container so it can write a directory you
+created — the container holds no capabilities, cannot gain privileges and has a
+read-only root filesystem, but the file lands owned by root. For a file owned
+by you, run with `FERROEHR_BACKUP_USER="$(id -u):$(id -g)"`.
 Under Kubernetes the chart renders one `CronJob` per domain — see the chart's
 `backup` values.
 

--- a/website/book/src/operations.md
+++ b/website/book/src/operations.md
@@ -296,9 +296,19 @@ root filesystem.
 Under Kubernetes the chart renders one `CronJob` per domain — see the chart's
 `backup` values.
 
-Two properties are yours to arrange, because no configuration file can enforce
-them: the two targets carry **different** access control, and the credential
-each job uses reaches **one** domain. Give the demographic job the demographic
+> [!WARNING]
+> **A backup credential needs `BYPASSRLS`, and the application role does not
+> have it.** Every tenant-scoped table carries `FORCE ROW LEVEL SECURITY`, so
+> the policy applies to the table's owner too, and `pg_dump` refuses a table it
+> would have to read through one: *"query would be affected by row-level
+> security policy"*. That refusal is the safe outcome. The unsafe one is
+> `--enable-row-security`, which makes the dump succeed and quietly contain a
+> single tenant's rows — never use it for a backup. Give the backup job a role
+> with `BYPASSRLS` (or a superuser), read-only on its own domain.
+
+Two further properties are yours to arrange, because no configuration file can
+enforce them: the two targets carry **different** access control, and the
+credential each job uses reaches **one** domain. Give the demographic job the demographic
 DSN once you run two ([Deploying](installation/kubernetes.md)); with a single
 credential you have separated the artefacts but not the authority to produce
 them.

--- a/website/book/src/operations.md
+++ b/website/book/src/operations.md
@@ -256,6 +256,76 @@ Enable WAL archiving and point-in-time recovery from day one (pgBackRest or a
 managed PITR), because a CDR's data is not reconstructible. Clinical and audit
 tables are never `UNLOGGED`. Test your restore, not just your backup.
 
+### Dump each domain separately
+
+A logical backup is where the two pseudonymisation domains are easiest to
+re-join by accident. One `pg_dump` of the whole database produces a single file
+holding both the pseudonymised clinical record and the identities of its
+subjects, and whoever can read that file can re-identify every record in it —
+which is the separation the schema split and the database roles exist to
+maintain. Dump per schema instead, into targets with different access control:
+
+```bash
+# The clinical domain
+pg_dump --dbname="$CLINICAL_DSN" --format=custom --no-owner \
+  --schema=ehr --schema=cold --schema=ext --schema=audit \
+  --file=/backups/clinical/clinical-$(date -u +%Y%m%dT%H%M%SZ).dump
+
+# The identities, into a different directory, owned by a different group
+pg_dump --dbname="$DEMOGRAPHIC_DSN" --format=custom --no-owner \
+  --schema=demographic --schema=cold_demographic \
+  --file=/backups/demographic/demographic-$(date -u +%Y%m%dT%H%M%SZ).dump
+```
+
+Both examples ship. In Compose they are the opt-in `backup` profile:
+
+```bash
+docker compose --profile backup run --rm ferroehr-backup-clinical
+docker compose --profile backup run --rm ferroehr-backup-demographic
+```
+
+Set `FERROEHR_BACKUP_CLINICAL_DIR` and `FERROEHR_BACKUP_DEMOGRAPHIC_DIR` to the
+two targets; they default to `./backups/clinical` and `./backups/demographic`.
+Under Kubernetes the chart renders one `CronJob` per domain — see the chart's
+`backup` values.
+
+Two properties are yours to arrange, because no configuration file can enforce
+them: the two targets carry **different** access control, and the credential
+each job uses reaches **one** domain. Give the demographic job the demographic
+DSN once you run two ([Deploying](installation/kubernetes.md)); with a single
+credential you have separated the artefacts but not the authority to produce
+them.
+
+> [!NOTE]
+> Point-in-time recovery stays instance-wide. Both domains live in one cluster,
+> so a WAL archive covers them together and a recovery target restores them
+> together. The separation this section is about is the logical dump.
+
+### Restoring
+
+A restore is not finished when `pg_restore` exits. The grants are the
+boundary — a database whose roles came back wrong is a database where the
+clinical role can read the identities — so re-apply the role grants before the
+server starts, then let the server check them:
+
+```bash
+createdb ferroehr_restored
+pg_restore --dbname=ferroehr_restored --no-owner clinical-….dump
+pg_restore --dbname=ferroehr_restored --no-owner demographic-….dump
+# then, before anything serves traffic:
+ferroehr db verify
+```
+
+`ferroehr db verify` issues no DDL. It checks that the database carries exactly
+this build's migrations and that no runtime role can read across the domain
+boundary, exiting non-zero when either is untrue — the same check the server
+runs at boot, which is why a server pointed at a badly restored database
+refuses to start rather than serving from it.
+
+Restoring only one domain is a supported outcome, not a mistake: a demographic
+dump restored on its own gives a database with identities and no clinical
+record, which is what a rehearsal of the identity domain's recovery looks like.
+
 ## Rotating the national-identifier key
 
 Only relevant when `[demographic.identifier_protection]` is on. With it on, a
@@ -297,7 +367,10 @@ The procedure:
 
 A per-tenant key is derived from the root key rather than stored, so adding a
 tenant needs no key management, and rotating the root rotates every tenant's
-subkeys together.
+subkeys together. The pseudonymisation domain is part of that derivation too:
+a subkey derived for the clinical domain opens nothing in the demographic one,
+so the per-schema backups above are separate artefacts under separate keys even
+where one root key is configured.
 
 ## The container image and pod hardening
 

--- a/website/book/src/operations.md
+++ b/website/book/src/operations.md
@@ -286,10 +286,13 @@ docker compose --profile backup run --rm ferroehr-backup-demographic
 
 Set `FERROEHR_BACKUP_CLINICAL_DIR` and `FERROEHR_BACKUP_DEMOGRAPHIC_DIR` to the
 two targets; they default to `./backups/clinical` and `./backups/demographic`.
-The dump runs as root inside the container so it can write a directory you
-created — the container holds no capabilities, cannot gain privileges and has a
-read-only root filesystem, but the file lands owned by root. For a file owned
-by you, run with `FERROEHR_BACKUP_USER="$(id -u):$(id -g)"`.
+Run it as yourself — `FERROEHR_BACKUP_USER="$(id -u):$(id -g)"` — and the dump
+lands owned by you. Left unset, the job runs as root inside the container and
+keeps one capability, `DAC_OVERRIDE`, because that is what writing a directory
+it does not own actually requires: the container drops every other capability,
+and without this one uid 0 is just another user against your directory's
+permission bits. Everything else stays off — no privilege escalation, read-only
+root filesystem.
 Under Kubernetes the chart renders one `CronJob` per domain — see the chart's
 `backup` values.
 


### PR DESCRIPTION
## What this changes

Closes #3157

A backup that carries the pseudonymised clinical record and the identities of its subjects in one file re-joins exactly what the schema split (#3153), the runtime roles (#3179) and the sealed identifiers (#3155) exist to keep apart. This closes that hole in two places — the keys and the dumps — and puts a gate on the restore.

**Keys.** The per-tenant subkeys protecting national identifiers now take the pseudonymisation domain as part of their SP 800-108 derivation context (`KeyDomain::{Ehr, Demographic, Linkage}`). A key derived for the clinical domain neither opens a demographic record nor reproduces its lookup digest, even when both derive from the same configured root key — which is what makes a per-schema dump a separate artefact under a separate key rather than two files under one. `the_clinical_domain_key_cannot_read_a_demographic_record` is **mutation-proven**: remove the domain from the derivation and it fails.

`[demographic.identifier_protection]` has not shipped in a release, so no stored data is affected.

**Dumps.** Compose gains an opt-in `backup` profile — `docker compose --profile backup run --rm ferroehr-backup-clinical` (and its demographic twin) — writing to two separate directories. The chart gains one CronJob per domain, each with its own schedule, its own claim and its own credential, and it refuses to render when a claim is missing or when both domains name the same one. The operations page carries the `pg_dump --schema` recipe, the restore procedure, and the two properties no configuration can enforce for you: different access control on the two targets, and a credential per job that reaches one domain.

**Restores.** `ferroehr db verify` is the gate — the same check the server runs at boot, issuing no DDL and refusing a database whose grants let a runtime role read across the boundary. The new `backup_restore` deploy-probe family dumps through the shipped recipe, asserts neither artefact carries the other domain's relations, restores into a fresh database and asks the server for its verdict — then proves the verdict is load-bearing by re-applying grants carelessly and requiring a refusal.

## Two gaps found on the way, both closed here

- **A gate that could not see the containers it was gating.** `deploy/helm/gates/restricted.jq` walked only `.spec.template`, so a CronJob's pod (`.spec.jobTemplate.spec.template`) was invisible and both new containers would have shipped unchecked. Fixed and mutation-proven — `--set securityContext.readOnlyRootFilesystem=false` now reports `CronJob/ferroehr-backup-clinical/pg-dump: readOnlyRootFilesystem must be true`.
- **Probes measuring the wrong image.** A local `deploy-probe.sh` run defaults to the published server image, which predates the demographic schema — so #3179's `P-ROLE-BOUNDARY` was passing against a database with no second domain to separate. Both domain families now read the catalogue first and declare themselves not exercised, naming the cause, instead of looking green. CI builds from source and measures the real thing.

Two coverage holes closed beside them: `boot-check.sh` had no stand-in for the demographic DSN, so **no overlay could exercise the two-credential branch from #3179** — it now renders in the all-features golden and boots in `chart-boot`.

## Adjudication worth your eye

`ferroehr-postgres` is listed in `artifacthub.io/images` again, reversing its recorded removal. The rule is "only images this chart actually deploys": it was removed because the chart provisions no database, and it returns because with `backup.enabled` the chart does install that image to run `pg_dump` — the same footing as the opt-in viewer. The annotation comment states the reversal. A three-line revert if you disagree.

## Honest about what is not measured

The restore probe's **pass** path has not been observed locally. A from-source image build was killed twice for memory on this machine, and the published image cannot demonstrate a domain it has no schema for; what I did verify locally is that the probe correctly *declines* on such a stack. The `deploy-probe` CI job builds from source, so this PR's own run is the first real exercise of it — if it is red, that is a defect in the probe or in the recipe and I will fix it rather than relax the probe.

The chart side is render-verified only: `validate.sh` says in its own output that a green run says nothing about whether a pod starts. Nobody has run these CronJobs against a real cluster.

En route: **#3197** (the migration Job's pod matches the server's Service and PDB selectors — latent, that pod exposes no `http` port) is filed rather than fixed here, since changing an existing workload's labels deserves its own review.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.

## Checks

- [x] `cargo fmt --all --check` · `cargo clippy --workspace --all-targets` · `cargo nextest run --workspace`
- [x] No test weakened, skipped, or edited to route around a bug
- [x] User-visible change → `CHANGELOG.md [Unreleased]` entry
- [x] REST/config/CLI/deployment change → matching `website/book/src` page updated
- [x] Implemented `docs/plans/*.md` plan file deleted (unless another open issue still consumes it)
- [x] New issues opened from this work are linked as GitHub relationships, not prose

## Privacy boundary

- [x] The data flow is described above: this change reads no personal data at runtime. It changes how the key protecting a national identifier is DERIVED (the domain enters the KDF context), and it adds jobs that export the two domains to two separate targets.
- [x] The roles are named: the clinical dump job runs as the clinical DSN's role, the demographic dump job as `database.demographicExistingSecret`'s when set; `ferroehr db verify` reads `pg_roles` and the four runtime roles' grants.
- [x] No new grant spans the clinical and demographic domains — the restore probe asserts the opposite would be refused.
- [x] Synthetic data only in tests, fixtures, seeds and examples
- [x] An access event is emitted wherever this change added a read of personal data (it adds none)

Local: `cargo nextest run --workspace --exclude ferroehr-viewer --all-features` (4743 passed, 6 skipped) · the clippy lanes · `deploy/helm/validate.sh` (13 refusals probed, 14 malformed-values probes) · `docs-claims`, `comment-style`, `spdx-headers`, `shellcheck-lane`, `compose-hardening`, `changelog-structure`, `privacy-boundary --self-test`.
