### PR TITLE
feat(its): a feature set a browser can take, with the flat and OPT code in it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1056,6 +1056,47 @@ jobs:
       - run: cargo clippy --locked -p ferroehr-server --no-default-features --features events --all-targets -- -D warnings
       - run: cargo clippy --locked -p ferroehr-server --no-default-features --features fhir --all-targets -- -D warnings
 
+  # ── openehr-its on wasm32: the browser-consumer feature selection ──────────
+  # `openehr-its` publishes a feature graph whose openEHR content layers
+  # (`json` → `xml` → `opt14` → `flat`) are meant to compile for a browser
+  # client, while `cache` (moka), `schema-validation` (jsonschema) and
+  # `rest-server` (axum) deliberately do not. Nothing else in CI compiles that
+  # selection: the clippy job runs --all-features, and the viewer's wasm lane
+  # takes the crate with default-features = false, which reaches only the
+  # dependency-free `rest::smart_scopes` island. So the property was claimed by
+  # the manifest and checked by no lane at all.
+  #
+  # Library target only, no --all-targets: the crate's dev-dependencies
+  # (testkit -> sqlx, tokio -> mio) are native by construction and cannot build
+  # for wasm32-unknown-unknown. The features are spelled out rather than left to
+  # `flat`'s implication chain, so a change to that chain cannot silently narrow
+  # what this lane covers.
+  its-wasm:
+    name: clippy (openehr-its on wasm32)
+    needs: changes
+    # The feature selection IS the test, and it is declared here (#2373).
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.workflows == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      # rust-cache, for the reason the clippy job states: sccache cannot cache
+      # clippy-driver invocations (mozilla/sccache#539). Its own cache entry:
+      # this target dir holds a wasm32 build of a different feature graph.
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          components: clippy
+          target: wasm32-unknown-unknown
+          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
+      - run: cargo clippy --locked -p openehr-its --target wasm32-unknown-unknown --no-default-features --features flat,opt14,xml,json -- -D warnings
+      # The island the manifest promises a scope-parsing client: no feature, no
+      # dependency, and it must still compile for the browser on its own.
+      - run: cargo clippy --locked -p openehr-its --target wasm32-unknown-unknown --no-default-features -- -D warnings
+
   # ── Rustdoc: intra-doc links + doc lints are inert unless rustdoc runs ──────
   # [workspace.lints.rustdoc] levels apply to every `cargo doc`; the -D
   # warnings env additionally promotes the warn-tier doc lints in CI
@@ -2410,6 +2451,7 @@ jobs:
       - vex
       - clippy
       - feature-combos
+      - its-wasm
       - doc
       - msrv
       - codegen-drift

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
+- **`openehr-its` compiles to `wasm32-unknown-unknown` with the flat and OPT
+  code in it** (#3149). The crate's one `full` feature dragged axum, moka and
+  jsonschema in with the parsers, so a browser consumer that wanted
+  `flat::build_web_template` or the OPT 1.4 reader had to take an HTTP server
+  and a cache too — and `default-features = false` left only the SMART scope
+  grammar. The features are layered now: `json` → `xml` → `opt14` → `flat` is
+  the parsing spine, and `cache` (moka), `schema-validation` (jsonschema) and
+  `rest-server` (axum, http, async-trait) are the layers a browser declines.
+  `full` is still the default and still means all of them, so no existing
+  consumer sees a change. A CI lane builds the wasm selection, and a second one
+  builds the dependency-free `rest::smart_scopes` island, so both are checked
+  rather than claimed.
+
 - **Backups are taken per pseudonymisation domain** (#3157). A single
   `pg_dump` of the whole database produces one file holding both the
   pseudonymised clinical record and the identities of its subjects, and
@@ -214,6 +227,16 @@ workflow refuses a tag that has no matching section here.
   anything. `.claude/rules/personal-data.md` carries the rules for agents.
 
 ### Changed
+
+- **The published model crates no longer carry a random-number generator.**
+  The workspace pinned `uuid` with `v4`/`v7`/`fast-rng` for everyone, but only
+  the server and the test harness ever mint an identifier; `openehr-base`,
+  `openehr-rm` and their siblings parse and serialize them. The unused
+  generator is what made those crates refuse to compile for
+  `wasm32-unknown-unknown`, which has no randomness source unless one is
+  configured — so a browser consumer had to supply a backend for a capability
+  none of the crates uses. The generator features now sit on the two crates
+  that generate.
 
 - **A key derived for one pseudonymisation domain opens nothing in another**
   (#3157). The per-tenant subkeys protecting national identifiers now take the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5503,7 +5503,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "indexmap 2.14.2",
  "openehr-am",
@@ -5519,7 +5519,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "serde",
  "serde_json",
@@ -5548,7 +5548,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "async-trait",
  "axum",
@@ -5578,7 +5578,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "assert_fs",
  "chumsky",
@@ -5592,7 +5592,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "chumsky",
  "logos",
@@ -5601,7 +5601,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "insta",
  "jsonschema",
@@ -5619,7 +5619,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -304,7 +304,14 @@ fancy-regex = "0.19.0"               # backreferences for cADL where needed (ver
 # parser diagnostics (great for ADL/AQL error reporting):
 
 # ── Identifiers, time, validation ────────────────────────────────────────────
-uuid = { version = "1", features = ["v4", "v7", "serde", "fast-rng"] }
+# No RNG features here, deliberately: only `app/ferroehr` (v7 ids) and
+# `tools/testkit` (v4 scratch names) mint UUIDs, and they ask for the generator
+# themselves. The five PUBLISHED model crates parse and serialize UUIDs and
+# never generate one — inheriting `v4`/`v7` gave them an RNG with no backend on
+# `wasm32-unknown-unknown`, so the crates refused to compile for the browser
+# over a capability none of them uses (uuid 1.26,
+# <https://docs.rs/uuid/1.26.0/uuid/#getting-random-numbers-on-the-web>).
+uuid = { version = "1", features = ["serde"] }
 jiff = { version = "0.2.31", features = ["serde"] }   # 1.0 not yet out as of 2026-07; 0.2.31 pinned for ISO 8601 temporal work
 url = "2"
 urlencoding = "2.1.3"

--- a/app/ferroehr/Cargo.toml
+++ b/app/ferroehr/Cargo.toml
@@ -82,7 +82,7 @@ thiserror.workspace = true
 # redacted TOML for `config check` / `/management/env`. No openEHR spec governs
 # configuration — our own design (no openEHR spec governs the config tree).
 toml.workspace = true
-uuid.workspace = true
+uuid = { workspace = true, features = ["v7", "fast-rng"] }   # ids are uuidv7 (docs/postgres-features.md pins the DB side)
 
 # `signing` module (RM common §Digital Signature; moved from the former
 # ferroehr-signing crate): OpenPGP (rPGP) detached signatures + SHA-256 digest mode.

--- a/crates/openehr-adl/Cargo.toml
+++ b/crates/openehr-adl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-adl"
-version = "0.0.63"
+version = "0.0.64"
 description = "openEHR ADL 2.4.0: hand-written ADL2/cADL/ODIN parser, AOM2 validation catalogue, specialisation flattener, OPT2 generator, and ADL 1.4→2 conversion over the generated openehr_am::v2_4::aom2 model"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,11 +16,11 @@ include = ["src/**", "README.md", "LICENSE"]
 thiserror.workspace = true   # typed SyntaxError
 regex.workspace = true       # compile-check cADL C_STRING / slot archetype-id regexes (SCSRE; master04.5)
 serde_json.workspace = true  # default_value payloads (C_DEFINED_OBJECT.default_value: serde_json::Value)
-openehr-base = { path = "../openehr-base", version = "0.0.63" }   # VersionStatus for the parsed HRID
-openehr-am = { path = "../openehr-am", version = "0.0.63" }       # v2_4 ArchetypeHrid (the identification target type)
-openehr-rm = { path = "../openehr-rm", version = "0.0.63" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
-openehr-lang = { path = "../openehr-lang", version = "0.0.63" }   # openehr_lang::odin — the ODIN section parser
-openehr-term = { path = "../openehr-term", version = "0.0.63" }   # the languages code set for the RM resource-meta rows
+openehr-base = { path = "../openehr-base", version = "0.0.64" }   # VersionStatus for the parsed HRID
+openehr-am = { path = "../openehr-am", version = "0.0.64" }       # v2_4 ArchetypeHrid (the identification target type)
+openehr-rm = { path = "../openehr-rm", version = "0.0.64" }       # openehr_rm::model — the generated RM attribute/type oracle (ProductionRmModel)
+openehr-lang = { path = "../openehr-lang", version = "0.0.64" }   # openehr_lang::odin — the ODIN section parser
+openehr-term = { path = "../openehr-term", version = "0.0.64" }   # the languages code set for the RM resource-meta rows
 uuid.workspace = true        # meta uid/build_uid (AUTHORED_ARCHETYPE.uid: Uuid)
 indexmap.workspace = true    # OdinValue::Object body (insertion-ordered map)
 

--- a/crates/openehr-am/Cargo.toml
+++ b/crates/openehr-am/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-am"
-version = "0.0.63"
+version = "0.0.64"
 description = "openEHR AM Archetype Model, generated from BMM: generations v1_4 (AM 1.4.0, ADL 1.4) and v2_4 (AM 2.4.0, ADL 2; current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,8 +13,8 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.63" }
-openehr-lang = { path = "../openehr-lang", version = "0.0.63" }
+openehr-base = { path = "../openehr-base", version = "0.0.64" }
+openehr-lang = { path = "../openehr-lang", version = "0.0.64" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also carries the untyped `Value` fields the generator

--- a/crates/openehr-base/Cargo.toml
+++ b/crates/openehr-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-base"
-version = "0.0.63"
+version = "0.0.64"
 description = "openEHR BASE foundation + base types, generated from BMM: generations v1_2 (BASE 1.2.0) and v1_3 (BASE 1.3.0, current)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-its/CLAUDE.md
+++ b/crates/openehr-its/CLAUDE.md
@@ -20,14 +20,17 @@ surface is API nobody can use.
 | `src/flat/` — Simplified Formats (FLAT / STRUCTURED / Web Template / TDD) | hand-written (BMM has no simplified-format model) | edit normally, with spec citations |
 | `src/rest/smart_scopes.rs` — the SMART on openEHR scope grammar (master08 resource scopes + master07/09 launch contexts) | hand-written (an ITS-REST sub-spec with no machine-readable model) | edit normally, with spec citations — the ONE grammar the CDR's scope gate AND scope-previewing REST clients (the viewer) parse with |
 
-**Feature `full` (default = everything).** Every dependency and every surface in
-the table above rides `full`, which is on by default — consumers are unaffected.
-`default-features = false` compiles `rest::smart_scopes` ALONE, with zero
-dependencies, so a REST client that must parse SMART scope strings on
-`wasm32-unknown-unknown` (the viewer's scope previewer) uses the same
-grammar the CDR's gate enforces instead of a second parser. Keep that island
-dependency-free: nothing under `rest::smart_scopes` may reach for serde, axum, a
-spec crate, or any other dep.
+**Features (`default = ["full"]` = everything, so consumers are unaffected).**
+The graph underneath is layered: `json` → `xml` → `opt14` → `flat` are the
+openEHR content surfaces and are all wasm-safe; `cache` (`moka`),
+`schema-validation` (`jsonschema` + the embedded RM schema) and `rest-server`
+(the generated contract + `axum`) sit outside that chain. A browser consumer
+takes `default-features = false, features = ["flat"]`, and CI clippies exactly
+that on `wasm32-unknown-unknown`. Two rules when adding surface: put a new
+dependency in the layer that uses it (never in `json`, which every layer
+inherits), and keep the `rest::smart_scopes` island dependency-free —
+`default-features = false` alone must still compile it, so nothing under it may
+reach for serde, axum, a spec crate, or any other dep.
 
 **Canonical JSON is EMITTED `serde` impls on the spec types themselves, and
 they do NOT live in this crate.** `serde::Serialize`/`Deserialize` and the spec

--- a/crates/openehr-its/Cargo.toml
+++ b/crates/openehr-its/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-its"
-version = "0.0.63"
+version = "0.0.64"
 description = "openEHR ITS (Implementation Technology Specifications): canonical JSON + canonical XML serialization of the RM, the generated ITS-REST 1.1.0 API contract, OPT 1.4 and AOM2 archetype XML codecs, and the Simplified Formats (FLAT / STRUCTURED / Web Template)"
 edition.workspace = true
 rust-version.workspace = true
@@ -12,10 +12,11 @@ keywords = ["openehr", "serialization", "rest", "healthcare", "json"]
 categories = ["encoding", "web-programming"]
 include = ["src/**", "schemas/json/openehr_rm_1.1.0_all.json", "README.md", "LICENSE", "LICENSE-APACHE-2.0"]
 
-# EVERY dependency rides the default `full` feature (see [features] below), so
-# `default-features = false` yields the dependency-free `rest::smart_scopes`
-# island alone — the std-only SMART scope grammar, which a REST client compiled
-# to `wasm32-unknown-unknown` (the viewer) can then parse with.
+# EVERY dependency is optional and belongs to exactly one layer of the [features]
+# graph below, so `default-features = false` still yields the dependency-free
+# `rest::smart_scopes` island alone — the std-only SMART scope grammar, which a
+# REST client compiled to `wasm32-unknown-unknown` (the viewer) can then parse
+# with — and a browser consumer adds only the layers it reads.
 [dependencies]
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
@@ -41,48 +42,79 @@ regex = { workspace = true, optional = true }
 fancy-regex = { workspace = true, optional = true }
 # The generated XML (de)serializers impl the crate's ToXml/FromXml traits for the
 # RM/BASE spec types, so these are real (non-dev) deps.
-openehr-base = { path = "../openehr-base", version = "0.0.63", optional = true }
-openehr-rm = { path = "../openehr-rm", version = "0.0.63", optional = true }
+openehr-base = { path = "../openehr-base", version = "0.0.64", optional = true }
+openehr-rm = { path = "../openehr-rm", version = "0.0.64", optional = true }
 # The native canonical-JSON codec (`json_codec/generated`, emit-json) implements
 # `ToJson` for EVERY generated spec type the `OpenEhrType` derive covers, so it
 # spans all five spec crates (not just the RM/BASE the XML codec needs).
-openehr-lang = { path = "../openehr-lang", version = "0.0.63", optional = true }
-openehr-am = { path = "../openehr-am", version = "0.0.63", optional = true }
-openehr-term = { path = "../openehr-term", version = "0.0.63", optional = true }
+openehr-lang = { path = "../openehr-lang", version = "0.0.64", optional = true }
+openehr-am = { path = "../openehr-am", version = "0.0.64", optional = true }
+openehr-term = { path = "../openehr-term", version = "0.0.64", optional = true }
 
-# `full` — every ITS surface (canonical JSON/XML, the generated ITS-REST
-# contract, `opt14`, Simplified Formats). ON BY DEFAULT, so every consumer sees
-# the crate exactly as before.
+# The graph is layered so a consumer takes only the surfaces it reads, and so
+# the openEHR content layers stay free of anything that needs a native platform.
 #
-# Taking the crate with `default-features = false` leaves only
-# `rest::smart_scopes`, the hand-written SMART on openEHR scope grammar
-# (`docs/specs/openehr/ITS-REST/docs/smart_app_launch/master08-scopes.adoc`),
-# which needs no dependency at all. That is what lets ONE grammar serve both the
-# CDR's scope gate and a browser-side scope previewer; the alternative would be a
-# second parser in the client — exactly the drift this module exists to prevent.
+# `default = ["full"]` — every surface, exactly as before.
+#
+# A `wasm32-unknown-unknown` consumer takes `default-features = false` plus
+# `flat`, which pulls `opt14` → `xml` → `json`: canonical JSON, canonical XML,
+# OPT 1.4 and the Simplified Formats. `rest::smart_scopes` needs no feature and
+# no dependency at all, which is what lets ONE grammar serve both the CDR's
+# scope gate and a browser-side scope previewer
+# (`docs/specs/openehr/ITS-REST/docs/smart_app_launch/master08-scopes.adoc`); the
+# alternative would be a second parser in the client — exactly the drift that
+# module exists to prevent. The wasm selection is checked, not claimed: CI
+# clippies the crate for that target on every code change.
+#
+# Three layers stay OUT of that selection, each for its dependency:
+# `cache` adds `moka`, an in-process cache the browser side does not keep;
+# `schema-validation` adds `jsonschema` and compiles in the 631 KiB vendored
+# ITS-JSON RM schema; `rest-server` adds `axum` + `http` — the SERVER half of
+# the ITS-REST contract, which a REST client never implements.
 [features]
 default = ["full"]
 full = [
+    "flat",
+    "cache",
+    "opt14",
+    "xml",
+    "json",
+    "schema-validation",
+    "rest-server",
+]
+
+# Canonical JSON (`json`, `json_codec`, `wire_validate`, `rm_instance`'s RM
+# passes) over the five generated spec crates — the base every other layer
+# builds on.
+json = [
     "dep:serde",
     "dep:serde_json",
     "dep:serde_path_to_error",
-    "dep:quick-xml",
     "dep:thiserror",
-    "dep:jsonschema",
     "dep:uuid",
     "dep:indexmap",
-    "dep:async-trait",
-    "dep:axum",
-    "dep:http",
-    "dep:moka",
-    "dep:regex",
-    "dep:fancy-regex",
     "dep:openehr-base",
     "dep:openehr-rm",
     "dep:openehr-lang",
     "dep:openehr-am",
     "dep:openehr-term",
 ]
+# Canonical XML plus the AOM2 archetype XML codecs (`xml`, `aom2`, `aom2_model`).
+xml = ["json", "dep:quick-xml"]
+# The OPT 1.4 operational-template reader (`opt14`), an XML codec consumer.
+opt14 = ["xml"]
+# Simplified Formats (`flat`) and the RM-instance validation composed over them
+# (`rm_instance`), WITHOUT the WebTemplate cache.
+flat = ["opt14", "dep:regex", "dep:fancy-regex"]
+
+# The async WebTemplate cache (`flat::cache`) — the crate's only `moka` user.
+cache = ["flat", "dep:moka"]
+# Validation against the compiled-in vendored ITS-JSON RM schema
+# (`json::validate_canonical`) — the crate's only `jsonschema` user.
+schema-validation = ["json", "dep:jsonschema"]
+# The generated ITS-REST contract (`rest::generated`) and its response runtime
+# (`rest::runtime`): server traits, DTOs and route tables.
+rest-server = ["json", "dep:axum", "dep:http", "dep:async-trait"]
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/openehr-its/README.md
+++ b/crates/openehr-its/README.md
@@ -24,9 +24,38 @@ Simplified Data Formats (FLAT / STRUCTURED / Web Template).
 - **Simplified Data Formats** — the hand-written `flat` module: Web Template
   building, FLAT and STRUCTURED composition reading/writing.
 - **OPT 1.4** (`opt14`) and both AOM2 archetype XML codecs.
-- `default-features = false` leaves a dependency-free island:
-  `rest::smart_scopes`, the SMART on openEHR scope grammar — parseable from
-  `wasm32-unknown-unknown` clients.
+- `rest::smart_scopes`, the SMART on openEHR scope grammar — always compiled,
+  with no dependency at all.
+
+## Features
+
+`default = ["full"]` is every surface above. Underneath it the graph is
+layered, so a consumer takes only what it reads:
+
+| Feature | Adds | Pulls in |
+|---|---|---|
+| `json` | `json`, `json_codec`, `wire_validate` | serde, the five spec crates |
+| `xml` | `xml`, `aom2`, `aom2_model` | `json` + `quick-xml` |
+| `opt14` | `opt14` | `xml` |
+| `flat` | `flat`, `rm_instance` | `opt14` + `regex`, `fancy-regex` |
+| `cache` | `flat::cache` | `flat` + `moka` |
+| `schema-validation` | `json::validate_canonical` | `json` + `jsonschema`, the embedded RM schema |
+| `rest-server` | `rest::generated`, `rest::runtime` | `json` + `axum`, `http`, `async-trait` |
+
+### On `wasm32-unknown-unknown`
+
+```console
+$ cargo add openehr-its --no-default-features --features flat
+```
+
+That selection carries the openEHR content layers: canonical JSON, canonical
+XML, OPT 1.4 and the Simplified Formats. `flat` pulls `opt14`, `xml` and `json`
+in with it. `cache`, `schema-validation` and `rest-server` stay out; the last of
+those is the server half of the contract, which a client never implements.
+`rest::smart_scopes` needs no feature at all, so a browser client parses SMART
+scope strings with the same grammar a server enforces. FerroEHR's CI builds the
+crate for that target on every code change, so the selection is checked rather
+than claimed.
 
 ## Generated code — do not edit
 
@@ -69,8 +98,9 @@ Exactly one third-party file travels inside this package:
   Apache-2.0 ([`LICENSE-APACHE-2.0`](LICENSE-APACHE-2.0),
   <https://github.com/openEHR/specifications-ITS-JSON/blob/master/LICENSE>)
 - **Role here:** the consolidated ITS-JSON RM 1.1.0 JSON Schema, embedded as
-  `openehr_its::json::RM_SCHEMA_JSON` and used as the validation oracle for
-  canonical-JSON output — it is not a code source.
+  `openehr_its::json::RM_SCHEMA_JSON` under the `schema-validation` feature and
+  used as the validation oracle for canonical-JSON output — it is not a code
+  source.
 
 If you redistribute this crate, that file and this attribution travel with it.
 The rest of the vendored ITS-JSON tree, and the ITS-XML XSDs and ITS-REST

--- a/crates/openehr-its/src/flat/mod.rs
+++ b/crates/openehr-its/src/flat/mod.rs
@@ -27,6 +27,9 @@
 )]
 
 pub mod build;
+// The WebTemplate cache is the crate's only `moka` user, and a browser-side
+// consumer of the Simplified Formats keeps no such cache.
+#[cfg(feature = "cache")]
 pub mod cache;
 pub mod convert;
 pub(crate) mod ctx;

--- a/crates/openehr-its/src/json.rs
+++ b/crates/openehr-its/src/json.rs
@@ -29,6 +29,7 @@ use serde::de::DeserializeOwned;
 /// The vendored ITS-JSON RM all-schema (draft-07), used to validate output in
 /// the fidelity-gate tests, vendored at a pinned upstream commit (see the
 /// bundled schema's provenance record).
+#[cfg(feature = "schema-validation")]
 pub const RM_SCHEMA_JSON: &str = include_str!("../schemas/json/openehr_rm_1.1.0_all.json");
 
 /// A canonical-JSON deserialization failure: the message, the JSON path to the
@@ -263,6 +264,7 @@ pub fn from_canonical_value<T: DeserializeOwned>(
 /// NOTE: the two causes stay flattened into the stored `String` rather than
 /// carried as a source (RFC 0201) — the schema is a compiled-in constant, so a
 /// failure here is a packaging fault with no caller that could branch on it.
+#[cfg(feature = "schema-validation")]
 static RM_VALIDATOR: std::sync::LazyLock<Result<jsonschema::Validator, String>> =
     std::sync::LazyLock::new(|| {
         let schema: serde_json::Value =
@@ -334,6 +336,7 @@ pub fn reject_undeclared_keys(value: &serde_json::Value) -> Result<(), JsonParse
 /// # Errors
 /// Returns every schema violation (path + message), or a single-element error if
 /// the schema itself failed to compile.
+#[cfg(feature = "schema-validation")]
 pub fn validate_canonical(value: &serde_json::Value) -> Result<(), Vec<String>> {
     match &*RM_VALIDATOR {
         Ok(validator) => {

--- a/crates/openehr-its/src/lib.rs
+++ b/crates/openehr-its/src/lib.rs
@@ -47,36 +47,47 @@
 //! `FromJson` codec and the canonical-XML codec are generated over hand-written
 //! runtimes, so the spec crates carry no serde derive.
 //!
-//! # Feature `full` (default)
+//! # Features
 //!
-//! Every surface above rides the default `full` feature. Taken with
-//! `default-features = false` the crate compiles to `rest::smart_scopes` alone —
-//! the std-only SMART scope grammar, with no dependency of any kind — so a REST
-//! client that must parse scope strings on `wasm32-unknown-unknown` (the
-//! viewer's scope previewer) shares the very grammar the CDR enforces instead
-//! of carrying a second parser.
+//! The default `full` feature is every surface above. The graph underneath it
+//! is layered so a consumer takes only what it reads: `json` is the canonical
+//! JSON base, `xml` adds the XML codecs, `opt14` the operational-template
+//! reader, and `flat` the Simplified Formats. A `wasm32-unknown-unknown`
+//! consumer takes `default-features = false, features = ["flat"]`, which pulls
+//! that whole chain; `cache` (`moka`), `schema-validation` (`jsonschema` plus
+//! the compiled-in ITS-JSON RM schema) and `rest-server` (the generated server
+//! contract, `axum`) stay outside it.
+//!
+//! Taken with `default-features = false` and nothing else the crate compiles to
+//! [`rest::smart_scopes`] alone — the std-only SMART scope grammar, with no
+//! dependency of any kind — so a REST client that must parse scope strings in
+//! the browser (the viewer's scope previewer) shares the very grammar the CDR
+//! enforces instead of carrying a second parser.
 
 // Doctests are copy-paste templates: they must use `?`, never unwrap
 // (C-QUESTION-MARK, https://rust-lang.github.io/api-guidelines/documentation.html#c-question-mark).
 #![doc(test(attr(deny(warnings))))]
-#[cfg(feature = "full")]
+#[cfg(feature = "xml")]
 pub mod aom2;
-#[cfg(feature = "full")]
+#[cfg(feature = "xml")]
 pub mod aom2_model;
-#[cfg(feature = "full")]
+#[cfg(feature = "flat")]
 pub mod flat;
-#[cfg(feature = "full")]
+#[cfg(feature = "json")]
 pub mod json;
-#[cfg(feature = "full")]
+#[cfg(feature = "json")]
 pub mod json_codec;
-#[cfg(feature = "full")]
+#[cfg(feature = "opt14")]
 pub mod opt14;
 pub mod rest;
-#[cfg(feature = "full")]
+// `rm_instance` composes the template pass of `flat::validation` over the RM
+// pass, and `flat::validation` reads its report shape back from here, so the
+// two are one layer rather than two.
+#[cfg(feature = "flat")]
 pub mod rm_instance;
-#[cfg(feature = "full")]
+#[cfg(feature = "json")]
 pub mod wire_validate;
-#[cfg(feature = "full")]
+#[cfg(feature = "xml")]
 pub mod xml;
 
 /// The openEHR specification version this crate implements.

--- a/crates/openehr-its/src/rest/mod.rs
+++ b/crates/openehr-its/src/rest/mod.rs
@@ -14,11 +14,11 @@
 //! with the openEHR specs as the authority.
 //! Regenerate with `cargo run -p openehr-codegen -- emit-rest`.
 
-// The generated contract and its runtime need the crate's dependency set (axum,
-// serde, the spec crates), so they ride the default `full` feature; the
+// The generated contract and its response runtime are the SERVER half of the
+// contract (axum, serde, the spec crates), so they ride `rest-server`; the
 // std-only `smart_scopes` grammar is always compiled — see the crate docs.
-#[cfg(feature = "full")]
+#[cfg(feature = "rest-server")]
 pub mod generated;
-#[cfg(feature = "full")]
+#[cfg(feature = "rest-server")]
 pub mod runtime;
 pub mod smart_scopes;

--- a/crates/openehr-lang/Cargo.toml
+++ b/crates/openehr-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-lang"
-version = "0.0.63"
+version = "0.0.64"
 description = "openEHR LANG BMM/P_BMM object model, generated from BMM: generations v1_0 (LANG 1.0.0) and v1_1 (LANG 1.1.0, current; the stable BMM v2.x unit beside the paused BMM3 unit), plus hand-written ODIN/BEL/EL readers"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ categories = ["parser-implementations", "data-structures"]
 include = ["src/**", "README.md", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.63" }
+openehr-base = { path = "../openehr-base", version = "0.0.64" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the
 # generated types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) —
 # never a derive. `serde_json` also carries the untyped `Value` fields the

--- a/crates/openehr-query/Cargo.toml
+++ b/crates/openehr-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-query"
-version = "0.0.63"
+version = "0.0.64"
 description = "openEHR QUERY (AQL 1.1.0): hand-written lexer, parser, typed AST and canonical printer from the official grammar (no ANTLR runtime)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/openehr-rm/Cargo.toml
+++ b/crates/openehr-rm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-rm"
-version = "0.0.63"
+version = "0.0.64"
 description = "openEHR RM Reference Model, generated from BMM: generations v1_1 (RM 1.1.0) and v1_2 (RM 1.2.0, current)"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,11 +13,11 @@ categories = ["data-structures", "science"]
 include = ["src/**", "README.md", "LICENSE-APACHE-2.0"]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.63" }
+openehr-base = { path = "../openehr-base", version = "0.0.64" }
 # The terminology-backed RM class invariants (`validate::terminology`) resolve
 # openEHR terminology groups + code sets against the vendored TERM 3.1.0 bundle.
 # `openehr-term` itself depends only on `openehr-base`, so this is acyclic.
-openehr-term = { path = "../openehr-term", version = "0.0.63" }
+openehr-term = { path = "../openehr-term", version = "0.0.64" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive. `serde_json` also backs the untyped `Value` RM representation used by

--- a/crates/openehr-term/Cargo.toml
+++ b/crates/openehr-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openehr-term"
-version = "0.0.63"
+version = "0.0.64"
 description = "openEHR TERM terminology data model, generated from BMM (generation v3_1 = TERM 3.1.0), plus the embedded official terminology XML bundle"
 edition.workspace = true
 rust-version.workspace = true
@@ -34,7 +34,7 @@ include = [
 ]
 
 [dependencies]
-openehr-base = { path = "../openehr-base", version = "0.0.63" }
+openehr-base = { path = "../openehr-base", version = "0.0.64" }
 # Canonical-JSON (de)serialization is EMITTED manual `serde` impls on the spec
 # types (`openehr-codegen -- emit-json`, into `src/json_serde.rs`) — never a
 # derive.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1277,7 +1277,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openehr-adl"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "indexmap",
  "openehr-am",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-am"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "openehr-base",
  "openehr-lang",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-base"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "serde",
  "serde_json",
@@ -1313,7 +1313,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-its"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "async-trait",
  "axum",
@@ -1338,7 +1338,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-lang"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "chumsky",
  "indexmap",
@@ -1351,7 +1351,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-query"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "chumsky",
  "logos",
@@ -1360,7 +1360,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-rm"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "openehr-base",
  "openehr-term",
@@ -1375,7 +1375,7 @@ dependencies = [
 
 [[package]]
 name = "openehr-term"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "openehr-base",
  "roxmltree",

--- a/tools/testkit/Cargo.toml
+++ b/tools/testkit/Cargo.toml
@@ -34,7 +34,7 @@ tokio = { workspace = true }
 # macros). No subscriber is installed by the harness — a test binary that wants
 # the sweep's log installs one.
 tracing = { workspace = true }
-uuid = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }   # random scratch-database names
 # `reusable-containers` (experimental upstream) keeps ONE named PG container
 # alive across nextest's process-per-test model and across whole runs.
 testcontainers = { workspace = true, features = ["reusable-containers"] }


### PR DESCRIPTION
## What this changes

Closes #3149

`openehr-its` carried every dependency on one `full` feature, so a consumer that wanted `flat::build_web_template` or the OPT 1.4 reader took axum, moka and jsonschema with them — and `default-features = false` left only the SMART scope grammar. Three dependencies turned out to be the whole problem:

| Dependency | Reached by | Now behind |
|---|---|---|
| `moka` | `flat::cache` only | `cache` |
| `jsonschema` | the compiled RM validator in `json` only | `schema-validation` |
| `axum` / `http` / `async-trait` | `rest` only | `rest-server` |

Everything else — quick-xml, regex, fancy-regex, serde, indexmap, the model crates — is pure Rust and already builds for the browser. So the graph is layered on that fact: **`json` → `xml` → `opt14` → `flat`** is the parsing spine, and `cache`, `schema-validation`, `rest-server` are the layers a browser declines. `full` is still the default and still means all of them, so **no existing consumer sees a change**, and `rest::smart_scopes` stays dependency-free at every selection — which is what keeps one grammar serving both the CDR's scope gate and the viewer's previewer.

Two deviations from the plan, both with reasons:

- **`rm_instance` rides `flat`, not `json`.** It and `flat::validation` call each other (`rm_instance/mod.rs` uses `flat::webtemplate::model::WebTemplate` and `flat::validation::validate_archetype_conformance`; `flat/validation/mod.rs` uses `rm_instance::{ValidationKind, ValidationMessage}`). They are one layer; separating them would move the report shape into a third. `flat` is in the wasm selection, so a browser consumer loses nothing.
- **`ApiError` keeps its `IntoResponse`** and the whole of `rest::runtime` rides `rest-server`. Nothing outside the server layer consumes the type, so splitting the impl from it would create a seam with no user. Criterion 2 holds either way: the impl is behind the server feature.

## The uuid finding, fixed at the cause

The wasm build then failed inside `uuid`: no randomness source on `wasm32-unknown-unknown`. The tempting fix is a target-conditional `features = ["js"]` in this crate, and that works — but it makes every browser consumer of the *published* crates inherit `wasm-bindgen` and `js-sys` for a capability they do not use.

The actual cause is upstream of that: the workspace pinned `uuid` with `v4`/`v7`/`fast-rng` for **every** member, while only `app/ferroehr` (v7 ids) and `tools/testkit` (v4 scratch names) ever mint one. `openehr-base`, `openehr-rm` and their siblings parse and serialize UUIDs and never generate any — they were carrying a generator they never call, and that unused generator is what has no backend in a browser.

The RNG features move to the two crates that generate, and the target-conditional override disappears with its cause. The wasm lane passes without it, and `cargo clippy --workspace --all-targets --all-features` is unaffected.

## Checked, not claimed

Two CI lanes in `its-wasm`: the wasm selection (`--no-default-features --features flat,opt14,xml,json`) and the dependency-free island (`--no-default-features`), both at `-D warnings`. Neither uses `--all-targets` — the crate's dev-dependencies (`testkit` → sqlx, `tokio` → mio) are native by construction and fail to build for wasm — and the job comment records that rather than leaving a reader to wonder. The features are spelled out instead of relying on `flat`'s implication chain, so a change to the chain cannot silently narrow what the lane covers.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.

## Checks

- [x] `cargo fmt --all --check` · `cargo clippy --workspace --all-targets` · `cargo nextest run --workspace`
- [x] No test weakened, skipped, or edited to route around a bug
- [x] User-visible change → `CHANGELOG.md [Unreleased]` entry
- [x] REST/config/CLI/deployment change → matching `website/book/src` page updated (none: this is a crate-facing change; the crate README carries the feature table)
- [x] Implemented `docs/plans/*.md` plan file deleted (unless another open issue still consumes it)
- [x] New issues opened from this work are linked as GitHub relationships, not prose

The eight published crates step to **0.0.64** (packaged content changed), with `fuzz/Cargo.lock` refreshed.

Local: the two wasm lanes · `cargo clippy -p openehr-its --all-targets --all-features` · each of the seven features in isolation via `cargo check --no-default-features --features <f>` · `cargo nextest run -p openehr-its -p ferroehr` (1753 passed) · both viewer targets · `RUSTDOCFLAGS=-D warnings cargo doc -p openehr-its --all-features` · `cargo deny check` · `cargo machete` · `actionlint` + `zizmor --min-severity=low` on the workflow · `comment-style`, `spdx-headers`, `docs-claims`, `no-python`, `licensing-declarations`, `packaged-includes`, `typed-status`, `default-style`, `shellcheck-lane`, `changelog-structure`.
