### PR TITLE
test(db): the two-DSN posture is exercised, not just documented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -327,6 +327,20 @@ workflow refuses a tag that has no matching section here.
 
 ### Changed
 
+- **The two-DSN posture is exercised, and the deployment probe says exactly
+  what still is not** (#3222). Pointing `[db] demographic_url` at a role of
+  its own turns the schema separation between the clinical and demographic
+  pseudonymisation domains into a credential separation, and nothing ran it:
+  every test drove both domains through one login role. A new integration
+  suite assembles the server the way the binary does — two DSNs, two pools —
+  on one login role per domain against a real PostgreSQL, serves an EHR and a
+  party through the wire, and asserts that each of the running server's own
+  pools is refused the other domain's relations for want of privilege. The
+  single-DSN fallback is covered beside it, so the split stays a deployment
+  choice. The Compose deployment probe keeps its honest "not exercised" entry
+  for credential separation, now narrowed to what genuinely remains: a real
+  deployment booting on two mounted DSNs. No behaviour changes.
+
 - **A default deployment accepts a named composer again** (#3190). With
   `[privacy] allow_identified_parties_in_ehr` off, the clinical side refused
   both `name` and `identifiers` on both party proxy classes, so a server

--- a/app/ferroehr-rest/tests/it/credential_separation.rs
+++ b/app/ferroehr-rest/tests/it/credential_separation.rs
@@ -1,0 +1,249 @@
+// SPDX-FileCopyrightText: Ruben Talstra
+// SPDX-License-Identifier: BUSL-1.1
+
+//! The two-DSN posture: the server assembled on one login role per
+//! pseudonymisation domain, serving both domains and reaching neither across.
+//!
+//! Every other suite here runs the schema separation through ONE credential —
+//! `FerroEhrService::new` derives the demographic pool from the clinical pool's
+//! own connect options and swaps only the `search_path`. That proves the
+//! routing, and nothing about the posture the book recommends and the chart
+//! configures: `[db] demographic_url` pointing at a role that is a member of
+//! `ferroehr_demographic` while `[db] url` authenticates as `ferroehr_ehr`.
+//!
+//! So these tests take the path the binary takes — two [`DbConfig`] DSNs,
+//! [`ferroehr::db::connect`] and [`ferroehr::db::connect_demographic`], the two
+//! pools handed to the service — and then assert three things: both domains
+//! serve through the assembled router, each of the server's OWN pools is
+//! refused the other domain's relations for want of privilege, and a
+//! single-DSN deployment still serves both domains, so the split stays a
+//! choice rather than a requirement.
+//!
+//! NOTE: no openEHR spec governs database roles or the pseudonymisation
+//! boundary — our own design/extension (GDPR Art. 4(5) and Art. 32(1)(a); the
+//! migrations carry the derivation).
+
+#![expect(
+    clippy::expect_used,
+    reason = "clippy's in-test lint scoping (clippy.toml `allow-*-in-tests`) only \
+              reaches `#[test]`-annotated functions, so it misses this integration \
+              module's helpers and async bodies; panicking assertions are the \
+              intended shape here (the Rust Book ch11)"
+)]
+
+use std::sync::Arc;
+
+use axum::Router;
+use ferroehr::config::secret::SecretUrl;
+use ferroehr::db::DbConfig;
+use ferroehr::service::FerroEhrService;
+use http::StatusCode;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::common;
+use crate::common::BASE;
+
+/// `SQLSTATE` 42501 `insufficient_privilege` — what `PostgreSQL` reports for a
+/// refused read, whether the missing grant is on the relation or on its schema
+/// (`PostgreSQL` docs § Appendix A "`PostgreSQL` Error Codes", class 42).
+const SQLSTATE_INSUFFICIENT_PRIVILEGE: &str = "42501";
+
+/// Relations of the demographic domain no clinical credential may read.
+const DEMOGRAPHIC_RELATIONS: &[&str] = &[
+    "demographic.vo_version",
+    "demographic.node",
+    "demographic.contribution",
+    "cold_demographic.vo_version",
+];
+
+/// Relations of the clinical domain no demographic credential may read.
+const CLINICAL_RELATIONS: &[&str] = &["ehr.ehr", "ehr.vo_version", "ehr.node", "cold.vo_version"];
+
+/// A password for a throwaway login role, fresh per call.
+///
+/// The value is never a secret: the role lives as long as one test against an
+/// ephemeral clone. It is generated rather than written down because a literal
+/// here is indistinguishable, to a scanner and to a reader, from a credential
+/// that does matter.
+fn throwaway_password() -> String {
+    format!("pw{}", Uuid::now_v7().simple())
+}
+
+/// Rewrite the userinfo of a testkit clone DSN so a pool can connect to the
+/// same database as a different login role (scheme/host/port/database
+/// preserved).
+fn with_role(base_url: &str, user: &str, password: &str) -> String {
+    let (scheme, rest) = base_url.split_once("://").expect("dsn scheme");
+    let host_and_path = rest.split_once('@').map_or(rest, |(_, tail)| tail);
+    format!("{scheme}://{user}:{password}@{host_and_path}")
+}
+
+/// A DSN authenticating as a fresh non-superuser login role that is a member
+/// of `domain_roles` (a comma-separated `IN ROLE` list) — how a production
+/// deployment runs, and never as superuser, which would bypass both RLS and
+/// every privilege check these tests are about.
+///
+/// Roles are cluster-global on the shared testkit server, so the login role is
+/// named off the clone's database name and the testkit sweep reaps it.
+async fn dsn_as(db: &testkit::TestDb, suffix: &str, domain_roles: &str) -> String {
+    let login = format!("{}_{suffix}", db.name());
+    let password = throwaway_password();
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "CREATE ROLE {login} LOGIN PASSWORD '{password}' IN ROLE {domain_roles}"
+    )))
+    .execute(&db.pool())
+    .await
+    .expect("create the login role");
+    with_role(db.url(), &login, &password)
+}
+
+/// The two pools and the router the binary would assemble from `settings`.
+///
+/// This is `ferroehr-server`'s own sequence
+/// (`connect` + `connect_demographic` → `FerroEhrService::new` →
+/// `with_demographic_pool`), so the credential each domain uses is the one the
+/// configuration names rather than one derived from the other.
+struct Deployment {
+    /// The pool serving the `ehr` schema.
+    clinical: PgPool,
+    /// The pool serving the `demographic` schema.
+    demographic: PgPool,
+    /// The assembled ITS-REST router over both.
+    router: Router,
+}
+
+/// Build the two pools and the router `settings` describes.
+async fn deployment(settings: &DbConfig) -> Deployment {
+    let clinical = ferroehr::db::connect(settings)
+        .await
+        .expect("the clinical pool connects");
+    let demographic = ferroehr::db::connect_demographic(settings)
+        .await
+        .expect("the demographic pool connects");
+    let service =
+        Arc::new(FerroEhrService::new(clinical.clone()).with_demographic_pool(demographic.clone()));
+    let router = common::router_with(common::api_config(false), service);
+    Deployment {
+        clinical,
+        demographic,
+        router,
+    }
+}
+
+/// Create an EHR through the wire and read it back.
+async fn the_clinical_domain_serves(router: &Router) {
+    let ehr_id = common::create_ehr(router).await;
+    let (status, body) =
+        common::send_body(router, common::get(&format!("{BASE}/ehr/{ehr_id}"))).await;
+    assert_eq!(status, StatusCode::OK, "read the EHR back: {body}");
+}
+
+/// Commit a PERSON through the wire and read it back.
+async fn the_demographic_domain_serves(router: &Router) {
+    let (status, headers, body) = common::send(
+        router,
+        common::post_json(
+            &format!("{BASE}/demographic/person"),
+            &crate::demographic_http::person_body().to_string(),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "commit a PERSON: {body}");
+    let ovid = common::etag_uid(&headers);
+    let (status, body) = common::send_body(
+        router,
+        common::get(&format!("{BASE}/demographic/person/{ovid}")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "read the PERSON back: {body}");
+}
+
+/// Assert that `pool` — a pool the assembled server is holding, not a fresh
+/// connection opened for the occasion — is refused every relation in
+/// `relations` for want of privilege.
+async fn refused_every_relation(pool: &PgPool, whose: &str, relations: &[&str]) {
+    for relation in relations {
+        let probe = format!("SELECT 1 FROM {relation} LIMIT 1");
+        let error = sqlx::query(sqlx::AssertSqlSafe(probe))
+            .execute(pool)
+            .await
+            .expect_err(&format!(
+                "the {whose} pool must not be able to read {relation}"
+            ));
+        let code = error
+            .as_database_error()
+            .and_then(sqlx::error::DatabaseError::code)
+            .map(std::borrow::Cow::into_owned);
+        assert_eq!(
+            code.as_deref(),
+            Some(SQLSTATE_INSUFFICIENT_PRIVILEGE),
+            "the {whose} pool reading {relation} must be refused for want of \
+             privilege, not fail some other way: {error}"
+        );
+    }
+}
+
+/// Two DSNs, two login roles: both domains serve, and neither of the server's
+/// own pools can reach the other domain.
+///
+/// The refusal half is measured through the pools the router is dispatching
+/// on — `PgPool` is a handle, so the clones held here and the ones inside the
+/// service are one pool — because the claim is about the RUNNING server's
+/// credentials, not about what a fresh connection would be allowed.
+#[tokio::test]
+async fn two_credentials_serve_both_domains_and_reach_neither_across() {
+    let db = common::test_db().await;
+    let settings = DbConfig {
+        url: SecretUrl::new(dsn_as(&db, "credclin", "ferroehr_ehr").await),
+        demographic_url: Some(SecretUrl::new(
+            dsn_as(&db, "creddemo", "ferroehr_demographic").await,
+        )),
+        ..DbConfig::default()
+    };
+    assert!(
+        settings.roles_are_separated(),
+        "the fixture must actually configure two DSNs, else this passes vacuously"
+    );
+    assert_ne!(
+        settings.demographic_dsn(),
+        settings.url.expose(),
+        "and they must be different credentials"
+    );
+
+    let deployment = deployment(&settings).await;
+
+    the_clinical_domain_serves(&deployment.router).await;
+    the_demographic_domain_serves(&deployment.router).await;
+
+    refused_every_relation(&deployment.clinical, "clinical", DEMOGRAPHIC_RELATIONS).await;
+    refused_every_relation(&deployment.demographic, "demographic", CLINICAL_RELATIONS).await;
+}
+
+/// One DSN: the fallback posture still serves both domains, so the credential
+/// split stays a deployment choice rather than a requirement.
+///
+/// The credential here is a member of both domain roles, which is what a stock
+/// deployment (and the compose stack) runs, so the schema separation is the
+/// only boundary in force — exactly the half the two-credential test above
+/// adds to.
+#[tokio::test]
+async fn one_credential_still_serves_both_domains() {
+    let db = common::test_db().await;
+    let settings =
+        DbConfig::new(dsn_as(&db, "credboth", "ferroehr_ehr, ferroehr_demographic").await);
+    assert!(
+        !settings.roles_are_separated(),
+        "the fallback posture leaves `demographic_url` unset"
+    );
+    assert_eq!(
+        settings.demographic_dsn(),
+        settings.url.expose(),
+        "and the demographic pool falls back to the clinical DSN"
+    );
+
+    let deployment = deployment(&settings).await;
+
+    the_clinical_domain_serves(&deployment.router).await;
+    the_demographic_domain_serves(&deployment.router).await;
+}

--- a/app/ferroehr-rest/tests/it/demographic_http.rs
+++ b/app/ferroehr-rest/tests/it/demographic_http.rs
@@ -43,7 +43,10 @@ use crate::common;
 const BASE: &str = "/ferroehr/rest/openehr/v1";
 
 /// A spec-valid PERSON body (the shape `service_demographic.rs` commits).
-fn person_body() -> Value {
+///
+/// Shared with the credential-separation suite, which commits a party to prove
+/// the demographic domain serves on its own credential.
+pub(crate) fn person_body() -> Value {
     json!({
         "_type": "PERSON",
         "archetype_node_id": "openEHR-DEMOGRAPHIC-PERSON.person.v1",

--- a/app/ferroehr-rest/tests/it/main.rs
+++ b/app/ferroehr-rest/tests/it/main.rs
@@ -38,6 +38,7 @@ mod authz_route_matrix;
 mod base_path_http;
 mod composition_validation_http;
 mod connection_bounds;
+mod credential_separation;
 mod definition_adl2_http;
 mod definition_archetype_http;
 mod demographic_http;

--- a/scripts/deploy-probes/compose.sh
+++ b/scripts/deploy-probes/compose.sh
@@ -594,12 +594,18 @@ probes_domain_roles() {
   esac
   probe_done
 
-  uncovered "the CREDENTIAL separation" \
-    "this stack runs one login role that is a member of every domain, so what is
-     measured above is the SCHEMA separation and the grant boundary. Whether a
-     deployment with a DSN per domain keeps working — the posture the book recommends and
-     the chart's database.demographicExistingSecret configures — is not exercised
-     by any probe here."
+  uncovered "the CREDENTIAL separation AT DEPLOYMENT LEVEL" \
+    "this stack still runs one login role that is a member of every domain, so what is
+     measured above is the SCHEMA separation and the grant boundary. The in-process half
+     is covered elsewhere as of #3222: app/ferroehr-rest/tests/it/credential_separation.rs
+     assembles the server on one login role per domain against a real PostgreSQL, serves
+     both domains through the wire, and asserts that each of the server's own pools is
+     refused the other domain's relations with SQLSTATE 42501. What remains uncovered by
+     any probe is a real DEPLOYMENT on two DSNs: a container booting with
+     FERROEHR__DB__DEMOGRAPHIC_URL_FILE mounted, schema preparation by a role that is
+     neither runtime credential, and the chart's database.demographicExistingSecret
+     wiring that pair. The linkage domain is outside both: it has no pool of its own
+     yet, so there is no third credential to separate."
   uncovered "role provisioning on a managed database" \
     "the compose init creates the domain roles as the bootstrap superuser. A managed
      PostgreSQL where the migrator holds no CREATEROLE takes the documented manual


### PR DESCRIPTION
The in-process half of #3222. **Does not close it** — its first criterion asks for a server that BOOTS on separated credentials, and building this measured that it cannot (#3224, filed, blocking).

## What ran nowhere before this

`DbConfig::demographic_dsn()` falls back to the clinical `url` when `[db] demographic_url` is unset, which is the default. `demographic_pool_from()` — the helper every DB-backed test uses — clones the same connect options and swaps only the `search_path`. So the schema boundary was proven through one credential, and the credential boundary was proven not at all, while the book recommends it, the chart configures it, and the compliance pages describe the separation as a control.

## What is proven now

The server assembled the way the binary assembles it — `db::connect` + `db::connect_demographic` from a `DbConfig` carrying both DSNs, then `FerroEhrService::new(clinical).with_demographic_pool(demographic)` — on **one login role per domain** against a real PostgreSQL:

- **Both domains serve through the wire.** `POST /ehr` → 201 and `GET /ehr/{id}` → 200; `POST /demographic/person` → 201 and `GET /demographic/person/{ovid}` → 200. A real party write, not a narrowed substitute.
- **Each credential is refused the other domain, from the server's own pools.** The clinical pool against `demographic.vo_version`, `demographic.node`, `demographic.contribution`, `cold_demographic.vo_version`; the demographic pool against `ehr.ehr`, `ehr.vo_version`, `ehr.node`, `cold.vo_version`. `PgPool` is a handle, so these are the pools the running service holds, not connections the test opened for itself. Each refusal must carry SQLSTATE **42501** exactly, not merely be an error.
- **The single-DSN fallback still serves both domains**, so this does not quietly become a required posture.

Two fixture guards keep it from passing vacuously: `roles_are_separated()` must be true and `demographic_dsn() != url.expose()`.

## Mutation-proven from both directions

**One shared credential** — the current default — trips the guard before any assertion:
```
assertion `left != right` failed: and they must be different credentials
```

**Two distinct credentials, each a member of both domains** clears both guards, reaches the assertion that matters, and fails it:
```
the clinical pool must not be able to read demographic.vo_version: PgQueryResult { rows_affected: 1 }
```

That second one is the important proof: distinctness alone is not separation, and the test knows the difference.

## The probe's boundary is narrowed, not deleted

The compose probe declared credential separation "not exercised by any probe here". It still is not — this coverage is in-process. So the entry now names where the in-process half lives and states exactly what remains uncovered: a container booting with `FERROEHR__DB__DEMOGRAPHIC_URL_FILE` mounted, schema preparation by a role that is neither runtime credential, and the chart's `database.demographicExistingSecret` wiring that pair. It also records that `linkage` is outside both, having no pool yet.

Deleting the entry would have been the easy move and a false one.

## What this found, and why the issue stays open

`app/ferroehr-server/src/lib.rs:592` calls `db::prepare(&config.db, &clinical)` — the clinical pool — and `prepare` verifies all five migration sets, reading each schema's `_sqlx_migrations`. A role that is a member of `ferroehr_ehr` and nothing else holds none of the others. Measured as exactly such a role:

```
ext          ERROR:  permission denied for table _sqlx_migrations
ehr          8
demographic  ERROR:  permission denied for schema demographic
linkage      ERROR:  permission denied for schema linkage
audit        ERROR:  permission denied for schema audit
```

So the documented posture cannot boot, and `verify` mode reports it as a bare 42501 about a table the operator has never heard of. This test sidesteps it by assembling the router over an already-migrated harness database. **#3224** carries the product fix and blocks #3222.

Also corrected on #3222: I had written an acceptance criterion requiring a distinct *linkage* credential. That is unsatisfiable today — `linkage` has a schema, a table and a role but no pool and no reader. It belongs to #3158 increment B, and this coverage should extend to it when that lands.

## Gates

`cargo fmt --all`; `cargo clippy -p ferroehr -p ferroehr-rest --all-targets --all-features -- -D warnings`; **`cargo nextest run -p ferroehr-rest --all-features` 797/797**; `pseudonymisation` 16/16; `shellcheck-lane`, `comment-style`, `docs-claims` green. No `#[expect]`/`#[allow]` added to production code. No book page changed: every page describing the posture was checked and none claimed it was tested.

## Privacy boundary

**What personal data this change touches.** None that is new. The test writes one synthetic EHR and one synthetic party into a throwaway testkit clone, using the fixture body the demographic wire tests already use. Nothing is exported and no production path changes — this branch adds a test and rewrites one probe's prose.

**The roles.** It creates two throwaway LOGIN roles on the clone, one `IN ROLE ferroehr_ehr` and one `IN ROLE ferroehr_demographic`, each named off the clone database so the testkit sweep reaps them, with a freshly generated password per call and no credential literal in the tree. Those are the two identities the assertions measure.

**Grants.** No grant changes anywhere. The test's whole purpose is to observe the existing grants from the server's own pools.

**Access events.** No new read of personal data on any production path, so no access event belongs here.

- [x] The data flow is described above: what personal data this change reads, writes or exports, and where it goes
- [x] The roles are named: which database roles and which caller roles reach that data
- [x] No new grant spans the clinical and demographic domains
- [x] Synthetic data only in tests, fixtures, seeds and examples
- [x] An access event is emitted wherever this change added a read of personal data

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.
