### PR TITLE
fix(demographic): three tenant-scoped tables enforce the isolation they claimed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -401,6 +401,32 @@ workflow refuses a tag that has no matching section here.
   `vo_id` is a `400` rather than a filter that would match one version of every
   object.
 
+### Security
+
+- **Three tenant-scoped tables enforce tenant isolation that they carried a
+  column for but no policy** (#3219). `demographic.national_identifier` holds
+  sealed national identifiers and the keyed digests that resolve them;
+  `demographic.contribution` and `demographic.audit` hold the change-control
+  trail over the demographic domain. All three carried a `tenant_id`, and the
+  equality lookups on them were tenant-scoped, so no resolve could ever cross
+  a tenant. What was exposed is the unscoped read: a plain `SELECT` by the
+  demographic role returned every tenant's rows. Each now enables and forces
+  row-level security with the same `tenant_isolation` policy its sibling
+  relations have carried since the baseline. Deployments that run a single
+  tenant are unaffected, because an unset session resolves to the reserved
+  default tenant exactly as before.
+
+  The cause is worth stating, because it will recur otherwise: a baseline
+  migration applies row-level security by looping over a list of relation
+  names, and a table added by a later migration joins nothing. The omission is
+  invisible in the table's own definition. A test now asks the catalog instead
+  of a reviewer — any relation carrying a `tenant_id` must enable and force
+  row-level security — so the next table added after a baseline is caught by
+  the build rather than by an audit. `audit.audit_event` is the one named
+  exception: its drain batches many tenants' records in a single insert from a
+  task outside any request's tenant session, so a policy there would reject
+  audit rows rather than isolate them.
+
 ### Fixed
 
 - **The template upload dialog opens empty** (#3200). It cleared the source

--- a/app/ferroehr/migrations/demographic/0004_national_identifier_rls.sql
+++ b/app/ferroehr/migrations/demographic/0004_national_identifier_rls.sql
@@ -1,0 +1,42 @@
+-- SPDX-FileCopyrightText: Ruben Talstra
+-- SPDX-License-Identifier: BUSL-1.1
+--
+-- Tenant isolation for the sealed identifiers, which the baseline's RLS loop
+-- never reached.
+--
+-- `0001_baseline.sql` enables and FORCEs row-level security on every relation
+-- it creates and gives each one the same `tenant_isolation` policy.
+-- `demographic.national_identifier` was created afterwards, by
+-- `0003_national_identifier.sql`, so the loop had already run and the table
+-- joined its siblings in every respect but this one. The omission is not
+-- visible from the table's own definition, which is why it survived: the
+-- tenant column, its DEFAULT and its uniqueness are all there.
+--
+-- What was exposed is the unscoped read. `uq_national_identifier_value` is
+-- tenant-scoped, so an equality lookup by digest could never return another
+-- tenant's party, and the resolve function goes through it. But a bare
+-- `SELECT` by the demographic role returned every tenant's rows, on the table
+-- holding sealed national identifiers and the keyed digests that resolve
+-- them. GDPR Art. 32(1)(a) names the measures
+-- (https://eur-lex.europa.eu/eli/reg/2016/679/oj); no openEHR spec governs
+-- database policies — our own design/extension.
+--
+-- FORCE, like the siblings, so the policy applies to the table owner too. That
+-- is safe for `demographic.resolve_national_identifier` even though it is
+-- SECURITY DEFINER and therefore runs as that owner: every caller derives its
+-- tenant from the same task-local context that stamps the
+-- `ferroehr.tenant_id` GUC, so the function's `WHERE tenant_id = p_tenant`
+-- and this policy's `ext.current_tenant_id()` are the same value by
+-- construction. A caller that ever passed a different tenant would now be
+-- refused by the database rather than trusted, which is the point.
+--
+-- `demographic.identifier_scheme` deliberately gets NO policy: it is the
+-- global registry of which identifier kinds this deployment may store, it
+-- carries no tenant column, and every tenant reads the same rows.
+
+ALTER TABLE demographic.national_identifier ENABLE ROW LEVEL SECURITY;
+ALTER TABLE demographic.national_identifier FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY tenant_isolation ON demographic.national_identifier
+    USING (tenant_id = ext.current_tenant_id())
+    WITH CHECK (tenant_id = ext.current_tenant_id());

--- a/app/ferroehr/migrations/demographic/0005_change_control_rls.sql
+++ b/app/ferroehr/migrations/demographic/0005_change_control_rls.sql
@@ -1,0 +1,39 @@
+-- SPDX-FileCopyrightText: Ruben Talstra
+-- SPDX-License-Identifier: BUSL-1.1
+--
+-- Tenant isolation for the demographic change-control records, which the
+-- baseline's RLS loop also never reached.
+--
+-- Found by the catalog sweep added with `0004`, which asks which relations
+-- carry a `tenant_id` and are not isolated rather than trusting a list. The
+-- clinical loop (`ehr/0004_multitenancy.sql`) scopes `contribution` and
+-- `audit`; the demographic baseline loop names only `vo_version`, `node`,
+-- `item_tag` and `event_outbox`. The demographic relations were built with
+-- `CREATE TABLE … LIKE`, which copies columns, defaults and constraints but
+-- NOT row-level security, so both tables arrived carrying a `tenant_id` that
+-- nothing enforced.
+--
+-- What was exposed is the same shape as `0004`: an unscoped read. These rows
+-- are the change-control trail over the demographic domain — who committed a
+-- party version, when and under which contribution — so cross-tenant
+-- visibility here says which tenants hold records for whom, without the
+-- records themselves. GDPR Art. 32(1)(a)
+-- (https://eur-lex.europa.eu/eli/reg/2016/679/oj); no openEHR spec governs
+-- database policies — our own design/extension.
+--
+-- FORCE, like every sibling, so the owner is covered too.
+
+DO $$
+DECLARE
+    rel text;
+BEGIN
+    FOREACH rel IN ARRAY ARRAY['contribution', 'audit'] LOOP
+        EXECUTE format('ALTER TABLE demographic.%I ENABLE ROW LEVEL SECURITY', rel);
+        EXECUTE format('ALTER TABLE demographic.%I FORCE ROW LEVEL SECURITY', rel);
+        EXECUTE format(
+            'CREATE POLICY tenant_isolation ON demographic.%I '
+            'USING (tenant_id = ext.current_tenant_id()) '
+            'WITH CHECK (tenant_id = ext.current_tenant_id())',
+            rel);
+    END LOOP;
+END $$;

--- a/app/ferroehr/tests/it/pseudonymisation_boundary.rs
+++ b/app/ferroehr/tests/it/pseudonymisation_boundary.rs
@@ -775,6 +775,148 @@ async fn the_cutover_runs_as_a_non_superuser_owner_for_a_tenant_owned_party() {
 /// nobody.
 const SYNTHETIC_BSN: &str = "111222333"; // privacy-allow: synthetic
 
+/// Every tenant-scoped table forces row-level security.
+///
+/// `national_identifier` carried a `tenant_id` for two releases with no
+/// policy, because the baseline's RLS loop names its relations by hand and a
+/// table added by a later migration joins nothing. The omission is invisible
+/// in the table's own definition, so this asks the catalog instead of a
+/// reviewer: any relation carrying a `tenant_id` is one whose rows belong to a
+/// tenant, and it has to be isolated as one.
+///
+/// FORCE as well as ENABLE, because the owner is the identity a
+/// `SECURITY DEFINER` function runs as, and plain ENABLE exempts it.
+///
+/// `audit.audit_event` is the one adjudicated exception, named rather than
+/// skipped by schema so the rest of `audit` stays covered. Its drain batches
+/// many tenants' records in one insert from a task that runs outside any
+/// request's tenant session (`system_log::store`), so a `WITH CHECK` against
+/// the session tenant would reject audit rows rather than isolate them — and
+/// silently losing an access record is worse than the unscoped read.
+#[tokio::test]
+async fn every_tenant_scoped_table_forces_row_level_security() {
+    let db = testkit::db().await.expect("testkit database");
+    let unguarded: Vec<(String, String, bool, bool)> = sqlx::query_as(
+        "SELECT n.nspname::text, c.relname::text, c.relrowsecurity, c.relforcerowsecurity
+         FROM pg_class c
+         JOIN pg_namespace n ON n.oid = c.relnamespace
+         WHERE c.relkind = 'r'
+           AND n.nspname = ANY($1)
+           AND EXISTS (
+               SELECT 1 FROM pg_attribute a
+               WHERE a.attrelid = c.oid AND a.attname = 'tenant_id' AND NOT a.attisdropped)
+           AND NOT (c.relrowsecurity AND c.relforcerowsecurity)
+           AND (n.nspname, c.relname) <> ('audit', 'audit_event')
+         ORDER BY 1, 2",
+    )
+    .bind(vec![
+        "ehr".to_owned(),
+        "cold".to_owned(),
+        "demographic".to_owned(),
+        "cold_demographic".to_owned(),
+        "linkage".to_owned(),
+        "audit".to_owned(),
+    ])
+    .fetch_all(&db.pool())
+    .await
+    .expect("read the catalog");
+
+    assert!(
+        unguarded.is_empty(),
+        "every table carrying a tenant_id must ENABLE and FORCE row-level \
+         security; these do not: {unguarded:?}"
+    );
+
+    // The sweep must actually see tables, or an empty result proves nothing.
+    let scoped: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM pg_class c
+         JOIN pg_namespace n ON n.oid = c.relnamespace
+         WHERE c.relkind = 'r'
+           AND n.nspname = ANY($1)
+           AND EXISTS (
+               SELECT 1 FROM pg_attribute a
+               WHERE a.attrelid = c.oid AND a.attname = 'tenant_id' AND NOT a.attisdropped)",
+    )
+    .bind(vec![
+        "ehr".to_owned(),
+        "cold".to_owned(),
+        "demographic".to_owned(),
+        "cold_demographic".to_owned(),
+        "linkage".to_owned(),
+        "audit".to_owned(),
+    ])
+    .fetch_one(&db.pool())
+    .await
+    .expect("count the tenant-scoped tables");
+    assert!(
+        scoped > 5,
+        "the sweep found only {scoped} tenant-scoped tables, so it is not \
+         looking at the schemas it thinks it is"
+    );
+}
+
+/// The sealed identifiers are tenant-isolated by policy, not only by the
+/// uniqueness of their lookup key.
+///
+/// `0001_baseline.sql` gives every relation it creates a `tenant_isolation`
+/// policy; `national_identifier` arrived in a later migration and missed the
+/// loop. The equality lookup was always tenant-scoped, so no resolve could
+/// cross — what was exposed is the unscoped read, on the one table holding
+/// sealed national identifiers and the digests that resolve them.
+#[tokio::test]
+async fn sealed_identifiers_of_another_tenant_are_invisible() {
+    let db = testkit::db().await.expect("testkit database");
+    let alpha = Uuid::now_v7();
+    let beta = Uuid::now_v7();
+
+    // Seeded through the owner pool, each row under its own tenant GUC so the
+    // policy's WITH CHECK admits it — the same path a tenant-scoped write
+    // takes at runtime.
+    let mut seed = db.pool().acquire().await.expect("a seeding connection");
+    for (tenant, digest_byte) in [(alpha, 0xAA_u8), (beta, 0xBB_u8)] {
+        sqlx::query("SELECT set_config('ferroehr.tenant_id', $1, false)")
+            .bind(tenant.to_string())
+            .execute(&mut *seed)
+            .await
+            .expect("stamp the tenant GUC");
+        sqlx::query(
+            "INSERT INTO demographic.national_identifier
+                 (party_id, scheme, tenant_id, nonce, ciphertext, lookup_digest)
+             VALUES ($1, 'nl-bsn', $2, $3, $4, $5)",
+        )
+        .bind(Uuid::now_v7())
+        .bind(tenant)
+        .bind(vec![0_u8; 12])
+        .bind(vec![1_u8; 16])
+        .bind(vec![digest_byte; 32])
+        .execute(&mut *seed)
+        .await
+        .expect("seed a sealed identifier");
+    }
+    drop(seed);
+
+    let mut conn = role_conn(&db, "nidrls", "ferroehr_demographic").await;
+    sqlx::query("SELECT set_config('ferroehr.tenant_id', $1, false)")
+        .bind(alpha.to_string())
+        .execute(&mut conn)
+        .await
+        .expect("stamp the tenant GUC");
+    let visible: Vec<Uuid> =
+        sqlx::query_scalar("SELECT tenant_id FROM demographic.national_identifier")
+            .fetch_all(&mut conn)
+            .await
+            .expect("an unscoped read of the sealed identifiers");
+    drop(conn.close().await);
+
+    assert_eq!(
+        visible,
+        vec![alpha],
+        "an unscoped SELECT must return only the reading tenant's rows; \
+         both tenants were seeded, so a result carrying {beta} means the \
+         tenant_isolation policy is missing or not FORCEd"
+    );
+}
+
 /// A test root key. Sixty-four hex characters, and a literal here is not a
 /// credential: it protects one ephemeral clone for the length of one test.
 const TEST_ROOT_KEY: &str = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";


### PR DESCRIPTION
Closes #3219.

`demographic.national_identifier` carried a `tenant_id` and no policy to enforce it, so a bare `SELECT` by the demographic role returned every tenant's rows — on the table holding sealed national identifiers and the keyed digests that resolve them.

## The cause, because it will recur otherwise

A baseline migration applies row-level security by looping over a list of relation names it was written with. `demographic/0001_baseline.sql` names `vo_version`, `node`, `item_tag`, `event_outbox`. Anything added by a later migration joins nothing, and `CREATE TABLE … LIKE` — how the demographic relations were built — copies columns, defaults and constraints but **not** policies. The result is a table that looks correct in its own definition: the tenant column is there, its `DEFAULT` is there, its uniqueness is tenant-scoped. Only the catalog knows the policy is missing.

## What was actually exposed

Not resolution. `uq_national_identifier_value` is tenant-scoped and the resolve function goes through it, so no lookup could ever cross a tenant. What was exposed is the **unscoped read** — enumeration by anything holding the demographic role: a report, an ad-hoc query, or a future code path that forgets its own `WHERE tenant_id`.

## The sweep found two more

Rather than answer the issue's "check for the same omission elsewhere" criterion with a one-time grep, it is now a test that asks the catalog: any relation carrying a `tenant_id` must enable **and** force row-level security. It immediately named two tables beyond the one reported:

- `demographic.contribution` and `demographic.audit` — the change-control trail over the demographic domain. The clinical loop scopes both of their twins; the demographic mirrors missed it the same way.

Both are fixed here. The test is what catches the next one at build time instead of at an audit.

`audit.audit_event` is the one **named** exception — named, not skipped by schema, so the rest of `audit` stays covered. Its drain batches many tenants' records in a single insert from a task that runs outside any request's tenant session (`system_log::store`, whose own comment records the design), so a `WITH CHECK` against the session tenant would reject audit rows rather than isolate them. Silently losing an access record is worse than the unscoped read.

## Why `FORCE` is safe on the identifier table

`demographic.resolve_national_identifier` is `SECURITY DEFINER`, and `FORCE` applies the policy to the owner it runs as — so this had to be checked rather than assumed. Every caller reaches it through `IdentifierEngine`, which derives `tenant` from `current_tenant()`: the same task-local context that `stamp_tenant_guc` uses to set `ferroehr.tenant_id`. The function's `WHERE tenant_id = p_tenant` and the policy's `ext.current_tenant_id()` are therefore the same value by construction.

That makes the change strictly stronger than a no-op: `p_tenant` was a parameter the database trusted, and a caller that ever passed a different tenant would now be refused rather than served.

Backups are unaffected — the domain dumps run as `postgres`, and a superuser bypasses RLS even under `FORCE`. That was worth verifying, because `FORCE` on the tenant-scoped tables is what once made the application role unable to take a logical backup at all.

Single-tenant deployments are unaffected: an unset session resolves to the reserved default tenant, which is what the rows already carry.

## Mutation proofs

Both new tests fail when the thing they assert is removed.

Isolation — policy replaced with `USING (true)` and `FORCE` dropped:
```
assertion `left == right` failed: an unscoped SELECT must return only the reading tenant's rows
  left: [<alpha>, <beta>]
 right: [<alpha>]
```

The catalog sweep — `audit` dropped from the new migration's loop:
```
every table carrying a tenant_id must ENABLE and FORCE row-level security;
these do not: [("demographic", "audit", false, false)]
```

The sweep also asserts it found more than five tenant-scoped tables, so an empty result cannot pass for a clean one.

## Gates

`cargo fmt --all --check`; `cargo clippy -p ferroehr --tests --all-features -- -D warnings`; **`cargo nextest run -p ferroehr --all-features` 1151/1151**, which includes the pre-existing seal/open/resolve round-trip — the evidence that `FORCE` did not break the `SECURITY DEFINER` path; `comment-style`, `spec-citations`, `docs-claims`, `spdx-headers`, `sql-string-building`, `changelog-structure`, `migration-immutability --diff main` all green. Both migrations are new files; none was edited.
## Privacy boundary

**What personal data this change touches.** Three tables, all already holding it: `demographic.national_identifier` (AES-256-GCM sealed national identifiers and their HMAC lookup digests), `demographic.contribution` and `demographic.audit` (who committed which party version, when, under which contribution). Nothing is read, written, exported or moved by this change. It adds a database policy that narrows what an existing read returns.

**The roles.** `ferroehr_demographic` and `ferroehr_demographic_reader` reach these tables; the clinical and linkage roles are already revoked from the schema entirely. `FORCE` extends the policy to the table owner, which is the identity `demographic.resolve_national_identifier` runs as, so the `SECURITY DEFINER` path is covered rather than exempt.

**Grants.** No grant changes at all, in either direction. The boot gate and the cross-domain enumeration tests are untouched and still pass.

**Access events.** No new read of personal data is added, so no access event belongs here. The reads that already exist are unchanged in shape and now return fewer rows.

- [x] The data flow is described above: what personal data this change reads, writes or exports, and where it goes
- [x] The roles are named: which database roles and which caller roles reach that data
- [x] No new grant spans the clinical and demographic domains
- [x] Synthetic data only in tests, fixtures, seeds and examples
- [x] An access event is emitted wherever this change added a read of personal data

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.
