### PR TITLE
fix(terminology): ADL2 VETDF asks the server about the binding URI's system and code, and an unserved code system is a warning, not a refusal

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -19,8 +19,9 @@
 # predicate matches that whole string, and `/…/` is a regex matcher
 # (https://nexte.st/docs/filtersets/reference/). Scoping with
 # `package(ferroehr) & binary(it)` keeps a same-named module in another crate's
-# `it` binary out of the group. Group membership is therefore unchanged: exactly
-# the tests of those three suites, serialized, with one retry.
+# `it` binary out of the group. Group membership is therefore exactly the tests
+# of those three suites plus `adl2_vetdf_ferroterm` (a FerroTERM container per
+# test, #3311), serialized, with one retry.
 [test-groups.containers]
 max-threads = 1
 
@@ -35,7 +36,7 @@ max-threads = 1
 # the container tests, so a new test in these modules is serialized by default:
 # the safe direction is a container test that waits, never one that does not.
 [[profile.default.overrides]]
-filter = 'package(ferroehr) & binary(it) & test(/^(events_amqp|fhir_outbound_amqp|multimedia_s3)::/) - test(/^multimedia_s3::(disabled_by_default_stores_inline_verbatim|unreachable_store_refuses_expansion_instead_of_answering_silently)$/)'
+filter = 'package(ferroehr) & binary(it) & test(/^(events_amqp|fhir_outbound_amqp|multimedia_s3|adl2_vetdf_ferroterm)::/) - test(/^multimedia_s3::(disabled_by_default_stores_inline_verbatim|unreachable_store_refuses_expansion_instead_of_answering_silently)$/)'
 test-group = 'containers'
 retries = 1
 
@@ -51,6 +52,6 @@ fail-fast = false
 slow-timeout = { period = "60s" }
 
 [[profile.ci.overrides]]
-filter = 'package(ferroehr) & binary(it) & test(/^(events_amqp|fhir_outbound_amqp|multimedia_s3)::/)'
+filter = 'package(ferroehr) & binary(it) & test(/^(events_amqp|fhir_outbound_amqp|multimedia_s3|adl2_vetdf_ferroterm)::/)'
 test-group = 'containers'
 retries = 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@ workflow refuses a tag that has no matching section here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **ADL 2 archetypes with SNOMED CT or LOINC term bindings upload against a
+  terminology server that does not serve those code systems** (#3311). The
+  VETDF check asked the server about `system=SNOMED-CT&code=<the binding URI>`
+  and read every miss as "the term does not exist", so with FerroTERM beside
+  the CDR six archetypes of the sandbox dataset were refused and the seed
+  failed. A binding target in the IHTSDO URI model (`http://snomed.info/id/…`,
+  `http://loinc.org/id/…`) is now taken apart into the FHIR system and code the
+  server is asked about, and the server's `OperationOutcome` decides the
+  outcome: a code system it does not serve leaves the binding unverified and
+  the archetype accepted with a warning, as AOM2's VETDF prescribes; a code
+  absent from a served system is still refused with `422`. Verified against a
+  real FerroTERM in the test suite.
+
 ## [4.2.3] - 2026-09-12
 
 ### Added

--- a/app/ferroehr-ext/src/fhir/terminology.rs
+++ b/app/ferroehr-ext/src/fhir/terminology.rs
@@ -175,3 +175,93 @@ fn member(contains: &ValueSetExpansionContains) -> ExpansionMember {
         children: contains.contains.iter().flatten().map(member).collect(),
     }
 }
+
+/// The `tx-issue-type` code system the terminology-service specifications use
+/// to say WHY an operation failed
+/// (<https://build.fhir.org/ig/HL7/fhir-tools-ig/CodeSystem-tx-issue-type.html>).
+pub const TX_ISSUE_TYPE_SYSTEM: &str = "http://hl7.org/fhir/tools/CodeSystem/tx-issue-type";
+
+/// Decodes a FHIR `OperationOutcome` into the `tx-issue-type` codes its issues
+/// carry (`not-found`, `invalid-code`, …), in document order.
+///
+/// Only `issue.details.coding` entries whose `system` is
+/// [`TX_ISSUE_TYPE_SYSTEM`] count; `issue.code` (the generic `IssueType`) is not
+/// read, because servers use it inconsistently for the same cause.
+///
+/// # Errors
+///
+/// [`TerminologyDecodeError::WrongResource`] when the body declares another
+/// `resourceType`; [`TerminologyDecodeError::Malformed`] when it is not a
+/// valid R4B `OperationOutcome` resource.
+pub fn decode_outcome_issue_types(body: &[u8]) -> Result<Vec<String>, TerminologyDecodeError> {
+    expect_resource(body, "OperationOutcome")?;
+    let outcome: fhir_model::r4b::resources::OperationOutcome = serde_json::from_slice(body)?;
+    Ok(outcome
+        .0
+        .issue
+        .iter()
+        .flatten()
+        .filter_map(|issue| issue.details.as_ref())
+        .flat_map(|details| details.0.coding.iter().flatten())
+        .filter(|coding| coding.0.system.as_deref() == Some(TX_ISSUE_TYPE_SYSTEM))
+        .filter_map(|coding| coding.0.code.clone())
+        .collect())
+}
+
+/// Decodes a search `Bundle` into its `total` (the answer to a
+/// `_summary=count` search; `None` when the server reports no total).
+///
+/// # Errors
+///
+/// [`TerminologyDecodeError::WrongResource`] when the body declares another
+/// `resourceType`; [`TerminologyDecodeError::Malformed`] when it is not a
+/// valid R4B `Bundle` resource.
+pub fn decode_bundle_total(body: &[u8]) -> Result<Option<u32>, TerminologyDecodeError> {
+    expect_resource(body, "Bundle")?;
+    let bundle: fhir_model::r4b::resources::Bundle = serde_json::from_slice(body)?;
+    Ok(bundle.0.total)
+}
+
+#[cfg(test)]
+mod outcome_tests {
+    use super::{TX_ISSUE_TYPE_SYSTEM, decode_bundle_total, decode_outcome_issue_types};
+
+    #[test]
+    fn tx_issue_types_are_read_from_details_codings_only() {
+        let body = format!(
+            r#"{{"resourceType":"OperationOutcome","issue":[
+                {{"severity":"error","code":"not-found","details":{{"coding":[{{"system":"{TX_ISSUE_TYPE_SYSTEM}","code":"not-found"}}],"text":"code system `SNOMED-CT` is not served"}}}},
+                {{"severity":"error","code":"code-invalid","details":{{"coding":[{{"system":"http://example.org/other","code":"invalid-code"}}]}}}}
+            ]}}"#
+        );
+        assert_eq!(
+            decode_outcome_issue_types(body.as_bytes()).unwrap(),
+            vec!["not-found"]
+        );
+    }
+
+    #[test]
+    fn an_outcome_without_details_classifies_nothing() {
+        let body = br#"{"resourceType":"OperationOutcome","issue":[{"severity":"error","code":"not-found","diagnostics":"Unknown code"}]}"#;
+        assert!(decode_outcome_issue_types(body).unwrap().is_empty());
+    }
+
+    #[test]
+    fn another_resource_is_refused() {
+        let body = br#"{"resourceType":"Parameters","parameter":[]}"#;
+        assert!(decode_outcome_issue_types(body).is_err());
+    }
+
+    #[test]
+    fn a_count_bundle_yields_its_total() {
+        assert_eq!(
+            decode_bundle_total(br#"{"resourceType":"Bundle","type":"searchset","total":1}"#)
+                .unwrap(),
+            Some(1)
+        );
+        assert_eq!(
+            decode_bundle_total(br#"{"resourceType":"Bundle","type":"searchset"}"#).unwrap(),
+            None
+        );
+    }
+}

--- a/app/ferroehr/src/service/definition/adl2.rs
+++ b/app/ferroehr/src/service/definition/adl2.rs
@@ -67,11 +67,13 @@ const ADL2_CACHE_NS: &str = "adl2\u{1f}";
 /// synchronous [`TerminologyResolver`] seam, while a terminology lookup is
 /// asynchronous. The service therefore pre-resolves every external term binding
 /// of the uploaded archetype against its terminology service
-/// ([`FerroEhrService::has_term`]) and hands the validator this memoised map.
+/// ([`FerroEhrService::term_existence`], on the system and code the binding
+/// URI names) and hands the validator this memoised map.
 ///
 /// `code_exists` returns `Some(true)`/`Some(false)` for a binding the service
 /// could answer, and `None` for one it could not (no external provider
-/// configured, an unknown terminology, or a transport fault) — matching the
+/// configured, a code system the server does not serve, or a transport
+/// fault) — matching the
 /// VETDF "subject to tool accessibility; … no verification was possible"
 /// carve-out (AM ADL2 `master03-archetype_package.adoc` §Validity Rules).
 #[derive(Debug, Default)]

--- a/app/ferroehr/src/service/definition/adl2.rs
+++ b/app/ferroehr/src/service/definition/adl2.rs
@@ -38,6 +38,9 @@ use openehr_am::v2_4::aom2::archetype::operational_template::OperationalTemplate
 use openehr_base::validate::InvariantViolation;
 use openehr_its::flat::example::{DetailLevel, ExampleType, apply_output_uid, example_composition};
 use openehr_its::flat::webtemplate::builder_v2_4::build_web_template_v2_4;
+
+use crate::service::definition::binding_uri::code_system_and_code;
+use crate::service::terminology::fhir::TermExistence;
 use openehr_its::flat::webtemplate::model::WebTemplate;
 use serde_json::Value;
 use sqlx::Row;
@@ -363,20 +366,48 @@ impl FerroEhrService {
     /// terminology service, building the [`AdlTerminologyResolver`] the VETDF
     /// check consults (see its docs — the seam is synchronous, a lookup is not).
     ///
-    /// A binding the service cannot answer — no configured external provider, an
-    /// unknown terminology, or a transport fault — is left unresolved, so VETDF
-    /// is not raised for it (`master03` §Validity Rules "subject to tool
-    /// accessibility"). Only genuinely external terminologies are consulted; the
+    /// A binding target is a URI in the IHTSDO model (`…/id/<code>`), so it is
+    /// taken apart into the FHIR `(system, code)` the server is asked about
+    /// ([`code_system_and_code`]); a target of another shape is asked as
+    /// written under the binding's own terminology id. Only a definite answer
+    /// lands in the resolver: exists, or absent from a code system the server
+    /// serves. A binding the service cannot verify — no configured external
+    /// provider, a code system the server does not serve, a transport fault —
+    /// is left unresolved and logged, so VETDF is not raised for it
+    /// (`master03` §Validity Rules: "codes for inaccessible terminologies
+    /// should be flagged with a warning indicating that no verification was
+    /// possible"). Only genuinely external terminologies are consulted; the
     /// archetype-internal `local`/`openehr` ids are excluded by
     /// [`external_term_bindings`] (their keys are covered by VTTBK/VTCBK).
     async fn adl2_terminology_resolver(&self, archetype: &Archetype) -> AdlTerminologyResolver {
         let mut resolved = HashMap::new();
         for binding in external_term_bindings(archetype) {
-            if let Ok(exists) = self
-                .has_term(&binding.terminology_id, &binding.target, None)
+            let (system, code) = code_system_and_code(&binding.target)
+                .unwrap_or_else(|| (binding.terminology_id.clone(), binding.target.clone()));
+            match self
+                .term_existence(&binding.terminology_id, &system, &code)
                 .await
             {
-                resolved.insert((binding.terminology_id, binding.target), exists);
+                Ok(TermExistence::Exists) => {
+                    resolved.insert((binding.terminology_id, binding.target), true);
+                }
+                Ok(TermExistence::Absent) => {
+                    resolved.insert((binding.terminology_id, binding.target), false);
+                }
+                Ok(TermExistence::Unverifiable(reason)) => tracing::warn!(
+                    terminology = %binding.terminology_id,
+                    target = %binding.target,
+                    system = %system,
+                    reason,
+                    "VETDF: no verification was possible for this term binding; accepted unverified"
+                ),
+                Err(e) => tracing::warn!(
+                    terminology = %binding.terminology_id,
+                    target = %binding.target,
+                    system = %system,
+                    error = %e,
+                    "VETDF: the terminology server could not be asked; accepted unverified"
+                ),
             }
         }
         AdlTerminologyResolver { resolved }

--- a/app/ferroehr/src/service/definition/binding_uri.rs
+++ b/app/ferroehr/src/service/definition/binding_uri.rs
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: Ruben Talstra
+// SPDX-License-Identifier: BUSL-1.1
+
+//! The code system and code an ADL2 term-binding target names.
+//!
+//! ADL2 binding targets "are expressed as URIs that follow the model for
+//! terminology URIs published by IHTSDO or a similar model, in the case of
+//! terminologies other than SNOMED CT" (AM ADL2
+//! `master07.13-adl_terminology.adoc` §Terminology bindings, whose example
+//! binds `<http://loinc.org/id/48334-7>`). That model puts the concept
+//! identifier last, behind an `/id/` segment. A FHIR terminology server is
+//! asked about a `(system, code)` pair, so VETDF has to take the target apart
+//! before it can ask: the outer binding key (`SNOMED-CT`, `Snomed`, `LOINC`,
+//! spelled however the author spelled it) routes to a provider but is not a
+//! code system URI.
+//!
+//! No openEHR specification maps a binding URI to a FHIR `system`; the SNOMED
+//! CT URI Standard does for SNOMED CT (<https://snomed.org/uri>: a concept is
+//! `http://snomed.info/id/{sctid}`, the code system is `http://snomed.info/sct`),
+//! and for every other terminology the URI up to the `/id/` segment is offered
+//! as the system, which is right for LOINC (`http://loinc.org`, the FHIR
+//! registry's system) and leaves any other answer to the server: one it does
+//! not serve is reported back as unverifiable, never as a refusal.
+
+use url::Url;
+
+/// The FHIR code system URI of SNOMED CT (SNOMED CT URI Standard §3).
+pub(crate) const SNOMED_CT_SYSTEM: &str = "http://snomed.info/sct";
+
+/// The `(system, code)` a binding target names, when it follows the
+/// `<terminology>/id/<code>` model; `None` for a plain code or a URI of
+/// another shape, which the caller passes through unchanged.
+///
+/// `http://snomed.info/id/{sctid}` (and the `snomedct.info` host the ADL2
+/// spec's own examples use) is SNOMED CT; anything else yields the URI before
+/// `/id/` as the system.
+pub(crate) fn code_system_and_code(target: &str) -> Option<(String, String)> {
+    let url = Url::parse(target).ok()?;
+    if !matches!(url.scheme(), "http" | "https") {
+        return None;
+    }
+    let mut segments: Vec<&str> = url.path_segments()?.filter(|s| !s.is_empty()).collect();
+    let code = segments.pop()?;
+    if segments.pop()? != "id" || code.is_empty() {
+        return None;
+    }
+    let host = url.host_str()?.trim_start_matches("www.");
+    if matches!(host, "snomed.info" | "snomedct.info") {
+        return Some((SNOMED_CT_SYSTEM.to_owned(), code.to_owned()));
+    }
+    let mut system = url.clone();
+    system.set_query(None);
+    system.set_fragment(None);
+    let path = if segments.is_empty() {
+        String::new()
+    } else {
+        format!("/{}", segments.join("/"))
+    };
+    system.set_path(&path);
+    let mut system = system.to_string();
+    if system.ends_with('/') {
+        system.pop();
+    }
+    Some((system, code.to_owned()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pair(system: &str, code: &str) -> (String, String) {
+        (system.to_owned(), code.to_owned())
+    }
+
+    #[test]
+    fn snomed_concept_uris_name_the_snomed_code_system() {
+        assert_eq!(
+            code_system_and_code("http://snomed.info/id/50121007"),
+            Some(pair(SNOMED_CT_SYSTEM, "50121007"))
+        );
+        assert_eq!(
+            code_system_and_code("http://snomedct.info/id/271649006"),
+            Some(pair(SNOMED_CT_SYSTEM, "271649006"))
+        );
+        assert_eq!(
+            code_system_and_code("https://www.snomed.info/id/404684003"),
+            Some(pair(SNOMED_CT_SYSTEM, "404684003"))
+        );
+    }
+
+    #[test]
+    fn loinc_and_other_id_uris_yield_the_uri_before_id() {
+        assert_eq!(
+            code_system_and_code("http://loinc.org/id/LA6742-6"),
+            Some(pair("http://loinc.org", "LA6742-6"))
+        );
+        assert_eq!(
+            code_system_and_code("http://umls.nlm.edu/id/C124305"),
+            Some(pair("http://umls.nlm.edu", "C124305"))
+        );
+        assert_eq!(
+            code_system_and_code("http://cnf.example.test/fhir/CodeSystem/sct-shaped/id/1000001"),
+            Some(pair(
+                "http://cnf.example.test/fhir/CodeSystem/sct-shaped",
+                "1000001"
+            ))
+        );
+    }
+
+    #[test]
+    fn a_plain_code_or_another_uri_shape_is_left_to_the_caller() {
+        assert_eq!(code_system_and_code("50121007"), None);
+        assert_eq!(code_system_and_code("http://snomed.info/sct"), None);
+        assert_eq!(code_system_and_code("http://example.org/terms/12345"), None);
+        assert_eq!(code_system_and_code("urn:oid:2.16.840.1.113883.6.96"), None);
+        assert_eq!(code_system_and_code("http://loinc.org/id/"), None);
+    }
+}

--- a/app/ferroehr/src/service/definition/mod.rs
+++ b/app/ferroehr/src/service/definition/mod.rs
@@ -43,6 +43,7 @@
 
 mod adl14;
 mod adl2;
+mod binding_uri;
 pub(super) mod lineage;
 mod opt14_convert;
 mod query;

--- a/app/ferroehr/src/service/terminology/fhir.rs
+++ b/app/ferroehr/src/service/terminology/fhir.rs
@@ -81,10 +81,10 @@ pub struct FhirTerminologyProvider {
     /// The configured provider name (for error/log context).
     name: String,
     /// TTL-bounded response cache keyed by the full operation URL (`None`
-    /// when disabled). Caches the DECODED response — including the 404
-    /// "unknown resource" outcome — so a validation burst over the same codes
-    /// costs one remote round trip per TTL window.
-    cache: Option<moka::future::Cache<String, Option<DecodedResponse>>>,
+    /// when disabled). Caches the DECODED response — including a classified
+    /// "not found" outcome — so a validation burst over the same codes costs
+    /// one remote round trip per TTL window.
+    cache: Option<moka::future::Cache<String, Fetched>>,
     /// The `OAuth2` client-credentials token source whose bearer credential
     /// authenticates every request, when the provider configures one. `None` =
     /// unauthenticated requests.
@@ -156,16 +156,24 @@ impl FhirTerminologyProvider {
         &self.name
     }
 
-    /// GET a FHIR operation with query params, returning the decoded response.
+    /// GET a FHIR operation with query params, returning the decoded response
+    /// or a classified absence.
     ///
-    /// `404`/`410` → `Ok(None)` (the resource is unknown → a precondition the
-    /// caller maps to `VersionedObjectDoesNotExist`).
+    /// A non-2xx answer is read through the `OperationOutcome` it carries: a
+    /// `tx-issue-type` `not-found` issue is [`Absence::UnknownSystem`], an
+    /// `invalid-code` issue is [`Absence::UnknownCode`], and a bare `404`/`410`
+    /// with no classifying issue is [`Absence::Unclassified`] (the resource is
+    /// unknown, which of system or code is not stated). Any other failure is a
+    /// provider fault. The coding is the HL7 terminology-service vocabulary
+    /// (<https://build.fhir.org/ig/HL7/fhir-tools-ig/CodeSystem-tx-issue-type.html>);
+    /// the status alone cannot be read, because servers differ on it (`FerroTERM`
+    /// answers an unknown code with `400`, an unknown system with `404`).
     async fn fetch(
         &self,
         op_path: &str,
         query: &[(&str, &str)],
         kind: ResponseKind,
-    ) -> Result<Option<DecodedResponse>, SmError> {
+    ) -> Result<Fetched, SmError> {
         let mut url = reqwest::Url::parse(&format!("{}{op_path}", self.base))
             .map_err(|e| self.provider_fault(op_path, &format_args!("invalid url: {e}")))?;
         {
@@ -195,42 +203,100 @@ impl FhirTerminologyProvider {
             .await
             .map_err(|e| self.transport_error(op_path, &e))?;
         let status = response.status();
-        if status == reqwest::StatusCode::NOT_FOUND || status == reqwest::StatusCode::GONE {
-            if let Some(cache) = &self.cache {
-                cache.insert(cache_key, None).await;
-            }
-            return Ok(None);
-        }
-        if !status.is_success() {
-            return Err(self.provider_fault(
-                op_path,
-                &format_args!("upstream returned HTTP {}", status.as_u16()),
-            ));
-        }
         let body = response
             .bytes()
             .await
             .map_err(|e| self.transport_error(op_path, &e))?;
-        let decoded = decode(kind, &body).map_err(|e| {
-            self.provider_fault(op_path, &format_args!("malformed FHIR response: {e}"))
-        })?;
+        let fetched = if status.is_success() {
+            Fetched::Found(decode(kind, &body).map_err(|e| {
+                self.provider_fault(op_path, &format_args!("malformed FHIR response: {e}"))
+            })?)
+        } else {
+            let issues = outcome_issue_types(&body);
+            let gone =
+                status == reqwest::StatusCode::NOT_FOUND || status == reqwest::StatusCode::GONE;
+            if issues.iter().any(|c| c == TX_ISSUE_NOT_FOUND) {
+                Fetched::Absent(Absence::UnknownSystem)
+            } else if issues.iter().any(|c| c == TX_ISSUE_INVALID_CODE) {
+                Fetched::Absent(Absence::UnknownCode)
+            } else if gone {
+                Fetched::Absent(Absence::Unclassified)
+            } else {
+                return Err(self.provider_fault(
+                    op_path,
+                    &format_args!("upstream returned HTTP {}", status.as_u16()),
+                ));
+            }
+        };
         if let Some(cache) = &self.cache {
-            cache.insert(cache_key, Some(decoded.clone())).await;
+            cache.insert(cache_key, fetched.clone()).await;
         }
-        Ok(Some(decoded))
+        Ok(fetched)
     }
 
-    /// The named scalar values of a `Parameters` response.
+    /// The named scalar values of a `Parameters` response, or `None` for any
+    /// classified absence (the callers that read this map it to a
+    /// `VersionedObjectDoesNotExist` precondition).
     async fn parameters(
         &self,
         op_path: &str,
         query: &[(&str, &str)],
     ) -> Result<Option<ParameterValues>, SmError> {
         match self.fetch(op_path, query, ResponseKind::Parameters).await? {
-            None => Ok(None),
-            Some(DecodedResponse::Parameters(values)) => Ok(Some(values)),
-            Some(DecodedResponse::Expansion(_)) => {
+            Fetched::Absent(_) => Ok(None),
+            Fetched::Found(DecodedResponse::Parameters(values)) => Ok(Some(values)),
+            Fetched::Found(DecodedResponse::Expansion(_) | DecodedResponse::Count(_)) => {
                 Err(self.provider_fault(op_path, &format_args!("expected a Parameters response")))
+            }
+        }
+    }
+
+    /// Whether `code` exists in the code system `system`, as three answers
+    /// rather than two: exists, is absent from a system the server serves, or
+    /// could not be verified because the server does not serve the system (or
+    /// could not say). The ADL2 VETDF check needs the third answer, because an
+    /// inaccessible terminology is a warning there and not a refusal (AM ADL2
+    /// `master03-archetype_package.adoc` §Validity Rules, VETDF).
+    ///
+    /// Reads `CodeSystem/$lookup`. A bare `404` that names neither cause is
+    /// resolved with one more question, `CodeSystem?url=<system>&_summary=count`:
+    /// a served system makes the code absent, an unserved one makes the
+    /// binding unverifiable, and a server that cannot answer the question
+    /// leaves it unverifiable too.
+    ///
+    /// # Errors
+    ///
+    /// Exception on a transport fault, a non-2xx status carrying no
+    /// classifying `OperationOutcome` and not `404`/`410`, or a malformed body.
+    pub async fn term_existence(&self, system: &str, code: &str) -> Result<TermExistence, SmError> {
+        let query = [("system", system), ("code", code)];
+        match self
+            .fetch("/CodeSystem/$lookup", &query, ResponseKind::Parameters)
+            .await?
+        {
+            Fetched::Found(_) => Ok(TermExistence::Exists),
+            Fetched::Absent(Absence::UnknownCode) => Ok(TermExistence::Absent),
+            Fetched::Absent(Absence::UnknownSystem) => Ok(TermExistence::Unverifiable(
+                "the terminology server does not serve the code system",
+            )),
+            Fetched::Absent(Absence::Unclassified) => {
+                let probe = [("url", system), ("_summary", "count")];
+                match self
+                    .fetch("/CodeSystem", &probe, ResponseKind::BundleCount)
+                    .await
+                {
+                    Ok(Fetched::Found(DecodedResponse::Count(Some(n)))) if n > 0 => {
+                        Ok(TermExistence::Absent)
+                    }
+                    Ok(Fetched::Found(DecodedResponse::Count(_))) => {
+                        Ok(TermExistence::Unverifiable(
+                            "the terminology server does not serve the code system",
+                        ))
+                    }
+                    Ok(_) | Err(_) => Ok(TermExistence::Unverifiable(
+                        "the terminology server could not say whether it serves the code system",
+                    )),
+                }
             }
         }
     }
@@ -299,12 +365,13 @@ impl FhirTerminologyProvider {
             .fetch("/ValueSet/$expand", &query, ResponseKind::ValueSet)
             .await?
         {
-            None => Ok(None),
-            Some(DecodedResponse::Expansion(expansion)) => Ok(Some(expansion)),
-            Some(DecodedResponse::Parameters(_)) => Err(self.provider_fault(
-                "/ValueSet/$expand",
-                &format_args!("expected a ValueSet response"),
-            )),
+            Fetched::Absent(_) => Ok(None),
+            Fetched::Found(DecodedResponse::Expansion(expansion)) => Ok(Some(expansion)),
+            Fetched::Found(DecodedResponse::Parameters(_) | DecodedResponse::Count(_)) => Err(self
+                .provider_fault(
+                    "/ValueSet/$expand",
+                    &format_args!("expected a ValueSet response"),
+                )),
         }
     }
 
@@ -601,6 +668,50 @@ enum ResponseKind {
     Parameters,
     /// `$expand`.
     ValueSet,
+    /// A `_summary=count` search: the `Bundle.total` alone.
+    BundleCount,
+}
+
+/// The `tx-issue-type` code for "the code system is not known to the server"
+/// (<https://build.fhir.org/ig/HL7/fhir-tools-ig/CodeSystem-tx-issue-type.html>).
+const TX_ISSUE_NOT_FOUND: &str = "not-found";
+
+/// The `tx-issue-type` code for "the code is not in the code system".
+const TX_ISSUE_INVALID_CODE: &str = "invalid-code";
+
+/// Why an operation answered "not found", read from its `OperationOutcome`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Absence {
+    /// The server does not serve the code system asked about (`not-found`).
+    UnknownSystem,
+    /// The code system is served and the code is not in it (`invalid-code`).
+    UnknownCode,
+    /// A `404`/`410` with no classifying issue: the resource is unknown, and
+    /// whether that is the system or the code is not stated.
+    Unclassified,
+}
+
+/// What one fetch produced: a decoded resource, or a classified absence. The
+/// cache holds this, so a repeated question costs one round trip per TTL.
+#[derive(Debug, Clone)]
+enum Fetched {
+    /// A 2xx answer, decoded.
+    Found(DecodedResponse),
+    /// A "not found" answer, classified.
+    Absent(Absence),
+}
+
+/// The three answers to "does this code exist in this code system": the
+/// distinction VETDF turns on (a terminology the server does not serve is a
+/// warning, not a refusal).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TermExistence {
+    /// The server serves the code system and knows the code.
+    Exists,
+    /// The server serves the code system and the code is not in it.
+    Absent,
+    /// No verification was possible; the reason, for the operator's log.
+    Unverifiable(&'static str),
 }
 
 /// A decoded FHIR terminology response, reduced to what the SM calls read.
@@ -619,6 +730,9 @@ enum DecodedResponse {
     Parameters(ParameterValues),
     /// The membership + hierarchy of a `ValueSet` expansion.
     Expansion(Expansion),
+    /// The `total` of a `_summary=count` search `Bundle` (absent when the
+    /// server does not report one).
+    Count(Option<u32>),
 }
 
 /// The named scalar values a `Parameters` response carries.
@@ -740,7 +854,23 @@ fn decode(kind: ResponseKind, body: &[u8]) -> Result<DecodedResponse, DecodeErro
             }
             Ok(DecodedResponse::Expansion(expansion))
         }
+        ResponseKind::BundleCount => Ok(DecodedResponse::Count(
+            ferroehr_ext::fhir::terminology::decode_bundle_total(body)?,
+        )),
     }
+}
+
+/// The `tx-issue-type` codes a failing response's `OperationOutcome` carries;
+/// empty when the body is not one (a bare status, an HTML error page).
+#[cfg(feature = "fhir")]
+fn outcome_issue_types(body: &[u8]) -> Vec<String> {
+    ferroehr_ext::fhir::terminology::decode_outcome_issue_types(body).unwrap_or_default()
+}
+
+/// A slim build reads no `OperationOutcome`; every failure stays unclassified.
+#[cfg(not(feature = "fhir"))]
+fn outcome_issue_types(_body: &[u8]) -> Vec<String> {
+    Vec::new()
 }
 
 /// Collect one expansion member (and its descendants) into the flat `terms`
@@ -795,14 +925,18 @@ mod tests {
     fn parameters(json: &str) -> ParameterValues {
         match decode(ResponseKind::Parameters, json.as_bytes()).expect("decode Parameters") {
             DecodedResponse::Parameters(values) => values,
-            DecodedResponse::Expansion(_) => panic!("expected Parameters"),
+            DecodedResponse::Expansion(_) | DecodedResponse::Count(_) => {
+                panic!("expected Parameters")
+            }
         }
     }
 
     fn expansion(json: &str) -> Expansion {
         match decode(ResponseKind::ValueSet, json.as_bytes()).expect("decode ValueSet") {
             DecodedResponse::Expansion(expansion) => expansion,
-            DecodedResponse::Parameters(_) => panic!("expected ValueSet"),
+            DecodedResponse::Parameters(_) | DecodedResponse::Count(_) => {
+                panic!("expected ValueSet")
+            }
         }
     }
 

--- a/app/ferroehr/src/service/terminology/routing.rs
+++ b/app/ferroehr/src/service/terminology/routing.rs
@@ -106,6 +106,34 @@ impl FerroEhrService {
         }
     }
 
+    /// Whether `code` exists in the external code system `system`, as the three
+    /// answers ADL2 VETDF distinguishes ([`super::fhir::TermExistence`]): the
+    /// binding's outer key `terminology_id` only helps pick the provider (its
+    /// own route, then the system's route, then the default); with no external
+    /// provider configured nothing is asked and the binding is unverifiable
+    /// (AM ADL2 `master03-archetype_package.adoc` §Validity Rules, VETDF).
+    ///
+    /// # Errors
+    ///
+    /// The FHIR provider's: a transport fault, an unclassified non-2xx status,
+    /// or a malformed body.
+    pub async fn term_existence(
+        &self,
+        terminology_id: &str,
+        system: &str,
+        code: &str,
+    ) -> Result<super::fhir::TermExistence, SmError> {
+        let provider = self
+            .terminology_route(system)
+            .or_else(|| self.terminology_provider(terminology_id));
+        match provider {
+            Some(p) => p.term_existence(system, code).await,
+            None => Ok(super::fhir::TermExistence::Unverifiable(
+                "no external terminology provider is configured",
+            )),
+        }
+    }
+
     /// `get_term` — a single-term `Terminology_extract`. Routed to the bundle
     /// when it knows the terminology (no meta-model `attributes` exist for
     /// the openEHR bundle; `at_date` is a no-op on the pinned version), else to the configured FHIR provider (`CodeSystem/$lookup`).

--- a/app/ferroehr/tests/it/adl2_vetdf.rs
+++ b/app/ferroehr/tests/it/adl2_vetdf.rs
@@ -2,13 +2,22 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //! ADL2 VETDF validation over the terminology-service resolver seam, end to
-//! end (AM ADL2 `master03-archetype_package.adoc` §Validity Rules).
+//! end (AM ADL2 `master03-archetype_package.adoc` §Validity Rules, VETDF:
+//! "each external term used within the archetype definition must exist in the
+//! relevant terminology (subject to tool accessibility; codes for inaccessible
+//! terminologies should be flagged with a warning indicating that no
+//! verification was possible)").
 //!
-//! An uploaded archetype whose external SNOMED CT term binding the (mocked)
-//! FHIR terminology server does not know (`CodeSystem/$lookup` → `404`) is
-//! rejected `422` with the VETDF rule code; one the server knows (`200`) is
-//! accepted. The terminology backend is a hermetic `wiremock` FHIR R4B server —
-//! no live network. Real `PostgreSQL` 18 via the shared testkit harness.
+//! The binding target `<http://snomedct.info/id/271649006>` is taken apart into
+//! the FHIR pair the server is asked about (`system=http://snomed.info/sct`,
+//! `code=271649006`), and the server's `OperationOutcome` decides the outcome:
+//! a code system it does not serve leaves the binding unverified (accepted), a
+//! code absent from a served system is VETDF (`422`), a resolving lookup is
+//! accepted. The terminology backend here is a hermetic `wiremock` FHIR R4B
+//! server, so every answer shape a real server can give is pinned, including
+//! the bare `404` older servers answer with and the `CodeSystem?url=` probe
+//! that resolves it; the same contract against a real `FerroTERM` is
+//! `adl2_vetdf_ferroterm`. Real `PostgreSQL` 18 via the shared testkit harness.
 
 #![expect(
     clippy::expect_used,
@@ -29,12 +38,16 @@ use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 const HRID: &str = "openEHR-EHR-OBSERVATION.vetdf.v1.0.0";
-const SNOMED_ID: &str = "SNOMED-CT";
-const SNOMED_TARGET: &str = "http://snomedct.info/id/271649006";
+/// The FHIR code system the binding target's URI names (SNOMED CT URI Standard).
+const SNOMED_SYSTEM: &str = "http://snomed.info/sct";
+/// The concept the binding target's URI names.
+const SNOMED_CODE: &str = "271649006";
+const TX_ISSUE_TYPE: &str = "http://hl7.org/fhir/tools/CodeSystem/tx-issue-type";
 
 /// A minimal spec-valid ADL2 archetype (the same shape the passing
 /// `service_definition` upload test uses) whose root node `id1` carries an
-/// external SNOMED CT term binding — the VETDF subject.
+/// external SNOMED CT term binding in the ADL2 spec's own URI form (the
+/// `snomedct.info` host its `master07.13` example uses) — the VETDF subject.
 fn archetype_with_external_binding() -> String {
     "\
 archetype (adl_version=2.0.6; rm_release=1.1.0)
@@ -75,7 +88,7 @@ fn provider(base: &str) -> FhirTerminologyProvider {
     let cfg = FhirProviderConfig {
         kind: ProviderKind::Fhir,
         url: base.to_owned(),
-        // has_term uses `CodeSystem/$lookup` regardless of the membership op.
+        // VETDF uses `CodeSystem/$lookup` regardless of the membership op.
         operation: FhirOperation::ValidateCode,
         connect_timeout_ms: 500,
         request_timeout_ms: 800,
@@ -89,26 +102,61 @@ fn provider(base: &str) -> FhirTerminologyProvider {
     FhirTerminologyProvider::new("test", &cfg).expect("build provider")
 }
 
-#[tokio::test]
-async fn unknown_external_binding_is_rejected_with_vetdf() {
-    let server = MockServer::start().await;
-    // The terminology server does not know the bound SNOMED CT code → 404.
+/// An `OperationOutcome` carrying one `tx-issue-type` coding.
+fn outcome(issue_type: &str, text: &str) -> serde_json::Value {
+    json!({
+        "resourceType": "OperationOutcome",
+        "issue": [{
+            "severity": "error",
+            "code": "not-found",
+            "details": {
+                "coding": [{"system": TX_ISSUE_TYPE, "code": issue_type}],
+                "text": text
+            }
+        }]
+    })
+}
+
+/// The `$lookup` mock for the decomposed binding: `system` is the SNOMED CT
+/// code system URI and `code` the bare concept id, never the binding URI or
+/// the archetype's `SNOMED-CT` key.
+async fn mount_lookup(server: &MockServer, response: ResponseTemplate) {
     Mock::given(method("GET"))
         .and(path("/CodeSystem/$lookup"))
-        .and(query_param("system", SNOMED_ID))
-        .and(query_param("code", SNOMED_TARGET))
-        .respond_with(ResponseTemplate::new(404))
-        .mount(&server)
+        .and(query_param("system", SNOMED_SYSTEM))
+        .and(query_param("code", SNOMED_CODE))
+        .respond_with(response)
+        .mount(server)
         .await;
+}
 
+/// The `CodeSystem?url=…&_summary=count` probe an unclassified `404` triggers.
+async fn mount_system_probe(server: &MockServer, total: u32) {
+    Mock::given(method("GET"))
+        .and(path("/CodeSystem"))
+        .and(query_param("url", SNOMED_SYSTEM))
+        .and(query_param("_summary", "count"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "resourceType": "Bundle",
+            "type": "searchset",
+            "total": total
+        })))
+        .mount(server)
+        .await;
+}
+
+async fn service_at(server: &MockServer) -> (testkit::TestDb, FerroEhrService) {
     let db = testkit::db().await.expect("testkit database");
     let svc = FerroEhrService::new(db.pool())
         .with_external_terminology(Arc::new(provider(&server.uri())));
+    (db, svc)
+}
 
+async fn assert_vetdf_refusal(svc: &FerroEhrService) {
     let err = svc
         .upload_artefact(archetype_with_external_binding())
         .await
-        .expect_err("an unknown external term binding must be rejected");
+        .expect_err("a term the served code system does not contain must be refused");
     assert_eq!(
         err.status,
         CallStatusType::ContentInvalid,
@@ -120,35 +168,99 @@ async fn unknown_external_binding_is_rejected_with_vetdf() {
         err.message
     );
     assert!(
-        !svc.has_artefact(HRID.to_owned()).await.unwrap(),
+        !svc.has_artefact(HRID.to_owned())
+            .await
+            .expect("has_artefact answers"),
         "a rejected artefact is not stored"
     );
 }
 
-#[tokio::test]
-async fn known_external_binding_is_accepted() {
-    let server = MockServer::start().await;
-    // The terminology server knows the bound code → 200 (a $lookup resolves).
-    Mock::given(method("GET"))
-        .and(path("/CodeSystem/$lookup"))
-        .and(query_param("system", SNOMED_ID))
-        .and(query_param("code", SNOMED_TARGET))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "resourceType": "Parameters",
-            "parameter": [{"name": "display", "valueString": "Entire lung"}]
-        })))
-        .mount(&server)
-        .await;
-
-    let db = testkit::db().await.expect("testkit database");
-    let svc = FerroEhrService::new(db.pool())
-        .with_external_terminology(Arc::new(provider(&server.uri())));
-
+async fn assert_accepted(svc: &FerroEhrService) {
     svc.upload_artefact(archetype_with_external_binding())
         .await
-        .expect("a known external term binding is accepted");
+        .expect("the archetype is accepted");
     assert!(
-        svc.has_artefact(HRID.to_owned()).await.unwrap(),
+        svc.has_artefact(HRID.to_owned())
+            .await
+            .expect("has_artefact answers"),
         "the accepted artefact is stored"
     );
+}
+
+#[tokio::test]
+async fn a_code_absent_from_a_served_system_is_rejected_with_vetdf() {
+    let server = MockServer::start().await;
+    // FerroTERM's shape: 400 with an `invalid-code` issue.
+    mount_lookup(
+        &server,
+        ResponseTemplate::new(400).set_body_json(outcome(
+            "invalid-code",
+            "code `271649006` is not in code system `http://snomed.info/sct`",
+        )),
+    )
+    .await;
+    let (_db, svc) = service_at(&server).await;
+    assert_vetdf_refusal(&svc).await;
+}
+
+#[tokio::test]
+async fn a_code_system_the_server_does_not_serve_leaves_the_binding_unverified() {
+    let server = MockServer::start().await;
+    // FerroTERM's shape: 404 with a `not-found` issue. The spec's VETDF makes
+    // this a warning, not a refusal: no verification was possible.
+    mount_lookup(
+        &server,
+        ResponseTemplate::new(404).set_body_json(outcome(
+            "not-found",
+            "code system `http://snomed.info/sct` is not served",
+        )),
+    )
+    .await;
+    let (_db, svc) = service_at(&server).await;
+    assert_accepted(&svc).await;
+}
+
+#[tokio::test]
+async fn a_resolving_lookup_is_accepted() {
+    let server = MockServer::start().await;
+    mount_lookup(
+        &server,
+        ResponseTemplate::new(200).set_body_json(json!({
+            "resourceType": "Parameters",
+            "parameter": [{"name": "display", "valueString": "Entire lung"}]
+        })),
+    )
+    .await;
+    let (_db, svc) = service_at(&server).await;
+    assert_accepted(&svc).await;
+}
+
+#[tokio::test]
+async fn a_bare_404_on_a_served_system_is_rejected_after_the_probe() {
+    let server = MockServer::start().await;
+    // An older server answers every miss with a bare 404. The probe finds the
+    // code system served, so the miss means the code is absent.
+    mount_lookup(&server, ResponseTemplate::new(404)).await;
+    mount_system_probe(&server, 1).await;
+    let (_db, svc) = service_at(&server).await;
+    assert_vetdf_refusal(&svc).await;
+}
+
+#[tokio::test]
+async fn a_bare_404_on_an_unserved_system_leaves_the_binding_unverified() {
+    let server = MockServer::start().await;
+    mount_lookup(&server, ResponseTemplate::new(404)).await;
+    mount_system_probe(&server, 0).await;
+    let (_db, svc) = service_at(&server).await;
+    assert_accepted(&svc).await;
+}
+
+#[tokio::test]
+async fn a_bare_404_the_probe_cannot_resolve_leaves_the_binding_unverified() {
+    let server = MockServer::start().await;
+    // No `CodeSystem` search at all: the server cannot say whether it serves
+    // the system, so nothing was verified and nothing is refused.
+    mount_lookup(&server, ResponseTemplate::new(404)).await;
+    let (_db, svc) = service_at(&server).await;
+    assert_accepted(&svc).await;
 }

--- a/app/ferroehr/tests/it/adl2_vetdf_ferroterm.rs
+++ b/app/ferroehr/tests/it/adl2_vetdf_ferroterm.rs
@@ -1,0 +1,245 @@
+// SPDX-FileCopyrightText: Ruben Talstra
+// SPDX-License-Identifier: BUSL-1.1
+
+//! ADL2 VETDF against a REAL terminology server: `FerroTERM`, the one the
+//! product ships beside the CDR (`docker-compose.terminology.yml`), serving the
+//! same licence-free shaped seed the conformance lane binds to.
+//!
+//! `adl2_vetdf` pins every answer shape with a mock; this module proves the
+//! contract on the server people actually run. Three bindings, three answers
+//! (AM ADL2 `master03-archetype_package.adoc` §Validity Rules, VETDF):
+//!
+//! - a SNOMED CT concept URI, on a server that serves no SNOMED CT: the code
+//!   system is not served, so "no verification was possible" and the archetype
+//!   is accepted with a warning, never refused;
+//! - a code of the served shaped system that exists: accepted;
+//! - a code of the served shaped system that does not exist: VETDF, `422`.
+//!
+//! The container is `ghcr.io/rubentalstra/ferroterm` at the release the compose
+//! overlay pins, started through `testcontainers` with `docker/terminology/seed`
+//! mounted as its `FERROTERM_CODESYSTEMS`; the harness's `PostgreSQL` 18 backs
+//! the service. Serialized with the other container suites by the nextest
+//! `containers` group.
+
+#![expect(
+    clippy::expect_used,
+    reason = "clippy's in-test lint scoping (clippy.toml `allow-*-in-tests`) only \
+              reaches `#[test]`-annotated functions, so it misses this integration \
+              module's helpers and async bodies; panicking assertions are the \
+              intended shape here (the Rust Book ch11)"
+)]
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use ferroehr::service::FerroEhrService;
+use ferroehr::service::status::CallStatusType;
+use ferroehr::service::terminology::config::{FhirOperation, FhirProviderConfig, ProviderKind};
+use ferroehr::service::terminology::fhir::FhirTerminologyProvider;
+use testcontainers::core::{ContainerPort, Mount};
+use testcontainers::runners::AsyncRunner;
+use testcontainers::{ContainerAsync, GenericImage, ImageExt};
+
+/// The `FerroTERM` release the compose overlay pins (`docker-compose.terminology.yml`).
+const FERROTERM_IMAGE: &str = "ghcr.io/rubentalstra/ferroterm";
+const FERROTERM_TAG: &str = "0.1.3";
+const FERROTERM_PORT: ContainerPort = ContainerPort::Tcp(8080);
+/// The shaped code system the seed serves (`docker/terminology/seed/`).
+const SHAPED_SYSTEM: &str = "http://cnf.example.test/fhir/CodeSystem/sct-shaped";
+/// A concept the shaped system defines, and one it does not.
+const SHAPED_MEMBER: &str = "1000001";
+const SHAPED_ABSENT: &str = "9999999";
+
+struct FerroTerm {
+    _container: ContainerAsync<GenericImage>,
+    /// The R4B base URL the CDR's provider points at.
+    base: String,
+}
+
+impl FerroTerm {
+    /// Start `FerroTERM` over the shaped seed and wait until its own health route
+    /// answers (the image carries a `HEALTHCHECK`, but readiness is asserted
+    /// from here so a slow pull never races the first lookup).
+    async fn start() -> Self {
+        let seed = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../docker/terminology/seed")
+            .canonicalize()
+            .expect("the shaped terminology seed directory exists");
+        let container = GenericImage::new(FERROTERM_IMAGE, FERROTERM_TAG)
+            .with_exposed_port(FERROTERM_PORT)
+            .with_env_var("FERROTERM_CODESYSTEMS", "/data/codesystems")
+            .with_env_var("FERROTERM_UI", "off")
+            .with_env_var("FERROTERM_LOG_FORMAT", "json")
+            .with_mount(Mount::bind_mount(
+                seed.to_string_lossy().into_owned(),
+                "/data/codesystems",
+            ))
+            .with_startup_timeout(Duration::from_secs(120))
+            .start()
+            .await
+            .expect("start FerroTERM (is Docker running?)");
+        let host = container.get_host().await.expect("host").to_string();
+        let port = container
+            .get_host_port_ipv4(FERROTERM_PORT)
+            .await
+            .expect("mapped port");
+        let root = format!("http://{host}:{port}");
+        let client = reqwest::Client::new();
+        let mut healthy = false;
+        for _ in 0..60 {
+            if let Ok(r) = client.get(format!("{root}/health")).send().await
+                && r.status().is_success()
+            {
+                healthy = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+        assert!(healthy, "FerroTERM never answered GET /health");
+        Self {
+            _container: container,
+            base: format!("{root}/r4b"),
+        }
+    }
+}
+
+/// A provider at `FerroTERM`'s R4B base, cache off so every test asks the server.
+fn provider(base: &str) -> FhirTerminologyProvider {
+    let cfg = FhirProviderConfig {
+        kind: ProviderKind::Fhir,
+        url: base.to_owned(),
+        operation: FhirOperation::ValidateCode,
+        connect_timeout_ms: 2000,
+        request_timeout_ms: 5000,
+        oauth2_client: None,
+        client_cert_path: None,
+        client_key_path: None,
+        ca_bundle_path: None,
+        cache_ttl_secs: 0,
+        cache_capacity: 0,
+    };
+    FhirTerminologyProvider::new("ferroterm", &cfg).expect("build provider")
+}
+
+/// A minimal spec-valid ADL2 archetype named `concept` whose root node binds
+/// `target` under the outer terminology key `terminology`.
+fn archetype(concept: &str, terminology: &str, target: &str) -> String {
+    format!(
+        "\
+archetype (adl_version=2.0.6; rm_release=1.1.0)
+    openEHR-EHR-OBSERVATION.{concept}.v1.0.0
+
+language
+    original_language = <[ISO_639-1::en]>
+
+description
+    lifecycle_state = <\"published\">
+    details = <
+        [\"en\"] = <
+            language = <[ISO_639-1::en]>
+        >
+    >
+
+definition
+    OBSERVATION[id1] matches {{ *}}
+
+terminology
+    term_definitions = <
+        [\"en\"] = <
+            [\"id1\"] = <text = <\"Root\"> description = <\"Root.\">>
+        >
+    >
+    term_bindings = <
+        [\"{terminology}\"] = <
+            [\"id1\"] = <{target}>
+        >
+    >
+"
+    )
+}
+
+#[tokio::test]
+async fn ferroterm_decides_vetdf_for_the_three_binding_outcomes() {
+    let ferroterm = FerroTerm::start().await;
+    let db = testkit::db().await.expect("testkit database");
+    let svc = FerroEhrService::new(db.pool())
+        .with_external_terminology(Arc::new(provider(&ferroterm.base)));
+
+    // 1. A SNOMED CT concept URI on a server that serves no SNOMED CT: the
+    //    binding is unverifiable, so the archetype is accepted (the sandbox
+    //    seed's five refused archetypes, #3311).
+    svc.upload_artefact(archetype(
+        "snomed_unserved",
+        "SNOMED-CT",
+        "http://snomed.info/id/50121007",
+    ))
+    .await
+    .expect("a code system the server does not serve leaves the binding unverified");
+    assert!(
+        svc.has_artefact("openEHR-EHR-OBSERVATION.snomed_unserved.v1.0.0".to_owned())
+            .await
+            .expect("has_artefact answers"),
+        "the unverified archetype is stored"
+    );
+
+    // 2. A concept the served shaped system defines: accepted.
+    svc.upload_artefact(archetype(
+        "shaped_member",
+        "CNF-SHAPED",
+        &format!("{SHAPED_SYSTEM}/id/{SHAPED_MEMBER}"),
+    ))
+    .await
+    .expect("a concept the served system defines resolves");
+
+    // 3. A concept the served shaped system does not define: VETDF.
+    let err = svc
+        .upload_artefact(archetype(
+            "shaped_absent",
+            "CNF-SHAPED",
+            &format!("{SHAPED_SYSTEM}/id/{SHAPED_ABSENT}"),
+        ))
+        .await
+        .expect_err("a concept absent from a served system is refused");
+    assert_eq!(err.status, CallStatusType::ContentInvalid);
+    assert!(
+        err.message.contains("VETDF") && err.message.contains(SHAPED_ABSENT),
+        "the rejection names the rule and the code: {}",
+        err.message
+    );
+    assert!(
+        !svc.has_artefact("openEHR-EHR-OBSERVATION.shaped_absent.v1.0.0".to_owned())
+            .await
+            .expect("has_artefact answers"),
+        "a refused archetype is not stored"
+    );
+}
+
+/// The archetype the sandbox seed lost first (#3311): a CKM archetype with
+/// real SNOMED CT bindings under the key `SNOMED-CT`, uploaded to a CDR whose
+/// `FerroTERM` serves no SNOMED CT. Before the fix every binding was asked as
+/// `system=SNOMED-CT&code=<uri>` and refused; now the bindings are unverifiable
+/// and the archetype is stored.
+#[tokio::test]
+async fn a_ckm_archetype_with_snomed_bindings_uploads_when_snomed_is_not_served() {
+    let ferroterm = FerroTerm::start().await;
+    let db = testkit::db().await.expect("testkit database");
+    let svc = FerroEhrService::new(db.pool())
+        .with_external_terminology(Arc::new(provider(&ferroterm.base)));
+
+    let source = std::fs::read_to_string(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(
+            "../../corpus/archetypes/adl2/ckm-2013-12-09/entry/observation/openEHR-EHR-OBSERVATION.refraction.v1.0.0.adls",
+        ),
+    )
+    .expect("the vendored CKM archetype");
+    svc.upload_artefact(source)
+        .await
+        .expect("SNOMED CT bindings on a server without SNOMED CT are unverifiable, not invalid");
+    assert!(
+        svc.has_artefact("openEHR-EHR-OBSERVATION.refraction.v1.0.0".to_owned())
+            .await
+            .expect("has_artefact answers"),
+        "the CKM archetype is stored"
+    );
+}

--- a/app/ferroehr/tests/it/main.rs
+++ b/app/ferroehr/tests/it/main.rs
@@ -27,6 +27,7 @@ mod access_origins;
 mod adl14_knowledge_archetypes;
 mod adl2_fixture;
 mod adl2_vetdf;
+mod adl2_vetdf_ferroterm;
 mod admin_fixture;
 mod aql_planner;
 mod audit_chain;

--- a/website/book/src/beyond-core/terminology.md
+++ b/website/book/src/beyond-core/terminology.md
@@ -102,6 +102,30 @@ local terminologies are still answered in-process.
 > disagree on that spelling, align them in the terminology-server configuration.
 > The CDR does not rewrite the value.
 
+### What it changes when an ADL 2 archetype is uploaded
+
+An ADL 2 archetype's `term_bindings` are checked too (AOM2 validity rule
+VETDF). A binding target is a URI in the IHTSDO model, `…/id/<code>`, and the
+CDR takes it apart before asking: `http://snomed.info/id/50121007` (or the
+`snomedct.info` host the ADL 2 specification's own examples use) is asked as
+`system=http://snomed.info/sct`, `code=50121007`, per the SNOMED CT URI Standard;
+`http://loinc.org/id/LA6742-6` as `system=http://loinc.org`; any other `…/id/…`
+URI as the URI before `/id/`. The outer binding key (`SNOMED-CT`, `Snomed`,
+`LOINC`, however the author spelled it) only picks the provider. The server's
+answer then decides:
+
+- the code **exists** → accepted;
+- the code system is served and the code is **not in it** → `422`, naming the
+  rule, the binding and the code;
+- the code system is **not served** by the terminology server (or the server
+  cannot say) → accepted with a warning in the log. AOM2 puts it this way:
+  codes for inaccessible terminologies "should be flagged with a warning
+  indicating that no verification was possible", so a CDR wired at a server
+  that carries only LOINC still stores archetypes with SNOMED CT bindings.
+
+The same rule holds with no external terminology server configured at all:
+nothing is asked and nothing is refused.
+
 ### Which FHIR operation is used
 
 Membership is tested with `ValueSet/$validate-code` by default: one direct


### PR DESCRIPTION
Closes #3311

## The defect

With FerroTERM beside the sandbox CDR (v4.2.3) the seed failed: 227 accepted / 95 refused ADL 2 archetypes against the pinned 233 / 89. Every new refusal was `VETDF: external term "http://snomed.info/id/50121007" bound to "at72" does not exist in terminology "SNOMED-CT"` (or LOINC). The resolver asked the server `CodeSystem/$lookup?system=SNOMED-CT&code=http://snomed.info/id/50121007` (the outer binding key as the FHIR system, the whole URI as the code) and mapped every miss to `false`. FerroTERM answers an unknown code system with `404` + `tx-issue-type not-found` and an unknown code in a served system with `400` + `invalid-code`, so the old client refused the former and treated the latter as a provider fault: the two answers inverted.

## The fix

- **`service/definition/binding_uri.rs`** (new): a binding target in the IHTSDO URI model becomes `(system, code)`. `http://snomed.info/id/{sctid}` and the `snomedct.info` host the ADL2 spec's own examples use map to `http://snomed.info/sct` (SNOMED CT URI Standard); any other `…/id/<code>` URI yields the URI before `/id/` (`http://loinc.org` for LOINC, the FHIR registry's system); a plain code or another shape is asked as written under the binding's own key. Grounded in AM ADL2 `master07.13-adl_terminology.adoc` §Terminology bindings ("URIs that follow the model for terminology URIs published by IHTSDO or a similar model").
- **`service/terminology/fhir.rs`**: `fetch` classifies a failing answer by its `OperationOutcome`'s `tx-issue-type` coding (`not-found` → unknown system, `invalid-code` → unknown code, a bare `404`/`410` → unclassified), caching the classification like a response. New `term_existence(system, code)` returns `Exists`, `Absent` or `Unverifiable(reason)`; an unclassified `404` is resolved with one `CodeSystem?url=<system>&_summary=count` probe (served → absent, unserved or unanswerable → unverifiable). `has_term`/`get_term` keep their wire behaviour.
- **`service/terminology/routing.rs`**: `term_existence` routes by the derived system first, then the binding's key, then the default; with no external provider the binding is unverifiable.
- **`service/definition/adl2.rs`**: the VETDF pre-resolver decomposes each binding and records only definite answers; unverifiable bindings are logged at warn and accepted, which is AOM2 `master03-archetype_package.adoc` §Validity Rules VETDF verbatim ("codes for inaccessible terminologies should be flagged with a warning indicating that no verification was possible").
- **`ferroehr-ext`**: `decode_outcome_issue_types` and `decode_bundle_total` over the typed R4B model.

## Tests

- Unit: the URI decomposition (SNOMED both hosts and `www.`, LOINC, UMLS, the shaped seed's system, plain codes and other shapes), the outcome decoders.
- `adl2_vetdf` (wiremock) rewritten to the spec's contract, six answer shapes: `400 invalid-code` → 422 VETDF; `404 not-found` → accepted; `200` → accepted; bare `404` + served system → 422; bare `404` + unserved system → accepted; bare `404` with no `CodeSystem` search → accepted. The mocks match `system=http://snomed.info/sct&code=271649006`, never the key or the URI.
- `adl2_vetdf_ferroterm` (new, nextest `containers` group): a real `ghcr.io/rubentalstra/ferroterm:0.1.3` container over `docker/terminology/seed`. Three bindings, three answers, plus the vendored CKM `openEHR-EHR-OBSERVATION.refraction.v1.0.0.adls` (the archetype the sandbox lost) uploading against a server that serves no SNOMED CT.
- Workspace clippy, rustdoc on both crates, 143 terminology/definition/ADL2 tests, docs-claims, tracker-status, changelog-structure, comment-style, typed-status, default-style all green locally.

## Docs

Terminology page: a section on what the upload check does with binding URIs and the three answers. Changelog `### Fixed` under `[Unreleased]` for v4.2.4.

- [x] I accept the terms in [CONTRIBUTING.md § Licensing of contributions](../CONTRIBUTING.md#licensing-of-contributions): I have the right to submit this work, I license it under the project licence of the version it lands in, and I grant the Licensor the relicensing right stated there.
