### PR TITLE
chore(deploy): adopt FerroTERM 0.1.3's healthcheck: the CDR waits on service_healthy and the probe stops polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,9 @@ workflow refuses a tag that has no matching section here.
   which is the posture the SNOMED CT Affiliate Licence asks of a public system,
   and its dataset gains a composition whose coded text resolves through it. The
   deployment probe observes the overlay off, on and resolving, and the server
-  down under both fail postures.
+  down under both fail postures. FerroTERM is pinned at 0.1.3, whose image
+  carries its own `HEALTHCHECK` (`ferroterm healthcheck`), so both compose files
+  start the CDR only once the terminology server reports healthy (#3307).
 
 ## [4.2.2] - 2026-09-12
 

--- a/deploy/hosted/docker-compose.yml
+++ b/deploy/hosted/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       - "8080"
     depends_on:
       ferroterm:
-        condition: service_started
+        condition: service_healthy
 
   # FerroTERM, the terminology server, beside the CDR on the same box (#3304):
   # no ports, no Caddy route, viewer off. It is reachable as ferroterm:8080 on
@@ -79,9 +79,18 @@ services:
   # 702 MB resident); the 1536m cap also fits the Netherlands edition (889 MB).
   # The CDR's cap moved from 4096m to 3072m to make room on the 8 GB box.
   ferroterm:
-    image: ${FERROTERM_IMAGE:-ghcr.io/rubentalstra/ferroterm:0.1.2@sha256:9cc75a1321fad3dd419776ee3781eaa309a8eaecf22aa4be9a2ac2b68fc31b4b}
+    image: ${FERROTERM_IMAGE:-ghcr.io/rubentalstra/ferroterm:0.1.3@sha256:b1ef80382e03c2474bfec2ec57a698d83314e1290dd0cb5a2612ea208bde020c}
     container_name: ferroehr-sandbox-ferroterm
     restart: unless-stopped
+    # The image is its own health probe (`ferroterm healthcheck`, 0.1.3): no
+    # shell, no curl in the distroless base. Same cadence as the CDR's above;
+    # the start period covers loading a SNOMED CT edition.
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/ferroterm", "healthcheck"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
     deploy:
       resources:
         limits:

--- a/docker-compose.terminology.yml
+++ b/docker-compose.terminology.yml
@@ -53,8 +53,8 @@
 
 services:
   ferroterm:
-    # Digest-pinned FerroTERM 0.1.2 (resolved 2026-09-12); no `:latest`.
-    image: ghcr.io/rubentalstra/ferroterm:0.1.2@sha256:9cc75a1321fad3dd419776ee3781eaa309a8eaecf22aa4be9a2ac2b68fc31b4b
+    # Digest-pinned FerroTERM 0.1.3 (resolved 2026-09-12); no `:latest`.
+    image: ghcr.io/rubentalstra/ferroterm:0.1.3@sha256:b1ef80382e03c2474bfec2ec57a698d83314e1290dd0cb5a2612ea208bde020c
     environment:
       # The shaped seed, read straight out of the ferroehr image: the whole
       # image is mounted read-only at /image (a Compose `type: image` volume,
@@ -82,9 +82,19 @@ services:
         read_only: true
     ports:
       - "${FERROEHR_BIND_HOST:-127.0.0.1}:${FERROEHR_TERMINOLOGY_PORT:-8090}:8080"
+    # The image is its own health probe (`ferroterm healthcheck`, FerroTERM
+    # 0.1.3): the distroless base carries no shell and no HTTP client, so the
+    # binary sends the one GET /health itself and exits 0 on 200. The values
+    # restate the image's HEALTHCHECK, and the 60 s start period is for a large
+    # edition's load; `healthy` means the code systems are served.
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/ferroterm", "healthcheck"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
     # Distroless, uid 65532, writes nothing while serving: read-only root, every
-    # capability dropped. No HEALTHCHECK: the image has no shell or HTTP client;
-    # probe GET /health from outside.
+    # capability dropped.
     read_only: true
     cap_drop: [ALL]
     security_opt:
@@ -102,7 +112,7 @@ services:
   # never starts it. Same image; the release archive you hold a licence for is
   # mounted read-only and the index lands in the volume the server reads.
   ferroterm-build:
-    image: ghcr.io/rubentalstra/ferroterm:0.1.2@sha256:9cc75a1321fad3dd419776ee3781eaa309a8eaecf22aa4be9a2ac2b68fc31b4b
+    image: ghcr.io/rubentalstra/ferroterm:0.1.3@sha256:b1ef80382e03c2474bfec2ec57a698d83314e1290dd0cb5a2612ea208bde020c
     profiles: [terminology-build]
     entrypoint: ["/usr/local/bin/ferroterm-build"]
     command: ["--rf2", "/rf2/release.zip", "--out", "/data/index"]
@@ -130,10 +140,11 @@ services:
       FERROEHR__TERMINOLOGY__EXTERNAL__ENABLED: "true"
       FERROEHR__TERMINOLOGY__EXTERNAL__FAIL_ON_ERROR: ${FERROEHR__TERMINOLOGY__EXTERNAL__FAIL_ON_ERROR:-false}
     depends_on:
-      # No healthcheck to wait on (see above); the CDR's provider client has its
-      # own timeouts and the fail posture decides what an early request gets.
+      # The CDR starts once FerroTERM reports healthy, so the first binding a
+      # composition carries finds a serving terminology server; the fail posture
+      # above still decides what happens if it goes away later.
       ferroterm:
-        condition: service_started
+        condition: service_healthy
 
 volumes:
   ferroehr-ferroterm-index:

--- a/scripts/deploy-probes/terminology.sh
+++ b/scripts/deploy-probes/terminology.sh
@@ -191,8 +191,9 @@ TERM_FT_MEMBER="corpus/fixtures/composition/terminology_binding_sct_member.json"
 TERM_FT_NON_MEMBER="corpus/fixtures/composition/terminology_binding_sct_non_member.json"
 
 # The overlay stack: base file + overlay, the s3 profile the other families
-# assume, and ferroterm explicitly (it has no healthcheck, so --wait treats
-# running as ready).
+# assume, and ferroterm explicitly. `--wait` returns once FerroTERM's own
+# HEALTHCHECK (`ferroterm healthcheck`, 0.1.3) reports healthy and the CDR,
+# which depends on that, is healthy too; no host-side polling is needed.
 term_ft_up() {
   dc -f docker-compose.yml -f "$TERM_FT_OVERLAY" --profile s3 up -d --wait ferroehr ferroterm >/dev/null 2>&1
 }
@@ -239,13 +240,15 @@ probes_terminology_ferroterm() {
   probe_done
 
   probe "P-FT-UP" "working" "compose" "#3304" \
-    "the overlay starts FerroTERM and it answers its capability statement"
-  if ! term_ft_up || ! wait_http "http://localhost:${TERM_FT_PORT}/health" 60; then
-    probe_fail "a serving FerroTERM" "$(dc -f docker-compose.yml -f "$TERM_FT_OVERLAY" logs --tail 5 ferroterm 2>&1 | tail -3)" \
-      "the overlay must bring the terminology server up from the shaped seed alone"
+    "the overlay starts FerroTERM, waits on its own healthcheck, and it answers its capability statement"
+  if ! term_ft_up; then
+    probe_fail "a healthy FerroTERM and CDR from \`up --wait\`" "$(dc -f docker-compose.yml -f "$TERM_FT_OVERLAY" logs --tail 5 ferroterm 2>&1 | tail -3)" \
+      "the overlay must bring the terminology server up from the shaped seed alone, and its HEALTHCHECK must report it"
     probe_done
     return 0
   fi
+  assert_eq "200" "$(http_code "http://localhost:${TERM_FT_PORT}/health")" \
+    "the health route the image's own probe reads answers from the host too"
   local meta; meta="$(curl -s "http://localhost:${TERM_FT_PORT}/r4b/metadata?mode=terminology")"
   assert_contains "$meta" 'http://cnf.example.test/fhir/CodeSystem/sct-shaped' \
     "the shaped seed mounted out of the ferroehr image is what the server serves"

--- a/website/book/src/installation/compose.md
+++ b/website/book/src/installation/compose.md
@@ -284,7 +284,10 @@ curl 'http://localhost:8090/r4b/metadata?mode=terminology'
 
 It is an overlay rather than a profile for the same reason as the Keycloak and
 observability ones: enabling it has to change the CDR's environment, which a
-profile cannot do.
+profile cannot do. FerroTERM's image carries its own health probe (the binary's
+`healthcheck` subcommand, since the distroless image has no shell), and the CDR
+is declared to start only once that probe reports healthy, so `docker compose up
+--wait` returns with both serving.
 
 Out of the box FerroTERM serves the licence-free shaped seed this repository
 ships (two code systems and two value sets under the reserved `example.test`


### PR DESCRIPTION
Closes #3307

FerroTERM 0.1.3 (released today) ships `ferroterm healthcheck` and a `HEALTHCHECK` in its image (FerroTERM #565, filed from the sandbox work). This adopts it with no workaround left in place:

- **Pin**: `ghcr.io/rubentalstra/ferroterm:0.1.3@sha256:b1ef8038…` in `docker-compose.terminology.yml` (server and build services) and `deploy/hosted/docker-compose.yml`.
- **Health**: a `healthcheck:` block on the FerroTERM service in both files, restating the image's own command and cadence (`/usr/local/bin/ferroterm healthcheck`, 10 s interval in the overlay, 30 s on the sandbox like its neighbours, 5 s timeout, 3 retries, 60 s start period for a loaded edition).
- **Sequencing**: the CDR's `depends_on: ferroterm` is `condition: service_healthy` in both files; the "no healthcheck" comments are gone.
- **Probe**: `term_ft_up` relies on `up --wait`; `P-FT-UP` keeps one `GET /health` as the host-side capability check and drops the polling loop; the down states (`--no-deps`, "ferroterm not running") are unchanged.
- **Docs**: the compose page's overlay section says the CDR starts once FerroTERM reports healthy; the changelog's `[4.2.3]` entry (unpublished until the tag) names the pin and the sequencing.

Verified locally against the 4.2.2 images with the seed bound in: `up --wait` returned after 27 s with `ferroterm running healthy` (inspect shows the image's `HEALTHCHECK` test and `healthy`), the CDR started after it, `/health` answers 200 from the host, template 201, member 201, non-member 422, and with FerroTERM stopped and the CDR recreated with `--no-deps` FerroTERM stays `exited` and fail-open answers 201. Both compose stacks parse; `compose-hardening`, `hosted-deploy-script`, `docs-claims`, `changelog-structure` and shellcheck pass.

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.
