### PR TITLE
test(demographic): a sealed identifier resolves on the separated credential

### DIFF
--- a/app/ferroehr/tests/it/pseudonymisation_boundary.rs
+++ b/app/ferroehr/tests/it/pseudonymisation_boundary.rs
@@ -1335,3 +1335,90 @@ async fn one_party_holds_one_open_mapping_at_a_time() {
          composition was written stays answerable"
     );
 }
+
+/// A login DSN for a throwaway role holding `domain_role` and nothing else.
+///
+/// The pool equivalent of [`role_conn`]: the same clone-named role so the
+/// testkit sweep reaps it, the same generated password, but handed back as a
+/// DSN so a real `DbConfig` can be built from it.
+async fn dsn_as(db: &testkit::TestDb, suffix: &str, domain_role: &str) -> String {
+    let login = format!("{}_{suffix}", db.name());
+    let password = throwaway_password();
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "CREATE ROLE {login} LOGIN PASSWORD '{password}' IN ROLE {domain_role}"
+    )))
+    .execute(&db.pool())
+    .await
+    .expect("create the login role");
+    with_role(db.url(), &login, &password)
+}
+
+/// A sealed identifier seals and resolves on the SEPARATED demographic
+/// credential.
+///
+/// Three things meet on this path, and each was proven only on its own: the
+/// demographic pool authenticating as its own login role, a `SECURITY DEFINER`
+/// resolve function owned by the migrator, and `FORCE ROW LEVEL SECURITY` on
+/// `demographic.national_identifier`. FORCE applies the tenant policy to the
+/// function's owner, and the separated role is not that owner, so whether a
+/// resolve still returns its party is a question about the three together.
+///
+/// The digest half is the one that would fail silently: a policy excluding the
+/// row returns `None`, which reads exactly like an identifier nobody holds.
+#[tokio::test]
+async fn a_sealed_identifier_resolves_on_the_separated_demographic_credential() {
+    use ferroehr::db::DbConfig;
+    use ferroehr::service::demographic::identifier::store::IdentifierStore;
+
+    let db = testkit::db().await.expect("testkit database");
+    let settings = DbConfig {
+        url: ferroehr::config::secret::SecretUrl::new(
+            dsn_as(&db, "sealclin", "ferroehr_ehr").await,
+        ),
+        demographic_url: Some(ferroehr::config::secret::SecretUrl::new(
+            dsn_as(&db, "sealdemo", "ferroehr_demographic").await,
+        )),
+        ..DbConfig::default()
+    };
+    assert!(
+        settings.roles_are_separated(),
+        "the fixture must actually separate the credentials, or this measures \
+         the shared-credential path again"
+    );
+
+    let demographic = ferroehr::db::connect_demographic(&settings)
+        .await
+        .expect("the demographic pool connects on its own credential");
+    let store = IdentifierStore::new(demographic);
+    let tenant = Uuid::nil();
+    let keys = test_keys(tenant);
+    let party = Uuid::now_v7();
+
+    let row = store
+        .seal(&keys, tenant, party, "nl-bsn", SYNTHETIC_BSN)
+        .await
+        .expect("the separated credential seals an identifier");
+    assert_eq!(
+        store.open(&keys, tenant, row).await.expect("open"),
+        Some(SYNTHETIC_BSN.to_owned()),
+        "the key holder reads the value back through the separated credential"
+    );
+    assert_eq!(
+        store
+            .resolve(&keys, tenant, "nl-bsn", SYNTHETIC_BSN)
+            .await
+            .expect("resolve"),
+        Some(party),
+        "the SECURITY DEFINER resolve returns the party under FORCE row-level \
+         security, on a credential that does not own the function"
+    );
+    assert_eq!(
+        store
+            .resolve(&keys, tenant, "nl-bsn", "987654321")
+            .await
+            .expect("resolve a value nobody holds"),
+        None,
+        "and an identifier nobody holds still resolves to nothing, so the \
+         assertion above cannot be met by a resolve that answers everything"
+    );
+}


### PR DESCRIPTION
Closes #3222.

Its last open criterion asked for "an identifier seal and resolve" under the separated posture. Neither #3225 (the wire coverage) nor #3229 (the boot fix) covered it, and it turned out to be the one genuinely risky intersection in this programme.

## Why this specific path

Three things meet on a resolve, and each had been proven only on its own:

- the demographic pool authenticating as **its own login role** (#3225),
- a **`SECURITY DEFINER`** resolve function owned by the migrator (#3155),
- **`FORCE ROW LEVEL SECURITY`** on `demographic.national_identifier` (#3223, landed this cycle).

`FORCE` applies the tenant policy to the function's *owner*, and the separated role is not that owner. Whether a resolve still returns its party is a question about the three together, and nothing was asking it.

**The failure would have been silent.** A policy that excluded the row returns `None`, which is indistinguishable from "no party holds this identifier". A deployment on separated credentials could have stopped resolving identifiers without erroring anywhere — no exception, no log line, just a lookup that always says nobody.

It resolves. The test seals, opens, resolves, and then resolves a value nobody holds, so the positive assertion cannot be satisfied by a resolve that answers everything.

## Where it lives, and why not where I first put it

I wrote it in `ferroehr-rest` beside the other credential-separation coverage and hit a missing `secrecy` dev-dep. That was the signal rather than an obstacle: this test drives no request. It is the demographic **pool's credential** against a function and a policy, so it belongs with the other boundary tests in `app/ferroehr`, where `TEST_ROOT_KEY`, `SYNTHETIC_BSN`, `test_keys`, `throwaway_password` and `with_role` already exist. Adding a dependency to justify the wrong location would have been the worse trade.

`dsn_as` is the pool-shaped sibling of the existing `role_conn`: same clone-named role so the testkit sweep reaps it, same generated password, handed back as a DSN so a real `DbConfig` can be built from it.

## Gates

`cargo fmt --all --check`; `cargo clippy -p ferroehr --tests --all-features -- -D warnings`; the boundary suite **17/17**; `comment-style` green; the privacy guard's own self-test green. No migration touched, no production code changed — this branch is one test and its helper.

**`no-changelog`**: the diff is one file, 87 lines, entirely test code — no REST surface, configuration, storage, CLI or deployment artifact changes, so there is nothing a user could read in a changelog entry. The behaviour it proves shipped in #3223 and #3225 and is already described there.

## Privacy boundary

**What personal data this change touches.** One synthetic BSN (`111222333`, constructed by running the elfproef forward and issued to nobody), sealed into a throwaway testkit clone and read back within the same test. Nothing is exported and no production path changes.

**The roles.** It creates two throwaway LOGIN roles on the clone — one `IN ROLE ferroehr_ehr`, one `IN ROLE ferroehr_demographic` — named off the clone database so the harness reaps them, with a freshly generated password per call and no credential literal. The demographic one is the identity under test.

**Grants.** No grant changes. The test exists to observe the existing grants and policy from a credential that holds only one domain.

**Access events.** No new read of personal data on any production path, so none belongs here.

- [x] The data flow is described above: what personal data this change reads, writes or exports, and where it goes
- [x] The roles are named: which database roles and which caller roles reach that data
- [x] No new grant spans the clinical and demographic domains
- [x] Synthetic data only in tests, fixtures, seeds and examples
- [x] An access event is emitted wherever this change added a read of personal data

## Licensing of contributions

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.

