### PR TITLE
fix(helm): the migration hook's pod is not the server's pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -288,6 +288,19 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **The migration hook's pod is no longer selected by the server's Service and
+  PodDisruptionBudget** (#3197). A selector is a subset match, and the hook pod
+  carried the server's selector pair plus a `component` label, so for as long
+  as it existed it satisfied both — during exactly the install and upgrade when
+  a rollout or a drain reads them. It exposed no port named `http`, so the
+  Service had no endpoint to route to it, but the PodDisruptionBudget match was
+  real and the port was a property of that pod rather than a promise about the
+  next one. The hook now carries its own `app.kubernetes.io/name`, as the
+  viewer and the backup jobs already do. The chart's selector gate was looking
+  only at Deployments and could not have seen this; it now judges every
+  workload that carries a pod template, and the migration Job renders in a
+  committed value set so the gate has something to judge.
+
 - **A physically deleted party takes its multimedia with it** (#3180).
   `physical_delete_party` removed the party's rows without collecting the
   externalized blob keys they referenced, so a blob held only by that party

--- a/deploy/helm/ci/all-features-values.yaml
+++ b/deploy/helm/ci/all-features-values.yaml
@@ -271,6 +271,14 @@ serviceAccount:
 # Per-domain logical backups, so the two CronJobs reach a golden render and the
 # restricted-profile gate — the claims are render fixtures, nothing provisions
 # them here. Two DIFFERENT claim names: one claim for both domains is refused.
+# The pre-install/pre-upgrade migration hook. Rendered here because a workload
+# no value set renders is a workload no golden shows and no gate judges — the
+# selector gate could not see this Job's pod at all until it did (#3197).
+migrations:
+  job:
+    enabled: true
+    existingSecret: ferroehr-migrator-dsn
+
 backup:
   enabled: true
   timeZone: Europe/Amsterdam

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # A published OCI version is immutable by refusal rather than by the registry —
 # `helm push` over an existing tag replaces it silently — so a correction always
 # ships as a NEW version and the published one stands as it was.
-version: 7.2.0
+version: 7.3.0
 # The DEFAULT container image tag (overridable via image.tag). Equals the
 # workspace version in Cargo.toml, bumped in the release PR beside the
 # docker-compose.yml image tags — one version sweep, the compose treatment

--- a/deploy/helm/ferroehr/README.md
+++ b/deploy/helm/ferroehr/README.md
@@ -2,7 +2,7 @@
 
 Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.1.0 + AQL 1.1). A single static binary deployed with a hardened-by-default security posture: runs as a non-root, read-only-rootfs workload whose NetworkPolicy admits its serving port only, and that connects to an EXTERNAL PostgreSQL 18 as an unprivileged app role (migrations are run out of band by a separate migrator role).
 
-![Version: 7.2.0](https://img.shields.io/badge/Version-7.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.1.1](https://img.shields.io/badge/AppVersion-4.1.1-informational?style=flat-square)
+![Version: 7.3.0](https://img.shields.io/badge/Version-7.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.1.1](https://img.shields.io/badge/AppVersion-4.1.1-informational?style=flat-square)
 
 FerroEHR is a pure-Rust openEHR Clinical Data Repository: ITS-REST 1.1.0 at the
 API, AQL 1.1 as the query language, PostgreSQL 18-native storage, shipped as a
@@ -33,7 +33,7 @@ to add; `helm repo add` does not apply to this chart:
 
 ```console
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 7.2.0 \
+  --version 7.3.0 \
   --namespace ferroehr --create-namespace \
   --set database.existingSecret=ferroehr-db \
   --set image.tag=4.1.1
@@ -47,7 +47,7 @@ They are independent SemVer lines and they move independently:
 
 | What | Set with | This release |
 |---|---|---|
-| the **chart** (templates, defaults, this document) | `--version` | `7.2.0` |
+| the **chart** (templates, defaults, this document) | `--version` | `7.3.0` |
 | the **server image** | `image.tag` | `4.1.1` |
 
 `appVersion` is the image the chart defaults to; pinning `image.tag` explicitly
@@ -59,7 +59,7 @@ The chart carries two keyless Sigstore artifacts, and they answer different
 questions. A **cosign signature:** who signed this:
 
 ```console
-cosign verify ghcr.io/rubentalstra/charts/ferroehr:7.2.0 \
+cosign verify ghcr.io/rubentalstra/charts/ferroehr:7.3.0 \
   --certificate-identity-regexp '^https://github\.com/rubentalstra/FerroEHR/\.github/workflows/publish-chart\.yml@' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
@@ -67,7 +67,7 @@ cosign verify ghcr.io/rubentalstra/charts/ferroehr:7.2.0 \
 A **SLSA build provenance attestation:** what source it was built from, and how:
 
 ```console
-gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:7.2.0 \
+gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:7.3.0 \
   -R rubentalstra/FerroEHR
 gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:4.1.1 \
   -R rubentalstra/FerroEHR

--- a/deploy/helm/ferroehr/templates/_helpers.tpl
+++ b/deploy/helm/ferroehr/templates/_helpers.tpl
@@ -420,6 +420,35 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+The migration hook pod's labels, and its own `app.kubernetes.io/name`.
+
+Same reason the viewer carries one (see above): a Service selector is a SUBSET
+match, so a pod labelled with the server's selector pair is selected by the
+server's Service and PodDisruptionBudget for as long as it exists — and this
+pod exists during every install and upgrade, which is exactly when a drain or
+a rollout is reading those objects. The migration pod exposes no port named
+`http`, so the Service has no endpoint to route to it today; the PDB match is
+real, and the port is a property of this pod rather than a guarantee about the
+next one. Giving the hook its own name takes both out of scope rather than
+relying on that.
+*/}}
+{{- define "ferroehr.migrationLabels" -}}
+helm.sh/chart: {{ include "ferroehr.chart" . }}
+{{ include "ferroehr.migrationSelectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: ferroehr
+app.kubernetes.io/component: migration
+{{- end }}
+
+{{- define "ferroehr.migrationSelectorLabels" -}}
+app.kubernetes.io/name: {{ printf "%s-migration" (include "ferroehr.name" .) }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
 The viewer image reference — digest wins over tag, as for the server.
 */}}
 {{- define "ferroehr.viewerImage" -}}

--- a/deploy/helm/ferroehr/templates/migration-job.yaml
+++ b/deploy/helm/ferroehr/templates/migration-job.yaml
@@ -19,8 +19,7 @@ kind: Job
 metadata:
   name: {{ include "ferroehr.fullname" . }}-migrate
   labels:
-    {{- include "ferroehr.labels" . | nindent 4 }}
-    app.kubernetes.io/component: migration
+    {{- include "ferroehr.migrationLabels" . | nindent 4 }}
   annotations:
     kubernetes.io/description: >-
       Applies the schema migrations as ferroehr_migrator — a DIFFERENT credential from the runtime DSN — before the server rolls. A Helm pre-install/pre-upgrade hook, so a failed migration fails the release.
@@ -56,8 +55,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "ferroehr.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: migration
+        {{- include "ferroehr.migrationLabels" . | nindent 8 }}
       {{- with .Values.migrations.job.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/gates/selector.jq
+++ b/deploy/helm/gates/selector.jq
@@ -11,6 +11,15 @@
     | { name:   .metadata.name,
         labels: (.spec.template.metadata.labels // {}),
         keys:   ((.spec.selector.matchLabels // {}) | keys) } ] as $deps
+# Every pod a release puts in the namespace, whatever workload declares it.
+| [ $docs[]
+    | select(.kind == "Deployment" or .kind == "StatefulSet" or .kind == "DaemonSet"
+             or .kind == "ReplicaSet" or .kind == "Job" or .kind == "CronJob")
+    | { kind:   .kind,
+        name:   .metadata.name,
+        labels: ( if .kind == "CronJob"
+                  then (.spec.jobTemplate.spec.template.metadata.labels // {})
+                  else (.spec.template.metadata.labels // {}) end ) } ] as $pods
 | (
     [ $deps[]
       | select(.keys != $expect)
@@ -22,17 +31,23 @@
     # labels two workloads share silently selects both. Key sets alone cannot
     # catch this: after the CDR/viewer fix both Deployments have the SAME
     # selector keys and differ only in the name's value.
+    #
+    # EVERY workload carrying a pod template is a candidate, not just the
+    # Deployments: a Job's pod is selected for as long as it exists, and the
+    # migration hook exists during exactly the install and upgrade a Service
+    # and a PodDisruptionBudget are being read (#3197). A CronJob's template
+    # sits one level deeper, under jobTemplate.
     [ $docs[]
       | select(.kind == "Service" or .kind == "PodDisruptionBudget")
       | . as $d
       | ( ($d.spec.selector // {})
           | if (type == "object" and has("matchLabels")) then .matchLabels else . end ) as $sel
       | select(($sel | type) == "object" and ($sel | length) > 0)
-      | ( [ $deps[]
-            | . as $dep
-            | select([ $sel | to_entries[] | ($dep.labels[.key] == .value) ] | all)
-            | $dep.name ] ) as $hit
+      | ( [ $pods[]
+            | . as $pod
+            | select([ $sel | to_entries[] | ($pod.labels[.key] == .value) ] | all)
+            | "\($pod.kind)/\($pod.name)" ] ) as $hit
       | select(($hit | length) > 1)
-      | "\($d.kind)/\($d.metadata.name): selector \($sel | tostring) matches \($hit) — a subset match selects BOTH workloads; give each its own app.kubernetes.io/name rather than a shared name plus a component" ]
+      | "\($d.kind)/\($d.metadata.name): selector \($sel | tostring) matches \($hit) — a subset match selects EVERY one of them; give each workload its own app.kubernetes.io/name rather than a shared name plus a component" ]
   )
 | .[]

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), and only from the networkPolicy.ingressFrom peers.
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -97,7 +97,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -118,7 +118,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -150,7 +150,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -176,7 +176,7 @@ kind: Secret
 metadata:
   name: ferroehr-config
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -197,7 +197,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -402,7 +402,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr-grafana-dashboard
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -653,7 +653,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -687,7 +687,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -929,7 +929,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -966,7 +966,7 @@ metadata:
     kubernetes.io/description: >-
       Logical backup of the clinical pseudonymisation domain: pg_dump of ehr, cold, ext, audit into the ferroehr-backup-clinical claim, under the DSN that domain's pool uses. Separate claim, separate credential, separate schedule from the other domain, so no one artefact carries both the clinical record and the identifying data.
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr-backup-clinical
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -1069,7 +1069,7 @@ metadata:
     kubernetes.io/description: >-
       Logical backup of the demographic pseudonymisation domain: pg_dump of demographic, cold_demographic into the ferroehr-backup-demographic claim, under the DSN that domain's pool uses. Separate claim, separate credential, separate schedule from the other domain, so no one artefact carries both the clinical record and the identifying data.
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr-backup-demographic
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -1170,7 +1170,7 @@ kind: Ingress
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -1208,7 +1208,7 @@ kind: ServiceMonitor
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -1231,3 +1231,116 @@ spec:
       interval: 30s
       scrapeTimeout: 10s
       scheme: http
+---
+# Source: ferroehr/templates/migration-job.yaml
+# Out-of-band schema migration, as a Helm pre-install/pre-upgrade hook Job.
+#
+# Migrations are DDL, so whoever applies them can rewrite the schema. Running
+# them here — as `ferroehr_migrator`, in a pod that exits — lets the SERVER run
+# as `ferroehr_app` with no DDL rights at all, which is what
+# config.db.migrate=verify then enforces (it refuses to boot against a database
+# this job has not migrated, rather than migrating it itself).
+#
+# As a hook, Helm creates it before the Deployment and WAITS for it: a failed
+# migration fails the release instead of rolling pods against a schema that was
+# never applied. Deliberately lean — the migration step needs the DSN and
+# nothing else, so it mounts no ConfigMap and runs on the built-in defaults.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ferroehr-migrate
+  labels:
+    helm.sh/chart: ferroehr-7.3.0
+    app.kubernetes.io/name: ferroehr-migration
+    app.kubernetes.io/instance: ferroehr
+    app.kubernetes.io/version: "4.1.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: ferroehr
+    app.kubernetes.io/component: migration
+  annotations:
+    kubernetes.io/description: >-
+      Applies the schema migrations as ferroehr_migrator — a DIFFERENT credential from the runtime DSN — before the server rolls. A Helm pre-install/pre-upgrade hook, so a failed migration fails the release.
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 600
+  activeDeadlineSeconds: 600
+  podFailurePolicy:
+    rules:
+      - action: Ignore
+        onPodConditions:
+          - type: DisruptionTarget
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: ferroehr-7.3.0
+        app.kubernetes.io/name: ferroehr-migration
+        app.kubernetes.io/instance: ferroehr
+        app.kubernetes.io/version: "4.1.1"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: ferroehr
+        app.kubernetes.io/component: migration
+    spec:
+      restartPolicy: Never
+      serviceAccountName: ferroehr
+      automountServiceAccountToken: false
+      # Same reason as the Deployment: the kubelet's per-Service link variables
+      # land inside the server's reserved FERROEHR_ namespace and the strict
+      # boot-time env sweep then refuses to start.
+      enableServiceLinks: false
+      hostUsers: false
+      securityContext:
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 65532
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
+        supplementalGroupsPolicy: Strict
+      containers:
+        - name: migrate
+          image: "ghcr.io/rubentalstra/ferroehr:4.1.1"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          args: ["db", "migrate"]
+          env:
+            # The migrator DSN, as a mounted file rather than an environment
+            # value (readable through /proc/<pid>/environ and inherited by every
+            # child process — OWASP Kubernetes Security Cheat Sheet).
+            - name: FERROEHR__DB__URL_FILE
+              value: "/etc/ferroehr-secrets/db.url"
+            # This pod's job IS the DDL, whatever the server's posture is.
+            - name: FERROEHR__DB__MIGRATE
+              value: apply
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: migrator-secret
+              mountPath: /etc/ferroehr-secrets
+              readOnly: true
+          resources:
+            {}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: migrator-secret
+          secret:
+            secretName: ferroehr-migrator-dsn
+            defaultMode: 0440
+            items:
+              - key: FERROEHR__DB__URL
+                path: db.url
+

--- a/deploy/helm/golden/basic-auth.yaml
+++ b/deploy/helm/golden/basic-auth.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -51,7 +51,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -72,7 +72,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -102,7 +102,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -119,7 +119,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -247,7 +247,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -277,7 +277,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -51,7 +51,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -72,7 +72,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -87,7 +87,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -212,7 +212,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -242,7 +242,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"

--- a/deploy/helm/golden/viewer.yaml
+++ b/deploy/helm/golden/viewer.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -61,7 +61,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the viewer: only its HTTP port, but from EVERY source — this policy narrows ports, NOT sources (viewer.networkPolicy.ingressAllowAll=true). Set viewer.networkPolicy.ingressFrom for a PHI workload. Egress admits the CDR Service and DNS only.
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr-viewer
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -118,7 +118,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -139,7 +139,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -154,7 +154,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr-viewer
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr-viewer
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -184,7 +184,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -201,7 +201,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -329,7 +329,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -359,7 +359,7 @@ metadata:
     kubernetes.io/description: >-
       In-cluster address for the FerroEHR Viewer. The viewer is a REST client of the CDR and holds no data of its own; it is the human-facing surface, so this is the Service an Ingress normally publishes.
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr-viewer
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -385,7 +385,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -581,7 +581,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR Viewer: a Leptos SSR web UI that consumes the CDR strictly over ITS-REST. It never reaches the database, which the viewer NetworkPolicy enforces rather than assumes.
   labels:
-    helm.sh/chart: ferroehr-7.2.0
+    helm.sh/chart: ferroehr-7.3.0
     app.kubernetes.io/name: ferroehr-viewer
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"

--- a/website/book/src/installation/kubernetes.md
+++ b/website/book/src/installation/kubernetes.md
@@ -38,7 +38,7 @@ kubectl -n ferroehr create secret generic ferroehr-db \
   --from-literal=FERROEHR__DB__URL='postgres://ferroehr_app:***@pg-host:5432/ferroehr?sslmode=verify-full'
 
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 7.2.0 -n ferroehr \
+  --version 7.3.0 -n ferroehr \
   --set database.existingSecret=ferroehr-db \
   --set image.tag=4.1.1
 ```
@@ -55,7 +55,7 @@ helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
 reference. To read the chart's metadata without installing it:
 
 ```shell
-helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 7.2.0
+helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 7.3.0
 ```
 
 ### Pin two versions, not one
@@ -68,7 +68,7 @@ against.
 
 | | Selects | Pin with | Line |
 |---|---|---|---|
-| Chart version | templates, values schema, defaults | `--version 7.2.0` | SemVer over the chart's own contract |
+| Chart version | templates, values schema, defaults | `--version 7.3.0` | SemVer over the chart's own contract |
 | Image tag | the server binary | `--set image.tag=4.1.1` (or `image.digest`) | the application's SemVer line |
 
 Always pin the image to an immutable version or, better, a `@sha256` digest,
@@ -167,7 +167,7 @@ metadata lists: the server, and the optional viewer.
 > the image itself as the authority:
 >
 > ```shell
-> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 7.2.0 \
+> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 7.3.0 \
 >   -s templates/configmap.yaml --set database.existingSecret=ferroehr-db \
 >   | sed -n '/ferroehr.toml/,$p' | sed '1d;s/^    //' > /tmp/ferroehr.toml
 > docker run --rm -v /tmp/ferroehr.toml:/etc/ferroehr/ferroehr.toml:ro \
@@ -572,7 +572,7 @@ config:
 
 ```shell
 helm upgrade ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 7.2.0 -n ferroehr --reuse-values \
+  --version 7.3.0 -n ferroehr --reuse-values \
   --set config.query.plan_cache_capacity=512
 ```
 
@@ -752,7 +752,7 @@ Preview an upgrade against what you have installed with
 `helm diff`, or render the new chart version and read it:
 
 ```shell
-helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 7.2.0 \
+helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 7.3.0 \
   -n ferroehr -f my-values.yaml | less
 ```
 


### PR DESCRIPTION
## What this changes

Closes #3197

A Service selector is a **subset** match. The migration hook's pod carried the server's selector pair plus a `component` label, so for as long as it existed it satisfied both the server's `Service` and its `PodDisruptionBudget` — during exactly the install and upgrade when a rollout or a drain is reading them.

It exposed no port named `http`, so the Service had no endpoint to route to it. The PodDisruptionBudget match was real, and the port is a property of *that* pod rather than a promise about the next one.

The hook now carries its own `app.kubernetes.io/name`, which is what the viewer was given for this same reason and what the backup CronJobs were given when they landed. Adding `component` to the **server's** selector would fix the overlap too, and is still the wrong fix for the reason recorded beside the viewer's helper: a Service applied before its Deployment selects zero pods until the new ReplicaSet is Ready — a brief total outage on a clinical API at every upgrade.

## The gate could not have caught it, twice over

- **It wasn't looking.** `selector.jq` collected candidate pods from `Deployment`s alone, so a Job's pod — or a CronJob's — was invisible to the subset-match assertion. It now collects from every workload that carries a pod template, CronJobs included at their deeper `jobTemplate` path. (Same blindness class as the restricted-profile gate in #3157, which walked only `.spec.template`.)
- **It had nothing to judge.** No committed value set enabled the migration hook, so no golden ever rendered a `Job`. Widening the gate alone would have left it passing vacuously. The all-features overlay enables the hook now, which is what makes the assertion real rather than merely available.

**Mutation-proven.** Restore the old labels and the gate names both objects and both workloads:

```
PodDisruptionBudget/ferroehr: selector {"app.kubernetes.io/name":"ferroehr",…} matches
  ["Deployment/ferroehr","Job/ferroehr-migrate"] — a subset match selects EVERY one of them
Service/ferroehr: selector {…} matches ["Deployment/ferroehr","Job/ferroehr-migrate"]
```

Chart 7.2.0 → 7.3.0, goldens and the book's pinned `--version` follow.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.

## Checks

- [x] `cargo fmt --all --check` · `cargo clippy --workspace --all-targets` · `cargo nextest run --workspace` (no Rust changed)
- [x] No test weakened, skipped, or edited to route around a bug
- [x] User-visible change → `CHANGELOG.md [Unreleased]` entry
- [x] REST/config/CLI/deployment change → matching `website/book/src` page updated
- [x] Implemented `docs/plans/*.md` plan file deleted (unless another open issue still consumes it)
- [x] New issues opened from this work are linked as GitHub relationships, not prose

Local: `deploy/helm/validate.sh` green (14 refusals probed, 14 malformed-values probes, goldens regenerated) · the mutation above · `chart-appversion` · `docs-claims` · `changelog-structure`.

`boot-check.sh` still refuses `all-features` locally, unchanged by this PR and for the reason it prints itself: the **published** 4.1.1 image predates `db.demographic_url` from #3179. CI's `chart-boot` builds the image from source and does not hit that skew.
