### PR TITLE
fix(audit): DICOM defines no PurposeOfUse, and the page said it did

### DIFF
--- a/app/ferroehr/tests/it/audit_ehds_mapping.rs
+++ b/app/ferroehr/tests/it/audit_ehds_mapping.rs
@@ -184,13 +184,18 @@ fn element_e_the_origin_of_the_data_is_not_recorded_yet() {
     assert_eq!(event.client_ip.as_deref(), Some("10.0.0.9"));
 }
 
-/// The purpose of use is recorded but reaches neither rendering — a gap of a
-/// different kind, and one a reader of the exported trail would not see.
+/// The purpose of use is recorded but reaches neither rendering, and only one
+/// of the two could carry it.
 ///
-/// DICOM PS3.15 §A.5 gives `EventIdentification` a `PurposeOfUse`, and the
-/// FHIR `AuditEvent` gives `agent.purposeOfUse`; the record has the value and
-/// neither rendering carries it, so a purpose collected at the door is
-/// invisible to anything consuming the feed.
+/// FHIR R4 `AuditEvent` defines `agent.purposeOfUse`
+/// (<https://hl7.org/fhir/R4/auditevent.html>) and this rendering does not
+/// populate it — a real gap. The DICOM Audit Message schema of PS3.15 §A.5
+/// defines no purpose element at all: its `AuditMessage` carries
+/// `EventIdentification`, `ActiveParticipant`, `AuditSourceIdentification`
+/// and `ParticipantObjectIdentification`, and none of them has one
+/// (<https://dicom.nema.org/medical/dicom/current/output/chtml/part15/sect_A.5.html>).
+/// So the DICOM side is a limit of the format rather than of this code, and
+/// the assertion below pins both halves for what each of them is.
 #[test]
 fn the_declared_purpose_is_stored_but_reaches_neither_rendering() {
     let event = access_event();

--- a/website/book/src/audit.md
+++ b/website/book/src/audit.md
@@ -150,9 +150,15 @@ the provenance of the content it served. openEHR models that provenance as
 `FEEDER_AUDIT` on the content itself, and the access log does not read it.
 
 One further gap, adjacent to the five: **the declared purpose of use reaches
-neither export.** It is stored on the record and served by ITI-81, but the
-DICOM rendering has no `PurposeOfUse` and the FHIR rendering no
-`agent.purposeOfUse`, so a consumer of the feed cannot see it.
+neither export**, though only one of them could carry it. It is stored on the
+record and served by ITI-81. FHIR R4 `AuditEvent` defines
+[`agent.purposeOfUse`](https://hl7.org/fhir/R4/auditevent.html) and this
+rendering does not populate it, which is a gap worth closing. The
+[DICOM Audit Message schema](https://dicom.nema.org/medical/dicom/current/output/chtml/part15/sect_A.5.html)
+of PS3.15 §A.5 defines no purpose element at all — `EventIdentification`,
+`ActiveParticipant`, `AuditSourceIdentification` and
+`ParticipantObjectIdentification`, and none of them carries one — so on that
+side it is a limit of the format, not something this code withholds.
 
 > [!NOTE]
 > Every row of this table is asserted by a test


### PR DESCRIPTION
## What this changes

#3170 published a claim I did not check: that **DICOM PS3.15 §A.5 gives `EventIdentification` a `PurposeOfUse`**. It does not. The Audit Message schema carries `EventIdentification`, `ActiveParticipant`, `AuditSourceIdentification` and `ParticipantObjectIdentification`, and [none of them has a purpose element](https://dicom.nema.org/medical/dicom/current/output/chtml/part15/sect_A.5.html).

I found it by reading the schema while starting #3204 — the issue that was going to *implement* the thing I had described — rather than by trusting the sentence I had written about it.

## Why it matters more than a wording slip

It turned one gap into two halves that are not alike, and got both the standard and our own position wrong:

- **FHIR R4 `AuditEvent` really does define `agent.purposeOfUse`.** This rendering not populating it is a genuine gap, worth closing.
- **DICOM has nowhere standards-defined to put it.** The absence there is a limit of the format, not something this code withholds.

Describing both as "our rendering does not carry it" implied a defect that is not ours, *and* misdescribed a published standard on a page aimed at people assessing compliance. The audit page and the test's own documentation now say which is which, with the schema linked in both places.

**#3204's acceptance criterion is corrected too**, so it asks only for what can exist: purpose reaches the FHIR rendering, and the DICOM side is out of scope with the reason recorded. Left alone it would have sent someone hunting for an element that is not there.

The gap tests are unchanged and still pass — the assertion that neither rendering carries a purpose was always true; only the explanation was wrong.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.

## Checks

- [x] `cargo fmt --all --check` · `cargo clippy --workspace --all-targets` · `cargo nextest run --workspace`
- [x] No test weakened, skipped, or edited to route around a bug
- [x] User-visible change → `CHANGELOG.md [Unreleased]` entry — this corrects a documentation claim published in the same unreleased cycle as the entry that introduced it, so there is nothing for a reader of the release notes to learn: the changelog never carried the false statement. Carries `no-changelog` rather than an entry that would describe a correction to something never released.
- [x] REST/config/CLI/deployment change → matching `website/book/src` page updated
- [x] Implemented `docs/plans/*.md` plan file deleted (unless another open issue still consumes it)
- [x] New issues opened from this work are linked as GitHub relationships, not prose

Local: `cargo nextest run -p ferroehr --all-features -E 'test(audit_ehds_mapping)'` (7 passed) · `docs-claims` (73 pages).
