### PR TITLE
docs(terminology): the sandbox serves SNOMED CT International 20260901 and LOINC 2.83, with both licence notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ on the documentation site.
 - **Demographics:** a versioned party store (person, organisation, group,
   agent, role) with relationships
 - **Terminology:** the bundled openEHR terminology plus pluggable external
-  FHIR terminology servers (validate, expand, subsume)
+  FHIR terminology servers (validate, expand, subsume); FerroTERM, the Ferro
+  family's terminology server, ships with the quickstart as a compose overlay
 
 ### Integration
 

--- a/deploy/hosted/env.example
+++ b/deploy/hosted/env.example
@@ -23,14 +23,16 @@ FERROEHR_IMAGE=ghcr.io/rubentalstra/ferroehr:latest
 FERROEHR_VIEWER_IMAGE=ghcr.io/rubentalstra/ferroehr-viewer:latest
 
 # FerroTERM (#3304). Unset, the server serves the licence-free shaped seed it
-# mounts from the ferroehr image. The edition this sandbox loads is the SNOMED CT
-# International Edition: build its index off-box
-# (ferroterm-build --rf2 SnomedCT_InternationalRF2_<release>.zip --out <dir>;
-# the archive never comes to this box), copy <dir> to
-# /opt/ferroehr-sandbox/ferroterm-index (or FERROTERM_INDEX_DIR), and set
-# FERROTERM_INDEX=/data/index so the server opens it.
-# The release is licensed content: the Affiliate Licence, the clause 8.3.1
-# notice and the edition's version and date on the terminology page are the
-# operator's obligations, and the index never leaves this box.
+# mounts from the ferroehr image. The editions this sandbox loads are the SNOMED
+# CT International Edition and LOINC: build each index off-box
+# (ferroterm-build --rf2 SnomedCT_InternationalRF2_<release>.zip --out int;
+# the LOINC build per FerroTERM's loading page; no release archive ever comes
+# to this box), copy the directories under /opt/ferroehr-sandbox/ferroterm-index
+# (the compose file binds that directory at /data/index; FERROTERM_INDEX_DIR
+# names another), and list them in FERROTERM_INDEX, colon-separated, so the
+# server opens them. The releases are licensed content: the SNOMED CT Affiliate
+# Licence with its clause 8.3.1 notice, the LOINC licence with its short notice,
+# and each edition's version on the terminology page are the operator's
+# obligations, and the indexes never leave this box.
 # FERROTERM_INDEX_DIR=/opt/ferroehr-sandbox/ferroterm-index
-# FERROTERM_INDEX=/data/index
+# FERROTERM_INDEX=/data/index/int:/data/index/loinc

--- a/website/book/src/beyond-core/index.md
+++ b/website/book/src/beyond-core/index.md
@@ -78,7 +78,8 @@ for the exact list of settings a slim binary rejects.
   that mirrors the EHR APIs.
 - **[Terminology servers](terminology.md):** the bundled openEHR terminology
   for local codes, plus any number of external FHIR terminology servers for
-  validating coded values against external value sets.
+  validating coded values against external value sets; FerroTERM ships with the
+  quickstart as the terminology overlay and runs beside the sandbox CDR.
 - **[Subject Proxy](subject-proxy.md):** read facts about a subject
   ("date of birth", "latest blood pressure") through named variables backed by
   data frames: AQL against this CDR, reads from configured external FHIR

--- a/website/book/src/beyond-core/terminology.md
+++ b/website/book/src/beyond-core/terminology.md
@@ -235,12 +235,13 @@ A raw FHIR terminology endpoint open to anonymous callers would let anyone walk
 a code system or expand large value sets; per-code operations through the CDR,
 behind its rate limit, do not.
 
-The edition the sandbox loads is the SNOMED CT International Edition: it needs
-the Affiliate Licence alone (a Member's national release also needs an agreement
-with that Member), its English displays fit an international audience, and it
-is the lighter of the two. When the operator has built its index off-box and the
-server opens it, this page states the release date beside the edition, and every
-surface showing that content carries the notice the licence prescribes:
+The sandbox serves the **SNOMED CT International Edition, release 20260901**
+(`http://snomed.info/sct/900000000000207008/version/20260901`), loaded by the
+operator under their Affiliate Licence from an index built off the machine. The
+International Edition rather than a national one: it needs the Affiliate Licence
+alone (a Member's national release also needs an agreement with that Member), its
+English displays fit an international audience, and it is the lighter of the two.
+Every surface showing that content carries the notice the licence prescribes:
 
 > This material includes SNOMED Clinical Terms® (SNOMED CT®) which is used by
 > permission of the International Health Terminology Standards Development
@@ -252,6 +253,28 @@ No SNOMED CT content is in this repository, in any image, or in CI; the index
 exists only on the sandbox machine. This is a description of the arrangement,
 not legal advice: the licence text is the authority and the Member's conditions
 apply in each territory.
+
+### LOINC on the sandbox
+
+The sandbox also serves **LOINC version 2.83** (`http://loinc.org`), from an
+index built the same way. The LOINC licence
+([loinc.org/license](https://loinc.org/license)) grants use and distribution
+"for any commercial or non-commercial purpose" without fees and names "online
+terminology services" among the permitted products, on three conditions this
+deployment meets: the notice below is available where the service's terms are
+stated, every LOINC code is shown with one of its LOINC display names (the FHIR
+operations return the long common name), and the version is stated. Where a
+LOINC record carries a third-party copyright notice of its own, that notice
+travels with the record.
+
+> This material contains content from LOINC (http://loinc.org). LOINC is
+> copyright © Regenstrief Institute, Inc. and the Logical Observation
+> Identifiers Names and Codes (LOINC) Committee and is available at no cost
+> under the license at http://loinc.org/license. LOINC® is a registered United
+> States trademark of Regenstrief Institute, Inc.
+
+Neither index is in the repository, an image or CI; both exist only on the
+sandbox machine, beside the licence-free shaped seed the compose profile ships.
 
 ## Running one locally (development and CI)
 

--- a/website/book/src/beyond-core/terminology.md
+++ b/website/book/src/beyond-core/terminology.md
@@ -45,10 +45,11 @@ is a `400`.
 
 > [!NOTE]
 > **The CDR is only ever a client of the terminology server.** FerroEHR does not
-> implement one: you run an off-the-shelf FHIR terminology server and point the
-> CDR at it by URL. HAPI FHIR is a good open, single-container default for
-> development and CI; Snowstorm is the choice for genuine SNOMED CT subsumption
-> (heavier: it needs Elasticsearch and a SNOMED CT licence).
+> implement one: you run a FHIR terminology server and point the CDR at it by
+> URL. The one that ships with the product is
+> [FerroTERM](#ferroterm-beside-the-cdr), started by the quickstart's
+> terminology overlay; any other server speaking the FHIR terminology
+> operations (Ontoserver, Snowstorm, HAPI FHIR) works the same way.
 
 External terminology is off by default, and while it is off nothing is
 requested: validation uses the in-process bundle alone. The keys live under
@@ -278,9 +279,13 @@ sandbox machine, beside the licence-free shaped seed the compose profile ships.
 
 ## Running one locally (development and CI)
 
-From a checkout of the repository, the conformance stack can start a real HAPI
-FHIR JPA server beside the CDR, seeded with a small set of synthetic test code
-systems and value sets:
+The quickest local terminology server is the quickstart's
+[terminology overlay](../installation/compose.md#the-terminology-overlay-ferroterm):
+FerroTERM beside the CDR, the shaped seed served, the CDR wired, one command
+and no checkout. The conformance lane still runs its own server: from a
+checkout of the repository, the conformance stack can start a HAPI FHIR JPA
+server beside the CDR, seeded with the same synthetic code systems and value
+sets over its FHIR API (the lane moves to FerroTERM under #3085):
 
 ```bash
 docker compose -p ferroehr-cnf --project-directory . --profile terminology \
@@ -295,8 +300,9 @@ inside a later run. The overlay file is what points the CDR at it, by switching
 on the `[terminology.external]` providers the development configuration already
 carries in the disabled state.
 
-None of this touches the downloadable quickstart Compose file, which has no
-terminology server and uses the in-process openEHR terminology only.
+None of this touches the downloadable quickstart Compose file on its own, which
+uses the in-process openEHR terminology only; the terminology overlay is the
+opt-in that adds FerroTERM to it.
 
 > [!WARNING]
 > The seeded content is synthetic and lives under the reserved `example.test`

--- a/website/book/src/installation/compose.md
+++ b/website/book/src/installation/compose.md
@@ -414,10 +414,10 @@ each is a separate file instead:
 - **OIDC / Keycloak** is the `docker-compose.keycloak.yml` overlay above (and,
   in a repository checkout, a `keycloak` profile of the development override
   described below).
-- **A real FHIR terminology server** now lives in the repository's
-  self-contained conformance stack; see
-  [Terminology servers](../beyond-core/terminology.md) for the invocation and
-  what is seeded.
+- **A terminology server** is the `docker-compose.terminology.yml` overlay
+  [above](#the-terminology-overlay-ferroterm), FerroTERM beside the CDR; the
+  repository's conformance stack additionally runs its own seeded server for
+  the acceptance lane, see [Terminology servers](../beyond-core/terminology.md).
 
 ## Port already in use?
 


### PR DESCRIPTION
The operator has loaded two editions into the sandbox's FerroTERM (indexes built off the machine, copied to `/opt/ferroehr-sandbox/ferroterm-index/{int,loinc}`, SHA-256 verified): the SNOMED CT International Edition, release 20260901, and LOINC 2.83. The terminology page now states both, as each licence asks:

- SNOMED CT: the edition and release date beside the clause 8.3.1 notice that was already there (Affiliate Licence Agreement, April 2023).
- LOINC: a new section with the short notice the LOINC licence requires "where the product or service is provided as an online resource", the version, and the three conditions the deployment meets (notice available, codes shown with a LOINC display name, version stated).

A sweep of the book, the README and the architecture doc for terminology-server claims the FerroTERM work made stale: the terminology page's callout no longer tells readers to run HAPI or Snowstorm (FerroTERM ships with the product; other FHIR terminology servers work the same way), its local-run section points at the overlay first and names the conformance lane's HAPI server as what it is (moving under #3085), the sentence saying the quickstart "has no terminology server" is corrected, the compose page's development section names the overlay, and the beyond-core index and README feature list mention FerroTERM. Everything else found (config examples with example hosts, the threat model's trust boundary, the viewer page, the conformance record) was still true.

`env.example` shows the two-directory form (`FERROTERM_INDEX=/data/index/int:/data/index/loinc`) and names both licences among the operator's obligations. Prose only; `docs-claims` passes.

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.
