### PR TITLE
fix(checks): the migration guard's self-test names its base branch instead of guessing main or master

### DIFF
--- a/scripts/checks/migration-immutability.sh
+++ b/scripts/checks/migration-immutability.sh
@@ -64,7 +64,10 @@ self_test() {
   trap "rm -rf '$tmp'" RETURN
   (
     cd "$tmp" || exit 1
-    git init -q .
+    # The base branch is NAMED, so the diff below does not guess at the
+    # machine's init.defaultBranch (#3285: a main/master fallback chained with
+    # `||` always ran the master diff and died on a checkout defaulting to main).
+    git init -q --initial-branch=base .
     git config user.email t@example.invalid
     git config user.name t
     mkdir -p "$MIGRATIONS/ehr"
@@ -79,8 +82,7 @@ self_test() {
     git add -A && git commit -qm work
   )
   local found
-  found="$(cd "$tmp" && git diff --name-status --diff-filter=MDRCT main work -- "$MIGRATIONS" 2>/dev/null \
-    || cd "$tmp" && git diff --name-status --diff-filter=MDRCT master work -- "$MIGRATIONS")"
+  found="$(cd "$tmp" && git diff --name-status --diff-filter=MDRCT base work -- "$MIGRATIONS")"
   local failures=0
   grep -q '0001_baseline.sql' <<<"$found" || { echo "self-test: a MODIFIED migration was not caught" >&2; failures=1; }
   grep -q '0002_second.sql' <<<"$found" || { echo "self-test: a DELETED migration was not caught" >&2; failures=1; }


### PR DESCRIPTION
Closes #3285

`self_test` created its temporary repository with `git init` and then diffed `main work` with a `|| … master work` fallback that the shell parsed as `(A || cd) && git diff … master work`, so the master diff always ran: on a checkout whose `init.defaultBranch` is `main` the self-test died with `fatal: bad revision 'master'` (exit 128), and it passed in CI only because the runner's git still defaults to `master`. The repository is now initialised with `--initial-branch=base` and the diff names `base work`; no guessing, the same on every machine. `bash scripts/checks/migration-immutability.sh --self-test` passes locally on a `main`-default machine. The guard's detection itself is unchanged.

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.
