### PR TITLE
fix(db): schema preparation gets its own credential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -443,6 +443,28 @@ workflow refuses a tag that has no matching section here.
 
 ### Fixed
 
+- **The documented two-DSN posture boots: schema preparation has its own
+  credential** (#3224). The server prepared the schema on the CLINICAL runtime
+  pool, and preparation spans every schema — the DDL of all five migration
+  sets under `db.migrate = "apply"`, all five `_sqlx_migrations` bookkeeping
+  tables under `"verify"`. A role that is a member of `ferroehr_ehr` and
+  nothing else — what the book recommends and the chart configures — holds
+  neither, so it was refused on the first set and the deployment could not
+  start; `ferroehr_app` could not run `verify` either. The new `[db]
+  migrate_url` (or `migrate_url_file`, and `database.migrateExistingSecret`
+  on the chart) names the credential that prepares the schema, used for that
+  one boot step on a connection that is opened and closed again — no pool is
+  held on it and no request is served through it. Unset, it falls back to
+  `[db] url`, so a single-credential deployment is unchanged. The
+  pseudonymisation boot gate deliberately stays on the RUNTIME pool: it
+  measures what the serving credential can reach, and asking the migration
+  credential — which holds every domain by design — would stop measuring
+  anything. A credential that cannot read a set is now refused with the
+  schema and the role it authenticates as, and the remedy, instead of a bare
+  `42501` about a table no operator has heard of. `ferroehr db verify` splits
+  the same way. Chart values contract grows three optional keys, so the chart
+  goes to 8.1.0.
+
 - **The template upload dialog opens empty** (#3200). It cleared the source
   it was holding only when the CDR accepted it, so after an upload that was
   refused — or one whose click never reached the handler — re-opening the

--- a/app/ferroehr-server/src/lib.rs
+++ b/app/ferroehr-server/src/lib.rs
@@ -160,23 +160,44 @@ async fn run_db(
     let telemetry =
         telemetry::init(&telemetry_config, &build_info).context("initialising telemetry")?;
 
-    // The plain pool: the migrator identity is a database role, never a tenant.
-    let pool = db::connect(&config.db)
-        .await
-        .context("connecting to PostgreSQL")?;
+    // Both subcommands read the schema on the migration DSN
+    // (`[db].migrate_url`, falling back to `[db].url`), which is the
+    // credential that can reach every schema when the runtime ones each hold
+    // one pseudonymisation domain.
     let outcome = match cmd {
-        DbCmd::Migrate => db::run_migrations(&pool)
+        DbCmd::Migrate => db::apply_schema(&config.db)
             .await
             .context("applying migrations"),
-        DbCmd::Verify => match db::verify_migrations(&pool).await {
-            Ok(()) => db::verify_domain_isolation(&pool)
-                .await
-                .context("verifying the pseudonymisation domain isolation"),
-            Err(error) => Err(anyhow::Error::new(error).context("verifying the schema")),
-        },
+        DbCmd::Verify => verify_schema_and_isolation(&config.db).await,
     };
-    pool.close().await;
     telemetry.shutdown().await;
+    outcome
+}
+
+/// `ferroehr db verify`: the recorded schema state, then the pseudonymisation
+/// boundary.
+///
+/// The two checks deliberately authenticate as different credentials, exactly
+/// as [`ferroehr::db::prepare`] does at boot. The schema state is read on the
+/// migration DSN, which spans all five migration sets; the isolation check
+/// runs on the RUNTIME pool, because what it measures is what the serving
+/// credential can reach — asked of the migration credential it would report
+/// on a role that holds every domain by design.
+///
+/// # Errors
+/// A schema divergence, an unreadable migration set, a breached domain
+/// boundary, or a connection failure.
+async fn verify_schema_and_isolation(settings: &db::DbConfig) -> anyhow::Result<()> {
+    db::verify_schema(settings)
+        .await
+        .map_err(|error| anyhow::Error::new(error).context("verifying the schema"))?;
+    let pool = db::connect(settings)
+        .await
+        .context("connecting to PostgreSQL")?;
+    let outcome = db::verify_domain_isolation(&pool)
+        .await
+        .context("verifying the pseudonymisation domain isolation");
+    pool.close().await;
     outcome
 }
 
@@ -561,10 +582,11 @@ struct Pools {
 /// schema one. Neither multi-tenancy nor the domain split is governed by an
 /// openEHR spec; both are our own deployment extensions.
 ///
-/// Schema preparation runs on the clinical pool alone: it applies every
-/// embedded migration set, and it ends in
-/// [`ferroehr::db::verify_domain_isolation`], which refuses to boot a database
-/// whose grants let one runtime role read both domains.
+/// Schema preparation is [`ferroehr::db::prepare`], which spans every schema
+/// on the migration DSN (`[db].migrate_url`, falling back to `[db].url`) and
+/// then measures the CLINICAL pool's own reach with
+/// [`ferroehr::db::verify_domain_isolation`], refusing to boot a database
+/// whose grants let one runtime role read another domain.
 ///
 /// # Errors
 /// A connection, migration or domain-isolation failure, contextualized for the

--- a/app/ferroehr/assets/ferroehr.default.toml
+++ b/app/ferroehr/assets/ferroehr.default.toml
@@ -131,6 +131,14 @@ url = "postgres://ferroehr:ferroehr@localhost:5432/ferroehr"  # PROD: real DSN v
 # when either role can reach across the boundary.
 #? demographic_url = "postgres://ferroehr_demographic:...@localhost:5432/ferroehr"
 #? demographic_url_file = "/run/secrets/db-demographic-dsn"
+# The credential that PREPARES the schema, used for that one boot step and
+# then closed. Preparing spans every schema — the DDL of all five migration
+# sets under migrate = "apply", all five bookkeeping tables under "verify" —
+# so a deployment whose runtime DSNs each hold one pseudonymisation domain
+# names the credential that can reach them all here. Unset, it falls back to
+# the url above, which is what every single-credential deployment runs.
+#? migrate_url = "postgres://ferroehr_migrator:...@localhost:5432/ferroehr"
+#? migrate_url_file = "/run/secrets/db-migrate-dsn"
 # Whether the server issues DDL at boot. "apply" runs the embedded migrations
 # then verifies, which is what makes an empty configuration boot against an
 # empty database; "verify" never issues DDL and refuses to serve unless the

--- a/app/ferroehr/src/config/loader.rs
+++ b/app/ferroehr/src/config/loader.rs
@@ -477,6 +477,12 @@ fn resolve_secret_files(config: &mut FerroEhrConfig, errors: &mut Vec<ConfigErro
         config.db.demographic_url_file.take(),
         errors,
     );
+    resolve_optional_secret_url(
+        "db.migrate_url",
+        &mut config.db.migrate_url,
+        config.db.migrate_url_file.take(),
+        errors,
+    );
     let default_broker = EventsConfig::default().url;
     resolve_secret_url(
         "events.url",

--- a/app/ferroehr/src/config/mod.rs
+++ b/app/ferroehr/src/config/mod.rs
@@ -1188,7 +1188,7 @@ mod tests {
     }
 
     /// Setting a credential both inline and as a file is refused for each of the
-    /// four, rather than one silently winning.
+    /// six, rather than one silently winning.
     ///
     /// Each of these fields has a non-empty dev default, so "the operator set it"
     /// means "it differs from that default" — the default itself must NOT count
@@ -1197,6 +1197,10 @@ mod tests {
     fn a_credential_set_both_inline_and_as_a_file_is_refused() {
         let cases = [
             "[db]\nurl = \"postgres://u:p@h:5432/d\"\nurl_file = \"/dev/null\"\n",
+            "[db]\nmigrate_url = \"postgres://u:p@h:5432/d\"\n\
+             migrate_url_file = \"/dev/null\"\n",
+            "[db]\ndemographic_url = \"postgres://u:p@h:5432/d\"\n\
+             demographic_url_file = \"/dev/null\"\n",
             "[events]\nurl = \"amqp://u:p@h:5672/%2f\"\nurl_file = \"/dev/null\"\n",
             "[fhir.outbound]\nurl = \"amqp://u:p@h:5672/%2f\"\nurl_file = \"/dev/null\"\n",
             "[[auth.basic.users]]\nusername = \"a\"\npassword_hash = \"x\"\n\
@@ -1212,7 +1216,7 @@ mod tests {
         }
     }
 
-    /// The three URL file routes are reachable through the environment grammar
+    /// The four URL file routes are reachable through the environment grammar
     /// too, which is how a container passes a mount path without a config file.
     ///
     /// Without this the documented env form could ship dead — the whole reason
@@ -1223,11 +1227,21 @@ mod tests {
         dsn.write_str("postgres://u:p@h:5432/d\n").expect("write");
         let broker = assert_fs::NamedTempFile::new("broker").expect("temp");
         broker.write_str("amqps://u:p@b:5671/%2f\n").expect("write");
+        // A DIFFERENT DSN, so the assertion below cannot pass by falling back
+        // to `db.url` — which is what an unwired `migrate_url_file` would do.
+        let migrate = assert_fs::NamedTempFile::new("migrate-dsn").expect("temp");
+        migrate
+            .write_str("postgres://m:p@h:5432/d\n")
+            .expect("write");
 
         let c = assemble_ok(
             None,
             &env(&[
                 ("FERROEHR__DB__URL_FILE", &dsn.path().display().to_string()),
+                (
+                    "FERROEHR__DB__MIGRATE_URL_FILE",
+                    &migrate.path().display().to_string(),
+                ),
                 (
                     "FERROEHR__EVENTS__URL_FILE",
                     &broker.path().display().to_string(),
@@ -1240,6 +1254,7 @@ mod tests {
             &[],
         );
         assert_eq!(c.db.url.expose(), "postgres://u:p@h:5432/d");
+        assert_eq!(c.db.migrate_dsn(), "postgres://m:p@h:5432/d");
         assert_eq!(c.events.url.expose(), "amqps://u:p@b:5671/%2f");
         assert_eq!(c.fhir.outbound.url.expose(), "amqps://u:p@b:5671/%2f");
     }

--- a/app/ferroehr/src/db/mod.rs
+++ b/app/ferroehr/src/db/mod.rs
@@ -9,11 +9,13 @@
 //! crate obtains a database handle: [`DbConfig`] (the `[db]` config section)
 //! feeds [`connect`] and [`connect_tenant_scoped`] for the clinical domain and
 //! [`connect_demographic`] / [`connect_tenant_scoped_demographic`] for the
-//! demographic one, and [`run_migrations`] bootstraps every schema and
-//! applies every embedded migration set. The two served domains differ only in
-//! the `search_path` their connections carry, so one set of storage functions
-//! serves both; the `linkage` schema is migrated beside them and has no pool
-//! of its own. [`verify_domain_isolation`] is the boot gate that refuses to
+//! demographic one, and [`prepare`] brings the schema to the state this build
+//! requires — on the migration DSN ([`DbConfig::migrate_dsn`]), a third
+//! credential a deployment may name because preparation spans every schema
+//! while each runtime credential holds one domain. The two served domains
+//! differ only in the `search_path` their connections carry, so one set of
+//! storage functions serves both; the `linkage` schema is migrated beside
+//! them and has no pool of its own. [`verify_domain_isolation`] is the boot gate that refuses to
 //! serve when the runtime roles can read across those boundaries. The `sea-query`
 //! identifier vocabulary for the live schema lives in [`iden`]. This is the
 //! defining module for the whole bootstrap surface, with no re-exports.
@@ -96,6 +98,23 @@ pub struct DbConfig {
     /// of it — the mounted-secret route, as [`Self::url_file`] is for the
     /// clinical DSN. Setting both is a boot error.
     pub demographic_url_file: Option<PathBuf>,
+    /// DSN that schema preparation ([`prepare`]) authenticates as; unset (the
+    /// default) reuses [`Self::url`].
+    ///
+    /// Preparing the schema spans EVERY schema, whatever [`Self::migrate`]
+    /// says: `apply` issues the DDL of all five migration sets, and `verify`
+    /// reads all five `_sqlx_migrations` bookkeeping tables. A runtime
+    /// credential that holds one pseudonymisation domain can do neither, so
+    /// under the separated-role posture this key is what names the credential
+    /// that can, while the pools stay narrow. It is used for that one boot
+    /// step on a connection that is closed again — no pool is ever held on it,
+    /// and no request is ever served through it. No openEHR spec governs
+    /// migration mechanics or database roles — our own design/extension.
+    pub migrate_url: Option<SecretUrl>,
+    /// Path to a file holding [`Self::migrate_url`], read at boot in place of
+    /// it — the mounted-secret route, as [`Self::url_file`] is for the
+    /// clinical DSN. Setting both is a boot error.
+    pub migrate_url_file: Option<PathBuf>,
     /// Upper bound of the connection pool.
     pub max_connections: u32,
     /// Connections the pool keeps open when idle (avoids cold reopen +
@@ -136,6 +155,8 @@ impl Default for DbConfig {
             url_file: None,
             demographic_url: None,
             demographic_url_file: None,
+            migrate_url: None,
+            migrate_url_file: None,
             // Deliberate defaults: 20 max (10 hard-capped realistic write
             // concurrency ×2), 2 min (no cold reopen churn at idle).
             max_connections: 20,
@@ -176,11 +197,27 @@ impl DbConfig {
             .map_or_else(|| self.url.expose(), SecretUrl::expose)
     }
 
+    /// The DSN schema preparation connects with: [`Self::migrate_url`] when
+    /// the deployment names a credential for it, else [`Self::url`].
+    #[must_use]
+    pub fn migrate_dsn(&self) -> &str {
+        self.migrate_url
+            .as_ref()
+            .map_or_else(|| self.url.expose(), SecretUrl::expose)
+    }
+
     /// Whether the demographic domain authenticates as its own database role
     /// (a distinct DSN), rather than sharing the clinical one.
     #[must_use]
     pub fn roles_are_separated(&self) -> bool {
         self.demographic_url.is_some()
+    }
+
+    /// Whether schema preparation authenticates as its own database role
+    /// (a distinct DSN), rather than as the clinical runtime one.
+    #[must_use]
+    pub fn migrator_is_separated(&self) -> bool {
+        self.migrate_url.is_some()
     }
 }
 
@@ -205,6 +242,27 @@ pub enum DbError {
          migrations out of band with the migrator role, then start it again"
     )]
     SchemaNotReady(#[source] SchemaMismatch),
+
+    /// The credential preparing the schema cannot read a migration set's
+    /// bookkeeping at all, so the migration state is unknown rather than
+    /// wrong.
+    #[error(
+        "database role `{role}` cannot read the migration state of schema `{schema}`: \
+         preparing the schema reads every schema's `_sqlx_migrations` bookkeeping table, and \
+         this credential holds no privilege on `{schema}`. Under the separated-domain posture \
+         no runtime credential ever can, because each holds one domain: point `[db] \
+         migrate_url` (or `migrate_url_file`) at the credential that prepares the schema — \
+         unset, it falls back to `[db] url`"
+    )]
+    SchemaUnreadable {
+        /// The schema whose migration bookkeeping could not be read.
+        schema: String,
+        /// The database role the refused connection authenticates as.
+        role: String,
+        /// `PostgreSQL`'s own refusal (`SQLSTATE` 42501).
+        #[source]
+        source: sqlx::Error,
+    },
 
     /// A cold archival tier outlived the primary tier it mirrors, in either
     /// the clinical or the demographic domain.
@@ -647,44 +705,125 @@ pub fn migration_fingerprint() -> String {
 pub async fn run_migrations(pool: &PgPool) -> Result<(), DbError> {
     let mut conn = pool.acquire().await?.detach();
     let outcome = apply_migrations(&mut conn).await;
+    close_quietly(conn).await;
+    outcome
+}
+
+/// Open the one-shot connection schema preparation runs on: the migration DSN
+/// ([`DbConfig::migrate_dsn`]), which is `[db].migrate_url` when a deployment
+/// names a credential for this step and `[db].url` otherwise.
+///
+/// Preparation is a boot step rather than a serving path, so it takes a single
+/// connection that is closed again instead of a third pool held for the
+/// process lifetime, and it carries none of the pools' session setup: no
+/// domain `search_path` (the sequence sets its own per set, and the
+/// bookkeeping reads are schema-qualified) and no `statement_timeout`, which
+/// is the backstop for request-serving statements and would cancel a long
+/// migration partway
+/// (<https://www.postgresql.org/docs/18/runtime-config-client.html>).
+async fn migration_connection(settings: &DbConfig) -> Result<PgConnection, DbError> {
+    let conn = PgConnection::connect(settings.migrate_dsn()).await?;
+    Ok(conn)
+}
+
+/// Close a detached connection, reporting a failure to close as a trace event
+/// rather than as the operation's outcome: the work is already done, and a
+/// failed close must not mask its result.
+async fn close_quietly(conn: PgConnection) {
     if let Err(error) = conn.close().await {
         tracing::debug!(%error, "closing the migration connection failed");
     }
+}
+
+/// Applies the embedded migrations on the migration DSN
+/// ([`DbConfig::migrate_dsn`]) — the credential half of
+/// [`MigrationMode::Apply`].
+///
+/// [`run_migrations`] over a connection of its own rather than one from a
+/// runtime pool, so a deployment whose runtime credentials each hold a single
+/// pseudonymisation domain can still prepare a schema that spans all five.
+///
+/// # Errors
+///
+/// [`DbError::Sqlx`] when the migration DSN does not parse, the connection
+/// fails, or a bootstrap statement is refused (a credential without `CREATE`
+/// on the database or on a schema), and [`DbError::Migrate`] when a migration
+/// fails to apply or an already-applied one fails checksum validation.
+pub async fn apply_schema(settings: &DbConfig) -> Result<(), DbError> {
+    let mut conn = migration_connection(settings).await?;
+    let outcome = apply_migrations(&mut conn).await;
+    close_quietly(conn).await;
+    outcome
+}
+
+/// Verifies the recorded migration state on the migration DSN
+/// ([`DbConfig::migrate_dsn`]) — the credential half of
+/// [`MigrationMode::Verify`].
+///
+/// [`verify_migrations`] over a connection of its own, for the same reason
+/// [`apply_schema`] takes one: the check reads all five schemas'
+/// `_sqlx_migrations` tables, which no single-domain runtime credential can
+/// do. Issues no DDL, so the credential it names needs read access and
+/// nothing more.
+///
+/// # Errors
+///
+/// [`DbError::SchemaNotReady`] naming the first divergence found,
+/// [`DbError::SchemaUnreadable`] when the credential cannot read a set's
+/// bookkeeping at all, or [`DbError::Sqlx`] when the connection or the read
+/// fails for any other reason.
+pub async fn verify_schema(settings: &DbConfig) -> Result<(), DbError> {
+    let mut conn = migration_connection(settings).await?;
+    let outcome = verify_recorded_state(&mut conn).await;
+    close_quietly(conn).await;
     outcome
 }
 
 /// Brings the database to the state this build requires, as
-/// [`DbConfig::migrate`] directs.
+/// [`DbConfig::migrate`] directs, and then proves the pseudonymisation
+/// boundary holds.
 ///
-/// [`MigrationMode::Apply`] runs [`run_migrations`]; [`MigrationMode::Verify`]
-/// issues no DDL and only checks, so the DSN may authenticate as a role that
-/// holds no DDL rights at all. This is the boot-path entry point — call it
-/// instead of [`run_migrations`] anywhere the operator's configuration should
-/// decide.
+/// The boot-path entry point — call it rather than the halves it composes
+/// wherever the operator's configuration should decide. [`MigrationMode::Apply`]
+/// applies the embedded migrations ([`apply_schema`]);
+/// [`MigrationMode::Verify`] issues no DDL and only checks
+/// ([`verify_schema`]).
 ///
-/// Either way it ends with [`verify_domain_isolation`]: a schema that is
-/// current but whose grants let one runtime role read both pseudonymisation
-/// domains is not a database this server will serve from.
+/// **The two halves deliberately authenticate as different credentials, and
+/// that is the whole point of the split.** Schema preparation spans every
+/// schema — the DDL of all five migration sets under `apply`, all five
+/// `_sqlx_migrations` bookkeeping tables under `verify` — so it runs on the
+/// migration DSN ([`DbConfig::migrate_dsn`]), which a deployment separating
+/// its runtime roles points at a credential that can reach them all.
+/// [`verify_domain_isolation`] runs on `runtime_pool` instead, because it
+/// exists to measure what THAT credential can reach: it reads `pg_catalog`
+/// and the `has_*_privilege` functions, which any role may call
+/// (<https://www.postgresql.org/docs/18/functions-info.html>), so running it
+/// on the migration credential would not fail — it would silently measure a
+/// role that holds every domain by design, and the boot gate would stop
+/// saying anything about the roles that serve requests.
 ///
 /// # Errors
 ///
-/// In `apply` mode, whatever [`run_migrations`] returns. In `verify` mode,
+/// In `apply` mode, whatever [`apply_schema`] returns. In `verify` mode,
 /// [`DbError::SchemaNotReady`] when the database does not carry exactly this
-/// build's migrations, or [`DbError::Sqlx`] when the check itself cannot run.
-/// In both modes, [`DbError::DomainIsolationBreached`] when a runtime role can
-/// reach the other domain.
-pub async fn prepare(settings: &DbConfig, pool: &PgPool) -> Result<(), DbError> {
+/// build's migrations, [`DbError::SchemaUnreadable`] when the migration
+/// credential cannot read a set's bookkeeping at all, or [`DbError::Sqlx`]
+/// when the check itself cannot run. In both modes,
+/// [`DbError::DomainIsolationBreached`] when a runtime role can reach another
+/// pseudonymisation domain.
+pub async fn prepare(settings: &DbConfig, runtime_pool: &PgPool) -> Result<(), DbError> {
     match settings.migrate {
-        MigrationMode::Apply => run_migrations(pool).await?,
+        MigrationMode::Apply => apply_schema(settings).await?,
         MigrationMode::Verify => {
             tracing::info!(
                 "[db].migrate is `verify`: this server issues no DDL and requires an \
                  already-migrated database"
             );
-            verify_migrations(pool).await?;
+            verify_schema(settings).await?;
         }
     }
-    verify_domain_isolation(pool).await
+    verify_domain_isolation(runtime_pool).await
 }
 
 /// Verifies, without issuing any DDL, that the database carries exactly the
@@ -698,11 +837,24 @@ pub async fn prepare(settings: &DbConfig, pool: &PgPool) -> Result<(), DbError> 
 ///
 /// # Errors
 ///
-/// [`DbError::SchemaNotReady`] naming the first divergence found, or
-/// [`DbError::Sqlx`] when a connection or the bookkeeping read fails.
+/// [`DbError::SchemaNotReady`] naming the first divergence found,
+/// [`DbError::SchemaUnreadable`] when this pool's credential cannot read a
+/// set's bookkeeping at all, or [`DbError::Sqlx`] when a connection or the
+/// bookkeeping read fails for any other reason.
 pub async fn verify_migrations(pool: &PgPool) -> Result<(), DbError> {
+    let mut conn = pool.acquire().await?;
+    verify_recorded_state(&mut conn).await
+}
+
+/// Compare every migration set's bookkeeping against its embedded source, on
+/// one connection.
+///
+/// The shared body of [`verify_migrations`] (a pooled connection) and
+/// [`verify_schema`] (the one-shot migration connection), so the boot gate and
+/// the operator check cannot drift apart.
+async fn verify_recorded_state(conn: &mut PgConnection) -> Result<(), DbError> {
     for (schema, migrator) in MIGRATION_SETS {
-        verify_set(pool, schema, migrator).await?;
+        verify_set(&mut *conn, schema, migrator).await?;
     }
     Ok(())
 }
@@ -849,16 +1001,77 @@ pub async fn default_tenant_versions(pool: &PgPool) -> Result<i64, DbError> {
     Ok(count)
 }
 
+/// `SQLSTATE` 42501 `insufficient_privilege` — what `PostgreSQL` reports for a
+/// refused read, whether the missing grant is on the relation or on its schema
+/// (`PostgreSQL` docs § Appendix A "`PostgreSQL` Error Codes", class 42,
+/// <https://www.postgresql.org/docs/18/errcodes-appendix.html>).
+const SQLSTATE_INSUFFICIENT_PRIVILEGE: &str = "42501";
+
+/// Whether `PostgreSQL` refused this statement for lack of privilege, rather
+/// than failing for any other reason.
+fn is_insufficient_privilege(error: &sqlx::Error) -> bool {
+    matches!(
+        error,
+        sqlx::Error::Database(refusal)
+            if refusal.code().as_deref() == Some(SQLSTATE_INSUFFICIENT_PRIVILEGE)
+    )
+}
+
+/// The database role this session authenticates as, for an error that must
+/// name the credential and not only the schema.
+///
+/// A failure to read it renders as `unknown`: this runs only while another
+/// error is already being reported, and replacing that error with this one
+/// would hide the boot failure the operator has to act on.
+async fn current_role(conn: &mut PgConnection) -> String {
+    sqlx::query_scalar("SELECT current_user::text")
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap_or_else(|_| "unknown".to_owned())
+}
+
+/// Classify a failed bookkeeping read: a privilege refusal becomes
+/// [`DbError::SchemaUnreadable`], naming the schema and the credential;
+/// anything else stays the driver error it was.
+///
+/// A bare 42501 about `_sqlx_migrations` is unactionable — it names a table an
+/// operator has never heard of and no credential at all — and the separated
+/// posture reaches it on the very first set.
+async fn unreadable_bookkeeping(
+    conn: &mut PgConnection,
+    schema: &str,
+    error: sqlx::Error,
+) -> DbError {
+    if !is_insufficient_privilege(&error) {
+        return DbError::Sqlx(error);
+    }
+    DbError::SchemaUnreadable {
+        schema: schema.to_owned(),
+        role: current_role(&mut *conn).await,
+        source: error,
+    }
+}
+
 /// Compare one migration set's bookkeeping table against its embedded source.
-async fn verify_set(pool: &PgPool, schema: &str, migrator: &Migrator) -> Result<(), DbError> {
+async fn verify_set(
+    conn: &mut PgConnection,
+    schema: &str,
+    migrator: &Migrator,
+) -> Result<(), DbError> {
     // The schema name is one of the literals in `MIGRATION_SETS`, never
     // input: `to_regclass` answers NULL for a missing relation rather than
-    // failing (PostgreSQL 18 docs, "System Information Functions").
+    // failing (PostgreSQL 18 docs, "System Information Functions") — but it
+    // still raises 42501 for a schema this credential may not enter, which is
+    // why both statements here classify their failure.
     let bookkeeping = format!("{schema}._sqlx_migrations");
-    let present: bool = sqlx::query_scalar("SELECT to_regclass($1) IS NOT NULL")
+    let present: bool = match sqlx::query_scalar("SELECT to_regclass($1) IS NOT NULL")
         .bind(&bookkeeping)
-        .fetch_one(pool)
-        .await?;
+        .fetch_one(&mut *conn)
+        .await
+    {
+        Ok(present) => present,
+        Err(error) => return Err(unreadable_bookkeeping(&mut *conn, schema, error).await),
+    };
     if !present {
         return Err(DbError::SchemaNotReady(SchemaMismatch::NeverMigrated {
             schema: schema.to_owned(),
@@ -866,9 +1079,13 @@ async fn verify_set(pool: &PgPool, schema: &str, migrator: &Migrator) -> Result<
     }
 
     let query = format!("SELECT version, success, checksum FROM {bookkeeping} ORDER BY version");
-    let applied: Vec<(i64, bool, Vec<u8>)> = sqlx::query_as(sqlx::AssertSqlSafe(query))
-        .fetch_all(pool)
-        .await?;
+    let applied: Vec<(i64, bool, Vec<u8>)> = match sqlx::query_as(sqlx::AssertSqlSafe(query))
+        .fetch_all(&mut *conn)
+        .await
+    {
+        Ok(applied) => applied,
+        Err(error) => return Err(unreadable_bookkeeping(&mut *conn, schema, error).await),
+    };
 
     let mut unknown: Vec<i64> = applied.iter().map(|(version, _, _)| *version).collect();
     let mut missing: Vec<i64> = Vec::new();

--- a/app/ferroehr/tests/it/main.rs
+++ b/app/ferroehr/tests/it/main.rs
@@ -47,6 +47,7 @@ mod privacy_leak;
 mod privacy_policy;
 mod privacy_rules;
 mod pseudonymisation_boundary;
+mod schema_preparation_credential;
 mod service_admin;
 mod service_aql;
 mod service_aql_terminology;

--- a/app/ferroehr/tests/it/schema_preparation_credential.rs
+++ b/app/ferroehr/tests/it/schema_preparation_credential.rs
@@ -1,0 +1,295 @@
+// SPDX-FileCopyrightText: Ruben Talstra
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Schema preparation under the separated-credential posture: which
+//! credential [`ferroehr::db::prepare`] runs each half on, and what an
+//! operator is told when it is the wrong one.
+//!
+//! These tests run the REAL boot sequence — the pools the binary opens, then
+//! `db::prepare` over them — rather than assembling a router over a database
+//! something else already migrated. That distinction is the whole point of
+//! the module: preparation spans every schema (the DDL of all five migration
+//! sets under `apply`, all five `_sqlx_migrations` bookkeeping tables under
+//! `verify`), while each runtime credential of the documented posture holds
+//! exactly one pseudonymisation domain, so a test that never boots cannot see
+//! the failure at all.
+//!
+//! NOTE: no openEHR spec governs migration mechanics or database roles — our
+//! own design/extension (GDPR Art. 4(5) and Art. 32(1)(a); the migrations
+//! carry the derivation).
+
+#![expect(
+    clippy::expect_used,
+    reason = "clippy's in-test lint scoping (clippy.toml `allow-*-in-tests`) only \
+              reaches `#[test]`-annotated functions, so it misses this module's \
+              fixture helpers and async bodies; a failing fixture must panic at \
+              the fixture (the Rust Book ch11)"
+)]
+
+use ferroehr::config::secret::SecretUrl;
+use ferroehr::db::{DbConfig, DbError, MigrationMode};
+use uuid::Uuid;
+
+/// `SQLSTATE` 42501 `insufficient_privilege` — what `PostgreSQL` reports for a
+/// refused read, whether the missing grant is on the relation or on its schema
+/// (`PostgreSQL` docs § Appendix A "`PostgreSQL` Error Codes", class 42).
+const SQLSTATE_INSUFFICIENT_PRIVILEGE: &str = "42501";
+
+/// A password for a throwaway login role, fresh per call.
+///
+/// The value is never a secret: the role lives as long as one test against an
+/// ephemeral clone. It is generated rather than written down because a literal
+/// here is indistinguishable, to a scanner and to a reader, from a credential
+/// that does matter.
+fn throwaway_password() -> String {
+    format!("pw{}", Uuid::now_v7().simple())
+}
+
+/// Rewrite the userinfo of a testkit clone DSN so a connection reaches the
+/// same database as a different login role (scheme/host/port/database
+/// preserved).
+fn with_role(base_url: &str, user: &str, password: &str) -> String {
+    let (scheme, rest) = base_url.split_once("://").expect("dsn scheme");
+    let host_and_path = rest.split_once('@').map_or(rest, |(_, tail)| tail);
+    format!("{scheme}://{user}:{password}@{host_and_path}")
+}
+
+/// A fresh non-superuser login role that is a member of `roles` (a
+/// comma-separated `IN ROLE` list), returned as `(role name, DSN)`.
+///
+/// How a production deployment runs, and never as superuser, which would
+/// bypass every privilege check these tests are about. Roles are
+/// cluster-global on the shared testkit server, so the login role is named off
+/// the clone's database name and the testkit sweep reaps it.
+async fn login_role(db: &testkit::TestDb, suffix: &str, roles: &str) -> (String, String) {
+    let login = format!("{}_{suffix}", db.name());
+    let password = throwaway_password();
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "CREATE ROLE {login} LOGIN PASSWORD '{password}' IN ROLE {roles}"
+    )))
+    .execute(&db.pool())
+    .await
+    .expect("create the login role");
+    let dsn = with_role(db.url(), &login, &password);
+    (login, dsn)
+}
+
+/// A DSN for a credential that can actually prepare the schema.
+///
+/// The clone's relations are owned by the harness role that built the
+/// template, so a login role that is a MEMBER of it holds what
+/// `ferroehr_migrator` holds in a deployment where that role owns them —
+/// every schema, and no superuser attribute (which is an attribute, never
+/// inherited: `PostgreSQL` 18, CREATE ROLE,
+/// <https://www.postgresql.org/docs/18/sql-createrole.html>).
+async fn migrator_dsn(db: &testkit::TestDb) -> String {
+    let owner: String = sqlx::query_scalar("SELECT current_user::text")
+        .fetch_one(&db.pool())
+        .await
+        .expect("read the harness role");
+    login_role(db, "prepmig", &owner).await.1
+}
+
+/// The real boot sequence on three credentials: one per pseudonymisation
+/// domain plus the one that prepares the schema.
+///
+/// This is what the book recommends and the chart configures, and until
+/// `[db] migrate_url` existed it could not get past boot at all: `verify`
+/// failed on the FIRST migration set, because a role that is a member of
+/// `ferroehr_ehr` and nothing else cannot read `ext._sqlx_migrations`.
+#[tokio::test]
+async fn the_boot_sequence_prepares_the_schema_on_separated_credentials() {
+    let db = testkit::db().await.expect("testkit database");
+    let settings = DbConfig {
+        url: SecretUrl::new(login_role(&db, "prepclin", "ferroehr_ehr").await.1),
+        demographic_url: Some(SecretUrl::new(
+            login_role(&db, "prepdemo", "ferroehr_demographic").await.1,
+        )),
+        migrate_url: Some(SecretUrl::new(migrator_dsn(&db).await)),
+        migrate: MigrationMode::Verify,
+        ..DbConfig::default()
+    };
+    assert!(
+        settings.roles_are_separated() && settings.migrator_is_separated(),
+        "the fixture must configure three DSNs, else this passes vacuously"
+    );
+    assert_ne!(
+        settings.migrate_dsn(),
+        settings.url.expose(),
+        "and preparation must not be running as the clinical credential"
+    );
+    assert_ne!(
+        settings.migrate_dsn(),
+        settings.demographic_dsn(),
+        "nor as the demographic one"
+    );
+
+    // The binary's own sequence: both runtime pools, then preparation.
+    let clinical = ferroehr::db::connect(&settings)
+        .await
+        .expect("the clinical pool connects");
+    let demographic = ferroehr::db::connect_demographic(&settings)
+        .await
+        .expect("the demographic pool connects");
+    ferroehr::db::prepare(&settings, &clinical)
+        .await
+        .expect("`verify` prepares the schema on the migration credential");
+
+    // And `apply` reaches the same state: on an already-migrated database it
+    // is the bootstrap statements plus five no-op migrator runs, all of which
+    // the migration credential may issue and neither runtime one may.
+    let applying = DbConfig {
+        migrate: MigrationMode::Apply,
+        ..settings
+    };
+    ferroehr::db::prepare(&applying, &clinical)
+        .await
+        .expect("`apply` prepares the schema on the migration credential");
+
+    // The sequence ends with two usable runtime pools, each on its own domain.
+    let versions: i64 = sqlx::query_scalar("SELECT count(*) FROM ehr.vo_version")
+        .fetch_one(&clinical)
+        .await
+        .expect("the clinical pool reads its own domain");
+    let parties: i64 = sqlx::query_scalar("SELECT count(*) FROM demographic.vo_version")
+        .fetch_one(&demographic)
+        .await
+        .expect("the demographic pool reads its own domain");
+    assert_eq!(
+        (versions, parties),
+        (0, 0),
+        "a freshly prepared database carries no content"
+    );
+}
+
+/// A single-DSN deployment is byte-identical to what it was: `migrate_url`
+/// unset falls back to `url`, in both migration modes.
+#[tokio::test]
+async fn a_single_dsn_deployment_prepares_the_schema_as_before() {
+    let db = testkit::db().await.expect("testkit database");
+    let settings = DbConfig {
+        migrate: MigrationMode::Verify,
+        ..DbConfig::new(db.url())
+    };
+    assert!(
+        !settings.migrator_is_separated(),
+        "the fallback posture leaves `migrate_url` unset"
+    );
+    assert_eq!(
+        settings.migrate_dsn(),
+        settings.url.expose(),
+        "and preparation then runs on the clinical DSN"
+    );
+
+    let pool = ferroehr::db::connect(&settings)
+        .await
+        .expect("the pool connects");
+    ferroehr::db::prepare(&settings, &pool)
+        .await
+        .expect("`verify` prepares the schema on the one DSN");
+
+    let applying = DbConfig {
+        migrate: MigrationMode::Apply,
+        ..settings
+    };
+    ferroehr::db::prepare(&applying, &pool)
+        .await
+        .expect("`apply` prepares the schema on the one DSN");
+}
+
+/// A credential that cannot read a migration set is told which schema and
+/// which role, not handed a bare 42501 about a table it has never heard of.
+///
+/// The refusal here is on the bookkeeping TABLE: a member of `ferroehr_ehr`
+/// may enter `ext` (its helper functions are on the clinical search path) and
+/// is refused the `SELECT`.
+#[tokio::test]
+async fn a_refused_bookkeeping_table_names_the_schema_and_the_role() {
+    let db = testkit::db().await.expect("testkit database");
+    let (role, dsn) = login_role(&db, "prepnoext", "ferroehr_ehr").await;
+    let settings = DbConfig {
+        migrate_url: Some(SecretUrl::new(dsn.clone())),
+        migrate: MigrationMode::Verify,
+        ..DbConfig::new(dsn)
+    };
+
+    let error = ferroehr::db::verify_schema(&settings)
+        .await
+        .expect_err("a clinical credential cannot read every migration set");
+
+    let rendered = error.to_string();
+    assert!(
+        rendered.contains("migrate_url"),
+        "the refusal must carry the remedy: {rendered}"
+    );
+    let DbError::SchemaUnreadable {
+        schema,
+        role: named,
+        source,
+    } = error
+    else {
+        panic!("a privilege refusal must not surface as a bare driver error: {rendered}")
+    };
+    assert_eq!(schema, "ext", "the first set it cannot read");
+    assert_eq!(named, role, "the credential the operator has to change");
+    assert!(
+        rendered.contains("ext") && rendered.contains(&role),
+        "and both must reach the operator's terminal: {rendered}"
+    );
+    let sqlx::Error::Database(refusal) = &source else {
+        panic!("the cause must be PostgreSQL's own refusal: {source}")
+    };
+    assert_eq!(
+        refusal.code().as_deref(),
+        Some(SQLSTATE_INSUFFICIENT_PRIVILEGE),
+        "and it must be the privilege refusal, kept as the cause: {source}"
+    );
+}
+
+/// The same for a refusal on the SCHEMA rather than on the table — a distinct
+/// statement in the check, and the shape a separated deployment hits on every
+/// domain it does not own.
+///
+/// The fixture grants the clinical credential the two bookkeeping tables it
+/// would otherwise stop at, so the check reaches `demographic`, which it
+/// cannot enter at all.
+#[tokio::test]
+async fn a_refused_schema_names_the_schema_and_the_role() {
+    let db = testkit::db().await.expect("testkit database");
+    let (role, dsn) = login_role(&db, "prepnodem", "ferroehr_ehr").await;
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "GRANT SELECT ON ext._sqlx_migrations, ehr._sqlx_migrations TO {role}"
+    )))
+    .execute(&db.pool())
+    .await
+    .expect("grant the two sets this credential is allowed to see");
+    let settings = DbConfig {
+        migrate_url: Some(SecretUrl::new(dsn.clone())),
+        migrate: MigrationMode::Verify,
+        ..DbConfig::new(dsn)
+    };
+
+    let error = ferroehr::db::verify_schema(&settings)
+        .await
+        .expect_err("a clinical credential cannot enter the demographic schema");
+
+    let rendered = error.to_string();
+    let DbError::SchemaUnreadable {
+        schema,
+        role: named,
+        source,
+    } = error
+    else {
+        panic!("a privilege refusal must not surface as a bare driver error: {rendered}")
+    };
+    assert_eq!(schema, "demographic", "the first set it cannot reach");
+    assert_eq!(named, role, "the credential the operator has to change");
+    let sqlx::Error::Database(refusal) = &source else {
+        panic!("the cause must be PostgreSQL's own refusal: {source}")
+    };
+    assert_eq!(
+        refusal.code().as_deref(),
+        Some(SQLSTATE_INSUFFICIENT_PRIVILEGE),
+        "and it must be the privilege refusal, kept as the cause: {source}"
+    );
+}

--- a/deploy/helm/ci/all-features-values.yaml
+++ b/deploy/helm/ci/all-features-values.yaml
@@ -10,6 +10,11 @@ database:
   # and no boot check ever sees.
   demographicExistingSecret: ferroehr-db-demographic
   demographicExistingSecretKey: FERROEHR__DB__DEMOGRAPHIC_URL
+  # The third credential (#3224): schema preparation spans every schema, so a
+  # pod whose runtime DSNs are domain-scoped roles cannot perform it on either
+  # of them. Same reason as above — an unrendered branch is an unchecked one.
+  migrateExistingSecret: ferroehr-db-migrate
+  migrateExistingSecretKey: FERROEHR__DB__MIGRATE_URL
 
 secrets:
   # 40 bytes of obvious filler. RFC 8725 §3.5 puts a 32-byte floor under a

--- a/deploy/helm/ci/boot-check.sh
+++ b/deploy/helm/ci/boot-check.sh
@@ -245,6 +245,12 @@ boot_one() {
       # separate credentials would stay unexercised by construction.
       db.demographic_url)
         printf 'postgres://ferroehr_demographic:pw@postgres:5432/ferroehr' > "${secdir}/${base}" ;;
+      # The credential that prepares the schema (#3224), for the same reason:
+      # an overlay setting database.migrateExistingSecret would otherwise fail
+      # this check, leaving the branch that separates preparation from the
+      # runtime credentials unexercised.
+      db.migrate_url)
+        printf 'postgres://ferroehr_migrator:pw@postgres:5432/ferroehr' > "${secdir}/${base}" ;;
       *)
         red "  ${p} is referenced but no rendered Secret key supplies it"
         return 1

--- a/deploy/helm/ferroehr/Chart.yaml
+++ b/deploy/helm/ferroehr/Chart.yaml
@@ -5,8 +5,8 @@ description: >-
   1.1). A single static binary deployed with a hardened-by-default security posture:
   runs as a non-root, read-only-rootfs workload whose NetworkPolicy admits its
   serving port only, and that
-  connects to an EXTERNAL PostgreSQL 18 as an unprivileged app role (migrations
-  are run out of band by a separate migrator role).
+  connects to an EXTERNAL PostgreSQL 18 as an unprivileged app role, with schema
+  preparation on its own credential.
 type: application
 
 # Chart versioning is independent of the application version, and is SemVer 2
@@ -19,7 +19,7 @@ type: application
 # A published OCI version is immutable by refusal rather than by the registry —
 # `helm push` over an existing tag replaces it silently — so a correction always
 # ships as a NEW version and the published one stands as it was.
-version: 8.0.0
+version: 8.1.0
 # The DEFAULT container image tag (overridable via image.tag). Equals the
 # workspace version in Cargo.toml, bumped in the release PR beside the
 # docker-compose.yml image tags — one version sweep, the compose treatment

--- a/deploy/helm/ferroehr/README.md
+++ b/deploy/helm/ferroehr/README.md
@@ -1,8 +1,8 @@
 # ferroehr
 
-Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.1.0 + AQL 1.1). A single static binary deployed with a hardened-by-default security posture: runs as a non-root, read-only-rootfs workload whose NetworkPolicy admits its serving port only, and that connects to an EXTERNAL PostgreSQL 18 as an unprivileged app role (migrations are run out of band by a separate migrator role).
+Pure-Rust, openEHR-conformant clinical data repository (ITS-REST 1.1.0 + AQL 1.1). A single static binary deployed with a hardened-by-default security posture: runs as a non-root, read-only-rootfs workload whose NetworkPolicy admits its serving port only, and that connects to an EXTERNAL PostgreSQL 18 as an unprivileged app role, with schema preparation on its own credential.
 
-![Version: 8.0.0](https://img.shields.io/badge/Version-8.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.1.1](https://img.shields.io/badge/AppVersion-4.1.1-informational?style=flat-square)
+![Version: 8.1.0](https://img.shields.io/badge/Version-8.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.1.1](https://img.shields.io/badge/AppVersion-4.1.1-informational?style=flat-square)
 
 FerroEHR is a pure-Rust openEHR Clinical Data Repository: ITS-REST 1.1.0 at the
 API, AQL 1.1 as the query language, PostgreSQL 18-native storage, shipped as a
@@ -33,7 +33,7 @@ to add; `helm repo add` does not apply to this chart:
 
 ```console
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 8.0.0 \
+  --version 8.1.0 \
   --namespace ferroehr --create-namespace \
   --set database.existingSecret=ferroehr-db \
   --set image.tag=4.1.1
@@ -47,7 +47,7 @@ They are independent SemVer lines and they move independently:
 
 | What | Set with | This release |
 |---|---|---|
-| the **chart** (templates, defaults, this document) | `--version` | `8.0.0` |
+| the **chart** (templates, defaults, this document) | `--version` | `8.1.0` |
 | the **server image** | `image.tag` | `4.1.1` |
 
 `appVersion` is the image the chart defaults to; pinning `image.tag` explicitly
@@ -59,7 +59,7 @@ The chart carries two keyless Sigstore artifacts, and they answer different
 questions. A **cosign signature:** who signed this:
 
 ```console
-cosign verify ghcr.io/rubentalstra/charts/ferroehr:8.0.0 \
+cosign verify ghcr.io/rubentalstra/charts/ferroehr:8.1.0 \
   --certificate-identity-regexp '^https://github\.com/rubentalstra/FerroEHR/\.github/workflows/publish-chart\.yml@' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
@@ -67,7 +67,7 @@ cosign verify ghcr.io/rubentalstra/charts/ferroehr:8.0.0 \
 A **SLSA build provenance attestation:** what source it was built from, and how:
 
 ```console
-gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:8.0.0 \
+gh attestation verify oci://ghcr.io/rubentalstra/charts/ferroehr:8.1.0 \
   -R rubentalstra/FerroEHR
 gh attestation verify oci://ghcr.io/rubentalstra/ferroehr:4.1.1 \
   -R rubentalstra/FerroEHR
@@ -253,6 +253,9 @@ Kubernetes: `>=1.36.0-0`
 | database.demographicUrl | string | `""` | Inline demographic DSN (DEV/TEST ONLY — lands in a chart-managed Secret). Ignored when demographicExistingSecret is set. |
 | database.existingSecret | string | `""` | Reference an existing Secret holding the app-role DSN (STRONGLY preferred for production — keeps the credential out of chart values and git). The secret's value must be a full `postgres://ferroehr_app:...@host:5432/ferroehr` (optionally `?sslmode=verify-full`). |
 | database.existingSecretKey | string | `"FERROEHR__DB__URL"` | Key WITHIN existingSecret that holds the DSN. This is a Secret key name, not an environment variable name: the chart mounts that key as a file and passes only its PATH as `FERROEHR__DB__URL_FILE`, so the DSN never enters the pod's environment. The default spelling is kept for compatibility with existing Secrets created for the older env-borne arrangement. |
+| database.migrateExistingSecret | string | `""` | Reference an existing Secret holding the DSN that PREPARES the schema (`postgres://ferroehr_migrator:...@host:5432/ferroehr`). Required when the runtime DSNs are domain-scoped roles, including under `config.db.migrate=verify`. |
+| database.migrateExistingSecretKey | string | `"FERROEHR__DB__MIGRATE_URL"` | Key WITHIN migrateExistingSecret holding that DSN. Mounted as a file; only its PATH reaches the pod's environment. |
+| database.migrateUrl | string | `""` | Inline schema-preparation DSN (DEV/TEST ONLY — lands in a chart-managed Secret). Ignored when migrateExistingSecret is set. |
 | database.url | string | `""` | Inline DSN (DEV/TEST ONLY — lands in a chart-managed Secret). Leave empty and use existingSecret in production. Ignored when existingSecret is set. |
 | extraEnv | list | `[]` | Extra raw env vars (list of {name,value} or {name,valueFrom}). Escape hatch for anything not surfaced above (array-valued keys via comma-separated values, one-off FERROEHR_* overrides). |
 | extraEnvFrom | list | `[]` | Extra envFrom sources (configMapRef/secretRef). |

--- a/deploy/helm/ferroehr/templates/_helpers.tpl
+++ b/deploy/helm/ferroehr/templates/_helpers.tpl
@@ -117,7 +117,8 @@ when there is at least one secret value to carry).
 {{- define "ferroehr.hasChartSecret" -}}
 {{- $inlineDb := and (not .Values.database.existingSecret) .Values.database.url }}
 {{- $inlineDemographic := and (not .Values.database.demographicExistingSecret) .Values.database.demographicUrl }}
-{{- if or $inlineDb $inlineDemographic .Values.secrets.basicUserPasswordHashes .Values.secrets.authOidcHmacSecret .Values.secrets.signingKeyPassphrase .Values.secrets.eventsUrl .Values.secrets.fhirOutboundUrl .Values.secrets.auditFhirFeedUrl .Values.secrets.multimediaAccessKeyId .Values.secrets.multimediaSecretAccessKey .Values.secrets.terminologyOauth2ClientSecrets -}}
+{{- $inlineMigrate := and (not .Values.database.migrateExistingSecret) .Values.database.migrateUrl }}
+{{- if or $inlineDb $inlineDemographic $inlineMigrate .Values.secrets.basicUserPasswordHashes .Values.secrets.authOidcHmacSecret .Values.secrets.signingKeyPassphrase .Values.secrets.eventsUrl .Values.secrets.fhirOutboundUrl .Values.secrets.auditFhirFeedUrl .Values.secrets.multimediaAccessKeyId .Values.secrets.multimediaSecretAccessKey .Values.secrets.terminologyOauth2ClientSecrets -}}
 true
 {{- end -}}
 {{- end }}
@@ -129,7 +130,7 @@ OWASP Kubernetes Security Cheat Sheet prefers over an environment variable
 (https://cheatsheetseries.owasp.org/cheatsheets/Kubernetes_Security_Cheat_Sheet.html).
 */}}
 {{- define "ferroehr.hasFileSecrets" -}}
-{{- if or (eq (include "ferroehr.hasChartFileSecrets" .) "true") .Values.database.existingSecret .Values.database.demographicExistingSecret -}}
+{{- if or (eq (include "ferroehr.hasChartFileSecrets" .) "true") .Values.database.existingSecret .Values.database.demographicExistingSecret .Values.database.migrateExistingSecret -}}
 true
 {{- end -}}
 {{- end }}
@@ -143,7 +144,8 @@ names a Secret nothing created makes the pod fail to mount.
 {{- define "ferroehr.hasChartFileSecrets" -}}
 {{- $inlineDb := and (not .Values.database.existingSecret) .Values.database.url -}}
 {{- $inlineDemographic := and (not .Values.database.demographicExistingSecret) .Values.database.demographicUrl -}}
-{{- if or $inlineDb $inlineDemographic .Values.secrets.authOidcHmacSecret .Values.secrets.signingKeyPassphrase .Values.secrets.multimediaSecretAccessKey .Values.secrets.terminologyOauth2ClientSecrets .Values.secrets.basicUserPasswordHashes .Values.secrets.eventsUrl .Values.secrets.fhirOutboundUrl -}}
+{{- $inlineMigrate := and (not .Values.database.migrateExistingSecret) .Values.database.migrateUrl -}}
+{{- if or $inlineDb $inlineDemographic $inlineMigrate .Values.secrets.authOidcHmacSecret .Values.secrets.signingKeyPassphrase .Values.secrets.multimediaSecretAccessKey .Values.secrets.terminologyOauth2ClientSecrets .Values.secrets.basicUserPasswordHashes .Values.secrets.eventsUrl .Values.secrets.fhirOutboundUrl -}}
 true
 {{- end -}}
 {{- end }}

--- a/deploy/helm/ferroehr/templates/deployment.yaml
+++ b/deploy/helm/ferroehr/templates/deployment.yaml
@@ -129,6 +129,16 @@ spec:
             - name: FERROEHR__DB__DEMOGRAPHIC_URL_FILE
               value: {{ printf "%s/db.demographic_url" (include "ferroehr.secretMountPath" .) | quote }}
             {{- end }}
+            {{- if or .Values.database.migrateExistingSecret .Values.database.migrateUrl }}
+            {{- /* The credential schema preparation runs as, mounted the same
+                   way and for the same reason. Preparation spans every schema —
+                   all five migration sets' DDL under migrate=apply, all five
+                   bookkeeping tables under verify — so a pod whose runtime DSNs
+                   are domain-scoped roles cannot do it on either of them. Unset,
+                   preparation falls back to the clinical DSN. */}}
+            - name: FERROEHR__DB__MIGRATE_URL_FILE
+              value: {{ printf "%s/db.migrate_url" (include "ferroehr.secretMountPath" .) | quote }}
+            {{- end }}
             {{- if .Values.secrets.authOidcHmacSecret }}
             - name: FERROEHR__AUTH__OIDC__HMAC_SECRET_FILE
               value: {{ printf "%s/auth.oidc.hmac_secret" (include "ferroehr.secretMountPath" .) | quote }}
@@ -304,6 +314,16 @@ spec:
                     - key: {{ .Values.database.demographicExistingSecretKey }}
                       path: db.demographic_url
               {{- end }}
+              {{- if .Values.database.migrateExistingSecret }}
+              # The schema-preparation Secret — usually the same credential the
+              # migration Job carries, which is why it is a third source rather
+              # than a key of either runtime one.
+              - secret:
+                  name: {{ .Values.database.migrateExistingSecret }}
+                  items:
+                    - key: {{ .Values.database.migrateExistingSecretKey }}
+                      path: db.migrate_url
+              {{- end }}
               {{- if eq (include "ferroehr.hasChartFileSecrets" .) "true" }}
               - secret:
                   name: {{ include "ferroehr.secretName" . }}
@@ -315,6 +335,10 @@ spec:
               {{- if and (not .Values.database.demographicExistingSecret) .Values.database.demographicUrl }}
                     - key: db.demographic_url
                       path: db.demographic_url
+              {{- end }}
+              {{- if and (not .Values.database.migrateExistingSecret) .Values.database.migrateUrl }}
+                    - key: db.migrate_url
+                      path: db.migrate_url
               {{- end }}
               {{- if .Values.secrets.eventsUrl }}
                     - key: events.url

--- a/deploy/helm/ferroehr/templates/secret.yaml
+++ b/deploy/helm/ferroehr/templates/secret.yaml
@@ -43,6 +43,9 @@ stringData:
   {{- if and (not .Values.database.demographicExistingSecret) .Values.database.demographicUrl }}
   db.demographic_url: {{ .Values.database.demographicUrl | quote }}
   {{- end }}
+  {{- if and (not .Values.database.migrateExistingSecret) .Values.database.migrateUrl }}
+  db.migrate_url: {{ .Values.database.migrateUrl | quote }}
+  {{- end }}
   {{- with .Values.secrets.eventsUrl }}
   events.url: {{ . | quote }}
   {{- end }}

--- a/deploy/helm/ferroehr/values.schema.json
+++ b/deploy/helm/ferroehr/values.schema.json
@@ -142,6 +142,18 @@
         "demographicUrl": {
           "description": "Inline demographic DSN (dev/test only). Ignored when demographicExistingSecret is set.",
           "type": "string"
+        },
+        "migrateExistingSecret": {
+          "description": "Secret holding the DSN that prepares the schema, which spans every schema and is therefore neither runtime credential. Unset, preparation falls back to the clinical DSN.",
+          "type": "string"
+        },
+        "migrateExistingSecretKey": {
+          "description": "A key name INSIDE migrateExistingSecret; the chart mounts that key as a file and passes only its path.",
+          "type": "string"
+        },
+        "migrateUrl": {
+          "description": "Inline schema-preparation DSN (dev/test only). Ignored when migrateExistingSecret is set.",
+          "type": "string"
         }
       }
     },

--- a/deploy/helm/ferroehr/values.yaml
+++ b/deploy/helm/ferroehr/values.yaml
@@ -150,6 +150,34 @@ database:
   # Secret). Ignored when demographicExistingSecret is set.
   demographicUrl: ""
 
+  # ── the credential that prepares the schema ────────────────────────────────
+  # Neither DSN above can do it. Preparing spans every schema at once — the DDL
+  # of all five migration sets under config.db.migrate=apply, all five
+  # _sqlx_migrations bookkeeping tables under verify — while each runtime role
+  # holds one pseudonymisation domain, so a pod on ferroehr_ehr cannot even
+  # VERIFY, and is refused on the first set.
+  #
+  # Set this whenever the pod's DSN is a domain-scoped role. The server opens
+  # it for that one boot step and closes it again: no pool is held on it and no
+  # request is served through it. Unset, it falls back to the DSN above, which
+  # is what a single-credential deployment runs.
+  #
+  # It is the same credential migrations.job.existingSecret carries. Pointing
+  # both at one Secret is the ordinary arrangement; the Job needs its own copy
+  # because it runs before the Deployment exists.
+
+  # -- Reference an existing Secret holding the DSN that PREPARES the schema
+  # (`postgres://ferroehr_migrator:...@host:5432/ferroehr`). Required when the
+  # runtime DSNs are domain-scoped roles, including under
+  # `config.db.migrate=verify`.
+  migrateExistingSecret: ""
+  # -- Key WITHIN migrateExistingSecret holding that DSN. Mounted as a file;
+  # only its PATH reaches the pod's environment.
+  migrateExistingSecretKey: FERROEHR__DB__MIGRATE_URL
+  # -- Inline schema-preparation DSN (DEV/TEST ONLY — lands in a chart-managed
+  # Secret). Ignored when migrateExistingSecret is set.
+  migrateUrl: ""
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Migrations: who runs the schema.
 #

--- a/deploy/helm/golden/all-features.yaml
+++ b/deploy/helm/golden/all-features.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), and only from the networkPolicy.ingressFrom peers.
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -97,7 +97,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -118,7 +118,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -150,7 +150,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -176,7 +176,7 @@ kind: Secret
 metadata:
   name: ferroehr-config
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -197,7 +197,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -402,7 +402,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr-grafana-dashboard
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -653,7 +653,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -687,7 +687,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -772,6 +772,8 @@ spec:
               value: "/etc/ferroehr-secrets/db.url"
             - name: FERROEHR__DB__DEMOGRAPHIC_URL_FILE
               value: "/etc/ferroehr-secrets/db.demographic_url"
+            - name: FERROEHR__DB__MIGRATE_URL_FILE
+              value: "/etc/ferroehr-secrets/db.migrate_url"
             - name: FERROEHR__AUTH__OIDC__HMAC_SECRET_FILE
               value: "/etc/ferroehr-secrets/auth.oidc.hmac_secret"
             - name: FERROEHR__SIGNING__KEY_PASSPHRASE_FILE
@@ -896,6 +898,14 @@ spec:
                   items:
                     - key: FERROEHR__DB__DEMOGRAPHIC_URL
                       path: db.demographic_url
+              # The schema-preparation Secret — usually the same credential the
+              # migration Job carries, which is why it is a third source rather
+              # than a key of either runtime one.
+              - secret:
+                  name: ferroehr-db-migrate
+                  items:
+                    - key: FERROEHR__DB__MIGRATE_URL
+                      path: db.migrate_url
               - secret:
                   name: ferroehr-env
                   items:
@@ -929,7 +939,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -966,7 +976,7 @@ metadata:
     kubernetes.io/description: >-
       Logical backup of the clinical pseudonymisation domain: pg_dump of ehr, cold, ext, audit into the ferroehr-backup-clinical claim, under that domain's own backup DSN. Separate claim, separate credential, separate schedule from every other domain, so no one artefact carries two of the clinical record, the identifying data and the map between them.
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr-backup-clinical
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -1069,7 +1079,7 @@ metadata:
     kubernetes.io/description: >-
       Logical backup of the demographic pseudonymisation domain: pg_dump of demographic, cold_demographic into the ferroehr-backup-demographic claim, under that domain's own backup DSN. Separate claim, separate credential, separate schedule from every other domain, so no one artefact carries two of the clinical record, the identifying data and the map between them.
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr-backup-demographic
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -1172,7 +1182,7 @@ metadata:
     kubernetes.io/description: >-
       Logical backup of the linkage pseudonymisation domain: pg_dump of linkage into the ferroehr-backup-linkage claim, under that domain's own backup DSN. Separate claim, separate credential, separate schedule from every other domain, so no one artefact carries two of the clinical record, the identifying data and the map between them.
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr-backup-linkage
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -1273,7 +1283,7 @@ kind: Ingress
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -1311,7 +1321,7 @@ kind: ServiceMonitor
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -1353,7 +1363,7 @@ kind: Job
 metadata:
   name: ferroehr-migrate
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr-migration
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -1378,7 +1388,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: ferroehr-8.0.0
+        helm.sh/chart: ferroehr-8.1.0
         app.kubernetes.io/name: ferroehr-migration
         app.kubernetes.io/instance: ferroehr
         app.kubernetes.io/version: "4.1.1"

--- a/deploy/helm/golden/basic-auth.yaml
+++ b/deploy/helm/golden/basic-auth.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -51,7 +51,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -72,7 +72,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -102,7 +102,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -119,7 +119,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -247,7 +247,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -277,7 +277,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"

--- a/deploy/helm/golden/default.yaml
+++ b/deploy/helm/golden/default.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -51,7 +51,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -72,7 +72,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -87,7 +87,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -212,7 +212,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -242,7 +242,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"

--- a/deploy/helm/golden/viewer.yaml
+++ b/deploy/helm/golden/viewer.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the CDR: only the API port (and the management port when enabled), but from EVERY source — this policy narrows ports, NOT sources (networkPolicy.ingressAllowAll=true). Set networkPolicy.ingressFrom for a PHI workload.
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -61,7 +61,7 @@ metadata:
     kubernetes.io/description: >-
       Ingress for the viewer: only its HTTP port, but from EVERY source — this policy narrows ports, NOT sources (viewer.networkPolicy.ingressAllowAll=true). Set viewer.networkPolicy.ingressFrom for a PHI workload. Egress admits the CDR Service and DNS only.
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr-viewer
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -118,7 +118,7 @@ metadata:
     kubernetes.io/description: >-
       Keeps the CDR available during voluntary disruption (node drains, cluster upgrades). AlwaysAllow lets a drain evict already-unhealthy pods rather than waiting for them to recover.
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -139,7 +139,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -154,7 +154,7 @@ kind: ServiceAccount
 metadata:
   name: ferroehr-viewer
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr-viewer
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -184,7 +184,7 @@ kind: Secret
 metadata:
   name: ferroehr-env
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -201,7 +201,7 @@ kind: ConfigMap
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -329,7 +329,7 @@ kind: Service
 metadata:
   name: ferroehr
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -359,7 +359,7 @@ metadata:
     kubernetes.io/description: >-
       In-cluster address for the FerroEHR Viewer. The viewer is a REST client of the CDR and holds no data of its own; it is the human-facing surface, so this is the Service an Ingress normally publishes.
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr-viewer
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -385,7 +385,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR CDR itself: a stateless openEHR ITS-REST API server against an EXTERNAL PostgreSQL 18. It stores nothing locally, so a pod is disposable; readiness reports the database and its schema, liveness does not.
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"
@@ -581,7 +581,7 @@ metadata:
     kubernetes.io/description: >-
       The FerroEHR Viewer: a Leptos SSR web UI that consumes the CDR strictly over ITS-REST. It never reaches the database, which the viewer NetworkPolicy enforces rather than assumes.
   labels:
-    helm.sh/chart: ferroehr-8.0.0
+    helm.sh/chart: ferroehr-8.1.0
     app.kubernetes.io/name: ferroehr-viewer
     app.kubernetes.io/instance: ferroehr
     app.kubernetes.io/version: "4.1.1"

--- a/website/book/src/installation/kubernetes.md
+++ b/website/book/src/installation/kubernetes.md
@@ -38,7 +38,7 @@ kubectl -n ferroehr create secret generic ferroehr-db \
   --from-literal=FERROEHR__DB__URL='postgres://ferroehr_app:***@pg-host:5432/ferroehr?sslmode=verify-full'
 
 helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 8.0.0 -n ferroehr \
+  --version 8.1.0 -n ferroehr \
   --set database.existingSecret=ferroehr-db \
   --set image.tag=4.1.1
 ```
@@ -55,7 +55,7 @@ helm install ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
 reference. To read the chart's metadata without installing it:
 
 ```shell
-helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 8.0.0
+helm show chart oci://ghcr.io/rubentalstra/charts/ferroehr --version 8.1.0
 ```
 
 ### Pin two versions, not one
@@ -68,7 +68,7 @@ against.
 
 | | Selects | Pin with | Line |
 |---|---|---|---|
-| Chart version | templates, values schema, defaults | `--version 8.0.0` | SemVer over the chart's own contract |
+| Chart version | templates, values schema, defaults | `--version 8.1.0` | SemVer over the chart's own contract |
 | Image tag | the server binary | `--set image.tag=4.1.1` (or `image.digest`) | the application's SemVer line |
 
 Always pin the image to an immutable version or, better, a `@sha256` digest,
@@ -167,7 +167,7 @@ metadata lists: the server, and the optional viewer.
 > the image itself as the authority:
 >
 > ```shell
-> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 8.0.0 \
+> helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 8.1.0 \
 >   -s templates/configmap.yaml --set database.existingSecret=ferroehr-db \
 >   | sed -n '/ferroehr.toml/,$p' | sed '1d;s/^    //' > /tmp/ferroehr.toml
 > docker run --rm -v /tmp/ferroehr.toml:/etc/ferroehr/ferroehr.toml:ro \
@@ -284,20 +284,34 @@ config:
 ```
 
 The demographic domain takes a third credential the same way, and it is the
-one that turns the schema separation into a credential separation:
+one that turns the schema separation into a credential separation. A **fourth**
+goes with it, because neither runtime credential can prepare the schema:
 
 ```yaml
 database:
   existingSecret: ferroehr-db                        # postgres://ferroehr_ehr:…
   demographicExistingSecret: ferroehr-db-demographic # postgres://ferroehr_demographic:…
+  migrateExistingSecret: ferroehr-db-migrator        # postgres://ferroehr_migrator:…
 ```
 
-Both are mounted as files, so neither DSN enters the pod's environment. Unset
-the second and both pools share the first, which is the schema-only posture —
-still separated, still verified at boot. Creating the four domain roles is a
-database step the chart cannot do for you;
+All three are mounted as files, so no DSN enters the pod's environment. Unset
+the demographic one and both pools share the first, which is the schema-only
+posture — still separated, still verified at boot. Creating the four domain
+roles is a database step the chart cannot do for you;
 [Operations](../operations.md#turning-the-schema-split-into-a-role-split) has
 the statements and what `ferroehr db verify` reports.
+
+`database.migrateExistingSecret` is what the pod prepares the schema with, and
+it is required as soon as `database.existingSecret` is a domain-scoped role.
+Preparation spans every schema at once — the DDL of all five migration sets
+under `config.db.migrate: apply`, all five `_sqlx_migrations` bookkeeping
+tables under `verify` — while `ferroehr_ehr` holds one domain, so **`verify`
+is not the exception**: without this value the pod is refused on the first
+set and does not start. It is normally the same credential
+`migrations.job.existingSecret` carries; the Job needs its own copy because it
+runs before the Deployment exists. Unset, preparation falls back to
+`database.existingSecret`, which is what a single-credential install has
+always done.
 
 Give the migrator DSN a short `lock_timeout`
 (`?options=-c%20lock_timeout%3D5s`) so DDL blocked behind live traffic fails
@@ -572,7 +586,7 @@ config:
 
 ```shell
 helm upgrade ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr \
-  --version 8.0.0 -n ferroehr --reuse-values \
+  --version 8.1.0 -n ferroehr --reuse-values \
   --set config.query.plan_cache_capacity=512
 ```
 
@@ -756,7 +770,7 @@ Preview an upgrade against what you have installed with
 `helm diff`, or render the new chart version and read it:
 
 ```shell
-helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 8.0.0 \
+helm template ferroehr oci://ghcr.io/rubentalstra/charts/ferroehr --version 8.1.0 \
   -n ferroehr -f my-values.yaml | less
 ```
 

--- a/website/book/src/operations.md
+++ b/website/book/src/operations.md
@@ -74,6 +74,42 @@ two pools on two credentials, and a flaw that reaches one of them reaches one
 domain. Left unset, both pools share the DSN above and the separation is
 schema-only.
 
+### Which credential prepares the schema
+
+**Neither of the two above.** Preparing the schema spans every schema at once:
+the DDL of all five migration sets under `db.migrate = "apply"`, and all five
+`_sqlx_migrations` bookkeeping tables under `"verify"` — a read, but a read
+across the whole database. Each runtime role holds exactly one pseudonymisation
+domain, so neither can do it, and `verify` is not the exception: a role that is
+a member of `ferroehr_ehr` and nothing else is refused on the very first set.
+That applies to the older single-domain roles too — `ferroehr_app` cannot read
+the `ext`, `demographic`, `linkage` or `audit` bookkeeping either.
+
+So the credential that prepares the schema is named separately, and the server
+uses it for that one boot step:
+
+```toml
+[db]
+url = "postgres://ferroehr_ehr:***@pg:5432/ferroehr"
+demographic_url = "postgres://ferroehr_demographic:***@pg:5432/ferroehr"
+migrate_url = "postgres://ferroehr_migrator:***@pg:5432/ferroehr"
+```
+
+(or `migrate_url_file`, for a mounted secret). The connection is opened for
+preparation and closed again: no pool is held on it, and no request is ever
+served through it. Left unset it falls back to `url`, which is exactly what a
+single-credential deployment has always run — its behaviour is unchanged by
+this key existing.
+
+A credential that cannot read a set is told which schema and which role, so
+the fix is visible from the message:
+
+```text
+database role `app_ehr` cannot read the migration state of schema
+`ext`: … point `[db] migrate_url` (or `migrate_url_file`) at the credential
+that prepares the schema — unset, it falls back to `[db] url`
+```
+
 Either way the server **refuses to boot** when the grants themselves are wrong:
 a self-check enumerates every table, view, sequence and function in each
 domain and fails, naming the role and the object, if either runtime role can
@@ -138,9 +174,13 @@ of both `ferroehr_migrator` and `ferroehr_app`.
   life. Least isolation.
 - **`verify`:** the server issues **no DDL at all**. At boot it checks that the
   database carries exactly this build's migrations and refuses to start
-  otherwise, naming the schema and what is wrong with it. The DSN can then be
-  `ferroehr_app` only, which is the least-privilege production posture: an
-  application-level SQL flaw can then reach rows, never the schema.
+  otherwise, naming the schema and what is wrong with it. The pools can then
+  hold no schema rights at all, which is the least-privilege production
+  posture: an application-level SQL flaw can reach rows, never the schema. The
+  check itself still reads every schema's bookkeeping, so it runs on
+  `db.migrate_url` — see [which credential prepares the
+  schema](#which-credential-prepares-the-schema), and set that key whenever
+  `db.url` is a role that holds one domain.
 
 Migrations are **append-only**, so upgrading an existing database in place is
 the supported path and always has been the one your data takes. A released
@@ -160,9 +200,16 @@ different credential from the runtime one, and rendering fails without it):
 ```shell
 FERROEHR__DB__URL='postgres://ferroehr_migrator:***@pg:5432/ferroehr' \
   ferroehr db migrate     # applies; exits when done
-FERROEHR__DB__URL='postgres://ferroehr_app:***@pg:5432/ferroehr' \
+FERROEHR__DB__URL='postgres://ferroehr_ehr:***@pg:5432/ferroehr' \
+FERROEHR__DB__MIGRATE_URL='postgres://ferroehr_migrator:***@pg:5432/ferroehr' \
   ferroehr db verify      # read-only check; exit 0 iff the schema is current
 ```
+
+`db verify` splits the same way the boot sequence does, and for the same
+reason: the schema state is read on `migrate_url`, while the pseudonymisation
+boundary is measured on the runtime DSN — asking the migrator credential
+whether it can reach every domain would answer yes by design and tell you
+nothing about the roles that serve requests.
 
 Gate the rollout on the migration step so two server versions never race the
 schema. Note the difference in failure shape: a `verify` server refuses to boot


### PR DESCRIPTION
Closes #3224. Unblocks #3222.

A deployment that separates the pseudonymisation domains **could not start**. `db::prepare` ran on the clinical runtime pool and reads every schema's migration bookkeeping, so a role holding one domain was refused on the other four:

```
ext          ERROR:  permission denied for table _sqlx_migrations
ehr          8
demographic  ERROR:  permission denied for schema demographic
linkage      ERROR:  permission denied for schema linkage
audit        ERROR:  permission denied for schema audit
```

The only way through was to point `[db].url` at a role holding rights across every domain — the thing the separation exists to forbid. So the posture the book recommends, the chart configures, and the compliance pages describe as a control was unreachable.

## It was wider than the issue it was filed for

`ferroehr_app` cannot run `verify` either. Measured on a clone as a login role `IN ROLE ferroehr_app`: `ext` and `audit` refuse the bookkeeping table, `demographic` and `linkage` refuse the schema. So the **single**-DSN least-privilege recommendation was broken the same way, and `verify` mode was usable only by a credential that could equally have applied the migrations — which defeats the point of the mode. Filed **#3228** to audit the other documents that still recommend the old posture; the mechanism is fixed here, the recommendations elsewhere are not.

## The change

`[db] migrate_url`, with the `migrate_url_file` mounted-secret sibling the other credentials have, **falling back to `url` when unset** — an existing single-credential deployment behaves identically, byte for byte. It carries the migration half alone, over a connection opened for that step and closed again rather than a third pool held for the process lifetime, with no session `statement_timeout` (a DDL migration must not be cancelled at 60s).

## The half that deliberately did not move

`verify_domain_isolation` **stays on the runtime pool**, and this is the part worth reviewing closely. It asks, per barrier role, whether that role can reach a domain it does not own — questions `pg_roles` and `has_table_privilege` answer for anybody. Moving it onto the migration connection would therefore not have errored. It would have quietly measured a credential that by design reaches every domain, and the gate would have gone on printing green while saying nothing about the roles that actually serve requests.

A gate that cannot fail is worse than no gate. The two halves of `prepare` take different credentials on purpose, and its doc comment says so; `ferroehr db verify` is split the same way.

## The refusal says what to do

```
database role `…_prepnoext` cannot read the migration state of schema `ext`:
preparing the schema reads every schema's `_sqlx_migrations` bookkeeping table,
and this credential holds no privilege on `ext`. Under the separated-domain
posture no runtime credential ever can, because each holds one domain: point
`[db] migrate_url` (or `migrate_url_file`) at the credential that prepares the
schema — unset, it falls back to `[db] url`
```

The `sqlx::Error` carrying 42501 is kept under `#[source]`, and the test downcasts to it rather than asserting `source().is_some()`.

## The test calls the real boot sequence

This is the point. The coverage merged as #3225 assembles a router over an **already-migrated** database, which is precisely why it never saw this — the boot path was never run. The new test creates three login roles on a testkit clone (one per domain, one that can migrate), sets all three keys, and calls `db::prepare` for real in both `verify` and `apply` modes, then reads through both runtime pools afterwards.

**Mutation proofs.** Pointing `migrate_url` back at the clinical runtime role fails it:
```
`verify` prepares the schema on the migration credential: SchemaUnreadable { schema: "ext", role: "…_prepmig", source: Database(PgDatabaseError { code: "42501", message: "permission denied for table _sqlx_migrations" }) }
```
Emptying the schema and role from the error fails the two refusal tests. Removing the loader wiring fails both config tests — added because a config test that passes without its wiring is worthless.

## Also in here

- **The chart description was wrong.** It said "migrations are run out of band by a separate migrator role", true of one posture while the default (`config.db.migrate: apply`) is the other — and it is the text Artifact Hub shows. Corrected, README regenerated rather than hand-edited (validation caught the drift).
- **`db.demographic_url` had no both-set-refusal case**, while the test's own doc said "each of the five" and listed five that excluded it. Added and mutation-proven.
- Chart `8.0.0 → 8.1.0` (additive values contract), with `installation/kubernetes.md` pins following, which `docs-claims` required.

## Gates

`cargo fmt --all --check`; `cargo clippy --workspace --exclude ferroehr-viewer --all-targets --all-features -- -D warnings`; **`cargo nextest run -p ferroehr -p ferroehr-rest -p ferroehr-server --all-features` 1970/1970**; `RUSTDOCFLAGS="-D warnings" cargo doc` green; `comment-style`, `default-style`, `docs-claims`, `typed-status`, `spec-citations`, `spdx-headers`, `migration-immutability --diff main`, `chart-appversion`, `shellcheck-lane`, `deploy/helm/validate.sh` all green. No migration touched. No `#[expect]`/`#[allow]` in production code.

## Privacy boundary

**What personal data this change touches.** None. It changes which database credential performs schema preparation at boot, and the text of one error. No personal data is read, written, exported or moved; no query against a domain relation changes.

**The roles.** It introduces a credential whose only job is schema preparation — DDL and migration bookkeeping — and which touches no row of clinical or demographic content. The runtime credentials are unchanged, and the boot gate that measures what they can reach still runs as them, which is the reason `verify_domain_isolation` deliberately did not move.

**Grants.** No grant changes. The tests create throwaway login roles on a testkit clone, named off the clone database so the harness reaps them, each with a freshly generated password and no literal in the tree.

**Access events.** No new read of personal data, so none belongs here.

- [x] The data flow is described above: what personal data this change reads, writes or exports, and where it goes
- [x] The roles are named: which database roles and which caller roles reach that data
- [x] No new grant spans the clinical and demographic domains
- [x] Synthetic data only in tests, fixtures, seeds and examples
- [x] An access event is emitted wherever this change added a read of personal data

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.
