### PR TITLE
fix(privacy): a provider name is not patient identifying information

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,7 +287,14 @@ jobs:
           # Dockerfile change, or a change to the job's own build recipe each
           # alter what is under test, and without them a build/caching-only PR
           # could not even run the job it changes.
-          if echo "$changed" | grep -qE '^(app/ferroehr-viewer/|scripts/ui-e2e\.sh$|scripts/cargo-leptos\.sh$|docker-compose\.yml$|docker-compose\.override\.yml$|docker-compose\.keycloak\.yml$|docker/Dockerfile$|docker/viewer/|docker/keycloak/|docker/postgres/|Cargo\.lock$|\.github/workflows/ci\.yml$)' ; then
+          # The boot-installed POLICY inputs are here for the same reason
+          # (issue #3190): the battery is the only lane that runs the real
+          # binary on the real shipped configuration, and the unit suites
+          # cannot see a default posture at all — they build the service with
+          # `FerroEhrService::new()`, which installs no policy. A privacy
+          # default that refused the server's own example composition reached
+          # main because both PRs that produced it missed this filter.
+          if echo "$changed" | grep -qE '^(app/ferroehr-viewer/|app/ferroehr-server/src/|app/ferroehr/src/privacy/|app/ferroehr/src/config/|app/ferroehr/assets/ferroehr\.default\.toml$|scripts/ui-e2e\.sh$|scripts/cargo-leptos\.sh$|docker-compose\.yml$|docker-compose\.override\.yml$|docker-compose\.dev\.yml$|docker-compose\.keycloak\.yml$|docker/Dockerfile$|docker/viewer/|docker/keycloak/|docker/postgres/|Cargo\.lock$|\.github/workflows/ci\.yml$)' ; then
             echo "viewer=true" >> "$GITHUB_OUTPUT"
           else
             echo "viewer=false" >> "$GITHUB_OUTPUT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,22 @@ workflow refuses a tag that has no matching section here.
 
 ### Changed
 
+- **A default deployment accepts a named composer again** (#3190). With
+  `[privacy] allow_identified_parties_in_ehr` off, the clinical side refused
+  both `name` and `identifiers` on both party proxy classes, so a server
+  running the shipped configuration rejected the very composition its own
+  `/definition/template/adl1.4/{id}/example` endpoint hands out — anything
+  built from `ctx/composer_name` included. The default now follows what the
+  two Reference Model classes actually mean. A `PARTY_IDENTIFIED` name is
+  accepted: that class is the proxy for a party "other than the subject of
+  the record", "Typically for health care providers", so a composer or
+  performer name is provider identity. Still refused: `identifiers` on either
+  class, which is the national-identifier slot, and `name` on a
+  `PARTY_RELATED`, which is defined by its relationship to the subject and
+  may be the subject itself. The configuration key is unchanged and means
+  what it always did when set to `true`, so a deployment that opted in keeps
+  working, and nothing that committed before this change is refused now.
+
 - **The published model crates no longer carry a random-number generator.**
   The workspace pinned `uuid` with `v4`/`v7`/`fast-rng` for everyone, but only
   the server and the test harness ever mint an identifier; `openehr-base`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2856,9 +2856,11 @@ name = "ferroehr-server"
 version = "4.1.1"
 dependencies = [
  "anyhow",
+ "assert_fs",
  "clap",
  "ferroehr",
  "ferroehr-rest",
+ "openehr-its",
  "reqwest 0.13.4",
  "serde_json",
  "sqlx",

--- a/app/ferroehr-server/CLAUDE.md
+++ b/app/ferroehr-server/CLAUDE.md
@@ -13,15 +13,21 @@ bin-only crate is untestable by construction — Book ch11.3).
   (the lib target is the binary's own logic half, not a consumable library);
   `thiserror` everywhere else.
 - **`tests/it/` may test ONLY the wiring seam** — `Cli` parsing (incl. the
-  `--set key=value` override parser), the subcommand shapes, and the `run`
-  branches that need no database, listener, or network (`config default`).
-  Everything past that seam belongs to the crate that owns it: `ferroehr` API
-  behaviour in `app/ferroehr/tests/it/`, the assembled `ferroehr-rest` router in
-  `app/ferroehr-rest/tests/it/`. Parking either here made them invisible to the
-  owning crate's gate — the four that had been (`persistence`, `telemetry`,
-  `fhir_inbound`, `service_query`) were relocated to their owners. The
-  dev-dependency set is scoped to that seam (`anyhow`, `clap`, `tokio`); a new
-  dev-dep here is a signal the test belongs in another crate.
+  `--set key=value` override parser), the subcommand shapes, the `run`
+  branches that need no database, listener, or network (`config default`), and
+  the **boot-installed POLICY posture**: what the shipped configuration
+  compiles into and this crate installs on the service (`build_authz`, the
+  `[privacy]` policy). That last one belongs here and nowhere else — the
+  platform suites build with `FerroEhrService::new()`, which installs no
+  collaborator, so a default posture is invisible to every other gate
+  (#3190). Everything past that seam belongs to the crate that owns it:
+  `ferroehr` API behaviour in `app/ferroehr/tests/it/`, the assembled
+  `ferroehr-rest` router in `app/ferroehr-rest/tests/it/`. Parking either here
+  made them invisible to the owning crate's gate — the four that had been
+  (`persistence`, `telemetry`, `fhir_inbound`, `service_query`) were relocated
+  to their owners. The dev-dependency set is scoped to that seam (`anyhow`,
+  `assert_fs`, `clap`, `openehr-its`, `tokio`); a new dev-dep here is a signal
+  the test belongs in another crate.
 - The bin target is named `ferroehr` (`[[bin]] name = "ferroehr"`; container
   entrypoints/compose/Helm and `scripts/*` invoke that name — do not rename).
 - Gates: `cargo clippy -p ferroehr-server --all-targets` +

--- a/app/ferroehr-server/Cargo.toml
+++ b/app/ferroehr-server/Cargo.toml
@@ -40,11 +40,16 @@ uuid.workspace = true
 workspace = true
 
 [dev-dependencies]
-# The wiring-seam tests (`tests/it/`) drive `Cli` parsing and the pure-stdout
-# `config default` dispatch: the CLI derive, the async `run` entry point, and
-# its `anyhow` result. Everything past that seam is tested in the crate that
-# owns it (`app/ferroehr/tests/it/`, `app/ferroehr-rest/tests/it/`), so no
-# database, HTTP, or container harness is needed here.
+# The wiring-seam tests (`tests/it/`) drive `Cli` parsing, the pure-stdout
+# `config default` dispatch and the `[privacy]` policy the run path compiles
+# out of the shipped defaults: the CLI derive, the async `run` entry point,
+# its `anyhow` result, a temp file for the shipped template, and `openehr-its`
+# for the example COMPOSITION that policy has to accept. Everything past that
+# seam is tested in the crate that owns it (`app/ferroehr/tests/it/`,
+# `app/ferroehr-rest/tests/it/`), so no database, HTTP, or container harness
+# is needed here.
 anyhow.workspace = true
+assert_fs.workspace = true
 clap.workspace = true
+openehr-its = { path = "../../crates/openehr-its" }
 tokio.workspace = true

--- a/app/ferroehr-server/src/lib.rs
+++ b/app/ferroehr-server/src/lib.rs
@@ -477,11 +477,13 @@ fn warn_boot_postures(config: &ferroehr::config::FerroEhrConfig) {
     }
     if config.privacy.allow_identified_parties_in_ehr {
         tracing::warn!(
-            "[privacy].allow_identified_parties_in_ehr is ON: clinical content may carry a \
-             PARTY_IDENTIFIED or PARTY_RELATED name and formal identifiers (composer, \
-             participations, health_care_facility, feeder audit). The clinical side then \
-             holds identifying data of its own — GDPR Art. 25(2) data minimisation is on \
-             this deployment to justify."
+            "[privacy].allow_identified_parties_in_ehr is ON: beyond the provider names a \
+             PARTY_IDENTIFIED may carry by default, clinical content may now also carry \
+             formal identifiers on either party class and a PARTY_RELATED name (composer, \
+             participations, health_care_facility, feeder audit). Formal identifiers are \
+             the national-identifier slot, and a party named in relation to the subject \
+             re-identifies the subject — GDPR Art. 25(2) data minimisation is on this \
+             deployment to justify."
         );
     }
     if config.privacy.identifier_scan.mode == ferroehr::privacy::config::ScanMode::Warn {

--- a/app/ferroehr-server/tests/it/main.rs
+++ b/app/ferroehr-server/tests/it/main.rs
@@ -8,11 +8,16 @@
 //! Only the seam that needs no database, no listener, and no network is
 //! exercised here: the authorization construction seam
 //! ([`build_authz`](ferroehr_server::build_authz), `authz_wiring`), [`Cli`](ferroehr_server::Cli) parsing (including the
-//! `--set key=value` override parser and the subcommand shapes) and the
+//! `--set key=value` override parser and the subcommand shapes), the
 //! pure-stdout `ferroehr config default` path through
-//! [`run`](ferroehr_server::run). Everything past that seam is tested where it
-//! lives — platform behaviour in `app/ferroehr/tests/it/`, the assembled
-//! ITS-REST router in `app/ferroehr-rest/tests/it/`.
+//! [`run`](ferroehr_server::run), and the `[privacy]` policy the run path
+//! compiles out of the shipped defaults. Everything past that seam is tested
+//! where it lives — platform behaviour in `app/ferroehr/tests/it/`, the
+//! assembled ITS-REST router in `app/ferroehr-rest/tests/it/`.
+//!
+//! A default posture is a wiring fact: the platform suites build the service
+//! with `FerroEhrService::new()`, whose collaborators are all unwired, so only
+//! a test on this side sees what a booted server actually enforces.
 //!
 //! One binary per crate, split into topic modules
 //! (`.claude/rules/testing.md` §One integration-test binary per crate).

--- a/app/ferroehr-server/tests/it/wiring.rs
+++ b/app/ferroehr-server/tests/it/wiring.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //! The binary's command-line seam: `--set` override parsing, the subcommand
-//! shapes, and the one dispatch branch of `run` that touches nothing external.
+//! shapes, the one dispatch branch of `run` that touches nothing external, and
+//! the `[privacy]` policy the run path compiles out of the shipped defaults.
 //!
 //! `Cli`'s fields are private by design (visibility is deliberate — the type is
 //! a `clap` parse target, not a record), so a parse result is observed through
@@ -13,6 +14,12 @@
     reason = "the blessed test shape (the Rust Book ch11-01): `?` propagates \
               plumbing failures — here the clap parse — while the assertion \
               carries the behaviour under test and is meant to panic"
+)]
+#![expect(
+    clippy::expect_used,
+    reason = "clippy's in-test lint scoping (clippy.toml `allow-*-in-tests`) only reaches \
+              `#[test]`-annotated functions, so it misses this module's fixture helpers; a \
+              failing fixture must panic at the fixture (the Rust Book ch11)"
 )]
 
 use clap::Parser as _;
@@ -178,4 +185,78 @@ fn unknown_subcommand_is_rejected() {
 async fn run_config_default_is_a_pure_stdout_path() -> anyhow::Result<()> {
     let cli = Cli::try_parse_from(["ferroehr", "config", "default"])?;
     run(cli).await
+}
+
+// ── the boot-installed [privacy] policy ───────────────────────────────────────
+
+/// The SHIPPED DEFAULT configuration, assembled through the loader the binary
+/// runs, with no file, environment or override of this test's own.
+///
+/// [`ferroehr::config::assemble`] is the pure seam
+/// [`load`](ferroehr::config::load) is a process-environment shim over, so the
+/// shipped template travels through the real loader while a test runner's own
+/// `FERROEHR_*` variables stay out of the subject.
+fn shipped_default_config() -> ferroehr::config::FerroEhrConfig {
+    let file = assert_fs::NamedTempFile::new("ferroehr.toml").expect("a temp config path");
+    assert_fs::prelude::FileWriteStr::write_str(&file, ferroehr::config::DEFAULT_TEMPLATE)
+        .expect("write the shipped template");
+    ferroehr::config::assemble(Some(file.path()), &std::collections::HashMap::new(), &[])
+        .expect("the shipped template assembles")
+}
+
+/// The [`WebTemplate`](openehr_its::flat::webtemplate::model::WebTemplate) of
+/// the operational template the browser journey battery seeds.
+///
+/// The real generator is driven off this rather than a literal body: a
+/// hand-written composition would drift away from what
+/// `GET /definition/template/adl1.4/{id}/example` actually hands out, which is
+/// the loop that has to hold.
+fn seed_web_template() -> openehr_its::flat::webtemplate::model::WebTemplate {
+    let opt = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../ferroehr-viewer/tests/fixtures/minimal_evaluation.opt");
+    let xml = std::fs::read_to_string(&opt).expect("the seed operational template reads");
+    let parsed = openehr_its::opt14::from_xml(&xml).expect("the seed OPT parses");
+    openehr_its::flat::webtemplate::builder::build_web_template(&parsed)
+        .expect("the seed OPT builds a WebTemplate")
+}
+
+/// A server booted on the shipped defaults accepts the composition its own
+/// example endpoint generates, at every detail level that endpoint offers.
+///
+/// The regression this pins is a wiring one, which is why it lives here: the
+/// platform suites build the service with `FerroEhrService::new()`, which
+/// carries the unenforced [`ferroehr::privacy::PrivacyPolicy`] default, and
+/// only the binary compiles `[privacy]` and installs it
+/// ([`ferroehr::privacy::PrivacyPolicy::compile`] + `with_privacy`). A default
+/// posture that refuses `ctx/composer_name` therefore looks green everywhere
+/// except in a real deployment.
+#[test]
+fn the_shipped_privacy_default_accepts_this_servers_own_example_composition() {
+    let config = shipped_default_config();
+    assert!(
+        !config.privacy.allow_identified_parties_in_ehr,
+        "the shipped default must stay the minimising posture"
+    );
+    let policy = ferroehr::privacy::PrivacyPolicy::compile(&config.privacy)
+        .expect("the shipped [privacy] section compiles");
+    let wt = seed_web_template();
+    for (label, level) in [
+        (
+            "required",
+            openehr_its::flat::example::DetailLevel::Required,
+        ),
+        ("medium", openehr_its::flat::example::DetailLevel::Medium),
+        (
+            "complete",
+            openehr_its::flat::example::DetailLevel::Complete,
+        ),
+    ] {
+        let example = openehr_its::flat::example::example_composition(&wt, level);
+        let findings = policy.findings("COMPOSITION", &example);
+        assert!(
+            findings.is_empty(),
+            "the shipped default refuses the example this server generates at \
+             detail_level={label}: {findings:?}"
+        );
+    }
 }

--- a/app/ferroehr/assets/ferroehr.default.toml
+++ b/app/ferroehr/assets/ferroehr.default.toml
@@ -538,7 +538,12 @@ max_retries = 3
 subject_namespaces = []
 # Accept PARTY_IDENTIFIED / PARTY_RELATED carrying `name` or `identifiers` in
 # clinical content (composer, participations, health_care_facility, feeder
-# audit). Off by default, and announced at boot when on.
+# audit). Off by default, and announced at boot when on. OFF still accepts a
+# PARTY_IDENTIFIED `name` — the RM class is the proxy for a party "other than
+# the subject of the record", "Typically for health care providers", so a
+# composer or performer name is provider identity. OFF refuses `identifiers`
+# on either class (the national-identifier slot) and `name` on PARTY_RELATED,
+# which is defined by its relationship to the subject and may be the subject.
 allow_identified_parties_in_ehr = false
 
 # The identifier scanner, run over every string leaf of every clinical write.

--- a/app/ferroehr/src/privacy/config.rs
+++ b/app/ferroehr/src/privacy/config.rs
@@ -113,11 +113,17 @@ pub struct PrivacyConfig {
     /// `identifiers` in clinical content
     /// (`FERROEHR__PRIVACY__ALLOW_IDENTIFIED_PARTIES_IN_EHR`).
     ///
-    /// Off by default, and announced at boot when on. The RM itself advises
-    /// against it (RM common `UML/classes/org.openehr.rm.common.party_identified.adoc`
-    /// §Description), and `PARTY_IDENTIFIED.Basic_validity` is satisfied by
-    /// `external_ref` alone, so refusing the other two leaves every party
-    /// proxy expressible.
+    /// Off by default, and announced at boot when on. Off refuses two of the
+    /// four combinations: `identifiers` on either class — "One or more formal
+    /// identifiers (possibly computable)" (RM common
+    /// `UML/classes/org.openehr.rm.common.party_identified.adoc` §Attributes),
+    /// the national-identifier slot — and `name` on `PARTY_RELATED`, which is
+    /// defined by its relationship to the subject and may be the subject
+    /// itself (RM common `UML/classes/org.openehr.rm.common.party_related.adoc`
+    /// §Attributes). A `PARTY_IDENTIFIED.name` is accepted either way: that
+    /// class is the proxy for a party "other than the subject of the record",
+    /// "Typically for health care providers". `Basic_validity` is satisfied by
+    /// `external_ref` alone, so the refused shapes stay expressible.
     pub allow_identified_parties_in_ehr: bool,
     /// `[privacy.identifier_scan]` — the identifier scanner.
     pub identifier_scan: IdentifierScanConfig,

--- a/app/ferroehr/src/privacy/mod.rs
+++ b/app/ferroehr/src/privacy/mod.rs
@@ -11,7 +11,9 @@
 //! `UML/classes/org.openehr.rm.ehr.ehr_status.adoc` §Attributes; RM common
 //! `UML/classes/org.openehr.rm.common.party_self.adoc`), and
 //! `PARTY_IDENTIFIED` says of itself "Should not be used to include patient
-//! identifying information" (RM common
+//! identifying information", a sentence the same paragraph scopes: the class
+//! covers a party "other than the subject of the record", with health care
+//! providers as its typical case (RM common
 //! `UML/classes/org.openehr.rm.common.party_identified.adoc` §Description).
 //! Neither is a machine-checkable rule, so this module is where FerroEHR makes
 //! them ones. The legal ground is GDPR Art. 4(5) and Art. 25(2)
@@ -27,9 +29,11 @@
 //!    configured pseudonym namespace and carry a UUID. In force only once the
 //!    deployment declares its namespaces
 //!    ([`config::PrivacyConfig::subject_namespaces`]).
-//! 2. **Identified parties.** A `PARTY_IDENTIFIED` or `PARTY_RELATED` in
-//!    clinical content may carry `external_ref` but not `name` or
-//!    `identifiers`, unless the deployment opts in. `Basic_validity` is
+//! 2. **Identified parties.** In clinical content a `PARTY_IDENTIFIED` may
+//!    carry `name` — the class is explicitly the provider proxy, "other than
+//!    the subject of the record" — but not `identifiers`, and a
+//!    `PARTY_RELATED` carries neither, being defined by its relationship to
+//!    the subject. The deployment can opt in to both. `Basic_validity` is
 //!    satisfied by `external_ref` alone, so every party proxy stays
 //!    expressible.
 //! 3. **The identifier scanner.** No string leaf may carry a value one of the
@@ -335,30 +339,59 @@ impl PrivacyPolicy {
     }
 }
 
-/// Refuse `name` / `identifiers` on a party proxy in clinical content.
+/// Refuse the party-proxy attributes that identify the record's subject.
+///
+/// `PARTY_IDENTIFIED.name` is permitted: the class is "Proxy data for an
+/// identified party **other than the subject of the record**", "Typically for
+/// health care providers, e.g. name and provider number of an institution"
+/// (RM common `UML/classes/org.openehr.rm.common.party_identified.adoc`
+/// §Description), so a name there is clinician or institution identity — the
+/// class's own paradigm case, not patient identity.
+///
+/// Two attributes stay refused. `identifiers` is "One or more formal
+/// identifiers (possibly computable)" (same file, §Attributes) — the
+/// national-identifier slot the pseudonymisation boundary exists to keep off
+/// the clinical side — and `PARTY_RELATED.name` with it, because that class is
+/// "Proxy type for identifying a party **and its relationship to the subject**
+/// of the record" and may BE the subject ("If it is the patient, coded as
+/// self"; RM common `UML/classes/org.openehr.rm.common.party_related.adoc`).
+/// `Basic_validity` is satisfied by `external_ref` alone, so every refused
+/// proxy stays expressible.
 ///
 /// A free function rather than a method: the caller has already decided the
 /// rule is in force, so this reads no policy state.
 fn check_party(at: &str, map: &serde_json::Map<String, Value>, findings: &mut Vec<Finding>) {
-    if !matches!(
-        map.get("_type").and_then(Value::as_str),
-        Some("PARTY_IDENTIFIED" | "PARTY_RELATED")
-    ) {
-        return;
+    let related = match map.get("_type").and_then(Value::as_str) {
+        Some("PARTY_RELATED") => true,
+        Some("PARTY_IDENTIFIED") => false,
+        _ => return,
+    };
+    let present = |attribute: &str| map.get(attribute).is_some_and(|v| !v.is_null());
+    if related && present("name") {
+        findings.push(Finding {
+            path: format!("{at}/name"),
+            message: "names a party in relation to the record's subject: PARTY_RELATED \
+                      identifies a party AND its relationship to the subject, coded `self` \
+                      where that party IS the patient (PARTY_RELATED §Description, \
+                      §Attributes), so a name here identifies or re-identifies the subject. \
+                      external_ref alone satisfies Basic_validity. Set \
+                      privacy.allow_identified_parties_in_ehr to accept it."
+                .to_owned(),
+            class: FindingClass::Refusal,
+        });
     }
-    for attribute in ["name", "identifiers"] {
-        if map.get(attribute).is_some_and(|v| !v.is_null()) {
-            findings.push(Finding {
-                path: format!("{at}/{attribute}"),
-                message: "identifies a party on the clinical side: a PARTY_IDENTIFIED or \
-                         PARTY_RELATED here may carry external_ref only (PARTY_IDENTIFIED \
-                         §Description: \"Should not be used to include patient identifying \
-                         information\"; Basic_validity is satisfied by external_ref alone). \
-                         Set privacy.allow_identified_parties_in_ehr to accept it."
-                    .to_owned(),
-                class: FindingClass::Refusal,
-            });
-        }
+    if present("identifiers") {
+        findings.push(Finding {
+            path: format!("{at}/identifiers"),
+            message: "carries a formal identifier on the clinical side: identifiers is \"One \
+                      or more formal identifiers (possibly computable)\" (PARTY_IDENTIFIED \
+                      §Attributes) — a national identifier or provider number, which the \
+                      clinical side does not hold. external_ref alone satisfies \
+                      Basic_validity. Set privacy.allow_identified_parties_in_ehr to accept \
+                      it."
+            .to_owned(),
+            class: FindingClass::Refusal,
+        });
     }
 }
 

--- a/app/ferroehr/tests/it/privacy_policy.rs
+++ b/app/ferroehr/tests/it/privacy_policy.rs
@@ -233,21 +233,49 @@ async fn the_subject_rule_also_binds_the_ehr_status_update_path() {
 
 // ── identified parties ────────────────────────────────────────────────────────
 
+/// The write path takes a named composer under the shipped default — the
+/// accepted cell of the matrix, proven through the service rather than the
+/// rule.
+///
+/// `composition()` composes as a `PARTY_IDENTIFIED` carrying a name, which is
+/// what `ctx/composer_name` and this server's own example generator produce.
+/// The class is the proxy for a party "other than the subject of the record",
+/// "Typically for health care providers" (RM common
+/// `UML/classes/org.openehr.rm.common.party_identified.adoc` §Description).
 #[tokio::test]
-async fn a_named_composer_is_refused_by_default_and_accepted_under_the_opt_in() {
+async fn a_named_composer_is_accepted_by_default() {
     let db = testkit::db().await.expect("testkit database");
     let strict = service(&db, &PrivacyConfig::default());
     let ehr_id = strict.create_ehr(None).await.expect("create_ehr");
 
-    // `composition()` composes as a PARTY_IDENTIFIED carrying a name — the
-    // shape the RM itself advises against on the clinical side (RM common
-    // `UML/classes/org.openehr.rm.common.party_identified.adoc` §Description).
     let named = composition("privacy composition");
-    let error = strict
+    strict
         .create_composition(ehr_id, uv(&named, "249", None))
         .await
-        .expect_err("a named party in clinical content is refused by default");
-    assert_refused_service(&error, "COMPOSITION/composer/name");
+        .expect("a provider name on the composer is not the boundary's business");
+}
+
+/// The write path refuses a composer's formal identifiers under the shipped
+/// default, and takes them under the opt-in — the refused cell of the
+/// `PARTY_IDENTIFIED` row.
+///
+/// `identifiers` is "One or more formal identifiers (possibly computable)"
+/// (same file, §Attributes): the national-identifier slot, whoever the party
+/// is.
+#[tokio::test]
+async fn composer_identifiers_are_refused_by_default_and_accepted_under_the_opt_in() {
+    let db = testkit::db().await.expect("testkit database");
+    let strict = service(&db, &PrivacyConfig::default());
+    let ehr_id = strict.create_ehr(None).await.expect("create_ehr");
+
+    let mut identified = composition("privacy composition");
+    identified["composer"]["identifiers"] =
+        json!([{ "_type": "DV_IDENTIFIER", "id": "GMC-1234567" }]);
+    let error = strict
+        .create_composition(ehr_id, uv(&identified, "249", None))
+        .await
+        .expect_err("a formal identifier in clinical content is refused by default");
+    assert_refused_service(&error, "COMPOSITION/composer/identifiers");
 
     let permissive = service(
         &db,
@@ -257,7 +285,7 @@ async fn a_named_composer_is_refused_by_default_and_accepted_under_the_opt_in() 
         },
     );
     permissive
-        .create_composition(ehr_id, uv(&named, "249", None))
+        .create_composition(ehr_id, uv(&identified, "249", None))
         .await
         .expect("the documented tenant opt-in accepts it");
 }

--- a/app/ferroehr/tests/it/privacy_rules.rs
+++ b/app/ferroehr/tests/it/privacy_rules.rs
@@ -60,8 +60,11 @@ fn paths(findings: &[Finding]) -> Vec<&str> {
 
 // ── the shipped default ───────────────────────────────────────────────────────
 
+/// The shipped default is the minimising posture: the identified-party opt-in
+/// off (which half of that rule bites is the matrix below), the scanner
+/// strict, and the subject rule waiting for a deployment fact.
 #[test]
-fn the_configuration_default_refuses_identified_parties_and_scans_strictly() {
+fn the_configuration_default_is_the_minimising_posture_and_scans_strictly() {
     let default = PrivacyConfig::default();
     assert!(!default.allow_identified_parties_in_ehr);
     assert_eq!(default.identifier_scan.mode, ScanMode::Strict);
@@ -171,14 +174,72 @@ fn the_subject_rule_binds_ehr_status_only() {
 
 // ── rule 2: identified parties ────────────────────────────────────────────────
 
+/// The permitted half of the matrix: `PARTY_IDENTIFIED.name` under the
+/// shipped default.
+///
+/// The class is "Proxy data for an identified party other than the subject of
+/// the record", "Typically for health care providers" (RM common
+/// `UML/classes/org.openehr.rm.common.party_identified.adoc` §Description), so
+/// a composer name is provider identity and the boundary does not reach it.
 #[test]
-fn a_named_party_in_clinical_content_is_refused_by_default() {
+fn a_named_party_identified_in_clinical_content_is_accepted_by_default() {
     let composition = json!({
         "_type": "COMPOSITION",
         "composer": { "_type": "PARTY_IDENTIFIED", "name": "Dr Author" }
     });
     let findings = policy(&PrivacyConfig::default()).findings("COMPOSITION", &composition);
-    assert_eq!(paths(&findings), ["COMPOSITION/composer/name"]);
+    assert!(findings.is_empty(), "{findings:?}");
+}
+
+/// The refused half of the matrix on the same class: `identifiers`.
+///
+/// "One or more formal identifiers (possibly computable)" (same file,
+/// §Attributes) is the national-identifier slot, which the clinical side does
+/// not hold whatever the party is.
+#[test]
+fn formal_identifiers_on_a_party_identified_are_refused_by_default() {
+    let composition = json!({
+        "_type": "COMPOSITION",
+        "composer": {
+            "_type": "PARTY_IDENTIFIED",
+            "name": "Dr Author",
+            "identifiers": [{ "_type": "DV_IDENTIFIER", "id": "GMC-1234567" }]
+        }
+    });
+    let findings = policy(&PrivacyConfig::default()).findings("COMPOSITION", &composition);
+    assert_eq!(paths(&findings), ["COMPOSITION/composer/identifiers"]);
+    assert_eq!(findings[0].class, FindingClass::Refusal);
+}
+
+/// The refused half of the matrix on `PARTY_RELATED`: a bare name.
+///
+/// That class is "Proxy type for identifying a party and its relationship to
+/// the subject of the record" and may BE the subject ("If it is the patient,
+/// coded as self"; RM common
+/// `UML/classes/org.openehr.rm.common.party_related.adoc`), so a name there is
+/// patient-identifying where the same name on a `PARTY_IDENTIFIED` is not.
+#[test]
+fn a_named_party_related_in_clinical_content_is_refused_by_default() {
+    let composition = json!({
+        "_type": "COMPOSITION",
+        "content": [{
+            "_type": "OBSERVATION",
+            "other_participations": [{
+                "_type": "PARTICIPATION",
+                "performer": {
+                    "_type": "PARTY_RELATED",
+                    "name": "A Relative",
+                    "relationship": { "_type": "DV_CODED_TEXT", "value": "mother" }
+                }
+            }]
+        }]
+    });
+    let findings = policy(&PrivacyConfig::default()).findings("COMPOSITION", &composition);
+    assert_eq!(
+        paths(&findings),
+        ["COMPOSITION/content[0]/other_participations[0]/performer/name"]
+    );
+    assert_eq!(findings[0].class, FindingClass::Refusal);
 }
 
 #[test]
@@ -198,6 +259,8 @@ fn an_identified_party_reduced_to_its_external_ref_passes() {
     );
 }
 
+/// Both refused cells of the `PARTY_RELATED` row at once, and the opt-in over
+/// the same body.
 #[test]
 fn identifiers_on_a_party_related_are_refused_too_and_the_opt_in_accepts_both() {
     let composition = json!({
@@ -227,6 +290,37 @@ fn identifiers_on_a_party_related_are_refused_too_and_the_opt_in_accepts_both() 
         ..PrivacyConfig::default()
     });
     assert!(permitted.findings("COMPOSITION", &composition).is_empty());
+}
+
+/// The opt-in accepts every cell of the matrix, both classes and both
+/// attributes, so the key still means what it always meant when set.
+#[test]
+fn the_opt_in_accepts_every_cell_of_the_matrix() {
+    let composition = json!({
+        "_type": "COMPOSITION",
+        "composer": {
+            "_type": "PARTY_IDENTIFIED",
+            "name": "Dr Author",
+            "identifiers": [{ "_type": "DV_IDENTIFIER", "id": "GMC-1234567" }]
+        },
+        "content": [{
+            "_type": "OBSERVATION",
+            "other_participations": [{
+                "_type": "PARTICIPATION",
+                "performer": {
+                    "_type": "PARTY_RELATED",
+                    "name": "A Relative",
+                    "identifiers": [{ "_type": "DV_IDENTIFIER", "id": "REL-7" }]
+                }
+            }]
+        }]
+    });
+    let permitted = policy(&PrivacyConfig {
+        allow_identified_parties_in_ehr: true,
+        ..PrivacyConfig::default()
+    });
+    let findings = permitted.findings("COMPOSITION", &composition);
+    assert!(findings.is_empty(), "{findings:?}");
 }
 
 #[test]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -63,15 +63,6 @@ services:
       # knob (the pull-only quickstart carries no such env: its pinned released
       # images may predate the key, whose strict sweep would refuse it at boot).
       FERROEHR__SPEC_PROFILE: ${FERROEHR__SPEC_PROFILE:-development}
-      # The dev stack keeps named party proxies in clinical content, which the
-      # shipped default refuses (`[privacy] allow_identified_parties_in_ehr`).
-      # A COMPOSITION's composer is the case: RM common master06 §Composer
-      # admits a PARTY_IDENTIFIED with a name, the FLAT `ctx/composer_name`
-      # produces exactly that, and the viewer displays it — so this stack is
-      # the opted-in posture the flag exists for, not an accident. A deployment
-      # that wants the minimising default leaves this unset and carries
-      # composers as `external_ref` alone.
-      FERROEHR__PRIVACY__ALLOW_IDENTIFIED_PARTIES_IN_EHR: "true"
 
   ferroehr-viewer:
     image: ${FERROEHR_VIEWER_IMAGE:-ghcr.io/rubentalstra/ferroehr-viewer:local}

--- a/website/book/src/installation/config-privacy.md
+++ b/website/book/src/installation/config-privacy.md
@@ -10,9 +10,9 @@ environment-name grammar, and file discovery are on the
 
 FerroEHR keeps clinical content and demographic parties in separate database
 schemas reached by separate roles. That separation is only worth something if
-the clinical side does not carry the identity anyway — in the subject
-reference, in a party proxy's name, or in free text. This section is the three
-rules that keep it out.
+the clinical side does not carry the subject's identity anyway — in the
+subject reference, in a party proxy, or in free text. This section is the
+three rules that keep it out.
 
 No openEHR specification governs any of them. The Reference Model leaves
 `EHR_STATUS.subject.external_ref` open and only advises against identifying
@@ -43,7 +43,7 @@ patterns = []
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `subject_namespaces` | list of strings | `[]` | The pseudonymisation domains this deployment issues subject pseudonyms in. |
-| `allow_identified_parties_in_ehr` | bool | `false` | Accept `PARTY_IDENTIFIED` / `PARTY_RELATED` carrying `name` or `identifiers` in clinical content. |
+| `allow_identified_parties_in_ehr` | bool | `false` | Accept `PARTY_IDENTIFIED` / `PARTY_RELATED` carrying `name` or `identifiers` in clinical content. Off still accepts a `PARTY_IDENTIFIED` name; see the matrix below. |
 
 ### The subject reference
 
@@ -73,17 +73,44 @@ spellings of one pseudonym would be four subjects.
 
 ### Identified parties
 
-A `PARTY_IDENTIFIED` or `PARTY_RELATED` inside clinical content may carry
-`external_ref` but not `name` and not `identifiers`. This covers the
-composer, participations, the health care facility and feeder-audit party
-slots. `PARTY_IDENTIFIED`'s own validity rule is satisfied by `external_ref`
-alone, so every party proxy stays expressible — it points into the demographic
-domain instead of restating the identity.
+A party proxy inside clinical content — the composer, participations, the
+health care facility and the feeder-audit party slots — is governed by which
+class it is:
+
+| | `name` | `identifiers` |
+|---|---|---|
+| `PARTY_IDENTIFIED` | accepted | refused |
+| `PARTY_RELATED` | refused | refused |
+
+The two classes mean different things, so one rule for both was the wrong
+shape. `PARTY_IDENTIFIED` is the Reference Model's own provider proxy: "Proxy
+data for an identified party **other than the subject of the record**",
+"Typically for health care providers, e.g. name and provider number of an
+institution". A composer name or a performing clinician's name is that, not
+patient identity, and refusing it invented a prohibition the specification
+does not contain. `ctx/composer_name` in the simplified formats produces
+exactly this shape, and so does the example composition this server generates
+for a template.
+
+`identifiers` stays refused on both classes. It is "One or more formal
+identifiers (possibly computable)" — the NHS-number and BSN slot — and a
+national identifier on the clinical side is what the separation between the
+two database schemas exists to prevent.
+
+`PARTY_RELATED` carries neither. It is the "Proxy type for identifying a party
+**and its relationship to the subject** of the record", and that relationship
+is coded `self` where the party *is* the patient, so a name there is patient
+identity or patient-adjacent — a named next of kin re-identifies the subject.
+
+A refused proxy stays expressible: `PARTY_IDENTIFIED`'s own validity rule is
+satisfied by `external_ref` alone, so it points into the demographic domain
+instead of restating the identity.
 
 The commit's own `AUDIT_DETAILS.committer` is not clinical content and is never
 touched by this rule.
 
-A deployment that needs the names on the clinical side sets:
+A deployment that needs formal identifiers, or names on parties related to the
+subject, sets:
 
 ```toml
 [privacy]


### PR DESCRIPTION
Closes #3190.

`[privacy] allow_identified_parties_in_ehr` defaults to `false`, and the rule behind it refused `name` and `identifiers` on both `PARTY_IDENTIFIED` and `PARTY_RELATED`. The effect was that a deployment running the shipped default could not commit the composition its own example endpoint hands out: `ctx/composer_name` produces a `PARTY_IDENTIFIED` carrying a name, and `crates/openehr-its/src/flat/example.rs` emits exactly that.

## The decision

The first acceptance criterion asked for a default posture, decided explicitly. Reading the two classes apart settles it more finely than the issue's own "split `name` from `identifiers`" proposal, because the one switch was conflating two different things.

`PARTY_IDENTIFIED` is "proxy data for an identified party **other than the subject of the record**", "**typically for health care providers**, e.g. name and provider number of an institution", and the sentence it carries warns against "**patient** identifying information" (`docs/specs/openehr/RM/docs/UML/classes/org.openehr.rm.common.party_identified.adoc` §Description). A named provider is not something the class tolerates, it is what the class is for.

`PARTY_RELATED` is a different animal: it identifies "a party **and its relationship to the subject** of the record", and that relationship is "coded as `self`" where the party is the patient (`…party_related.adoc` §Description, §Attributes). A name there is the patient, or someone whose name re-identifies them.

So with the flag off:

| | `name` | `identifiers` |
|---|---|---|
| `PARTY_IDENTIFIED` | **accepted** | refused |
| `PARTY_RELATED` | refused | refused |

`identifiers` stays refused on both, because the attribute is "one or more formal identifiers (possibly computable)" — the NHS-number and BSN class, which is precisely what the pseudonymisation boundary exists to keep off the clinical side. What the old default got wrong was treating a provider's name as the same kind of thing. `PARTY_RELATED` inherits `PARTY_IDENTIFIED`, so the check branches on the concrete `_type` and the permission does not leak.

Turning the flag on still accepts all four, unchanged.

**The configuration surface does not move.** The privacy config structs carry `deny_unknown_fields`, so renaming or removing the key would refuse the configuration of every deployment that sets it; and the new posture only ever relaxes a refusal, so nothing that commits successfully today starts failing. No second key, no enum, no migration.

## Why it reached main, and what now catches it

Nothing ran the real binary on the real shipped configuration. The unit suites build the service with `FerroEhrService::new()`, which installs no policy at all, so the whole class was invisible to them; only the binary compiles `[privacy]` and installs it.

`the_shipped_privacy_default_accepts_this_servers_own_example_composition` (`app/ferroehr-server/tests/it/wiring.rs`) closes that. It writes the shipped `DEFAULT_TEMPLATE` out, runs it through the real loader, compiles the policy exactly as `lib.rs` does, and asserts the result accepts what this server's own generator emits — the real OPT→WebTemplate→`example_composition` path over the same fixture `scripts/ui-e2e.sh` seeds, at all three detail levels. No hand-written fixture, because one would drift away from the generator and stop testing the loop that broke. It also asserts the flag is still `false`, so it cannot go green by someone flipping the default.

Mutation-proven twice, once by the implementer and once independently here: restoring the old behaviour fails it with `COMPOSITION/composer/name`, and the restore is byte-identical with 18/18 passing.

## The gate that would have reported green about nothing

The `ui-e2e` filter gains the boot-installed policy inputs (`app/ferroehr-server/src/`, `app/ferroehr/src/privacy/`, `app/ferroehr/src/config/`, the shipped TOML) — criterion 3.

That alone would have been vacuous. `scripts/ui-e2e.sh` composes `docker-compose.dev.yml`, which set `FERROEHR__PRIVACY__ALLOW_IDENTIFIED_PARTIES_IN_EHR: "true"` as the #3189 workaround, so the battery would have triggered on privacy changes and then run with the opt-in, never touching the default it was newly guarding. The override existed for the composer name, which is no longer refused, so it is removed. The battery seeds only the server's own example output, which the wiring test proves is accepted, and the battery gates this PR, so the removal verifies itself here.

`docker-compose.dev.yml` was also missing from the filter, which meant that very edit would not have raised the battery it configures. Added, and the regex checked in both directions: the policy inputs and the dev overlay trigger it, an unrelated AQL file does not.

## Also

The privacy module doc quoted "Should not be used to include patient identifying information" without the clause that bounds it, which reads as a prohibition on the whole class — the misreading that produced this defect. It now carries the "other than the subject of the record" scope and the provider-typical-case sentence.

`app/ferroehr-server/CLAUDE.md` said a new dev-dep there signals the test belongs in another crate. True for behaviour tests, wrong for boot-posture tests, which can only live in that crate; amended rather than left contradicting the test criterion 2 demands.

## Gates

`cargo fmt --all --check`; `cargo clippy --workspace --exclude ferroehr-viewer --all-targets --all-features -- -D warnings`; 211/211 across the privacy, wiring and config suites; `ferroehr-server` 18/18; `comment-style`, `default-style`, `typed-status`, `docs-claims`, `spec-citations`, `error-hygiene`, `no-python`, `spdx-headers`, `compose-hardening` green; `actionlint` clean on the edited workflow. No `#[expect]` or `#[allow]` added to production code. No test deleted or weakened — the two whose expectation moved were retargeted and say in their doc comments which half of the matrix they pin.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.
