### PR TITLE
fix(storage): a party's contacts, addresses, identities and capabilities decompose into node rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ workflow refuses a tag that has no matching section here.
 
 ### Added
 
+- **The storage-parity sweep reports rows an older release decomposed**
+  (#3273). A fifth `defect` value, `stale_decomposition`, on
+  `POST {base}/admin/integrity/verify` and its NDJSON stream: the rows
+  reassemble into exactly the stored document, so nothing is damaged, but they
+  are not the rows this version writes for it. The sweep now decomposes each
+  version's document a second time and compares, which is the only way that
+  case is visible; `POST {base}/admin/integrity/rebuild-nodes` repairs it like
+  any other finding. A release that changes how content is decomposed is
+  therefore an upgrade step an operator runs and verifies, instead of a shape
+  that waits for each object's next commit.
+
 - **Cohort queries across the pseudonymisation boundary** (#3159). A new
   `POST /query/cohort` runs an AQL query over a population selected in the
   demographic domain: a predicate from a deployment-declared allow-list
@@ -638,6 +649,24 @@ workflow refuses a tag that has no matching section here.
   audit rows rather than isolate them.
 
 ### Fixed
+
+- **A party's contacts, addresses, identities and capabilities are decomposed
+  into node rows** (#3273). `CONTACT`, `ADDRESS`, `PARTY_IDENTITY` and
+  `CAPABILITY` were stored inline on the party root, so nothing under them
+  carried a row and no row-level predicate could reach it — a cohort predicate
+  could only be bound to an archetype under the party's own `details`, never to
+  the address a party actually lives at. Each container now gets its own row,
+  along with the `ITEM_STRUCTURE` and `ELEMENT`s beneath it, and an archetyped
+  container scopes its own leaves. `openEHR-DEMOGRAPHIC-ADDRESS.address.v1` is
+  bindable in `[cohort.predicates]`; the served body is unchanged.
+
+  **Upgrade step.** After deploying this version, run the storage-parity sweep
+  (`POST {base}/admin/integrity/verify`). Every party version stored before it
+  reports the new `stale_decomposition` defect: the rows hold the right
+  content, in the shape the previous release wrote. Run the node rebuild once,
+  unscoped (`POST {base}/admin/integrity/rebuild-nodes`), and the next sweep is
+  clean. Until then a predicate bound to a container archetype matches a party
+  only from its next commit onward.
 
 - **Every documented least-privilege posture names a credential that can do
   what the page asks** (#3228). `db.migrate = "verify"` reads all five

--- a/app/ferroehr/assets/ferroehr.default.toml
+++ b/app/ferroehr/assets/ferroehr.default.toml
@@ -619,14 +619,13 @@ max_cohort_size = 100000
 # `age_band` is the birth_date predicate and the only one.
 #
 # The archetype must be one the node model actually decomposes into a row: the
-# party root, and any archetyped ITEM_TREE or CLUSTER under the party's
-# `details`. Content under `identities` and `contacts` is stored inline on the
-# party root and carries no row of its own, so it cannot be bound today. The
-# bindings below are EXAMPLES of the shape — a deployment names the archetypes
-# and at-codes its own templates produce.
+# party root, the CONTACT / ADDRESS / PARTY_IDENTITY / CAPABILITY containers
+# nested in it, and any archetyped ITEM_TREE or CLUSTER under any of their
+# `details`. The bindings below are EXAMPLES of the shape — a deployment names
+# the archetypes and at-codes its own templates produce.
 [cohort.predicates]
-#? city          = { archetype = "openEHR-DEMOGRAPHIC-CLUSTER.address.v1", node = "at0012", kind = "text" }
-#? postcode_area = { archetype = "openEHR-DEMOGRAPHIC-CLUSTER.address.v1", node = "at0014", kind = "text_prefix" }
+#? city          = { archetype = "openEHR-DEMOGRAPHIC-ADDRESS.address.v1", node = "at0012", kind = "text" }
+#? postcode_area = { archetype = "openEHR-DEMOGRAPHIC-ADDRESS.address.v1", node = "at0014", kind = "text_prefix" }
 #? sex           = { archetype = "openEHR-DEMOGRAPHIC-PERSON.person.v1", node = "at0017", kind = "coded" }
 #? age_band      = { archetype = "openEHR-DEMOGRAPHIC-PERSON.person.v1", node = "at0010", kind = "birth_date" }
 #? organisation  = { archetype = "openEHR-DEMOGRAPHIC-ORGANISATION.organisation.v1", node = "at0003", kind = "text" }

--- a/app/ferroehr/src/aql/sql/mod.rs
+++ b/app/ferroehr/src/aql/sql/mod.rs
@@ -28,11 +28,17 @@
 //! The builder references the `node`/`vo_version`/`ehr`/`audit` column
 //! vocabulary directly and encodes the nested-set, `sys_period` and
 //! `branch_number` semantics of the greenfield store;
-//! `analyze::is_structure_root` must stay in lockstep with
-//! `storage::codec::STRUCTURE_TYPES`, which the `emit-rm-model` generator
-//! enforces. The `column_vocab` unit test pins every column name the builder
-//! emits against `migrations/ehr/0001_baseline.sql`, so a schema rename surfaces
-//! as a failing test rather than a runtime SQL error.
+//! the planner's own structure-root notion is the RM model's
+//! ([`openehr_rm::v1_2::model::is_structure_root`], kept in lockstep with the
+//! vendored BMM by the `emit-rm-model` generator), which covers the clinical
+//! content every AQL scope reaches today.
+//! [`crate::storage::structure::is_structure_type`] is that set plus the
+//! demographic party roots and the containers nested in them, which no FROM
+//! class resolves to (`from::is_vo_root_type`).
+//!
+//! The `column_vocab` unit test pins every column name the builder emits
+//! against `migrations/ehr/0001_baseline.sql`, so a schema rename surfaces as a
+//! failing test rather than a runtime SQL error.
 
 mod expr;
 mod from;

--- a/app/ferroehr/src/service/admin/integrity/mod.rs
+++ b/app/ferroehr/src/service/admin/integrity/mod.rs
@@ -17,6 +17,12 @@
 //! and compares the result to the stored body, so a tampered or corrupt row in
 //! either copy becomes visible.
 //!
+//! Reassembly is only half of it. Rows written by an OLDER decomposition still
+//! reassemble into exactly their body: the same content, in a different shape.
+//! A version whose rows agree is therefore decomposed a second time from its
+//! body and the two row sets compared, which is what makes a release that
+//! changes the decomposition an upgrade step an operator can run and verify.
+//!
 //! It runs off the request path on an administrator's call and reads every
 //! stored version in both storage tiers. It never logs content; a mismatch is
 //! reported by identifier alone.
@@ -39,8 +45,9 @@ use crate::ids::VoId;
 use crate::service::FerroEhrService;
 use crate::service::error::ServiceError;
 use crate::service::status::SmError;
-use crate::storage::codec::reassemble;
+use crate::storage::codec::{decompose, reassemble};
 use crate::storage::node_repo::read_version_rows_all;
+use crate::storage::row::ReadRow;
 
 /// How many version rows one page of the sweep's cursor query returns.
 ///
@@ -93,7 +100,7 @@ impl StorageDomain {
     }
 }
 
-/// The way one stored version's two content copies disagree.
+/// What the sweep found wrong with one stored version's two content copies.
 ///
 /// NOTE: no openEHR spec governs storage mechanics — our own design/extension.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -109,6 +116,13 @@ pub enum StorageParityDefect {
     /// `master06-change_control_package.adoc` §Logical Deletion) and therefore
     /// stores no body, yet node rows exist for it.
     UnexpectedNodes,
+    /// The rows reassemble into exactly the stored body, but they are not the
+    /// rows the current decomposition writes for it: an older decomposition
+    /// produced them. The content is intact and every point read serves it
+    /// correctly; what is stale is the index over it, so a row-level predicate
+    /// bound to a part that now earns its own row does not reach this version
+    /// until its rows are rebuilt.
+    StaleDecomposition,
 }
 
 impl StorageParityDefect {
@@ -120,11 +134,12 @@ impl StorageParityDefect {
             Self::NodesMissing => "nodes_missing",
             Self::NodesUnreadable => "nodes_unreadable",
             Self::UnexpectedNodes => "unexpected_nodes",
+            Self::StaleDecomposition => "stale_decomposition",
         }
     }
 }
 
-/// One stored version whose two content copies disagree.
+/// One stored version whose two content copies did not pass the sweep.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StorageParityMismatch {
     /// Which domain's storage the version lives in.
@@ -136,7 +151,7 @@ pub struct StorageParityMismatch {
     /// The `vo_version.kind` discriminator (`COMPOSITION` / `EHR_STATUS` /
     /// `FOLDER` / a demographic PARTY class / …).
     pub kind: String,
-    /// How the two copies disagree.
+    /// What the sweep found wrong with the two copies.
     pub defect: StorageParityDefect,
 }
 
@@ -239,10 +254,46 @@ struct VersionKey {
     has_body: bool,
 }
 
+/// Whether one version's stored rows are the rows the current decomposition
+/// writes for its body.
+///
+/// Only asked of a version whose rows already reassemble into exactly that
+/// body, which is what makes the comparison well founded: decomposition and
+/// reassembly are inverses, so rows in the current shape are byte for byte
+/// what `decompose` returns, and any difference is a shape the codec no longer
+/// produces. Compared over every field the read row carries — the nested-set
+/// index, the materialized path, the fragment; the promoted query columns are
+/// derived from the fragment and the archetype chain, so rows agreeing on
+/// these agree on those.
+///
+/// A body that does not decompose at all is not current either: the codec
+/// would write no rows for it. The rebuild answers that case with a refusal
+/// naming the body, which is the honest outcome for a version whose two copies
+/// agree on content the codec can no longer index.
+fn rows_are_current(stored: &[ReadRow], body: &Value) -> bool {
+    let Ok(fresh) = decompose(body.clone()) else {
+        return false;
+    };
+    stored.len() == fresh.len()
+        && stored.iter().zip(&fresh).all(|(stored, fresh)| {
+            stored.num == fresh.num
+                && stored.num_cap == fresh.num_cap
+                && stored.parent_num == fresh.parent_num
+                && stored.path == fresh.path
+                && stored.data == fresh.data
+        })
+}
+
 impl FerroEhrService {
     /// Re-derives every stored version's content from its `node` rows and
     /// compares it to the materialized `vo_version.body`, reporting every
     /// disagreement.
+    ///
+    /// A version whose two copies agree is then decomposed once more from its
+    /// body, so rows carrying the right content in a shape an older
+    /// decomposition wrote are reported as
+    /// [`StorageParityDefect::StaleDecomposition`] rather than passed as
+    /// healthy.
     ///
     /// The sweep reads BOTH storage tiers (the `vo_version_all` / `node_all`
     /// union views), so archived content is checked like everything else. It
@@ -379,9 +430,16 @@ impl FerroEhrService {
                     (false, _, None) | (true, None, _) => None,
                     (true, Some(_), None) => Some(StorageParityDefect::NodesMissing),
                     (true, Some(_), Some(Err(_))) => Some(StorageParityDefect::NodesUnreadable),
-                    (true, Some(body), Some(Ok(value))) => {
-                        (&value != body).then_some(StorageParityDefect::ContentDiffers)
+                    (true, Some(body), Some(Ok(value))) if &value != body => {
+                        Some(StorageParityDefect::ContentDiffers)
                     }
+                    // The rows say what the body says. Whether they say it in
+                    // the shape this build writes is the second question, and
+                    // the only one that catches an older decomposition.
+                    (true, Some(body), Some(Ok(_))) => rows
+                        .get(&id)
+                        .is_some_and(|stored| !rows_are_current(stored, body))
+                        .then_some(StorageParityDefect::StaleDecomposition),
                 };
                 (key, defect)
             })
@@ -625,6 +683,10 @@ mod tests {
         assert_eq!(
             StorageParityDefect::UnexpectedNodes.as_str(),
             "unexpected_nodes"
+        );
+        assert_eq!(
+            StorageParityDefect::StaleDecomposition.as_str(),
+            "stale_decomposition"
         );
     }
 

--- a/app/ferroehr/src/service/admin/integrity/rebuild.rs
+++ b/app/ferroehr/src/service/admin/integrity/rebuild.rs
@@ -7,7 +7,14 @@
 //! NOTE: no openEHR spec governs storage mechanics — our own design/extension;
 //! the storage keeps a version's content twice, as `vo_version.body` and as the
 //! decomposed `node` rows, and the sweep ([`super`]) reports where the two
-//! disagree.
+//! disagree — in content, or in the shape the rows were decomposed into.
+//!
+//! Every defect the sweep reports is repaired the same way, because there is
+//! only one repair: the rows are written again from the body. That covers a
+//! [`StorageParityDefect::StaleDecomposition`] exactly as it covers damage,
+//! since writing the rows again is what re-decomposing an old shape into the
+//! current one takes. A release that changes the decomposition is therefore an
+//! upgrade an operator performs and verifies.
 //!
 //! Which copy is authoritative is not a choice this module makes, it is a
 //! property of the storage: `body` is the version's canonical serialized form,
@@ -53,7 +60,7 @@ use crate::storage::version_repo::tier;
 /// damaged store passes it.
 const MAX_REPORTED_RECORDS: usize = 1000;
 
-/// What happened to one damaged version the rebuild reached.
+/// What happened to one version the rebuild reached.
 ///
 /// NOTE: no openEHR spec governs storage mechanics — our own design/extension.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -97,7 +104,7 @@ pub struct NodeRebuildRecord {
     /// The `vo_version.kind` discriminator (`COMPOSITION` / `EHR_STATUS` /
     /// `FOLDER` / a demographic PARTY class / …).
     pub kind: String,
-    /// The disagreement the sweep found, which is what selected this version.
+    /// What the sweep found, which is what selected this version.
     pub defect: StorageParityDefect,
     /// What the rebuild did about it.
     pub outcome: NodeRebuildOutcome,
@@ -149,9 +156,12 @@ impl FerroEhrService {
     /// The scope is the sweep's own ([`StorageParityScope`]): the whole
     /// repository, one EHR, one versioned object, one version of it, or
     /// everything committed since an instant. Whatever the scope covers, only
-    /// the versions the sweep reports damaged are written — a clean version is
-    /// read and left alone, so running this over a healthy repository writes
-    /// nothing.
+    /// the versions the sweep reports are written — a clean version is read and
+    /// left alone, so running this over a healthy repository writes nothing.
+    /// That includes a version reported
+    /// [`StorageParityDefect::StaleDecomposition`], whose rows are intact but
+    /// in the shape an older decomposition wrote: writing them again from the
+    /// body is what brings it to the current one.
     ///
     /// Each version is repaired in its own transaction: the body is read under
     /// a row lock, decomposed, the old rows deleted, the new set inserted, and

--- a/app/ferroehr/src/storage/codec.rs
+++ b/app/ferroehr/src/storage/codec.rs
@@ -474,7 +474,8 @@ mod tests {
     /// A realistic PERSON with `identities` (each carrying a nested
     /// `details: ITEM_TREE` inside its `PARTY_IDENTITY`), `contacts` (with an
     /// `ADDRESS.details: ITEM_TREE`), a top-level `details: ITEM_TREE`,
-    /// `languages`, and `roles` refs.
+    /// `languages`, and `roles` refs. Every container carries an at-code, so
+    /// the archetyped-container case is a separate fixture.
     fn person() -> Value {
         json!({
             "_type": "PERSON",
@@ -582,28 +583,45 @@ mod tests {
         })
     }
 
+    /// A party's `identities`, `contacts`, `contacts.addresses` and the
+    /// `details` `ITEM_TREE` under each become rows of their own, exactly as
+    /// composition content does — the containers are archetypable structures
+    /// (RM demographic `master02-demographic_package.adoc` §Archetyping), so
+    /// leaving them inline would put their content out of reach of every
+    /// row-level predicate.
     #[test]
     fn person_round_trips_losslessly() {
         let original = person();
         let rows = decompose(original.clone()).unwrap();
-        // Only the top-level `details: ITEM_TREE` is a direct structure child,
-        // so it and its ELEMENT children are split out; the identities/contacts
-        // arrays (with their own nested ITEM_TREEs) stay inline in the PERSON
-        // fragment.
         assert_eq!(rows[0].rm_type, "PERSON");
-        assert!(
-            rows[0].data.get("identities").is_some(),
-            "identities inline"
+        for attribute in ["identities", "contacts", "details"] {
+            assert!(
+                rows[0].data.get(attribute).is_none(),
+                "{attribute} is pruned off the party root"
+            );
+        }
+        let paths: Vec<(&str, &str)> = rows
+            .iter()
+            .map(|r| (r.rm_type.as_str(), r.path.as_str()))
+            .collect();
+        assert_eq!(
+            paths,
+            vec![
+                ("PERSON", ""),
+                ("PARTY_IDENTITY", "identities0."),
+                ("ITEM_TREE", "identities0.details."),
+                ("ELEMENT", "identities0.details.items0."),
+                ("CONTACT", "contacts0."),
+                ("ADDRESS", "contacts0.addresses0."),
+                ("ITEM_TREE", "contacts0.addresses0.details."),
+                ("ELEMENT", "contacts0.addresses0.details.items0."),
+                ("ITEM_TREE", "details."),
+                ("ELEMENT", "details.items0."),
+            ]
         );
-        assert!(rows[0].data.get("contacts").is_some(), "contacts inline");
-        assert!(
-            rows[0].data.get("details").is_none(),
-            "top-level details pruned"
-        );
-        assert!(
-            rows.iter().any(|r| r.path == "details."),
-            "top-level ITEM_TREE promoted to its own node"
-        );
+        // Every container is at-coded here, so the whole tree is scoped by the
+        // PERSON root's own archetype id.
+        assert!(rows.iter().skip(1).all(|r| r.citem_num == Some(0)));
         assert_eq!(round_trip(&rows), original);
     }
 
@@ -611,12 +629,60 @@ mod tests {
     fn role_round_trips_losslessly() {
         let original = role();
         let rows = decompose(original.clone()).unwrap();
-        assert_eq!(rows[0].rm_type, "ROLE");
-        // performer + capabilities (with nested credentials ITEM_TREE) stay
-        // inline; ROLE has no direct structure child, so a single row.
-        assert_eq!(rows.len(), 1, "ROLE has no direct structure child");
-        assert!(rows[0].data.get("capabilities").is_some());
+        let paths: Vec<(&str, &str)> = rows
+            .iter()
+            .map(|r| (r.rm_type.as_str(), r.path.as_str()))
+            .collect();
+        assert_eq!(
+            paths,
+            vec![
+                ("ROLE", ""),
+                ("PARTY_IDENTITY", "identities0."),
+                ("ITEM_TREE", "identities0.details."),
+                ("CAPABILITY", "capabilities0."),
+                ("ITEM_TREE", "capabilities0.credentials."),
+                ("ELEMENT", "capabilities0.credentials.items0."),
+            ]
+        );
+        // `performer` is a PARTY_REF, not a structure: it stays on the root.
         assert!(rows[0].data.get("performer").is_some());
+        assert!(rows[0].data.get("capabilities").is_none());
+        assert_eq!(round_trip(&rows), original);
+    }
+
+    /// An archetyped container is the `citem` ancestor of its own subtree, so
+    /// an at-coded leaf under an `ADDRESS` is scoped by the ADDRESS archetype
+    /// rather than by the party root's.
+    #[test]
+    fn an_archetyped_address_scopes_its_own_leaves() {
+        let mut original = person();
+        original["contacts"][0]["addresses"][0]["archetype_node_id"] =
+            json!("openEHR-DEMOGRAPHIC-ADDRESS.address.v1");
+        let rows = decompose(original.clone()).unwrap();
+        let row = |path: &str| {
+            rows.iter()
+                .find(|r| r.path == path)
+                .unwrap_or_else(|| panic!("no row at {path}"))
+        };
+        let address = row("contacts0.addresses0.");
+        assert_eq!(
+            address.arch_concept.as_deref(),
+            Some("address"),
+            "the ADDRESS row carries the promoted subsumption columns"
+        );
+        assert_eq!(address.citem_num, Some(0), "scoped by the PERSON root");
+        for path in [
+            "contacts0.addresses0.details.",
+            "contacts0.addresses0.details.items0.",
+        ] {
+            assert_eq!(
+                row(path).citem_num,
+                Some(address.num),
+                "{path} is scoped by the ADDRESS"
+            );
+        }
+        // An at-coded sibling container keeps inheriting the party root.
+        assert_eq!(row("identities0.details.items0.").citem_num, Some(0));
         assert_eq!(round_trip(&rows), original);
     }
 

--- a/app/ferroehr/src/storage/mod.rs
+++ b/app/ferroehr/src/storage/mod.rs
@@ -21,7 +21,8 @@
 //!   lean read row shapes.
 //! - [`structure::is_structure_type`] / [`structure::is_versioned_root_type`] /
 //!   [`structure::archetype_parts`] — the decomposition granularity, delegated
-//!   to the BMM-generated RM model.
+//!   to the BMM-generated RM model plus the demographic delta (the party roots
+//!   and the containers nested in them).
 //! - [`error::StorageError`] plus the crate-internal `error::classify_sqlx` —
 //!   the error surface and the SQLSTATE to SM-status bridge.
 //! - [`promoted::PROMOTED_LEAVES`] — the `(rm_type, path)` to node-column

--- a/app/ferroehr/src/storage/structure.rs
+++ b/app/ferroehr/src/storage/structure.rs
@@ -9,10 +9,9 @@
 //! structure set is NOT hand-maintained here: it is delegated to the single
 //! BMM-generated oracle [`openehr_rm::v1_2::model::is_structure_root`], which the
 //! codegen keeps in lockstep with this codec — never a local duplicate
-//! constant. The only local addition is the five demographic **party roots**,
-//! which are versioned objects of their own but are deliberately outside the
-//! composition-content set (the RM model excludes the demographic LOCATABLE
-//! hierarchy, since a party is never composition content).
+//! constant. The local additions are the demographic types the RM model
+//! deliberately excludes (a party is never composition content): the five
+//! **party roots** and the four archetypable **containers** nested inside them.
 
 use openehr_base::prelude::ArchetypeId;
 
@@ -20,38 +19,56 @@ use openehr_base::prelude::ArchetypeId;
 /// standalone versioned object that reuses the `node`/`vo_version` machinery
 /// (with a NULL `ehr_id`), so it must be accepted as a decomposition root — yet
 /// it is intentionally NOT part of the composition-content structure set the RM
-/// model tracks. The demographic *container* classes nested inside a party
-/// (`PARTY_IDENTITY`, `CONTACT`, `ADDRESS`, `CAPABILITY`, `PARTY_RELATIONSHIP`)
-/// are NOT structure types: they are reached only through non-structure array
-/// attributes (`identities`, `contacts`, `relationships`, `capabilities`) and
-/// stay inline verbatim in the party's fragment (see the codec's
-/// `prune_children`), which is lossless and needs no per-container row.
+/// model tracks.
 /// (The delta is pinned against [`crate::versioning::Kind`] by
 /// `tests::demographic_party_roots_mirror_the_versioning_kinds` — the
 /// versioned-object domain is the owner of "which RM types are party roots";
 /// this list only records which of them the node codec also splits into rows.)
 const DEMOGRAPHIC_PARTY_ROOTS: [&str; 5] = ["PERSON", "ORGANISATION", "GROUP", "AGENT", "ROLE"];
 
+/// The four archetypable demographic **containers** nested inside a party,
+/// reached through its `identities`, `contacts`, `contacts.addresses` and
+/// `capabilities` attributes.
+///
+/// Each carries a `details`/`credentials` `ITEM_STRUCTURE` and is therefore "a
+/// completely archetypable structure" in its own right (RM demographic
+/// `master02-demographic_package.adoc` §Archetyping), so its content is
+/// decomposed exactly like composition content: the container gets a row, its
+/// `ITEM_TREE` and `ELEMENT` descendants get theirs, and a full archetype HRID
+/// on the container becomes the `citem_num` ancestor its at-coded leaves are
+/// scoped by. Leaving them inline on the party root put that content out of
+/// reach of every row-level predicate.
+///
+/// `PARTY_RELATIONSHIP` is deliberately absent: it is a versioned object of its
+/// own, and a relationship nested in a party's `relationships` list stays
+/// inline verbatim (see [`is_versioned_root_type`]).
+const DEMOGRAPHIC_CONTAINERS: [&str; 4] = ["CONTACT", "ADDRESS", "PARTY_IDENTITY", "CAPABILITY"];
+
 /// Whether an RM `_type` gets its own `node` row: the BMM-generated
-/// composition-content structure set, plus the demographic party roots.
+/// composition-content structure set, plus the demographic party roots and the
+/// demographic containers nested inside them.
 #[must_use]
 pub fn is_structure_type(rm_type: &str) -> bool {
     openehr_rm::v1_2::model::is_structure_root(rm_type)
         || DEMOGRAPHIC_PARTY_ROOTS.contains(&rm_type)
+        || DEMOGRAPHIC_CONTAINERS.contains(&rm_type)
 }
 
 /// Whether an RM `_type` may be the **root** of a versioned object handed to
 /// [`crate::storage::codec::decompose`].
 ///
-/// This is [`is_structure_type`] plus `PARTY_RELATIONSHIP`: a relationship is
-/// a standalone versioned object with its own `node`/`vo_version` rows, yet
-/// it is deliberately **not** a structure type for child-pruning purposes — a
-/// `PARTY_RELATIONSHIP` nested inside a party's `relationships` attribute
-/// must stay inline. Splitting the two predicates gives both behaviours from
-/// one codec.
+/// This is [`is_structure_type`] minus the demographic containers, plus
+/// `PARTY_RELATIONSHIP`. A container is decomposed into rows but is never a
+/// versioned object: only `PARTY` and its descendants are versioned in a
+/// demographic system (RM demographic `master02-demographic_package.adoc`
+/// §Versioning Semantics), alongside `PARTY_RELATIONSHIP` — which in turn is
+/// deliberately **not** a structure type, so a relationship nested inside a
+/// party's `relationships` attribute stays inline. Splitting the two predicates
+/// gives all three behaviours from one codec.
 #[must_use]
 pub fn is_versioned_root_type(rm_type: &str) -> bool {
-    is_structure_type(rm_type) || rm_type == crate::versioning::Kind::PartyRelationship.as_str()
+    (is_structure_type(rm_type) && !DEMOGRAPHIC_CONTAINERS.contains(&rm_type))
+        || rm_type == crate::versioning::Kind::PartyRelationship.as_str()
 }
 
 /// Parses a full archetype HRID `archetype_node_id` into its identifying parts.
@@ -119,31 +136,44 @@ mod tests {
         }
     }
 
+    /// The storage set = the RM-model structure set ⊎ the party roots ⊎ the
+    /// demographic containers, and the two additions are disjoint from the
+    /// model's own set (which excludes the demographic hierarchy).
+    ///
+    /// The containers earn a row because each carries an archetypable
+    /// `ITEM_STRUCTURE` (RM demographic `master02-demographic_package.adoc`
+    /// §Archetyping); they are still never versioned objects, because only
+    /// `PARTY` and its descendants are (§Versioning Semantics), so
+    /// [`is_versioned_root_type`] excludes them again.
     #[test]
-    fn party_roots_are_the_only_delta_from_the_rm_model() {
-        // The storage set = the RM-model structure set ⊎ the party roots, and
-        // nothing else diverges: a party root is NOT in the RM model's set (the
-        // model excludes the demographic hierarchy), confirming the split.
-        for t in DEMOGRAPHIC_PARTY_ROOTS {
+    fn party_roots_and_containers_are_the_storage_delta_from_the_rm_model() {
+        for t in DEMOGRAPHIC_PARTY_ROOTS
+            .iter()
+            .chain(&DEMOGRAPHIC_CONTAINERS)
+        {
             assert!(
                 !openehr_rm::v1_2::model::is_structure_root(t),
                 "{t} unexpectedly in the RM-model structure set"
+            );
+            assert!(is_structure_type(t), "{t} must get its own node row");
+        }
+        for t in DEMOGRAPHIC_PARTY_ROOTS {
+            assert!(is_versioned_root_type(t), "{t} is a versioned object");
+        }
+        for t in DEMOGRAPHIC_CONTAINERS {
+            assert!(
+                !is_versioned_root_type(t),
+                "{t} is decomposed but never a versioned object"
             );
         }
     }
 
     #[test]
-    fn demographic_containers_are_not_structure_types() {
-        for t in [
-            "PARTY_IDENTITY",
-            "CONTACT",
-            "ADDRESS",
-            "CAPABILITY",
-            "PARTY_RELATIONSHIP",
-        ] {
-            assert!(!is_structure_type(t), "{t} must stay inline");
-        }
-        // …though a PARTY_RELATIONSHIP is still a valid versioned-object root.
+    fn a_nested_relationship_stays_inline_and_is_still_a_versioned_root() {
+        assert!(
+            !is_structure_type("PARTY_RELATIONSHIP"),
+            "a relationship nested in a party's `relationships` stays inline"
+        );
         assert!(is_versioned_root_type("PARTY_RELATIONSHIP"));
     }
 

--- a/app/ferroehr/tests/it/cohort_query.rs
+++ b/app/ferroehr/tests/it/cohort_query.rs
@@ -34,11 +34,16 @@ use ferroehr::service::linkage::cohort::{CohortError, CohortPredicate, CohortQue
 
 use crate::fixtures::{composition, uv};
 
-/// The address CLUSTER archetype the city and postcode predicates bind to: a
-/// CLUSTER under the party's `details`, which the node codec decomposes into
-/// its own row, so its ELEMENT children's nearest archetyped ancestor is the
-/// CLUSTER rather than the party root.
-const ADDRESS_ARCHETYPE: &str = "openEHR-DEMOGRAPHIC-CLUSTER.address.v1";
+/// The archetype of the `ADDRESS` under the party's `contacts`, which the
+/// `city` predicate binds to. A demographic container is decomposed into its
+/// own row like composition content (`ferroehr::storage::structure`), so an
+/// archetyped ADDRESS is the nearest archetyped ancestor of the ELEMENTs in its
+/// `details`.
+const CONTACT_ADDRESS_ARCHETYPE: &str = "openEHR-DEMOGRAPHIC-ADDRESS.address.v1";
+/// The address CLUSTER archetype the postcode predicate binds to: a CLUSTER
+/// under the party's `details`, so its ELEMENT children's nearest archetyped
+/// ancestor is the CLUSTER rather than the party root.
+const ADDRESS_CLUSTER_ARCHETYPE: &str = "openEHR-DEMOGRAPHIC-CLUSTER.address.v1";
 /// The person archetype the sex and age-band predicates bind to: those leaves
 /// sit under a plain at-coded `details` `ITEM_TREE`, so their nearest archetyped
 /// ancestor is the PERSON root itself. Exercising both shapes is the point —
@@ -58,11 +63,15 @@ fn cohort_config(small_cell_threshold: u32) -> CohortConfig {
         predicates: BTreeMap::from([
             (
                 "city".to_owned(),
-                text(ADDRESS_ARCHETYPE, "at0012", PredicateKind::Text),
+                text(CONTACT_ADDRESS_ARCHETYPE, "at0012", PredicateKind::Text),
             ),
             (
                 "postcode_area".to_owned(),
-                text(ADDRESS_ARCHETYPE, "at0014", PredicateKind::TextPrefix),
+                text(
+                    ADDRESS_CLUSTER_ARCHETYPE,
+                    "at0014",
+                    PredicateKind::TextPrefix,
+                ),
             ),
             (
                 "sex".to_owned(),
@@ -78,15 +87,19 @@ fn cohort_config(small_cell_threshold: u32) -> CohortConfig {
 
 /// A PERSON carrying the four selectable leaves.
 ///
-/// Two ancestor shapes on purpose. The party's `details` `ITEM_TREE` carries a
-/// plain at-code, so the `sex` and birth-date ELEMENTs' nearest archetyped
-/// ancestor row is the PERSON root; the address leaves sit under a CLUSTER that
-/// carries a full archetype HRID, so theirs is that CLUSTER. Both are what the
-/// predicate statement joins on (`node.citem_num` — the nearest ancestor row
-/// carrying an archetype id, `ferroehr::storage::codec`).
+/// Three ancestor shapes on purpose. The party's `details` `ITEM_TREE` carries
+/// a plain at-code, so the `sex` and birth-date ELEMENTs' nearest archetyped
+/// ancestor row is the PERSON root; the postcode sits under a CLUSTER carrying
+/// a full archetype HRID, so its ancestor is that CLUSTER; the city sits in the
+/// `details` of an archetyped `ADDRESS` under `contacts`, so its ancestor is
+/// the ADDRESS row. All three are what the predicate statement joins on
+/// (`node.citem_num` — the nearest ancestor row carrying an archetype id,
+/// `ferroehr::storage::codec`), and the third only exists because the
+/// demographic containers are decomposed into rows of their own.
 ///
-/// RM shapes: `PERSON` (`identities` 1..*, `details`), `ITEM_TREE`
-/// (`items`), `CLUSTER` (`items`), `ELEMENT` (`value`) — `openehr_rm::v1_2`.
+/// RM shapes: `PERSON` (`identities` 1..*, `contacts`, `details`), `CONTACT`
+/// (`addresses` 1..*), `ADDRESS` (`details`), `ITEM_TREE` (`items`), `CLUSTER`
+/// (`items`), `ELEMENT` (`value`) — `openehr_rm::v1_2`.
 fn person(name: &str, city: &str, postcode: &str, sex: &str, born: &str) -> Value {
     json!({
         "_type": "PERSON",
@@ -110,6 +123,30 @@ fn person(name: &str, city: &str, postcode: &str, sex: &str, born: &str) -> Valu
                     "value": { "_type": "DV_TEXT", "value": name }
                 }]
             }
+        }],
+        "contacts": [{
+            "_type": "CONTACT",
+            "archetype_node_id": "at0005",
+            "name": { "_type": "DV_TEXT", "value": "home" },
+            "addresses": [{
+                "_type": "ADDRESS",
+                "archetype_node_id": CONTACT_ADDRESS_ARCHETYPE,
+                "archetype_details": { "_type": "ARCHETYPED",
+                    "archetype_id": { "_type": "ARCHETYPE_ID", "value": CONTACT_ADDRESS_ARCHETYPE },
+                    "rm_version": "1.1.0" },
+                "name": { "_type": "DV_TEXT", "value": "postal" },
+                "details": {
+                    "_type": "ITEM_TREE",
+                    "archetype_node_id": "at0006",
+                    "name": { "_type": "DV_TEXT", "value": "address" },
+                    "items": [{
+                        "_type": "ELEMENT",
+                        "archetype_node_id": "at0012",
+                        "name": { "_type": "DV_TEXT", "value": "city" },
+                        "value": { "_type": "DV_TEXT", "value": city }
+                    }]
+                }
+            }]
         }],
         "details": {
             "_type": "ITEM_TREE",
@@ -137,18 +174,13 @@ fn person(name: &str, city: &str, postcode: &str, sex: &str, born: &str) -> Valu
                 },
                 {
                     "_type": "CLUSTER",
-                    "archetype_node_id": ADDRESS_ARCHETYPE,
+                    "archetype_node_id": ADDRESS_CLUSTER_ARCHETYPE,
                     "archetype_details": { "_type": "ARCHETYPED",
-                        "archetype_id": { "_type": "ARCHETYPE_ID", "value": ADDRESS_ARCHETYPE },
+                        "archetype_id": { "_type": "ARCHETYPE_ID",
+                            "value": ADDRESS_CLUSTER_ARCHETYPE },
                         "rm_version": "1.1.0" },
                     "name": { "_type": "DV_TEXT", "value": "address" },
                     "items": [
-                        {
-                            "_type": "ELEMENT",
-                            "archetype_node_id": "at0012",
-                            "name": { "_type": "DV_TEXT", "value": "city" },
-                            "value": { "_type": "DV_TEXT", "value": city }
-                        },
                         {
                             "_type": "ELEMENT",
                             "archetype_node_id": "at0014",

--- a/app/ferroehr/tests/it/storage_parity.rs
+++ b/app/ferroehr/tests/it/storage_parity.rs
@@ -26,17 +26,18 @@ use serde_json::Value;
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use ferroehr::ids::EhrId;
+use ferroehr::ids::{EhrId, VoId};
 use ferroehr::service::FerroEhrService;
 use ferroehr::service::admin::integrity::StorageDomain;
 use ferroehr::service::admin::integrity::rebuild::NodeRebuildOutcome;
 use ferroehr::service::admin::integrity::{
     StorageParityDefect, StorageParityEvent, StorageParityScope,
 };
+use ferroehr::storage::codec::reassemble;
+use ferroehr::storage::row::ReadRow;
 
 use crate::fixtures::{composition, folder, uv};
 
-/// A minimal *valid* root FOLDER (a folder-hierarchy root).
 /// An EHR carrying one committed COMPOSITION — three content versions in all
 /// (`EHR_STATUS`, `EHR_ACCESS`, the COMPOSITION), every one of which the sweep
 /// reads.
@@ -1011,4 +1012,284 @@ async fn a_damaged_party_is_rebuilt_and_reads_correctly_afterwards() {
     .await
     .expect("read the rebuilt name");
     assert_ne!(name, "tampered", "the corrupted value is gone");
+}
+
+// ── an older decomposition (#3273) ───────────────────────────────────────────
+//
+// Rows an older decomposition wrote are not damaged: they reassemble into
+// exactly their body. Only the second comparison — against the rows this build
+// would write — tells them apart from healthy ones, and the rebuild is the
+// upgrade step that brings them over.
+
+/// A PERSON whose contact address carries the leaf a row-level predicate binds
+/// to, plus a top-level `details` `ITEM_TREE` that was a row under the older
+/// decomposition too.
+///
+/// The contact subtree is what distinguishes the two shapes: `CONTACT`,
+/// `ADDRESS` and `PARTY_IDENTITY` earn their own rows now
+/// (`ferroehr::storage::structure`) and were inline on the party root before.
+///
+/// RM shapes: `PERSON` (`identities` 1..*, `contacts`, `details`), `CONTACT`
+/// (`addresses` 1..*), `ADDRESS` (`details`), `ITEM_TREE` (`items`), `ELEMENT`
+/// (`value`) — `openehr_rm::v1_2`.
+fn a_person_with_a_contact_address() -> Value {
+    serde_json::json!({
+        "_type": "PERSON",
+        "archetype_node_id": "openEHR-DEMOGRAPHIC-PERSON.person.v1",
+        "archetype_details": {
+            "_type": "ARCHETYPED",
+            "archetype_id": { "_type": "ARCHETYPE_ID", "value": "openEHR-DEMOGRAPHIC-PERSON.person.v1" },
+            "rm_version": "1.1.0"
+        },
+        "name": { "_type": "DV_TEXT", "value": "Ada Lovelace" },
+        "identities": [{
+            "_type": "PARTY_IDENTITY",
+            "archetype_node_id": "at0001",
+            "name": { "_type": "DV_TEXT", "value": "legal name" },
+            "details": {
+                "_type": "ITEM_TREE",
+                "archetype_node_id": "at0002",
+                "name": { "_type": "DV_TEXT", "value": "structure" },
+                "items": [{
+                    "_type": "ELEMENT",
+                    "archetype_node_id": "at0003",
+                    "name": { "_type": "DV_TEXT", "value": "family" },
+                    "value": { "_type": "DV_TEXT", "value": "Lovelace" }
+                }]
+            }
+        }],
+        "contacts": [{
+            "_type": "CONTACT",
+            "archetype_node_id": "at0005",
+            "name": { "_type": "DV_TEXT", "value": "home" },
+            "addresses": [{
+                "_type": "ADDRESS",
+                "archetype_node_id": "openEHR-DEMOGRAPHIC-ADDRESS.address.v1",
+                "archetype_details": {
+                    "_type": "ARCHETYPED",
+                    "archetype_id": { "_type": "ARCHETYPE_ID", "value": "openEHR-DEMOGRAPHIC-ADDRESS.address.v1" },
+                    "rm_version": "1.1.0"
+                },
+                "name": { "_type": "DV_TEXT", "value": "postal" },
+                "details": {
+                    "_type": "ITEM_TREE",
+                    "archetype_node_id": "at0006",
+                    "name": { "_type": "DV_TEXT", "value": "address" },
+                    "items": [{
+                        "_type": "ELEMENT",
+                        "archetype_node_id": "at0012",
+                        "name": { "_type": "DV_TEXT", "value": "city" },
+                        "value": { "_type": "DV_TEXT", "value": "Groningen" }
+                    }]
+                }
+            }]
+        }],
+        "details": {
+            "_type": "ITEM_TREE",
+            "archetype_node_id": "at0010",
+            "name": { "_type": "DV_TEXT", "value": "structure" },
+            "items": [{
+                "_type": "ELEMENT",
+                "archetype_node_id": "at0011",
+                "name": { "_type": "DV_TEXT", "value": "sex" },
+                "value": { "_type": "DV_TEXT", "value": "F" }
+            }]
+        }
+    })
+}
+
+/// Commit [`a_person_with_a_contact_address`] through the service seam, and
+/// return the versioned object plus the storage ordinal of its one version.
+async fn seed_contactable_party(svc: &FerroEhrService, pool: &PgPool) -> (VoId, i32) {
+    let vo_id = Box::pin(svc.create_party(uv(&a_person_with_a_contact_address(), "249", None)))
+        .await
+        .expect("create a person through the service seam");
+    let sys_version: i32 = sqlx::query_scalar(
+        "SELECT sys_version FROM demographic.vo_version WHERE vo_id = $1 \
+         ORDER BY sys_version DESC LIMIT 1",
+    )
+    .bind(vo_id.0)
+    .fetch_one(pool)
+    .await
+    .expect("the stored party version");
+    (vo_id, sys_version)
+}
+
+/// The stored `vo_version.body` of one demographic version, parsed.
+async fn stored_demographic_body(pool: &PgPool, vo_id: VoId, sys_version: i32) -> Value {
+    let text: String = sqlx::query_scalar(
+        "SELECT body FROM demographic.vo_version WHERE vo_id = $1 AND sys_version = $2",
+    )
+    .bind(vo_id.0)
+    .bind(sys_version)
+    .fetch_one(pool)
+    .await
+    .expect("the stored body");
+    serde_json::from_str(&text).expect("the stored body parses")
+}
+
+/// The stored node rows of one demographic version, in the read shape the
+/// codec reassembles from.
+async fn stored_demographic_rows(pool: &PgPool, vo_id: VoId, sys_version: i32) -> Vec<ReadRow> {
+    let rows: Vec<(i32, i32, i32, String, Value)> = sqlx::query_as(
+        "SELECT num, num_cap, parent_num, path, data FROM demographic.node \
+         WHERE vo_id = $1 AND sys_version = $2 ORDER BY num",
+    )
+    .bind(vo_id.0)
+    .bind(sys_version)
+    .fetch_all(pool)
+    .await
+    .expect("the stored node rows");
+    rows.into_iter()
+        .map(|(num, num_cap, parent_num, path, data)| ReadRow {
+            num,
+            num_cap,
+            parent_num,
+            path,
+            data,
+        })
+        .collect()
+}
+
+/// Rewrite one party version's rows into the shape the decomposition wrote
+/// before the demographic containers earned rows of their own: the
+/// `identities` and `contacts` subtrees inline on the party root, and only the
+/// top-level `details` `ITEM_STRUCTURE` split out.
+///
+/// The rewrite reaches past the service into the stored rows on purpose — an
+/// installation that upgrades has exactly these rows and no way to have
+/// written them through this build's commit path.
+async fn write_the_old_party_shape(pool: &PgPool, vo_id: VoId, sys_version: i32) {
+    let removed = sqlx::query(
+        "DELETE FROM demographic.node WHERE vo_id = $1 AND sys_version = $2 \
+         AND (path LIKE 'identities%' OR path LIKE 'contacts%')",
+    )
+    .bind(vo_id.0)
+    .bind(sys_version)
+    .execute(pool)
+    .await
+    .expect("drop the container rows")
+    .rows_affected();
+    assert!(
+        removed > 0,
+        "the fixture must actually remove the container rows, or it models nothing"
+    );
+
+    // The old root fragment is the body with its one structure child pruned,
+    // which is exactly what the pre-#3273 codec kept inline.
+    let inlined = sqlx::query(
+        "UPDATE demographic.node n SET data = (\
+           SELECT v.body::jsonb - 'details' FROM demographic.vo_version v \
+           WHERE v.vo_id = n.vo_id AND v.sys_version = n.sys_version) \
+         WHERE n.vo_id = $1 AND n.sys_version = $2 AND n.num = 0",
+    )
+    .bind(vo_id.0)
+    .bind(sys_version)
+    .execute(pool)
+    .await
+    .expect("inline the containers on the party root")
+    .rows_affected();
+    assert_eq!(inlined, 1, "the fixture must rewrite exactly the root row");
+}
+
+#[tokio::test]
+async fn a_stale_decomposition_is_reported_and_rebuilt() {
+    let db = testkit::db().await.expect("testkit database");
+    let pool = db.pool();
+    let svc = FerroEhrService::new(pool.clone());
+    let (vo_id, sys_version) = seed_contactable_party(&svc, &pool).await;
+    let served = svc.get_party(vo_id).await.expect("read the fresh party");
+
+    write_the_old_party_shape(&pool, vo_id, sys_version).await;
+
+    // The tampering really does model the older shape rather than damage: the
+    // rows still reassemble into exactly the body they were written from, so
+    // the only thing left to disagree about is their shape.
+    let body = stored_demographic_body(&pool, vo_id, sys_version).await;
+    let old_rows = stored_demographic_rows(&pool, vo_id, sys_version).await;
+    assert_eq!(
+        reassemble(&old_rows).expect("the old rows form one tree"),
+        body,
+        "an older decomposition carries the same content, which is why the \
+         reassembly comparison alone passes it as healthy"
+    );
+    assert!(
+        !old_rows.iter().any(|row| row.path.starts_with("contacts")),
+        "and it carries the contact subtree inline, out of reach of a row-level predicate"
+    );
+
+    let report = svc
+        .verify_storage_parity(StorageParityScope::default())
+        .await
+        .expect("sweep");
+    assert_eq!(
+        report.mismatch_count, 1,
+        "exactly the re-shaped version is reported: {report:?}"
+    );
+    let found = &report.mismatches[0];
+    assert_eq!(found.vo_id, vo_id.0);
+    assert_eq!(found.sys_version, sys_version);
+    assert_eq!(found.domain, StorageDomain::Demographic);
+    assert_eq!(found.defect, StorageParityDefect::StaleDecomposition);
+
+    let rebuild = svc
+        .rebuild_version_nodes(StorageParityScope::default())
+        .await
+        .expect("rebuild");
+    assert_eq!(rebuild.versions_rebuilt, 1, "{rebuild:?}");
+    assert_eq!(rebuild.versions_refused, 0);
+    assert_eq!(
+        rebuild.records[0].defect,
+        StorageParityDefect::StaleDecomposition,
+        "the sweep verdict that selected it is carried through"
+    );
+
+    let after = svc
+        .verify_storage_parity(StorageParityScope::default())
+        .await
+        .expect("sweep");
+    assert!(
+        after.is_clean(),
+        "one rebuild is the whole upgrade step: {after:?}"
+    );
+    let current_rows = stored_demographic_rows(&pool, vo_id, sys_version).await;
+    assert!(
+        current_rows
+            .iter()
+            .any(|row| row.path == "contacts0.addresses0."),
+        "the contact address is a row of its own now, so a predicate bound to \
+         its archetype reaches this version: {:?}",
+        current_rows.iter().map(|row| &row.path).collect::<Vec<_>>()
+    );
+
+    assert_eq!(
+        svc.get_party(vo_id).await.expect("read the repaired party"),
+        served,
+        "and the served body never moved: only the index over it did"
+    );
+}
+
+#[tokio::test]
+async fn a_freshly_committed_repository_reports_no_stale_decomposition() {
+    let db = testkit::db().await.expect("testkit database");
+    let pool = db.pool();
+    let svc = FerroEhrService::new(pool.clone());
+    seed_ehr_with_composition(&svc).await;
+    seed_contactable_party(&svc, &pool).await;
+
+    let report = svc
+        .verify_storage_parity(StorageParityScope::default())
+        .await
+        .expect("sweep");
+
+    assert!(
+        report.is_clean(),
+        "a clinical composition and a party written by this build are both \
+         already in the current shape, so the second comparison must find \
+         nothing: {report:?}"
+    );
+    assert!(
+        report.versions_checked >= 4,
+        "and both domains were actually read: {report:?}"
+    );
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,7 +108,10 @@ fresh** (the diagrammed deep-dive is the book's Storage architecture page,
 - **`demographic`** — the pseudonymisation domain: a relation-for-relation
   mirror of the clinical schema (built with `CREATE TABLE … LIKE`) holding the
   PARTY versioned objects and their change control, with its own
-  `cold_demographic` archival tier. Nothing selects a domain but the pool's
+  `cold_demographic` archival tier. A party body decomposes like clinical
+  content: the party root, each `PARTY_IDENTITY`, `CONTACT`, `ADDRESS` and
+  `CAPABILITY` nested in it, and the `ITEM_STRUCTURE` under each get their own
+  `node` row. Nothing selects a domain but the pool's
   `search_path`, so one set of storage code serves both; a CHECK on each side
   refuses the other's rows. Four `NOINHERIT` runtime roles
   (`ferroehr_ehr`, `ferroehr_demographic` and a read-only twin of each) hold

--- a/website/book/src/concepts/storage.md
+++ b/website/book/src/concepts/storage.md
@@ -212,6 +212,11 @@ verbatim** (the ITS-JSON encoding) with its structure children pruned out: no
 alias compaction, no synthetic fields, so what sits in `node.data` is
 byte-identical in shape to what the API serves. Storage equals wire.
 
+A party body decomposes the same way. The party root, each `PARTY_IDENTITY`,
+`CONTACT`, `ADDRESS` and `CAPABILITY` nested in it, and the `ITEM_STRUCTURE`
+under each get their own row, so a predicate over a contact address reaches it
+by the same interval join a clinical predicate uses.
+
 The tree shape is captured as a **nested-set interval**: nodes are numbered
 in pre-order (`num`, root = 0), and each row records the maximum number in
 its subtree (`num_cap`). "B is contained in A" is then the integer test

--- a/website/book/src/installation/config-privacy.md
+++ b/website/book/src/installation/config-privacy.md
@@ -283,7 +283,7 @@ small_cell_threshold = 5
 max_cohort_size = 100000
 
 [cohort.predicates]
-city = { archetype = "openEHR-DEMOGRAPHIC-CLUSTER.address.v1", node = "at0012", kind = "text" }
+city = { archetype = "openEHR-DEMOGRAPHIC-ADDRESS.address.v1", node = "at0012", kind = "text" }
 ```
 
 | Key | Type | Default | Description |
@@ -309,10 +309,10 @@ boot errors, because a mismatch would bind a predicate that matches nothing
 while reporting an empty cohort.
 
 **The archetype must be one the node model reaches.** A party is decomposed into
-its own rows for the party root and every archetyped `ITEM_TREE` or `CLUSTER`
-under its `details`. Content under `identities` and `contacts` — including an
-`ADDRESS` under a `CONTACT` — is stored inline on the party root and carries no
-row of its own, so it cannot be bound today.
+its own rows for the party root, for each `PARTY_IDENTITY`, `CONTACT`, `ADDRESS`
+and `CAPABILITY` nested in it, and for every archetyped `ITEM_TREE` or `CLUSTER`
+under any of their `details`. An `ADDRESS` under a `CONTACT` is therefore
+bindable like anything else.
 
 
 ## Interaction with the audit trail

--- a/website/book/src/operations-admin-apis.md
+++ b/website/book/src/operations-admin-apis.md
@@ -192,7 +192,9 @@ The sweep covers **both pseudonymisation domains**, clinical and demographic,
 in one pass. Every finding names the domain it came from, so a report can never
 describe half the store while looking like it described all of it. It re-derives
 every stored version from its decomposed rows and compares the result with the
-stored document. It reads the archived tier as well, takes
+stored document, then decomposes that document again and compares the rows it
+would write, which is what catches rows an older release left in a shape this
+one no longer produces. It reads the archived tier as well, takes
 no lock, and runs outside the request path of any clinical call, so it is safe
 to run on a live server. It is also a full scan of what it covers, so schedule
 it rather than calling it per request.
@@ -265,13 +267,18 @@ at all, gets the aggregated document below, unchanged.
 `domain` is `clinical` or `demographic`, naming the schema the damaged version
 lives in. It is also what the repair below uses to reach it.
 
-`defect` is one of four values:
+`defect` is one of five values:
 
 - `content_differs`: both copies exist and hold different content.
 - `nodes_missing`: the version has a stored document but no decomposed rows.
 - `nodes_unreadable`: the decomposed rows exist but no longer form one tree.
 - `unexpected_nodes`: the version is a logical delete, which stores no
   document, yet decomposed rows exist for it.
+- `stale_decomposition`: the rows hold exactly the stored document, but not in
+  the shape this version of the server decomposes it into. An older release
+  wrote them. The content is intact and every read serves it correctly; what is
+  stale is the index over it, so a query that depends on the current shape does
+  not reach this version until the repair below rewrites its rows.
 
 `mismatch_count` is the full count. `mismatches` is capped at 1000 entries and
 `truncated` says whether the cap was reached; every mismatch is logged at
@@ -328,6 +335,19 @@ happens in the primary tier.
 
 A logically deleted version stores no document, so it rebuilds to no rows,
 which is the repair for `unexpected_nodes`.
+
+The same route is the upgrade step after a release that changes how content is
+decomposed. Rows written by the older release hold the right content, so
+nothing is damaged, but they are the wrong shape for the new one and the sweep
+reports them `stale_decomposition`. Rebuilding writes them again from the
+stored document, which is all the upgrade is. Run it unscoped once and the next
+sweep is clean:
+
+```bash
+curl -s -X POST "$BASE/admin/integrity/rebuild-nodes"
+```
+
+The changelog names the affected object type at each such release.
 
 ```json
 {

--- a/website/book/src/signing/digest.md
+++ b/website/book/src/signing/digest.md
@@ -121,7 +121,7 @@ re-derives every stored version from its decomposed rows and reports any
 that no longer match the stored document. It is an admin route, it runs
 outside the request path, and it reports by identifier rather than by
 content. The [admin API reference](../operations-admin-apis.md#storage-integrity)
-documents the report and its four defect values.
+documents the report and its five defect values.
 
 ## Verification at read
 


### PR DESCRIPTION
Closes #3273

A party's `contacts[]`, `contacts[].addresses[]`, `identities[]` and a role's `capabilities[]` are now decomposed into their own `node` rows, with their `details` trees and ELEMENT leaves below them, exactly as clinical content decomposes. Until now the node codec kept them inline in the party root's `data` (the generated RM model marks `CONTACT`, `ADDRESS`, `PARTY_IDENTITY` and `CAPABILITY` as ordinary locatables, not structure roots), so no node-level predicate could reach an address or a legal name and the cohort allow-list of #3159 had to bind a `details`-level cluster.

## The decision, as recorded on the issue

The storage-side delta, not an emitter change: `storage::structure::is_structure_type` already extends the RM model's structure set with the five party roots as this CDR's own granularity; the four containers join that delta. The published `openehr-rm` crate keeps describing the RM. `is_versioned_root_type` is narrowed at the same time so a bare `ADDRESS` can still not be committed as a versioned object (RM demographic `master02` §Versioning Semantics: only `PARTY` and its descendants are versioned). No openEHR spec governs storage layout; our own design.

## The upgrade step is real, not a note

Existing party versions are stored in the old shape. The storage-parity sweep compared `reassemble(rows)` against the body, which the old rows still satisfy, so it would have reported them healthy and the rebuild would never have touched them; an address-bound cohort predicate would have under-selected on every pre-upgrade party silently. The sweep now also compares the stored rows against `decompose(body)` and reports a version that reassembles but differs as the new defect `stale_decomposition`; the node rebuild repairs it through its existing per-version path in whichever domain reported it. After deploying: run the sweep over the demographic domain, every pre-upgrade party reports `stale_decomposition`, run `POST /admin/integrity/rebuild-nodes` once, and the sweep is clean. The changelog and the admin-operations page say so; `versions_damaged` on the report keeps its wire name and now also counts these.

## Tests

Codec: the PERSON round trip pins the ten-row shape (root, identity, its tree and leaf, contact, address, its tree and leaf, the top-level tree and leaf) and the ROLE round trip its six rows, both lossless and order-independent; an archetyped `ADDRESS` scopes its own leaves through `citem_num` while an at-coded sibling's leaves inherit the root. Structure: the storage delta is exactly the nine demographic types, none a versioned root but the five parties. Parity: `a_stale_decomposition_is_reported_and_rebuilt` rewrites a stored party into the old shape by SQL, proves the tampering still reassembles (so it models a shape, not damage), and asserts one `stale_decomposition`, a rebuild of one version, a clean second sweep and an identical party read; a fresh repository reports nothing. Cohort: the fixture person's city lives under an archetyped `ADDRESS` and the `city` predicate binds to `openEHR-DEMOGRAPHIC-ADDRESS.address.v1`, so the address binding is exercised end to end while the `details`-level binding stays covered by `postcode_area`. The template, the `[cohort]` configuration page and the querying page drop the limitation.

## Verification

Workspace clippy, the slim server combos, the rustdoc gate with private items, the full `ferroehr`, `ferroehr-rest`, `ferroehr-server` and `ferroehr-ext` suites, `docs-claims`, `comment-style`, `default-style`, `typed-status`, the stale-numbers gate, `ehds-pages --check`, the privacy-boundary self-test, and `control-matrix.sh --check --closing`.

## Privacy boundary

- [x] The data flow is described above: what personal data this change reads, writes or exports, and where it goes (the same party bodies, decomposed into more rows of the same `demographic.node` table; nothing leaves the demographic domain)
- [x] The roles are named: which database roles and which caller roles reach that data (`ferroehr_demographic` and its reader, unchanged; the sweep and rebuild run as before per domain)
- [x] No new grant spans the clinical and demographic domains
- [x] Synthetic data only in tests, fixtures, seeds and examples
- [x] An access event is emitted wherever this change added a read of personal data (no new read path)

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.
