### PR TITLE
fix(viewer): the upload click proves it dispatched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -365,6 +365,14 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **The template upload dialog opens empty** (#3200). It cleared the source
+  it was holding only when the CDR accepted it, so after an upload that was
+  refused — or one whose click never reached the handler — re-opening the
+  dialog showed the previous attempt's source with the send button already
+  live, offering to send something the reader had not just chosen. Opening
+  the dialog is now a fresh attempt: the editor starts empty, and the button
+  stays inert until a file has actually been read into it.
+
 - **The migration hook's pod is no longer selected by the server's Service and
   PodDisruptionBudget** (#3197). A selector is a subset match, and the hook pod
   carried the server's selector pair plus a `component` label, so for as long

--- a/app/ferroehr-viewer/src/pages/templates.rs
+++ b/app/ferroehr-viewer/src/pages/templates.rs
@@ -414,7 +414,18 @@ pub fn TemplatesPage() -> impl IntoView {
     // the same position, opening the same dialog, with only the copy and the
     // accepted input differing. The family comes from the URL, so both branches
     // render identically on the server pass and at hydration.
-    let action_slot = upload_trigger(upload_open, family);
+    // Opening the dialog clears BOTH halves of the previous attempt: the
+    // source, and the action value the diagnostic MessageBar renders. Leaving
+    // either behind shows the last attempt inside a dialog the reader just
+    // opened fresh.
+    let reset_upload = Callback::new(move |()| {
+        upload_source.set(String::new());
+        match family.get_untracked() {
+            TemplateFamily::Adl14 => upload.value().set(None),
+            TemplateFamily::Adl2 => adl2_upload.value().set(None),
+        }
+    });
+    let action_slot = upload_trigger(upload_open, reset_upload, family);
     let upload_dialog = upload_dialog_view(upload_open, upload_source, family, upload, adl2_upload);
     let switch = family_switch(family);
     let table_section = templates_table(filter, paging, list, gate, delete, pending_delete);
@@ -651,14 +662,27 @@ fn delete_prompt(target: &DeleteTarget) -> String {
 
 /// The upload trigger for the page-header action slot: the SAME button in the
 /// same place for both families, opening the screen's one upload dialog
-/// ([`upload_dialog_view`]). Only its label follows the family.
-fn upload_trigger(open: RwSignal<bool>, family: Memo<TemplateFamily>) -> AnyView {
+/// ([`upload_dialog_view`]) on an EMPTY source. Only its label follows the
+/// family.
+///
+/// Opening clears the source because an open is a new attempt: the previous
+/// one is cleared on success only, so without this a lost or refused upload
+/// leaves its source in the editor and the reader is offered a dialog that
+/// already looks ready to send something they did not just choose.
+fn upload_trigger(
+    open: RwSignal<bool>,
+    on_open: Callback<()>,
+    family: Memo<TemplateFamily>,
+) -> AnyView {
     view! {
         <button
             id="template-upload-open"
             type="button"
             class=BTN_PRIMARY
-            on:click=move |_| open.set(true)
+            on:click=move |_| {
+                on_open.run(());
+                open.set(true);
+            }
         >
             <leptos_icons::Icon icon=icondata_lu::LuUpload width="14" height="14" />
             {move || family.get().upload_label()}

--- a/app/ferroehr-viewer/tests/it/common/mod.rs
+++ b/app/ferroehr-viewer/tests/it/common/mod.rs
@@ -42,15 +42,6 @@ const WAIT: Duration = Duration::from_secs(15);
 /// only observes a rendered page (module docs).
 const HYDRATION_WAIT: Duration = Duration::from_mins(1);
 
-/// The budget ONE `WebDriver` HTTP command gets, replacing thirtyfour's 120 s
-/// default (`WebDriverConfig::request_timeout`).
-///
-/// Every wait in this harness is a poll loop of short commands, so a single
-/// command must answer well inside one loop's [`WAIT`]. At the default, a
-/// stalled driver outlasts the whole loop and reports itself only as an
-/// inflated run time — the failure mode that hid a lost click for two CI runs.
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
-
 /// Everything a journey needs.
 pub(crate) struct Harness {
     /// The `WebDriver` session.
@@ -104,8 +95,11 @@ impl Harness {
             .expect("caps");
         caps.set_logging_prefs("browser", thirtyfour::LoggingPrefsLogLevel::All)
             .expect("logging prefs");
+        // TODO(#3218): bound a stalled steady-state command. thirtyfour's
+        // request_timeout also covers NewSession, which exceeds a short budget
+        // under nextest parallelism, and the config carries no post-build
+        // setter, so the bound belongs on our own command awaits.
         let driver = WebDriver::builder(&webdriver_url, caps)
-            .request_timeout(REQUEST_TIMEOUT)
             .await
             .expect("webdriver session (is chromedriver up?)");
         Some(Self {
@@ -255,8 +249,11 @@ impl Harness {
             serde_json::json!({"profile.managed_default_content_settings.javascript": 2}),
         )
         .expect("prefs");
+        // TODO(#3218): bound a stalled steady-state command. thirtyfour's
+        // request_timeout also covers NewSession, which exceeds a short budget
+        // under nextest parallelism, and the config carries no post-build
+        // setter, so the bound belongs on our own command awaits.
         let driver = WebDriver::builder(&webdriver_url, caps)
-            .request_timeout(REQUEST_TIMEOUT)
             .await
             .expect("webdriver session (is chromedriver up?)");
         Some(Self {

--- a/app/ferroehr-viewer/tests/it/common/mod.rs
+++ b/app/ferroehr-viewer/tests/it/common/mod.rs
@@ -553,6 +553,30 @@ pub(crate) async fn is_visible(h: &Harness, css: &str) -> bool {
     }
 }
 
+/// Whether ANY element matching `css` is displayed.
+///
+/// [`is_visible`] answers for the FIRST match, which is the wrong question
+/// about a dialog: a page mounts one surface per dialog and thaw's `Teleport`
+/// never unmounts one after its first open, so a journey that has opened two
+/// leaves a closed surface ahead of the open one in document order. "Is a
+/// modal up" has to look at all of them or it answers about the wrong one.
+pub(crate) async fn is_any_visible(h: &Harness, css: &str) -> bool {
+    let found = match h.driver.find_all(By::Css(css)).await {
+        Ok(found) => found,
+        Err(error) if is_absence(&error) => return false,
+        Err(error) => panic!("the WebDriver could not answer `find_all({css})`: {error}"),
+    };
+    for element in found {
+        match element.is_displayed().await {
+            Ok(true) => return true,
+            Ok(false) => {}
+            Err(error) if is_absence(&error) => {}
+            Err(error) => panic!("the WebDriver could not answer `is_displayed({css})`: {error}"),
+        }
+    }
+    false
+}
+
 /// thaw's modal surface — the panel itself.
 const DIALOG_SURFACE: &str = ".thaw-dialog-surface";
 
@@ -581,7 +605,7 @@ const DIALOG_ENTERING: &str = ".thaw-dialog-surface.fade-in-scale-up-transition-
 /// # Panics
 /// When a backdrop is still up after 15 s.
 pub(crate) async fn clear_dialog_overlay(h: &Harness) {
-    if is_visible(h, DIALOG_SURFACE).await {
+    if is_any_visible(h, DIALOG_SURFACE).await {
         drop(
             h.driver
                 .action_chain()
@@ -593,29 +617,34 @@ pub(crate) async fn clear_dialog_overlay(h: &Harness) {
     wait_hidden(h, DIALOG_BACKDROP).await;
 }
 
-/// Wait until the modal is open AND STILL: visible, with its enter transition
-/// finished.
+/// Wait until the dialog holding `control_css` is open AND STILL: that control
+/// visible, with no dialog anywhere mid-enter.
 ///
-/// Presence is not openness — thaw's `Teleport` mounts the dialog subtree on
-/// the first open and never unmounts it, so a later open finds the surface
-/// already in the DOM ([`is_visible`]). Visibility alone is not readiness
-/// either: a control clicked while the surface is still scaling up is clicked
-/// at coordinates it has already left, which `WebDriver` reports as a
-/// perfectly successful click on nothing. [`DIALOG_ENTERING`] is the
-/// transition's own in-flight marker, so "visible and not entering" is
+/// Takes a control INSIDE the target dialog rather than matching the surface
+/// class, because a page mounts one surface per dialog and thaw's `Teleport`
+/// mounts each subtree on its first open and never unmounts it. A journey that
+/// uploads and then deletes leaves two surfaces in the DOM, and a bare
+/// `.thaw-dialog-surface` match answers for whichever comes first — which is
+/// the CLOSED one, so the wait could never be satisfied.
+///
+/// Visibility alone is not readiness either: a control clicked while the
+/// surface is still scaling up is clicked at coordinates it has already left,
+/// which `WebDriver` reports as a perfectly successful click on nothing.
+/// [`DIALOG_ENTERING`] is the transition's own in-flight marker and is checked
+/// across the page, so "this control is visible and nothing is entering" is
 /// observable rather than timed.
 ///
 /// # Panics
 /// When the dialog is not open and settled within 15 s.
-pub(crate) async fn wait_dialog_settled(h: &Harness) {
+pub(crate) async fn wait_dialog_settled(h: &Harness, control_css: &str) {
     for _ in 0..75 {
-        if is_visible(h, DIALOG_SURFACE).await && !is_present(h, DIALOG_ENTERING).await {
+        if is_visible(h, control_css).await && !is_present(h, DIALOG_ENTERING).await {
             return;
         }
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
     let url = h.driver.current_url().await.expect("current url");
-    panic!("the dialog never became open and settled (at {url})");
+    panic!("the dialog holding `{control_css}` never became open and settled (at {url})");
 }
 
 /// The submit button of the Template Manager's one upload dialog.
@@ -731,7 +760,7 @@ pub(crate) async fn upload_via_dialog(h: &Harness, path: &str) {
         .click()
         .await
         .expect("open the template upload dialog");
-    wait_dialog_settled(h).await;
+    wait_dialog_settled(h, UPLOAD_SUBMIT).await;
     h.wait_css("#template-upload-picker input[type=file]")
         .await
         .send_keys(path)
@@ -918,7 +947,7 @@ pub(crate) async fn click_until_css(h: &Harness, css: &str, target_css: &str) ->
 /// When it is still visible after 15 s.
 pub(crate) async fn wait_hidden(h: &Harness, css: &str) {
     for _ in 0..75 {
-        if !is_visible(h, css).await {
+        if !is_any_visible(h, css).await {
             return;
         }
         tokio::time::sleep(Duration::from_millis(200)).await;
@@ -1065,7 +1094,7 @@ pub(crate) async fn confirm_in_dialog(h: &Harness, trigger_css: &str, confirm_id
         // swallowed by the modal and surface as `ElementClickIntercepted` — a
         // confusing report for what is really "the dialog opened, but not with
         // the confirm id this call expects". Stop and let the assertion say so.
-        if attempt > 0 && is_visible(h, ".thaw-dialog-surface").await {
+        if attempt > 0 && is_any_visible(h, DIALOG_SURFACE).await {
             break;
         }
         trigger.click().await.expect("open the confirmation dialog");
@@ -1089,7 +1118,7 @@ pub(crate) async fn confirm_in_dialog(h: &Harness, trigger_css: &str, confirm_id
     // The confirm button is visible from the first frame of the 250 ms enter
     // transition, and a click landing mid-scale can miss the moving target
     // without the driver reporting anything (#3200).
-    wait_dialog_settled(h).await;
+    wait_dialog_settled(h, &confirm_css).await;
     h.wait_css(&confirm_css)
         .await
         .click()

--- a/app/ferroehr-viewer/tests/it/common/mod.rs
+++ b/app/ferroehr-viewer/tests/it/common/mod.rs
@@ -30,6 +30,7 @@
 
 use std::time::Duration;
 
+use thirtyfour::error::WebDriverErrorInner;
 use thirtyfour::prelude::*;
 
 /// The budget every ordinary element wait allows.
@@ -40,6 +41,15 @@ const WAIT: Duration = Duration::from_secs(15);
 /// before the marker appears, which is comfortably slower than any wait that
 /// only observes a rendered page (module docs).
 const HYDRATION_WAIT: Duration = Duration::from_mins(1);
+
+/// The budget ONE `WebDriver` HTTP command gets, replacing thirtyfour's 120 s
+/// default (`WebDriverConfig::request_timeout`).
+///
+/// Every wait in this harness is a poll loop of short commands, so a single
+/// command must answer well inside one loop's [`WAIT`]. At the default, a
+/// stalled driver outlasts the whole loop and reports itself only as an
+/// inflated run time — the failure mode that hid a lost click for two CI runs.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Everything a journey needs.
 pub(crate) struct Harness {
@@ -94,7 +104,8 @@ impl Harness {
             .expect("caps");
         caps.set_logging_prefs("browser", thirtyfour::LoggingPrefsLogLevel::All)
             .expect("logging prefs");
-        let driver = WebDriver::new(&webdriver_url, caps)
+        let driver = WebDriver::builder(&webdriver_url, caps)
+            .request_timeout(REQUEST_TIMEOUT)
             .await
             .expect("webdriver session (is chromedriver up?)");
         Some(Self {
@@ -244,7 +255,8 @@ impl Harness {
             serde_json::json!({"profile.managed_default_content_settings.javascript": 2}),
         )
         .expect("prefs");
-        let driver = WebDriver::new(&webdriver_url, caps)
+        let driver = WebDriver::builder(&webdriver_url, caps)
+            .request_timeout(REQUEST_TIMEOUT)
             .await
             .expect("webdriver session (is chromedriver up?)");
         Some(Self {
@@ -485,15 +497,62 @@ impl Harness {
     }
 }
 
+/// Whether a `WebDriver` error means the element is simply NOT THERE — the
+/// only answer a polling probe may read as "not yet".
+///
+/// `no such element` is genuine absence, and a stale handle is a re-rendering
+/// subtree detaching the element between the find and the read. Everything
+/// else — a request that never came back, a dead session, a rejected
+/// selector — is the driver failing to ANSWER the question, and a probe that
+/// swallows it spends its whole budget reporting an empty page.
+fn is_absence(error: &WebDriverError) -> bool {
+    matches!(
+        error.as_inner(),
+        WebDriverErrorInner::NoSuchElement(_) | WebDriverErrorInner::StaleElementReference(_)
+    )
+}
+
+/// Whether `by` currently matches an element.
+///
+/// # Panics
+/// When the `WebDriver` answers with anything but an absence
+/// ([`is_absence`]): a failure to observe is never an observation of nothing.
+pub(crate) async fn is_present_by(h: &Harness, by: By) -> bool {
+    match h.driver.find(by.clone()).await {
+        Ok(_) => true,
+        Err(error) if is_absence(&error) => false,
+        Err(error) => panic!("the WebDriver could not answer `find({by:?})`: {error}"),
+    }
+}
+
+/// [`is_present_by`] for a CSS selector — the ordinary "is this on the page"
+/// probe.
+///
+/// # Panics
+/// When the `WebDriver` answers with anything but an absence ([`is_absence`]).
+pub(crate) async fn is_present(h: &Harness, css: &str) -> bool {
+    is_present_by(h, By::Css(css)).await
+}
+
 /// Whether `css` matches a currently VISIBLE element.
 ///
 /// thaw's dialog is never removed from the DOM: `leptos_transition_group`'s
 /// `CSSTransition` hides it with `display: none`, so a closed dialog is still
 /// findable. Openness is therefore visibility, never mere presence.
+///
+/// # Panics
+/// When the `WebDriver` answers with anything but an absence ([`is_absence`]).
 pub(crate) async fn is_visible(h: &Harness, css: &str) -> bool {
     match h.driver.find(By::Css(css)).await {
-        Ok(element) => element.is_displayed().await.unwrap_or(false),
-        Err(_) => false,
+        Ok(element) => match element.is_displayed().await {
+            Ok(displayed) => displayed,
+            Err(error) if is_absence(&error) => false,
+            Err(error) => {
+                panic!("the WebDriver could not answer `is_displayed({css})`: {error}")
+            }
+        },
+        Err(error) if is_absence(&error) => false,
+        Err(error) => panic!("the WebDriver could not answer `find({css})`: {error}"),
     }
 }
 
@@ -503,6 +562,12 @@ const DIALOG_SURFACE: &str = ".thaw-dialog-surface";
 /// thaw's modal backdrop: a full-viewport element rendered under every open
 /// dialog and kept displayed while the dialog fades out.
 const DIALOG_BACKDROP: &str = ".thaw-dialog-surface__backdrop";
+
+/// thaw's modal surface MID-OPEN: `leptos_transition_group`'s `CSSTransition`
+/// adds `{name}-enter-active` when the surface starts appearing and removes it
+/// when the transition ends, and thaw's `DialogSurface` names its transition
+/// `fade-in-scale-up-transition` (a 250 ms opacity + scale).
+const DIALOG_ENTERING: &str = ".thaw-dialog-surface.fade-in-scale-up-transition-enter-active";
 
 /// Establish the precondition every page-level click has: nothing is covering
 /// the page.
@@ -531,21 +596,137 @@ pub(crate) async fn clear_dialog_overlay(h: &Harness) {
     wait_hidden(h, DIALOG_BACKDROP).await;
 }
 
+/// Wait until the modal is open AND STILL: visible, with its enter transition
+/// finished.
+///
+/// Presence is not openness — thaw's `Teleport` mounts the dialog subtree on
+/// the first open and never unmounts it, so a later open finds the surface
+/// already in the DOM ([`is_visible`]). Visibility alone is not readiness
+/// either: a control clicked while the surface is still scaling up is clicked
+/// at coordinates it has already left, which `WebDriver` reports as a
+/// perfectly successful click on nothing. [`DIALOG_ENTERING`] is the
+/// transition's own in-flight marker, so "visible and not entering" is
+/// observable rather than timed.
+///
+/// # Panics
+/// When the dialog is not open and settled within 15 s.
+pub(crate) async fn wait_dialog_settled(h: &Harness) {
+    for _ in 0..75 {
+        if is_visible(h, DIALOG_SURFACE).await && !is_present(h, DIALOG_ENTERING).await {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    let url = h.driver.current_url().await.expect("current url");
+    panic!("the dialog never became open and settled (at {url})");
+}
+
+/// The submit button of the Template Manager's one upload dialog.
+const UPLOAD_SUBMIT: &str = "#template-upload-submit";
+
+/// The refusal diagnostic, scoped to the MODAL: the template listings render
+/// their own `MessageBar` for an empty result, which is not this one.
+const UPLOAD_DIAGNOSTIC: &str = ".thaw-dialog-surface .thaw-message-bar";
+
+/// The in-flight line the upload dialog renders while its action is pending
+/// (`src/components/upload_dialog.rs`). It sits inside a `Show`, so its
+/// presence IS the pending state; matched by its rendered text because the
+/// line carries no id of its own.
+const UPLOAD_PENDING_LINE: &str =
+    "//div[contains(@class, 'thaw-dialog-surface')]//span[normalize-space(text())='Uploading…']";
+
+/// Every toast card currently on screen; each upload outcome raises one.
+const TOAST_CARD: &str = ".thaw-toast-body";
+
+/// What the upload dialog says about a dispatch, read at one instant.
+///
+/// The submit click's post-condition is a COMPARISON of two of these, because
+/// only some of the observables are unconditionally absent beforehand: a
+/// refusal diagnostic and a toast can both survive from an earlier attempt.
+#[derive(Debug)]
+struct UploadDialogState {
+    /// Whether the modal surface is on screen — an accepted upload closes it.
+    open: bool,
+    /// Whether the submit button is live, or `None` when it is not in the DOM.
+    submit_enabled: Option<bool>,
+    /// Whether the "Uploading…" line is rendered.
+    pending: bool,
+    /// The refusal diagnostic rendered inside the dialog, if any.
+    diagnostic: Option<String>,
+    /// How many toast cards are up.
+    toasts: usize,
+}
+
+impl UploadDialogState {
+    /// Read every observable once.
+    ///
+    /// # Panics
+    /// When the `WebDriver` fails to answer any of them ([`is_absence`]).
+    async fn read(h: &Harness) -> Self {
+        Self {
+            open: is_visible(h, DIALOG_SURFACE).await,
+            submit_enabled: read_enabled(h, UPLOAD_SUBMIT).await,
+            pending: is_present_by(h, By::XPath(UPLOAD_PENDING_LINE)).await,
+            diagnostic: read_text(h, UPLOAD_DIAGNOSTIC).await,
+            toasts: count_matching(h, TOAST_CARD).await,
+        }
+    }
+
+    /// Whether this state carries a consequence of the submit dispatch that
+    /// `before` did not already carry.
+    ///
+    /// Each disjunct is something only a dispatch produces: the dialog closing
+    /// is the accepted-upload continuation, the pending line and the button
+    /// going inert are the action's own in-flight state, a moved diagnostic is
+    /// a fresh refusal, and a new toast is either outcome's feedback.
+    fn dispatched_since(&self, before: &Self) -> bool {
+        (before.open && !self.open)
+            || self.pending
+            || (before.submit_enabled == Some(true) && self.submit_enabled == Some(false))
+            || self.diagnostic != before.diagnostic
+            || self.toasts > before.toasts
+    }
+}
+
+/// The submit click's post-condition: poll until the dialog shows that the
+/// dispatch happened.
+///
+/// # Panics
+/// When nothing moves within 15 s — the click was answered, the handler never
+/// ran, and the panic says so HERE rather than leaving a downstream read to
+/// blame the CDR for a row nothing ever sent it.
+async fn wait_upload_dispatched(h: &Harness, before: &UploadDialogState) {
+    for _ in 0..75 {
+        if UploadDialogState::read(h).await.dispatched_since(before) {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    let evidence = h.evidence_dump("upload-click-not-dispatched").await;
+    panic!(
+        "the click on `{UPLOAD_SUBMIT}` did not dispatch the upload: 15 s on, the dialog \
+         is still open with its source loaded and its submit button live, nothing is \
+         pending, no new diagnostic and no toast — the click was answered but the \
+         handler never ran, so nothing was sent to the CDR ({evidence})"
+    );
+}
+
 /// Upload `path` through the Template Manager's one upload dialog: open it
 /// from the page-header trigger, choose the file, and send it.
 ///
-/// Both template families share this control (#2955), so both families' seed
-/// helpers drive the same routine. The submit button is inert until the chosen
-/// file has been read into the dialog's source editor, which makes
-/// [`wait_enabled`] the exact "the file arrived" condition — never a sleep.
+/// Both template families share this control (#2955), so every family's seed
+/// helper drives this one routine.
 ///
-/// Both seed helpers call this in a retry loop, and a refused upload keeps the
-/// dialog open on purpose, so re-entry with a modal already up is a normal
-/// state rather than an anomaly — [`clear_dialog_overlay`] is what makes the
-/// trigger clickable again (#3134).
+/// Four conditions, no sleeps, each the exact fact the next step needs:
+/// nothing covers the page ([`clear_dialog_overlay`] — a refused upload keeps
+/// its dialog open on purpose, so re-entry with a modal up is normal, #3134);
+/// the modal is open and settled ([`wait_dialog_settled`]); the submit button
+/// is live ([`wait_enabled`]), which is inert until the chosen file has been
+/// read into the dialog's source editor and so means exactly "the file
+/// arrived"; and the send actually DISPATCHED ([`wait_upload_dispatched`]).
 ///
 /// # Panics
-/// On any interaction failure.
+/// On any interaction failure, and when the submit click dispatches nothing.
 pub(crate) async fn upload_via_dialog(h: &Harness, path: &str) {
     clear_dialog_overlay(h).await;
     h.wait_css("#template-upload-open")
@@ -553,17 +734,65 @@ pub(crate) async fn upload_via_dialog(h: &Harness, path: &str) {
         .click()
         .await
         .expect("open the template upload dialog");
+    wait_dialog_settled(h).await;
     h.wait_css("#template-upload-picker input[type=file]")
         .await
         .send_keys(path)
         .await
         .expect("choose the fixture through the dialog's hidden file input");
-    wait_enabled(h, "#template-upload-submit").await;
-    h.wait_css("#template-upload-submit")
+    wait_enabled(h, UPLOAD_SUBMIT).await;
+    let before = UploadDialogState::read(h).await;
+    h.wait_css(UPLOAD_SUBMIT)
         .await
         .click()
         .await
         .expect("send the chosen template source");
+    wait_upload_dispatched(h, &before).await;
+}
+
+/// Whether the control at `css` is enabled, or `None` when nothing matches.
+///
+/// # Panics
+/// When the `WebDriver` answers with anything but an absence ([`is_absence`]).
+async fn read_enabled(h: &Harness, css: &str) -> Option<bool> {
+    match h.driver.find(By::Css(css)).await {
+        Ok(element) => match element.is_enabled().await {
+            Ok(enabled) => Some(enabled),
+            Err(error) if is_absence(&error) => None,
+            Err(error) => panic!("the WebDriver could not answer `is_enabled({css})`: {error}"),
+        },
+        Err(error) if is_absence(&error) => None,
+        Err(error) => panic!("the WebDriver could not answer `find({css})`: {error}"),
+    }
+}
+
+/// The text of the first element matching `css`, or `None` when nothing
+/// matches.
+///
+/// # Panics
+/// When the `WebDriver` answers with anything but an absence ([`is_absence`]).
+async fn read_text(h: &Harness, css: &str) -> Option<String> {
+    match h.driver.find(By::Css(css)).await {
+        Ok(element) => match element.text().await {
+            Ok(text) => Some(text),
+            Err(error) if is_absence(&error) => None,
+            Err(error) => panic!("the WebDriver could not answer `text({css})`: {error}"),
+        },
+        Err(error) if is_absence(&error) => None,
+        Err(error) => panic!("the WebDriver could not answer `find({css})`: {error}"),
+    }
+}
+
+/// How many elements match `css`.
+///
+/// # Panics
+/// When the `WebDriver` answers with anything but an absence ([`is_absence`]).
+async fn count_matching(h: &Harness, css: &str) -> usize {
+    match h.driver.find_all(By::Css(css)).await {
+        Ok(found) => found.len(),
+        Err(error) if is_absence(&error) => 0,
+        Err(error) => panic!("the WebDriver could not answer `find_all({css})`: {error}"),
+    }
 }
 
 /// Poll until the control at `css` is present and ENABLED.
@@ -574,12 +803,11 @@ pub(crate) async fn upload_via_dialog(h: &Harness, path: &str) {
 /// commit the pre-seed draft.
 ///
 /// # Panics
-/// When it never becomes enabled within 15 s.
+/// When it never becomes enabled within 15 s, or when the `WebDriver` stops
+/// answering — a stalled driver used to look exactly like an unseeded form.
 pub(crate) async fn wait_enabled(h: &Harness, css: &str) {
     for _ in 0..75 {
-        if let Ok(element) = h.driver.find(By::Css(css)).await
-            && element.is_enabled().await.unwrap_or(false)
-        {
+        if read_enabled(h, css).await == Some(true) {
             return;
         }
         tokio::time::sleep(Duration::from_millis(200)).await;
@@ -861,6 +1089,10 @@ pub(crate) async fn confirm_in_dialog(h: &Harness, trigger_css: &str, confirm_id
          never landed (pre-hydration) or a dialog opened whose confirm id is not \
          `{confirm_id}`"
     );
+    // The confirm button is visible from the first frame of the 250 ms enter
+    // transition, and a click landing mid-scale can miss the moving target
+    // without the driver reporting anything (#3200).
+    wait_dialog_settled(h).await;
     h.wait_css(&confirm_css)
         .await
         .click()

--- a/app/ferroehr-viewer/tests/it/e2e_adl2.rs
+++ b/app/ferroehr-viewer/tests/it/e2e_adl2.rs
@@ -44,11 +44,10 @@ use crate::common;
 use std::time::Duration;
 
 use common::{
-    Harness, confirm_in_dialog, env, login_basic_as, retype, wait_css_absent, wait_enabled,
+    Harness, confirm_in_dialog, env, is_present, login_basic_as, retype, wait_css_absent,
     wait_text, wait_text_contains,
 };
 use reqwest::StatusCode;
-use thirtyfour::prelude::*;
 
 /// The versioned fixture pair: one HRID family, two release versions, so the
 /// versioned get has a genuine highest match to resolve a prefix to.
@@ -127,47 +126,20 @@ fn row_link(hrid: &str) -> String {
     format!("a[href='/templates/adl2/{hrid}']")
 }
 
-/// Open the upload dialog, load `relative` into its source editor, and send it.
-///
-/// The trigger is the page-header button both families share (#2955); the file
-/// picker and the paste area inside the dialog feed ONE source signal, and the
-/// submit button is inert until that signal holds something — so
-/// `wait_enabled` on the button is exactly the "the file has been read into the
-/// editor" condition, never a sleep.
-///
-/// # Panics
-/// On any interaction failure.
-async fn upload_source_file(h: &Harness, relative: &str) {
-    let path = fixture_adl2_path(relative);
-    h.wait_css("#template-upload-open")
-        .await
-        .click()
-        .await
-        .expect("open the upload dialog");
-    // The change event that fills the editor is a HYDRATED listener, and a file
-    // set before it exists is unrecoverable by retrying — a re-send of the same
-    // path fires no change event (#2285). `goto` already waited for the shell's
-    // hydration marker, so the first send lands on a live listener.
-    h.wait_css("#template-upload-picker input[type=file]")
-        .await
-        .send_keys(&path)
-        .await
-        .expect("choose the ADL2 fixture through the hidden file input");
-    wait_enabled(h, "#template-upload-submit").await;
-    h.wait_css("#template-upload-submit")
-        .await
-        .click()
-        .await
-        .expect("send the ADL2 source");
-}
-
 /// Guarantee `hrid` is in the CDR's ADL2 store: land on the listing and upload
 /// `relative` only when its row is absent.
+///
+/// The upload goes through the screen's one dialog
+/// ([`common::upload_via_dialog`]), the same control the ADL 1.4 family drives
+/// — including its post-condition on the send, so a click that dispatches
+/// nothing fails at the click rather than here (#3200).
 ///
 /// Returns `true` when this call performed the upload.
 ///
 /// # Panics
-/// When the row never appears after the upload.
+/// When the row never appears after a dispatched upload — which, the send now
+/// being post-conditioned, means the CDR accepted nothing or the listing never
+/// refetched.
 async fn ensure_adl2_template_present(h: &Harness, relative: &str, hrid: &str) -> bool {
     h.goto(LIST_URL).await;
     // Let the listing Transition resolve — to a row link, the rendered table,
@@ -176,12 +148,12 @@ async fn ensure_adl2_template_present(h: &Harness, relative: &str, hrid: &str) -
     h.wait_css("a[href^='/templates/adl2/'], table, .border-dashed, [role='alert']")
         .await;
     let link = row_link(hrid);
-    if h.driver.find(By::Css(&link)).await.is_ok() {
+    if is_present(h, &link).await {
         return false;
     }
-    upload_source_file(h, relative).await;
+    common::upload_via_dialog(h, &fixture_adl2_path(relative)).await;
     for _ in 0..75 {
-        if h.driver.find(By::Css(&link)).await.is_ok() {
+        if is_present(h, &link).await {
             return true;
         }
         tokio::time::sleep(Duration::from_millis(200)).await;
@@ -255,7 +227,7 @@ async fn adl2_upload_lists_and_serves_source_and_json() {
     h.wait_css("#adl2-catalog-pane ul.text-sm li button").await;
     wait_text_contains(&h, "#adl2-catalog-pane", "Node inspector").await;
     assert!(
-        h.driver.find(By::Css("#adl2-no-catalog")).await.is_err(),
+        !is_present(&h, "#adl2-no-catalog").await,
         "the ADL2 screen no longer claims it has no path catalog"
     );
     h.shot(5, "adl2-catalog-pane").await;
@@ -379,7 +351,7 @@ async fn an_unparseable_adl2_source_surfaces_the_engine_diagnostic() {
     h.goto(LIST_URL).await;
     h.wait_css("#template-upload-open").await;
 
-    upload_source_file(&h, "invalid/unparseable.adls").await;
+    common::upload_via_dialog(&h, &fixture_adl2_path("invalid/unparseable.adls")).await;
 
     // The engine reports AOM2 rule codes with their positions; both the code
     // and its message must survive the trip to the screen unedited.
@@ -401,12 +373,11 @@ async fn an_unparseable_adl2_source_surfaces_the_engine_diagnostic() {
 
     // Nothing was stored: the refused artefact has no row.
     assert!(
-        h.driver
-            .find(By::Css(row_link(
-                "openEHR-EHR-COMPOSITION.cnf_unparseable.v1.0.0"
-            )))
-            .await
-            .is_err(),
+        !is_present(
+            &h,
+            &row_link("openEHR-EHR-COMPOSITION.cnf_unparseable.v1.0.0")
+        )
+        .await,
         "a refused ADL2 source must not appear in the listing"
     );
 

--- a/website/book/src/viewer/browsing.md
+++ b/website/book/src/viewer/browsing.md
@@ -24,7 +24,9 @@ inputs feed one editor, so a chosen file can be read over, corrected, and
 sent from there. **Upload template** stays disabled until there is something
 to send, a refusal keeps the dialog open with the server's diagnostic beside
 the source it rejected, and a successful upload closes the dialog and
-refreshes the list.
+refreshes the list. Each time you open the dialog it starts empty, so a
+refused source is yours to correct while the dialog is up, and closing it
+discards the attempt.
 
 ![Templates](img/templates/templates.png)
 


### PR DESCRIPTION
Closes #3200.

`e2e_adl2::adl2_versioned_get_reaches_both_stored_versions` failed intermittently, reporting that the template "never appeared in the ADL2 listing after the upload". It was not the CDR, and the listing was right.

## What actually happened

The `ui-e2e-screenshots-3` artifact from run 34420843364 carries the `evidence_dump` capture taken at the instant of the panic. At that moment the dialog was open with the fixture source loaded, there was no "Uploading…" line, no `MessageBar`, no toast, the submit button was at full opacity, and the listing behind the dialog showed its empty state. `pending == false` and the action value `None` with a non-empty source means the upload action was **never dispatched** — not in flight, not refused, not succeeded. Nothing was POSTed, so no read could have missed anything.

That rules the server out independently: `upload_artefact` → `adl2_persist` is one committed transaction (`app/ferroehr/src/service/definition/adl2.rs:395`), the listing is a plain `SELECT` on the same pool (`adl2.rs:749`), and nothing on the path is cached. It rules out a missing refetch too: the list resource's source already includes `adl2_upload.version()` (`templates.rs:393`), which only moves on a completed dispatch.

The durations corroborate it. Both failures took 138.1 s and 138.3 s against a 4.6 s green baseline, and thirtyfour's default per-request timeout is 120 s. Two runs agreeing to 0.13 s while their neighbouring journeys differed fourfold is a timeout sum, not load.

So the WebDriver click was answered without the handler running, and **the click had no post-condition at all** — the helper clicked and returned, so the first thing to notice was a poll fifteen seconds later, 190 lines away, pointing at the wrong component.

## Why this journey and not the others

`e2e_adl2.rs` kept a private `upload_source_file` when #2956 moved the upload behind a thaw dialog and re-pointed the element ids. As a result it is the only seeder that received neither hardening the shared helper has: the `clear_dialog_overlay` from #3134, or the outcome backstop from #2285. Its dialog-open wait was presence-only, and thaw's `Teleport` keeps the subtree mounted after the first open — so on the re-open this very journey performs, that wait was satisfied by pre-action state. The harness already documents why presence is the wrong condition for a thaw dialog (`common/mod.rs:706`); this helper used the wrong half of that knowledge.

## The fix

**The click proves it dispatched.** A baseline of the dialog's state is read immediately before the click and polled after. Each disjunct is something that cannot be true beforehand: the surface hiding (the baseline is taken after the settled-wait, so it is provably visible), the pending line (the action's own in-flight signal), the submit button going disabled, a diagnostic *different from the one already there* (compared rather than tested for presence, because a refusal survives a re-open), or a new toast (the one persistent observable for a repeat refusal with byte-identical text). On failure it panics at the click site saying the click did not dispatch.

**"Open" becomes visibility-and-settled.** thaw's `CSSTransition` adds `{name}-enter-active` before unsetting `display` and removes it on transitionend, so "visible and not entering" has no false window. Verified in the vendored sources rather than assumed.

**The private helper is gone** and both ADL2 seeders route through `common::upload_via_dialog`, which also gives the sibling families the post-condition and the settled wait.

**Driver errors stop being swallowed.** One typed predicate: only `NoSuchElement` and `StaleElementReference` mean "not yet"; everything else panics naming the command. That is what let a two-minute stall show up only as an inflated duration.

**The per-request timeout was tried and reverted, and CI is why.** Setting it to 10 s (below the 15 s poll budget) also bounded `NewSession`: every journey creates its own session, nextest runs them in parallel processes, and shards 1 and 3 both failed at `Harness::start` with `HttpError` on `POST /session` (run 34523832090). Not a readiness race — the script already waits on `/status`, and both shards failed on a later journey than their first. thirtyfour keeps `request_timeout` on an `Arc<WebDriverConfig>` built once with no post-build setter, so one value must serve both a session create and a steady-state command, and raising it until CI agrees is the move this branch exists to avoid. Reverted to the default and registered as **#3218**: the bound belongs on our own command awaits via `tokio::time::timeout`, where the poll loops are, not on the transport.

## Two more of the same class, found in review

Both are the same defect in the other half of the same dialog, so they are fixed here rather than filed:

- `confirm_in_dialog` clicked the confirm button as soon as it was *visible*, never waiting out its own 250 ms enter transition — the identical mid-transition hazard, used by the ADL2 delete, admin ops, EHR ops and directory journeys. It now settles first.
- Clearing `upload_source` on open (which is what restores meaning to `wait_enabled`) left the *diagnostic* behind: a re-opened dialog showed an empty editor with the previous attempt's red `MessageBar` under it. Opening now clears both halves of the previous attempt, which is also the honest user-facing behaviour.

## Deliberately not done

No retry, no widened budget, no `#[ignore]`. The only new number is a *reduction* of the request timeout. The caller-side re-attempt loops in `e2e_browse`/`e2e_admin_ops` were not copied to ADL2 — they are retries, and the rule governs. Note the consequence: a lost click now panics inside the shared helper, so those loops no longer re-attempt that case; they still cover "dispatched but never listed". That is the intended trade.

**Why `no-ui-visual-change` despite a real behaviour change:** the diff touches `app/ferroehr-viewer/src/`, and a re-opened upload dialog genuinely looks different now. No committed screenshot depicts the open dialog — `website/book/src/viewer/img/templates/` holds listing and detail captures, and `e2e_docs_shots.rs` captures those screens with the dialog closed — so a capture pass would produce a byte-identical set. Labelling rather than committing identical PNGs, and saying so here rather than silently.

## Gates

Both clippy lanes (`ssr` native and `hydrate` on wasm32) at `-D warnings`; `cargo nextest run -p ferroehr-viewer --features ssr` 551/551; `leptosfmt` + `cargo fmt --all --check` clean; `comment-style` OK; `cargo leptos build` EXIT=0.

**The browser battery was not run locally** — no chromedriver on the dev host — so no journey result is claimed here. CI's `ui-e2e` is the gate, and it must exercise all five `e2e_adl2` journeys (particularly `adl2_versioned_get_reaches_both_stored_versions`, the double-seed that re-opens the dialog, and the unparseable-source journey, the only one exercising the diagnostic disjunct), plus `e2e_browse` and `e2e_admin_ops` which inherit the extended shared helper, plus every journey touching a thaw dialog now that the helpers are loud on driver errors. In practice the whole battery.

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.

