### PR TITLE
fix(admin): a physically deleted party takes its multimedia with it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -288,6 +288,16 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **A physically deleted party takes its multimedia with it** (#3180).
+  `physical_delete_party` removed the party's rows without collecting the
+  externalized blob keys they referenced, so a blob held only by that party
+  stayed in the object store forever — a storage leak, and on a party also a
+  deletion that did not delete, since a blob is content and an operator who
+  ran a physical delete has reason to believe it is gone. It now collects the
+  keys inside the same transaction and hands them to the same garbage
+  collection `delete_ehr` uses, which scans both pseudonymisation domains, so
+  a blob a clinical record still references survives.
+
 - **The ADL 2 corpus provenance claimed a licence the files do not state**
   (#3150). `corpus/archetypes/adl2/PROVENANCE.md` said the archetypes were
   "predominantly CC-BY-SA 3.0 where stated" and pointed at the root CC-BY-SA

--- a/app/ferroehr/src/service/admin/delete.rs
+++ b/app/ferroehr/src/service/admin/delete.rs
@@ -378,6 +378,38 @@ impl FerroEhrService {
         Ok(keys)
     }
 
+    /// Collect the distinct externalized-blob keys the given demographic
+    /// versioned objects reference (empty when externalization is disabled).
+    ///
+    /// Reads inside the caller's transaction, because the rows are about to be
+    /// deleted by it: a read on the pool could miss a row the transaction has
+    /// already removed, and a blob whose last reference vanished unseen is a
+    /// blob nothing will ever collect.
+    ///
+    /// Our own extension — no openEHR spec governs multimedia offload.
+    #[cfg(feature = "multimedia")]
+    async fn collect_party_blob_keys(
+        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+        vo_ids: &[VoId],
+    ) -> Result<Vec<String>, ServiceError> {
+        let Some(engine) = &self.multimedia else {
+            return Ok(Vec::new());
+        };
+        let datas: Vec<serde_json::Value> =
+            sqlx::query_scalar("SELECT data FROM node_all WHERE vo_id = ANY($1)")
+                .bind(vo_ids)
+                .fetch_all(&mut **tx)
+                .await?;
+        let mut keys: Vec<String> = datas
+            .iter()
+            .flat_map(|d| engine.referenced_keys(d))
+            .collect();
+        keys.sort_unstable();
+        keys.dedup();
+        Ok(keys)
+    }
+
     /// Delete each candidate blob no longer referenced by any surviving `node`.
     /// Our own extension — no openEHR spec governs multimedia offload. A
     /// conservative scan-based GC (a `blob_ref` count table is a scale
@@ -511,6 +543,18 @@ impl FerroEhrService {
         .fetch_all(&mut *tx)
         .await?;
 
+        // The blob keys these rows reference, before the delete removes the
+        // rows that name them (#3180). `delete_ehr` has always done this; a
+        // party physically deleted without it left its blobs in the object
+        // store forever, which is both a leak and a delete that did not
+        // delete — a blob is content.
+        #[cfg(feature = "multimedia")]
+        let candidate_blobs = self.collect_party_blob_keys(&mut tx, &vo_ids).await?;
+        // Externalization is compiled out of this build, so no stored node
+        // references a blob and there is nothing to collect.
+        #[cfg(not(feature = "multimedia"))]
+        let candidate_blobs: Vec<String> = Vec::new();
+
         // Delete the versioned objects — cascades node + vo_attestation. The
         // cold archival tier is foreign-key-free by design, so its rows and the
         // archive markers go explicitly (`crate::storage::version_repo::tier`).
@@ -548,6 +592,11 @@ impl FerroEhrService {
             .await?;
 
         tx.commit().await?;
+
+        // After the commit, so a blob is only collected once nothing can
+        // reference it again. The scan covers both domains, so a blob this
+        // party shared with a clinical record survives.
+        self.gc_unreferenced_blobs(candidate_blobs).await;
         Ok(())
     }
 }

--- a/app/ferroehr/tests/it/multimedia_s3.rs
+++ b/app/ferroehr/tests/it/multimedia_s3.rs
@@ -39,6 +39,7 @@ use uuid::Uuid;
 use ferroehr::extensions::multimedia::config::MultimediaConfig;
 use ferroehr::service::FerroEhrService;
 use ferroehr::service::admin::types::ExportSpec;
+use ferroehr::service::demographic::types::PartyKind;
 use ferroehr_ext::multimedia::MultimediaEngine;
 use ferroehr_ext::multimedia::store::BlobStore;
 
@@ -170,6 +171,70 @@ fn multimedia(n: usize) -> Value {
         "size": n,
         "data": base64::engine::general_purpose::STANDARD.encode(&payload),
     })
+}
+
+/// A demographic `PERSON` carrying `media` as the value of an identity ELEMENT.
+///
+/// The party path externalizes exactly as the clinical one does — the
+/// versioning layer is shared — so this is how a blob comes to be referenced
+/// only by a party.
+fn person_with_media(name: &str, media: &Value) -> Value {
+    json!({
+        "_type": "PERSON",
+        "archetype_node_id": "openEHR-DEMOGRAPHIC-PERSON.person.v1",
+        "archetype_details": { "_type": "ARCHETYPED",
+            "archetype_id": { "_type": "ARCHETYPE_ID",
+                              "value": "openEHR-DEMOGRAPHIC-PERSON.person.v1" },
+            "rm_version": "1.1.0" },
+        "name": { "_type": "DV_TEXT", "value": name },
+        "identities": [{
+            "_type": "PARTY_IDENTITY",
+            "archetype_node_id": "at0001",
+            "name": { "_type": "DV_TEXT", "value": "legal name" },
+            "details": {
+                "_type": "ITEM_TREE",
+                "archetype_node_id": "at0002",
+                "name": { "_type": "DV_TEXT", "value": "structure" },
+                "items": [{
+                    "_type": "ELEMENT",
+                    "archetype_node_id": "at0003",
+                    "name": { "_type": "DV_TEXT", "value": "portrait" },
+                    "value": media.clone()
+                }]
+            }
+        }]
+    })
+}
+
+/// Create a PERSON and return its bare versioned-object id.
+async fn make_person_with_media(svc: &FerroEhrService, name: &str, media: &Value) -> String {
+    let created = svc
+        .party_create(
+            PartyKind::Person,
+            openehr_its::json::from_canonical_value(&person_with_media(name, media))
+                .expect("the PERSON decodes"),
+            None,
+        )
+        .await
+        .expect("create person");
+    created
+        .body
+        .pointer("/uid/value")
+        .and_then(Value::as_str)
+        .expect("uid")
+        .split("::")
+        .next()
+        .expect("vo uuid")
+        .to_owned()
+}
+
+/// The blob key referenced by a stored PERSON's identity ELEMENT.
+fn party_blob_key(person: &Value) -> String {
+    let uri = person
+        .pointer("/identities/0/details/items/0/value/uri/value")
+        .and_then(Value::as_str)
+        .expect("the externalized media carries a uri");
+    uri.rsplit('/').next().expect("hex").to_owned()
 }
 
 /// A valid `EHR_STATUS` carrying `media` inside `other_details` (an ELEMENT value).
@@ -425,6 +490,68 @@ async fn gc_removes_unreferenced_but_keeps_shared_blobs() {
     assert!(
         !sw.engine().store().exists(&key).await.unwrap(),
         "an unreferenced blob must be GC'd on physical delete"
+    );
+}
+
+/// #3180: a physically deleted party takes its blobs with it, and leaves a
+/// blob anything else still references alone.
+#[tokio::test]
+async fn physical_party_delete_collects_its_blobs_but_keeps_shared_ones() {
+    let db = testkit::db().await.expect("testkit database");
+    let sw = Seaweed::start().await;
+    let svc = FerroEhrService::new(db.pool()).with_multimedia(sw.engine());
+
+    // One party holds a blob nothing else references; a second holds one it
+    // shares with a clinical record (identical bytes dedup to one blob).
+    let solo_media = multimedia(1100);
+    let shared_media = multimedia(1200);
+    let solo = make_person_with_media(&svc, "Solo", &solo_media).await;
+    let sharer = make_person_with_media(&svc, "Sharer", &shared_media).await;
+    let ehr = svc
+        .create_ehr(Some(status_with_media(shared_media.clone())))
+        .await
+        .expect("ehr sharing the blob");
+
+    let solo_key = party_blob_key(
+        &svc.party_get(PartyKind::Person, solo.clone(), None)
+            .await
+            .expect("read solo")
+            .body,
+    );
+    let shared_key = party_blob_key(
+        &svc.party_get(PartyKind::Person, sharer.clone(), None)
+            .await
+            .expect("read sharer")
+            .body,
+    );
+    assert_eq!(
+        shared_key,
+        blob_key(
+            &svc.get_ehr_status_at_time(ehr, None)
+                .await
+                .expect("read the sharing EHR")
+        ),
+        "identical media must dedup to one blob for the cross-domain case to mean anything"
+    );
+    assert_ne!(solo_key, shared_key);
+    assert!(sw.engine().store().exists(&solo_key).await.unwrap());
+    assert!(sw.engine().store().exists(&shared_key).await.unwrap());
+
+    svc.physical_party_delete(solo.clone())
+        .await
+        .expect("delete the solo party");
+    assert!(
+        !sw.engine().store().exists(&solo_key).await.unwrap(),
+        "a blob only the deleted party referenced must be collected — a blob is \
+         content, and the operator asked for a physical delete"
+    );
+
+    svc.physical_party_delete(sharer.clone())
+        .await
+        .expect("delete the sharing party");
+    assert!(
+        sw.engine().store().exists(&shared_key).await.unwrap(),
+        "a blob a clinical record still references must survive the party delete"
     );
 }
 


### PR DESCRIPTION
## What this changes

Closes #3180

`physical_delete_party` removed a party's rows without collecting the externalized blob keys those rows referenced, so a blob held only by that party stayed in the object store forever. `delete_ehr` has always collected them, which is what made the omission read as an inconsistency rather than a decision.

It is a storage leak, and on a party it is also **a deletion that did not delete**: a blob is content, and an operator who ran a physical delete has reason to believe it is gone.

Two details worth stating, because both could have been done wrong:

- **The keys are collected inside the same transaction that removes the rows.** A read on the pool could miss a row the transaction has already deleted, and a blob whose last reference vanished unseen is a blob nothing will ever collect.
- **The collection runs after the commit, through the existing collector.** That scan already covers *both* pseudonymisation domains — added when the demographic schema landed — so a blob a clinical record still references survives the party delete. No second garbage-collection path exists.

## The test

One blob referenced only by a party, one the party shares with an EHR (identical bytes, so they dedup to a single content-addressed blob, and the test asserts that dedup rather than assuming it). Delete both parties: the solo blob is collected, the shared one survives.

**Mutation-proven**: hand the collector an empty candidate set and the test fails.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.

## Checks

- [x] `cargo fmt --all --check` · `cargo clippy --workspace --all-targets` · `cargo nextest run --workspace`
- [x] No test weakened, skipped, or edited to route around a bug
- [x] User-visible change → `CHANGELOG.md [Unreleased]` entry
- [x] REST/config/CLI/deployment change → matching `website/book/src` page updated (none: no surface, config or artifact changes)
- [x] Implemented `docs/plans/*.md` plan file deleted (unless another open issue still consumes it)
- [x] New issues opened from this work are linked as GitHub relationships, not prose

## Privacy boundary

- [x] The data flow is described above: this change reads `node_all` in the demographic domain to learn which blobs a party's rows reference, then deletes those blobs from the object store when nothing else references them. It exports nothing and adds no new read of personal data — the rows are ones the same transaction is deleting.
- [x] The roles are named: the demographic pool's role reads and deletes the party rows; the reference scan runs on both pools with their own roles; the blob store is reached with the multimedia credential.
- [x] No new grant spans the clinical and demographic domains — the existing GC scan already queries each pool with its own credential.
- [x] Synthetic data only in tests, fixtures, seeds and examples
- [x] An access event is emitted wherever this change added a read of personal data (it adds none; the read is part of an administrative delete that already records its own audit)

Local: `cargo nextest run -p ferroehr --all-features` (1132 passed) · `cargo clippy -p ferroehr --all-targets --all-features -D warnings` · `cargo fmt --check` · `comment-style` · `privacy-boundary --self-test` · `changelog-structure`.
