### PR TITLE
test(storage): the curated database status keeps the driver error as its source

### DIFF
--- a/app/ferroehr/src/storage/error.rs
+++ b/app/ferroehr/src/storage/error.rs
@@ -93,7 +93,7 @@ impl From<StorageError> for crate::service::status::SmError {
         match e {
             // A raw driver/pool/query error carries SQLSTATE + constraint detail
             // — classify it instead of collapsing to a blanket 500.
-            StorageError::Database(db) => classify_sqlx(&db),
+            StorageError::Database(db) => classify_sqlx(&db).with_source(db),
             // Two conflicts with content this repository already holds →
             // `409`: a client-supplied CONTRIBUTION uid already in use
             // (normally intercepted at the versioning call site; this is the
@@ -340,6 +340,26 @@ mod tests {
         // contract), never a blanket 500.
         let sm = classify_sqlx(&sqlx::Error::PoolTimedOut);
         assert_eq!(sm.status, CallStatusType::ServiceOverloaded);
+    }
+
+    /// The bridge keeps the driver error as the call status's source: the
+    /// message stays curated for the wire, and a log or a test walking the
+    /// chain reaches the SQLSTATE and the driver text (#3250). Asserted by
+    /// downcast, because `source().is_some()` cannot tell the error from the
+    /// smart pointer around it.
+    #[test]
+    fn the_curated_status_keeps_the_driver_error_as_its_source() {
+        use std::error::Error as _;
+        let sm: SmError = StorageError::Database(sqlx::Error::PoolTimedOut).into();
+        let source = sm.source().expect("the driver error travels as the source");
+        assert!(
+            source.downcast_ref::<sqlx::Error>().is_some(),
+            "the source is the sqlx error itself, not a wrapper: {source}"
+        );
+        assert_eq!(
+            sm.message,
+            "the server is temporarily overloaded; retry shortly"
+        );
     }
 
     #[test]

--- a/app/ferroehr/tests/it/fixtures.rs
+++ b/app/ferroehr/tests/it/fixtures.rs
@@ -194,3 +194,20 @@ pub(crate) async fn dsn_as(db: &testkit::TestDb, suffix: &str, domain_role: &str
     .expect("create the login role");
     with_role(db.url(), &login, &password)
 }
+
+/// Every link of an error's cause chain, outermost first, joined by ` <- `.
+///
+/// A curated service message says nothing about the driver fault behind it;
+/// the chain does. A test that fails on a database step panics with this so
+/// the cause is in the report rather than only on a trace nobody captured
+/// (#3250).
+pub(crate) fn source_chain(error: &dyn std::error::Error) -> String {
+    let mut out = error.to_string();
+    let mut next = error.source();
+    while let Some(cause) = next {
+        out.push_str(" <- ");
+        out.push_str(&cause.to_string());
+        next = cause.source();
+    }
+    out
+}

--- a/app/ferroehr/tests/it/service_dump_load.rs
+++ b/app/ferroehr/tests/it/service_dump_load.rs
@@ -53,7 +53,7 @@ use ferroehr::service::FerroEhrService;
 use crate::admin_fixture::{
     archive_dir, count_for_ehr, repository, seed_full_ehr, truncate_to_half,
 };
-use crate::fixtures::{change_type, committer, composition, uid, uv};
+use crate::fixtures::{change_type, committer, composition, source_chain, uid, uv};
 use crate::typed_body::typed;
 use ferroehr::service::admin::types::{
     CompressionFormat, DumpLoadFailReport, ExportFormat, ExportSpec,
@@ -891,7 +891,12 @@ async fn load_from_a_truncated_container_is_file_not_writable() {
         Some(ExportFormat::OpenehrCanonicalJson),
         Some(CompressionFormat::Zip),
     );
-    let reports = source.export_ehrs(dir.clone(), spec).await.expect("export");
+    // The export step has failed once under parallel suite load with the
+    // curated internal-database message (#3250); the chain names the cause.
+    let reports = source
+        .export_ehrs(dir.clone(), spec)
+        .await
+        .unwrap_or_else(|e| panic!("export: {}", source_chain(&e)));
     assert!(reports.is_empty());
 
     // Drop the ZIP central directory (the trailing bytes): the file still


### PR DESCRIPTION
Refs #3250

`service_dump_load::load_from_a_truncated_container_is_file_not_writable` failed once at its export step with the curated "internal database error" and nothing else to go on: `classify_sqlx` built a fresh `SmError` and let the `sqlx::Error` drop, so the SQLSTATE and driver text lived only on a trace record no test captures.

- The bridge attaches the driver error as the call status's `source` (`SmError::with_source`); the message, and therefore the wire body, is byte-identical. A downcast test pins that the source is the `sqlx::Error` itself rather than a wrapper, per the source-chain rule.
- `fixtures::source_chain` renders a cause chain outermost-first, and the export step of the flaky test panics with it, so the next recurrence names its cause in the report.

Measured while investigating: the shared testkit server runs `max_connections=200`; sampling `pg_stat_activity` every second through the full `ferroehr` suite at default parallelism (1 242 tests) peaked at 35 connections, and the suite passed three times in a row today, so connection exhaustion is not the cause and the failure has not reproduced. The issue stays open until the chain names it.

No changelog: an error's cause chain and a test's panic text are not user-visible behaviour.

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.
