### PR TITLE
chore(harness,guards): bounded WebDriver commands, no swallowed driver errors, guards refuse unknown flags, and two record pointers

### DIFF
--- a/.claude/rules/kubernetes-helm.md
+++ b/.claude/rules/kubernetes-helm.md
@@ -26,7 +26,17 @@ That acceptance is now an INSTRUMENT rather than a habit:
 reads each answer from the layer that actually decides it — the container
 runtime's own spec for the security posture, the API server for admission, the
 EndpointSlice for readiness. Run it for any chart change with behavioural
-reach and quote the record (`docs/conformance/deployment/kubernetes.json`).
+reach and quote its record. The record is NOT in the tree: the harness writes
+`kubernetes.json` under `docs/conformance/deployment/`, which is gitignored
+there on purpose (a record measures ONE system under test, and a committed
+file would invite comparing runs that measured different images, overlays and
+profiles; the reasoning lives in `docs/conformance/deployment/README.md`). So a
+quoted record comes from exactly one of two places, and the quote says which:
+the artifact the CI job uploaded for a named run, or the local run you
+performed for this change. Either way, quote the SUT identification the
+harness prints beside it (the image reference and the overlays/profiles it
+drove); a record without its SUT is the failure the ignore exists to prevent,
+and a file left on disk by an earlier local run describes a different system.
 The `/k8s-test` skill stays the manual procedure for what the harness does not
 cover, and the harness declares those gaps in its own output.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,9 @@ bash scripts/ui-e2e.sh        # the browser journey battery against the composed
 bash scripts/deploy-probe.sh  # the DEPLOYMENT-conformance harness: brings a real stack up and probes observable
                               # behaviour at the FAR END (a blob in the bucket, the server's own effective config),
                               # each integration off / working / dependency-broken. Its report ends with what it did
-                              # NOT exercise — silence is never read as coverage. Record: docs/conformance/deployment/
+                              # NOT exercise — silence is never read as coverage. Record: the JSON the harness
+                              # writes under docs/conformance/deployment/ (gitignored: one SUT per record, see its
+                              # README) — read the CI artifact of a named run, or your own run, never a stale file.
 ```
 
 ### Target-dir & warm-build discipline (owner rules 2026-07-12, tightened 2026-07-16)

--- a/app/ferroehr-viewer/Cargo.toml
+++ b/app/ferroehr-viewer/Cargo.toml
@@ -175,7 +175,7 @@ tower.workspace = true
 # E2E journeys (tests/e2e_*.rs): Rust-native WebDriver + the async runtime;
 # the browser-console gate reads the browser log via thirtyfour's legacy-log API.
 thirtyfour.workspace = true
-tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time", "test-util"] }
 # The docs-shots journey seeds stored queries over the Definition API
 # directly (bypassing the UI) — a plain HTTP client for test setup. `form`
 # (test-only): the export journey re-posts the viewer's own

--- a/app/ferroehr-viewer/tests/it/common/mod.rs
+++ b/app/ferroehr-viewer/tests/it/common/mod.rs
@@ -28,6 +28,7 @@
               (.claude/rules/testing.md §Test-fixture construction)"
 )]
 
+use std::future::Future;
 use std::time::Duration;
 
 use thirtyfour::error::WebDriverErrorInner;
@@ -35,6 +36,14 @@ use thirtyfour::prelude::*;
 
 /// The budget every ordinary element wait allows.
 const WAIT: Duration = Duration::from_secs(15);
+
+/// The budget one steady-state `WebDriver` command gets ([`bounded`]).
+///
+/// Two thirds of [`WAIT`], so a command that never answers fails INSIDE the
+/// poll loop that issued it and still leaves that loop a third of its budget
+/// to report the failure — instead of running out thirtyfour's 120 s
+/// per-request default and inflating the whole journey.
+const COMMAND_BUDGET: Duration = Duration::from_secs(10);
 
 /// The budget [`Harness::wait_hydrated`] allows, four times [`WAIT`]: the host
 /// lane's debug WASM is ~91 MB and the browser has to fetch, compile and run it
@@ -95,10 +104,9 @@ impl Harness {
             .expect("caps");
         caps.set_logging_prefs("browser", thirtyfour::LoggingPrefsLogLevel::All)
             .expect("logging prefs");
-        // TODO(#3218): bound a stalled steady-state command. thirtyfour's
-        // request_timeout also covers NewSession, which exceeds a short budget
-        // under nextest parallelism, and the config carries no post-build
-        // setter, so the bound belongs on our own command awaits.
+        // NOTE: session creation keeps thirtyfour's own 120 s request timeout —
+        // a budget short enough for a steady-state command is exceeded here
+        // under nextest parallelism; those commands are bounded by `bounded`.
         let driver = WebDriver::builder(&webdriver_url, caps)
             .await
             .expect("webdriver session (is chromedriver up?)");
@@ -120,15 +128,11 @@ impl Harness {
         // is attributed to the page that produced it, not discovered by the
         // end-of-journey sweep with no locality (`get_log` drains, so the
         // final sweep still covers everything after the last navigation).
-        let leaving = self
-            .driver
-            .current_url()
+        let leaving = bounded("current_url()", self.driver.current_url())
             .await
             .map(|u| u.to_string())
             .unwrap_or_default();
-        let entries = self
-            .driver
-            .get_log("browser")
+        let entries = bounded("get_log(browser)", self.driver.get_log("browser"))
             .await
             .expect("browser log (chromedriver legacy endpoint)");
         let severe: Vec<String> = entries
@@ -142,8 +146,7 @@ impl Harness {
             "browser console has SEVERE entries on {leaving} (before navigating to {path}):\n{}",
             severe.join("\n")
         );
-        self.driver
-            .goto(format!("{}{path}", self.base))
+        bounded("goto()", self.driver.goto(format!("{}{path}", self.base)))
             .await
             .expect("navigate");
         // Every full navigation restarts hydration, and any first click or
@@ -170,12 +173,15 @@ impl Harness {
     /// # Panics
     /// When the element never appears — with the selector in the message.
     async fn wait_css_for(&self, css: &str, budget: Duration) -> WebElement {
-        match self
-            .driver
-            .query(By::Css(css))
-            .wait(budget, Duration::from_millis(200))
-            .first()
-            .await
+        match bounded_for(
+            &format!("query(css={css}).wait()"),
+            budget + COMMAND_BUDGET,
+            self.driver
+                .query(By::Css(css))
+                .wait(budget, Duration::from_millis(200))
+                .first(),
+        )
+        .await
         {
             Ok(element) => element,
             Err(e) => {
@@ -186,23 +192,26 @@ impl Harness {
                 // WASM module, after which no client-side navigation completes
                 // and the page only moves on a full reload. Without it a
                 // timeout reports a missing selector and hides its cause.
-                let url = self
-                    .driver
-                    .current_url()
+                let url = bounded("current_url()", self.driver.current_url())
                     .await
                     .map(|u| u.to_string())
                     .unwrap_or_default();
                 let path = format!("{}/{}-fail.png", self.shots_dir, self.journey);
-                drop(self.driver.screenshot(std::path::Path::new(&path)).await);
-                let console: Vec<String> = self
-                    .driver
-                    .get_log("browser")
-                    .await
-                    .unwrap_or_default()
-                    .into_iter()
-                    .filter(|entry| entry.level == "SEVERE")
-                    .map(|entry| entry.message)
-                    .collect();
+                drop(
+                    bounded(
+                        "screenshot()",
+                        self.driver.screenshot(std::path::Path::new(&path)),
+                    )
+                    .await,
+                );
+                let console: Vec<String> =
+                    bounded("get_log(browser)", self.driver.get_log("browser"))
+                        .await
+                        .unwrap_or_default()
+                        .into_iter()
+                        .filter(|entry| entry.level == "SEVERE")
+                        .map(|entry| entry.message)
+                        .collect();
                 let console = if console.is_empty() {
                     "  (no SEVERE console entries)".to_owned()
                 } else {
@@ -249,10 +258,9 @@ impl Harness {
             serde_json::json!({"profile.managed_default_content_settings.javascript": 2}),
         )
         .expect("prefs");
-        // TODO(#3218): bound a stalled steady-state command. thirtyfour's
-        // request_timeout also covers NewSession, which exceeds a short budget
-        // under nextest parallelism, and the config carries no post-build
-        // setter, so the bound belongs on our own command awaits.
+        // NOTE: session creation keeps thirtyfour's own 120 s request timeout —
+        // a budget short enough for a steady-state command is exceeded here
+        // under nextest parallelism; those commands are bounded by `bounded`.
         let driver = WebDriver::builder(&webdriver_url, caps)
             .await
             .expect("webdriver session (is chromedriver up?)");
@@ -271,13 +279,17 @@ impl Harness {
     /// When the URL still matches after 15 s.
     pub(crate) async fn wait_url_not_contains(&self, fragment: &str) {
         for _ in 0..75 {
-            let url = self.driver.current_url().await.expect("current url");
+            let url = bounded("current_url()", self.driver.current_url())
+                .await
+                .expect("current url");
             if !url.as_str().contains(fragment) {
                 return;
             }
             tokio::time::sleep(Duration::from_millis(200)).await;
         }
-        let url = self.driver.current_url().await.expect("current url");
+        let url = bounded("current_url()", self.driver.current_url())
+            .await
+            .expect("current url");
         panic!("URL still contains `{fragment}` (last: {url})");
     }
 
@@ -287,23 +299,30 @@ impl Harness {
     /// # Panics
     /// When the element never appears.
     pub(crate) async fn wait_xpath(&self, xpath: &str) -> WebElement {
-        match self
-            .driver
-            .query(By::XPath(xpath))
-            .wait(WAIT, Duration::from_millis(200))
-            .first()
-            .await
+        match bounded_for(
+            &format!("query(xpath={xpath}).wait()"),
+            WAIT + COMMAND_BUDGET,
+            self.driver
+                .query(By::XPath(xpath))
+                .wait(WAIT, Duration::from_millis(200))
+                .first(),
+        )
+        .await
         {
             Ok(element) => element,
             Err(e) => {
-                let url = self
-                    .driver
-                    .current_url()
+                let url = bounded("current_url()", self.driver.current_url())
                     .await
                     .map(|u| u.to_string())
                     .unwrap_or_default();
                 let path = format!("{}/{}-fail.png", self.shots_dir, self.journey);
-                drop(self.driver.screenshot(std::path::Path::new(&path)).await);
+                drop(
+                    bounded(
+                        "screenshot()",
+                        self.driver.screenshot(std::path::Path::new(&path)),
+                    )
+                    .await,
+                );
                 panic!("waiting for xpath `{xpath}` at {url}: {e}");
             }
         }
@@ -322,24 +341,31 @@ impl Harness {
     /// # Panics
     /// When the element never becomes clickable.
     pub(crate) async fn wait_clickable_xpath(&self, xpath: &str) -> WebElement {
-        match self
-            .driver
-            .query(By::XPath(xpath))
-            .and_clickable()
-            .wait(WAIT, Duration::from_millis(200))
-            .first()
-            .await
+        match bounded_for(
+            &format!("query(xpath={xpath}).and_clickable().wait()"),
+            WAIT + COMMAND_BUDGET,
+            self.driver
+                .query(By::XPath(xpath))
+                .and_clickable()
+                .wait(WAIT, Duration::from_millis(200))
+                .first(),
+        )
+        .await
         {
             Ok(element) => element,
             Err(e) => {
-                let url = self
-                    .driver
-                    .current_url()
+                let url = bounded("current_url()", self.driver.current_url())
                     .await
                     .map(|u| u.to_string())
                     .unwrap_or_default();
                 let path = format!("{}/{}-fail.png", self.shots_dir, self.journey);
-                drop(self.driver.screenshot(std::path::Path::new(&path)).await);
+                drop(
+                    bounded(
+                        "screenshot()",
+                        self.driver.screenshot(std::path::Path::new(&path)),
+                    )
+                    .await,
+                );
                 panic!("waiting for xpath `{xpath}` to become clickable at {url}: {e}");
             }
         }
@@ -363,7 +389,9 @@ impl Harness {
         let step = Duration::from_millis(200);
         let mut waited = Duration::ZERO;
         loop {
-            let url = self.driver.current_url().await.expect("current url");
+            let url = bounded("current_url()", self.driver.current_url())
+                .await
+                .expect("current url");
             if url.as_str().contains(fragment) {
                 return;
             }
@@ -381,15 +409,11 @@ impl Harness {
     /// an explicit condition, not a sleep). Toasts auto-dismiss; bounded wait.
     ///
     /// # Panics
-    /// When a toast is still visible after 15 s.
+    /// When a toast is still visible after 15 s, or when the `WebDriver` stops
+    /// answering — a stalled driver used to look exactly like a cleared screen.
     pub(crate) async fn wait_toasts_cleared(&self) {
         for _ in 0..75 {
-            let toasts = self
-                .driver
-                .find_all(By::Css(".thaw-toast-body"))
-                .await
-                .unwrap_or_default();
-            if toasts.is_empty() {
+            if count_matching(self, TOAST_CARD).await == 0 {
                 return;
             }
             tokio::time::sleep(Duration::from_millis(200)).await;
@@ -418,15 +442,21 @@ impl Harness {
     /// panics land there), and any visible message-bar text — returned as one
     /// line for the panic message.
     pub(crate) async fn evidence_dump(&self, slug: &str) -> String {
-        let url = self
-            .driver
-            .current_url()
+        let url = bounded("current_url()", self.driver.current_url())
             .await
             .map(|u| u.to_string())
             .unwrap_or_default();
         let path = format!("{}/{}-{slug}.png", self.shots_dir, self.journey);
-        drop(self.driver.screenshot(std::path::Path::new(&path)).await);
-        let entries = self.driver.get_log("browser").await.unwrap_or_default();
+        drop(
+            bounded(
+                "screenshot()",
+                self.driver.screenshot(std::path::Path::new(&path)),
+            )
+            .await,
+        );
+        let entries = bounded("get_log(browser)", self.driver.get_log("browser"))
+            .await
+            .unwrap_or_default();
         let mut severe = 0usize;
         for entry in &entries {
             if entry.level == "SEVERE" {
@@ -434,8 +464,17 @@ impl Harness {
             }
             println!("console[{}]: {}", entry.level, entry.message);
         }
-        let bar = match self.driver.find(By::Css(".thaw-message-bar")).await {
-            Ok(el) => el.text().await.unwrap_or_default(),
+        // Evidence gathering, so this one read stays best-effort: panicking
+        // here would destroy the report the caller is about to print.
+        let bar = match bounded(
+            "find(.thaw-message-bar)",
+            self.driver.find(By::Css(".thaw-message-bar")),
+        )
+        .await
+        {
+            Ok(el) => bounded("text(.thaw-message-bar)", el.text())
+                .await
+                .unwrap_or_default(),
             Err(_) => String::new(),
         };
         format!(
@@ -450,10 +489,12 @@ impl Harness {
     /// On capture/IO failure.
     pub(crate) async fn shot(&self, step: u8, slug: &str) {
         let path = format!("{}/{}-{step:02}-{slug}.png", self.shots_dir, self.journey);
-        self.driver
-            .screenshot(std::path::Path::new(&path))
-            .await
-            .expect("screenshot");
+        bounded(
+            "screenshot()",
+            self.driver.screenshot(std::path::Path::new(&path)),
+        )
+        .await
+        .expect("screenshot");
     }
 
     /// The standing browser-console gate: read the browser log (thirtyfour's
@@ -464,9 +505,7 @@ impl Harness {
     /// # Panics
     /// When the log contains a SEVERE entry not covered by `allowed`.
     pub(crate) async fn assert_console_clean(&self, allowed: &[&str]) {
-        let entries = self
-            .driver
-            .get_log("browser")
+        let entries = bounded("get_log(browser)", self.driver.get_log("browser"))
             .await
             .expect("browser log (chromedriver legacy endpoint)");
         let severe: Vec<String> = entries
@@ -475,9 +514,7 @@ impl Harness {
             .map(|e| format!("[ts={}] {}", e.timestamp, e.message))
             .filter(|m| !allowed.iter().any(|a| m.contains(a)))
             .collect();
-        let at = self
-            .driver
-            .current_url()
+        let at = bounded("current_url()", self.driver.current_url())
             .await
             .map(|u| u.to_string())
             .unwrap_or_default();
@@ -490,7 +527,52 @@ impl Harness {
 
     /// End the session (screenshots + console gate are per-journey calls).
     pub(crate) async fn finish(self) {
-        self.driver.quit().await.expect("quit");
+        bounded("quit()", self.driver.quit()).await.expect("quit");
+    }
+}
+
+/// Run one steady-state `WebDriver` command under [`COMMAND_BUDGET`].
+///
+/// thirtyfour bounds a request only by its 120 s per-request default, which
+/// outlasts every poll loop here: a driver that never answers reads as a page
+/// that never changed, and the journey reports an inflated run time instead of
+/// the stall. Bounding the await is ours to do — the transport cannot be
+/// bounded instead, because thirtyfour's `request_timeout` covers the
+/// `NewSession` request too, has no post-build setter, and a budget short
+/// enough for a steady-state command is exceeded by session creation under
+/// nextest parallelism (that is why [`Harness::start`] keeps the default).
+///
+/// A stall is reported as an ordinary command failure — a
+/// `WebDriverErrorInner::Timeout` naming the command and the budget — so every
+/// caller keeps the error path it already had: [`is_absence`] refuses it (a
+/// stall is never an absence) and the panic names the command, while an
+/// `expect`-based call site prints it verbatim.
+///
+/// A free function rather than a method: it needs nothing from the harness,
+/// and a plain unit test can then prove the bound without a browser session.
+async fn bounded<T>(
+    what: &str,
+    command: impl Future<Output = WebDriverResult<T>>,
+) -> WebDriverResult<T> {
+    bounded_for(what, COMMAND_BUDGET, command).await
+}
+
+/// [`bounded`] with an explicit budget, for thirtyfour's OWN polling queries.
+///
+/// `ElementQuery::wait` is a poll loop, not one command, so it is given its own
+/// budget plus [`COMMAND_BUDGET`]: the loop is designed to finish within its
+/// budget, and the grace is the one command it may be inside when the driver
+/// stops answering.
+async fn bounded_for<T>(
+    what: &str,
+    budget: Duration,
+    command: impl Future<Output = WebDriverResult<T>>,
+) -> WebDriverResult<T> {
+    match tokio::time::timeout(budget, command).await {
+        Ok(answer) => answer,
+        Err(_) => Err(WebDriverError::Timeout(format!(
+            "`{what}` did not answer within {budget:?} (the harness command budget)"
+        ))),
     }
 }
 
@@ -515,7 +597,7 @@ fn is_absence(error: &WebDriverError) -> bool {
 /// When the `WebDriver` answers with anything but an absence
 /// ([`is_absence`]): a failure to observe is never an observation of nothing.
 pub(crate) async fn is_present_by(h: &Harness, by: By) -> bool {
-    match h.driver.find(by.clone()).await {
+    match bounded(&format!("find({by:?})"), h.driver.find(by.clone())).await {
         Ok(_) => true,
         Err(error) if is_absence(&error) => false,
         Err(error) => panic!("the WebDriver could not answer `find({by:?})`: {error}"),
@@ -540,8 +622,9 @@ pub(crate) async fn is_present(h: &Harness, css: &str) -> bool {
 /// # Panics
 /// When the `WebDriver` answers with anything but an absence ([`is_absence`]).
 pub(crate) async fn is_visible(h: &Harness, css: &str) -> bool {
-    match h.driver.find(By::Css(css)).await {
-        Ok(element) => match element.is_displayed().await {
+    match bounded(&format!("find({css})"), h.driver.find(By::Css(css))).await {
+        Ok(element) => match bounded(&format!("is_displayed({css})"), element.is_displayed()).await
+        {
             Ok(displayed) => displayed,
             Err(error) if is_absence(&error) => false,
             Err(error) => {
@@ -561,13 +644,13 @@ pub(crate) async fn is_visible(h: &Harness, css: &str) -> bool {
 /// leaves a closed surface ahead of the open one in document order. "Is a
 /// modal up" has to look at all of them or it answers about the wrong one.
 pub(crate) async fn is_any_visible(h: &Harness, css: &str) -> bool {
-    let found = match h.driver.find_all(By::Css(css)).await {
+    let found = match bounded(&format!("find_all({css})"), h.driver.find_all(By::Css(css))).await {
         Ok(found) => found,
         Err(error) if is_absence(&error) => return false,
         Err(error) => panic!("the WebDriver could not answer `find_all({css})`: {error}"),
     };
     for element in found {
-        match element.is_displayed().await {
+        match bounded(&format!("is_displayed({css})"), element.is_displayed()).await {
             Ok(true) => return true,
             Ok(false) => {}
             Err(error) if is_absence(&error) => {}
@@ -607,11 +690,11 @@ const DIALOG_ENTERING: &str = ".thaw-dialog-surface.fade-in-scale-up-transition-
 pub(crate) async fn clear_dialog_overlay(h: &Harness) {
     if is_any_visible(h, DIALOG_SURFACE).await {
         drop(
-            h.driver
-                .action_chain()
-                .send_keys(Key::Escape)
-                .perform()
-                .await,
+            bounded(
+                "action_chain(Escape).perform()",
+                h.driver.action_chain().send_keys(Key::Escape).perform(),
+            )
+            .await,
         );
     }
     wait_hidden(h, DIALOG_BACKDROP).await;
@@ -643,7 +726,9 @@ pub(crate) async fn wait_dialog_settled(h: &Harness, control_css: &str) {
         }
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
-    let url = h.driver.current_url().await.expect("current url");
+    let url = bounded("current_url()", h.driver.current_url())
+        .await
+        .expect("current url");
     panic!("the dialog holding `{control_css}` never became open and settled (at {url})");
 }
 
@@ -755,22 +840,19 @@ async fn wait_upload_dispatched(h: &Harness, before: &UploadDialogState) {
 /// On any interaction failure, and when the submit click dispatches nothing.
 pub(crate) async fn upload_via_dialog(h: &Harness, path: &str) {
     clear_dialog_overlay(h).await;
-    h.wait_css("#template-upload-open")
-        .await
-        .click()
+    let open = h.wait_css("#template-upload-open").await;
+    bounded("click(#template-upload-open)", open.click())
         .await
         .expect("open the template upload dialog");
     wait_dialog_settled(h, UPLOAD_SUBMIT).await;
-    h.wait_css("#template-upload-picker input[type=file]")
-        .await
-        .send_keys(path)
+    let picker = h.wait_css("#template-upload-picker input[type=file]").await;
+    bounded("send_keys(#template-upload-picker)", picker.send_keys(path))
         .await
         .expect("choose the fixture through the dialog's hidden file input");
     wait_enabled(h, UPLOAD_SUBMIT).await;
     let before = UploadDialogState::read(h).await;
-    h.wait_css(UPLOAD_SUBMIT)
-        .await
-        .click()
+    let submit = h.wait_css(UPLOAD_SUBMIT).await;
+    bounded(&format!("click({UPLOAD_SUBMIT})"), submit.click())
         .await
         .expect("send the chosen template source");
     wait_upload_dispatched(h, &before).await;
@@ -781,8 +863,8 @@ pub(crate) async fn upload_via_dialog(h: &Harness, path: &str) {
 /// # Panics
 /// When the `WebDriver` answers with anything but an absence ([`is_absence`]).
 async fn read_enabled(h: &Harness, css: &str) -> Option<bool> {
-    match h.driver.find(By::Css(css)).await {
-        Ok(element) => match element.is_enabled().await {
+    match bounded(&format!("find({css})"), h.driver.find(By::Css(css))).await {
+        Ok(element) => match bounded(&format!("is_enabled({css})"), element.is_enabled()).await {
             Ok(enabled) => Some(enabled),
             Err(error) if is_absence(&error) => None,
             Err(error) => panic!("the WebDriver could not answer `is_enabled({css})`: {error}"),
@@ -798,8 +880,8 @@ async fn read_enabled(h: &Harness, css: &str) -> Option<bool> {
 /// # Panics
 /// When the `WebDriver` answers with anything but an absence ([`is_absence`]).
 async fn read_text(h: &Harness, css: &str) -> Option<String> {
-    match h.driver.find(By::Css(css)).await {
-        Ok(element) => match element.text().await {
+    match bounded(&format!("find({css})"), h.driver.find(By::Css(css))).await {
+        Ok(element) => match bounded(&format!("text({css})"), element.text()).await {
             Ok(text) => Some(text),
             Err(error) if is_absence(&error) => None,
             Err(error) => panic!("the WebDriver could not answer `text({css})`: {error}"),
@@ -814,7 +896,7 @@ async fn read_text(h: &Harness, css: &str) -> Option<String> {
 /// # Panics
 /// When the `WebDriver` answers with anything but an absence ([`is_absence`]).
 async fn count_matching(h: &Harness, css: &str) -> usize {
-    match h.driver.find_all(By::Css(css)).await {
+    match bounded(&format!("find_all({css})"), h.driver.find_all(By::Css(css))).await {
         Ok(found) => found.len(),
         Err(error) if is_absence(&error) => 0,
         Err(error) => panic!("the WebDriver could not answer `find_all({css})`: {error}"),
@@ -844,29 +926,32 @@ pub(crate) async fn wait_enabled(h: &Harness, css: &str) {
 /// Poll until no element matches `css` — the assert-gone half of a delete.
 ///
 /// # Panics
-/// When something still matches after [`WAIT`], with the page it was on.
+/// When something still matches after [`WAIT`], with the page it was on, or
+/// when the `WebDriver` answers with anything but an absence ([`is_absence`]).
 pub(crate) async fn wait_css_absent(h: &Harness, css: &str) {
     for _ in 0..75 {
-        if h.driver
-            .find_all(By::Css(css))
-            .await
-            .unwrap_or_default()
-            .is_empty()
-        {
+        if count_matching(h, css).await == 0 {
             return;
         }
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
-    let url = h.driver.current_url().await.expect("current url");
+    let url = bounded("current_url()", h.driver.current_url())
+        .await
+        .expect("current url");
     panic!("`{css}` never disappeared (at {url})");
 }
 
 /// Wait until some element's text contains `needle` (a toast title, a status
 /// line), returning whether it appeared.
+///
+/// # Panics
+/// When the `WebDriver` answers with anything but an absence ([`is_absence`]):
+/// "the page never said it" is a claim about the page, so it may only be made
+/// on an answer.
 pub(crate) async fn wait_text(h: &Harness, needle: &str) -> bool {
     let xpath = format!("//*[contains(normalize-space(.), '{needle}')]");
     for _ in 0..75 {
-        if h.driver.find(By::XPath(&xpath)).await.is_ok() {
+        if is_present_by(h, By::XPath(&xpath)).await {
             return true;
         }
         tokio::time::sleep(Duration::from_millis(200)).await;
@@ -879,13 +964,12 @@ pub(crate) async fn wait_text(h: &Harness, needle: &str) -> bool {
 /// sleep.
 ///
 /// # Panics
-/// When it never does within [`WAIT`], reporting what it said instead.
+/// When it never does within [`WAIT`], reporting what it said instead, or when
+/// the `WebDriver` answers with anything but an absence ([`is_absence`]).
 pub(crate) async fn wait_text_contains(h: &Harness, css: &str, fragment: &str) {
     let mut last = String::new();
     for _ in 0..75 {
-        if let Ok(element) = h.driver.find(By::Css(css)).await
-            && let Ok(text) = element.text().await
-        {
+        if let Some(text) = read_text(h, css).await {
             if text.contains(fragment) {
                 return;
             }
@@ -900,12 +984,13 @@ pub(crate) async fn wait_text_contains(h: &Harness, css: &str, fragment: &str) {
 /// number the screen must have caught up to).
 ///
 /// # Panics
-/// When it never does within [`WAIT`], reporting the last text seen.
+/// When it never does within [`WAIT`], reporting the last text seen, or when
+/// the `WebDriver` answers with anything but an absence ([`is_absence`]).
 pub(crate) async fn wait_text_suffix(h: &Harness, css: &str, suffix: &str) {
     let mut last = String::new();
     for _ in 0..75 {
-        if let Ok(element) = h.driver.find(By::Css(css)).await {
-            last = element.text().await.unwrap_or_default();
+        if let Some(text) = read_text(h, css).await {
+            last = text;
             if last.trim_end().ends_with(suffix) {
                 return;
             }
@@ -921,18 +1006,30 @@ pub(crate) async fn wait_text_suffix(h: &Harness, css: &str, suffix: &str) {
 /// On any interaction failure.
 pub(crate) async fn retype(h: &Harness, css: &str, text: &str) {
     let field = h.wait_css(css).await;
-    field.clear().await.expect("clear the field");
-    field.send_keys(text).await.expect("type into the field");
+    bounded(&format!("clear({css})"), field.clear())
+        .await
+        .expect("clear the field");
+    bounded(&format!("send_keys({css})"), field.send_keys(text))
+        .await
+        .expect("type into the field");
 }
 
 /// Click `css` until `target_css` shows up, returning whether it did (the
 /// pre-hydration-click precedent; re-clicking an "open this version" button is
 /// idempotent).
+///
+/// # Panics
+/// On a click failure, and when the `WebDriver` answers the probe with
+/// anything but an absence ([`is_absence`]) — five rounds of a dead driver
+/// would otherwise report "the target never appeared".
 pub(crate) async fn click_until_css(h: &Harness, css: &str, target_css: &str) -> bool {
     for _ in 0..5 {
-        h.wait_css(css).await.click().await.expect("click");
+        let button = h.wait_css(css).await;
+        bounded(&format!("click({css})"), button.click())
+            .await
+            .expect("click");
         for _ in 0..25 {
-            if h.driver.find(By::Css(target_css)).await.is_ok() {
+            if is_present(h, target_css).await {
                 return true;
             }
             tokio::time::sleep(Duration::from_millis(200)).await;
@@ -952,7 +1049,9 @@ pub(crate) async fn wait_hidden(h: &Harness, css: &str) {
         }
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
-    let url = h.driver.current_url().await.expect("current url");
+    let url = bounded("current_url()", h.driver.current_url())
+        .await
+        .expect("current url");
     panic!("`{css}` never hid (at {url})");
 }
 
@@ -970,7 +1069,9 @@ pub(crate) async fn wait_visible(h: &Harness, css: &str) {
         }
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
-    let url = h.driver.current_url().await.expect("current url");
+    let url = bounded("current_url()", h.driver.current_url())
+        .await
+        .expect("current url");
     panic!("`{css}` never became visible (at {url})");
 }
 
@@ -988,8 +1089,7 @@ pub(crate) async fn wait_visible(h: &Harness, css: &str) {
 /// On any interaction failure, or when the field is not empty afterwards.
 pub(crate) async fn clear_field(h: &Harness, css: &str) {
     let field = h.wait_css(css).await;
-    let held = field
-        .prop("value")
+    let held = bounded(&format!("prop({css}.value)"), field.prop("value"))
         .await
         .expect("read the field's value")
         .unwrap_or_default();
@@ -998,9 +1098,10 @@ pub(crate) async fn clear_field(h: &Harness, css: &str) {
         Key::Backspace.value(),
         held.chars().count(),
     ));
-    field.send_keys(keys).await.expect("erase the field");
-    let left = field
-        .prop("value")
+    bounded(&format!("send_keys({css})"), field.send_keys(keys))
+        .await
+        .expect("erase the field");
+    let left = bounded(&format!("prop({css}.value)"), field.prop("value"))
         .await
         .expect("read the field's value")
         .unwrap_or_default();
@@ -1017,14 +1118,16 @@ pub(crate) async fn clear_field(h: &Harness, css: &str) {
 /// re-rendering table detaches the handle between the find and the read, and
 /// `attr` then answers `stale element reference` — a retry, never a failure.
 pub(crate) async fn read_attr(h: &Harness, css: &str, attribute: &str) -> Option<String> {
-    h.driver
-        .find(By::Css(css))
+    let element = bounded(&format!("find({css})"), h.driver.find(By::Css(css)))
         .await
-        .ok()?
-        .attr(attribute)
-        .await
-        .ok()
-        .flatten()
+        .ok()?;
+    bounded(
+        &format!("attr({css}[{attribute}])"),
+        element.attr(attribute),
+    )
+    .await
+    .ok()
+    .flatten()
 }
 
 /// `attribute` of the first element matching `css`, waited for — the rendered
@@ -1039,7 +1142,9 @@ pub(crate) async fn wait_attr(h: &Harness, css: &str, attribute: &str) -> String
         }
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
-    let url = h.driver.current_url().await.expect("current url");
+    let url = bounded("current_url()", h.driver.current_url())
+        .await
+        .expect("current url");
     panic!("no element matched `{css}` with a readable `{attribute}` (at {url})");
 }
 
@@ -1066,7 +1171,9 @@ pub(crate) async fn wait_attr_change(
         }
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
-    let url = h.driver.current_url().await.expect("current url");
+    let url = bounded("current_url()", h.driver.current_url())
+        .await
+        .expect("current url");
     panic!("`{css}`'s `{attribute}` never moved off `{previous}` (at {url})");
 }
 
@@ -1097,7 +1204,9 @@ pub(crate) async fn confirm_in_dialog(h: &Harness, trigger_css: &str, confirm_id
         if attempt > 0 && is_any_visible(h, DIALOG_SURFACE).await {
             break;
         }
-        trigger.click().await.expect("open the confirmation dialog");
+        bounded(&format!("click({trigger_css})"), trigger.click())
+            .await
+            .expect("open the confirmation dialog");
         for _ in 0..10 {
             if is_visible(h, &confirm_css).await {
                 opened = true;
@@ -1119,9 +1228,8 @@ pub(crate) async fn confirm_in_dialog(h: &Harness, trigger_css: &str, confirm_id
     // transition, and a click landing mid-scale can miss the moving target
     // without the driver reporting anything (#3200).
     wait_dialog_settled(h, &confirm_css).await;
-    h.wait_css(&confirm_css)
-        .await
-        .click()
+    let confirm = h.wait_css(&confirm_css).await;
+    bounded(&format!("click({confirm_css})"), confirm.click())
         .await
         .expect("confirm in the dialog");
     // The dialog hides on confirm — that it hid proves the click landed. The
@@ -1152,14 +1260,12 @@ pub(crate) async fn login_basic_as(h: &Harness, user: &str, pass: &str) {
     let user = user.to_owned();
     let pass = pass.to_owned();
     h.goto("/login").await;
-    h.wait_css("#login-username")
-        .await
-        .send_keys(&user)
+    let username = h.wait_css("#login-username").await;
+    bounded("send_keys(#login-username)", username.send_keys(&user))
         .await
         .expect("type user");
-    h.wait_css("#login-password")
-        .await
-        .send_keys(&pass)
+    let password = h.wait_css("#login-password").await;
+    bounded("send_keys(#login-password)", password.send_keys(&pass))
         .await
         .expect("type pass");
     // Submit with a bounded retry: a click landing exactly while hydration
@@ -1168,15 +1274,12 @@ pub(crate) async fn login_basic_as(h: &Harness, user: &str, pass: &str) {
     // gets a short bounded wait; leaving /login ends the loop.
     let mut attempts = 0;
     loop {
-        h.wait_css("button[type=submit]")
-            .await
-            .click()
+        let submit = h.wait_css("button[type=submit]").await;
+        bounded("click(button[type=submit])", submit.click())
             .await
             .expect("submit");
         for _ in 0..15 {
-            if !h
-                .driver
-                .current_url()
+            if !bounded("current_url()", h.driver.current_url())
                 .await
                 .expect("current url")
                 .as_str()
@@ -1186,9 +1289,7 @@ pub(crate) async fn login_basic_as(h: &Harness, user: &str, pass: &str) {
             }
             tokio::time::sleep(Duration::from_millis(200)).await;
         }
-        let off_login = !h
-            .driver
-            .current_url()
+        let off_login = !bounded("current_url()", h.driver.current_url())
             .await
             .expect("current url")
             .as_str()
@@ -1199,8 +1300,16 @@ pub(crate) async fn login_basic_as(h: &Harness, user: &str, pass: &str) {
         attempts += 1;
         if attempts >= 3 {
             let path = format!("{}/{}-login-stuck.png", h.shots_dir, h.journey);
-            drop(h.driver.screenshot(std::path::Path::new(&path)).await);
-            let log = h.driver.get_log("browser").await.unwrap_or_default();
+            drop(
+                bounded(
+                    "screenshot()",
+                    h.driver.screenshot(std::path::Path::new(&path)),
+                )
+                .await,
+            );
+            let log = bounded("get_log(browser)", h.driver.get_log("browser"))
+                .await
+                .unwrap_or_default();
             for entry in &log {
                 println!("console[{}]: {}", entry.level, entry.message);
             }
@@ -1209,4 +1318,71 @@ pub(crate) async fn login_basic_as(h: &Harness, user: &str, pass: &str) {
     }
     // The shell footer is the authenticated-chrome marker.
     h.wait_css("footer").await;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use thirtyfour::error::WebDriverErrorInner;
+
+    use super::{COMMAND_BUDGET, WAIT, bounded, is_absence};
+
+    /// The bound is proven, not asserted: a command that never answers fails
+    /// within its budget, names itself, and is not read as an absence.
+    ///
+    /// Time is paused, so the runtime auto-advances the clock while the future
+    /// is idle — the measured elapsed is the virtual budget and the test
+    /// itself takes no wall time
+    /// (<https://docs.rs/tokio/latest/tokio/time/fn.pause.html>).
+    #[tokio::test(start_paused = true)]
+    async fn a_command_that_never_answers_fails_inside_the_poll_budget() {
+        let started = tokio::time::Instant::now();
+        let answer: Result<(), _> = bounded(
+            "find(.never-answers)",
+            std::future::pending::<Result<(), thirtyfour::error::WebDriverError>>(),
+        )
+        .await;
+
+        let error = answer.expect_err("a future that never resolves must not report success");
+        let elapsed = started.elapsed();
+        assert!(
+            matches!(error.as_inner(), WebDriverErrorInner::Timeout(_)),
+            "a stall is reported as a timeout, not as {error}"
+        );
+        assert!(
+            error.to_string().contains("find(.never-answers)"),
+            "the failure names the command it bounded: {error}"
+        );
+        assert!(
+            !is_absence(&error),
+            "a stall is never an absence — a probe must not read it as `not yet`"
+        );
+        assert_eq!(elapsed, COMMAND_BUDGET, "the bound is the command budget");
+        assert!(
+            elapsed < WAIT,
+            "the bound fires inside the poll budget that issued the command"
+        );
+    }
+
+    /// A command that answers is handed back untouched — the bound adds no
+    /// behaviour of its own to the ordinary path.
+    #[tokio::test(start_paused = true)]
+    async fn a_command_that_answers_passes_through_unchanged() {
+        let started = tokio::time::Instant::now();
+        let answer = bounded("current_url()", async {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            Ok::<_, thirtyfour::error::WebDriverError>("http://127.0.0.1:3000/login")
+        })
+        .await;
+
+        assert_eq!(
+            answer.expect("the command answered"),
+            "http://127.0.0.1:3000/login"
+        );
+        assert!(
+            started.elapsed() < COMMAND_BUDGET,
+            "an answered command returns as soon as it answers"
+        );
+    }
 }

--- a/corpus/archetypes/adl2/PROVENANCE.md
+++ b/corpus/archetypes/adl2/PROVENANCE.md
@@ -52,8 +52,13 @@ wrong on both counts and is corrected here (#3150). The wording appears to
 have been inherited from the CKM template pack, where a mixed CC-BY-SA
 population genuinely is what the files say.
 
-Whether a tree whose terms are unstated may stay committed is a separate
-decision, tracked on issue 3194; nothing here asserts that it may.
+Whether a tree whose terms are unstated may stay committed was decided by the
+Licensor on 2026-09-12 (issue 3194): the tree stays committed with this
+position stated. The material is the openEHR Foundation's own published test
+corpus, the use here is validating an ADL 1.4 to ADL 2 converter against it,
+and the records above claim no grant. No request for a licence statement was
+filed upstream; a downstream reader takes these files under the same unstated
+terms this record describes, not under any grant this repository makes.
 
 ## Contents
 

--- a/scripts/checks/access-provenance.sh
+++ b/scripts/checks/access-provenance.sh
@@ -20,8 +20,12 @@
 # Scope is the access layer plus its configuration, because that is where the
 # stale attribution lived and where a rationale is most load-bearing.
 #
-# Usage: scripts/checks/access-provenance.sh
+# Usage: scripts/checks/access-provenance.sh   (no arguments)
 set -euo pipefail
+
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_no_args "$@"
 cd "$(dirname "$0")/../.."
 
 PATHS=(

--- a/scripts/checks/advisory-exceptions.sh
+++ b/scripts/checks/advisory-exceptions.sh
@@ -20,7 +20,13 @@
 #
 # Mutation-proven in both directions: a bogus ignore fails the gate naming its
 # id, and removing it turns the gate green again.
+#
+# Usage: scripts/checks/advisory-exceptions.sh   (no arguments)
 set -euo pipefail
+
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_no_args "$@"
 cd "$(dirname "$0")/../.."
 
 for tool in cargo jq; do

--- a/scripts/checks/changelog-structure.sh
+++ b/scripts/checks/changelog-structure.sh
@@ -16,6 +16,10 @@
 # structural validity of the file).
 set -euo pipefail
 
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_known_flags "[<file>]" "" "$@"
+
 file="${1:-CHANGELOG.md}"
 
 # awk, not python: this repository ships no Python, and the check is a line scan

--- a/scripts/checks/chart-appversion.sh
+++ b/scripts/checks/chart-appversion.sh
@@ -38,13 +38,17 @@
 #      the package front page — restates the same appVersion. It is generated
 #      FROM Chart.yaml, so a disagreement means it was never regenerated.
 #
-# Usage: scripts/checks/chart-appversion.sh
+# Usage: scripts/checks/chart-appversion.sh   (no arguments)
 # Callers: the `chart-appversion` job in ci.yml, and the `plan` job of
 # release.yml (which re-runs the whole guard tier at the tagged commit; plan
 # separately asserts the tag equals the workspace version, so property 1 there
 # transitively pins appVersion == ${TAG#v}).
 
 set -euo pipefail
+
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_no_args "$@"
 cd "$(dirname "$0")/../.."
 
 CHART=deploy/helm/ferroehr/Chart.yaml

--- a/scripts/checks/ci-conclusion-complete.sh
+++ b/scripts/checks/ci-conclusion-complete.sh
@@ -20,6 +20,10 @@
 #   No args: the built-in table below. Args: explicit workflow/sink pairs.
 set -euo pipefail
 
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_known_flags "[<workflow> <sink>]..." "" "$@"
+
 cd "$(dirname "$0")/../.."
 
 check_graph() {

--- a/scripts/checks/codegen-drift.sh
+++ b/scripts/checks/codegen-drift.sh
@@ -8,7 +8,13 @@
 # a clean checkout must regenerate byte-identically. This guards against someone
 # hand-editing a `// @generated` file, or changing the emitter without
 # regenerating. Run in CI and locally before committing generator changes.
+#
+# Usage: scripts/checks/codegen-drift.sh   (no arguments)
 set -euo pipefail
+
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_no_args "$@"
 cd "$(dirname "$0")/../.."
 
 # Paths the emit targets own (and only those).

--- a/scripts/checks/compose-hardening.sh
+++ b/scripts/checks/compose-hardening.sh
@@ -29,8 +29,12 @@
 #      0.0.0.0 is DNAT'd ahead of the host firewall's chains, so `ufw deny` does
 #      not stop it (docs.docker.com/engine/network/packet-filtering-firewalls).
 #
-# Usage: scripts/checks/compose-hardening.sh
+# Usage: scripts/checks/compose-hardening.sh   (no arguments)
 set -euo pipefail
+
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_no_args "$@"
 cd "$(dirname "$0")/../.."
 
 # Every committed compose artifact: the root files plus the `services:`-bearing

--- a/scripts/checks/compose-image-tags.sh
+++ b/scripts/checks/compose-image-tags.sh
@@ -11,7 +11,13 @@
 # release). The hosted sandbox's compose file (deploy/hosted/docker-compose.yml)
 # deliberately tracks the `:latest` release pointer instead (#2974), so its
 # defaults are held to that pointer. Dependency-free: grep + sed only.
+#
+# Usage: scripts/checks/compose-image-tags.sh   (no arguments)
 set -Eeuo pipefail
+
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_no_args "$@"
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"

--- a/scripts/checks/conformance-numbers.sh
+++ b/scripts/checks/conformance-numbers.sh
@@ -8,7 +8,13 @@
 # scripts/render/conformance-stats.sh and scripts/render/perf-assets.sh) —
 # sources must carry only the data-cnf markers / {{#include}} directives / the
 # generated SVG assets, never literal numbers.
+#
+# Usage: scripts/checks/conformance-numbers.sh   (no arguments)
 set -euo pipefail
+
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_no_args "$@"
 cd "$(dirname "$0")/../.."
 
 # Three claim shapes are forbidden in website/landing + website/book/src +

--- a/scripts/checks/contribution-licence.sh
+++ b/scripts/checks/contribution-licence.sh
@@ -14,8 +14,12 @@
 # of their own (dependency and pin bumps); the workflow skips them by author
 # type before this script runs.
 #
-# Usage: PR_BODY="$body" scripts/checks/contribution-licence.sh
+# Usage: PR_BODY="$body" scripts/checks/contribution-licence.sh   (no arguments)
 set -euo pipefail
+
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_no_args "$@"
 
 readonly ACCEPTED='^[[:space:]]*[-*] \[[xX]\] I accept the terms in \[CONTRIBUTING\.md § Licensing of contributions\]'
 readonly UNTICKED='^[[:space:]]*[-*] \[ \] I accept the terms in \[CONTRIBUTING\.md § Licensing of contributions\]'

--- a/scripts/checks/copyright-holder.sh
+++ b/scripts/checks/copyright-holder.sh
@@ -16,7 +16,13 @@
 # NOT compared: `CITATION.cff` authors and `.zenodo.json` creators. Those record
 # AUTHORSHIP for citation, which is a different datum from the copyright holder
 # and is correctly a named person.
+#
+# Usage: scripts/checks/copyright-holder.sh   (no arguments)
 set -euo pipefail
+
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_no_args "$@"
 
 cd "$(dirname "$0")/../.."
 

--- a/scripts/checks/dashboard-drift.sh
+++ b/scripts/checks/dashboard-drift.sh
@@ -6,7 +6,13 @@
 # (downloadable with no repo checkout), so it inlines the same JSON with `$`
 # escaped as `$$` against compose interpolation. This guard holds the two
 # byte-identical (modulo that escaping); issue #2641.
+#
+# Usage: scripts/checks/dashboard-drift.sh   (no arguments)
 set -euo pipefail
+
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_no_args "$@"
 cd "$(dirname "$0")/../.."
 
 CANONICAL=deploy/helm/ferroehr/files/dashboards/ferroehr-overview.json

--- a/scripts/checks/default-style.sh
+++ b/scripts/checks/default-style.sh
@@ -36,6 +36,10 @@
 #   no args  → the files changed against origin/main
 #   --all    → every .rs file, tracked or untracked (unignored)
 set -euo pipefail
+
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_known_flags "[--all | <file>...]" "--all" "$@"
 cd "$(dirname "$0")/../.."
 
 # `Option::default` and `Vec::default` are std paths, not project helpers: they

--- a/scripts/checks/docs-claims.sh
+++ b/scripts/checks/docs-claims.sh
@@ -56,6 +56,10 @@
 #   --diff   → only the book files changed against [base] (default
 #              origin/main); the explicit opt-in for a scoped run
 set -euo pipefail
+
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_known_flags "[--all | --diff [base] | <file>...]" "--all --diff" "$@"
 cd "$(dirname "$0")/../.."
 
 BOOK=website/book/src

--- a/scripts/checks/error-hygiene.sh
+++ b/scripts/checks/error-hygiene.sh
@@ -33,8 +33,12 @@
 # e.to_string();`), interpolated more than two lines below the constructor, or
 # formatted inside a helper the constructor merely calls, passes it.
 #
-# Usage: scripts/checks/error-hygiene.sh
+# Usage: scripts/checks/error-hygiene.sh   (no arguments)
 set -euo pipefail
+
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_no_args "$@"
 cd "$(dirname "$0")/../.."
 
 # The guarded constructors — every spelling that renders a free-form string into

--- a/scripts/checks/error-source-chain.sh
+++ b/scripts/checks/error-source-chain.sh
@@ -25,8 +25,15 @@
 #
 # An entry added without one of those reasons makes this gate decoration.
 #
-# Usage: scripts/checks/error-source-chain.sh [--all]
+# Usage: scripts/checks/error-source-chain.sh   (no arguments)
+#
+# The whole tree is always counted — there is no narrower scope to ask for, so
+# there is no flag to pass.
 set -euo pipefail
+
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_no_args "$@"
 cd "$(dirname "$0")/../.." || exit 1
 
 # The sweep (#2034) is CLOSED: every remaining site below was judged and carries

--- a/scripts/checks/first-party-license-text.sh
+++ b/scripts/checks/first-party-license-text.sh
@@ -20,7 +20,13 @@
 # under terms recorded in each tree's PROVENANCE.md. Its licences are facts
 # about somebody else's work, and flagging them here would say this project
 # adopted them.
+#
+# Usage: scripts/checks/first-party-license-text.sh   (no arguments)
 set -euo pipefail
+
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_no_args "$@"
 
 cd "$(dirname "$0")/../.."
 

--- a/scripts/checks/hosted-deploy-script.sh
+++ b/scripts/checks/hosted-deploy-script.sh
@@ -29,6 +29,10 @@
 #   scripts/checks/hosted-deploy-script.sh --self-test
 set -euo pipefail
 
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_known_flags "[--self-test]" "--self-test" "$@"
+
 cd "$(dirname "$0")/../.."
 
 readonly CLOUD_INIT=deploy/hosted/cloud-init.yaml

--- a/scripts/checks/image-labels.sh
+++ b/scripts/checks/image-labels.sh
@@ -38,8 +38,12 @@
 #     since a Dockerfile cannot know them
 #   ref.name — deliberately unset; see the waiver below
 #
-# Usage: scripts/checks/image-labels.sh
+# Usage: scripts/checks/image-labels.sh   (no arguments)
 set -euo pipefail
+
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_no_args "$@"
 cd "$(dirname "$0")/../.."
 
 WORKFLOWS=".github/workflows/containers.yml

--- a/scripts/checks/ixit-declarations.sh
+++ b/scripts/checks/ixit-declarations.sh
@@ -35,6 +35,10 @@
 #   party-dir  a directory holding ixit.json (and optionally ixit-undeclared.json)
 
 set -euo pipefail
+
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_known_flags "[--schema PATH] <party-dir>..." "--schema" "$@"
 cd "$(dirname "$0")/../.."
 
 command -v jq >/dev/null || { echo "error: jq is required" >&2; exit 1; }

--- a/scripts/checks/licensing-declarations.sh
+++ b/scripts/checks/licensing-declarations.sh
@@ -27,7 +27,13 @@
 # What it deliberately does NOT check: whether the chapter's PROSE about a
 # licence is correct. No tool can judge that, and a check that pretended to
 # would be the kind of unenforced rule `.claude/rules/reliability.md` refuses.
+#
+# Usage: scripts/checks/licensing-declarations.sh   (no arguments)
 set -euo pipefail
+
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_no_args "$@"
 cd "$(dirname "$0")/../.."
 
 readonly REUSE_TOML='REUSE.toml'

--- a/scripts/checks/no-python.sh
+++ b/scripts/checks/no-python.sh
@@ -15,8 +15,12 @@
 # yq + jq under #2220, every assertion re-proven against the same mutations it
 # caught before.
 #
-# Usage: scripts/checks/no-python.sh
+# Usage: scripts/checks/no-python.sh   (no arguments)
 set -euo pipefail
+
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_no_args "$@"
 cd "$(dirname "$0")/../.." || exit 1
 
 # No file is exempt. If one ever has to be, it goes here WITH its tracking

--- a/scripts/checks/packaged-attribution.sh
+++ b/scripts/checks/packaged-attribution.sh
@@ -17,7 +17,13 @@
 #      in the packaged attribution file;
 #   2. that attribution file is itself in the crate's `include` list, so it
 #      actually reaches a consumer.
+#
+# Usage: scripts/checks/packaged-attribution.sh   (no arguments)
 set -euo pipefail
+
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_no_args "$@"
 
 cd "$(dirname "$0")/../.."
 

--- a/scripts/checks/packaged-includes.sh
+++ b/scripts/checks/packaged-includes.sh
@@ -16,7 +16,13 @@
 # list by eye. Every literal is resolved against the including file and must
 # land inside that list; a non-literal include is reported rather than assumed
 # safe, because this gate cannot evaluate it.
+#
+# Usage: scripts/checks/packaged-includes.sh   (no arguments)
 set -euo pipefail
+
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_no_args "$@"
 
 cd "$(dirname "$0")/../.."
 ROOT="$(pwd -P)"

--- a/scripts/checks/shellcheck-lane.sh
+++ b/scripts/checks/shellcheck-lane.sh
@@ -22,10 +22,20 @@
 # what covers `.githooks/commit-msg` — the one such program today — and covers
 # the next hook the day it lands rather than the day someone remembers.
 #
-# Usage: scripts/checks/shellcheck-lane.sh [<file>...]
+# Usage: scripts/checks/shellcheck-lane.sh [--all | <file>...]
 #   no args  → every tracked shell program outside the vendored trees
+#   --all    → the same scope, said explicitly
 #   <file>…  → just those files, at the same severity
+#
+# An unrecognised flag is a usage error (exit 2), refused by name before any
+# checking runs: forwarding it to shellcheck reported a wrong command line as a
+# lint finding, with this lane's own findings epilogue under it.
 set -euo pipefail
+
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_known_flags "[--all | <file>...]" "--all" "$@"
+
 cd "$(dirname "$0")/../.."
 
 # Vendored trees are upstream material, vendored verbatim by a
@@ -65,7 +75,13 @@ command -v shellcheck >/dev/null 2>&1 || {
 }
 
 count=$(printf '%s\n' "$files" | wc -l | tr -d ' ')
-if ! printf '%s\n' "$files" | xargs shellcheck --severity=style --format=gcc; then
+# `--external-sources` lets a `# shellcheck source=…` directive be FOLLOWED
+# rather than reported as SC1091: the guards source scripts/lib/*.sh, and a
+# sourced file that is merely announced teaches the checker nothing about the
+# functions it defines. Paths in those directives are repo-root-relative, which
+# is where this lane runs shellcheck from.
+if ! printf '%s\n' "$files" \
+  | xargs shellcheck --external-sources --severity=style --format=gcc; then
   echo >&2
   echo "shellcheck-lane: findings above. Fix each one, or — where the flagged" >&2
   echo "form is deliberate — add a '# shellcheck disable=SCnnnn' directive on" >&2

--- a/scripts/checks/spdx-headers-text.sh
+++ b/scripts/checks/spdx-headers-text.sh
@@ -29,6 +29,10 @@
 #   scripts/checks/spdx-headers-text.sh --fix    # insert missing headers
 set -euo pipefail
 
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_known_flags "[--fix]" "--fix" "$@"
+
 cd "$(dirname "$0")/../.."
 
 mode="${1:-}"

--- a/scripts/checks/spdx-headers.sh
+++ b/scripts/checks/spdx-headers.sh
@@ -33,6 +33,10 @@
 #   scripts/checks/spdx-headers.sh --fix    # insert missing headers (hand-written only)
 set -euo pipefail
 
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_known_flags "[--fix]" "--fix" "$@"
+
 cd "$(dirname "$0")/../.."
 
 # The expected tags below are DATA this gate compares against, not this file's

--- a/scripts/checks/spec-citations.sh
+++ b/scripts/checks/spec-citations.sh
@@ -20,6 +20,10 @@
 # Usage: spec-citations.sh [--all | <file>...]
 set -euo pipefail
 
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_known_flags "[--all | <file>...]" "--all" "$@"
+
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 cd "$repo_root"
 

--- a/scripts/checks/sql-string-building.sh
+++ b/scripts/checks/sql-string-building.sh
@@ -36,6 +36,10 @@
 #   no args  → the changed files that fall inside the scanned directories
 #   --all    → every tracked .rs file in those directories
 set -euo pipefail
+
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_known_flags "[--all | <file>...]" "--all" "$@"
 cd "$(dirname "$0")/../.."
 
 # The directories whose SQL is built at runtime. Everything else in the tree

--- a/scripts/checks/statement-version.sh
+++ b/scripts/checks/statement-version.sh
@@ -10,8 +10,12 @@
 # failing check that keeps them together. The ehrbase party statement is
 # deliberately NOT checked — it declares another vendor's product.
 #
-# Usage: scripts/checks/statement-version.sh
+# Usage: scripts/checks/statement-version.sh   (no arguments)
 set -euo pipefail
+
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_no_args "$@"
 cd "$(dirname "$0")/../.."
 
 workspace=$(grep -m1 '^version = "' Cargo.toml | sed 's/version = "\(.*\)"/\1/')

--- a/scripts/checks/typed-status.sh
+++ b/scripts/checks/typed-status.sh
@@ -42,6 +42,10 @@
 #   no args  → the files changed against origin/main
 #   --all    → every tracked .rs file
 set -euo pipefail
+
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_known_flags "[--all | --all-really | <file>...]" "--all --all-really" "$@"
 cd "$(dirname "$0")/../.."
 
 # `--all` covers the WHOLE tree. Both parked sweeps have landed: the runner

--- a/scripts/checks/vex-advisories.sh
+++ b/scripts/checks/vex-advisories.sh
@@ -23,7 +23,13 @@
 # upgrade resolves the advisory, at which point both are stale and both still
 # pass here. `scripts/checks/advisory-exceptions.sh` is that half, and it runs in
 # the cargo-deny job, which is where the graph is resolvable.
+#
+# Usage: scripts/checks/vex-advisories.sh   (no arguments)
 set -euo pipefail
+
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_no_args "$@"
 cd "$(dirname "$0")/../.."
 
 readonly OUT='security/vex/rust-advisories.openvex.json'

--- a/scripts/checks/vex-reachability.sh
+++ b/scripts/checks/vex-reachability.sh
@@ -48,7 +48,13 @@
 #
 # Mutation-proven in both directions: adding a carrier no graph edge supports
 # fails naming it, and removing a real one fails naming the unlisted path.
+#
+# Usage: scripts/checks/vex-reachability.sh   (no arguments)
 set -euo pipefail
+
+# shellcheck source=scripts/lib/guard-args.sh
+. "$(dirname "$0")/../lib/guard-args.sh"
+guard_no_args "$@"
 cd "$(dirname "$0")/../.."
 
 readonly DOC='security/vex/rust-advisories.openvex.json'

--- a/scripts/lib/guard-args.sh
+++ b/scripts/lib/guard-args.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Ruben Talstra
+# SPDX-License-Identifier: BUSL-1.1
+# The one refusal path every guard under scripts/checks/ shares.
+#
+# The guards are run by hand constantly and their flag vocabularies genuinely
+# differ (`--all`, `--diff <base> [head]`, `--files`, `--fix`, `--self-test`,
+# `--schema PATH`, named files, nothing at all). What must NOT differ is what
+# happens to a flag a guard does not know: it is refused by name, before any
+# checking runs, so a wrong command line can never be read as a finding.
+#
+# Deliberately two functions and no parser. Modelling six grammars in one
+# place would either force a false uniform vocabulary onto the guards or grow
+# into a configuration language; the duplication this removes is the refusal
+# and its message shape, which is the part that was inconsistent.
+#
+# Source it from a guard as:
+#
+#   # shellcheck source=scripts/lib/guard-args.sh
+#   . "$(dirname "$0")/../lib/guard-args.sh"
+#
+# Exit code 2 is the usage code every guard here already used, distinct from
+# 1 (findings) and 0 (clean), so a caller can tell the three apart.
+
+# Refuse the command line: print `usage: <script> <grammar>` and exit 2.
+# $1 = the accepted grammar, e.g. "[--all | --diff <base> [head]]".
+guard_usage() {
+  echo "usage: $0 $1" >&2
+  exit 2
+}
+
+# Refuse any argument at all, for a guard whose scope is fixed. Call it as
+# `guard_no_args "$@"` before the guard does any work.
+guard_no_args() {
+  [[ "$#" -eq 0 ]] || {
+    echo "error: $0 takes no arguments (got: $*)" >&2
+    guard_usage "(no arguments — this guard's scope is fixed)"
+  }
+}
+
+# Refuse any dash-led argument outside the guard's own vocabulary, for a guard
+# that also takes bare file paths. A wrong flag is then a usage error rather
+# than a filename the guard goes looking for.
+# $1 = the accepted grammar, $2 = the accepted flags (space-separated),
+# then "$@" of the caller.
+guard_known_flags() {
+  local grammar="$1" accepted=" $2 " arg
+  shift 2
+  for arg in "$@"; do
+    case "$arg" in
+    -*)
+      [[ "$accepted" == *" $arg "* ]] || {
+        echo "error: $0: unknown flag $arg" >&2
+        guard_usage "$grammar"
+      }
+      ;;
+    *) ;;
+    esac
+  done
+}


### PR DESCRIPTION
Closes #3217
Closes #3218
Closes #3227
Closes #3230
Closes #3194

Five v4.3.0 items with no user-visible behaviour (hence `no-changelog`; the viewer diff is `tests/` and a dev-dependency only, hence `no-ui-visual-change`).

- **#3218** Every steady-state WebDriver command the e2e harness issues runs under `bounded`, a 10 s budget (two thirds of the 15 s poll `WAIT`), so a driver that stalls fails inside the loop that issued it, naming the command, as a `WebDriverError::Timeout` the absence predicate does not accept. Session creation keeps thirtyfour's default, for the reason the issue records. Proven by two paused-clock unit tests (a never-answering future fails at exactly the budget and under `WAIT`; a resolving one passes through).
- **#3217** The three named probes and three more found by the sweep route through `is_absence`; the deliberate swallows are documented in place.
- **#3227** Every script under `scripts/checks/` refuses an unrecognised flag with `usage:` naming the script and exit 2 before any finding output, through `scripts/lib/guard-args.sh` (three functions: the refusal and its message shape are shared, each guard's accepted grammar stays its own, because the grammars genuinely differ). `shellcheck-lane.sh` parses its own flags first and follows `source=` directives. `error-source-chain.sh` documented an `--all` it never read; it now states it takes no arguments.
- **#3230** The two instructions that pointed at the gitignored deployment record now say where a record comes from (the CI artifact of a named run or the reader's own run), that the SUT identification the harness prints is quoted with it, and why the file is not in the tree; the grep for other rules naming the ignored paths found none.
- **#3194** The Licensor chose option 1: the ADL 2 corpus stays committed with its unstated-terms position recorded, no upstream request; `PROVENANCE.md` closes with that answer.

Gates: viewer clippy (`ssr`), viewer nextest (556), shellcheck lane, `comment-style --all`, `docs-claims`; every guard exercised once with a wrong flag and once normally.

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.
