### PR TITLE
fix(deps): the test binary declares the feature it uses

### DIFF
--- a/app/ferroehr/Cargo.toml
+++ b/app/ferroehr/Cargo.toml
@@ -126,7 +126,19 @@ openehr-adl = { path = "../../crates/openehr-adl" }
 openehr-query = { path = "../../crates/openehr-query" }
 
 [dev-dependencies]
-ferroehr-ext = { path = "../ferroehr-ext", features = ["multimedia", "events"] }
+# Every feature the integration modules USE, named here rather than left to
+# unification. Three of them reach `ferroehr_ext::fhir`
+# (`fhir_ingest_translate`, `fhir_outbound_amqp`, `fhir_priority_categories`),
+# which that feature gates; without it here the test binary compiled only
+# because cargo unified the feature in from the library's own default set
+# (#3207).
+#
+# There is deliberately NO lane building these targets with the library's
+# `fhir` feature off, because they cannot compile that way and should not:
+# four modules import `ferroehr::system_log::fhir`, a LIBRARY module the same
+# feature gates, so the integration binary genuinely requires it. The
+# declaration below is therefore honest rather than load-bearing.
+ferroehr-ext = { path = "../ferroehr-ext", features = ["multimedia", "events", "fhir"] }
 testkit = { path = "../../tools/testkit" }
 serde_norway.workspace = true
 # Temp config files for the pure-loader (`config` module) tests.


### PR DESCRIPTION
## What this changes

Closes #3207

`app/ferroehr`'s dev-dependency on `ferroehr-ext` named `multimedia` and `events`, while three integration modules — `fhir_ingest_translate`, `fhir_outbound_amqp`, `fhir_priority_categories` — reach `ferroehr_ext::fhir`, which the `fhir` feature gates. It compiled because cargo unifies features across the graph and the library's own default set turned that feature on, so the test binary's compilation rested on a sibling's feature selection rather than on its own declaration.

One line: the dev-dependency now names `fhir` too.

## The check the issue asked for cannot exist, and here is why

#3207's second criterion was "a lane that builds the test targets without the library's `fhir` feature, or a recorded reason why that lane is not worth having." I tried to build the lane, and it does not work — for a reason worth writing down rather than leaving for the next person:

**Four of these modules import `ferroehr::system_log::fhir`**, a *library* module behind the same feature. The integration binary genuinely requires `ferroehr/fhir`; asking it to compile without it is asking for something that should not work.

I proved that rather than assuming it. The dev-dependency cycle (`ferroehr` → dev-dep `testkit` → `ferroehr` with default features) is what hides the unification, so I cut it temporarily with `default-features = false` on testkit's dependency and re-ran a reduced-feature build. It failed — but on `ferroehr::system_log::fhir` in four modules, not on `ferroehr_ext::fhir`. That is the tests needing the library feature, not the declaration being wrong. The testkit change was reverted; it existed only to answer the question.

So the outcome is: the declaration is corrected because it should state what the tests use, and the reason no lane guards it sits in the manifest beside it. **Honest rather than load-bearing** — which is the accurate description, and better than a lane that would have to be deleted the first time someone read it.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.

## Checks

- [x] `cargo fmt --all --check` · `cargo clippy --workspace --all-targets` · `cargo nextest run --workspace`
- [x] No test weakened, skipped, or edited to route around a bug
- [x] User-visible change → `CHANGELOG.md [Unreleased]` entry — carries the **`no-changelog`** label. This changes a dev-dependency's feature list only: nothing shipped, published or configurable moves, which is exactly what that escape hatch is for. (I first wrote that no label was needed; the guard is mechanical and wants an entry or the label, and it was right.)
- [x] REST/config/CLI/deployment change → matching `website/book/src` page updated (none)
- [x] Implemented `docs/plans/*.md` plan file deleted (unless another open issue still consumes it)
- [x] New issues opened from this work are linked as GitHub relationships, not prose

Local: `cargo check -p ferroehr --tests` · `cargo clippy -p ferroehr --all-targets --all-features -D warnings` · the mutation described above, in both directions.

